### PR TITLE
Fix for issue 2871

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/WhiteboardCanvasDisplayModel.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/WhiteboardCanvasDisplayModel.as
@@ -92,7 +92,7 @@ package org.bigbluebutton.modules.whiteboard
           case DrawObject.DRAW_UPDATE:
           case DrawObject.DRAW_END:
             if (_annotationsList.length > 0) {
-              var gobj:DrawObject = _annotationsList.pop();  
+              var gobj:Object = _annotationsList.pop();
               if (gobj.id == o.id) {
                 // LogUtil.debug("Removing shape [" + gobj.id + "]");
                 wbCanvas.removeGraphic(gobj as DisplayObject);


### PR DESCRIPTION
The last annotation was being retrieved and cast as a DrawObject, but the text annotations don't subclass it so an exception was being thrown. I changed the cast to Object because the only thing checked is the "id" property.