### PR TITLE
fix duplicated publish video windows after reconnection #2808

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMap.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMap.mxml
@@ -56,10 +56,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
   <EventHandlers type="{BBBEvent.CAMERA_SETTING}" >
     <MethodInvoker generator="{VideoEventMapDelegate}" method="handleCameraSetting" arguments="{event}"/>
   </EventHandlers>
-	
-	<EventHandlers type="{BBBEvent.RECONNECT_CONNECTION_ATTEMPT_SUCCEEDED_EVENT}" >
-		<MethodInvoker generator="{VideoEventMapDelegate}" method="handleRestream" arguments="{event}"/>
-	</EventHandlers>
   
 	<EventHandlers type="{BBBEvent.ERASE_CAMERA_SETTING}" >
 		<MethodInvoker generator="{VideoEventMapDelegate}" method="handleEraseCameraSetting" arguments="{event}"/>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMapDelegate.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMapDelegate.as
@@ -448,13 +448,14 @@ package org.bigbluebutton.modules.videoconf.maps
     public function connectedToVideoApp(event: ConnectedEvent):void{
       LOGGER.debug("VideoEventMapDelegate:: [{0}] Connected to video application.", [me]);
       _ready = true;
-		if (event.reconnection) {
-		 closeAllWindows()
-		} else {
-			addToolbarButton();					  
-		}
-		openWebcamWindows();
-	
+      if (event.reconnection) {
+        closeAllWindows();
+        handleRestream();
+      } else {
+        addToolbarButton();
+      }
+      
+      openWebcamWindows();
     }
 
     public function handleCameraSetting(event:BBBEvent):void {
@@ -471,7 +472,7 @@ package org.bigbluebutton.modules.videoconf.maps
 		_restream = event.payload.restream;
 	}
 	
-	public function handleRestream(event:BBBEvent):void {
+	private function handleRestream():void {
 		if(_restream){
 			LOGGER.debug("VideoEventMapDelegate::handleRestream [{0},{1}]", [_cameraIndex, _videoProfile.id]);
 			initCameraWithSettings(_cameraIndex, _videoProfile);


### PR DESCRIPTION
The problem was that we were handling the reconnecton succeeded event to start streaming again, but this event is dispatched for every connection, not only for the video connection, and it was causing restream to be called multiple times after the reconnection, eventually duplicating the publish windows; when it occurred, the user was publishing two separate video streams.
The solution was to use the ConnectedEvent used only by the video connection, which also carries the information if that connection is due to a reconnect.
It looks like the current solution to restream after a reconnect doesn't work if the user was publishing two cameras at the same time. In that case, I think only the second camera will be published again.