### PR TITLE
Correctly use jquery to modify links in chat messages.

### DIFF
--- a/record-and-playback/presentation/playback/presentation/0.9.0/lib/popcorn.chattimeline.js
+++ b/record-and-playback/presentation/playback/presentation/0.9.0/lib/popcorn.chattimeline.js
@@ -58,18 +58,11 @@
 
     i++;
 
-    //  Default to empty if not used
-    //options.innerHTML = options.innerHTML || "";
+    contentDiv.innerHTML = "<strong>" + options.name + ":</strong>" + options.message;
 
     //If chat message contains a link, we add to it a target attribute
     //So when the user clicks on it, it opens in a new tab
-    if($(options.message).attr('href')) {
-       var tempHtml = $('<div/>',{html:options.message});
-       $(tempHtml).find('a').attr("target","_blank");
-       options.message = tempHtml.html();
-    }
-
-    contentDiv.innerHTML = "<strong>" + options.name + ":</strong>" + options.message;
+    $(contentDiv).find('a').attr('target', '_blank');
 
     return {
 


### PR DESCRIPTION
The code was previously passing the message string provided by the user
directly to jQuery - which works okish if the first character is '<' since
it'll parse it as HTML, but the chat messages don't. As a result, it was
sometimes being parsed as a selector, failing, and raising an exception.

The fix is to put the chat message into a DOM node (have the browser parse
the HTML) before doing the jQuery operation to modify the link targets.

Fixes #3670