### PR TITLE
Presentation name is displayed instead of empty string

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/model/PresentationModel.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/model/PresentationModel.as
@@ -79,7 +79,7 @@ package org.bigbluebutton.modules.present.model
     public function getCurrentPresentationName():String {
       for (var i:int = 0; i < _presentations.length; i++) {
         var pres: Presentation = _presentations.getItemAt(i) as Presentation;
-        if (pres.current) return pres.id;
+        if (pres.current) return pres.name;
       }   
       
       return null;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -369,24 +369,25 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				}
 				displaySlideNavigationControls(isPresenter);
 			}
-					
-			private function handlePresentationChangedEvent(e:PresentationChangedEvent):void {	
-        var newPresName:String =  PresentationModel.getInstance().getCurrentPresentationName();
-        
-      	slideView.setSlides();    		            		
-				slideView.visible = true;		
-	      var page:Page = PresentationModel.getInstance().getCurrentPage();
-        if (page != null) {
-          displaySlideNumber(page.num);
-        }
-					      
-				if (UsersUtil.amIPresenter()) {
-					displaySlideNavigationControls(true);					
-				} else {
-          displaySlideNavigationControls(false)
-				}
-				onResetZoom();
-			}
+            private function handlePresentationChangedEvent(e:PresentationChangedEvent) : void {
+				currentPresentation = PresentationModel.getInstance().getCurrentPresentationName();
+
+                slideView.setSlides();
+                slideView.visible = true;
+                var page : Page = PresentationModel.getInstance().getCurrentPage();
+                if (page != null) {
+                    displaySlideNumber(page.num);
+                }
+
+                if (UsersUtil.amIPresenter()) {
+                    displaySlideNavigationControls(true);
+                }
+                else {
+                    displaySlideNavigationControls(false)
+                }
+                onResetZoom();
+            }
+
 			
 			private function displaySlideNavigationControls(show:Boolean):void {
 				backButton.visible = show;


### PR DESCRIPTION
The presentation name is displayed again, no empty string after the colon
