### PR TITLE
fixed some issues with the css related to focus and nofocus

### DIFF
--- a/bigbluebutton-client/branding/default/style/css/BBBDefault.css
+++ b/bigbluebutton-client/branding/default/style/css/BBBDefault.css
@@ -53,7 +53,7 @@ Button {
   textRollOverColor: #5e5f63;
   textSelectedColor: #5e5f63;
   borderColor: #b9babc;
-  themeColor: #aaaaaa;
+  themeColor: haloBlue;
   fontFamily: Arial;
   fontSize: 12;
 }
@@ -67,7 +67,7 @@ Button {
   textRollOverColor: #ffffff;
   textSelectedColor: #262626;
   borderColor: #000000;
-  themeColor: #000000;
+  themeColor: haloBlue;
   fontFamily: Arial;
   fontSize: 12;
 }
@@ -81,7 +81,7 @@ Button {
   textRollOverColor: #ffffff;
   textSelectedColor: #262626;
   borderColor: #000000;
-  themeColor: #000000;
+  themeColor: haloBlue;
   fontFamily: Arial;
   fontSize: 12;
 }
@@ -89,7 +89,7 @@ Button {
 .helpLinkButtonStyle {
   rollOverColor: #cccccc;
   selectionColor: #999999;
-  color: #504f3d;
+  color: #ffffff;
   textRollOverColor: #504f3d;
   textSelectedColor: #504f3d;
 }
@@ -130,7 +130,7 @@ DataGrid {
   textRollOverColor: #5e5f63;
   textSelectedColor: #5e5f63;
   borderColor: #b9babc;
-  themeColor: #aaaaaa;
+  themeColor: haloBlue;
   fontFamily: Arial;
   fontSize: 12;
 }
@@ -187,7 +187,7 @@ DataGrid {
   textRollOverColor: #5e5f63;
   textSelectedColor: #5e5f63;
   borderColor: #b9babc;
-  themeColor: #aaaaaa;
+  themeColor: haloBlue;
   fontFamily: Arial;
   fontSize: 12;
 }
@@ -224,7 +224,7 @@ DataGrid {
   invertThumbDirection: false;
   borderColor: #b9babc;
   trackColors: #aaaaaa, #aaaaaa;
-  themeColor: #aaaaaa;
+  themeColor: haloBlue;
   fillAlphas: 1, 1, 1, 1;
   fillColors: #fefeff, #e1e2e5, #ffffff, #eeeeee;
   labelStyleName: "presentationZoomSliderLabelStyle";
@@ -236,13 +236,13 @@ DataGrid {
 }
 
 MDIWindow {
-  resizeCursorHorizontalXOffset: 2;	
+  
 }
 
-.mdiWindowFocus, .mdiWindowNoFocus, .presentationWindowStyleNoFocus, .presentationWindowStyleFocus, .videoDockStyleNoFocus, .videoDockStyleFocus
+.mdiWindowFocus, .presentationWindowStyleFocus, .videoDockStyleFocus
 {
   headerHeight: 26;
-  roundedBottomCorners: false;
+  roundedBottomCorners: true;
   backgroundAlpha: 1;
   backgroundColor: #b9babc;
   backgroundSize: '100%';
@@ -250,6 +250,37 @@ MDIWindow {
   borderStyle: solid;
   borderColor: #b9babc;
   borderAlpha: 1;
+  borderThickness: 1;
+  borderThicknessLeft: 1;
+  borderThicknessTop: 1;
+  borderThicknessBottom: 1;
+  borderThicknessRight: 1;
+  cornerRadius: 0;
+  dropShadowEnabled: false;
+  titleStyleName: "mypanelTitle";
+  
+  cornerResizeImg: Embed(source="assets/swf/Blue.swf", symbol="Corner_Resize");
+  cornerResizeWidth: 2;
+  cornerResizeHeight: 2;
+  cornerResizePaddingRight: 2;
+  cornerResizePaddingBottom: 2;
+  
+  controlButtonWidth: 10;
+  controlButtonHeight: 10;
+  controlButtonGap: 4;
+}
+
+.mdiWindowNoFocus, .presentationWindowStyleNoFocus, .videoDockStyleNoFocus
+{
+  headerHeight: 26;
+  roundedBottomCorners: false;
+  backgroundAlpha: 0.5;
+  backgroundColor: #b9babc;
+  backgroundSize: '100%';
+  
+  borderStyle: solid;
+  borderColor: #b9babc;
+  borderAlpha: 0.5;
   borderThickness: 1;
   borderThicknessLeft: 1;
   borderThicknessTop: 1;
@@ -287,7 +318,7 @@ MDIWindow {
 .videoViewStyleNoFocus 
 {
   borderColor: #b9babc;
-  borderAlpha: 1;
+  borderAlpha: 0.5;
   borderThicknessLeft: 5;
   borderThicknessTop: 5;
   borderThicknessBottom: 5;
@@ -296,6 +327,7 @@ MDIWindow {
   cornerRadius: 5;
   headerHeight: 20;
   backgroundColor: #b9babc;
+  backgroundAlpha: 0.5;
   dropShadowEnabled: false;
   titleStyleName: "mypanelTitle";
 }
@@ -312,6 +344,7 @@ MDIWindow {
   cornerRadius: 5;
   headerHeight: 20;
   backgroundColor: #b9babc;
+  backgroundAlpha: 1;
   dropShadowEnabled: false;
   titleStyleName: "mypanelTitle";
 }
@@ -319,7 +352,7 @@ MDIWindow {
 .videoPublishStyleNoFocus 
 {
   borderColor: #b9babc;
-  borderAlpha: 1;
+  borderAlpha: 0.5;
   borderThicknessLeft: 5;
   borderThicknessTop: 5;
   borderThicknessBottom: 5;
@@ -328,6 +361,7 @@ MDIWindow {
   cornerRadius: 5;
   headerHeight: 20;
   backgroundColor: #b9babc;
+  backgroundAlpha: 0.5;
   dropShadowEnabled: false;
   titleStyleName: "mypanelTitle";
 }
@@ -344,6 +378,7 @@ MDIWindow {
   cornerRadius: 5;
   headerHeight: 20;
   backgroundColor: #b9babc;
+  backgroundAlpha: 1;
   dropShadowEnabled: false;
   titleStyleName: "mypanelTitle";
 }
@@ -351,7 +386,7 @@ MDIWindow {
 .videoAvatarStyleNoFocus 
 {
   borderColor: #b9babc;
-  borderAlpha: 1;
+  borderAlpha: 0.5;
   borderThicknessLeft: 5;
   borderThicknessTop: 5;
   borderThicknessBottom: 5;
@@ -360,6 +395,7 @@ MDIWindow {
   cornerRadius: 5;
   headerHeight: 20;
   backgroundColor: #b9babc;
+  backgroundAlpha: 0.5;
   dropShadowEnabled: false;
   titleStyleName: "mypanelTitle";
 }
@@ -376,6 +412,7 @@ MDIWindow {
   cornerRadius: 5;
   headerHeight: 20;
   backgroundColor: #b9babc;
+  backgroundAlpha: 1;
   dropShadowEnabled: false;
   titleStyleName: "mypanelTitle";
 }


### PR DESCRIPTION
The themeColor css property was modified in a bunch of places, the only thing this changes is the focus rectangle colour. I've changed them all back to haloBlue which is the default.

There was a property set for resizeHandleXOffset, I don't really know why this was modified because it just made the cursor jump away. I removed that.

I also added in borderAlpha and backgroundAlpha changes for when a window gains or loses focus, much easier to see what currently has focus in the client.

I also modified the Help link's text colour when not rolled over. It used to be the same colour as the background and blended in so I changed it to white. It's now much easier to see.
