### PR TITLE
 Cast Exception when sending Number from client to Red5

### DIFF
--- a/bigbluebutton-apps/src/main/java/org/bigbluebutton/red5/service/CaptionService.java
+++ b/bigbluebutton-apps/src/main/java/org/bigbluebutton/red5/service/CaptionService.java
@@ -59,15 +59,29 @@ public class CaptionService {
 	}
 	
 	public void editCaptionHistory(Map<String, Object> msg) {
-		int startIndex = (Integer) msg.get("startIndex");
-		int endIndex = (Integer) msg.get("endIndex");
 		String locale = msg.get("locale").toString();
 		String localeCode = msg.get("localeCode").toString();
 		String text = msg.get("text").toString();
 		
 		String meetingID = Red5.getConnectionLocal().getScope().getName();
 		String userID = getBbbSession().getInternalUserID();
-		
+
+		Integer startIndex;
+		if (msg.get("startIndex") instanceof Double) {
+			Double tempStartIndex = (Double) msg.get("startIndex");
+			startIndex = tempStartIndex.intValue();
+		} else {
+			startIndex = (Integer) msg.get("startIndex");
+		}
+
+		Integer endIndex;
+		if (msg.get("endIndex") instanceof Double) {
+			Double tempEndIndex = (Double) msg.get("endIndex");
+			endIndex = tempEndIndex.intValue();
+		} else {
+			endIndex = (Integer) msg.get("endIndex");
+		}
+
 		red5InGW.editCaptionHistory(meetingID, userID, startIndex, endIndex, locale, localeCode, text);
 	}
 }

--- a/bigbluebutton-apps/src/main/java/org/bigbluebutton/red5/service/PollingService.java
+++ b/bigbluebutton-apps/src/main/java/org/bigbluebutton/red5/service/PollingService.java
@@ -41,9 +41,23 @@ public class PollingService {
 		String meetingID = Red5.getConnectionLocal().getScope().getName();
 		String userId = getBbbSession().getInternalUserID();
 		String pollId = (String) message.get("pollId");
-		Integer questionId = (Integer) message.get("answerId");
-		Integer answerId = (Integer) message.get("answerId");
-										
+
+		Integer questionId;
+		if (message.get("answerId") instanceof Double) {
+			Double tempQuestionId = (Double) message.get("answerId");
+			questionId = tempQuestionId.intValue();
+		} else {
+			questionId = (Integer) message.get("answerId");
+		}
+
+		Integer answerId;
+		if (message.get("answerId") instanceof Double) {
+			Double tempAnswerId = (Double) message.get("answerId");
+			answerId = tempAnswerId.intValue();
+		} else {
+			answerId = (Integer) message.get("answerId");
+		}
+
 		red5GW.votePoll(meetingID, userId, pollId, questionId, answerId);
 	}
 	


### PR DESCRIPTION
 When responding to a poll, the client sends a Number type which gets encoded in Red5
 as a Double. However, we expect an Integer which results in an exception. Cast the
 received Number properly into an Integer.

 I notice too that EditCaptionHistory is sending a Number. In Red5, we should check if
 we received a Double and cast it to Integer properly.