### PR TITLE
Breakout rooms update related to the users list

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/BBBUser.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/BBBUser.as
@@ -20,7 +20,9 @@ package org.bigbluebutton.main.model.users
 {
 	import com.asfusion.mate.events.Dispatcher;
 	
-	import org.as3commons.lang.StringUtils;
+	import flash.events.Event;
+	
+	import org.as3commons.lang.ArrayUtils;
 	import org.as3commons.logging.api.ILogger;
 	import org.as3commons.logging.api.getClassLogger;
 	import org.bigbluebutton.common.Role;
@@ -329,25 +331,37 @@ package org.bigbluebutton.main.model.users
 			return _status.getStatus(name);
 		}
 
-		private var _breakoutRoom : String = null;
+		private var _breakoutRooms : Array = [];
 		
 		[Bindable("displayNameChange")]
 		public function get displayName() : String {
-			if (StringUtils.isBlank(_breakoutRoom)){
+			if (ArrayUtils.isEmpty(_breakoutRooms)){
 				return name;
 			}
 			else {
-				return "[" + _breakoutRoom + "] " +name;
+				return "[" + _breakoutRooms.join(",") + "] " +name;
 			}
 		}
-		
-		public function get breakoutRoom() : String {
-			return _breakoutRoom;
+
+		public function get breakoutRooms():Array {
+			return _breakoutRooms;
 		}
-		
-		public function set breakoutRoom( roomNumber : String ) : void {
-			_breakoutRoom = roomNumber;
-			dispatchEvent(new Event("displayNameChange")); 
+
+		public function set breakoutRooms(rooms:Array):void {
+			_breakoutRooms = rooms;
+			dispatchEvent(new Event("displayNameChange"));
+		}
+
+		public function addBreakoutRoom(roomNumber:String):void {
+			if (!ArrayUtils.contains(_breakoutRooms, roomNumber)) {
+				_breakoutRooms.push(roomNumber);
+				dispatchEvent(new Event("displayNameChange"));
+			}
+		}
+
+		public function removeBreakoutRoom(roomNumber:String):void {
+			_breakoutRooms.splice(_breakoutRooms.indexOf(roomNumber), 1);
+			dispatchEvent(new Event("displayNameChange"));
 		}
 
 		public static function copy(user:BBBUser):BBBUser {

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/Conference.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/Conference.as
@@ -18,6 +18,8 @@
  */
 package org.bigbluebutton.main.model.users {
 	
+	import flash.utils.Dictionary;
+	
 	import mx.collections.ArrayCollection;
 	import mx.collections.Sort;
 	
@@ -536,13 +538,25 @@ package org.bigbluebutton.main.model.users {
 			breakoutRooms.addItem(newRoom);
 			breakoutRooms.refresh();
 		}
-		
+
 		public function updateBreakoutRoomUsers(breakoutId:String, breakoutUsers:Array):void {
 			var room:Object = getBreakoutRoom(breakoutId);
 			if (room != null) {
 				BreakoutRoom(room).users = new ArrayCollection(breakoutUsers);
+				var breakoutRoomNumber:String = StringUtils.substringAfterLast(breakoutId, "-");
+				var updateUsers:Array = [];
+				// Update users breakout rooms
 				for (var i:int = 0; i < breakoutUsers.length; i++) {
-					getUser(StringUtils.substringBeforeLast(breakoutUsers[i].id,"-")).breakoutRoom = StringUtils.substringAfterLast(breakoutId, "-");
+					var userId:String = StringUtils.substringBeforeLast(breakoutUsers[i].id, "-");
+					getUser(userId).breakoutRoom = breakoutRoomNumber;
+					updateUsers.push(userId);
+				}
+				// Remove users breakout rooms if the users left the breakout rooms
+				for (var j:int = 0; j < users.length; j++) {
+					var user:BBBUser = BBBUser(users.getItemAt(j));
+					if (updateUsers.indexOf(BBBUser(users.getItemAt(j)).userID) == -1 && user.breakoutRoom == breakoutRoomNumber) {
+						user.breakoutRoom = null;
+					}
 				}
 				users.refresh();
 			}

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/Conference.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/Conference.as
@@ -18,11 +18,12 @@
  */
 package org.bigbluebutton.main.model.users {
 	
-	import flash.utils.Dictionary;
+	import com.adobe.utils.ArrayUtil;
 	
 	import mx.collections.ArrayCollection;
 	import mx.collections.Sort;
 	
+	import org.as3commons.lang.ArrayUtils;
 	import org.as3commons.lang.StringUtils;
 	import org.as3commons.logging.api.ILogger;
 	import org.as3commons.logging.api.getClassLogger;
@@ -548,14 +549,14 @@ package org.bigbluebutton.main.model.users {
 				// Update users breakout rooms
 				for (var i:int = 0; i < breakoutUsers.length; i++) {
 					var userId:String = StringUtils.substringBeforeLast(breakoutUsers[i].id, "-");
-					getUser(userId).breakoutRoom = breakoutRoomNumber;
+					getUser(userId).addBreakoutRoom(breakoutRoomNumber);
 					updateUsers.push(userId);
 				}
 				// Remove users breakout rooms if the users left the breakout rooms
 				for (var j:int = 0; j < users.length; j++) {
 					var user:BBBUser = BBBUser(users.getItemAt(j));
-					if (updateUsers.indexOf(BBBUser(users.getItemAt(j)).userID) == -1 && user.breakoutRoom == breakoutRoomNumber) {
-						user.breakoutRoom = null;
+					if (updateUsers.indexOf(BBBUser(users.getItemAt(j)).userID) == -1 && ArrayUtils.contains(user.breakoutRooms, breakoutRoomNumber)) {
+						user.removeBreakoutRoom(breakoutRoomNumber);
 					}
 				}
 				users.refresh();
@@ -587,22 +588,21 @@ package org.bigbluebutton.main.model.users {
 			// Breakout room not found.
 			return null;
 		}
-		
+
 		public function removeBreakoutRoom(breakoutId:String):void {
 			var p:Object = getBreakoutRoomIndex(breakoutId);
 			if (p != null) {
 				breakoutRooms.removeItemAt(p.index);
 				breakoutRooms.refresh();
-
 				// Remove breakout room number display from users
-				for(var i:int; i < users.length; i++) {
-					if (users[i].breakoutRoom == StringUtils.substringAfterLast(breakoutId, "-")) {
-						users[i].breakoutRoom = null;
+				for (var i:int; i < users.length; i++) {
+					var breakoutRoomNumber:String = StringUtils.substringAfterLast(breakoutId, "-");
+					if (ArrayUtils.contains(users[i].breakoutRooms, breakoutRoomNumber)) {
+						users[i].removeBreakoutRoom(breakoutRoomNumber);
 					}
 				}
 				users.refresh();
 			}
-			
 		}
 		
 		public function hasBreakoutRoom(breakoutId:String):Boolean {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
@@ -317,7 +317,7 @@
 
 			private function breakoutRoomsListChangeListener(event:CollectionEvent):void {
 				if(breakoutRoomsList.length == 0) {
-					breakoutTimeLabel.text = ResourceUtil.getInstance().getString('bbb.users.breakout.breakoutRooms');
+					breakoutTimeLabel.text = "...";
 					TimerUtil.stopTimer(breakoutTimeLabel.id);
 				}
 			}
@@ -588,7 +588,7 @@
 			 width="100%" height="180">
 		<mx:HBox width="100%">
 			<mx:Label text="{ResourceUtil.getInstance().getString('bbb.users.breakout.breakoutRooms')}"/>
-			<mx:Label width="100%" textAlign="right" id="breakoutTimeLabel"/>
+			<mx:Label width="100%" textAlign="right" id="breakoutTimeLabel" text="..."/>
 		</mx:HBox>
 
 		<mx:DataGrid id="roomsGrid" editable="false" sortableColumns="false" dataProvider="{breakoutRoomsList}"


### PR DESCRIPTION
- Fix the issue where the breakout room number was not removed before the username when the user left a breakout room.
- Handle multiple breakout rooms display for a single user.