### PR TITLE
Added scrolling dots to the reconnect popup

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/ReconnectionPopup.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/ReconnectionPopup.mxml
@@ -26,11 +26,28 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     horizontalScrollPolicy="off"
     horizontalAlign="center"
     width="250"
-    title="{ResourceUtil.getInstance().getString('bbb.connection.failure')}">
+    title="{ResourceUtil.getInstance().getString('bbb.connection.failure')}"
+    creationComplete="onCreationComplete()">
   
   <mx:Script>
     <![CDATA[
       import org.bigbluebutton.util.i18n.ResourceUtil;
+      
+      private var dotTimer:Timer;
+      
+      private function onCreationComplete():void {
+        dotTimer = new Timer(200, 0);
+        dotTimer.addEventListener(TimerEvent.TIMER, dotAnimate);
+        dotTimer.start();
+      }
+      
+      private function dotAnimate(e:TimerEvent):void {
+        if (lblConnectDots.text.length > 5) {
+          lblConnectDots.text = "";
+        } else {
+          lblConnectDots.text += ".";
+        }
+      }
     ]]>
   </mx:Script>
   <mx:HBox width="100%" height="100%" verticalAlign="middle">
@@ -38,13 +55,14 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         paddingBottom="10"
         paddingTop="10"
         paddingLeft="10"
-        paddingRight="10"
+        paddingRight="0"
     >
       <mx:Image id="typeImg" source="{typeImg.getStyle('refreshImage')}" width="34" height="34" styleName="statusImageStyle" />
     </mx:Box>
     <mx:Text
         selectable="false"
         text="{ResourceUtil.getInstance().getString('bbb.connection.reconnecting')}"
-        width="100%"/>
+        styleName="micSettingsWindowSpeakIntoMicLabelStyle"/>
+    <mx:Label id="lblConnectDots" width="100%" textAlign="left" styleName="micSettingsWindowSpeakIntoMicLabelStyle" text="" />
   </mx:HBox>
 </mx:Panel> 


### PR DESCRIPTION
I added scrolling dots to the reconnect popup so that users are aware that the client isn't frozen.

I also added the same styleName as is used in our other pop ups.