### PR TITLE
[HTML5] Fix client freeze on private chat partner leaving. Fix for #3786

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/component.jsx
@@ -28,6 +28,7 @@ class Chat extends Component {
       scrollPosition,
       hasUnreadMessages,
       lastReadMessageTime,
+      partnerIsLoggedOut,
       isChatLocked,
       actions,
       intl,
@@ -65,6 +66,7 @@ class Chat extends Component {
           handleScrollUpdate={actions.handleScrollUpdate}
           handleReadMessage={actions.handleReadMessage}
           lastReadMessageTime={lastReadMessageTime}
+          partnerIsLoggedOut={partnerIsLoggedOut}
         />
         <MessageForm
           disabled={isChatLocked}

--- a/bigbluebutton-html5/imports/ui/components/chat/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/container.jsx
@@ -54,6 +54,9 @@ export default injectIntl(createContainer(({ params, intl }) => {
     messages = ChatService.getPrivateMessages(chatID);
   }
 
+  let user = ChatService.getUser(chatID, '{{NAME}}');
+  const partnerIsLoggedOut = user.isLoggedOut;
+
   if (messages && chatID !== PUBLIC_CHAT_KEY) {
     let userMessage = messages.find(m => m.sender !== null);
     let user = ChatService.getUser(chatID, '{{NAME}}');
@@ -62,7 +65,7 @@ export default injectIntl(createContainer(({ params, intl }) => {
     title = intl.formatMessage(intlMessages.titlePrivate, { name: user.name });
     chatName = user.name;
 
-    if (user.isLoggedOut) {
+    if (partnerIsLoggedOut) {
       let time = Date.now();
       let id = `partner-disconnected-${time}`;
       let messagePartnerLoggedOut = {
@@ -92,6 +95,7 @@ export default injectIntl(createContainer(({ params, intl }) => {
     messages,
     lastReadMessageTime,
     hasUnreadMessages,
+    partnerIsLoggedOut,
     isChatLocked,
     scrollPosition,
     actions: {

--- a/bigbluebutton-html5/imports/ui/components/chat/message-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-list/component.jsx
@@ -124,12 +124,13 @@ class MessageList extends Component {
     // console.log('hasNewUnreadMessages=' + hasNewUnreadMessages);
 
     // check if the messages include <user has left the meeting>
-    const lastMessageId = nextProps.messages[nextProps.messages.length - 1].id;
-    const userLeftIsDisplayed = lastMessageId.includes('partner-disconnected');
+    const lastMessage = nextProps.messages[nextProps.messages.length - 1];
+    if (lastMessage) {
+      const userLeftIsDisplayed = lastMessage.id.includes('partner-disconnected');
+      if (partnerIsLoggedOut && userLeftIsDisplayed) return false; // update leads to endless loop
+    }
 
     if (switchingCorrespondent || hasNewUnreadMessages) return true;
-
-    if (partnerIsLoggedOut && userLeftIsDisplayed) return false; // update leads to endless loop
 
     return true;
   }

--- a/bigbluebutton-html5/imports/ui/components/chat/message-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-list/component.jsx
@@ -120,19 +120,16 @@ class MessageList extends Component {
     const switchingCorrespondent = chatId !== nextProps.chatId;
     const hasNewUnreadMessages = hasUnreadMessages !== nextProps.hasUnreadMessages;
 
-    // console.log('switchingCorrespondent=' + switchingCorrespondent);
-    // console.log('hasNewUnreadMessages=' + hasNewUnreadMessages);
-
     // check if the messages include <user has left the meeting>
     const lastMessage = nextProps.messages[nextProps.messages.length - 1];
     if (lastMessage) {
       const userLeftIsDisplayed = lastMessage.id.includes('partner-disconnected');
-      if (partnerIsLoggedOut && userLeftIsDisplayed) return false; // update leads to endless loop
+      if (!(partnerIsLoggedOut && userLeftIsDisplayed)) return true;
     }
 
     if (switchingCorrespondent || hasNewUnreadMessages) return true;
 
-    return true;
+    return false;
   }
 
   render() {

--- a/bigbluebutton-html5/imports/ui/components/chat/message-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-list/component.jsx
@@ -1,4 +1,3 @@
-
 import React, { Component, PropTypes } from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import _ from 'lodash';
@@ -112,14 +111,27 @@ class MessageList extends Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    if (this.props.chatId !== nextProps.chatId
-      || this.props.hasUnreadMessages !== nextProps.hasUnreadMessages
-      || this.props.messages.length !== nextProps.messages.length
-      || !_.isEqual(this.props.messages, nextProps.messages)) {
-      return true;
-    }
+    const {
+      chatId,
+      hasUnreadMessages,
+      partnerIsLoggedOut,
+    } = this.props;
 
-    return false;
+    const switchingCorrespondent = chatId !== nextProps.chatId;
+    const hasNewUnreadMessages = hasUnreadMessages !== nextProps.hasUnreadMessages;
+
+    // console.log('switchingCorrespondent=' + switchingCorrespondent);
+    // console.log('hasNewUnreadMessages=' + hasNewUnreadMessages);
+
+    // check if the messages include <user has left the meeting>
+    const lastMessageId = nextProps.messages[nextProps.messages.length - 1].id;
+    const userLeftIsDisplayed = lastMessageId.includes('partner-disconnected');
+
+    if (switchingCorrespondent || hasNewUnreadMessages) return true;
+
+    if (partnerIsLoggedOut && userLeftIsDisplayed) return false; // update leads to endless loop
+
+    return true;
   }
 
   render() {


### PR DESCRIPTION
Fix for #3786 

Improved the logic for when to update the messages list in the private chat, in particular don't update the messages list if the private chat partner is offline.. (Before this fix the scenario was leading to forever loop freezing the client)