### PR TITLE
Shrink notification area to contents

### DIFF
--- a/bigbluebutton-html5/app/client/stylesheets/style.less
+++ b/bigbluebutton-html5/app/client/stylesheets/style.less
@@ -395,8 +395,7 @@ body {
 }
 
 #notificationArea {
-  bottom:0;
-  height: 50%;
+  height: auto;
   left:0;
   margin: auto;
   margin-top: 0px;


### PR DESCRIPTION
Notification area previously was in the foreground over other element preventing interaction.
Fix: Adjust height to expand with content, and prevent it from taking up unnecessary space.