### PR TITLE
fixed the annotations disappearing on page change

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/models/Page.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/models/Page.as
@@ -38,6 +38,8 @@ package org.bigbluebutton.modules.whiteboard.models
             var a:Annotation = getAnnotation(annotation.id);
             if (a != null) {
                 a.annotation = annotation.annotation;
+            } else {
+                addAnnotation(annotation);
             }
         }
         


### PR DESCRIPTION
This pull request is for the issue here, http://code.google.com/p/bigbluebutton/issues/detail?id=1596. Annotations now get added to the list of annotations in the client if an update is called without an add.
