### PR TITLE
Fix issue 1889

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -95,17 +95,20 @@ class ApiController {
 		return
 	}
 
-/*
-	if (StringUtils.isEmpty(params.name)) {
-		invalid("missingParamName", "You must specify a name for the meeting.");
+	if(!StringUtils.isEmpty(params.meetingID))
+    {
+    	params.meetingID = StringUtils.strip(params.meetingID);
+    	if (StringUtils.isEmpty(params.meetingID))
+    	{
+    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+		    return
+    	}
+    }
+    else {
+    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
 		return
-	}
-*/
-	if (StringUtils.isEmpty(params.meetingID)) {
-		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		return
-	}
-	
+    }
+
 	if (! paramsProcessorUtil.isChecksumSame(API_CALL, params.checksum, request.getQueryString())) {
 		invalid("checksumError", "You did not pass the checksum security check")
 		return
@@ -196,10 +199,19 @@ class ApiController {
 		return
     }
 	
-	if (StringUtils.isEmpty(params.meetingID)) {
-		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+	if(!StringUtils.isEmpty(params.meetingID))
+    {
+    	params.meetingID = StringUtils.strip(params.meetingID);
+    	if (StringUtils.isEmpty(params.meetingID))
+    	{
+    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+		    return
+    	}
+    }
+    else {
+    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
 		return
-	}
+    }
 	
 	if (StringUtils.isEmpty(params.password)) {
 		invalid("invalidPassword","You either did not supply a password or the password supplied is neither the attendee or moderator password for this conference.");
@@ -210,7 +222,8 @@ class ApiController {
 		invalid("checksumError", "You did not pass the checksum security check")
 		return
 	}
-	// END - backward compatibility
+
+	// END - backward compatibility 
   
     // Do we have a checksum? If none, complain.
     if (StringUtils.isEmpty(params.checksum)) {
@@ -218,16 +231,33 @@ class ApiController {
     }
 
     // Do we have a name for the user joining? If none, complain.
-    String fullName = params.fullName
-    if (StringUtils.isEmpty(fullName)) {
-      errors.missingParamError("fullName");
+    if(!StringUtils.isEmpty(params.fullName))
+    {
+    	params.fullName = StringUtils.strip(params.fullName);
+
+    	if (StringUtils.isEmpty(params.fullName))
+    	{
+    		errors.missingParamError("fullName");
+    	}
     }
+    else {
+    	errors.missingParamError("fullName");
+    }
+    String fullName = params.fullName
 
     // Do we have a meeting id? If none, complain.
-    String externalMeetingId = params.meetingID
-    if (StringUtils.isEmpty(externalMeetingId)) {
-      errors.missingParamError("meetingID");
+    if(!StringUtils.isEmpty(params.meetingID))
+    {
+    	params.meetingID = StringUtils.strip(params.meetingID);
+    	if (StringUtils.isEmpty(params.meetingID))
+    	{
+    		errors.missingParamError("meetingID");
+    	}
     }
+    else {
+    	errors.missingParamError("meetingID");
+    }
+    String externalMeetingId = params.meetingID
 
     // Do we have a password? If not, complain.
     String attPW = params.password
@@ -458,10 +488,19 @@ class ApiController {
 		return
 	}
 
-	if (StringUtils.isEmpty(params.meetingID)) {
-		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+	if(!StringUtils.isEmpty(params.meetingID))
+    {
+    	params.meetingID = StringUtils.strip(params.meetingID);
+    	if (StringUtils.isEmpty(params.meetingID))
+    	{
+    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+		    return
+    	}
+    }
+    else {
+    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
 		return
-	}
+    }
 	
 	if (! paramsProcessorUtil.isChecksumSame(API_CALL, params.checksum, request.getQueryString())) {
 		invalid("checksumError", "You did not pass the checksum security check")
@@ -477,10 +516,19 @@ class ApiController {
     }
 
     // Do we have a meeting id? If none, complain.
-    String externalMeetingId = params.meetingID
-    if (StringUtils.isEmpty(externalMeetingId)) {
-      errors.missingParamError("meetingID");
+    if(!StringUtils.isEmpty(params.meetingID))
+    {
+    	params.meetingID = StringUtils.strip(params.meetingID);
+    	if (StringUtils.isEmpty(params.meetingID))
+    	{
+    		errors.missingParamError("meetingID");
+    	}
     }
+    else {
+    	errors.missingParamError("meetingID");
+    }
+    String externalMeetingId = params.meetingID
+
 
     if (errors.hasErrors()) {
     	respondWithErrors(errors)
@@ -528,10 +576,19 @@ class ApiController {
 		return
 	}
 
-	if (StringUtils.isEmpty(params.meetingID)) {
-		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+	if(!StringUtils.isEmpty(params.meetingID))
+    {
+    	params.meetingID = StringUtils.strip(params.meetingID);
+    	if (StringUtils.isEmpty(params.meetingID))
+    	{
+    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+		    return
+    	}
+    }
+    else {
+    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
 		return
-	}
+    }
 	
 	if (StringUtils.isEmpty(params.password)) {
 		invalid("invalidPassword","You must supply the moderator password for this call.");
@@ -552,10 +609,18 @@ class ApiController {
     }
 
     // Do we have a meeting id? If none, complain.
-    String externalMeetingId = params.meetingID
-    if (StringUtils.isEmpty(externalMeetingId)) {
-      errors.missingParamError("meetingID");
+    if(!StringUtils.isEmpty(params.meetingID))
+    {
+    	params.meetingID = StringUtils.strip(params.meetingID);
+    	if (StringUtils.isEmpty(params.meetingID))
+    	{
+    		errors.missingParamError("meetingID");
+    	}
     }
+    else {
+    	errors.missingParamError("meetingID");
+    }
+    String externalMeetingId = params.meetingID
 
     // Do we have a password? If not, complain.
     String modPW = params.password
@@ -631,10 +696,19 @@ class ApiController {
   		return
   	}
 
-  	if (StringUtils.isEmpty(params.meetingID)) {
-  		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-  		return
-  	}
+  	if(!StringUtils.isEmpty(params.meetingID))
+    {
+    	params.meetingID = StringUtils.strip(params.meetingID);
+    	if (StringUtils.isEmpty(params.meetingID))
+    	{
+    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+		    return
+    	}
+    }
+    else {
+    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+		return
+    }
   	
  	
   	if (! paramsProcessorUtil.isChecksumSame(API_CALL, params.checksum, request.getQueryString())) {
@@ -651,10 +725,18 @@ class ApiController {
     }
 
     // Do we have a meeting id? If none, complain.
-    String externalMeetingId = params.meetingID
-    if (StringUtils.isEmpty(externalMeetingId)) {
-      errors.missingParamError("meetingID");
+    if(!StringUtils.isEmpty(params.meetingID))
+    {
+    	params.meetingID = StringUtils.strip(params.meetingID);
+    	if (StringUtils.isEmpty(params.meetingID))
+    	{
+    		errors.missingParamError("meetingID");
+    	}
     }
+    else {
+    	errors.missingParamError("meetingID");
+    }
+    String externalMeetingId = params.meetingID
 
     if (errors.hasErrors()) {
     	respondWithErrors(errors)
@@ -833,9 +915,18 @@ class ApiController {
         return
     }
 
-    if (StringUtils.isEmpty(params.meetingID)) {
-        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-        return
+    if(!StringUtils.isEmpty(params.meetingID))
+    {
+    	params.meetingID = StringUtils.strip(params.meetingID);
+    	if (StringUtils.isEmpty(params.meetingID))
+    	{
+    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+		    return
+    	}
+    }
+    else {
+    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+		return
     }
     
     // Translate the external meeting id into an internal meeting id.
@@ -932,10 +1023,19 @@ class ApiController {
   		return
   	}
 
-  	if (StringUtils.isEmpty(params.meetingID)) {
-  		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-  		return
-  	}
+  	if(!StringUtils.isEmpty(params.meetingID))
+    {
+    	params.meetingID = StringUtils.strip(params.meetingID);
+    	if (StringUtils.isEmpty(params.meetingID))
+    	{
+    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+		    return
+    	}
+    }
+    else {
+    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+		return
+    }
 	
     // Translate the external meeting id into an internal meeting id.
     String internalMeetingId = paramsProcessorUtil.convertToInternalMeetingId(params.meetingID);
@@ -1025,9 +1125,18 @@ class ApiController {
       return
     }
 
-    if (StringUtils.isEmpty(params.meetingID)) {
-      invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-      return
+    if(!StringUtils.isEmpty(params.meetingID))
+    {
+    	params.meetingID = StringUtils.strip(params.meetingID);
+    	if (StringUtils.isEmpty(params.meetingID))
+    	{
+    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+		    return
+    	}
+    }
+    else {
+    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+		return
     }
 
     String internalMeetingId = paramsProcessorUtil.convertToInternalMeetingId(params.meetingID);
@@ -1106,9 +1215,18 @@ class ApiController {
       return
     }
 
-    if (StringUtils.isEmpty(params.meetingID)) {
-      invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-      return
+    if(!StringUtils.isEmpty(params.meetingID))
+    {
+    	params.meetingID = StringUtils.strip(params.meetingID);
+    	if (StringUtils.isEmpty(params.meetingID))
+    	{
+    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+		    return
+    	}
+    }
+    else {
+    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+		return
     }
 
     String internalMeetingId = paramsProcessorUtil.convertToInternalMeetingId(params.meetingID);
@@ -1183,9 +1301,18 @@ class ApiController {
       return
     }
 
-    if (StringUtils.isEmpty(params.meetingID)) {
-      invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-      return
+    if(!StringUtils.isEmpty(params.meetingID))
+    {
+    	params.meetingID = StringUtils.strip(params.meetingID);
+    	if (StringUtils.isEmpty(params.meetingID))
+    	{
+    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+		    return
+    	}
+    }
+    else {
+    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+		return
     }
 
     String internalMeetingId = paramsProcessorUtil.convertToInternalMeetingId(params.meetingID);

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -91,27 +91,24 @@ class ApiController {
   	
 	// BEGIN - backward compatibility
 	if (StringUtils.isEmpty(params.checksum)) {
-		invalid("checksumError", "You did not pass the checksum security check")
-		return
+      invalid("checksumError", "You did not pass the checksum security check")
+	  return
 	}
 
-	if(!StringUtils.isEmpty(params.meetingID))
-    {
-    	params.meetingID = StringUtils.strip(params.meetingID);
-    	if (StringUtils.isEmpty(params.meetingID))
-    	{
-    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		    return
-    	}
-    }
-    else {
-    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		return
+	if(!StringUtils.isEmpty(params.meetingID)) {
+      params.meetingID = StringUtils.strip(params.meetingID);
+      if (StringUtils.isEmpty(params.meetingID)) {
+        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+        return
+      }
+    } else {
+        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+        return
     }
 
 	if (! paramsProcessorUtil.isChecksumSame(API_CALL, params.checksum, request.getQueryString())) {
-		invalid("checksumError", "You did not pass the checksum security check")
-		return
+      invalid("checksumError", "You did not pass the checksum security check")
+      return
 	}
 	// END - backward compatibility
 	
@@ -119,15 +116,15 @@ class ApiController {
 	paramsProcessorUtil.processRequiredCreateParams(params, errors);
 
     if (errors.hasErrors()) {
-    	respondWithErrors(errors)
-    	return
+      respondWithErrors(errors)
+      return
     }
             
     // Do we agree with the checksum? If not, complain.
     if (! paramsProcessorUtil.isChecksumSame(API_CALL, params.checksum, request.getQueryString())) {
       errors.checksumError()
-    	respondWithErrors(errors)
-    	return
+      respondWithErrors(errors)
+      return
     }
     
     
@@ -144,14 +141,14 @@ class ApiController {
         //uploadDocuments(existing);
         respondWithConference(existing, "duplicateWarning", "This conference was already in existence and may currently be in progress.");
       } else {
-	  	// BEGIN - backward compatibility
-	  	invalid("idNotUnique", "A meeting already exists with that meeting ID.  Please use a different meeting ID.");
-		  return;
-	  	// END - backward compatibility
-	  
-        // enforce meetingID unique-ness
-        errors.nonUniqueMeetingIdError()
-        respondWithErrors(errors)
+          // BEGIN - backward compatibility
+          invalid("idNotUnique", "A meeting already exists with that meeting ID.  Please use a different meeting ID.");
+	      return;
+          // END - backward compatibility
+
+          // enforce meetingID unique-ness
+          errors.nonUniqueMeetingIdError()
+          respondWithErrors(errors)
       } 
       
       return;    
@@ -159,9 +156,9 @@ class ApiController {
      
     Meeting newMeeting = paramsProcessorUtil.processCreateParams(params);      
 		
-		if (! StringUtils.isEmpty(params.moderatorOnlyMessage)) {
-			newMeeting.setModeratorOnlyMessage(params.moderatorOnlyMessage);
-		}
+    if (! StringUtils.isEmpty(params.moderatorOnlyMessage)) {
+	  newMeeting.setModeratorOnlyMessage(params.moderatorOnlyMessage);
+    }
 		
     meetingService.createMeeting(newMeeting);
     
@@ -178,52 +175,46 @@ class ApiController {
     log.debug CONTROLLER_NAME + "#${API_CALL}"
   	ApiErrors errors = new ApiErrors()
   	  
-	// BEGIN - backward compatibility
+    // BEGIN - backward compatibility
     if (StringUtils.isEmpty(params.checksum)) {
-		invalid("checksumError", "You did not pass the checksum security check")
-		return
-	}
+      invalid("checksumError", "You did not pass the checksum security check")
+      return
+    }
     
     //checking for an empty username or for a username containing whitespaces only
-    if(!StringUtils.isEmpty(params.fullName))
-    {
-    	params.fullName = StringUtils.strip(params.fullName);
-    	if (StringUtils.isEmpty(params.fullName))
-    	{
-    		invalid("missingParamFullName", "You must specify a name for the attendee who will be joining the meeting.");
-		    return
-    	}
-    }
-    else {
-    	invalid("missingParamFullName", "You must specify a name for the attendee who will be joining the meeting.");
-		return
+    if(!StringUtils.isEmpty(params.fullName)) {
+      params.fullName = StringUtils.strip(params.fullName);
+      if (StringUtils.isEmpty(params.fullName)) {
+        invalid("missingParamFullName", "You must specify a name for the attendee who will be joining the meeting.");
+        return
+      }
+    } else {
+        invalid("missingParamFullName", "You must specify a name for the attendee who will be joining the meeting.");
+        return
     }
 	
-	if(!StringUtils.isEmpty(params.meetingID))
-    {
-    	params.meetingID = StringUtils.strip(params.meetingID);
-    	if (StringUtils.isEmpty(params.meetingID))
-    	{
-    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		    return
-    	}
-    }
-    else {
-    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		return
+    if(!StringUtils.isEmpty(params.meetingID)) {
+      params.meetingID = StringUtils.strip(params.meetingID);
+      if (StringUtils.isEmpty(params.meetingID)) {
+        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+        return
+      }
+    } else {
+        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+        return
     }
 	
-	if (StringUtils.isEmpty(params.password)) {
-		invalid("invalidPassword","You either did not supply a password or the password supplied is neither the attendee or moderator password for this conference.");
-		return
-	}
+    if (StringUtils.isEmpty(params.password)) {
+      invalid("invalidPassword","You either did not supply a password or the password supplied is neither the attendee or moderator password for this conference.");
+      return
+    }
 	
-	if (!paramsProcessorUtil.isChecksumSame(API_CALL, params.checksum, request.getQueryString())) {
-		invalid("checksumError", "You did not pass the checksum security check")
-		return
-	}
+    if (!paramsProcessorUtil.isChecksumSame(API_CALL, params.checksum, request.getQueryString())) {
+      invalid("checksumError", "You did not pass the checksum security check")
+      return
+    }
 
-	// END - backward compatibility 
+    // END - backward compatibility 
   
     // Do we have a checksum? If none, complain.
     if (StringUtils.isEmpty(params.checksum)) {
@@ -231,31 +222,25 @@ class ApiController {
     }
 
     // Do we have a name for the user joining? If none, complain.
-    if(!StringUtils.isEmpty(params.fullName))
-    {
-    	params.fullName = StringUtils.strip(params.fullName);
-
-    	if (StringUtils.isEmpty(params.fullName))
-    	{
-    		errors.missingParamError("fullName");
-    	}
-    }
-    else {
-    	errors.missingParamError("fullName");
+    if(!StringUtils.isEmpty(params.fullName)) {
+      params.fullName = StringUtils.strip(params.fullName);
+      if (StringUtils.isEmpty(params.fullName)) {
+        errors.missingParamError("fullName");
+        }
+    } else {
+        errors.missingParamError("fullName");
     }
     String fullName = params.fullName
 
     // Do we have a meeting id? If none, complain.
-    if(!StringUtils.isEmpty(params.meetingID))
-    {
-    	params.meetingID = StringUtils.strip(params.meetingID);
-    	if (StringUtils.isEmpty(params.meetingID))
-    	{
-    		errors.missingParamError("meetingID");
-    	}
+    if(!StringUtils.isEmpty(params.meetingID)) {
+      params.meetingID = StringUtils.strip(params.meetingID);
+      if (StringUtils.isEmpty(params.meetingID)) {
+        errors.missingParamError("meetingID");
+      }
     }
     else {
-    	errors.missingParamError("meetingID");
+      errors.missingParamError("meetingID");
     }
     String externalMeetingId = params.meetingID
 
@@ -266,15 +251,15 @@ class ApiController {
     }
     
     if (errors.hasErrors()) {
-    	respondWithErrors(errors)
-    	return
+      respondWithErrors(errors)
+      return
     }
         
     // Do we agree on the checksum? If not, complain.		
     if (! paramsProcessorUtil.isChecksumSame(API_CALL, params.checksum, request.getQueryString())) {
-      	errors.checksumError()
-    	respondWithErrors(errors)
-    	return
+      errors.checksumError()
+      respondWithErrors(errors)
+      return
     }
 
     // Everything is good so far. Translate the external meeting id to an internal meeting id. If
@@ -283,39 +268,39 @@ class ApiController {
     log.info("Retrieving meeting ${internalMeetingId}")		
     Meeting meeting = meetingService.getMeeting(internalMeetingId);
     if (meeting == null) {
-		// BEGIN - backward compatibility
-		invalid("invalidMeetingIdentifier", "The meeting ID that you supplied did not match any existing meetings");
-		return;
-		// END - backward compatibility
+      // BEGIN - backward compatibility
+      invalid("invalidMeetingIdentifier", "The meeting ID that you supplied did not match any existing meetings");
+      return;
+      // END - backward compatibility
 		
-	   errors.invalidMeetingIdError();
-	   respondWithErrors(errors)
-	   return;
+      errors.invalidMeetingIdError();
+      respondWithErrors(errors)
+      return;
     }
 
-	// the createTime mismatch with meeting's createTime, complain
-	// In the future, the createTime param will be required
-	if (params.createTime != null){
-		long createTime = 0;
-		try{
-			createTime=Long.parseLong(params.createTime);
-		}catch(Exception e){
-			log.warn("could not parse createTime param");
-			createTime = -1;
-		}
-		if(createTime != meeting.getCreateTime()){
-			errors.mismatchCreateTimeParam();
-			respondWithErrors(errors);
-			return;
-		}
-	}
+    // the createTime mismatch with meeting's createTime, complain
+    // In the future, the createTime param will be required
+    if (params.createTime != null) {
+      long createTime = 0;
+      try{
+        createTime=Long.parseLong(params.createTime);
+      } catch(Exception e){
+          log.warn("could not parse createTime param");
+          createTime = -1;
+      }
+      if(createTime != meeting.getCreateTime()) {
+      errors.mismatchCreateTimeParam();
+      respondWithErrors(errors);
+      return;
+      }
+    }
     
     // Is this user joining a meeting that has been ended. If so, complain.
     if (meeting.isForciblyEnded()) {
-		// BEGIN - backward compatibility
-		invalid("meetingForciblyEnded", "You can not re-join a meeting that has already been forcibly ended.  However, once the meeting is removed from memory (according to the timeout configured on this server, you will be able to once again create a meeting with the same meeting ID");
-		return;
-		// END - backward compatibility
+        // BEGIN - backward compatibility
+        invalid("meetingForciblyEnded", "You can not re-join a meeting that has already been forcibly ended.  However, once the meeting is removed from memory (according to the timeout configured on this server, you will be able to once again create a meeting with the same meeting ID");
+        return;
+        // END - backward compatibility
 		
       errors.meetingForciblyEndedError();
       respondWithErrors(errors)
@@ -331,50 +316,50 @@ class ApiController {
     }
     
     if (role == null) {
-		// BEGIN - backward compatibility
-		invalid("invalidPassword","You either did not supply a password or the password supplied is neither the attendee or moderator password for this conference.");
-		return
-		// END - backward compatibility
-		
-    	errors.invalidPasswordError()
-	    respondWithErrors(errors)
-	    return;
+      // BEGIN - backward compatibility
+      invalid("invalidPassword","You either did not supply a password or the password supplied is neither the attendee or moderator password for this conference.");
+      return
+      // END - backward compatibility
+    
+      errors.invalidPasswordError()
+      respondWithErrors(errors)
+      return;
     }
 	
-	String webVoice = StringUtils.isEmpty(params.webVoiceConf) ? meeting.getTelVoice() : params.webVoiceConf
+    String webVoice = StringUtils.isEmpty(params.webVoiceConf) ? meeting.getTelVoice() : params.webVoiceConf
 
     boolean redirectImm = parseBoolean(params.redirectImmediately)
     
-	String internalUserID = RandomStringUtils.randomAlphanumeric(12).toLowerCase()
+    String internalUserID = RandomStringUtils.randomAlphanumeric(12).toLowerCase()
 
-	String authToken = RandomStringUtils.randomAlphanumeric(12).toLowerCase()
+    String authToken = RandomStringUtils.randomAlphanumeric(12).toLowerCase()
 	
     String externUserID = params.userID
     if (StringUtils.isEmpty(externUserID)) {
       externUserID = internalUserID
     }
 	
-	//Return a Map with the user custom data
-	Map<String,String> userCustomData = paramsProcessorUtil.getUserCustomData(params);
+    //Return a Map with the user custom data
+    Map<String,String> userCustomData = paramsProcessorUtil.getUserCustomData(params);
 
-	//Currently, it's associated with the externalUserID
-	if (userCustomData.size() > 0)
-		meetingService.addUserCustomData(meeting.getInternalId(), externUserID, userCustomData);
+    //Currently, it's associated with the externalUserID
+    if (userCustomData.size() > 0)
+      meetingService.addUserCustomData(meeting.getInternalId(), externUserID, userCustomData);
     
-	String configxml = null;
+    String configxml = null;
 		
-	if (! StringUtils.isEmpty(params.configToken)) {
-		Config conf = meeting.getConfig(params.configToken);
-		if (conf == null) {
-			// Check if this config is one of our pre-built config
-			configxml = configService.getConfig(params.configToken)
-			if (configxml == null) {
-				// Default to the default config.
-				configxml = conf.config;
-			}
-		} else {
-			configxml = conf.config;
-		}
+    if (! StringUtils.isEmpty(params.configToken)) {
+      Config conf = meeting.getConfig(params.configToken);
+      if (conf == null) {
+      // Check if this config is one of our pre-built config
+        configxml = configService.getConfig(params.configToken)
+        if (configxml == null) {
+        // Default to the default config.
+          configxml = conf.config;
+        }
+      } else {
+      configxml = conf.config;
+      }
 	} else {
 		Config conf = meeting.getDefaultConfig();
 		if (conf == null) {
@@ -390,24 +375,23 @@ class ApiController {
 		respondWithErrors(errors);
 	}
 	
-	UserSession us = new UserSession();
-	us.authToken = authToken;
-	us.internalUserId = internalUserID
-  us.conferencename = meeting.getName()
-  us.meetingID = meeting.getInternalId()
-	us.externMeetingID = meeting.getExternalId()
-  us.externUserID = externUserID
-  us.fullname = fullName 
-  us.role = role
-  us.conference = meeting.getInternalId()
-  us.room = meeting.getInternalId()
-  us.voicebridge = meeting.getTelVoice()
-  us.webvoiceconf = meeting.getWebVoice()
-  us.mode = "LIVE"
-  us.record = meeting.isRecord()
-  us.welcome = meeting.getWelcomeMessage()
-	us.logoutUrl = meeting.getLogoutUrl();
-	us.configXML = configxml;
+    us.authToken = authToken;
+    us.internalUserId = internalUserID
+    us.conferencename = meeting.getName()
+    us.meetingID = meeting.getInternalId()
+    us.externMeetingID = meeting.getExternalId()
+    us.externUserID = externUserID
+    us.fullname = fullName 
+    us.role = role
+    us.conference = meeting.getInternalId()
+    us.room = meeting.getInternalId()
+    us.voicebridge = meeting.getTelVoice()
+    us.webvoiceconf = meeting.getWebVoice()
+    us.mode = "LIVE"
+    us.record = meeting.isRecord()
+    us.welcome = meeting.getWelcomeMessage()
+    us.logoutUrl = meeting.getLogoutUrl();
+    us.configXML = configxml;
 			
 	if (! StringUtils.isEmpty(params.defaultLayout)) {
 		us.defaultLayout = params.defaultLayout;
@@ -483,32 +467,29 @@ class ApiController {
     log.debug CONTROLLER_NAME + "#${API_CALL}"
 
 	// BEGIN - backward compatibility
-	if (StringUtils.isEmpty(params.checksum)) {
-		invalid("checksumError", "You did not pass the checksum security check")
-		return
-	}
+    if (StringUtils.isEmpty(params.checksum)) {
+      invalid("checksumError", "You did not pass the checksum security check")
+      return
+    }
 
-	if(!StringUtils.isEmpty(params.meetingID))
-    {
-    	params.meetingID = StringUtils.strip(params.meetingID);
-    	if (StringUtils.isEmpty(params.meetingID))
-    	{
-    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		    return
-    	}
-    }
-    else {
-    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		return
+    if(!StringUtils.isEmpty(params.meetingID)) {
+      params.meetingID = StringUtils.strip(params.meetingID);
+      if (StringUtils.isEmpty(params.meetingID)) {
+        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+        return
+      }
+    } else {
+        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+        return
     }
 	
-	if (! paramsProcessorUtil.isChecksumSame(API_CALL, params.checksum, request.getQueryString())) {
-		invalid("checksumError", "You did not pass the checksum security check")
-		return
-	}
-	// END - backward compatibility
+    if (! paramsProcessorUtil.isChecksumSame(API_CALL, params.checksum, request.getQueryString())) {
+      invalid("checksumError", "You did not pass the checksum security check")
+      return
+    }
+    // END - backward compatibility
 	
-  	ApiErrors errors = new ApiErrors()
+    ApiErrors errors = new ApiErrors()
   	
     // Do we have a checksum? If none, complain.
     if (StringUtils.isEmpty(params.checksum)) {
@@ -516,16 +497,13 @@ class ApiController {
     }
 
     // Do we have a meeting id? If none, complain.
-    if(!StringUtils.isEmpty(params.meetingID))
-    {
-    	params.meetingID = StringUtils.strip(params.meetingID);
-    	if (StringUtils.isEmpty(params.meetingID))
-    	{
-    		errors.missingParamError("meetingID");
-    	}
-    }
-    else {
-    	errors.missingParamError("meetingID");
+    if(!StringUtils.isEmpty(params.meetingID)) {
+      params.meetingID = StringUtils.strip(params.meetingID);
+      if (StringUtils.isEmpty(params.meetingID)) {
+        errors.missingParamError("meetingID");
+      }
+    } else {
+      errors.missingParamError("meetingID");
     }
     String externalMeetingId = params.meetingID
 
@@ -572,28 +550,25 @@ class ApiController {
 	
 	// BEGIN - backward compatibility
 	if (StringUtils.isEmpty(params.checksum)) {
-		invalid("checksumError", "You did not pass the checksum security check")
-		return
-	}
-
-	if(!StringUtils.isEmpty(params.meetingID))
-    {
-    	params.meetingID = StringUtils.strip(params.meetingID);
-    	if (StringUtils.isEmpty(params.meetingID))
-    	{
-    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		    return
-    	}
+      invalid("checksumError", "You did not pass the checksum security check")
+      return
     }
-    else {
-    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		return
+
+    if(!StringUtils.isEmpty(params.meetingID)) {
+      params.meetingID = StringUtils.strip(params.meetingID);
+      if (StringUtils.isEmpty(params.meetingID)) {
+        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+        return
+      }
+    } else {
+        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+        return
     }
 	
 	if (StringUtils.isEmpty(params.password)) {
-		invalid("invalidPassword","You must supply the moderator password for this call.");
-		return
-	}
+      invalid("invalidPassword","You must supply the moderator password for this call.");
+      return
+    }
 	
 	if (! paramsProcessorUtil.isChecksumSame(API_CALL, params.checksum, request.getQueryString())) {
 		invalid("checksumError", "You did not pass the checksum security check")
@@ -609,16 +584,13 @@ class ApiController {
     }
 
     // Do we have a meeting id? If none, complain.
-    if(!StringUtils.isEmpty(params.meetingID))
-    {
-    	params.meetingID = StringUtils.strip(params.meetingID);
-    	if (StringUtils.isEmpty(params.meetingID))
-    	{
-    		errors.missingParamError("meetingID");
-    	}
-    }
-    else {
-    	errors.missingParamError("meetingID");
+    if(!StringUtils.isEmpty(params.meetingID)) {
+      params.meetingID = StringUtils.strip(params.meetingID);
+      if (StringUtils.isEmpty(params.meetingID)) {
+        errors.missingParamError("meetingID");
+      }
+    } else {
+        errors.missingParamError("meetingID");
     }
     String externalMeetingId = params.meetingID
 
@@ -696,18 +668,15 @@ class ApiController {
   		return
   	}
 
-  	if(!StringUtils.isEmpty(params.meetingID))
-    {
-    	params.meetingID = StringUtils.strip(params.meetingID);
-    	if (StringUtils.isEmpty(params.meetingID))
-    	{
-    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		    return
-    	}
-    }
-    else {
-    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		return
+  	if(!StringUtils.isEmpty(params.meetingID)) {
+      params.meetingID = StringUtils.strip(params.meetingID);
+      if (StringUtils.isEmpty(params.meetingID)) {
+        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+        return
+      }
+    } else {
+        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+        return
     }
   	
  	
@@ -725,16 +694,13 @@ class ApiController {
     }
 
     // Do we have a meeting id? If none, complain.
-    if(!StringUtils.isEmpty(params.meetingID))
-    {
-    	params.meetingID = StringUtils.strip(params.meetingID);
-    	if (StringUtils.isEmpty(params.meetingID))
-    	{
-    		errors.missingParamError("meetingID");
-    	}
-    }
-    else {
-    	errors.missingParamError("meetingID");
+    if(!StringUtils.isEmpty(params.meetingID)) {
+      params.meetingID = StringUtils.strip(params.meetingID);
+      if (StringUtils.isEmpty(params.meetingID)) {
+        errors.missingParamError("meetingID");
+      }
+    } else {
+        errors.missingParamError("meetingID");
     }
     String externalMeetingId = params.meetingID
 
@@ -915,18 +881,15 @@ class ApiController {
         return
     }
 
-    if(!StringUtils.isEmpty(params.meetingID))
-    {
-    	params.meetingID = StringUtils.strip(params.meetingID);
-    	if (StringUtils.isEmpty(params.meetingID))
-    	{
-    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		    return
-    	}
-    }
-    else {
-    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		return
+    if(!StringUtils.isEmpty(params.meetingID)) {
+      params.meetingID = StringUtils.strip(params.meetingID);
+      if (StringUtils.isEmpty(params.meetingID)) {
+        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+        return
+      }
+    } else {
+        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+        return
     }
     
     // Translate the external meeting id into an internal meeting id.
@@ -1023,18 +986,15 @@ class ApiController {
   		return
   	}
 
-  	if(!StringUtils.isEmpty(params.meetingID))
-    {
-    	params.meetingID = StringUtils.strip(params.meetingID);
-    	if (StringUtils.isEmpty(params.meetingID))
-    	{
-    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		    return
-    	}
-    }
-    else {
-    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		return
+  	if(!StringUtils.isEmpty(params.meetingID)) {
+      params.meetingID = StringUtils.strip(params.meetingID);
+      if (StringUtils.isEmpty(params.meetingID)) {
+        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+        return
+      }
+    } else {
+        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+        return
     }
 	
     // Translate the external meeting id into an internal meeting id.
@@ -1125,18 +1085,15 @@ class ApiController {
       return
     }
 
-    if(!StringUtils.isEmpty(params.meetingID))
-    {
-    	params.meetingID = StringUtils.strip(params.meetingID);
-    	if (StringUtils.isEmpty(params.meetingID))
-    	{
-    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		    return
-    	}
-    }
-    else {
-    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		return
+    if(!StringUtils.isEmpty(params.meetingID)) {
+      params.meetingID = StringUtils.strip(params.meetingID);
+      if (StringUtils.isEmpty(params.meetingID)) {
+        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+        return
+      }
+    } else {
+        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+        return
     }
 
     String internalMeetingId = paramsProcessorUtil.convertToInternalMeetingId(params.meetingID);
@@ -1215,18 +1172,15 @@ class ApiController {
       return
     }
 
-    if(!StringUtils.isEmpty(params.meetingID))
-    {
-    	params.meetingID = StringUtils.strip(params.meetingID);
-    	if (StringUtils.isEmpty(params.meetingID))
-    	{
-    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		    return
-    	}
-    }
-    else {
-    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		return
+    if(!StringUtils.isEmpty(params.meetingID)) {
+      params.meetingID = StringUtils.strip(params.meetingID);
+      if (StringUtils.isEmpty(params.meetingID)) {
+        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+        return
+      }
+    } else {
+        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+        return
     }
 
     String internalMeetingId = paramsProcessorUtil.convertToInternalMeetingId(params.meetingID);
@@ -1242,7 +1196,6 @@ class ApiController {
      return;
     }
   
-    
     if (! paramsProcessorUtil.isChecksumSame(API_CALL, params.checksum, request.getQueryString())) {     
       response.addHeader("Cache-Control", "no-cache")
       withFormat {
@@ -1301,18 +1254,15 @@ class ApiController {
       return
     }
 
-    if(!StringUtils.isEmpty(params.meetingID))
-    {
-    	params.meetingID = StringUtils.strip(params.meetingID);
-    	if (StringUtils.isEmpty(params.meetingID))
-    	{
-    		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		    return
-    	}
-    }
-    else {
-    	invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
-		return
+    if(!StringUtils.isEmpty(params.meetingID)) {
+      params.meetingID = StringUtils.strip(params.meetingID);
+      if (StringUtils.isEmpty(params.meetingID)) {
+      invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+       return
+      }
+    } else {
+        invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");
+        return
     }
 
     String internalMeetingId = paramsProcessorUtil.convertToInternalMeetingId(params.meetingID);

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -180,11 +180,21 @@ class ApiController {
 		invalid("checksumError", "You did not pass the checksum security check")
 		return
 	}
-
-	if (StringUtils.isEmpty(params.fullName)) {
-		invalid("missingParamFullName", "You must specify a name for the attendee who will be joining the meeting.");
+    
+    //checking for an empty username or for a username containing whitespaces only
+    if(!StringUtils.isEmpty(params.fullName))
+    {
+    	params.fullName = StringUtils.strip(params.fullName);
+    	if (StringUtils.isEmpty(params.fullName))
+    	{
+    		invalid("missingParamFullName", "You must specify a name for the attendee who will be joining the meeting.");
+		    return
+    	}
+    }
+    else {
+    	invalid("missingParamFullName", "You must specify a name for the attendee who will be joining the meeting.");
 		return
-	}
+    }
 	
 	if (StringUtils.isEmpty(params.meetingID)) {
 		invalid("missingParamMeetingID", "You must specify a meeting ID for the meeting.");

--- a/bigbluebutton-web/src/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -98,18 +98,19 @@ public class ParamsProcessorUtil {
 	    if (StringUtils.isEmpty(params.get("checksum"))) {
 	      errors.missingParamError("checksum");
 	    }
-/*	    
-	    // Do we have a meeting name? If not, complain.
-	    String meetingName = params.get("name");
-	    if (StringUtils.isEmpty(meetingName) ) {
-	      errors.missingParamError("name");
-	    }
-*/	    
+        
 	    // Do we have a meeting id? If not, complain.
-	    String externalMeetingId = params.get("meetingID");
-	    if (StringUtils.isEmpty(externalMeetingId)) {
-	      errors.missingParamError("meetingID");
-	    }
+	    if(!StringUtils.isEmpty(params.get("meetingID")))
+        {
+    	  if (StringUtils.isEmpty(StringUtils.strip(params.get("meetingID"))))
+    	  {
+    		errors.missingParamError("meetingID");
+		    
+    	  }
+        }
+        else {
+    	errors.missingParamError("meetingID");
+        }
 	}
 
 	public void updateMeeting(Map<String, Object> updateParams, Meeting existing) {


### PR DESCRIPTION
Leading and trailing whitespaces in the meetingId and fullName are now trimmed.
Also, changed it into ParamsProcessorUtil and all calls, connected with ApiErrors.