### PR TITLE
Make generation of png images for pdf pages more resiliant.

### DIFF
--- a/record-and-playback/presentation/scripts/process/presentation.rb
+++ b/record-and-playback/presentation/scripts/process/presentation.rb
@@ -84,14 +84,11 @@ if not FileTest.directory?(target_dir)
         pres_pdf = "#{pres_dir}/#{pres}"
       end
       if !File.exists?(pres_pdf)
-        raise "Could not find pdf file for presentation #{pres}"
+        BigBlueButton.logger.warning("Could not find pdf file for presentation #{pres}")
       end
       1.upto(num_pages) do |page| 
-        pdf_page = "#{pres_dir}/slide-#{page}.pdf"
-        BigBlueButton::Presentation.extract_page_from_pdf(page, pres_pdf, pdf_page)
-        #BigBlueButton::Presentation.convert_pdf_to_png(pdf_page, "#{target_pres_dir}/slide-#{page}.png")
-        command = "convert -density 300x300 #{pdf_page} -resize 1600x1200 -background white -flatten -quality 90 +dither -depth 8 -colors 256 #{target_pres_dir}/slide-#{page}.png"
-        BigBlueButton.execute(command)
+        BigBlueButton::Presentation.extract_png_page_from_pdf(
+          page, pres_pdf, "#{target_pres_dir}/slide-#{page}.png", '1600x1200')
         if File.exist?("#{pres_dir}/textfiles/slide-#{page}.txt") then
           FileUtils.cp("#{pres_dir}/textfiles/slide-#{page}.txt", "#{target_pres_dir}/textfiles")
         end


### PR DESCRIPTION
We now use ghostscript to output pngs directly from the original pdf, rather than using convert on the split pages. This should make corrupt or strange pdfs less likely to cause issues.

As well, if a pdf page conversion fails (for any reason, including that the original pdf is missing...) it will be logged, and a blank page generated, and processing will continue.

(As a somewhat amusing side-effect, this _increases_ the quality of graphics in the slides, because it doesn't recompress embedded jpg images at lower quality like the page-splitting does)
