### PR TITLE
Update paths to reflect the current version of bbb-demo's requirements

### DIFF
--- a/labs/stress-testing/bbb-test
+++ b/labs/stress-testing/bbb-test
@@ -57,10 +57,10 @@ fi
 # http://192.168.0.104/bigbluebutton/demo/demo1.jsp?username=Fred2&action=create
 
 # HOST="http://$HOST/bigbluebutton/demo/demo1.jsp?action=create&username=user"
-HOST="http://$HOST/bigbluebutton"
+HOST="http://$HOST"
 
 
-if ! wget $HOST/api -O - --quiet | grep -q SUCCESS; then
+if ! wget $HOST/bigbluebutton/api -O - --quiet | grep -q SUCCESS; then
 	echo "Startup unsuccessful: could not connect to $HOST/api"
         exit 1
 fi


### PR DESCRIPTION
The path expected when the client connects is /demo/demo1.jsp but as the script currently stands is tries to load from /bigbluebutton/demo/demo1.jsp instead. I've tried this modified version and was able to load test clients.
