### PR TITLE
Display the filename of the presentation (partial revert of #548)

### DIFF
--- a/bigbluebutton-html5/app/client/globals.coffee
+++ b/bigbluebutton-html5/app/client/globals.coffee
@@ -57,6 +57,10 @@
 @getTimeOfJoining = ->
   Meteor.Users.findOne(userId: getInSession "userId")?.user?.time_of_joining
 
+@getPresentationFilename = ->
+  currentPresentation = Meteor.Presentations.findOne({"presentation.current": true})
+  currentPresentation?.presentation?.name
+
 Handlebars.registerHelper "colourToHex", (value) =>
   @window.colourToHex(value)
 
@@ -100,7 +104,7 @@ Handlebars.registerHelper "getUsersInMeeting", ->
   raised.concat lowered
 
 Handlebars.registerHelper "getWhiteboardTitle", ->
-  "Presentation"
+  "Presentation: " + (getPresentationFilename() or "Loading...")
 
 Handlebars.registerHelper "isCurrentUser", (userId) ->
   userId is null or userId is BBB.getCurrentUser()?.userId


### PR DESCRIPTION
In https://github.com/bigbluebutton/bigbluebutton/pull/548/files I think we removed too much.
On the Flash client we have "Presentation: default.pdf". I believe we should also display the filename in the HTML5 client.
