### PR TITLE
Reconnect fixes

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/UsersApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/UsersApp.scala
@@ -26,7 +26,7 @@ trait UsersApp {
 
     val user = usersModel.getUser(msg.userid)
     user foreach { u =>
-      if (usersModel.addVoiceConnection(msg.userid)) {
+      if (usersModel.addGlobalAudioConnection(msg.userid)) {
         val vu = u.voiceUser.copy(joined = false, talking = false)
         val uvo = u.copy(listenOnly = true, voiceUser = vu)
         usersModel.addUser(uvo)
@@ -41,7 +41,7 @@ trait UsersApp {
 
     val user = usersModel.getUser(msg.userid)
     user foreach { u =>
-      if (usersModel.removeVoiceConnection(msg.userid)) {
+      if (usersModel.removeGlobalAudioConnection(msg.userid)) {
         if (!u.joinedWeb) {
           val userLeaving = usersModel.removeUser(u.userID)
           log.info("Not web user. Send user left message. meetingId=" + mProps.meetingID + " userId=" + u.userID + " user=" + u)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/UsersModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/UsersModel.scala
@@ -14,11 +14,11 @@ class UsersModel {
 
   private var regUsers = new collection.immutable.HashMap[String, RegisteredUser]
 
-  /* When reconnecting SIP audio, users may receive the connection message
+  /* When reconnecting SIP global audio, users may receive the connection message
    * before the disconnection message.
    * This variable is a connection counter that should control this scenario.
    */
-  private var voiceConnectionCounter = new collection.immutable.HashMap[String, Integer]
+  private var globalAudioConnectionCounter = new collection.immutable.HashMap[String, Integer]
 
   private var locked = false
   private var meetingMuted = false
@@ -151,27 +151,27 @@ class UsersModel {
     }
   }
 
-  def addVoiceConnection(userID: String): Boolean = {
-    voiceConnectionCounter.get(userID) match {
+  def addGlobalAudioConnection(userID: String): Boolean = {
+    globalAudioConnectionCounter.get(userID) match {
       case Some(vc) => {
-        voiceConnectionCounter += userID -> (vc + 1)
+        globalAudioConnectionCounter += userID -> (vc + 1)
         false
       }
       case None => {
-        voiceConnectionCounter += userID -> 1
+        globalAudioConnectionCounter += userID -> 1
         true
       }
     }
   }
 
-  def removeVoiceConnection(userID: String): Boolean = {
-    voiceConnectionCounter.get(userID) match {
+  def removeGlobalAudioConnection(userID: String): Boolean = {
+    globalAudioConnectionCounter.get(userID) match {
       case Some(vc) => {
         if (vc == 1) {
-          voiceConnectionCounter -= userID
+          globalAudioConnectionCounter -= userID
           true
         } else {
-          voiceConnectionCounter += userID -> (vc - 1)
+          globalAudioConnectionCounter += userID -> (vc - 1)
           false
         }
       }

--- a/bigbluebutton-apps/src/main/java/org/bigbluebutton/red5/BigBlueButtonApplication.java
+++ b/bigbluebutton-apps/src/main/java/org/bigbluebutton/red5/BigBlueButtonApplication.java
@@ -133,6 +133,7 @@ public class BigBlueButtonApplication extends MultiThreadedApplicationAdapter {
 		connection.setAttribute(Constants.SESSION, bbbSession);        
 		connection.setAttribute("INTERNAL_USER_ID", internalUserID);
 		connection.setAttribute("USER_SESSION_ID", sessionId);
+		connection.setAttribute("TIMESTAMP", System.currentTimeMillis());
         
 		red5InGW.initLockSettings(room, lsMap);
 		

--- a/bigbluebutton-apps/src/main/java/org/bigbluebutton/red5/client/messaging/ConnectionInvokerService.java
+++ b/bigbluebutton-apps/src/main/java/org/bigbluebutton/red5/client/messaging/ConnectionInvokerService.java
@@ -21,6 +21,7 @@ package org.bigbluebutton.red5.client.messaging;
 import java.util.Set;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.HashSet;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -274,15 +275,32 @@ public class ConnectionInvokerService {
   }
 
   private IConnection getConnection(IScope scope, String userID) {
-    Set<IConnection> conns = scope.getClientConnections();
-    for (IConnection conn : conns) {
+    Set<IConnection> conns = new HashSet<IConnection>();
+    System.out.println(scope.getClientConnections().size());
+    for (IConnection conn : scope.getClientConnections()) {
       String connID = (String) conn.getAttribute("USER_SESSION_ID");
       if (connID != null && connID.equals(userID)) {
-        return conn;
+        conns.add(conn);
       }
     }
-    log.warn("Failed to get connection for userId = " + userID);
-    return null;		
+    if (!conns.isEmpty()) {
+      return getLastConnection(conns);
+    } else {
+      log.warn("Failed to get connection for userId = " + userID);
+      return null;
+    }
+  }
+
+  private IConnection getLastConnection(Set<IConnection> conns) {
+    IConnection conn = null;
+    for (IConnection c : conns) {
+      if (conn == null) {
+        conn = c;
+      } else if ((long) conn.getAttribute("TIMESTAMP") < (long) c.getAttribute("TIMESTAMP")) {
+        conn = c;
+      }
+    }
+    return conn;
   }
 
   public IScope getScope(String meetingID) {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/ConnectionManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/ConnectionManager.as
@@ -53,6 +53,7 @@ package org.bigbluebutton.modules.phone.managers {
     private var closedByUser:Boolean = false;
 
 		private var reconnecting:Boolean = false;
+		private var amIListenOnly:Boolean = false;
     
 		private var dispatcher:Dispatcher;
 		
@@ -83,19 +84,24 @@ package org.bigbluebutton.modules.phone.managers {
     }
     
 		public function connect():void {				
-      closedByUser = false;
-      var isTunnelling:Boolean = BBB.initConnectionManager().isTunnelling;
-      if (isTunnelling) {
-        uri = uri.replace(/rtmp:/gi, "rtmpt:");
-      }
-	  LOGGER.debug("Connecting to uri=[{0}]", [uri]);
-			NetConnection.defaultObjectEncoding = flash.net.ObjectEncoding.AMF0;	
-			netConnection = new NetConnection();
-			netConnection.proxyType = "best";
-			netConnection.client = this;
-			netConnection.addEventListener( NetStatusEvent.NET_STATUS , netStatus );
-			netConnection.addEventListener(SecurityErrorEvent.SECURITY_ERROR, securityErrorHandler);
-			netConnection.connect(uri, meetingId, externUserId, username);
+			if (!reconnecting || amIListenOnly) {
+				closedByUser = false;
+				var isTunnelling:Boolean = BBB.initConnectionManager().isTunnelling;
+				if (isTunnelling) {
+					uri = uri.replace(/rtmp:/gi, "rtmpt:");
+				}
+				LOGGER.debug("Connecting to uri=[{0}]", [uri]);
+				NetConnection.defaultObjectEncoding = flash.net.ObjectEncoding.AMF0;
+				netConnection = new NetConnection();
+				netConnection.proxyType = "best";
+				netConnection.client = this;
+				netConnection.addEventListener( NetStatusEvent.NET_STATUS , netStatus );
+				netConnection.addEventListener(SecurityErrorEvent.SECURITY_ERROR, securityErrorHandler);
+				netConnection.connect(uri, meetingId, externUserId, username);
+			}
+			if (reconnecting && !amIListenOnly) {
+				handleConnectionSuccess();
+			}
 		}
 
 		public function disconnect(requestByUser:Boolean):void {
@@ -212,12 +218,14 @@ package org.bigbluebutton.modules.phone.managers {
 		//
 		//********************************************************************************************		
 		public function doCall(dialStr:String, listenOnly:Boolean = false):void {
+			amIListenOnly = listenOnly;
 			LOGGER.debug("in doCall - Calling {0} {1}", [dialStr, listenOnly? "*listen only*": ""]);
 			netConnection.call("voiceconf.call", null, "default", username, dialStr, listenOnly.toString());
 		}
 				
 		public function doHangUp():void {			
 			if (isConnected()) {
+				amIListenOnly = false;
         		LOGGER.debug("hanging up call");
 				netConnection.call("voiceconf.hangup", null, "default");
 			}

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/ConnectionManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/ConnectionManager.as
@@ -134,7 +134,7 @@ package org.bigbluebutton.modules.phone.managers {
         disconnectedEvent.payload.callbackParameters = [];
         dispatcher.dispatchEvent(disconnectedEvent);
 
-        dispatcher.dispatchEvent(new FlashVoiceConnectionStatusEvent(FlashVoiceConnectionStatusEvent.DISCONNECTED));
+        dispatcher.dispatchEvent(new FlashVoiceConnectionStatusEvent(FlashVoiceConnectionStatusEvent.DISCONNECTED, reconnecting));
       }
     }
 

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/FlashCallManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/FlashCallManager.as
@@ -12,6 +12,7 @@
   import org.as3commons.logging.util.jsonXify;
   import org.bigbluebutton.common.Media;
   import org.bigbluebutton.core.UsersUtil;
+  import org.bigbluebutton.core.events.VoiceConfEvent;
   import org.bigbluebutton.main.api.JSLog;
   import org.bigbluebutton.modules.phone.PhoneOptions;
   import org.bigbluebutton.modules.phone.events.FlashCallConnectedEvent;
@@ -451,6 +452,14 @@
       if (isConnected()) {
         streamManager.stopStreams();
         connectionManager.disconnect(true);
+      }
+    }
+
+    public function handleReconnectSIPSucceededEvent():void {
+      if (state != ON_LISTEN_ONLY_STREAM) {
+        var e:VoiceConfEvent = new VoiceConfEvent(VoiceConfEvent.EJECT_USER);
+        e.userid = UsersUtil.getMyUserID();
+        dispatcher.dispatchEvent(e);
       }
     }
   }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/phone/maps/FlashCallEventMap.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/phone/maps/FlashCallEventMap.mxml
@@ -28,6 +28,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import mx.events.FlexEvent;
 			
 			import org.bigbluebutton.main.events.MadePresenterEvent;
+			import org.bigbluebutton.main.events.BBBEvent;
 			import org.bigbluebutton.main.model.users.events.ConnectionFailedEvent;
 			import org.bigbluebutton.modules.phone.events.FlashCallConnectedEvent;
 			import org.bigbluebutton.modules.phone.events.FlashCallDisconnectedEvent;
@@ -118,5 +119,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
   
   <EventHandlers type="{MadePresenterEvent.SWITCH_TO_VIEWER_MODE}">        
     <MethodInvoker generator="{FlashCallManager}" method="handleBecomeViewer"/>
+  </EventHandlers>
+
+  <EventHandlers type="{BBBEvent.RECONNECT_SIP_SUCCEEDED_EVENT}">
+    <MethodInvoker generator="{FlashCallManager}" method="handleReconnectSIPSucceededEvent"/>
   </EventHandlers>
 </EventMap>


### PR DESCRIPTION
Main connection wasn't always being reconnected because server's direct messages were selecting the wrong connection. There are multiple connections for the same client that is reconnecting.

SIP global audio reconnection wasn't working because of a missing parameter. Also fixed the cases when bbb-voice disconnect message is sent only after timeout.

SIP mic reconnection now closes the SIP connection.