### PR TITLE
RaP: Adjust the 'convert' command to make opaque images

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/generators/presentation.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/presentation.rb
@@ -61,7 +61,7 @@ module BigBlueButton
     # Convert a pdf page to a png.
     def self.convert_pdf_to_png(pdf_page, png_out)
         BigBlueButton.logger.info("Task: Converting .pdf to .png")      
-        command = "convert -density 300x300 -resize 800x600 -quality 90 +dither -depth 8 -colors 256 #{pdf_page} #{png_out}"
+        command = "convert -density 300x300 #{pdf_page} -background white -flatten -resize 800x600 -quality 90 +dither -depth 8 -colors 256 #{png_out}"
         BigBlueButton.execute(command)
 #        Process.wait  
     end
@@ -69,7 +69,7 @@ module BigBlueButton
     #Convert an image to a png	
     def self.convert_image_to_png(image,png_image)
         BigBlueButton.logger.info("Task: Converting image to .png")      
-        command="convert -resize 800x600 #{image} #{png_image}"
+        command="convert #{image} -resize 800x600 -background white -flatten #{png_image}"
         BigBlueButton.execute(command)
     end
 

--- a/record-and-playback/presentation/scripts/process/presentation.rb
+++ b/record-and-playback/presentation/scripts/process/presentation.rb
@@ -89,7 +89,7 @@ if not FileTest.directory?(target_dir)
         pdf_page = "#{pres_dir}/slide-#{page}.pdf"
         BigBlueButton::Presentation.extract_page_from_pdf(page, pres_pdf, pdf_page)
         #BigBlueButton::Presentation.convert_pdf_to_png(pdf_page, "#{target_pres_dir}/slide-#{page}.png")
-        command = "convert -density 300x300 -resize 1600x1200 -quality 90 +dither -depth 8 -colors 256 #{pdf_page} #{target_pres_dir}/slide-#{page}.png"
+        command = "convert -density 300x300 #{pdf_page} -resize 1600x1200 -background white -flatten -quality 90 +dither -depth 8 -colors 256 #{target_pres_dir}/slide-#{page}.png"
         BigBlueButton.execute(command)
         if File.exist?("#{pres_dir}/textfiles/slide-#{page}.txt") then
           FileUtils.cp("#{pres_dir}/textfiles/slide-#{page}.txt", "#{target_pres_dir}/textfiles")
@@ -98,7 +98,7 @@ if not FileTest.directory?(target_dir)
     else
       ext = File.extname("#{images[0]}")
       #BigBlueButton::Presentation.convert_image_to_png(images[0],"#{target_pres_dir}/slide-1.png")
-      command="convert -resize 1600x1200 #{images[0]} #{target_pres_dir}/slide-1.png"
+      command="convert #{images[0]} -resize 1600x1200 -background white -flatten #{target_pres_dir}/slide-1.png"
       BigBlueButton.execute(command)
     end
   


### PR DESCRIPTION
This forces a background colour of white on the generated png images for
slides in the slides and presentation recording formats. Fixes Issue
1588.

https://code.google.com/p/bigbluebutton/issues/detail?id=1588
