### PR TITLE
Rework setting the whiteboardId to display

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -68,7 +68,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		<mate:Listener type="{ShareEvent.OPEN_SCREENSHARE_VIEW_TAB}" method="openScreenshareViewTab" />
 		<mate:Listener type="{ShareEvent.CLOSE_SCREENSHARE_VIEW_TAB}" method="closeScreenshareViewTab" />
 		<mate:Listener type="{ShareEvent.REFRESH_SCREENSHARE_PUBLISH_TAB}" method="handleRefreshScreenshareTab" />
-		<mate:Listener type="{PageLoadedEvent.PAGE_LOADED_EVENT}" method="addWhiteboardCanvasToSlideView" />
 	</fx:Declarations>
 
 	<fx:Script>
@@ -104,7 +103,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.modules.present.commands.GoToPrevPageCommand;
 			import org.bigbluebutton.modules.present.events.DisplaySlideEvent;
 			import org.bigbluebutton.modules.present.events.DownloadEvent;
-			import org.bigbluebutton.modules.present.events.PageLoadedEvent;
 			import org.bigbluebutton.modules.present.events.PresentationChangedEvent;
 			import org.bigbluebutton.modules.present.events.PresenterCommands;
 			import org.bigbluebutton.modules.present.events.RemovePresentationEvent;
@@ -508,14 +506,13 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         slideView.thumbnailView.visible = !slideView.thumbnailView.visible;
       }
 
-      private function addWhiteboardCanvasToSlideView(e:PageLoadedEvent = null):void{
+      private function addWhiteboardCanvasToSlideView():void{
         if(whiteboardOverlay != null) {
-           LOGGER.debug("addWhiteboardCanvasToSlideView: Adding whiteboard canvas to SlideView");
-           changeWhiteboardPageOnly(PresentationModel.getInstance().getCurrentPage().id);
-           slideView.acceptOverlayCanvas(whiteboardOverlay);
-           if (screenshareView) {
-             screenshareView.removeOverlayCanvas();
-           }
+          LOGGER.debug("addWhiteboardCanvasToSlideView: Adding whiteboard canvas to SlideView");
+          slideView.acceptOverlayCanvas(whiteboardOverlay);
+          if (screenshareView) {
+            screenshareView.removeOverlayCanvas();
+          }
         } else {
           LOGGER.debug("addWhiteboardCanvasToSlideView: NOT adding whiteboard canvas to Slide View.");
           delayedWhiteboardOverlayAdd = "slide";
@@ -525,7 +522,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       private function addWhiteboardCanvasToScreenshareView():void {
         if(whiteboardOverlay != null) {
           LOGGER.debug("addWhiteboardCanvasToScreenshareView: Adding whiteboard canvas to Screenshare View");
-          changeWhiteboardPageOnly("deskshare");
           slideView.removeOverlayCanvas();
           if (screenshareView) {
             screenshareView.acceptOverlayCanvas(whiteboardOverlay);
@@ -982,15 +978,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					pollStartBtn.visible = true;
 					btnClosePublish.visible = true;
 					btnPauseScreenshare.visible = true;
-				}
-			}
-
-			private function changeWhiteboardPageOnly(whiteboardId:String):void {
-				if (whiteboardOverlay) {
-					LOGGER.debug("Telling the WhiteboardCanvas to switch ids. Id: " + whiteboardId);
-					whiteboardOverlay.displayWhiteboardById(whiteboardId);
-				} else {
-					LOGGER.debug("No WhiteboardCanvas overlayed cannot switch ids. Id: " + whiteboardId);
 				}
 			}
 

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/SlideView.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/SlideView.mxml
@@ -323,6 +323,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
           slideLoader.source = page.swfData;
           LOGGER.debug("Displaying page [{0}]", [e.pageId]);
 //          positionPage(page);
+          if (whiteboardCanvas != null) {
+            whiteboardCanvas.displayWhiteboardById(page.id);
+          }
           
           //slideLoader.accessibilityProperties.description = "Slide text start:  " + e.slideText + "    Slide text end";
           slideLoader.accessibilityDescription = ResourceUtil.getInstance().getString("bbb.presentation.slideloader.starttext") + 
@@ -390,9 +393,13 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 			public function acceptOverlayCanvas(overlay:WhiteboardCanvas):void{
 				whiteboardCanvas = overlay;
-                // add the canvas below the thumbnails
+				
+				var currPage:Page = PresentationModel.getInstance().getCurrentPage();
+				if (currPage != null) {
+					whiteboardCanvas.displayWhiteboardById(currPage.id);
+				}
+				
 				this.addChildAt(whiteboardCanvas, this.getChildIndex(thumbnailView));
-				zoomCanvas(slideLoader.width, slideLoader.height);
 				fitSlideToLoader();
 				whiteboardCanvas.addEventListener(MouseEvent.MOUSE_DOWN, handleWhiteboardCanvasClick);
 				slideLoader.addEventListener(MouseEvent.MOUSE_DOWN, handleWhiteboardCanvasClick);

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/ScreenshareViewWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/ScreenshareViewWindow.mxml
@@ -320,6 +320,7 @@
 			public function acceptOverlayCanvas(overlay:WhiteboardCanvas):void {
 				LOGGER.debug("ScreenshareViewWindow: acceptOverlayCanvas");
 				whiteboardCanvas = overlay;
+				whiteboardCanvas.displayWhiteboardById("deskshare");
 			}
 			
 			public function removeOverlayCanvas():void {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/managers/WhiteboardManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/managers/WhiteboardManager.as
@@ -20,23 +20,12 @@ package org.bigbluebutton.modules.whiteboard.managers
 {
 	import com.asfusion.mate.events.Dispatcher;
 	
-	import flash.events.TimerEvent;
-	import flash.utils.Timer;
-	
 	import org.as3commons.logging.api.ILogger;
 	import org.as3commons.logging.api.getClassLogger;
-	import org.bigbluebutton.common.events.AddUIComponentToMainCanvas;
-	import org.bigbluebutton.modules.present.events.PageLoadedEvent;
-	import org.bigbluebutton.modules.whiteboard.WhiteboardCanvasDisplayModel;
-	import org.bigbluebutton.modules.whiteboard.WhiteboardCanvasModel;
 	import org.bigbluebutton.modules.whiteboard.commands.GetWhiteboardAccessCommand;
 	import org.bigbluebutton.modules.whiteboard.events.RequestNewCanvasEvent;
-	import org.bigbluebutton.modules.whiteboard.events.WhiteboardButtonEvent;
-	import org.bigbluebutton.modules.whiteboard.events.WhiteboardUpdateReceived;
 	import org.bigbluebutton.modules.whiteboard.models.WhiteboardModel;
 	import org.bigbluebutton.modules.whiteboard.views.WhiteboardCanvas;
-	import org.bigbluebutton.modules.whiteboard.views.WhiteboardTextToolbar;
-	import org.bigbluebutton.modules.whiteboard.views.WhiteboardToolbar;
 	
 	public class WhiteboardManager
 	{


### PR DESCRIPTION
There was a three way race on client load to try and add the WhiteboardCanvas to the SlideView and set the whiteboardId that is supposed to be displayed. This PR moves the setting of the whiteboardId out of the PresentationWindow to split that logic up and hopefully make it more clear.