### PR TITLE
Check for corrupt video files, don't attempt to render them

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl.rb
@@ -23,7 +23,7 @@ require File.expand_path('../edl/audio', __FILE__)
 module BigBlueButton
   module EDL
     FFMPEG = ['ffmpeg', '-y', '-v', 'warning', '-nostats']
-    FFPROBE = ['ffprobe', '-v', 'warning', '-print_format', 'json', '-show_format', '-show_streams']
+    FFPROBE = ['ffprobe', '-v', 'warning', '-print_format', 'json', '-show_format', '-show_streams', '-count_frames']
 
     def self.encode(audio, video, format, output_basename, audio_offset = 0)
       output = "#{output_basename}.#{format[:extension]}"


### PR DESCRIPTION
A corrupt video file is defined as one where ffprobe either finds no video stream, or it finds a video stream but cannot read any frames.
