### PR TITLE
Fix for locking not initializing

### DIFF
--- a/akka-bbb-apps/build.sbt
+++ b/akka-bbb-apps/build.sbt
@@ -50,7 +50,7 @@ libraryDependencies ++= {
 	  "com.google.code.gson"      %  "gson"              % "1.7.1",
 	  "redis.clients"             %  "jedis"             % "2.7.2",
       "org.apache.commons"        %  "commons-lang3"     % "3.2",
-      "org.bigbluebutton"         %  "bbb-common-message" % "0.0.14"
+      "org.bigbluebutton"         %  "bbb-common-message" % "0.0.15"
 	)}
 
 seq(Revolver.settings: _*)

--- a/bbb-common-message/build.sbt
+++ b/bbb-common-message/build.sbt
@@ -4,7 +4,7 @@ name := "bbb-common-message"
 
 organization := "org.bigbluebutton"
 
-version := "0.0.14"
+version := "0.0.15"
 
 // We want to have our jar files in lib_managed dir.
 // This way we'll have the right path when we import

--- a/bbb-common-message/src/main/java/org/bigbluebutton/common/messages/Constants.java
+++ b/bbb-common-message/src/main/java/org/bigbluebutton/common/messages/Constants.java
@@ -118,8 +118,8 @@ public class Constants {
   public static final String FROM_TIME                       = "from_time";
   public static final String PERM_DISABLE_CAM                = "disableCam";
   public static final String PERM_DISABLE_MIC                = "disableMic";
-  public static final String PERM_DISABLE_PRIVCHAT           = "disablePrivChat";
-  public static final String PERM_DISABLE_PUBCHAT            = "disablePubChat";
+  public static final String PERM_DISABLE_PRIVCHAT           = "disablePrivateChat";
+  public static final String PERM_DISABLE_PUBCHAT            = "disablePublicChat";
   public static final String PERM_LOCKED_LAYOUT              = "lockedLayout";
   public static final String PERM_LOCK_ON_JOIN               = "lockOnJoin";
   public static final String PERM_LOCK_ON_JOIN_CONFIG        = "lockOnJoinConfigurable";

--- a/bbb-common-message/src/main/java/org/bigbluebutton/common/messages/InitAudioSettingsMessage.java
+++ b/bbb-common-message/src/main/java/org/bigbluebutton/common/messages/InitAudioSettingsMessage.java
@@ -23,7 +23,9 @@ public class InitAudioSettingsMessage implements ISubscribedMessage {
 	public String toJson() {
 		HashMap<String, Object> payload = new HashMap<String, Object>();
 		payload.put(Constants.MEETING_ID, meetingId);
-
+		payload.put(Constants.USER_ID, userId);
+		payload.put(Constants.MUTED, muted);
+		
 		java.util.HashMap<String, Object> header = MessageBuilder.buildHeader(INIT_AUDIO_SETTING, VERSION, null);
 
 		return MessageBuilder.buildJson(header, payload);				

--- a/bbb-common-message/src/main/java/org/bigbluebutton/common/messages/InitPermissionsSettingMessage.java
+++ b/bbb-common-message/src/main/java/org/bigbluebutton/common/messages/InitPermissionsSettingMessage.java
@@ -21,7 +21,8 @@ public class InitPermissionsSettingMessage implements ISubscribedMessage {
 	public String toJson() {
 		HashMap<String, Object> payload = new HashMap<String, Object>();
 		payload.put(Constants.MEETING_ID, meetingId);
-
+		payload.put(Constants.PERMISSIONS, permissions);
+		
 		java.util.HashMap<String, Object> header = MessageBuilder.buildHeader(INIT_PERMISSIONS_SETTING, VERSION, null);
 
 		return MessageBuilder.buildJson(header, payload);				
@@ -29,17 +30,15 @@ public class InitPermissionsSettingMessage implements ISubscribedMessage {
 	public static InitPermissionsSettingMessage fromJson(String message) {
 		JsonParser parser = new JsonParser();
 		JsonObject obj = (JsonObject) parser.parse(message);
-
 		if (obj.has("header") && obj.has("payload")) {
 			JsonObject header = (JsonObject) obj.get("header");
 			JsonObject payload = (JsonObject) obj.get("payload");
-
 			if (header.has("name")) {
 				String messageName = header.get("name").getAsString();
 				if (INIT_PERMISSIONS_SETTING.equals(messageName)) {
 					if (payload.has(Constants.MEETING_ID)
-							&& payload.has(Constants.USERS)
 							&& payload.has(Constants.PERMISSIONS)) {
+								
 						String meetingID = payload.get(Constants.MEETING_ID).getAsString();
 
 						JsonObject permissions = (JsonObject) payload.get(Constants.PERMISSIONS);

--- a/bbb-common-message/src/main/java/org/bigbluebutton/common/messages/Util.java
+++ b/bbb-common-message/src/main/java/org/bigbluebutton/common/messages/Util.java
@@ -15,7 +15,7 @@ public class Util {
 				&& vu.has(Constants.PERM_DISABLE_PRIVCHAT) && vu.has(Constants.PERM_DISABLE_PUBCHAT)
 				&& vu.has(Constants.PERM_LOCKED_LAYOUT) && vu.has(Constants.PERM_LOCK_ON_JOIN)
 				&& vu.has(Constants.PERM_LOCK_ON_JOIN_CONFIG)){
-				
+			
 			Map<String, Boolean> vuMap = new HashMap<String, Boolean>();
 			Boolean disableCam = vu.get(Constants.PERM_DISABLE_CAM).getAsBoolean();
 			Boolean disableMic = vu.get(Constants.PERM_DISABLE_MIC).getAsBoolean();

--- a/bigbluebutton-apps/build.gradle
+++ b/bigbluebutton-apps/build.gradle
@@ -105,7 +105,7 @@ dependencies {
    compile 'com.google.code.gson:gson:1.7.1'
    providedCompile 'org.apache.commons:commons-lang3:3.2'
 
-  compile 'org.bigbluebutton:bbb-common-message:0.0.14'
+  compile 'org.bigbluebutton:bbb-common-message:0.0.15'
 }
 
 test {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/polling/service/PollDataProcessor.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/polling/service/PollDataProcessor.as
@@ -93,7 +93,7 @@ package org.bigbluebutton.modules.polling.service
               if (localizedKey == null || localizedKey == "" || localizedKey == "undefined") {
                 localizedKey = answers[k].key;
               } 
-              accessibleAnswers += ResourceUtil.getInstance().getString("bbb.polling.results.accessible.answer", [localizedKey, a.num_votes]) + "<br />";
+              accessibleAnswers += ResourceUtil.getInstance().getString("bbb.polling.results.accessible.answer", [localizedKey, answers[k].num_votes]) + "<br />";
             }
             
             var pollResultMessage:ChatMessageVO = new ChatMessageVO();

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/polling/views/PollGraphic.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/polling/views/PollGraphic.as
@@ -40,7 +40,6 @@ package org.bigbluebutton.modules.polling.views
 		private const vPaddingPercent:Number = 0.25;
 		private const hPaddingPercent:Number = 0.1;
 		private const labelWidthPercent:Number = 0.3;
-		private const labelMaxWidthInPixels:int = 100;
 		
 		private var sampledata:Array = [{a:"A", v:3}, 
 									{a:"B", v:1},

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/PollResultObject.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/PollResultObject.as
@@ -41,7 +41,6 @@ package org.bigbluebutton.modules.whiteboard.business.shapes
     private const vPaddingPercent:Number = 0.25;
     private const hPaddingPercent:Number = 0.1;
     private const labelWidthPercent:Number = 0.3;
-    private const labelMaxWidthInPixels:int = 40;
     
     private var sampledata:Array = [{a:"A", v:3}, {a:"B", v:1}, {a:"C", v:5}, {a:"D", v:8}];
     private var _data:Array;


### PR DESCRIPTION
Also removed an unneeded warning for Chrome users about Java being missing, and corrected the vote counts on the accessible poll message.

In order to fix the locking not initializing I had to change two of the message property constants for locking: "disablePrivChat" -> "disablePrivateChat" and "disablePubChat" -> "disablePublicChat"

I also bumped the version number on the common-messages.