### PR TITLE
Allow LTI consumers to send along a duration parameter

### DIFF
--- a/bbb-lti/grails-app/controllers/ToolController.groovy
+++ b/bbb-lti/grails-app/controllers/ToolController.groovy
@@ -86,6 +86,11 @@ class ToolController {
 						log.debug "This session will be recorded!"
 					}
 					
+					// Detect if the LTI has set a maximum duration
+					if (params.get(Parameter.CUSTOM_DURATION) != null) {
+						log.debug "A maximum duration has been provided; this room will automatically close after " + params.get(Parameter.CUSTOM_DURATION) + " minutes"
+					}
+					
                     //String destinationURL = "http://www.bigbluebutton.org/"
                     String destinationURL = bigbluebuttonService.getJoinURL(params, welcome)
                     

--- a/bbb-lti/grails-app/services/BigbluebuttonService.groovy
+++ b/bbb-lti/grails-app/services/BigbluebuttonService.groovy
@@ -87,13 +87,14 @@ class BigbluebuttonService {
         String courseTitle = getValidatedCourseTitle(params.get(Parameter.COURSE_TITLE))
         String userID = getValidatedUserId(params.get(Parameter.USER_ID))
         String record = getValidatedRecord(params.get(Parameter.CUSTOM_RECORD))
+		String duration = getValidatedDuration(params.get(Parameter.CUSTOM_DURATION))
         
         String[] values = [meetingName, courseTitle]
         String welcomeMsg = MessageFormat.format(welcome, values)
         
         String meta = getMonitoringMetaData(params)
         
-        String createURL = getCreateURL( meetingName, meetingID, attendeePW, moderatorPW, welcomeMsg, logoutURL, record, meta )
+        String createURL = getCreateURL( meetingName, meetingID, attendeePW, moderatorPW, welcomeMsg, logoutURL, record, duration, meta )
         //log.debug "createURL: " + createURL
         Map<String, Object> createResponse = doAPICall(createURL)
         //log.debug "createResponse: " + createResponse
@@ -111,10 +112,10 @@ class BigbluebuttonService {
         
     }
     
-    private String getCreateURL(String name, String meetingID, String attendeePW, String moderatorPW, String welcome, String logoutURL, String record, String meta ) {
+    private String getCreateURL(String name, String meetingID, String attendeePW, String moderatorPW, String welcome, String logoutURL, String record, String duration, String meta ) {
         Integer voiceBridge = 70000 + new Random(System.currentTimeMillis()).nextInt(10000);
 
-        String url = bbbProxy.getCreateURL(name, meetingID, attendeePW, moderatorPW, welcome, "", voiceBridge.toString(), "", logoutURL, "", record, "", meta );
+        String url = bbbProxy.getCreateURL(name, meetingID, attendeePW, moderatorPW, welcome, "", voiceBridge.toString(), "", logoutURL, "", record, duration, meta );
         return url;
     }
     
@@ -160,6 +161,16 @@ class BigbluebuttonService {
 	
 	private String getValidatedRecord(String record){
 		return (record != "true")? "": record
+	}
+
+	private String getValidatedDuration(String duration){
+		// Check with isInteger() first to prevent conversion error from being thrown
+		if (duration.isInteger()){
+			if (duration.toInteger() >= 0){
+				return duration
+			}
+		}
+		return ""
 	}
     
     private String getMonitoringMetaData(params){

--- a/bbb-lti/src/java/org/bigbluebutton/lti/Parameter.java
+++ b/bbb-lti/src/java/org/bigbluebutton/lti/Parameter.java
@@ -49,6 +49,7 @@ public class Parameter {
     public static final String CUSTOM_USER_ID = "custom_lis_person_sourcedid";
 	public static final String CUSTOM_WELCOME = "custom_welcome";
 	public static final String CUSTOM_RECORD = "custom_record";
+	public static final String CUSTOM_DURATION = "custom_duration";
 
 
 }


### PR DESCRIPTION
Have you ever accidentally left a recorded BigBlueButton room open in a tab over night? :) If so, this commit is for you!

I extended the LTI bridge a little further to allow it to send along a duration parameter if the LTI consumer so desires to specify a limit.
