### PR TITLE
html5client: Improve on actions and permissions

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/methods/setUserPresenter.js
+++ b/bigbluebutton-html5/imports/api/users/server/methods/setUserPresenter.js
@@ -5,7 +5,7 @@ import { appendMessageHeader } from '/imports/api/common/server/helpers';
 Meteor.methods({
   //meetingId: the meeting where the user is
   //newPresenterId: the userid of the new presenter
-  //requesterSetPresenter: the userid of the user that wants to change the presenter
+  //requesterUserId: the userid of the user that wants to change the presenter
   //newPresenterName: user name of the new presenter
   //authToken: the authToken of the user that wants to kick
   setUserPresenter(
@@ -13,7 +13,7 @@ Meteor.methods({
     newPresenterId,
     newPresenterName) {
     const REDIS_CONFIG = Meteor.settings.redis;
-    const { meetingId, requesterSetPresenter, requesterToken } = credentials;
+    const { meetingId, requesterUserId } = credentials;
     let message;
     if (isAllowedTo('setPresenter', credentials)) {
       message = {
@@ -21,7 +21,7 @@ Meteor.methods({
           new_presenter_id: newPresenterId,
           new_presenter_name: newPresenterName,
           meeting_id: meetingId,
-          assigned_by: requesterSetPresenter,
+          assigned_by: requesterUserId,
         },
       };
 

--- a/bigbluebutton-html5/imports/startup/server/userPermissions.js
+++ b/bigbluebutton-html5/imports/startup/server/userPermissions.js
@@ -144,23 +144,24 @@ export function isAllowedTo(action, credentials) {
 
   // logger.info "user=" + JSON.stringify user
   if ((user != null) && authToken === user.authToken) { // check if the user is who he claims to be
-    if (user.validated && user.clientType === 'HTML5') {
+    if (user.validated && user.clientType === 'HTML5' && user.user != null) {
+
+      // MODERATOR
+      if (user.user.role === 'MODERATOR') {
+        logger.info('user permissions moderator case');
+        return moderator[action] || false;
 
       // PRESENTER
       // check presenter specific actions or fallback to regular viewer actions
-      if (user.user != null && user.user.presenter) {
+      } else if (user.user.presenter) {
         logger.info('user permissions presenter case');
         return presenter[action] || viewer(meetingId, userId)[action] || false;
 
       // VIEWER
-      } else if (user.user != null && user.user.role === 'VIEWER') {
+      } else if (user.user.role === 'VIEWER') {
         logger.info('user permissions viewer case');
         return viewer(meetingId, userId)[action] || false;
 
-      // MODERATOR
-      } else if (user.user != null && user.user.role === 'MODERATOR') {
-        logger.info('user permissions moderator case');
-        return moderator[action] || false;
       } else {
         logger.warn(`UNSUCCESSFULL ATTEMPT FROM userid=${userId} to perform:${action}`);
         return false;

--- a/bigbluebutton-html5/imports/startup/server/userPermissions.js
+++ b/bigbluebutton-html5/imports/startup/server/userPermissions.js
@@ -27,6 +27,8 @@ const moderator = {
   // muting
   muteSelf: true,
   unmuteSelf: true,
+  muteOther: true,
+  unmuteOther: true,
 
   logoutSelf: true,
 

--- a/bigbluebutton-html5/imports/startup/server/userPermissions.js
+++ b/bigbluebutton-html5/imports/startup/server/userPermissions.js
@@ -78,9 +78,9 @@ const viewer = function (meetingId, userId) {
     // muting
     muteSelf: true,
     unmuteSelf:
-      !((meeting = Meetings.findOne({ meetingId: meetingId })) != null &&
+      !((meeting = Meetings.findOne({ meetingId })) != null &&
         meeting.roomLockSettings.disableMic) ||
-      !((user = Users.findOne({ meetingId: meetingId, userId: userId })) != null &&
+      !((user = Users.findOne({ meetingId, userId })) != null &&
         user.user.locked),
 
     logoutSelf: true,
@@ -90,15 +90,15 @@ const viewer = function (meetingId, userId) {
     subscribeChat: true,
 
     //chat
-    chatPublic: !((meeting = Meetings.findOne({ meetingId: meetingId })) != null &&
+    chatPublic: !((meeting = Meetings.findOne({ meetingId })) != null &&
       meeting.roomLockSettings.disablePublicChat) ||
-      !((user = Users.findOne({ meetingId: meetingId, userId: userId })) != null &&
+      !((user = Users.findOne({ meetingId, userId })) != null &&
       user.user.locked) ||
       (user != null && user.user.presenter),
 
-    chatPrivate: !((meeting = Meetings.findOne({ meetingId: meetingId })) != null &&
+    chatPrivate: !((meeting = Meetings.findOne({ meetingId })) != null &&
       meeting.roomLockSettings.disablePrivateChat) ||
-      !((user = Users.findOne({ meetingId: meetingId, userId: userId })) != null &&
+      !((user = Users.findOne({ meetingId, userId })) != null &&
       user.user.locked) ||
       (user != null && user.user.presenter),
 
@@ -122,13 +122,13 @@ export function isAllowedTo(action, credentials) {
   const userId = credentials.requesterUserId;
   const authToken = credentials.requesterToken;
 
-  let user;
   let validated;
 
-  user = Users.findOne({
-    meetingId: meetingId,
-    userId: userId,
+  let user = Users.findOne({
+    meetingId,
+    userId,
   });
+
   if (user != null) {
     validated = user.validated;
   }
@@ -137,10 +137,6 @@ export function isAllowedTo(action, credentials) {
     `in isAllowedTo: action-${action}, userId=${userId}, ` +
     `authToken=${authToken} validated:${validated}`
   );
-  user = Users.findOne({
-    meetingId: meetingId,
-    userId: userId,
-  });
 
   // logger.info "user=" + JSON.stringify user
   if ((user != null) && authToken === user.authToken) { // check if the user is who he claims to be
@@ -170,10 +166,7 @@ export function isAllowedTo(action, credentials) {
       // user was not validated
       if (action === 'logoutSelf') {
         // on unsuccessful sign-in
-        logger.warn(
-          'a user was successfully removed from the ' +
-          'meeting following an unsuccessful login'
-        );
+        logger.warn('a user was successfully removed from the meeting after failed login');
         return true;
       }
 

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -28,11 +28,12 @@ export default class ApplicationMenu extends BaseMenu {
           <div className={styles.row} role='presentation'>
             <label>
               <input type='checkbox'
-                          tabIndex='7'
-                          onChange={this.checkBoxHandler.bind(this, "audioNotifChat")}
-                          checked={this.state.audioNotifChat}
-                          aria-labelledby='audioNotifLabel'
-                          aria-describedby='audioNotifDesc' />
+                tabIndex='7'
+                onChange={this.checkBoxHandler.bind(this, "audioNotifChat")}
+                checked={this.state.audioNotifChat}
+                aria-labelledby='audioNotifLabel'
+                aria-describedby='audioNotifDesc'
+              />
               Audio notifications for chat
             </label>
             <div id='audioNotifLabel' hidden>Audio notifications</div>

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -224,17 +224,12 @@ const userActions = {
   },
   setPresenter: {
     label: 'Make Presenter',
-    handler: user => callServer('setUserPresenter', user.userid, user.name),
+    handler: user => callServer('setUserPresenter', user.id, user.name),
     icon: 'presentation',
-  },
-  promote: {
-    label: 'Promote',
-    handler: user => console.log('missing promote', user),
-    icon: 'promote',
   },
   kick: {
     label: 'Kick User',
-    handler: user => callServer('kickUser', user.userid),
+    handler: user => callServer('kickUser', user.id),
     icon: 'kick-user',
   },
   mute: {

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -234,12 +234,12 @@ const userActions = {
   },
   mute: {
     label: 'Mute Audio',
-    handler: user=> callServer('muteUser', Auth.userID),
+    handler: user=> callServer('muteUser', user.id),
     icon: 'mute',
   },
   unmute: {
     label: 'Unmute Audio',
-    handler: user=> callServer('unmuteUser', Auth.userID),
+    handler: user=> callServer('unmuteUser', user.id),
     icon: 'unmute',
   },
 };

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-item/component.jsx
@@ -113,18 +113,16 @@ class UserListItem extends Component {
       unmute,
     } = userActions;
 
+    const hasAuthority = currentUser.isModerator || user.isCurrent;
     let allowedToChatPrivately = !user.isCurrent;
-    let allowedToMuteAudio = (currentUser.isModerator || user.isCurrent) && user.isVoiceUser && user.isMuted;
-    let allowedToUnmuteAudio = (currentUser.isModerator || user.isCurrent) && user.isVoiceUser && !user.isMuted;
-
-    // if currentUser is a moderator or user is currently logged in,
-    // can clear status from the userlist.
-    let allowedToResetStatus = !!(currentUser.isModerator || user.isCurrent);
+    let allowedToMuteAudio = hasAuthority && user.isVoiceUser && user.isMuted;
+    let allowedToUnmuteAudio = hasAuthority && user.isVoiceUser && !user.isMuted;
+    let allowedToResetStatus = hasAuthority;
 
     // if currentUser is a moderator, allow kicking other users
     let allowedToKick = currentUser.isModerator && !user.isCurrent;
 
-    let allowedToSetPresenter = currentUser.isModerator || currentUser.isPresenter;
+    let allowedToSetPresenter = (currentUser.isModerator || currentUser.isPresenter) && !user.isPresenter;
 
     return _.compact([
       (allowedToChatPrivately ? this.renderUserAction(openChat, router, user) : null),

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-item/component.jsx
@@ -108,35 +108,31 @@ class UserListItem extends Component {
       openChat,
       clearStatus,
       setPresenter,
-      promote,
       kick,
       mute,
       unmute,
     } = userActions;
 
-    let muteAudio, unmuteAudio;
-
-    // Check the state of joining the audio currently for current user
-    if (user.isCurrent && user.isVoiceUser) {
-      if (user.isMuted) {
-        muteAudio = true;
-      } else {
-        unmuteAudio = true;
-      }
-    }
+    let allowedToChatPrivately = !user.isCurrent;
+    let allowedToMuteAudio = (currentUser.isModerator || user.isCurrent) && user.isVoiceUser && user.isMuted;
+    let allowedToUnmuteAudio = (currentUser.isModerator || user.isCurrent) && user.isVoiceUser && !user.isMuted;
 
     // if currentUser is a moderator or user is currently logged in,
     // can clear status from the userlist.
-    let allowedToResetStatus = currentUser.isModerator || user.isCurrent ? true : false;
+    let allowedToResetStatus = !!(currentUser.isModerator || user.isCurrent);
+
+    // if currentUser is a moderator, allow kicking other users
+    let allowedToKick = currentUser.isModerator && !user.isCurrent;
+
+    let allowedToSetPresenter = currentUser.isModerator || currentUser.isPresenter;
 
     return _.compact([
-      (!user.isCurrent ? this.renderUserAction(openChat, router, user) : null),
-      (muteAudio ? this.renderUserAction(unmute, user) : null),
-      (unmuteAudio ? this.renderUserAction(mute, user) : null),
+      (allowedToChatPrivately ? this.renderUserAction(openChat, router, user) : null),
+      (allowedToMuteAudio ? this.renderUserAction(unmute, user) : null),
+      (allowedToUnmuteAudio ? this.renderUserAction(mute, user) : null),
       (allowedToResetStatus ? this.renderUserAction(clearStatus, user) : null),
-      (currentUser.isModerator ? this.renderUserAction(setPresenter, user) : null),
-      (currentUser.isModerator ? this.renderUserAction(promote, user) : null),
-      (currentUser.isModerator ? this.renderUserAction(kick, user) : null),
+      (allowedToSetPresenter ? this.renderUserAction(setPresenter, user) : null),
+      (allowedToKick ? this.renderUserAction(kick, user) : null),
     ]);
   }
 
@@ -162,9 +158,6 @@ class UserListItem extends Component {
 
   render() {
     const {
-      user,
-      currentUser,
-      userActions,
       compact,
     } = this.props;
 


### PR DESCRIPTION
Restructured, fixed or improved the following actions triggered by the html5 client user (viewer and/or moderator):
* start private chat
* kick user
* promote to presenter
* mute / unmute self and others
* clear status
And also refactored permission controls