### PR TITLE
Show audio modal on client load

### DIFF
--- a/bigbluebutton-html5/client/main.jsx
+++ b/bigbluebutton-html5/client/main.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { Meteor } from 'meteor/meteor';
 import { render } from 'react-dom';
+import { showModal } from '/imports/ui/components/app/service';
 import { renderRoutes } from '../imports/startup/client/routes.js';
 import { IntlProvider } from 'react-intl';
 import Singleton from '/imports/ui/services/storage/local.js';
+import AudioModalContainer  from '/imports/ui/components/audio-modal/container';
 
 function loadUserSettings() {
     const userSavedFontSize = Singleton.getItem('bbbSavedFontSizePixels');
@@ -11,6 +13,15 @@ function loadUserSettings() {
     if (userSavedFontSize) {
       document.getElementsByTagName('html')[0].style.fontSize = userSavedFontSize;
     }
+}
+
+function setAudio() {
+  const LOG_CONFIG = Meteor.settings || {};
+  let autoJoinAudio = LOG_CONFIG.public.app.autoJoinAudio;
+
+  if (autoJoinAudio) {
+    showModal( <AudioModalContainer /> );
+  }
 }
 
 function setMessages(data) {
@@ -22,6 +33,8 @@ function setMessages(data) {
       {renderRoutes()}
     </IntlProvider>
   ), document.getElementById('app'));
+
+  setAudio();
 }
 
 // Helper to load javascript libraries from the BBB server

--- a/bigbluebutton-html5/imports/locales/en.json
+++ b/bigbluebutton-html5/imports/locales/en.json
@@ -89,5 +89,7 @@
   "app.breakoutJoinConfirmation.dismissDesc": "Closes and rejects Joining the Breakout Room",
   "app.breakoutTimeRemainingMessage": "Breakout Room time remaining: {time}",
   "app.breakoutWillCloseMessage": "Time ended. Breakout Room will close soon",
-  "app.calculatingBreakoutTimeRemaining": "Calculating remaining time..."
+  "app.calculatingBreakoutTimeRemaining": "Calculating remaining time...",
+  "app.audioModal.microphoneLabel": "Microphone",
+  "app.audioModal.listenOnlyLabel": "Listen Only"
 }

--- a/bigbluebutton-html5/imports/ui/components/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio-modal/container.jsx
@@ -1,0 +1,24 @@
+import React, { Component, PropTypes } from 'react';
+import { createContainer } from 'meteor/react-meteor-data';
+import Audio from './component';
+import { joinListenOnly } from '/imports/api/phone';
+
+export default class AudioModalContainer extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+
+    let handleJoinListenOnly = () => {
+      return joinListenOnly();
+    };
+
+    return (
+
+      <Audio
+        handleJoinListenOnly={handleJoinListenOnly}
+      />
+    );
+  }
+}

--- a/bigbluebutton-html5/imports/ui/components/audio-modal/join-audio/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio-modal/join-audio/component.jsx
@@ -44,7 +44,7 @@ export default class JoinAudio extends React.Component {
         </div>
         <div className={styles.center}>
           <Button className={styles.audioBtn}
-            label={'Audio'}
+            label={'Microphone'}
             icon={'audio'}
             circle={true}
             size={'jumbo'}

--- a/bigbluebutton-html5/imports/ui/components/audio-modal/join-audio/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio-modal/join-audio/component.jsx
@@ -1,9 +1,19 @@
 import React from 'react';
+import styles from '../styles.scss';
 import Button from '/imports/ui/components/button/component';
 import { clearModal } from '/imports/ui/components/app/service';
-import styles from '../styles.scss';
+import { defineMessages, injectIntl } from 'react-intl';
 
-export default class JoinAudio extends React.Component {
+const intlMessages = defineMessages({
+  microphoneLabel: {
+    id: 'app.audioModal.microphoneLabel',
+  },
+  listenOnlyLabel: {
+    id: 'app.audioModal.listenOnlyLabel',
+  },
+});
+
+class JoinAudio extends React.Component {
   constructor(props) {
     super(props);
 
@@ -27,6 +37,7 @@ export default class JoinAudio extends React.Component {
   }
 
   render() {
+    const { intl } = this.props;
     return (
       <div>
         <div className={styles.center}>
@@ -44,14 +55,14 @@ export default class JoinAudio extends React.Component {
         </div>
         <div className={styles.center}>
           <Button className={styles.audioBtn}
-            label={'Microphone'}
+            label={intl.formatMessage(intlMessages.microphoneLabel)}
             icon={'audio'}
             circle={true}
             size={'jumbo'}
             onClick={this.openAudio}
           />
           <Button className={styles.audioBtn}
-            label={'Listen Only'}
+            label={intl.formatMessage(intlMessages.listenOnlyLabel)}
             icon={'listen'}
             circle={true}
             size={'jumbo'}
@@ -62,3 +73,5 @@ export default class JoinAudio extends React.Component {
     );
   }
 };
+
+export default injectIntl(JoinAudio);

--- a/bigbluebutton-html5/imports/ui/components/audio-modal/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/audio-modal/styles.scss
@@ -16,6 +16,7 @@
 Button.closeBtn span:first-child {
   color: $color-gray-light;
   background: none;
+  background-color: $color-primary;
   border: none;
   box-shadow: none;
 }
@@ -23,7 +24,8 @@ Button.closeBtn span:first-child {
 // Modifies the audio button icon colour
 Button.audioBtn span:first-child {
   color: #25385D;
-  border: 5px solid #FFF;
+  border: 5px solid $color-white;
+  background-color: $color-primary;
   box-shadow: none;
 }
 

--- a/bigbluebutton-html5/private/config/public/app.yaml
+++ b/bigbluebutton-html5/private/config/public/app.yaml
@@ -5,7 +5,7 @@ app:
   desktopFont: 14
 
   # Will offer the user to join the audio when entering the meeting
-  autoJoinAudio: false
+  autoJoinAudio: true
   listenOnly: false
   skipCheck: false
 


### PR DESCRIPTION
When the client loads, the audio modal is displayed first to get the users audio preference.
The modal buttons have been made more visible and renamed one of the labels.