### PR TITLE
Fix recording playback hang in Firefox

### DIFF
--- a/record-and-playback/presentation/playback/presentation/0.9.0/lib/writing.js
+++ b/record-and-playback/presentation/playback/presentation/0.9.0/lib/writing.js
@@ -19,7 +19,6 @@
 
 
 // - - - START OF GLOBAL VARIABLES - - - //
-"use strict";
 
 function getUrlParameters() {
     console.log("** Getting url params");

--- a/record-and-playback/presentation/playback/presentation/0.9.0/lib/writing.js
+++ b/record-and-playback/presentation/playback/presentation/0.9.0/lib/writing.js
@@ -520,14 +520,8 @@ svgobj.setAttribute('data', shapes_svg);
 svgobj.setAttribute('height', '100%');
 svgobj.setAttribute('width', '100%');
 
-svgobj.addEventListener('load', function() {
-  console.log("got svgobj 'load' event");
+var setupWriting = function() {
   runPopcorn();
-
-  if (svjobjLoaded) {
-    return;
-  }
-  svjobjLoaded = true;
 
   generateThumbnails();
 
@@ -535,6 +529,17 @@ svgobj.addEventListener('load', function() {
   p.currentTime(defineStartTime());
 
   removeLoadingScreen();
+}
+
+svgobj.addEventListener('load', function() {
+  console.log("got svgobj 'load' event");
+
+  if (svjobjLoaded) {
+    return;
+  }
+  svjobjLoaded = true;
+
+  window.await_video_loaded(setupWriting);
 }, false);
 
 // Fetches the metadata associated with the recording and uses it to configure

--- a/record-and-playback/presentation/playback/presentation/0.9.0/playback.js
+++ b/record-and-playback/presentation/playback/presentation/0.9.0/playback.js
@@ -422,6 +422,24 @@ load_spinner = function(){
   spinner = new Spinner(opts).spin(target);
 };
 
+var video_loaded_callbacks = [];
+var video_loaded = false;
+
+var notify_video_loaded = function() {
+  video_loaded = true;
+  for (i = 0; i < video_loaded_callbacks.length; i++) {
+    video_loaded_callbacks[i]();
+  }
+};
+window.await_video_loaded = function(callback) {
+  if (video_loaded) {
+    /* Video is already loaded, just immediately execute the callback */
+    callback();
+  } else {
+    video_loaded_callbacks.push(callback);
+  }
+}
+
 
 document.addEventListener("DOMContentLoaded", function() {
   console.log("==DOM content loaded");
@@ -433,6 +451,11 @@ document.addEventListener("DOMContentLoaded", function() {
     google_frame_warning();
   }
 
+  load_spinner();
+  console.log("==Hide playback content");
+  $("#playback-content").css('visibility', 'hidden');
+
+
   if (checkUrl(RECORDINGS + '/video/webcams.webm') == true) {
     hasVideo = true;
     $("#audio-area").attr("style", "display:none;");
@@ -443,10 +466,6 @@ document.addEventListener("DOMContentLoaded", function() {
     load_audio();
   }
 
-  load_spinner();
-  console.log("==Hide playback content");
-  $("#playback-content").css('visibility', 'hidden');
-
   //load up the acorn controls
   console.log("==Loading acorn media player ");
   $('#video').acornMediaPlayer({
@@ -456,6 +475,8 @@ document.addEventListener("DOMContentLoaded", function() {
   $('#video').on("swap", function() {
     swapVideoPresentation();
   });
+
+  notify_video_loaded();
 
   resizeComponents();
 }, false);

--- a/record-and-playback/presentation/playback/presentation/0.9.0/playback.js
+++ b/record-and-playback/presentation/playback/presentation/0.9.0/playback.js
@@ -286,19 +286,6 @@ generateThumbnails = function() {
   }
 }
 
-google_frame_warning = function(){
-  console.log("==Google frame warning");
-  var message = "To support this playback please install 'Google Chrome Frame', or use other browser: Firefox, Safari, Chrome, Opera";
-  var line = document.createElement("p");
-  var link = document.createElement("a");
-  line.appendChild(document.createTextNode(message));
-  link.setAttribute("href", "http://www.google.com/chromeframe")
-  link.setAttribute("target", "_blank")
-  link.appendChild(document.createTextNode("Install Google Chrome Frame"));
-  document.getElementById("chat").appendChild(line);
-  document.getElementById("chat").appendChild(link);
-}
-
 function checkUrl(url)
 {
   try {
@@ -446,10 +433,6 @@ document.addEventListener("DOMContentLoaded", function() {
   var appName = navigator.appName;
   var appVersion = navigator.appVersion;
   var spinner;
-
-  if (appName == "Microsoft Internet Explorer" && navigator.userAgent.match("chromeframe") == false ) {
-    google_frame_warning();
-  }
 
   load_spinner();
   console.log("==Hide playback content");


### PR DESCRIPTION
In some cases, the recording playback would hang on loading in Firefox. I've traced this down to a race condition between an asynchronous load that tries to use the video element and the code which actually sets up the video element. It might sometimes attempt to set up popcorn prior to the video element being available on the page. (This was made worse when caption support was added, because captions adds an extra http request that slows down the video element creation).

The fix is to add a callback when the video element is set up, and have the "writing" (presentation area) setup be delayed until that callback is fired.