### PR TITLE
html5: Correctly kick user out of voice in markUserOffline

### DIFF
--- a/bigbluebutton-html5/app/server/collection_methods/users.js
+++ b/bigbluebutton-html5/app/server/collection_methods/users.js
@@ -233,9 +233,9 @@ this.markUserOffline = function(meetingId, userId, callback) {
     }, {
       $set: {
         'user.connection_status': 'offline',
-        'voiceUser.talking': false,
-        'voiceUser.joined': false,
-        'voiceUser.muted': false,
+        'user.voiceUser.talking': false,
+        'user.voiceUser.joined': false,
+        'user.voiceUser.muted': false,
         'user.time_of_joining': 0,
         'user.listenOnly': false
       }


### PR DESCRIPTION

The old code was wrongly setting obj.voiceUser when it should set obj.user.voiceUser
and caused problems when for example:

* user joins audio
* user hits F5
* user reconnects without webrtc audio enabled
* html5 client reports user still in audio and leaving/joining doesnt work anymore