### PR TITLE
Fix logout exception

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
@@ -44,7 +44,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		<![CDATA[
 			import com.asfusion.mate.events.Dispatcher;
 			
-			import mx.accessibility.AlertAccImpl;
 			import mx.controls.Alert;
 			import mx.core.UIComponent;
 			import mx.events.CloseEvent;
@@ -88,10 +87,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private var xml:XML;
 			
 			private function init():void{
-				if (Capabilities.hasAccessibility) {
-					AlertAccImpl.enableAccessibility();
-				}
-				
 				numButtons = 0;
                 
                 // Accessibility isn't active till a few second after the client starts to load so we need a delay
@@ -243,7 +238,14 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private function alertLogout(e:CloseEvent):void {
 				// Check to see if the YES button was pressed.
 				if (e.detail==Alert.YES) {
-					 doLogout();
+					/* 
+					 * If doLogout() is called immediately there is a null exception in AlertAccImpl
+					 * line 185, but if we delay calling doLogout() until the next frame the Alert 
+					 * will close correctly and the logout succeeds as normal. It looks like the 
+					 * stage is unset at some point in the core class and there's not much we can do
+					 * to correct it other than avoid it. - Chad Aug 8, 2016 
+					 */
+					callLater(doLogout);
 				}
 			}
 			


### PR DESCRIPTION
The following exception is thrown when you press "Yes" on the logout confirmation:

```
TypeError: Error #1009: Cannot access a property or method of a null object reference.
at mx.accessibility::AlertAccImpl/eventHandler()[/Users/aharui/release4.13.0/frameworks/projects/mx/src/mx/accessibility/AlertAccImpl.as:185]
at flash.events::EventDispatcher/dispatchEventFunction()
at flash.events::EventDispatcher/dispatchEvent()
at mx.core::UIComponent/dispatchEvent()[/Users/aharui/release4.13.0/frameworks/projects/framework/src/mx/core/UIComponent.as:13682]
at mx.controls.alertClasses::AlertForm/removeAlert()[/Users/aharui/release4.13.0/frameworks/projects/mx/src/mx/controls/alertClasses/AlertForm.as:545]
at mx.controls.alertClasses::AlertForm/clickHandler()[/Users/aharui/release4.13.0/frameworks/projects/mx/src/mx/controls/alertClasses/AlertForm.as:586]
```
The issue seems to be that the "stage" variable is unset at some point before the Alert finishes closing and causes the exception to be thrown. My fix is kind of a hack. but it just ensures the the Alert closes completely before triggering the rest of the logout functionality on the next frame.

I also removed the AlertAccImpl use because it didn't actually do anything and was causing confusion around the exception.