### PR TITLE
Record extra SharePresentationEvent when conversion complete and current

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
@@ -120,6 +120,10 @@ class RedisRecorderActor(val system: ActorSystem)
     ev.setOriginalFilename(msg.body.presentation.name)
 
     record(msg.header.meetingId, ev.toMap)
+
+    if (msg.body.presentation.current) {
+      recordSharePresentationEvent(msg.header.meetingId, msg.body.presentation.id)
+    }
   }
 
   private def handleSetCurrentPageEvtMsg(msg: SetCurrentPageEvtMsg) {
@@ -152,12 +156,16 @@ class RedisRecorderActor(val system: ActorSystem)
   }
 
   private def handleSetCurrentPresentationEvtMsg(msg: SetCurrentPresentationEvtMsg) {
+    recordSharePresentationEvent(msg.header.meetingId, msg.body.presentationId)
+  }
+
+  private def recordSharePresentationEvent(meetingId: String, presentationId: String) {
     val ev = new SharePresentationRecordEvent()
-    ev.setMeetingId(msg.header.meetingId)
-    ev.setPresentationName(msg.body.presentationId)
+    ev.setMeetingId(meetingId)
+    ev.setPresentationName(presentationId)
     ev.setShare(true)
 
-    record(msg.header.meetingId, ev.toMap)
+    record(meetingId, ev.toMap)
   }
 
   private def getPageNum(id: String): Integer = {


### PR DESCRIPTION
This PR records a SharePresentationEvent when a ConversionComplete comes in with current=true. This is to match a similar behaviour from 1.1.