### PR TITLE
[HTML5] Fix handler for 'get_whiteboard_shapes_reply'

### DIFF
--- a/bigbluebutton-html5/imports/api/shapes/server/modifiers/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/shapes/server/modifiers/eventHandlers.js
@@ -14,9 +14,9 @@ eventEmitter.on('get_whiteboard_shapes_reply', function (arg) {
       let whiteboardId = shape.wb_id;
       addShapeToCollection(meetingId, whiteboardId, shape);
     }
-
-    return arg.callback();
   }
+
+  return arg.callback();
 });
 
 eventEmitter.on('send_whiteboard_shape_message', function (arg) {


### PR DESCRIPTION
There is some cases where the handler will not call the next message on the queue making the client frozen.