### PR TITLE
fix blurriness in the client caused by Flex SDK 4.14

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
@@ -381,15 +381,22 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				}	   			
 	   		}
 
-			private function handleFlashMicSettingsEvent(event:FlashMicSettingsEvent):void { 
-				var micSettings:FlashMicSettings = PopUpManager.createPopUp(mdiCanvas, FlashMicSettings, true) as FlashMicSettings;
-				micSettings.addEventListener(FlexEvent.CREATION_COMPLETE, function(e:Event):void {
-					var point1:Point = new Point();
-					// Calculate position of TitleWindow in Application's coordinates. 
-					point1.x = width/2;
-					point1.y = height/2;
-					micSettings.x = point1.x - (micSettings.width/2);
-					micSettings.y = point1.y - (micSettings.height/2);
+			private function handleFlashMicSettingsEvent(event:FlashMicSettingsEvent):void {
+				/**
+				 * There is a bug in Flex SDK 4.14 where the screen stays blurry if a 
+				 * pop-up is opened from another pop-up. I delayed the second open to 
+				 * avoid this case. - Chad
+				 */
+				this.callLater( function() {
+					var micSettings:FlashMicSettings = PopUpManager.createPopUp(mdiCanvas, FlashMicSettings, true) as FlashMicSettings;
+					micSettings.addEventListener(FlexEvent.CREATION_COMPLETE, function(e:Event):void {
+						var point1:Point = new Point();
+						// Calculate position of TitleWindow in Application's coordinates. 
+						point1.x = width/2;
+						point1.y = height/2;
+						micSettings.x = point1.x - (micSettings.width/2);
+						micSettings.y = point1.y - (micSettings.height/2);
+					});
 				});
 			}
 			

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/WebRTCCallManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/WebRTCCallManager.as
@@ -212,9 +212,19 @@ package org.bigbluebutton.modules.phone.managers
       sendWebRTCAlert(ResourceUtil.getInstance().getString("bbb.webrtcWarning.title"), ResourceUtil.getInstance().getString("bbb.webrtcWarning.message", [errorString]), errorString);
     }
     
+    var popUpDelayTimer:Timer = new Timer(100, 1);
+    
     private function handleCallFailedUserResponse(e:CloseEvent):void {
       if (e.detail == Alert.YES){
-        dispatcher.dispatchEvent(new UseFlashModeCommand());
+        /**
+         * There is a bug in Flex SDK 4.14 where the screen stays blurry if a 
+         * pop-up is opened from another pop-up. I delayed the second open to 
+         * avoid this case. - Chad
+         */
+        popUpDelayTimer.addEventListener(TimerEvent.TIMER, function(e:TimerEvent) {
+          dispatcher.dispatchEvent(new UseFlashModeCommand());
+        });
+        popUpDelayTimer.start();
       } else {
         dispatcher.dispatchEvent(new AudioSelectionWindowEvent(AudioSelectionWindowEvent.CLOSED_AUDIO_SELECTION));
       }


### PR DESCRIPTION
There is a bug in Flex 4.14 where the screen will stay blurry if a pop-up window is opened from within another pop-up window. I was able to find two situations where that occurs in the client and I put in delays for the second pop-up so that it opens after the first has closed.