### PR TITLE
[HTML5] Fix renderCircle and add hideLabel prop to button component

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/button/base/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/button/base/component.jsx
@@ -13,25 +13,35 @@ const propTypes = {
    */
   tagName: PropTypes.string,
 
+  /**
+   * Defines the button label
+   * @defaultValue undefined
+   */
+  label: PropTypes.string.isRequired,
+
+  /**
+   * Defines the button click handler
+   * @defaultValue undefined
+   */
   onClick: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
   disabled: false,
   tagName: 'button',
+  role: 'button',
 };
 
 export default class ButtonBase extends Component {
   constructor(props) {
     super(props);
-    props.role = 'button';
   }
 
   render() {
     let Component = this.props.tagName;
 
     return (
-      <Component {...this.props}>
+      <Component aria-label={this.props.label} {...this.props}>
         {this.props.children}
       </Component>
     );

--- a/bigbluebutton-html5/imports/ui/components/button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/button/component.jsx
@@ -2,7 +2,6 @@ import React, { PropTypes } from 'react';
 import BaseButton from './base/component';
 import styles from './styles';
 import cx from 'classnames';
-import _ from 'underscore';
 
 import Icon from '../icon/component';
 
@@ -61,10 +60,10 @@ const propTypes = {
   iconRight: PropTypes.bool,
 
   /**
-   * Defines the button label
-   * @defaultValue undefined
+   * Defines the button label should be visible
+   * @defaultValue false
    */
-  label: PropTypes.string,
+  hideLabel: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -75,16 +74,12 @@ const defaultProps = {
   circle: false,
   block: false,
   iconRight: false,
+  hideLabel: false,
 };
 
 export default class Button extends BaseButton {
   constructor(props) {
     super(props);
-    props['aria-labelledby'] = this.id;
-  }
-
-  componentWillMount() {
-    this.labelId = _.uniqueId('btn-label-');
   }
 
   _getClassNames() {
@@ -119,13 +114,10 @@ export default class Button extends BaseButton {
 
   renderDefault() {
     const {
-      tagName,
       className,
       iconRight,
       ...otherProps,
     } = this.props;
-
-    const Component = tagName;
 
     /* TODO: We can change this and make the button with flexbox to avoid html
       changes */
@@ -133,34 +125,33 @@ export default class Button extends BaseButton {
     const renderRightFuncName = !iconRight ? 'renderLabel' : 'renderIcon';
 
     return (
-      <Component
+      <BaseButton
         className={cx(this._getClassNames(), className)}
         {...otherProps}>
         {this[renderLeftFuncName]()}
         {this[renderRightFuncName]()}
-      </Component>
+      </BaseButton>
     );
   }
 
   renderCircle() {
     const {
-      tagName,
       className,
       size,
       iconRight,
       ...otherProps,
     } = this.props;
 
-    const Component = tagName;
-
     return (
-      <span className={cx(styles[size], styles.buttonWrapper, className)} {...otherProps}>
-        {!iconRight ? null : this.renderLabel(true)}
-        <Component className={cx(this._getClassNames())} aria-labelledby={this.labelId}>
+      <BaseButton
+        className={cx(styles[size], styles.buttonWrapper, className)}
+        {...otherProps}>
+        {!iconRight ? null : this.renderLabel()}
+        <span className={cx(this._getClassNames())}>
           {this.renderIcon()}
-        </Component>
-        {iconRight ? null : this.renderLabel(true)}
-      </span>
+        </span>
+        {iconRight ? null : this.renderLabel()}
+      </BaseButton>
     );
   }
 
@@ -174,28 +165,20 @@ export default class Button extends BaseButton {
     return null;
   }
 
-  renderLabel(labelledBy = false) {
-    const label = this.props.label;
+  renderLabel() {
+    const { label, hideLabel } = this.props;
 
-    if (label) {
-      if (labelledBy) {
-        return (
-          <span className={styles.label} id={this.labelId}>
-            {label}
-            {this.props.children}
-          </span>
-        );
-      }
+    let classNames = {};
 
-      return (
-        <span className={styles.label}>
-          {label}
-          {this.props.children}
-        </span>
-      );
-    }
+    classNames[styles.label] = true;
+    classNames[styles.hideLabel] = hideLabel;
 
-    return null;
+    return (
+      <span className={cx(classNames)}>
+        {label}
+        {this.props.children}
+      </span>
+    );
   }
 }
 

--- a/bigbluebutton-html5/imports/ui/components/button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/button/styles.scss
@@ -112,6 +112,16 @@ $btn-lg-padding: $lg-padding-y $lg-padding-x;
   }
 }
 
+.hideLabel {
+  font-size: 0;
+  height: 0;
+  width: 0;
+  margin: 0 !important;
+  padding: 0 !important;
+  overflow: hidden;
+  display: block;
+}
+
 .icon {
   width: 1.28571429em;
   text-align: center;

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -37,6 +37,8 @@ class NavBar extends Component {
           onClick={this.handleToggleUserList}
           ghost={true}
           circle={true}
+          hideLabel={true}
+          label={'Toggle User-List'}
           icon={'user'}
           className={styles.btn}
         />


### PR DESCRIPTION
- Fix renderCircle rendering a `<span>` tag before the component itself
- Fix inheritance not working (related to https://github.com/facebook/react/issues/5772)
- Change `label` property to be required
- Add `aria-label` attribute
- Add `hideLabel` prop to hide label (to be used on icon-only buttons)
