### PR TITLE
improved disabling private chat so that the whole tab doesn't disappear

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/AddChatTabBox.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/AddChatTabBox.mxml
@@ -86,9 +86,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	</mx:Script>
 	
 	<mx:HBox width="100%" height="100%" >
-		<mx:VBox height="100%" width="50%" visible="{chatOptions.privateEnabled}">
-			<mx:Label id="lblSelect" text="{ResourceUtil.getInstance().getString('bbb.chat.privateChatSelect')}" />
+		<mx:VBox height="100%" width="50%" >
+			<mx:Label id="lblSelect" text="{ResourceUtil.getInstance().getString('bbb.chat.privateChatSelect')}" visible="{chatOptions.privateEnabled}" includeInLayout="{chatOptions.privateEnabled}"/>
 			<mx:List id="usersList" height="100%" width="100%" dataProvider="{users}" dragEnabled="false"
+                     visible="{chatOptions.privateEnabled}" includeInLayout="{chatOptions.privateEnabled}"
                itemRenderer="org.bigbluebutton.modules.chat.views.UserRenderer"
                itemClick="openPrivateChat(event)" toolTip="{ResourceUtil.getInstance().getString('bbb.chat.usersList.toolTip')}"/>
 			<mx:VBox id="optionsBox" height="100%" width="50%" >

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatView.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatView.mxml
@@ -123,10 +123,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				openChatBoxFor(PUBLIC_CHAT_USERID, true);
 		        makePublicChatUncloseable();
 		        
-		        if (chatOptions.privateEnabled) {
-		          createAddTabBox();
-		          makeAddPrivateChatUncloseable();
-		        }
+                // you have to always create the AddTabBox because we always need to give people access to the dropdown to change font size
+		        createAddTabBox();
+		        makeAddPrivateChatUncloseable();
 				
 				
 				addEventListener(SuperTabEvent.TAB_CLOSE, onUserClosedTab);


### PR DESCRIPTION
When you disabled the private chat it used to remove the whole "+" tab from the chat window. This had the additional unintended effect of disabling the ability to change the size of the font in the chat window. I've made a change so that disabling the private chat just removes the private chat sections from the "+" tab and changed the tab so that it's always added.
