### PR TITLE
Use hostname instead of host on javascript webrtc bridge client code

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/bbb_webrtc_bridge_sip.js
+++ b/bigbluebutton-client/resources/prod/lib/bbb_webrtc_bridge_sip.js
@@ -238,7 +238,7 @@ function webrtc_call(username, voiceBridge, callback) {
 		return;
 	}
 	
-	var server = window.document.location.host;
+	var server = window.document.location.hostname;
 	console.log("user " + username + " calling to " +  voiceBridge);
 	
 	if (!userAgent) {


### PR DESCRIPTION
This prevents it from appending the port number when a request is made from
the HTML5 client
