### PR TITLE
Fix typo in recording sanity script.

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video.rb
@@ -280,7 +280,7 @@ module BigBlueButton
           return {} if !info[:format]
 
           info[:video] = info[:streams].find do |stream|
-            stream[:codec_type] == 'audio'
+            stream[:codec_type] == 'video'
           end
 
           return {} if !info[:video]


### PR DESCRIPTION
This caused it to think all video files were corrupt.