### PR TITLE
 - for some reason we either (a) get duplicate events for user join from...

### DIFF
--- a/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersModel.scala
+++ b/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersModel.scala
@@ -43,6 +43,10 @@ class UsersModel {
     uservos.values find (u => u.externUserID == userID) 
   }
     
+  def getUserWithVoiceUserId(voiceUserId: String):Option[UserVO] = {
+    uservos.values find (u => u.voiceUser.userId == voiceUserId)  
+  }
+    
   def getUser(userID:String):Option[UserVO] = {
     uservos.values find (u => u.userID == userID) 
   }


### PR DESCRIPTION
... FS or (b) FS-ESL isn't handling

   the event properly. This results in duplicate entries on the user's list when user calls in from the
   phone. Check if a voice user with the same id is already in the voice conference and ignore the second
   event.
