### PR TITLE
html5client: lock settings fixes

### DIFF
--- a/bigbluebutton-html5/app/client/globals.coffee
+++ b/bigbluebutton-html5/app/client/globals.coffee
@@ -46,6 +46,10 @@ Handlebars.registerHelper "amIInAudio", ->
 Handlebars.registerHelper "amIListenOnlyAudio", ->
   BBB.amIListenOnlyAudio()
 
+# helper to determine whether the user is in the listen only audio stream
+Handlebars.registerHelper "isMyMicLocked", ->
+  BBB.isMyMicLocked()
+
 Handlebars.registerHelper "colourToHex", (value) =>
   @window.colourToHex(value)
 
@@ -612,3 +616,4 @@ Handlebars.registerHelper "getPollQuestions", ->
     $('.panel-footer').attr('style','')
     $('#chatbody').attr('style','')
     $('#newMessageInput').attr('style','')
+

--- a/bigbluebutton-html5/app/client/views/chat/chat_bar.coffee
+++ b/bigbluebutton-html5/app/client/views/chat/chat_bar.coffee
@@ -53,14 +53,14 @@ Handlebars.registerHelper "autoscroll", ->
 # true if the lock settings limit public chat and the current user is locked
 Handlebars.registerHelper "publicChatDisabled", ->
   userIsLocked = Meteor.Users.findOne({userId:getInSession 'userId'})?.user.locked
-  publicChatIsDisabled = Meteor.Meetings.findOne({})?.roomLockSettings.disablePubChat
+  publicChatIsDisabled = Meteor.Meetings.findOne({})?.roomLockSettings.disablePublicChat
   presenter = Meteor.Users.findOne({userId:getInSession 'userId'})?.user.presenter
   return userIsLocked and publicChatIsDisabled and !presenter
 
 # true if the lock settings limit private chat and the current user is locked
 Handlebars.registerHelper "privateChatDisabled", ->
   userIsLocked = Meteor.Users.findOne({userId:getInSession 'userId'})?.user.locked
-  privateChatIsDisabled = Meteor.Meetings.findOne({})?.roomLockSettings.disablePrivChat
+  privateChatIsDisabled = Meteor.Meetings.findOne({})?.roomLockSettings.disablePrivateChat
   presenter = Meteor.Users.findOne({userId:getInSession 'userId'})?.user.presenter
   return userIsLocked and privateChatIsDisabled and !presenter
 

--- a/bigbluebutton-html5/app/client/views/modals/modals.html
+++ b/bigbluebutton-html5/app/client/views/modals/modals.html
@@ -14,8 +14,10 @@
       {{/if}}
     {{else}}
       <!-- display both with join -->
-      {{> makeButton id="joinMicrophone" btn_class="joinMicrophone settingsButton joinAudioButton" i_class="fi-microphone"
-      rel="tooltip" data_placement="bottom" title="Join Microphone"}}
+      {{#unless isMyMicLocked}}
+        {{> makeButton id="joinMicrophone" btn_class="joinMicrophone settingsButton joinAudioButton" i_class="fi-microphone"
+        rel="tooltip" data_placement="bottom" title="Join Microphone"}}
+      {{/unless}}
       {{> makeButton id="joinListenOnly" btn_class="joinListenOnly settingsButton joinAudioButton" i_class="fi-volume"
       rel="tooltip" data_placement="bottom" title="Join Listen only"}}
     {{/if}}

--- a/bigbluebutton-html5/app/client/views/users/user_item.coffee
+++ b/bigbluebutton-html5/app/client/views/users/user_item.coffee
@@ -15,11 +15,11 @@ Template.displayUserIcons.helpers
     # the user is set to be locked and there is a relevant lock in place
     locked = BBB.getUser(userId)?.user.locked
     settings = Meteor.Meetings.findOne()?.roomLockSettings
-    lockInAction = settings.disablePrivChat or
+    lockInAction = settings.disablePrivateChat or
                     settings.disableCam or
                     settings.disableMic or
                     settings.lockedLayout or
-                    settings.disablePubChat
+                    settings.disablePublicChat
     return locked and lockInAction
 
 # Opens a private chat tab when a username from the userlist is clicked

--- a/bigbluebutton-html5/app/server/redispubsub.coffee
+++ b/bigbluebutton-html5/app/server/redispubsub.coffee
@@ -305,20 +305,23 @@ class Meteor.RedisPubSub
 
       if message.header.name is "new_permission_settings"
         oldSettings = Meteor.Meetings.findOne({meetingId:meetingId})?.roomLockSettings
-        newSettings = message.payload
+        newSettings = message.payload?.permissions
 
         # if the disableMic setting was turned on
         if !oldSettings?.disableMic and newSettings.disableMic
           handleLockingMic(meetingId, newSettings)
 
+        Meteor.log.error newSettings
+        Meteor.log.error oldSettings
         # substitute with the new lock settings
         Meteor.Meetings.update({meetingId: meetingId}, {$set: {
-          'roomLockSettings.disablePrivChat': message.payload.disablePrivChat
-          'roomLockSettings.disableCam': message.payload.disableCam
-          'roomLockSettings.disableMic': message.payload.disableMic
-          'roomLockSettings.lockOnJoin': message.payload.lockOnJoin
-          'roomLockSettings.lockedLayout': message.payload.lockedLayout
-          'roomLockSettings.disablePubChat': message.payload.disablePubChat
+          'roomLockSettings.disablePrivChat': newSettings.disablePrivateChat #TODO change naming on client
+          'roomLockSettings.disableCam': newSettings.disableCam
+          'roomLockSettings.disableMic': newSettings.disableMic
+          'roomLockSettings.lockOnJoin': newSettings.lockOnJoin
+          'roomLockSettings.lockedLayout': newSettings.lockedLayout
+          'roomLockSettings.disablePubChat': newSettings.disablePublicChat #TODO change naming on client
+          'roomLockSettings.lockOnJoinConfigurable': newSettings.lockOnJoinConfigurable #TODO
         }})
         return
 

--- a/bigbluebutton-html5/app/server/redispubsub.coffee
+++ b/bigbluebutton-html5/app/server/redispubsub.coffee
@@ -311,16 +311,14 @@ class Meteor.RedisPubSub
         if !oldSettings?.disableMic and newSettings.disableMic
           handleLockingMic(meetingId, newSettings)
 
-        Meteor.log.error newSettings
-        Meteor.log.error oldSettings
         # substitute with the new lock settings
         Meteor.Meetings.update({meetingId: meetingId}, {$set: {
-          'roomLockSettings.disablePrivChat': newSettings.disablePrivateChat #TODO change naming on client
+          'roomLockSettings.disablePrivateChat': newSettings.disablePrivateChat
           'roomLockSettings.disableCam': newSettings.disableCam
           'roomLockSettings.disableMic': newSettings.disableMic
           'roomLockSettings.lockOnJoin': newSettings.lockOnJoin
           'roomLockSettings.lockedLayout': newSettings.lockedLayout
-          'roomLockSettings.disablePubChat': newSettings.disablePublicChat #TODO change naming on client
+          'roomLockSettings.disablePublicChat': newSettings.disablePublicChat
           'roomLockSettings.lockOnJoinConfigurable': newSettings.lockOnJoinConfigurable #TODO
         }})
         return


### PR DESCRIPTION
-Adapted to the restructured message format for permissions
-Edited UI so the user is not offered to join with microphone if the permissions prohibit it