### PR TITLE
Added a footer to welcome message.

### DIFF
--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -77,6 +77,7 @@ defaultDialAccessNumber=613-555-1234
 # conference. This is only used for the old scheduling which will be
 # removed in the future. Use the API to create a conference.
 defaultWelcomeMessage=<br>Welcome to <b>%%CONFNAME%%</b>!<br><br>For help on using BigBlueButton see these (short) <a href="event:http://www.bigbluebutton.org/content/videos"><u>tutorial videos</u></a>.<br><br>To join the audio bridge click the headset icon (upper-left hand corner). <b>You can mute yourself in the Listeners window.</b><br>
+defaultWelcomeMessageFooter=This BigBlueButton server runs the latest 0.81-dev version. <br><br>For more details about this release visit <a href="http://code.google.com/p/bigbluebutton/wiki/RoadMap" target="_blank"><u>contact us</u></a>.
 
 # Default maximum number of users a meeting can have.
 # Doesn't get enforced yet but is the default value when the create
@@ -108,7 +109,7 @@ disableRecordingDefault=false
 #----------------------------------------------------
 # This URL is where the BBB client is accessible. When a user sucessfully
 # enters a name and password, she is redirected here to load the client.
-bigbluebutton.web.serverURL=http://192.168.0.249
+bigbluebutton.web.serverURL=http://192.168.0.158
 
 #----------------------------------------------------
 # Assign URL where the logged-out participant will be redirected after sign-out.
@@ -127,7 +128,7 @@ defaultAvatarURL=${bigbluebutton.web.serverURL}/client/avatar.png
 apiVersion=0.8
 
 # Salt which is used by 3rd-party apps to authenticate api calls
-securitySalt=90ae86441b1211a4cbb3671f369fb031
+securitySalt=a106c6cff65f94ad5c846df9e230b480
 
 # Directory where we drop the <meeting-id-recorded>.done file
 recordStatusDir=/var/bigbluebutton/recording/status/recorded

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -93,6 +93,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     <property name="securitySalt" value="${securitySalt}"/>
     <property name="defaultMaxUsers" value="${defaultMaxUsers}"/>
     <property name="defaultWelcomeMessage" value="${defaultWelcomeMessage}"/>
+    <property name="defaultWelcomeMessageFooter" value="${defaultWelcomeMessageFooter}"/>
     <property name="defaultDialAccessNumber" value="${defaultDialAccessNumber}"/>
     <property name="testVoiceBridge" value="${testVoiceBridge}"/>
     <property name="testConferenceMock" value="${testConferenceMock}"/>

--- a/bigbluebutton-web/src/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -43,6 +43,7 @@ public class ParamsProcessorUtil {
 	private String securitySalt;
 	private int defaultMaxUsers = 20;
 	private String defaultWelcomeMessage;
+	private String defaultWelcomeMessageFooter;
 	private String defaultDialAccessNumber;
 	private String testVoiceBridge;
 	private String testConferenceMock;
@@ -342,6 +343,8 @@ public class ParamsProcessorUtil {
 		if (StringUtils.isEmpty(message)) {
 			welcomeMessage = defaultWelcomeMessage;
 		}
+		if( !StringUtils.isEmpty(defaultWelcomeMessageFooter) )
+		    welcomeMessage += "<br><br>" + defaultWelcomeMessageFooter;
 		return welcomeMessage;
 	}
 
@@ -482,6 +485,10 @@ public class ParamsProcessorUtil {
 
 	public void setDefaultWelcomeMessage(String defaultWelcomeMessage) {
 		this.defaultWelcomeMessage = defaultWelcomeMessage;
+	}
+	
+	public void setDefaultWelcomeMessageFooter(String defaultWelcomeMessageFooter) {
+	    this.defaultWelcomeMessageFooter = defaultWelcomeMessageFooter;
 	}
 
 	public void setDefaultDialAccessNumber(String defaultDialAccessNumber) {


### PR DESCRIPTION
The defaultWelcomeMessageFooter parameter can now be set up on bigbluebutton.properties

This parameter is used to create a fixed footer that will be used as part of the welcomeMessage shown in the chat.

A disclaimer or copyright signature can be placed here for all the meetings in a server.
