### PR TITLE
 - change jws failed to start timeout from 60s to 90s. Sometimes it t…

### DIFF
--- a/bbb-screenshare/app/src/main/scala/org/bigbluebutton/app/screenshare/server/sessions/Screenshare.scala
+++ b/bbb-screenshare/app/src/main/scala/org/bigbluebutton/app/screenshare/server/sessions/Screenshare.scala
@@ -119,7 +119,7 @@ class Screenshare(val sessionManager: ScreenshareManager,
   private var lastJwsStatusUpdate = 0L
 
   private var sessionStartedTimestamp:Long = 0L
-  private val JWS_START_TIMEOUT = 60
+  private val JWS_START_TIMEOUT = 90
 
   // The number of seconds we wait for the JWS to launch when
   // resuming sharing. Sometimes, on PAUSE, the JWS crashes but


### PR DESCRIPTION
…akes about

   30s to download the libs especially for those far from the server or those with
   slow connection.