### PR TITLE
Switch the order of the audio formats on firefox playback

### DIFF
--- a/record-and-playback/presentation/playback/presentation/playback.js
+++ b/record-and-playback/presentation/playback/presentation/playback.js
@@ -341,13 +341,21 @@ load_audio = function() {
    var webmsource = document.createElement("source");
    webmsource.setAttribute('src', RECORDINGS + '/audio/audio.webm');
    webmsource.setAttribute('type', 'audio/webm; codecs="vorbis"');
-   audio.appendChild(webmsource);
 
    // Need to keep the ogg source around for compat with old recordings
    var oggsource = document.createElement("source");
    oggsource.setAttribute('src', RECORDINGS + '/audio/audio.ogg');
    oggsource.setAttribute('type', 'audio/ogg; codecs="vorbis"');
-   audio.appendChild(oggsource);
+
+   // Browser Bug Workaround: The ogg file should be preferred in Firefox,
+   // since it can't seek in audio-only webm files.
+   if (navigator.userAgent.indexOf("Firefox") != -1) {
+      audio.appendChild(oggsource);
+      audio.appendChild(webmsource);
+   } else {
+      audio.appendChild(webmsource);
+      audio.appendChild(oggsource);
+   }
 
    audio.setAttribute('data-timeline-sources', SLIDES_XML);
    //audio.setAttribute('controls','');


### PR DESCRIPTION
Firefox has a bug where it can't seek in the audio-only webm files with no cues, and it seems like they have no intention of fixing this... Serve up the ogg files first for them.

Adding cues to audio-only webm files is _hard_, there are no standard tools that support doing this cleanly.
