### PR TITLE
Update webrtc stats bridge for modern Chrome/Firefox APIs

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/webrtc_stats_bridge.js
+++ b/bigbluebutton-client/resources/prod/lib/webrtc_stats_bridge.js
@@ -1,9 +1,5 @@
 var monitoredTracks = {};
 
-function isFirefox() {
-    return typeof mozRTCPeerConnection !== 'undefined';
-}
-
 function arrayAverage(array) {
     var sum = 0;
     for( var i = 0; i < array.length; i++ ){
@@ -22,180 +18,138 @@ function customGetStats(peer, mediaStreamTrack, callback, interval) {
     var nomore = false;
 
     (function getPrivateStats() {
-        var promise = _getStats(peer, mediaStreamTrack);
+        var promise;
+        try {
+            promise = peer.getStats(mediaStreamTrack);
+        } catch (e) {
+            promise = Promise.reject(e);
+        }
         promise.then(function(results) {
-            var result = {
-                audio: {},
-                //video: {},
-                // TODO remove the raw results
-                results: results,
-                nomore: function() {
-                    nomore = true;
+
+            var inbound = {};
+            var outbound = {};
+            var localCandidate = {};
+            var remoteCandidate = {};
+
+            results.forEach(function(res) {
+                if ((res.type == 'outbound-rtp' || res.type == 'outboundrtp') && res.mediaType == 'audio') {
+                    outbound = res;
                 }
+                if ((res.type == 'inbound-rtp' || res.type == 'inboundrtp') && res.mediaType == 'audio') {
+                    inbound = res;
+                }
+                if (res.type == 'ssrc' && res.mediaType == 'audio') {
+                    if (typeof (res.audioInputLevel) !== 'undefined') {
+                        inbound = res;
+                        outbound = res;
+                        res.packetsSent = parseInt(res.packetsSent);
+                        res.bytesSent = parseInt(res.bytesSent);
+                        res.packetsLost = parseInt(res.packetsLost);
+                        res.jitter = parseInt(res.googJitterReceived) / 1000;
+                        res.packetsReceived = res.packetsSent - res.packetsLost;
+                    }
+                }
+                if ((res.type == 'candidate-pair' && res.selected) ||
+                    (res.type == 'googCandidatePair' && res.googActiveConnection == "true")) {
+                    localCandidate = results[res.localCandidateId];
+                    remoteCandidate = results[res.remoteCandidateId];
+                }
+            });
+            /*
+            console.log("Inbound:");
+            console.log(inbound);
+            console.log("Outbound:");
+            console.log(outbound);
+            */
+            var audioStats = {
+                inboundTimestamp: inbound.timestamp,
+                packetsReceived: inbound.packetsReceived,
+                bytesReceived: inbound.bytesReceived,
+                packetsLost: inbound.packetsLost,
+                jitter: inbound.jitter,
+                outboundTimestamp: outbound.timestamp,
+                packetsSent: outbound.packetsSent,
+                bytesSent: outbound.bytesSent,
             };
+            if (typeof globalObject.audio.statsArray === 'undefined') {
+                globalObject.audio.statsArray = [];
+                globalObject.audio.haveStats = false;
+            }
+            var statsArray = globalObject.audio.statsArray;
+            statsArray.push(audioStats);
+            while (statsArray.length > 12) {
+                statsArray.shift();
+            }
 
-            for (var key in results) {
-                var res = results[key];
+            var firstAudioStats = statsArray[0];
+            var lastAudioStats = statsArray[statsArray.length - 1];
 
-                res.timestamp = typeof res.timestamp === 'object'? res.timestamp.getTime(): res.timestamp;
-                res.packetsLost = typeof res.packetsLost === 'string'? parseInt(res.packetsLost): res.packetsLost;
-                res.packetsReceived = typeof res.packetsReceived === 'string'? parseInt(res.packetsReceived): res.packetsReceived;
-                res.bytesReceived = typeof res.bytesReceived === 'string'? parseInt(res.bytesReceived): res.bytesReceived;
+            var intervalPacketsLost = lastAudioStats.packetsLost - firstAudioStats.packetsLost;
+            var intervalPacketsReceived = lastAudioStats.packetsReceived - firstAudioStats.packetsReceived;
+            var intervalPacketsSent = lastAudioStats.packetsSent - firstAudioStats.packetsSent;
+            var intervalBytesReceived = lastAudioStats.bytesReceived - firstAudioStats.bytesReceived;
+            var intervalBytesSent = lastAudioStats.bytesSent - firstAudioStats.bytesSent;
 
-                if ((res.mediaType == 'audio' || (res.type == 'ssrc' && res.googCodecName == 'opus')) && typeof res.bytesSent !== 'undefined') {
-                    if (typeof globalObject.audio.prevSent === 'undefined') {
-                        globalObject.audio.prevSent = res;
-                    }
+            var receivedInterval = lastAudioStats.inboundTimestamp - firstAudioStats.inboundTimestamp;
+            var sentInterval = lastAudioStats.outboundTimestamp - firstAudioStats.outboundTimestamp;
 
-                    var bytes = res.bytesSent - globalObject.audio.prevSent.bytesSent;
-                    var diffTimestamp = res.timestamp - globalObject.audio.prevSent.timestamp;
+            var kbitsReceivedPerSecond = intervalBytesReceived * 8 / receivedInterval;
+            var kbitsSentPerSecond = intervalBytesSent * 8 / sentInterval;
+            var packetDuration = intervalPacketsSent / sentInterval * 1000;
 
-                    var kilobytes = bytes / 1024;
-                    var kbitsSentPerSecond = (kilobytes * 8) / (diffTimestamp / 1000.0);
-
-                    result.audio = merge(result.audio, {
-                        availableBandwidth: kilobytes,
-                        inputLevel: res.audioInputLevel,
-                        packetsSent: res.packetsSent,
-                        bytesSent: res.bytesSent,
-                        kbitsSentPerSecond: kbitsSentPerSecond
-                    });
-
-                    globalObject.audio.prevSent = res;
+            var r = undefined, mos = undefined;
+            if (isNaN(intervalPacketsLost) && !globalObject.audio.haveStats) {
+                r = 100;
+            } else {
+                globalObject.audio.haveStats = true;
+                r = (Math.max(0, intervalPacketsReceived - intervalPacketsLost) / intervalPacketsReceived) * 100;
+                if (r > 100) {
+                    r = 100;
                 }
-                if ((res.mediaType == 'audio' || (res.type == 'ssrc' && res.googCodecName == 'opus')) && typeof res.bytesReceived !== 'undefined') {
-                    if (typeof globalObject.audio.prevReceived === 'undefined') {
-                        globalObject.audio.prevReceived = res;
-                        globalObject.audio.consecutiveFlaws = 0;
-                        globalObject.audio.globalBitrateArray = [ ];
-                    }
+            }
+            mos = 1 + (0.035) * r + (0.000007) * r * (r-60) * (100-r);
 
-                    var intervalPacketsLost = res.packetsLost - globalObject.audio.prevReceived.packetsLost;
-                    var intervalPacketsReceived = res.packetsReceived - globalObject.audio.prevReceived.packetsReceived;
-                    var intervalBytesReceived = res.bytesReceived - globalObject.audio.prevReceived.bytesReceived;
-                    var intervalLossRate = intervalPacketsLost + intervalPacketsReceived == 0? 1: intervalPacketsLost / (intervalPacketsLost + intervalPacketsReceived);
-                    var intervalBitrate = (intervalBytesReceived / interval) * 8;
-                    var globalBitrate = arrayAverage(globalObject.audio.globalBitrateArray);
-                    var intervalEstimatedLossRate;
-                    if (isFirefox()) {
-                        intervalEstimatedLossRate = Math.max(0, globalBitrate - intervalBitrate) / globalBitrate;
-                    } else {
-                        intervalEstimatedLossRate = intervalLossRate;
-                    }
+            var intervalLossRate = 1 - (r / 100);
+            console.log("Interval loss rate: " + intervalLossRate);
+            console.log("MOS: " + mos);
 
-                    var flaws = intervalPacketsLost;
-                    if (flaws > 0) {
-                        if (globalObject.audio.consecutiveFlaws > 0) {
-                            flaws *= 2;
-                        }
-                        ++globalObject.audio.consecutiveFlaws;
-                    } else {
-                        globalObject.audio.consecutiveFlaws = 0;
-                    }
-                    var packetsLost = res.packetsLost + flaws;
-                    var r = (Math.max(0, res.packetsReceived - packetsLost) / res.packetsReceived) * 100;
-                    if (r > 100) {
-                        r = 100;
-                    }
-                    // https://freeswitch.org/stash/projects/FS/repos/freeswitch/browse/src/switch_rtp.c?at=refs%2Fheads%2Fv1.4#1671
-                    var mos = 1 + (0.035) * r + (0.000007) * r * (r-60) * (100-r);
-
-                    var bytes = res.bytesReceived - globalObject.audio.prevReceived.bytesReceived;
-                    var diffTimestamp = res.timestamp - globalObject.audio.prevReceived.timestamp;
-                    var packetDuration = diffTimestamp / (res.packetsReceived - globalObject.audio.prevReceived.packetsReceived);
-                    var kilobytes = bytes / 1024;
-                    var kbitsReceivedPerSecond = (kilobytes * 8) / (diffTimestamp / 1000.0);
-
-                    result.audio = merge(result.audio, {
-                        availableBandwidth: kilobytes,
-                        outputLevel: res.audioOutputLevel,
-                        packetsLost: res.packetsLost,
-                        jitter: typeof res.googJitterReceived !== 'undefined'? res.googJitterReceived: res.jitter,
-                        jitterBuffer: res.googJitterBufferMs,
-                        delay: res.googCurrentDelayMs,
-                        packetsReceived: res.packetsReceived,
-                        bytesReceived: res.bytesReceived,
-                        kbitsReceivedPerSecond: kbitsReceivedPerSecond,
-                        packetDuration: packetDuration,
-                        r: r,
-                        mos: mos,
-                        intervalLossRate: intervalLossRate,
-                        intervalEstimatedLossRate: intervalEstimatedLossRate,
-                        globalBitrate: globalBitrate
-                    });
-                    
-                    globalObject.audio.prevReceived = res;
-                    globalObject.audio.globalBitrateArray.push(intervalBitrate);
-                    // 12 is the number of seconds we use to calculate the global bitrate
-                    if (globalObject.audio.globalBitrateArray.length > 12 / (interval / 1000)) {
-                        globalObject.audio.globalBitrateArray.shift();
-                    }
-                }
-
-                /*
-                // TODO make it work on Firefox
-                if (res.googCodecName == 'VP8') {
-                    if (!globalObject.video.prevBytesSent)
-                        globalObject.video.prevBytesSent = res.bytesSent;
-
-                    var bytes = res.bytesSent - globalObject.video.prevBytesSent;
-                    globalObject.video.prevBytesSent = res.bytesSent;
-
-                    var kilobytes = bytes / 1024;
-
-                    result.video = merge(result.video, {
-                        availableBandwidth: kilobytes.toFixed(1),
-                        googFrameHeightInput: res.googFrameHeightInput,
-                        googFrameWidthInput: res.googFrameWidthInput,
-                        googCaptureQueueDelayMsPerS: res.googCaptureQueueDelayMsPerS,
-                        rtt: res.googRtt,
-                        packetsLost: res.packetsLost,
-                        packetsSent: res.packetsSent,
-                        googEncodeUsagePercent: res.googEncodeUsagePercent,
-                        googCpuLimitedResolution: res.googCpuLimitedResolution,
-                        googNacksReceived: res.googNacksReceived,
-                        googFrameRateInput: res.googFrameRateInput,
-                        googPlisReceived: res.googPlisReceived,
-                        googViewLimitedResolution: res.googViewLimitedResolution,
-                        googCaptureJitterMs: res.googCaptureJitterMs,
-                        googAvgEncodeMs: res.googAvgEncodeMs,
-                        googFrameHeightSent: res.googFrameHeightSent,
-                        googFrameRateSent: res.googFrameRateSent,
-                        googBandwidthLimitedResolution: res.googBandwidthLimitedResolution,
-                        googFrameWidthSent: res.googFrameWidthSent,
-                        googFirsReceived: res.googFirsReceived,
-                        bytesSent: res.bytesSent
-                    });
-                }
-
-                if (res.type == 'VideoBwe') {
-                    result.video.bandwidth = {
-                        googActualEncBitrate: res.googActualEncBitrate,
-                        googAvailableSendBandwidth: res.googAvailableSendBandwidth,
-                        googAvailableReceiveBandwidth: res.googAvailableReceiveBandwidth,
-                        googRetransmitBitrate: res.googRetransmitBitrate,
-                        googTargetEncBitrate: res.googTargetEncBitrate,
-                        googBucketDelay: res.googBucketDelay,
-                        googTransmitBitrate: res.googTransmitBitrate
-                    };
-                }
-                */
-
-                // res.googActiveConnection means either STUN or TURN is used.
-
-                if (res.type == 'googCandidatePair' && res.googActiveConnection == 'true') {
-                    result.connectionType = {
-                        local: {
-                            candidateType: res.googLocalCandidateType,
-                            ipAddress: res.googLocalAddress
-                        },
-                        remote: {
-                            candidateType: res.googRemoteCandidateType,
-                            ipAddress: res.googRemoteAddress
-                        },
-                        transport: res.googTransportType
-                    };
-                }
+            result = {
+                audio: {
+                    availableBandwidth: undefined,
+                    bytesReceived: audioStats.bytesReceived,
+                    bytesSent: audioStats.bytesSent,
+                    delay: undefined,
+                    globalBitrate: undefined,
+                    inputLevel: undefined,
+                    intervalEstimatedLossRate: intervalLossRate,
+                    intervalLossRate: intervalLossRate,
+                    jitter: audioStats.jitter,
+                    jitterBuffer: undefined,
+                    kbitsReceivedPerSecond: kbitsReceivedPerSecond,
+                    kbitsSentPerSecond: kbitsSentPerSecond,
+                    mos: mos,
+                    outputLevel: undefined,
+                    packetDuration: packetDuration,
+                    packetsLost: audioStats.packetsLost,
+                    packetsReceived: audioStats.packetsReceived,
+                    packetsSent: audioStats.packetsSent,
+                    r: r,
+                },
+                video: {},
+                connectionType: {
+                    local: {
+                        candidateType: localCandidate.candidateType,
+                        ipAddress: localCandidate.ipAddress,
+                        transport: localCandidate.transport,
+                    },
+                    remote: {
+                        candidateType: remoteCandidate.candidateType,
+                        ipAddress: remoteCandidate.ipAddress,
+                        transport: remoteCandidate.transport,
+                    },
+                    transport: localCandidate.transport
+                },
+                nomore: function() { nomore = true; }
             }
 
             callback(result);
@@ -210,29 +164,6 @@ function customGetStats(peer, mediaStreamTrack, callback, interval) {
         });
     })();
 
-    // taken from http://blog.telenor.io/webrtc/2015/06/11/getstats-chrome-vs-firefox.html
-    function _getStats(pc, selector) {
-        if (navigator.mozGetUserMedia) {
-            return pc.getStats(selector);
-        }
-        return new Promise(function(resolve, reject) {
-            pc.getStats(function(response) {
-                var standardReport = {};
-                response.result().forEach(function(report) {
-                    var standardStats = {
-                        id: report.id,
-                        timestamp: report.timestamp,
-                        type: report.type
-                    };
-                    report.names().forEach(function(name) {
-                        standardStats[name] = report.stat(name);
-                    });
-                    standardReport[standardStats.id] = standardStats;
-                });
-                resolve(standardReport);
-            }, selector, reject);
-        });
-    }
 }
 
 function merge(mergein, mergeto) {
@@ -246,7 +177,8 @@ function merge(mergein, mergeto) {
 }
 
 function monitorTrackStart(peer, track, local) {
-    if (! monitoredTracks.hasOwnProperty(track.id)) {
+    console.log("Starting stats monitoring on " + track.id);
+    if (!monitoredTracks[track.id]) {
         monitoredTracks[track.id] = function() { console.log("Still didn't have any report for this track"); };
         customGetStats(
             peer,
@@ -257,7 +189,6 @@ function monitorTrackStart(peer, track, local) {
                 } else {
                     monitoredTracks[track.id] = results.nomore;
                     results.audio.type = local? "local": "remote",
-                    delete results.results;
                     BBB.webRTCMonitorUpdate(JSON.stringify(results));
                     console.log(JSON.stringify(results));
                 }
@@ -270,9 +201,13 @@ function monitorTrackStart(peer, track, local) {
 }
 
 function monitorTrackStop(trackId) {
-    monitoredTracks[trackId]();
-    delete monitoredTracks[trackId];
-    console.log("Track removed, monitoredTracks.length = " + Object.keys(monitoredTracks).length);
+    if (typeof (monitoredTracks[trackId]) === "function") {
+        monitoredTracks[trackId]();
+        delete monitoredTracks[trackId];
+        console.log("Track removed, monitoredTracks.length = " + Object.keys(monitoredTracks).length);
+    } else {
+        console.log("Track is not monitored");
+    }
 }
 
 function monitorTracksStart() {
@@ -289,12 +224,12 @@ function monitorTracksStart() {
                 monitorTrackStart(peer, track, true);
             }
         }
-        for (var streamId = 0; streamId < peer.getRemoteStreams().length; ++streamId) {
+        /*for (var streamId = 0; streamId < peer.getRemoteStreams().length; ++streamId) {
             for (var trackId = 0; trackId < peer.getRemoteStreams()[streamId].getAudioTracks().length; ++trackId) {
                 var track = peer.getRemoteStreams()[streamId].getAudioTracks()[trackId];
                 monitorTrackStart(peer, track, false);
             }
-        }
+        }*/
     }, 2000);
 }
 


### PR DESCRIPTION
Switch to the promise-based getStats, and use the standardized
property names where available, with fallback to handle Chrome,
which hasn't fully switched yet.

The stats now only track the outgoing audio stream, as a way to
indicate quality, since the user can't hear themselves. This
might be revisited later; it would require tracking the stats
separately for incoming vs. outgoing and e.g. returning whichever
is worse.