### PR TITLE
Chrome can manually allow NPAPI until version 45, modified publish window to match

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/deskshare/view/components/DesktopPublishWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/deskshare/view/components/DesktopPublishWindow.mxml
@@ -115,14 +115,16 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				
 				if (isUsingLessThanChrome38OnMac()) {
 					setCurrentState("chromeOnMacWarningState");
-				} else if (isChrome42OrHigher()) {
-					setCurrentState("chrome42WarningState");
 				} else {
 					var javaIssue:String = JavaCheck.checkJava();
 					
 					if (javaIssue != null) {
-						setCurrentState("javaIssueWarningState");
-						javaIssueWarningStateLbl.htmlText = javaIssue;
+						if (isChrome42OrHigher()) {
+							setCurrentState("chrome42WarningState");
+						} else {
+							setCurrentState("javaIssueWarningState");
+							javaIssueWarningStateLbl.htmlText = javaIssue;
+						}
 					} else {
 						setCurrentState("dispFullRegionControlBar");
 					}


### PR DESCRIPTION
In Chrome 42 until 45 there is a flag in chrome://flags called "Enable NPAPI" and if you enable that then the Java deskshare app will work until Chrome 45 when the flag will be removed.