### PR TITLE
Hotkey cleanup

### DIFF
--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -361,6 +361,8 @@ bbb.shortcutkey.users.muteall = 65
 bbb.shortcutkey.users.muteall.function = Mute or Unmute all users
 bbb.shortcutkey.users.focusUsers = 85
 bbb.shortcutkey.users.focusUsers.function = Focus to users list
+bbb.shortcutkey.users.muteAllButPres = 65
+bbb.shortcutkey.users.muteAllButPres.function = Mute everyone but the Presenter
 
 bbb.shortcutkey.chat.focusTabs = 89
 bbb.shortcutkey.chat.focusTabs.function = Focus to chat tabs

--- a/bigbluebutton-client/src/BigBlueButton.mxml
+++ b/bigbluebutton-client/src/BigBlueButton.mxml
@@ -129,6 +129,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		keyCombos[globalModifier+(ResourceUtil.getInstance().getString('bbb.shortcutkey.shortcutWindow') as String)] = ShortcutEvent.REMOTE_OPEN_SHORTCUT_WIN;
 		keyCombos[globalModifier+(ResourceUtil.getInstance().getString('bbb.shortcutkey.logout') as String)] = ShortcutEvent.LOGOUT;
 		keyCombos[globalModifier+(ResourceUtil.getInstance().getString('bbb.shortcutkey.raiseHand') as String)] = ShortcutEvent.RAISE_HAND;
+		keyCombos[globalModifier+(ResourceUtil.getInstance().getString('bbb.shortcutkey.users.muteAllButPres') as String)] = ShortcutEvent.MUTE_ALL_BUT_PRES;
 	}
 	
     public function hotkeyCapture():void{

--- a/bigbluebutton-client/src/org/bigbluebutton/main/events/ShortcutEvent.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/events/ShortcutEvent.as
@@ -71,6 +71,8 @@ package org.bigbluebutton.main.events {
 		public static const CHANGE_FONT_COLOUR:String = 'CHANGE_FONT_COLOUR';
 		public static const SEND_MESSAGE:String = 'SEND_MESSAGE';
 		
+		public static const MUTE_ALL_BUT_PRES:String = 'MUTE_ALL_BUT_PRES';
+		
 		// Temporary string to help fix chat message navigation for screen readers
 		public static const CHAT_DEBUG:String = 'CHAT_DEBUG';
 		

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/ShortcutHelpWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/ShortcutHelpWindow.mxml
@@ -53,7 +53,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 											 'bbb.shortcutkey.focus.users', 'bbb.shortcutkey.focus.video', 'bbb.shortcutkey.focus.presentation',  
 											 'bbb.shortcutkey.focus.chat', 'bbb.shortcutkey.chat.chatinput', 'bbb.shortcutkey.share.desktop', 
 											 'bbb.shortcutkey.share.microphone', 'bbb.shortcutkey.share.webcam', 'bbb.shortcutkey.shortcutWindow', 
-											 'bbb.shortcutkey.logout', 'bbb.shortcutkey.raiseHand', 'bbb.shortcutkey.users.muteme'];
+											 'bbb.shortcutkey.logout', 'bbb.shortcutkey.raiseHand', 'bbb.shortcutkey.users.muteme',
+											 'bbb.shortcutkey.users.muteAllButPres'];
 											 
 			private var presResource:Array = ['bbb.shortcutkey.present.focusslide', /*'bbb.shortcutkey.whiteboard.undo',*/ 'bbb.shortcutkey.present.upload',  
 											  'bbb.shortcutkey.present.previous', 'bbb.shortcutkey.present.select', 'bbb.shortcutkey.present.next', 	

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
@@ -33,6 +33,7 @@
 	<mate:Listener type="{ShortcutEvent.RAISE_HAND}" method="remoteRaiseHand" />
 	<mate:Listener type="{ShortcutEvent.FOCUS_USERS_WINDOW}" method="focusWindow" />
 	<mate:Listener type="{UsersEvent.ROOM_MUTE_STATE}" method="setRoomMute" />
+	<mate:Listener type="{ShortcutEvent.MUTE_ALL_BUT_PRES}" method="remoteMuteAllButPres" />
 	<mx:Script>
 		<![CDATA[
 			import com.asfusion.mate.events.Dispatcher;
@@ -65,6 +66,8 @@
 			import org.bigbluebutton.modules.users.events.UsersEvent;
 			import org.bigbluebutton.modules.users.model.UsersOptions;
 			import org.bigbluebutton.util.i18n.ResourceUtil;		
+			
+			import org.bigbluebutton.common.LogUtil;
 			
 			private var dispatcher:Dispatcher;
 			
@@ -362,6 +365,10 @@
 			public function remoteFocusUsers():void{
 				focusManager.setFocus(usersGrid);
 				usersGrid.drawFocus(true);
+			}
+			
+			private function remoteMuteAllButPres():void{
+				muteAlmostAll();
 			}
 			
 		]]>


### PR DESCRIPTION
Some small updates, and one new hotkey: Mute all users except Presenter. New hotkey is Global, in case the Presenter needs to mute the rest of the meeting/classroom in a hurry.
