### PR TITLE
[HTML5] - Missing dropdown menu chevron fix

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-item/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-item/styles.scss
@@ -157,6 +157,7 @@
   cursor: default;
   min-width: 10vw;
   max-width: 100%;
+  overflow: visible;
 }
 
 .actionsHeader {


### PR DESCRIPTION
Fixes the missing chevron issue.
![withoutchevron](https://user-images.githubusercontent.com/22058534/26985032-babf1ac6-4d0f-11e7-81e9-a6d4f38dc356.png)

now visible:
![withchevron](https://user-images.githubusercontent.com/22058534/26985045-d57012e4-4d0f-11e7-96c8-9cb05ea654f1.png)

