### PR TITLE
Fixing scrollbars

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
@@ -120,10 +120,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			[Bindable] private var layoutOptions:LayoutOptions;
 			
 			[Bindable] private var showToolbarOpt:Boolean = true;
-			[Bindable] private var toolbarHeight:Number = 30;
+			[Bindable] private var toolbarHeight:Number = 32;
       [Bindable] private var toolbarPaddingTop:Number = 4;
       [Bindable] private var showFooterOpt:Boolean = true;
-      [Bindable] private var footerHeight:Number = 20;
+      [Bindable] private var footerHeight:Number = 24;
       
       [Bindable] private var isTunneling:Boolean = false;
 			
@@ -149,6 +149,20 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 			protected function initializeShell():void {	
 				globalDispatcher = new Dispatcher();
+
+				systemManager.addEventListener(Event.RESIZE, updateCopyrightLabelDimensions);
+				copyrightLabel2.addEventListener(FlexEvent.UPDATE_COMPLETE, updateCopyrightLabelDimensions);
+				updateCopyrightLabelDimensions();
+			}
+
+			private function updateCopyrightLabelDimensions(e:Event = null):void {
+				var screenRect:Rectangle = systemManager.screen;
+
+				if (spacer.width == 0) {
+					copyrightLabel2.width += (screenRect.width - controlBar.width);
+				} else {
+					copyrightLabel2.width += Math.min(spacer.width, copyrightLabel2.measuredWidth - copyrightLabel2.width);
+				}
 			}
 		
 			protected function initFullScreen():void {				
@@ -427,23 +441,39 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		<views:BrandingLogo x="{this.width - 300}" y="{this.height - 300}" />
 	</views:MainCanvas>	
 	
-	<mx:ControlBar width="100%" height="{footerHeight}" paddingTop="0">		
-	  <mx:Text htmlText="{ResourceUtil.getInstance().getString('bbb.mainshell.copyrightLabel2',[appVersion])}" id="copyrightLabel2"/>
-	 	<mx:Spacer width="20"/>
-		<mx:Spacer width="100%"/> 
-    <mx:Label text="{isTunneling ? '[Tunnelling]' : ''}" id="isTunnellingLbl"/>
-		
-		<mx:Button width="20" 
-				   height="20" 
-				   visible="{layoutOptions.showLogButton}" 
-				   toolTip="{ResourceUtil.getInstance().getString('bbb.mainshell.logBtn.toolTip')}" 
-				   id="logBtn" 
-				   icon="{logs_icon}" 
-				   click="openLogWindow()" 
-				   tabIndex="{baseIndex}"/>
-		
-		<!-- mx:Button width="20" height="20" visible="{layoutOptions.showResetLayout}" toolTip="{ResourceUtil.getInstance().getString('bbb.mainshell.resetLayoutBtn.toolTip')}" id="btnResetLayout" icon="{reset_layout_icon}" click="resetLayout()" /-->
-		<mx:Button id="btnNetwork" icon="{statsIcon}" width="20" height="20" mouseOver="openNetworkStatsWindow()" mouseOut="closeNetworkStatsWindow()" tabFocusEnabled="false" visible="{layoutOptions.showNetworkMonitor}" />		
+	<mx:ControlBar width="100%" height="{footerHeight}" paddingTop="0" id="controlBar">
+		<mx:Label
+				htmlText="{ResourceUtil.getInstance().getString('bbb.mainshell.copyrightLabel2',[appVersion])}"
+				id="copyrightLabel2"
+				selectable="false" />
+		<mx:Spacer width="20"/>
+		<mx:Spacer width="100%" id="spacer" />
+		<mx:Label
+				text="[Tunnelling]"
+				id="isTunnellingLbl"
+				visible="{isTunneling}"
+				includeInLayout="{isTunneling}" />
+
+		<mx:Button
+				width="20"
+				height="20"
+				visible="{layoutOptions.showLogButton}"
+				includeInLayout="{layoutOptions.showLogButton}"
+				toolTip="{ResourceUtil.getInstance().getString('bbb.mainshell.logBtn.toolTip')}"
+				id="logBtn"
+				icon="{logs_icon}"
+				click="openLogWindow()"
+				tabIndex="{baseIndex}"/>
+		<mx:Button
+				id="btnNetwork"
+				icon="{statsIcon}"
+				width="20"
+				height="20"
+				mouseOver="openNetworkStatsWindow()"
+				mouseOut="closeNetworkStatsWindow()"
+				tabFocusEnabled="false"
+				visible="{layoutOptions.showNetworkMonitor}"
+				includeInLayout="{layoutOptions.showNetworkMonitor}" />
 		<mx:HBox id="addedBtns" />
 	</mx:ControlBar>
 </mx:VBox>

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
@@ -330,7 +330,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
                        tabIndex="{baseIndex+4}" height="22" styleName="quickWindowLinkStyle" />
     </mx:HBox>
 	<mx:HBox id="addedBtns"/>
-	<mx:VRule strokeWidth="2" height="100%" visible="{muteMeBtn.visible}"/>
+	<mx:VRule strokeWidth="2" height="100%" visible="{muteMeBtn.visible}" includeInLayout="{muteMeBtn.includeInLayout}"/>
 	<views:MuteMeButton id="muteMeBtn"  height="20" tabIndex="{baseIndex+numButtons+10}"/>
 	<mx:Spacer width="50%"/>
     <mx:Label id="meetingNameLbl" styleName="meetingNameLabelStyle" />

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MuteMeButton.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MuteMeButton.mxml
@@ -25,6 +25,7 @@ $Id: $
 	xmlns:flc="flexlib.controls.*"
 	xmlns:mate="http://mate.asfusion.com/"
 	visible="false" 
+	includeInLayout="false"
 	creationComplete="onCreationComplete()"
 	toolTip="{UserManager.getInstance().getConference().voiceMuted ? ResourceUtil.getInstance().getString('bbb.users.pushToTalk.toolTip') : ResourceUtil.getInstance().getString('bbb.users.pushToMute.toolTip')}" 
 	click="toggleMuteMeState()" width="140" maxWidth="180"
@@ -81,9 +82,9 @@ $Id: $
 			
 			private function updateMuteMeBtn(placeholder:Boolean = false):void {
 				if (!UserManager.getInstance().getConference().voiceJoined || (UserManager.getInstance().getConference().voiceLocked && !UserManager.getInstance().getConference().amIModerator())) {
-					this.visible = false;
+					this.visible = this.includeInLayout = false;
 				} else {
-					this.visible = true;
+					this.visible = this.includeInLayout = true;
 					
 					if (muteMeRolled) {
 						if (UserManager.getInstance().getConference().voiceMuted) {


### PR DESCRIPTION
Hi guys, see these screenshots: 

![screenshot from 2013-10-11 11 31 07](https://f.cloud.github.com/assets/502164/1315272/6c279c70-3284-11e3-9ebc-2f0eba8f2915.png)

The left one is demo.bigbluebutton.org running v0.81rc3, while the right one is the patched version. If you use a small screen OR a normal size screen and a (not so) long copyright message, the scrollbars will appear and it will disturb the user experience. The modification will make the copyright message to get truncated, and also I've modified some other components that could be invisible but still were included in the layout, requiring more space in the UI.

Also as part of this patch I've fixed the issue #1609, that was too much simple to create a patch for it's own.

Unfortunately when I modified MainApplicationShell.mxml, my text editor fixed CR+LF of the file, so on GitHub compare it seems that there are a lot of modifications, while in fact there are just a few.
