### PR TITLE
Adding the list of participants in metadata.xml

### DIFF
--- a/bigbluebutton-web/src/groovy/org/bigbluebutton/api/RecordingServiceHelperImp.groovy
+++ b/bigbluebutton-web/src/groovy/org/bigbluebutton/api/RecordingServiceHelperImp.groovy
@@ -135,7 +135,7 @@ public class RecordingServiceHelperImp implements RecordingServiceHelper {
         r.setPublished(Boolean.parseBoolean(rec.published.text()));
         r.setStartTime(rec.start_time.text());
         r.setEndTime(rec.end_time.text());
-        r.setNumParticipants(rec.participants.text());
+        r.setNumParticipants(rec.participants_count.text());
         if ( !rec.playback.text().equals("") ) {
             r.setPlaybackFormat(rec.playback.format.text());
             r.setPlaybackLink(rec.playback.link.text());

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -26,11 +26,12 @@ require 'nokogiri'
 module BigBlueButton
   module Events
   
-    # Get the total number of participants
-    def self.get_num_participants(events_xml)
-      BigBlueButton.logger.info("Task: Getting num participants")
+    # Get the list of participants
+    def self.get_participants_info(events_xml)
+      BigBlueButton.logger.info("Task: Getting participants info")
       doc = Nokogiri::XML(File.open(events_xml))
       participants_ids = []
+      participants_info = []
 
       doc.xpath("//event[@eventname='ParticipantJoinEvent']").each do |joinEvent|
          userId = joinEvent.xpath(".//userId").text
@@ -39,13 +40,14 @@ module BigBlueButton
          userId.gsub!(/_\d*/, "")
 
          if !participants_ids.include? userId
-            BigBlueButton.logger.info("Counting id = #{userId}")
             participants_ids << userId
+
+            participant_name = joinEvent.xpath(".//name").text
+            participant_role = joinEvent.xpath(".//role").text
+            participants_info << [userId, participant_name, participant_role]
          end
       end
-
-      BigBlueButton.logger.info("get_num_participants = #{participants_ids.length}")
-      participants_ids.length
+      participants_info
     end
 
     # Get the meeting metadata

--- a/record-and-playback/presentation/scripts/process/presentation.rb
+++ b/record-and-playback/presentation/scripts/process/presentation.rb
@@ -68,6 +68,7 @@ if not FileTest.directory?(target_dir)
       b.published(false)
       b.start_time
       b.end_time
+      b.participants_count
       b.participants
       b.playback
       b.meta
@@ -109,8 +110,28 @@ if not FileTest.directory?(target_dir)
     end_time = recording.at_xpath("end_time")
     end_time.content = real_end_time
 
-    participants = recording.at_xpath("participants")
-    participants.content = BigBlueButton::Events.get_num_participants("#{target_dir}/events.xml")
+    participants_info = BigBlueButton::Events.get_participants_info("#{target_dir}/events.xml")
+
+    participants_count = recording.at_xpath("participants_count")
+    participants_count.content = participants_info.length
+
+    ## Remove empty participants
+    metadata.search('//recording/participants').each do |participants|
+      participants.remove
+    end
+    ## Add the actual participants
+    Nokogiri::XML::Builder.with(metadata.at('recording')) do |xml|
+      xml.participants {
+        participants_info.each do |participant_info|
+          xml.participant {
+            xml.userId participant_info[0]
+            xml.role participant_info[1]
+            xml.userId participant_info[2]
+          }
+        end
+      }
+    end
+
 
     ## Remove empty meta
     metadata.search('//recording/meta').each do |meta|


### PR DESCRIPTION
So GreenLight can read these informations from metadata.xml to send e-mail notifications about the recordings

This commit is needed to resolve this: https://github.com/bigbluebutton/greenlight/issues/116