### PR TITLE
fix null ref when presenter switches before video control buttons load fully

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/ControlButtons.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/ControlButtons.mxml
@@ -81,16 +81,20 @@
       
       private function showControlButtons(presenter:Boolean):void {
           var vidOptions:VideoConfOptions = new VideoConfOptions();
-          if (UsersUtil.amIModerator()) {
-            muteUnmuteBtn.visible = switchPresenter.visible = ejectUserBtn.visible = true;
-          } else if (vidOptions.controlsForPresenter) {
-            muteUnmuteBtn.visible = switchPresenter.visible = ejectUserBtn.visible = presenter;
-          } else {
-            muteUnmuteBtn.visible = switchPresenter.visible = ejectUserBtn.visible = false;
+          
+          if (muteUnmuteBtn != null && switchPresenter != null && ejectUserBtn != null) {
+	          if (UsersUtil.amIModerator()) {
+	            muteUnmuteBtn.visible = switchPresenter.visible = ejectUserBtn.visible = true;
+	          } else if (vidOptions.controlsForPresenter) {
+	            muteUnmuteBtn.visible = switchPresenter.visible = ejectUserBtn.visible = presenter;
+	          } else {
+	            muteUnmuteBtn.visible = switchPresenter.visible = ejectUserBtn.visible = false;
+	          }
+	          
+	          muteUnmuteBtn.toolTip = ResourceUtil.getInstance().getString('bbb.video.controls.muteButton.toolTip', [UsersUtil.getUserName(sharerUserID)]);
+	          switchPresenter.toolTip = ResourceUtil.getInstance().getString('bbb.video.controls.switchPresenter.toolTip', [UsersUtil.getUserName(sharerUserID)]);
+	          ejectUserBtn.toolTip = ResourceUtil.getInstance().getString('bbb.video.controls.ejectUserBtn.toolTip', [UsersUtil.getUserName(sharerUserID)]);
           }
-          muteUnmuteBtn.toolTip = ResourceUtil.getInstance().getString('bbb.video.controls.muteButton.toolTip', [UsersUtil.getUserName(sharerUserID)]);
-          switchPresenter.toolTip = ResourceUtil.getInstance().getString('bbb.video.controls.switchPresenter.toolTip', [UsersUtil.getUserName(sharerUserID)]);
-          ejectUserBtn.toolTip = ResourceUtil.getInstance().getString('bbb.video.controls.ejectUserBtn.toolTip', [UsersUtil.getUserName(sharerUserID)]);
       }
       
       private function showPrivateChatButton():void {


### PR DESCRIPTION
If you share your webcam and before the video has fully published switch presenter a null object reference is thrown. I just added in a check to make sure everything exists before modifying it.
