### PR TITLE
[HTML5 2.0] Fix VoiceUser microphone state

### DIFF
--- a/bigbluebutton-html5/imports/api/2.0/users/server/modifiers/addUser.js
+++ b/bigbluebutton-html5/imports/api/2.0/users/server/modifiers/addUser.js
@@ -71,6 +71,7 @@ export default function addUser(meetingId, user) {
     callingWith: '',
     listenOnly: false,
     voiceConf: '',
+    joined: false,
   });
 
   const cb = (err, numChanged) => {

--- a/bigbluebutton-html5/imports/api/2.0/voice-users/server/handlers/joinVoiceUser.js
+++ b/bigbluebutton-html5/imports/api/2.0/voice-users/server/handlers/joinVoiceUser.js
@@ -4,6 +4,7 @@ import addVoiceUser from '../modifiers/addVoiceUser';
 
 export default function handleJoinVoiceUser({ body }, meetingId) {
   const voiceUser = body;
+  voiceUser.joined = true;
 
   check(meetingId, String);
 

--- a/bigbluebutton-html5/imports/api/2.0/voice-users/server/modifiers/addVoiceUser.js
+++ b/bigbluebutton-html5/imports/api/2.0/voice-users/server/modifiers/addVoiceUser.js
@@ -15,6 +15,7 @@ export default function addVoiceUser(meetingId, voiceUser) {
     callingWith: String,
     listenOnly: Boolean,
     voiceConf: String,
+    joined: Boolean, // This is a HTML5 only param.
   });
 
   const { intId } = voiceUser;

--- a/bigbluebutton-html5/imports/api/2.0/voice-users/server/modifiers/removeVoiceUser.js
+++ b/bigbluebutton-html5/imports/api/2.0/voice-users/server/modifiers/removeVoiceUser.js
@@ -18,9 +18,12 @@ export default function removeVoiceUser(meetingId, voiceUser) {
   };
 
   const modifier = {
-    muted: false,
-    talking: false,
-    listenOnly: false,
+    $set: {
+      muted: false,
+      talking: false,
+      listenOnly: false,
+      joined: false,
+    },
   };
 
   const cb = (err) => {


### PR DESCRIPTION
Missing the `joined` state, user couldn't leave audio when using microphone in the HTML5 client.