### PR TITLE
HTML5 - Audio Notification Update1

### DIFF
--- a/bigbluebutton-html5/imports/api/phone/index.js
+++ b/bigbluebutton-html5/imports/api/phone/index.js
@@ -118,6 +118,12 @@ function joinVoiceCallSIP(options) {
             status: 'MediaFailed' });
           window.dispatchEvent(mediaFailed);
           break;
+        case 'mediasuccess':
+        case 'started':
+          let connected = new CustomEvent('bbb.webrtc.connected', {
+            status: 'started' });
+          window.dispatchEvent(connected);
+          break;
       }
     }, options.isListenOnly, st);
     return;

--- a/bigbluebutton-html5/imports/ui/components/audio-notification/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio-notification/container.jsx
@@ -36,14 +36,16 @@ class AudioNotificationContainer extends Component {
   componentDidMount() {
     window.addEventListener("bbb.webrtc.failed", this.handleAudioFailure);
     window.addEventListener("bbb.webrtc.mediaFailed", this.handleMediaFailure);
+    window.addEventListener("bbb.webrtc.connected", this.handleClose);
   }
 
   componentWillUnmount() {
     window.removeEventListener("bbb.webrtc.failed", this.handleAudioFailure);
     window.removeEventListener("bbb.webrtc.mediaFailed", this.handleMediaFailure);
+    window.removeEventListener("bbb.webrtc.connected", this.handleClose);
   }
 
-  handleClose(){
+  handleClose() {
     this.color = null;
     this.message = null;
     this.setState({status: null});


### PR DESCRIPTION
Added a success event to discard any previously displayed failure notification to solve the following use case:

(http) try joining with mic -> fail -> notification -> joining listenOnly -> *red notification was still on but we should probably discard*
