### PR TITLE
[HTML5] - JoinAudio btn fix

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/service.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/service.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import AuthSingleton from '/imports/ui/services/auth/index.js';
 import Users from '/imports/api/users';
 import { joinListenOnly } from '/imports/api/phone';


### PR DESCRIPTION
added missing import that was causing the join audio button to not display the modal when clicked.