### PR TITLE
Put the fix for #2437 back in

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
@@ -176,22 +176,30 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				if (!showToolbarOpt) {
 					toolbarHeight = 0;
 					toolbarPaddingTop = 0;
+					calculateCanvasHeight();
 				}
 				toolbar.displayToolbar();
-      
-        showFooterOpt = layoutOptions.showFooter;
-        
-        var locale:Object = BBB.initConfigManager().config.language;
-        langSelector.visible = locale.userSelectionEnabled
- 
-        if (!showFooterOpt) {
-          footerHeight = 0;
-          controlBar.visible = false;
-        }        
-      }
+				
+				showFooterOpt = layoutOptions.showFooter;
+				var locale:Object = BBB.initConfigManager().config.language;
+				langSelector.visible = locale.userSelectionEnabled;
+				
+				if (!showFooterOpt) {
+					footerHeight = 0;
+					controlBar.visible = false;
+					calculateCanvasHeight();
+				}
+			}
 		
 			protected function initializeShell():void {	
 				globalDispatcher = new Dispatcher();
+				
+				systemManager.addEventListener(Event.RESIZE, handleApplicationResizeEvent);
+				calculateCanvasHeight();
+			}
+			
+			private function handleApplicationResizeEvent(e:Event):void {
+				calculateCanvasHeight();
 			}
 		
 			protected function initFullScreen():void {				
@@ -201,6 +209,15 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}					
 			
 			private var sendStartModulesEvent:Boolean = true;
+			
+			// We have to calculate the canvas height manually because if you set it to a 
+			// percentage you will get execution timeout errors.
+			// See issue #2437 for why you shouldn't set height to 100% 
+			//             https://github.com/bigbluebutton/bigbluebutton/issues/2437
+			private function calculateCanvasHeight():void {
+				var screenRect:Rectangle = systemManager.screen;
+				mdiCanvas.height = screenRect.height - footerHeight - toolbarHeight - 12;
+			}
 			
 			private function handleApplicationVersionEvent(event:AppVersionEvent):void {
 				if (event.configLocaleVersion == true) {
@@ -663,8 +680,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					  horizontalScrollPolicy="off" 
 					  verticalScrollPolicy="off" 
 					  effectsLib="{flexlib.mdi.effects.effectsLib.MDIVistaEffects}" 
-					  width="100%" 
-					  height="100%">
+					  width="100%" >
 		<views:LoadingBar id="progressBar" horizontalCenter="0" verticalCenter="0" width="50%" />
 		<views:BrandingLogo x="{this.width - 300}" y="{this.height - 300}" />
 	</views:MainCanvas>	


### PR DESCRIPTION
If you set the height of MainCanvas to a percent value it results in execution timeout errors in certain situations when windows are maximized. I was overzealous when removing a chunk of unused code and removed the manual height calculation as well. This pull request puts the manual calculation back in and contains a comment before the calculation describing why the calculation is required to try and avoid future removals.