### PR TITLE
HTML5 client: push menu adjustments for listen only mode.

### DIFF
--- a/bigbluebutton-html5/app/client/main.coffee
+++ b/bigbluebutton-html5/app/client/main.coffee
@@ -219,6 +219,10 @@ Template.slidingMenu.events
     toggleSlidingMenu()
     $('.collapseButton').blur()
 
+  "click .leaveAudioButton": (event) ->
+    exitVoiceCall event
+    toggleSlidingMenu()
+
 Template.main.helpers
   setTitle: ->
     document.title = "BigBlueButton #{window.getMeetingName() ? 'HTML5'}"

--- a/bigbluebutton-html5/app/client/main.html
+++ b/bigbluebutton-html5/app/client/main.html
@@ -190,31 +190,9 @@
       {{/if}}
 
       {{#if amIInAudio}}
-        <!-- This button is for leaving audio -->
-        <div class='hiddenNavbarSection'>
-          <!-- display the button for leaving audio -->
-          {{> makeButton btn_class="navbarIconToggleActive audioFeedIcon navbarButton audioButton leaveAudioButton" i_class="ion-volume-mute" sharingAudio=true rel="tooltip" data_placement="bottom" title="Leave Audio Call"}}
-        </div>
-        {{#unless amIListenOnlyAudio}}
-          {{#if isCurrentUserMuted}}
-            <!-- if you are muted the button representing your status will show volume off -->
-            {{> makeButton btn_class="muteIcon navbarButton audioButton" i_class="glyphicon glyphicon-volume-off" sharingAudio=true rel="tooltip" data_placement="bottom" title="Unmute"}}
-          {{else}}
-            {{#if isCurrentUserTalking}}
-              <!-- you are talking. Display a high volume/volume up representing voice activity -->
-              {{> makeButton btn_class="navbarIconToggleActive muteIcon navbarButton audioButton" i_class="glyphicon glyphicon-volume-up" sharingAudio=true rel="tooltip" data_placement="bottom" title="Mute"}}
-            {{else}}
-              <!-- you are not talking. Display low volume/volume down representing no voice activity -->
-              {{> makeButton btn_class="navbarIconToggleActive muteIcon navbarButton audioButton" i_class="glyphicon glyphicon-volume-down" sharingAudio=true rel="tooltip" data_placement="bottom" title="Mute"}}
-            {{/if}}
-          {{/if}}
-        {{/unless}}
+        {{> makeButton btn_class="navbarIconToggleActive audioFeedIcon slideButton audioButton leaveAudioButton" i_class="ion-volume-mute" sharingAudio=true rel="tooltip" data_placement="bottom" title="Leave Audio Call"}}
       {{else}}
-        <div class='hiddenNavbarSection'>
-          <div id="shareMicrophonePanel">
-              {{> makeButton btn_class="audioFeedIcon navbarButton audioButton joinAudioButton" i_class="glyphicon glyphicon-headphones" sharingAudio=false rel="tooltip" data_placement="bottom" title="Join Audio Call"}}
-          </div>
-        </div>
+        {{> makeButton btn_class="audioFeedIcon slideButton audioButton joinAudioButton" i_class="glyphicon glyphicon-headphones" sharingAudio=false rel="tooltip" data_placement="bottom" title="Join Audio Call"}}
       {{/if}}
 
       {{#if isCurrentUserRaisingHand}}


### PR DESCRIPTION
- Fixes the issue with inability to join audio due to missing sliding menu buttons.
- Makes the push menu work correctly in listen only mode.