### PR TITLE
recording: Escape custom poll answers in gnuplot file

### DIFF
--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -467,7 +467,7 @@ def storePollResultShape(xml, shape)
   end
   File.open(gpl_file, 'w') do |g|
     g.puts('reset')
-    g.puts("set term pdfcairo size #{height / 72}, #{width / 72} font \"Arial,48\"")
+    g.puts("set term pdfcairo size #{height / 72}, #{width / 72} font \"Arial,48\" noenhanced")
     g.puts('unset key')
     g.puts('set style data boxes')
     g.puts('set style fill solid border -1')
@@ -475,7 +475,7 @@ def storePollResultShape(xml, shape)
     g.puts('set yrange [0:*]')
     g.puts('unset border')
     g.puts('unset ytics')
-    xtics = result.map{ |r| "\"#{r['key'].gsub('%', '%%')}\" #{r['id']}" }.join(', ')
+    xtics = result.map{ |r| "#{r['key'].gsub('%', '%%').inspect} #{r['id']}" }.join(', ')
     g.puts("set xtics rotate by 90 scale 0 right (#{xtics})")
     if num_responders > 0
       x2tics = result.map{ |r| "\"#{(r['num_votes'].to_f / num_responders * 100).to_i}%%\" #{r['id']}" }.join(', ')


### PR DESCRIPTION
Custom poll answers were previously printed into the gnuplot control
file directly, between double-quotes. As a result, if a poll answer
contains a double-quote, it could cause a syntax error in the gnuplot
script, or worse.

Gnuplot accepts standard C-style double-quoted string escapes, so I can
just use ruby's "inspect" method to generate a safetly escaped string.

Note that within the string, % still has to be escaped separately
(doubled) to avoid issues with the string formatting. As well, I have
disabled "enhanced" mode which allows using special characters for
formatting commands.

Fixes #3039