### PR TITLE
Disable the mobile support when the mobile security key is empty

### DIFF
--- a/bbb-api-demo/src/main/webapp/mobile.jsp
+++ b/bbb-api-demo/src/main/webapp/mobile.jsp
@@ -33,36 +33,19 @@
 <%@ include file="mobile_api.jsp"%>
 
 <%
+    String result = error(E_INVALID_URL);
     if (request.getParameterMap().isEmpty()) {
+    	result = success("mobileSupported", "This server supports mobile devices.");
+    } else if (request.getParameter("action") == null) {
+        // return the default result
     } else if (request.getParameter("action").equals("getTimestamp")) {
-    	String message = "<response><returncode>FAILED</returncode></response>";
-    	
-    	if (isRequestValid(request))
-    		message = "<response><returncode>SUCCESS</returncode><timestamp>" + getTimestamp() + "</timestamp></response>";
-%>
-<%=message%>
-<%
+    	result = getTimestamp(request);
     } else if (request.getParameter("action").equals("getMeetings")) {
-    	String meetings = "<meetings><meeting><returncode>FAILED</returncode></meeting></meetings>";
-    	
-    	if (isRequestValid(request))
-    		meetings = getMeetings();
-%>
-<%=meetings%>
-<%
+    	result = mobileGetMeetings(request);
     } else if (request.getParameter("action").equals("join")) {
-        String result = mobileJoinMeeting(request);
-%>
-<%=result%>
-<%
+    	result = mobileJoinMeeting(request);
     } else if (request.getParameter("action").equals("create")) {
-        String meetingID = request.getParameter("meetingID");
-        String result = "<response><returncode>FAILED</returncode></response>";
-        
-        if (isRequestValid(request))
-        	result = createMeeting(meetingID, "", "", "", 0, BigBlueButtonURL);
+    	result = mobileCreate(request);
+	}
 %>
 <%=result%>
-<%
-    }
-%>

--- a/bbb-api-demo/src/main/webapp/mobile_api.jsp
+++ b/bbb-api-demo/src/main/webapp/mobile_api.jsp
@@ -27,11 +27,42 @@
 <%@page import="org.apache.commons.httpclient.methods.GetMethod"%>
 
 <%!
+	public final int E_OK = 0;
+	public final int E_CHECKSUM_NOT_INFORMED = 1;
+	public final int E_INVALID_CHECKSUM = 2;
+	public final int E_INVALID_TIMESTAMP = 3;
+	public final int E_EMPTY_SECURITY_KEY = 4;
+	public final int E_MISSING_PARAM_MEETINGID = 5;
+	public final int E_MISSING_PARAM_FULLNAME = 6;
+	public final int E_MISSING_PARAM_PASSWORD = 7;
+	public final int E_MISSING_PARAM_TIMESTAMP = 8;
+	public final int E_INVALID_URL = 9;
+
+    public String error(int code) {
+        switch(code) {
+            case E_CHECKSUM_NOT_INFORMED:
+            case E_INVALID_CHECKSUM:
+                return error("checksumError", "You did not pass the checksum security check.");
+            case E_INVALID_TIMESTAMP:
+                return error("invalidTimestamp", "You did not pass the timestamp check.");
+            case E_EMPTY_SECURITY_KEY:
+                return error("emptySecurityKey", "The mobile security key is empty. Please contact the administrator.");
+            case E_MISSING_PARAM_MEETINGID:
+                return error("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+            case E_MISSING_PARAM_FULLNAME:
+                return error("missingParamFullName", "You must specify a name for the attendee who will be joining the meeting.");
+            case E_MISSING_PARAM_PASSWORD:
+                return error("invalidPassword", "You either did not supply a password or the password supplied is neither the attendee or moderator password for this conference.");
+            case E_MISSING_PARAM_TIMESTAMP:
+                return error("missingParamTimestamp", "You must specify the timestamp provided by the server when you called the method getTimestamp.");
+            case E_INVALID_URL:
+                return error("invalidAction", "The requested URL is unavailable.");
+            default:
+                return error("unknownError", "An unexpected error occurred");
+        }
+    }
+    
 	private String getRequestURL(HttpServletRequest request) {
-		//String requestURL = request.getRequestURL().toString().replace("http://127.0.0.1:8080/bigbluebutton/", BigBlueButtonURL);
-		//if (!request.getQueryString().isEmpty());
-		//	requestURL += "?" + request.getQueryString();
-		//return requestURL;
 		return request.getQueryString();
 	}
 	
@@ -43,49 +74,79 @@
 		return requestURL + "&checksum=" + checksum(requestURL + mobileSalt);
 	}
 	
-	private boolean checkTimestamp(HttpServletRequest request) {
-    	String requestTimestamp = request.getParameter("timestamp");
-    	if (requestTimestamp == null)
-    		return false;
-    		
-		Long requestTimestampL = Long.valueOf(requestTimestamp);
-		
-		return (getTimestamp() - requestTimestampL <= 60);		
-	}
-
-	public boolean isRequestValid(HttpServletRequest request) {
+	private int isRequestValid(HttpServletRequest request) {
 		// if there's no checksum parameter, the request isn't valid
 		if (request.getParameter("checksum") == null)
-			return false;
-			
-		// check the timestamp for all the requests except getTimestamp
-		if (!request.getParameter("action").equals("getTimestamp")
-				&& !checkTimestamp(request))
-			return false;
-	
-		String requestURL = getRequestURL(request);
+			return E_CHECKSUM_NOT_INFORMED;
 		
+		// check the timestamp for all the requests except getTimestamp
+		if (!request.getParameter("action").equals("getTimestamp")) {
+	    	String requestTimestamp = request.getParameter("timestamp");
+	    	if (requestTimestamp == null)
+	    		return E_MISSING_PARAM_TIMESTAMP;
+			
+			Long requestTimestampL = Long.valueOf(requestTimestamp);
+			// the timestamp is valid for 60 seconds
+			if (Math.abs(getTimestamp() - requestTimestampL) > 60)
+				return E_INVALID_TIMESTAMP;
+		}
+		
+		if (mobileSalt.isEmpty())
+			return E_EMPTY_SECURITY_KEY;
+		
+		String requestURL = getRequestURL(request);
 		String urlWithoutChecksum = removeChecksum(requestURL);
 		String urlWithChecksum = addValidChecksum(urlWithoutChecksum);
-		return (requestURL.equals(urlWithChecksum));
+		return (requestURL.equals(urlWithChecksum)? E_OK: E_INVALID_CHECKSUM);
 	}
 	
-	public long getTimestamp() {
+	private String mountResponse(String returncode, String messageKey, String message) {
+	    return "<response><returncode>" + returncode + "</returncode><messageKey>" + messageKey + "</messageKey><message>" + message + "</message></response>";	
+	}
+	
+	public String success(String messageKey, String message) {
+		return mountResponse("SUCCESS", messageKey, message);
+	}
+	
+	public String error(String messageKey, String message) {
+		return mountResponse("FAILED", messageKey, message);
+	}
+	
+	private long getTimestamp() {
 		return (System.currentTimeMillis() / 1000L);
+	}
+
+	public String getTimestamp(HttpServletRequest request) {
+		int code = isRequestValid(request);
+    	if (code != E_OK)
+			return error(code);
+
+		return "<response><returncode>SUCCESS</returncode><timestamp>" + getTimestamp() + "</timestamp></response>";
+	}
+	
+	public String mobileGetMeetings(HttpServletRequest request) {
+		int code = isRequestValid(request);
+    	if (code != E_OK)
+			return error(code);
+			
+		return getMeetings();
 	}
 	
 	public String mobileJoinMeeting(HttpServletRequest request) {
-        String result = "<response><returncode>FAILED</returncode><message>Can't join the meeting</message></response>";
-        
-        if (!isRequestValid(request))
-        	return result;
+		int code = isRequestValid(request);
+    	if (code != E_OK)
+			return error(code);
         	
         String meetingID = request.getParameter("meetingID");
-        String fullName = request.getParameter("fullName");
-        String password = request.getParameter("password");
-        if (fullName == null || meetingID == null || password == null)
-        	return result;
+        if (meetingID == null) return error(E_MISSING_PARAM_MEETINGID);
         
+        String fullName = request.getParameter("fullName");
+        if (fullName == null) return error(E_MISSING_PARAM_FULLNAME);
+        
+        String password = request.getParameter("password");
+        if (password == null) return error(E_MISSING_PARAM_PASSWORD);
+        
+        String result = error("failedJoin", "Couldn't join the meeting.");
         String joinUrl = getJoinMeetingURL(fullName, meetingID, password);
         String enterUrl = BigBlueButtonURL + "api/enter";
         try {
@@ -103,8 +164,19 @@
         return result;
     }
 	
+	public String mobileCreate(HttpServletRequest request) {
+		int code = isRequestValid(request);
+    	if (code != E_OK)
+			return error(code);
+			
+        String meetingID = request.getParameter("meetingID");
+        if (meetingID == null) return error(E_MISSING_PARAM_MEETINGID);
+        
+        return createMeeting(meetingID, "", "", "", 0, BigBlueButtonURL);
+	}
+	
 	// it's just for testing purposes
-	public String fixURL(HttpServletRequest request) {
+	private String fixURL(HttpServletRequest request) {
 		return addValidChecksum(removeChecksum(getRequestURL(request)));
 	}
 %>	

--- a/bbb-api-demo/src/main/webapp/mobile_conf.jsp
+++ b/bbb-api-demo/src/main/webapp/mobile_conf.jsp
@@ -1,6 +1,6 @@
 
 <%!
-// This is the mobile security salt that must match the value set in the BigBlueButton server
+// This is the mobile security salt that must be used to check the requests on mobile.jsp
 String mobileSalt = "03b07";
 %>
 


### PR DESCRIPTION
I've done an important refactoring in the mobile demo to improve the fail responses. Also now if the admin hasn't explicitly set the mobile security key, the mobile.jsp will refuse the calls and return an error message.
