### PR TITLE
fix demo12.jsp when camera is disabled

### DIFF
--- a/bbb-api-demo/src/main/webapp/demo12.jsp
+++ b/bbb-api-demo/src/main/webapp/demo12.jsp
@@ -170,8 +170,9 @@ Author: Jesus Federico <jesus@123it.ca>
 	Element webcamElement = getElementWithAttribute(firstChild, "name", "VideoconfModule");
 	if(param_VideoModule.equals("disable")){
 		webcamElement.getParentNode().removeChild(webcamElement);
-		Element videodockModule = getElementWithAttribute(firstChild, "name", "VideodockModule");
-		videodockModule.getParentNode().removeChild(videodockModule);
+		//This is not returning null, removing the next 2 lines fixes the issue with demo12.jsp
+		//Element videodockModule = getElementWithAttribute(firstChild, "name", "VideodockModule");
+		//videodockModule.getParentNode().removeChild(videodockModule);
 	}else{
 	        webcamElement.setAttribute("autoStart", param_VideoModule);		
 	}


### PR DESCRIPTION
The following code was returning a null pointer

Element videodockModule = getElementWithAttribute(firstChild, "name", "VideodockModule");
Removing the lines solves the issue and does not load the videodockModule. This issue could have been introduced with a change to the xml client file.

This closes #2713