### PR TITLE
Reduce Modal Size

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/mute-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/mute-button/component.jsx
@@ -7,7 +7,7 @@ export default class MuteAudio extends React.Component {
   render() {
     const { isInAudio, isMuted, callback } = this.props;
     let label = !isMuted ? 'Mute' : 'Unmute';
-    let icon = !isMuted ? 'audio-off' : 'audio';
+    let icon = !isMuted ? 'audio' : 'audio-off';
     let className = !isInAudio ? styles.invisible : null;
     let tabIndex = !isInAudio ? -1 : 0;
 

--- a/bigbluebutton-html5/imports/ui/components/modal/base/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/modal/base/styles.scss
@@ -22,9 +22,7 @@
 
 .overlay {
   z-index: 1000;
-  // background: transparentize($color-white, .35);
-  background: #fff;
-  // background: transparentize($color-gray-dark, .40);
+  background: transparentize($color-gray-dark, .40);
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
The modal size stays the same, but by adding a transparent style background to the modal, we are able to see the application behind it, giving the appearance of it now being smaller.

Also fixed the inverted icon on the Actionbar Mute button for displaying the status of the mic to match the icon in the Userslist.