### PR TITLE
html5client: limit sound on unread chat via Settings and Config

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -7,11 +7,11 @@ import KickedScreen from '../kicked-screen/component';
 
 import NotificationsBarContainer from '../notifications-bar/container';
 
+import LocalStorage from '/imports/ui/services/storage/local.js';
+
 import Button from '../button/component';
 import styles from './styles';
 import cx from 'classnames';
-
-import ChatService from '../chat/service';
 
 const propTypes = {
   navbar: PropTypes.element,
@@ -169,7 +169,8 @@ export default class App extends Component {
 
       // compare openChats(chatID) to chatID of currently opened chat room
       if (openChats[i] !== openChat) {
-        if (chat > prevProps.unreadMessageCount[i]) {
+        let shouldPlaySound = LocalStorage.getItem('audioNotifChat') || Meteor.settings.public.app.audioChatNotification;
+        if (shouldPlaySound && chat > prevProps.unreadMessageCount[i]) {
           this.playSoundForUnreadMessages();
         }
       }

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -17,11 +17,9 @@ export default class ApplicationMenu extends BaseMenu {
 
   checkBoxHandler(fieldname) {
     let obj = {};
-    console.log("in checkBoxHandler " + fieldname + "   " + this.state[fieldname]);
     obj[fieldname] = !this.state[fieldname];
     LocalStorage.setItem('audioNotifChat', obj[fieldname]);
     this.setState(obj);
-    console.log(obj); //
   }
 
   getContent() {

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -5,18 +5,38 @@ import Button from '/imports/ui/components/button/component';
 import BaseMenu from '../base/component';
 import ReactDOM from 'react-dom';
 import styles from '../styles.scss';
+import LocalStorage from '/imports/ui/services/storage/local.js';
 
 export default class ApplicationMenu extends BaseMenu {
   constructor(props) {
     super(props);
+    this.state = {
+      audioNotifChat: LocalStorage.getItem('audioNotifChat') || Meteor.settings.public.app.audioChatNotification,
+    }
+  }
+
+  checkBoxHandler(fieldname) {
+    let obj = {};
+    console.log("in checkBoxHandler " + fieldname + "   " + this.state[fieldname]);
+    obj[fieldname] = !this.state[fieldname];
+    LocalStorage.setItem('audioNotifChat', obj[fieldname]);
+    this.setState(obj);
+    console.log(obj); //
   }
 
   getContent() {
     return (
       <div className={styles.full} role='presentation'>
           <div className={styles.row} role='presentation'>
-            <label><input type='checkbox' tabIndex='7' aria-labelledby='audioNotifLabel'
-              aria-describedby='audioNotifDesc' />Audio notifications for chat</label>
+            <label>
+              <input type='checkbox'
+                          tabIndex='7'
+                          onChange={this.checkBoxHandler.bind(this, "audioNotifChat")}
+                          checked={this.state.audioNotifChat}
+                          aria-labelledby='audioNotifLabel'
+                          aria-describedby='audioNotifDesc' />
+              Audio notifications for chat
+            </label>
             <div id='audioNotifLabel' hidden>Audio notifications</div>
             <div id='audioNotifDesc' hidden>
               Toggles the audio notifications for chat.</div>

--- a/bigbluebutton-html5/private/config/public/app.yaml
+++ b/bigbluebutton-html5/private/config/public/app.yaml
@@ -4,6 +4,9 @@ app:
   mobileFont: 16
   desktopFont: 14
 
+  # Audio notification for unread chat message
+  audioChatNotification: false
+
   # Will offer the user to join the audio when entering the meeting
   autoJoinAudio: true
   listenOnly: false


### PR DESCRIPTION
We added sound on unread chat message but we missed a few points and this PR is addressing them:
* add a config option and set the feature to false (default)
* hook existing the Settings ->Application checkbox to correspond to the above config
* check the settings to decide whether to play the sound on unread message