### PR TITLE
Fixed userlist and chat scrolling in Firefox

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-list/styles.scss
@@ -7,6 +7,10 @@
   flex-grow: 1;
   flex-shrink: 1;
   position: relative;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding-right: 12px;
+  padding-bottom: 12px;
 }
 
 .messageList {

--- a/bigbluebutton-html5/imports/ui/components/chat/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/chat/styles.scss
@@ -6,6 +6,7 @@
   display: flex;
   flex-grow: 1;
   flex-direction: column;
+  overflow: hidden;
 }
 
 .closeChat {

--- a/bigbluebutton-html5/imports/ui/components/user-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-list/styles.scss
@@ -91,6 +91,7 @@ $user-icons-color-hover: $color-gray;
 .content {
   @extend %flex-column;
   flex-grow: 9;
+  overflow: hidden;
 }
 
 .lists {
@@ -135,6 +136,8 @@ $user-icons-color-hover: $color-gray;
   flex-basis: 31rem;
   flex-grow: 1;
   flex-shrink: 1;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .separator {


### PR DESCRIPTION
fixes #3597
- Users list in participants menu is now scrollable
- Chat message area now scrolls properly in Firefox
- Chat message area now properly scrolls to the bottom to instantly to see new messages in Firefox