### PR TITLE
fixed https chat linking

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/ChatUtil.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/ChatUtil.as
@@ -62,8 +62,8 @@ package org.bigbluebutton.modules.chat
       for (var n:Number = 0; n < words.length; n++){
         var word:String = words[n] as String;
         if (word.indexOf("http://") != -1) parsedString += '<a href="event:' + word + '"> <u>' + word + '</u></a> ';
-        else if (word.indexOf("www.") != -1) parsedString += '<a href="event:http://' + word + '"> <u>' + word + '</u></a> ';
         else if (word.indexOf("https://") != -1) parsedString += '<a href="event:' + word + '"> <u>' + word + '</u></a> ';
+        else if (word.indexOf("www.") != -1) parsedString += '<a href="event:http://' + word + '"> <u>' + word + '</u></a> ';
         else parsedString += word + ' ';
       }
       return parsedString;


### PR DESCRIPTION
This is a fix for the issue listed here, http://code.google.com/p/bigbluebutton/issues/detail?id=1566&can=1&sort=-modified&colspec=ID%20Type%20Status%20Priority%20Milestone%20Owner%20Component%20Summary%20Modified

Previously if you entered https://www.google.com into the chat it would find the "www" first and then attach "http://" on the front of the linked address making an invalid URL
