### PR TITLE
convert graphics to bitmap

### DIFF
--- a/bigbluebutton-web/src/java/org/bigbluebutton/presentation/imp/Pdf2SwfPageConverter.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/presentation/imp/Pdf2SwfPageConverter.java
@@ -44,8 +44,16 @@ public class Pdf2SwfPageConverter implements PageConverter {
 		if (done && destFile.exists()) {
 			return true;		
 		} else {
-			log.warn("Failed to convert: " + dest + " does not exist.");
-			return false;
+			COMMAND = SWFTOOLS_DIR + File.separator + "pdf2swf " + AVM2SWF + " -s poly2bitmap  -F " + fontsDir + " -p " + page + " " + source + " -o " + dest;
+			log.debug("Converting graphics to bitmaps");
+			log.debug("Executing: " + COMMAND);
+			done = new ExternalProcessExecutor().exec(COMMAND, 60000);
+			if (done && destFile.exists()){
+				return true;
+			} else {
+				log.warn("Failed to convert: " + dest + " does not exist.");
+				return false;
+			}
 		}
 		
 	}


### PR DESCRIPTION
Some files are too complex to render and conversion from .pdf to .swf fails. Converting graphics to bitmaps fixes the problem for these files.
