### PR TITLE
[HTML5 2.0]  - Move screenshare messages to 2.0

### DIFF
--- a/bigbluebutton-html5/imports/api/2.0/screenshare/index.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/index.js
@@ -1,0 +1,1 @@
+export default new Mongo.Collection('screenshare');

--- a/bigbluebutton-html5/imports/api/2.0/screenshare/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/server/eventHandlers.js
@@ -1,0 +1,14 @@
+import RedisPubSub from '/imports/startup/server/redis2x';
+import handleBroadcastStartedVoice from './handlers/broadcastStartedVoice';
+import handleBroadcastStarted from './handlers/broadcastStarted';
+import handleBroadcastStoppedVoice from './handlers/broadcastStoppedVoice';
+import handleBroadcastStopped from './handlers/broadcastStopped';
+import handleStartedVoice from './handlers/startedVoice';
+import handleStoppedVoice from './handlers/stoppedVoice';
+
+RedisPubSub.on('ScreenshareRtmpBroadcastStartedVoiceConfEvtMsg', handleBroadcastStartedVoice);
+RedisPubSub.on('ScreenshareRtmpBroadcastStartedEvtMsg', handleBroadcastStarted);
+RedisPubSub.on('ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg', handleBroadcastStoppedVoice);
+RedisPubSub.on('ScreenshareRtmpBroadcastStoppedEvtMsg', handleBroadcastStopped);
+RedisPubSub.on('ScreenshareStartedVoiceConfEvtMsg', handleStartedVoice);
+RedisPubSub.on('ScreenshareStoppedVoiceConfEvtMsg', handleStoppedVoice);

--- a/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/broadcastStarted.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/broadcastStarted.js
@@ -1,0 +1,6 @@
+import { check } from 'meteor/check';
+
+export default function handleBroadcastStartedVoice({ body }, meetingId) {
+  check(meetingId, String);
+  return meetingId;
+}

--- a/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/broadcastStarted.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/broadcastStarted.js
@@ -1,6 +1,9 @@
 import { check } from 'meteor/check';
+import addBroadcast from '../modifiers/addBroadcast';
 
 export default function handleBroadcastStartedVoice({ body }, meetingId) {
   check(meetingId, String);
-  return meetingId;
+  check(body, Object);
+
+  return addBroadcast(meetingId, body);
 }

--- a/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/broadcastStartedVoice.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/broadcastStartedVoice.js
@@ -1,0 +1,6 @@
+import { check } from 'meteor/check';
+
+export default function handleBroadcastStarted({ body }, meetingId) {
+  check(meetingId, String);
+  return meetingId;
+}

--- a/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/broadcastStopped.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/broadcastStopped.js
@@ -1,0 +1,6 @@
+import { check } from 'meteor/check';
+
+export default function handleBroadcastStoppedVoice({ body }, meetingId) {
+  check(meetingId, String);
+  return meetingId;
+}

--- a/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/broadcastStopped.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/broadcastStopped.js
@@ -1,6 +1,10 @@
 import { check } from 'meteor/check';
+import clearBroadcast from '../modifiers/clearBroadcast';
 
-export default function handleBroadcastStoppedVoice({ body }, meetingId) {
+export default function handleBroadcastStartedVoice({ body }, meetingId) {
   check(meetingId, String);
-  return meetingId;
+
+  const { screenshareConf } = body;
+
+  return clearBroadcast(meetingId, screenshareConf);
 }

--- a/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/broadcastStoppedVoice.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/broadcastStoppedVoice.js
@@ -1,0 +1,6 @@
+import { check } from 'meteor/check';
+
+export default function handleBroadcastStopped({ header, body }, meetingId) {
+  check(meetingId, String);
+  return meetingId;
+}

--- a/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/startedVoice.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/startedVoice.js
@@ -1,6 +1,12 @@
 import { check } from 'meteor/check';
+import addVoiceUser from '../modifiers/addVoiceUser';
 
 export default function handleStartedVoice({ body }, meetingId) {
   check(meetingId, String);
-  return meetingId;
+
+  const { screenshareConf } = body;
+
+  check(screenshareConf, String);
+
+  return addVoiceUser(meetingId, screenshareConf, body);
 }

--- a/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/startedVoice.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/startedVoice.js
@@ -1,0 +1,6 @@
+import { check } from 'meteor/check';
+
+export default function handleStartedVoice({ body }, meetingId) {
+  check(meetingId, String);
+  return meetingId;
+}

--- a/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/stoppedVoice.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/stoppedVoice.js
@@ -1,6 +1,13 @@
 import { check } from 'meteor/check';
+import clearVoiceUser from '../modifiers/clearVoiceUser';
 
 export default function handleStoppedVoice({ body }, meetingId) {
   check(meetingId, String);
-  return meetingId;
+
+  const { callerIdNum } = body;
+  const { screenshareConf } = body;
+
+  check(callerIdNum, String);
+
+  return clearVoiceUser(meetingId, screenshareConf, callerIdNum);
 }

--- a/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/stoppedVoice.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/server/handlers/stoppedVoice.js
@@ -1,0 +1,6 @@
+import { check } from 'meteor/check';
+
+export default function handleStoppedVoice({ body }, meetingId) {
+  check(meetingId, String);
+  return meetingId;
+}

--- a/bigbluebutton-html5/imports/api/2.0/screenshare/server/index.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/server/index.js
@@ -1,0 +1,3 @@
+import './eventHandlers';
+import './methods';
+import './publishers';

--- a/bigbluebutton-html5/imports/api/2.0/screenshare/server/methods.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/server/methods.js
@@ -1,0 +1,4 @@
+import { Meteor } from 'meteor/meteor';
+
+Meteor.methods({
+});

--- a/bigbluebutton-html5/imports/api/2.0/screenshare/server/modifiers/addBroadcast.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/server/modifiers/addBroadcast.js
@@ -1,0 +1,29 @@
+import { check } from 'meteor/check';
+import flat from 'flat';
+import Logger from '/imports/startup/server/logger';
+import Screenshare from '/imports/api/2.0/screenshare';
+
+export default function addBroadcast(meetingId, body) {
+  check(meetingId, String);
+
+  const selector = {
+    meetingId,
+  };
+
+  const modifier = {
+    $set: {
+      meetingId,
+      broadcast: flat(body),
+    },
+  };
+
+  const cb = (err) => {
+    if (err) {
+      return Logger.error(`Adding broadcast to collection: ${err}`);
+    }
+
+    return Logger.info(`Upserted broadcast id=${body.screenshareConf}`);
+  };
+
+  return Screenshare.upsert(selector, modifier, cb);
+}

--- a/bigbluebutton-html5/imports/api/2.0/screenshare/server/modifiers/addVoiceUser.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/server/modifiers/addVoiceUser.js
@@ -1,0 +1,30 @@
+import { check } from 'meteor/check';
+import flat from 'flat';
+import Logger from '/imports/startup/server/logger';
+import Screenshare from '/imports/api/2.0/screenshare';
+
+export default function addVoiceUser(meetingId, screenshareConf, body) {
+  check(meetingId, String);
+  check(screenshareConf, String);
+
+  const selector = {
+    meetingId,
+    'broadcast.screenshareConf': screenshareConf,
+  };
+
+  const modifier = {
+    $push: {
+      'broadcast.voiceUsers': flat(body),
+    },
+  };
+
+  const cb = (err) => {
+    if (err) {
+      return Logger.error(`Adding voiceUser to collection: ${err}`);
+    }
+
+    return Logger.info(`Upserted voiceUser id=${body.callerIdNum}, name=${body.callerIdName}`);
+  };
+
+  return Screenshare.upsert(selector, modifier, cb);
+}

--- a/bigbluebutton-html5/imports/api/2.0/screenshare/server/modifiers/clearBroadcast.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/server/modifiers/clearBroadcast.js
@@ -1,0 +1,10 @@
+import Logger from '/imports/startup/server/logger';
+import Screenshare from '/imports/api/2.0/screenshare';
+
+export default function clearBroadcast(meetingId, screenshareConf) {
+  if (meetingId && screenshareConf) {
+    return Screenshare.remove({ meetingId, 'broadcast.screenshareConf': screenshareConf }, Logger.info(`Cleared Screenshare (${meetingId}) , (${screenshareConf})`));
+  }
+
+  return Screenshare.remove({}, Logger.info('Cleared Screenshare (all)'));
+}

--- a/bigbluebutton-html5/imports/api/2.0/screenshare/server/modifiers/clearVoiceUser.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/server/modifiers/clearVoiceUser.js
@@ -1,0 +1,28 @@
+import Logger from '/imports/startup/server/logger';
+import Screenshare from '/imports/api/2.0/screenshare';
+
+export default function clearVoiceUser(meetingId, screenshareConf, callerIdNum) {
+  check(meetingId, String);
+  check(callerIdNum, String);
+
+  const selector = {
+    meetingId,
+    'broadcast.screenshareConf': screenshareConf,
+  };
+
+  const modifier = {
+    $pull: {
+      'broadcast.voiceUsers': { callerIdNum },
+    },
+  };
+
+  const cb = (err) => {
+    if (err) {
+      return Logger.error(`Remove voiceUser to collection: ${err}`);
+    }
+
+    return Logger.info(`Remove voiceUser id=${callerIdNum}`);
+  };
+
+  return Screenshare.update(selector, modifier, cb);
+}

--- a/bigbluebutton-html5/imports/api/2.0/screenshare/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/server/publishers.js
@@ -1,0 +1,23 @@
+import Screenshare from '/imports/api/2.0/screenshare';
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+import Logger from '/imports/startup/server/logger';
+import mapToAcl from '/imports/startup/mapToAcl';
+
+function screenshare(credentials) {
+  const { meetingId, requesterUserId } = credentials;
+
+  check(meetingId, String);
+  check(requesterUserId, String);
+
+  Logger.info(`Publishing Screenshare for ${meetingId} ${requesterUserId}`);
+
+  return Screenshare.find({ meetingId });
+}
+
+function publish(...args) {
+  const boundScreenshare = screenshare.bind(this);
+  return mapToAcl('subscriptions.screenshare', boundScreenshare)(args);
+}
+
+Meteor.publish('screenshare', publish);

--- a/bigbluebutton-html5/server/main.js
+++ b/bigbluebutton-html5/server/main.js
@@ -19,6 +19,7 @@ import '/imports/api/2.0/cursor/server';
 import '/imports/api/2.0/presentations/server';
 import '/imports/api/2.0/slides/server';
 import '/imports/api/2.0/chat/server';
+import '/imports/api/2.0/screenshare/server';
 
 // Commons
 import '/imports/api/log-client/server';


### PR DESCRIPTION
The following messages are handle in this PR:

- [x] ScreenshareRtmpBroadcastStartedVoiceConfEvtMsg - **TODO** Implement handler’s logic 
- [x]  ScreenshareRtmpBroadcastStartedEvtMsg
- [x] ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg - **TODO** Implement handler’s logic 
- [x] ScreenshareRtmpBroadcastStoppedEvtMsg
- [x] ScreenshareStartedVoiceConfEvtMsg
- [x] ScreenshareStoppedVoiceConfEvtMsg