### PR TITLE
[HTML5] Fix presentations/shapes reply messages

### DIFF
--- a/bigbluebutton-html5/imports/api/presentations/server/handlers/presentationInfoReply.js
+++ b/bigbluebutton-html5/imports/api/presentations/server/handlers/presentationInfoReply.js
@@ -1,8 +1,10 @@
 import Logger from '/imports/startup/server/logger';
 import { check } from 'meteor/check';
 import { inReplyToHTML5Client } from '/imports/api/common/server/helpers';
+import Presentations from '/imports/api/presentations';
 
 import addPresentation from '../modifiers/addPresentation';
+import removePresentation from '../modifiers/removePresentation';
 
 export default function handlePresentationInfoReply({ payload }) {
   if (!inReplyToHTML5Client({ payload })) {
@@ -14,6 +16,14 @@ export default function handlePresentationInfoReply({ payload }) {
 
   check(meetingId, String);
   check(presentations, Array);
+
+  const presentationsIds = presentations.map(_ => _.id);
+  const presentationsToRemove = Presentations.find({
+    meetingId,
+    'presentation.id': { $nin: presentationsIds },
+  }).fetch();
+
+  presentationsToRemove.forEach(p => removePresentation(meetingId, p.presentation.id));
 
   let presentationsAdded = [];
   presentations.forEach(presentation => {

--- a/bigbluebutton-html5/imports/api/shapes/server/handlers/whiteboardGetReply.js
+++ b/bigbluebutton-html5/imports/api/shapes/server/handlers/whiteboardGetReply.js
@@ -1,8 +1,10 @@
 import Logger from '/imports/startup/server/logger';
 import { check } from 'meteor/check';
 import { inReplyToHTML5Client } from '/imports/api/common/server/helpers';
+import Shapes from '/imports/api/shapes';
 
 import addShape from '../modifiers/addShape';
+import removeShape from '../modifiers/removeShape';
 
 export default function handleWhiteboardGetReply({ payload }) {
   if (!inReplyToHTML5Client({ payload })) {
@@ -14,6 +16,14 @@ export default function handleWhiteboardGetReply({ payload }) {
 
   check(meetingId, String);
   check(shapes, Array);
+
+  const shapesIds = shapes.map(_ => _.id);
+  const shapesToRemove = Shapes.find({
+    meetingId,
+    'shape.id': { $nin: shapesIds },
+  }).fetch();
+
+  shapesToRemove.forEach(s => removeShape(meetingId, s.shape.wb_id, s.shape.id));
 
   let shapesAdded = [];
   shapes.forEach(shape => {

--- a/bigbluebutton-html5/imports/api/slides/server/modifiers/addSlide.js
+++ b/bigbluebutton-html5/imports/api/slides/server/modifiers/addSlide.js
@@ -65,8 +65,9 @@ export default function addSlide(meetingId, presentationId, slide) {
 
     const { insertedId } = numChanged;
 
+    requestWhiteboardHistory(meetingId, slide.id);
+
     if (insertedId) {
-      requestWhiteboardHistory(meetingId, slide.id);
       return Logger.info(`Added slide id=${slide.id} to presentation=${presentationId}`);
     }
 


### PR DESCRIPTION
Fix shapes and presentations not being removed while non existent on the payload of the reply messages.

Bug Scenario:
- Start HTML5 server
- Add two presentations on Flash client
- Stop HTML5 server
- Remove a presentation on Flash client
- Start HTML5 server

The removed presentation will never be deleted from the HTML5 DB. 