### PR TITLE
Improvements on MDIWindow context menu

### DIFF
--- a/bigbluebutton-client/src/SharedNotesModule.mxml
+++ b/bigbluebutton-client/src/SharedNotesModule.mxml
@@ -25,8 +25,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		<![CDATA[
 			import com.asfusion.mate.events.Dispatcher;
 			
-			import flexlib.mdi.containers.MDIWindow;
-			
 			import org.bigbluebutton.common.IBbbModuleWindow;
 			import org.bigbluebutton.common.LogUtil;
 			import org.bigbluebutton.common.events.CloseWindowEvent;

--- a/bigbluebutton-client/src/org/bigbluebutton/common/CustomMdiWindow.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/common/CustomMdiWindow.as
@@ -1,0 +1,91 @@
+/**
+* BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+* 
+* Copyright (c) 2015 BigBlueButton Inc. and by respective authors (see below).
+*
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License as published by the Free Software
+* Foundation; either version 3.0 of the License, or (at your option) any later
+* version.
+* 
+* BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License along
+* with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+*
+*/
+package org.bigbluebutton.common
+{
+  import flash.ui.ContextMenu;
+  
+  import flexlib.mdi.containers.MDIWindow;
+  import flexlib.mdi.managers.MDIManager;
+  
+  import mx.utils.ObjectUtil;
+  
+  /**
+   *  This class exists so we can properly handle context menus on MDIWindow
+   *  instances. Also, we'll be able in the future to properly handle shortcuts
+   *  such as SHIFT + LEFT/RIGHT ARROW while in a text area (today, besides
+   *  selecting the text, it will move the window).
+   */
+  public class CustomMdiWindow extends MDIWindow {
+    
+    private static const IGNORED_MENU_ITEMS:Array = new Array(
+        MDIWindow.CONTEXT_MENU_LABEL_CLOSE,
+        MDIManager.CONTEXT_MENU_LABEL_TILE,
+        MDIManager.CONTEXT_MENU_LABEL_TILE_FILL,
+        MDIManager.CONTEXT_MENU_LABEL_CASCADE,
+        MDIManager.CONTEXT_MENU_LABEL_SHOW_ALL );
+        
+    private var _customContextMenuItems:Array = null;
+    
+    private function filterContextMenu(item:*, index:int, array:Array):Boolean {
+      return IGNORED_MENU_ITEMS.indexOf(item.caption) < 0;
+    }
+    
+    override public function updateContextMenu():void {
+      super.updateContextMenu();
+      
+      var modifiedContextMenuItems:Array = new Array();
+      
+      if (customContextMenuItems != null) {
+        if (modifiedContextMenuItems.length > 0 && customContextMenuItems.length > 0) {
+          modifiedContextMenuItems[0].separatorBefore = true;
+        }
+        modifiedContextMenuItems = customContextMenuItems.concat(modifiedContextMenuItems);
+      }
+      
+      if (this.contextMenu != null) {
+        var filteredMenu:Array = this.contextMenu.customItems.filter(filterContextMenu);
+        if (modifiedContextMenuItems.length > 0 && filteredMenu.length > 0) {
+          filteredMenu[0].separatorBefore = true;
+        }
+        modifiedContextMenuItems = modifiedContextMenuItems.concat(filteredMenu);
+      }
+      
+      var modifiedContextMenu:ContextMenu = new ContextMenu();
+      modifiedContextMenu.hideBuiltInItems();
+      modifiedContextMenu.customItems = modifiedContextMenuItems;
+      this.contextMenu = modifiedContextMenu;
+    }
+    
+    override public function set showCloseButton(value:Boolean):void {
+      super.showCloseButton = value;
+      
+      updateContextMenu();
+    }
+    
+    public function get customContextMenuItems():Array {
+      return _customContextMenuItems;
+    }
+    
+    public function set customContextMenuItems(value:Array):void {
+      _customContextMenuItems = value;
+      
+      updateContextMenu();
+    }
+  }
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/LogWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/LogWindow.mxml
@@ -20,7 +20,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 -->
 
-<MDIWindow xmlns="flexlib.mdi.containers.*" 
+<CustomMdiWindow xmlns="org.bigbluebutton.common.*" 
 	       xmlns:mx="http://www.adobe.com/2006/mxml" 
 	       title="Log Window" creationComplete="displayLogMessages();"
 	       showCloseButton="true" xmlns:text="flash.text.*">
@@ -88,4 +88,4 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		<mx:Button label="Refresh" click="displayLogMessages()"/>
 	</mx:HBox>			    
 	</mx:ApplicationControlBar>
-</MDIWindow>
+</CustomMdiWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
@@ -65,7 +65,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import flash.events.MouseEvent;
 			import flash.geom.Point;
 			
-			import flexlib.mdi.containers.MDIWindow;
 			import flexlib.mdi.effects.effectsLib.MDIVistaEffects;
 			
 			import mx.collections.ArrayCollection;

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/NetworkStatsWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/NetworkStatsWindow.mxml
@@ -20,7 +20,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 -->
 
-<MDIWindow xmlns="flexlib.mdi.containers.*" 
+<CustomMdiWindow xmlns="org.bigbluebutton.common.*" 
 		xmlns:mx="http://www.adobe.com/2006/mxml" 
 		xmlns:mate="http://mate.asfusion.com/"
 		title="Network monitor" 
@@ -136,4 +136,4 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		</mx:VBox>
 	</mx:Panel>
 
-</MDIWindow>
+</CustomMdiWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/ShortcutHelpWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/ShortcutHelpWindow.mxml
@@ -20,7 +20,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 -->
 
-<MDIWindow xmlns="flexlib.mdi.containers.*" 
+<CustomMdiWindow xmlns="org.bigbluebutton.common.*" 
 	       xmlns:mx="http://www.adobe.com/2006/mxml" 
 	       showCloseButton="true"
 		   initialize="init()"
@@ -289,4 +289,4 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			<mx:DataGridColumn dataField="func" headerText="{ResourceUtil.getInstance().getString('bbb.shortcuthelp.headers.function')}"/>
 		</mx:columns>
 	</mx:DataGrid>
-</MDIWindow>
+</CustomMdiWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/broadcast/views/BroadcastWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/broadcast/views/BroadcastWindow.mxml
@@ -18,8 +18,8 @@ You should have received a copy of the GNU Lesser General Public License along
 with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 -->
-<bcast:MDIWindow xmlns:mx="http://www.adobe.com/2006/mxml" 
-					  xmlns:bcast="flexlib.mdi.containers.*" 
+<bcast:CustomMdiWindow xmlns:mx="http://www.adobe.com/2006/mxml" 
+					  xmlns:bcast="org.bigbluebutton.common.*" 
 					  implements="org.bigbluebutton.common.IBbbModuleWindow" 
             styleNameFocus="broadcastStyleFocus" 
             styleNameNoFocus="broadcastStyleNoFocus"
@@ -30,7 +30,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 	<mx:Script>
 		<![CDATA[
-			import flexlib.mdi.events.MDIWindowEvent;			
 			import mx.core.UIComponent;
 			import mx.events.ResizeEvent;
 			import mx.skins.Border;			
@@ -146,4 +145,4 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       <mx:Button id="playBtn" label="Play" width="15% " click="playStopVideo()" toggle="true"/>				
     </mx:HBox>
   </mx:ControlBar>
-</bcast:MDIWindow>
+</bcast:CustomMdiWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatView.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatView.mxml
@@ -45,7 +45,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       import flexlib.controls.tabBarClasses.SuperTab;
       import flexlib.controls.textClasses.StringBoundaries;
       import flexlib.events.SuperTabEvent;
-      import flexlib.mdi.containers.MDIWindow;
       import mx.collections.ArrayCollection;
       import mx.containers.ControlBar;
       import mx.controls.Button;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatWindow.mxml
@@ -20,7 +20,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 -->
 
-<MDIWindow xmlns="flexlib.mdi.containers.*" 
+<CustomMdiWindow xmlns="org.bigbluebutton.common.*" 
 	       xmlns:mx="http://www.adobe.com/2006/mxml" 
 	       xmlns:chat="org.bigbluebutton.modules.chat.views.components.*"
 	       showCloseButton="false"
@@ -40,7 +40,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		<![CDATA[
 			import org.bigbluebutton.modules.chat.model.ChatOptions;
 			import com.asfusion.mate.events.Dispatcher;			
-			import flexlib.mdi.events.MDIWindowEvent;			
 			import mx.controls.Alert;
 			import mx.core.Application;
 			import mx.core.FlexGlobals;
@@ -192,4 +191,4 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	</mx:Script>
 	
 	<views:ChatView id="chatView" chatOptions="{chatOptions}" includeInLayout="false"/>
-</MDIWindow>
+</CustomMdiWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/deskshare/view/components/DesktopPublishWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/deskshare/view/components/DesktopPublishWindow.mxml
@@ -20,11 +20,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 -->
 
-<dspub:MDIWindow 
+<dspub:CustomMdiWindow 
 	xmlns:mx="http://www.adobe.com/2006/mxml" 
 	implements="org.bigbluebutton.common.IBbbModuleWindow"
 	xmlns:mate="http://mate.asfusion.com/"
-	xmlns:dspub="flexlib.mdi.containers.*"
+	xmlns:dspub="org.bigbluebutton.common.*"
 	backgroundColor="#C0C0C0"
 	initialize="init()"
 	creationComplete="onCreationComplete()"	
@@ -48,7 +48,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		<![CDATA[
 			import com.asfusion.mate.events.Dispatcher;
 			
-			import flexlib.mdi.events.MDIWindowEvent;
 			import flexlib.scheduling.scheduleClasses.BackgroundItem;
 			
 			import mx.core.UIComponent;
@@ -474,4 +473,4 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	</dspub:states>
 	<mx:Image id="cursorImg" visible="false" source="@Embed('../../assets/images/cursor4.png')"/>
 
-</dspub:MDIWindow>
+</dspub:CustomMdiWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/deskshare/view/components/DesktopViewWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/deskshare/view/components/DesktopViewWindow.mxml
@@ -20,7 +20,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 -->
 
-<MDIWindow xmlns="flexlib.mdi.containers.*" 
+<CustomMdiWindow xmlns="org.bigbluebutton.common.*" 
 	xmlns:mx="http://www.adobe.com/2006/mxml" 
 	width="600" height="400"
 	initialize="init()"
@@ -321,4 +321,4 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				   toolTip="{btnActualSize.selected ? ResourceUtil.getInstance().getString('bbb.desktopView.fitToWindow') : ResourceUtil.getInstance().getString('bbb.desktopView.actualSize')}" 
 				   tabIndex="{baseIndex+4}"/>
 	</mx:HBox>
-</MDIWindow>
+</CustomMdiWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/example/ExampleChatWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/example/ExampleChatWindow.mxml
@@ -23,15 +23,13 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 <!--
 Notes.mxml is the main view of the SharedNotes application
 -->
-<MDIWindow xmlns="flexlib.mdi.containers.*" xmlns:mx="http://www.adobe.com/2006/mxml" 
+<CustomMdiWindow xmlns="org.bigbluebutton.common.*" xmlns:mx="http://www.adobe.com/2006/mxml" 
 	width="400" height="300" xmlns:mate="http://mate.asfusion.com/" 
 	implements="org.bigbluebutton.common.IBbbModuleWindow" creationComplete="onCreationComplete()"
 	label="Example Chat Window" layout="vertical">
 	
 	<mx:Script>
 		<![CDATA[
-			import flexlib.mdi.events.MDIWindowEvent;
-			
 			import org.bigbluebutton.main.views.MainCanvas;
 
 			private var proxy:ExampleChatProxy;
@@ -65,4 +63,4 @@ Notes.mxml is the main view of the SharedNotes application
 		<mx:TextInput id="txtInput" width="90%" />
 		<mx:Button id="btnSendMessage" label="Send Message" click="sendNewMessage()" />
 	</mx:HBox>
-</MDIWindow>
+</CustomMdiWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/layout/views/LayoutsCombo.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/layout/views/LayoutsCombo.mxml
@@ -41,9 +41,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import flash.net.FileReference;
 			
 			import flexlib.mdi.containers.MDICanvas;
-			import flexlib.mdi.containers.MDIWindow;
 			import flexlib.mdi.events.MDIManagerEvent;
-			import flexlib.mdi.events.MDIWindowEvent;
 			import flexlib.mdi.managers.MDIManager;
 			
 			import mx.collections.ArrayCollection;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/notes/views/NotesWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/notes/views/NotesWindow.mxml
@@ -18,8 +18,8 @@ You should have received a copy of the GNU Lesser General Public License along
 with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 -->
-<ns:MDIWindow xmlns:mx="http://www.adobe.com/2006/mxml" 
-              xmlns:ns="http://code.google.com/p/flexlib/" 
+<ns:CustomMdiWindow xmlns:mx="http://www.adobe.com/2006/mxml" 
+              xmlns:ns="org.bigbluebutton.common.*" 
               xmlns:views="org.bigbluebutton.modules.notes.views.*"
               implements="org.bigbluebutton.common.IBbbModuleWindow" 
               title="Notes"
@@ -46,4 +46,4 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
   </mx:Script>
   
   <views:NotesView id="notesView" notesArray="{notesModel}"/>
-</ns:MDIWindow>
+</ns:CustomMdiWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/polling/views/CreatePollWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/polling/views/CreatePollWindow.mxml
@@ -18,7 +18,7 @@ $Id: $
 <!--
 Notes.mxml is the main view of the SharedNotes application
 -->
-<MDIWindow xmlns="flexlib.mdi.containers.*"
+<CustomMdiWindow xmlns="org.bigbluebutton.common.*"
            xmlns:mx="http://www.adobe.com/2006/mxml"
            width="510" height="600"
            xmlns:mate="http://mate.asfusion.com/"
@@ -46,4 +46,4 @@ Notes.mxml is the main view of the SharedNotes application
 
   
   <poll:PollCreatePanel width="100%" height="100%"/>  
-</MDIWindow>
+</CustomMdiWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/polling/views/DisplayResultWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/polling/views/DisplayResultWindow.mxml
@@ -20,7 +20,7 @@
   $Id: $
 -->
 
-<MDIWindow xmlns="flexlib.mdi.containers.*" 
+<CustomMdiWindow xmlns="org.bigbluebutton.common.*" 
            xmlns:mx="http://www.adobe.com/2006/mxml" 
            xmlns:poll="org.bigbluebutton.modules.polling.views.*"
 		   height="510"
@@ -54,4 +54,4 @@
 	</mx:Script>
   
   <poll:PollResultPanel width="100%" height="100%" viewModel="{viewModel}" pollID="{pollID}"/>
-</MDIWindow>
+</CustomMdiWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/polling/views/PollCreateWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/polling/views/PollCreateWindow.mxml
@@ -18,7 +18,7 @@ $Id: $
 <!--
 Notes.mxml is the main view of the SharedNotes application
 -->
-<MDIWindow xmlns="flexlib.mdi.containers.*"
+<CustomMdiWindow xmlns="org.bigbluebutton.common.*"
            xmlns:mx="http://www.adobe.com/2006/mxml"
            width="510" height="600"
            xmlns:mate="http://mate.asfusion.com/"
@@ -31,8 +31,6 @@ Notes.mxml is the main view of the SharedNotes application
   <mx:Script>
     <![CDATA[
       import com.asfusion.mate.events.Dispatcher;
-      
-      import flexlib.mdi.events.MDIWindowEvent;
       
       import mx.collections.ArrayCollection;
       import mx.containers.HBox;
@@ -179,4 +177,4 @@ Notes.mxml is the main view of the SharedNotes application
                  label="{ResourceUtil.getInstance().getString('bbb.polling.pollPreview.cancel')}" />
     </mx:ControlBar>    
 	  
-</MDIWindow>
+</CustomMdiWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/polling/views/PollMainWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/polling/views/PollMainWindow.mxml
@@ -18,7 +18,7 @@ $Id: $
 <!--
 Notes.mxml is the main view of the SharedNotes application
 -->
-<MDIWindow xmlns="flexlib.mdi.containers.*"
+<CustomMdiWindow xmlns="org.bigbluebutton.common.*"
            xmlns:mx="http://www.adobe.com/2006/mxml"
            width="700" height="450"
            xmlns:mate="http://mate.asfusion.com/"
@@ -49,4 +49,4 @@ Notes.mxml is the main view of the SharedNotes application
   
   <poll:PollMainPanel width="100%" height="100%" viewModel="{viewModel}"/>
   
-</MDIWindow>
+</CustomMdiWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/polling/views/TakePollWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/polling/views/TakePollWindow.mxml
@@ -18,7 +18,7 @@ $Id: $
 <!--
 Notes.mxml is the main view of the SharedNotes application
 -->
-<MDIWindow xmlns="flexlib.mdi.containers.*"
+<CustomMdiWindow xmlns="org.bigbluebutton.common.*"
            xmlns:mx="http://www.adobe.com/2006/mxml"
            width="510" height="450"
            xmlns:mate="http://mate.asfusion.com/"
@@ -49,4 +49,4 @@ Notes.mxml is the main view of the SharedNotes application
 
   
   <poll:TakePollPanel id="takePollPanel" width="100%" height="100%" viewModel="{viewModel}" pollID="{pollID}"/>  
-</MDIWindow>
+</CustomMdiWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/polling/views/UpdatePollWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/polling/views/UpdatePollWindow.mxml
@@ -18,7 +18,7 @@ $Id: $
 <!--
 Notes.mxml is the main view of the SharedNotes application
 -->
-<MDIWindow xmlns="flexlib.mdi.containers.*"
+<CustomMdiWindow xmlns="org.bigbluebutton.common.*"
            xmlns:mx="http://www.adobe.com/2006/mxml"
            width="510" height="450"
            xmlns:mate="http://mate.asfusion.com/"
@@ -49,4 +49,4 @@ Notes.mxml is the main view of the SharedNotes application
 
   
   <poll:UpdatePollPanel width="100%" height="100%" viewModel="{viewModel}" pollID="{pollID}"/>  
-</MDIWindow>
+</CustomMdiWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -103,8 +103,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       private static const LOG:String = "Present::PresentationWindow - ";
       
       public static const TITLE:String = "Presentation";
-			private static const NEXT_BUTTON:String = "Next";
-			private static const PREVIOUS_BUTTON:String = "Previous";
 			private static const GOTO_PAGE_BUTTON:String = "Go to Page...";
 						
 			[Bindable] 
@@ -400,28 +398,17 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private function addContextMenuItems():void{
 				var contextMenuItems:Array = new Array();
 				
-				var nextButton:ContextMenuItem = new ContextMenuItem(NEXT_BUTTON);
-				nextButton.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, menuItemHandler);
+				var nextButton:ContextMenuItem = new ContextMenuItem(ResourceUtil.getInstance().getString('bbb.presentation.forwardBtn.toolTip'));
+				nextButton.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, function(e:ContextMenuEvent):void { gotoNextSlide(); });
 				contextMenuItems.push(nextButton);
 				
-				var previousButton:ContextMenuItem = new ContextMenuItem(PREVIOUS_BUTTON);
-				previousButton.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, menuItemHandler);
+				var previousButton:ContextMenuItem = new ContextMenuItem(ResourceUtil.getInstance().getString('bbb.presentation.backBtn.toolTip'));
+				previousButton.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, function(e:ContextMenuEvent):void { gotoPreviousSlide(); });
 				contextMenuItems.push(previousButton);
 								
 				this.customContextMenuItems = contextMenuItems;
 			}
 			
-			private function menuItemHandler(e:ContextMenuEvent):void{
-				switch(e.target.caption){
-					case NEXT_BUTTON:
-						gotoNextSlide();
-						break;
-					case PREVIOUS_BUTTON:
-						gotoPreviousSlide();
-						break;
-				}
-			}
-						
 			private function notifyOthersOfSharingPresentation(presentationName:String):void {
 				var shareEvent:PresenterCommands = new PresenterCommands(PresenterCommands.SHARE_PRESENTATION_COMMAND);
 					shareEvent.presentationName = presentationName;
@@ -526,6 +513,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				
 				if(Capabilities.hasAccessibility)
 					Accessibility.updateProperties();
+
+				addContextMenuItems();
 			}
 			
 			private function localeChanged(e:Event):void{

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -21,9 +21,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 -->
 
 
-<pres:MDIWindow xmlns:mx="http://www.adobe.com/2006/mxml" 
+<pres:CustomMdiWindow xmlns:mx="http://www.adobe.com/2006/mxml" 
 	xmlns:thumb="org.bigbluebutton.modules.present.views.*"
-	xmlns:pres="flexlib.mdi.containers.*"
+	xmlns:pres="org.bigbluebutton.common.*"
 	xmlns:code="http://code.google.com/p/flexlib/" 
 	xmlns:containers="flexlib.containers.*"
 	xmlns:mate="http://mate.asfusion.com/"
@@ -346,8 +346,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private function becomeViewer():void{
 				setupPresenter(false);
 				dispatchEvent(new UploadEvent(UploadEvent.CLOSE_UPLOAD_WINDOW));
-				this.contextMenu = new ContextMenu();
-				this.contextMenu.hideBuiltInItems();
+				this.customContextMenuItems = new Array();
 				if (slideView.thumbnailView.visible)
 					showThumbnails();
 			}
@@ -399,18 +398,17 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 			
 			private function addContextMenuItems():void{
-				var contextMenu:ContextMenu = new ContextMenu();
-				contextMenu.hideBuiltInItems();
+				var contextMenuItems:Array = new Array();
 				
 				var nextButton:ContextMenuItem = new ContextMenuItem(NEXT_BUTTON);
 				nextButton.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, menuItemHandler);
-				contextMenu.customItems.push(nextButton);
+				contextMenuItems.push(nextButton);
 				
 				var previousButton:ContextMenuItem = new ContextMenuItem(PREVIOUS_BUTTON);
 				previousButton.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, menuItemHandler);
-				contextMenu.customItems.push(previousButton);
+				contextMenuItems.push(previousButton);
 								
-				this.contextMenu = contextMenu;
+				this.customContextMenuItems = contextMenuItems;
 			}
 			
 			private function menuItemHandler(e:ContextMenuEvent):void{
@@ -646,4 +644,4 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     <!-- This spacer is to prevent the whiteboard toolbar from overlapping the fit-ot-page button -->
     <mx:Spacer width="30" height="30" id="spacer4"/>	
     </mx:ControlBar>
-</pres:MDIWindow>
+</pres:CustomMdiWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/SharedNotesWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/SharedNotesWindow.mxml
@@ -17,7 +17,7 @@ You should have received a copy of the GNU Lesser General Public License along
 with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 -->
-<containers:MDIWindow xmlns:mx="http://www.adobe.com/2006/mxml" xmlns:containers="flexlib.mdi.containers.*" 
+<containers:CustomMdiWindow xmlns:mx="http://www.adobe.com/2006/mxml" xmlns:containers="org.bigbluebutton.common.*" 
 					 layout="absolute" width="508" height="494" implements="org.bigbluebutton.common.IBbbModuleWindow" 
 					 title="Notes" creationComplete="init()" xmlns:components="org.bigbluebutton.modules.sharednotes.components.*">
 	<mx:Script>
@@ -216,4 +216,4 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	<mx:Label x="211.5" y="186" text="Connecting..." id="lblConnecting"/>
 		
 	</mx:Canvas>
-</containers:MDIWindow>
+</containers:CustomMdiWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
@@ -20,8 +20,8 @@
   $Id: $
 --> 
 
-<mdi:MDIWindow xmlns:mx="http://www.adobe.com/2006/mxml"
-	xmlns:mdi="flexlib.mdi.containers.*" 
+<mdi:CustomMdiWindow xmlns:mx="http://www.adobe.com/2006/mxml"
+	xmlns:mdi="org.bigbluebutton.common.*" 
 	xmlns:flc="flexlib.controls.*"
 	implements="org.bigbluebutton.common.IBbbModuleWindow" 
 	xmlns:mate="http://mate.asfusion.com/"
@@ -530,4 +530,4 @@
 		</mx:VBox>
 	</mx:ControlBar>
 	
-</mdi:MDIWindow>
+</mdi:CustomMdiWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
@@ -144,14 +144,13 @@
 			}
 			
 			private function addContextMenuItems():void {
-				var contextMenu:ContextMenu = new ContextMenu();
-				contextMenu.hideBuiltInItems();
+				var contextMenuItems:Array = new Array();
 				
 				var exportUsersItem:ContextMenuItem = new ContextMenuItem(ResourceUtil.getInstance().getString("bbb.users.usersGrid.contextmenu.exportusers"));
 				exportUsersItem.addEventListener(ContextMenuEvent.MENU_ITEM_SELECT, exportUsersItemHandler);
-				contextMenu.customItems.push(exportUsersItem);
+				contextMenuItems.push(exportUsersItem);
 				
-				this.contextMenu = contextMenu;
+				this.customContextMenuItems = contextMenuItems;
 			}
 			
 			private function exportUsersItemHandler(e:ContextMenuEvent):void{
@@ -387,6 +386,8 @@
 						raiseHandBtn.accessibilityName = ResourceUtil.getInstance().getString('bbb.users.raiseHandBtn.toolTip');
 					}
 				}
+				
+				addContextMenuItems();
 			}
 			
 			private function loadKeyCombos(modifier:String):void {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/business/VideoWindowItf.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/business/VideoWindowItf.as
@@ -25,7 +25,6 @@ package org.bigbluebutton.modules.videoconf.business
 	import flash.geom.Point;
 	import flash.media.Video;
 	
-	import flexlib.mdi.containers.MDIWindow;
 	import flexlib.mdi.events.MDIWindowEvent;
 	
 	import mx.containers.Panel;
@@ -33,6 +32,7 @@ package org.bigbluebutton.modules.videoconf.business
 	import mx.core.UIComponent;
 	import mx.events.FlexEvent;
 	
+	import org.bigbluebutton.common.CustomMdiWindow;
 	import org.bigbluebutton.common.IBbbModuleWindow;
 	import org.bigbluebutton.common.Images;
 	import org.bigbluebutton.common.LogUtil;
@@ -51,7 +51,7 @@ package org.bigbluebutton.modules.videoconf.business
 	import org.bigbluebutton.modules.videoconf.views.ControlButtons;
 	import org.bigbluebutton.util.i18n.ResourceUtil;
 	
-	public class VideoWindowItf extends MDIWindow implements IBbbModuleWindow
+	public class VideoWindowItf extends CustomMdiWindow implements IBbbModuleWindow
 	{
 		protected var _video:Video;
 		protected var _videoHolder:UIComponent;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videodock/views/VideoDock.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videodock/views/VideoDock.mxml
@@ -20,7 +20,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 -->
 
-<MDIWindow xmlns="flexlib.mdi.containers.*" 
+<CustomMdiWindow xmlns="org.bigbluebutton.common.*" 
 		   xmlns:mx="http://www.adobe.com/2006/mxml" 
 		   initialize="init()" 
        horizontalScrollPolicy="off"
@@ -43,6 +43,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	  import org.bigbluebutton.main.events.ShortcutEvent;
       import com.asfusion.mate.events.Dispatcher;
       
+      import flexlib.mdi.containers.MDIWindow;
+
       import mx.events.ChildExistenceChangedEvent;
       
       import org.bigbluebutton.common.Images;
@@ -488,4 +490,4 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	
 	<mate:Listener type="{OpenVideoWindowEvent.OPEN_VIDEO_WINDOW_EVENT}" method="onOpenWindow" />
 	<mate:Listener type="{CloseWindowEvent.CLOSE_WINDOW_EVENT}" method="onCloseWindow" />
-</MDIWindow>
+</CustomMdiWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardToolbar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardToolbar.mxml
@@ -64,7 +64,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     <![CDATA[
       import com.asfusion.mate.events.Listener;            
       import flash.ui.Keyboard;		
-      import flexlib.mdi.events.MDIWindowEvent;			
       import mx.containers.ControlBar;
       import mx.events.MoveEvent;
       import mx.events.ResizeEvent;


### PR DESCRIPTION
- removed the "Close" option from the context menu, since we do not have any option for a user to restore a closed MDIWindow
- fix the issue when the window is minimized and the custom context menu items are removed (users window and presentation window)
- fix the localization of the custom context menu items (users window and presentation window)
- removed imports of MDI classes where they aren't needed