### PR TITLE
Cleaned up the FileUploadWindow

### DIFF
--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -145,6 +145,7 @@ bbb.presentation.maximizeRestoreBtn.accessibilityName = Maximize the Presentatio
 bbb.presentation.closeBtn.accessibilityName = Close the Presentation Window
 bbb.fileupload.title = Add Files to Your Presentation
 bbb.fileupload.fileLbl = Choose File to Upload:
+bbb.fileupload.lblFileName.defaultText = No file selected
 bbb.fileupload.selectBtn.label = Select File
 bbb.fileupload.selectBtn.toolTip = Open dialog box to select a file
 bbb.fileupload.uploadBtn = Upload

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/FileUploadWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/FileUploadWindow.mxml
@@ -22,7 +22,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 <mx:TitleWindow xmlns:mx="http://www.adobe.com/2006/mxml" 
 	xmlns:mate="http://mate.asfusion.com/"
-	 layout="absolute" width="580" height="425" styleName="presentationFileUploadWindowStyle"
+	 layout="absolute" width="580" height="405" styleName="presentationFileUploadWindowStyle"
       initialize="initData();">
 
     <mate:Dispatcher id="globalDispatch" />
@@ -137,7 +137,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       }
 
       private function onSelectFile(e:Event):void{
-        fileTxtInput.text = fileToUpload.name;
+        lblFileName.text = fileToUpload.name;
         uploadBtn.enabled = true;
       }
 
@@ -173,7 +173,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
           okCancelBtn.visible = true;
           selectBtn.enabled = false;
           uploadBtn.enabled = false;
-          fileTxtInput.enabled = false;
+          lblFileName.enabled = false;
 		  
           presentationNamesLb.visible = false;
         }       		
@@ -194,7 +194,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         fileLbl.visible = false;
         selectBtn.visible = false;
         uploadBtn.visible = false;
-        fileTxtInput.visible = false;
+        lblFileName.visible = false;
       }
 
       private function handleOfficeDocumentConversionFailed(e:OfficeDocConvertFailedEvent):void {
@@ -253,7 +253,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         okCancelBtn.visible = true;
         selectBtn.enabled = true;
         uploadBtn.enabled = true;
-        fileTxtInput.enabled = true;			
+        lblFileName.enabled = true;			
       }
 
       private function handleConvertUpdate(e:ConversionUpdateEvent):void{
@@ -273,13 +273,13 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
   </mx:Script>
 
   <mx:VBox width="100%" height="100%" verticalAlign="top">
-    <mx:Label text="{ResourceUtil.getInstance().getString('bbb.fileupload.title')}" styleName="presentationUploadTitleStyle" paddingBottom="12"/>
-    <mx:HBox width="100%" paddingTop="5">
+    <mx:Label text="{ResourceUtil.getInstance().getString('bbb.fileupload.title')}" styleName="presentationUploadTitleStyle" paddingBottom="0"/>
+    <mx:HBox width="100%" paddingTop="0">
       <mx:Label id="fileLbl" text="{ResourceUtil.getInstance().getString('bbb.fileupload.fileLbl')}" styleName="presentationUploadChooseFileLabelStyle"/>
     </mx:HBox>
-    <mx:HBox width="100%" paddingLeft="5" paddingTop="5"> 
-      <mx:TextInput id="fileTxtInput" width="328" editable="false"/>
-	  <mx:Button label="{ResourceUtil.getInstance().getString('bbb.fileupload.selectBtn.label')}" id="selectBtn" 
+    <mx:HBox width="100%" paddingLeft="5" paddingTop="0" verticalAlign="middle"> 
+      <mx:Label id="lblFileName" width="{lblFileName.parent.width-selectBtn.width-uploadBtn.width-30}" selectable="false" click="selectFile()" text="{ResourceUtil.getInstance().getString('bbb.fileupload.lblFileName.defaultText')}" />
+	  <mx:Button id="selectBtn" label="{ResourceUtil.getInstance().getString('bbb.fileupload.selectBtn.label')}" 
 				   toolTip="{ResourceUtil.getInstance().getString('bbb.fileupload.selectBtn.toolTip')}" 
 				   click="selectFile()" styleName="presentationUploadChooseFileButtonStyle"/>
       <mx:Button id="uploadBtn" label="{ResourceUtil.getInstance().getString('bbb.fileupload.uploadBtn')}" 

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/UploadedPresentationRenderer.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/UploadedPresentationRenderer.mxml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<mx:HBox xmlns:mx="http://www.adobe.com/2006/mxml" width="90%" verticalScrollPolicy="off" horizontalScrollPolicy="off" toolTip="{data as String}">
+<mx:HBox xmlns:mx="http://www.adobe.com/2006/mxml" 
+		 width="90%" 
+		 verticalScrollPolicy="off" 
+		 horizontalScrollPolicy="off" 
+		 toolTip="{data as String}" 
+		 verticalAlign="middle">
   <mx:Script>
     <![CDATA[
       import com.asfusion.mate.events.Dispatcher;
@@ -28,10 +33,10 @@
       }
     ]]>
   </mx:Script>
-  <mx:Label id="presentationNameLabel" width="420" text="{data.name as String}" styleName="presentationNameLabelStyle"/>
+  <mx:Label id="presentationNameLabel" width="{this.width-showBtn.width-deleteBtn.width-30}" text="{data.name as String}" styleName="presentationNameLabelStyle"/>
   <mx:Button id="showBtn" label="{ResourceUtil.getInstance().getString('bbb.fileupload.showBtn')}" 
              toolTip="{ResourceUtil.getInstance().getString('bbb.fileupload.showBtn.toolTip')}" 
-             styleName="presentationUploadShowButtonStyle"
+             styleName="presentationUploadShowButtonStyle" height="26"
              click="showPresentation()" enabled="true"/>
   <mx:Button id="deleteBtn" label="" toolTip="{ResourceUtil.getInstance().getString('bbb.fileupload.deleteBtn.toolTip')}" 
              styleName="presentationUploadDeleteButtonStyle"


### PR DESCRIPTION
Previously the window couldn't handle long file names or languages with words longer than their English counterparts. I changed the widths to better handle the differences. I also made the window a little shorter because there was a lot of empty space.

This pull request enables the clicking of the file name label to spawn the native file upload dialog box. This keeps the functionality more in-line with the HTML equivalent.
