### PR TITLE
HTML5: Make moderator role features configurable in html5 client

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -53,7 +53,8 @@ class ActionsDropdown extends Component {
   render() {
     const { intl, isUserPresenter } = this.props;
 
-    if (!isUserPresenter) return null;
+    // if (!isUserPresenter) return null;
+    return null; // temporarily disabling the functionality
 
     return (
       <Dropdown ref="dropdown">

--- a/bigbluebutton-html5/imports/ui/components/settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/component.jsx
@@ -131,10 +131,10 @@ class Settings extends Component {
             <Icon iconName='application' className={styles.icon}/>
             <span id="appTab">{intl.formatMessage(intlMessages.appTabLabel)}</span>
           </Tab>
-          <Tab className={styles.tabSelector} aria-labelledby="videoTab">
-            <Icon iconName='video' className={styles.icon}/>
-            <span id="videoTab">{intl.formatMessage(intlMessages.videoTabLabel)}</span>
-          </Tab>
+          {/*<Tab className={styles.tabSelector} aria-labelledby="videoTab">*/}
+            {/*<Icon iconName='video' className={styles.icon}/>*/}
+            {/*<span id="videoTab">{intl.formatMessage(intlMessages.videoTabLabel)}</span>*/}
+          {/*</Tab>*/}
           <Tab className={styles.tabSelector} aria-labelledby="ccTab">
             <Icon iconName='user' className={styles.icon}/>
             <span id="ccTab">{intl.formatMessage(intlMessages.closecaptionTabLabel)}</span>
@@ -153,12 +153,12 @@ class Settings extends Component {
             settings={this.state.current.application}
             />
         </TabPanel>
-        <TabPanel className={styles.tabPanel}>
-          <Video
-            handleUpdateSettings={this.handleUpdateSettings}
-            settings={this.state.current.video}
-            />
-        </TabPanel>
+        {/*<TabPanel className={styles.tabPanel}>*/}
+          {/*<Video*/}
+            {/*handleUpdateSettings={this.handleUpdateSettings}*/}
+            {/*settings={this.state.current.video}*/}
+            {/*/>*/}
+        {/*</TabPanel>*/}
         <TabPanel className={styles.tabPanel}>
           <ClosedCaptions
             settings={this.state.current.cc}

--- a/bigbluebutton-html5/imports/ui/components/settings/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/container.jsx
@@ -5,7 +5,7 @@ import SettingsService from '/imports/ui/services/settings';
 
 import {
     getClosedCaptionLocales,
-    getUserRoles,
+    getModeratorRole,
     updateSettings,
     getAvailableLocales,
   } from './service';
@@ -28,6 +28,6 @@ export default createContainer(() => {
     updateSettings,
     locales: getClosedCaptionLocales(),
     availableLocales: getAvailableLocales(),
-    isModerator: getUserRoles() === 'MODERATOR',
+    isModerator: getModeratorRole(),
   };
 }, SettingsContainer);

--- a/bigbluebutton-html5/imports/ui/components/settings/service.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/service.js
@@ -4,6 +4,8 @@ import Auth from '/imports/ui/services/auth';
 import _ from 'lodash';
 import Settings from '/imports/ui/services/settings';
 
+const APP_CONFIG = Meteor.settings.public.app;
+
 const getClosedCaptionLocales = () => {
   //list of unique locales in the Captions Collection
   const locales = _.uniq(Captions.find({}, {
@@ -24,6 +26,10 @@ const getUserRoles = () => {
   return user.role;
 };
 
+const getModeratorRole = () => {
+  return APP_CONFIG.allowHTML5Moderator && getUserRoles() === 'MODERATOR';
+};
+
 const updateSettings = (obj) => {
   Object.keys(obj).forEach(k => Settings[k] = obj[k]);
   Settings.save();
@@ -35,7 +41,7 @@ const getAvailableLocales = () => {
 
 export {
   getClosedCaptionLocales,
-  getUserRoles,
+  getModeratorRole,
   updateSettings,
   getAvailableLocales,
 };

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-item/component.jsx
@@ -16,6 +16,7 @@ import DropdownList from '/imports/ui/components/dropdown/list/component';
 import DropdownListItem from '/imports/ui/components/dropdown/list/item/component';
 import DropdownListSeparator from '/imports/ui/components/dropdown/list/separator/component';
 import DropdownListTitle from '/imports/ui/components/dropdown/list/title/component';
+import { getModeratorRole } from '/imports/ui/components/settings/service';
 
 const propTypes = {
   user: React.PropTypes.shape({
@@ -120,17 +121,18 @@ class UserListItem extends Component {
       unmute,
     } = userActions;
 
-    const hasAuthority = currentUser.isModerator || user.isCurrent;
+    const currentUserIsModerator = currentUser.isModerator && getModeratorRole();
+    const hasAuthority = currentUserIsModerator || user.isCurrent;
     let allowedToChatPrivately = !user.isCurrent;
     let allowedToMuteAudio = hasAuthority && user.isVoiceUser && user.isMuted;
     let allowedToUnmuteAudio = hasAuthority && user.isVoiceUser && !user.isMuted;
-    let allowedToResetStatus = hasAuthority && user.emoji.status != 'none';
+    let allowedToResetStatus = hasAuthority && user.emoji.status !== 'none';
 
     // if currentUser is a moderator, allow kicking other users
-    let allowedToKick = currentUser.isModerator && !user.isCurrent && !isBreakoutRoom;
+    let allowedToKick = currentUserIsModerator && !user.isCurrent && !isBreakoutRoom;
 
     let allowedToSetPresenter =
-      (currentUser.isModerator || currentUser.isPresenter) && !user.isPresenter;
+      (currentUserIsModerator || currentUser.isPresenter) && !user.isPresenter;
 
     return _.compact([
       (allowedToChatPrivately ? this.renderUserAction(openChat, router, user) : null),

--- a/bigbluebutton-html5/private/config/public/app.yaml
+++ b/bigbluebutton-html5/private/config/public/app.yaml
@@ -15,7 +15,7 @@ app:
   # Default global variables
   appName: "BigBlueButton HTML5 Client"
   bbbServerVersion: "1.1-beta"
-  copyright: "©2016 BigBlueButton Inc."
+  copyright: "©2017 BigBlueButton Inc."
   html5ClientBuild: "HTML5_CLIENT_VERSION"
   defaultWelcomeMessage: Welcome to %%CONFNAME%%!<br /><br />For help on using BigBlueButton see these (short) <a href="event:http://www.bigbluebutton.org/content/videos"><u>tutorial videos</u></a>.<br /><br />To join the audio bridge click the gear icon (upper-right hand corner).  Use a headset to avoid causing background noise for others.<br /><br /><br />
   lockOnJoin: true
@@ -53,3 +53,7 @@ app:
       publicChat: false
       privateChat: false
       layout: false
+
+  # The initial client version has limited moderator capabilities
+  # The following flag disables moderator-only features
+  allowHTML5Moderator: false


### PR DESCRIPTION
WIth this new flag we can turn off/on the overall moderator functionalities to date. Should ` allowHTML5Moderator` be `false`, these are the features that will be disabled:
-there will be no 'Participants' section in Settings
-there will be no way to kick/mute/unmute user

As a side note, this pull requests also hides the Actions button which currently only holds features not yet implemented.
The Video section of the settings is also temporarily hidden until the video capabilities require its display