### PR TITLE
Added check to restart libreoffice if no users are logged in

### DIFF
--- a/bigbluebutton-config/cron.daily/bigbluebutton
+++ b/bigbluebutton-config/cron.daily/bigbluebutton
@@ -105,3 +105,9 @@ remove_raw_of_published_recordings(){
 find /tmp -name "*.afm" -mtime +$history -delete
 find /tmp -name "*.pfb" -mtime +$history -delete
 
+#
+# If there are no users currently logged in, restart libreoffice to clear its memory usage
+#
+if [[ $(netstat -ant | egrep ":1935\ " | egrep -v ":::|0.0.0.0"  | wc | awk '{print $1}') == 0 ]]; then
+  service bbb-office restart
+fi


### PR DESCRIPTION
To reduce memory usage by libreoffice, added a check in cron.daily to see restart libreoffice if there are no users currently logged into the server.