### PR TITLE
Set specific versions for the HTML5 client's dependencies

### DIFF
--- a/labs/bbb-html5-client/package.json
+++ b/labs/bbb-html5-client/package.json
@@ -5,7 +5,7 @@
   "description": "The node.js application that serves BigBlueButton's HTML5 client",
   "dependencies": {
     "express": "2.5.8",
-    "jade": "0.33.0",
+    "jade": "0.34.1",
     "connect-redis": "1.4.5",
     "connect": "2.8.5",
     "socket.io": "0.9.16",

--- a/labs/bbb-html5-client/views/layout.jade
+++ b/labs/bbb-html5-client/views/layout.jade
@@ -18,7 +18,7 @@ html
   // javascript variables in the module "globals"
   - if (typeof(meetings) == 'undefined')
     - meetings = []
-  script(type='text/javascript')
+  script(type='text/javascript').
     define('globals', function() {
       server = window.location.protocol + '//' + window.location.host;
       server = server.replace(/:\d+/, ''); // remove :port


### PR DESCRIPTION
It's always better to have specific version to force all developers to use exactly the same dependencies and avoid errors that will eventually happen when libs are updated.

Used up-to-date versions already being used by me, @GaryDeng and @jent46.
