### PR TITLE
Fix the modal text size on small screen overflowing the content

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/modal/fullscreen/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/modal/fullscreen/styles.scss
@@ -33,6 +33,10 @@
   flex: 1;
   margin: 0;
   font-weight: 400;
+
+  @include mq($small-only) {
+    font-size: x-large;
+  }
 }
 
 %btn {

--- a/bigbluebutton-html5/imports/ui/components/modal/fullscreen/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/modal/fullscreen/styles.scss
@@ -19,6 +19,11 @@
   padding: $line-height-computed 0;
   border-bottom: $border-size solid $color-gray-lighter;
   flex-shrink: 0;
+  @include mq($small-only) {
+    text-align: center;
+    display: block;
+  }
+
 }
 
 .actions {
@@ -34,9 +39,6 @@
   margin: 0;
   font-weight: 400;
 
-  @include mq($small-only) {
-    font-size: x-large;
-  }
 }
 
 %btn {


### PR DESCRIPTION
Fix the modal text size when leaving, scale down the text on small screen
![screenshot from 2017-05-12 14-25-20](https://cloud.githubusercontent.com/assets/17770979/26009362/e079f1e8-371e-11e7-8932-a12df12cc5f4.png)
![screenshot from 2017-05-12 14-25-30](https://cloud.githubusercontent.com/assets/17770979/26009363/e07ad428-371e-11e7-8be0-c7769def829c.png)

