### PR TITLE
Remove screenshare WebRTC options from config.xml

### DIFF
--- a/bigbluebutton-client/resources/config.xml.template
+++ b/bigbluebutton-client/resources/config.xml.template
@@ -47,8 +47,6 @@
 			uri="rtmp://HOST/screenshare"
 			showButton="true"
 			baseTabIndex="201"
-			tryWebRTCFirst="false"
-			chromeExtensionKey=""
 			help="http://HOST/client/help/screenshare-help.html"
 		/>
     


### PR DESCRIPTION
Removing the options from config.xml because the functionality isn't finished and people are trying to turn it on because it's there.