### PR TITLE
Add a default message length to avoid issues of missing property

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/model/ChatOptions.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/model/ChatOptions.as
@@ -38,7 +38,7 @@ package org.bigbluebutton.modules.chat.model {
 		public var colorPickerIsVisible:Boolean = false;
 		
 		[Bindable]
-		public var maxMessageLength:uint;
+		public var maxMessageLength:uint = 1024;
 		
 		public function ChatOptions() {
 			var cxml:XML = BBB.getConfigForModule("ChatModule");


### PR DESCRIPTION
If maxMessageLength is missing from config.xml no chat messages could be sent because a uint defaults to zero. I added a proper default value set to the same as config.xml.template.