### PR TITLE
Fix focus chat message list key and label

### DIFF
--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -580,8 +580,8 @@ bbb.shortcutkey.users.joinBreakoutRoom.function = Join selected breakout room
 
 bbb.shortcutkey.chat.focusTabs = 89
 bbb.shortcutkey.chat.focusTabs.function = Focus to chat tabs
-bbb.shortcutkey.chat.focusBox = 77
-bbb.shortcutkey.chat.focusBox.function = Focus to chat box
+bbb.shortcutkey.chat.focusBox = 82
+bbb.shortcutkey.chat.focusBox.function = Focus to chat message list
 bbb.shortcutkey.chat.changeColour = 67
 bbb.shortcutkey.chat.changeColour.function = Focus to font color picker.
 bbb.shortcutkey.chat.sendMessage = 83


### PR DESCRIPTION
This PR switches the key for focusing the chat message list from 'M' to 'R' because m is taken by IE. This PR also clarifies the the purpose of the key to avoid confusion with the global key to focus the chat input area.