### PR TITLE
Backported #3519 to 1.0 so Chrome works better

### DIFF
--- a/bigbluebutton-client/resources/prod/BigBlueButton.html
+++ b/bigbluebutton-client/resources/prod/BigBlueButton.html
@@ -23,6 +23,7 @@
       }
     </style>
     
+    <script src="lib/bbb_blinker.js?v=VERSION" language="javascript"></script>
     <script type="text/javascript" src="swfobject/swfobject.js"></script>
     <script src="lib/deployJava.js?v=VERSION" language="javascript"></script>
     <script type="text/javascript">
@@ -62,8 +63,23 @@
       attributes.name = "BigBlueButton";
       attributes.align = "middle";
       attributes.tabIndex = 0;
-      swfobject.embedSWF("BigBlueButton.swf?v=VERSION", "altFlash", "100%", "100%", "11.0.0", "expressInstall.swf", flashvars, params, attributes, embedCallback);
-      
+
+      // In Chrome 56 Google started blocking Flash by default so we force the SWF to 
+      // be loaded in the DOM rather than relying on the SWFObject code to detect 
+      // Flash because it can't.
+      var browserInfo = determineBrowser();
+      if (browserInfo && browserInfo[0] === "Chrome") {
+        // Added a sort of callback idea because when this script runs "content" doesn't exist yet
+        var fillContent = function(){
+          var content = document.getElementById("content");
+          if (content) {
+            content.innerHTML = '<object type="application/x-shockwave-flash" id="BigBlueButton" name="BigBlueButton" tabindex="0" data="BigBlueButton.swf?v=VERSION" style="position: relative; top: 0.5px;" width="100%" height="100%" align="middle"><param name="quality" value="high"><param name="bgcolor" value="#869ca7"><param name="allowfullscreen" value="true"><param name="wmode" value="window"><param name="allowscriptaccess" value="true"><param name="seamlesstabbing" value="true"></object>';
+          }
+        };
+      } else {
+        swfobject.embedSWF("BigBlueButton.swf?v=VERSION", "altFlash", "100%", "100%", "11.0.0", "expressInstall.swf", flashvars, params, attributes, embedCallback);
+      }
+
       function embedCallback(e) {
         // Work around pixel alignment bug with Chrome 21 on Mac.
         // See: http://code.google.com/p/bigbluebutton/issues/detail?id=1294
@@ -90,7 +106,6 @@
     <script src="lib/bbblogger.js?v=VERSION" language="javascript"></script>
     <script src="lib/bigbluebutton.js?v=VERSION" language="javascript"></script>
     <script src="lib/bbb_localization.js?v=VERSION" language="javascript"></script>
-    <script src="lib/bbb_blinker.js?v=VERSION" language="javascript"></script>
     <script src="lib/bbb_deskshare.js?v=VERSION" language="javascript"></script>
     <script src="lib/bbb_api_bridge.js?v=VERSION" language="javascript"></script>
     <script src="lib/sip.js?v=VERSION" language="javascript"></script> 
@@ -114,6 +129,8 @@
             document.getElementById('html5Section').style.display='inherit';
           }
         });
+        
+        if (fillContent) fillContent();
       };
 
       function html5() {


### PR DESCRIPTION
This PR backports the hack I put in #3519 to force the SWF content to load in Chrome because they are hiding the fact that Flash is available in newer versions.