### PR TITLE
Multiple fixes to the presentation module

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/maps/PresentEventMap.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/maps/PresentEventMap.mxml
@@ -126,10 +126,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	<EventHandlers type="{RemovePresentationEvent.REMOVE_PRESENTATION_EVENT}">
 		<MethodInvoker generator="{PresentProxy}" method="removePresentation" arguments="{event}" />
 	</EventHandlers>
- 
-	<EventHandlers type="{RemovePresentationEvent.PRESENTATION_REMOVED_EVENT}">
-		<MethodInvoker generator="{PresentManager}" method="removePresentation" arguments="{event}" />
-	</EventHandlers>
 	
   <EventHandlers type="{ChangePresentationCommand.CHANGE_PRESENTATION}">
     <MethodInvoker generator="{PresentProxy}" method="handleChangePresentationCommand" arguments="{event}" />

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/services/PresentationService.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/services/PresentationService.as
@@ -157,7 +157,9 @@ package org.bigbluebutton.modules.present.services
 		removedEvent.presentationName = presentationID;
 		dispatcher.dispatchEvent(removedEvent);
 		
-		if(presentationID == model.getCurrentPresentation().id) {
+		var currPresentation:Presentation = model.getCurrentPresentation();
+		
+		if(currPresentation && presentationID == currPresentation.id) {
 			var uploadEvent:UploadEvent = new UploadEvent(UploadEvent.CLEAR_PRESENTATION);
 			dispatcher.dispatchEvent(uploadEvent);
 		}

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -361,7 +361,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				if (page != null) {
 					displaySlideNumber(page.num);		
 				}
-				displaySlideNavigationControls(isPresenter);
+				displaySlideNavigationControls(isPresenter, !!page);
 			}
             private function handlePresentationChangedEvent(e:PresentationChangedEvent) : void {
 				currentPresentation = PresentationModel.getInstance().getCurrentPresentationName();
@@ -374,23 +374,26 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
                 }
 
                 if (UsersUtil.amIPresenter()) {
-                    displaySlideNavigationControls(true);
+                    displaySlideNavigationControls(true, !!page);
                 }
                 else {
-                    displaySlideNavigationControls(false)
+                    displaySlideNavigationControls(false, !!page)
                 }
                 onResetZoom();
             }
 
 			
-			private function displaySlideNavigationControls(show:Boolean):void {
-				backButton.visible = show;
-				forwardButton.visible = show;
-				zoomSlider.visible = show;
-				btnSlideNum.visible = show;
-				btnFitToWidth.visible = show;
-				btnFitToPage.visible = show;
-				if(show) {
+			private function displaySlideNavigationControls(isPresenter:Boolean, activePresentation:Boolean):void {
+				var showButtons:Boolean = isPresenter && activePresentation;
+				
+				backButton.visible = showButtons;
+				forwardButton.visible = showButtons;
+				zoomSlider.visible = showButtons;
+				btnSlideNum.visible = showButtons;
+				btnFitToWidth.visible = showButtons;
+				btnFitToPage.visible = showButtons;
+				
+				if(isPresenter) {
 					CONTROL_BAR_HEIGHT = 45;
 				} else {
 					CONTROL_BAR_HEIGHT = 0;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/UploadedPresentationRenderer.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/UploadedPresentationRenderer.mxml
@@ -37,7 +37,7 @@
   <mx:Button id="showBtn" label="{ResourceUtil.getInstance().getString('bbb.fileupload.showBtn')}" 
              toolTip="{ResourceUtil.getInstance().getString('bbb.fileupload.showBtn.toolTip')}" 
              styleName="presentationUploadShowButtonStyle" height="26"
-             click="showPresentation()" enabled="true"/>
+             click="showPresentation()" enabled="{!data.current}"/>
   <mx:Button id="deleteBtn" label="" toolTip="{ResourceUtil.getInstance().getString('bbb.fileupload.deleteBtn.toolTip')}" 
              styleName="presentationUploadDeleteButtonStyle"
              click="deletePresentation()" visible="{String(data.name) != 'default.pdf'}"/>


### PR DESCRIPTION
- Fixed a crash related to deleting presentations
- Hid the presenter buttons in the PresentationWindow when there's no presentation to show
- Disabled the "Show" button in the FileUploadWindow for the current presentation
- Cleaned up an event listener that wasn't used anymore
