### PR TITLE
Fallback to Java screenshare when WebRTC audio fails

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/verto_extension.js
+++ b/bigbluebutton-client/resources/prod/lib/verto_extension.js
@@ -11,8 +11,8 @@ Verto = function (
   this.share_call = null;
   this.vertoHandle;
 
-  this.vid_width = window.screen.width;
-  this.vid_height = window.screen.height;
+  this.vid_width = Math.max(window.screen.width, 1920);
+  this.vid_height = Math.max(window.screen.height, 1080);
 
   this.outgoingBandwidth = "default";
   this.incomingBandwidth = "default";
@@ -359,8 +359,6 @@ Verto.prototype.makeShare = function () {
       screenInfo = {
         chromeMediaSource: "desktop",
         chromeMediaSourceId: constraints.streamId,
-        maxWidth: window.screen.width > 1920 ? window.screen.width : 1920,
-        maxHeight: window.screen.height > 1080 ? window.screen.height : 1080
       };
 
       _this.logger(screenInfo);

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/WebRTCCallManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/WebRTCCallManager.as
@@ -26,6 +26,7 @@ package org.bigbluebutton.modules.phone.managers
   import org.bigbluebutton.modules.phone.events.WebRTCEchoTestStartedEvent;
   import org.bigbluebutton.modules.phone.events.WebRTCJoinedVoiceConferenceEvent;
   import org.bigbluebutton.modules.phone.models.Constants;
+  import org.bigbluebutton.modules.phone.models.WebRTCAudioStatus;
   import org.bigbluebutton.modules.phone.models.WebRTCModel;
   import org.bigbluebutton.util.i18n.ResourceUtil;
 
@@ -188,6 +189,7 @@ package org.bigbluebutton.modules.phone.managers
 	
     public function handleUseFlashModeCommand():void {
       usingWebRTC = false;
+      WebRTCAudioStatus.getInstance().setAudioFailState(true);
     }
 
     public function handleWebRTCEchoTestFailedEvent(event:WebRTCEchoTestEvent):void {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/phone/models/WebRTCAudioStatus.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/phone/models/WebRTCAudioStatus.as
@@ -1,0 +1,66 @@
+/**
+* BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+* 
+* Copyright (c) 2012 BigBlueButton Inc. and by respective authors (see below).
+*
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License as published by the Free Software
+* Foundation; either version 3.0 of the License, or (at your option) any later
+* version.
+* 
+* BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License along
+* with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+*
+*/
+package org.bigbluebutton.modules.phone.models {
+	/**
+	 * Keeps track of whether WebRTC audio has been flagged as unusable
+	 * 
+	 */	
+	public class WebRTCAudioStatus {
+		private static var instance:WebRTCAudioStatus = null;
+		private var didWebRTCAudioFail:Boolean = false;
+		
+		/**
+		 * This class is a singleton. Please initialize it using the getInstance() method.
+		 * 
+		 */		
+		public function WebRTCAudioStatus(enforcer:SingletonEnforcer) {
+			if (enforcer == null) {
+				throw new Error("There can only be 1 WebRTCAudioStatus instance");
+			}
+			initialize();
+		}
+		
+		/*
+		 * Initializes members. Keeping structure in place incase we add more complex data
+		 */
+		private function initialize():void {
+			didWebRTCAudioFail = false;
+		}
+		
+		/**
+		 * Return the single instance of the WebRTCAudioStatus class
+		 */
+		public static function getInstance():WebRTCAudioStatus {
+			if (instance == null){
+				instance = new WebRTCAudioStatus(new SingletonEnforcer());
+			}
+			return instance;
+		}
+							
+		public function setAudioFailState(newAudioState:Boolean):void {
+			this.didWebRTCAudioFail = newAudioState;
+		}
+
+		public function getDidWebRTCAudioFail():Boolean {
+			return this.didWebRTCAudioFail;
+		}
+	}
+}
+
+class SingletonEnforcer{}

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/managers/WebRTCDeskshareManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/managers/WebRTCDeskshareManager.as
@@ -51,6 +51,7 @@ package org.bigbluebutton.modules.screenshare.managers
 		private var sharing:Boolean = false;
 		private var usingWebRTC:Boolean = false;
 		private var chromeExtensionKey:String = null;
+		private var webRTCAudioFailed:Boolean = false;
 
 		public function WebRTCDeskshareManager() {
 			LOGGER.debug("WebRTCDeskshareManager::WebRTCDeskshareManager");
@@ -186,7 +187,7 @@ package org.bigbluebutton.modules.screenshare.managers
 				startWebRTCDeskshare();
 			};
 
-			if (options.tryWebRTCFirst && BrowserCheck.isWebRTCSupported()) {
+			if (options.tryWebRTCFirst && BrowserCheck.isWebRTCSupported() && BrowserCheck.isHttps()) {
 				LOGGER.debug("WebRTCDeskshareManager::handleStartSharingEvent WebRTC Supported");
 				if (BrowserCheck.isFirefox()) {
 					onSuccess("Firefox, lets try");
@@ -224,6 +225,12 @@ package org.bigbluebutton.modules.screenshare.managers
 		/*handle start sharing event*/
 		public function handleStartSharingEvent():void {
 			LOGGER.debug("WebRTCDeskshareManager::handleStartSharingEvent");
+			if (webRTCAudioFailed) {
+                               usingWebRTC = false;
+                               globalDispatcher.dispatchEvent(new UseJavaModeCommand());
+                               return;
+                       }
+
 			canIUseVertoOnThisBrowser();
 		}
 
@@ -293,5 +300,9 @@ package org.bigbluebutton.modules.screenshare.managers
 			var dispatcher:Dispatcher = new Dispatcher();
 			dispatcher.dispatchEvent(new WebRTCViewStreamEvent(WebRTCViewStreamEvent.START));
 		}
+
+		public function handleUseFlashModeCommand():void {
+                       webRTCAudioFailed = true;
+                }
 	}
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/managers/WebRTCDeskshareManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/managers/WebRTCDeskshareManager.as
@@ -28,6 +28,7 @@ package org.bigbluebutton.modules.screenshare.managers
 	import org.bigbluebutton.core.UsersUtil;
 	import org.bigbluebutton.core.managers.UserManager;
 	import org.bigbluebutton.main.events.MadePresenterEvent;
+	import org.bigbluebutton.modules.phone.models.WebRTCAudioStatus;
 	import org.bigbluebutton.modules.screenshare.events.UseJavaModeCommand;
 	import org.bigbluebutton.modules.screenshare.events.WebRTCViewStreamEvent;
 	import org.bigbluebutton.modules.screenshare.model.ScreenshareOptions;
@@ -51,7 +52,6 @@ package org.bigbluebutton.modules.screenshare.managers
 		private var sharing:Boolean = false;
 		private var usingWebRTC:Boolean = false;
 		private var chromeExtensionKey:String = null;
-		private var webRTCAudioFailed:Boolean = false;
 
 		public function WebRTCDeskshareManager() {
 			LOGGER.debug("WebRTCDeskshareManager::WebRTCDeskshareManager");
@@ -225,11 +225,11 @@ package org.bigbluebutton.modules.screenshare.managers
 		/*handle start sharing event*/
 		public function handleStartSharingEvent():void {
 			LOGGER.debug("WebRTCDeskshareManager::handleStartSharingEvent");
-			if (webRTCAudioFailed) {
+			if (WebRTCAudioStatus.getInstance().getDidWebRTCAudioFail()) {
                                usingWebRTC = false;
                                globalDispatcher.dispatchEvent(new UseJavaModeCommand());
                                return;
-                       }
+			}
 
 			canIUseVertoOnThisBrowser();
 		}
@@ -300,9 +300,5 @@ package org.bigbluebutton.modules.screenshare.managers
 			var dispatcher:Dispatcher = new Dispatcher();
 			dispatcher.dispatchEvent(new WebRTCViewStreamEvent(WebRTCViewStreamEvent.START));
 		}
-
-		public function handleUseFlashModeCommand():void {
-                       webRTCAudioFailed = true;
-                }
 	}
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/maps/WebRTCDeskshareEventMap.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/maps/WebRTCDeskshareEventMap.mxml
@@ -45,6 +45,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.modules.screenshare.events.StartedViewingEvent;
 			import org.bigbluebutton.modules.screenshare.events.IsSharingScreenEvent;
 			import org.bigbluebutton.modules.screenshare.services.red5.WebRTCConnectionEvent;
+			import org.bigbluebutton.modules.phone.events.UseFlashModeCommand;
 		]]>
 	</mx:Script>
 
@@ -131,8 +132,22 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		<MethodInvoker generator="{WebRTCDeskshareManager}" method="handleStartModuleEvent" arguments="{event.module}"/>
 	</EventHandlers>
 
-	<EventHandlers type="{UseJavaModeCommand.USE_JAVA_MODE}">
-		<MethodInvoker generator="{WebRTCDeskshareManager}" method="handleUseJavaModeCommand"/>
-	</EventHandlers>
+        <!--
+        This is when the WebRTC deskshare manager detects that either WebRTC is
+        not supported, one one of the requirements (browser version, extension,
+        etc) is not met so it issues a fallback to Java deskshare event
+        -->
+        <EventHandlers type="{UseJavaModeCommand.USE_JAVA_MODE}">
+                <MethodInvoker generator="{WebRTCDeskshareManager}" method="handleUseJavaModeCommand"/>
+        </EventHandlers>
 
+        <!--
+        This is when the phone module's WebRTC call manager detects a problem
+        trying to make a WebRTC calls and emits an event for the flash
+        call manager. The WebRTC deskshare manager will listen for this and
+        automatically fallback to flash
+        -->
+        <EventHandlers type="{UseFlashModeCommand.USE_FLASH_MODE}">
+                <MethodInvoker generator="{WebRTCDeskshareManager}" method="handleUseFlashModeCommand"/>
+        </EventHandlers>
 </EventMap>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/maps/WebRTCDeskshareEventMap.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/maps/WebRTCDeskshareEventMap.mxml
@@ -140,14 +140,4 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <EventHandlers type="{UseJavaModeCommand.USE_JAVA_MODE}">
                 <MethodInvoker generator="{WebRTCDeskshareManager}" method="handleUseJavaModeCommand"/>
         </EventHandlers>
-
-        <!--
-        This is when the phone module's WebRTC call manager detects a problem
-        trying to make a WebRTC calls and emits an event for the flash
-        call manager. The WebRTC deskshare manager will listen for this and
-        automatically fallback to flash
-        -->
-        <EventHandlers type="{UseFlashModeCommand.USE_FLASH_MODE}">
-                <MethodInvoker generator="{WebRTCDeskshareManager}" method="handleUseFlashModeCommand"/>
-        </EventHandlers>
 </EventMap>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/utils/BrowserCheck.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/utils/BrowserCheck.as
@@ -42,5 +42,11 @@ package org.bigbluebutton.modules.screenshare.utils
 			var browser:Array = ExternalInterface.call("determineBrowser");
 			return browser[0] == "Firefox";
 		}
+
+		public static function isHttps():Boolean {
+                        var url:String = ExternalInterface.call("window.location.href.toString");
+                        var httpsPattern:RegExp = /^https/;
+                        return httpsPattern.test(url);
+                }
 	}
 }


### PR DESCRIPTION
- adds a WebRTC audio status class for checking if webrtc audio has failed
- webrtc deskshare module will fallback to flash if webrtc audio encounters an issue
- webrtc deskshare module will now automatically fallback to java if https is not present (required for browsers to grant peripheral access to webrtc as well as required for verto to connect to freeswitch)