### PR TITLE
Actually fix slide indexes.

### DIFF
--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -533,10 +533,10 @@ def processSlideEvents
 			slide_timestamp =  node[:timestamp]
 			slide_start = ( translateTimestamp(slide_timestamp) / 1000 ).round(1)
 			orig_slide_start = ( slide_timestamp.to_f / 1000 ).round(1)
-			slide_number = node.xpath(".//slide")[0].text()
-                        slide_number = slide_number.to_i < 0 ? "0" : slide_number
-			slide_src = "presentation/#{$presentation_name}/slide-#{slide_number.to_i}.png"
-                        txt_file_path = "presentation/#{$presentation_name}/textfiles/slide-#{slide_number.to_i}.txt"
+			slide_number = node.xpath(".//slide")[0].text().to_i
+                        slide_number = slide_number < 0 ? 0 : slide_number
+			slide_src = "presentation/#{$presentation_name}/slide-#{slide_number + 1}.png"
+                        txt_file_path = "presentation/#{$presentation_name}/textfiles/slide-#{slide_number + 1}.txt"
                         slide_text = File.exist?("#{$process_dir}/#{txt_file_path}") ? txt_file_path : nil
 			image_url = "#{$process_dir}/#{slide_src}"
 


### PR DESCRIPTION
While the page numbers from BigBlueButton are zero-based, the slide images and text files
are generated as 1-based.
