### PR TITLE
Fix multiple connections to redis on webhooks

### DIFF
--- a/bbb-webhooks/application.coffee
+++ b/bbb-webhooks/application.coffee
@@ -1,3 +1,5 @@
+redis = require("redis")
+
 config = require("./config")
 Hook = require("./hook")
 IDMapping = require("./id_mapping")
@@ -10,6 +12,10 @@ WebServer = require("./web_server")
 module.exports = class Application
 
   constructor: ->
+    # one for pub/sub, another to read/write data
+    config.redis.pubSubClient = redis.createClient()
+    config.redis.client = redis.createClient()
+
     @webHooks = new WebHooks()
     @webServer = new WebServer()
 

--- a/bbb-webhooks/hook.coffee
+++ b/bbb-webhooks/hook.coffee
@@ -36,7 +36,7 @@ module.exports = class Hook
     @externalMeetingID = null
     @queue = []
     @emitter = null
-    @redisClient = redis.createClient()
+    @redisClient = config.redis.client
 
   save: (callback) ->
     @redisClient.hmset config.redis.keys.hook(@id), @toRedis(), (error, reply) =>
@@ -180,7 +180,7 @@ module.exports = class Hook
   # Gets all hooks from redis to populate the local database.
   # Calls `callback()` when done.
   @resync = (callback) ->
-    client = redis.createClient()
+    client = config.redis.client
     tasks = []
 
     client.smembers config.redis.keys.hooks, (error, hooks) =>

--- a/bbb-webhooks/id_mapping.coffee
+++ b/bbb-webhooks/id_mapping.coffee
@@ -32,7 +32,7 @@ module.exports = class IDMapping
     @externalMeetingID = null
     @internalMeetingID = null
     @lastActivity = null
-    @redisClient = redis.createClient()
+    @redisClient = config.redis.client
 
   save: (callback) ->
     @redisClient.hmset config.redis.keys.mapping(@id), @toRedis(), (error, reply) =>
@@ -137,7 +137,7 @@ module.exports = class IDMapping
   # Gets all mappings from redis to populate the local database.
   # Calls `callback()` when done.
   @resync = (callback) ->
-    client = redis.createClient()
+    client = config.redis.client
     tasks = []
 
     client.smembers config.redis.keys.mappings, (error, mappings) =>

--- a/bbb-webhooks/web_hooks.coffee
+++ b/bbb-webhooks/web_hooks.coffee
@@ -13,7 +13,7 @@ Logger = require("./logger")
 module.exports = class WebHooks
 
   constructor: ->
-    @subscriberEvents = redis.createClient()
+    @subscriberEvents = config.redis.pubSubClient
 
   start: ->
     @_subscribeToEvents()


### PR DESCRIPTION
Was creating a new connection for each hook or mapping created and never closed them.
Now it created 2 connections only, one to read/write hooks and mappings and another to listen to events (pubsub).

The connection to read/write could be created and removed on demand, but decided not to do it because it could more easily result in connections being left open.