### PR TITLE
Fixed chatBox AccessibilityProperties that was seted before being initia...

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
@@ -172,7 +172,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		        
 		        queryForChatHistory();
 
-		        chatMessagesList.accessibilityProperties = new AccessibilityProperties();
+		        if(chatMessagesList.accessibilityProperties == null)
+		        	chatMessagesList.accessibilityProperties = new AccessibilityProperties();
 
 				chatMessagesList.accessibilityProperties.description = ResourceUtil.getInstance().getString('bbb.accessibility.chat.initialDescription');
 				


### PR DESCRIPTION
Fix http://code.google.com/p/bigbluebutton/issues/detail?id=1602 and http://code.google.com/p/bigbluebutton/issues/detail?id=1603 that would throw an exception because the program tried to set AccessibilityProperties before set a variable before initializing it.
