### PR TITLE
1.0 client fixes

### DIFF
--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -435,7 +435,7 @@ bbb.shortcutkey.general.minimize.function = Minimize current window
 bbb.shortcutkey.general.maximize = 187
 bbb.shortcutkey.general.maximize.function = Maximize current window
 
-bbb.shortcutkey.flash.exit = 81
+bbb.shortcutkey.flash.exit = 79
 bbb.shortcutkey.flash.exit.function = Focus out of the Flash window
 bbb.shortcutkey.users.muteme = 77
 bbb.shortcutkey.users.muteme.function = Mute and Unmute your microphone
@@ -457,10 +457,6 @@ bbb.shortcutkey.focus.chat.function = Move focus to the Chat window
 
 bbb.shortcutkey.share.desktop = 68
 bbb.shortcutkey.share.desktop.function = Open desktop sharing window
-bbb.shortcutkey.share.microphone = 79
-bbb.shortcutkey.share.microphone.function = Open audio settings window
-bbb.shortcutkey.share.pauseRemoteStream = 80
-bbb.shortcutkey.share.pauseRemoteStream.function = Start/Stop listening the conference
 bbb.shortcutkey.share.webcam = 66
 bbb.shortcutkey.share.webcam.function = Open webcam sharing window
 

--- a/bigbluebutton-client/src/BigBlueButtonMainContainer.mxml
+++ b/bigbluebutton-client/src/BigBlueButtonMainContainer.mxml
@@ -171,10 +171,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         if (ShortcutOptions.deskshareActive){
           keyCombos[globalModifier+(ResourceUtil.getInstance().getString('bbb.shortcutkey.share.desktop') as String)] = ShortcutEvent.SHARE_DESKTOP;
         }
-        if (ShortcutOptions.audioActive){
-          keyCombos[globalModifier+(ResourceUtil.getInstance().getString('bbb.shortcutkey.share.microphone') as String)] = ShortcutEvent.SHARE_MICROPHONE;
-          keyCombos[globalModifier+(ResourceUtil.getInstance().getString('bbb.shortcutkey.share.pauseRemoteStream') as String)] = ShortcutEvent.PAUSE_REMOTE_STREAM;
-        }
       }
       
       public function hotkeyCapture():void{

--- a/bigbluebutton-client/src/org/bigbluebutton/main/maps/ApplicationEventMap.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/maps/ApplicationEventMap.mxml
@@ -56,6 +56,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	<EventHandlers type="{LogoutEvent.USER_LOGGED_OUT}" >
 		<MethodInvoker generator="{ModulesProxy}" method="handleLogout" />
 	</EventHandlers>
+	
+	<EventHandlers type="{ConnectionFailedEvent.USER_EJECTED_FROM_MEETING}" >
+		<MethodInvoker generator="{ModulesProxy}" method="handleLogout" />
+	</EventHandlers>
 		
 	<EventHandlers type="{ConfigEvent.CONFIG_EVENT}" >
 		<MethodInvoker generator="{ConfigManager}" method="setConfig" arguments="{event.config}" />
@@ -90,18 +94,19 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
   
 	<mx:Script>
 	<![CDATA[
-    import mx.events.FlexEvent;
-    
-    import org.bigbluebutton.core.managers.ConfigManager;
-    import org.bigbluebutton.core.managers.ReconnectionManager;
-    import org.bigbluebutton.core.services.SkinningService;
-    import org.bigbluebutton.main.events.BBBEvent;
-    import org.bigbluebutton.main.events.ConfigEvent;
-    import org.bigbluebutton.main.events.LogoutEvent;
-    import org.bigbluebutton.main.events.ModuleLoadEvent;
-    import org.bigbluebutton.main.events.PortTestEvent;
-    import org.bigbluebutton.main.events.SuccessfulLoginEvent;
-    import org.bigbluebutton.main.model.modules.ModulesProxy;
+		import mx.events.FlexEvent;
+		
+		import org.bigbluebutton.core.managers.ConfigManager;
+		import org.bigbluebutton.core.managers.ReconnectionManager;
+		import org.bigbluebutton.core.services.SkinningService;
+		import org.bigbluebutton.main.events.BBBEvent;
+		import org.bigbluebutton.main.events.ConfigEvent;
+		import org.bigbluebutton.main.events.LogoutEvent;
+		import org.bigbluebutton.main.events.ModuleLoadEvent;
+		import org.bigbluebutton.main.events.PortTestEvent;
+		import org.bigbluebutton.main.events.SuccessfulLoginEvent;
+		import org.bigbluebutton.main.model.modules.ModulesProxy;
+		import org.bigbluebutton.main.model.users.events.ConnectionFailedEvent;
 		
 	]]>
 	</mx:Script>

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/ShortcutOptions.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/ShortcutOptions.as
@@ -82,10 +82,6 @@ package org.bigbluebutton.main.model
 			if (presentation){generalResource.push('bbb.shortcutkey.focus.presentation');}
 			if (chat){generalResource.push('bbb.shortcutkey.focus.chat');}
 			
-			if (audio){
-				generalResource.push('bbb.shortcutkey.share.microphone');
-				generalResource.push('bbb.shortcutkey.share.pauseRemoteStream');
-			}
 			if (deskshare){generalResource.push('bbb.shortcutkey.share.desktop');}
 			if (webcam){generalResource.push('bbb.shortcutkey.share.webcam');}
 			generalResource.push('bbb.shortcutkey.shortcutWindow');

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/AddChatTabBox.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/AddChatTabBox.mxml
@@ -71,6 +71,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
                 }
                 chatNoiseCheckBox.selected = Accessibility.active;
                 changeChatNoise();
+                
+                lockSettingsChanged();
             }
             
             public function accessibleClick(event:KeyboardEvent):void{
@@ -93,6 +95,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
             protected function openPrivateChat(event:Event):void{
                 if (usersList.selectedIndex == -1) return;
+                
+                if (!usersList.visible || !usersList.enabled) return;
                 
                 var chatWithUserID:String = usersList.selectedItem.userID;
                 
@@ -121,7 +125,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
               }
             }
           
-          private function lockSettingsChanged(e:Event):void {
+          private function lockSettingsChanged(e:Event = null):void {
             
             if (UsersUtil.amIModerator() || UsersUtil.amIPresenter()) return; // Settings only affect viewers.
             

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
@@ -434,7 +434,10 @@
 			}
 			
 			public function remoteRaiseHand(e:ShortcutEvent):void{
-				dispatchEvent(new EmojiStatusEvent(EmojiStatusEvent.EMOJI_STATUS, "raiseHand"));
+				if (UserManager.getInstance().getConference().myEmojiStatus == "raiseHand")
+					dispatchEvent(new EmojiStatusEvent(EmojiStatusEvent.EMOJI_STATUS, "none"));
+				else 
+					dispatchEvent(new EmojiStatusEvent(EmojiStatusEvent.EMOJI_STATUS, "raiseHand"));
 			}
 
 			private function remoteMinimize():void{
@@ -492,7 +495,11 @@
 			}
 			
 			private function remoteMuteAllButPres(e:ShortcutEvent):void{
-				muteAlmostAll();
+				if (!roomMuted) {
+					muteAlmostAll();
+				} else {
+					muteAll();
+				}
 			}
 			
 		]]>


### PR DESCRIPTION
* Fixed #3106 and #3088 
* Fixes for issues in #2507 
 * Removed two keys that weren't used
 * Switched the key to leave Flash from "Q" to "O"
 * The key to raise your hand now lowers it
 * The key to mute the meeting now unmutes as well