### PR TITLE
Adding list of participants in metadata.xml

### DIFF
--- a/bigbluebutton-web/src/groovy/org/bigbluebutton/api/RecordingServiceHelperImp.groovy
+++ b/bigbluebutton-web/src/groovy/org/bigbluebutton/api/RecordingServiceHelperImp.groovy
@@ -135,7 +135,7 @@ public class RecordingServiceHelperImp implements RecordingServiceHelper {
         r.setPublished(Boolean.parseBoolean(rec.published.text()));
         r.setStartTime(rec.start_time.text());
         r.setEndTime(rec.end_time.text());
-        r.setNumParticipants(rec.participants.text());
+        r.setNumParticipants(rec.participants_count.text());
         if ( !rec.playback.text().equals("") ) {
             r.setPlaybackFormat(rec.playback.format.text());
             r.setPlaybackLink(rec.playback.link.text());

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -26,11 +26,12 @@ require 'nokogiri'
 module BigBlueButton
   module Events
   
-    # Get the total number of participants
-    def self.get_num_participants(events_xml)
-      BigBlueButton.logger.info("Task: Getting num participants")
+    # Get the list of participants
+    def self.get_participants_info(events_xml)
+      BigBlueButton.logger.info("Task: Getting participants info")
       doc = Nokogiri::XML(File.open(events_xml))
       participants_ids = []
+      participants_info = []
 
       doc.xpath("//event[@eventname='ParticipantJoinEvent']").each do |joinEvent|
          userId = joinEvent.xpath(".//userId").text
@@ -39,13 +40,14 @@ module BigBlueButton
          userId.gsub!(/_\d*/, "")
 
          if !participants_ids.include? userId
-            BigBlueButton.logger.info("Counting id = #{userId}")
             participants_ids << userId
+
+            participant_name = joinEvent.xpath(".//name").text
+            participant_role = joinEvent.xpath(".//role").text
+            participants_info << [userId, participant_name, participant_role]
          end
       end
-
-      BigBlueButton.logger.info("get_num_participants = #{participants_ids.length}")
-      participants_ids.length
+      participants_info
     end
 
     # Get the meeting metadata

--- a/record-and-playback/core/scripts/bigbluebutton.yml
+++ b/record-and-playback/core/scripts/bigbluebutton.yml
@@ -7,6 +7,7 @@ raw_deskshare_src: /var/bigbluebutton/deskshare
 raw_presentation_src: /var/bigbluebutton
 redis_host: 127.0.0.1
 redis_port: 6379
+store_participants_list: false
 
 
 # For PRODUCTION

--- a/record-and-playback/presentation/scripts/process/presentation.rb
+++ b/record-and-playback/presentation/scripts/process/presentation.rb
@@ -68,6 +68,7 @@ if not FileTest.directory?(target_dir)
       b.published(false)
       b.start_time
       b.end_time
+      b.participants_count
       b.participants
       b.playback
       b.meta
@@ -109,8 +110,32 @@ if not FileTest.directory?(target_dir)
     end_time = recording.at_xpath("end_time")
     end_time.content = real_end_time
 
-    participants = recording.at_xpath("participants")
-    participants.content = BigBlueButton::Events.get_num_participants("#{target_dir}/events.xml")
+    participants_info = BigBlueButton::Events.get_participants_info("#{target_dir}/events.xml")
+
+    participants_count = recording.at_xpath("participants_count")
+    participants_count.content = participants_info.length
+
+    ## Remove empty participants
+    metadata.search('//recording/participants').each do |participants|
+      participants.remove
+    end
+
+    if(props['store_participants_list'])
+       BigBlueButton.logger.info("Storing participants in metadata.xml")
+       Nokogiri::XML::Builder.with(metadata.at('recording')) do |xml|
+         xml.participants {
+           participants_info.each do |participant_info|
+             xml.participant {
+               xml.userId participant_info[0]
+               xml.name_ participant_info[1]
+               xml.role participant_info[2]
+             }
+           end
+         }
+       end
+    else
+       BigBlueButton.logger.info("NOT storing participants in metadata.xml")
+    end
 
     ## Remove empty meta
     metadata.search('//recording/meta').each do |meta|

--- a/record-and-playback/presentation/scripts/process/presentation.rb
+++ b/record-and-playback/presentation/scripts/process/presentation.rb
@@ -127,7 +127,11 @@ if not FileTest.directory?(target_dir)
            participants_info.each do |participant_info|
              xml.participant {
                xml.userId participant_info[0]
-               xml.name_ participant_info[1]
+
+               xml.method_missing("name"){
+                 xml.cdata(participant_info[1].tr("\u0000-\u001f\u007f\u2028",''))
+               }
+
                xml.role participant_info[2]
              }
            end


### PR DESCRIPTION
However, we only add the list of participants in metadata.xml if 'store_participants_list' field in bigbluebutton.yml is 'true'. Default value: 'false'

This commit is needed to resolve this: bigbluebutton/greenlight#116

So GreenLight can read these informations from metadata.xml to send e-mail notifications about the recordings

Example of the updated metadata.xml:

```xml
<recording>
  <id>8647de1d47befd3a0df5e5b3784445ad436c1cad-1487188867218</id>
  <state>published</state>
  <published>true</published>
  <start_time>1487188867218</start_time>
  <end_time>1487189092755</end_time>
  <participants_count>4</participants_count>
  <participants>
    <participant>
      <userId>mkchjcwnayib</userId>
      <name>Felipe</name>
      <role>MODERATOR</role>
    </participant>
    <participant>
      <userId>2u7fizgschyy</userId>
      <name>Alexandre</name>
      <role>VIEWER</role>
    </participant>
    <participant>
      <userId>pwwzpk8pp6ev</userId>
      <name>Leonardo</name>
      <role>VIEWER</role>
    </participant>
    <participant>
      <userId>sftfbcp8gkjm</userId>
      <name>Valter</name>
      <role>MODERATOR</role>
    </participant>
  </participants>
  <meta>
    <meetingId>random-5620074</meetingId>
    <isBreakout>false</isBreakout>
    <meetingName>random-5620074</meetingName>
  </meta>
  <playback>
    <format>presentation</format>
    <link>http://10.0.3.16/playback/presentation/0.9.0/playback.html?meetingId=8647de1d47befd3a0df5e5b3784445ad436c1cad-1487188867218</link>
    <processing_time>24661</processing_time>
    <duration>204684</duration>
  </playback>
</recording>
```