### PR TITLE
Fixed a typo in the loading string while waiting for a whiteboard's presentation

### DIFF
--- a/bigbluebutton-html5/app/client/globals.coffee
+++ b/bigbluebutton-html5/app/client/globals.coffee
@@ -112,7 +112,7 @@ Handlebars.registerHelper "getUsersInMeeting", ->
   raised.concat lowered
 
 Handlebars.registerHelper "getWhiteboardTitle", ->
-  (getPresentationFilename() or "Loading presentaion...")
+  (getPresentationFilename() or "Loading presentation...")
 
 Handlebars.registerHelper "isCurrentUser", (userId) ->
   userId is null or userId is BBB.getCurrentUser()?.userId


### PR DESCRIPTION
- updated 'presentaion' to 'presentation'