### PR TITLE
fixed a bug where panning was too fast

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/models/SlideViewModel.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/models/SlideViewModel.as
@@ -190,8 +190,8 @@ package org.bigbluebutton.modules.present.ui.views.models
 		}
 		
 		public function onMove(deltaX:Number, deltaY:Number):void {
-			_calcPageX += deltaX;
-			_calcPageY += deltaY;
+			_calcPageX += deltaX / MYSTERY_NUM;
+			_calcPageY += deltaY / MYSTERY_NUM;
 			
 			onResizeMove();	
 			calcViewedRegion();


### PR DESCRIPTION
When you panned with your mouse the presentation would move twice as far as your mouse. This pull request divides the move values by two which keeps the presentation under the mouse correctly.
