### PR TITLE
Add a language prompt to closed caption dropdown

### DIFF
--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -439,6 +439,7 @@ bbb.caption.transcript.youowner = You
 bbb.caption.option.label = Options
 bbb.caption.option.language = Language:
 bbb.caption.option.language.tooltip = Select Caption Language
+bbb.caption.option.language.prompt = Select a language ({0})
 bbb.caption.option.takeowner = Take Ownership
 bbb.caption.option.takeowner.tooltip = Take Ownership of Selected Language
 bbb.caption.option.fontfamily = Font Family:

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/caption/views/OptionsTab.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/caption/views/OptionsTab.mxml
@@ -106,6 +106,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 						 dataProvider="{transcriptsCollection}"
 						 labelField="locale" 
 						 selectedIndex="-1"
+						 prompt="{ResourceUtil.getInstance().getString('bbb.caption.option.language.prompt', [transcriptsCollection.length])}"
 						 enabled="{transcriptsCollection.length > 0}" 
 						 change="onLocaleComboChange()"
 						 toolTip="{ResourceUtil.getInstance().getString('bbb.caption.option.language.tooltip')}"/>


### PR DESCRIPTION
When there was only one language to select from in the Options tab it was being automatically selected. I added a prompt so that a viewer can select the option manually and ensure that the normal flow is preserved.