### PR TITLE
fix for issue 1635, some of the values needed to be reset

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/SlideView.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/SlideView.mxml
@@ -213,6 +213,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				
 				if (UserManager.getInstance().getConference().amIPresenter) {
 					slideModel.adjustSlideAfterParentResized();
+					slideModel.onMove(0, 0); // fake a move to reset some values
 					slideModel.displayPresenterView();
 					slideModel.printViewedRegion();
 					fitSlideToLoader();


### PR DESCRIPTION
When the page changes and the slide is sized the values in _calcPageX, _calcPageY, _calcPageH, and _calcPageW (SlideViewModel.as) weren't being changes from their values from the previous slide. This would cause the presenter to send incorrect information to all of the clients. I put in a move call that doesn't actually move anywhere and it causes a recalculation of the values before sending them off to the other clients.