### PR TITLE
Archive recording files for sessions without recording marks

### DIFF
--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -60,18 +60,16 @@ mark_for_rebuild() {
 		exit 1
 	fi
 
-	# Remove the existing 'published' recording files
-	rm -rvf /var/bigbluebutton/published/$type/$MEETING_ID
-	rm -rvf /var/bigbluebutton/unpublished/$type/$MEETING_ID
+	# Clear out the relevant done files
+	rm -vf $STATUS/archived/$MEETING_ID.norecord
+	rm -vf $STATUS/sanity/$MEETING_ID*
+	rm -vf $STATUS/processed/$MEETING_ID*
+	rm -vf $STATUS/published/$MEETING_ID*
 
-	# Clear out all the done files
-	rm -vf $STATUS/sanity/$MEETING_ID.done
-	rm -vf $STATUS/sanity/$MEETING_ID.fail
+	# Remove the existing 'published' recording files
 	for type in $TYPES; do
-		rm -vf $STATUS/published/$MEETING_ID-$type.fail
-		rm -vf $STATUS/published/$MEETING_ID-$type.done
-		rm -vf $STATUS/processed/$MEETING_ID-$type.fail
-		rm -vf $STATUS/processed/$MEETING_ID-$type.done
+		rm -rf /var/bigbluebutton/published/$type/$MEETING_ID
+		rm -rf /var/bigbluebutton/unpublished/$type/$MEETING_ID
 	done
 
 	# Restart processing at the 'archived' step

--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -94,6 +94,7 @@ mark_for_republish() {
                         rm -rf /var/bigbluebutton/unpublished/$type/$MEETING_ID
                 fi
 	done
+	touch $STATUS/processed/$MEETING_ID.done
 }
 
 need_root() {

--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -80,20 +80,23 @@ mark_for_rebuild() {
 
 mark_for_republish() { 
 	MEETING_ID=$1
-	#set -x
-	for type in $TYPES; do                
-                if [ -d $BASE/publish/$type/$MEETING_ID ]; then
-			rm -rf $BASE/publish/$type/$MEETING_ID
-		fi
-              
-                if [ -d /var/bigbluebutton/published/$type/$MEETING_ID ]; then
-                        rm -rf /var/bigbluebutton/published/$type/$MEETING_ID
-                fi
+	echo "Marking for republish $MEETING_ID"
+	if [[ ! -d $BASE/process/$MEETING_ID ]]; then
+		echo "Processed files for $MEETING_ID do not exist, can't republish"
+		echo "Try rebuilding the recording instead."
+		exit 1
+	fi
 
-                if [ -d /var/bigbluebutton/unpublished/$type/$MEETING_ID ]; then
-                        rm -rf /var/bigbluebutton/unpublished/$type/$MEETING_ID
-                fi
+	# Clear out the publish done files
+	rm -vf $STATUS/published/$MEETING_ID*
+
+	# Remove the existing 'published' recording files
+	for type in $TYPES; do
+		rm -rf /var/bigbluebutton/published/$type/$MEETING_ID
+		rm -rf /var/bigbluebutton/unpublished/$type/$MEETING_ID
 	done
+
+	# Restart processing at the 'processed' step
 	touch $STATUS/processed/$MEETING_ID.done
 }
 

--- a/bigbluebutton-config/cron.daily/bigbluebutton
+++ b/bigbluebutton-config/cron.daily/bigbluebutton
@@ -46,6 +46,21 @@ find /var/bigbluebutton/deskshare/ -name "*.flv" -mtime +$history -exec rm '{}' 
 find /var/freeswitch/meetings/ -name "*.wav" -mtime +$history -exec rm '{}' \;
 
 #
+# Delete raw files of recordings without recording marks older than N days
+#
+remove_raw_of_recordings_without_marks() {
+	logger "Removing old raw directory of recordings without marks"
+	find /var/bigbluebutton/recording/status -name '*.norecord' -mtime +$history | while read archived_norecord; do
+		recording_id=${archived_norecord%.norecord}
+		recording_id=${recording_id##*/}
+		bbb-record --delete $recording_id 2>&1 | logger
+	done
+}
+
+# Enabled by default; comment to disable.
+remove_raw_of_recordings_without_marks
+
+#
 # Delete old raw dirs from recordings properly published using 'presentation' scripts.
 #
 

--- a/record-and-playback/core/scripts/archive/archive.rb
+++ b/record-and-playback/core/scripts/archive/archive.rb
@@ -123,29 +123,28 @@ target_dir = "#{raw_archive_dir}/#{meeting_id}"
 if not FileTest.directory?(target_dir)
   FileUtils.mkdir_p target_dir
   archive_events(meeting_id, redis_host, redis_port, raw_archive_dir)
-  # we will abort the archiving if there's no marks to start and stop the recording
-  if not archive_has_recording_marks?(meeting_id, raw_archive_dir)
-    BigBlueButton.logger.info("There's no recording marks for #{meeting_id}, aborting the archive process")
+  archive_audio(meeting_id, audio_dir, raw_archive_dir)
+  archive_presentation(meeting_id, presentation_dir, raw_archive_dir)
+  archive_deskshare(meeting_id, deskshare_dir, raw_archive_dir)
+  archive_video(meeting_id, video_dir, raw_archive_dir)
 
-    # we need to delete the keys here because the sanity phase won't never happen for this recording
-    BigBlueButton.logger.info("Deleting keys")
+  if not archive_has_recording_marks?(meeting_id, raw_archive_dir)
+    BigBlueButton.logger.info("There's no recording marks for #{meeting_id}, not processing recording.")
+
+    # we need to delete the keys here because the sanity phase won't
+    # automatically happen for this recording
+    BigBlueButton.logger.info("Deleting redis keys")
     redis = BigBlueButton::RedisWrapper.new(redis_host, redis_port)
     events_archiver = BigBlueButton::RedisEventsArchiver.new redis
     events_archiver.delete_events(meeting_id)
 
-    BigBlueButton.logger.info("Removing events.xml")
-    FileUtils.rm_r target_dir
-    BigBlueButton.logger.info("Removing the recorded flag")
-    FileUtils.rm("#{recording_dir}/status/recorded/#{meeting_id}.done")
+    File.open("#{recording_dir}/status/archived/#{meeting_id}.norecord", "w") do |archive_norecord|
+      archive_norecord.write("Archived #{meeting_id} (no recording marks")
+    end
+
   else
-    archive_audio(meeting_id, audio_dir, raw_archive_dir)
-    archive_presentation(meeting_id, presentation_dir, raw_archive_dir)
-    archive_deskshare(meeting_id, deskshare_dir, raw_archive_dir)
-    archive_video(meeting_id, video_dir, raw_archive_dir)
-    archive_done = File.new("#{recording_dir}/status/archived/#{meeting_id}.done", "w")
-    archive_done.write("Archived #{meeting_id}")
-    archive_done.close
+    File.open("#{recording_dir}/status/archived/#{meeting_id}.done", "w") do |archive_done|
+      archive_done.write("Archived #{meeting_id}")
+    end
   end
-#else
-#	BigBlueButton.logger.debug("Skipping #{meeting_id} as it has already been archived.")
 end

--- a/record-and-playback/core/scripts/rap-worker.rb
+++ b/record-and-playback/core/scripts/rap-worker.rb
@@ -45,6 +45,9 @@ def archive_recorded_meeting(recording_dir)
     archived_done = "#{recording_dir}/status/archived/#{meeting_id}.done"
     next if File.exists?(archived_done)
 
+    archived_norecord = "#{recording_dir}/status/archived/#{meeting_id}.norecord"
+    next if File.exists?(archived_norecord)
+
     archived_fail = "#{recording_dir}/status/archived/#{meeting_id}.fail"
     next if File.exists?(archived_fail)
 
@@ -55,12 +58,7 @@ def archive_recorded_meeting(recording_dir)
     step_stop_time = BigBlueButton.monotonic_clock
     step_time = step_stop_time - step_start_time
 
-    if not File.exists?(recorded_done)
-      BigBlueButton.logger.info("There's no recording marks in #{meeting_id}, skipping it")
-      return
-    end
-
-    step_succeeded = (ret == 0 && File.exists?(archived_done))
+    step_succeeded = (ret == 0 && (File.exists?(archived_done) || File.exists?(archived_norecord)))
 
     BigBlueButton.redis_publisher.put_archive_ended meeting_id, {
       "success" => step_succeeded,


### PR DESCRIPTION
Instead of deleting the files immediately. This allows a recording to be recovered (by running `bbb-record --rebuild` on the meeting id) if, e.g. the moderator forgot to press the recording button during the session.

The bigbluebutton cron.daily job has been updated to automatically delete the recorded sessions with no recording marks after 5 days (configurable by adjusting the `history` value at the top).