### PR TITLE
Use protocol-relative links to load the 'get flash' button image

### DIFF
--- a/bigbluebutton-client/resources/prod/BigBlueButton.html
+++ b/bigbluebutton-client/resources/prod/BigBlueButton.html
@@ -158,7 +158,7 @@
         <br/>
         <div style="width:50%; margin-left: auto; margin-right: auto; ">
           <a href="http://www.adobe.com/go/getflashplayer">
-            <img src="http://www.adobe.com/images/shared/download_buttons/get_flash_player.gif" alt="Get Adobe Flash player" />
+            <img src="//www.adobe.com/images/shared/download_buttons/get_flash_player.gif" alt="Get Adobe Flash player" />
           </a>
           <p style="margin-left:50px;" >OR</p>
           <button type="button" onclick="html5();"><h3>Launch the HTML5 client instead</h3></button>

--- a/bigbluebutton-client/resources/prod/BigBlueButtonTest.html
+++ b/bigbluebutton-client/resources/prod/BigBlueButtonTest.html
@@ -76,11 +76,7 @@
                 To view this page ensure that Adobe Flash Player version 
                 10.3.0 or greater is installed. 
             </p>
-            <script type="text/javascript"> 
-                var pageHost = ((document.location.protocol == "https:") ? "https://" : "http://"); 
-                document.write("<a href='http://www.adobe.com/go/getflashplayer'><img src='" 
-                                + pageHost + "www.adobe.com/images/shared/download_buttons/get_flash_player.gif' alt='Get Adobe Flash player' /></a>" ); 
-            </script> 
+	    <a href="http://www.adobe.com/go/getflashplayer"><img src="//www.adobe.com/images/shared/download_buttons/get_flash_player.gif" alt="Get Adobe Flash player"></a>
         </div>
         
         <noscript>

--- a/bigbluebutton-client/resources/prod/DeskshareStandalone.html
+++ b/bigbluebutton-client/resources/prod/DeskshareStandalone.html
@@ -31,7 +31,7 @@
                                         <param name="bgcolor" value="#869ca7" />
                                 <!--<![endif]-->
                                         <a href="http://www.adobe.com/go/getflashplayer">
-                                                <img src="http://www.adobe.com/images/shared/download_buttons/get_flash_player.gif" alt="Get Adobe Flash player" />
+                                                <img src="//www.adobe.com/images/shared/download_buttons/get_flash_player.gif" alt="Get Adobe Flash player" />
                                         </a>
                                 <!--[if !IE]>-->
                                 </object>

--- a/bigbluebutton-client/resources/prod/EmbedBigBlueButton.html
+++ b/bigbluebutton-client/resources/prod/EmbedBigBlueButton.html
@@ -33,7 +33,7 @@
             <param name="bgcolor" value="#869ca7" />
         <!--<![endif]-->
             <a href="http://www.adobe.com/go/getflashplayer">
-              <img src="http://www.adobe.com/images/shared/download_buttons/get_flash_player.gif" alt="Get Adobe Flash player" />
+              <img src="//www.adobe.com/images/shared/download_buttons/get_flash_player.gif" alt="Get Adobe Flash player" />
             </a>
         <!--[if !IE]>-->
           </object>


### PR DESCRIPTION
This fixes a mixed content warning when loading the client over https