### PR TITLE
Breakout rooms UI imporve

### DIFF
--- a/bigbluebutton-client/branding/default/style/css/BBBDefault.css
+++ b/bigbluebutton-client/branding/default/style/css/BBBDefault.css
@@ -1061,6 +1061,11 @@ EmojiGrid {
 	horizontalGap: 6;
 }
 
+RoomActionsRenderer {
+	paddingLeft  : 5;
+	paddingRight : 5;
+}
+
 .breakoutRoomUserWindowHeadingStyle {
 	fontWeight: bold;
 }

--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -641,10 +641,9 @@ bbb.lockSettings.lockOnJoin=Lock On Join
 
 bbb.users.breakout.breakoutRooms = Breakout Rooms
 bbb.users.breakout.updateBreakoutRooms = Update Breakout Rooms
-bbb.users.breakout.remainingTimeBreakout = {0}: <b>{1} remaining</b>
-bbb.users.breakout.remainingTimeParent = <b>{1} remaining</b>
+bbb.users.breakout.timer = <b>{1}</b>
 bbb.users.breakout.calculatingRemainingTime = Calculating remaining time...
-bbb.users.breakout.remainingTimeEnded = Time ended, breakout room will close.
+bbb.users.breakout.closing = Closing
 bbb.users.breakout.rooms = Rooms
 bbb.users.breakout.roomsCombo.accessibilityName = Number of rooms to create
 bbb.users.breakout.room = Room

--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -641,7 +641,7 @@ bbb.lockSettings.lockOnJoin=Lock On Join
 
 bbb.users.breakout.breakoutRooms = Breakout Rooms
 bbb.users.breakout.updateBreakoutRooms = Update Breakout Rooms
-bbb.users.breakout.timer = <b>{1}</b>
+bbb.users.breakout.timer = <b>{0}</b>
 bbb.users.breakout.calculatingRemainingTime = Calculating remaining time...
 bbb.users.breakout.closing = Closing
 bbb.users.breakout.rooms = Rooms

--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -642,6 +642,7 @@ bbb.lockSettings.lockOnJoin=Lock On Join
 bbb.users.breakout.breakoutRooms = Breakout Rooms
 bbb.users.breakout.updateBreakoutRooms = Update Breakout Rooms
 bbb.users.breakout.timer = <b>{0}</b>
+bbb.users.breakout.timer.toolTip = Time left for breakout rooms
 bbb.users.breakout.calculatingRemainingTime = Calculating remaining time...
 bbb.users.breakout.closing = Closing
 bbb.users.breakout.rooms = Rooms

--- a/bigbluebutton-client/src/org/bigbluebutton/core/TimerUtil.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/TimerUtil.as
@@ -36,13 +36,10 @@ package org.bigbluebutton.core {
 				timer.addEventListener(TimerEvent.TIMER, function():void {
 					var remainingSeconds:int = timer.repeatCount - timer.currentCount;
 					var formattedTime:String = (Math.floor(remainingSeconds / 60)) + ":" + (remainingSeconds % 60 >= 10 ? "" : "0") + (remainingSeconds % 60);
-					label.htmlText = ResourceUtil.getInstance().getString(
-						UserManager.getInstance().getConference().isBreakout ? 'bbb.users.breakout.remainingTimeBreakout' : 'bbb.users.breakout.remainingTimeParent',
-						[UserManager.getInstance().getConference().meetingName, formattedTime]
-					);
+					label.htmlText = ResourceUtil.getInstance().getString('bbb.users.breakout.timer', [formattedTime]);
 				});
 				timer.addEventListener(TimerEvent.TIMER_COMPLETE, function():void {
-					label.text = ResourceUtil.getInstance().getString('bbb.users.breakout.remainingTimeEnded');
+					label.text = ResourceUtil.getInstance().getString('bbb.users.breakout.closing');
 				});
 			} else {
 				timer.stop();

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
@@ -782,7 +782,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		<mx:HBox id="timerBox" styleName="breakoutRoomTimerBox"
 				 includeInLayout="false" visible="false"
 				 width="100%" height="0">
-			<mx:Label id="timerLabel" text="{ResourceUtil.getInstance().getString('bbb.users.breakout.calculatingRemainingTime')}"/>
+			<mx:Label id="timerLabel" 
+					  text="{ResourceUtil.getInstance().getString('bbb.users.breakout.calculatingRemainingTime')}"
+					  toolTip="{ResourceUtil.getInstance().getString('bbb.users.breakout.timer.toolTip')}"/>
 		</mx:HBox>
 	</mx:VBox>
 

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
@@ -665,7 +665,7 @@
 	</mx:VBox>
 
 	<mx:ControlBar width="100%">
-		<mx:Button id="emojiStatusBtn" icon="{images.emoji_raiseHand}" width="30" height="30"
+		<mx:Button id="emojiStatusBtn" icon="{images.emoji_happy}" width="30" height="30"
 				   accessibilityName="{ResourceUtil.getInstance().getString('bbb.users.emojiStatusBtn.toolTip')}"
 				   toolTip="{ResourceUtil.getInstance().getString('bbb.users.emojiStatusBtn.toolTip')}" click="openEmojiStatusMenu()"
 				   visible="true" />

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
@@ -629,7 +629,8 @@
 			 width="100%" height="180">
 		<mx:HBox width="100%">
 			<mx:Label styleName="breakoutRoomUserWindowHeadingStyle" text="{ResourceUtil.getInstance().getString('bbb.users.breakout.breakoutRooms')}"/>
-			<mx:Label styleName="breakoutRoomUserWindowHeadingStyle" width="100%" textAlign="right" id="breakoutTimeLabel" text="..."/>
+			<mx:Label styleName="breakoutRoomUserWindowHeadingStyle" width="100%" textAlign="right" id="breakoutTimeLabel"
+					  text="..." toolTip="{ResourceUtil.getInstance().getString('bbb.users.breakout.timer.toolTip')}"/>
 		</mx:HBox>
 
 		<mx:DataGrid id="roomsGrid" editable="false" sortableColumns="false" dataProvider="{breakoutRoomsList}"

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
@@ -602,6 +602,15 @@
 			private function breakoutRoomNameLabelFunction(item:Object, column:DataGridColumn) : String {
 				return ResourceUtil.getInstance().getString('bbb.users.roomsGrid.room') + " " + item.sequence;
 			}
+
+            private function breakoutRoomsToolTip(item:Object):String {
+                var room:BreakoutRoom = item as BreakoutRoom;
+                var names:Array = [];
+                for (var i:int = 0; i < room.users.length; i++) {
+                    names.push(room.users.getItemAt(i)["name"]);
+                }
+                return names.join("\n");
+            }
 		]]>
 	</mx:Script>
 
@@ -633,14 +642,20 @@
 					  text="..." toolTip="{ResourceUtil.getInstance().getString('bbb.users.breakout.timer.toolTip')}"/>
 		</mx:HBox>
 
-		<mx:DataGrid id="roomsGrid" editable="false" sortableColumns="false" dataProvider="{breakoutRoomsList}"
+		<mx:DataGrid id="roomsGrid" editable="false" sortableColumns="false"
+					 dataProvider="{breakoutRoomsList}" dataTipFunction="breakoutRoomsToolTip"
 					 dragEnabled="false" width="100%" height="100%" draggableColumns="false"
 					 accessibilityName="{ResourceUtil.getInstance().getString('bbb.users.breakout.breakoutRooms')}">
 			<mx:columns>
-				<mx:DataGridColumn labelFunction="breakoutRoomNameLabelFunction" headerText="{ResourceUtil.getInstance().getString('bbb.users.roomsGrid.room')}" />
-				<mx:DataGridColumn dataField="numberOfUsers" headerText="{ResourceUtil.getInstance().getString('bbb.users.roomsGrid.users')}"/>
-				<mx:DataGridColumn dataField="meetingId" headerText="{ResourceUtil.getInstance().getString('bbb.users.roomsGrid.action')}"
+				<mx:DataGridColumn labelFunction="breakoutRoomNameLabelFunction"
+								   showDataTips="true"
+								   headerText="{ResourceUtil.getInstance().getString('bbb.users.roomsGrid.room')}" />
+				<mx:DataGridColumn dataField="numberOfUsers"
+								   showDataTips="true"
+								   headerText="{ResourceUtil.getInstance().getString('bbb.users.roomsGrid.users')}"/>
+				<mx:DataGridColumn dataField="meetingId"
 								   visible="{amIModerator}"
+								   headerText="{ResourceUtil.getInstance().getString('bbb.users.roomsGrid.action')}"
 								   itemRenderer="org.bigbluebutton.modules.users.views.RoomActionsRenderer"/>
 			</mx:columns>
 		</mx:DataGrid>


### PR DESCRIPTION
- Update timer display and text for breakout rooms.
- #3619 Display breakout room users in row tooltip, separated by a new line.
- Minor improvement to breakout room action buttons position.
- Change the emoji menu icon to the happy face.