### PR TITLE
 Check userId when validating token

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/UsersApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/UsersApp.scala
@@ -86,7 +86,7 @@ trait UsersApp {
 
   def handleValidateAuthToken(msg: ValidateAuthToken) {
     log.info("Got ValidateAuthToken message. meetingId=" + msg.meetingID + " userId=" + msg.userId)
-    usersModel.getRegisteredUserWithToken(msg.token) match {
+    usersModel.getRegisteredUserWithToken(msg.token, msg.userId) match {
       case Some(u) =>
         {
           val replyTo = mProps.meetingID + '/' + msg.userId
@@ -319,7 +319,7 @@ trait UsersApp {
   def handleUserJoin(msg: UserJoining): Unit = {
     log.debug("Received user joined meeting. metingId=" + mProps.meetingID + " userId=" + msg.userID)
 
-    val regUser = usersModel.getRegisteredUserWithToken(msg.authToken)
+    val regUser = usersModel.getRegisteredUserWithToken(msg.authToken, msg.userID)
     regUser foreach { ru =>
       log.debug("Found registered user. metingId=" + mProps.meetingID + " userId=" + msg.userID + " ru=" + ru)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/UsersModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/UsersModel.scala
@@ -38,8 +38,21 @@ class UsersModel {
     regUsers += token -> regUser
   }
 
-  def getRegisteredUserWithToken(token: String): Option[RegisteredUser] = {
-    regUsers.get(token)
+  def getRegisteredUserWithToken(token: String, userId: String): Option[RegisteredUser] = {
+
+    def isSameUserId(ru: RegisteredUser, userId: String): Option[RegisteredUser] = {
+      if (userId.startsWith(ru.id)) {
+        Some(ru)
+      } else {
+        None
+      }
+    }
+
+    for {
+      ru <- regUsers.get(token)
+      user <- isSameUserId(ru, userId)
+    } yield user
+
   }
 
   def generateWebUserId: String = {


### PR DESCRIPTION
 - check if the client validating the token mathes the userId of the registered user. If
   we don't, the client can pass any token and impersonate other users.