### PR TITLE
Delay sending DisconnectAllUsers at EndMeeting handler in akka-bbb-apps

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/LiveMeeting.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/LiveMeeting.scala
@@ -2,14 +2,15 @@ package org.bigbluebutton.core
 
 import java.util.concurrent.TimeUnit
 
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+
 import org.bigbluebutton.core.api._
 import org.bigbluebutton.core.apps._
 import org.bigbluebutton.core.bus.IncomingEventBus
 
 import akka.actor.ActorContext
 import akka.event.Logging
-import org.bigbluebutton.core.apps.CaptionApp
-import org.bigbluebutton.core.apps.CaptionModel
 
 class LiveMeeting(val mProps: MeetingProperties,
                   val eventBus: IncomingEventBus,
@@ -122,7 +123,11 @@ class LiveMeeting(val mProps: MeetingProperties,
     handleEndAllBreakoutRooms(new EndAllBreakoutRooms(msg.meetingId))
 
     outGW.send(new MeetingEnded(msg.meetingId, mProps.recorded, mProps.voiceBridge))
-    outGW.send(new DisconnectAllUsers(msg.meetingId))
+    // Delay sending DisconnectAllUsers because of RTMPT connection being dropped before UserEject message arrives to the client  
+    context.system.scheduler.scheduleOnce(Duration.create(2500, TimeUnit.MILLISECONDS)) {
+      log.info("Sending delayed DisconnectUser. meetingId={}", mProps.meetingID)
+      outGW.send(new DisconnectAllUsers(msg.meetingId))
+    }
   }
 
   def handleAllowUserToShareDesktop(msg: AllowUserToShareDesktop): Unit = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/LiveMeeting.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/LiveMeeting.scala
@@ -2,7 +2,6 @@ package org.bigbluebutton.core
 
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 
 import org.bigbluebutton.core.api._
@@ -124,6 +123,7 @@ class LiveMeeting(val mProps: MeetingProperties,
 
     outGW.send(new MeetingEnded(msg.meetingId, mProps.recorded, mProps.voiceBridge))
     // Delay sending DisconnectAllUsers because of RTMPT connection being dropped before UserEject message arrives to the client  
+    import context.dispatcher
     context.system.scheduler.scheduleOnce(Duration.create(2500, TimeUnit.MILLISECONDS)) {
       log.info("Sending delayed DisconnectUser. meetingId={}", mProps.meetingID)
       outGW.send(new DisconnectAllUsers(msg.meetingId))


### PR DESCRIPTION
Attempt to fix the issue for users using RTMPT noticing the meeting ended status too late. The application is only aware of the meeting status after it auto-reconnects to the streaming server.