### PR TITLE
Support passing through XML extensions in getRecordings

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1503,6 +1503,7 @@ class ApiController {
 							  type(item.getFormat())
 							  url(item.getUrl())
 							  length(item.getLength())
+							  mkp.yield(item.getExtensions())
 						  }
 					  }
                   }

--- a/bigbluebutton-web/src/groovy/org/bigbluebutton/api/RecordingServiceHelperImp.groovy
+++ b/bigbluebutton-web/src/groovy/org/bigbluebutton/api/RecordingServiceHelperImp.groovy
@@ -32,22 +32,25 @@ public class RecordingServiceHelperImp implements RecordingServiceHelper {
 	private static Logger log = LoggerFactory.getLogger(RecordingServiceHelperImp.class);
 	/*
 	<recording>
-		<id>Demo Meeting-3243244</id>
+		<id>6e35e3b2778883f5db637d7a5dba0a427f692e91-1398363221956</id>
 		<state>available</state>
 		<published>true</published>
-		<start_time>3553545445</start_time>
-		<end_time>5674545234</end_time>
+		<start_time>1398363223514</start_time>
+		<end_time>1398363348994</end_time>
 		<playback>
-			<format>simple</format>
-			<link>http://server.com/simple/playback?recordingID=Demo Meeting-3243244</link>
+			<format>presentation</format>
+			<link>http://example.com/playback/presentation/playback.html?meetingID=6e35e3b2778883f5db637d7a5dba0a427f692e91-1398363221956</link>
+			<processing_time>5429</processing_time>
+			<duration>101014</duration>
+			<extension>
+				... Any XML element, to be passed through into playback format element.
+			</extension>
 		</playback>
 		<meta>
-			<title>Test Recording 2</title>
-			<subject>English 232 session</subject>
-			<description>Second  test recording</description>
-			<creator>Omar Shammas</creator>
-			<contributor>Blindside</contributor>
-			<language>en_US</language>
+			<meetingId>English 101</meetingId>
+			<meetingName>English 101</meetingName>
+			<description>Test recording</description>
+			<title>English 101</title>
 		</meta>
 	</recording>
 	*/
@@ -65,6 +68,7 @@ public class RecordingServiceHelperImp implements RecordingServiceHelper {
 				builder.format(info.getPlaybackFormat())
 				builder.link(info.getPlaybackLink())	
 				builder.duration(info.getPlaybackDuration())
+				builder.extension(info.getPlaybackExtensions())
 			}
 			Map<String,String> metainfo = info.getMetadata();
 			builder.meta{
@@ -99,6 +103,7 @@ public class RecordingServiceHelperImp implements RecordingServiceHelper {
 		r.setPlaybackFormat(rec.playback.format.text());
 		r.setPlaybackLink(rec.playback.link.text());
 		r.setPlaybackDuration(rec.playback.duration.text());
+		r.setPlaybackExtensions(rec.playback.extension.children());
 		
 		Map<String, String> meta = new HashMap<String, String>();		
 		rec.meta.children().each { anode ->

--- a/bigbluebutton-web/src/java/org/bigbluebutton/api/MeetingService.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/api/MeetingService.java
@@ -180,14 +180,16 @@ public class MeetingService {
 				
 				plays.add(new Playback(r.getPlaybackFormat(), r.getPlaybackLink(), 
 						getDurationRecording(r.getPlaybackDuration(), 
-								r.getEndTime(), r.getStartTime())));
+								r.getEndTime(), r.getStartTime()),
+						r.getPlaybackExtensions()));
 				r.setPlaybacks(plays);
 				map.put(r.getId(), r);
 			} else {
 				Recording rec = map.get(r.getId());
 				rec.getPlaybacks().add(new Playback(r.getPlaybackFormat(), r.getPlaybackLink(), 
 						getDurationRecording(r.getPlaybackDuration(), 
-								r.getEndTime(), r.getStartTime())));
+								r.getEndTime(), r.getStartTime()),
+						r.getPlaybackExtensions()));
 			}
 		}
 		

--- a/bigbluebutton-web/src/java/org/bigbluebutton/api/domain/Playback.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/api/domain/Playback.java
@@ -18,16 +18,19 @@
 */
 
 package org.bigbluebutton.api.domain;
+import groovy.util.slurpersupport.GPathResult;
 
 public class Playback {
 	private String format;
 	private String url;
 	private int length;
+	private GPathResult extensions;
 	
-	public Playback(String format, String url, int length) {
+	public Playback(String format, String url, int length, GPathResult extensions) {
 		this.format = format;
 		this.url = url;
 		this.length = length;
+		this.extensions = extensions;
 	}
 	public String getFormat() {
 		return format;
@@ -47,6 +50,11 @@ public class Playback {
 	public void setLength(int length) {
 		this.length = length;
 	}
-	
+	public GPathResult getExtensions() {
+		return extensions;
+	}
+	public void setExtensions(GPathResult extensions) {
+		this.extensions = extensions;
+	}
 	
 }

--- a/bigbluebutton-web/src/java/org/bigbluebutton/api/domain/Recording.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/api/domain/Recording.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
+import groovy.util.slurpersupport.GPathResult;
 
 public class Recording {
 	private String id;
@@ -41,6 +42,7 @@ public class Recording {
 	private String playbackLink;
 	private String playbackFormat;
 	private String playbackDuration;
+	private GPathResult playbackExtensions;
 	
 	
 	public String getId() {
@@ -105,6 +107,14 @@ public class Recording {
 	
 	public void setPlaybackDuration(String playbackDuration) {
 		this.playbackDuration = playbackDuration;
+	}
+
+	public GPathResult getPlaybackExtensions() {
+		return playbackExtensions;
+	}
+
+	public void setPlaybackExtensions(GPathResult playbackExtensions) {
+		this.playbackExtensions = playbackExtensions;
 	}
 	
 	public Map<String, String> getMetadata() {


### PR DESCRIPTION
Recording processing scripts can now add arbitrary XML elements in the extensions section of the metadata.xml file, and those element will be copied to the getRecordings XML response.

This is still buggy: Currently, publishing/unpublishing a recording will corrupt the extension XML.
