### PR TITLE
Reverse the check for http response code.

### DIFF
--- a/record-and-playback/presentation/playback/presentation/playback.js
+++ b/record-and-playback/presentation/playback/presentation/playback.js
@@ -307,7 +307,7 @@ function checkUrl(url)
     var http = new XMLHttpRequest();
     http.open('HEAD', url, false);
     http.send();
-    return http.status!=404;
+    return http.status==200;
 }
 
 load_video = function(){


### PR DESCRIPTION
There are many codes other than '404' which indicate that the media
file is not present or otherwise unusable. Instead of checking for
a particular failure mode, check for explicit success.

I ran into this on a server that had directory listing disabled, and
returned a 403 (access denied) error on non-existant files.
