### PR TITLE
A few fixes for event socket differences between FreeSWITCH 1.4 and 1.6

### DIFF
--- a/akka-bbb-fsesl/build.sbt
+++ b/akka-bbb-fsesl/build.sbt
@@ -51,7 +51,7 @@ libraryDependencies ++= {
 	  "redis.clients"             %  "jedis"             % "2.1.0",
       "org.apache.commons"        %  "commons-lang3"     % "3.2",
       "org.bigbluebutton"         %  "bbb-common-message" % "0.0.15",
-      "org.bigbluebutton"         %  "bbb-fsesl-client"   % "0.0.2"
+      "org.bigbluebutton"         %  "bbb-fsesl-client"   % "0.0.3"
 	)}
 
 seq(Revolver.settings: _*)

--- a/bbb-fsesl-client/build.sbt
+++ b/bbb-fsesl-client/build.sbt
@@ -6,7 +6,7 @@ description := "BigBlueButton custom FS-ESL client built on top of FS-ESL Java l
 
 organization := "org.bigbluebutton"
 
-version := "0.0.2"
+version := "0.0.3"
 
 // We want to have our jar files in lib_managed dir.
 // This way we'll have the right path when we import

--- a/bbb-fsesl-client/build.sbt
+++ b/bbb-fsesl-client/build.sbt
@@ -80,5 +80,4 @@ pomExtra := (
   
 licenses := Seq("Apache License, Version 2.0" -> url("http://opensource.org/licenses/Apache-2.0"))
 
-homepage := Some(url("http://www.bigbluebutton.org"))
-  
+homepage := Some(url("http://www.bigbluebutton.org")) 

--- a/bbb-fsesl-client/src/main/java/org/freeswitch/esl/client/inbound/Client.java
+++ b/bbb-fsesl-client/src/main/java/org/freeswitch/esl/client/inbound/Client.java
@@ -479,18 +479,41 @@ public class Client
                                         //Member transfered to another conf...
                                         listener.conferenceEventTransfer(uniqueId, confName, confSize, event);
                                         return;
+                                    //API has changed between freeswitch 1.4 and 1.6
+                                    } else if (eventFunc.equals("conference_api_sub_transfer")) {
+                                        //Member transfered to another conf...
+                                        listener.conferenceEventTransfer(uniqueId, confName, confSize, event);
+                                        return;
                                     } else if (eventFunc.equals("conference_add_member")) {
                                     	System.out.println("##### Client conference_add_member");
+                                        listener.conferenceEventJoin(uniqueId, confName, confSize, event);
+                                        return;
+                                    //API has changed between freeswitch 1.4 and 1.6
+                                    } else if (eventFunc.equals("conference_member_add")) {
+                                        System.out.println("##### Client conference_member_add");
                                         listener.conferenceEventJoin(uniqueId, confName, confSize, event);
                                         return;
                                     } else if (eventFunc.equals("conference_del_member")) {
                                     	System.out.println("##### Client conference_del_member");
                                         listener.conferenceEventLeave(uniqueId, confName, confSize, event);
                                         return;
+                                    //API has changed between freeswitch 1.4 and 1.6
+                                    } else if (eventFunc.equals("conference_member_del")) {
+                                        System.out.println("##### Client conference_member_del");
+                                        listener.conferenceEventLeave(uniqueId, confName, confSize, event);
+                                        return;
                                     } else if (eventFunc.equals("conf_api_sub_mute")) {
                                         listener.conferenceEventMute(uniqueId, confName, confSize, event);
                                         return;
+                                    //API has changed between freeswitch 1.4 and 1.6
+                                    } else if (eventFunc.equals("conference_api_sub_mute")) {
+                                        listener.conferenceEventMute(uniqueId, confName, confSize, event);
+                                        return;
                                     } else if (eventFunc.equals("conf_api_sub_unmute")) {
+                                        listener.conferenceEventUnMute(uniqueId, confName, confSize, event);
+                                        return;
+                                    //API has changed between freeswitch 1.4 and 1.6
+                                    } else if (eventFunc.equals("conference_api_sub_unmute")) {
                                         listener.conferenceEventUnMute(uniqueId, confName, confSize, event);
                                         return;
                                     } else if (eventFunc.equals("conference_record_thread_run")) {

--- a/bbb-fsesl-client/src/main/java/org/freeswitch/esl/client/inbound/Client.java
+++ b/bbb-fsesl-client/src/main/java/org/freeswitch/esl/client/inbound/Client.java
@@ -475,47 +475,30 @@ public class Client
                                     	System.out.println("##### Client member_add_file_data");
                                         listener.conferenceEventPlayFile(uniqueId, confName, confSize, event);
                                         return;
-                                    } else if (eventFunc.equals("conf_api_sub_transfer")) {
+                                    //API has changed between freeswitch 1.4 and 1.6
+                                    } else if (eventFunc.equals("conf_api_sub_transfer") || eventFunc.equals("conference_api_sub_transfer")) {
                                         //Member transfered to another conf...
                                         listener.conferenceEventTransfer(uniqueId, confName, confSize, event);
                                         return;
                                     //API has changed between freeswitch 1.4 and 1.6
-                                    } else if (eventFunc.equals("conference_api_sub_transfer")) {
-                                        //Member transfered to another conf...
-                                        listener.conferenceEventTransfer(uniqueId, confName, confSize, event);
-                                        return;
-                                    } else if (eventFunc.equals("conference_add_member")) {
+                                    } else if (eventFunc.equals("conference_add_member") || eventFunc.equals("conference_member_add")) {
                                     	System.out.println("##### Client conference_add_member");
                                         listener.conferenceEventJoin(uniqueId, confName, confSize, event);
                                         return;
                                     //API has changed between freeswitch 1.4 and 1.6
-                                    } else if (eventFunc.equals("conference_member_add")) {
-                                        System.out.println("##### Client conference_member_add");
-                                        listener.conferenceEventJoin(uniqueId, confName, confSize, event);
-                                        return;
-                                    } else if (eventFunc.equals("conference_del_member")) {
+                                    } else if (eventFunc.equals("conference_del_member") || eventFunc.equals("conference_member_del")) {
                                     	System.out.println("##### Client conference_del_member");
                                         listener.conferenceEventLeave(uniqueId, confName, confSize, event);
                                         return;
                                     //API has changed between freeswitch 1.4 and 1.6
-                                    } else if (eventFunc.equals("conference_member_del")) {
-                                        System.out.println("##### Client conference_member_del");
-                                        listener.conferenceEventLeave(uniqueId, confName, confSize, event);
-                                        return;
-                                    } else if (eventFunc.equals("conf_api_sub_mute")) {
+                                    } else if (eventFunc.equals("conf_api_sub_mute") || eventFunc.equals("conference_api_sub_mute")) {
                                         listener.conferenceEventMute(uniqueId, confName, confSize, event);
                                         return;
                                     //API has changed between freeswitch 1.4 and 1.6
-                                    } else if (eventFunc.equals("conference_api_sub_mute")) {
-                                        listener.conferenceEventMute(uniqueId, confName, confSize, event);
-                                        return;
-                                    } else if (eventFunc.equals("conf_api_sub_unmute")) {
+                                    } else if (eventFunc.equals("conf_api_sub_unmute") || eventFunc.equals("conference_api_sub_unmute")) {
                                         listener.conferenceEventUnMute(uniqueId, confName, confSize, event);
                                         return;
                                     //API has changed between freeswitch 1.4 and 1.6
-                                    } else if (eventFunc.equals("conference_api_sub_unmute")) {
-                                        listener.conferenceEventUnMute(uniqueId, confName, confSize, event);
-                                        return;
                                     } else if (eventFunc.equals("conference_record_thread_run")) {
                                     	System.out.println("##### Client conference_record_thread_run");
                                         listener.conferenceEventRecord(uniqueId, confName, confSize, event);

--- a/bbb-fsesl-client/src/main/java/org/freeswitch/esl/client/inbound/Client.java
+++ b/bbb-fsesl-client/src/main/java/org/freeswitch/esl/client/inbound/Client.java
@@ -498,7 +498,6 @@ public class Client
                                     } else if (eventFunc.equals("conf_api_sub_unmute") || eventFunc.equals("conference_api_sub_unmute")) {
                                         listener.conferenceEventUnMute(uniqueId, confName, confSize, event);
                                         return;
-                                    //API has changed between freeswitch 1.4 and 1.6
                                     } else if (eventFunc.equals("conference_record_thread_run")) {
                                     	System.out.println("##### Client conference_record_thread_run");
                                         listener.conferenceEventRecord(uniqueId, confName, confSize, event);


### PR DESCRIPTION
I did not test the recording functionality to see if there is anything that needs changing with that but these changes will allow you to join/leave/mute/unmute/kick on freeswitch 1.6