### PR TITLE
 Add catch all exception to bbb-web redis subscriber

### DIFF
--- a/bigbluebutton-web/src/java/org/bigbluebutton/api/messaging/MessageReceiver.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/api/messaging/MessageReceiver.java
@@ -45,8 +45,10 @@ public class MessageReceiver {
 			    		} catch(JedisConnectionException ex) {
 			    			log.warn("Exception on Jedis connection. Resubscribing to pubsub.");
 			    			start();
-			    		}			    		 
-			    	}
+			    		} catch (Exception e) {
+							log.error("Error resubscribing to channels: " + e.getMessage());
+						}
+					}
 			    }
 			};
 			msgReceiverExec.execute(messageReceiver);

--- a/bigbluebutton-web/src/java/org/bigbluebutton/web/services/KeepAliveService.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/web/services/KeepAliveService.java
@@ -125,11 +125,14 @@ public class KeepAliveService implements MessageListener {
   	
   private void processPing(KeepAlivePing msg) {
 	  service.sendKeepAlive(SYSTEM, System.currentTimeMillis());
-	  
+	  Boolean akkaAppsIsAvalable = available;
+
 	  if (lastKeepAliveMessage != 0 && (System.currentTimeMillis() - lastKeepAliveMessage > 30000)) {
-		  log.error("BBB Web pubsub error!");
-	   		// BBB-Apps has gone down. Mark it as unavailable. (ralam - april 29, 2014)
-	   		available = false;
+	  	if (akkaAppsIsAvalable) {
+			log.error("BBB Web pubsub error!");
+			// BBB-Apps has gone down. Mark it as unavailable. (ralam - april 29, 2014)
+			available = false;
+		}
 	  }		
   }
   	

--- a/bigbluebutton-web/src/java/org/bigbluebutton/web/services/KeepAliveService.java
+++ b/bigbluebutton-web/src/java/org/bigbluebutton/web/services/KeepAliveService.java
@@ -125,10 +125,10 @@ public class KeepAliveService implements MessageListener {
   	
   private void processPing(KeepAlivePing msg) {
 	  service.sendKeepAlive(SYSTEM, System.currentTimeMillis());
-	  Boolean akkaAppsIsAvalable = available;
+	  Boolean akkaAppsIsAvailable = available;
 
 	  if (lastKeepAliveMessage != 0 && (System.currentTimeMillis() - lastKeepAliveMessage > 30000)) {
-	  	if (akkaAppsIsAvalable) {
+	  	if (akkaAppsIsAvailable) {
 			log.error("BBB Web pubsub error!");
 			// BBB-Apps has gone down. Mark it as unavailable. (ralam - april 29, 2014)
 			available = false;


### PR DESCRIPTION
 On redis-cli, we noticed that BbbWebSub isn't on the "client list". The auto-reconnect on bbb-web
 wasn't triggered as not log was generated in bbb-web.log. Maybe the exception was something we
 did not handle. Try catching all exception on this jedis connection.