### PR TITLE
Three fixes for audio in the Flash client

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MuteMeButton.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MuteMeButton.mxml
@@ -77,7 +77,7 @@ $Id: $
 					if (e.message.talking){
 						muteMeBtnImg.filters = [new GlowFilter(0x000000, 1, 6, 6, 2, BitmapFilterQuality.HIGH, false, false)];
 					} else {
-						muteMeBtnImg.filters = [new GlowFilter(0x555555, 1, 6, 6, 2, BitmapFilterQuality.HIGH, true, true)];
+						muteMeBtnImg.filters = [];
 					}
 				}
 			}
@@ -98,7 +98,8 @@ $Id: $
       private function handleJoinedVoiceConferenceEvent(event:BBBEvent):void {
         if (UsersUtil.isMe(event.payload.userID)) {
           trace(LOG + "User has joined the conference using flash");
-          updateMuteMeBtn();          
+          updateMuteMeBtn();
+          muteMeBtnImg.filters = [];
         }
       }
          

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/WebRTCCallManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/WebRTCCallManager.as
@@ -58,6 +58,8 @@ package org.bigbluebutton.modules.phone.managers
           ResourceUtil.getInstance().getString("bbb.clientstatus.webrtc.title"), 
           ResourceUtil.getInstance().getString("bbb.clientstatus.webrtc.message")));
       }
+      
+      usingWebRTC = checkIfToUseWebRTC();
     }
     
     private function isWebRTCSupported():Boolean {
@@ -144,8 +146,6 @@ package org.bigbluebutton.modules.phone.managers
     
     public function handleJoinVoiceConferenceCommand(event:JoinVoiceConferenceCommand):void {
       trace(LOG + "handleJoinVoiceConferenceCommand - usingWebRTC: " + usingWebRTC + ", event.mic: " + event.mic);
-      
-      usingWebRTC = checkIfToUseWebRTC();
       
       if (!usingWebRTC || !event.mic) return;
       

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/MediaItemRenderer.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/MediaItemRenderer.mxml
@@ -191,7 +191,7 @@
 							if(data.talking && !rolledOver){
 								muteImg.filters = [new GlowFilter(0x000000, 1, 6, 6, 2, BitmapFilterQuality.HIGH, false, false)];
 							}else{
-								muteImg.filters = [new GlowFilter(0x555555, 1, 6, 6, 2, BitmapFilterQuality.HIGH, true, true)];
+								muteImg.filters = [];
 							}
 						}
 					}


### PR DESCRIPTION
Includes:
* fix for issue 1868 (https://code.google.com/p/bigbluebutton/issues/detail?id=1868)
* if you left the audio while talking the MuteMeButton stayed glowing when you rejoined - fixed now
* removed the non-visible glow when not talking from MuteMeButton and MediaItemRenderer