### PR TITLE
Meeting stays created infinitely when defaultMeetingCreateJoinDuration=0

### DIFF
--- a/bigbluebutton-web/src/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/api/domain/Meeting.java
@@ -198,6 +198,7 @@ public class Meeting {
 	}
 	
 	private boolean nobodyJoined(int expiry) {
+		if (expiry == 0) return false; /* Meeting stays created infinitely */
 		return (System.currentTimeMillis() - createdTime) >  (expiry * MILLIS_IN_A_MINUTE);
 	}
 	


### PR DESCRIPTION
Solves issue 1097
