### PR TITLE
Changes to the chat audio cue control

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/AddChatTabBox.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/AddChatTabBox.mxml
@@ -64,7 +64,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
                 } else {
                     LOGGER.debug("fontSize in config.xml not found: {0}", [chatOptions.fontSize]);
                 }
-                chatNoiseCheckBox.visible = Accessibility.active;
+                chatNoiseCheckBox.selected = Accessibility.active;
+                changeChatNoise();
             }
             
             public function accessibleClick(event:KeyboardEvent):void{
@@ -140,5 +141,5 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
                      selectedIndex="1" toolTip="{ResourceUtil.getInstance().getString('bbb.chat.cmbFontSize.toolTip')}" />
     </mx:HBox>
 	<mx:CheckBox id="chatNoiseCheckBox"  label="Audible Chat Notification" labelPlacement="left" 
-				 selected="true" change="changeChatNoise()" styleName="chatOptionsLabel" />
+				 change="changeChatNoise()" styleName="chatOptionsLabel" />
 </mx:VBox>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatView.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatView.mxml
@@ -71,7 +71,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		  private var publicWaiting:Boolean = false;
 		  private var publicFocus:Boolean = false;
 		  private var noticeLabel:String;
-		  private var chatNoiseEnabled:Boolean = true;
+		  private var chatNoiseEnabled:Boolean = false;
 			
 		  [Embed(source="../sounds/notice.mp3")] 
 		  private var noticeSoundClass:Class;
@@ -309,7 +309,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 			
 			private function playSound():void {
-				if (Accessibility.active && chatNoiseEnabled){
+				if (chatNoiseEnabled){
 					noticeSound.play();
 				}
 			}


### PR DESCRIPTION
I made the chat audio cue a little more resilient and made the checkbox control visible to all users. It will now always be able to be turned off and if someone wants to turn it on before going to a different tab they may do so.