### PR TITLE
Bugfix issue 1892 (ChatBox)

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
@@ -71,6 +71,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import com.asfusion.mate.events.Dispatcher;
 			
 			import flash.accessibility.AccessibilityProperties;
+			import flash.events.TextEvent;
 			
 			import mx.binding.utils.BindingUtils;
 			import mx.collections.ArrayCollection;
@@ -168,7 +169,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		        hotkeyCapture();
 			
 		        // Listen for the ENTER key to send the message.
-		        txtMsgArea.addEventListener(KeyboardEvent.KEY_UP, handleTextAreaKeyUpEvent);
+		        txtMsgArea.addEventListener(TextEvent.TEXT_INPUT, handleTextInput);
 		        
 		        queryForChatHistory();
 
@@ -607,8 +608,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         globalDispatcher.dispatchEvent(privateEvent);
       }
 
-      private function handleTextAreaKeyUpEvent(e:KeyboardEvent):void {
-		if (e.keyCode == Keyboard.ENTER) {
+      private function handleTextInput(e:TextEvent):void {
+		if ((e.text.length == 1) && (e.text.charCodeAt(0) == 10)) //ENTER-KEY
 			sendMessages();
 		}     
 	  }
@@ -638,6 +639,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
           }
         }
         txtMsgArea.text = "";
+        txtMsgArea.validateNow();
+        txtMsgArea.setSelection(0, 0);
       }	
 	  
 		private function focusChatInput(e:ShortcutEvent):void{


### PR DESCRIPTION
-Fixed issue in chatbox.mxml described in: https://code.google.com/p/bigbluebutton/issues/detail?id=1892
Tested on Mac Mavericks, Windows 8 and Ubuntu 14.04. Solved bug in 'Enter' sending incomplete text when IME is being used as input method.
