### PR TITLE
Fix 2810

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/WhiteboardCanvasDisplayModel.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/WhiteboardCanvasDisplayModel.as
@@ -62,15 +62,19 @@ package org.bigbluebutton.modules.whiteboard
 	private var zoomPercentage:Number = 1;
 	
     public function doMouseDown(mouseX:Number, mouseY:Number):void {
+      publishText();
+    }
+    
+    private function publishText():void {
       /**
-        * Check if the presenter is starting a new text annotation without committing the last one.
-        * If so, publish the last text annotation. 
-        */
+       * Check if the presenter is starting a new text annotation without committing the last one.
+       * If so, publish the last text annotation. 
+       */
       if (currentlySelectedTextObject != null && currentlySelectedTextObject.status != TextObject.TEXT_PUBLISHED) {
         sendTextToServer(TextObject.TEXT_PUBLISHED, currentlySelectedTextObject);
       }
     }
-        
+    
     public function drawGraphic(event:WhiteboardUpdate):void{
       var o:Annotation = event.annotation;
       //  LogUtil.debug("**** Drawing graphic [" + o.type + "] *****");
@@ -161,6 +165,9 @@ package org.bigbluebutton.modules.whiteboard
       }
       
       tobj.registerListeners(textObjGainedFocusListener, textObjLostFocusListener, textObjTextChangeListener, textObjSpecialListener);
+      
+      tobj._whiteboardID = whiteboardModel.getCurrentWhiteboardId();
+      
       wbCanvas.addGraphic(tobj);
       wbCanvas.stage.focus = tobj;
             _annotationsList.push(tobj);
@@ -329,7 +336,9 @@ package org.bigbluebutton.modules.whiteboard
         
         /**********************************************************/
         
-    public function changePage(wbId:String):void{
+        public function changePage(wbId:String):void{
+            publishText();
+            
 //            LogUtil.debug("**** CanvasDisplay changePage. Clearing page *****");
             clearBoard();
             
@@ -541,9 +550,8 @@ package org.bigbluebutton.modules.whiteboard
       annotation["textBoxWidth"] = tobj.textBoxWidth;
       annotation["textBoxHeight"] = tobj.textBoxHeight;
       
-      var wbId:String = whiteboardModel.getCurrentWhiteboardId();
-      if (wbId != null) {
-        annotation["whiteboardId"] = wbId;        
+      if (tobj._whiteboardID != null) {
+        annotation["whiteboardId"] = tobj._whiteboardID;        
         var msg:Annotation = new Annotation(tobj.id, "text", annotation);
         wbCanvas.sendGraphicToServer(msg, WhiteboardDrawEvent.SEND_TEXT);
       }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/TextObject.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/TextObject.as
@@ -59,6 +59,8 @@ package org.bigbluebutton.modules.whiteboard.business.shapes
     private var _origParentHeight:Number = 0;
     public var fontStyle:String = "arial";
     private var _calcedFontSize:Number;
+	
+    public var _whiteboardID:String;
     
     public function TextObject(text:String, textColor:uint, x:Number, y:Number, boxWidth:Number, 
                                boxHeight:Number, textSize:Number, calcedFontSize:Number) {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/managers/WhiteboardManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/managers/WhiteboardManager.as
@@ -108,7 +108,9 @@ package org.bigbluebutton.modules.whiteboard.managers
 		}
 
 		public function drawGraphic(event:WhiteboardUpdate):void {
-			displayModel.drawGraphic(event);
+			if (event.annotation.whiteboardId == whiteboardModel.getCurrentWhiteboardId()) {
+				displayModel.drawGraphic(event);
+			}
 		}
 		
 		public function clearAnnotations():void {


### PR DESCRIPTION
This pull request implements a fix to make sure that text annotations are published to the correct whiteboard.

There is also a change to apply a check that ensures that only annotations that have a whiteboardID equal to the current one are shown. A similar check will likely need to be made in the recording processing scripts and the HTML5 client.