### PR TITLE
initialize html5StunTurn properly - complication from PR 3628

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/bbb_webrtc_bridge_sip.js
+++ b/bigbluebutton-client/resources/prod/lib/bbb_webrtc_bridge_sip.js
@@ -47,8 +47,10 @@ function callIntoConference(voiceBridge, callback, isListenOnly, stunTurn = null
 
 	// if additional stun configuration is passed, store the information
 	if (stunTurn != null) {
-		html5StunTurn['stunServers'] = stunTurn.stun;
-		html5StunTurn['turnServers'] = stunTurn.turn;
+		html5StunTurn = {
+			stunServers: stunTurn.stun,
+			turnServers: stunTurn.turn,
+		};
 	}
 
 	// reset callerIdName


### PR DESCRIPTION
In #3628 we had to switch from initializing `html5StunTurn = {};` to `html5StunTurn = null;`
This pull request resolves a consequence of this change.