### PR TITLE
Fix end time format

### DIFF
--- a/bigbluebutton-web/web-app/WEB-INF/freemarker/get-meeting-info.ftlx
+++ b/bigbluebutton-web/web-app/WEB-INF/freemarker/get-meeting-info.ftlx
@@ -17,7 +17,7 @@
   <recording>${meeting.isRecord()?c}</recording>
   <hasBeenForciblyEnded>${meeting.isForciblyEnded()?c}</hasBeenForciblyEnded>
   <startTime>${meeting.getStartTime()?c}</startTime>
-  <endTime>${meeting.getEndTime()}</endTime>
+  <endTime>${meeting.getEndTime()?c}</endTime>
   <participantCount>${meeting.getNumUsers()}</participantCount>
   <listenerCount>${meeting.getNumListenOnly()}</listenerCount>
   <voiceParticipantCount>${meeting.getNumVoiceJoined()}</voiceParticipantCount>


### PR DESCRIPTION
Display end time as number without commas. Currently, it show this.

<startTime>1496417934271</startTime>
<endTime>1,496,417,978,863</endTime>