### PR TITLE
[Flash] Corrected the cursor icon for the rectangle tool

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/common/Images.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/common/Images.as
@@ -166,7 +166,7 @@ package org.bigbluebutton.common
         [Embed(source="assets/images/pencil.png")]
         public var pencil_icon:Class;
 
-        [Embed(source="assets/images/shape_square.png")]
+        [Embed(source="assets/images/square.png")]
         public var square_icon:Class;
 
         [Embed(source="assets/images/undo.png")]


### PR DESCRIPTION
All the cursor icons used for the whiteboard tools have their upper left part colored in white. Except the rectangle.
Currently used cursor icons: [Triangle](https://github.com/bigbluebutton/bigbluebutton/blob/master/bigbluebutton-client/src/org/bigbluebutton/common/assets/images/triangle.png), [Ellipse ](https://github.com/bigbluebutton/bigbluebutton/blob/master/bigbluebutton-client/src/org/bigbluebutton/common/assets/images/ellipse.png), [Line](https://github.com/bigbluebutton/bigbluebutton/blob/master/bigbluebutton-client/src/org/bigbluebutton/common/assets/images/line.png)

But for the rectangle we are using an icon with solid borders [shape_square](https://github.com/bigbluebutton/bigbluebutton/blob/master/bigbluebutton-client/src/org/bigbluebutton/common/assets/images/shape_square.png). Changed to the [square ](https://github.com/bigbluebutton/bigbluebutton/blob/master/bigbluebutton-client/src/org/bigbluebutton/common/assets/images/square.png) to be consistent with the rest of the tools.