### PR TITLE
Screenshare loading screen

### DIFF
--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -416,6 +416,7 @@ bbb.screensharePublish.WebRTCExtensionFailFallback.label = Unable to detect scre
 bbb.screensharePublish.WebRTCPrivateBrowsingWarning.label = It seems you may be Incognito or using private browsing. Make sure under your extension settings you allow the extension the run in Incognito/private browsing.
 bbb.screensharePublish.WebRTCExtensionInstallButton.label = Click here to install
 bbb.screensharePublish.WebRTCUseJavaButton.label = Use Java Screen Sharing
+bbb.screensharePublish.WebRTCVideoLoading.label = Video is loading... Please wait
 bbb.screensharePublish.sharingMessage= This is your screen being shared
 bbb.screenshareView.title = Screen Sharing
 bbb.screenshareView.fitToWindow = Fit to Window

--- a/bigbluebutton-client/resources/prod/lib/verto_extension.js
+++ b/bigbluebutton-client/resources/prod/lib/verto_extension.js
@@ -5,7 +5,8 @@ Verto = function (
   userCallback,
   onFail = null,
   chromeExtension = null,
-  stunTurnInfo = null) {
+  stunTurnInfo = null,
+  loadingCallback = null) {
 
   voiceBridge += "-SCREENSHARE";
   this.cur_call = null;
@@ -40,6 +41,12 @@ Verto = function (
   this.shouldConnect = true;
   this.iceServers = stunTurnInfo;
   this.userCallback = userCallback;
+
+  if (loadingCallback != null) {
+    this.videoLoadingCallback = Verto.normalizeCallback(loadingCallback);
+  } else {
+    this.videoLoadingCallback = function() {};
+  }
 
   if (chromeExtension != null) {
     this.chromeExtension = chromeExtension;
@@ -302,6 +309,7 @@ Verto.prototype.setScreenShare = function (tag) {
   // tell Verto we want to share webcam so it knows there will be a video stream
   // but instead of a webcam we pass screen constraints
   this.useCamera = 'any';
+  this.useMic = 'none';
   this.mediaCallback = this.makeShare;
   this.create(tag);
 };
@@ -412,6 +420,8 @@ Verto.prototype.doShare = function (screenConstraints) {
   var _this = this;
   // Override onStream callback in $.FSRTC instance
   this.share_call.rtc.options.callbacks.onStream = function (rtc, stream) {
+    _this.videoLoadingCallback();
+
     if (stream) {
       var StreamTrack = stream.getVideoTracks()[0];
       StreamTrack.addEventListener('ended', stopSharing.bind(_this));

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/events/WebRTCPublishWindowChangeState.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/events/WebRTCPublishWindowChangeState.as
@@ -25,6 +25,7 @@ package org.bigbluebutton.modules.screenshare.events
 		public static const DISPLAY_INSTALL:String = "WebRTC Deskshare Display Install Screen";
 		public static const DISPLAY_RETRY:String = "WebRTC Deskshare Display Retry Screen";
 		public static const DISPLAY_FALLBACK:String = "WebRTC Deskshare Display Fallback Screen";
+		public static const DISPLAY_VIDEO_LOADING:String = "WebRTC Deskshare Display Video Loading Screen";
 
 		public function WebRTCPublishWindowChangeState(type:String, bubbles:Boolean=true, cancelable:Boolean=false)
 		{

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/managers/WebRTCDeskshareManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/managers/WebRTCDeskshareManager.as
@@ -54,6 +54,7 @@ package org.bigbluebutton.modules.screenshare.managers
 		private var usingKurentoWebRTC:Boolean = false;
 		private var chromeExtensionKey:String = null;
 		private var options:ScreenshareOptions;
+		private var videoLoadingCallbackName:String = "videoLoadingCallback";
 
 		public function WebRTCDeskshareManager() {
 			LOGGER.debug("WebRTCDeskshareManager::WebRTCDeskshareManager");
@@ -145,15 +146,26 @@ package org.bigbluebutton.modules.screenshare.managers
 							chromeExtensionKey
 							);
 				} else {
+					var videoLoadingCallback:Function = function():void {
+						ExternalInterface.addCallback(videoLoadingCallbackName, null);
+						publishWindowManager.openWindow();
+						globalDispatcher.dispatchEvent(new WebRTCPublishWindowChangeState(WebRTCPublishWindowChangeState.DISPLAY_VIDEO_LOADING));
+					}
+
+					ExternalInterface.addCallback(videoLoadingCallbackName, videoLoadingCallback);
+					var dummyStunTurn:Object = null;
+
 					ExternalInterface.call(
-							'vertoShareScreen',
-							videoTag,
-							voiceBridge,
-							myName,
-							null,
-							"onFail",
-							chromeExtensionKey
-							);
+						'vertoShareScreen',
+						videoTag,
+						voiceBridge,
+						myName,
+						null,
+						"onFail",
+						chromeExtensionKey,
+						dummyStunTurn,
+						videoLoadingCallbackName
+					);
 				}
 			}
 		}

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopPublishWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopPublishWindow.mxml
@@ -44,6 +44,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		<mate:Listener type="{WebRTCPublishWindowChangeState.DISPLAY_INSTALL}" method="displayInstall" />
 		<mate:Listener type="{WebRTCPublishWindowChangeState.DISPLAY_RETRY}" method="displayRetry" />
 		<mate:Listener type="{WebRTCPublishWindowChangeState.DISPLAY_FALLBACK}" method="displayFallback" />
+		<mate:Listener type="{WebRTCPublishWindowChangeState.DISPLAY_VIDEO_LOADING}" method="displayLoadingScreen" />
 	</fx:Declarations>
 
 	<fx:Script>
@@ -121,6 +122,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					ExternalInterface.addCallback("isNotIncognito", isNotIncognito);
 					ExternalInterface.call("checkIfIncognito", "isIncognito", "isNotIncognito");
 				}
+			}
+
+			private function displayLoadingScreen(e:Event):void {
+				setCurrentState("displayLoadingScreen");
 			}
 
 			private function onInstallButtonClicked():void {
@@ -340,7 +345,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				streaming = false;
 				captureHeight = Capabilities.screenResolutionY;
 				captureWidth = Capabilities.screenResolutionX;
-				ns.close();
+				if (ns != null) {
+					ns.close();
+				}
 			}
 
 			private function onAsyncError(e:AsyncErrorEvent):void{
@@ -423,6 +430,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		<mx:State name="displayInstall" />
 		<mx:State name="displayRetry" />
 		<mx:State name="displayFallback" />
+		<mx:State name="displayLoadingScreen" />
 	</dspub:states>
 
 	<mx:VBox id="mainContainer" width="100%" height="100%"  paddingBottom="2" paddingLeft="2" paddingRight="2" paddingTop="2">
@@ -467,6 +475,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			</mx:HBox>
 			<mx:HBox width="100%" height="100%" horizontalAlign="center">
 				<mx:Button id="btnFallback" label="{ResourceUtil.getInstance().getString('bbb.screensharePublish.WebRTCUseJavaButton.label')}" visible="true" enabled="true" click="onFallbackButtonClicked()" />
+			</mx:HBox>
+		</mx:VBox>
+		<mx:VBox includeIn="displayLoadingScreen" width="100%" height="100%" horizontalAlign="center">
+			<mx:HBox width="100%" height="100%" horizontalAlign="center">
+				<mx:Text fontSize="16" width="100%" textAlign="center" styleName="" text="{ResourceUtil.getInstance().getString('bbb.screensharePublish.WebRTCVideoLoading.label')}" />
 			</mx:HBox>
 		</mx:VBox>
 	</mx:VBox>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopViewWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopViewWindow.mxml
@@ -293,6 +293,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 
 			private function fitWindowToVideo():void {
+				// throws exception in race conditon where video is null
+				// check first
+				if (this.video == null) {
+					return;
+				}
+
 				video.width = videoWidth;
 				videoHolder.width = videoWidth;
 				video.height = videoHeight;


### PR DESCRIPTION
Once you start sharing the publish window opens and displays a loading message

![loading_screen 1](https://user-images.githubusercontent.com/6475374/28642899-f04cdde0-7221-11e7-922b-03be82c5a316.png)
