### PR TITLE
Focus moves to the 'start' of the BigBlueButton window when user leaves ...

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/events/BBBEvent.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/events/BBBEvent.as
@@ -41,6 +41,7 @@ package org.bigbluebutton.main.events {
     public static const OPEN_WEBCAM_PREVIEW:String = "open webcam preview event";
 	public static const MIC_SETTINGS_CLOSED:String = "MIC_SETTINGS_CLOSED";
 	public static const CAM_SETTINGS_CLOSED:String = "CAM_SETTINGS_CLOSED";
+	public static const JOIN_VOICE_FOCUS_HEAD:String = "JOIN_VOICE_FOCUS_HEAD";
    
 		public var message:String;
 		public var payload:Object = new Object();

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/PhoneManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/PhoneManager.as
@@ -119,6 +119,8 @@ package org.bigbluebutton.modules.phone.managers {
 			var uid:String = String(Math.floor(new Date().getTime()));
 			var uname:String = encodeURIComponent(UsersUtil.getMyExternalUserID() + "-" + attributes.username);
 			connectionManager.connect(uid, attributes.internalUserID, uname , attributes.room, attributes.uri);
+			var dispatcher:Dispatcher = new Dispatcher();
+			dispatcher.dispatchEvent(new BBBEvent(BBBEvent.JOIN_VOICE_FOCUS_HEAD));
 		}		
 		
 		public function rejoin():void {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/phone/views/components/ToolbarButton.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/phone/views/components/ToolbarButton.mxml
@@ -29,6 +29,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	
 	<mate:Listener type="{BBBEvent.JOIN_VOICE_CONFERENCE}" method="handleBBBJoinConferenceEvent"/>
 	<mate:Listener type="{BBBEvent.MIC_SETTINGS_CLOSED}" method="handleMicSettingsClosedEvent"/>
+	<mate:Listener type="{BBBEvent.JOIN_VOICE_FOCUS_HEAD}" method="joinVoiceFocusHead"/>
 	
 	<mate:Listener type="{ShortcutEvent.SHARE_MICROPHONE}" method="remoteClick" />
 
@@ -184,6 +185,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 			private function handleMicSettingsClosedEvent(event:BBBEvent):void {
 				userJoinedConference(false);
+				this.setFocus();
 			}
 			
 			private function handleBBBJoinConferenceEvent(event:BBBEvent):void {
@@ -203,6 +205,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 			public function theory():String{
 				return "Audio button";
+			}
+			
+			private function joinVoiceFocusHead(e:BBBEvent):void{
+				this.setFocus();
 			}
 		]]>
 	</mx:Script>


### PR DESCRIPTION
...Audio Settings. This allows a user who relies on a screen reader to know that they are still in BigBlueButton once they leave Audio Settings, and can begin navigating through the application.
