### PR TITLE
HTML5 client: resizable layout.

### DIFF
--- a/bigbluebutton-html5/app/client/globals.coffee
+++ b/bigbluebutton-html5/app/client/globals.coffee
@@ -391,7 +391,7 @@ Handlebars.registerHelper 'whiteboardSize', (section) ->
   setInSession "display_chatbar", true
   setInSession "display_whiteboard", true
   setInSession "display_chatPane", true
-  
+
   #if it is a desktop version of the client
   if isPortraitMobile() or isLandscapeMobile()
     setInSession "messageFontSize", Meteor.config.app.mobileFont
@@ -405,7 +405,7 @@ Handlebars.registerHelper 'whiteboardSize', (section) ->
   else
     setInSession 'display_usersList', false
   setInSession 'display_menu', false
-  setInSession 'textarea_min_height', 0
+  setInSession 'chatInputMinHeight', 0
 
   #keep notifications and an opened private chat tab if page was refreshed
   #reset to default if that's a new user
@@ -430,7 +430,7 @@ Handlebars.registerHelper 'whiteboardSize', (section) ->
   else if userId isnt checkId
     setInSession 'checkId', userId
     return true
-  else 
+  else
     return false
 
 @onLoadComplete = ->
@@ -458,7 +458,7 @@ Handlebars.registerHelper 'whiteboardSize', (section) ->
   window.matchMedia('(orientation: landscape)').matches and      # browser is landscape
   window.matchMedia('(min-device-aspect-ratio: 1/1)').matches    # device is landscape
 
-@isPortrait = -> 
+@isPortrait = ->
   not isMobile() and
   window.matchMedia('(orientation: portrait)').matches and       # browser is portrait
   window.matchMedia('(min-device-aspect-ratio: 1/1)').matches    # device is landscape
@@ -492,3 +492,22 @@ Handlebars.registerHelper 'whiteboardSize', (section) ->
     return 'IE'
   else
     return null
+
+# changes the height of the chat input area if needed (based on the textarea content)
+@adjustChatInputHeight = () ->
+  $('#newMessageInput').css('height', 'auto')
+  projectedHeight = $('#newMessageInput')[0].scrollHeight + 23
+  if projectedHeight isnt $('.panel-footer').height() and
+  projectedHeight >= getInSession('chatInputMinHeight')
+    $('#newMessageInput').css('overflow', 'hidden') # prevents a scroll bar
+
+    # resizes the chat input area
+    $('.panel-footer').css('top', - (projectedHeight - 70) + 'px')
+    $('.panel-footer').css('height', projectedHeight + 'px')
+
+    $('#newMessageInput').height($('#newMessageInput')[0].scrollHeight)
+
+    # resizes the chat messages container
+    $('#chatbody').height($('#chat').height() - projectedHeight - 45)
+    $('#chatbody').scrollTop($('#chatbody')[0]?.scrollHeight)
+  $('#newMessageInput').css('height', '')

--- a/bigbluebutton-html5/app/client/globals.coffee
+++ b/bigbluebutton-html5/app/client/globals.coffee
@@ -405,6 +405,7 @@ Handlebars.registerHelper 'whiteboardSize', (section) ->
   else
     setInSession 'display_usersList', false
   setInSession 'display_menu', false
+  setInSession 'textarea_min_height', 0
 
   #keep notifications and an opened private chat tab if page was refreshed
   #reset to default if that's a new user

--- a/bigbluebutton-html5/app/client/stylesheets/chat.less
+++ b/bigbluebutton-html5/app/client/stylesheets/chat.less
@@ -176,7 +176,7 @@
   margin: 0px;
 
   @media @landscape {
-    height: 40px; /* same height as send button */
+    height: 100%; /* same height as send button */
   }
   @media @mobile-portrait {
     font-size: 4vw;
@@ -197,7 +197,7 @@
   position: relative;
   background: extract(@white, 1);
   padding: 0;
-  border-top: 1px solid #E5E5E5;
+  border-top: 1px solid extract(@lightGrey, 3);
 }
 
 #sendMessageButton {
@@ -229,6 +229,8 @@
   @media @landscape {
     height: 50px;
     padding: 0px;
+    position: absolute;
+    bottom: 10px;
     &:hover {
       background: #3A82D4;
     }
@@ -242,5 +244,18 @@
 #chatbar-contents {
   @media @landscape {
     min-width: 140px;
+  }
+}
+
+.button-group {
+  @media @landscape {
+    height: 100%;
+  }
+}
+
+#chatInput {
+  @media @landscape {
+    height: 100%;
+    padding-bottom: 10px;
   }
 }

--- a/bigbluebutton-html5/app/client/stylesheets/chat.less
+++ b/bigbluebutton-html5/app/client/stylesheets/chat.less
@@ -141,7 +141,7 @@
   float: left;
   width: 75%;
   resize: none;
-  padding-top: 5px;
+  padding-top: 0px;
   padding-bottom: 0px;
 
   border:1px solid extract(@lightGrey, 3);

--- a/bigbluebutton-html5/app/client/stylesheets/chat.less
+++ b/bigbluebutton-html5/app/client/stylesheets/chat.less
@@ -66,10 +66,10 @@
 
 #chat {
   @media @landscape {
-    -webkit-flex: 3 3 30%;
-    -moz-flex: 3 3 30%;
-    -ms-flex: 3 3 30%;
-    flex: 3 3 30%;
+    -webkit-flex: 1 1;
+    -moz-flex: 1 1;
+    -ms-flex: 1 1;
+    flex: 1 1;
     height: 100%;
     border-top: 0px;
     border-right: 0px;

--- a/bigbluebutton-html5/app/client/stylesheets/chat.less
+++ b/bigbluebutton-html5/app/client/stylesheets/chat.less
@@ -74,6 +74,7 @@
     border-top: 0px;
     border-right: 0px;
     border-top-left-radius: 0px;
+    overflow: hidden;
   }
   order: 3;
 }

--- a/bigbluebutton-html5/app/client/stylesheets/style.less
+++ b/bigbluebutton-html5/app/client/stylesheets/style.less
@@ -109,7 +109,6 @@ body {
     span { background-color: #469DCF; }
   }
   @media @landscape {
-    min-width: 768px;
     height: 50px;
   }
   @media @mobile-portrait-with-keyboard, @mobile-portrait {
@@ -311,10 +310,10 @@ body {
 
 #main {
   @media @landscape {
-    -webkit-flex: 4 4 80%;
-    -moz-flex: 4 4 80%;
-    -ms-flex: 4 4 80%;
-    flex: 4 4 80%;
+    -webkit-flex: 1 1;
+    -moz-flex: 1 1;
+    -ms-flex: 1 1;
+    flex: 1 1;
     height: 100%;
   }
   @media @mobile-portrait-with-keyboard, @desktop-portrait, @mobile-portrait {
@@ -510,7 +509,7 @@ body {
     z-index: 1000;
     position: fixed;
     left: -400px;
-    width: 400px;
+    width: 400px !important; // overrides any width value set manually in landscape
     &.sl-left-drawer-out {
       left: 0px;
     }
@@ -529,10 +528,7 @@ body {
 .sl-left-drawer {
   height: 100%;
   @media @landscape {
-    -webkit-flex: 1 1 20%;
-    -moz-flex: 1 1 20%;
-    -ms-flex: 1 1 20%;
-    flex: 1 1 20%;
+    width: 300px;
   }
 }
 
@@ -581,5 +577,11 @@ body {
   }
   100% {
     opacity: 0.5;
+  }
+}
+
+.ui-resizable-handle {
+  @media @mobile-portrait, @desktop-portrait, @mobile-portrait-with-keyboard {
+    display: none; // hides the sizing handle everywhere except the landscape mode
   }
 }

--- a/bigbluebutton-html5/app/client/stylesheets/whiteboard.less
+++ b/bigbluebutton-html5/app/client/stylesheets/whiteboard.less
@@ -9,19 +9,13 @@
     border-right: 0px;
     border-top-left-radius: 0;
     border-top-right-radius: 0;
-    -webkit-order: 2;
-    order: 2;
-    -webkit-flex: 7 7 70%;
-    -moz-flex: 7 7 70%;
-    -ms-flex: 7 7 70%;
-    flex: 7 7 70%;
-    min-width: 50%;
+    width: 70%;
     height: 100%;
   }
   @media @mobile-portrait-with-keyboard, @desktop-portrait, @mobile-portrait {
     -webkit-order: 1;
     order: 1;
-    width: 100%;
+    width: 100% !important; // overrides any width value set manually in landscape
   }
   &:-webkit-full-screen {
     width: 100%;

--- a/bigbluebutton-html5/app/client/views/chat/chat_bar.coffee
+++ b/bigbluebutton-html5/app/client/views/chat/chat_bar.coffee
@@ -125,9 +125,28 @@ Template.chatbar.helpers
 Template.chatbar.rendered = ->
   detectUnreadChat()
   $('#newMessageInput').on('input keydown paste cut', () -> setTimeout(() ->
-    $('#newMessageInput').height('auto')
-    $('.chatBodyContainer').height($('#chat').height() - ($('#newMessageInput')[0].scrollHeight + 22))
-    $('#newMessageInput').height($('#newMessageInput')[0].scrollHeight)
+    if $('#newMessageInput')[0].scrollHeight > $('#newMessageInput').height() and $('#newMessageInput')[0].scrollHeight + 24 >= getInSession('textarea_min_height')
+      $('#newMessageInput').css('overflow', 'hidden')
+      $('.panel-footer').css('top', - ($('#newMessageInput')[0].scrollHeight - 70 + 24) + 'px')
+      $('.panel-footer').css('height', $('#newMessageInput')[0].scrollHeight + 24 + 'px')
+      $('#chatbody').height($('#chat').height() - $('.panel-footer').height() - 45)
+      $('#chatbody').scrollTop($('#chatbody')[0]?.scrollHeight)
+    else
+      numLines = ($('#newMessageInput').val().match(/\n/g)||[]).length + 1
+      if numLines > 2
+        if 66 + (numLines - 3) * 21 < $('#newMessageInput').height()
+          if 67 + (numLines - 3) * 21 >= getInSession('textarea_min_height')
+            $('.panel-footer').css('top', - ((67 + (numLines - 3) * 21) - 50) + 'px')
+            $('.panel-footer').css('height', (67 + (numLines - 3) * 21) + 21 + 'px')
+            $('#chatbody').height($('#chat').height() - $('.panel-footer').height() - 45)
+            $('#chatbody').scrollTop($('#chatbody')[0]?.scrollHeight)
+      else if numLines is 2
+        if 50 < $('#newMessageInput').height()
+          if 71 >= getInSession('textarea_min_height')
+            $('.panel-footer').css('top', '0px')
+            $('.panel-footer').css('height', '71px')
+            $('#chatbody').height($('#chat').height() - $('.panel-footer').height() - 45)
+            $('#chatbody').scrollTop($('#chatbody')[0]?.scrollHeight)
   , 0))
 
 # When "< Public" is clicked, go to public chat 
@@ -157,10 +176,15 @@ Template.chatInput.rendered = ->
     resize: (event, ui) ->
       if $('.panel-footer').css('top') is '0px'
         $('.panel-footer').height(70) # prevents the element from shrinking vertically for 1-2 px
+      else
+        $('.panel-footer').css('top', parseInt($('.panel-footer').css('top')) + 1 + 'px')
       $('#chatbody').height($('#chat').height() - $('.panel-footer').height() - 45)
       $('#chatbody').scrollTop($('#chatbody')[0]?.scrollHeight)
     start: (event, ui) ->
+      $('#newMessageInput').css('overflow', '')
       $('.panel-footer').resizable('option', 'maxHeight', Math.max($('.panel-footer').height(), $('#chat').height() / 2))
+    stop: (event, ui) ->
+      setInSession 'textarea_min_height', $('.panel-footer').height() + 1
 
 Template.chatInput.events
   'click #sendMessageButton': (event) ->

--- a/bigbluebutton-html5/app/client/views/chat/chat_bar.coffee
+++ b/bigbluebutton-html5/app/client/views/chat/chat_bar.coffee
@@ -124,38 +124,17 @@ Template.chatbar.helpers
 # When chatbar gets rendered, launch the auto-check for unread chat
 Template.chatbar.rendered = ->
   detectUnreadChat()
-  $('#newMessageInput').on('input keydown paste cut', () -> setTimeout(() ->
-    if $('#newMessageInput')[0].scrollHeight > $('#newMessageInput').height() and $('#newMessageInput')[0].scrollHeight + 24 >= getInSession('textarea_min_height')
-      $('#newMessageInput').css('overflow', 'hidden')
-      $('.panel-footer').css('top', - ($('#newMessageInput')[0].scrollHeight - 70 + 24) + 'px')
-      $('.panel-footer').css('height', $('#newMessageInput')[0].scrollHeight + 24 + 'px')
-      $('#chatbody').height($('#chat').height() - $('.panel-footer').height() - 45)
-      $('#chatbody').scrollTop($('#chatbody')[0]?.scrollHeight)
-    else
-      numLines = ($('#newMessageInput').val().match(/\n/g)||[]).length + 1
-      if numLines > 2
-        if 66 + (numLines - 3) * 21 < $('#newMessageInput').height()
-          if 67 + (numLines - 3) * 21 >= getInSession('textarea_min_height')
-            $('.panel-footer').css('top', - ((67 + (numLines - 3) * 21) - 50) + 'px')
-            $('.panel-footer').css('height', (67 + (numLines - 3) * 21) + 21 + 'px')
-            $('#chatbody').height($('#chat').height() - $('.panel-footer').height() - 45)
-            $('#chatbody').scrollTop($('#chatbody')[0]?.scrollHeight)
-      else if numLines is 2
-        if 50 < $('#newMessageInput').height()
-          if 71 >= getInSession('textarea_min_height')
-            $('.panel-footer').css('top', '0px')
-            $('.panel-footer').css('height', '71px')
-            $('#chatbody').height($('#chat').height() - $('.panel-footer').height() - 45)
-            $('#chatbody').scrollTop($('#chatbody')[0]?.scrollHeight)
+  $('#newMessageInput').on('keydown paste cut', () -> setTimeout(() ->
+    adjustChatInputHeight()
   , 0))
 
-# When "< Public" is clicked, go to public chat 
+# When "< Public" is clicked, go to public chat
 Template.chatbar.events
   'click .toPublic': (event) ->
     setInSession 'inChatWith', 'PUBLIC_CHAT'
     setInSession 'chats', getInSession('chats').map((chat) ->
       if chat.userId is "PUBLIC_CHAT"
-        chat.gotMail = false 
+        chat.gotMail = false
         chat.number = 0
       chat
     )
@@ -184,12 +163,13 @@ Template.chatInput.rendered = ->
       $('#newMessageInput').css('overflow', '')
       $('.panel-footer').resizable('option', 'maxHeight', Math.max($('.panel-footer').height(), $('#chat').height() / 2))
     stop: (event, ui) ->
-      setInSession 'textarea_min_height', $('.panel-footer').height() + 1
+      setInSession 'chatInputMinHeight', $('.panel-footer').height() + 1
 
 Template.chatInput.events
   'click #sendMessageButton': (event) ->
     $('#sendMessageButton').blur()
     sendMessage()
+    adjustChatInputHeight()
 
   'keypress #newMessageInput': (event) -> # user pressed a button inside the chatbox
     key = (if event.charCode then event.charCode else (if event.keyCode then event.keyCode else 0))

--- a/bigbluebutton-html5/app/client/views/chat/chat_bar.coffee
+++ b/bigbluebutton-html5/app/client/views/chat/chat_bar.coffee
@@ -120,7 +120,14 @@ Template.chatbar.helpers
       return Meteor.Users.findOne({userId: getInSession('inChatWith')})?
 
 # When chatbar gets rendered, launch the auto-check for unread chat
-Template.chatbar.rendered = -> detectUnreadChat()
+Template.chatbar.rendered = ->
+  detectUnreadChat()
+  $('#newMessageInput').on('input keydown paste cut', () -> setTimeout(() ->
+    $('#newMessageInput').height('auto')
+    $('.chatBodyContainer').height($('#chat').height() - ($('#newMessageInput')[0].scrollHeight + 22))
+    $('#newMessageInput').height($('#newMessageInput')[0].scrollHeight)
+    $('#sendMessageButton').css('margin-top', ($('#newMessageInput').height() - 48) / 2 + 'px')
+  , 0))
 
 # When "< Public" is clicked, go to public chat 
 Template.chatbar.events

--- a/bigbluebutton-html5/app/client/views/chat/chat_bar.coffee
+++ b/bigbluebutton-html5/app/client/views/chat/chat_bar.coffee
@@ -128,7 +128,6 @@ Template.chatbar.rendered = ->
     $('#newMessageInput').height('auto')
     $('.chatBodyContainer').height($('#chat').height() - ($('#newMessageInput')[0].scrollHeight + 22))
     $('#newMessageInput').height($('#newMessageInput')[0].scrollHeight)
-    $('#sendMessageButton').css('margin-top', ($('#newMessageInput').height() - 48) / 2 + 'px')
   , 0))
 
 # When "< Public" is clicked, go to public chat 
@@ -150,6 +149,18 @@ Template.privateChatTab.rendered = ->
 Template.message.rendered = ->
   $('#chatbody').scrollTop($('#chatbody')[0]?.scrollHeight)
   false
+
+Template.chatInput.rendered = ->
+  $('.panel-footer').resizable
+    handles: 'n'
+    minHeight: 70
+    resize: (event, ui) ->
+      if $('.panel-footer').css('top') is '0px'
+        $('.panel-footer').height(70) # prevents the element from shrinking vertically for 1-2 px
+      $('#chatbody').height($('#chat').height() - $('.panel-footer').height() - 45)
+      $('#chatbody').scrollTop($('#chatbody')[0]?.scrollHeight)
+    start: (event, ui) ->
+      $('.panel-footer').resizable('option', 'maxHeight', Math.max($('.panel-footer').height(), $('#chat').height() / 2))
 
 Template.chatInput.events
   'click #sendMessageButton': (event) ->

--- a/bigbluebutton-html5/app/client/views/chat/chat_bar.coffee
+++ b/bigbluebutton-html5/app/client/views/chat/chat_bar.coffee
@@ -124,9 +124,6 @@ Template.chatbar.helpers
 # When chatbar gets rendered, launch the auto-check for unread chat
 Template.chatbar.rendered = ->
   detectUnreadChat()
-  $('#newMessageInput').on('keydown paste cut', () -> setTimeout(() ->
-    adjustChatInputHeight()
-  , 0))
 
 # When "< Public" is clicked, go to public chat
 Template.chatbar.events
@@ -185,6 +182,11 @@ Template.chatInput.events
       sendMessage()
       $('#newMessageInput').val("")
       return false
+
+Template.chatInputControls.rendered = ->
+  $('#newMessageInput').on('keydown paste cut', () -> setTimeout(() ->
+    adjustChatInputHeight()
+  , 0))
 
 Template.message.helpers
   sanitizeAndFormat: (str) ->

--- a/bigbluebutton-html5/app/client/views/users/user_list.coffee
+++ b/bigbluebutton-html5/app/client/views/users/user_list.coffee
@@ -6,6 +6,10 @@ Template.usersList.helpers
     # do not display the label if there are just a few users
 
 Template.usersList.rendered = ->
+  $('.sl-left-drawer').resizable
+    handles: 'e'
+    maxWidth: 600
+    minWidth: 200
   Tracker.autorun (comp) ->
     setInSession 'userListRenderedTime', TimeSync.serverTime()
     if getInSession('userListRenderedTime') isnt undefined

--- a/bigbluebutton-html5/app/client/views/users/user_list.coffee
+++ b/bigbluebutton-html5/app/client/views/users/user_list.coffee
@@ -10,6 +10,8 @@ Template.usersList.rendered = ->
     handles: 'e'
     maxWidth: 600
     minWidth: 200
+    resize: () ->
+      adjustChatInputHeight()
   Tracker.autorun (comp) ->
     setInSession 'userListRenderedTime', TimeSync.serverTime()
     if getInSession('userListRenderedTime') isnt undefined

--- a/bigbluebutton-html5/app/client/views/whiteboard/slide.coffee
+++ b/bigbluebutton-html5/app/client/views/whiteboard/slide.coffee
@@ -6,7 +6,8 @@ Template.slide.rendered = ->
     setInSession 'slideOriginalHeight', this.height
     $(window).resize( ->
       # redraw the whiteboard to adapt to the resized window
-      redrawWhiteboard()
+      if !$('.panel-footer').hasClass('ui-resizable-resizing') # not in the middle of resizing the message input
+        redrawWhiteboard()
     )
     if currentSlide?.slide?.png_uri?
       createWhiteboardPaper (wpm) ->

--- a/bigbluebutton-html5/app/client/views/whiteboard/whiteboard.coffee
+++ b/bigbluebutton-html5/app/client/views/whiteboard/whiteboard.coffee
@@ -51,6 +51,8 @@ Template.whiteboard.rendered = ->
   $('#whiteboard').resizable
     handles: 'e'
     minWidth: 150
+    resize: () ->
+      adjustChatInputHeight()
     start: () ->
       $('#whiteboard').resizable('option', 'maxWidth', $('#panels').width() - 200) # gives the chat enough space (200px)
     stop: () ->

--- a/bigbluebutton-html5/app/client/views/whiteboard/whiteboard.coffee
+++ b/bigbluebutton-html5/app/client/views/whiteboard/whiteboard.coffee
@@ -54,7 +54,10 @@ Template.whiteboard.rendered = ->
     resize: () ->
       adjustChatInputHeight()
     start: () ->
-      $('#whiteboard').resizable('option', 'maxWidth', $('#panels').width() - 200) # gives the chat enough space (200px)
+      if $('#chat').width() / $('#panels').width() > 0.2 # chat shrinking can't make it smaller than one fifth of the whiteboard-chat area
+        $('#whiteboard').resizable('option', 'maxWidth', $('#panels').width() - 200) # gives the chat enough space (200px)
+      else
+        $('#whiteboard').resizable('option', 'maxWidth', $('#whiteboard').width())
     stop: () ->
       $('#whiteboard').css('width', 100 * $('#whiteboard').width() / $('#panels').width() + '%') # transforms width to %
       $('#whiteboard').resizable('option', 'maxWidth', null)

--- a/bigbluebutton-html5/app/client/views/whiteboard/whiteboard.coffee
+++ b/bigbluebutton-html5/app/client/views/whiteboard/whiteboard.coffee
@@ -46,3 +46,13 @@ Template.whiteboard.events
 
   'click .lowerHand': (event) ->
     BBB.lowerHand(BBB.getMeetingId(), getInSession('userId'), getInSession('userId'), getInSession('authToken'))
+
+Template.whiteboard.rendered = ->
+  $('#whiteboard').resizable
+    handles: 'e'
+    minWidth: 150
+    start: () ->
+      $('#whiteboard').resizable('option', 'maxWidth', $('#panels').width() - 200) # gives the chat enough space (200px)
+    stop: () ->
+      $('#whiteboard').css('width', 100 * $('#whiteboard').width() / $('#panels').width() + '%') # transforms width to %
+      $('#whiteboard').resizable('option', 'maxWidth', null)


### PR DESCRIPTION
- Automatically resizes the message input textarea based on its content.
- Allows users to change the height of the chat input area manually.
- Manually modified height is a higher priority than an autoresizing.
- Adds the ability to manually resize the userlist or change the proportion between the whiteboard and chat.
- Automatically adjusts the chat input area's height when page layout is resized.