### PR TITLE
Restream video after disconnect

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/events/BBBEvent.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/events/BBBEvent.as
@@ -37,6 +37,7 @@ package org.bigbluebutton.main.events {
     public static const USER_VOICE_LEFT:String = "user voice left event";
     public static const USER_VOICE_TALKING:String = "user voice talking event";
     public static const CAMERA_SETTING:String = "camera settings event";
+	public static const ERASE_CAMERA_SETTING:String = "ERASE_CAMERA_SETTING";
     public static const OPEN_WEBCAM_PREVIEW:String = "open webcam preview event";
 	public static const MIC_SETTINGS_CLOSED:String = "MIC_SETTINGS_CLOSED";
 	public static const CAM_SETTINGS_CLOSED:String = "CAM_SETTINGS_CLOSED";

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/CameraDisplaySettings.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/CameraDisplaySettings.mxml
@@ -163,6 +163,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			camEvent.payload.cameraIndex = selectedCam;
 			camEvent.payload.videoProfile = selectedVideoProfile;
 			camEvent.payload.publishInClient = publishInClient;
+			camEvent.payload.restream = true;
 			
 			globalDispatcher.dispatchEvent(camEvent);
 			

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMap.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMap.mxml
@@ -56,7 +56,15 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
   <EventHandlers type="{BBBEvent.CAMERA_SETTING}" >
     <MethodInvoker generator="{VideoEventMapDelegate}" method="handleCameraSetting" arguments="{event}"/>
   </EventHandlers>
+	
+	<EventHandlers type="{BBBEvent.RECONNECT_CONNECTION_ATTEMPT_SUCCEEDED_EVENT}" >
+		<MethodInvoker generator="{VideoEventMapDelegate}" method="handleRestream" arguments="{event}"/>
+	</EventHandlers>
   
+	<EventHandlers type="{BBBEvent.ERASE_CAMERA_SETTING}" >
+		<MethodInvoker generator="{VideoEventMapDelegate}" method="handleEraseCameraSetting" arguments="{event}"/>
+	</EventHandlers>	
+	
   <EventHandlers type="{ConnectAppEvent.CONNECT_VIDEO_APP}">
     <MethodInvoker generator="{VideoEventMapDelegate}" method="connectToVideoApp"/>
   </EventHandlers>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMapDelegate.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMapDelegate.as
@@ -78,6 +78,10 @@ package org.bigbluebutton.modules.videoconf.maps
     private var streamList:ArrayList = new ArrayList();
     private var numberOfWindows:Object = new Object();
 
+	private var _restream:Boolean = false;
+	private var _cameraIndex:int;
+	private var _videoProfile:VideoProfile;
+	
     public function VideoEventMapDelegate(dispatcher:IEventDispatcher)
     {
       _dispatcher = dispatcher;
@@ -454,12 +458,26 @@ package org.bigbluebutton.modules.videoconf.maps
     }
 
     public function handleCameraSetting(event:BBBEvent):void {
-      var cameraIndex:int = event.payload.cameraIndex;
-      var videoProfile:VideoProfile = event.payload.videoProfile;
-      LOGGER.debug("VideoEventMapDelegate::handleCameraSettings [{0},{1}]", [cameraIndex, videoProfile.id]);
-      initCameraWithSettings(cameraIndex, videoProfile);
+	  _cameraIndex = event.payload.cameraIndex;
+      _videoProfile = event.payload.videoProfile;
+	  _restream = event.payload.restream;
+      LOGGER.debug("VideoEventMapDelegate::handleCameraSettings [{0},{1}]", [_cameraIndex, _videoProfile.id]);
+      initCameraWithSettings(_cameraIndex, _videoProfile);
     }
 
+	public function handleEraseCameraSetting(event:BBBEvent):void {
+		_cameraIndex = -1;
+		_videoProfile = null;
+		_restream = event.payload.restream;
+	}
+	
+	public function handleRestream(event:BBBEvent):void {
+		if(_restream){
+			LOGGER.debug("VideoEventMapDelegate::handleRestream [{0},{1}]", [_cameraIndex, _videoProfile.id]);
+			initCameraWithSettings(_cameraIndex, _videoProfile);
+		}
+	}
+	
     private function initCameraWithSettings(camIndex:int, videoProfile:VideoProfile):void {
       var camSettings:CameraSettingsVO = new CameraSettingsVO();
       camSettings.camIndex = camIndex;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/ToolbarPopupButton.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/ToolbarPopupButton.mxml
@@ -163,6 +163,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					switchStateToNormal();
 					var stopShareCameraRequestEvent:StopShareCameraRequestEvent = new StopShareCameraRequestEvent(StopShareCameraRequestEvent.STOP_SHARE_ALL_CAMERA_REQUEST);
 					dispatchEvent(stopShareCameraRequestEvent);
+					
+					var camEvent:BBBEvent = new BBBEvent(BBBEvent.ERASE_CAMERA_SETTING);
+					camEvent.payload.restream = false;
+					dispatchEvent(camEvent);
+					
 					this.enabled = true;		
 				} else {
 					LOGGER.debug("Share camera");


### PR DESCRIPTION
This commit will enable the client to restream video in the case of a disconnect.

A _restream variable has been added to the VideoEventMapDelegate.as, that will dictate if the stream needs to be restream.
The setting are stored also stored so ensure that no user interaction is needed to restream the video.

VideoEventMapDelegate.as now listens to BBBEvent.RECONNECT_CONNECTION_ATTEMPT_SUCCEEDED_EVENT, and will restream the video in the case _restream is true.

_restream is set to true when the user shares his camera, and set to false when the user manually closes his camera.