### PR TITLE
Restore functionality to properly detect mobile and choose correct icon

### DIFF
--- a/bigbluebutton-html5/app/client/globals.coffee
+++ b/bigbluebutton-html5/app/client/globals.coffee
@@ -147,8 +147,8 @@ Handlebars.registerHelper "isUserTalking", (userId) ->
 Handlebars.registerHelper 'isMobile', () ->
   isMobile()
 
-Handlebars.registerHelper 'isMobile', () ->
-  isMobile()
+Handlebars.registerHelper 'isPortraitMobile', () ->
+  isPortraitMobile()
 
 Handlebars.registerHelper 'isMobileChromeOrFirefox', () ->
   isMobile() and ((getBrowserName() is 'Chrome') or (getBrowserName() is 'Firefox'))


### PR DESCRIPTION
Method was removed when it should not have been.
Prevented detection of mobile portrait in certain areas.
Provided incorrect menu icon.