### PR TITLE
Recording: Fix video EDL merge function on EDLs with recording marks applied

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video.rb
@@ -145,6 +145,18 @@ module BigBlueButton
             end
           end
 
+          # Pull in timestamps from the next entry to respect edit cuts
+          next_entry[:areas].each do |area, videos|
+            videos.each do |video|
+              merged_video = merged_entry[:areas][area].find do |v|
+                v[:filename] == video[:filename]
+              end
+              if !merged_video.nil?
+                merged_video[:timestamp] = video[:timestamp]
+              end
+            end
+          end
+
           entries_i[next_edl] += 1
           if entries_i[next_edl] >= edls[next_edl].length
             done[next_edl] = true


### PR DESCRIPTION
If the video EDL merge function is applied to an EDL that has already been edited to apply recording marks, the merge function will change the video start times to incorrect values on edit points during the timestamp recalculation.

The fix is pretty simple; just pull in the timestamps from the entry that's being merged in and apply them to the relevant videos.

This bug doesn't currently cause any issues in the BigBlueButton recording scripts, since the existing code does the merge before the start/stop marks are applied. But to avoid surprises later, it would be good to fix this.