### PR TITLE
HTML5 - Fullscreen Label Change

### DIFF
--- a/bigbluebutton-html5/imports/locales/en.json
+++ b/bigbluebutton-html5/imports/locales/en.json
@@ -30,6 +30,7 @@
   "app.waitingMessage": "Disconnected. Trying to reconnect in {seconds} seconds...",
   "app.navBar.settingsDropdown.optionsLabel": "Options",
   "app.navBar.settingsDropdown.fullscreenLabel": "Make fullscreen",
+  "app.navBar.settingsDropdown.exitfullscreenLabel": "Exit fullscreen",
   "app.navBar.settingsDropdown.settingsLabel": "Open settings",
   "app.navBar.settingsDropdown.aboutLabel": "About",
   "app.navBar.settingsDropdown.leaveSessionLabel": "Logout",

--- a/bigbluebutton-html5/imports/ui/components/dropdown/list/item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/list/item/component.jsx
@@ -25,6 +25,7 @@ class DropdownListItem extends Component {
     this.descID = _.uniqueId('dropdown-item-desc-');
 
     this.setMenuItem = this.setMenuItem.bind(this);
+    this.items = 0;
   }
 
   renderDefault() {
@@ -37,7 +38,7 @@ class DropdownListItem extends Component {
       document.mozFullScreenElement ||
       document.msFullscreenElement
     ) {
-      if (label === 'Make fullscreen') {
+      if ( icon === 'fullscreen') {
         return this.setMenuItem(icon, intl.formatMessage(intlMessages.exitfullscreenLabel));
       }
     }

--- a/bigbluebutton-html5/imports/ui/components/dropdown/list/item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/list/item/component.jsx
@@ -4,6 +4,14 @@ import _ from 'underscore';
 import cx from 'classnames';
 
 import Icon from '/imports/ui/components/icon/component';
+import { defineMessages, injectIntl } from 'react-intl';
+
+const intlMessages = defineMessages({
+  exitfullscreenLabel: {
+    id: 'app.navBar.settingsDropdown.exitfullscreenLabel',
+    defaultMessage: 'Exit fullscreen',
+  },
+});
 
 const propTypes = {
   icon: PropTypes.string,
@@ -11,17 +19,34 @@ const propTypes = {
   description: PropTypes.string,
 };
 
-export default class DropdownListItem extends Component {
+class DropdownListItem extends Component {
   constructor(props) {
     super(props);
     this.labelID = _.uniqueId('dropdown-item-label-');
     this.descID = _.uniqueId('dropdown-item-desc-');
+
+    this.setMenuItem = this.setMenuItem.bind(this);
   }
 
   renderDefault() {
-    let children = [];
-    const { icon, label } = this.props;
 
+    let children = [];
+    const { icon, label, intl } = this.props;
+
+    if (
+      document.fullscreenElement ||
+      document.webkitFullscreenElement ||
+      document.mozFullScreenElement ||
+      document.msFullscreenElement
+    ) {
+      if (label === 'Make fullscreen') {
+        return this.setMenuItem(icon, intl.formatMessage(intlMessages.exitfullscreenLabel));
+      }
+    }
+    return this.setMenuItem(icon, label);
+  }
+
+  setMenuItem(icon, label) {
     return [
       (icon ? <Icon iconName={icon} key="icon" className={styles.itemIcon}/> : null),
       (<span className={styles.itemLabel} key="label">{label}</span>),
@@ -29,6 +54,7 @@ export default class DropdownListItem extends Component {
   }
 
   render() {
+
     const { label, description, children,
       injectRef, tabIndex, onClick, onKeyDown,
       className, style, } = this.props;
@@ -64,3 +90,4 @@ export default class DropdownListItem extends Component {
 }
 
 DropdownListItem.propTypes = propTypes;
+export default injectIntl(DropdownListItem);

--- a/bigbluebutton-html5/imports/ui/components/dropdown/list/item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/list/item/component.jsx
@@ -2,7 +2,6 @@ import React, { Component, PropTypes } from 'react';
 import styles from '../styles';
 import _ from 'underscore';
 import cx from 'classnames';
-
 import Icon from '/imports/ui/components/icon/component';
 import { defineMessages, injectIntl } from 'react-intl';
 
@@ -29,7 +28,6 @@ class DropdownListItem extends Component {
   }
 
   renderDefault() {
-
     let children = [];
     const { icon, label, intl } = this.props;
 
@@ -54,7 +52,6 @@ class DropdownListItem extends Component {
   }
 
   render() {
-
     const { label, description, children,
       injectRef, tabIndex, onClick, onKeyDown,
       className, style, } = this.props;

--- a/bigbluebutton-html5/imports/ui/components/dropdown/list/item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/list/item/component.jsx
@@ -25,7 +25,6 @@ class DropdownListItem extends Component {
     this.descID = _.uniqueId('dropdown-item-desc-');
 
     this.setMenuItem = this.setMenuItem.bind(this);
-    this.items = 0;
   }
 
   renderDefault() {


### PR DESCRIPTION
When the Full-screen option is selected, its detected and switches the label for that button to 'Exit fullscreen'. When the full-screen mode exits the label returns to 'Make fullscreen' 