### PR TITLE
recording presentation: Improve calculations of bar sizes in poll results

### DIFF
--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -466,6 +466,7 @@ def storePollResultShape(xml, shape)
   result = JSON.load(shape.at_xpath('result').text)
   num_responders = shape.at_xpath('num_responders').text.to_i
   presentation = shape.at_xpath('presentation').text
+  max_num_votes = result.map{ |r| r['num_votes'] }.max
 
   $global_shape_count += 1
   $poll_result_count += 1
@@ -503,7 +504,7 @@ def storePollResultShape(xml, shape)
     end
     g.puts('set linetype 1 linewidth 1 linecolor rgb "black"')
     result.each do |r|
-      if r['num_votes'] == 0 or r['num_votes'].to_f / num_responders <= 0.5
+      if r['num_votes'] == 0 or r['num_votes'].to_f / max_num_votes <= 0.5
         g.puts("set label \"#{r['num_votes']}\" at #{r['id']},#{r['num_votes']} left rotate by 90 offset 0,character 0.5 front")
       else
         g.puts("set label \"#{r['num_votes']}\" at #{r['id']},#{r['num_votes']} right rotate by 90 offset 0,character -0.5 textcolor rgb \"white\" front")

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -489,6 +489,8 @@ def storePollResultShape(xml, shape)
   File.open(gpl_file, 'w') do |g|
     g.puts('reset')
     g.puts("set term pdfcairo size #{height / 72}, #{width / 72} font \"Arial,48\" noenhanced")
+    g.puts('set lmargin 0.5')
+    g.puts('set rmargin 0.5')
     g.puts('unset key')
     g.puts('set style data boxes')
     g.puts('set style fill solid border -1')


### PR DESCRIPTION
The code was previously dividing by the total number of votes rather than the max number of votes, which meant it was underestimating the width of the bars. In some cases, this meant that the label for number of votes would overlap the percentages.

Now fixed:
![screen shot 2017-04-06 at 16 47 00-fullpage](https://cloud.githubusercontent.com/assets/38788/24775024/33f6f00c-1ae9-11e7-83fd-2e055124c737.png)

Also, the margins at the top/bottom were too large, meaning that in some cases (wide aspect ratio slides with few poll results) the bars were too squished. Also fixed:
![screenshot from 2017-04-06 18-07-34](https://cloud.githubusercontent.com/assets/38788/24777580/fc339f66-1af3-11e7-9448-d017663dbcb5.png)


Fixes #3725 

