### PR TITLE
Added auto join audio for the HTML5 client

### DIFF
--- a/bigbluebutton-html5/app/client/NotificationControl.coffee
+++ b/bigbluebutton-html5/app/client/NotificationControl.coffee
@@ -71,15 +71,14 @@ class @NotificationControl
   .registerShow("webRTC_AudioJoining", ->
   ).display("webRTC_AudioJoining")
   # joined. Displayed joined notification and hide the joining notification
-  if !BBB.amIInAudio()
-    Tracker.autorun (comp) -> # wait until user is in
-      if BBB.amIInAudio() # display notification when you are in audio
-        comp.stop() # prevents computation from running twice (which can happen occassionally)
-        Meteor.NotificationControl.create("webRTC_AudioJoined", 'success ', '', 2500)
-        .registerShow("webRTC_AudioJoined", ->
-          Meteor.NotificationControl.hideANotification('webRTC_AudioJoining')
-          $("#webRTC_AudioJoined").prepend("You've joined the #{if BBB.amIListenOnlyAudio() then 'Listen Only' else ''} audio")
-        ).display("webRTC_AudioJoined")
+  Tracker.autorun (comp) -> # wait until user is in
+    if BBB.amIInAudio() # display notification when you are in audio
+      comp.stop() # prevents computation from running twice (which can happen occassionally)
+      Meteor.NotificationControl.create("webRTC_AudioJoined", 'success ', '', 2500)
+      .registerShow("webRTC_AudioJoined", ->
+        Meteor.NotificationControl.hideANotification('webRTC_AudioJoining')
+        $("#webRTC_AudioJoined").prepend("You've joined the #{if BBB.amIListenOnlyAudio() then 'Listen Only' else ''} audio")
+      ).display("webRTC_AudioJoined")
 
 @notification_WebRTCNotSupported = -> # shown when the user's browser does not support WebRTC
   # create a new notification at the audio button they clicked to trigger the event

--- a/bigbluebutton-html5/app/client/main.coffee
+++ b/bigbluebutton-html5/app/client/main.coffee
@@ -137,7 +137,12 @@ Template.main.rendered = ->
     toggleSlidingMenu()
 
   if Meteor.config.app.autoJoinAudio
-    onAudioJoinHelper()
+    if Meteor.config.app.skipCheck
+      joinVoiceCall @, isListenOnly: Meteor.config.app.listenOnly
+    else
+      $("#settingsModal").foundation('reveal', 'open')
+      if Meteor.config.app.listenOnly
+        $('#joinMicrophone').prop('disabled', true)
 
 Template.main.events
   'click .shield': (event) ->

--- a/bigbluebutton-html5/app/client/views/modals/modals.html
+++ b/bigbluebutton-html5/app/client/views/modals/modals.html
@@ -15,10 +15,10 @@
         {{/if}}
       {{else}}
         <!-- display both with join -->
-        {{#unless isMyMicLocked}}
+        {{#if canJoinWithMic}}
           {{> makeButton id="joinMicrophone" btn_class="joinMicrophone settingsButton joinAudioButton" i_class="fi-microphone"
           rel="tooltip" data_placement="bottom" title="Join Microphone"}}
-        {{/unless}}
+        {{/if}}
         {{> makeButton id="joinListenOnly" btn_class="joinListenOnly settingsButton joinAudioButton" i_class="fi-volume"
         rel="tooltip" data_placement="bottom" title="Join Listen only"}}
       {{/if}}

--- a/bigbluebutton-html5/app/config.coffee
+++ b/bigbluebutton-html5/app/config.coffee
@@ -24,7 +24,10 @@ config.app.mobileFont=16
 config.app.desktopFont=14
 
 # Will offer the user to join the audio when entering the meeting
-config.app.autoJoinAudio = false
+config.app.autoJoinAudio = true
+config.app.listenOnly = true
+config.app.skipCheck = true
+
 # The amount of time the client will wait before making another call to successfully hangup the WebRTC conference call
 config.app.WebRTCHangupRetryInterval = 2000
 


### PR DESCRIPTION
Added the ability to use and configure the HTML5 client auto join voice chat.

The configuration can be done in bigbluebutton-html5/app/config.coffee, for example:
config.app.autoJoinAudio = true // Auto join enabled
config.app.listenOnly = true // Listen only 
config.app.skipCheck = true // Join the user without the need to click something in the settings modal