### PR TITLE
BigBlueButton 2.0 recording fixes

### DIFF
--- a/record-and-playback/core/scripts/bigbluebutton.yml
+++ b/record-and-playback/core/scripts/bigbluebutton.yml
@@ -1,4 +1,4 @@
-bbb_version: '2.0'
+bbb_version: '2.0.0'
 raw_audio_src: /var/freeswitch/meetings
 raw_video_src: /usr/share/red5/webapps/video/streams
 raw_screenshare_src: /usr/share/red5/webapps/screenshare/streams

--- a/record-and-playback/core/scripts/bigbluebutton.yml
+++ b/record-and-playback/core/scripts/bigbluebutton.yml
@@ -1,4 +1,4 @@
-bbb_version: '0.9.0'
+bbb_version: '2.0'
 raw_audio_src: /var/freeswitch/meetings
 raw_video_src: /usr/share/red5/webapps/video/streams
 raw_screenshare_src: /usr/share/red5/webapps/screenshare/streams

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -940,8 +940,8 @@ def processShapesAndClears
               end
 
               if $version_atleast_2_0
-                # Shape thickness is now calculated as a fraction of page width
-                $shapeThickness = $shapeThickness.to_f * $vbox_width
+                # Shape thickness is now calculated as a percentage of page width
+                $shapeThickness = $shapeThickness.to_f * $vbox_width / 100.0
               end
 
               case $shapeType

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -373,21 +373,21 @@ def storePencilShape
       # BBB 2.0 recording, we have a path with commands that has to be converted to SVG path
       $shapeCommands.each do |command|
         case command
-        when 1 # MOVE_TO
+        when '1' # MOVE_TO
           x = dataPoints.shift.to_f / 100 * $vbox_width
           y = dataPoints.shift.to_f / 100 * $vbox_height
           path.push("M #{x} #{y}")
-        when 2 # LINE_TO
+        when '2' # LINE_TO
           x = dataPoints.shift.to_f / 100 * $vbox_width
           y = dataPoints.shift.to_f / 100 * $vbox_height
           path.push("L #{x} #{y}")
-        when 3 # Q_CURVE_TO
+        when '3' # Q_CURVE_TO
           cx1 = dataPoints.shift.to_f / 100 * $vbox_width
           cy1 = dataPoints.shift.to_f / 100 * $vbox_height
           x = dataPoints.shift.to_f / 100 * $vbox_width
           y = dataPoints.shift.to_f / 100 * $vbox_height
           path.push("Q #{cx1} #{cy2}, #{x} #{y}")
-        when 4 # C_CURVE_TO
+        when '4' # C_CURVE_TO
           cx1 = dataPoints.shift.to_f / 100 * $vbox_width
           cy1 = dataPoints.shift.to_f / 100 * $vbox_height
           cx2 = dataPoints.shift.to_f / 100 * $vbox_width

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -797,10 +797,10 @@ def processSlideEvents
     end
     $slides_compiled[[slide_src, slide_size[1], slide_size[0]]][4] << orig_slide_start
     $slides_compiled[[slide_src, slide_size[1], slide_size[0]]][5] << orig_slide_end
-  end
 
-  $ss[(slide_start..slide_end)] = slide_size # store the size of the slide at that range of time
-  puts "#{slide_src} : #{slide_start} -> #{slide_end}"
+    $ss[(slide_start..slide_end)] = slide_size # store the size of the slide at that range of time
+    puts "#{slide_src} : #{slide_start} -> #{slide_end}"
+  end
 end
 
 def processShapesAndClears

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -942,7 +942,7 @@ def processShapesAndClears
                   colour = shape.xpath(".//color")[0].text()
                   commands = shape.at_xpath('.//commands')
                   if commands
-                    $shapeCommands = command.text().split(',')
+                    $shapeCommands = commands.text().split(',')
                   else
                     $shapeCommands = nil
                   end

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -785,23 +785,22 @@ def processSlideEvents
       next
     end
 
-      BigBlueButton.logger.info("Processing slide image: #{slide_src} : #{slide_start} -> #{slide_end}")
-      # Is this a new image or one previously viewed?
-      if($slides_compiled[[slide_src, slide_size[1], slide_size[0]]] == nil)
-        # If it is, add it to the list with all the data.
-        $slides_compiled[[slide_src, slide_size[1], slide_size[0]]] = [[slide_start], [slide_end], $global_slide_count, slide_text, [orig_slide_start], [orig_slide_end], $presentation_name, slide_number]
-        $global_slide_count = $global_slide_count + 1
-      else
-        $slides_compiled[[slide_src, slide_size[1], slide_size[0]]][0] << slide_start
-        $slides_compiled[[slide_src, slide_size[1], slide_size[0]]][1] << slide_end
-      end
-      $slides_compiled[[slide_src, slide_size[1], slide_size[0]]][4] << orig_slide_start
-      $slides_compiled[[slide_src, slide_size[1], slide_size[0]]][5] << orig_slide_end
+    BigBlueButton.logger.info("Processing slide image: #{slide_src} : #{slide_start} -> #{slide_end}")
+    # Is this a new image or one previously viewed?
+    if($slides_compiled[[slide_src, slide_size[1], slide_size[0]]] == nil)
+      # If it is, add it to the list with all the data.
+      $slides_compiled[[slide_src, slide_size[1], slide_size[0]]] = [[slide_start], [slide_end], $global_slide_count, slide_text, [orig_slide_start], [orig_slide_end], $presentation_name, slide_number]
+      $global_slide_count = $global_slide_count + 1
+    else
+      $slides_compiled[[slide_src, slide_size[1], slide_size[0]]][0] << slide_start
+      $slides_compiled[[slide_src, slide_size[1], slide_size[0]]][1] << slide_end
     end
-
-    $ss[(slide_start..slide_end)] = slide_size # store the size of the slide at that range of time
-    puts "#{slide_src} : #{slide_start} -> #{slide_end}"
+    $slides_compiled[[slide_src, slide_size[1], slide_size[0]]][4] << orig_slide_start
+    $slides_compiled[[slide_src, slide_size[1], slide_size[0]]][5] << orig_slide_end
   end
+
+  $ss[(slide_start..slide_end)] = slide_size # store the size of the slide at that range of time
+  puts "#{slide_src} : #{slide_start} -> #{slide_end}"
 end
 
 def processShapesAndClears

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -728,7 +728,7 @@ def processSlideEvents
       slide_number = $presentation_current_slide[$presentation_name].to_i
       BigBlueButton.logger.info("Switching to presentation #{$presentation_name}, saved slide is #{slide_number}")
 
-    elsif eventname == 'GotoSlide'
+    elsif eventname == 'GotoSlideEvent'
       slide_number = node.xpath(".//slide")[0].text().to_i
       BigBlueButton.logger.info("Switching to slide #{slide_number} in presentation #{$presentation_name}")
 

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -939,6 +939,11 @@ def processShapesAndClears
                 end
               end
 
+              if $version_atleast_2_0
+                # Shape thickness is now calculated as a fraction of page width
+                $shapeThickness = $shapeThickness.to_f * $vbox_width
+              end
+
               case $shapeType
                 when 'pencil'
                   storePencilShape()
@@ -1179,9 +1184,9 @@ begin
         $meeting_start = @doc.xpath("//event")[0][:timestamp]
         $meeting_end = @doc.xpath("//event").last()[:timestamp]
 
-        ## These $version variables are not used anywere in this code ##
         $version = BigBlueButton::Events.bbb_version("#{$process_dir}/events.xml")
         $version_atleast_0_9_0 = BigBlueButton::Events.bbb_version_compare("#{$process_dir}/events.xml", 0, 9, 0)
+        $version_atleast_2_0 = BigBlueButton::Events.bbb_version_compare("#{$process_dir}/events.xml", 2, 0, 0)
         BigBlueButton.logger.info("Creating metadata.xml")
 
         # Get the real-time start and end timestamp

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -369,9 +369,9 @@ def storePencilShape
     path = []
     dataPoints = $shapeDataPoints.dup
 
-    if $shapeCommand
+    if $shapeCommands
       # BBB 2.0 recording, we have a path with commands that has to be converted to SVG path
-      $shapeCommand.each do |command|
+      $shapeCommands.each do |command|
         case command
         when 1 # MOVE_TO
           x = dataPoints.shift.to_f / 100 * $vbox_width
@@ -940,11 +940,11 @@ def processShapesAndClears
                 when 'pencil'
                   $shapeThickness = shape.xpath(".//thickness")[0].text()
                   colour = shape.xpath(".//color")[0].text()
-                  command = shape.at_xpath('.//command')
-                  if command
-                    $shapeCommand = command.text().split(',')
+                  commands = shape.at_xpath('.//commands')
+                  if commands
+                    $shapeCommands = command.text().split(',')
                   else
-                    $shapeCommand = nil
+                    $shapeCommands = nil
                   end
                 when 'rectangle', 'ellipse', 'triangle', 'line'
                   $shapeThickness = shape.xpath(".//thickness")[0].text()


### PR DESCRIPTION
This fixes a few syntax errors and issues with the changes for bbb 2.0 GotoSlide events

It also marks recordings made on a 2.0 server with the '2.0' version, so we can handle things like the new thickness values correctly.

Add handling for the new 'command' element on the pencil shape, for the smooth curves feature. Also draw single-point paths as dots.