### PR TITLE
Video auto start

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMapDelegate.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMapDelegate.as
@@ -318,7 +318,7 @@ package org.bigbluebutton.modules.videoconf.maps
 
       _dispatcher.dispatchEvent(broadcastEvent);
 	  if (proxy.videoOptions.showButton) {
-		  button.publishingStatus(button.START_PUBLISHING);
+		  button.callLater(button.publishingStatus, [button.START_PUBLISHING]);
 	  }
     }
 

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMapDelegate.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMapDelegate.as
@@ -198,15 +198,26 @@ package org.bigbluebutton.modules.videoconf.maps
 
     private function skipCameraSettingsCheck(camIndex:int = -1):void {
       if (camIndex == -1) {
-        var cam:Camera = changeDefaultCamForMac();
+        var cam:Camera = getDefaultCamera();
         if (cam == null) {
-          cam = Camera.getCamera();
+          LOGGER.debug("VideoEventMapDelegate:: Could not find a default camera");
+          return;
         }
         camIndex = cam.index;
       }
 
       var videoProfile:VideoProfile = BBB.defaultVideoProfile;
       initCameraWithSettings(camIndex, videoProfile);
+    }
+
+    private function getDefaultCamera():Camera {
+      var cam:Camera = null;
+      cam = changeDefaultCamForMac();
+      if (cam == null) {
+        cam = Camera.getCamera();
+      }
+
+      return cam;
     }
 
     private function openWebcamWindows():void {
@@ -380,7 +391,7 @@ package org.bigbluebutton.modules.videoconf.maps
     public function handleShareCameraRequestEvent(event:ShareCameraRequestEvent):void {
 		LOGGER.debug("[VideoEventMapDelegate:handleShareCameraRequestEvent]");
 		if (options.skipCamSettingsCheck) {
-			skipCameraSettingsCheck(int(event.defaultCamera));
+			skipCameraSettingsCheck();
 		} else {
 			openWebcamPreview(event.publishInClient, event.defaultCamera, event.camerasArray);
 		}

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/ToolbarPopupButton.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/ToolbarPopupButton.mxml
@@ -22,7 +22,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 <mx:PopUpButton xmlns:mx="http://www.adobe.com/2006/mxml" styleName="webcamDefaultButtonStyle"
 		   xmlns:mate="http://mate.asfusion.com/"
-		   click="openPublishWindow()" creationComplete="init()" 
+		   click="openPublishWindow()"
+		   initialize="init()"
 		   mouseOver = "mouseOverHandler(event)"
 		   mouseOut = "mouseOutHandler(event)"
            height="24"


### PR DESCRIPTION
Setting video as skipCheck and autoStart to true at the config.xml was causing the client to throw an exception like this one:
```
TypeError: Error #1010: A term is undefined and has no properties.
    at org.bigbluebutton.modules.videoconf.views::ToolbarPopupButton/setCamAsActive()[/home/ubuntu/dev/bigbluebutton/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/ToolbarPopupButton.mxml:267]
    at org.bigbluebutton.modules.videoconf.maps::VideoEventMapDelegate/initCameraWithSettings()[/home/ubuntu/dev/bigbluebutton/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMapDelegate.as:513]
    at org.bigbluebutton.modules.videoconf.maps::VideoEventMapDelegate/skipCameraSettingsCheck()[/home/ubuntu/dev/bigbluebutton/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMapDelegate.as:222]
    at org.bigbluebutton.modules.videoconf.maps::VideoEventMapDelegate/autoStart()[/home/ubuntu/dev/bigbluebutton/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMapDelegate.as:187]
    at org.bigbluebutton.modules.videoconf.maps::VideoEventMapDelegate/openWebcamWindowFor()[/home/ubuntu/dev/bigbluebutton/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMapDelegate.as:251]
    at org.bigbluebutton.modules.videoconf.maps::VideoEventMapDelegate/openWebcamWindows()[/home/ubuntu/dev/bigbluebutton/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMapDelegate.as:233]
    at org.bigbluebutton.modules.videoconf.maps::VideoEventMapDelegate/connectedToVideoApp()[/home/ubuntu/dev/bigbluebutton/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/maps/VideoEventMapDelegate.as:480]
    at Function/http://adobe.com/AS3/2006/builtin::apply()
    at com.asfusion.mate.core::MethodCaller/call()[/Users/nahuel/Documents/Flex Builder 3/MateDevelopment/src/com/asfusion/mate/core/MethodCaller.as:107]
    at com.asfusion.mate.actions.builders::MethodInvoker/run()[/Users/nahuel/Documents/Flex Builder 3/MateDevelopment/src/com/asfusion/mate/actions/builders/MethodInvoker.as:113]
    at com.asfusion.mate.actions::AbstractAction/trigger()[/Users/nahuel/Documents/Flex Builder 3/MateDevelopment/src/com/asfusion/mate/actions/AbstractAction.as:61]
    at com.asfusion.mate.actionLists::AbstractHandlers/runSequence()[/Users/nahuel/Documents/Flex Builder 3/MateDevelopment/src/com/asfusion/mate/actionLists/AbstractHandlers.as:331]
    at com.asfusion.mate.actionLists::EventHandlers/fireEvent()[/Users/nahuel/Documents/Flex Builder 3/MateDevelopment/src/com/asfusion/mate/actionLists/EventHandlers.as:257]
    at flash.events::EventDispatcher/dispatchEventFunction()
    at flash.events::EventDispatcher/dispatchEvent()
    at mx.core::UIComponent/dispatchEvent()[/Users/aharui/release4.13.0/frameworks/projects/framework/src/mx/core/UIComponent.as:13682]
    at com.asfusion.mate.core::GlobalDispatcher/dispatchEvent()[/Users/nahuel/Documents/Flex Builder 3/MateDevelopment/src/com/asfusion/mate/core/GlobalDispatcher.as:110]
    at com.asfusion.mate.events::Dispatcher/dispatchEvent()[/Users/nahuel/Documents/Flex Builder 3/MateDevelopment/src/com/asfusion/mate/events/Dispatcher.as:240]
    at org.bigbluebutton.modules.videoconf.business::VideoProxy/onConnectedToVideoApp()[/home/ubuntu/dev/bigbluebutton/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/business/VideoProxy.as:102]
    at org.bigbluebutton.modules.videoconf.business::VideoProxy/onNetStatus()[/home/ubuntu/dev/bigbluebutton/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/business/VideoProxy.as:122]
```
Changed a little bit to avoid this scenario.