### PR TITLE
Pres hotkey focus fix

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -617,23 +617,38 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 			
 			private function remotePrevious(e:ShortcutEvent):void{
-				gotoPreviousSlide();
+				if (backButton.visible && backButton.enabled){
+					backButton.setFocus();
+					gotoPreviousSlide();
+				}
 			}
 			
 			private function remoteSelect(e:ShortcutEvent):void{
-				showThumbnails();
+				if (btnSlideNum.visible){
+					btnSlideNum.setFocus();
+					showThumbnails();
+				}
 			}
 			
 			private function remoteNext(e:ShortcutEvent):void{
-				gotoNextSlide();
+				if (forwardButton.visible && forwardButton.enabled){
+					forwardButton.setFocus();
+					gotoNextSlide();
+				}
 			}
 			
 			private function remoteWidth(e:ShortcutEvent):void{
-				onFitToPage(false);
+				if (btnFitToWidth.visible){
+					btnFitToWidth.setFocus();
+					onFitToPage(false);
+				}
 			}
 			
 			private function remotePage(e:ShortcutEvent):void{
-				onFitToPage(true);
+				if (btnFitToPage.visible){
+					btnFitToPage.setFocus();
+					onFitToPage(true);
+				}
 			}
 			
 			private function onUploadButtonClicked():void {


### PR DESCRIPTION
This fixes two things in the Presentation window:
1) Hotkeys being available to meeting participants who don't have access to the buttons themselves
2) Focus not following along when hotkeys are used to activate buttons
