### PR TITLE
Removes iframe reference to outside domain

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/getScreenId.js
+++ b/bigbluebutton-client/resources/prod/lib/getScreenId.js
@@ -97,7 +97,7 @@
     iframe.onload = function() {
         iframe.isLoaded = true;
     };
-    iframe.src = 'https://www.webrtc-experiment.com/getSourceId/';
+    // iframe.src = 'https://www.webrtc-experiment.com/getSourceId/';
     iframe.style.display = 'none';
     (document.body || document.documentElement).appendChild(iframe);
 })();


### PR DESCRIPTION
iFrame hack is used to trigger screenshare in Firefox. May end up removing this entire solution when FF is focused on again. For now commented out