### PR TITLE
Fixes LTI custom welcome message for bbb-lti 0.1.1

### DIFF
--- a/bbb-lti/grails-app/controllers/ToolController.groovy
+++ b/bbb-lti/grails-app/controllers/ToolController.groovy
@@ -235,6 +235,12 @@ class ToolController {
         log.debug "Locale has been set to " + locale
         String welcome = message(code: "bigbluebutton.welcome", args: ["\"{0}\"", "\"{1}\""])
         log.debug "Localized default welcome message: [" + welcome + "]"
+
+		// Check for [custom_]welcome parameter being passed from the LTI
+		if (params.get(Parameter.CUSTOM_BBB_WELCOME) != null) {
+			welcome = params.get(Parameter.CUSTOM_BBB_WELCOME)
+			log.debug "Overriding default welcome message with: [" + welcome + "]"
+		}
            
         String destinationURL = bigbluebuttonService.getJoinURL(params, welcome, ltiService.mode)
         log.debug "redirecting to " + destinationURL

--- a/bbb-lti/src/java/org/bigbluebutton/lti/Parameter.java
+++ b/bbb-lti/src/java/org/bigbluebutton/lti/Parameter.java
@@ -52,7 +52,7 @@ public class Parameter {
     public static final String CUSTOM_BBB_RECORD = "custom_bbb_record";
     public static final String CUSTOM_BBB_VOICEBRIDGE = "custom_bbb_voicebridge";
     public static final String CUSTOM_BBB_DURATION = "custom_bbb_duration";
-    public static final String CUSTOM_WELCOME = "custom_bbb_welcome";
+    public static final String CUSTOM_BBB_WELCOME = "custom_bbb_welcome";
     
     ///BigBlueButton internal parameters
     public static final String BBB_RECORDING_ID = "bbb_recording_id";


### PR DESCRIPTION
This commit renames custom_record to custom_bbb_record and overrides the meeting's welcome message when appropriate.

(This is an updated version of a previous contribution after reviewing the 0.1.1 version of bbb-lti. From my testing, an LTI's custom welcome message is being ignored in 0.1.1.)
