### PR TITLE
Fix issue 1964 - Meeting name label truncation

### DIFF
--- a/bigbluebutton-client/branding/default/style/css/BBBDefault.css
+++ b/bigbluebutton-client/branding/default/style/css/BBBDefault.css
@@ -54,6 +54,7 @@ ToolTip {
   fontWeight: bold;
   fontSize: 15;
   fontFamily: Arial;
+  textAlign: center;
   color: #e1e2e5;
 }
 

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
@@ -152,7 +152,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			[Bindable] private var toolbarPaddingTop:Number = 4;
 			[Bindable] private var showFooterOpt:Boolean = true;
 			[Bindable] private var footerHeight:Number = 24;
-			[Bindable] private var globalHeight:Number = 0;
 			
 			[Bindable] private var isTunneling:Boolean = false;
 			
@@ -183,22 +182,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		
 			protected function initializeShell():void {	
 				globalDispatcher = new Dispatcher();
-
-				systemManager.addEventListener(Event.RESIZE, updateCopyrightLabelDimensions);
-				copyrightLabel2.addEventListener(FlexEvent.UPDATE_COMPLETE, updateCopyrightLabelDimensions);
-				updateCopyrightLabelDimensions();
-			}
-
-			private function updateCopyrightLabelDimensions(e:Event = null):void {
-				var screenRect:Rectangle = systemManager.screen;
-
-				if (spacer.width == 0) {
-					copyrightLabel2.width += (screenRect.width - controlBar.width);
-				} else {
-					copyrightLabel2.width += Math.min(spacer.width, copyrightLabel2.measuredWidth - copyrightLabel2.width);
-				}
-				
-				globalHeight = screenRect.height;
 			}
 		
 			protected function initFullScreen():void {				
@@ -671,7 +654,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					  verticalScrollPolicy="off" 
 					  effectsLib="{flexlib.mdi.effects.effectsLib.MDIVistaEffects}" 
 					  width="100%" 
-					  height="{globalHeight - footerHeight - toolbarHeight - 12}">
+					  height="100%">
 		<views:LoadingBar id="progressBar" horizontalCenter="0" verticalCenter="0" width="50%" />
 		<views:BrandingLogo x="{this.width - 300}" y="{this.height - 300}" />
 	</views:MainCanvas>	
@@ -681,8 +664,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				htmlText="{ResourceUtil.getInstance().getString('bbb.mainshell.copyrightLabel2',[appVersion])}"
 				link="onFooterLinkClicked(event)"
 				id="copyrightLabel2" truncateToFit="true"
+				width="100%" minWidth="1"
 				selectable="true" paddingRight="10"/>
-		<mx:Spacer width="100%" id="spacer" />
+		
 		<mx:Label 
 				id="lblWebRTC"
 				text="{'[ '+ResourceUtil.getInstance().getString('bbb.mainshell.notification.webrtc')+' ]'}"

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
@@ -28,6 +28,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		xmlns:maps="org.bigbluebutton.main.maps.*"
 		xmlns:api="org.bigbluebutton.main.api.*"
 		width="100%" height="100%" 
+		horizontalScrollPolicy="off" verticalScrollPolicy="off"
 		creationComplete="initializeShell()" 
 		xmlns:common="org.bigbluebutton.common.*">
 		

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
@@ -101,15 +101,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
       
       private function onCreationComplete():void {
-        if (this.width < 800) {
-          meetingNameLbl.visible = false;
-          shortcutKeysBtn.visible = false;
-          helpBtn.visible = false;      
-          muteMeBtn.visible = false;
-          meetingNameLbl.width = 0;
-          shortcutKeysBtn.width = 0;
-          helpBtn.width = 0;          
-        }
       }
       
       private function checkAccessiblity(e:TimerEvent):void {
@@ -158,6 +149,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
               var meetingTitle:String = BBB.initUserConfigManager().getMeetingTitle();                   
               if (meetingTitle != null) {
                   meetingNameLbl.text = meetingTitle;
+                  meetingNameLbl.toolTip = meetingTitle;
                } 
           }
       }
@@ -355,9 +347,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	<views:RecordButton id="recordBtn" tabIndex="{baseIndex+numButtons+10}" />
 	<mx:VRule strokeWidth="2" height="100%" visible="{muteMeBtn.visible}" includeInLayout="{muteMeBtn.includeInLayout}"/>
 	<views:MuteMeButton id="muteMeBtn"  height="20" tabIndex="{baseIndex+numButtons+11}"/>
-	<mx:Spacer width="50%"/>
-  <mx:Label id="meetingNameLbl" styleName="meetingNameLabelStyle" />
-  <mx:Spacer width="50%"/>
+	<mx:Label id="meetingNameLbl" width="100%" minWidth="1" styleName="meetingNameLabelStyle" />
 
 <!--
   <mx:Button label="DISCONNECT!" click="BBB.initConnectionManager().forceClose()" height="22" toolTip="Click to simulate disconnection" />


### PR DESCRIPTION
I adjusted the meetingName Label width so that it will truncate if the full length can't fit in the browser window. I also applied the same modification to the copyright Label in the footer.