### PR TITLE
 Joining voice conf of breakout room

### DIFF
--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/FreeswitchApplication.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/FreeswitchApplication.java
@@ -153,6 +153,11 @@ public class FreeswitchApplication {
 						EjectAllUsersCommand cmd = (EjectAllUsersCommand) command;
 						System.out.println("Sending EjectAllUsersCommand for conference = [" + cmd.getRoom() + "]");
 						manager.ejectAll(cmd);
+					} else if (command instanceof TransferUsetToMeetingCommand) {
+						TransferUsetToMeetingCommand cmd = (TransferUsetToMeetingCommand) command;
+						System.out.println("Sending TransferUsetToMeetingCommand for conference = ["
+										+ cmd.getRoom() + "]");
+						manager.tranfer(cmd);
 					} else if (command instanceof RecordConferenceCommand) {
 						manager.record((RecordConferenceCommand) command);
 					} else if (command instanceof DeskShareBroadcastRTMPCommand) {


### PR DESCRIPTION
 A moderator should be able to listen-in on the breakout room. During a previous merge, the
 handler of the transfer message in FSESL was accidentally removed. The user isn't able to
 the breakout room's voice conference anymore.