### PR TITLE
Don't display the LoggedOutWindow.mxml if the user asked to logout

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/events/ExitApplicationEvent.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/events/ExitApplicationEvent.as
@@ -1,0 +1,30 @@
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ *
+ * Copyright (c) 2017 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.bigbluebutton.main.events {
+    import flash.events.Event;
+
+    public class ExitApplicationEvent extends Event {
+
+        public static const EXIT_APPLICATION:String = "EXIT_APPLICATION";
+
+        public function ExitApplicationEvent(type:String, bubbles:Boolean = true, cancelable:Boolean = false) {
+            super(type, bubbles, cancelable);
+        }
+    }
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/Conference.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/Conference.as
@@ -50,6 +50,8 @@ package org.bigbluebutton.main.model.users {
 		
 		public var isBreakout:Boolean;
 		
+		public var iAskedToLogout:Boolean
+		
 		[Bindable]
 		public var record:Boolean;
 		

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/NetConnectionDelegate.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/NetConnectionDelegate.as
@@ -18,7 +18,8 @@
 */
 package org.bigbluebutton.main.model.users
 {
-	import com.asfusion.mate.events.Dispatcher;	
+	import com.asfusion.mate.events.Dispatcher;
+	
 	import flash.events.AsyncErrorEvent;
 	import flash.events.IOErrorEvent;
 	import flash.events.NetStatusEvent;
@@ -27,13 +28,12 @@ package org.bigbluebutton.main.model.users
 	import flash.net.NetConnection;
 	import flash.net.Responder;
 	import flash.utils.Timer;
+	
 	import org.as3commons.logging.api.ILogger;
 	import org.as3commons.logging.api.getClassLogger;
 	import org.bigbluebutton.core.BBB;
 	import org.bigbluebutton.core.UsersUtil;
 	import org.bigbluebutton.core.managers.ReconnectionManager;
-	import org.bigbluebutton.core.services.BandwidthMonitor;
-	import org.bigbluebutton.main.api.JSLog;
 	import org.bigbluebutton.main.events.BBBEvent;
 	import org.bigbluebutton.main.events.InvalidAuthTokenEvent;
 	import org.bigbluebutton.main.model.ConferenceParameters;

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/LoggedOutWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/LoggedOutWindow.mxml
@@ -26,6 +26,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     x="168" y="86" layout="vertical" width="400" height="110" horizontalAlign="center">
 	<mx:Script>
 		<![CDATA[
+			import com.asfusion.mate.events.Dispatcher;
+			
 			import flash.net.navigateToURL;
 			
 			import mx.managers.PopUpManager;
@@ -35,6 +37,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.core.BBB;
 			import org.bigbluebutton.core.UsersUtil;
 			import org.bigbluebutton.core.managers.UserManager;
+			import org.bigbluebutton.main.events.ExitApplicationEvent;
 			import org.bigbluebutton.main.model.users.events.ConnectionFailedEvent;
 			import org.bigbluebutton.util.i18n.ResourceUtil;
 
@@ -62,11 +65,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 
 			private function exitApplication():void {
-				if (!UserManager.getInstance().getConference().isBreakout) {
-					navigateToURL(new URLRequest(BBB.getLogoutURL()), "_self");
-				} else {
-					ExternalInterface.call("window.close");
-				}
+				var d:Dispatcher = new Dispatcher();
+				d.dispatchEvent(new ExitApplicationEvent(ExitApplicationEvent.EXIT_APPLICATION));
 			}
 
 			private function handleComplete(e:Event):void {

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
@@ -51,6 +51,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	<mate:Listener type="{ConnectionFailedEvent.CONNECTION_CLOSED}" method="attemptReconnect"  />
 	<mate:Listener type="{ConnectionFailedEvent.UNKNOWN_REASON}" method="attemptReconnect"  />
 	<mate:Listener type="{ConnectionFailedEvent.CONNECTION_REJECTED}" method="attemptReconnect"  />
+	<mate:Listener type="{ExitApplicationEvent.EXIT_APPLICATION}" method="handleExitApplicationEvent" />
 	<mate:Listener type="{ConfigLoadedEvent.CONFIG_LOADED_EVENT}" method="initOptions"  />
 	<mate:Listener type="{FlashMicSettingsEvent.FLASH_MIC_SETTINGS}" method="handleFlashMicSettingsEvent"  />
 	<mate:Listener type="{WebRTCEchoTestEvent.WEBRTC_ECHO_TEST_CONNECTING}" method="handleWebRTCEchoTestConnectingEvent"  />
@@ -77,6 +78,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import flash.events.IOErrorEvent;
 			import flash.events.TextEvent;
 			import flash.geom.Point;
+			import flash.net.navigateToURL;
 			
 			import mx.collections.ArrayCollection;
 			import mx.controls.Alert;
@@ -97,6 +99,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.common.events.OpenWindowEvent;
 			import org.bigbluebutton.common.events.ToolbarButtonEvent;
 			import org.bigbluebutton.core.BBB;
+			import org.bigbluebutton.core.UsersUtil;
 			import org.bigbluebutton.core.events.LockControlEvent;
 			import org.bigbluebutton.core.managers.UserManager;
 			import org.bigbluebutton.core.vo.LockSettingsVO;
@@ -105,6 +108,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.main.events.BreakoutRoomEvent;
 			import org.bigbluebutton.main.events.ClientStatusEvent;
 			import org.bigbluebutton.main.events.ConfigLoadedEvent;
+			import org.bigbluebutton.main.events.ExitApplicationEvent;
 			import org.bigbluebutton.main.events.InvalidAuthTokenEvent;
 			import org.bigbluebutton.main.events.MeetingNotFoundEvent;
 			import org.bigbluebutton.main.events.ModuleLoadEvent;
@@ -120,7 +124,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.modules.users.views.BreakoutRoomSettings;
 			import org.bigbluebutton.modules.videoconf.events.ShareCameraRequestEvent;
 			import org.bigbluebutton.util.i18n.ResourceUtil;
-            import org.bigbluebutton.core.UsersUtil;
 	
 			private static const LOGGER:ILogger = getClassLogger(MainApplicationShell);      
       
@@ -507,53 +510,64 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       private function handleMeetingNotFoundEvent(e:MeetingNotFoundEvent):void {
         showlogoutWindow(ResourceUtil.getInstance().getString('bbb.mainshell.meetingNotFound'));
       }
-      
-      private function showlogoutWindow(reason:String):void {
-        if (layoutOptions!= null && layoutOptions.showLogoutWindow) {
-          if (logoutWindow != null) return;
-          logoutWindow = LoggedOutWindow(PopUpManager.createPopUp( mdiCanvas, LoggedOutWindow, true));
-          
-          var point1:Point = new Point();
-          // Calculate position of TitleWindow in Application's coordinates. 
-          point1.x = width/2;
-          point1.y = height/2;                 
-          logoutWindow.x = point1.x - (logoutWindow.width/2);
-          logoutWindow.y = point1.y - (logoutWindow.height/2);
-          
-          logoutWindow.setReason(reason);
-          mdiCanvas.removeAllPopUps();
-		  removeToolBars();
-        } else {
-          mdiCanvas.removeAllPopUps();
-		  removeToolBars();
-          var pageHost:String = FlexGlobals.topLevelApplication.url.split("/")[0];
-          var pageURL:String = FlexGlobals.topLevelApplication.url.split("/")[2];
-          LOGGER.debug("SingOut to [{0}//{1}/bigbluebutton/api/signOut]", [pageHost, pageURL]);
-          var request:URLRequest = new URLRequest(pageHost + "//" + pageURL + "/bigbluebutton/api/signOut");
-          var urlLoader:URLLoader = new URLLoader();
-          urlLoader.addEventListener(Event.COMPLETE, handleLogoutComplete);	
-          urlLoader.addEventListener(IOErrorEvent.IO_ERROR, handleLogoutError);
-          urlLoader.load(request);
-        }	        
-      }
-	
-	  /**
-	   * Removes toolbars from the display list.
-	   * Used only when the user completely logged out.
-	   */
-	  private function removeToolBars():void{
-		  this.removeChild(toolbar);
-		  this.removeChild(controlBar);
-	  }
-      
-      
-      private function handleLogout(e:ConnectionFailedEvent):void {
-        if (e is ConnectionFailedEvent) {
-          showlogoutWindow((e as ConnectionFailedEvent).type);
-        }
-        else showlogoutWindow("You have logged out of the conference");	
-      }
-      
+
+			private function showlogoutWindow(reason:String):void {
+				if (layoutOptions!= null && layoutOptions.showLogoutWindow) {
+					if (UserManager.getInstance().getConference().iAskedToLogout) {
+						handleExitApplicationEvent();
+						return;
+					}
+					if (logoutWindow != null) return;
+					logoutWindow = LoggedOutWindow(PopUpManager.createPopUp( mdiCanvas, LoggedOutWindow, true));
+					
+					var point1:Point = new Point();
+					// Calculate position of TitleWindow in Application's coordinates. 
+					point1.x = width/2;
+					point1.y = height/2;                 
+					logoutWindow.x = point1.x - (logoutWindow.width/2);
+					logoutWindow.y = point1.y - (logoutWindow.height/2);
+					
+					logoutWindow.setReason(reason);
+					mdiCanvas.removeAllPopUps();
+					removeToolBars();
+				} else {
+					mdiCanvas.removeAllPopUps();
+					removeToolBars();
+					var pageHost:String = FlexGlobals.topLevelApplication.url.split("/")[0];
+					var pageURL:String = FlexGlobals.topLevelApplication.url.split("/")[2];
+					LOGGER.debug("SingOut to [{0}//{1}/bigbluebutton/api/signOut]", [pageHost, pageURL]);
+					var request:URLRequest = new URLRequest(pageHost + "//" + pageURL + "/bigbluebutton/api/signOut");
+					var urlLoader:URLLoader = new URLLoader();
+					urlLoader.addEventListener(Event.COMPLETE, handleLogoutComplete);	
+					urlLoader.addEventListener(IOErrorEvent.IO_ERROR, handleLogoutError);
+					urlLoader.load(request);
+				}	        
+			}
+
+            /**
+             * Removes toolbars from the display list.
+             * Used only when the user completely logged out.
+             */
+            private function removeToolBars():void {
+                this.removeChild(toolbar);
+                this.removeChild(controlBar);
+            }
+
+            private function handleLogout(e:ConnectionFailedEvent):void {
+                if (e is ConnectionFailedEvent) {
+                    showlogoutWindow((e as ConnectionFailedEvent).type);
+                } else
+                    showlogoutWindow("You have logged out of the conference");
+            }
+
+            private function handleExitApplicationEvent(e:ExitApplicationEvent = null):void {
+                if (!UserManager.getInstance().getConference().isBreakout) {
+                    navigateToURL(new URLRequest(BBB.getLogoutURL()), "_self");
+                } else {
+                    ExternalInterface.call("window.close");
+                }
+            }
+
 			private function redirectToLogoutUrl ():void {
         		var logoutURL:String = BBB.getLogoutURL();
 				var request:URLRequest = new URLRequest(logoutURL);
@@ -591,12 +605,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private function handleWebRTCCallEndedEvent(e:WebRTCCallEvent):void {
 				lblWebRTC.visible = lblWebRTC.includeInLayout = false;
 			}
-      
-      private function handleInvalidAuthToken(event:InvalidAuthTokenEvent):void {
-        showlogoutWindow(ResourceUtil.getInstance().getString('bbb.mainshell.invalidAuthToken'));
-        globalDispatcher.dispatchEvent(new BBBEvent(BBBEvent.CANCEL_RECONNECTION_EVENT));
-      }
-			
+
+            private function handleInvalidAuthToken(event:InvalidAuthTokenEvent):void {
+                showlogoutWindow(ResourceUtil.getInstance().getString('bbb.mainshell.invalidAuthToken'));
+                globalDispatcher.dispatchEvent(new BBBEvent(BBBEvent.CANCEL_RECONNECTION_EVENT));
+            }
+
 			private function handleRemoveToolbarComponent(event:ToolbarButtonEvent):void {
 				if (addedBtns.contains(event.button as UIComponent))
 					addedBtns.removeChild(event.button as UIComponent);

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
@@ -54,6 +54,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.common.events.ToolbarButtonEvent;
 			import org.bigbluebutton.core.BBB;
 			import org.bigbluebutton.core.UsersUtil;
+			import org.bigbluebutton.core.managers.UserManager;
 			import org.bigbluebutton.main.events.BBBEvent;
 			import org.bigbluebutton.main.events.ConfigEvent;
 			import org.bigbluebutton.main.events.LogoutEvent;
@@ -238,6 +239,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private function alertLogout(e:CloseEvent):void {
 				// Check to see if the YES button was pressed.
 				if (e.detail==Alert.YES) {
+					UserManager.getInstance().getConference().iAskedToLogout = true;
 					/* 
 					 * If doLogout() is called immediately there is a null exception in AlertAccImpl
 					 * line 185, but if we delay calling doLogout() until the next frame the Alert 


### PR DESCRIPTION
- Move the responsability of closing the client to the MainApplicationShell.mxml
- If user clicks on "yes" to confirm logout, the LoggedOutWindow.mxml window is no more displayed.