### PR TITLE
Force MediaItemRenderer to update

### DIFF
--- a/bigbluebutton-client/.project
+++ b/bigbluebutton-client/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>o-old-bbb-client</name>
+	<name>bbb-client</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/BBBUser.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/BBBUser.as
@@ -364,7 +364,7 @@ package org.bigbluebutton.main.model.users
 			var lockSettings:LockSettingsVO = UserManager.getInstance().getConference().getLockSettings();
 			var amNotModerator:Boolean = !UsersUtil.amIModerator();
 			var amNotPresenter:Boolean = !UsersUtil.amIPresenter();
-			var lockAppliesToMe:Boolean = me && amNotModerator && amNotPresenter && !userLocked;
+			var lockAppliesToMe:Boolean = me && amNotModerator && amNotPresenter && userLocked;
 			
 			disableMyCam = lockAppliesToMe && lockSettings.getDisableCam();
 			disableMyMic = lockAppliesToMe && lockSettings.getDisableMic();

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/Conference.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/Conference.as
@@ -524,6 +524,7 @@ package org.bigbluebutton.main.model.users {
 		public function setLockSettings(lockSettings:LockSettingsVO):void {
 			this.lockSettings = lockSettings;
 			applyLockSettings();
+			users.refresh(); // we need to refresh after updating the lock settings to trigger the user item renderers to redraw
 		}
 		
 		public function applyLockSettings():void {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/FlashCallManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/FlashCallManager.as
@@ -69,7 +69,7 @@
     }
         
     private function initConnectionManager():void {
-      var options:PhoneOptions = new PhoneOptions();
+      options = new PhoneOptions();
       var uid:String = String(Math.floor(new Date().getTime()));
       var uname:String = encodeURIComponent(UsersUtil.getMyExternalUserID() + "-bbbID-" + UsersUtil.getMyUsername()); 
       connectionManager.setup(uid, UsersUtil.getMyUserID(), uname , UsersUtil.getInternalMeetingID(), options.uri);
@@ -198,7 +198,6 @@
     
     public function initialize():void {      
       printMics();
-      options = new PhoneOptions();
       if (options.useWebRTCIfAvailable && isWebRTCSupported()) {
         usingFlash = false;
       } else {


### PR DESCRIPTION
The lock icon in the UsersList isn't updating enough. I added a refresh on the user collection to force the MediaItemRenderers to update.

I also fixed a potential null exception in FlashCallManager.