### PR TITLE
Fix shape drawing and set max text length for text annotations

### DIFF
--- a/bigbluebutton-apps/src/main/java/org/bigbluebutton/red5/service/WhiteboardService.java
+++ b/bigbluebutton-apps/src/main/java/org/bigbluebutton/red5/service/WhiteboardService.java
@@ -35,6 +35,9 @@ public class WhiteboardService {
 	 private final static String STATUS = "status";
 	 private final static String COR_ID = "id";
 	 private final static String WB_ID = "whiteboardId";
+	 private final static String TEXT_TYPE = "text";
+	 private final static String TEXT_PROP = "text";
+	 private final static int MAX_TEXT_LEN = 1024;
 	
 	public void setWhiteboardApplication(WhiteboardApplication a){
 		log.debug("Setting whiteboard application instance");
@@ -43,7 +46,15 @@ public class WhiteboardService {
 		
 	private boolean validMessage(Map<String, Object> shp) {
 		if (shp.containsKey(COR_ID) && shp.containsKey(TYPE) &&
-				shp.containsKey(STATUS) && shp.containsKey(WB_ID)) return true;
+				shp.containsKey(STATUS) && shp.containsKey(WB_ID)) {
+			// Need to add a special case for when the text annotation is too long
+			if (shp.get(TYPE).toString().equals(TEXT_TYPE) && 
+					shp.containsKey(TEXT_PROP) && shp.get(TEXT_PROP).toString().length() > MAX_TEXT_LEN) {
+				log.warn("sendAnnotation detected type is" + TEXT_TYPE + " and message length exceeds max chars of " + MAX_TEXT_LEN + ". Annotation invalid");
+				return false;
+			}
+			return true;
+		}
 		
 		return false;
 	}

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/TextObject.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/TextObject.as
@@ -53,6 +53,7 @@ package org.bigbluebutton.modules.whiteboard.business.shapes {
 			mouseWheelEnabled = false;
 			multiline = true;
 			wordWrap = true;
+			maxChars = 1024;
 			
 			//determine editability
 			makeEditable(userId == UserManager.getInstance().getConference().getMyUserId() && status != AnnotationStatus.DRAW_END);

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/ShapeDrawListener.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/ShapeDrawListener.as
@@ -116,7 +116,7 @@ package org.bigbluebutton.modules.whiteboard.views
     }
     
     private function sendShapeToServer(status:String, tool:WhiteboardTool):void {
-      if (_segment.length > 2) {
+      if (_segment.length <= 2) {
         // LogUtil.debug("SEGMENT too short");
         return;
       }


### PR DESCRIPTION
* Corrected an inverted length check in the ShapeDrawListener that stopped shapes from drawing
* Added a maximum char length for text annotations of 1024