### PR TITLE
recording: Strip out the 'event:' from the beginning of urls in chat

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -398,6 +398,7 @@ module BigBlueButton
       s = text.to_s
       s.gsub!( generic_URL_regexp, '\1<a href="\2">\2</a>' )
       s.gsub!( starts_with_www_regexp, '\1<a href="http://\2">\2</a>' )
+      s.gsub!('href="event:', 'href="')
       s
     end
 


### PR DESCRIPTION
Fixes https://code.google.com/p/bigbluebutton/issues/detail?id=1843
