### PR TITLE
set absolute path to ffmpeg

### DIFF
--- a/record-and-playback/core/scripts/sanity/sanity.rb
+++ b/record-and-playback/core/scripts/sanity/sanity.rb
@@ -111,6 +111,8 @@ redis_host = props['redis_host']
 redis_port = props['redis_port']
 
 BigBlueButton.logger = Logger.new("#{log_dir}/sanity.log", 'daily' )
+FFMPEG.ffmpeg_binary=("/usr/local/bin/ffmpeg")
+
 begin
 	BigBlueButton.logger.info("Starting sanity check for recording #{meeting_id}.")
 	BigBlueButton.logger.info("Checking events.xml")


### PR DESCRIPTION
the method _ffmpeg_binary_ belongs to the gem ffmpeg-streamio. The sanity script failed with "file not found" before this change.
