### PR TITLE
applied a fix to global audio so that leaving notifies clients correctly

### DIFF
--- a/bigbluebutton-apps/src/main/java/org/bigbluebutton/conference/meeting/messaging/redis/MeetingMessageHandler.java
+++ b/bigbluebutton-apps/src/main/java/org/bigbluebutton/conference/meeting/messaging/redis/MeetingMessageHandler.java
@@ -59,7 +59,7 @@ public class MeetingMessageHandler implements MessageHandler {
 				} else if (msg instanceof UserDisconnectedFromGlobalAudio) {
 					UserDisconnectedFromGlobalAudio emm = (UserDisconnectedFromGlobalAudio) msg;
 					log.debug("Received UserDisconnectedFromGlobalAudio toekn request. Meeting id [{}]", emm.name);
-					bbbGW.userConnectedToGlobalAudio(emm.voiceConf, emm.userid, emm.name);
+					bbbGW.userDisconnectedFromGlobalAudio(emm.voiceConf, emm.userid, emm.name);
 				}
 			}
 		} else if (channel.equalsIgnoreCase(MessagingConstants.TO_SYSTEM_CHANNEL)) {

--- a/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
+++ b/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
@@ -42,7 +42,7 @@ trait UsersApp {
   }
   
   def handleUserDisconnectedFromGlobalAudio(msg: UserDisconnectedFromGlobalAudio) {
-//    println("*************** Got UserDisconnectedToGlobalAudio message for [" + msg.name + "] ********************" )
+    println("*************** Got UserDisconnectedToGlobalAudio message for [" + msg.name + "] ********************" )
     val user = users.getUser(msg.userid)
     user foreach {u =>
       val uvo = u.copy(listenOnly=false)


### PR DESCRIPTION
This pull request fixes the issue where leaving the global audio doesn't send the correct message to the clients. The fix was taken from the following commit, https://github.com/pedrobmarin/bigbluebutton/commit/24398a13c879b0f6af7ae9ac8151dfe6dca2ebbe.
