### PR TITLE
Compiling bbb-fsesl-client

### DIFF
--- a/bbb-fsesl-client/src/main/java/org/freeswitch/esl/client/internal/debug/ChannelEventRunnable.java
+++ b/bbb-fsesl-client/src/main/java/org/freeswitch/esl/client/internal/debug/ChannelEventRunnable.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  * @author The Netty Project (netty-dev@lists.jboss.org)
  * @author Trustin Lee (tlee@redhat.com)
  *
- * @version $Rev: 1685 $, $Date: 2009-08-28 16:15:49 +0900 (금, 28 8 2009) $
+ * @version $Rev: 1685 $, $Date: 2009-08-28 16:15:49 +0900 $
  *
  */
 public class ChannelEventRunnable implements Runnable, EstimatableObjectWrapper {

--- a/bbb-fsesl-client/src/main/java/org/freeswitch/esl/client/internal/debug/ExecutionHandler.java
+++ b/bbb-fsesl-client/src/main/java/org/freeswitch/esl/client/internal/debug/ExecutionHandler.java
@@ -54,7 +54,7 @@ import org.jboss.netty.util.internal.ExecutorUtil;
  * @author The Netty Project (netty-dev@lists.jboss.org)
  * @author Trustin Lee (tlee@redhat.com)
  *
- * @version $Rev: 1685 $, $Date: 2009-08-28 16:15:49 +0900 (금, 28 8 2009) $
+ * @version $Rev: 1685 $, $Date: 2009-08-28 16:15:49 +0900 $
  *
  * @apiviz.landmark
  * @apiviz.has java.util.concurrent.ThreadPoolExecutor


### PR DESCRIPTION
Remove the Korean characters (apparently the symbol means "gold": https://www.google.com/search?client=ubuntu&channel=fs&q=%EA%B8%88&ie=utf-8&oe=utf-8) that were preventing bbb-fsesl-client to get compiled successfully.