### PR TITLE
Added extra webcam warning for Chrome users

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/CameraDisplaySettings.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/CameraDisplaySettings.mxml
@@ -259,6 +259,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				//        controls.btnStartPublish.enabled = true;
 				_waitingForActivation = false;
 				btnStartPublish.enabled = true;
+				_videoHolder.imgChromeHelp.visible = false;
 			}
 		}
 		
@@ -293,6 +294,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		
 		private function activationTimeout(e:TimerEvent):void {
 			_videoHolder.showWarning('bbb.video.publish.hint.cameraIsBeingUsed');
+			
+			//check for Chrome and show image
+			var browserType:Array = ExternalInterface.call('determineBrowser');
+			if (browserType[0] == "Chrome") {
+				_videoHolder.imgChromeHelp.visible = true;
+			}
 		} 
 		
 		private function showCameraSettings():void {

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/VideoHolder.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/VideoHolder.mxml
@@ -71,7 +71,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
   <mx:Fade id="dissolveIn" duration="1000" alphaFrom="0.0" alphaTo="1.0"/>
   
   <mx:UIComponent id="_videoHolder"/>
-  
+  <mx:Image id="imgChromeHelp" y="60" x="{this.width/2 - imgChromeHelp.width/2}" visible="false"
+			source="@Embed('assets/chrome-allow-mic-access.png')"/>
   <mx:Text id="lblWarning" width="100%" textAlign="center" fontSize="14" fontWeight="bold" 
            y="{this.height - lblWarning.height - 30}" 
            visible="true" selectable="false" hideEffect="{dissolveOut}" showEffect="{dissolveIn}"/>


### PR DESCRIPTION
Sometimes users miss the "Allow" button when trying to share their webcam from Chrome. After 10 seconds the activation timer expires and a warning is shown for "Camera already in use", but the user just has to click on the Allow button. This pull request adds an additional image showing the user the button when the activation timer expires.