### PR TITLE
Fix for the case where last voice user was kicked

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/UsersApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/UsersApp.scala
@@ -577,9 +577,8 @@ trait UsersApp {
           userLeaving foreach (u => outGW.send(new UserLeft(mProps.meetingID, mProps.recorded, u)))
         }
       }
-
-      stopRecordingVoiceConference()
     }
+    stopRecordingVoiceConference()
   }
 
   def handleUserMutedInVoiceConfMessage(msg: UserMutedInVoiceConfMessage) {


### PR DESCRIPTION
Issue: Incorrect state in akka-apps leads to recording start/stop inconsistencies
Solution: move the clean-up logic so it triggers even if the voice user is ejected. This eliminates the application state issue and the recording start/stop execute correctly