### PR TITLE
Synchronize create meeting

### DIFF
--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -56,7 +56,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
   <bean id="recordingServiceHelper" class="org.bigbluebutton.api.RecordingServiceHelperImp"/>
   
-  <bean id="presDownloadService" class="org.bigbluebutton.presentation.PresentationUrlDownloadService">
+  <bean id="presDownloadService" class="org.bigbluebutton.presentation.PresentationUrlDownloadService" destroy-method="stop">
     <property name="presentationDir" value="${presentationDir}"/>
     <property name="presentationBaseURL" value="${presentationBaseURL}"/>
    	<property name="pageExtractor" ref="pageExtractor"/>  

--- a/bigbluebutton-web/src/java/org/bigbluebutton/api/MeetingService.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/api/MeetingService.java
@@ -289,12 +289,19 @@ public class MeetingService implements MessageListener {
                 : Collections.unmodifiableCollection(sessions.values());
     }
 
-    public void createMeeting(Meeting m) {
-        handle(new CreateMeeting(m));
+    public  synchronized boolean createMeeting(Meeting m) {
+        String internalMeetingId = paramsProcessorUtil.convertToInternalMeetingId(m.getExternalId());
+        Meeting existing = getNotEndedMeetingWithId(internalMeetingId);
+        if (existing == null) {
+            meetings.put(m.getInternalId(), m);
+            handle(new CreateMeeting(m));
+            return true;
+        }
+
+        return false;
     }
 
     private void handleCreateMeeting(Meeting m) {
-        meetings.put(m.getInternalId(), m);
         if (m.isRecord()) {
             Map<String, String> metadata = new TreeMap<String, String>();
             metadata.putAll(m.getMetadata());
@@ -551,7 +558,7 @@ public class MeetingService implements MessageListener {
 
             Meeting breakout = paramsProcessorUtil.processCreateParams(params);
 
-            handleCreateMeeting(breakout);
+            createMeeting(breakout);
 
             presDownloadService.extractPage(message.parentMeetingId,
                     message.sourcePresentationId,

--- a/bigbluebutton-web/src/java/org/bigbluebutton/api/MeetingService.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/api/MeetingService.java
@@ -560,7 +560,7 @@ public class MeetingService implements MessageListener {
 
             createMeeting(breakout);
 
-            presDownloadService.extractPage(message.parentMeetingId,
+            presDownloadService.extractPresentationPage(message.parentMeetingId,
                     message.sourcePresentationId,
                     message.sourcePresentationSlide, breakout.getInternalId());
         } else {


### PR DESCRIPTION
Sometimes, several create meeting API requests are received for the same meeting at the same time. An example would be the Demo Meeting. We don't synchronize the creation of meeting that it results in a meeting with 2 different voice conference number between akka-apps and bbb-web. The first create request processed would be in akka-apps while the last request would be in bbb-web. 

So if the first request had a voice conf of 12345 while the last request has voice conf 67890, the meeting actor in akka-apps would be listening for ESL events on 12345 while the client would be joining 67890 voice conference.

This results in the client not displaying the voice icons but the users can hear each other.

This PR makes sure that there can only be one meeting created for multiple create requests by synchronizing the creation of the meeting.
