### PR TITLE
Fixes #3068 - Detecting Microsoft Edge as Google Chrome

### DIFF
--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -292,6 +292,7 @@ bbb.desktopPublish.maximizeRestoreBtn.toolTip = You cannot maximize this window.
 bbb.desktopPublish.closeBtn.toolTip = Stop Sharing and Close
 bbb.desktopPublish.chromeOnMacUnsupportedHint = Desktop sharing is not currently supported on Chrome running under Mac OS X. You must use a different web browser (Firefox recommended) to share your desktop.
 bbb.desktopPublish.chrome42UnsupportedHint = Chrome no longer supports Java Applets. You must use a different web browser (Firefox recommended) to share your desktop.
+bbb.desktopPublish.edgePluginUnsupportedHint = Edge does not support Java Applets. You must use a different web browser (Firefox recommended) to share your desktop.
 bbb.desktopPublish.minimizeBtn.toolTip = Minimize
 bbb.desktopPublish.minimizeBtn.accessibilityName = Minimize the Desktop Sharing Publish Window
 bbb.desktopPublish.maximizeRestoreBtn.accessibilityName = Maximize the Desktop Sharing Publish Window

--- a/bigbluebutton-client/resources/prod/lib/bbb_blinker.js
+++ b/bigbluebutton-client/resources/prod/lib/bbb_blinker.js
@@ -78,6 +78,15 @@ function determineBrowser()
 		browserName = "Puffin";
 		fullVersion = nAgt.substring(verOffset+7);
 	}
+	// search for Edge before Chrome or Safari because Microsoft
+	// includes Chrome and Safari user agents in Edge's UA
+	// In Microsoft Edge, the true version is the last chunk of the UA
+	// it follows "Edge"
+	else if ((verOffset=nAgt.indexOf("Edge"))!=-1) {
+		browserName = "Edge";
+		// "Edge".length = 4, plus 1 character for the trailing slash
+		fullVersion = nAgt.substring(verOffset+5);
+	}
 	// In Chrome, the true version is after "Chrome" 
 	else if ((verOffset=nAgt.indexOf("Chrome"))!=-1) {
 		browserName = "Chrome";

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/deskshare/utils/BrowserCheck.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/deskshare/utils/BrowserCheck.as
@@ -1,0 +1,53 @@
+/**
+* BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+*
+* Copyright (c) 2012 BigBlueButton Inc. and by respective authors (see below).
+*
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License as published by the Free Software
+* Foundation; either version 3.0 of the License, or (at your option) any later
+* version.
+*
+* BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License along
+* with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+package org.bigbluebutton.modules.deskshare.utils
+{
+	import flash.external.ExternalInterface;
+	import org.bigbluebutton.core.BBB;
+	import flash.system.Capabilities;
+	import org.as3commons.logging.api.getClassLogger;
+	import org.as3commons.logging.api.ILogger;
+
+	public class BrowserCheck {
+		private static const LOGGER:ILogger = getClassLogger(BrowserCheck);
+
+		public static function isChrome42OrHigher():Boolean {
+			var browser:Array = ExternalInterface.call("determineBrowser");
+			return ((browser[0] == "Chrome") && (parseInt(browser[1]) >= 42));
+		}
+
+		public static function isUsingLessThanChrome38OnMac():Boolean {
+			var browser:Array = ExternalInterface.call("determineBrowser");
+			return ((browser[0] == "Chrome") && (parseInt(browser[1]) <= 38) && (Capabilities.os.indexOf("Mac") >= 0));
+		}
+
+		public static function isWebRTCSupported():Boolean {
+			LOGGER.debug("isWebRTCSupported - ExternalInterface.available=[{0}], isWebRTCAvailable=[{1}]", [ExternalInterface.available, ExternalInterface.call("isWebRTCAvailable")]);
+			return (ExternalInterface.available && ExternalInterface.call("isWebRTCAvailable"));
+		}
+
+		public static function isUsingEdgePluginUnsupported():Boolean {
+			var browser:Array = ExternalInterface.call("determineBrowser");
+			/* Currently no browser version of Edge supports plugins */
+			return browser[0] == "Edge";
+		}
+	}
+}
+

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/deskshare/utils/JavaCheck.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/deskshare/utils/JavaCheck.as
@@ -26,6 +26,7 @@ package org.bigbluebutton.modules.deskshare.utils
 	import org.bigbluebutton.core.BBB;
 	import org.bigbluebutton.main.events.ClientStatusEvent;
 	import org.bigbluebutton.util.i18n.ResourceUtil;
+	import org.bigbluebutton.modules.deskshare.utils.BrowserCheck;
 	
 	public class JavaCheck {
     public static function checkJava():String {
@@ -44,7 +45,7 @@ package org.bigbluebutton.modules.deskshare.utils
         return null;        
      
       } else if (isJavaOk.result == "JAVA_NOT_INSTALLED") {
-        if (!isChrome42OrHigher()) {
+        if (!BrowserCheck.isChrome42OrHigher()) {
           dispatcher.dispatchEvent(new ClientStatusEvent(ClientStatusEvent.FAIL_MESSAGE_EVENT, ResourceUtil.getInstance().getString("bbb.clientstatus.java.title"), ResourceUtil.getInstance().getString("bbb.clientstatus.java.notinstalled")));
         }
         return ResourceUtil.getInstance().getString("bbb.clientstatus.java.notinstalled");        
@@ -59,11 +60,6 @@ package org.bigbluebutton.modules.deskshare.utils
        
     private static function checkJavaVersion(minVersion: String):Object {
       return ExternalInterface.call("checkJavaVersion", minVersion);
-    }
-    
-    private static function isChrome42OrHigher():Boolean {
-      var browser:Array = ExternalInterface.call("determineBrowser");
-      return ((browser[0] == "Chrome") && (parseInt(browser[1]) >= 42));
     }
   }
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/deskshare/view/components/DesktopPublishWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/deskshare/view/components/DesktopPublishWindow.mxml
@@ -117,6 +117,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				
 				if (isUsingLessThanChrome38OnMac()) {
 					setCurrentState("chromeOnMacWarningState");
+				} else if (isUsingEdgePluginUnsupported()) {
+					setCurrentState("edgePluginWarningState");
 				} else {
 					var javaIssue:String = JavaCheck.checkJava();
 					
@@ -414,6 +416,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				var browser:Array = ExternalInterface.call("determineBrowser");
 				return ((browser[0] == "Chrome") && (parseInt(browser[1]) >= 42));
 			}
+
+			public static function isUsingEdgePluginUnsupported():Boolean {
+				var browser:Array = ExternalInterface.call("determineBrowser");
+				/* Currently no browser version of Edge supports plugins */
+				return browser[0] == "Edge";
+			}
 		]]>
 	</mx:Script>
 
@@ -472,6 +480,14 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				<mx:VBox height="100%" width="100%" verticalAlign="middle" horizontalAlign="center">
 					<mx:Text id="chrome42WarningLbl" width="80%" textAlign="center" styleName="desktopShareTextStyle"
 							 text="{ResourceUtil.getInstance().getString('bbb.desktopPublish.chrome42UnsupportedHint')}" />
+				</mx:VBox>
+			</mx:AddChild>
+		</mx:State>
+		<mx:State name="edgePluginWarningState">
+			<mx:AddChild>
+				<mx:VBox height="100%" width="100%" verticalAlign="middle" horizontalAlign="center">
+					<mx:Text id="edgePluginWarningLbl" width="80%" textAlign="center" styleName="desktopShareTextStyle"
+							 text="{ResourceUtil.getInstance().getString('bbb.desktopPublish.edgePluginUnsupportedHint')}" />
 				</mx:VBox>
 			</mx:AddChild>
 		</mx:State>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/deskshare/view/components/DesktopPublishWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/deskshare/view/components/DesktopPublishWindow.mxml
@@ -68,6 +68,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.modules.deskshare.events.ViewStreamEvent;
 			import org.bigbluebutton.modules.deskshare.model.DeskshareOptions;
 			import org.bigbluebutton.modules.deskshare.utils.JavaCheck;
+			import org.bigbluebutton.modules.deskshare.utils.BrowserCheck;
+			
 			import org.bigbluebutton.util.i18n.ResourceUtil;
 			
 			private static const LOGGER:ILogger = getClassLogger(DesktopPublishWindow);      
@@ -115,15 +117,15 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				cursor.graphics.lineStyle(6, 0xFF0000, 0.6);
 				cursor.graphics.drawCircle(0,0,3);		
 				
-				if (isUsingLessThanChrome38OnMac()) {
+				if (BrowserCheck.isUsingLessThanChrome38OnMac()) {
 					setCurrentState("chromeOnMacWarningState");
-				} else if (isUsingEdgePluginUnsupported()) {
+				} else if (BrowserCheck.isUsingEdgePluginUnsupported()) {
 					setCurrentState("edgePluginWarningState");
 				} else {
 					var javaIssue:String = JavaCheck.checkJava();
 					
 					if (javaIssue != null) {
-						if (isChrome42OrHigher()) {
+						if (BrowserCheck.isChrome42OrHigher()) {
 							setCurrentState("chrome42WarningState");
 						} else {
 							setCurrentState("javaIssueWarningState");
@@ -405,22 +407,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private function closePublishWindow(event:ViewStreamEvent):void{
 				stopStream();
 				closeWindow();
-			}
-			
-			private function isUsingLessThanChrome38OnMac():Boolean {
-				var browser:Array = ExternalInterface.call("determineBrowser");
-				return ((browser[0] == "Chrome") && (parseInt(browser[1]) <= 38) && (Capabilities.os.indexOf("Mac") >= 0));
-			}
-			
-			private function isChrome42OrHigher():Boolean {
-				var browser:Array = ExternalInterface.call("determineBrowser");
-				return ((browser[0] == "Chrome") && (parseInt(browser[1]) >= 42));
-			}
-
-			public static function isUsingEdgePluginUnsupported():Boolean {
-				var browser:Array = ExternalInterface.call("determineBrowser");
-				/* Currently no browser version of Edge supports plugins */
-				return browser[0] == "Edge";
 			}
 		]]>
 	</mx:Script>


### PR DESCRIPTION
- Adds a check in the user agent detection for Microsoft Edge
- Desktop publish window displays message for Edge instead of Chrome
- Adds en_US locale for the Edge desktop sharing message
- Configuration notification where it detect Chrome instead of Edge is now avoided
- Moves duplicated browser check functions into one class