### PR TITLE
HTML5 - Chat links fix

### DIFF
--- a/bigbluebutton-html5/imports/api/chat/server/methods/sendChat.js
+++ b/bigbluebutton-html5/imports/api/chat/server/methods/sendChat.js
@@ -48,6 +48,8 @@ export default function sendChat(credentials, message) {
   let actionName = message.to_userid === requesterUserId ? 'chatSelf' : 'chatPrivate';
   let eventName = 'send_private_chat_message';
 
+  message.message = parseMessage(message.message);
+
   if (message.chat_type === PUBLIC_CHAT_TYPE) {
     eventName = 'send_public_chat_message';
     actionName = 'chatPublic';


### PR DESCRIPTION
Function parseMessage was never called before publishing the chat message to Redis. Thus links sent from HTML5 client were never recognized and they were published as plain text in both html5 and Flash clients.