### PR TITLE
Stop screenshare and poll on presenter leave

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareStoppedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareStoppedVoiceConfEvtMsgHdlr.scala
@@ -10,6 +10,10 @@ trait ScreenshareStoppedVoiceConfEvtMsgHdlr {
   val outGW: OutMsgRouter
 
   def handleScreenshareStoppedVoiceConfEvtMsg(msg: ScreenshareStoppedVoiceConfEvtMsg): Unit = {
+    handleScreenshareStoppedVoiceConfEvtMsg(msg.body.voiceConf, msg.body.screenshareConf)
+  }
+
+  def handleScreenshareStoppedVoiceConfEvtMsg(voiceConf: String, screenshareConf: String): Unit = {
 
     def broadcastEvent(voiceConf: String, screenshareConf: String, url: String, timestamp: String): BbbCommonEnvCoreMsg = {
       val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
@@ -24,14 +28,14 @@ trait ScreenshareStoppedVoiceConfEvtMsgHdlr {
       BbbCommonEnvCoreMsg(envelope, event)
     }
 
+    val broadcastUrl = ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel)
     log.info("handleScreenshareStoppedRequest: dsStarted=" +
       ScreenshareModel.getScreenshareStarted(liveMeeting.screenshareModel) +
-      " URL:" + ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel))
+      " URL:" + broadcastUrl)
 
     val timestamp = System.currentTimeMillis().toString
     // Tell FreeSwitch to stop broadcasting to RTMP
-    val msgEvent = broadcastEvent(msg.body.voiceConf, msg.body.screenshareConf,
-      ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel), timestamp)
+    val msgEvent = broadcastEvent(voiceConf, screenshareConf, broadcastUrl, timestamp)
     outGW.send(msgEvent)
 
     ScreenshareModel.setScreenshareStarted(liveMeeting.screenshareModel, false)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
@@ -28,6 +28,12 @@ trait UserLeaveReqMsgHdlr {
 
       if (u.presenter) {
         automaticallyAssignPresenter(outGW, liveMeeting)
+
+        // request screenshare to end
+        screenshareApp2x.handleScreenshareStoppedVoiceConfEvtMsg(liveMeeting.props.voiceProp.voiceConf, liveMeeting.props.screenshareProps.screenshareConf)
+
+        // request ongoing poll to end
+        handleStopPollReqMsg(u.intId)
       }
     }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -315,7 +315,11 @@ class MeetingActor(
     // switch user presenter status for old and new presenter
     usersApp.handleAssignPresenterReqMsg(msg)
 
-    // TODO stop current screen sharing session (initiated by the old presenter)
+    // request screenshare to end
+    screenshareApp2x.handleScreenshareStoppedVoiceConfEvtMsg(
+      liveMeeting.props.voiceProp.voiceConf,
+      liveMeeting.props.screenshareProps.screenshareConf
+    )
 
   }
 


### PR DESCRIPTION
Note:
We currently do the same (handle captions, polls, screenshare) on Presenter Switch and on Presenter Left. But Presenter Switch follows from Presenter Left so we technically handle the same twice (second time is ignored).
In my opinion we should keep it like this but if reviewer thinks we should not, please suggest so