### PR TITLE
Fix chat times

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/model/ChatMessage.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/model/ChatMessage.as
@@ -42,14 +42,16 @@ package org.bigbluebutton.modules.chat.model {
 		[Bindable] public var translated:Boolean = false;
 		[Bindable] public var translatedColor:uint;
 
+	
     // Stores the time (millis) when the sender sent the message.
     public var fromTime:Number;
     // Stores the timezone offset (minutes) of the sender.
     public var fromTimezoneOffset:Number;
-    
+	
+	/*
     // Stores what we display to the user. The converted fromTime and fromTimezoneOffset to local time.
     [Bindable] public var senderTime:String;
-    
+    */
 		private var g:GoogleTranslation;	 
 			 
 		public function ChatMessage() {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/model/ChatMessages.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/model/ChatMessages.as
@@ -34,13 +34,10 @@ package org.bigbluebutton.modules.chat.model
     public function numMessages():int {
       return messages.length;
     }
-    
+	
     public function newChatMessage(msg:ChatMessageVO):void {
       var cm:ChatMessage = new ChatMessage();
-      
-      var time:Date = new Date();
-      cm.time = ChatUtil.getHours(time) + ":" + ChatUtil.getMinutes(time);
-      
+	  
       if (messages.length == 0) {
         cm.lastSenderId = "";
         cm.lastTime = cm.time;
@@ -48,7 +45,6 @@ package org.bigbluebutton.modules.chat.model
         cm.lastSenderId = getLastSender();
         cm.lastTime = getLastTime();
       }
-      
       cm.senderId = msg.fromUserID;
       
       cm.senderLanguage = msg.fromLang;
@@ -67,7 +63,7 @@ package org.bigbluebutton.modules.chat.model
       
       var sentTime:Date = new Date();
       sentTime.setTime(cm.fromTime);
-      cm.senderTime = ChatUtil.getHours(sentTime) + ":" + ChatUtil.getMinutes(sentTime);
+      cm.time = ChatUtil.getHours(sentTime) + ":" + ChatUtil.getMinutes(sentTime);
       
       messages.addItem(cm); 
     }
@@ -88,7 +84,7 @@ package org.bigbluebutton.modules.chat.model
     
     private function getLastTime():String {
       var msg:ChatMessage = messages.getItemAt(messages.length - 1) as ChatMessage;
-      return msg.senderTime;
+      return msg.time;
     }
             
   }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatMessageRenderer.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatMessageRenderer.mxml
@@ -110,7 +110,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
   <mx:HBox width="100%" id="hbHeader">
     <mx:Label id="lblName" text="{data.name} " visible="true" color="gray" width="100%" textAlign="left"/>
     <mx:Spacer width="100%"/>
-    <mx:Text id="lblTime" htmlText="{data.translateLocale} {rolledOver ? data.senderTime : data.time}" textAlign="right"
+    <mx:Text id="lblTime" htmlText="{data.translateLocale} {data.time}" textAlign="right"
              visible="true" 
              color="gray"  width="100%"/>       
   </mx:HBox>


### PR DESCRIPTION
The chat times had been bugging me. They now only contain the message send time corrected to the local user's timezone. 

All messages now also condense when the time and senderID are the same.
