### PR TITLE
[HTML5] Increases default font size

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/settings/service.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/service.js
@@ -39,7 +39,7 @@ const setDefaultSettings = () => {
     application: {
       chatAudioNotifications: false,
       chatPushNotifications: false,
-      fontSize: '14px',
+      fontSize: '16px',
     },
     audio: {
       inputDeviceId: undefined,


### PR DESCRIPTION
Increase default font size to 16px because this is the browser default.