### PR TITLE
Added null validation to the querystring in the checksum calculation

### DIFF
--- a/bigbluebutton-web/src/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -542,18 +542,22 @@ public class ParamsProcessorUtil {
 	
 	public boolean isChecksumSame(String apiCall, String checksum, String queryString) {
 		log.debug("checksum: [{}] ; query string: [{}]", checksum, queryString);
-	
+
 		if (StringUtils.isEmpty(securitySalt)) {
 			log.warn("Security is disabled in this service. Make sure this is intentional.");
 			return true;
 		}
-		
-		// handle either checksum as first or middle / end parameter
-		// TODO: this is hackish - should be done better
-		queryString = queryString.replace("&checksum=" + checksum, "");
-		queryString = queryString.replace("checksum=" + checksum + "&", "");
-		queryString = queryString.replace("checksum=" + checksum, "");
-		
+
+		if( queryString == null ) {
+		    queryString = "";
+		} else {
+		    // handle either checksum as first or middle / end parameter
+		    // TODO: this is hackish - should be done better
+		    queryString = queryString.replace("&checksum=" + checksum, "");
+		    queryString = queryString.replace("checksum=" + checksum + "&", "");
+		    queryString = queryString.replace("checksum=" + checksum, "");
+		}
+
 		log.debug("query string after checksum removed: [{}]", queryString);
 		String cs = DigestUtils.shaHex(apiCall + queryString + securitySalt);
 		log.debug("our checksum: [{}], client: [{}]", cs, checksum);


### PR DESCRIPTION
In the current version of the method isChecksumSame, the queryString received as a parameter and used to calculate and validate the checksum received as part of the request is used with no verification of a null value.

This is OK for all GET requests because there is always a validation of the required parameters so when the method is called the parameter querystring has a value. 

When using a POST request that includes the parameters as part of the message (instead of the querystring), the parameter validation passes (as it should) but if the querystring is null (which it would normally be to make a good use of the POST request), the checksum validation doesn't. The grails application triggers an exception because the replace can not be executed.

With this little change the POST will be fully supported, even though the checksume is calculated using an empy (but not null) query string.

e.g.
apiCall + "" + securitySalt
