### PR TITLE
Fix screenshare preview on reconnect. Fixes #3252

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/services/red5/Connection.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/services/red5/Connection.as
@@ -70,7 +70,12 @@ package org.bigbluebutton.modules.screenshare.services.red5 {
             netConnection.client = this;
             netConnection.addEventListener( NetStatusEvent.NET_STATUS , netStatusHandler);
             netConnection.addEventListener(SecurityErrorEvent.SECURITY_ERROR, securityErrorHandler);
-            uri = uri + "/" + UsersUtil.getInternalMeetingID();
+
+            // uri may include internal meetingId if we are reconnecting
+            var internalMeetingID:String = UsersUtil.getInternalMeetingID();
+            if (uri.indexOf(internalMeetingID) == -1) {
+                uri = uri + "/" + internalMeetingID;
+            }
 
             LOGGER.debug("Connecting to uri=[{0}]", [uri]);
             netConnection.connect(uri);

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/ScreenshareViewWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/ScreenshareViewWindow.mxml
@@ -134,9 +134,9 @@
 					
 			public function startVideo(connection:Connection):void{
         var logData:Object = new Object();
-        logData.width = videoWidth;
-        logData.height = videoHeight;
-        logData.streamId = streamId;
+        logData.width = ScreenshareModel.getInstance().width;
+        logData.height = ScreenshareModel.getInstance().height;
+        logData.streamId = ScreenshareModel.getInstance().streamId;
         
         JSLog.debug(LOG + "startVideo", logData);
         


### PR DESCRIPTION
The uri for the screenshare stream was incorrectly modified on reconnect, resulting in blank view in the screenshare views. This pull request adds a check to see if we need to append the meetingID to ensure the stream uri is always of the correct form.
Fixes #3252