### PR TITLE
Webhooks: Fix "ReferenceError: hook is not defined" when removing hook

### DIFF
--- a/bbb-webhooks/hook.coffee
+++ b/bbb-webhooks/hook.coffee
@@ -105,7 +105,7 @@ module.exports = class Hook
 
     # gave up trying to perform the callback, remove the hook forever
     @emitter.on "stopped", (error) =>
-      Logger.warn "Hook: too many failed attempts to perform a callback call, removing the hook", JSON.stringify(hook)
+      Logger.warn "Hook: too many failed attempts to perform a callback call, removing the hook for", @callbackURL
       @destroy()
 
   @addSubscription = (callbackURL, meetingID=null, callback) ->


### PR DESCRIPTION
Simple fix for an error that crashed the app when it tried to remove a hook after a timeout.