### PR TITLE
Presenter and slide size fix for 2.0

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -122,7 +122,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			[Bindable] private var DEFAULT_X_POSITION:Number = 237;
 			[Bindable] private var DEFAULT_Y_POSITION:Number = 0;
 			
-			private static const TOP_WINDOW_BORDER:Number = 54;
+			private static const TOP_WINDOW_BORDER:Number = 30;
 			private static const WIDTH_PADDING:Number = 8;
 
 			[Bindable] private var DEFAULT_WINDOW_WIDTH:Number = 510;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
@@ -594,11 +594,13 @@ package org.bigbluebutton.modules.users.services
       UsersUtil.setUserAsPresent(newPresenterID, true);
       sendSwitchedPresenterEvent(true, newPresenterID);
 
-      var e:MadePresenterEvent = new MadePresenterEvent(MadePresenterEvent.SWITCH_TO_PRESENTER_MODE);
-      e.userID = newPresenterID;
-      e.presenterName = newPresenterName;
-      e.assignedBy = assignedBy;
-      dispatcher.dispatchEvent(e);
+      if (UsersUtil.getMyUserID() == newPresenterID) {
+        var e:MadePresenterEvent = new MadePresenterEvent(MadePresenterEvent.SWITCH_TO_PRESENTER_MODE);
+        e.userID = newPresenterID;
+        e.presenterName = newPresenterName;
+        e.assignedBy = assignedBy;
+        dispatcher.dispatchEvent(e);
+      }
       
       dispatcher.dispatchEvent(new UserStatusChangedEvent(newPresenterID));
     }
@@ -613,12 +615,13 @@ package org.bigbluebutton.modules.users.services
       UsersUtil.setUserAsPresent(oldPresenterID, false);
       sendSwitchedPresenterEvent(false, oldPresenterID);
 
-      var e:MadePresenterEvent = new MadePresenterEvent(MadePresenterEvent.SWITCH_TO_VIEWER_MODE);
-      e.userID = oldPresenterID;
-      e.presenterName = oldPresenterName;
-      e.assignedBy = assignedBy;
-
-      dispatcher.dispatchEvent(e);
+      if (UsersUtil.getMyUserID() == oldPresenterID) {
+        var e:MadePresenterEvent = new MadePresenterEvent(MadePresenterEvent.SWITCH_TO_VIEWER_MODE);
+        e.userID = oldPresenterID;
+        e.presenterName = oldPresenterName;
+        e.assignedBy = assignedBy;
+        dispatcher.dispatchEvent(e);
+      }
 
       dispatcher.dispatchEvent(new UserStatusChangedEvent(oldPresenterID));
     }


### PR DESCRIPTION
Fixed an error in the dispatching of the MadePresenterEvents. Those events are used when the state of the local user changes, but they were being dispatched when any user was changed instead.

I also corrected the maximum slide height calculation so that it didn't reserve too much space.