### PR TITLE
custom start time of recording now works in firefox

### DIFF
--- a/record-and-playback/presentation/playback/presentation/lib/writing.js
+++ b/record-and-playback/presentation/playback/presentation/lib/writing.js
@@ -435,6 +435,13 @@ svgobj.addEventListener('load', function() {
   p.on('loadeddata', function() {
     p.currentTime(defineStartTime());
   });
+
+  // Sometimes media has already loaded before our loadeddata listener is 
+  // attached. If the media is already past the loadeddata stage then we 
+  // trigger the event manually ourselves
+  if ($('#video')[0].readyState > 0) {
+    p.emit('loadeddata');
+  }
 }, false);
 
 


### PR DESCRIPTION
The custom start time parameter that Felipe had added in wasn't working in Firefox. It turns out it wasn't functioning because Firefox sends the 'loadeddata' event really early and by the time our listener was attached the event had already passed.

My fix checks to see if the media is already ready and if it is then triggers the event manually.
