### PR TITLE
[HTML5 2.0] Fix meeting add

### DIFF
--- a/bigbluebutton-html5/imports/api/2.0/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/2.0/meetings/server/modifiers/addMeeting.js
@@ -11,11 +11,14 @@ export default function addMeeting(meeting) {
   check(meetingId, String);
 
   const selector = {
-    'meetingProp.intId': meetingId,
+    meetingId,
   };
 
   const modifier = {
-    $set: flat(meeting),
+    $set: Object.assign(
+      { meetingId },
+      flat(meeting),
+    ),
   };
 
   const cb = (err, numChanged) => {

--- a/bigbluebutton-html5/imports/api/2.0/users/server/handlers/validateAuthToken.js
+++ b/bigbluebutton-html5/imports/api/2.0/users/server/handlers/validateAuthToken.js
@@ -11,8 +11,6 @@ const addWelcomeChatMessage = (meetingId, userId) => {
 
   const Meeting = Meetings.findOne({ meetingId });
 
-  if (!Meeting) return;
-
   const message = {
     chatType: CHAT_CONFIG.type_system,
     message: Meeting.welcomeProp.welcomeMsg,

--- a/bigbluebutton-html5/imports/api/2.0/users/server/handlers/validateAuthToken.js
+++ b/bigbluebutton-html5/imports/api/2.0/users/server/handlers/validateAuthToken.js
@@ -7,23 +7,15 @@ import addChat from '/imports/api/2.0/chat/server/modifiers/addChat';
 import clearUserSystemMessages from '/imports/api/2.0/chat/server/modifiers/clearUserSystemMessages';
 
 const addWelcomeChatMessage = (meetingId, userId) => {
-  const APP_CONFIG = Meteor.settings.public.app;
   const CHAT_CONFIG = Meteor.settings.public.chat;
 
-  const Meeting = Meetings.findOne({ 'meetingProp.intId': meetingId });
+  const Meeting = Meetings.findOne({ meetingId });
 
-  if (!Meeting) {
-    // TODO add meeting properly so it does not get reset
-    return;
-  }
-
-  const welcomeMessage = APP_CONFIG.defaultWelcomeMessage
-    .concat(APP_CONFIG.defaultWelcomeMessageFooter)
-    .replace(/%%CONFNAME%%/, Meeting.meetingProp.name);
+  if (!Meeting) return;
 
   const message = {
     chatType: CHAT_CONFIG.type_system,
-    message: welcomeMessage,
+    message: Meeting.welcomeProp.welcomeMsg,
     fromColor: '0x3399FF',
     toUserId: userId,
     fromUserId: CHAT_CONFIG.type_system,

--- a/bigbluebutton-html5/private/config/public/app.yaml
+++ b/bigbluebutton-html5/private/config/public/app.yaml
@@ -17,9 +17,7 @@ app:
   bbbServerVersion: "1.1-beta"
   copyright: "©2017 BigBlueButton Inc."
   html5ClientBuild: "HTML5_CLIENT_VERSION"
-  defaultWelcomeMessage: Welcome to %%CONFNAME%%!<br /><br />For help on using BigBlueButton see these (short) <a href="event:http://www.bigbluebutton.org/content/videos"><u>tutorial videos</u></a>.<br /><br />To join the audio bridge click the gear icon (upper-right hand corner).  Use a headset to avoid causing background noise for others.<br /><br /><br />
   lockOnJoin: true
-  defaultWelcomeMessageFooter: This server is running a build of <a href="http://docs.bigbluebutton.org/1.1/overview.html" target="_blank"><u>BigBlueButton 1.1-beta</u></a>.
 
   # Name displayed in the brower URL
   basename: '/html5client'


### PR DESCRIPTION
 - Add missing property `meetingId` on the meeting object.
 - Remove the welcomeMessage from the HTML5 config and get it from the meeting api.