### PR TITLE
html5client: Slow connection caused users to be refused access but also to be added to the userlist

### DIFF
--- a/labs/meteor-client/app/lib/router.coffee
+++ b/labs/meteor-client/app/lib/router.coffee
@@ -13,7 +13,11 @@
         #if error
         #  # Was unable to authorize the user. Redirect to the home page
         #  # alert error.reason
-        clearSessionVar alert "Please sign in again"
+
+        #make sure the user is not let through
+        Meteor.call("userLogout", meetingId, userId, authToken)
+
+        clearSessionVar (alert "Please sign in again")
         document.location = Meteor.config.app.logOutUrl
         return
 

--- a/labs/meteor-client/app/server/user_permissions.coffee
+++ b/labs/meteor-client/app/server/user_permissions.coffee
@@ -21,19 +21,29 @@ viewer =
   chatPrivate: true #should make this dynamically modifiable later on
 
 @isAllowedTo = (action, meetingId, userId, authToken) ->
+  # Disclaimer:the current version of the HTML5 client represents only VIEWER users
+
   validated = Meteor.Users.findOne({meetingId:meetingId, userId: userId})?.validated
   Meteor.log.info "in isAllowedTo: action-#{action}, userId=#{userId}, authToken=#{authToken} validated:#{validated}"
 
   user = Meteor.Users.findOne({meetingId:meetingId, userId: userId})
-  if user? and user.validated and user.clientType is "HTML5"
-    # we check if the user is who he claims to be
-    if authToken is user.authToken
+
+  if user? and authToken is user.authToken # check if the user is who he claims to be
+    if user.validated and user.clientType is "HTML5"
       if user.user?.role is 'VIEWER' or user.user?.role is undefined
         return viewer[action] or false
+      else
+        Meteor.log.warn "UNSUCCESSFULL ATTEMPT FROM userid=#{userId} to perform:#{action}"
+        return false
+    else
+      # user was not validated
+      if action is "logoutSelf"
+        # on unsuccessful sign-in
+        Meteor.log.warn "a user was successfully removed from the meeting following an unsuccessful login"
+        return true
+      return false
+
+  else
     Meteor.log.error "in meetingId=#{meetingId} userId=#{userId} tried to perform #{action} without permission" +
      "\n..while the authToken was #{user.authToken}    and the user's object is #{JSON.stringify user}"
-
-    # the current version of the HTML5 client represents only VIEWER users
-  else
-    Meteor.log.warn "UNSUCCESSFULL ATTEMPT FROM userid=#{userId} to perform:#{action}"
-  return false
+    return false


### PR DESCRIPTION
Slow connection sometimes causes users to be refused access but also to be added to the userlist. Now the users won't be added to the userlist if they were refused access.
-rearranged the permissions so that even invalidated users should be allowed to logoutSelf as long as authenticated
-added a call to logOut the user before redirecting to the landing page (on unsuccessful login)

Conflicts:
	labs/meteor-client/app/lib/router.coffee