### PR TITLE
Delete presentations of recording when using bbb-record --delete

### DIFF
--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -217,6 +217,7 @@ if [ $DELETE ]; then
         rm -rf /usr/share/red5/webapps/video/streams/$MEETING_ID
         rm -f /var/bigbluebutton/deskshare/$MEETING_ID*.flv
         rm -f /var/freeswitch/meetings/$MEETING_ID*.wav
+		rm -rf /var/bigbluebutton/$MEETING_ID
 
         echo "deleting: $MEETING_ID"
   else


### PR DESCRIPTION
MEETING_Id.

Fixes http://code.google.com/p/bigbluebutton/issues/detail?id=1177
