### PR TITLE
Implement issue 1863

### DIFF
--- a/bigbluebutton-client/resources/config.xml.template
+++ b/bigbluebutton-client/resources/config.xml.template
@@ -6,7 +6,8 @@
     <javaTest url="http://HOST/testjava.html"/>
     <porttest host="HOST" application="video/portTest" timeout="10000"/>    
     <bwMon server="HOST" application="video/bwTest"/>
-    <application uri="rtmp://HOST/bigbluebutton" host="http://HOST/bigbluebutton/api/enter" />
+    <application uri="rtmp://HOST/bigbluebutton" host="http://HOST/bigbluebutton/api/enter" 
+                  stuns="http://HOST/bigbluebutton/api/stuns"/>
     <language userSelectionEnabled="true" />
     <skinning enabled="true" url="http://HOST/client/branding/css/BBBDefault.css.swf" />
     <shortcutKeys showButton="true" />

--- a/bigbluebutton-client/src/org/bigbluebutton/core/model/Config.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/model/Config.as
@@ -62,6 +62,7 @@ package org.bigbluebutton.core.model
 			var a:Object = new Object();
 			a.uri = config.application.@uri;
 			a.host = config.application.@host;
+      a.stuns = config.application.@stuns;
 			return a;
 		}
 		

--- a/bigbluebutton-client/src/org/bigbluebutton/core/model/MeetingModel.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/model/MeetingModel.as
@@ -11,6 +11,7 @@ package org.bigbluebutton.core.model
     private var _meetingMuted:Boolean = false;
     private var _lockSettings:LockSettingsVO;
     private var _modOnlyMessage:String = null;
+    private var _stunAndTurnServers: Object = new Object();
     
     public function MeetingModel(enforcer: MeetingModelSingletonEnforcer)
     {
@@ -28,6 +29,14 @@ package org.bigbluebutton.core.model
     
     public function set meeting(value: Meeting):void {
       _meeting = value;
+    }
+    
+    public function set stunAndTurnServers(value: Object):void {
+      _stunAndTurnServers = value;
+    }
+    
+    public function get stunAndTurnServers():Object {
+      return _stunAndTurnServers;
     }
     
     public function get meeting():Meeting {

--- a/bigbluebutton-client/src/org/bigbluebutton/core/model/StunOption.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/model/StunOption.as
@@ -1,0 +1,13 @@
+package org.bigbluebutton.core.model
+{
+  import org.bigbluebutton.core.BBB;
+  
+  public class StunOption
+  {
+    public var stuns: String = "";
+    
+    public function parseOptions():void {
+      stuns =  BBB.initConfigManager().config.application.stuns;
+    }
+  }
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/JoinService.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/JoinService.as
@@ -149,9 +149,26 @@ package org.bigbluebutton.main.model.users
         
 				if (_resultListener != null) _resultListener(true, response);
 			}
-				
+			
+      loadStuns();
 		}
 		
+    private function loadStuns():void {
+      request = new URLRequest("http://192.168.23.3/bigbluebutton/api/stuns");
+      request.method = URLRequestMethod.GET;		
+      
+      urlLoader.removeEventListener(Event.COMPLETE, handleComplete);
+      urlLoader.addEventListener(Event.COMPLETE, handleCompleteStuns);
+      urlLoader.addEventListener(HTTPStatusEvent.HTTP_STATUS, httpStatusHandler);
+      urlLoader.addEventListener(IOErrorEvent.IO_ERROR, ioErrorHandler);
+      urlLoader.load(request);	      
+    }
+    
+    private function handleCompleteStuns(e:Event):void {			
+      var result:Object = JSON.parse(e.target.data);
+      trace(LOG + "Stun response = " + JSON.stringify(result));
+    }
+    
 		public function get loader():URLLoader{
 			return this.urlLoader;
 		}

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -125,7 +125,7 @@ allowStartStopRecording=true
 #----------------------------------------------------
 # This URL is where the BBB client is accessible. When a user sucessfully
 # enters a name and password, she is redirected here to load the client.
-bigbluebutton.web.serverURL=http://192.168.153.149
+bigbluebutton.web.serverURL=http://192.168.23.3
 
 
 #----------------------------------------------------
@@ -149,7 +149,7 @@ defaultConfigURL=${bigbluebutton.web.serverURL}/client/conf/config.xml
 apiVersion=0.9
 
 # Salt which is used by 3rd-party apps to authenticate api calls
-securitySalt=f49af027bcdf2c3f7fbc4066d8cf9567
+securitySalt=778818ef77e83a9b1cab2fd7c908e975
 
 # Directory where we drop the <meeting-id-recorded>.done file
 recordStatusDir=/var/bigbluebutton/recording/status/recorded
@@ -203,3 +203,17 @@ accessControlAllowOrigin=${bigbluebutton.web.serverURL}
 # The lapsus of seconds for polling the BBB Server in order to check if it's down.
 # After 5 tries if there isn't response, it will be declared down
 checkBBBServerEvery=10
+
+# Stun Servers
+stun1.url=stun:example.org
+stun2.url=stuns:example.org
+
+# Turn Servers
+turn1.secret=Turn1Secret
+turn1.url=turn1.example.org
+turn1.ttl=86400
+turn2.secret=Turn2Secret
+turn2.url=turn2.example.org
+turn2.ttl=86400
+        
+

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -92,4 +92,5 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	<import resource="doc-conversion.xml" />
 	<import resource="bbb-redis-pool.xml" />
 	<import resource="bbb-redis-messaging.xml" />
+	<import resource="turn-stun-servers.xml" />
 </beans>

--- a/bigbluebutton-web/grails-app/conf/spring/turn-stun-servers.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/turn-stun-servers.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+
+Copyright (c) 2012 BigBlueButton Inc. and by respective authors (see below).
+
+This program is free software; you can redistribute it and/or modify it under the
+terms of the GNU Lesser General Public License as published by the Free Software
+Foundation; either version 3.0 of the License, or (at your option) any later
+version.
+
+BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
+			http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+			">  
+				
+	<bean id="turn1" class="org.bigbluebutton.web.services.turn.TurnServer">
+      <constructor-arg index="0" value="${turn1.secret}"/>
+      <constructor-arg index="1" value="${turn1.url}"/>
+      <constructor-arg index="2" value="${turn1.ttl}"/>
+	</bean>	
+
+  <bean id="turn2" class="org.bigbluebutton.web.services.turn.TurnServer">
+      <constructor-arg index="0" value="${turn2.secret}"/>
+      <constructor-arg index="1" value="${turn2.url}"/>
+      <constructor-arg index="2" value="${turn2.ttl}"/>
+  </bean> 
+  
+  <bean id="stun1" class="org.bigbluebutton.web.services.turn.StunServer">
+      <constructor-arg index="0" value="${stun1.url}"/>
+  </bean> 
+  
+  <bean id="stun2" class="org.bigbluebutton.web.services.turn.StunServer">
+      <constructor-arg index="0" value="${stun2.url}"/>
+  </bean> 
+  		
+	<bean id="stunTurnService" class="org.bigbluebutton.web.services.turn.StunTurnService">
+		<property name="stunServers">
+        <set>
+          <ref bean="stun1" />  
+          <ref bean="stun2" />       
+        </set>
+     </property> 
+     <property name="turnServers">
+        <set>
+          <ref bean="turn1" />  
+          <ref bean="turn2" />            
+        </set>
+     </property> 
+	</bean>	
+</beans>

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1453,7 +1453,7 @@ class ApiController {
       }
     } else {
       Set<String> stuns = stunTurnService.getStunServers()
-      Set<TurnEntry> turns = stunTurnService.getStunAndTurnServersFor("richard")
+      Set<TurnEntry> turns = stunTurnService.getStunAndTurnServersFor(us.internalUserId)
       
       response.addHeader("Cache-Control", "no-cache")
       withFormat {

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -33,6 +33,8 @@ import org.bigbluebutton.api.domain.UserSession;
 import org.bigbluebutton.api.MeetingService;
 import org.bigbluebutton.api.domain.Recording;
 import org.bigbluebutton.web.services.PresentationService
+import org.bigbluebutton.web.services.turn.StunTurnService;
+import org.bigbluebutton.web.services.turn.TurnEntry;
 import org.bigbluebutton.presentation.PresentationUrlDownloadService;
 import org.bigbluebutton.presentation.UploadedPresentation
 import java.security.MessageDigest;
@@ -58,8 +60,9 @@ class ApiController {
   MeetingService meetingService;
   PresentationService presentationService
   ParamsProcessorUtil paramsProcessorUtil
-	ClientConfigService configService
-	PresentationUrlDownloadService presDownloadService
+  ClientConfigService configService
+  PresentationUrlDownloadService presDownloadService
+  StunTurnService stunTurnService
 	
   /* general methods */
   def index = {
@@ -1390,6 +1393,95 @@ class ApiController {
       }
       }  
   }
+
+  /***********************************************
+   * STUN/TURN API
+   ***********************************************/
+  def stuns = {
+    boolean reject = false;
+
+    UserSession us = null;
+    Meeting meeting = null;
+
+    if (!session["user-token"]) {
+      reject = true;
+    } else {
+      if (meetingService.getUserSession(session['user-token']) == null)
+        reject = true;
+      else {
+        us = meetingService.getUserSession(session['user-token']);
+        meeting = meetingService.getMeeting(us.meetingID);
+        if (meeting == null || meeting.isForciblyEnded()) {
+          reject = true
+        }
+      }
+    }
+
+    if (reject) {
+      log.info("No session for user in conference.")
+
+      // Determine the logout url so we can send the user there.
+      String logoutUrl = session["logout-url"]
+
+      if (! session['meeting-id']) {
+        meeting = meetingService.getMeeting(session['meeting-id']);
+      }
+
+      // Log the user out of the application.
+      session.invalidate()
+
+      if (meeting != null) {
+        log.debug("Logging out from [" + meeting.getInternalId() + "]");
+        logoutUrl = meeting.getLogoutUrl();
+      }
+
+      if (StringUtils.isEmpty(logoutUrl)) {
+        logoutUrl = paramsProcessorUtil.getDefaultLogoutUrl()
+      }
+      
+      response.addHeader("Cache-Control", "no-cache")
+      withFormat {
+        json {
+          render(contentType: "application/json") {
+            response = {
+              returncode = "FAILED"
+              message = "Could not find conference."
+              logoutURL = logoutUrl
+            }
+          }
+        }
+      }
+    } else {
+      Set<String> stuns = stunTurnService.getStunServers()
+      Set<TurnEntry> turns = stunTurnService.getStunAndTurnServersFor("richard")
+      
+      response.addHeader("Cache-Control", "no-cache")
+      withFormat {
+        json {
+          render(contentType: "application/json") {
+              stunServers = array {
+                stuns.each { stun ->
+                  stunData = {
+                    url = stun.url
+                  }
+                }
+              }
+              turnServers = array {
+                turns.each { turn -> 
+                  turnData = {
+                     username = turn.username
+                     password = turn.password
+                     url = turn.url
+                     ttl = turn.ttl 
+                   }
+                }
+              }
+            }
+          }
+        }
+      }
+  }
+
   
   /*************************************************
    * SIGNOUT API

--- a/bigbluebutton-web/src/java/org/bigbluebutton/web/services/turn/StunServer.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/web/services/turn/StunServer.java
@@ -1,0 +1,10 @@
+package org.bigbluebutton.web.services.turn;
+
+public class StunServer {
+
+  public final String url;
+  
+  public StunServer(String url) {
+    this.url = url;
+  }
+}

--- a/bigbluebutton-web/src/java/org/bigbluebutton/web/services/turn/StunTurnService.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/web/services/turn/StunTurnService.java
@@ -1,0 +1,36 @@
+package org.bigbluebutton.web.services.turn;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class StunTurnService {
+
+  private Set<StunServer> stunServers;
+  private Set<TurnServer> turnServers;
+
+  public Set<StunServer> getStunServers() {
+    return stunServers;
+  }
+
+  public Set<TurnEntry> getStunAndTurnServersFor(String userId) {
+    Set<TurnEntry> turns = new HashSet<TurnEntry>();
+
+    for (TurnServer ts : turnServers) {
+      TurnEntry entry = ts.generatePasswordFor(userId);
+      if (entry != null) {
+        turns.add(entry);
+      }
+    }
+    
+    return turns;
+  }
+
+  public void setStunServers(Set<StunServer> stuns) {
+    stunServers = stuns;
+  }
+
+  public void setTurnServers(Set<TurnServer> turns) {
+    turnServers = turns;
+  }
+
+}

--- a/bigbluebutton-web/src/java/org/bigbluebutton/web/services/turn/TurnEntry.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/web/services/turn/TurnEntry.java
@@ -1,0 +1,33 @@
+package org.bigbluebutton.web.services.turn;
+
+public class TurnEntry {
+
+  public final String username;
+  public final String url;
+  public final String password;
+  public final int ttl;
+  
+  public TurnEntry(String username, String password, int ttl, String url) {
+    this.username = username;
+    this.url = url;
+    this.password = password;
+    this.ttl = ttl;
+  }
+/*  
+  public String getUsername() {
+    return username;
+  }
+  
+  public String getUrl() {
+    return url;
+  }
+  
+  public String getPassord() {
+    return password;
+  }
+  
+  public int getTtl() {
+    return ttl;
+  }
+  */
+}

--- a/bigbluebutton-web/src/java/org/bigbluebutton/web/services/turn/TurnServer.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/web/services/turn/TurnServer.java
@@ -1,0 +1,77 @@
+package org.bigbluebutton.web.services.turn;
+
+import java.security.SignatureException;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.apache.commons.codec.binary.Base64;
+
+public class TurnServer {
+
+  private final String HMAC_SHA1_ALGORITHM = "HmacSHA1";
+  private final String COLON = ":";
+  
+  private final String secretKey;
+  private final String url;
+  private final int ttl;
+
+  public TurnServer(String secretKey, String url, int ttl) {
+    this.secretKey = secretKey;
+    this.url = url;
+    this.ttl = ttl;
+  }
+
+  public TurnEntry generatePasswordFor(String userId) {
+    TurnEntry turn = null;
+    
+    try {
+      Long timestamp = System.currentTimeMillis();
+      String username = timestamp + COLON + userId;
+      String password = calculateRFC2104HMAC(username, secretKey);
+      turn = new TurnEntry(username, password, ttl, url);
+    } catch (SignatureException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    }
+
+    return turn;
+  }
+
+
+
+
+  /**
+   * Computes RFC 2104-compliant HMAC signature.
+   * * @param data
+   * The data to be signed.
+   * @param key
+   * The signing key.
+   * @return
+   * The Base64-encoded RFC 2104-compliant HMAC signature.
+   * @throws
+   * java.security.SignatureException when signature generation fails
+   */
+  private String calculateRFC2104HMAC(String data, String key)
+      throws java.security.SignatureException
+      {
+    String result;
+    try {
+
+      // get an hmac_sha1 key from the raw key bytes
+      SecretKeySpec signingKey = new SecretKeySpec(key.getBytes(), HMAC_SHA1_ALGORITHM);
+
+      // get an hmac_sha1 Mac instance and initialize with the signing key
+      Mac mac = Mac.getInstance(HMAC_SHA1_ALGORITHM);
+      mac.init(signingKey);
+
+      // compute the hmac on input data bytes
+      byte[] rawHmac = mac.doFinal(data.getBytes());
+
+      // base64-encode the hmac
+      result = new String(Base64.encodeBase64(rawHmac));
+
+    } catch (Exception e) {
+      throw new SignatureException("Failed to generate HMAC : " + e.getMessage());
+    }
+    return result;
+      }
+}


### PR DESCRIPTION
Add Stun/Turn server support for BigBlueButton as described in https://code.google.com/p/bigbluebutton/issues/detail?id=1863

To configure:
1. Define Stun and Turn servers in /var/lib/tomcat7/webapps/bigbluebutton/bigbluebutton.properties

# Stun Servers
stun1.url=stun:example.org
stun2.url=stuns:example.org

# Turn Servers
turn1.secret=Turn1Secret
turn1.url=turn1.example.org
turn1.ttl=86400
turn2.secret=Turn2Secret
turn2.url=turn2.example.org
turn2.ttl=86400

2. Define your servers in /var/lib/tomcat7/webapps/bigbluebutton/WEB-INF/spring/turn-stun-servers.xml

3. Make sure your config.xml has the /stuns API URL defined.

    <application uri="rtmp://192.168.23.3/bigbluebutton" host="http://192.168.23.3/bigbluebutton/api/enter" stuns="http://192.168.23.3/bigbluebutton/api/stuns"/>

Here is the response to the /stuns API call:

{
    "turns": [
        {
            "ttl": 86400,
            "username": "1423256629586:qrdvj4ucujrb",
            "password": "itZ42Rh0HPvN1iX7NiksrQ5F1/4=",
            "url": "turn2.example.org"
        },
        {
            "ttl": 86400,
            "username": "1423256629585:qrdvj4ucujrb",
            "password": "8F/5z1UGyjn8lskMKrrPKe3JfUc=",
            "url": "turn1.example.org"
        }
    ],
    "stuns": [
        {
            "url": "stun:example.org"
        },
        {
            "url": "stuns:example.org"
        }
    ]
}

