### PR TITLE
MainApplicationShell height binding update fix application freeze

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
@@ -27,11 +27,18 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		xmlns:mate="http://mate.asfusion.com/"
 		xmlns:maps="org.bigbluebutton.main.maps.*"
 		xmlns:api="org.bigbluebutton.main.api.*"
-		width="100%" height="100%" 
+		width="100%" height="{parentApplication.height - 1}"
 		horizontalScrollPolicy="off" verticalScrollPolicy="off"
 		creationComplete="initializeShell()" 
 		xmlns:common="org.bigbluebutton.common.*">
+
+	<!--
+	height="{parentApplication.height - 1}" : The container height is set to fix height because the percentHeight
+	generates a script execution timeout in the GraphicsWrapper class. We also remove one pixel to force the first
+	update as the height property needs a value different from thec current one to be updated.
 		
+	-->
+	
 	<mate:Listener type="{OpenWindowEvent.OPEN_WINDOW_EVENT}" method="handleOpenWindowEvent" />	
 	<mate:Listener type="{CloseWindowEvent.CLOSE_WINDOW_EVENT}" method="handleCloseWindowEvent"/>
 	<mate:Listener type="{AddUIComponentToMainCanvas.ADD_COMPONENT}" method="addComponentToCanvas" />


### PR DESCRIPTION
Fix the issue where the application freezes because of a using percentHeight in MainApplicationShell by forcing its height to a dynamic value in pixels.