### PR TITLE
Webcams only for moderator fix

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/Conference.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/Conference.as
@@ -201,11 +201,8 @@ package org.bigbluebutton.main.model.users {
         }
 
         public function userIsModerator(userId:String):Boolean {
-            var moderator:BBBUser = getTheOnlyModerator();
-            if (moderator != null) {
-                return moderator.userID == userId;
-            }
-            return false;
+            var user:BBBUser = getUser(userId);
+            return user != null && user.role == Role.MODERATOR;
         }
 
 		public function getPresenter():BBBUser {

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/Conference.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/Conference.as
@@ -29,6 +29,7 @@ package org.bigbluebutton.main.model.users {
 	import org.bigbluebutton.common.Role;
 	import org.bigbluebutton.core.BBB;
 	import org.bigbluebutton.core.model.Config;
+	import org.bigbluebutton.core.model.MeetingModel;
 	import org.bigbluebutton.core.vo.CameraSettingsVO;
 	import org.bigbluebutton.core.vo.LockSettingsVO;
 	
@@ -197,14 +198,14 @@ package org.bigbluebutton.main.model.users {
 				}
 			}
 			return null;
-		}
+        }
 
-        public function getModeratorUserId():String {
+        public function userIsModerator(userId:String):Boolean {
             var moderator:BBBUser = getTheOnlyModerator();
             if (moderator != null) {
-                return moderator.userID;
+                return moderator.userID == userId;
             }
-            return null;
+            return false;
         }
 
 		public function getPresenter():BBBUser {
@@ -417,14 +418,19 @@ package org.bigbluebutton.main.model.users {
 			}
 			users.refresh();
 		}
-		
-		public function sharedWebcam(userId:String, stream:String):void {
-			var aUser:BBBUser = getUser(userId);
-			if (aUser != null) {
-				aUser.sharedWebcam(stream)
-			}
-			users.refresh();
-		}
+
+        public function sharedWebcam(userId:String, stream:String):void {
+            var webcamsOnlyForModerator:Boolean = MeetingModel.getInstance().meeting.webcamsOnlyForModerator;
+            if (!webcamsOnlyForModerator || 
+				(webcamsOnlyForModerator && (amIModerator() || userIsModerator(userId)))
+			) {
+                var aUser:BBBUser = getUser(userId);
+                if (aUser != null) {
+                    aUser.sharedWebcam(stream)
+                }
+                users.refresh();
+            }
+        }
 		
 		public function unsharedWebcam(userId:String, stream:String):void {
 			var aUser:BBBUser = getUser(userId);

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/Conference.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/Conference.as
@@ -198,7 +198,15 @@ package org.bigbluebutton.main.model.users {
 			}
 			return null;
 		}
-		
+
+        public function getModeratorUserId():String {
+            var moderator:BBBUser = getTheOnlyModerator();
+            if (moderator != null) {
+                return moderator.userID;
+            }
+            return null;
+        }
+
 		public function getPresenter():BBBUser {
 			var p:BBBUser;
 			for (var i:int = 0; i < users.length; i++) {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
@@ -550,15 +550,10 @@ package org.bigbluebutton.modules.users.services
       UserManager.getInstance().getConference().emojiStatus(map.userId, map.emojiStatus);
     }
 
-        private function handleUserSharedWebcam(msg:Object):void {
-            var map:Object = JSON.parse(msg.msg);
-            var webcamsOnlyForModerator:Boolean = MeetingModel.getInstance().meeting.webcamsOnlyForModerator;
-            if (!webcamsOnlyForModerator) {
-                UserManager.getInstance().getConference().sharedWebcam(map.userId, map.webcamStream);
-            } else if (webcamsOnlyForModerator && (UserManager.getInstance().getConference().amIModerator() || (map.userId == UserManager.getInstance().getConference().getModeratorUserId()))) {
-                UserManager.getInstance().getConference().sharedWebcam(map.userId, map.webcamStream);
-            }
-        }
+    private function handleUserSharedWebcam(msg:Object):void {
+        var map:Object = JSON.parse(msg.msg);
+        UserManager.getInstance().getConference().sharedWebcam(map.userId, map.webcamStream);
+    }
 
     private function handleUserUnsharedWebcam(msg: Object):void {  
 	  var map:Object = JSON.parse(msg.msg);

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
@@ -548,19 +548,17 @@ package org.bigbluebutton.modules.users.services
     private function handleEmojiStatusHand(msg: Object): void {   
       var map:Object = JSON.parse(msg.msg);      
       UserManager.getInstance().getConference().emojiStatus(map.userId, map.emojiStatus);
-        }
-
-    private function handleUserSharedWebcam(msg:Object):void {
-        var map:Object = JSON.parse(msg.msg);
-        if (!MeetingModel.getInstance().meeting.webcamsOnlyForModerator) {
-            UserManager.getInstance().getConference().sharedWebcam(map.userId, map.webcamStream);
-        } else if (
-			UserManager.getInstance().getConference().amIModerator() || 
-			(UserManager.getInstance().getConference().getUser(map.userId) != null && UserManager.getInstance().getConference().getUser(map.userId).role == Role.MODERATOR)
-		) {
-            UserManager.getInstance().getConference().sharedWebcam(map.userId, map.webcamStream);
-        }
     }
+
+        private function handleUserSharedWebcam(msg:Object):void {
+            var map:Object = JSON.parse(msg.msg);
+            var webcamsOnlyForModerator:Boolean = MeetingModel.getInstance().meeting.webcamsOnlyForModerator;
+            if (!webcamsOnlyForModerator) {
+                UserManager.getInstance().getConference().sharedWebcam(map.userId, map.webcamStream);
+            } else if (webcamsOnlyForModerator && (UserManager.getInstance().getConference().amIModerator() || (map.userId == UserManager.getInstance().getConference().getModeratorUserId()))) {
+                UserManager.getInstance().getConference().sharedWebcam(map.userId, map.webcamStream);
+            }
+        }
 
     private function handleUserUnsharedWebcam(msg: Object):void {  
 	  var map:Object = JSON.parse(msg.msg);


### PR DESCRIPTION
Fix webcamsOnlyForModerator feature:

- Whatever the connection order of users, webcams will only be displayed to the moderator.
- Late joiners will only see the moderator webcam instead of seeing all webcams.