### PR TITLE
HTML5: Unify user and audiouser in verto bridge

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/verto.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/verto.js
@@ -1,4 +1,3 @@
-import { getVoiceBridge } from '/imports/ui/components/audio/service';
 import BaseAudioBridge from './base';
 
 export default class VertoBridge extends BaseAudioBridge {

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/verto.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/verto.js
@@ -5,12 +5,13 @@ export default class VertoBridge extends BaseAudioBridge {
   constructor(userData) {
     super();
     const {
+      userId,
       username,
       voiceBridge,
     } = userData;
 
     this.voiceBridge = voiceBridge;
-    this.vertoUsername = 'FreeSWITCH User - ' + encodeURIComponent(username);
+    this.vertoUsername = `${userId}-bbbID-${username}`;
   }
 
   exitAudio(listenOnly) {


### PR DESCRIPTION
Before this fix Verto audio users in html5 client were appearing as two users - a web and a voice one.