### PR TITLE
html5client: fix bug-shapes were flushed no matter which meeting ends

### DIFF
--- a/bigbluebutton-html5/app/client/views/users/user_item.html
+++ b/bigbluebutton-html5/app/client/views/users/user_item.html
@@ -99,14 +99,14 @@
 
     {{#if isCurrentUser userId}}
       <span class="userCurrent usernameEntry {{#if hasGotUnreadMailClass 'PUBLIC_CHAT'}}gotUnreadMail{{/if}}" rel="tooltip" data-placement="bottom" title="{{user.name}} (you)">
-        <span class="userName">{{user.name}} {{#if user.presenter}} (presenter) {{/if}} (you)</span>
+        <span class="userName">{{user.name}} (you)</span>
       </span>
       {{#if hasGotUnreadMailClass 'PUBLIC_CHAT' }}
         <div class="unreadChatNumber">{{getNumberOfUnreadMessages 'PUBLIC_CHAT'}}</div>
       {{/if}}
     {{else}}
       <span class="usernameEntry {{#if hasGotUnreadMailClass user.userid}}gotUnreadMail{{/if}}" rel="tooltip" data-placement="bottom" title="{{user.name}}">
-        <span class="userName"> {{user.name}} {{#if user.presenter}} (presenter) {{/if}}</span>
+        <span class="userName"> {{user.name}}</span>
       </span>
       {{#if hasGotUnreadMailClass user.userid }}
         <div class="unreadChatNumber">{{getNumberOfUnreadMessages user.userid}}</div>

--- a/bigbluebutton-html5/app/server/collection_methods/shapes.coffee
+++ b/bigbluebutton-html5/app/server/collection_methods/shapes.coffee
@@ -89,7 +89,7 @@
 # called on server start and meeting end
 @clearShapesCollection = (meetingId) ->
   if meetingId?
-    Meteor.Shapes.remove {}, ->
+    Meteor.Shapes.remove {meetingId: meetingId}, ->
       Meteor.log.info "cleared Shapes Collection (meetingId: #{meetingId}!"
       Meteor.WhiteboardCleanStatus.update({meetingId: meetingId}, {$set: {in_progress: false}})
   else


### PR DESCRIPTION
-annotation bug fixed - when a meeting ends the shapes for ALL meetings were wiped out. Fixed the db filter so only that meeting's shapes are removed
-remove (presenter) in user item (UI)