### PR TITLE
Add Kick user to HTML5

### DIFF
--- a/bigbluebutton-html5/app/client/globals.coffee
+++ b/bigbluebutton-html5/app/client/globals.coffee
@@ -111,6 +111,9 @@ Handlebars.registerHelper "isCurrentUserTalking", ->
 Handlebars.registerHelper "isCurrentUserPresenter", ->
   BBB.isUserPresenter(getInSession('userId'))
 
+Handlebars.registerHelper "isCurrentUserModerator", ->
+  BBB.getMyRole() is "MODERATOR"
+
 Handlebars.registerHelper "isDisconnected", ->
   return !Meteor.status().connected
 
@@ -443,6 +446,9 @@ Handlebars.registerHelper "getPollQuestions", ->
   Meteor.call("userLogout", meeting, user, getInSession("authToken"))
   console.log "logging out"
   clearSessionVar(document.location = getInSession 'logoutURL') # navigate to logout
+
+@kickUser = (meetingId, toKickUserId, requesterUserId, authToken) ->
+  Meteor.call("kickUser", meetingId, toKickUserId, requesterUserId, authToken)
 
 # Clear the local user session
 @clearSessionVar = (callback) ->

--- a/bigbluebutton-html5/app/client/stylesheets/users.less
+++ b/bigbluebutton-html5/app/client/stylesheets/users.less
@@ -42,11 +42,11 @@
   // 120px is size of the icon list with all icons enabled (lock, cam, mic/listen)
 
   @media @landscape {
-    height: 27px;
+    min-height: 30px;
     font-size: 4.5mm;
   }
   @media @desktop-portrait {
-    height: 27px;
+    min-height: 30px;
     font-size: 4.5mm;
   }
   @media @phone-portrait, @phone-portrait-with-keyboard {
@@ -104,9 +104,25 @@
     max-height: 100% !important;
     height: 100%;
 
+    #content{
+      @media @desktop-landscape, @desktop-portrait {
+        .kickUser{
+          opacity:0;
+          cursor: pointer;
+          display: none;
+          -webkit-animation: fadeInAnimation .5s;
+          animation: fadeInAnimation .5s;
+        }
+      }
+    }
     #content:hover {
         @media @landscape, @desktop-portrait {
           background-color: #2C4155;
+
+          .kickUser{
+            display: inline;
+            opacity:1;
+          }
         }
       }
     #content {
@@ -193,5 +209,14 @@
   color: #FFFFFF;
   span {
     padding-left: 5px;
+  }
+}
+
+@-webkit-keyframes fadeInAnimation {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
   }
 }

--- a/bigbluebutton-html5/app/client/views/users/user_item.coffee
+++ b/bigbluebutton-html5/app/client/views/users/user_item.coffee
@@ -9,6 +9,10 @@ Template.displayUserIcons.events
     # the userId of the person who is lowering the hand
     BBB.lowerHand(getInSession("meetingId"), @userId, getInSession("userId"), getInSession("authToken"))
 
+  'click .kickUser': (event) ->
+    kickUser BBB.getMeetingId(), @.userId, getInSession("userId"), getInSession("authToken")
+
+
 Template.displayUserIcons.helpers
   userLockedIconApplicable: (userId) ->
     # the lock settings affect the user (and requiire a lock icon) if

--- a/bigbluebutton-html5/app/client/views/users/user_item.html
+++ b/bigbluebutton-html5/app/client/views/users/user_item.html
@@ -43,6 +43,14 @@
     {{/if}}
   {{/if}}
 
+  {{#unless isCurrentUser userId}}
+    {{#if isCurrentUserModerator}}
+      <span class="kickUser" rel="tooltip" data-placement="bottom" title="Kick {{user.name}}">
+        <i class="icon fi-x-circle usericon"></i>
+      </span>
+    {{/if}}
+  {{/unless}}
+
   {{#if isUserSharingVideo userId}}
     <span rel="tooltip" data-placement="bottom" title="{{user.name}} is sharing their webcam">
       <i class="icon fi-video usericon"></i>

--- a/bigbluebutton-html5/app/server/collection_methods/users.coffee
+++ b/bigbluebutton-html5/app/server/collection_methods/users.coffee
@@ -131,6 +131,19 @@ Meteor.methods
       Meteor.log.info "a user is logging out from #{meetingId}:" + userId
       requestUserLeaving meetingId, userId
 
+  kickUser: (meetingId, toKickUserId, requesterUserId, authToken) ->
+    if isAllowedTo('kickUser', meetingId, requesterUserId, authToken)
+      message =
+        "payload":
+          "userid": toKickUserId
+          "ejected_by": requesterUserId
+          "meeting_id": meetingId
+        "header":
+          "name": "eject_user_from_meeting_request_message"
+
+      Meteor.log.info "DISCONNECT USER"
+      publish Meteor.config.redis.channels.toBBBApps.users, message
+
 # --------------------------------------------------------------------------------------------
 # Private methods on server
 # --------------------------------------------------------------------------------------------

--- a/bigbluebutton-html5/app/server/user_permissions.coffee
+++ b/bigbluebutton-html5/app/server/user_permissions.coffee
@@ -42,6 +42,9 @@ moderator =
   setEmojiStatus: true
   clearEmojiStatus: true
 
+  #user control
+  kickUser: true
+
 # holds the values for whether the viewer user is allowed to perform an action (true)
 # or false if not allowed. Some actions have dynamic values depending on the current lock settings
 viewer = (meetingId, userId) ->


### PR DESCRIPTION
I added a little icon to the user panel that appears when the user row is hovered on desktop. On mobile it is always visible. When this icon is available and is clicked, the server sends a message to Redis `eject_user_from_meeting_request_message` requesting that the user is removed from the meeting.
In order to kick another user from the meeting the HTML5 user has to be either Moderator or Presenter.