### PR TITLE
 user internal userId instead of external userId 

### DIFF
--- a/bbb-common-message/src/main/java/org/bigbluebutton/common/messages/RegisterUserMessage.java
+++ b/bbb-common-message/src/main/java/org/bigbluebutton/common/messages/RegisterUserMessage.java
@@ -55,18 +55,19 @@ public class RegisterUserMessage implements IBigBlueButtonMessage {
 					if (payload.has(Constants.MEETING_ID)
 							&& payload.has(Constants.NAME)
 							&& payload.has(Constants.ROLE)
+							&& payload.has(Constants.USER_ID)
 							&& payload.has(Constants.EXT_USER_ID)
 							&& payload.has(Constants.AUTH_TOKEN)) {
 
 						String meetingID = payload.get(Constants.MEETING_ID).getAsString();
 						String fullname = payload.get(Constants.NAME).getAsString();
 						String role = payload.get(Constants.ROLE).getAsString();
+						String userId = payload.get(Constants.USER_ID).getAsString();
 						String externUserID = payload.get(Constants.EXT_USER_ID).getAsString();
 						String authToken = payload.get(Constants.AUTH_TOKEN).getAsString();
 						String avatarURL = payload.get(Constants.AVATAR_URL).getAsString();
-
-						//use externalUserId twice - once for external, once for internal
-						return new RegisterUserMessage(meetingID, externUserID, fullname, role, externUserID, authToken, avatarURL);
+						
+						return new RegisterUserMessage(meetingID, userId, fullname, role, externUserID, authToken, avatarURL);
 					}
 				}
 			}


### PR DESCRIPTION
In register user message, we were putting the externalUserId as the internal userId. When we use the internal userId to validate the token, the validate token reply reruns false if the internal userId and external userId are different as the case in breakout rooms.