### PR TITLE
[HTML5 - 2.0] Change relative path of the sass imports to absolute

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
@@ -1,4 +1,4 @@
-@import "../../stylesheets/variables/_all";
+@import "/imports/ui/stylesheets/variables/_all";
 
 .actionsbar,
 .left,

--- a/bigbluebutton-html5/imports/ui/components/app/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.scss
@@ -1,4 +1,4 @@
-@import "../../stylesheets/variables/_all";
+@import "/imports/ui/stylesheets/variables/_all";
 
 $navbar-height: 60px; // TODO: Change to NavBar real height
 $actionsbar-height: 50px; // TODO: Change to ActionsBar real height

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/styles.scss
@@ -1,5 +1,5 @@
-@import "../../../stylesheets/variables/_all";
-@import "../../modal/simple/styles";
+@import "/imports/ui/stylesheets/variables/_all";
+@import "/imports/ui/components/modal/simple/styles";
 
 .overlay {
   @extend .overlay;

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-notification/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-notification/styles.scss
@@ -1,4 +1,4 @@
-@import "../../../stylesheets/variables/_all";
+@import "/imports/ui/stylesheets/variables/_all";
 
 $nb-default-color: $color-gray;
 $nb-default-bg: $color-white;

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-test/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-test/styles.scss
@@ -1,4 +1,4 @@
-@import "../../../stylesheets/variables/all";
+@import "/imports/ui/stylesheets/variables/_all";
 
 .testAudioBtn {
   border: none;

--- a/bigbluebutton-html5/imports/ui/components/button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/button/styles.scss
@@ -1,4 +1,4 @@
-@import "../../stylesheets/variables/_all";
+@import "/imports/ui/stylesheets/variables/_all";
 
 $btn-default-color: $color-gray;
 $btn-default-bg: $color-white;

--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/message-form-actions/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/message-form-actions/styles.scss
@@ -1,1 +1,1 @@
-@import "../../../../stylesheets/variables/_all";
+@import "/imports/ui/stylesheets/variables/_all";

--- a/bigbluebutton-html5/imports/ui/components/chat/message-list/message-list-item/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-list/message-list-item/styles.scss
@@ -1,4 +1,4 @@
-@import "../../../../stylesheets/variables/_all";
+@import "/imports/ui/stylesheets/variables/_all";
 
 .item {
   font-size: $font-size-base * .90;

--- a/bigbluebutton-html5/imports/ui/components/chat/message-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-list/styles.scss
@@ -1,5 +1,5 @@
-@import "../../../stylesheets/variables/_all";
-@import "../../../stylesheets/mixins/_scrollable";
+@import "/imports/ui/stylesheets/variables/_all";
+@import "/imports/ui/stylesheets/mixins/_scrollable";
 
 .messageListWrapper {
   display: flex;

--- a/bigbluebutton-html5/imports/ui/components/dropdown/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/styles.scss
@@ -1,5 +1,5 @@
-@import "../../stylesheets/variables/_all";
-@import "../../stylesheets/mixins/_scrollable";
+@import "/imports/ui/stylesheets/variables/_all";
+@import "/imports/ui/stylesheets/mixins/_scrollable";
 
 $dropdown-bg: $color-white;
 $dropdown-color: $color-text;

--- a/bigbluebutton-html5/imports/ui/components/error-screen/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/error-screen/styles.scss
@@ -1,4 +1,4 @@
-@import '/imports/ui/stylesheets/variables/palette';
+@import "/imports/ui/stylesheets/variables/palette";
 
 $bg: $color-gray-dark;
 $color: $color-white;

--- a/bigbluebutton-html5/imports/ui/components/error-screen/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/error-screen/styles.scss
@@ -1,4 +1,4 @@
-@import '../../stylesheets/variables/palette';
+@import '/imports/ui/stylesheets/variables/palette';
 
 $bg: $color-gray-dark;
 $color: $color-white;

--- a/bigbluebutton-html5/imports/ui/components/loading-screen/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/loading-screen/styles.scss
@@ -1,4 +1,4 @@
-@import '../../stylesheets/variables/_all';
+@import "/imports/ui/stylesheets/variables/_all";
 
 /* Variables
  * ==========

--- a/bigbluebutton-html5/imports/ui/components/modal/base/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/modal/base/styles.scss
@@ -1,5 +1,5 @@
-@import "../../../stylesheets/variables/_all";
-@import "../../../stylesheets/mixins/_scrollable";
+@import "/imports/ui/stylesheets/variables/_all";
+@import "/imports/ui/stylesheets/mixins/_scrollable";
 
 .modal {
   @include scrollbox-vertical();

--- a/bigbluebutton-html5/imports/ui/components/modal/simple/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/modal/simple/styles.scss
@@ -1,4 +1,4 @@
-@import "../../../stylesheets/variables/_all";
+@import "/imports/ui/stylesheets/variables/_all";
 @import "../base/styles";
 
 .modal {

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.scss
@@ -1,5 +1,5 @@
-@import "../../button/styles.scss";
-@import "../../../stylesheets/variables/_all";
+@import "/imports/ui/components/button/styles.scss";
+@import "/imports/ui/stylesheets/variables/_all";
 
 $controls-color: #212121 !default;
 $controls-background: #F0F2F6 !default;

--- a/bigbluebutton-html5/imports/ui/components/presentation/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/presentation/styles.scss
@@ -1,4 +1,4 @@
-@import "../../stylesheets/variables/_all";
+@import "/imports/ui/stylesheets/variables/_all";
 
 .enter {
   opacity: 0.01;

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/styles.scss
@@ -1,4 +1,4 @@
-@import "../../../stylesheets/variables/_all";
+@import "/imports/ui/stylesheets/variables/_all";
 
 .title {
   color: $color-gray-dark;

--- a/bigbluebutton-html5/imports/ui/components/user-avatar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-avatar/styles.scss
@@ -1,4 +1,4 @@
-@import '../../stylesheets/variables/palette';
+@import '/imports/ui/stylesheets/variables/palette';
 
 /* Variables
  * ==========

--- a/bigbluebutton-html5/imports/ui/components/user-avatar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-avatar/styles.scss
@@ -1,4 +1,4 @@
-@import '/imports/ui/stylesheets/variables/palette';
+@import "/imports/ui/stylesheets/variables/palette";
 
 /* Variables
  * ==========

--- a/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/styles.scss
@@ -1,4 +1,4 @@
-@import '../styles.scss';
+@import "../styles.scss";
 
 .chatListItem {
   @extend %list-item;

--- a/bigbluebutton-html5/imports/ui/components/user-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-list/styles.scss
@@ -1,5 +1,5 @@
-@import '../../stylesheets/variables/_all';
-@import '../../stylesheets/mixins/_scrollable';
+@import "/imports/ui/stylesheets/variables/_all";
+@import '/imports/ui/stylesheets/mixins/_scrollable';
 
 /* Variables
  * ==========

--- a/bigbluebutton-html5/imports/ui/components/user-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-list/styles.scss
@@ -1,5 +1,5 @@
 @import "/imports/ui/stylesheets/variables/_all";
-@import '/imports/ui/stylesheets/mixins/_scrollable';
+@import "/imports/ui/stylesheets/mixins/_scrollable";
 
 /* Variables
  * ==========

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-item/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-item/styles.scss
@@ -1,4 +1,4 @@
-@import '../styles.scss';
+@import "../styles.scss";
 
 .userListItem {
   @extend %list-item;

--- a/bigbluebutton-html5/imports/ui/components/video-dock/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-dock/styles.scss
@@ -1,4 +1,4 @@
-@import "../../stylesheets/variables/_all";
+@import "/imports/ui/stylesheets/variables/_all";
 
 .videoDock {
   position: absolute;


### PR DESCRIPTION
On this PR we change the import from relative to absolute, preventing when moving components around directories, `npm start` crashing with no help messages because could not find the .sass file.

Using the absolute path on the inner components, even moving them around will keep the same location to `_all`

Example of crashing message:


![screenshot from 2017-07-17 15-42-55](https://user-images.githubusercontent.com/17770979/28284237-a7ea64d6-6b06-11e7-8e57-71b2d87dcc69.png)
