### PR TITLE
Logout dialog box modifications + push menu enhancements.

### DIFF
--- a/bigbluebutton-html5/app/client/globals.coffee
+++ b/bigbluebutton-html5/app/client/globals.coffee
@@ -366,6 +366,15 @@ Handlebars.registerHelper "visibility", (section) ->
 @listSessionVars = ->
   console.log SessionAmplify.keys
 
+# Detects a mobile device
+@isMobile = ->
+  navigator.userAgent.match(/Android/i) or
+  navigator.userAgent.match(/iPad/i) or
+  navigator.userAgent.match(/iPhone/i) or
+  navigator.userAgent.match(/iPod/i) or
+  navigator.userAgent.match(/Windows Phone/i) or
+  navigator.userAgent.match(/BlackBerry/i) or
+  navigator.userAgent.match(/webOS/i)
 
 # Checks if the view is portrait and a mobile device is being used
 @isPortraitMobile = () ->

--- a/bigbluebutton-html5/app/client/globals.coffee
+++ b/bigbluebutton-html5/app/client/globals.coffee
@@ -442,7 +442,6 @@ Handlebars.registerHelper "visibility", (section) ->
   # positioning the whiteboard
 
   if getInSession 'display_whiteboard'
-    console.log 'display_whiteboard'
     whiteboardHeight = $('#whiteboard').height()
     $('#whiteboard').css('position', 'fixed')
     $('#whiteboard').css('left', '15%')
@@ -452,7 +451,6 @@ Handlebars.registerHelper "visibility", (section) ->
   # positioning the chatbar
 
   if getInSession 'display_chatbar'
-    console.log 'display_chatbar'
     chatHeight = $('#chat').height()
     $('#chat').css('position', 'fixed')
     $('#chat').css('left', '15%')
@@ -465,7 +463,6 @@ Handlebars.registerHelper "visibility", (section) ->
   # positioning the userlist
 
   if getInSession 'display_usersList'
-    console.log 'display_usersList'
     chatHeight = $('#chat').height()
     usersHeight = $('#users').height()
     usersWidth = $('#users').width()

--- a/bigbluebutton-html5/app/client/main.coffee
+++ b/bigbluebutton-html5/app/client/main.coffee
@@ -47,7 +47,6 @@ Template.header.events
 
   "click .chatBarIcon": (event) ->
     $(".tooltip").hide()
-    toggleSlidingMenu()
     toggleChatbar()
 
   "click .collapseSlidingMenuButton": (event) ->
@@ -67,7 +66,6 @@ Template.header.events
 
   "click .lowerHand": (event) ->
     $(".tooltip").hide()
-    toggleSlidingMenu()
     Meteor.call('userLowerHand', getInSession("meetingId"), getInSession("userId"), getInSession("userId"), getInSession("authToken"))
 
   "click .muteIcon": (event) ->
@@ -78,7 +76,6 @@ Template.header.events
     #Meteor.log.info "navbar raise own hand from client"
     console.log "navbar raise own hand from client"
     $(".tooltip").hide()
-    toggleSlidingMenu()
     Meteor.call('userRaiseHand', getInSession("meetingId"), getInSession("userId"), getInSession("userId"), getInSession("authToken"))
     # "click .settingsIcon": (event) ->
     #   alert "settings"
@@ -98,7 +95,6 @@ Template.header.events
 
   "click .usersListIcon": (event) ->
     $(".tooltip").hide()
-    toggleSlidingMenu
     toggleUsersList()
 
   "click .videoFeedIcon": (event) ->
@@ -107,7 +103,6 @@ Template.header.events
 
   "click .whiteboardIcon": (event) ->
     $(".tooltip").hide()
-    toggleSlidingMenu
     toggleWhiteBoard()
 
   "mouseout #navbarMinimizedButton": (event) ->

--- a/bigbluebutton-html5/app/client/main.coffee
+++ b/bigbluebutton-html5/app/client/main.coffee
@@ -85,14 +85,10 @@ Template.header.events
 
   "click .signOutIcon": (event) ->
     $('.signOutIcon').blur()
-    if window.matchMedia('(orientation: portrait)').matches and window.matchMedia('(max-device-width: 1279px)').matches
-      if $('#dialog').dialog('option', 'height') isnt 450
-        $('#dialog').dialog('option', 'width', '100%')
-        $('#dialog').dialog('option', 'height', 450)
+    if isLandscapeMobile()
+      $('.logout-dialog').addClass('landscape-mobile-logout-dialog')
     else
-      if $('#dialog').dialog('option', 'height') isnt 115
-        $('#dialog').dialog('option', 'width', 270)
-        $('#dialog').dialog('option', 'height', 115)
+      $('.logout-dialog').addClass('desktop-logout-dialog')
     $("#dialog").dialog("open")
   "click .hideNavbarIcon": (event) ->
     $(".tooltip").hide()

--- a/bigbluebutton-html5/app/client/main.coffee
+++ b/bigbluebutton-html5/app/client/main.coffee
@@ -186,6 +186,10 @@ Template.main.rendered = ->
         class: 'btn btn-xs btn-default'
       }
     ]
+    open: (event, ui) ->
+      $('.ui-widget-overlay').bind 'click', () ->
+        if isMobile()
+          $("#dialog").dialog('close')
     position:
       my: 'right top'
       at: 'right bottom'

--- a/bigbluebutton-html5/app/client/stylesheets/style.less
+++ b/bigbluebutton-html5/app/client/stylesheets/style.less
@@ -334,15 +334,15 @@ body {
       font-size: 100% !important;
     }
     height: 22% !important; /* overriding "height: auto;" */
-    width: 40% !important; /* overriding "width: auto;" */
-    font-size: 110% !important; /* overriding "font-size: 11px;" */
+    width: 45% !important; /* overriding "width: auto;" */
+    font-size: 2.5vh !important; /* overriding "font-size: 11px;" */
     .ui-dialog-content {
       /*min-height: 0px !important;*/
       height: 31% !important; /* overriding "height: auto;" */
     }
     .ui-dialog-buttonset {
       width: 100%;
-      font-size: 130%;
+      font-size: 3vh;
       button {
         width: 40%;
         margin-left: 5% !important;

--- a/bigbluebutton-html5/app/client/stylesheets/style.less
+++ b/bigbluebutton-html5/app/client/stylesheets/style.less
@@ -334,22 +334,22 @@ body {
       font-size: 100% !important;
     }
     height: 22% !important; /* overriding "height: auto;" */
-    width: 45% !important; /* overriding "width: auto;" */
-    font-size: 2.5vh !important; /* overriding "font-size: 11px;" */
+    width: 55% !important; /* overriding "width: auto;" */
+    font-size: 3vh !important; /* overriding "font-size: 11px;" */
     .ui-dialog-content {
       /*min-height: 0px !important;*/
-      height: 31% !important; /* overriding "height: auto;" */
+      height: 30% !important; /* overriding "height: auto;" */
     }
     .ui-dialog-buttonset {
       width: 100%;
-      font-size: 3vh;
+      font-size: 4vh;
       button {
         width: 40%;
         margin-left: 5% !important;
         margin-right: 5% !important;
       }
     }
-    height: 27% !important;
+    height: 32% !important;
   }
 }
 

--- a/bigbluebutton-html5/app/client/stylesheets/style.less
+++ b/bigbluebutton-html5/app/client/stylesheets/style.less
@@ -333,11 +333,9 @@ body {
     .ui-widget-header {
       font-size: 100% !important;
     }
-    height: 22% !important; /* overriding "height: auto;" */
     width: 55% !important; /* overriding "width: auto;" */
     font-size: 3vh !important; /* overriding "font-size: 11px;" */
     .ui-dialog-content {
-      /*min-height: 0px !important;*/
       height: 30% !important; /* overriding "height: auto;" */
     }
     .ui-dialog-buttonset {

--- a/bigbluebutton-html5/app/client/stylesheets/style.less
+++ b/bigbluebutton-html5/app/client/stylesheets/style.less
@@ -327,6 +327,41 @@ body {
 
 /* Custom alert box */
 
+/* Logout menu's properties on mobile devices in landscape orientation */
+.landscape-mobile-logout-dialog {
+  @media @landscape {
+    .ui-widget-header {
+      font-size: 100% !important;
+    }
+    height: 22% !important; /* overriding "height: auto;" */
+    width: 40% !important; /* overriding "width: auto;" */
+    font-size: 110% !important; /* overriding "font-size: 11px;" */
+    .ui-dialog-content {
+      /*min-height: 0px !important;*/
+      height: 31% !important; /* overriding "height: auto;" */
+    }
+    .ui-dialog-buttonset {
+      width: 100%;
+      font-size: 130%;
+      button {
+        width: 40%;
+        margin-left: 5% !important;
+        margin-right: 5% !important;
+      }
+    }
+    height: 27% !important;
+  }
+}
+
+/* Logout menu's properties on desktop */
+.desktop-logout-dialog {
+  @media @desktop-portrait, @landscape {
+    .ui-dialog-content {
+      height: 36px !important; /* overriding "height: auto;" */
+    }
+  }
+}
+
 .no-close .ui-dialog-titlebar-close {
   display: none; /* no close button */
 }
@@ -344,8 +379,11 @@ body {
     font-weight: bold;
     text-align: center;
     @media @desktop-portrait, @landscape {
-      font-size: 11px;
+      min-height: 0px !important; /* overriding "min-height: 47px;"*/
     }
+  }
+  @media @mobile-portrait-with-keyboard, @mobile-portrait {
+    width: 100% !important;
   }
 }
 
@@ -353,7 +391,7 @@ body {
   background: extract(@white, 3);
   border: 5px solid extract(@darkGrey, 3);
   @media @desktop-portrait, @landscape {
-    font-size: 10px;
+    font-size: 11px;
   }
   @media @mobile-portrait-with-keyboard, @mobile-portrait {
     font-size: 280%;


### PR DESCRIPTION
- Logout dialog box has different (much bigger) size on mobile devices in landscape orientation (mobile devices only).
- User can now close the Logout dialog box by simply clicking somewhere outside. That feature only exists on mobile devices.
- All the calls for the push menu in landscape view have been eliminated to prevent interference with the views when sliding menu doesn't even exist.