### PR TITLE
User settings menu repositioned

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
@@ -186,7 +186,7 @@
 				myMenu = Menu.createMenu(null, myMenuData, true);
 				
 				myMenu.variableRowHeight = true;
-				myMenu.show(this.x + settingsBtn.x + 2, this.y + this.height + 25);
+				myMenu.show(this.x + settingsBtn.x + settingsBtn.width + 2, this.y + this.height);
 				myMenu.addEventListener(MenuEvent.ITEM_CLICK, menuClickHandler);
 				myMenu.setFocus();
 			}


### PR DESCRIPTION
User settings menu got a new position. It is now placed at the same vertical level of setting button and horizontally at its right. The main reason why I did that is that when maximising the UsersWindow we get this menu truncated when open. This should no more happen now.
