### PR TITLE
Remove broken parts of getRecordings response building

### DIFF
--- a/bigbluebutton-web/web-app/WEB-INF/freemarker/include-recording.ftlx
+++ b/bigbluebutton-web/web-app/WEB-INF/freemarker/include-recording.ftlx
@@ -15,8 +15,6 @@
 <state>${r.getState()?string}</state>
 <startTime><#if r.getStartTime()?? && r.getStartTime() != "">${r.getStartTime()}</#if></startTime>
 <endTime><#if r.getEndTime()?? && r.getEndTime() != "">${r.getEndTime()}</#if></endTime>
-<size><#if r.getSize()?? && r.getSize() != "">${r.getSize()}</#if></size>
-<rawSize><#if r.getRawSize()?? && r.getRawSize() != "">${r.getRawSize()}</#if></rawSize>
 <participants><#if r.getParticipants()??>${r.getParticipants()}</#if></participants>
 
 <#if r.getBreakout()??>
@@ -50,7 +48,6 @@
         <type>${pb.getFormat()}</type>
         <url>${pb.getLink()}</url>
         <processingTime>${pb.getProcessingTime()?c}</processingTime>
-        <size>${pb.getSize()}</size>
         <#if pb.getDuration() == 0>
             <length>${r.calculateDuration()?c}</length>
         <#else>
@@ -77,20 +74,3 @@
         </#if>
     </format>
 </playback>
-
-<download>
-    <#if r.getDownloads()??>
-    <#list r.getDownloads() as p>
-        <#if p?? && p.getFormat()??>
-        <format>
-            <type>${p.getFormat()}</type>
-            <url>${p.getUrl()}</url>
-            <md5>${p.getMd5()}</md5>
-            <key>${p.getKey()}</key>
-            <length>${p.getLength()}</length>
-            <size>${p.getSize()}</size>
-        </format>
-        </#if>
-    </#list>
-    </#if>
-</download>


### PR DESCRIPTION
There were some new parts added to the getRecordings template, but not included in the recording metadata which resulted in some exceptions being thrown when trying to build the getRecordings response. I've removed the offending pieces and the response is working like it was in 1.1 again.