### PR TITLE
HTML5 client: redesigned mobile navbar and offset menus + small mobile view adjustments.

### DIFF
--- a/bigbluebutton-html5/app/client/globals.coffee
+++ b/bigbluebutton-html5/app/client/globals.coffee
@@ -385,10 +385,8 @@ Handlebars.registerHelper "getPollQuestions", ->
 @closeMenus = ->
   if $('.userlistMenu').hasClass('menuOut')
     toggleUserlistMenu()
-    toggleLeftHamburderIcon()
   else if $('.settingsMenu').hasClass('menuOut')
     toggleSettingsMenu()
-    toggleRightHamburderIcon()
 
 # Periodically check the status of the WebRTC call, when a call has been established attempt to hangup,
 # retry if a call is in progress, send the leave voice conference message to BBB
@@ -656,26 +654,30 @@ Handlebars.registerHelper "getPollQuestions", ->
     $('.FABContainer').removeClass('closedFAB')
     $('.FABContainer').addClass('openedFAB')
 
-@toggleLeftHamburderIcon = () ->
-  if $('.leftHamburgerButton').hasClass('hamburgerToggledOn')
-    $('.leftHamburgerButton').removeClass('hamburgerToggledOn')
-  else
-    $('.leftHamburgerButton').addClass('hamburgerToggledOn')
-
-@toggleRightHamburderIcon = () ->
-  if $('.rightHamburgerButton').hasClass('hamburgerToggledOn')
-    $('.rightHamburgerButton').removeClass('hamburgerToggledOn')
-  else
-    $('.rightHamburgerButton').addClass('hamburgerToggledOn')
-
 @toggleUserlistMenu = () ->
+
+  # menu
   if $('.userlistMenu').hasClass('menuOut')
     $('.userlistMenu').removeClass('menuOut')
   else
     $('.userlistMenu').addClass('menuOut')
 
+  # icon
+  if $('.toggleUserlistButton').hasClass('menuToggledOn')
+    $('.toggleUserlistButton').removeClass('menuToggledOn')
+  else
+    $('.toggleUserlistButton').addClass('menuToggledOn')
+
 @toggleSettingsMenu = () ->
+
+  # menu
   if $('.settingsMenu').hasClass('menuOut')
     $('.settingsMenu').removeClass('menuOut')
   else
     $('.settingsMenu').addClass('menuOut')
+
+  # icon
+  if $('.toggleMenuButton').hasClass('menuToggledOn')
+    $('.toggleMenuButton').removeClass('menuToggledOn')
+  else
+    $('.toggleMenuButton').addClass('menuToggledOn')

--- a/bigbluebutton-html5/app/client/main.coffee
+++ b/bigbluebutton-html5/app/client/main.coffee
@@ -58,20 +58,17 @@ Template.header.events
     else
       if $('.settingsMenu').hasClass('menuOut')
         toggleSettingsMenu()
-        toggleRightHamburderIcon()
       else
         toggleShield()
       toggleUserlistMenu()
-      toggleLeftHamburderIcon()
 
   "click .toggleMenuButton": (event) ->
     if $('.userlistMenu').hasClass('menuOut')
       toggleUserlistMenu()
-      toggleLeftHamburderIcon()
     else
       toggleShield()
+    $('.toggleMenuButton').blur()
     toggleSettingsMenu()
-    toggleRightHamburderIcon()
 
   "click .btn": (event) ->
     $(".ui-tooltip").hide()
@@ -80,7 +77,6 @@ Template.menu.events
   'click .slideButton': (event) ->
     toggleShield()
     toggleSettingsMenu()
-    toggleRightHamburderIcon()
     $('.slideButton').blur()
 
   'click .toggleChatButton': (event) ->
@@ -197,14 +193,14 @@ Template.main.gestures
           $('.shield').css('opacity', '')
           $('.left-drawer').removeClass('menuOut')
           $('.left-drawer').css('transform', '')
-          $('.toggleUserlistButton').removeClass('hamburgerToggledOn')
+          $('.toggleUserlistButton').removeClass('menuToggledOn')
           $('.shield').removeClass('darken') # in case it was opened by clicking a button
         else
           $('.left-drawer').css('transform', 'translateX(' + leftDrawerWidth + 'px)')
           $('.shield').css('opacity', 0.5)
           $('.left-drawer').addClass('menuOut')
           $('.left-drawer').css('transform', '')
-          $('.toggleUserlistButton').addClass('hamburgerToggledOn')
+          $('.toggleUserlistButton').addClass('menuToggledOn')
 
       if panIsValid and
       menuPanned is 'right' and
@@ -216,14 +212,14 @@ Template.main.gestures
           $('.right-drawer').css('transform', 'translateX(' + screenWidth + 'px)')
           $('.right-drawer').removeClass('menuOut')
           $('.right-drawer').css('transform', '')
-          $('.toggleMenuButton').removeClass('hamburgerToggledOn')
+          $('.toggleMenuButton').removeClass('menuToggledOn')
           $('.shield').removeClass('darken') # in case it was opened by clicking a button
         else
           $('.shield').css('opacity', 0.5)
           $('.right-drawer').css('transform', 'translateX(' + (screenWidth - $('.right-drawer').width()) + 'px)')
           $('.right-drawer').addClass('menuOut')
           $('.right-drawer').css('transform', '')
-          $('.toggleMenuButton').addClass('hamburgerToggledOn')
+          $('.toggleMenuButton').addClass('menuToggledOn')
 
       $('.left-drawer').addClass('userlistMenu')
       $('.userlistMenu').removeClass('left-drawer')
@@ -301,7 +297,6 @@ Template.main.gestures
 
         if $('.settingsMenu').hasClass('menuOut')
           toggleSettingsMenu()
-          toggleRightHamburderIcon()
 
         $('.left-drawer').css('transform', 'translateX(' + (initTransformValue + event.deltaX) + 'px)')
 
@@ -318,7 +313,6 @@ Template.main.gestures
 
         if $('.userlistMenu').hasClass('menuOut')
           toggleUserlistMenu()
-          toggleLeftHamburderIcon()
 
         $('.right-drawer').css('transform', 'translateX(' + (initTransformValue + event.deltaX) + 'px)')
 

--- a/bigbluebutton-html5/app/client/main.html
+++ b/bigbluebutton-html5/app/client/main.html
@@ -1,6 +1,6 @@
 <template name="header">
   <nav id="navbar" class="myNavbar top-bar" role="navigation">
-    {{> makeButton btn_class="btn toggleUserlistButton navbarButton leftHamburgerButton" rel="tooltip" title="Toggle Userlist" span=true notification="all_chats"}}
+    {{> makeButton btn_class="btn toggleUserlistButton navbarButton" i_class="ion-navicon" rel="tooltip" title="Toggle Userlist" span=true notification="all_chats"}}
 
       {{#if amIInAudio}}
         <div class="audioNavbarSection">
@@ -37,7 +37,7 @@
       {{> makeButton id="logout" btn_class="signOutIcon navbarButton" i_class="ion-log-out" rel="tooltip"
       title="Logout"}}
     </div>
-    {{> makeButton btn_class="btn toggleMenuButton navbarButton rightHamburgerButton" rel="tooltip" title="Toggle Menu" span=true}}
+    {{> makeButton btn_class="btn toggleMenuButton navbarButton" i_class="ion-android-more-vertical" rel="tooltip" title="Toggle Menu" span=true}}
   </nav>
 </template>
 
@@ -54,7 +54,6 @@
         {{> usersList id="users" name="usersList"}}
       </div>
       <div class="settingsMenu">
-        <div class="titleArea"></div>
         {{> menu id="menu"}}
       </div>
       <div id="main">

--- a/bigbluebutton-html5/app/client/stylesheets/chat.less
+++ b/bigbluebutton-html5/app/client/stylesheets/chat.less
@@ -74,6 +74,9 @@
     border-top-left-radius: 0px;
     overflow: hidden;
   }
+  @media @mobile-portrait-with-keyboard, @mobile-portrait {
+    border-top: none;
+  }
   order: 3;
 }
 

--- a/bigbluebutton-html5/app/client/stylesheets/style.less
+++ b/bigbluebutton-html5/app/client/stylesheets/style.less
@@ -372,12 +372,6 @@ body {
         background-color: black;
         opacity: 0;
         cursor: pointer;
-        @media @landscape, @desktop-portrait {
-          top: 50px;
-        }
-        @media @mobile-portrait-with-keyboard, @mobile-portrait {
-          top: 110px;
-        }
       }
     }
   }
@@ -744,7 +738,6 @@ body {
 
 @media @desktop-portrait {
   .userlistMenu {
-    z-index: 1000;
     position: fixed;
     left: -400px;
     width: 400px !important; // overrides any width value set manually in landscape
@@ -753,7 +746,6 @@ body {
     }
   }
   .settingsMenu {
-    z-index: 1000;
     position: fixed;
     right: -400px;
     width: 400px;
@@ -765,6 +757,7 @@ body {
 
 .userlistMenu {
   height: 100%;
+  z-index: 1000;
   @media @tablet-landscape {
     width: 200px;
   }
@@ -777,7 +770,6 @@ body {
   @media @mobile-portrait-with-keyboard, @mobile-portrait {
     @userListMenuPortaitWidth: (2/3 * 100vw);
 
-    z-index: 1000;
     position: fixed;
     left: -@userListMenuPortaitWidth;
     width: @userListMenuPortaitWidth;
@@ -879,12 +871,7 @@ body {
   opacity: 0;
   z-index: 999;
   cursor: pointer;
-  @media @desktop-portrait {
-    top: 50px;
-  }
-  @media @mobile-portrait-with-keyboard, @mobile-portrait {
-    top: 50px;
-  }
+  top: 0px;
   @media @landscape {
     display: none;
   }
@@ -913,7 +900,6 @@ body {
   }
 }
 
-// same as Sled's left drawer except for animations
 .left-drawer {
   z-index: 1000;
   position: fixed;
@@ -922,7 +908,6 @@ body {
   height: 100%;
 }
 
-// same as Sled's right drawer except for animations
 .right-drawer {
   z-index: 1000;
   position: fixed;

--- a/bigbluebutton-html5/app/client/stylesheets/style.less
+++ b/bigbluebutton-html5/app/client/stylesheets/style.less
@@ -40,13 +40,26 @@ body {
 }
 
 @media @mobile-portrait {
-  .hamburgerToggledOn .unreadChat {
+  .menuToggledOn .unreadChat {
     display: none;
   }
 }
 
 .navbarButton {
   color: #469DCF;
+  &:hover, &:focus {
+    i {
+      color: #2A5E7C;
+    }
+  }
+  @media @phone-portrait-with-keyboard, @phone-portrait, @phone-landscape {
+    padding-top: 2px !important;
+    padding-bottom: 2px !important;
+  }
+  @media @tablet-portrait-with-keyboard, @tablet-portrait, @tablet-landscape {
+    padding-top: 4px !important;
+    padding-bottom: 4px !important;
+  }
   .unreadChat {
     position: absolute;
     z-index: 1;
@@ -67,17 +80,44 @@ body {
   }
 
   i {
-    @media @phone-landscape {
-      font-size: 29px;
-    }
-    @media @desktop-portrait, @desktop-landscape, @tablet-landscape {
-      font-size: 30px;
-    }
+
+    // phone
     @media @phone-portrait-with-keyboard, @phone-portrait {
-      font-size: 35px;
+      font-size: 42px;
     }
+    @media @phone-landscape {
+      &.ion-navicon {
+        font-size: 35px;
+      }
+      &:not(.ion-navicon) {
+        font-size: 29px;
+      }
+    }
+
+    // tablet
     @media @tablet-portrait-with-keyboard, @tablet-portrait {
-      font-size: 40px;
+      font-size: 47px;
+    }
+    @media @tablet-landscape {
+      &.ion-navicon {
+        font-size: 37px;
+      }
+      &:not(.ion-navicon) {
+        font-size: 30px;
+      }
+    }
+
+    // desktop
+    @media @desktop-landscape {
+      &.ion-navicon {
+        font-size: 34px;
+      }
+      &:not(.ion-navicon) {
+        font-size: 30px;
+      }
+    }
+    @media @desktop-portrait {
+      font-size: 35px;
     }
   }
 }
@@ -412,12 +452,12 @@ body {
     margin-top: 0;
     margin-bottom: 0;
     &:hover {
-      background-color: extract(@lightGrey, 1);
+      background-color: white;
       span{
-        color: #3B97D3;
+        color: #788897;
       }
     }
-    i{
+    i {
       margin-left: 5%;
       color: #3B97D3;
     }
@@ -520,12 +560,6 @@ body {
 
 .signOutIcon {
   @media @landscape {
-    &:hover {
-      color: #2A5E7C;
-    }
-    &:focus {
-      color: #2A5E7C;
-    }
     height: 28px;
     width: 75px;
     margin-left: 10px;
@@ -583,21 +617,11 @@ body {
 }
 
 .toggleUserlistButton, .toggleMenuButton {
-  z-index: 1001;
-}
-
-.toggleUserlistButton, .toggleMenuButton {
   outline: none;
 }
 
 .settingsIcon {
   @media @landscape {
-    &:hover {
-      color: #2A5E7C;
-    }
-    &:focus {
-      color: #2A5E7C;
-    }
     width: 57px;
     margin-right: 5px;
   }
@@ -890,7 +914,7 @@ body {
     opacity: 0;
   }
   100% {
-    opacity: 0.5;
+    opacity: 0.8;
   }
 }
 
@@ -916,156 +940,6 @@ body {
   .linear-gradient(rgb(65,68,77), rgb(58,60,69));
   width: 60vw;
 }
-
-.leftHamburgerButton, .rightHamburgerButton {
-  span {
-    &::before {
-      top: -225%;
-    }
-    &::before, &::after {
-      background-color: inherit;
-      content: '';
-      height: 100%;
-      width: 100%;
-      position: absolute;
-      left: 0;
-    }
-    &::after {
-      bottom: -225%;
-    }
-    background-color: inherit;
-    height: 10%;
-    position: absolute;
-    left: 15%;
-    right: 15%;
-    top: 45%;
-  }
-}
-
-.leftHamburgerButton {
-  @media @mobile-portrait-with-keyboard, @mobile-portrait {
-    span {
-      &::before {
-        transform-origin: top right;
-        -moz-transform-origin: top right;
-        -webkit-transform-origin: top right;
-        -ms-transform-origin: top right;
-        -o-transform-origin: top right;
-
-        transition: width 0.3s, transform 0.3s, top 0.3s;
-        -moz-transition: width 0.3s, -moz-transform 0.3s, top 0.3s;
-        -webkit-transition: width 0.3s, -webkit-transform 0.3s, top 0.3s;
-        -o-transition: width 0.3s, -o-transform 0.3s, top 0.3s;
-      }
-      &::after {
-        transform-origin: bottom right;
-        -moz-transform-origin: bottom right;
-        -webkit-transform-origin: bottom right;
-        -ms-transform-origin: bottom right;
-        -o-transform-origin: bottom right;
-
-        transition: width 0.3s, transform 0.3s, bottom 0.3s;
-        -moz-transition: width 0.3s, -moz-transform 0.3s, bottom 0.3s;
-        -webkit-transition: width 0.3s, -webkit-transform 0.3s, bottom 0.3s;
-        -ms-transition: width 0.3s, -ms-transform 0.3s, bottom 0.3s;
-        -o-transition: width 0.3s, -o-transform 0.3s, bottom 0.3s;
-      }
-      transition: transform 0.3s;
-      -moz-transition: -moz-transform 0.3s;
-      -webkit-transition: -webkit-transform 0.3s;
-      -o-transition: -o-transform 0.3s;
-    }
-    &.hamburgerToggledOn span {
-      &::before {
-        transform: translateY(50%) translateX(95%) rotate(45deg);
-        -moz-transform: translateY(50%) translateX(95%) rotate(45deg);
-        -webkit-transform: translateY(50%) translateX(95%) rotate(45deg);
-        -ms-transform: translateY(50%) translateX(95%) rotate(45deg);
-        -o-transform: translateY(50%) translateX(95%) rotate(45deg);
-        top: 0px;
-      }
-      &::before, &::after {
-        width: 55%;
-      }
-      &::after {
-        transform: translateY(-50%) translateX(95%) rotate(-45deg);
-        -moz-transform: translateY(-50%) translateX(95%) rotate(-45deg);
-        -webkit-transform: translateY(-50%) translateX(95%) rotate(-45deg);
-        -ms-transform: translateY(-50%) translateX(95%) rotate(-45deg);
-        -o-transform: translateY(-50%) translateX(95%) rotate(-45deg);
-        bottom: 0px;
-      }
-      transform: rotate(0.5turn);
-      -moz-transform: rotate(0.5turn);
-      -webkit-transform: rotate(0.5turn);
-      -ms-transform: rotate(0.5turn);
-      -o-transform: rotate(0.5turn);
-    }
-  }
-}
-
-.rightHamburgerButton {
-  @media @mobile-portrait-with-keyboard, @mobile-portrait {
-    span {
-      &::before {
-        transform-origin: top left;
-        -moz-transform-origin: top left;
-        -webkit-transform-origin: top left;
-        -ms-transform-origin: top left;
-        -o-transform-origin: top left;
-
-        transition: width 0.3s, transform 0.3s, top 0.3s;
-        -moz-transition: width 0.3s, -moz-transform 0.3s, top 0.3s;
-        -webkit-transition: width 0.3s, -webkit-transform 0.3s, top 0.3s;
-        -o-transition: width 0.3s, -o-transform 0.3s, top 0.3s;
-      }
-      &::after {
-        transform-origin: bottom left;
-        -moz-transform-origin: bottom left;
-        -webkit-transform-origin: bottom left;
-        -ms-transform-origin: bottom left;
-        -o-transform-origin: bottom left;
-
-        transition: transform 0.3s, width 0.3s, bottom 0.3s;
-        -moz-transition: -moz-transform 0.3s, width 0.3s, bottom 0.3s;
-        -webkit-transition: -webkit-transform 0.3s, width 0.3s, bottom 0.3s;
-        -ms-transition: -ms-transform 0.3s, width 0.3s, bottom 0.3s;
-        -o-transition: -o-transform 0.3s, width 0.3s, bottom 0.3s;
-      }
-      transition: transform 0.3s;
-      -moz-transition: -moz-transform 0.3s;
-      -webkit-transition: -webkit-transform 0.3s;
-      -o-transition: -o-transform 0.3s;
-    }
-    &.hamburgerToggledOn span {
-      &::before {
-        transform: translateY(53%) translateX(-20%) rotate(-45deg);
-        -moz-transform: translateY(53%) translateX(-20%) rotate(-45deg);
-        -webkit-transform: translateY(53%) translateX(-20%) rotate(-45deg);
-        -ms-transform: translateY(53%) translateX(-20%) rotate(-45deg);
-        -o-transform: translateY(53%) translateX(-20%) rotate(-45deg);
-        top: 0;
-      }
-      &::before, &::after {
-        width: 55%;
-      }
-      &::after {
-        transform: translateY(-53%) translateX(-20%) rotate(45deg);
-        -moz-transform: translateY(-53%) translateX(-20%) rotate(45deg);
-        -webkit-transform: translateY(-53%) translateX(-20%) rotate(45deg);
-        -ms-transform: translateY(-53%) translateX(-20%) rotate(45deg);
-        -o-transform: translateY(-53%) translateX(-20%) rotate(45deg);
-        bottom: 0;
-      }
-      transform: rotate(0.5turn);
-      -moz-transform: rotate(0.5turn);
-      -webkit-transform: rotate(0.5turn);
-      -ms-transform: rotate(0.5turn);
-      -o-transform: rotate(0.5turn);
-    }
-  }
-}
-
 
 /*********************************/
 /*Loading Spinning Bar's Styling */

--- a/bigbluebutton-html5/app/client/stylesheets/style.less
+++ b/bigbluebutton-html5/app/client/stylesheets/style.less
@@ -29,7 +29,6 @@ body {
 }
 
 .component {
-  .radius;
   background: extract(@white, 1);
   border: 1px solid extract(@lightGrey, 3);
   float: left;

--- a/bigbluebutton-html5/app/client/stylesheets/whiteboard.less
+++ b/bigbluebutton-html5/app/client/stylesheets/whiteboard.less
@@ -516,11 +516,9 @@
 }
 
 .soaringButton {
-
   @media @desktop-portrait{
     margin-top: -60px;
   }
-
   position: absolute;
   margin-bottom: 0;
   padding: 0;

--- a/bigbluebutton-html5/app/client/views/users/user_item.coffee
+++ b/bigbluebutton-html5/app/client/views/users/user_item.coffee
@@ -33,7 +33,6 @@ Template.usernameEntry.events
         setInSession "inChatWith", userIdSelected
     if isPortrait() or isPortraitMobile()
       toggleUserlistMenu()
-      toggleLeftHamburderIcon()
       toggleShield()
     setTimeout () -> # waits until the end of execution queue
       $("#newMessageInput").focus()


### PR DESCRIPTION
- Redesigns mobile navbar: changes the icons, removes animations.
- Modifies the offset menus behaviour: navbar is now included under the dark overlay.
- Removes border radius on both chat and presentation areas (mobile only) and makes the border between them thinner.