### PR TITLE
Enable IME for text tool's basic TextField - fixes #2678

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/common/IMETextField.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/common/IMETextField.as
@@ -1,0 +1,43 @@
+package org.bigbluebutton.common {
+	import flash.events.FocusEvent;
+	import flash.system.Capabilities;
+	import flash.system.IME;
+	import flash.text.TextField;
+	
+	import mx.core.IIMESupport;
+	
+	public class IMETextField extends TextField implements IIMESupport {
+		private var _imeMode:String = null;
+		
+		public function IMETextField() {
+			super();
+			
+			// Only bind to FOCUS_IN. The FOCUS_OUT doesn't matter
+			addEventListener(FocusEvent.FOCUS_IN, focusInHandler);
+		}
+		
+		public function get enableIME():Boolean {
+			return true;
+		}
+		
+		// This getter/setter pair is never used, but it's required for the interface
+		public function get imeMode():String {
+			return _imeMode;
+		}
+		
+		public function set imeMode(value:String):void {
+			_imeMode = value;
+		}
+		
+		protected function focusInHandler(e:FocusEvent):void {
+			/* The Adobe documentation on IME is out of date and should be ignored. 
+			 * See SDK FocusManager focusInHandler() function for current method of
+			 * handling. Unfortunately the TextField "focus in" is ignored by the 
+			 * FocusManager so we need to handle it ourselves.
+			 */
+			if (Capabilities.hasIME) {
+				IME.enabled = enableIME;
+			}
+		}
+	}
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/TextObject.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/TextObject.as
@@ -26,11 +26,12 @@ package org.bigbluebutton.modules.whiteboard.business.shapes {
 	import flash.text.TextFieldType;
 	import flash.text.TextFormat;
 	
+	import org.bigbluebutton.common.IMETextField;
 	import org.bigbluebutton.core.managers.UserManager;
 	import org.bigbluebutton.modules.whiteboard.models.Annotation;
 	import org.bigbluebutton.modules.whiteboard.models.AnnotationStatus;
 	
-	public class TextObject extends TextField implements GraphicObject {
+	public class TextObject extends IMETextField implements GraphicObject {
 		private var _id:String;
 		private var _type:String;
 		private var _status:String;


### PR DESCRIPTION
This PR manually enables the IME mode when focusing into the Whiteboard TextObject for editing. This change allows users to input text as expected when typing in Japanese, Korean, and Chinese and the IME mode is enabled in the OS.

The PR is a fix for issue #2678.