### PR TITLE
 - we are seeing redis sub reconnecting because of exception on null …

### DIFF
--- a/bigbluebutton-apps/src/main/java/org/bigbluebutton/red5/service/ParticipantsService.java
+++ b/bigbluebutton-apps/src/main/java/org/bigbluebutton/red5/service/ParticipantsService.java
@@ -27,6 +27,7 @@ import org.red5.server.api.scope.IScope;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.bigbluebutton.red5.BigBlueButtonSession;
 import org.bigbluebutton.red5.Constants;
 import org.bigbluebutton.red5.pubsub.MessagePublisher;
@@ -59,6 +60,11 @@ public class ParticipantsService {
 		String meetingId = scope.getName();
 		String userId = (String) msg.get("userId");
 		String emojiStatus = (String) msg.get("emojiStatus");
+		
+		if (StringUtils.isEmpty(emojiStatus)) {
+			// Set emojiStatus=none if passed is null.
+			emojiStatus = "none";
+		}
 		red5InGW.userEmojiStatus(meetingId, userId, emojiStatus);
 	}
 	


### PR DESCRIPTION
…emoji status in akka-apps.

   set the emojistatus to "none" (default) when it is null