### PR TITLE
Added TabIndexer to automate tab indexing

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/common/TabIndexer.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/common/TabIndexer.as
@@ -1,0 +1,84 @@
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ *
+ * Copyright (c) 2014 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.bigbluebutton.common
+{
+    import flash.events.Event;
+    import flash.events.EventDispatcher;
+
+    import mx.core.Container;
+    import mx.core.IMXMLObject;
+    import mx.core.UIComponent;
+    import mx.events.FlexEvent;
+
+    public class TabIndexer extends EventDispatcher implements IMXMLObject
+    {
+        private var _document : Container;
+        private var _id : String;
+        private var _tabIndices : Array;
+        private var _startIndex : int;
+
+        public function initialized( document : Object, id : String ) : void
+        {
+            _id = id;
+            _document = document as Container;
+            _document.addEventListener(FlexEvent.CREATION_COMPLETE, documentCreationCompleteHandler, false, 0, true);
+        }
+
+        private function documentCreationCompleteHandler( event : FlexEvent ) : void
+        {
+            _document.removeEventListener(FlexEvent.CREATION_COMPLETE, documentCreationCompleteHandler, false);
+            for (var i : int = 0; i < tabIndices.length; i++)
+            {
+                UIComponent(_tabIndices[i - 1]).tabIndex = startIndex + i;
+            }
+        }
+
+        [Bindable(event = "tabIndicesChange")]
+        public function get tabIndices() : Array
+        {
+            return _tabIndices;
+        }
+
+        public function set tabIndices( value : Array ) : void
+        {
+            if (_tabIndices !== value)
+            {
+                _tabIndices = value;
+                dispatchEvent(new Event("tabIndicesChange"));
+            }
+        }
+
+        [Bindable(event = "startIndexChange")]
+        public function get startIndex() : int
+        {
+            return _startIndex;
+        }
+
+        public function set startIndex( value : int ) : void
+        {
+            if (_startIndex !== value)
+            {
+                _startIndex = value;
+                dispatchEvent(new Event("startIndexChange"));
+            }
+        }
+
+
+    }
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/common/TabIndexer.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/common/TabIndexer.as
@@ -32,7 +32,11 @@ package org.bigbluebutton.common
         private var _id : String;
         private var _tabIndices : Array;
         private var _startIndex : int;
+        private var _ready : Boolean;
 
+        /**
+         * @inheritDoc
+         */
         public function initialized( document : Object, id : String ) : void
         {
             _id = id;
@@ -40,16 +44,38 @@ package org.bigbluebutton.common
             _document.addEventListener(FlexEvent.CREATION_COMPLETE, documentCreationCompleteHandler, false, 0, true);
         }
 
+        /**
+         *
+         * Sets state to ready to index after the document creation is compelete and starts
+         * the first tab indexation.
+         * @param event CREATION_COMPLETE event of the document
+         *
+         */
         private function documentCreationCompleteHandler( event : FlexEvent ) : void
         {
             _document.removeEventListener(FlexEvent.CREATION_COMPLETE, documentCreationCompleteHandler, false);
-            for (var i : int = 0; i < tabIndices.length; i++)
+            _ready = true;
+            indexTabs();
+        }
+
+        /**
+         * Runs a tab indexation on document components contained in tabIndices Array.
+         */
+        protected function indexTabs() : void
+        {
+            if (_ready)
             {
-                UIComponent(_tabIndices[i - 1]).tabIndex = startIndex + i;
+                for (var i : int = 0; i < tabIndices.length; i++)
+                {
+                    UIComponent(_tabIndices[i - 1]).tabIndex = startIndex + i;
+                }
             }
         }
 
         [Bindable(event = "tabIndicesChange")]
+        /**
+         * An array containing tab indexable properties to index. Tab indexing will use array order.
+         */
         public function get tabIndices() : Array
         {
             return _tabIndices;
@@ -61,10 +87,14 @@ package org.bigbluebutton.common
             {
                 _tabIndices = value;
                 dispatchEvent(new Event("tabIndicesChange"));
+                indexTabs();
             }
         }
 
         [Bindable(event = "startIndexChange")]
+        /**
+         * tabIndex value of the first element.
+         */
         public function get startIndex() : int
         {
             return _startIndex;
@@ -76,6 +106,7 @@ package org.bigbluebutton.common
             {
                 _startIndex = value;
                 dispatchEvent(new Event("startIndexChange"));
+                indexTabs();
             }
         }
 

--- a/bigbluebutton-client/src/org/bigbluebutton/common/TabIndexer.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/common/TabIndexer.as
@@ -67,7 +67,10 @@ package org.bigbluebutton.common
             {
                 for (var i : int = 0; i < tabIndices.length; i++)
                 {
-                    UIComponent(_tabIndices[i - 1]).tabIndex = startIndex + i;
+                    if (_tabIndices[i - 1] != null)
+                    {
+                        UIComponent(_tabIndices[i - 1]).tabIndex = startIndex + i;
+                    }
                 }
             }
         }

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/CameraDisplaySettings.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/CameraDisplaySettings.mxml
@@ -72,8 +72,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     }
       
 		private function onCreationComplete():void {
-            tabIndex = 51;
-            
 			changeDefaultCamForMac();
 			
 			if (resolutions.length > 1) {
@@ -295,7 +293,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     ]]>
   </mx:Script>
 	
-	<common:TabIndexer tabIndices="{[viewTitle, changeCamera, cmbResolution, btnStartPublish, btnClosePublish]}"/>
+	<common:TabIndexer startIndex="51" tabIndices="{[viewTitle, changeCamera, cmbResolution, btnStartPublish, btnClosePublish]}"/>
   
 	<mx:VBox id="webcamDisplay" width="100%" height="100%" paddingBottom="5" paddingLeft="5" paddingRight="5" paddingTop="5" styleName="cameraDisplaySettingsWindowBackground">
     <mx:HBox width="100%" horizontalAlign="left">

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/CameraDisplaySettings.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/CameraDisplaySettings.mxml
@@ -20,10 +20,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 -->
 <mx:TitleWindow xmlns:mx="http://www.adobe.com/2006/mxml" 
                 xmlns:view="org.bigbluebutton.main.views.*"
+				xmlns:common="org.bigbluebutton.common.*"
                 layout="absolute" 
                 verticalScrollPolicy="off" horizontalScrollPolicy="off"
                 width="630" height="450" creationComplete="onCreationComplete()" styleName="cameraDisplaySettingsWindowStyle" 
-                showCloseButton="false" close="onCancelClicked()" keyDown="handleKeyDown(event)">
+                showCloseButton="false" close="onCancelClicked()" keyDown="handleKeyDown(event)" >
+	
   <mx:Script>
     <![CDATA[
 		import com.asfusion.mate.events.Dispatcher;     
@@ -64,7 +66,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		private var _video:Video;
 		private var aspectRatio:Number = 1;
 		
-        [Bindable]private var baseIndex:int; 
     override public function move(x:Number, y:Number):void
     {
        return;
@@ -293,11 +294,14 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       
     ]]>
   </mx:Script>
+	
+	<common:TabIndexer tabIndices="{[viewTitle, changeCamera, cmbResolution, btnStartPublish, btnClosePublish]}"/>
   
 	<mx:VBox id="webcamDisplay" width="100%" height="100%" paddingBottom="5" paddingLeft="5" paddingRight="5" paddingTop="5" styleName="cameraDisplaySettingsWindowBackground">
     <mx:HBox width="100%" horizontalAlign="left">
-      <mx:TextArea width="100%" wordWrap="false" borderSkin="{null}" editable="false" text="{ResourceUtil.getInstance().getString('bbb.users.settings.webcamSettings')}" 
-                   styleName="webcamSettingsWindowTitleStyle" tabIndex="{baseIndex}"/>
+      <mx:TextArea id="viewTitle" width="100%" wordWrap="false" borderSkin="{null}" editable="false"
+				   text="{ResourceUtil.getInstance().getString('bbb.users.settings.webcamSettings')}"
+                   styleName="webcamSettingsWindowTitleStyle"/>
     </mx:HBox>
  
     <mx:HRule width="100%"/>
@@ -309,9 +313,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			<mx:Button id="changeCamera" styleName="cameraDisplaySettingsWindowChangeCamBtn" 
 					   label="{ResourceUtil.getInstance().getString('bbb.publishVideo.changeCameraBtn.labelText')}" 
 					   toolTip="{ResourceUtil.getInstance().getString('bbb.publishVideo.changeCameraBtn.toolTip')}" 
-					   click="showCameraSettings()" tabIndex="{baseIndex+1}"/>
+					   click="showCameraSettings()"/>
 			<mx:ComboBox id="cmbResolution" styleName="cameraDisplaySettingsWindowChangeResolutionCombo" 
-						 dataProvider="{resolutions}" visible="false" change="updateCamera()" tabIndex="{baseIndex+2}"
+						 dataProvider="{resolutions}" visible="false" change="updateCamera()"
                          toolTip="{ResourceUtil.getInstance().getString('bbb.publishVideo.cmbResolution.tooltip')}" height="30" />
     </mx:HBox>
     
@@ -320,10 +324,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     <mx:HBox width="100%" height="10%" horizontalAlign="right" horizontalGap="13" paddingRight="5" paddingBottom="5" paddingTop="1">
       <mx:Button id="btnStartPublish" toolTip="{ResourceUtil.getInstance().getString('bbb.publishVideo.startPublishBtn.toolTip')}" 
                  click="startPublishing()" enabled="true" styleName="cameraDisplaySettingsWindowStartBtn" 
-                 label="{ResourceUtil.getInstance().getString('bbb.publishVideo.startPublishBtn.labelText')}" tabIndex="{baseIndex+3}"  />
+                 label="{ResourceUtil.getInstance().getString('bbb.publishVideo.startPublishBtn.labelText')}"/>
       <mx:Button id="btnClosePublish"   
                  click="onCancelClicked()" 
-                 enabled="true" tabIndex="{baseIndex+4}"
+                 enabled="true"
                  label="{ResourceUtil.getInstance().getString('bbb.video.publish.closeBtn.label')}"
                  accessibilityName="{ResourceUtil.getInstance().getString('bbb.video.publish.closeBtn.accessName')}"/>
     </mx:HBox>

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/LockSettings.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/LockSettings.mxml
@@ -18,8 +18,9 @@ You should have received a copy of the GNU Lesser General Public License along
 with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 -->
-<mx:TitleWindow xmlns:mx="http://www.adobe.com/2006/mxml" 
-				xmlns:mate="http://mate.asfusion.com/" 
+<mx:TitleWindow xmlns:mx="http://www.adobe.com/2006/mxml"
+				xmlns:mate="http://mate.asfusion.com/"
+				xmlns:common="org.bigbluebutton.common.*"
 				width="300" height="400" 
 				creationComplete="creationCompleteHandler(event)" 
 				styleName="lockSettingsWindowStyle"
@@ -46,8 +47,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private var images:Images = new Images();
 			[Bindable] private var cancelIcon:Class = images.cancel;
             
-            [Bindable]private var baseIndex:int = 1;
-			
 			override public function move(x:Number, y:Number):void {
 				return;
 			}
@@ -93,9 +92,13 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 		]]>
 	</mx:Script>
+	
+	<common:TabIndexer tabIndices="{[viewTitle, saveBtn, cancelBtn]}"/>
+	
 	<mx:VBox width="100%" height="100%"  paddingBottom="5" paddingLeft="5" paddingRight="5" paddingTop="5">
-		<mx:TextArea borderSkin="{null}" editable="false" selectable="false" text="{ResourceUtil.getInstance().getString('bbb.lockSettings.title')}" styleName="lockSettingsWindowTitleStyle"
-					 tabIndex="{baseIndex}" width="100%" left="0"/>
+		<mx:TextArea id="viewTitle" borderSkin="{null}" editable="false" selectable="false"
+					 text="{ResourceUtil.getInstance().getString('bbb.lockSettings.title')}" styleName="lockSettingsWindowTitleStyle"
+					 width="100%" left="0"/>
 		<mx:HRule width="100%"/>
 		
 		<mx:Spacer height="20"/>
@@ -150,11 +153,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		
 		<mx:HBox width="100%" horizontalAlign="right" horizontalGap="18">
 			<mx:Button id="saveBtn" label="{ResourceUtil.getInstance().getString('bbb.lockSettings.save')}" 
-					   click="onSaveClicked()" tabIndex="{baseIndex+8}"
+					   click="onSaveClicked()"
 					   toolTip="{ResourceUtil.getInstance().getString('bbb.lockSettings.save.toolTip')}"/>
 			
 			<mx:Button id="cancelBtn" label="{ResourceUtil.getInstance().getString('bbb.lockSettings.cancel')}" 
-					   click="onCancelClicked()" tabIndex="{baseIndex+9}"
+					   click="onCancelClicked()"
 					   toolTip="{ResourceUtil.getInstance().getString('bbb.lockSettings.cancel.toolTip')}"/>
 		</mx:HBox>
 	</mx:VBox>		

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
@@ -55,9 +55,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import flash.events.MouseEvent;
 			import flash.geom.Point;
 			
-			import flexlib.mdi.containers.MDIWindow;
-			import flexlib.mdi.effects.effectsLib.MDIVistaEffects;
-			
 			import mx.collections.ArrayCollection;
 			import mx.containers.TitleWindow;
 			import mx.controls.Alert;
@@ -65,7 +62,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import mx.core.IFlexDisplayObject;
 			import mx.core.UIComponent;
 			import mx.events.CloseEvent;
+			import mx.events.FlexEvent;
 			import mx.managers.PopUpManager;
+			
+			import flexlib.mdi.containers.MDIWindow;
+			import flexlib.mdi.effects.effectsLib.MDIVistaEffects;
 			
 			import org.bigbluebutton.common.IBbbModuleWindow;
 			import org.bigbluebutton.common.Images;

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
@@ -100,8 +100,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private var logoutWindow:LoggedOutWindow;
 			private var connectionLostWindow:ConnectionLostWindow;
 			
-			[Bindable] private var baseIndex:int = 100000;
-			
 			// LIVE or PLAYBACK
 			private var _mode:String = 'LIVE';
 			[Bindable] public var appVersion:String = ' ';
@@ -397,7 +395,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 			private function handleAddToolbarComponent(event:ToolbarButtonEvent):void {
 				if (event.location == ToolbarButtonEvent.BOTTOM_TOOLBAR) {
-					(event.button as UIComponent).tabIndex = baseIndex;
+					(event.button as UIComponent).tabIndex = tabIndexer.startIndex;
 					addedBtns.addChild(event.button as UIComponent);
 					//realignButtons();
 				}
@@ -442,7 +440,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 		]]>
 	</mx:Script>
-			
+	<common:TabIndexer id="tabIndexer" startIndex="100000" tabIndices="{[logBtn]}"/>
+
 	<views:MainToolbar id="toolbar" 
 					   dock="true" 
 					   width="100%" 
@@ -483,8 +482,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				toolTip="{ResourceUtil.getInstance().getString('bbb.mainshell.logBtn.toolTip')}"
 				id="logBtn"
 				icon="{logs_icon}"
-				click="openLogWindow()"
-				tabIndex="{baseIndex}"/>
+				click="openLogWindow()"/>
 		<mx:Button
 				id="btnNetwork"
 				icon="{statsIcon}"

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
@@ -23,6 +23,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 <mx:ApplicationControlBar xmlns:mx="http://www.adobe.com/2006/mxml" 
 	xmlns:mate="http://mate.asfusion.com/" visible="{showToolbar}"
 	enabled="true" xmlns:views="org.bigbluebutton.main.views.*"
+	xmlns:common="org.bigbluebutton.common.*"
 	initialize="init()" creationComplete="onCreationComplete()" >   
 	
 	<mate:Listener type="{ToolbarButtonEvent.ADD}" method="handleAddToolbarButtonEvent" />	
@@ -77,8 +78,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			public var toolbarOptions:LayoutOptions = new LayoutOptions();
 			
 			[Bindable]
-			private var baseIndex:int;
-			[Bindable]
 			private var numButtons:int;
 			/*
 			 * Because of the de-centralized way buttons are added to the toolbar, there is a large gap between the tab indexes of the main buttons
@@ -95,7 +94,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					AlertAccImpl.enableAccessibility();
 				}
 				
-				baseIndex = 101;
 				numButtons = 0;
                 
                 // Accessibility isn't active till a few second after the client starts to load so we need a delay
@@ -274,7 +272,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 						addedBtns.setChildIndex(button, addedBtns.numChildren - 1);
 						//(addedBtns.getChildAt(0) as Button).tabIndex = addedBtns.numChildren - 1;
 					}*/
-					button.tabIndex = baseIndex + 5;
+					button.tabIndex = quickLinksTabIndexer.startIndex + 5;
 					//for (var i:int = 0; i < addedBtns.numChildren; i++){
 					//	(addedBtns.getChildAt(i) as Button).tabIndex = baseIndex + i;
 					//}
@@ -330,30 +328,34 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		]]>
 	</mx:Script>
     
+	<common:TabIndexer id="quickLinksTabIndexer" startIndex="101" tabIndices="{[usersLinkBtn, webcamLinkButton, presentationLinkBtn, chatLinkBtn]}"/>
+	
+	<common:TabIndexer id="tabIndexer" startIndex="{quickLinksTabIndexer.startIndex + numButtons + 10}"
+					   tabIndices="{[recordBtn, muteMeBtn, langSelector, shortcutKeysBtn, helpBtn, btnLogout]}"/>
+	
     <mx:HBox id="quickLinks" width="1" includeInLayout="false">
         <mx:LinkButton id="usersLinkBtn" click="onQuickLinkClicked('users')" label="{ResourceUtil.getInstance().getString('bbb.users.quickLink.label')}"
                        accessibilityDescription="{usersLinkBtn.label}" toolTip="{usersLinkBtn.label}"
-                       tabIndex="{baseIndex+1}" height="22" styleName="quickWindowLinkStyle" />
+                       height="22" styleName="quickWindowLinkStyle" />
         <mx:LinkButton id="webcamLinkButton" click="onQuickLinkClicked('webcams')" label="{ResourceUtil.getInstance().getString('bbb.videodock.quickLink.label')}" 
                        accessibilityDescription="{webcamLinkButton.label}" toolTip="{webcamLinkButton.label}"
-                       tabIndex="{baseIndex+2}" height="22" styleName="quickWindowLinkStyle" />
+                       height="22" styleName="quickWindowLinkStyle" />
         <mx:LinkButton id="presentationLinkBtn" click="onQuickLinkClicked('presentation')" label="{ResourceUtil.getInstance().getString('bbb.presentation.quickLink.label')}"
                        accessibilityDescription="{presentationLinkBtn.label}" toolTip="{presentationLinkBtn.label}"
-                       tabIndex="{baseIndex+3}" height="22" styleName="quickWindowLinkStyle" />
+                       height="22" styleName="quickWindowLinkStyle" />
         <mx:LinkButton id="chatLinkBtn" click="onQuickLinkClicked('chat')" label="{ResourceUtil.getInstance().getString('bbb.chat.quickLink.label')}" 
                        accessibilityDescription="{chatLinkBtn.label}" toolTip="{chatLinkBtn.label}"
-                       tabIndex="{baseIndex+4}" height="22" styleName="quickWindowLinkStyle" />
+                       height="22" styleName="quickWindowLinkStyle" />
     </mx:HBox>
 	<mx:HBox id="addedBtns"/>
-	<views:RecordButton id="recordBtn" tabIndex="{baseIndex+numButtons+10}" />
+	<views:RecordButton id="recordBtn" />
 	<mx:VRule strokeWidth="2" height="100%" visible="{muteMeBtn.visible}" includeInLayout="{muteMeBtn.includeInLayout}"/>
-	<views:MuteMeButton id="muteMeBtn"  height="20" tabIndex="{baseIndex+numButtons+11}"/>
+	<views:MuteMeButton id="muteMeBtn" height="20"/>
 	<mx:Spacer width="50%"/>
     <mx:Label id="meetingNameLbl" styleName="meetingNameLabelStyle" />
     <mx:Spacer width="50%"/>
 	<views:LanguageSelector id="langSelector" 
 							visible="false" 
-							tabIndex="{baseIndex+numButtons+12}"
 							accessibilityName="{ResourceUtil.getInstance().getString('bbb.mainToolbar.langSelector')}"
 							styleName="languageSelectorStyle" />
 <!--
@@ -361,13 +363,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 -->
 	<mx:Button id="shortcutKeysBtn" label="{ResourceUtil.getInstance().getString('bbb.mainToolbar.shortcutBtn')}" styleName="shortcutButtonStyle"
              click="onShortcutButtonClick()" height="22" 
-             toolTip="{ResourceUtil.getInstance().getString('bbb.mainToolbar.shortcutBtn.toolTip')}" 
-             tabIndex="{baseIndex+numButtons+13}" />
+             toolTip="{ResourceUtil.getInstance().getString('bbb.mainToolbar.shortcutBtn.toolTip')}" />
 	<mx:LinkButton id="helpBtn" visible="{showHelpBtn}" label="?" click="onHelpButtonClicked()" height="22" 
-                   styleName="helpLinkButtonStyle" tabIndex="{baseIndex+numButtons+14}" 
+                   styleName="helpLinkButtonStyle" 
                    toolTip="{ResourceUtil.getInstance().getString('bbb.mainToolbar.helpBtn')}" 
 				   accessibilityDescription="{ResourceUtil.getInstance().getString('bbb.mainToolbar.helpBtn')}"/>
 	<mx:Button label="" id="btnLogout" styleName="logoutButtonStyle"
-                 toolTip="{ResourceUtil.getInstance().getString('bbb.mainToolbar.logoutBtn.toolTip')}" right="10" click="confirmLogout()" height="22"
-                 tabIndex="{baseIndex+numButtons+15}" />
+                 toolTip="{ResourceUtil.getInstance().getString('bbb.mainToolbar.logoutBtn.toolTip')}" right="10" click="confirmLogout()" height="22" />
 </mx:ApplicationControlBar>

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MicSettings.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MicSettings.mxml
@@ -18,8 +18,9 @@ You should have received a copy of the GNU Lesser General Public License along
 with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 -->
-<mx:TitleWindow xmlns:mx="http://www.adobe.com/2006/mxml" 
-				xmlns:mate="http://mate.asfusion.com/" 
+<mx:TitleWindow xmlns:mx="http://www.adobe.com/2006/mxml"
+				xmlns:mate="http://mate.asfusion.com/"
+				xmlns:common="org.bigbluebutton.common.*"
 				width="500" height="240" 
 				creationComplete="initDefaultMic()" 
 				styleName="micSettingsWindowStyle"
@@ -68,7 +69,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			[Bindable] private var cancelIcon:Class = images.cancel;
 
 			[Bindable] private var microphoneList:Array;      
-			[Bindable]private var baseIndex:int = 1;
 			
 			override public function move(x:Number, y:Number):void
 			{
@@ -334,25 +334,25 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		]]>
 	</mx:Script>
 	
+	<common:TabIndexer startIndex="1" tabIndices="{[viewTitle, helpLink, comboMicList, micRecordVolume, micLevel, webrtcSupportLabel, settingBtn, dontUseWebrtcBtn, notCapableText, playButton, okBtn, cancelBtn]}"/>
+	
 	<mx:VBox width="100%" height="100%"  paddingBottom="5" paddingLeft="5" paddingRight="5" paddingTop="5">
 
         <!-- Audio Settings Title and help button -->
 		    <mx:Canvas width="100%">
-			    <mx:TextArea borderSkin="{null}"
+			    <mx:TextArea id="viewTitle" borderSkin="{null}"
 	                 editable="false"
 	                 text="{ResourceUtil.getInstance().getString('bbb.users.settings.audioSettings')}"
 	                 styleName="micSettingsWindowTitleStyle"
-      						 tabIndex="{baseIndex}"
-      						 width="400"
-      						 left="0"/>
+  					 width="400"
+  					 left="0"/>
 			    <!-- accessibilityName="{ResourceUtil.getInstance().getString('bbb.micSettings.access.title')} "/ -->
-			    <mx:LinkButton toolTip="{ResourceUtil.getInstance().getString('bbb.mainToolbar.helpBtn')}"
+			    <mx:LinkButton id="helpLink" toolTip="{ResourceUtil.getInstance().getString('bbb.mainToolbar.helpBtn')}"
     						   label="?"
           			   styleName="micSettingsWindowHelpButtonStyle" 
           			   right="0"
           			   height="22"
           			   click="onHelpButtonClicked()"
-          			   tabIndex="{baseIndex+1}"
           			   accessibilityName="{ResourceUtil.getInstance().getString('bbb.micSettings.access.helpButton')}"/>
 		    </mx:Canvas>
 		      
@@ -396,7 +396,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 							  dataProvider="{microphoneList}" 
 							  change="selectMicrophone(event)"
 							  height="30" 
-							  tabIndex="{baseIndex+2}" 
 							  toolTip="{ResourceUtil.getInstance().getString('bbb.micSettings.comboMicList.toolTip')}" />
 				  <mx:HSlider id="micRecordVolume"
 							  maximum="100"
@@ -408,7 +407,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 							  showTrackHighlight="true"
 							  trackColors="[ 0xEEEEEE, 0xFFFFFF ]"
 							  value="60"
-							  tabIndex="{baseIndex+3}" 
 							  toolTip="{ResourceUtil.getInstance().getString('bbb.micSettings.micRecordVolume.toolTip')}" />                           
 			  </mx:HBox>
 			  <mx:ProgressBar id="micLevel" 
@@ -421,8 +419,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 							  width="450"
 							  height="27"
 							  trackHeight="25"
-							  verticalGap="-20" 
-							  tabIndex="{baseIndex+4}" />
+							  verticalGap="-20" />
 		  </mx:VBox>
                    
 
@@ -440,8 +437,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
                     <mx:Label id="webrtcSupportLabel" 
                         text="{ResourceUtil.getInstance().getString('bbb.micSettings.webrtc.capableBrowser')}"      
                         styleName="micSettingsWindowTestSpeakersLabelStyle" 
-                        paddingTop="5" 
-                        tabIndex="{baseIndex+8}"/>
+                        paddingTop="5" />
 <!--                    <mx:Text    width="100%" 
                             text="{ResourceUtil.getInstance().getString('bbb.micSettings.webrtc.capableBrowser')}" 
                             styleName="micSettingsWindowHearFromHeadsetLabelStyle" 
@@ -452,44 +448,40 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
                            label="{ResourceUtil.getInstance().getString('bbb.micSettings.changeMic')}" 
                            styleName="micSettingsWindowChangeMicButtonStyle" 
                            toggle="true"
-                           tabIndex="{baseIndex+4}"
                            toolTip="{ResourceUtil.getInstance().getString('bbb.micSettings.changeMic.toolTip')}"/>		
                       <mx:Button  id="dontUseWebrtcBtn" 
                           label="{ResourceUtil.getInstance().getString('bbb.micSettings.webrtc.capableBrowser.dontuseit')}"
                           click="dontUseWebrtc()" 
                           styleName="micSettingsWindowPlaySoundButtonStyle"
-                          toolTip="{ResourceUtil.getInstance().getString('bbb.micSettings.webrtc.capableBrowser.dontuseit.toolTip')}"
-                          tabIndex="{baseIndex+10}" />
+                          toolTip="{ResourceUtil.getInstance().getString('bbb.micSettings.webrtc.capableBrowser.dontuseit.toolTip')}" />
                      
                     </mx:HBox>
                 </mx:VBox>
                 <!-- Not webrtc capable browser message -->
                 <mx:HBox width="100%" visible="{!webrtcCapable}" includeInLayout="{!webrtcCapable}">
-                    <mx:Text  width="100%" 
+                    <mx:Text id="notCapableText" width="100%" 
                           text="{ResourceUtil.getInstance().getString('bbb.micSettings.webrtc.notCapableBrowser')}" 
-                          styleName="micSettingsWindowHearFromHeadsetLabelStyle" 
-                          tabIndex="{baseIndex+11}"/>
+                          styleName="micSettingsWindowHearFromHeadsetLabelStyle" />
                 </mx:HBox>
                 
             </mx:HBox>            
         </mx:VBox>
-
+		
     <!-- Play Sound, Join and Cancel buttons -->
       <mx:HRule width="100%"/>
   		<mx:Spacer height="10"/>
 			<mx:HBox width="100%" horizontalAlign="right" horizontalGap="18">
 				<mx:Button id="playButton" label="{ResourceUtil.getInstance().getString('bbb.micSettings.playSound')}" 
 						   click="playButtonClickHandler()" toggle="true" styleName="micSettingsWindowPlaySoundButtonStyle"
-						   toolTip="{ResourceUtil.getInstance().getString('bbb.micSettings.playSound.toolTip')}"
-						   tabIndex="{baseIndex+7}" />
+						   toolTip="{ResourceUtil.getInstance().getString('bbb.micSettings.playSound.toolTip')}" />
 				<mx:Button id="okBtn" 
 				       label="{ResourceUtil.getInstance().getString('bbb.micSettings.join')}" 
 						   styleName="micSettingsWindowJoinButtonStyle"
-						   click="onJoinClicked()" tabIndex="{baseIndex+8}"
+						   click="onJoinClicked()"
 						   toolTip="{ResourceUtil.getInstance().getString('bbb.micSettings.join.toolTip')}"/>
 				<mx:Button id="cancelBtn" label="{ResourceUtil.getInstance().getString('bbb.micSettings.cancel')}" 
 						   styleName="micSettingsWindowCancelButtonStyle"
-						   click="onCancelClicked()" tabIndex="{baseIndex+9}"
+						   click="onCancelClicked()"
 						   toolTip="{ResourceUtil.getInstance().getString('bbb.micSettings.cancel.toolTip')}"/>
 			</mx:HBox>
 		</mx:VBox>		

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/ShortcutHelpWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/ShortcutHelpWindow.mxml
@@ -20,13 +20,14 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 -->
 
-<MDIWindow xmlns="flexlib.mdi.containers.*" 
-	       xmlns:mx="http://www.adobe.com/2006/mxml" 
+<MDIWindow xmlns="flexlib.mdi.containers.*"
+	       xmlns:mx="http://www.adobe.com/2006/mxml"
+		   xmlns:common="org.bigbluebutton.common.*"
 	       showCloseButton="true"
 		   initialize="init()"
 	       creationComplete="onCreationComplete()"
 		   xmlns:mate="http://mate.asfusion.com/" 
-		   title="{ResourceUtil.getInstance().getString('bbb.shortcuthelp.title')}" >
+		   title="{ResourceUtil.getInstance().getString('bbb.shortcuthelp.title')}">
 		   
 	<mate:Listener type="{LocaleChangeEvent.LOCALE_CHANGED}" method="localeChanged" />
 	<mate:Listener type="{MDIWindowEvent.CLOSE}" method="focusButton" />
@@ -86,9 +87,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			[Bindable]
 			private var shownKeys:ArrayCollection;
 			
-			[Bindable]
-			private var baseIndex:int = 100;
-			
 			private var modifier:String;
 			private var globalModifier:String;
 			
@@ -100,11 +98,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 			private function onCreationComplete():void {
 				localeChanged();
-				titleBarOverlay.tabIndex = baseIndex;
 				
-				minimizeBtn.tabIndex = baseIndex + 1;
-				maximizeRestoreBtn.tabIndex = baseIndex + 2;
-				closeBtn.tabIndex = baseIndex + 3;
+				titleBarOverlay.tabIndex = 100;
 			}
 			
 			private function populateModules():void{
@@ -267,11 +262,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 		]]>
 	</mx:Script>
+
+	<common:TabIndexer startIndex="101" tabIndices="{[minimizeBtn, maximizeRestoreBtn, closeBtn, categories, keyList]}"/>
 	
 	<mx:ComboBox id="categories" labelField="Please select an area for which to view shortcut keys: " 
 				 editable="false" 
-				 change="changeArray()"
-				 tabIndex="{baseIndex + 10}">
+				 change="changeArray()">
 		<mx:ArrayCollection id="categoryAC">
         	<!--
 			<mx:String>{ResourceUtil.getInstance().getString("bbb.shortcuthelp.dropdown.general")}</mx:String>
@@ -283,7 +279,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			-->
       	</mx:ArrayCollection>
 	</mx:ComboBox>
-	<mx:DataGrid id="keyList" draggableColumns="false" dataProvider="{shownKeys}" width="100%" height="100%" tabIndex="{baseIndex + 15}" >
+	<mx:DataGrid id="keyList" draggableColumns="false" dataProvider="{shownKeys}" width="100%" height="100%">
 		<mx:columns>
 			<mx:DataGridColumn dataField="shortcut" headerText="{ResourceUtil.getInstance().getString('bbb.shortcuthelp.headers.shortcut')}"/>
 			<mx:DataGridColumn dataField="func" headerText="{ResourceUtil.getInstance().getString('bbb.shortcuthelp.headers.function')}"/>

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/ShortcutHelpWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/ShortcutHelpWindow.mxml
@@ -99,7 +99,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private function onCreationComplete():void {
 				localeChanged();
 				
-				titleBarOverlay.tabIndex = 100;
+				titleBarOverlay.tabIndex = tabIndexer.startIndex - 1;
 			}
 			
 			private function populateModules():void{
@@ -263,7 +263,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		]]>
 	</mx:Script>
 
-	<common:TabIndexer startIndex="101" tabIndices="{[minimizeBtn, maximizeRestoreBtn, closeBtn, categories, keyList]}"/>
+	<common:TabIndexer id="tabIndexer" startIndex="101" tabIndices="{[minimizeBtn, maximizeRestoreBtn, closeBtn, categories, keyList]}"/>
 	
 	<mx:ComboBox id="categories" labelField="Please select an area for which to view shortcut keys: " 
 				 editable="false" 

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
@@ -22,8 +22,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 <mx:VBox xmlns:mx="http://www.adobe.com/2006/mxml" 
 	xmlns:mate="http://mate.asfusion.com/"
-  xmlns:chat="org.bigbluebutton.modules.chat.views.*"
-  implements="org.bigbluebutton.modules.chat.views.IChatTab"
+	xmlns:common="org.bigbluebutton.common.*"
+    xmlns:chat="org.bigbluebutton.modules.chat.views.*"
+    implements="org.bigbluebutton.modules.chat.views.IChatTab"
 	click="setMessageRead()" verticalScrollPolicy="off"
 	creationComplete="onCreationComplete()">
 
@@ -140,9 +141,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private var spacerNeeded:Boolean = false;
 			private var indicatorNeeded:Boolean = false
 			private var repeat:Boolean = false;
-			
-			[Bindable]
-			public var baseIndex:int;
 			
 		      [Bindable]
 		      private var chatListHeight:Number = 100;
@@ -637,11 +635,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		
 	</mx:Script>
 
+  <common:TabIndexer id="tabIndexer" tabIndices="{[chatMessagesList, txtMsgArea, sendBtn, cmpColorPicker]}"/>
+	
   <mx:HBox width="100%" height="{chatListHeight}" verticalScrollPolicy="off">
     <chat:AdvancedList width="100%" height="{chatListHeight}" id="chatMessagesList" selectable="false" variableRowHeight="true" 
              itemRenderer="org.bigbluebutton.modules.chat.views.ChatMessageRenderer" verticalScrollPolicy="auto" wordWrap="true"
              dataProvider="{chatMessages.messages}"
-             tabIndex="{baseIndex}"
              accessibilityName="{ResourceUtil.getInstance().getString('bbb.chat.messageList')}" />    
   </mx:HBox>
   
@@ -650,19 +649,16 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     <mx:TextArea id="txtMsgArea" width="100%" height="100%"
                  styleName="chatControlBarTextMsgStyle" 
                  toolTip="{ResourceUtil.getInstance().getString('bbb.accessibility.chat.chatwindow.input')}"
-                 tabIndex="{baseIndex+1}"
 				 accessibilityName="{ResourceUtil.getInstance().getString('bbb.chat.input.accessibilityName')}" />
     <mx:VBox verticalScrollPolicy="off" verticalAlign="middle" height="100%" >
       <mx:Button label="{ResourceUtil.getInstance().getString('bbb.chat.sendBtn')}" id="sendBtn"
                  styleName="chatControlBarSendButtonStyle"
                  toolTip="{ResourceUtil.getInstance().getString('bbb.chat.sendBtn.toolTip')}" 
                  click="sendMessages()"
-                 tabIndex="{baseIndex+2}"
                  accessibilityName="{ResourceUtil.getInstance().getString('bbb.chat.sendBtn.accessibilityName')}"/>  
 		<mx:ColorPicker id="cmpColorPicker" showTextField="false" width="100%" visible="{chatOptions.colorPickerIsVisible}" includeInLayout="{chatOptions.colorPickerIsVisible}" 
 						toolTip="{ResourceUtil.getInstance().getString('bbb.chat.cmpColorPicker.toolTip')}" 
-						selectedColor="0x000000" dataProvider="{colorPickerColours}" swatchPanelStyleName="chatColorPickerStyle"
-						tabIndex="{baseIndex+3}" />
+						selectedColor="0x000000" dataProvider="{colorPickerColours}" swatchPanelStyleName="chatColorPickerStyle" />
     </mx:VBox>
   </mx:HBox>	
 </mx:VBox>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatView.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatView.mxml
@@ -22,10 +22,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 <mx:VBox xmlns:mx="http://www.adobe.com/2006/mxml"
     xmlns:mate="http://mate.asfusion.com/"
+	xmlns:flexlib="http://code.google.com/p/flexlib/"
+	xmlns:common="org.bigbluebutton.common.*"
+	xmlns:containers="flexlib.containers.*"
     creationComplete="onCreationComplete()"
     initialize="init()"
-    xmlns:flexlib="http://code.google.com/p/flexlib/"
-    width="100%" height="100%" xmlns:containers="flexlib.containers.*"
+    width="100%" height="100%"
     verticalScrollPolicy="off">
 
   <mate:Listener type="{PrivateChatMessageEvent.PRIVATE_CHAT_MESSAGE_EVENT}" method="handlePrivateChatMessageEvent"/>
@@ -91,8 +93,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       [Bindable] 
       public var chatOptions:ChatOptions;
 	  
-	  [Bindable]
-		private var baseIndex:int;
 		private static const PUBLIC_TAB_NEW:String = ResourceUtil.getInstance().getString("bbb.accessibility.chat.chatView.publicTabNew");
 		private var publicWaiting:Boolean = false;
 		private var publicFocus:Boolean = false;
@@ -109,7 +109,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				chatOptions = new ChatOptions();
 				noticeLabel = ResourceUtil.getInstance().getString('bbb.chat.chatTabs.accessibleNotice');
 				// Get the base tab index from config, and add four to make up for the min/max/close buttons and title overlay
-				baseIndex = chatOptions.getBaseIndex() + 4;
 			}
 			
 
@@ -284,7 +283,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				var chatBox:ChatBox = new ChatBox();
 				chatBox.id = chatWithUserID;
 		        chatBox.name = chatWithUserID;
-				chatBox.baseIndex = baseIndex;
 		        
 		        if (publicChat) {
 		          chatBox.label = PUBLIC_CHAT_USERNAME
@@ -377,7 +375,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 		]]>
 	</mx:Script>
+	
+	<common:TabIndexer id="tabIndexer" startIndex="{chatOptions.getBaseIndex() + 4}" tabIndices="{[chatTabs]}"/>
+	
 	<containers:SuperTabNavigator includeInLayout="false" id="chatTabs" width="100%" height="100%" change="onTabNavChange()" tabClose="onTabClose(event)" minTabWidth="20"
-								  dragEnabled="false" popUpButtonPolicy="off" tabIndex="{baseIndex}"
-								  />
+								  dragEnabled="false" popUpButtonPolicy="off" />
 </mx:VBox>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatWindow.mxml
@@ -23,9 +23,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 <MDIWindow xmlns="flexlib.mdi.containers.*" 
 	       xmlns:mx="http://www.adobe.com/2006/mxml" 
 	       xmlns:chat="org.bigbluebutton.modules.chat.views.components.*"
+		   xmlns:common="org.bigbluebutton.common.*"
 	       showCloseButton="false"
 	       implements="org.bigbluebutton.common.IBbbModuleWindow" 
-	       initialize="init()"
 	       creationComplete="onCreationComplete()"
 	       xmlns:components="org.bigbluebutton.modules.chat.view.components.*" 
 		   xmlns:mate="http://mate.asfusion.com/" 
@@ -60,11 +60,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private var dispState:String;
 			[Bindable] public var chatOptions:ChatOptions;
 			
-			[Bindable] private var baseIndex:int;
-			private function init():void{
-				baseIndex = chatOptions.baseTabIndex;
-			}
-			
 			public function getPrefferedPosition():String{
 				return chatOptions.position;
 			} 
@@ -79,12 +74,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 //				disp.dispatchEvent(new TranscriptEvent(TranscriptEvent.LOAD_TRANSCRIPT));
 
 				hotkeyCapture();
-				titleBarOverlay.tabIndex = baseIndex;
+				titleBarOverlay.tabIndex = tabIndexer.startIndex - 1;
 				
-				minimizeBtn.tabIndex = baseIndex+1;
-				maximizeRestoreBtn.tabIndex = baseIndex+2;
-				closeBtn.tabIndex = baseIndex+3;
-
 				resourcesChanged(); // update the window controls once they've been created
 			}
 			
@@ -192,6 +183,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 		]]>
 	</mx:Script>
+	
+	<common:TabIndexer id="tabIndexer" startIndex="{chatOptions.baseTabIndex + 1}" tabIndices="{[minimizeBtn, maximizeRestoreBtn, closeBtn]}"/>
 	
 	<views:ChatView id="chatView" chatOptions="{chatOptions}" includeInLayout="false"/>
 </MDIWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/deskshare/view/components/DesktopPublishWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/deskshare/view/components/DesktopPublishWindow.mxml
@@ -25,6 +25,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	implements="org.bigbluebutton.common.IBbbModuleWindow"
 	xmlns:mate="http://mate.asfusion.com/"
 	xmlns:dspub="flexlib.mdi.containers.*"
+	xmlns:common="org.bigbluebutton.common.*"
 	backgroundColor="#C0C0C0"
 	initialize="init()"
 	creationComplete="onCreationComplete()"	
@@ -96,12 +97,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private var globalDispatcher:Dispatcher = new Dispatcher();
 			
 			[Bindable] private var cursor:Sprite;
-			[Bindable] private var baseIndex:int;
 			[Bindable] private var dsOptions:DeskshareOptions;
 			
 			private function init():void {
 				dsOptions = new DeskshareOptions();
-				baseIndex = dsOptions.baseTabIndex;
 			}
 			
 			private function onCreationComplete():void {
@@ -115,12 +114,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				
 				resourcesChanged();
 				
-				titleBarOverlay.tabIndex = baseIndex;
+				titleBarOverlay.tabIndex = tabIndexer.startIndex - 1;
 				titleBarOverlay.focusEnabled = true;
-								
-				minimizeBtn.tabIndex = baseIndex+1;
-				maximizeRestoreBtn.tabIndex = baseIndex+2;
-				closeBtn.tabIndex = baseIndex+3;
 			}
 			
 			private function remoteFocus(e:ShortcutEvent):void{
@@ -364,7 +359,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       }
 		]]>
 	</mx:Script>
-
+	
+	<common:TabIndexer id="tabIndexer" startIndex="{dsOptions.baseTabIndex + 1}"
+					   tabIndices="{[minimizeBtn, maximizeRestoreBtn, closeBtn, btnFSPublish, btnClosePublish, btnRegionPublish]}"/>
+	
 	<!--http://stackoverflow.com/questions/369120/why-does-mxstates-have-trouble-being-resolved-to-a-component-implementation-->
 	<dspub:states>	    
         <mx:State name="dispFullRegionControlBar">   
@@ -377,23 +375,20 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
                                  toolTip="{ResourceUtil.getInstance().getString('bbb.desktopPublish.fullscreen.tooltip')}" 
                                  label="{ResourceUtil.getInstance().getString('bbb.desktopPublish.fullscreen.label')}" 
                                  visible="true" 
-                                 click="shareScreen(true)" 
-                                 tabIndex="{baseIndex+4}"/>
+                                 click="shareScreen(true)"/>
                       <mx:Spacer width="100%"/>
                       <mx:Button id="btnClosePublish" 
                                  toolTip="{ResourceUtil.getInstance().getString('bbb.desktopPublish.stop.tooltip')}" 
                                  label="{ResourceUtil.getInstance().getString('bbb.desktopPublish.stop.label')}" 
                                  visible="true" 
                                  enabled="false" 
-                                 click="stopSharing()" 
-                                 tabIndex="{baseIndex+5}"/>
+                                 click="stopSharing()"/>
                       <mx:Spacer width="100%"/>
                       <mx:Button id="btnRegionPublish"
                                  toolTip="{ResourceUtil.getInstance().getString('bbb.desktopPublish.region.tooltip')}" 
                                  label="{ResourceUtil.getInstance().getString('bbb.desktopPublish.region.label')}" 
                                  visible="true" 
                                  click="shareScreen(false)" 
-                                 tabIndex="{baseIndex+6}"
                                  focusEnabled="false"
                                  tabEnabled="false"/>
                       <mx:Spacer width="100%"/>                      

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/deskshare/view/components/DesktopViewWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/deskshare/view/components/DesktopViewWindow.mxml
@@ -27,6 +27,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	creationComplete="onCreationComplete()"
 	implements="org.bigbluebutton.common.IBbbModuleWindow"
 	xmlns:mate="http://mate.asfusion.com/"
+	xmlns:common="org.bigbluebutton.common.*"
 	title="{ResourceUtil.getInstance().getString('bbb.desktopView.title')}" 
 	showCloseButton="false"
 	resize="fitToWindow()" >
@@ -80,12 +81,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private var savedY:Number;
 			private var isMaximized:Boolean = false;
 			
-			[Bindable] private var baseIndex:int;
 			[Bindable] private var dsOptions:DeskshareOptions;
 									
 			private function init():void{
 				dsOptions = new DeskshareOptions();
-				baseIndex = dsOptions.baseTabIndex;
 			}
 									
 			private function onCreationComplete():void{
@@ -105,10 +104,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				
 				resourcesChanged();
 				
-				titleBarOverlay.tabIndex = baseIndex;
-				minimizeBtn.tabIndex = baseIndex+1;
-				maximizeRestoreBtn.tabIndex = baseIndex+2;
-				closeBtn.tabIndex = baseIndex+3;
+				titleBarOverlay.tabIndex = tabIndexer.startIndex - 1;
 			}
 			
 			private function onResizeEndEvent(event:MDIWindowEvent):void {
@@ -294,6 +290,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 		]]>
 	</mx:Script>
+	
+	<common:TabIndexer id="tabIndexer" startIndex="{dsOptions.baseTabIndex + 1}"
+					   tabIndices="{[minimizeBtn, maximizeRestoreBtn, closeBtn, btnActualSize]}"/>
+	
 	<mx:Move id="cursorMove" target="{cursorImg}"/>
 	<mx:Image id="cursorImg" visible="false" source="@Embed('../../assets/images/cursor4.png')"/>
 		
@@ -304,7 +304,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				   selected="false"
 				   height="90%" 
 				   label="{btnActualSize.selected ? ResourceUtil.getInstance().getString('bbb.desktopView.fitToWindow') : ResourceUtil.getInstance().getString('bbb.desktopView.actualSize')}" 
-				   toolTip="{btnActualSize.selected ? ResourceUtil.getInstance().getString('bbb.desktopView.fitToWindow') : ResourceUtil.getInstance().getString('bbb.desktopView.actualSize')}" 
-				   tabIndex="{baseIndex+4}"/>
+				   toolTip="{btnActualSize.selected ? ResourceUtil.getInstance().getString('bbb.desktopView.fitToWindow') : ResourceUtil.getInstance().getString('bbb.desktopView.actualSize')}"/>
 	</mx:ControlBar>
 </MDIWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/layout/views/ToolbarComponent.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/layout/views/ToolbarComponent.mxml
@@ -22,6 +22,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		   creationComplete="init()" visible="{_visibleTools}"
 		   xmlns:mate="http://mate.asfusion.com/"
 		   xmlns:views="org.bigbluebutton.modules.layout.views.*"
+		   xmlns:common="org.bigbluebutton.common.*"
 		   implements="org.bigbluebutton.common.IBbbToolbarComponent">
 	
 	<mx:Script>
@@ -38,8 +39,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private var _dispatcher:Dispatcher = new Dispatcher();
 			[Bindable] private var _enableEdit:Boolean = false;
 			[Bindable] private var _visibleTools:Boolean = true;
-			
-			[Bindable] private var baseIndex:int = 110000;
 			
 			private function init():void {
 				var evt:ViewInitializedEvent = new ViewInitializedEvent();
@@ -77,21 +76,18 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 		]]>
 	</mx:Script>
+	
+	<common:TabIndexer id="tabIndexer" startIndex="110000" tabIndices="{[comboBox, addButton, saveButton, loadButton, lockButton]}"/>
 
-	<views:LayoutsCombo id="comboBox" 
-						tabIndex="{baseIndex}"/>
+	<views:LayoutsCombo id="comboBox"/>
 	<views:AddButton id="addButton" 
 					 includeInLayout="{_enableEdit}" 
-					 visible="{_enableEdit}" 
-					 tabIndex="{baseIndex+1}"/>
+					 visible="{_enableEdit}"/>
 	<views:SaveButton id="saveButton" 
 					  includeInLayout="{_enableEdit}" 
-					  visible="{_enableEdit}" 
-					  tabIndex="{baseIndex+2}"/>
+					  visible="{_enableEdit}"/>
 	<views:LoadButton id="loadButton" 
 					  includeInLayout="{_enableEdit}" 
-					  visible="{_enableEdit}" 
-					  tabIndex="{baseIndex+3}"/>
-	<views:LockButton id="lockButton"
-					  tabIndex="{baseIndex+4}"/>
+					  visible="{_enableEdit}"/>
+	<views:LockButton id="lockButton"/>
 </mx:HBox>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -31,16 +31,15 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	verticalScrollPolicy="off" 
 	horizontalScrollPolicy="off" 
 	showControls="true" resize="maximizeHandler()"
-  styleNameFocus="presentationWindowStyleFocus"
-  styleNameNoFocus="presentationWindowStyleNoFocus"
+    styleNameFocus="presentationWindowStyleFocus"
+    styleNameNoFocus="presentationWindowStyleNoFocus"
 	implements="org.bigbluebutton.common.IBbbModuleWindow"
 	initialize="init()"
 	creationComplete="onCreationComplete()" 
 	width="{DEFAULT_WINDOW_WIDTH}" height="{DEFAULT_WINDOW_HEIGHT}" 
 	x="{DEFAULT_X_POSITION}" y="{DEFAULT_Y_POSITION}"
 	title="{ResourceUtil.getInstance().getString('bbb.presentation.titleWithPres',[currentPresentation])}"
-	xmlns:views="org.bigbluebutton.modules.present.ui.views.*"
-	>
+	xmlns:views="org.bigbluebutton.modules.present.ui.views.*" xmlns:common="org.bigbluebutton.common.*" >
 	
 	<mate:Dispatcher id="globalDispatcher" />
 	<mate:Listener type="{ShortcutEvent.FOCUS_PRESENTATION_WINDOW}" method="focusWindow" />
@@ -139,7 +138,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			[Bindable] private var presentationLoaded:Boolean = false;
 			[Bindable] private var currentPresentation:String = "";
 			
-			[Bindable] private var baseIndex:int; 
 			[Bindable] private var presentOptions:PresentOptions;
 			
 			private var keyCombos:Object;
@@ -147,7 +145,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 			private function init():void{
 				presentOptions = new PresentOptions();
-				baseIndex = presentOptions.baseTabIndex;;
 			}
 			
 			private function onCreationComplete():void{
@@ -158,13 +155,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				slideView.addEventListener(ListEvent.ITEM_ROLL_OVER, onItemRollOver);
 				resourcesChanged();
 				
-				titleBarOverlay.tabIndex = baseIndex;
+				titleBarOverlay.tabIndex = tabIndexer.startIndex - 1;
 				
-				minimizeBtn.tabIndex = baseIndex+1;
-				maximizeRestoreBtn.tabIndex = baseIndex+2;
-				closeBtn.tabIndex = baseIndex+3;
-				
-				slideView.slideLoader.tabIndex = baseIndex+4;
 				hotkeyCapture();
                 
                 //Necessary now because of module loading race conditions
@@ -636,37 +628,35 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
   	 
 	<mx:Fade id="thumbFadeIn" alphaFrom="1" alphaTo="0" duration="100" />
 	<mx:Fade id="thumbFadeOut" alphaFrom="0" alphaTo="1" duration="100" />
+	
+	<common:TabIndexer id="tabIndexer" startIndex="{presentOptions.baseTabIndex + 1}"
+					   tabIndices="{[minimizeBtn, maximizeRestoreBtn, closeBtn, slideView, uploadPres, backButton, btnSlideNum, forwardButton, zoomSlider, btnFitToWidth, btnFitToPage]}"/>
 
 	<views:SlideView id="slideView" width="100%" height="100%" visible="false" mouseDown="mouseDown = true"
-		mouseUp="mouseDown = false" verticalScrollPolicy="off" horizontalScrollPolicy="off" tabIndex="{baseIndex+4}"/>			    
+		mouseUp="mouseDown = false" verticalScrollPolicy="off" horizontalScrollPolicy="off"/>			    
 	<mx:ControlBar id="presCtrlBar" name="presCtrlBar" width="100%" height="{CONTROL_BAR_HEIGHT}" styleName="presentationWindowControlsStyle" >
 		<mx:Button id="uploadPres" visible="false" height="30" styleName="presentationUploadButtonStyle"
     		toolTip="{ResourceUtil.getInstance().getString('bbb.presentation.uploadPresBtn.toolTip')}" 
-    	   	click="onUploadButtonClicked()" tabIndex="{baseIndex+5}"/>        	  
+    	   	click="onUploadButtonClicked()"/>        	  
     	<mx:Spacer width="100%" id="spacer1"/>
     	<mx:Button id="backButton" visible="false" width="45" height="30" styleName="presentationBackButtonStyle"
-    		toolTip="{ResourceUtil.getInstance().getString('bbb.presentation.backBtn.toolTip')}" click="gotoPreviousSlide()"
-    		tabIndex="{baseIndex+6}"/>
+    		toolTip="{ResourceUtil.getInstance().getString('bbb.presentation.backBtn.toolTip')}" click="gotoPreviousSlide()"/>
     	<mx:Button id="btnSlideNum" visible="false" label="" click="showThumbnails()" doubleClick="showPageDialog()" 
-			toolTip="{ResourceUtil.getInstance().getString('bbb.presentation.btnSlideNum.toolTip')}"
-			tabIndex="{baseIndex+7}"/>
+			toolTip="{ResourceUtil.getInstance().getString('bbb.presentation.btnSlideNum.toolTip')}"/>
     	<mx:Button id="forwardButton" visible="false" width="45" height="30" styleName="presentationForwardButtonStyle"
-    		toolTip="{ResourceUtil.getInstance().getString('bbb.presentation.forwardBtn.toolTip')}" click="gotoNextSlide()"
-    		tabIndex="{baseIndex+8}"/>    				
+    		toolTip="{ResourceUtil.getInstance().getString('bbb.presentation.forwardBtn.toolTip')}" click="gotoNextSlide()"/>    				
 		<mx:Spacer width="50%" id="spacer3"/>
 		<mx:HSlider id="zoomSlider" visible="false" value="{slideView.zoomPercentage}" styleName="presentationZoomSliderStyle"
     		minimum="100" maximum="400" dataTipPlacement="top" labels="['100%','400%']" 
     		useHandCursor="true" snapInterval="5" allowTrackClick="true" liveDragging="true" 
     		dataTipFormatFunction="removeDecimalFromDataTip" change="onSliderZoom()" width="100"
-    		tabIndex="{baseIndex+9}" accessibilityName="{ResourceUtil.getInstance().getString('bbb.presentation.slider')}"/>
+    		accessibilityName="{ResourceUtil.getInstance().getString('bbb.presentation.slider')}"/>
     	<mx:Button id="btnFitToWidth" visible="false" width="30" height="30" styleName="presentationFitToWidthButtonStyle"
 			toolTip="{ResourceUtil.getInstance().getString('bbb.presentation.fitToWidth.toolTip')}" 
-			click="onFitToPage(false)"
-			tabIndex="{baseIndex+10}"/>
+			click="onFitToPage(false)"/>
 		<mx:Button id="btnFitToPage" visible="false" width="30" height="30" styleName="presentationFitToPageButtonStyle"
 			toolTip="{ResourceUtil.getInstance().getString('bbb.presentation.fitToPage.toolTip')}" 
-			click="onFitToPage(true)"
-			tabIndex="{baseIndex+11}"/>
+			click="onFitToPage(true)"/>
     	
     </mx:ControlBar>
 </pres:MDIWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -630,7 +630,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	<mx:Fade id="thumbFadeOut" alphaFrom="0" alphaTo="1" duration="100" />
 	
 	<common:TabIndexer id="tabIndexer" startIndex="{presentOptions.baseTabIndex + 1}"
-					   tabIndices="{[minimizeBtn, maximizeRestoreBtn, closeBtn, slideView, uploadPres, backButton, btnSlideNum, forwardButton, zoomSlider, btnFitToWidth, btnFitToPage]}"/>
+					   tabIndices="{[minimizeBtn, maximizeRestoreBtn, closeBtn, slideView.slideLoader, uploadPres, backButton, btnSlideNum, forwardButton, zoomSlider, btnFitToWidth, btnFitToPage]}"/>
 
 	<views:SlideView id="slideView" width="100%" height="100%" visible="false" mouseDown="mouseDown = true"
 		mouseUp="mouseDown = false" verticalScrollPolicy="off" horizontalScrollPolicy="off"/>			    

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/PublishWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/PublishWindow.mxml
@@ -21,10 +21,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 -->
 
 <pubVid:VideoWindowItf
-	xmlns:mx="http://www.adobe.com/2006/mxml" 
+	xmlns:mx="http://www.adobe.com/2006/mxml"
 	xmlns:pubVid="org.bigbluebutton.modules.videoconf.business.*"
 	initialize="init()"
 	implements="org.bigbluebutton.common.IBbbModuleWindow"
+	xmlns:common="org.bigbluebutton.common.*"
 	styleNameFocus="videoPublishStyleFocus"
 	styleNameNoFocus="videoPublishStyleNoFocus"
 	creationComplete="onCreationComplete()" 
@@ -99,14 +100,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			static private var _cameraAccessDenied:Boolean = false;
 			
 			[Bindable] public var videoOptions:VideoConfOptions;
-			[Bindable] public var baseIndex:int;
 			
 			[Bindable] public var glowColor:String = ""; 
 			[Bindable] public var glowBlurSize:Number = 0;
 			
 			private function init():void{
 				videoOptions = new VideoConfOptions();
-				baseIndex = videoOptions.baseTabIndex;
 			}
 			
 			private var windowType:String = "PublishWindowType";
@@ -142,10 +141,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				}
 				
 				
-				titleBarOverlay.tabIndex = baseIndex;
+				titleBarOverlay.tabIndex = tabIndexer.startIndex;
 				titleBarOverlay.accessibilityName = ResourceUtil.getInstance().getString('bbb.video.publish.titleBar');
 				closeBtn.focusEnabled = true;
-				closeBtn.tabIndex = baseIndex+3;
 				
 				addEventListener(MDIWindowEvent.RESIZE_START, onResizeStart);
 				addEventListener(MDIWindowEvent.RESIZE_END, onResizeEnd);
@@ -461,6 +459,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 		]]>
 	</mx:Script>
+	
+	<common:TabIndexer id="tabIndexer" startIndex="{videoOptions.baseTabIndex + 3}"
+					   tabIndices="{[closeBtn]}"/>
 
   <mx:Glow id="talkingEffect" duration="500" alphaFrom="1.0" alphaTo="0.3" 
            blurXFrom="0.0" blurXTo="{glowBlurSize}" blurYFrom="0.0" blurYTo="{glowBlurSize}" color="{glowColor}"/>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videodock/views/VideoDock.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videodock/views/VideoDock.mxml
@@ -22,11 +22,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 <MDIWindow xmlns="flexlib.mdi.containers.*" 
 		   xmlns:mx="http://www.adobe.com/2006/mxml" 
-		   initialize="init()" 
-       horizontalScrollPolicy="off"
-       verticalScrollPolicy="off"
+           horizontalScrollPolicy="off"
+       	   verticalScrollPolicy="off"
 		   creationComplete="onCreationComplete()" 
 		   implements="org.bigbluebutton.common.IBbbModuleWindow"
+		   xmlns:common="org.bigbluebutton.common.*"
 		   title="{ResourceUtil.getInstance().getString('bbb.videodock.title')}"
 		   xmlns:mate="http://mate.asfusion.com/" styleNameFocus="videoDockStyleFocus"
 		   layout="absolute" visible="false" styleNameNoFocus="videoDockStyleNoFocus"
@@ -40,27 +40,28 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	<mate:Listener type="{ShortcutEvent.MAXIMIZE_DOCK}" method="remoteMaximize" />
 	<mx:Script>
 		<![CDATA[ 
-	  import org.bigbluebutton.main.events.ShortcutEvent;
-      import com.asfusion.mate.events.Dispatcher;
-      
-      import mx.events.ChildExistenceChangedEvent;
-      
-      import org.bigbluebutton.common.Images;
-
-      import org.bigbluebutton.common.LogUtil;
-      import org.bigbluebutton.common.events.CloseWindowEvent;
-      import org.bigbluebutton.common.events.DragWindowEvent;
-      import org.bigbluebutton.common.events.OpenWindowEvent;
-      import org.bigbluebutton.core.BBB;
-      import org.bigbluebutton.core.events.ConnectAppEvent;
-      import org.bigbluebutton.main.model.users.Conference;
-      import org.bigbluebutton.main.views.MainCanvas;
-      import org.bigbluebutton.modules.videoconf.business.VideoWindowItf;
-      import org.bigbluebutton.modules.videoconf.events.OpenVideoWindowEvent;
-      import org.bigbluebutton.modules.videoconf.events.UserTalkingEvent;
-      import org.bigbluebutton.modules.videoconf.model.VideoConfOptions;
-      import org.bigbluebutton.util.i18n.ResourceUtil;
-	  import org.bigbluebutton.common.events.LocaleChangeEvent;
+			import com.asfusion.mate.events.Dispatcher;
+			
+			import mx.events.ChildExistenceChangedEvent;
+			
+			import flexlib.mdi.containers.MDIWindow;
+			
+			import org.bigbluebutton.common.Images;
+			import org.bigbluebutton.common.LogUtil;
+			import org.bigbluebutton.common.events.CloseWindowEvent;
+			import org.bigbluebutton.common.events.DragWindowEvent;
+			import org.bigbluebutton.common.events.LocaleChangeEvent;
+			import org.bigbluebutton.common.events.OpenWindowEvent;
+			import org.bigbluebutton.core.BBB;
+			import org.bigbluebutton.core.events.ConnectAppEvent;
+			import org.bigbluebutton.main.events.ShortcutEvent;
+			import org.bigbluebutton.main.model.users.Conference;
+			import org.bigbluebutton.main.views.MainCanvas;
+			import org.bigbluebutton.modules.videoconf.business.VideoWindowItf;
+			import org.bigbluebutton.modules.videoconf.events.OpenVideoWindowEvent;
+			import org.bigbluebutton.modules.videoconf.events.UserTalkingEvent;
+			import org.bigbluebutton.modules.videoconf.model.VideoConfOptions;
+			import org.bigbluebutton.util.i18n.ResourceUtil;
 			
 			private var childrenDimension:Dictionary = new Dictionary();
 			private var borderColor:String;
@@ -78,13 +79,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private var confOptions:VideoConfOptions = new VideoConfOptions();
 			private var dispatcher:Dispatcher;			
 			private var keyCombos:Object;
-			
-			[Bindable] 
-			private var baseIndex:int;
-			
-			private function init():void{
-				baseIndex = options.baseTabIndex;
-			}
 			
 			private var images:Images = new Images();
       
@@ -109,12 +103,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				dispatcher = new Dispatcher();
 				hotkeyCapture();
 				
-				titleBarOverlay.tabIndex = baseIndex;
-				
-				minimizeBtn.tabIndex = baseIndex+1;
-				maximizeRestoreBtn.tabIndex = baseIndex+2;
-				
-				closeBtn.tabIndex = baseIndex+3;
+				titleBarOverlay.tabIndex = tabIndexer.startIndex - 1;
 				
 				if (options.maximize) this.maximize();
         
@@ -483,6 +472,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 						
 		]]>
 	</mx:Script>
+	
+	<common:TabIndexer id="tabIndexer" startIndex="{options.baseTabIndex + 1}"
+					   tabIndices="{[minimizeBtn, maximizeRestoreBtn, closeBtn]}"/>
 	
 	<mate:Listener type="{OpenVideoWindowEvent.OPEN_VIDEO_WINDOW_EVENT}" method="onOpenWindow" />
 	<mate:Listener type="{CloseWindowEvent.CLOSE_WINDOW_EVENT}" method="onCloseWindow" />

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videodock/views/VideoDock.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videodock/views/VideoDock.mxml
@@ -75,6 +75,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			// bigger the weight, bigger will be the window and less space the other windows will have
 			private var priorityWindowWeight:Number = 2/3;
 			
+			[Bindable]
 			private var options:DockOptions = new DockOptions();
 			private var confOptions:VideoConfOptions = new VideoConfOptions();
 			private var dispatcher:Dispatcher;			

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardToolbar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardToolbar.mxml
@@ -20,14 +20,15 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 -->
 
-<mx:VBox xmlns="flexlib.containers.*" 
-		initialize="init()" 
-		xmlns:mx="http://www.adobe.com/2006/mxml" 
+<mx:VBox xmlns="flexlib.containers.*"
+		initialize="init()"
+		xmlns:mx="http://www.adobe.com/2006/mxml"
 		xmlns:view="org.bigbluebutton.modules.whiteboard.views.*"
 		xmlns:wbBtns="org.bigbluebutton.modules.whiteboard.views.buttons.*"
-		xmlns:mate="http://mate.asfusion.com/" 
+		xmlns:mate="http://mate.asfusion.com/"
+		xmlns:common="org.bigbluebutton.common.*"
 		creationComplete="onCreationComplete()"
-		visible="{showWhiteboardToolbar}" 
+		visible="{showWhiteboardToolbar}"
 		styleName="whiteboardToolbarStyle">
 	
 	<mate:Listener type="{MadePresenterEvent.SWITCH_TO_PRESENTER_MODE}" method="presenterMode" />
@@ -121,7 +122,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			[Bindable] private var grid_icon:Class = images.grid_icon;
 			
 			[Bindable] public var wbOptions:WhiteboardOptions;
-			[Bindable] private var baseIndex:int;
 			
 			[Bindable] private var showWhiteboardToolbar:Boolean = false;
 
@@ -136,7 +136,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 			private function init():void{
 				wbOptions = new WhiteboardOptions();
-				baseIndex = wbOptions.baseTabIndex;
 			}
 			
             private function onCreationComplete():void {
@@ -344,39 +343,33 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		]]>
 	</mx:Script>
 	
+	<common:TabIndexer id="tabIndexer" startIndex="{wbOptions.baseTabIndex}"
+					   tabIndices="{[panzoomBtn, scribbleBtn, rectangleBtn, circleBtn, triangleBtn, lineBtn, textBtn, clearBtn, undoBtn, cpik, sld]}"/>
+	
 	<!-- Now, every 'tool' has two types of identifiers, one is found in WhiteboardConstants
 	that identifies the "category" of the tool (ex. shape vs text), and the other specifies the 
 	tool itself (ex. line tool vs triangle tool, even though both are "shapes")
 	-->
     <wbBtns:PanZoomButton id="panzoomBtn" 
-    					  tabIndex="{baseIndex}" 
     					  visible="{showWhiteboardToolbar}"/>
     <mx:Spacer height="10" visible="{showWhiteboardToolbar}"/>
 	<wbBtns:ScribbleButton id="scribbleBtn" 
-						   tabIndex="{baseIndex+1}" 
 						   visible="{showWhiteboardToolbar}"/>
 	<wbBtns:RectangleButton id="rectangleBtn" 
-							tabIndex="{baseIndex+2}" 
 							visible="{showWhiteboardToolbar}"/>
 	<wbBtns:CircleButton id="circleBtn" 
-						 tabIndex="{baseIndex+3}" 
 						 visible="{showWhiteboardToolbar}"/>
 	<wbBtns:TriangleButton id="triangleBtn" 
-						   tabIndex="{baseIndex+4}" 
 						   visible="{showWhiteboardToolbar}"/>
 	<wbBtns:LineButton id="lineBtn" 
-					   tabIndex="{baseIndex+5}" 
 					   visible="{showWhiteboardToolbar}"/>
 	<wbBtns:TextButton id="textBtn" 
-					   tabIndex="{baseIndex+6}" 
 					   visible="{showWhiteboardToolbar}"/>
 		
 	<mx:Spacer height="5" visible="{showWhiteboardToolbar}"/>
 	<wbBtns:ClearButton id="clearBtn" 
-						tabIndex="{baseIndex+7}" 
 						visible="{showWhiteboardToolbar}"/>
 	<wbBtns:UndoButton id="undoBtn" 
-					   tabIndex="{baseIndex+8}" 
 					   visible="{showWhiteboardToolbar}"/>
 	
 	<mx:Spacer height="5" visible="{showWhiteboardToolbar}"/>
@@ -395,7 +388,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	<mx:ColorPicker change="changeColor(event)" id="cpik"  visible="{showWhiteboardToolbar}"
                   selectedColor="0x000000" width="30" dataProvider="{colorPickerColours}" swatchPanelStyleName="colorPickerStyle"
                   toolTip="{ResourceUtil.getInstance().getString('bbb.highlighter.toolbar.color')}"
-                  tabIndex="{baseIndex+9}"
 				  accessibilityName="{ResourceUtil.getInstance().getString('bbb.highlighter.toolbar.color')}"/>
    
 	<mx:Spacer height="3" visible="{showWhiteboardToolbar}"/>
@@ -404,7 +396,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				toolTip="{ResourceUtil.getInstance().getString('bbb.highlighter.toolbar.thickness.accessibilityName')}" 
 				minimum="1" maximum="30" 
 				useHandCursor="true" value="2" showDataTip="true" snapInterval="1" dataTipOffset="0" labelOffset="0" 
-				tabIndex="{baseIndex+10}"
 				accessibilityName="{ResourceUtil.getInstance().getString('bbb.highlighter.toolbar.thickness.accessibilityName')}" />
 	<mx:Image source="{thin_icon}" horizontalAlign="center" width="30" visible="{showWhiteboardToolbar}"/>
 	


### PR DESCRIPTION
Added TabIndexer class to automate tab indexing. All basIndex were removed from views and replaced by a TabIndexer instance. Polling views are ountouched.

The purpose is to automate tab indexing and simplify it for developers.