### PR TITLE
Resolution from streamname

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/business/VideoWindowItf.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/business/VideoWindowItf.as
@@ -62,7 +62,14 @@ package org.bigbluebutton.modules.videoconf.business
 		protected function getVideoResolution(stream:String):Array {
 			// streamname: <width>x<height><userId>-<timestamp>
 			// example: 320x2405-1329334829687
-			return stream.substr(0, stream.split("-")[0].length - String(this.userId).length).split("x");
+			var pattern:RegExp = new RegExp("\\d+x\\d+-\\d+", "");
+			if (pattern.test(stream)) {
+				LogUtil.debug("The stream name is well formatted");
+				return stream.substr(0, stream.split("-")[0].length - String(this.userId).length).split("x");
+			} else {
+				LogUtil.error("The stream name doesn't follow the pattern <width>x<height><userId>-<timestamp>. However, the video resolution will be set to the lowest defined resolution in the config.xml: " + resolutions[0]);
+				return resolutions[0].split("x");
+			}
 		}
 		
 		protected function get paddingVertical():Number {


### PR DESCRIPTION
This pull request is related to a bug that affects the interaction with the Android client.
The Android client streams video with the lowest resolution possible accordingly to the device. The stream name is well formatted indicating the video resolution, the user ID and the timestamp.

A problem occurs when the Android client streams a video with a resolution that is not in the BBB config.xml. The "old" method of extracting the video resolution from the stream name compares the beginning of the stream name with the configured resolutions. If the stream name contains a resolution that has not been predefined, the function to get the video resolutions returns null and as a result the BBB client presents a blank video.

This new implementation parses the stream name not considering the predefined resolutions. It will enable any external client to stream video with arbitrary resolutions.
