### PR TITLE
HTML5 client: toast notification appearing when user joins the audio.

### DIFF
--- a/bigbluebutton-html5/app/client/main.coffee
+++ b/bigbluebutton-html5/app/client/main.coffee
@@ -48,6 +48,7 @@ Template.header.events
   "click .audioFeedIcon": (event) ->
     if getInSession('webrtc_notification_is_displayed') is false # prevents the notification from displaying until the previous one is hidden
       if !isWebRTCAvailable() # verifies if the browser supports WebRTC
+        $('.notification').addClass('webrtc-support-notification')
         setInSession 'webrtc_notification_is_displayed', true
         pp = new Raphael('browser-icon-container', 35, 35)
         if getBrowserName() is 'Safari'
@@ -66,9 +67,27 @@ Template.header.events
           $('.audioFeedIcon').blur()
           setTimeout () -> # waits 0.5 sec (time to hide the notification), then removes the icons
             pp.remove()
+            $('.notification').removeClass('webrtc-support-notification')
             setInSession 'webrtc_notification_is_displayed', false
           , 500
         , 2000
+      else
+        if !BBB.amISharingAudio()
+          Tracker.autorun (comp) ->
+            if BBB.amISharingAudio()
+              $('.notification').addClass('joined-audio-notification')
+              setInSession 'webrtc_notification_is_displayed', true
+              $('#notification-text').html("You've joined the audio")
+              $('#notification').dialog('open')
+              setTimeout () ->
+                $('#notification').dialog('close')
+                $('.audioFeedIcon').blur()
+                setTimeout () ->
+                  $('.notification').removeClass('joined-audio-notification')
+                  setInSession 'webrtc_notification_is_displayed', false
+                , 500
+              , 2000
+              comp.stop()
     $('.audioFeedIcon').blur()
     toggleVoiceCall @
     if BBB.amISharingAudio()

--- a/bigbluebutton-html5/app/client/stylesheets/style.less
+++ b/bigbluebutton-html5/app/client/stylesheets/style.less
@@ -580,8 +580,20 @@ body {
   opacity: 0.85;
 
   background: grey;
-  width: 300px !important;
-  height: 50px !important;
+  &.webrtc-support-notification {
+    width: 300px !important;
+    height: 50px !important;
+  }
+  &.joined-audio-notification {
+    width: 200px !important;
+    height: 32px !important;
+    #browser-icon-container {
+      display: none;
+    }
+    #notification-text {
+      height: 100% !important;
+    }
+  }
   min-height: 0px !important;
   font-weight: 900;
   &.ui-widget-content p {
@@ -589,7 +601,7 @@ body {
     font-size: 14px;
     height: 35px;
     margin: 0;
-    padding: 0;
+    padding: 1px;
   }
 }
 


### PR DESCRIPTION
When user actually joins the audio ("Leave Audio Call" and "Mute" buttons appear), notification slides out.