### PR TITLE
Change chat message selection indicator

### DIFF
--- a/bigbluebutton-client/branding/default/style/css/BBBDefault.css
+++ b/bigbluebutton-client/branding/default/style/css/BBBDefault.css
@@ -1043,6 +1043,11 @@ PollChoicesModal {
 	fontFamily: Arial;
 }
 
+.chatMessageListStyle {
+	rollOverColor: #ffffff;
+	selectionColor: #f3f3f3;
+}
+
 EmojiGrid {
 	backgroundColor: #ffffff;
 	horizontalAlign: center;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/AdvancedList.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/AdvancedList.as
@@ -37,22 +37,6 @@ package org.bigbluebutton.modules.chat.views
     {
       super();
     }
-    
-	override protected function drawSelectionIndicator(indicator:Sprite, x:Number, y:Number, width:Number, height:Number, color:uint, itemRenderer:IListItemRenderer):void {
-		var g:Graphics = Sprite(indicator).graphics;
-		g.clear();
-		//g.beginFill(color);
-		g.lineStyle(1, color, 1.0, true, "normal", CapsStyle.SQUARE, JointStyle.MITER);
-		g.drawRect(0, 0, width-2, height);
-		//g.endFill();
-		
-		indicator.x = x;
-		indicator.y = y;
-	}
-	
-	override protected function drawHighlightIndicator(indicator:Sprite, x:Number, y:Number, width:Number, height:Number, color:uint, itemRenderer:IListItemRenderer):void {
-		
-	}
 	
     override protected function measure():void
     {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
@@ -559,7 +559,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		<chat:AdvancedList width="100%" height="{chatListHeight - timerBox.height}" id="chatMessagesList" selectable="true" variableRowHeight="true" 
 						   itemRenderer="org.bigbluebutton.modules.chat.views.ChatMessageRenderer" verticalScrollPolicy="on" horizontalScrollPolicy="off" wordWrap="true"
 						   dataProvider="{chatMessages.messages}"
-						   rollOverColor="0xFFFFFF" selectionColor="0x000000"
+						   styleName="chatMessageListStyle"
 						   accessibilityName="{ResourceUtil.getInstance().getString('bbb.chat.messageList')}" />
 		<mx:HBox id="timerBox" styleName="breakoutRoomTimerBox"
 				 includeInLayout="false" visible="false"


### PR DESCRIPTION
This PR changes the chat indicator from a black box back to the default background highlight style.