### PR TITLE
fixed the ghost whiteboard objects

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/WhiteboardCanvasDisplayModel.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/WhiteboardCanvasDisplayModel.as
@@ -108,8 +108,9 @@ package org.bigbluebutton.modules.whiteboard
             if (gobj.id == o.id) {
 //              LogUtil.debug("Removing shape [" + gobj.id + "]");
               wbCanvas.removeGraphic(gobj as DisplayObject);
-            } else {
+            } else { // no DRAW_START event was thrown for o so place gobj back on the top
               LogUtil.debug("Not removing shape [" + gobj.id + "] new [" + o.id + "]");
+              _annotationsList.push(gobj);
             }
                   
             dobj = shapeFactory.makeDrawObject(o, whiteboardModel);  


### PR DESCRIPTION
This was an interesting bug to track down.

When the whiteboard receives a DRAW_UPDATE or DRAW_END it tries to match the shape that is being changed to the last shape added to the list of annotations. The update method does this by popping off the top object and comparing it to the object attached to the event. If the objects match then the top object is erased from the display and then the new object is drawn and pushed to the top of the annotation list.

I discovered after much digging that when you draw really fast there's no DRAW_START event sent out so when the update method pops off the top shape it doesn't match. Previously the method would do nothing with the popped shape and it would get garbage collected at the end of the method, but my fix pushes it back onto the list so that a reference always stays around. The new object is then drawn and placed on top and everything continues as normal.

This bug is another example of Flash just not sending events for some reason and there a couple other bugs related to this. I think more research is warranted to try and discover why these events aren't firing.
