### PR TITLE
recording: Restore the $meeting_start/end global variables

### DIFF
--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -972,8 +972,8 @@ begin
         # presentation_url = "/slides/" + $meeting_id + "/presentation"
         @doc = Nokogiri::XML(File.open("#{$process_dir}/events.xml"))
 
-        #$meeting_start = @doc.xpath("//event")[0][:timestamp]
-        #$meeting_end = @doc.xpath("//event").last()[:timestamp]
+        $meeting_start = @doc.xpath("//event")[0][:timestamp]
+        $meeting_end = @doc.xpath("//event").last()[:timestamp]
 
         ## These $version variables are not used anywere in this code ##
         $version = BigBlueButton::Events.bbb_version("#{$process_dir}/events.xml")


### PR DESCRIPTION
These were commented out, apparently by accident, when the metadata code
was being refactored. The effect was that the $meeting_end variable was
treated as if it had a value of zero, meaning that the last slide had a
start time of some positive number and an end time of zero. As a result,
it was never shown (and didn't get any shapes either).

Fixes #3021