### PR TITLE
Added support for POST requests to getRecordings and getMeetings

### DIFF
--- a/bigbluebutton-web/grails-app/conf/UrlMappings.groovy
+++ b/bigbluebutton-web/grails-app/conf/UrlMappings.groovy
@@ -50,11 +50,11 @@ class UrlMappings {
 		}
 
 		"/api/getMeetings"(controller:"api") {
-			action = [GET:'getMeetingsHandler']
+			action = [GET:'getMeetingsHandler', POST:'getMeetingsHandler']
 		}
 		
 		"/api/getRecordings"(controller:"api") {
-			action = [GET:'getRecordingsHandler']
+			action = [GET:'getRecordingsHandler', POST:'getRecordingsHandler']
 		}
 		
 		"/$controller/$action?/$id?(.${format})?"{


### PR DESCRIPTION
Required when making queries for a lot of recordings. It doesn't affect the GET at all.

Implemented right now in Moodle and Sakai integrations