### PR TITLE
HTML5 - dropdown click listeners' fix

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
@@ -103,11 +103,6 @@ class Dropdown extends Component {
     }
   }
 
-  componentWillUnmount () {
-    const { removeEventListener } = window;
-    removeEventListener('click', this.handleWindowClick, false);
-  }
-
   handleWindowClick(event) {
     const dropdownElement = findDOMNode(this);
     const shouldUpdateState = event.target !== dropdownElement &&

--- a/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
@@ -82,10 +82,16 @@ class Dropdown extends Component {
   }
 
   handleShow() {
+    const { addEventListener } = window;
+    addEventListener('click', this.handleWindowClick, false);
+
     this.setState({ isOpen: true }, this.handleStateCallback);
   }
 
   handleHide() {
+
+    const { removeEventListener } = window;
+    removeEventListener('click', this.handleWindowClick, false);
 
     const { autoFocus } = this.props;
 
@@ -95,11 +101,6 @@ class Dropdown extends Component {
       const triggerElement = findDOMNode(this.refs.trigger);
       triggerElement.focus();
     }
-  }
-
-  componentDidMount () {
-    const { addEventListener } = window;
-    addEventListener('click', this.handleWindowClick, false);
   }
 
   componentWillUnmount () {


### PR DESCRIPTION
We have a "click" listener in the dropdown component attached to the window. It listens to user clicks, closes the dropdown (Status/Settings etc) if it was open, and moves focus back to the button that opens/closes the dropdown.

For some reason "click" listener was added in the `componentDidMount`, and as a result we always had 2 "click" listeners hanging around and firing on every mouse click, since "Status" and "Settings" dropdowns are always rendered, but their contents are not shown by default.

Moved "click" listeners initialization to the `handleShow` / `handleHide`. Now they are attached and removed when the user actually opens/closes the dropdown.