### PR TITLE
Fix Firefox candidates

### DIFF
--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -76,6 +76,7 @@ bbb.webrtcWarning.failedError.1007 = Error 1007: ICE negotiation failed
 bbb.webrtcWarning.failedError.1008 = Error 1008: Transfer failed
 bbb.webrtcWarning.failedError.1009 = Error 1009: Could not fetch STUN/TURN server information
 bbb.webrtcWarning.failedError.1010 = Error 1010: ICE negotiation timeout
+bbb.webrtcWarning.failedError.1011 = Error 1011: ICE gathering timeout
 bbb.webrtcWarning.failedError.unknown = Error {0}: Unknown error code
 bbb.webrtcWarning.failedError.mediamissing = Could not get your microphone for a WebRTC call
 bbb.webrtcWarning.failedError.endedunexpectedly = The WebRTC echo test ended unexpectedly

--- a/bigbluebutton-client/resources/prod/lib/bbb_webrtc_bridge_sip.js
+++ b/bigbluebutton-client/resources/prod/lib/bbb_webrtc_bridge_sip.js
@@ -1,5 +1,5 @@
 
-var userID, callerIdName=null, conferenceVoiceBridge, userAgent=null, userMicMedia, userWebcamMedia, currentSession=null, callTimeout, callActive, callICEConnected, iceConnectedTimeout, callFailCounter, callPurposefullyEnded, uaConnected, transferTimeout;
+var userID, callerIdName=null, conferenceVoiceBridge, userAgent=null, userMicMedia, userWebcamMedia, currentSession=null, callTimeout, callActive, callICEConnected, iceConnectedTimeout, callFailCounter, callPurposefullyEnded, uaConnected, transferTimeout, iceGatheringTimeout;
 var inEchoTest = true;
 
 function webRTCCallback(message) {
@@ -367,6 +367,21 @@ function make_call(username, voiceBridge, server, callback, recall, isListenOnly
 		console.log('call connecting again');
 	}
 	
+	iceGatheringTimeout = setTimeout(function() {
+		console.log('Thirty seconds without ICE gathering finishing');
+		callback({'status':'failed', 'errorcode': 1011}); // ICE Gathering Failed
+		currentSession = null;
+		if (userAgent != null) {
+			var userAgentTemp = userAgent;
+			userAgent = null;
+			userAgentTemp.stop();
+		}
+	}, 30000);
+	
+	currentSession.mediaHandler.on('iceComplete', function() {
+		clearTimeout(iceGatheringTimeout);
+	});
+	
 	// The connecting event fires before the listener can be added
 	currentSession.on('connecting', function(){
 		clearTimeout(callTimeout);
@@ -426,7 +441,7 @@ function make_call(username, voiceBridge, server, callback, recall, isListenOnly
 			console.log('Waiting for ICE negotiation');
 			iceConnectedTimeout = setTimeout(function() {
 				console.log('60 seconds without ICE finishing');
-				callback({'status':'failed', 'errorcode': 1010}); // Failure on call
+				callback({'status':'failed', 'errorcode': 1010}); // ICE negotiation timeout
 				currentSession = null;
 				if (userAgent != null) {
 					var userAgentTemp = userAgent;


### PR DESCRIPTION
In Firefox if there are IPv6 ICE candidates and a TURN server that doesn't support IPv6 the ICE gathering stage of the WebRTC call never finishes. I added an iceCheckingTimeout from SIP.js master into our custom version of SIP.js.