### PR TITLE
bbb-record: also delete the sanity '.fail' file on --rebuild

### DIFF
--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -66,6 +66,7 @@ mark_for_rebuild() {
 
 	# Clear out all the done files
 	rm -vf $STATUS/sanity/$MEETING_ID.done
+	rm -vf $STATUS/sanity/$MEETING_ID.fail
 	for type in $TYPES; do
 		rm -vf $STATUS/published/$MEETING_ID-$type.fail
 		rm -vf $STATUS/published/$MEETING_ID-$type.done


### PR DESCRIPTION
This allows a rebuild to redo the sanity check if needed.