### PR TITLE
Recording notification configurable by the config.xml

### DIFF
--- a/bigbluebutton-client/resources/config.xml.template
+++ b/bigbluebutton-client/resources/config.xml.template
@@ -12,7 +12,8 @@
     <shortcutKeys showButton="true" />
     <layout showLogButton="false" showVideoLayout="false" showResetLayout="true" defaultLayout="bbb.layout.name.defaultlayout"
             showToolbar="true" showFooter="true" showMeetingName="true" showHelpButton="true" 
-            showLogoutWindow="true" showLayoutTools="true" showNetworkMonitor="false" confirmLogout="true"/>
+            showLogoutWindow="true" showLayoutTools="true" showNetworkMonitor="false" confirmLogout="true"
+            showRecordingNotification="true"/>
     <lock allowModeratorLocking="false" disableCamForLockedUsers="false" disableMicForLockedUsers="false" disablePrivateChatForLockedUsers="false" 
           disablePublicChatForLockedUsers="false" lockLayoutForLockedUsers="false"/>
             

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/LayoutOptions.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/LayoutOptions.as
@@ -34,6 +34,7 @@ package org.bigbluebutton.main.model
 		[Bindable] public var showLayoutTools:Boolean = true;
 		[Bindable] public var showNetworkMonitor:Boolean = true;
 		[Bindable] public var confirmLogout:Boolean = true;
+		[Bindable] public var showRecordingNotification:Boolean = true;
 		
 		
     public var defaultLayout:String = "Default";
@@ -93,6 +94,9 @@ package org.bigbluebutton.main.model
 			showNetworkMonitor = (vxml.@showNetworkMonitor.toString().toUpperCase() == "TRUE") ? true : false;
 		}
 		
+		if(vxml.@showRecordingNotification != undefined){
+			showRecordingNotification = (vxml.@showRecordingNotification.toString().toUpperCase() == "TRUE") ? true : false;
+		}
 			}
 		}
 		

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/RecordButton.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/RecordButton.mxml
@@ -48,12 +48,14 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       import org.bigbluebutton.core.managers.UserManager;
       import org.bigbluebutton.core.model.MeetingModel;
       import org.bigbluebutton.main.events.BBBEvent;
+      import org.bigbluebutton.main.model.LayoutOptions;
       import org.bigbluebutton.modules.phone.events.FlashJoinedVoiceConferenceEvent;
       import org.bigbluebutton.modules.phone.events.WebRTCCallEvent;
       import org.bigbluebutton.util.i18n.ResourceUtil;
 
 			private var recordingFlag:Boolean;
 			private var firstAudioJoin:Boolean = true;
+			private var layoutOptions:LayoutOptions = null;
 			
 			[Embed(source="/org/bigbluebutton/common/assets/images/record.png")]
 			private var recordReminderIcon:Class;
@@ -136,9 +138,15 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 			
 			private function showRecordingNotification():void {
+				if (layoutOptions == null) {
+					layoutOptions = new LayoutOptions();
+					layoutOptions.parseOptions();
+				}
+
 				if (firstAudioJoin && this.visible && !this.selected 
-            && UserManager.getInstance().getConference().amIModerator()
-            && MeetingModel.getInstance().meeting.allowStartStopRecording) {
+						&& layoutOptions.showRecordingNotification
+						&& UserManager.getInstance().getConference().amIModerator()
+						&& MeetingModel.getInstance().meeting.allowStartStopRecording) {
 					var alert:Alert = Alert.show(ResourceUtil.getInstance().getString("bbb.mainToolbar.recordBtn..notification.message1") + "\n\n" + ResourceUtil.getInstance().getString("bbb.mainToolbar.recordBtn..notification.message2"), ResourceUtil.getInstance().getString("bbb.mainToolbar.recordBtn..notification.title"), Alert.OK, this);
 					alert.titleIcon = recordReminderIcon;
 					


### PR DESCRIPTION
The notification shows up to remind the moderator to click the record button and start the recording, but for more experienced users it may be disturbing, since it's an extra click to start interacting in the session, and it shows up on every session.
