### PR TITLE
html5Client:fix emoji bug caused by Chrome vs FF behav difference

### DIFF
--- a/bigbluebutton-html5/app/client/views/whiteboard/whiteboard.js
+++ b/bigbluebutton-html5/app/client/views/whiteboard/whiteboard.js
@@ -60,7 +60,7 @@ Template.whiteboard.events({
         getInSession('userId'),
         getInSession('userId'),
         getInSession('authToken'),
-        event.target.value
+        this.name
       );
       $('.FABTriggerButton').blur();
       return toggleEmojisFAB();


### PR DESCRIPTION
FireFox returns the emoji's name on 'event.target.value' while for Chrome this is undefined