### PR TITLE
Fix for breakout room logout issue

### DIFF
--- a/akka-bbb-apps/scala/JsonTest.sc
+++ b/akka-bbb-apps/scala/JsonTest.sc
@@ -28,18 +28,18 @@ object JsonTest {
                                                   //> xroom3  : org.bigbluebutton.core.api.BreakoutRoomInPayload = BreakoutRoomInP
                                                   //| ayload(baz,Vector(q, r, s))
 
-  val xmsg = new CreateBreakoutRooms("test-meeting", 10, Vector(xroom1, xroom2, xroom3))
+  val xmsg = new CreateBreakoutRooms("test-meeting", 10, false, Vector(xroom1, xroom2, xroom3))
                                                   //> xmsg  : org.bigbluebutton.core.api.CreateBreakoutRooms = CreateBreakoutRoom
-                                                  //| s(test-meeting,10,Vector(BreakoutRoomInPayload(foo,Vector(a, b, c)), Breako
-                                                  //| utRoomInPayload(bar,Vector(x, y, z)), BreakoutRoomInPayload(baz,Vector(q, r
-                                                  //| , s))))
+                                                  //| s(test-meeting,10,false,Vector(BreakoutRoomInPayload(foo,Vector(a, b, c)), 
+                                                  //| BreakoutRoomInPayload(bar,Vector(x, y, z)), BreakoutRoomInPayload(baz,Vecto
+                                                  //| r(q, r, s))))
 
   val xjsonAst = xmsg.toJson                      //> xjsonAst  : spray.json.JsValue = {"meetingId":"test-meeting","durationInMin
-                                                  //| utes":10,"rooms":[{"name":"foo","users":["a","b","c"]},{"name":"bar","users
-                                                  //| ":["x","y","z"]},{"name":"baz","users":["q","r","s"]}]}
+                                                  //| utes":10,"record":false,"rooms":[{"name":"foo","users":["a","b","c"]},{"nam
+                                                  //| e":"bar","users":["x","y","z"]},{"name":"baz","users":["q","r","s"]}]}
   val xjson = xjsonAst.asJsObject                 //> xjson  : spray.json.JsObject = {"meetingId":"test-meeting","durationInMinut
-                                                  //| es":10,"rooms":[{"name":"foo","users":["a","b","c"]},{"name":"bar","users":
-                                                  //| ["x","y","z"]},{"name":"baz","users":["q","r","s"]}]}
+                                                  //| es":10,"record":false,"rooms":[{"name":"foo","users":["a","b","c"]},{"name"
+                                                  //| :"bar","users":["x","y","z"]},{"name":"baz","users":["q","r","s"]}]}
   val meetingId = for {
     meetingId <- xjson.fields.get("meetingId")
   } yield meetingId                               //> meetingId  : Option[spray.json.JsValue] = Some("test-meeting")
@@ -53,10 +53,7 @@ object JsonTest {
                                                   //| den","Yaya Dub"]}],"durationInMinutes":20}}
                                                   //|  "
 
-  JsonMessageDecoder.decode(cbrm)                 //> res0: Option[org.bigbluebutton.core.api.InMessage] = Some(CreateBreakoutRoo
-                                                  //| ms(abc123,20,Vector(BreakoutRoomInPayload(room1,Vector(Tidora, Nidora, Tini
-                                                  //| dora)), BreakoutRoomInPayload(room2,Vector(Jose, Wally, Paolo)), BreakoutRo
-                                                  //| omInPayload(room3,Vector(Alden, Yaya Dub)))))
+  JsonMessageDecoder.decode(cbrm)                 //> res0: Option[org.bigbluebutton.core.api.InMessage] = None
   val rbju = """
   {"header":{"name":"RequestBreakoutJoinURL"},"payload":{"userId":"id6pa5t8m1c9_1","meetingId":"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1452692983357","breakoutId":"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1452692983357-2"}}
  """                                              //> rbju  : String = "
@@ -91,10 +88,10 @@ object JsonTest {
   val vector = Vector(jsObj)                      //> vector  : scala.collection.immutable.Vector[spray.json.JsObject] = Vector({
                                                   //| "name":"Breakout Room","breakoutId":"br-id-1"})
 
-  val brlum = new BreakoutRoomsListOutMessage("main-meeting-1", Vector(brb))
+  val brlum = new BreakoutRoomsListOutMessage("main-meeting-1", Vector(brb), false)
                                                   //> brlum  : org.bigbluebutton.core.api.BreakoutRoomsListOutMessage = BreakoutR
                                                   //| oomsListOutMessage(main-meeting-1,Vector(BreakoutRoomBody(Breakout Room,br-
-                                                  //| id-1)))
+                                                  //| id-1)),false)
   var roomsJsVector: ListBuffer[JsObject] = new ListBuffer[JsObject]()
                                                   //> roomsJsVector  : scala.collection.mutable.ListBuffer[spray.json.JsObject] =
                                                   //|  ListBuffer()
@@ -112,9 +109,10 @@ object JsonTest {
                                                   //| ]
 
   MeetingMessageToJsonConverter.breakoutRoomsListOutMessageToJson(brlum);
-                                                  //> res5: String = {"payload":{"meetingId":"main-meeting-1","rooms":[{"name":"B
-                                                  //| reakout Room","breakoutId":"br-id-1"}]},"header":{"timestamp":47333494,"nam
-                                                  //| e":"BreakoutRoomsList","current_time":1453399680291,"version":"0.0.1"}}
+                                                  //> res5: String = {"payload":{"meetingId":"main-meeting-1","roomsReady":false,
+                                                  //| "rooms":[{"name":"Breakout Room","breakoutId":"br-id-1"}]},"header":{"times
+                                                  //| tamp":9652644,"name":"BreakoutRoomsList","current_time":1471504366540,"vers
+                                                  //| ion":"0.0.1"}}
 
   //  JsonMessageDecoder.unmarshall(cbrm) match {
   //    case Success(validMsg) => println(validMsg)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/JsonMessageSenderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/JsonMessageSenderActor.scala
@@ -86,7 +86,7 @@ class JsonMessageSenderActor(val service: MessageSender)
   private def handleBreakoutRoomsList(msg: BreakoutRoomsListOutMessage) {
     val rooms = new java.util.ArrayList[BreakoutRoomPayload]()
     msg.rooms.foreach(r => rooms.add(new BreakoutRoomPayload(msg.meetingId, r.breakoutId, r.name)))
-    val payload = new BreakoutRoomsListPayload(msg.meetingId, rooms)
+    val payload = new BreakoutRoomsListPayload(msg.meetingId, rooms, msg.roomsReady)
     val request = new BreakoutRoomsList(payload)
     service.send(MessagingConstants.FROM_MEETING_CHANNEL, request.toJson())
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/OutMessages.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/OutMessages.scala
@@ -28,7 +28,7 @@ case class PubSubPong(system: String, timestamp: Long) extends IOutMessage
 case object IsAliveMessage extends IOutMessage
 
 // Breakout Rooms
-case class BreakoutRoomsListOutMessage(meetingId: String, rooms: Vector[BreakoutRoomBody]) extends IOutMessage
+case class BreakoutRoomsListOutMessage(meetingId: String, rooms: Vector[BreakoutRoomBody], roomsReady: Boolean) extends IOutMessage
 case class CreateBreakoutRoom(meetingId: String, room: BreakoutRoomOutPayload) extends IOutMessage
 case class EndBreakoutRoom(breakoutId: String) extends IOutMessage
 case class BreakoutRoomOutPayload(breakoutId: String, name: String, parentId: String,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/BreakoutRoomApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/BreakoutRoomApp.scala
@@ -31,7 +31,7 @@ trait BreakoutRoomApp extends SystemConfiguration {
 
   def handleBreakoutRoomsList(msg: BreakoutRoomsListMessage) {
     val breakoutRooms = breakoutModel.getRooms().toVector map { r => new BreakoutRoomBody(r.name, r.id) }
-    outGW.send(new BreakoutRoomsListOutMessage(mProps.meetingID, breakoutRooms));
+    outGW.send(new BreakoutRoomsListOutMessage(mProps.meetingID, breakoutRooms, breakoutModel.pendingRoomsNumber == 0 && breakoutRooms.length > 0));
   }
 
   def handleCreateBreakoutRooms(msg: CreateBreakoutRooms) {
@@ -90,8 +90,8 @@ trait BreakoutRoomApp extends SystemConfiguration {
           }
         }
       }
+      handleBreakoutRoomsList( new BreakoutRoomsListMessage(mProps.meetingID) )
     }
-
   }
 
   def sendBreakoutRoomStarted(meetingId: String, breakoutName: String, breakoutId: String, voiceConfId: String) {
@@ -130,7 +130,7 @@ trait BreakoutRoomApp extends SystemConfiguration {
     else {
       targetVoiceBridge = mProps.voiceBridge.dropRight(1)
     }
-    // We check the iser from the mode
+    // We check the user from the mode
     usersModel.getUser(msg.userId) match {
       case Some(u) => {
         if (u.voiceUser.joined) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/BreakoutRoomModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/BreakoutRoomModel.scala
@@ -9,7 +9,9 @@ case class BreakoutRoom(id: String, name: String, voiceConfId: String,
 
 class BreakoutRoomModel {
   private var rooms = new collection.immutable.HashMap[String, BreakoutRoom]
-
+  
+  var pendingRoomsNumber: Integer = 0
+  
   def add(room: BreakoutRoom): BreakoutRoom = {
     rooms += room.id -> room
     room

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/MeetingMessageToJsonConverter.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/MeetingMessageToJsonConverter.scala
@@ -137,6 +137,7 @@ object MeetingMessageToJsonConverter {
     val payload = new java.util.HashMap[String, Any]()
     payload.put("meetingId", msg.meetingId)
     payload.put("rooms", msg.rooms.toArray)
+    payload.put("roomsReady", msg.roomsReady)
 
     val header = Util.buildHeader(BreakoutRoomsList.NAME, None)
     Util.buildJson(header, payload)

--- a/bbb-common-message/src/main/java/org/bigbluebutton/messages/payload/BreakoutRoomsListPayload.java
+++ b/bbb-common-message/src/main/java/org/bigbluebutton/messages/payload/BreakoutRoomsListPayload.java
@@ -22,12 +22,14 @@ import java.util.ArrayList;
 
 public class BreakoutRoomsListPayload {
 
-	public final String meetingId;
-	public final ArrayList<BreakoutRoomPayload> rooms;
+    public final String meetingId;
+    public final ArrayList<BreakoutRoomPayload> rooms;
+    public final Boolean roomsReady;
 
-	public BreakoutRoomsListPayload(String meetingId,
-			ArrayList<BreakoutRoomPayload> rooms) {
-		this.meetingId = meetingId;
-		this.rooms = rooms;
-	}
+    public BreakoutRoomsListPayload(String meetingId,
+            ArrayList<BreakoutRoomPayload> rooms, Boolean roomsReady) {
+        this.meetingId = meetingId;
+        this.rooms = rooms;
+        this.roomsReady = roomsReady;
+    }
 }

--- a/bigbluebutton-apps/src/main/java/org/bigbluebutton/red5/client/UserClientMessageSender.java
+++ b/bigbluebutton-apps/src/main/java/org/bigbluebutton/red5/client/UserClientMessageSender.java
@@ -531,6 +531,7 @@ public class UserClientMessageSender {
 	  Map<String, Object> args = new HashMap<String, Object>();	
 	  args.put("meetingId", msg.payload.meetingId);
 	  args.put("rooms", msg.payload.rooms);
+	  args.put("roomsReady", msg.payload.roomsReady);
 	  
 	  Map<String, Object> message = new HashMap<String, Object>();
       Gson gson = new Gson();

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/Conference.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/Conference.as
@@ -67,6 +67,9 @@ package org.bigbluebutton.main.model.users {
 		[Bindable]
 		public var breakoutRooms:ArrayCollection = null;
 		
+		[Bindable]
+		public var breakoutRoomsReady:Boolean = false;
+		
 		private var sort:Sort;
 		
 		private var defaultLayout:String;
@@ -596,6 +599,9 @@ package org.bigbluebutton.main.model.users {
 			if (p != null) {
 				breakoutRooms.removeItemAt(p.index);
 				breakoutRooms.refresh();
+				if (breakoutRooms.length == 0) {
+					breakoutRoomsReady = false;
+				}
 				// Remove breakout room number display from users
 				for (var i:int; i < users.length; i++) {
 					var breakoutRoomNumber:String = StringUtils.substringAfterLast(breakoutId, "-");

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
@@ -642,6 +642,7 @@ package org.bigbluebutton.modules.users.services
 			breakoutRoom.name = room.name;
 			UserManager.getInstance().getConference().addBreakoutRoom(breakoutRoom);
 		}
+		UserManager.getInstance().getConference().breakoutRoomsReady = map.roomsReady;
 	}
 	
 	private function handleBreakoutRoomJoinURL(msg:Object):void{

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/RoomActionsRenderer.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/RoomActionsRenderer.mxml
@@ -51,6 +51,7 @@
 	</mx:Script>
 
 	<mx:Button id="joinImg" width="20" height="20"
+			   includeInLayout="{UserManager.getInstance().getConference().breakoutRoomsReady}" visible="{joinImg.includeInLayout}"
 			   icon="{images.join}" toolTip="{ResourceUtil.getInstance().getString('bbb.users.roomsGrid.join')}"
 			   click="requestBreakoutJoinUrl(event)"/>
 	<mx:Button id="listenBtn" toggle="true"


### PR DESCRIPTION
Fixed the issue when a user tries to join a breakout rooms before all of the breakout room is fully ready.

The new behaviour is:

- We wait until all breakout rooms are created to send join breakout room URL.
- We don't give the hand to users for requesting any join breakout room URL while breakout rooms are being created.
- We ignore and put in logs any create breakout rooms request while breakout rooms are currently being created.
- Once all breakout rooms are created we inform the client that requesting a join breakout room URL can be enabled.