### PR TITLE
Reduce WebRTC reconnect attempts

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/WebRTCCallManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/WebRTCCallManager.as
@@ -33,7 +33,7 @@ package org.bigbluebutton.modules.phone.managers
   public class WebRTCCallManager
   {
 	private static const LOGGER:ILogger = getClassLogger(WebRTCCallManager);      
-    private const MAX_RETRIES:Number = 5;
+    private const MAX_RETRIES:Number = 3;
     
     private var browserType:String = "unknown";
     private var browserVersion:int = 0;


### PR DESCRIPTION
Reduced WebRTC reconnect attempts from 5 to 3. The time between connection attempts double everytime it fails. With 5 attempts it will take 15s to fall back to Flash, but with 3 attempts it will only take 3s.