### PR TITLE
Updated LogoutURL handling by client

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/core/BBB.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/BBB.as
@@ -19,10 +19,10 @@
 package org.bigbluebutton.core {
 
 	import flash.system.Capabilities;
-
+	
 	import mx.core.FlexGlobals;
 	import mx.utils.URLUtil;
-
+	
 	import org.bigbluebutton.core.managers.ConfigManager2;
 	import org.bigbluebutton.core.managers.ConnectionManager;
 	import org.bigbluebutton.core.managers.UserConfigManager;
@@ -131,19 +131,26 @@ package org.bigbluebutton.core {
 		}
 
 		public static function getLogoutURL():String {
-			var protocol:String = URLUtil.getProtocol(FlexGlobals.topLevelApplication.url);
-			var serverName:String = URLUtil.getServerNameWithPort(FlexGlobals.topLevelApplication.url);
-			var sessionToken:String = BBB.sessionTokenUtil.getSessionToken();
-			var logoutUrl:String = protocol + "://" + serverName;
-			if (sessionToken != "") {
-				logoutUrl += "/bigbluebutton/api/signOut?sessionToken=" + sessionToken;
-				if (!UserManager.getInstance().getConference().isBreakout) {
-					logoutUrl += "&redirect=true";
-				} else {
-					logoutUrl += "&redirect=true";
-				}
+			var logoutUrl:String = BBB.initUserConfigManager().getLogoutUrl();
+			if (logoutUrl == null) {
+				logoutUrl = getBaseURL();
 			}
 			return logoutUrl;
+		}
+
+		public static function getSignoutURL():String {
+			var sessionToken:String = BBB.sessionTokenUtil.getSessionToken();
+			var logoutUrl:String = getBaseURL();
+			if (sessionToken != "") {
+				logoutUrl += "/bigbluebutton/api/signOut?sessionToken=" + sessionToken;
+			}
+			return logoutUrl;
+		}
+
+		public static function getBaseURL():String {
+			var protocol:String = URLUtil.getProtocol(FlexGlobals.topLevelApplication.url);
+			var serverName:String = URLUtil.getServerNameWithPort(FlexGlobals.topLevelApplication.url);
+			return protocol + "://" + serverName;
 		}
 	}
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/core/BBB.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/BBB.as
@@ -1,13 +1,13 @@
 /**
  * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
- * 
+ *
  * Copyright (c) 2012 BigBlueButton Inc. and by respective authors (see below).
  *
  * This program is free software; you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
  * Foundation; either version 3.0 of the License, or (at your option) any later
  * version.
- * 
+ *
  * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
  * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
@@ -16,49 +16,56 @@
  * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
  *
  */
-package org.bigbluebutton.core
-{
+package org.bigbluebutton.core {
+
 	import flash.system.Capabilities;
-	
+
 	import mx.core.FlexGlobals;
-	
+	import mx.utils.URLUtil;
+
 	import org.bigbluebutton.core.managers.ConfigManager2;
 	import org.bigbluebutton.core.managers.ConnectionManager;
 	import org.bigbluebutton.core.managers.UserConfigManager;
+	import org.bigbluebutton.core.managers.UserManager;
 	import org.bigbluebutton.core.managers.VideoProfileManager;
 	import org.bigbluebutton.core.model.Session;
 	import org.bigbluebutton.core.model.VideoProfile;
 	import org.bigbluebutton.util.SessionTokenUtil;
-	
+
 	public class BBB {
 		private static var configManager:ConfigManager2 = null;
+
 		private static var connectionManager:ConnectionManager = null;
+
 		private static var session:Session = null;
+
 		private static var userConfigManager:UserConfigManager = null;
+
 		private static var videoProfileManager:VideoProfileManager = null;
+
 		private static var sessionTokenUtil:SessionTokenUtil = null;
-		
+
 		public static function getSessionTokenUtil():SessionTokenUtil {
 			if (sessionTokenUtil == null) {
 				sessionTokenUtil = new SessionTokenUtil();
 			}
 			return sessionTokenUtil;
 		}
-		
+
 		public static function initUserConfigManager():UserConfigManager {
 			if (userConfigManager == null) {
 				userConfigManager = new UserConfigManager();
 			}
 			return userConfigManager;
 		}
-		
+
 		public static function getConfigManager():ConfigManager2 {
 			if (configManager == null) {
 				configManager = new ConfigManager2();
 			}
 			return configManager;
 		}
-		
+
 		public static function loadConfig():void {
 			configManager.loadConfig();
 		}
@@ -86,7 +93,7 @@ package org.bigbluebutton.core
 		public static function get defaultVideoProfile():VideoProfile {
 			return initVideoProfileManager().defaultVideoProfile;
 		}
-		
+
 		public static function get fallbackVideoProfile():VideoProfile {
 			return initVideoProfileManager().fallbackVideoProfile;
 		}
@@ -96,46 +103,46 @@ package org.bigbluebutton.core
 				connectionManager = new ConnectionManager();
 			}
 			return connectionManager;
-		}		
+		}
 
 		public static function initSession():Session {
 			if (session == null) {
 				session = new Session();
 			}
 			return session;
-		}		
-		
+		}
+
 		public static function getFlashPlayerVersion():Number {
 			var versionString:String = Capabilities.version;
 			var pattern:RegExp = /^(\w*) (\d*),(\d*),(\d*),(\d*)$/;
 			var result:Object = pattern.exec(versionString);
 			if (result != null) {
-			//	trace("input: " + result.input);
-			//	trace("platform: " + result[1]);
-			//	trace("majorVersion: " + result[2]);
-			//	trace("minorVersion: " + result[3]);    
-			//	trace("buildNumber: " + result[4]);
-			//	trace("internalBuildNumber: " + result[5]);
+				//	trace("input: " + result.input);
+				//	trace("platform: " + result[1]);
+				//	trace("majorVersion: " + result[2]);
+				//	trace("minorVersion: " + result[3]);    
+				//	trace("buildNumber: " + result[4]);
+				//	trace("internalBuildNumber: " + result[5]);
 				return Number(result[2] + "." + result[3]);
 			} else {
-			//	trace("Unable to match RegExp.");
+				//	trace("Unable to match RegExp.");
 				return 0;
-			}		
+			}
 		}
-		
+
 		public static function getLogoutURL():String {
-			var logoutUrl:String = BBB.initUserConfigManager().getLogoutUrl();
-			if (logoutUrl == null) {
-				var pageHost:String = FlexGlobals.topLevelApplication.url.split("/")[0];
-				var pageURL:String = FlexGlobals.topLevelApplication.url.split("/")[2];
-				var sessionToken:String = BBB.sessionTokenUtil.getSessionToken();
-				logoutUrl = pageHost + "//" + pageURL;
-				if (sessionToken != "") {
-					logoutUrl = pageHost + "//" + pageURL + "/bigbluebutton/api/signOut?sessionToken=" + sessionToken;
+			var protocol:String = URLUtil.getProtocol(FlexGlobals.topLevelApplication.url);
+			var serverName:String = URLUtil.getServerNameWithPort(FlexGlobals.topLevelApplication.url);
+			var sessionToken:String = BBB.sessionTokenUtil.getSessionToken();
+			var logoutUrl:String = protocol + "://" + serverName;
+			if (sessionToken != "") {
+				logoutUrl += "/bigbluebutton/api/signOut?sessionToken=" + sessionToken;
+				if (!UserManager.getInstance().getConference().isBreakout) {
+					logoutUrl += "&redirect=true";
+				} else {
+					logoutUrl += "&redirect=true";
 				}
-				
-			}      
-			
+			}
 			return logoutUrl;
 		}
 	}

--- a/bigbluebutton-client/src/org/bigbluebutton/core/managers/UserConfigManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/managers/UserConfigManager.as
@@ -27,6 +27,12 @@ package org.bigbluebutton.core.managers {
 			conferenceParameters = c;
 		}
 
+		public function getLogoutUrl():String {
+			if (conferenceParameters == null)
+				return null;
+			return conferenceParameters.logoutUrl;
+		}
+
 		public function getWelcomeMessage():String {
 			if (conferenceParameters == null)
 				return null;

--- a/bigbluebutton-client/src/org/bigbluebutton/core/managers/UserConfigManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/managers/UserConfigManager.as
@@ -1,13 +1,13 @@
 /**
  * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
- * 
+ *
  * Copyright (c) 2012 BigBlueButton Inc. and by respective authors (see below).
  *
  * This program is free software; you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
  * Foundation; either version 3.0 of the License, or (at your option) any later
  * version.
- * 
+ *
  * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
  * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
@@ -16,33 +16,28 @@
  * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
  *
  */
-package org.bigbluebutton.core.managers
-{
+package org.bigbluebutton.core.managers {
+
 	import org.bigbluebutton.main.model.ConferenceParameters;
 
-	public class UserConfigManager
-	{
+	public class UserConfigManager {
 		private var conferenceParameters:ConferenceParameters = null;
-		
+
 		public function setConferenceParameters(c:ConferenceParameters):void {
 			conferenceParameters = c;
 		}
-		
-		public function getLogoutUrl():String {
-      if (conferenceParameters == null) return null;
-			return conferenceParameters.logoutUrl;
+
+		public function getWelcomeMessage():String {
+			if (conferenceParameters == null)
+				return null;
+			return conferenceParameters.welcome;
 		}
-    
-    public function getWelcomeMessage():String {
-      if (conferenceParameters == null) return null;
-      return conferenceParameters.welcome;
-    }
-        
-    public function getMeetingTitle():String {
-      if (conferenceParameters)
-         return conferenceParameters.meetingName;
-      else
-         return null;
-    }
+
+		public function getMeetingTitle():String {
+			if (conferenceParameters)
+				return conferenceParameters.meetingName;
+			else
+				return null;
+		}
 	}
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/LoggedOutWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/LoggedOutWindow.mxml
@@ -26,61 +26,75 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     x="168" y="86" layout="vertical" width="400" height="110" horizontalAlign="center">
 	<mx:Script>
 		<![CDATA[
-			import mx.core.FlexGlobals;
+			import flash.net.navigateToURL;
+
 			import mx.managers.PopUpManager;
-			
+
 			import org.as3commons.logging.api.ILogger;
 			import org.as3commons.logging.api.getClassLogger;
 			import org.bigbluebutton.core.BBB;
 			import org.bigbluebutton.core.managers.UserManager;
 			import org.bigbluebutton.main.model.users.events.ConnectionFailedEvent;
 			import org.bigbluebutton.util.i18n.ResourceUtil;
-			
-			private static const LOGGER:ILogger = getClassLogger(LoggedOutWindow);      
-      
-			[Bindable] private var message:String = "You have logged out of the conference";
+
+			private static const LOGGER:ILogger = getClassLogger(LoggedOutWindow);
+
+			[Bindable]
+			private var message:String = "You have logged out of the conference";
+
 			private var urlLoader:URLLoader;
-			
+
+			private var isBreakouRoom:Boolean;
+
 			private function init():void {
+				isBreakouRoom = UserManager.getInstance().getConference().isBreakout;
 				addEventListener(Event.CLOSE, onUserLoggedOutWindowClose);
 			}
 
 			private function redirect():void {
-				if (!UserManager.getInstance().getConference().isBreakout) {
-					var logoutURL:String = BBB.getLogoutURL();
-					var request:URLRequest = new URLRequest(logoutURL);
-					LOGGER.debug("Log out url: " + logoutURL);
+				var logoutURL:String = BBB.getLogoutURL();
+				var request:URLRequest = new URLRequest(logoutURL);
+				LOGGER.debug("Log out url: " + logoutURL);
+				if (!isBreakouRoom) {
+					navigateToURL(request, "_self");
+				} else {
 					request.method = URLRequestMethod.GET;
 					urlLoader = new URLLoader();
+					// If the redirect value is set to false handleComplete will be triggered
 					urlLoader.addEventListener(Event.COMPLETE, handleComplete);
 					urlLoader.addEventListener(IOErrorEvent.IO_ERROR, handleRedirectError);
 					urlLoader.load(request);
+				}
+			}
+
+			private function okBtnClickHandler(event:MouseEvent):void {
+				if (!isBreakouRoom) {
+					redirect();
 				} else {
 					ExternalInterface.call("window.close");
 				}
 			}
 
-      
 			private function handleComplete(e:Event):void {
-				LOGGER.debug("Client URL=[{0}]", [FlexGlobals.topLevelApplication.url]);
-                var logoutURL:String = BBB.getLogoutURL();
-        		var request:URLRequest = new URLRequest(logoutURL);
-				LOGGER.debug("Logging out to: {0}", [logoutURL]);
-        		navigateToURL(request, '_self');          
-        
-				PopUpManager.removePopUp(this);				
-			}
-			
-			private function handleRedirectError(e:IOErrorEvent):void {
+				// The server redirects by default to the logout URL
+				// If logout when redirection is disabled extra sign
+				// out step should be implemented here
 				PopUpManager.removePopUp(this);
 			}
 
-      private function onUserLoggedOutWindowClose(e:Event):void {
-       	PopUpManager.removePopUp(this);
-      }
-			
-			public function setReason(reason:String):void{
-				switch(reason){
+			private function handleRedirectError(e:IOErrorEvent):void {
+				LOGGER.error("Log out redirection returned with error.");
+				PopUpManager.removePopUp(this);
+			}
+
+			private function onUserLoggedOutWindowClose(e:Event):void {
+				LOGGER.debug("Closing UserLoggedOutWindow");
+				PopUpManager.removePopUp(this);
+			}
+
+			public function setReason(reason:String):void {
+				LOGGER.debug("Received ConnectionFailedEvent with reason: " + reason);
+				switch (reason) {
 					case ConnectionFailedEvent.APP_SHUTDOWN:
 						message = ResourceUtil.getInstance().getString('bbb.logout.appshutdown');
 						break;
@@ -102,12 +116,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					case ConnectionFailedEvent.UNKNOWN_REASON:
 						message = ResourceUtil.getInstance().getString('bbb.logout.unknown');
 						break;
-                    case ConnectionFailedEvent.USER_EJECTED_FROM_MEETING:
-                        message = ResourceUtil.getInstance().getString('bbb.logout.ejectedFromMeeting');
-                        break;
+					case ConnectionFailedEvent.USER_EJECTED_FROM_MEETING:
+						message = ResourceUtil.getInstance().getString('bbb.logout.ejectedFromMeeting');
+						break;
 					case ConnectionFailedEvent.USER_LOGGED_OUT:
 						message = ResourceUtil.getInstance().getString('bbb.logout.usercommand');
-						redirect(); // we know that the disconnect was requested so automatically redirect
+						redirect(); // we know that the disconnect was requested so automatically redirect 
 						break;
 				}
 			}
@@ -115,6 +129,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	</mx:Script>
 	<mx:VBox width="100%" height="100%" horizontalAlign="center">
 		<mx:Text text="{message}"/>
-		<mx:Button id="okBtn" label="{ResourceUtil.getInstance().getString('bbb.logout.button.label')}" click="redirect()"/>
+		<mx:Button id="okBtn" label="{ResourceUtil.getInstance().getString('bbb.logout.button.label')}" click="okBtnClickHandler(event)"/>
 	</mx:VBox>
 </mx:TitleWindow> 

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/LoggedOutWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/LoggedOutWindow.mxml
@@ -27,9 +27,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	<mx:Script>
 		<![CDATA[
 			import flash.net.navigateToURL;
-
+			
 			import mx.managers.PopUpManager;
-
+			
 			import org.as3commons.logging.api.ILogger;
 			import org.as3commons.logging.api.getClassLogger;
 			import org.bigbluebutton.core.BBB;
@@ -51,40 +51,39 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				addEventListener(Event.CLOSE, onUserLoggedOutWindowClose);
 			}
 
-			private function redirect():void {
-				var logoutURL:String = BBB.getLogoutURL();
+			private function callSignOut():void {
+				var logoutURL:String = BBB.getSignoutURL();
 				var request:URLRequest = new URLRequest(logoutURL);
 				LOGGER.debug("Log out url: " + logoutURL);
-				if (!isBreakouRoom) {
-					navigateToURL(request, "_self");
-				} else {
-					request.method = URLRequestMethod.GET;
-					urlLoader = new URLLoader();
-					// If the redirect value is set to false handleComplete will be triggered
-					urlLoader.addEventListener(Event.COMPLETE, handleComplete);
-					urlLoader.addEventListener(IOErrorEvent.IO_ERROR, handleRedirectError);
-					urlLoader.load(request);
-				}
+				request.method = URLRequestMethod.GET;
+				urlLoader = new URLLoader();
+				// If the redirect value is set to false handleComplete will be triggered
+				urlLoader.addEventListener(Event.COMPLETE, handleComplete);
+				urlLoader.addEventListener(IOErrorEvent.IO_ERROR, handleRedirectError);
+				urlLoader.load(request);
 			}
 
 			private function okBtnClickHandler(event:MouseEvent):void {
+				callSignOut();
+			}
+
+			private function exitApplication():void {
 				if (!isBreakouRoom) {
-					redirect();
+					navigateToURL(new URLRequest(BBB.getLogoutURL()), "_self");
 				} else {
 					ExternalInterface.call("window.close");
 				}
 			}
 
 			private function handleComplete(e:Event):void {
-				// The server redirects by default to the logout URL
-				// If logout when redirection is disabled extra sign
-				// out step should be implemented here
 				PopUpManager.removePopUp(this);
+				exitApplication();
 			}
 
 			private function handleRedirectError(e:IOErrorEvent):void {
 				LOGGER.error("Log out redirection returned with error.");
 				PopUpManager.removePopUp(this);
+				exitApplication();
 			}
 
 			private function onUserLoggedOutWindowClose(e:Event):void {
@@ -121,7 +120,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 						break;
 					case ConnectionFailedEvent.USER_LOGGED_OUT:
 						message = ResourceUtil.getInstance().getString('bbb.logout.usercommand');
-						redirect(); // we know that the disconnect was requested so automatically redirect 
+						callSignOut(); // we know that the disconnect was requested so automatically redirect 
 						break;
 				}
 			}

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1677,31 +1677,14 @@ class ApiController {
       println("SessionToken = " + sessionToken)
     }
 
-    //check if exists the param redirect
-    boolean redirectClient = true;
-    String clientURL = paramsProcessorUtil.getDefaultClientUrl();
-
-    if(! StringUtils.isEmpty(params.redirect)) {
-      try{
-        redirectClient = Boolean.parseBoolean(params.redirect);
-      }catch(Exception e){
-        redirectClient = true;
-      }
-    }
-
     Meeting meeting = null;
 
     if (sessionToken != null) {
       log.info("Found session for user in conference.")
       UserSession us = meetingService.removeUserSession(sessionToken);
       session.removeAttribute(sessionToken)
-      if ( redirectClient ) {
-        log.info("Successfully signed out. Redirecting to ${us.logoutUrl}");
-        redirect(url: us.logoutUrl);
-      }
     }
-    
-    /* If the redirection is not triggered we will render an XML answer */
+
     response.addHeader("Cache-Control", "no-cache")
     withFormat {
       xml {

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1677,14 +1677,31 @@ class ApiController {
       println("SessionToken = " + sessionToken)
     }
 
+    //check if exists the param redirect
+    boolean redirectClient = true;
+    String clientURL = paramsProcessorUtil.getDefaultClientUrl();
+
+    if(! StringUtils.isEmpty(params.redirect)) {
+      try{
+        redirectClient = Boolean.parseBoolean(params.redirect);
+      }catch(Exception e){
+        redirectClient = true;
+      }
+    }
+
     Meeting meeting = null;
 
     if (sessionToken != null) {
       log.info("Found session for user in conference.")
       UserSession us = meetingService.removeUserSession(sessionToken);
       session.removeAttribute(sessionToken)
+      if ( redirectClient ) {
+        log.info("Successfully signed out. Redirecting to ${us.logoutUrl}");
+        redirect(url: us.logoutUrl);
+      }
     }
-
+    
+    /* If the redirection is not triggered we will render an XML answer */
     response.addHeader("Cache-Control", "no-cache")
     withFormat {
       xml {


### PR DESCRIPTION
Removed URLLoader that calls logoutUrl that could be in an external domain.
Added two steps logged out action, we call signOut API then call the custom logoutUrl or just find the base servername if not defined and redirect to it.
Resolves #3208 