### PR TITLE
bbb-web: Simplified new action updateRecordings

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1984,17 +1984,11 @@ class ApiController {
        // END - backward compatibility
      }
 
-     // Do we have a publish status? If none, set default value.
-     String force = params.force
-     if (StringUtils.isEmpty(force)) {
-       force = "false"
-     }
-
      //Execute code specific for this call
      Map<String, String> metaParams = ParamsProcessorUtil.processMetaParam(params)
      if ( !metaParams.empty ) {
          //Proceed with the update
-         meetingService.updateRecordings(recordIdList, metaParams, force.toBoolean());
+         meetingService.updateRecordings(recordIdList, metaParams);
      }
      withFormat {
        xml {

--- a/bigbluebutton-web/src/java/org/bigbluebutton/api/MeetingService.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/api/MeetingService.java
@@ -485,8 +485,8 @@ public class MeetingService implements MessageListener {
         }
     }
 
-    public void updateRecordings(List<String> idList, Map<String, String> metaParams, boolean force) {
-        recordingService.updateMetaParams(idList, metaParams, force);
+    public void updateRecordings(List<String> idList, Map<String, String> metaParams) {
+        recordingService.updateMetaParams(idList, metaParams);
     }
 
     public void processRecording(String meetingId) {

--- a/bigbluebutton-web/src/java/org/bigbluebutton/api/RecordingService.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/api/RecordingService.java
@@ -397,10 +397,6 @@ public class RecordingService {
     }
 
     public void updateMetaParams(List<String> recordIDs, Map<String,String> metaParams) {
-        updateMetaParams(recordIDs, metaParams, false);
-    }
-
-    public void updateMetaParams(List<String> recordIDs, Map<String,String> metaParams, boolean force) {
 
         // Define the directories used to lookup the recording
         List<String> states = new ArrayList<String>();
@@ -422,20 +418,13 @@ public class RecordingService {
                     Recording rec = getRecordingInfo(recFile);
                     if (rec != null) {
                         for (Map.Entry<String,String> meta : metaParams.entrySet()) {
-                            if ( rec.containsMetadata(meta.getKey()) ) {
-                                // The meta parameter already exists
-                                if ( !"".equals(meta.getValue()) || !force ) {
-                                    // update it
-                                    rec.updateMetadata(meta.getKey(), meta.getValue());
-                                } else {
-                                    // delete it
-                                    rec.deleteMetadata(meta.getKey());
-                                }
+                            if ( !"".equals(meta.getValue()) ) {
+                                // As it has a value, if the meta parameter exists update it, otherwise add it
+                                rec.updateMetadata(meta.getKey(), meta.getValue());
                             } else {
-                                // The meta parameter doesn't exist
-                                if ( force ) {
-                                    // but force is set to true, then add it
-                                    rec.updateMetadata(meta.getKey(), meta.getValue());
+                                // As it doesn't have a value, if it exists delete it
+                                if ( rec.containsMetadata(meta.getKey()) ) {
+                                    rec.deleteMetadata(meta.getKey());
                                 }
                             }
                         }


### PR DESCRIPTION
Removed support for parameter force={true|false} used to differentiate the behavior of updateRecordings

So now, when executing updateRecordings:

- With [meta_parameter=NOT EMPTY], if meta+parameter exists it is updated, if it doesn't, it is added.
- With [meta_parameter=], if meta+parameter exists it is deleted, if it doesn't action is ignored.