### PR TITLE
Updated FileUploadWindow.mxml to never show scroll bars

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/FileUploadWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/FileUploadWindow.mxml
@@ -20,10 +20,15 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 -->
 
-<mx:TitleWindow xmlns:mx="http://www.adobe.com/2006/mxml" 
-	xmlns:mate="http://mate.asfusion.com/"
-	 layout="absolute" width="580" height="410" styleName="presentationFileUploadWindowStyle"
-      initialize="initData();">
+<mx:TitleWindow xmlns:mx="http://www.adobe.com/2006/mxml"
+                xmlns:mate="http://mate.asfusion.com/"
+                layout="absolute"
+                width="580"
+                height="410"
+				verticalScrollPolicy="off"
+				horizontalScrollPolicy="off"
+                styleName="presentationFileUploadWindowStyle"
+                initialize="initData();">
 
     <mate:Dispatcher id="globalDispatch" />
     <mate:Listener type="{UploadProgressEvent.UPLOAD_PROGRESS_UPDATE}" method="handleUploadProgressUpdate" />
@@ -308,9 +313,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     <mx:TextArea borderSkin="{null}"
 				 text="{ResourceUtil.getInstance().getString('bbb.fileupload.title')}"
                  editable="false" styleName="presentationUploadTitleStyle"
-                 width="400" left="0"/>
-    <mx:HBox id="fileUploadBox" width="100%" paddingLeft="5" paddingTop="0" verticalAlign="middle"> 
-      <mx:Label id="lblFileName" width="{fileUploadBox.width-selectBtn.width-uploadBtn.width-30}" selectable="false" click="selectFile()" text="{ResourceUtil.getInstance().getString('bbb.fileupload.lblFileName.defaultText')}" />
+                 width="100%"/>
+    <mx:HBox id="fileUploadBox" width="100%" paddingLeft="5" paddingRight="5" paddingTop="0" verticalAlign="middle"> 
+      <mx:Label id="lblFileName" truncateToFit="true" width="{fileUploadBox.width-selectBtn.width-uploadBtn.width-30}" selectable="false" click="selectFile()" text="{ResourceUtil.getInstance().getString('bbb.fileupload.lblFileName.defaultText')}" />
 	  <mx:Button id="selectBtn" label="{ResourceUtil.getInstance().getString('bbb.fileupload.selectBtn.label')}" 
 				   toolTip="{ResourceUtil.getInstance().getString('bbb.fileupload.selectBtn.toolTip')}" 
 				   click="selectFile()" styleName="presentationUploadChooseFileButtonStyle"/>
@@ -318,11 +323,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
                  toolTip="{ResourceUtil.getInstance().getString('bbb.fileupload.uploadBtn.toolTip')}"  click="startUpload()"
                  enabled="false" icon="{bulletGoIcon}"/>
     </mx:HBox>
-    <mx:HBox id="progressReportBox" width="100%" paddingLeft="10" paddingTop="5" paddingBottom="10" includeInLayout="true" visible="false">
+    <mx:HBox id="progressReportBox" width="100%" paddingLeft="10" paddingRight="10" paddingTop="5" paddingBottom="10" includeInLayout="true" visible="false">
       <mx:Label id="progBarLbl" text="{ResourceUtil.getInstance().getString('bbb.fileupload.progBarLbl')}" 
                 styleName="presentationUploadProgressBarLabelStyle" visible="false"/>
       <mx:ProgressBar id="progressBar" mode="manual" label="{ResourceUtil.getInstance().getString('bbb.fileupload.progBarLbl')}"
-                      styleName="presentationUploadProgressBarStyle" labelPlacement="center" width="460" visible="false"/>
+                      styleName="presentationUploadProgressBarStyle" labelPlacement="center" width="100%" visible="false"/>
     </mx:HBox>
 	<mx:Box width="100%" height="100%" paddingLeft="5" paddingRight="5">
 		<mx:Box width="100%" height="100%" verticalAlign="middle" horizontalAlign="center" styleName="presentationUploadFileFormatHintBoxStyle">
@@ -330,7 +335,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		</mx:Box>
     </mx:Box>
     <mx:Canvas width="100%" height="145" verticalScrollPolicy="off">
-      <mx:List width="100%" height="142" left="5" top="5" right="5" bottom="5" id="uploadedFilesList" alternatingItemColors="[#EFEFEF, #FEFEFE]" allowMultipleSelection="false"
+      <mx:List height="142" left="5" top="5" right="5" bottom="5" id="uploadedFilesList" alternatingItemColors="[#EFEFEF, #FEFEFE]" allowMultipleSelection="false"
                itemRenderer="org.bigbluebutton.modules.present.ui.views.UploadedPresentationRenderer"
                dragEnabled="false" dataProvider="{presentationNamesAC}">
       </mx:List>


### PR DESCRIPTION
Improved FileUploadWindow.mxml layout to fix #3668 :

- Title width set to 100% as in some languages like Greek it breaks in two lines.
- Progress bar width set to 100% to avoid expanding the popup.
- File label name has property `truncateToFit` enabled.

![image](https://cloud.githubusercontent.com/assets/4991088/23131633/fef1fdba-f78a-11e6-909a-c3e4dcb47f8c.png)
