### PR TITLE
Remove voice user on refresh

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
@@ -2,9 +2,10 @@ package org.bigbluebutton.core.apps.users
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.domain.{ MeetingExpiryTracker, MeetingState2x }
-import org.bigbluebutton.core.models.Users2x
+import org.bigbluebutton.core.models.{ Users2x, VoiceUserState, VoiceUsers }
 import org.bigbluebutton.core.running.{ LiveMeeting, MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core.util.TimeUtil
+import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait UserLeaveReqMsgHdlr {
@@ -24,7 +25,6 @@ trait UserLeaveReqMsgHdlr {
       // send a user left event for the clients to update
       val userLeftMeetingEvent = MsgBuilder.buildUserLeftMeetingEvtMsg(liveMeeting.props.meetingProp.intId, u.intId)
       outGW.send(userLeftMeetingEvent)
-      log.info("User left meetingId=" + liveMeeting.props.meetingProp.intId + " userId=" + msg.body.userId)
 
       if (u.presenter) {
         automaticallyAssignPresenter(outGW, liveMeeting)
@@ -34,6 +34,26 @@ trait UserLeaveReqMsgHdlr {
 
         // request ongoing poll to end
         handleStopPollReqMsg(u.intId)
+      }
+
+      def broadcastEvent(vu: VoiceUserState): Unit = {
+        val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId,
+          vu.intId)
+        val envelope = BbbCoreEnvelope(UserLeftVoiceConfToClientEvtMsg.NAME, routing)
+        val header = BbbClientMsgHeader(UserLeftVoiceConfToClientEvtMsg.NAME, liveMeeting.props.meetingProp.intId, vu.intId)
+
+        val body = UserLeftVoiceConfToClientEvtMsgBody(voiceConf = liveMeeting.props.voiceProp.voiceConf, intId = vu.intId, voiceUserId = vu.intId)
+
+        val event = UserLeftVoiceConfToClientEvtMsg(header, body)
+        val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+        outGW.send(msgEvent)
+      }
+
+      for {
+        user <- VoiceUsers.findWithIntId(liveMeeting.voiceUsers, msg.body.userId)
+      } yield {
+        VoiceUsers.removeWithIntId(liveMeeting.voiceUsers, user.intId)
+        broadcastEvent(user)
       }
     }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserLeftVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserLeftVoiceConfEvtMsgHdlr.scala
@@ -12,7 +12,6 @@ trait UserLeftVoiceConfEvtMsgHdlr {
   val outGW: OutMsgRouter
 
   def handleUserLeftVoiceConfEvtMsg(msg: UserLeftVoiceConfEvtMsg): Unit = {
-    log.debug("Received UserLeftVoiceConfEvtMsg from FS {} ", msg.body.voiceUserId)
 
     def broadcastEvent(vu: VoiceUserState): Unit = {
       val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId,
@@ -42,8 +41,6 @@ trait UserLeftVoiceConfEvtMsgHdlr {
       liveMeeting.props.recordProp.record &&
       MeetingStatus2x.isVoiceRecording(liveMeeting.status)) {
       MeetingStatus2x.stopRecordingVoice(liveMeeting.status)
-      log.info("Send STOP RECORDING voice conf. meetingId=" + liveMeeting.props.meetingProp.intId
-        + " voice conf=" + liveMeeting.props.voiceProp.voiceConf)
 
       val event = buildStopRecordingVoiceConfSysMsg(
         liveMeeting.props.meetingProp.intId,


### PR DESCRIPTION
 - When a user is in the voice conference using webrtc and the browser refreshes, FS doesn't detect that the
   webrtc connection has gone down so it is not able to send a user left voice conf message. It would take a
   media timeout for FS to send a user left voice conf event. Remove the user from voice list when user leaves
   the meeting. Not sure how this behaves on auto-reconnect of bbb-apps while the webrtc connection is actually
   still working.