### PR TITLE
css resizeWindows. footer no longer overlaps. height control

### DIFF
--- a/labs/meteor-client/app/client/globals.coffee
+++ b/labs/meteor-client/app/client/globals.coffee
@@ -210,31 +210,6 @@ Handlebars.registerHelper "visibility", (section) ->
       tabs.push {userId: u.userId, name: u.username, gotMail: false, class: 'privateChatTab'}
       setInSession 'chatTabs', tabs
 
-@resizeWindows = ->
-
-  chat = $('#chat')
-  navbarHeight = $('#navbar').height()
-  footerHeight = $('#footer').height()
-  bodyHeight = $('body').height()
-  margins = parseInt(chat.css('margin-top'))*2 # *2 for top & bottom
-  paddingSpace = 10
-  windowHeight = ( bodyHeight - ( navbarHeight + footerHeight + margins + paddingSpace ) )
-
-  if window.matchMedia('(orientation: landscape)').matches
-    chat.height(windowHeight + 'px') #TODO move to stylesheets
-    $("#chatbody").height( (windowHeight- ($("#chatInput").outerHeight())*2) + 'px') #TODO move to stylesheets
-
-    $("#users").height((windowHeight-paddingSpace) + 'px') #TODO move to stylesheets
-    $("#user-contents").height((windowHeight-$("#users").find('h3').outerHeight()) + 'px') #TODO move to stylesheets
-
-  else # the orientation is portrait. The values seem fine for a handheld but not for a narrow browser window
-    $('#chat').height('700px') #TODO move to stylesheets
-    $("#chatbody").height('470px') #TODO move to stylesheets
-
-    $("#users").height('400px') #TODO move to stylesheets
-    $("#user-contents").height('300px') #TODO move to stylesheets
-
-
 @setInSession = (k, v) -> SessionAmplify.set k, v
 
 @safeString = (str) ->

--- a/labs/meteor-client/app/client/main.coffee
+++ b/labs/meteor-client/app/client/main.coffee
@@ -206,7 +206,3 @@ Template.makeButton.rendered = ->
 
 Template.recordingStatus.rendered = ->
   $('button[rel=tooltip]').tooltip()
-
-$(window).resize( ->
-  resizeWindows()
-)

--- a/labs/meteor-client/app/client/stylesheets/chat.less
+++ b/labs/meteor-client/app/client/stylesheets/chat.less
@@ -22,6 +22,7 @@
   padding-right: 0px;
   width: 100%;
   @media @landscape {
+    height:98%;
     -webkit-order: 3;
     order: 3;
   }
@@ -56,6 +57,10 @@
 }
 
 #chatbody {
+  @media @landscape {
+    height: 80%;
+  }
+
   height: 90%;
   overflow-y: scroll;
   padding-left: 0px;
@@ -147,7 +152,7 @@
   border-radius:4px;
   border:1px solid extract(@lightGrey, 3);
   @media @landscape, @desktop-portrait {
-    height: 40px;
+    height: 15%;
   }
   @media @mobile-portrait-with-keyboard, @mobile-portrait {
     height: 60px;
@@ -206,7 +211,10 @@
   @media @mobile-portrait-with-keyboard, @mobile-portrait {
     height: 60px;
   }
-  @media @desktop-portrait, @landscape {
+  @media @desktop-portrait {
+    height: 60px;
+  }
+  @media @landscape {
     height: 40px;
   }
   @media @landscape {

--- a/labs/meteor-client/app/client/stylesheets/style.less
+++ b/labs/meteor-client/app/client/stylesheets/style.less
@@ -44,11 +44,11 @@ body {
 
 .myFooter {
   color: black;
-  max-height: 20px;
   padding-top: 13px;
   text-align: center;
   @media @landscape {
     font-size: 10px;
+    max-height: 20px;
   }
   @media @mobile-portrait-with-keyboard, @desktop-portrait, @mobile-portrait {
     font-size: 18px;

--- a/labs/meteor-client/app/client/stylesheets/users.less
+++ b/labs/meteor-client/app/client/stylesheets/users.less
@@ -33,7 +33,7 @@
     height: 20px;
   }
   @media @desktop-portrait {
-    height: 20px;
+    height: 25px;
   }
   @media @desktop-portrait, @mobile-portrait {
     font-size: 2vh;
@@ -47,6 +47,7 @@
   -webkit-flex: 1 1 25%;
   flex: 1 1 25%;
   @media @landscape {
+    height:98%;
     -webkit-order: 1;
     order: 1;
     min-width: 0;
@@ -55,7 +56,7 @@
     -webkit-order: 3;
     order: 3;
     margin-bottom: 0px;
-    padding-bottom: 0px;
+    padding-bottom: 55px; /*so that the footer does not overlap */
     max-height: 20%;
     min-height: 20%;
   }

--- a/labs/meteor-client/app/client/views/chat/chat_bar.coffee
+++ b/labs/meteor-client/app/client/views/chat/chat_bar.coffee
@@ -135,7 +135,6 @@ Template.chatbar.helpers
 # When chatbar gets rendered, launch the auto-check for unread chat
 Template.chatbar.rendered = ->
   detectUnreadChat()
-  resizeWindows()
 
 # When message gets rendered, scroll to the bottom
 Template.message.rendered = ->
@@ -166,7 +165,6 @@ Template.chatInput.rendered  = ->
   $('input[rel=tooltip]').tooltip()
   $('button[rel=tooltip]').tooltip()
   $("#newMessageInput").focus()
-  resizeWindows()
 
 Template.extraConversations.events
 	"click .extraConversation": (event) ->


### PR DESCRIPTION
Auto height control for the components. No need of overwriting settings with jquery when resizing (it was breaking the UI when switching between portrait and landscape orientation).
The footer no longer overlaps the users list on mobile (portrait).