### PR TITLE
Imporve document conversion fallback

### DIFF
--- a/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
@@ -66,7 +66,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	<bean id="pdf2SwfPageConverter" class="org.bigbluebutton.presentation.imp.Pdf2SwfPageConverter">
 		<property name="ghostscriptExec" value="${ghostScriptExec}"/>
 		<property name="swfToolsDir" value="${swfToolsDir}"/>
-		<property name="imageMagickDir" value="${imageMagickDir}"/>
 		<property name="fontsDir" value="${fontsDir}"/>
 		<property name="noPdfMarkWorkaround" value="${noPdfMarkWorkaround}"/>
 		<property name="placementsThreshold" value="${placementsThreshold}"/>

--- a/bigbluebutton-web/src/java/org/bigbluebutton/presentation/imp/Pdf2SwfPageConverter.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/presentation/imp/Pdf2SwfPageConverter.java
@@ -45,7 +45,6 @@ public class Pdf2SwfPageConverter implements PageConverter {
       .getLogger(Pdf2SwfPageConverter.class);
 
   private String GHOSTSCRIPT_EXEC;
-  private String IMAGEMAGICK_DIR;
   private String SWFTOOLS_DIR;
   private String fontsDir;
   private String noPdfMarkWorkaround;
@@ -55,7 +54,8 @@ public class Pdf2SwfPageConverter implements PageConverter {
   private String convTimeout = "7s";
   private int WAIT_FOR_SEC = 7;
 
-  public boolean convert(File presentation, File output, int page, UploadedPresentation pres) {
+  public boolean convert(File presentation, File output, int page,
+      UploadedPresentation pres) {
     long convertStart = System.currentTimeMillis();
 
     String source = presentation.getAbsolutePath();
@@ -64,22 +64,10 @@ public class Pdf2SwfPageConverter implements PageConverter {
 
     // Building the command line wrapped in shell to be able to use shell
     // feature like the pipe
-    NuProcessBuilder pb = new NuProcessBuilder(
-        Arrays.asList("timeout", convTimeout,
-            "/bin/sh",
-            "-c",
-            SWFTOOLS_DIR
-            + File.separator
-            + "pdf2swf"
-            + " -vv "
-            + AVM2SWF
-            + " -F "
-            + fontsDir
-            + " -p "
-            + String.valueOf(page)
-            + " "
-            + source
-            + " -o "
+    NuProcessBuilder pb = new NuProcessBuilder(Arrays.asList("timeout",
+        convTimeout, "/bin/sh", "-c",
+        SWFTOOLS_DIR + File.separator + "pdf2swf" + " -vv " + AVM2SWF + " -F "
+            + fontsDir + " -p " + String.valueOf(page) + " " + source + " -o "
             + dest
             + " | egrep  'shape id|Updating font|Drawing' | sed 's/  / /g' | cut -d' ' -f 1-3  | sort | uniq -cw 15"));
 
@@ -95,8 +83,9 @@ public class Pdf2SwfPageConverter implements PageConverter {
       log.error(e.getMessage());
     }
 
-    long pdf2SwfEnd = System.currentTimeMillis();   
-    log.debug("Pdf2Swf conversion duration: {} sec", (pdf2SwfEnd - pdf2SwfStart)/1000);
+    long pdf2SwfEnd = System.currentTimeMillis();
+    log.debug("Pdf2Swf conversion duration: {} sec",
+        (pdf2SwfEnd - pdf2SwfStart) / 1000);
 
     File destFile = new File(dest);
     if (pHandler.isConversionSuccessful() && destFile.exists()
@@ -105,7 +94,8 @@ public class Pdf2SwfPageConverter implements PageConverter {
         && pHandler.numberOfImageTags() < imageTagThreshold) {
       return true;
     } else {
-     // We need t delete the destination file as we are starting a new conversion process
+      // We need t delete the destination file as we are starting a new
+      // conversion process
       if (destFile.exists()) {
         destFile.delete();
       }
@@ -121,15 +111,15 @@ public class Pdf2SwfPageConverter implements PageConverter {
       logData.put("numTextTags", pHandler.numberOfTextTags());
       logData.put("numImageTags", pHandler.numberOfImageTags());
       Gson gson = new Gson();
-      String logStr =  gson.toJson(logData);
+      String logStr = gson.toJson(logData);
 
       log.warn("Potential problem with generated SWF: data={}", logStr);
 
       File tempPdfPage = null;
       File tempPng = null;
-      String basePresentationame = FilenameUtils.getBaseName(presentation.getName());
+      String basePresentationame = FilenameUtils
+          .getBaseName(presentation.getName());
       try {
-        tempPdfPage = File.createTempFile(basePresentationame + "-" + page, ".pdf");
         tempPng = File.createTempFile(basePresentationame + "-" + page, ".png");
       } catch (IOException ioException) {
         // We should never fall into this if the server is correctly configured
@@ -138,32 +128,14 @@ public class Pdf2SwfPageConverter implements PageConverter {
 
       long gsStart = System.currentTimeMillis();
 
-      // Step 1: Extract the PDF page into a single PDF file
-      NuProcessBuilder pbPdf = new NuProcessBuilder(Arrays.asList("timeout", convTimeout,
-          GHOSTSCRIPT_EXEC, "-sDEVICE=pdfwrite", "-dNOPAUSE", "-dQUIET",
-          "-dBATCH", "-dFirstPage=" + page, "-dLastPage=" + page,
-          "-sOutputFile=" + tempPdfPage.getAbsolutePath(), noPdfMarkWorkaround,
+      // Step 1: Convert a PDF page to PNG using a raw GhostScript command
+      NuProcessBuilder pbPng = new NuProcessBuilder(Arrays.asList("timeout",
+          convTimeout, GHOSTSCRIPT_EXEC, "-sDEVICE=png16m", "-dNOPAUSE",
+          "-dQUIET", "-dBATCH", "-r150", "-dGraphicsAlphaBits=4",
+          "-dTextAlphaBits=4", "-dFirstPage=" + page, "-dLastPage=" + page,
+          "-sOutputFile=" + tempPng.getAbsolutePath(), noPdfMarkWorkaround,
           presentation.getAbsolutePath()));
 
-      NuAbstractProcessHandler pbPdfHandler = new NuAbstractProcessHandler() {};
-      pbPdf.setProcessListener(pbPdfHandler);
-      NuProcess processPdf = pbPdf.start();
-      try {
-        processPdf.waitFor(WAIT_FOR_SEC, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        log.error(e.getMessage());
-      }
-
-      long gsEnd = System.currentTimeMillis();
-      log.debug("Ghostscript conversion duration: {} sec", (gsStart - gsEnd)/1000);
-
-      long magickStart = System.currentTimeMillis();
-
-      // Step 2: Convert a PDF page to PNG
-      NuProcessBuilder pbPng = new NuProcessBuilder(Arrays.asList("timeout", convTimeout,
-          IMAGEMAGICK_DIR + File.separator + "convert", "-density", "150",
-          "-quality", "90", "-flatten", "+dither", "-depth", "8",
-          tempPdfPage.getAbsolutePath(), tempPng.getAbsolutePath()));
       Pdf2PngPageConverterHandler pbPngHandler = new Pdf2PngPageConverterHandler();
       pbPng.setProcessListener(pbPngHandler);
       NuProcess processPng = pbPng.start();
@@ -172,25 +144,18 @@ public class Pdf2SwfPageConverter implements PageConverter {
       } catch (InterruptedException e) {
         log.error(e.getMessage());
       }
-      long magickEnd = System.currentTimeMillis();
 
-      logData = new HashMap<String, Object>();
-      logData.put("meetingId", pres.getMeetingId());
-      logData.put("presId", pres.getId());
-      logData.put("filename", pres.getName());
-      logData.put("page", page);
-      logData.put("conversionTime(sec)", (magickEnd - magickStart)/1000);
-
-      logStr =  gson.toJson(logData);
-
-      log.debug("ImageMagick conversion duration: {} sec", (magickEnd - magickStart)/1000);
+      long gsEnd = System.currentTimeMillis();
+      log.debug("Ghostscript conversion duration: {} sec",
+          (gsStart - gsEnd) / 1000);
 
       long png2swfStart = System.currentTimeMillis();
 
-      // Step 3: Convert a PNG image to SWF
+      // Step 2: Convert a PNG image to SWF
       source = tempPng.getAbsolutePath();
-      NuProcessBuilder pbSwf = new NuProcessBuilder(Arrays.asList("timeout", convTimeout, SWFTOOLS_DIR
-          + File.separator + "png2swf", "-o", dest, source));
+      NuProcessBuilder pbSwf = new NuProcessBuilder(
+          Arrays.asList("timeout", convTimeout,
+              SWFTOOLS_DIR + File.separator + "png2swf", "-o", dest, source));
       Png2SwfPageConverterHandler pSwfHandler = new Png2SwfPageConverterHandler();
       pbSwf.setProcessListener(pSwfHandler);
       NuProcess processSwf = pbSwf.start();
@@ -201,11 +166,11 @@ public class Pdf2SwfPageConverter implements PageConverter {
       }
 
       long png2swfEnd = System.currentTimeMillis();
-      log.debug("ImageMagick conversion duration: {} sec", (png2swfEnd - png2swfStart)/1000);
+      log.debug("ImageMagick conversion duration: {} sec",
+          (png2swfEnd - png2swfStart) / 1000);
 
       // Delete the temporary PNG and PDF files after finishing the image
       // conversion
-      tempPdfPage.delete();
       tempPng.delete();
 
       boolean doneSwf = pSwfHandler.isConversionSuccessful();
@@ -217,12 +182,12 @@ public class Pdf2SwfPageConverter implements PageConverter {
       logData.put("presId", pres.getId());
       logData.put("filename", pres.getName());
       logData.put("page", page);
-      logData.put("conversionTime(sec)", (convertEnd - convertStart)/1000);
+      logData.put("conversionTime(sec)", (convertEnd - convertStart) / 1000);
 
-      logStr =  gson.toJson(logData);
+      logStr = gson.toJson(logData);
 
-      log.debug("Problem page conversion duration: {} sec", (convertEnd - convertStart)/1000);
-
+      log.debug("Problem page conversion duration: {} sec",
+          (convertEnd - convertStart) / 1000);
 
       if (doneSwf && destFile.exists()) {
         return true;
@@ -235,10 +200,6 @@ public class Pdf2SwfPageConverter implements PageConverter {
 
   public void setSwfToolsDir(String dir) {
     SWFTOOLS_DIR = dir;
-  }
-
-  public void setImageMagickDir(String dir) {
-    IMAGEMAGICK_DIR = dir;
   }
 
   public void setFontsDir(String dir) {


### PR DESCRIPTION
Two new improvements to the document conversion fallback:

1. Remove page extraction to PDF and replace image `convert` conversion command with `gs`.
2. Image conversion uses 72 DPI option if the initial conversion has timed-out or the SWF object contained twice the number of allowed objects, or use the 150 DPI by default.