### PR TITLE
Fix exception in webrtc error logging

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/WebRTCCallManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/WebRTCCallManager.as
@@ -209,7 +209,7 @@ package org.bigbluebutton.modules.phone.managers
       logData.user.reason = errorString;
       logData.tags = ["voice", "webrtc"];
       logData.message = "WebRtc Echo test failed.";
-      logData.errorEvent = event;
+      logData.errorEvent = {code: event.errorCode, cause: event.cause};
       LOGGER.info(jsonXify(logData));
 
       sendWebRTCAlert(ResourceUtil.getInstance().getString("bbb.webrtcWarning.title"),
@@ -270,7 +270,7 @@ package org.bigbluebutton.modules.phone.managers
           
           var logData:Object = UsersUtil.initLogData();
           logData.tags = ["voice", "webrtc"];
-          logData.errorEvent = event;
+          logData.errorEvent = {code: event.errorCode, cause: event.cause};
           LOGGER.info(jsonXify(logData));
           
           sendWebRTCAlert(ResourceUtil.getInstance().getString("bbb.webrtcWarning.title"),


### PR DESCRIPTION
Trying to JSONify an Event throws an exception. Switched the logging to instead pull out the information that we care about and log that directly instead.