### PR TITLE
Remove autoStart and autoFullscreen options from new Screenshare Module

### DIFF
--- a/bigbluebutton-client/resources/config.xml.template
+++ b/bigbluebutton-client/resources/config.xml.template
@@ -46,8 +46,6 @@
 			url="http://HOST/client/ScreenshareModule.swf?v=VERSION"
 			uri="rtmp://HOST/screenshare"
 			showButton="true"
-			autoStart="false"
-			autoFullScreen="false"
 			baseTabIndex="201"
 			useWebRTCIfAvailable="false"
 			chromeExtensionKey=""

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/managers/PublishWindowManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/managers/PublishWindowManager.as
@@ -40,12 +40,6 @@ package org.bigbluebutton.modules.screenshare.managers {
         private var service:ScreenshareService;
         private var buttonShownOnToolbar:Boolean = false;
         
-        // Timer to auto-publish webcam. We need this timer to delay
-        // the auto-publishing until after the Viewers's window has loaded
-        // to receive the publishing events. Otherwise, the user joining next
-        // won't be able to view the webcam.
-        private var autoPublishTimer:Timer;
-        
         public function PublishWindowManager(service:ScreenshareService) {
             LOGGER.debug("PublishWindowManager init");
             globalDispatcher = new Dispatcher();
@@ -56,10 +50,10 @@ package org.bigbluebutton.modules.screenshare.managers {
             if (shareWindow != null) shareWindow.stopSharing();
         }
         
-        public function startSharing(uri:String, room:String, autoStart:Boolean, autoFullScreen:Boolean):void {
-            LOGGER.debug("DS:PublishWindowManager::opening desk share window, autostart=" + autoStart + " autoFullScreen=" + autoFullScreen);
+        public function startSharing(uri:String, room:String):void {
+            LOGGER.debug("DS:PublishWindowManager::opening desk share window");
             shareWindow = new ScreensharePublishWindow();
-            shareWindow.initWindow(service.getConnection(), uri, room, autoStart, autoFullScreen);
+            shareWindow.initWindow(service.getConnection(), uri, room);
             shareWindow.visible = true;
             openWindow(shareWindow);
         }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/managers/ScreenshareManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/managers/ScreenshareManager.as
@@ -125,9 +125,6 @@ package org.bigbluebutton.modules.screenshare.managers {
             sharing = false;
             var option:ScreenshareOptions = new ScreenshareOptions();
             option.parseOptions();
-            if (option.autoStart) {
-                handleStartSharingEvent(true);
-            }
             if (option.showButton) {
                 toolbarButtonManager.addToolbarButton();
             }
@@ -155,13 +152,13 @@ package org.bigbluebutton.modules.screenshare.managers {
 
             if (option.useWebRTCIfAvailable && !BrowserCheck.isWebRTCSupported()) {
               usingJava = true;
-              publishWindowManager.startSharing(module.getCaptureServerUri(), module.getRoom(), option.autoStart, option.autoFullScreen);
+              publishWindowManager.startSharing(module.getCaptureServerUri(), module.getRoom());
               sharing = true;
               service.requestStartSharing();
             } else {
               sharing = true;
               usingJava = false;
-              publishWindowManager.startSharing(module.getCaptureServerUri(), module.getRoom(), option.autoStart, option.autoFullScreen);
+              publishWindowManager.startSharing(module.getCaptureServerUri(), module.getRoom());
               service.requestStartSharing();
             }
         }
@@ -200,13 +197,13 @@ package org.bigbluebutton.modules.screenshare.managers {
             }
         }
         
-        public function handleStartSharingEvent(autoStart:Boolean):void {
+        public function handleStartSharingEvent():void {
             LOGGER.debug("handleStartSharingEvent");
             //toolbarButtonManager.disableToolbarButton();
             toolbarButtonManager.startedSharing();
             var option:ScreenshareOptions = new ScreenshareOptions();
             option.parseOptions();
-            publishWindowManager.startSharing(module.getCaptureServerUri(), module.getRoom(), option.autoStart, option.autoFullScreen);
+            publishWindowManager.startSharing(module.getCaptureServerUri(), module.getRoom());
             sharing = true;
         }
         
@@ -227,7 +224,7 @@ package org.bigbluebutton.modules.screenshare.managers {
         public function handleUseJavaModeCommand():void {
           JSLog.warn("ScreenshareManager::handleUseJavaModeCommand", {});
           usingJava = true;
-          handleStartSharingEvent(true);
+          handleStartSharingEvent();
         }
 
         public function handleDeskshareToolbarStopEvent():void {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/managers/WebRTCDeskshareManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/managers/WebRTCDeskshareManager.as
@@ -147,9 +147,6 @@ package org.bigbluebutton.modules.screenshare.managers
 			if (options.chromeExtensionKey) {
 				chromeExtensionKey = options.chromeExtensionKey;
 			}
-			if (options.autoStart) {
-				handleStartSharingEvent(true);
-			}
 		}
 
 		public function handleMadePresenterEvent(e:MadePresenterEvent):void {
@@ -207,7 +204,7 @@ package org.bigbluebutton.modules.screenshare.managers
 		}
 
 		/*handle start sharing event*/
-		public function handleStartSharingEvent(autoStart:Boolean):void {
+		public function handleStartSharingEvent():void {
 			LOGGER.debug("WebRTCDeskshareManager::handleStartSharingEvent");
 			JSLog.warn("WebRTCDeskshareManager::handleStartSharingEvent", {});
 
@@ -267,7 +264,7 @@ package org.bigbluebutton.modules.screenshare.managers
 		public function handleRequestStartSharingEvent():void {
 			JSLog.warn("WebRTCDeskshareManager::handleRequestStartSharingEvent", {});
 			initDeskshare();
-			handleStartSharingEvent(true);
+			handleStartSharingEvent();
 		}
 
 		public function handleStreamStartedEvent(event: WebRTCViewStreamEvent):void {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/maps/ScreenshareEventMap.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/maps/ScreenshareEventMap.mxml
@@ -58,11 +58,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	</EventHandlers>
 		
 	<EventHandlers type="{ShareEvent.START_SHARING}">
-		<MethodInvoker generator="{ScreenshareManager}" method="handleStartSharingEvent" arguments="{false}"/>
+		<MethodInvoker generator="{ScreenshareManager}" method="handleStartSharingEvent"/>
 	</EventHandlers>
 	
 	<EventHandlers type="{BBBEvent.START_DESKSHARE}">
-		<MethodInvoker generator="{ScreenshareManager}" method="handleStartSharingEvent" arguments="{true}"/>
+		<MethodInvoker generator="{ScreenshareManager}" method="handleStartSharingEvent"/>
 	</EventHandlers>
 	
   <EventHandlers type="{RequestToStartSharing.REQUEST_SHARE_START}">

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/maps/WebRTCDeskshareEventMap.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/maps/WebRTCDeskshareEventMap.mxml
@@ -55,11 +55,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	</EventHandlers>
 
 	<EventHandlers type="{ShareEvent.START_SHARING}">
-		<MethodInvoker generator="{WebRTCDeskshareManager}" method="handleStartSharingEvent" arguments="{false}"/>
+		<MethodInvoker generator="{WebRTCDeskshareManager}" method="handleStartSharingEvent"/>
 	</EventHandlers>
 
 	<EventHandlers type="{BBBEvent.START_DESKSHARE}">
-		<MethodInvoker generator="{WebRTCDeskshareManager}" method="handleStartSharingEvent" arguments="{true}"/>
+		<MethodInvoker generator="{WebRTCDeskshareManager}" method="handleStartSharingEvent"/>
 	</EventHandlers>
 	
 	<EventHandlers type="{RequestToStartSharing.REQUEST_SHARE_START}">

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/model/ScreenshareOptions.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/model/ScreenshareOptions.as
@@ -23,8 +23,6 @@ package org.bigbluebutton.modules.screenshare.model
 	public class ScreenshareOptions
 	{
 		[Bindable] public var showButton:Boolean = true;
-		[Bindable] public var autoStart:Boolean = false;
-		[Bindable] public var autoFullScreen:Boolean = false;
 		[Bindable] public var baseTabIndex:int;
 		[Bindable] public var useWebRTCIfAvailable:Boolean = false;
 		[Bindable] public var chromeExtensionKey:String = null;
@@ -33,12 +31,6 @@ package org.bigbluebutton.modules.screenshare.model
 		public function parseOptions():void {
 			var vxml:XML = BBB.getConfigForModule("ScreenshareModule");
 			if (vxml != null) {
-				if (vxml.@autoStart != undefined) {
-					autoStart = (vxml.@autoStart.toString().toUpperCase() == "TRUE") ? true : false;
-				}
-				if (vxml.@autoFullScreen != undefined){
-					autoFullScreen = (vxml.@autoFullScreen.toString().toUpperCase() == "TRUE") ? true : false;
-				}
 				if (vxml.@baseTabIndex != undefined) {
 					baseTabIndex = vxml.@baseTabIndex;
 				}

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/ScreensharePublishWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/ScreensharePublishWindow.mxml
@@ -98,7 +98,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       private var videoWidth:Number;
       private var captureHeight:Number = Capabilities.screenResolutionY;
       private var captureWidth:Number = Capabilities.screenResolutionX;
-      private var autoStart:Boolean = false;
       private var globalDispatcher:Dispatcher = new Dispatcher();
       
       [Bindable] private var baseIndex:int;
@@ -179,23 +178,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       */
       public function resetWidthAndHeight():void{/* do nothing */}
       
-      public function initWindow(connection:Connection, uri:String, room:String, autoStart:Boolean, autoFullScreen:Boolean):void {
+      public function initWindow(connection:Connection, uri:String, room:String):void {
         this.connection = connection;
         this.uri = uri;
         this.room = room;
-        this.autoStart = autoStart;
-        
-        // TODO: I'm not sure if auto-start still makes sense with the new JNLP workflow so I'm leaving it commented out for now
-        /*
-        if (autoStart || autoFullScreen) {
-          /*
-           * Need to have a timer to trigger auto-publishing of deskshare.
-            /
-          autoPublishTimer = new Timer(2000, 1);
-          autoPublishTimer.addEventListener(TimerEvent.TIMER, function() {shareWindow.shareScreen(true);});
-          autoPublishTimer.start();
-        }
-        */
       }
       
       private function handleStartShareRequestSuccessEvent(event:StartShareRequestSuccessEvent):void {
@@ -561,8 +547,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     </mx:VBox>
   </mx:Box>
   <mx:ControlBar horizontalAlign="right">
-    <mx:Button id="cancelBtn" click="closeWindow()" label="{ResourceUtil.getInstance().getString('bbb.screensharePublish.cancelButton.label')}" />
     <mx:Button id="startBtn" click="onStartButtonClick()" label="{ResourceUtil.getInstance().getString('bbb.screensharePublish.startButton.label')}" />
+    <mx:Button id="cancelBtn" click="closeWindow()" label="{ResourceUtil.getInstance().getString('bbb.screensharePublish.cancelButton.label')}" />
     <mx:Button id="stopBtn" visible="false" includeInLayout="false" click="close()" label="{ResourceUtil.getInstance().getString('bbb.screensharePublish.stopButton.label')}" />
   </mx:ControlBar>
 </dspub:MDIWindow>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopPublishWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopPublishWindow.mxml
@@ -88,7 +88,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private var videoWidth:Number;
 			private var captureHeight:Number = Capabilities.screenResolutionY;
 			private var captureWidth:Number = Capabilities.screenResolutionX;
-			private var autoStart:Boolean = false;
 			private var globalDispatcher:Dispatcher = new Dispatcher();
 
 			[Bindable] private var dsOptions:ScreenshareOptions;
@@ -136,14 +135,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			 */
 			public function resetWidthAndHeight():void{/* do nothing */}
 
-			public function initWindow(connection:NetConnection, uri:String, useTLS:Boolean , room:String, autoStart:Boolean, autoFullScreen:Boolean):void {
+			public function initWindow(connection:NetConnection, uri:String, useTLS:Boolean , room:String):void {
 				this.connection = connection;
 				this.uri = uri;
 				this.useTLS = useTLS;
 				this.room = room;
-				this.autoStart = autoStart;
-				/*if(autoFullScreen)
-					shareScreen(true);*/
 			}
 
 			public function shareScreen(fullScreen:Boolean):void {


### PR DESCRIPTION
The autoStart and autoFullscreen options aren't working anymore and they would hide the extra help information on JWS usage.