### PR TITLE
Unify uploaded presentation file naming across bigbluebutton-web

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -2089,7 +2089,7 @@ class ApiController {
     def presId = presDownloadService.generatePresentationId(presFilename)
     File uploadDir = presDownloadService.createPresentationDirectory(meetingId, presentationDir, presId)
     if (uploadDir != null) {
-      def newFilename = presDownloadService.createNewFilename(presId, filenameExt)
+      def newFilename = Util.createNewFilename(presId, filenameExt)
       def newFilePath = uploadDir.absolutePath + File.separatorChar + newFilename
 
       if (presDownloadService.savePresentation(meetingId, newFilePath, address)) {

--- a/bigbluebutton-web/src/java/org/bigbluebutton/api/Util.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/api/Util.java
@@ -10,9 +10,9 @@ public final class Util {
 		return DigestUtils.shaHex(name) + "-" + timestamp;
 	}
 	
-	public static String createNewFilename(String presId, String fileExt) {
-		return presId + fileExt;
-	}
+    public static String createNewFilename(String presId, String fileExt) {
+        return presId + "." + fileExt;
+    }
 	
 	public static File createPresentationDirectory(String meetingId, String presentationDir, String presentationId) {
 		String meetingPath = presentationDir + File.separatorChar + meetingId + File.separatorChar + meetingId;

--- a/bigbluebutton-web/src/java/org/bigbluebutton/presentation/PresentationUrlDownloadService.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/presentation/PresentationUrlDownloadService.java
@@ -14,6 +14,7 @@ import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.bigbluebutton.api.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +66,7 @@ public class PresentationUrlDownloadService {
             String filenameExt = FilenameUtils
                     .getExtension(sourcePresentationFile.getName());
             String presId = generatePresentationId(presentationId);
-            String newFilename = createNewFilename(presId, filenameExt);
+            String newFilename = Util.createNewFilename(presId, filenameExt);
 
             File uploadDir = createPresentationDirectory(destinationMeetingId,
                     presentationDir, presId);
@@ -84,10 +85,6 @@ public class PresentationUrlDownloadService {
     public String generatePresentationId(String name) {
         long timestamp = System.currentTimeMillis();
         return DigestUtils.shaHex(name) + "-" + timestamp;
-    }
-
-    public String createNewFilename(String presId, String fileExt) {
-        return presId + "." + fileExt;
     }
 
     public File createPresentationDirectory(String meetingId,

--- a/bigbluebutton-web/src/java/org/bigbluebutton/presentation/SupportedDocumentFilter.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/presentation/SupportedDocumentFilter.java
@@ -21,11 +21,13 @@ package org.bigbluebutton.presentation;
 
 import java.io.File;
 
+import org.apache.commons.io.FilenameUtils;
 import org.bigbluebutton.api.messaging.MessagingConstants;
 import org.bigbluebutton.api.messaging.MessagingService;
 import org.bigbluebutton.presentation.ConversionUpdateMessage.MessageBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.google.gson.Gson;
 
 public class SupportedDocumentFilter {
@@ -41,13 +43,15 @@ public class SupportedDocumentFilter {
 		File presentationFile = pres.getUploadedFile();
 		
 		/* Get file extension - Perhaps try to rely on a more accurate method than an extension type ? */
-		int fileExtIndex = presentationFile.getName().lastIndexOf('.') + 1;
-		String ext = presentationFile.getName().toLowerCase().substring(fileExtIndex);
-		boolean supported = SupportedFileTypes.isFileSupported(ext);
+		String extension = FilenameUtils.getExtension(presentationFile.getName());
+		boolean supported = SupportedFileTypes.isFileSupported(extension);
 		notifyProgressListener(supported, pres);
 		if (supported) {
-			log.info("Received supported file " + pres.getUploadedFile().getAbsolutePath());
-			pres.setFileType(ext);
+			log.info("Received supported file {}", pres.getUploadedFile().getAbsolutePath());
+			pres.setFileType(extension);
+		}
+		else {
+		    log.warn("Received not supported file {}", pres.getUploadedFile().getAbsolutePath());
 		}
 		return supported;
 	}


### PR DESCRIPTION
Fixes the issue where uploaded file is named without the dot before the extension.