### PR TITLE
Re-enabling the common shortcut keys to change the slides

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -204,6 +204,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 				keyCombos[Keyboard.LEFT] = ShortcutEvent.PREVIOUS_SLIDE;
 				keyCombos[Keyboard.RIGHT] = ShortcutEvent.NEXT_SLIDE;
+				keyCombos[Keyboard.PAGE_UP] = ShortcutEvent.PREVIOUS_SLIDE;
+				keyCombos[Keyboard.PAGE_DOWN] = ShortcutEvent.NEXT_SLIDE;
 			}
 			
 			// Handle presentation-scope hotkeys


### PR DESCRIPTION
Simple implementation to re-enable the LEFT/RIGHT/PAGE_UP/PAGE_DOWN keys to change the slides. LEFT/RIGHT is the most common keys to change the slides in a computer keyboard, but PAGE_UP/PAGE_DOWN is commonly used by presenter hardwares.
