### PR TITLE
HTML5: demote html5 moderator user to viewer based on flag

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/modifiers/addUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/addUser.js
@@ -1,7 +1,6 @@
 import { check } from 'meteor/check';
 import Logger from '/imports/startup/server/logger';
 
-import Meetings from '/imports/api/meetings';
 import Users from '/imports/api/users';
 
 import requestStunTurn from '../methods/requestStunTurn';
@@ -17,6 +16,21 @@ export default function addUser(meetingId, user) {
     meetingId,
     userId,
   };
+
+  const USER_CONFIG = Meteor.settings.public.user;
+  const ROLE_MODERATOR = USER_CONFIG.role_moderator;
+  const ROLE_VIEWER = USER_CONFIG.role_viewer;
+  const APP_CONFIG = Meteor.settings.public.app;
+  const ALLOW_HTML5_MODERATOR = APP_CONFIG.allowHTML5Moderator;
+
+  // override moderator status of html5 client users, depending on a system flag
+  let dummyUser = Users.findOne(selector);
+  if (dummyUser &&
+      dummyUser.clientType === 'HTML5' &&
+      user.role === ROLE_MODERATOR &&
+      !ALLOW_HTML5_MODERATOR) {
+      user.role = ROLE_VIEWER;
+  }
 
   const modifier = {
     $set: {

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/createDummyUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/createDummyUser.js
@@ -26,7 +26,7 @@ export default function createDummyUser(meetingId, userId, authToken) {
       return Logger.error(`Creating dummy user to collection: ${err}`);
     }
 
-    return Logger.info(`Created dummy user id=${userId} token=${authToken} meeting=${meetingId}`);
+    Logger.info(`Created dummy user id=${userId} token=${authToken} meeting=${meetingId}`);
   };
 
   return Users.insert(doc, cb);

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -53,7 +53,8 @@ class ActionsDropdown extends Component {
   render() {
     const { intl, isUserPresenter } = this.props;
 
-    if (!isUserPresenter) return null;
+    // if (!isUserPresenter) return null;
+    return null; // temporarily disabling the functionality
 
     return (
       <Dropdown ref="dropdown">

--- a/bigbluebutton-html5/imports/ui/components/settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/component.jsx
@@ -131,10 +131,10 @@ class Settings extends Component {
             <Icon iconName='application' className={styles.icon}/>
             <span id="appTab">{intl.formatMessage(intlMessages.appTabLabel)}</span>
           </Tab>
-          <Tab className={styles.tabSelector} aria-labelledby="videoTab">
-            <Icon iconName='video' className={styles.icon}/>
-            <span id="videoTab">{intl.formatMessage(intlMessages.videoTabLabel)}</span>
-          </Tab>
+          {/*<Tab className={styles.tabSelector} aria-labelledby="videoTab">*/}
+            {/*<Icon iconName='video' className={styles.icon}/>*/}
+            {/*<span id="videoTab">{intl.formatMessage(intlMessages.videoTabLabel)}</span>*/}
+          {/*</Tab>*/}
           <Tab className={styles.tabSelector} aria-labelledby="ccTab">
             <Icon iconName='user' className={styles.icon}/>
             <span id="ccTab">{intl.formatMessage(intlMessages.closecaptionTabLabel)}</span>
@@ -153,12 +153,12 @@ class Settings extends Component {
             settings={this.state.current.application}
             />
         </TabPanel>
-        <TabPanel className={styles.tabPanel}>
-          <Video
-            handleUpdateSettings={this.handleUpdateSettings}
-            settings={this.state.current.video}
-            />
-        </TabPanel>
+        {/*<TabPanel className={styles.tabPanel}>*/}
+          {/*<Video*/}
+            {/*handleUpdateSettings={this.handleUpdateSettings}*/}
+            {/*settings={this.state.current.video}*/}
+            {/*/>*/}
+        {/*</TabPanel>*/}
         <TabPanel className={styles.tabPanel}>
           <ClosedCaptions
             settings={this.state.current.cc}

--- a/bigbluebutton-html5/private/config/public/app.yaml
+++ b/bigbluebutton-html5/private/config/public/app.yaml
@@ -15,7 +15,7 @@ app:
   # Default global variables
   appName: "BigBlueButton HTML5 Client"
   bbbServerVersion: "1.1-beta"
-  copyright: "©2016 BigBlueButton Inc."
+  copyright: "©2017 BigBlueButton Inc."
   html5ClientBuild: "HTML5_CLIENT_VERSION"
   defaultWelcomeMessage: Welcome to %%CONFNAME%%!<br /><br />For help on using BigBlueButton see these (short) <a href="event:http://www.bigbluebutton.org/content/videos"><u>tutorial videos</u></a>.<br /><br />To join the audio bridge click the gear icon (upper-right hand corner).  Use a headset to avoid causing background noise for others.<br /><br /><br />
   lockOnJoin: true
@@ -53,3 +53,7 @@ app:
       publicChat: false
       privateChat: false
       layout: false
+
+  # The initial client version has limited moderator capabilities
+  # The following flag disables moderator-only features
+  allowHTML5Moderator: false

--- a/bigbluebutton-html5/private/config/public/user.yaml
+++ b/bigbluebutton-html5/private/config/public/user.yaml
@@ -1,2 +1,3 @@
 user:
   role_moderator: 'MODERATOR'
+  role_viewer: 'VIEWER'


### PR DESCRIPTION
WIth this new flag we can turn off/on the overall moderator functionalities to date. Should allowHTML5Moderator be false, these are the features that will be disabled:
-there will be no 'Participants' section in Settings
-there will be no way to kick/mute/unmute user

As a side note, this pull requests also hides the Actions button which currently only holds features not yet implemented.
The Video section of the settings is also temporarily hidden until the video capabilities require its display