### PR TITLE
Fix ´get_all_meetings_request´ being published multiple times

### DIFF
--- a/bigbluebutton-html5/imports/startup/server/redis.js
+++ b/bigbluebutton-html5/imports/startup/server/redis.js
@@ -62,7 +62,6 @@ class RedisPubSub {
 
     this.publish(this.config.channels.toBBBApps.meeting, REQUEST_EVENT);
     this.didSendRequestEvent = true;
-    console.log('oi');
   }
 
   handleMessage(pattern, channel, message = '') {

--- a/bigbluebutton-html5/imports/startup/server/redis.js
+++ b/bigbluebutton-html5/imports/startup/server/redis.js
@@ -9,6 +9,7 @@ class RedisPubSub {
   constructor(config = {}) {
     this.config = config;
 
+    this.didSendRequestEvent = false;
     this.pub = Redis.createClient();
     this.sub = Redis.createClient();
     this.emitter = new EventEmitter2();
@@ -57,7 +58,11 @@ class RedisPubSub {
   }
 
   handleSubscribe() {
+    if (this.didSendRequestEvent) return;
+
     this.publish(this.config.channels.toBBBApps.meeting, REQUEST_EVENT);
+    this.didSendRequestEvent = true;
+    console.log('oi');
   }
 
   handleMessage(pattern, channel, message = '') {


### PR DESCRIPTION
Fix a bug introduced on d21545c where the `get_all_meetings_request` was being published every time we subscribed to a Redis channel.