### PR TITLE
Avoid closing client's videoconf module window when reconnecting

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMap.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMap.mxml
@@ -135,7 +135,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
   </EventHandlers>
 
   <EventHandlers type="{BBBEvent.RECONNECT_DISCONNECTED_EVENT}">
-    <MethodInvoker generator="{VideoEventMapDelegate}" method="closeAllWindows"/>
+    <MethodInvoker generator="{VideoEventMapDelegate}" method="handleReconnectDisconnectedEvent"  arguments="{event}"/>
   </EventHandlers>
   <!-- ~~~~~~~~~~~~~~~~~~    INJECTORS     ~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
   

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMapDelegate.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMapDelegate.as
@@ -418,21 +418,20 @@ package org.bigbluebutton.modules.videoconf.maps
     public function stopModule():void {
       LOGGER.debug("VideoEventMapDelegate:: stopping video module");
       closeAllWindows();
+      var event:CloseWindowEvent = new CloseWindowEvent(CloseWindowEvent.CLOSE_WINDOW_EVENT);
+      event.window = _videoDock;
+      globalDispatcher.dispatchEvent(event);
 	  proxy.reconnectWhenDisconnected(false);
       proxy.disconnect();
     }
 
-    public function closeAllWindows():void{
+    private function closeAllWindows():void {
       LOGGER.debug("VideoEventMapDelegate:: closing all windows");
       if (_isPublishing) {
         stopBroadcasting();
       }
 
       _graphics.shutdown();
-	  
-	  var event:CloseWindowEvent = new CloseWindowEvent(CloseWindowEvent.CLOSE_WINDOW_EVENT);
-	  event.window = _videoDock;
-	  globalDispatcher.dispatchEvent(event);
     }
 
     public function switchToPresenter(event:MadePresenterEvent):void{
@@ -514,6 +513,10 @@ package org.bigbluebutton.modules.videoconf.maps
         LOGGER.debug("VideoEventMapDelegate::handleStoppedViewingWebcamEvent [{0}] Opening avatar for user [{1}]", [me, event.webcamUserID]);
         openAvatarWindowFor(event.webcamUserID);
       }
+    }
+
+    public function handleReconnectDisconnectedEvent(event:BBBEvent):void {
+      if (event.payload.type == "BIGBLUEBUTTON_CONNECTION") closeAllWindows();
     }
   }
 }


### PR DESCRIPTION
Reconnecting video won't dispatch a CloseWindowEvent.
