### PR TITLE
Whiteboard cursor fixes

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/WhiteboardCanvasDisplayModel.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/WhiteboardCanvasDisplayModel.as
@@ -27,6 +27,7 @@ package org.bigbluebutton.modules.whiteboard
   
   import org.as3commons.logging.api.ILogger;
   import org.as3commons.logging.api.getClassLogger;
+  import org.bigbluebutton.core.UsersUtil;
   import org.bigbluebutton.core.managers.UserManager;
   import org.bigbluebutton.main.events.MadePresenterEvent;
   import org.bigbluebutton.modules.whiteboard.business.shapes.DrawObject;
@@ -216,7 +217,8 @@ package org.bigbluebutton.modules.whiteboard
 		
 		public function drawCursor(userId:String, xPercent:Number, yPercent:Number):void {
 			if (!_cursors.hasOwnProperty(userId)) {
-				var newCursor:WhiteboardCursor = new WhiteboardCursor(userId, xPercent, yPercent, shapeFactory.parentWidth, shapeFactory.parentHeight, presenterId == userId);
+				var userName:String = UsersUtil.getUserName(userId);
+				var newCursor:WhiteboardCursor = new WhiteboardCursor(userId, userName, xPercent, yPercent, shapeFactory.parentWidth, shapeFactory.parentHeight, presenterId == userId);
 				wbCanvas.addCursor(newCursor);
 				
 				_cursors[userId] = newCursor;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/CursorPositionListener.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/CursorPositionListener.as
@@ -74,9 +74,12 @@ package org.bigbluebutton.modules.whiteboard.views {
 				_lastXPosition = x;
 				_lastYPosition = y;
 				
-				var np:Point = _shapeFactory.normalizePoint(x, y);
+				// Need to avoid divide by zero complications (definitely can happen, don't remove check unless you really know what you're doing)
+				if (_shapeFactory.parentHeight != 0 || _shapeFactory.parentWidth != 0) {
+					var np:Point = _shapeFactory.normalizePoint(x, y);
 				
-				_wbCanvas.sendCursorPositionToServer(np.x, np.y);
+					_wbCanvas.sendCursorPositionToServer(np.x, np.y);
+				}
 			}
 		}
 		

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardCanvas.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardCanvas.as
@@ -247,7 +247,9 @@ package org.bigbluebutton.modules.whiteboard.views {
 		}
 		
 		private function removeCursor():void {
-			CursorManager.removeCursor(CursorManager.currentCursorID);
+			if (CursorManager.currentCursorID != CursorManager.NO_CURSOR) {
+				CursorManager.removeCursor(CursorManager.currentCursorID);
+			}
 		}
 		
 		private function getMouseXY():Point {
@@ -354,6 +356,8 @@ package org.bigbluebutton.modules.whiteboard.views {
 		
 		private function onDisableWhiteboardEvent(e:WhiteboardButtonEvent):void {
 			e.stopPropagation();
+			
+			removeCursor()
 			
 			this.whiteboardEnabled = false;
 			setWhiteboardInteractable();

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardCursor.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardCursor.as
@@ -18,26 +18,53 @@
  */
 
 package org.bigbluebutton.modules.whiteboard.views {
-	import flash.display.Shape;
+	import flash.display.Sprite;
+	import flash.text.TextField;
+	import flash.text.TextFormat;
 	
-	public class WhiteboardCursor extends Shape {
+	public class WhiteboardCursor extends Sprite {
 		private static const PRESENTER_COLOR:uint = 0xFF0000;
-		private static const OTHER_COLOR:uint = 0x00FF00;
+		private static const OTHER_COLOR:uint = 0x2A992A;
 		
 		private var _userId:String;
+		private var _userName:String;
 		private var _origX:Number;
 		private var _origY:Number;
 		private var _parentWidth:Number;
 		private var _parentHeight:Number;
 		private var _isPresenter:Boolean;
 		
-		public function WhiteboardCursor(userId:String, x:Number, y:Number, parentWidth:Number, parentHeight:Number, isPresenter:Boolean) {
+		private var _nameTextField:TextField;
+		
+		public function WhiteboardCursor(userId:String, userName:String, x:Number, y:Number, parentWidth:Number, parentHeight:Number, isPresenter:Boolean) {
 			_userId = userId;
+			_userName = userName;
 			_origX = x;
 			_origY = y;
 			_parentWidth = parentWidth;
 			_parentHeight = parentHeight;
 			_isPresenter = isPresenter;
+			
+			_nameTextField = new TextField();
+			_nameTextField.text = _userName;
+			_nameTextField.x = 10;
+			_nameTextField.y = -3;
+			_nameTextField.alpha = 0.8;
+			_nameTextField.background = true;
+			_nameTextField.border = true;
+			_nameTextField.multiline = false;
+			_nameTextField.mouseEnabled = false;
+			
+			var tFormat:TextFormat = new TextFormat();
+			tFormat.size = 12;
+			tFormat.font = "arial";
+			tFormat.bold = true;
+			_nameTextField.setTextFormat(tFormat);
+			
+			_nameTextField.height = _nameTextField.textHeight+4;
+			_nameTextField.width = Math.min(65, _nameTextField.textWidth+4);
+			
+			addChild(_nameTextField);
 			
 			drawCursor();
 			setPosition();
@@ -89,6 +116,9 @@ package org.bigbluebutton.modules.whiteboard.views {
 		
 		private function drawCursor():void {
 			var cursorColor:uint = (_isPresenter ? PRESENTER_COLOR : OTHER_COLOR);
+			
+			_nameTextField.textColor = cursorColor;
+			_nameTextField.borderColor = cursorColor;
 			
 			graphics.clear();
 			graphics.lineStyle(6, cursorColor, 0.6);


### PR DESCRIPTION
* Fixed an issue where the custom whiteboard cursor wasn't reset when canvas editing was disabled
* Fixed a divide-by-zero case when the cursor position listener fires before the whiteboard canvas has been set up
* Added a name next to the whiteboard cursors to add clarity when there are more than one