### PR TITLE
HTML5 - Fix Recording Indicator Logic

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/component.jsx
@@ -10,8 +10,7 @@ export default class RecordingIndicator extends Component {
   render() {
     const { beingRecorded } = this.props;
     let classNames = {};
-    classNames[styles.indicator] = true;
-    classNames[styles.beingRecorded] = beingRecorded;
+    classNames[styles.indicator] = beingRecorded;
 
     return (
       <span className={cx(classNames)}></span>

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/styles.scss
@@ -18,7 +18,6 @@
     margin-top: -($font-size-base / 4);
     margin-left: -($font-size-base / 4);
     border-radius: 50%;
-    background-color: $color-white;
-    background-color: $color-danger !important;
+    background-color: $color-danger;
   }
 }

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/styles.scss
@@ -19,11 +19,6 @@
     margin-left: -($font-size-base / 4);
     border-radius: 50%;
     background-color: $color-white;
-  }
-}
-
-.beingRecorded {
-  &:after {
     background-color: $color-danger !important;
   }
 }


### PR DESCRIPTION
Original:
The indicator is always visible.
If the meeting is currently being recorded,
Then indicator turns red

Changed to:
If the meeting is currently being recorded
Then the indicator is displayed and red