### PR TITLE
user start/stop broadcast cam message

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgDeserializer.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgDeserializer.scala
@@ -12,38 +12,127 @@ trait ReceivedJsonMsgDeserializer extends SystemConfiguration {
 
   object JsonDeserializer extends Deserializer
 
-  def deserializeCreateMeetingReqMsg(jsonNode: JsonNode): Option[CreateMeetingReqMsg] = {
-    val (result, error) = JsonDeserializer.toBbbCommonMsg[CreateMeetingReqMsg](jsonNode)
-    result match {
-      case Some(msg) => Some(msg.asInstanceOf[CreateMeetingReqMsg])
-      case None =>
-        log.error("Failed to deserialize CreateMeetingReqMsg message " + error)
-        None
+  def routeCreateMeetingReqMsg(envelope: BbbCoreEnvelope, jsonNode: JsonNode): Unit = {
+    def deserialize(jsonNode: JsonNode): Option[CreateMeetingReqMsg] = {
+      val (result, error) = JsonDeserializer.toBbbCommonMsg[CreateMeetingReqMsg](jsonNode)
+      result match {
+        case Some(msg) => Some(msg.asInstanceOf[CreateMeetingReqMsg])
+        case None =>
+          log.error("Failed to deserialize CreateMeetingReqMsg message " + error)
+          None
+      }
+    }
+
+    def send(envelope: BbbCoreEnvelope, msg: CreateMeetingReqMsg): Unit = {
+      val event = BbbMsgEvent(meetingManagerChannel, BbbCommonEnvCoreMsg(envelope, msg))
+      publish(event)
+    }
+
+    for {
+      m <- deserialize(jsonNode)
+    } yield {
+      send(envelope, m)
     }
   }
 
-  def routeValidateAuthTokenReqMsg(jsonNode: JsonNode): Option[ValidateAuthTokenReqMsg] = {
-    val (result, error) = JsonDeserializer.toBbbCommonMsg[ValidateAuthTokenReqMsg](jsonNode)
+  def routeValidateAuthTokenReqMsg(envelope: BbbCoreEnvelope, jsonNode: JsonNode): Unit = {
+    def deserialize(jsonNode: JsonNode): Option[ValidateAuthTokenReqMsg] = {
+      val (result, error) = JsonDeserializer.toBbbCommonMsg[ValidateAuthTokenReqMsg](jsonNode)
 
-    result match {
-      case Some(msg) => Some(msg.asInstanceOf[ValidateAuthTokenReqMsg])
-      case None =>
-        log.error("Failed to deserialize ValidateAuthTokenReqMsg message " + error)
-        None
+      result match {
+        case Some(msg) => Some(msg.asInstanceOf[ValidateAuthTokenReqMsg])
+        case None =>
+          log.error("Failed to deserialize ValidateAuthTokenReqMsg message " + error)
+          None
+      }
+    }
+
+    def send(envelope: BbbCoreEnvelope, msg: ValidateAuthTokenReqMsg): Unit = {
+      val event = BbbMsgEvent(msg.header.meetingId, BbbCommonEnvCoreMsg(envelope, msg))
+      publish(event)
+    }
+
+    for {
+      m <- deserialize(jsonNode)
+    } yield {
+      send(envelope, m)
     }
   }
 
-  def routeRegisterUserReqMsg(jsonNode: JsonNode): Option[RegisterUserReqMsg] = {
-    val (result, error) = JsonDeserializer.toBbbCommonMsg[RegisterUserReqMsg](jsonNode)
+  def routeRegisterUserReqMsg(envelope: BbbCoreEnvelope, jsonNode: JsonNode): Unit = {
+    def deserialize(jsonNode: JsonNode): Option[RegisterUserReqMsg] = {
+      val (result, error) = JsonDeserializer.toBbbCommonMsg[RegisterUserReqMsg](jsonNode)
 
-    result match {
-      case Some(msg) =>
-        // Route via meeting manager as there is a race condition if we send directly to meeting
-        // because the meeting actor might not have been created yet.
-        Some(msg.asInstanceOf[RegisterUserReqMsg])
-      case None =>
-        log.error("Failed to RegisterUserReqMsg message " + error)
-        None
+      result match {
+        case Some(msg) =>
+          Some(msg.asInstanceOf[RegisterUserReqMsg])
+        case None =>
+          log.error("Failed to RegisterUserReqMsg message " + error)
+          None
+      }
+    }
+
+    def send(envelope: BbbCoreEnvelope, msg: RegisterUserReqMsg): Unit = {
+      // Route via meeting manager as there is a race condition if we send directly to meeting
+      // because the meeting actor might not have been created yet.
+      val event = BbbMsgEvent(meetingManagerChannel, BbbCommonEnvCoreMsg(envelope, msg))
+      publish(event)
+    }
+
+    for {
+      m <- deserialize(jsonNode)
+    } yield {
+      send(envelope, m)
+    }
+  }
+
+  def routeUserBroadcastCamStartMsg(envelope: BbbCoreEnvelope, jsonNode: JsonNode): Unit = {
+    def deserialize(jsonNode: JsonNode): Option[UserBroadcastCamStartMsg] = {
+      val (result, error) = JsonDeserializer.toBbbCommonMsg[UserBroadcastCamStartMsg](jsonNode)
+
+      result match {
+        case Some(msg) =>
+          Some(msg.asInstanceOf[UserBroadcastCamStartMsg])
+        case None =>
+          log.error("Failed to UserShareWebcamMsg message " + error)
+          None
+      }
+    }
+
+    def send(envelope: BbbCoreEnvelope, msg: UserBroadcastCamStartMsg): Unit = {
+      val event = BbbMsgEvent(msg.header.meetingId, BbbCommonEnvCoreMsg(envelope, msg))
+      publish(event)
+    }
+
+    for {
+      m <- deserialize(jsonNode)
+    } yield {
+      send(envelope, m)
+    }
+  }
+
+  def routeUserBroadcastCamStopMsg(envelope: BbbCoreEnvelope, jsonNode: JsonNode): Unit = {
+    def deserialize(jsonNode: JsonNode): Option[UserBroadcastCamStopMsg] = {
+      val (result, error) = JsonDeserializer.toBbbCommonMsg[UserBroadcastCamStopMsg](jsonNode)
+
+      result match {
+        case Some(msg) =>
+          Some(msg.asInstanceOf[UserBroadcastCamStopMsg])
+        case None =>
+          log.error("Failed to UserShareWebcamMsg message " + error)
+          None
+      }
+    }
+
+    def send(envelope: BbbCoreEnvelope, msg: UserBroadcastCamStopMsg): Unit = {
+      val event = BbbMsgEvent(msg.header.meetingId, BbbCommonEnvCoreMsg(envelope, msg))
+      publish(event)
+    }
+
+    for {
+      m <- deserialize(jsonNode)
+    } yield {
+      send(envelope, m)
     }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -3,7 +3,7 @@ package org.bigbluebutton.core.pubsub.senders
 import akka.actor.{ Actor, ActorLogging, Props }
 import org.bigbluebutton.SystemConfiguration
 import com.fasterxml.jackson.databind.JsonNode
-import org.bigbluebutton.common2.messages.{ BbbCoreEnvelope, CreateMeetingReqMsg, RegisterUserReqMsg, ValidateAuthTokenReqMsg }
+import org.bigbluebutton.common2.messages._
 import org.bigbluebutton.core.bus._
 import org.bigbluebutton.core2.ReceivedMessageRouter
 
@@ -32,39 +32,26 @@ class ReceivedJsonMsgHandlerActor(
   def handleReceivedJsonMessage(msg: ReceivedJsonMessage): Unit = {
     for {
       envJsonNode <- JsonDeserializer.toBbbCommonEnvJsNodeMsg(msg.data)
-    } yield route(envJsonNode.envelope, envJsonNode.core)
+    } yield handle(envJsonNode.envelope, envJsonNode.core)
   }
 
-  def route(envelope: BbbCoreEnvelope, jsonNode: JsonNode): Unit = {
-    log.debug("*************** Route envelope name " + envelope.name)
+  def handle(envelope: BbbCoreEnvelope, jsonNode: JsonNode): Unit = {
+    log.debug("Route envelope name " + envelope.name)
     envelope.name match {
       case CreateMeetingReqMsg.NAME =>
-        log.debug("**************** Route CreateMeetingReqMsg")
-        for {
-          m <- deserializeCreateMeetingReqMsg(jsonNode)
-        } yield {
-          log.debug("************ Sending CreateMeetingReqMsg")
-          send(envelope, m)
-        }
+        routeCreateMeetingReqMsg(envelope, jsonNode)
       case ValidateAuthTokenReqMsg.NAME =>
-        log.debug("**************** Route ValidateAuthTokenReqMsg")
-        for {
-          m <- routeValidateAuthTokenReqMsg(jsonNode)
-        } yield {
-          log.debug("************ Sending ValidateAuthTokenReqMsg")
-          send(envelope, m)
-        }
+        routeValidateAuthTokenReqMsg(envelope, jsonNode)
       case RegisterUserReqMsg.NAME =>
-        log.debug("**************** Route RegisterUserReqMsg")
-        for {
-          m <- routeRegisterUserReqMsg(jsonNode)
-        } yield {
-          log.debug("************ Sending RegisterUserReqMsg")
-          send(envelope, m)
-        }
+        routeRegisterUserReqMsg(envelope, jsonNode)
+      case UserBroadcastCamStartMsg.NAME =>
+        routeUserBroadcastCamStartMsg(envelope, jsonNode)
+      case UserBroadcastCamStopMsg.NAME =>
+        routeUserBroadcastCamStopMsg(envelope, jsonNode)
       case _ =>
-        log.debug("************ Cannot route envelope name " + envelope.name)
+        log.error("Cannot route envelope name " + envelope.name)
       // do nothing
     }
   }
+
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -15,6 +15,7 @@ import org.bigbluebutton.core.apps._
 import org.bigbluebutton.core.bus._
 import org.bigbluebutton.core.models.{ RegisteredUsers, Users }
 import org.bigbluebutton.core2.MeetingStatus2x
+import org.bigbluebutton.core2.message.handlers.{ UserBroadcastCamStartMsgHdlr, UserBroadcastCamStopMsgHdlr }
 
 import scala.concurrent.duration._
 
@@ -31,7 +32,10 @@ class MeetingActor(val props: DefaultProps,
     extends Actor with ActorLogging
     with UsersApp with PresentationApp
     with LayoutApp with ChatApp with WhiteboardApp with PollApp
-    with BreakoutRoomApp with CaptionApp with SharedNotesApp with PermisssionCheck {
+    with BreakoutRoomApp with CaptionApp
+    with SharedNotesApp with PermisssionCheck
+    with UserBroadcastCamStartMsgHdlr
+    with UserBroadcastCamStopMsgHdlr {
 
   override val supervisorStrategy = OneForOneStrategy(maxNrOfRetries = 10, withinTimeRange = 1 minute) {
     case e: Exception => {
@@ -180,6 +184,8 @@ class MeetingActor(val props: DefaultProps,
     msg.core match {
       case m: ValidateAuthTokenReqMsg => handleValidateAuthTokenReqMsg(m)
       case m: RegisterUserReqMsg => handleRegisterUserReqMsg(m)
+      case m: UserBroadcastCamStartMsg => handleUserBroadcastCamStartMsg(m)
+      case m: UserBroadcastCamStopMsg => handleUserBroadcastCamStopMsg(m)
       case _ => println("***** Cannot handle " + msg.envelope.name)
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/ReceivedMessageRouter.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/ReceivedMessageRouter.scala
@@ -1,7 +1,6 @@
 package org.bigbluebutton.core2
 
 import org.bigbluebutton.SystemConfiguration
-import org.bigbluebutton.common2.messages._
 import org.bigbluebutton.core.bus.{ BbbMsgEvent, BbbMsgRouterEventBus }
 
 trait ReceivedMessageRouter extends SystemConfiguration {
@@ -11,18 +10,4 @@ trait ReceivedMessageRouter extends SystemConfiguration {
     eventBus.publish(msg)
   }
 
-  def send(envelope: BbbCoreEnvelope, msg: CreateMeetingReqMsg): Unit = {
-    val event = BbbMsgEvent(meetingManagerChannel, BbbCommonEnvCoreMsg(envelope, msg))
-    publish(event)
-  }
-
-  def send(envelope: BbbCoreEnvelope, msg: ValidateAuthTokenReqMsg): Unit = {
-    val event = BbbMsgEvent(msg.header.meetingId, BbbCommonEnvCoreMsg(envelope, msg))
-    publish(event)
-  }
-
-  def send(envelope: BbbCoreEnvelope, msg: RegisterUserReqMsg): Unit = {
-    val event = BbbMsgEvent(meetingManagerChannel, BbbCommonEnvCoreMsg(envelope, msg))
-    publish(event)
-  }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/UserBroadcastCamStartMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/UserBroadcastCamStartMsgHdlr.scala
@@ -1,0 +1,33 @@
+package org.bigbluebutton.core2.message.handlers
+
+import org.bigbluebutton.common2.messages.MessageBody.{ UserBroadcastCamStartedEvtMsgBody }
+import org.bigbluebutton.common2.messages._
+import org.bigbluebutton.core.OutMessageGateway
+import org.bigbluebutton.core.models.Users
+import org.bigbluebutton.core.running.MeetingActor
+
+trait UserBroadcastCamStartMsgHdlr {
+  this: MeetingActor =>
+
+  val outGW: OutMessageGateway
+
+  def handleUserBroadcastCamStartMsg(msg: UserBroadcastCamStartMsg): Unit = {
+
+    def broadcastEvent(msg: UserBroadcastCamStartMsg): Unit = {
+      val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST, props.meetingProp.intId, msg.header.userId)
+      val envelope = BbbCoreEnvelope(UserBroadcastCamStartedEvtMsg.NAME, routing)
+      val header = BbbClientMsgHeader(UserBroadcastCamStartedEvtMsg.NAME, props.meetingProp.intId, msg.header.userId)
+
+      val body = UserBroadcastCamStartedEvtMsgBody(msg.header.userId, msg.body.stream)
+      val event = UserBroadcastCamStartedEvtMsg(header, body)
+      val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+      outGW.send(msgEvent)
+    }
+
+    for {
+      uvo <- Users.userSharedWebcam(msg.header.userId, liveMeeting.users, msg.body.stream)
+    } yield {
+      broadcastEvent(msg)
+    }
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/UserBroadcastCamStopMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/UserBroadcastCamStopMsgHdlr.scala
@@ -1,0 +1,33 @@
+package org.bigbluebutton.core2.message.handlers
+
+import org.bigbluebutton.common2.messages.MessageBody.{ UserBroadcastCamStoppedEvtMsgBody }
+import org.bigbluebutton.common2.messages._
+import org.bigbluebutton.core.OutMessageGateway
+import org.bigbluebutton.core.models.Users
+import org.bigbluebutton.core.running.MeetingActor
+
+trait UserBroadcastCamStopMsgHdlr {
+  this: MeetingActor =>
+
+  val outGW: OutMessageGateway
+
+  def handleUserBroadcastCamStopMsg(msg: UserBroadcastCamStopMsg): Unit = {
+
+    def broadcastEvent(msg: UserBroadcastCamStopMsg): Unit = {
+      val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST, props.meetingProp.intId, msg.header.userId)
+      val envelope = BbbCoreEnvelope(UserBroadcastCamStoppedEvtMsg.NAME, routing)
+      val header = BbbClientMsgHeader(UserBroadcastCamStoppedEvtMsg.NAME, props.meetingProp.intId, msg.header.userId)
+
+      val body = UserBroadcastCamStoppedEvtMsgBody(msg.header.userId, msg.body.stream)
+      val event = UserBroadcastCamStoppedEvtMsg(header, body)
+      val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+      outGW.send(msgEvent)
+    }
+
+    for {
+      uvo <- Users.userUnsharedWebcam(msg.header.userId, liveMeeting.users, msg.body.stream)
+    } yield {
+      broadcastEvent(msg)
+    }
+  }
+}

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/messages/MessageBody.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/messages/MessageBody.scala
@@ -15,8 +15,8 @@ object MessageBody {
   case class GetUsersReqMsgBody(requesterId: String)
   case class UserEmojiStatusChangeReqMsgBody(userId: String, emoji: String)
   case class EjectUserFromMeetingReqMsgBody(userId: String, requesterId: String)
-  case class UserShareWebcamMsgBody(stream: String)
-  case class UserUnshareWebcamMsgBody(stream: String)
+  case class UserBroadcastCamStartMsgBody(stream: String)
+  case class UserBroadcastCamStopMsgBody(stream: String)
   case class ChangeUserStatusReqMsgBody(userId: String, status: String, value: String)
   case class ChangeUserRoleReqMsgBody(userId: String, role: String)
   case class AssignPresenterReqMsgBody(userId: String, requesterId: String)
@@ -26,7 +26,7 @@ object MessageBody {
 
 
 
-  case class UserSharedWebcamEvtMsgBody(userId: String, stream: String)
-  case class UserUnsharedWebcamEvtMsgBody(userId: String, stream: String)
+  case class UserBroadcastCamStartedEvtMsgBody(userId: String, stream: String)
+  case class UserBroadcastCamStoppedEvtMsgBody(userId: String, stream: String)
 
 }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/messages/Messages.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/messages/Messages.scala
@@ -51,19 +51,22 @@ case class UserLeaveReqMsg(header: BbbClientMsgHeader, body: UserLeaveReqMsgBody
 object GetUsersReqMsg { val NAME = "GetUsersReqMsg" }
 case class GetUsersReqMsg(header: BbbClientMsgHeader, body: GetUsersReqMsgBody) extends BbbCoreMsg
 
-object UserShareWebcamMsg { val NAME = "UserShareWebcamMsg" }
-case class UserShareWebcamMsg(header: BbbClientMsgHeader, body: UserShareWebcamMsgBody)
+object UserBroadcastCamStartMsg { val NAME = "UserBroadcastCamStartMsg" }
+case class UserBroadcastCamStartMsg(header: BbbClientMsgHeader, body: UserBroadcastCamStartMsgBody) extends BbbCoreMsg
+
+object UserBroadcastCamStopMsg { val NAME = "UserBroadcastCamStopMsg"}
+case class UserBroadcastCamStopMsg(header: BbbClientMsgHeader, body: UserBroadcastCamStopMsgBody) extends BbbCoreMsg
 
 /** Event messages sent by Akka apps as result of receiving incoming messages ***/
 object ValidateAuthTokenRespMsg { val NAME = "ValidateAuthTokenRespMsg" }
 case class ValidateAuthTokenRespMsg(header: BbbClientMsgHeader,
                                     body: ValidateAuthTokenRespMsgBody) extends BbbCoreMsg
 
-object UserSharedWebcamEvtMsg { val NAME = "UserSharedWebcamEvtMsg" }
-case class UserSharedWebcamEvtMsg(header: BbbClientMsgHeader, body: UserSharedWebcamEvtMsgBody)
+object UserBroadcastCamStartedEvtMsg { val NAME = "UserBroadcastCamStartedEvtMsg" }
+case class UserBroadcastCamStartedEvtMsg(header: BbbClientMsgHeader, body: UserBroadcastCamStartedEvtMsgBody) extends BbbCoreMsg
 
-object UserUnsharedWebcamEvtMsg { val NAME = "UserUnsharedWebcamEvtMsg" }
-case class UserUnsharedWebcamEvtMsg(header: BbbClientMsgHeader, body: UserUnsharedWebcamEvtMsgBody)
+object UserBroadcastCamStoppedEvtMsg { val NAME = "UserUnsharedWebcamEvtMsg" }
+case class UserBroadcastCamStoppedEvtMsg(header: BbbClientMsgHeader, body: UserBroadcastCamStoppedEvtMsgBody) extends BbbCoreMsg
 
 
 /** System Messages **/

--- a/bigbluebutton-client/src/org/bigbluebutton/core/connection/messages/UserBroadcastCamStartMsg.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/connection/messages/UserBroadcastCamStartMsg.as
@@ -1,0 +1,13 @@
+package org.bigbluebutton.core.connection.messages
+{
+  public class UserBroadcastCamStartMsg
+  {
+    public var header: MsgFromClientHdr;
+    public var body: UserBroadcastCamStartMsgBody;
+
+    public function UserBroadcastCamStartMsg(header: MsgFromClientHdr, body: UserBroadcastCamStartMsgBody): void {
+    	this.header = header;
+    	this.body = body;
+    }
+  }
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/core/connection/messages/UserBroadcastCamStartMsgBody.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/connection/messages/UserBroadcastCamStartMsgBody.as
@@ -1,0 +1,11 @@
+package org.bigbluebutton.core.connection.messages
+{
+  public class UserBroadcastCamStartMsgBody
+  {
+    public var stream: String;
+
+    public function UserBroadcastCamStartMsgBody(stream: String): void {
+    	this.stream = stream;
+    }
+  }
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/core/connection/messages/UserBroadcastCamStopMsg.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/connection/messages/UserBroadcastCamStopMsg.as
@@ -1,0 +1,13 @@
+package org.bigbluebutton.core.connection.messages
+{
+  public class UserBroadcastCamStopMsg
+  {
+    public var header: MsgFromClientHdr;
+    public var body: UserBroadcastCamStopMsgBody;
+
+    public function UserBroadcastCamStopMsg(header: MsgFromClientHdr, body: UserBroadcastCamStopMsgBody): void {
+    	this.header = header;
+    	this.body = body;
+    }
+  }
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/core/connection/messages/UserBroadcastCamStopMsgBody.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/connection/messages/UserBroadcastCamStopMsgBody.as
@@ -1,0 +1,11 @@
+package org.bigbluebutton.core.connection.messages
+{
+  public class UserBroadcastCamStopMsgBody
+  {
+    public var stream: String;
+
+    public function UserBroadcastCamStopMsgBody(stream: String): void {
+    	this.stream = stream;
+    }
+  }
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/core/managers/ConnectionManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/managers/ConnectionManager.as
@@ -57,6 +57,10 @@ package org.bigbluebutton.core.managers {
             connDelegate.sendMessage(service, onSuccess, onFailure, message);
         }
 
+        public function sendMessage2x(onSuccess:Function, onFailure:Function, message:Object = null):void {
+            connDelegate.sendMessage2x(onSuccess, onFailure, message);
+        }
+
         public function forceClose():void {
             connDelegate.forceClose();
         }

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/NetConnectionDelegate.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/NetConnectionDelegate.as
@@ -113,13 +113,13 @@ package org.bigbluebutton.main.model.users
             
         public function onMessageFromServer2x(messageName:String, msg:String):void {
             trace("onMessageFromServer2x - " + msg);
-            var map:Object = JSON.parse(msg);  
-            var header: Object = map.header as Object;
-            var body: Object = map.body as Object;
+            //var map:Object = JSON.parse(msg);  
+            //var header: Object = map.header as Object;
+            //var body: Object = map.body as Object;
 
-            var tokenValid: Boolean = body.valid as Boolean;
-            var userId: String = body.userId as String;
-            trace("onMessageFromServer - " + tokenValid);
+            //var tokenValid: Boolean = body.valid as Boolean;
+            //var userId: String = body.userId as String;
+            //trace("onMessageFromServer - " + tokenValid);
         }
 
         public function onMessageFromServer(messageName:String, msg:Object):void {
@@ -147,14 +147,14 @@ package org.bigbluebutton.main.model.users
                               
             var header: MsgFromClientHdr = new MsgFromClientHdr("ValidateAuthTokenReqMsg",
                                                 confParams.meetingID, 
-                                                confParams.internalUserID)
+                                                confParams.internalUserID);
 
             var body: ValidateAuthTokenReqMsgBody = new ValidateAuthTokenReqMsgBody(confParams.internalUserID,
-                                                confParams.authToken)
+                                                confParams.authToken);
 
-            var message: ValidateAuthTokenReqMsg = new ValidateAuthTokenReqMsg(header, body)
+            var message: ValidateAuthTokenReqMsg = new ValidateAuthTokenReqMsg(header, body);
 
-            LOGGER.debug("******* msg \n" + JSON.stringify(message))
+            LOGGER.debug("******* msg \n" + JSON.stringify(message));
 
             sendMessage2x(
                 // result - On successful result

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/NetConnectionDelegate.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/NetConnectionDelegate.as
@@ -144,36 +144,19 @@ package org.bigbluebutton.main.model.users
 
         private function validateToken2x():void {
             var confParams:ConferenceParameters = BBB.initUserConfigManager().getConfParams();
-          
-			var header:Object = new Object();
-			header.name = "ValidateAuthTokenReqMsg";
-			header.meetingId = confParams.meetingID;
-
-			var body:Object = new Object();
-			body.userId = confParams.internalUserID;
-			body.authToken = confParams.authToken;
-			
-            //var message:Object = new Object();
-            //message["userId"] = confParams.internalUserID;
-            //message["authToken"] = confParams.authToken;
-			
-			var message:Object = new Object();
-			message.header = header;
-			message.body = body;
-                    
-            var header2: MsgFromClientHdr = new MsgFromClientHdr("ValidateAuthTokenReqMsg",
+                              
+            var header: MsgFromClientHdr = new MsgFromClientHdr("ValidateAuthTokenReqMsg",
                                                 confParams.meetingID, 
                                                 confParams.internalUserID)
 
-            var body2: ValidateAuthTokenReqMsgBody = new ValidateAuthTokenReqMsgBody(confParams.internalUserID,
+            var body: ValidateAuthTokenReqMsgBody = new ValidateAuthTokenReqMsgBody(confParams.internalUserID,
                                                 confParams.authToken)
 
-            var msg2: ValidateAuthTokenReqMsg = new ValidateAuthTokenReqMsg(header2, body2)
+            var message: ValidateAuthTokenReqMsg = new ValidateAuthTokenReqMsg(header, body)
 
-            LOGGER.debug("******* msg \n" + JSON.stringify(msg2))
+            LOGGER.debug("******* msg \n" + JSON.stringify(message))
 
-            sendMessage(
-                "onMessageFromClient",// Remote function name
+            sendMessage2x(
                 // result - On successful result
                 function(result:Object):void { 
               
@@ -192,6 +175,30 @@ package org.bigbluebutton.main.model.users
             _validateTokenTimer.addEventListener(TimerEvent.TIMER, validataTokenTimerHandler);
             _validateTokenTimer.start();
         }
+
+        public function sendMessage2x(onSuccess:Function, onFailure:Function, json:Object):void {
+
+            var service: String = "onMessageFromClient";
+
+            var responder:Responder =   new Responder(
+                function(result:Object):void { // On successful result
+                    onSuccess("Successfully sent [" + service + "]."); 
+                },
+                function(status:Object):void { // status - On error occurred
+                    var errorReason:String = "Failed to send [" + service + "]:\n"; 
+                    for (var x:Object in status) { 
+                        errorReason += "\t" + x + " : " + status[x]; 
+                    } 
+                }
+            );
+
+            if (json == null) {
+                _netConnection.call(service, responder);
+            } else {
+                _netConnection.call(service, responder, json);
+            }
+        }
+
 
         private function validateToken():void {
             var confParams:ConferenceParameters = BBB.initUserConfigManager().getConfParams();
@@ -304,6 +311,7 @@ package org.bigbluebutton.main.model.users
             dispatcher.dispatchEvent(e);
         }
         
+
         public function sendMessage(service:String, onSuccess:Function, onFailure:Function, message:Object=null):void {
             var responder:Responder =	new Responder(
                 function(result:Object):void { // On successful result

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageSender.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageSender.as
@@ -23,6 +23,7 @@ package org.bigbluebutton.modules.users.services
   import org.bigbluebutton.core.BBB;
   import org.bigbluebutton.core.UsersUtil;
   import org.bigbluebutton.core.managers.ConnectionManager;
+  import org.bigbluebutton.core.connection.messages.*;
 
   public class MessageSender {
 	private static const LOGGER:ILogger = getClassLogger(MessageSender);      
@@ -176,8 +177,16 @@ package org.bigbluebutton.modules.users.services
 		}
     
     public function addStream(userID:String, streamName:String):void {
+      var header: MsgFromClientHdr = new MsgFromClientHdr("UserBroadcastCamStartMsg",
+                                              UsersUtil.getInternalMeetingID(), 
+                                              UsersUtil.getMyUserID());
+
+      var body: UserBroadcastCamStartMsgBody = new UserBroadcastCamStartMsgBody(streamName);
+
+      var message: UserBroadcastCamStartMsg = new UserBroadcastCamStartMsg(header, body);
+
       var _nc:ConnectionManager = BBB.initConnectionManager();
-      _nc.sendMessage("participants.shareWebcam", 
+      _nc.sendMessage2x( 
         function(result:String):void { // On successful result
         },	                   
         function(status:String):void { // status - On error occurred
@@ -186,12 +195,20 @@ package org.bigbluebutton.modules.users.services
                 logData.message = "Error occured sharing webcam.";
                 LOGGER.info(JSON.stringify(logData));
         },
-        streamName
+        JSON.stringify(message)
       );
     }
     
     public function removeStream(userID:String, streamName:String):void {
   
+      var header: MsgFromClientHdr = new MsgFromClientHdr("UserBroadcastCamStopMsg",
+                                              UsersUtil.getInternalMeetingID(), 
+                                              UsersUtil.getMyUserID());
+
+      var body: UserBroadcastCamStopMsgBody = new UserBroadcastCamStopMsgBody(streamName);
+
+      var message: UserBroadcastCamStopMsg = new UserBroadcastCamStopMsg(header, body);
+
         var logData:Object = UsersUtil.initLogData();
         logData.tags = ["webcam"];
         logData.streamId = streamName;
@@ -200,7 +217,7 @@ package org.bigbluebutton.modules.users.services
 
   
       var _nc:ConnectionManager = BBB.initConnectionManager();
-      _nc.sendMessage("participants.unshareWebcam", 
+      _nc.sendMessage2x( 
         function(result:String):void { // On successful result
         },	                   
         function(status:String):void { // status - On error occurred
@@ -209,7 +226,7 @@ package org.bigbluebutton.modules.users.services
                 logData.message = "Error occured unsharing webcam.";
                 LOGGER.info(JSON.stringify(logData));
         },
-        streamName
+        JSON.stringify(message)
       );
     }
     


### PR DESCRIPTION
Implement user start/stop broadcast cam message using new message format. You can see how to send message from the client and how akka apps handles the message.

Also, how the cam started/stopped event messages are broadcasted to all clients.