### PR TITLE
Fixed unclosed video windows bug

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/GraphicsWrapper.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/GraphicsWrapper.as
@@ -252,6 +252,7 @@ package org.bigbluebutton.modules.videoconf.views
 			LOGGER.debug("[GraphicsWrapper:addVideoForHelper] streamName {0}", [streamName]);
             var graphic:UserGraphicHolder = new UserGraphicHolder();
             graphic.userId = userId;
+            graphic.streamName = streamName;
             graphic.addEventListener(FlexEvent.CREATION_COMPLETE, function(event:FlexEvent):void {
                 graphic.loadVideo(_options, connection, streamName);
                 onChildAdd(event);
@@ -375,7 +376,7 @@ package org.bigbluebutton.modules.videoconf.views
 
             for (var i:int = 0; i < numChildren; ++i) {
                 var item:UserGraphicHolder = getChildAt(i) as UserGraphicHolder;
-                if (item.user && item.user.userID == userId && item.visibleComponent is UserVideo && item.video.streamName == streamName) {
+                if (item.userId == userId && item.streamName == streamName) {
                     camIndex = item.video.camIndex;
                     removeChildHelper(item);
                     break;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/UserGraphicHolder.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/UserGraphicHolder.mxml
@@ -62,6 +62,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
             private var _dispatcher:Dispatcher = new Dispatcher();
             private var _images:Images = new Images();
             private var _user:BBBUser = null;
+            private var _streamName:String = "";
+            private var _userId:String = "";
 
             private var _hideMuteBtnTimer:Timer;
 
@@ -75,6 +77,19 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
             public function set userId(value:String):void {
                 _user = UsersUtil.getUser(value);
+                _userId = value;
+            }
+
+            public function set streamName(value:String):void {
+                _streamName = value;
+            }
+
+            public function get streamName():String {
+                return _streamName;
+            }
+
+            public function get userId():String {
+                return _userId;
             }
 
             public function loadAvatar(options:VideoConfOptions):void {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/UserVideo.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/UserVideo.as
@@ -79,14 +79,16 @@ package org.bigbluebutton.modules.videoconf.views
     }
 
     private function startPublishing():void {
-      _streamName = newStreamName();
-      _shuttingDown = false;
+      if(!_shuttingDown){
+        _streamName = newStreamName();
+        _shuttingDown = false;
 
-      var e:StartBroadcastEvent = new StartBroadcastEvent();
-      e.stream = _streamName;
-      e.camera = _video.getCamera();
-      e.videoProfile = _videoProfile;
-      _dispatcher.dispatchEvent(e);
+        var e:StartBroadcastEvent = new StartBroadcastEvent();
+        e.stream = _streamName;
+        e.camera = _video.getCamera();
+        e.videoProfile = _videoProfile;
+        _dispatcher.dispatchEvent(e);
+      }
     }
 
     public function shutdown():void {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/UserVideo.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/UserVideo.as
@@ -39,6 +39,11 @@ package org.bigbluebutton.modules.videoconf.views
     }
 
     public function publish(camIndex:int, videoProfile:VideoProfile):void {
+      if (_shuttingDown) {
+        LOGGER.warn("Method publish called while shutting down the video window, ignoring...");
+        return;
+      }
+
       _camIndex = camIndex;
       _videoProfile = videoProfile;
       setOriginalDimensions(_videoProfile.width, _videoProfile.height);
@@ -79,16 +84,14 @@ package org.bigbluebutton.modules.videoconf.views
     }
 
     private function startPublishing():void {
-      if(!_shuttingDown){
-        _streamName = newStreamName();
-        _shuttingDown = false;
+      _streamName = newStreamName();
+      _shuttingDown = false;
 
-        var e:StartBroadcastEvent = new StartBroadcastEvent();
-        e.stream = _streamName;
-        e.camera = _video.getCamera();
-        e.videoProfile = _videoProfile;
-        _dispatcher.dispatchEvent(e);
-      }
+      var e:StartBroadcastEvent = new StartBroadcastEvent();
+      e.stream = _streamName;
+      e.camera = _video.getCamera();
+      e.videoProfile = _videoProfile;
+      _dispatcher.dispatchEvent(e);
     }
 
     public function shutdown():void {
@@ -126,6 +129,11 @@ package org.bigbluebutton.modules.videoconf.views
     }
 
     public function view(connection:NetConnection, streamName:String):void {
+      if (_shuttingDown) {
+        LOGGER.warn("Method view called while shutting down the video window, ignoring...");
+        return;
+      }
+
       _streamName = streamName;
       _shuttingDown = false;
 


### PR DESCRIPTION
Sharing and unsharing the webcam repeatedly in a short time left some video windows unclosed even after their unshare commands.

This was happening either because:

1) The removeVideoByStreamName function was trying to remove the videos before their stream names were loaded.

The solution is setting the stream name before creating the video window.

2) startPublishing was being called after stopPublishing.

solution: only execute startPublishing if the window is not shutting down.