### PR TITLE
Added a SDP hack for Firefox to replace the 0.0.0.0 in the c line

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/sip.js
+++ b/bigbluebutton-client/resources/prod/lib/sip.js
@@ -2526,6 +2526,15 @@ var Hacks = module.exports = {
         }
       }
       return sdp;
+    },
+
+    hackCLinInIP: function (sdp) {
+      /* Starting in Firefox 34 they have set the c line to 0.0.0.0 which
+       * means "hold" according to legacy SIP standards and Freeswitch
+       * interprets it according to the SIP standards. We replace the
+       * 0.0.0.0 with any other IP so that the call continues.
+       */
+      return sdp.replace("c=IN IP4 0.0.0.0", "c=IN IP4 127.0.0.1");
     }
   },
 
@@ -6036,6 +6045,9 @@ InviteClientContext.prototype = {
           if (self.isCanceled || self.status === C.STATUS_TERMINATED) {
             return;
           }
+
+          offer = SIP.Hacks.Firefox.hackCLinInIP(offer);
+
           self.hasOffer = true;
           self.request.body = offer;
           self.status = C.STATUS_INVITE_SENT;


### PR DESCRIPTION
In Firefox 34+ they have decided to set the "c" line in the SDP to 0.0.0.0 and in legacy SIP an IP of 0.0.0.0 means "hold the call". Freeswitch interprets this hold by not sending audio back. My patch makes replaces the 0.0.0.0 with 127.0.0.1 which causes Freeswitch to handle the request appropriately.

It's possible that Freeswitch or SIP.js will fix the problem at some point on their own ends, but this is my hack to make sure that WebRTC works when Firefox 34 is released.
