### PR TITLE
Keyboard navigation controls

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/audio-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/audio-menu/component.jsx
@@ -12,7 +12,7 @@ export default class JoinAudioOptions extends React.Component {
           onClick={this.props.close}
           label={'Leave Audio'}
           color={'danger'}
-          icon={'audio'}
+          icon={'mute'}
           size={'lg'}
           circle={true}
         />
@@ -29,7 +29,7 @@ export default class JoinAudioOptions extends React.Component {
         onClick={this.props.open}
         label={'Join Audio'}
         color={'primary'}
-        icon={'audio'}
+        icon={'unmute'}
         size={'lg'}
         circle={true}
       />

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/mute-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/mute-button/component.jsx
@@ -7,7 +7,7 @@ export default class MuteAudio extends React.Component {
   render() {
     const { isInAudio, isMuted, callback } = this.props;
     let label = !isMuted ? 'Mute' : 'Unmute';
-    let icon = !isMuted ? 'mute' : 'unmute';
+    let icon = !isMuted ? 'audio-off' : 'audio';
     let className = !isInAudio ? styles.invisible : null;
     let tabIndex = !isInAudio ? -1 : 0;
 

--- a/bigbluebutton-html5/imports/ui/components/audio-modal/audio-settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio-modal/audio-settings/component.jsx
@@ -14,10 +14,16 @@ export default class AudioSettings extends React.Component {
     super(props);
 
     this.chooseAudio = this.chooseAudio.bind(this);
+    this.handleClose = this.handleClose.bind(this);
   }
 
   chooseAudio() {
     this.props.changeMenu(this.props.JOIN_AUDIO);
+  }
+
+  handleClose() {
+    this.setState({ isOpen: false });
+    clearModal();
   }
 
   render() {
@@ -31,6 +37,14 @@ export default class AudioSettings extends React.Component {
             color={'primary'}
             ghost={true}
             onClick={this.chooseAudio}
+          />
+          <Button className={styles.closeBtn}
+            label={'Close'}
+            icon={'close'}
+            size={'lg'}
+            circle={true}
+            hideLabel={true}
+            onClick={this.handleClose}
           />
           <div>
             Choose your audio settings

--- a/bigbluebutton-html5/imports/ui/components/audio-modal/join-audio/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio-modal/join-audio/component.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import Button from '/imports/ui/components/button/component';
 import { clearModal } from '/imports/ui/components/app/service';
-import classNames from 'classnames';
-import ReactDOM from 'react-dom';
 import styles from '../styles.scss';
 
 export default class JoinAudio extends React.Component {

--- a/bigbluebutton-html5/imports/ui/components/audio-modal/listen-only/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio-modal/listen-only/component.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import Button from '/imports/ui/components/button/component';
-import classNames from 'classnames';
-import ReactDOM from 'react-dom';
+import { clearModal } from '/imports/ui/components/app/service';
 import styles from '../styles.scss';
+
 import StreamVolume from '/imports/ui/components/stream-volume/component';
 import SpeakerSource from '/imports/ui/components/speaker-source/component';
 import AudioTestContainer from '/imports/ui/components/audio-test/container';
@@ -13,10 +13,16 @@ export default class ListenOnly extends React.Component {
     super(props);
 
     this.chooseAudio = this.chooseAudio.bind(this);
+    this.handleClose = this.handleClose.bind(this);
   }
 
   chooseAudio() {
     this.props.changeMenu(this.props.JOIN_AUDIO);
+  }
+
+  handleClose() {
+    this.setState({ isOpen: false });
+    clearModal();
   }
 
   render() {
@@ -30,6 +36,14 @@ export default class ListenOnly extends React.Component {
             color={'primary'}
             ghost={true}
             onClick={this.chooseAudio}
+          />
+          <Button className={styles.closeBtn}
+            label={'Close'}
+            icon={'close'}
+            size={'lg'}
+            circle={true}
+            hideLabel={true}
+            onClick={this.handleClose}
           />
           <div>
             Choose your listen only settings

--- a/bigbluebutton-html5/imports/ui/components/dropdown/list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/list/component.jsx
@@ -71,6 +71,7 @@ export default class DropdownList extends Component {
     }
 
     if ([KEY_CODES.TAB, KEY_CODES.ESCAPE].includes(event.which)) {
+      nextActiveItemIndex = 0;
       dropdownHide();
     }
 
@@ -79,6 +80,8 @@ export default class DropdownList extends Component {
     if (typeof callback === 'function') {
       callback(event);
     }
+    console.log("active: " + activeItemIndex);
+    console.log("next: " + nextActiveItemIndex);
   }
 
   handleItemClick(event, callback) {

--- a/bigbluebutton-html5/imports/ui/components/dropdown/list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/list/component.jsx
@@ -80,8 +80,6 @@ export default class DropdownList extends Component {
     if (typeof callback === 'function') {
       callback(event);
     }
-    console.log("active: " + activeItemIndex);
-    console.log("next: " + nextActiveItemIndex);
   }
 
   handleItemClick(event, callback) {


### PR DESCRIPTION
- Fixed an issue where a user could tab away from an element and it would break most keyboard navigation controls
- Focus is now reinitialzed to the start of the list when moving to a new element via keyboard navigation
- Updated mute and unmute icons to match latest designs
- Updated join and leave audio icons to match latest designs