### PR TITLE
Adding more data to bbb-apps event meeting_created_message

### DIFF
--- a/bigbluebutton-apps/src/main/java/org/bigbluebutton/conference/meeting/messaging/redis/MeetingMessageHandler.java
+++ b/bigbluebutton-apps/src/main/java/org/bigbluebutton/conference/meeting/messaging/redis/MeetingMessageHandler.java
@@ -42,7 +42,8 @@ public class MeetingMessageHandler implements MessageHandler {
 					CreateMeetingMessage emm = (CreateMeetingMessage) msg;
 					log.info("Received create meeting request. Meeting id [{}]", emm.id);
 					bbbGW.createMeeting2(emm.id, emm.externalId, emm.name, emm.record, emm.voiceBridge, 
-							  emm.duration, emm.autoStartRecording, emm.allowStartStopRecording);
+							  emm.duration, emm.autoStartRecording, emm.allowStartStopRecording,
+							  emm.moderatorPass, emm.viewerPass, emm.createTime, emm.createDate);
 				} else if (msg instanceof RegisterUserMessage) {
 					RegisterUserMessage emm = (RegisterUserMessage) msg;
 					log.info("Received register user request. Meeting id [{}], userid=[{}], token=[{}]", emm.meetingID, emm.internalUserId, emm.authToken);

--- a/bigbluebutton-apps/src/main/java/org/bigbluebutton/conference/service/messaging/Constants.java
+++ b/bigbluebutton-apps/src/main/java/org/bigbluebutton/conference/service/messaging/Constants.java
@@ -89,4 +89,8 @@ public class Constants {
   public static final String Y_PERCENT                       = "y_percent";
   public static final String KEEP_ALIVE_ID                   = "keep_alive_id";
   public static final String INTERNAL_USER_ID                = "internal_user_id";
+  public static final String MODERATOR_PASS                  = "moderator_pass";
+  public static final String VIEWER_PASS                     = "viewer_pass";
+  public static final String CREATE_TIME                     = "create_time";
+  public static final String CREATE_DATE                     = "create_date";
 }

--- a/bigbluebutton-apps/src/main/java/org/bigbluebutton/conference/service/messaging/CreateMeetingMessage.java
+++ b/bigbluebutton-apps/src/main/java/org/bigbluebutton/conference/service/messaging/CreateMeetingMessage.java
@@ -12,10 +12,15 @@ public class CreateMeetingMessage implements IMessage {
 	public final Long duration;
 	public final Boolean autoStartRecording;
 	public final Boolean allowStartStopRecording;
+	public final String moderatorPass;
+	public final String viewerPass;
+	public final Long createTime;
+	public final String createDate;
 	
 	public CreateMeetingMessage(String id, String externalId, String name, Boolean record, String voiceBridge, 
 			                        Long duration, Boolean autoStartRecording, 
-			                        Boolean allowStartStopRecording) {
+			                        Boolean allowStartStopRecording, String moderatorPass,
+			                        String viewerPass, Long createTime, String createDate) {
 		this.id = id;
 		this.externalId = externalId;
 		this.name = name;
@@ -24,5 +29,9 @@ public class CreateMeetingMessage implements IMessage {
 		this.duration = duration;	
 		this.autoStartRecording = autoStartRecording;
 		this.allowStartStopRecording = allowStartStopRecording;
+		this.moderatorPass = moderatorPass;
+		this.viewerPass = viewerPass;
+		this.createTime = createTime;
+		this.createDate = createDate;
 	}
 }

--- a/bigbluebutton-apps/src/main/java/org/bigbluebutton/conference/service/messaging/MessageFromJsonConverter.java
+++ b/bigbluebutton-apps/src/main/java/org/bigbluebutton/conference/service/messaging/MessageFromJsonConverter.java
@@ -60,9 +60,14 @@ public class MessageFromJsonConverter {
 		Long duration = payload.get(Constants.DURATION).getAsLong();
 		Boolean autoStartRecording = payload.get(Constants.AUTO_START_RECORDING).getAsBoolean();
 		Boolean allowStartStopRecording = payload.get(Constants.ALLOW_START_STOP_RECORDING).getAsBoolean();
+		String moderatorPassword = payload.get(Constants.MODERATOR_PASS).getAsString();
+		String viewerPassword = payload.get(Constants.VIEWER_PASS).getAsString();
+		Long createTime = payload.get(Constants.CREATE_TIME).getAsLong();
+		String createDate = payload.get(Constants.CREATE_DATE).getAsString();
 		
 		return new CreateMeetingMessage(id, externalId, name, record, voiceBridge, 
-				          duration, autoStartRecording, allowStartStopRecording);
+				          duration, autoStartRecording, allowStartStopRecording,
+				          moderatorPassword, viewerPassword, createTime, createDate);
 	}
 	
 	private static IMessage processDestroyMeeting(JsonObject payload) {

--- a/bigbluebutton-apps/src/main/java/org/bigbluebutton/core/api/IBigBlueButtonInGW.java
+++ b/bigbluebutton-apps/src/main/java/org/bigbluebutton/core/api/IBigBlueButtonInGW.java
@@ -11,7 +11,8 @@ public interface IBigBlueButtonInGW {
 	void endAllMeetings();
 	void createMeeting2(String meetingID, String externalMeetingID, String meetingName, boolean recorded, 
 			    String voiceBridge, long duration, boolean autoStartRecording,
-			    boolean allowStartStopRecording);
+			    boolean allowStartStopRecording, String moderatorPass, String viewerPass,
+			    long createTime, String createDate);
 	void destroyMeeting(String meetingID);
 	void getAllMeetings(String meetingID);
 	void lockSettings(String meetingID, Boolean locked, Map<String, Boolean> lockSettigs);

--- a/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -105,11 +105,13 @@ class BigBlueButtonActor(outGW: MessageOutGateway) extends Actor with LogHelper 
         logger.info("New meeting create request [" + msg.meetingName + "]")
     	  var m = new MeetingActor(msg.meetingID, msg.externalMeetingID, msg.meetingName, msg.recorded, 
     	                  msg.voiceBridge, msg.duration, 
-    	                  msg.autoStartRecording, msg.allowStartStopRecording,
+    	                  msg.autoStartRecording, msg.allowStartStopRecording, msg.moderatorPass,
+    	                  msg.viewerPass, msg.createTime, msg.createDate,
     	                  outGW)
     	  m.start
     	  meetings += m.meetingID -> m
-    	  outGW.send(new MeetingCreated(m.meetingID, m.externalMeetingID, m.recorded, m.meetingName, m.voiceBridge, msg.duration))
+    	  outGW.send(new MeetingCreated(m.meetingID, m.externalMeetingID, m.recorded, m.meetingName, m.voiceBridge, msg.duration,
+    	                     msg.moderatorPass, msg.viewerPass, msg.createTime, msg.createDate))
     	  
     	  m ! new InitializeMeeting(m.meetingID, m.recorded)
     	  m ! "StartTimer"

--- a/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonInGW.scala
+++ b/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonInGW.scala
@@ -19,11 +19,13 @@ class BigBlueButtonInGW(bbbGW: BigBlueButtonGateway, presUtil: PreuploadedPresen
   // Meeting
   def createMeeting2(meetingID: String, externalMeetingID:String, meetingName: String, record: Boolean, 
           voiceBridge: String, duration: Long, autoStartRecording: Boolean, 
-          allowStartStopRecording: Boolean) {
+          allowStartStopRecording: Boolean, moderatorPass: String, viewerPass: String,
+          createTime: Long, createDate: String) {
 //    println("******************** CREATING MEETING [" + meetingID + "] ***************************** ")
   	bbbGW.accept(new CreateMeeting(meetingID, externalMeetingID, meetingName, record, 
 	                   voiceBridge, duration, autoStartRecording,
-	                   allowStartStopRecording))
+	                   allowStartStopRecording, moderatorPass, viewerPass,
+	                   createTime, createDate))
   }
   
   def destroyMeeting(meetingID: String) {

--- a/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/CollectorActor.scala
+++ b/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/CollectorActor.scala
@@ -230,6 +230,10 @@ class CollectorActor(dispatcher: IDispatcher) extends Actor {
     payload.put(Constants.RECORDED, msg.recorded)
     payload.put(Constants.VOICE_CONF, msg.voiceBridge)
     payload.put(Constants.DURATION, msg.duration)     
+    payload.put(Constants.MODERATOR_PASS, msg.moderatorPass)
+    payload.put(Constants.VIEWER_PASS, msg.viewerPass)
+    payload.put(Constants.CREATE_TIME, msg.createTime)
+    payload.put(Constants.CREATE_DATE, msg.createDate)
     
     val header = new java.util.HashMap[String, Any]()
     header.put(Constants.NAME, MessageNames.CREATE_MEETING)

--- a/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/MeetingActor.scala
+++ b/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/MeetingActor.scala
@@ -20,6 +20,8 @@ case object StopMeetingActor
 class MeetingActor(val meetingID: String, val externalMeetingID: String, val meetingName: String, val recorded: Boolean, 
                    val voiceBridge: String, duration: Long, 
                    val autoStartRecording: Boolean, val allowStartStopRecording: Boolean,
+                   val moderatorPass: String, val viewerPass: String,
+                   val createTime: Long, val createDate: String,
                    val outGW: MessageOutGateway) 
                    extends Actor with UsersApp with PresentationApp
                    with PollApp with LayoutApp with ChatApp

--- a/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/api/Constants.scala
+++ b/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/api/Constants.scala
@@ -89,4 +89,8 @@ object Constants {
   val Y_PERCENT                       = "y_percent"
   val KEEP_ALIVE_ID                   = "keep_alive_id"  
   val LISTEN_ONLY                     = "listen_only"
+  val MODERATOR_PASS                  = "moderator_pass"
+  val VIEWER_PASS                     = "viewer_pass"
+  val CREATE_TIME                     = "create_time"
+  val CREATE_DATE                     = "create_date"
 }

--- a/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/api/InMessages.scala
+++ b/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/api/InMessages.scala
@@ -25,7 +25,11 @@ case class CreateMeeting
   voiceBridge: String,
   duration: Long,
   autoStartRecording: Boolean,
-  allowStartStopRecording: Boolean
+  allowStartStopRecording: Boolean,
+  moderatorPass: String,
+  viewerPass: String,
+  createTime: Long,
+  createDate: String
 ) extends InMessage
                          
 case class InitializeMeeting(

--- a/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/api/OutMessages.scala
+++ b/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/api/OutMessages.scala
@@ -49,6 +49,10 @@ case class MeetingCreated(
     name: String,
     voiceBridge: String,
     duration: Long,
+    moderatorPass: String,
+    viewerPass: String,
+    createTime: Long,
+    createDate: String,
     version:String = Versions.V_0_0_1
 ) extends IOutMessage
 

--- a/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/meeting/MeetingMessageToJsonConverter.scala
+++ b/bigbluebutton-apps/src/main/scala/org/bigbluebutton/core/meeting/MeetingMessageToJsonConverter.scala
@@ -30,6 +30,10 @@ object MeetingMessageToJsonConverter {
     payload.put(Constants.RECORDED, msg.recorded)
     payload.put(Constants.VOICE_CONF, msg.voiceBridge)
     payload.put(Constants.DURATION, msg.duration)
+    payload.put(Constants.MODERATOR_PASS, msg.moderatorPass)
+    payload.put(Constants.VIEWER_PASS, msg.viewerPass)
+    payload.put(Constants.CREATE_TIME, msg.createTime)
+    payload.put(Constants.CREATE_DATE, msg.createDate)
 
     val header = Util.buildHeader(MessageNames.MEETING_CREATED, msg.version, None)
     Util.buildJson(header, payload) 

--- a/bigbluebutton-web/src/java/org/bigbluebutton/api/MeetingService.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/api/MeetingService.java
@@ -283,7 +283,13 @@ public class MeetingService implements MessageListener {
 		log.info("Create meeting: data={}", logStr);
 		
 		messagingService.createMeeting(m.getInternalId(), m.getExternalId(), m.getName(), m.isRecord(), 
-				 m.getTelVoice(), m.getDuration(), m.getAutoStartRecording(), m.getAllowStartStopRecording());			
+				 m.getTelVoice(), m.getDuration(), m.getAutoStartRecording(), m.getAllowStartStopRecording(),
+				 m.getModeratorPassword(), m.getViewerPassword(), m.getCreateTime(),
+				 formatPrettyDate(m.getCreateTime()));
+	}
+
+	private String formatPrettyDate(Long timestamp) {
+		return new Date(timestamp).toString();
 	}
 	
 	private void processCreateMeeting(CreateMeeting message) {

--- a/bigbluebutton-web/src/java/org/bigbluebutton/api/messaging/Constants.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/api/messaging/Constants.java
@@ -88,4 +88,8 @@ public class Constants {
   public static final String X_PERCENT                       = "x_percent";
   public static final String Y_PERCENT                       = "y_percent";
   public static final String KEEP_ALIVE_ID                   = "keep_alive_id"; 
+  public static final String MODERATOR_PASS                  = "moderator_pass";
+  public static final String VIEWER_PASS                     = "viewer_pass";
+  public static final String CREATE_TIME                     = "create_time";
+  public static final String CREATE_DATE                     = "create_date";
 }

--- a/bigbluebutton-web/src/java/org/bigbluebutton/api/messaging/MessageToJson.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/api/messaging/MessageToJson.java
@@ -34,6 +34,10 @@ public class MessageToJson {
 		payload.put(Constants.DURATION, msg.duration);
 		payload.put(Constants.AUTO_START_RECORDING, msg.autoStartRecording);
 		payload.put(Constants.ALLOW_START_STOP_RECORDING, msg.allowStartStopRecording);
+		payload.put(Constants.MODERATOR_PASS, msg.moderatorPass);
+		payload.put(Constants.VIEWER_PASS, msg.viewerPass);
+		payload.put(Constants.CREATE_TIME, msg.createTime);
+		payload.put(Constants.CREATE_DATE, msg.createDate);
 		
 		java.util.HashMap<String, Object> header = MessageBuilder.buildHeader(CreateMeetingMessage.CREATE_MEETING_REQUEST_EVENT, CreateMeetingMessage.VERSION, null);
 		return MessageBuilder.buildJson(header, payload);				

--- a/bigbluebutton-web/src/java/org/bigbluebutton/api/messaging/MessagingService.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/api/messaging/MessagingService.java
@@ -27,7 +27,8 @@ public interface MessagingService {
 	void destroyMeeting(String meetingID);
 	void createMeeting(String meetingID, String externalMeetingID, String meetingName, Boolean recorded, 
 			      String voiceBridge, Long duration, Boolean autoStartRecording,
-			      Boolean allowStartStopRecording);
+			      Boolean allowStartStopRecording, String moderatorPass, String viewerPass,
+			      Long createTime, String createDate);
 	void endMeeting(String meetingId);
 	void send(String channel, String message);
 	void sendPolls(String meetingId, String title, String question, String questionType, List<String> answers);

--- a/bigbluebutton-web/src/java/org/bigbluebutton/api/messaging/RedisMessagingService.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/api/messaging/RedisMessagingService.java
@@ -67,10 +67,13 @@ public class RedisMessagingService implements MessagingService {
 	
 	public void createMeeting(String meetingID, String externalMeetingID, String meetingName, Boolean recorded, 
 			                      String voiceBridge, Long duration, 
-			                      Boolean autoStartRecording, Boolean allowStartStopRecording) {
+			                      Boolean autoStartRecording, Boolean allowStartStopRecording,
+			                      String moderatorPass, String viewerPass, Long createTime,
+			                      String createDate) {
 		CreateMeetingMessage msg = new CreateMeetingMessage(meetingID, externalMeetingID, meetingName, 
 				                                  recorded, voiceBridge, duration, 
-				                                  autoStartRecording, allowStartStopRecording);
+				                                  autoStartRecording, allowStartStopRecording,
+				                                  moderatorPass, viewerPass, createTime, createDate);
 		String json = MessageToJson.createMeetingMessageToJson(msg);
 		log.info("Sending create meeting message to bbb-apps:[{}]", json);
 		sender.send(MessagingConstants.TO_MEETING_CHANNEL, json);			

--- a/bigbluebutton-web/src/java/org/bigbluebutton/api/messaging/converters/messages/CreateMeetingMessage.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/api/messaging/converters/messages/CreateMeetingMessage.java
@@ -13,10 +13,16 @@ public class CreateMeetingMessage {
 	public final Long duration;
 	public boolean autoStartRecording;
 	public boolean allowStartStopRecording;
+	public final String moderatorPass;
+	public final String viewerPass;
+	public final Long createTime;
+	public final String createDate;
 	
 	public CreateMeetingMessage(String id, String externalId, String name, Boolean record, 
 						String voiceBridge, Long duration, 
-						Boolean autoStartRecording, Boolean allowStartStopRecording) {
+						Boolean autoStartRecording, Boolean allowStartStopRecording,
+						String moderatorPass, String viewerPass, Long createTime,
+						String createDate) {
 		this.id = id;
 		this.externalId = externalId;
 		this.name = name;
@@ -25,5 +31,9 @@ public class CreateMeetingMessage {
 		this.duration = duration;
 		this.autoStartRecording = autoStartRecording;	
 		this.allowStartStopRecording = allowStartStopRecording;
+		this.moderatorPass = moderatorPass;
+		this.viewerPass = viewerPass;
+		this.createTime = createTime;
+		this.createDate = createDate;
 	}
 }


### PR DESCRIPTION
The idea is to make this event send all the data returned by the CREATE API call - it already returned most of the data, but not all of it. It's important for the webhooks application.