### PR TITLE
Set Winston Logger Level

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -11,13 +11,13 @@ import org.bigbluebutton.SystemConfiguration
 
 object BigBlueButtonActor extends SystemConfiguration {
   def props(system: ActorSystem,
-            eventBus: IncomingEventBus,
-            outGW: OutMessageGateway): Props =
+    eventBus: IncomingEventBus,
+    outGW: OutMessageGateway): Props =
     Props(classOf[BigBlueButtonActor], system, eventBus, outGW)
 }
 
 class BigBlueButtonActor(val system: ActorSystem,
-                         eventBus: IncomingEventBus, outGW: OutMessageGateway) extends Actor with ActorLogging {
+    eventBus: IncomingEventBus, outGW: OutMessageGateway) extends Actor with ActorLogging {
 
   implicit def executionContext = system.dispatcher
   implicit val timeout = Timeout(5 seconds)
@@ -25,19 +25,19 @@ class BigBlueButtonActor(val system: ActorSystem,
   private var meetings = new collection.immutable.HashMap[String, RunningMeeting]
 
   def receive = {
-    case msg: CreateMeeting                    => handleCreateMeeting(msg)
-    case msg: DestroyMeeting                   => handleDestroyMeeting(msg)
-    case msg: KeepAliveMessage                 => handleKeepAliveMessage(msg)
-    case msg: PubSubPing                       => handlePubSubPingMessage(msg)
-    case msg: ValidateAuthToken                => handleValidateAuthToken(msg)
-    case msg: GetAllMeetingsRequest            => handleGetAllMeetingsRequest(msg)
-    case msg: UserJoinedVoiceConfMessage       => handleUserJoinedVoiceConfMessage(msg)
-    case msg: UserLeftVoiceConfMessage         => handleUserLeftVoiceConfMessage(msg)
-    case msg: UserLockedInVoiceConfMessage     => handleUserLockedInVoiceConfMessage(msg)
-    case msg: UserMutedInVoiceConfMessage      => handleUserMutedInVoiceConfMessage(msg)
-    case msg: UserTalkingInVoiceConfMessage    => handleUserTalkingInVoiceConfMessage(msg)
+    case msg: CreateMeeting => handleCreateMeeting(msg)
+    case msg: DestroyMeeting => handleDestroyMeeting(msg)
+    case msg: KeepAliveMessage => handleKeepAliveMessage(msg)
+    case msg: PubSubPing => handlePubSubPingMessage(msg)
+    case msg: ValidateAuthToken => handleValidateAuthToken(msg)
+    case msg: GetAllMeetingsRequest => handleGetAllMeetingsRequest(msg)
+    case msg: UserJoinedVoiceConfMessage => handleUserJoinedVoiceConfMessage(msg)
+    case msg: UserLeftVoiceConfMessage => handleUserLeftVoiceConfMessage(msg)
+    case msg: UserLockedInVoiceConfMessage => handleUserLockedInVoiceConfMessage(msg)
+    case msg: UserMutedInVoiceConfMessage => handleUserMutedInVoiceConfMessage(msg)
+    case msg: UserTalkingInVoiceConfMessage => handleUserTalkingInVoiceConfMessage(msg)
     case msg: VoiceConfRecordingStartedMessage => handleVoiceConfRecordingStartedMessage(msg)
-    case _                                     => // do nothing
+    case _ => // do nothing
   }
 
   private def findMeetingWithVoiceConfId(voiceConfId: String): Option[RunningMeeting] = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/JsonMessageDecoder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/JsonMessageDecoder.scala
@@ -51,7 +51,7 @@ object JsonMessageDecoder {
   def decode(json: String): Option[InMessage] = {
     unmarshall(json) match {
       case Success(validMsg) => Some(validMsg)
-      case Failure(ex)       => None
+      case Failure(ex) => None
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/JsonMessageSenderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/JsonMessageSenderActor.scala
@@ -38,16 +38,16 @@ class JsonMessageSenderActor(val service: MessageSender)
   def receive = {
 
     // Breakout
-    case msg: CreateBreakoutRoom            => handleCreateBreakoutRoom(msg)
-    case msg: EndBreakoutRoom               => handleEndBreakoutRoom(msg)
-    case msg: BreakoutRoomsListOutMessage   => handleBreakoutRoomsList(msg)
+    case msg: CreateBreakoutRoom => handleCreateBreakoutRoom(msg)
+    case msg: EndBreakoutRoom => handleEndBreakoutRoom(msg)
+    case msg: BreakoutRoomsListOutMessage => handleBreakoutRoomsList(msg)
     case msg: BreakoutRoomJoinURLOutMessage => handleBreakoutRoomJoinURL(msg)
     case msg: BreakoutRoomStartedOutMessage => handleBreakoutRoomStarted(msg)
-    case msg: BreakoutRoomEndedOutMessage   => handleBreakoutRoomEnded(msg)
+    case msg: BreakoutRoomEndedOutMessage => handleBreakoutRoomEnded(msg)
     case msg: UpdateBreakoutUsersOutMessage => handleUpdateBreakoutUsers(msg)
-    case msg: MeetingTimeRemainingUpdate    => handleMeetingTimeRemainingUpdate(msg)
+    case msg: MeetingTimeRemainingUpdate => handleMeetingTimeRemainingUpdate(msg)
 
-    case _                                  => // do nothing
+    case _ => // do nothing
   }
 
   // Breakout

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/LiveMeeting.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/LiveMeeting.scala
@@ -12,17 +12,17 @@ import akka.actor.ActorContext
 import akka.event.Logging
 
 class LiveMeeting(val mProps: MeetingProperties,
-                  val eventBus: IncomingEventBus,
-                  val outGW: OutMessageGateway,
-                  val chatModel: ChatModel,
-                  val layoutModel: LayoutModel,
-                  val meetingModel: MeetingModel,
-                  val usersModel: UsersModel,
-                  val pollModel: PollModel,
-                  val wbModel: WhiteboardModel,
-                  val presModel: PresentationModel,
-                  val breakoutModel: BreakoutRoomModel,
-                  val captionModel: CaptionModel)(implicit val context: ActorContext)
+  val eventBus: IncomingEventBus,
+  val outGW: OutMessageGateway,
+  val chatModel: ChatModel,
+  val layoutModel: LayoutModel,
+  val meetingModel: MeetingModel,
+  val usersModel: UsersModel,
+  val pollModel: PollModel,
+  val wbModel: WhiteboardModel,
+  val presModel: PresentationModel,
+  val breakoutModel: BreakoutRoomModel,
+  val captionModel: CaptionModel)(implicit val context: ActorContext)
     extends UsersApp with PresentationApp
     with LayoutApp with ChatApp with WhiteboardApp with PollApp
     with BreakoutRoomApp with CaptionApp {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/MeetingModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/MeetingModel.scala
@@ -5,14 +5,14 @@ import java.util.concurrent.TimeUnit
 
 case object StopMeetingActor
 case class MeetingProperties(meetingID: String, externalMeetingID: String, parentMeetingID: String, meetingName: String,
-                             recorded: Boolean, voiceBridge: String, deskshareBridge: String, duration: Int,
-                             autoStartRecording: Boolean, allowStartStopRecording: Boolean, moderatorPass: String,
-                             viewerPass: String, createTime: Long, createDate: String,
-                             red5DeskShareIP: String, red5DeskShareApp: String, isBreakout: Boolean, sequence: Int)
+  recorded: Boolean, voiceBridge: String, deskshareBridge: String, duration: Int,
+  autoStartRecording: Boolean, allowStartStopRecording: Boolean, moderatorPass: String,
+  viewerPass: String, createTime: Long, createDate: String,
+  red5DeskShareIP: String, red5DeskShareApp: String, isBreakout: Boolean, sequence: Int)
 
 case class MeetingExtensionProp(maxExtensions: Int = 2, numExtensions: Int = 0, extendByMinutes: Int = 20,
-                                sendNotice: Boolean = true, sent15MinNotice: Boolean = false,
-                                sent10MinNotice: Boolean = false, sent5MinNotice: Boolean = false)
+  sendNotice: Boolean = true, sent15MinNotice: Boolean = false,
+  sent10MinNotice: Boolean = false, sent5MinNotice: Boolean = false)
 
 class MeetingModel {
   private var audioSettingsInited = false

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/Protocol.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/Protocol.scala
@@ -20,7 +20,7 @@ object UserMessagesProtocol extends DefaultJsonProtocol {
 
     def read(json: JsValue): MessageType.MessageType = json match {
       case JsString(str) => MessageType.withName(str)
-      case _             => throw new DeserializationException("Enum string expected")
+      case _ => throw new DeserializationException("Enum string expected")
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/ProtocolMessages.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/ProtocolMessages.scala
@@ -8,6 +8,6 @@ trait OutMessage
 case class CreateBreakoutRoomOutMsgEnvelope(header: OutMsgEnvelopeHeader, payload: CreateBreakoutRoomOutMsgEnvelopePayload)
 case class CreateBreakoutRoomOutMsgEnvelopePayload(header: OutMsgHeader, payload: CreateBreakoutRoomOutMsgPayload)
 case class CreateBreakoutRoomOutMsgPayload(meetingId: String, parentId: String, name: String,
-                                           voiceConfId: String, moderatorPassword: String, viewerPassword: String,
-                                           durationInMinutes: Int, sourcePresentationId: String, sourcePresentationSlide: Int,
-                                           record: Boolean, sequence: Int)
+  voiceConfId: String, moderatorPassword: String, viewerPassword: String,
+  durationInMinutes: Int, sourcePresentationId: String, sourcePresentationSlide: Int,
+  record: Boolean, sequence: Int)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/InMessages.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/InMessages.scala
@@ -73,9 +73,9 @@ case class GetLockSettings(meetingID: String, userId: String) extends InMessage
 /////////////////////////////////////////////////////////////////////////////////
 
 case class ValidateAuthToken(meetingID: String, userId: String, token: String,
-                             correlationId: String, sessionId: String) extends InMessage
+  correlationId: String, sessionId: String) extends InMessage
 case class RegisterUser(meetingID: String, userID: String, name: String, role: Role,
-                        extUserID: String, authToken: String, avatarURL: String) extends InMessage
+  extUserID: String, authToken: String, avatarURL: String) extends InMessage
 case class UserJoining(meetingID: String, userID: String, authToken: String) extends InMessage
 case class UserLeaving(meetingID: String, userID: String, sessionId: String) extends InMessage
 case class GetUsers(meetingID: String, requesterID: String) extends InMessage
@@ -97,9 +97,9 @@ case class GetChatHistoryRequest(meetingID: String, requesterID: String, replyTo
 case class SendPublicMessageRequest(meetingID: String, requesterID: String, message: Map[String, String]) extends InMessage
 case class SendPrivateMessageRequest(meetingID: String, requesterID: String, message: Map[String, String]) extends InMessage
 case class UserConnectedToGlobalAudio(meetingID: String, /** Not used. Just to satisfy trait **/ voiceConf: String,
-                                      userid: String, name: String) extends InMessage
+  userid: String, name: String) extends InMessage
 case class UserDisconnectedFromGlobalAudio(meetingID: String, /** Not used. Just to satisfy trait **/ voiceConf: String,
-                                           userid: String, name: String) extends InMessage
+  userid: String, name: String) extends InMessage
 
 ///////////////////////////////////////////////////////////////////////////////////////
 // Layout
@@ -108,7 +108,7 @@ case class UserDisconnectedFromGlobalAudio(meetingID: String, /** Not used. Just
 case class GetCurrentLayoutRequest(meetingID: String, requesterID: String) extends InMessage
 case class SetLayoutRequest(meetingID: String, requesterID: String, layoutID: String) extends InMessage
 case class LockLayoutRequest(meetingID: String, setById: String, lock: Boolean, viewersOnly: Boolean,
-                             layout: Option[String]) extends InMessage
+  layout: Option[String]) extends InMessage
 case class BroadcastLayoutRequest(meetingID: String, requesterID: String, layout: String) extends InMessage
 
 //////////////////////////////////////////////////////////////////////////////////////
@@ -120,19 +120,19 @@ case class RemovePresentation(meetingID: String, presentationID: String) extends
 case class GetPresentationInfo(meetingID: String, requesterID: String, replyTo: String) extends InMessage
 case class SendCursorUpdate(meetingID: String, xPercent: Double, yPercent: Double) extends InMessage
 case class ResizeAndMoveSlide(meetingID: String, xOffset: Double, yOffset: Double,
-                              widthRatio: Double, heightRatio: Double) extends InMessage
+  widthRatio: Double, heightRatio: Double) extends InMessage
 case class GotoSlide(meetingID: String, page: String) extends InMessage
 case class SharePresentation(meetingID: String, presentationID: String, share: Boolean) extends InMessage
 case class GetSlideInfo(meetingID: String, requesterID: String, replyTo: String) extends InMessage
 case class PreuploadedPresentations(meetingID: String, presentations: Seq[Presentation]) extends InMessage
 case class PresentationConversionUpdate(meetingID: String, messageKey: String, code: String,
-                                        presentationId: String, presName: String) extends InMessage
+  presentationId: String, presName: String) extends InMessage
 case class PresentationPageCountError(meetingID: String, messageKey: String, code: String, presentationId: String,
-                                      numberOfPages: Int, maxNumberPages: Int, presName: String) extends InMessage
+  numberOfPages: Int, maxNumberPages: Int, presName: String) extends InMessage
 case class PresentationSlideGenerated(meetingID: String, messageKey: String, code: String, presentationId: String,
-                                      numberOfPages: Int, pagesCompleted: Int, presName: String) extends InMessage
+  numberOfPages: Int, pagesCompleted: Int, presName: String) extends InMessage
 case class PresentationConversionCompleted(meetingID: String, messageKey: String, code: String,
-                                           presentation: Presentation) extends InMessage
+  presentation: Presentation) extends InMessage
 
 /////////////////////////////////////////////////////////////////////////////////////  
 // Polling
@@ -161,9 +161,9 @@ case class MuteUserRequest(meetingID: String, requesterID: String, userID: Strin
 case class LockUserRequest(meetingID: String, requesterID: String, userID: String, lock: Boolean) extends InMessage
 case class EjectUserFromVoiceRequest(meetingID: String, userId: String, ejectedBy: String) extends InMessage
 case class VoiceUserJoinedMessage(meetingID: String, user: String, voiceConfId: String,
-                                  callerIdNum: String, callerIdName: String, muted: Boolean, talking: Boolean) extends InMessage
+  callerIdNum: String, callerIdName: String, muted: Boolean, talking: Boolean) extends InMessage
 case class UserJoinedVoiceConfMessage(voiceConfId: String, voiceUserId: String, userId: String, externUserId: String,
-                                      callerIdName: String, callerIdNum: String, muted: Boolean, talking: Boolean, avatarURL: String, listenOnly: Boolean) extends InMessage
+  callerIdName: String, callerIdNum: String, muted: Boolean, talking: Boolean, avatarURL: String, listenOnly: Boolean) extends InMessage
 case class UserLeftVoiceConfMessage(voiceConfId: String, voiceUserId: String) extends InMessage
 case class UserLockedInVoiceConfMessage(voiceConfId: String, voiceUserId: String, locked: Boolean) extends InMessage
 case class UserMutedInVoiceConfMessage(voiceConfId: String, voiceUserId: String, muted: Boolean) extends InMessage

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/OutMessages.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/OutMessages.scala
@@ -15,7 +15,7 @@ case class VoiceRecordingStopped(meetingID: String, recorded: Boolean, recording
 case class RecordingStatusChanged(meetingID: String, recorded: Boolean, userId: String, recording: Boolean) extends IOutMessage
 case class GetRecordingStatusReply(meetingID: String, recorded: Boolean, userId: String, recording: Boolean) extends IOutMessage
 case class MeetingCreated(meetingID: String, externalMeetingID: String, parentMeetingID: String, recorded: Boolean, name: String,
-                          voiceBridge: String, duration: Int, moderatorPass: String, viewerPass: String, createTime: Long, createDate: String, isBreakout: Boolean) extends IOutMessage
+  voiceBridge: String, duration: Int, moderatorPass: String, viewerPass: String, createTime: Long, createDate: String, isBreakout: Boolean) extends IOutMessage
 case class MeetingMuted(meetingID: String, recorded: Boolean, meetingMuted: Boolean) extends IOutMessage
 case class MeetingEnded(meetingID: String, recorded: Boolean, voiceBridge: String) extends IOutMessage
 case class MeetingState(meetingID: String, recorded: Boolean, userId: String, permissions: Permissions, meetingMuted: Boolean) extends IOutMessage

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/BreakoutRoomApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/BreakoutRoomApp.scala
@@ -190,7 +190,7 @@ object BreakoutRoomsUtil {
   }
 
   def joinParams(username: String, userId: String, isBreakout: Boolean, breakoutMeetingId: String,
-                 password: String): (mutable.Map[String, String], mutable.Map[String, String]) = {
+    password: String): (mutable.Map[String, String], mutable.Map[String, String]) = {
     val params = collection.mutable.HashMap(
       "fullName" -> urlEncode(username),
       "userID" -> urlEncode(userId),

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/BreakoutRoomModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/BreakoutRoomModel.scala
@@ -4,7 +4,7 @@ import scala.Vector
 
 case class BreakoutUser(id: String, name: String)
 case class BreakoutRoom(id: String, externalMeetingId: String, name: String, parentRoomId: String, sequence: Integer, voiceConfId: String,
-                        assignedUsers: Vector[String], users: Vector[BreakoutUser])
+  assignedUsers: Vector[String], users: Vector[BreakoutUser])
 
 class BreakoutRoomModel {
   private var rooms = new collection.immutable.HashMap[String, BreakoutRoom]
@@ -21,7 +21,7 @@ class BreakoutRoomModel {
   }
 
   def createBreakoutRoom(parentRoomId: String, id: String, externalMeetingId: String, name: String, sequence: Integer, voiceConfId: String,
-                         assignedUsers: Vector[String]): BreakoutRoom = {
+    assignedUsers: Vector[String]): BreakoutRoom = {
     val room = new BreakoutRoom(id, externalMeetingId, name, parentRoomId, sequence, voiceConfId, assignedUsers, Vector())
     add(room)
   }

--- a/bbb-screenshare/app/build.sbt
+++ b/bbb-screenshare/app/build.sbt
@@ -34,7 +34,7 @@ retrieveManaged := true
 
 libraryDependencies ++= {
     val akkaVersion  = "2.4.2"
-    val springVersion = "4.2.5.RELEASE"
+    val springVersion = "4.3.3.RELEASE"
   Seq(
     "com.typesafe.akka"        %%  "akka-actor"        % akkaVersion,
     "com.typesafe.akka"        %%  "akka-testkit"      % akkaVersion    % "test",
@@ -48,7 +48,7 @@ libraryDependencies ++= {
         "redis.clients"             %  "jedis"             % "2.7.2",
     //    "org.apache.commons"        %  "commons-lang3"     % "3.2",
     "org.apache.commons"        %  "commons-pool2"     % "2.3",
-    "org.red5"                  %  "red5-server"       % "1.0.7-M10",
+    "org.red5"                  %  "red5-server"       % "1.0.8-M13",
     "com.google.code.gson"      %  "gson"              % "2.5",
     "org.springframework"       %  "spring-web"        % springVersion,
     "org.springframework"       %  "spring-beans"      % springVersion,

--- a/bbb-screenshare/app/deploy.sh
+++ b/bbb-screenshare/app/deploy.sh
@@ -18,7 +18,7 @@ sudo cp ~/dev/bigbluebutton/bbb-screenshare/app/target/webapp/WEB-INF/lib/bbb-sc
  ~/dev/bigbluebutton/bbb-screenshare/app/target/webapp/WEB-INF/lib/gson-2.5.jar \
  ~/dev/bigbluebutton/bbb-screenshare/app/target/webapp/WEB-INF/lib/jedis-2.7.2.jar \
  ~/dev/bigbluebutton/bbb-screenshare/app/target/webapp/WEB-INF/lib/commons-pool2-2.3.jar \
- ~/dev/bigbluebutton/bbb-screenshare/app/target/webapp/WEB-INF/lib/spring-webmvc-4.2.5.RELEASE.jar  \
+ ~/dev/bigbluebutton/bbb-screenshare/app/target/webapp/WEB-INF/lib/spring-webmvc-4.3.3.RELEASE.jar  \
  ~/dev/bigbluebutton/bbb-screenshare/app/target/webapp/WEB-INF/lib/bbb-common-message-0.0.18-SNAPSHOT.jar \
   /usr/share/red5/webapps/screenshare/WEB-INF/lib/
 

--- a/bbb-video/build.gradle
+++ b/bbb-video/build.gradle
@@ -18,51 +18,51 @@ repositories {
 }
 
 dependencies {	 
-	// Servlet
-	providedCompile 'javax.servlet:servlet-api:2.5@jar'
+  // Servlet
+  providedCompile 'javax.servlet:servlet-api:2.5@jar'
+
+  // Mina
+  providedCompile 'org.apache.mina:mina-core:2.0.15@jar'
+  providedCompile 'org.apache.mina:mina-integration-beans:2.0.15@jar'
+  providedCompile 'org.apache.mina:mina-integration-jmx:2.0.14@jar'
+
+  // Spring 
+  providedCompile 'org.springframework:spring-web:4.3.3.RELEASE@jar' 
+  providedCompile  'org.springframework:spring-beans:4.3.3.RELEASE@jar'
+  providedCompile 'org.springframework:spring-context:4.3.3.RELEASE@jar'
+  providedCompile 'org.springframework:spring-core:4.3.3.RELEASE@jar'
 	
-	// Mina
-	providedCompile 'org.apache.mina:mina-core:2.0.13@jar'
-	providedCompile 'org.apache.mina:mina-integration-beans:2.0.13@jar'
-	providedCompile 'org.apache.mina:mina-integration-jmx:2.0.13@jar'
-	
-	// Spring 
-	providedCompile 'org.springframework:spring-web:4.2.5.RELEASE@jar' 
-	providedCompile  'org.springframework:spring-beans:4.2.5.RELEASE@jar'
-	providedCompile 'org.springframework:spring-context:4.2.5.RELEASE@jar'
-	providedCompile 'org.springframework:spring-core:4.2.5.RELEASE@jar'
-	
-	// Red5
-    providedCompile 'org.red5:red5-server:1.0.7-M10@jar'
-    providedCompile 'org.red5:red5-server-common:1.0.7-M10@jar'
-    providedCompile 'org.red5:red5-io:1.0.7-M8@jar'
+  // Red5
+  providedCompile 'org.red5:red5-server:1.0.8-M13@jar'
+  providedCompile 'org.red5:red5-server-common:1.0.8-M13@jar'
+  providedCompile 'org.red5:red5-io:1.0.8-M13@jar'
   
-	// Logging
-	providedCompile 'ch.qos.logback:logback-core:1.1.6@jar'
-	providedCompile 'ch.qos.logback:logback-classic:1.1.6@jar'
-	providedCompile 'org.slf4j:log4j-over-slf4j:1.7.18@jar'
-	providedCompile 'org.slf4j:jcl-over-slf4j:1.7.18@jar'
-	providedCompile 'org.slf4j:jul-to-slf4j:1.7.18@jar'
-	providedCompile 'org.slf4j:slf4j-api:1.7.18@jar'
+  // Logging
+  providedCompile 'ch.qos.logback:logback-core:1.1.7@jar'
+  providedCompile 'ch.qos.logback:logback-classic:1.1.7@jar'
+  providedCompile 'org.slf4j:log4j-over-slf4j:1.7.21@jar'
+  providedCompile 'org.slf4j:jcl-over-slf4j:1.7.21@jar'
+  providedCompile 'org.slf4j:jul-to-slf4j:1.7.21@jar'
+  providedCompile 'org.slf4j:slf4j-api:1.7.21@jar'
 	
-	// Needed for the JVM shutdown hook but needs to be put into red5/lib dir.
-	// Otherwise we get exception on aop utils class not found.
-	providedCompile 'org.springframework:spring-aop:4.2.5.RELEASE@jar'
-	compile 'aopalliance:aopalliance:1.0@jar'
+  // Needed for the JVM shutdown hook but needs to be put into red5/lib dir.
+  // Otherwise we get exception on aop utils class not found.
+  providedCompile 'org.springframework:spring-aop:4.3.3.RELEASE@jar'
+  compile 'aopalliance:aopalliance:1.0@jar'
 	
-    // Java Concurrency In Practice
-    providedCompile 'net.jcip:jcip-annotations:1.0@jar'
+  // Java Concurrency In Practice
+  providedCompile 'net.jcip:jcip-annotations:1.0@jar'
         
-    // Testing
-//    compile 'org.testng:testng:5.8@jar' 
-    compile 'org.easymock:easymock:2.4@jar'
+  // Testing
+  //    compile 'org.testng:testng:5.8@jar' 
+  compile 'org.easymock:easymock:2.4@jar'
   
-	//redis
-	compile 'redis.clients:jedis:2.0.0'
-	compile 'commons-pool:commons-pool:1.5.6'
-	compile 'com.google.code.gson:gson:2.5'
+  //redis
+  compile 'redis.clients:jedis:2.0.0'
+  compile 'commons-pool:commons-pool:1.5.6'
+  compile 'com.google.code.gson:gson:2.5'
 	
-	compile 'org.bigbluebutton:bbb-common-message:0.0.18-SNAPSHOT'
+  compile 'org.bigbluebutton:bbb-common-message:0.0.18-SNAPSHOT'
 }
 
 test {

--- a/bbb-voice/build.gradle
+++ b/bbb-voice/build.gradle
@@ -19,54 +19,48 @@ repositories {
 
 
 dependencies {	 
-	// Servlet
-	providedCompile 'javax.servlet:servlet-api:2.5@jar'
-	
-	// Mina
-	providedCompile 'org.apache.mina:mina-core:2.0.13@jar'
-	providedCompile 'org.apache.mina:mina-integration-beans:2.0.13@jar'
-	providedCompile 'org.apache.mina:mina-integration-jmx:2.0.13@jar'
+  // Servlet
+  providedCompile 'javax.servlet:servlet-api:2.5@jar'
+
+  // Mina
+  providedCompile 'org.apache.mina:mina-core:2.0.15@jar'
+  providedCompile 'org.apache.mina:mina-integration-beans:2.0.15@jar'
+  providedCompile 'org.apache.mina:mina-integration-jmx:2.0.14@jar'
 	
   // Spring 
-  providedCompile 'org.springframework:spring-web:4.2.5.RELEASE@jar' 
-  providedCompile  'org.springframework:spring-beans:4.2.5.RELEASE@jar'
-  providedCompile 'org.springframework:spring-context:4.2.5.RELEASE@jar'
-  providedCompile 'org.springframework:spring-core:4.2.5.RELEASE@jar'
+  providedCompile 'org.springframework:spring-web:4.3.3.RELEASE@jar' 
+  providedCompile  'org.springframework:spring-beans:4.3.3.RELEASE@jar'
+  providedCompile 'org.springframework:spring-context:4.3.3.RELEASE@jar'
+  providedCompile 'org.springframework:spring-core:4.3.3.RELEASE@jar'
 
-    providedCompile 'org.red5:red5-server:1.0.7-M10@jar'
-    providedCompile 'org.red5:red5-server-common:1.0.7-M10@jar'
-    providedCompile 'org.red5:red5-io:1.0.7-M10@jar'
+  providedCompile 'org.red5:red5-server:1.0.8-M13@jar'
+  providedCompile 'org.red5:red5-server-common:1.0.8-M13@jar'
+  providedCompile 'org.red5:red5-io:1.0.8-M13@jar'
 	  
-	// Logging
-	providedCompile 'ch.qos.logback:logback-core:1.1.6@jar'
-	providedCompile 'ch.qos.logback:logback-classic:1.1.6@jar'
-	providedCompile 'org.slf4j:log4j-over-slf4j:1.7.18@jar'
-	providedCompile 'org.slf4j:jcl-over-slf4j:1.7.18@jar'
-	providedCompile 'org.slf4j:jul-to-slf4j:1.7.18@jar'
-	providedCompile 'org.slf4j:slf4j-api:1.7.18@jar'
+  // Logging
+  providedCompile 'ch.qos.logback:logback-core:1.1.7@jar'
+  providedCompile 'ch.qos.logback:logback-classic:1.1.7@jar'
+  providedCompile 'org.slf4j:log4j-over-slf4j:1.7.21@jar'
+  providedCompile 'org.slf4j:jcl-over-slf4j:1.7.21@jar'
+  providedCompile 'org.slf4j:jul-to-slf4j:1.7.21@jar'
+  providedCompile 'org.slf4j:slf4j-api:1.7.21@jar'
 
-	// Needed for the JVM shutdown hook but needs to be put into red5/lib dir.
-	// Otherwise we get exception on aop utils class not found.
-	providedCompile 'org.springframework:spring-aop:4.2.5.RELEASE@jar'
-	compile 'aopalliance:aopalliance:1.0@jar'
+  // Needed for the JVM shutdown hook but needs to be put into red5/lib dir.
+  // Otherwise we get exception on aop utils class not found.
+  providedCompile 'org.springframework:spring-aop:4.3.3.RELEASE@jar'
+  compile 'aopalliance:aopalliance:1.0@jar'
 	
-    // Java Concurrency In Practice
-    //providedCompile 'net.jcip:jcip-annotations:1.0@jar'
-        
-    // Testing
-//    compile 'org.testng:testng:5.8@jar' 
-    compile 'org.easymock:easymock:2.4@jar'
+  // Testing
+  compile 'org.easymock:easymock:2.4@jar'
   
-	  // Testing
-//	  testRuntime 'org/testng:testng:5.8@jar'
-	  testRuntime 'org.easymock:easymock:2.4@jar'
+  // Testing
+  testRuntime 'org.easymock:easymock:2.4@jar'
 	    
-	// Redis pubsub
-	compile "redis.clients:jedis:2.1.0"
-	compile 'commons-pool:commons-pool:1.5.6'
-	compile 'com.google.code.gson:gson:2.5'
+  // Redis pubsub
+  compile "redis.clients:jedis:2.1.0"
+  compile 'commons-pool:commons-pool:1.5.6'
+  compile 'com.google.code.gson:gson:2.5'
   
-
 }
 
 test {

--- a/bbb-voice/src/main/java/org/bigbluebutton/voiceconf/red5/media/AudioBroadcastStream.java
+++ b/bbb-voice/src/main/java/org/bigbluebutton/voiceconf/red5/media/AudioBroadcastStream.java
@@ -149,33 +149,21 @@ public class AudioBroadcastStream implements IBroadcastStream, IProvider, IPipeC
 
 	public void onPipeConnectionEvent(PipeConnectionEvent event) {
 		log.trace("onPipeConnectionEvent(event:{})", event);
-		switch (event.getType()) {
-	    	case PipeConnectionEvent.PROVIDER_CONNECT_PUSH:
-	    		log.trace("PipeConnectionEvent.PROVIDER_CONNECT_PUSH");
-	    		System.out.println("PipeConnectionEvent.PROVIDER_CONNECT_PUSH");
-	    		if (event.getProvider() == this
-	    				&& (event.getParamMap() == null 
-	    				|| !event.getParamMap().containsKey("record"))) {
-	    			log.trace("Creating a live pipe");
-	    			this.livePipe = (IPipe) event.getSource();
-	    		}
-	    		break;
-	    	case PipeConnectionEvent.PROVIDER_DISCONNECT:
-	    		log.trace("PipeConnectionEvent.PROVIDER_DISCONNECT");
-	    		if (this.livePipe == event.getSource()) {
-	    			log.trace("PipeConnectionEvent.PROVIDER_DISCONNECT - this.mLivePipe = null;");
-	    			this.livePipe = null;
-	    		}
-	    		break;
-	    	case PipeConnectionEvent.CONSUMER_CONNECT_PUSH:
-	    		log.trace("PipeConnectionEvent.CONSUMER_CONNECT_PUSH");
-	    		break;
-	    	case PipeConnectionEvent.CONSUMER_DISCONNECT:
-	    		log.trace("PipeConnectionEvent.CONSUMER_DISCONNECT");
-	    		break;
-	    	default:
-	    		log.trace("PipeConnectionEvent default");
-	    		break;
+		if (event.getType() == PipeConnectionEvent.EventType.PROVIDER_CONNECT_PUSH) {
+			log.trace("PipeConnectionEvent.PROVIDER_CONNECT_PUSH");
+			System.out.println("PipeConnectionEvent.PROVIDER_CONNECT_PUSH");
+			if (event.getProvider() == this
+					&& (event.getParamMap() == null
+					|| !event.getParamMap().containsKey("record"))) {
+				log.trace("Creating a live pipe");
+				this.livePipe = (IPipe) event.getSource();
+			}
+		} else if (event.getType() == PipeConnectionEvent.EventType.PROVIDER_DISCONNECT) {
+			log.trace("PipeConnectionEvent.PROVIDER_DISCONNECT");
+			if (this.livePipe == event.getSource()) {
+				log.trace("PipeConnectionEvent.PROVIDER_DISCONNECT - this.mLivePipe = null;");
+				this.livePipe = null;
+			}
 		}
 	}
 	

--- a/bbb-voice/src/main/java/org/red5/app/sip/AudioStream.java
+++ b/bbb-voice/src/main/java/org/red5/app/sip/AudioStream.java
@@ -119,33 +119,20 @@ public class AudioStream implements IBroadcastStream, IProvider, IPipeConnection
 
 	public void onPipeConnectionEvent(PipeConnectionEvent event) {
 		log.trace("onPipeConnectionEvent(event:{})", event);
-		switch (event.getType())
-		{
-	    	case PipeConnectionEvent.PROVIDER_CONNECT_PUSH:
-	    		log.trace("PipeConnectionEvent.PROVIDER_CONNECT_PUSH");
-	    		System.out.println("PipeConnectionEvent.PROVIDER_CONNECT_PUSH");
-	    		if (event.getProvider() == this && (event.getParamMap() == null || !event.getParamMap().containsKey("record"))) {
-	    			log.trace("Creating a live pipe");
-	    			System.out.println("Creating a live pipe");
-	    			this.livePipe = (IPipe) event.getSource();
-	    		}
-	    		break;
-	    	case PipeConnectionEvent.PROVIDER_DISCONNECT:
-	    		log.trace("PipeConnectionEvent.PROVIDER_DISCONNECT");
-	    		if (this.livePipe == event.getSource()) {
-	    			log.trace("PipeConnectionEvent.PROVIDER_DISCONNECT - this.mLivePipe = null;");
-	    			this.livePipe = null;
-	    		}
-	    		break;
-	    	case PipeConnectionEvent.CONSUMER_CONNECT_PUSH:
-	    		log.trace("PipeConnectionEvent.CONSUMER_CONNECT_PUSH");
-	    		break;
-	    	case PipeConnectionEvent.CONSUMER_DISCONNECT:
-	    		log.trace("PipeConnectionEvent.CONSUMER_DISCONNECT");
-	    		break;
-	    	default:
-	    		log.trace("PipeConnectionEvent default");
-	    		break;
+		if (event.getType() == PipeConnectionEvent.EventType.PROVIDER_CONNECT_PUSH) {
+			log.trace("PipeConnectionEvent.PROVIDER_CONNECT_PUSH");
+			System.out.println("PipeConnectionEvent.PROVIDER_CONNECT_PUSH");
+			if (event.getProvider() == this && (event.getParamMap() == null || !event.getParamMap().containsKey("record"))) {
+				log.trace("Creating a live pipe");
+				System.out.println("Creating a live pipe");
+				this.livePipe = (IPipe) event.getSource();
+			}
+		} else if(event.getType() == PipeConnectionEvent.EventType.PROVIDER_DISCONNECT) {
+			log.trace("PipeConnectionEvent.PROVIDER_DISCONNECT");
+			if (this.livePipe == event.getSource()) {
+				log.trace("PipeConnectionEvent.PROVIDER_DISCONNECT - this.mLivePipe = null;");
+				this.livePipe = null;
+			}
 		}
 	}
 

--- a/bbb-voice/src/main/webapp/WEB-INF/bigbluebutton-sip.properties
+++ b/bbb-voice/src/main/webapp/WEB-INF/bigbluebutton-sip.properties
@@ -1,5 +1,5 @@
 # The ip and port the BBB SIP app is going to use
-bbb.sip.app.ip=192.168.23.44
+bbb.sip.app.ip=192.168.23.53
 bbb.sip.app.port=5070
 
 # The username and password the BBB SIP app to use to 
@@ -9,7 +9,7 @@ sip.server.password=secret
 
 
 # The ip and port of the FreeSWITCH server
-freeswitch.ip=192.168.23.44
+freeswitch.ip=192.168.23.53
 freeswitch.port=5060
 
 # The start/stop RTP port the application is going to use

--- a/bbb.sh
+++ b/bbb.sh
@@ -5,6 +5,8 @@ set -x
 RED5_DIR=/usr/share/red5
 BBB_DIR=$(pwd)
 
+sudo chmod -R 777 $RED5_DIR/webapps/
+
 cd $BBB_DIR
 
 DESKSHARE=$BBB_DIR/bbb-screenshare

--- a/bigbluebutton-apps/build.gradle
+++ b/bigbluebutton-apps/build.gradle
@@ -26,40 +26,31 @@ dependencies {
   providedCompile 'javax.servlet:servlet-api:2.5@jar'
 
   // Mina
-  providedCompile 'org.apache.mina:mina-core:2.0.13@jar'
-  providedCompile 'org.apache.mina:mina-integration-beans:2.0.13@jar'
-  providedCompile 'org.apache.mina:mina-integration-jmx:2.0.13@jar'
+  providedCompile 'org.apache.mina:mina-core:2.0.15@jar'
+  providedCompile 'org.apache.mina:mina-integration-beans:2.0.15@jar'
+  providedCompile 'org.apache.mina:mina-integration-jmx:2.0.14@jar'
 
   // Spring 
-  providedCompile 'org.springframework:spring-web:4.2.5.RELEASE@jar' 
-  providedCompile  'org.springframework:spring-beans:4.2.5.RELEASE@jar'
-  providedCompile 'org.springframework:spring-context:4.2.5.RELEASE@jar'
-  providedCompile 'org.springframework:spring-core:4.2.5.RELEASE@jar'
+  providedCompile 'org.springframework:spring-web:4.3.3.RELEASE@jar' 
+  providedCompile  'org.springframework:spring-beans:4.3.3.RELEASE@jar'
+  providedCompile 'org.springframework:spring-context:4.3.3.RELEASE@jar'
+  providedCompile 'org.springframework:spring-core:4.3.3.RELEASE@jar'
 
   // Red5
-  providedCompile 'org.red5:red5-server:1.0.7-M10@jar'
-  providedCompile 'org.red5:red5-server-common:1.0.7-M10@jar'
+  providedCompile 'org.red5:red5-server:1.0.8-M13@jar'
+  providedCompile 'org.red5:red5-server-common:1.0.8-M13@jar'
   
   // Logging
-  providedCompile 'ch.qos.logback:logback-core:1.1.6@jar'
-  providedCompile 'ch.qos.logback:logback-classic:1.1.6@jar'
-  providedCompile 'org.slf4j:log4j-over-slf4j:1.7.18@jar' 
-  providedCompile 'org.slf4j:jcl-over-slf4j:1.7.18@jar'
-  providedCompile 'org.slf4j:jul-to-slf4j:1.7.18@jar'
-  providedCompile 'org.slf4j:slf4j-api:1.7.18@jar'
+  providedCompile 'ch.qos.logback:logback-core:1.1.7@jar'
+  providedCompile 'ch.qos.logback:logback-classic:1.1.7@jar'
+  providedCompile 'org.slf4j:log4j-over-slf4j:1.7.21@jar' 
+  providedCompile 'org.slf4j:jcl-over-slf4j:1.7.21@jar'
+  providedCompile 'org.slf4j:jul-to-slf4j:1.7.21@jar'
+  providedCompile 'org.slf4j:slf4j-api:1.7.21@jar'
   	
-/*
-  compile "org.codehaus.jackson:jackson-core-asl:$jacksonVersion"
-  compile "org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion"
-  compile "javax.servlet:com.springsource.javax.servlet.jsp.jstl:1.2.0"
-  compile ("org.springframework.data:spring-data-redis:$springRedisVersion") {
-    exclude group: 'commons-logging'
-  }
-*/
-   
   // Needed for the JVM shutdown hook but needs to be put into red5/lib dir.
   // Otherwise we get exception on aop utils class not found.
-  providedCompile 'org.springframework:spring-aop:4.2.5.RELEASE@jar'
+  providedCompile 'org.springframework:spring-aop:4.3.3.RELEASE@jar'
   compile 'aopalliance:aopalliance:1.0@jar'
 	     
   // Testing

--- a/bigbluebutton-apps/src/main/java/org/bigbluebutton/red5/BigBlueButtonApplication.java
+++ b/bigbluebutton-apps/src/main/java/org/bigbluebutton/red5/BigBlueButtonApplication.java
@@ -94,7 +94,7 @@ public class BigBlueButtonApplication extends MultiThreadedApplicationAdapter {
 		Runnable getHeapTask = () -> getHeapStatsHelper();
 
 		ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
-		executor.scheduleAtFixedRate(getHeapTask, 0, 60, TimeUnit.SECONDS);
+		executor.scheduleAtFixedRate(getHeapTask, 0, 5, TimeUnit.SECONDS);
 	}
 
 	private void getHeapStatsHelper() {

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/PortTest.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/PortTest.as
@@ -174,7 +174,7 @@ package org.bigbluebutton.main.model
 
 			status = "FAILED";
 			_connectionListener(status, tunnel, hostname, port, application);
-      closeConnection();
+            closeConnection();
 		}
 		
 		/**
@@ -215,7 +215,11 @@ package org.bigbluebutton.main.model
     protected function netStatus(event : NetStatusEvent):void {
       
         //Stop timeout timer when connected/rejected
-        connectionTimer.stop();
+        if (connectionTimer != null && connectionTimer.running) {
+            connectionTimer.stop();
+            connectionTimer = null;
+        }
+            
       
         var info : Object = event.info;
         var statusCode : String = info.code;
@@ -224,7 +228,6 @@ package org.bigbluebutton.main.model
         logData.connection = this.baseURI;
         logData.tags = ["initialization", "port-test", "connection"];
 
-        
         if ( statusCode == "NetConnection.Connect.Success" ) {
             status = "SUCCESS";
             logData.message = "Port test successfully connected.";
@@ -234,7 +237,7 @@ package org.bigbluebutton.main.model
         } else if ( statusCode == "NetConnection.Connect.Rejected" ||
                     statusCode == "NetConnection.Connect.Failed" || 
                     statusCode == "NetConnection.Connect.Closed" ) {
-                        
+            logData.statusCode = statusCode;            
             logData.message = "Port test failed to connect.";
             LOGGER.info(JSON.stringify(logData));
             
@@ -242,8 +245,8 @@ package org.bigbluebutton.main.model
             _connectionListener(status, tunnel, hostname, port, application);
             
         }
-      
-      //closeConnection();
+        
+        closeConnection();
     }
 		
 		public function onBWCheck(... rest):Number { 

--- a/bigbluebutton-html5/imports/api/captions/server/modifiers/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/captions/server/modifiers/eventHandlers.js
@@ -4,9 +4,10 @@ import { addCaptionsToCollection } from './addCaptionsToCollection';
 import { updateCaptionsCollection } from './updateCaptionsCollection';
 import Meetings from '/imports/api/meetings';
 import Captions from '/imports/api/captions';
+import Logger from '/imports/startup/server/logger'
 
 eventEmitter.on('send_caption_history_reply_message', function (arg) {
-  console.error('message', JSON.stringify(arg));
+  Logger.debug('message', JSON.stringify(arg));
   if (inReplyToHTML5Client(arg)) {
     const meetingId = arg.payload.meeting_id;
     if (Captions.findOne({
@@ -23,7 +24,7 @@ eventEmitter.on('send_caption_history_reply_message', function (arg) {
 });
 
 eventEmitter.on('update_caption_owner_message', function (arg) {
-  console.error(JSON.stringify(arg));
+  Logger.debug(JSON.stringify(arg));
   const meetingId = arg.payload.meeting_id;
   let payload = arg.payload;
 
@@ -65,7 +66,7 @@ eventEmitter.on('update_caption_owner_message', function (arg) {
 });
 
 eventEmitter.on('edit_caption_history_message', function (arg) {
-  console.error(JSON.stringify(arg));
+  Logger.debug('edit_caption_history_message ' + JSON.stringify(arg));
   let payload = arg.payload;
   let meetingId = payload.meeting_id;
   let locale = payload.locale;

--- a/bigbluebutton-html5/imports/api/cursor/server/handlers/cursorUpdate.js
+++ b/bigbluebutton-html5/imports/api/cursor/server/handlers/cursorUpdate.js
@@ -11,7 +11,5 @@ export default function handleCursorUpdate({ payload }) {
   check(x, Number);
   check(y, Number);
 
-  Logger.silly(`new cursor location : X=${x} - Y=${y}  meetingId=${meetingId}`);
-
   return updateCursor(meetingId, x, y);
 };

--- a/bigbluebutton-html5/imports/api/cursor/server/handlers/cursorUpdate.js
+++ b/bigbluebutton-html5/imports/api/cursor/server/handlers/cursorUpdate.js
@@ -11,5 +11,7 @@ export default function handleCursorUpdate({ payload }) {
   check(x, Number);
   check(y, Number);
 
+  Logger.silly(`new cursor location : X=${x} - Y=${y}  meetingId=${meetingId}`);
+
   return updateCursor(meetingId, x, y);
 };

--- a/bigbluebutton-html5/imports/api/cursor/server/modifiers/updateCursor.js
+++ b/bigbluebutton-html5/imports/api/cursor/server/modifiers/updateCursor.js
@@ -25,11 +25,11 @@ export default function updateCursor(meetingId, x = 0, y = 0) {
 
     const { insertedId } = numChanged;
     if (insertedId) {
-      return Logger.info(`Initialized cursor meeting=${meetingId}`);
+      return Logger.debug(`Initialized cursor meeting=${meetingId}`);
     }
 
     if (numChanged) {
-      return Logger.info(`Updated cursor meeting=${meetingId}`);
+      return Logger.verbose(`Updated cursor meeting=${meetingId}`);
     }
   };
 

--- a/bigbluebutton-html5/imports/api/cursor/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/cursor/server/publishers.js
@@ -16,7 +16,7 @@ Meteor.publish('cursor', (credentials) => {
   check(requesterUserId, String);
   check(requesterToken, String);
 
-  Logger.verbose(`Publishing Cursor for ${meetingId} ${requesterUserId} ${requesterToken}`);
+  Logger.debug(`Publishing Cursor for ${meetingId} ${requesterUserId} ${requesterToken}`);
 
   return Cursor.find({ meetingId });
 });

--- a/bigbluebutton-html5/imports/api/cursor/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/cursor/server/publishers.js
@@ -16,7 +16,7 @@ Meteor.publish('cursor', (credentials) => {
   check(requesterUserId, String);
   check(requesterToken, String);
 
-  Logger.info(`Publishing Cursor for ${meetingId} ${requesterUserId} ${requesterToken}`);
+  Logger.verbose(`Publishing Cursor for ${meetingId} ${requesterUserId} ${requesterToken}`);
 
   return Cursor.find({ meetingId });
 });

--- a/bigbluebutton-html5/imports/api/meetings/server/handlers/permissionSettingsChange.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/handlers/permissionSettingsChange.js
@@ -1,6 +1,7 @@
 import { check } from 'meteor/check';
 import Logger from '/imports/startup/server/logger';
 import Meetings from '/imports/api/meetings';
+import { Meteor } from 'meteor/meteor';
 import handleLockingMic from '/imports/api/users/server/modifiers/handleLockingMic';
 
 export default function handlePermissionSettingsChange({ payload }) {
@@ -17,7 +18,7 @@ export default function handlePermissionSettingsChange({ payload }) {
   const Meeting = Meetings.findOne(selector);
 
   if (!Meeting) {
-    throw new Meteor.error('meeting-not-found', `Meeting id=${meetingId} was not found`);
+    throw new Meteor.Error('meeting-not-found', `Meeting id=${meetingId} was not found`);
   }
 
   const modifier = {

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/handleLockingMic.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/handleLockingMic.js
@@ -2,7 +2,7 @@ import Users from '/imports/api/users';
 
 // when new lock settings including disableMic are set,
 // all viewers that are in the audio bridge with a mic should be muted and locked
-export function handleLockingMic(meetingId, newSettings) {
+export default function handleLockingMic(meetingId, newSettings) {
   // send mute requests for the viewer users joined with mic
   let userObject;
   let results = [];

--- a/bigbluebutton-html5/imports/startup/server/logger.js
+++ b/bigbluebutton-html5/imports/startup/server/logger.js
@@ -3,13 +3,27 @@ import Winston from 'winston';
 
 let Logger = new Winston.Logger();
 
-// Write logs to console
+Logger.configure({
+  levels: { error: 0, warn: 1, info: 2, verbose: 3, debug: 4, silly: 5, },
+  colors: {
+    error: 'red',
+    warn: 'yellow',
+    info: 'green',
+    verbose: 'cyan',
+    debug: 'magenta',
+    silly: 'gray',
+  },
+});
+
 Logger.add(Winston.transports.Console, {
   prettyPrint: false,
   humanReadableUnhandledException: true,
   colorize: true,
   handleExceptions: true,
 });
+
+// Set Logger message level priority for the console
+Logger.transports.console.level = 'silly';
 
 Meteor.startup(() => {
   const LOG_CONFIG = Meteor.settings.log || {};

--- a/bigbluebutton-html5/imports/startup/server/logger.js
+++ b/bigbluebutton-html5/imports/startup/server/logger.js
@@ -4,14 +4,13 @@ import Winston from 'winston';
 let Logger = new Winston.Logger();
 
 Logger.configure({
-  levels: { error: 0, warn: 1, info: 2, verbose: 3, debug: 4, silly: 5, },
+  levels: { error: 0, warn: 1, info: 2, verbose: 3, debug: 4, },
   colors: {
     error: 'red',
     warn: 'yellow',
     info: 'green',
     verbose: 'cyan',
     debug: 'magenta',
-    silly: 'gray',
   },
 });
 
@@ -23,7 +22,7 @@ Logger.add(Winston.transports.Console, {
 });
 
 // Set Logger message level priority for the console
-Logger.transports.console.level = 'silly';
+Logger.transports.console.level = 'info';
 
 Meteor.startup(() => {
   const LOG_CONFIG = Meteor.settings.log || {};

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -4,7 +4,7 @@ import styles from '../styles';
 
 import { showModal } from '/imports/ui/components/app/service';
 import LogoutConfirmation from '/imports/ui/components/logout-confirmation/component';
-import Settings from '/imports/ui/components/settings/component';
+import SettingsMenuContainer from '/imports/ui/components/settings/container';
 
 import Button from '/imports/ui/components/button/component';
 import Dropdown from '/imports/ui/components/dropdown/component';
@@ -81,7 +81,7 @@ const toggleFullScreen = () => {
   }
 };
 
-const openSettings = () => showModal(<Settings />);
+const openSettings = () => showModal(<SettingsMenuContainer  />);
 
 const openLogoutConfirmation = () => showModal(<LogoutConfirmation />);
 

--- a/bigbluebutton-html5/imports/ui/components/settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/component.jsx
@@ -14,29 +14,58 @@ export default class Settings extends React.Component {
   constructor(props) {
     super(props);
     this.submenus = [];
+    this.state = { activeSubmenu: 0, focusSubmenu: 0 };
   }
 
-  componentWillMount() {
-    /* activeSubmenu represents the submenu in the submenus array to be displayed to the user,
-     * initialized to 0
-     */
-    this.setState({ activeSubmenu: 0 });
-    /* focusSubmenu represents the submenu in the submenus array which currently has focus,
-     * initialized to 0
-     */
-    this.setState({ focusSubmenu: 0 });
-    this.submenus.push({ componentName: AudioMenu, tabIndex: 3,
-      props: { title: 'Audio', prependIconName: 'icon-', icon: 'bbb-audio', }, });
-    this.submenus.push({ componentName: VideoMenu, tabIndex: 4,
-      props: { title: 'Video', prependIconName: 'icon-', icon: 'bbb-video', }, });
-    this.submenus.push({ componentName: ApplicationMenu, tabIndex: 5,
-      props: { title: 'Application', prependIconName: 'icon-', icon: 'bbb-application', }, });
-    this.submenus.push({ componentName: UsersMenu, tabIndex: 6,
-      props: { title: 'Participants', prependIconName: 'icon-', icon: 'bbb-user', }, });
+  renderSettingOptions() {
+    const { isPresenter, role } = this.props;
+    
+    this.submenus = [];
+    this.submenus.push(
+      { componentName: AudioMenu, tabIndex: 3,
+        props: { title: 'Audio', prependIconName: 'icon-', icon: 'bbb-audio', }, },
+      { componentName: VideoMenu, tabIndex: 4,
+        props: { title: 'Video', prependIconName: 'icon-', icon: 'bbb-video', }, },
+      { componentName: ApplicationMenu, tabIndex: 5,
+        props: { title: 'Application', prependIconName: 'icon-', icon: 'bbb-application', }, });
+
+    if (isPresenter || role === 'MODERATOR') {
+      this.submenus.push(
+        { componentName: UsersMenu, tabIndex: 6,
+          props: { title: 'Participants', prependIconName: 'icon-', icon: 'bbb-user', }, });
+    }
+
+    return (
+      <div className={styles.full} role='presentation'>
+        <div className={styles.settingsMenuLeft}>
+          <ul className={styles.settingsSubmenu} role='menu'>
+            {this.submenus.map((value, index) => (
+              <li key={index} ref={'submenu' + index} role='menuitem' tabIndex={value.tabIndex}
+                onClick={this.handleClickSubmenu.bind(this, index)}
+                onKeyDown={this.handleKeyDown.bind(this)}
+                onFocus={this.handleFocus.bind(this, index)}
+                className={classNames(styles.settingsSubmenuItem,
+                  index == this.state.activeSubmenu ? styles.settingsSubmenuItemActive : null)}>
+                <Icon key={index} prependIconName={value.props.prependIconName}
+                  iconName={value.props.icon} title={value.props.title}/>
+                <span className={styles.settingsSubmenuItemText}>{value.props.title}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className={styles.settingsMenuRight} role='presentation'>
+          {this.renderMenu()}
+        </div>
+      </div>
+    );
   }
 
-  createMenu() {
-    const curr = this.state.activeSubmenu === undefined ? 0 : this.state.activeSubmenu;
+  renderMenu() {
+    let curr = this.state.activeSubmenu === undefined ? 0 : this.state.activeSubmenu;
+
+    if (!this.submenus[curr]) {
+      curr = (this.state.activeSubmenu - 1);
+    }
 
     let props = {
       title: this.submenus[curr].props.title,
@@ -54,7 +83,7 @@ export default class Settings extends React.Component {
    * activeSubmenu: the submenu to be displayed to the user
    * focusSubmenu: the submenu to set focus to
    */
-  clickSubmenu(i) {
+  handleClickSubmenu(i) {
     if (i <= 0) {
       this.setState({ activeSubmenu: 0, focusSubmenu: 0, });
       return;
@@ -174,27 +203,7 @@ export default class Settings extends React.Component {
           label: 'Cancel',
           description: 'Discart the changes and close the settings menu',
         }}>
-        <div className={styles.full} role='presentation'>
-          <div className={styles.settingsMenuLeft}>
-            <ul className={styles.settingsSubmenu} role='menu'>
-              {this.submenus.map((value, index) => (
-                <li key={index} ref={'submenu' + index} role='menuitem' tabIndex={value.tabIndex}
-                  onClick={this.clickSubmenu.bind(this, index)}
-                  onKeyDown={this.handleKeyDown.bind(this)}
-                  onFocus={this.handleFocus.bind(this, index)}
-                  className={classNames(styles.settingsSubmenuItem,
-                    index == this.state.activeSubmenu ? styles.settingsSubmenuItemActive : null)}>
-                  <Icon key={index} prependIconName={value.props.prependIconName}
-                    iconName={value.props.icon} title={value.props.title}/>
-                  <span className={styles.settingsSubmenuItemText}>{value.props.title}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div className={styles.settingsMenuRight} role='presentation'>
-            {this.createMenu()}
-          </div>
-        </div>
+          {this.renderSettingOptions()}
       </Modal>
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/settings/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/container.jsx
@@ -1,0 +1,24 @@
+import React, { Component, PropTypes } from 'react';
+import { createContainer } from 'meteor/react-meteor-data';
+
+import Settings from './component';
+import Service from './service';
+
+class SettingsMenuContainer extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <Settings {...this.props}>
+        {this.props.children}
+      </Settings>
+    );
+  }
+}
+
+export default createContainer(() => {
+  let data = Service.checkUserRoles();
+  return data;
+}, SettingsMenuContainer);

--- a/bigbluebutton-html5/imports/ui/components/settings/service.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/service.js
@@ -1,0 +1,17 @@
+import Users from '/imports/api/users';
+import AuthSingleton from '/imports/ui/services/auth/index.js';
+
+checkUserRoles = () => {
+  const user = Users.findOne({
+     userId: AuthSingleton.getCredentials().requesterUserId,
+   }).user;
+
+  return {
+    isPresenter: user.presenter,
+    role: user.role,
+  };
+};
+
+export default {
+  checkUserRoles,
+};


### PR DESCRIPTION
In order to log messages, the default Winston Logger priority configuration is used.

By default it's priority levels are:
{ error: 0, warn: 1, info: 2, verbose: 3, debug: 4, silly: 5 }

The higher the message priority, the lower the corresponding integer.

To set the logger message priority you can just change the `Logger.transports.console.level` variable to the priority level you want.

If the `Logger.transports.console.level` is set to 'warn', then all 'warn' and 'error' messages will be shown in the console. If it is set to 'debug', all messages will be shown except for 'silly'. etc.

I've added new priority messages to the cursor module to illustrate how the logger will filter the messages.

These priority settings do not apply to the logger file transport, it remains the same and logs all messages.
