### PR TITLE
Fix exception with closed caption tab for viewers

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/caption/views/CaptionWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/caption/views/CaptionWindow.mxml
@@ -110,7 +110,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					var codes:Array = ResourceUtil.getInstance().localeCodes;
 					
 					for (var i:int=0; i<names.length; i++) {
-						transcriptsCollection.addItem({locale: names[i], code: codes[i]});
+						transcriptsCollection.addItem({locale: names[i], localeCode: codes[i]});
 					}
 				} else {
 					transcriptsCollection = t.transcriptCollection;
@@ -144,7 +144,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 			
 			private function onLocaleChange(item:Object):void {
-				currentTranscript = transcriptsObject.findLocale(item.locale, item.code);
+				currentTranscript = transcriptsObject.findLocale(item.locale, item.localeCode);
 				
 				optionsTab.setCurrentTranscript(currentTranscript);
 				textTab.setCurrentTranscript(currentTranscript);


### PR DESCRIPTION
I originally was using the variable name "code" for the locale code, but I changed it part way through to "localeCode" to be consistent. Seems I had missed one and an exception was being thrown for viewers. This PR will fix the issue.