### PR TITLE
Fixes unreachable code error

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/verto_extension.js
+++ b/bigbluebutton-client/resources/prod/lib/verto_extension.js
@@ -155,7 +155,6 @@ docall_verto = function(extension, conferenceUsername, conferenceIdNumber, callb
 		return;
 	}
 	// determine the resolution the user chose for webcam video
-	my_check_vid_res();
 	outgoingBandwidth = "default";
 	incomingBandwidth = "default";
 	var useVideo = useCamera = useMic = false;
@@ -335,7 +334,6 @@ function makeVerto(callbacks, stunsConfig, videoTag, vertoServerCredentials) {
 
 // sets verto to begin using the resolution that the user selected
 my_check_vid_res = function() {
-	return;
 	var selectedVideoConstraints = getChosenWebcamResolution();
 	my_real_size(selectedVideoConstraints);
 


### PR DESCRIPTION
- I put a return just to skip a function. Didn't realize it was used just once. Console complained about unreachable error due to return statement. Removes return statement and function call.

- Function is still kept in code because it may be used later on.