### PR TITLE
[HTML5] Text Shape 2.0

### DIFF
--- a/bigbluebutton-html5/imports/api/shapes/server/modifiers/addShape.js
+++ b/bigbluebutton-html5/imports/api/shapes/server/modifiers/addShape.js
@@ -43,7 +43,7 @@ export default function addShape(meetingId, whiteboardId, shape) {
         'shape.shape.id': shape.shape.id,
         'shape.shape.y': shape.shape.y,
         'shape.shape.calcedFontSize': shape.shape.calcedFontSize,
-        'shape.shape.text': shape.shape.text,
+        'shape.shape.text': shape.shape.text.replace(/[\r]/g, '\n'),
       });
       break;
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/shapes/text/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/shapes/text/component.jsx
@@ -38,6 +38,7 @@ export default class TextDrawComponent extends React.Component {
       fontStretch: 'normal',
       lineHeight: 'normal',
       fontFamily: 'Arial',
+      whiteSpace: 'pre-wrap',
       wordWrap: 'break-word',
       wordBreak: 'normal',
       textAlign: 'left',


### PR DESCRIPTION
Fixed 2 Text shape bugs:
- it didn't handle new lines for some reason.
- it didn't preserve inner white spaces, they were always combined into one.

Resolves #3938 