### PR TITLE
Fix a logger method call in presentation script

### DIFF
--- a/record-and-playback/presentation/scripts/process/presentation.rb
+++ b/record-and-playback/presentation/scripts/process/presentation.rb
@@ -84,7 +84,7 @@ if not FileTest.directory?(target_dir)
         pres_pdf = "#{pres_dir}/#{pres}"
       end
       if !File.exists?(pres_pdf)
-        BigBlueButton.logger.warning("Could not find pdf file for presentation #{pres}")
+        BigBlueButton.logger.warn("Could not find pdf file for presentation #{pres}")
       end
       1.upto(num_pages) do |page| 
         BigBlueButton::Presentation.extract_png_page_from_pdf(


### PR DESCRIPTION
This shouldn't normally be hit... but if it ever is, the processing will fail with an error, since the Logger class doesn't have a method named 'warning'.
