### PR TITLE
[HTML5 2.0] Fix Audio Modal on Meeting Join

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -20,7 +20,7 @@ const AudioContainer = props =>
   </Audio>
   );
 
-let didMountedAutoJoin = false;
+let didMountAutoJoin = false;
 
 export default withModalMounter(createContainer(({ mountModal }) => {
   const APP_CONFIG = Meteor.settings.public.app;
@@ -30,9 +30,9 @@ export default withModalMounter(createContainer(({ mountModal }) => {
   return {
     init: () => {
       Service.init();
-      if (!autoJoinAudio || didMountedAutoJoin) return;
+      if (!autoJoinAudio || didMountAutoJoin) return;
       mountModal(<AudioModal handleJoinListenOnly={Service.joinListenOnly} />);
-      didMountedAutoJoin = true;
+      didMountAutoJoin = true;
     },
   };
 }, AudioContainer));

--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -1,32 +1,38 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { createContainer } from 'meteor/react-meteor-data';
 import { withModalMounter } from '/imports/ui/components/modal/service';
-
+import PropTypes from 'prop-types';
 import Service from './service';
 import Audio from './component';
 import AudioModal from './audio-modal/component';
 
-class AudioContainer extends Component {
-  render() {
-    return (
-      <Audio {...this.props}>
-        {this.props.children}
-      </Audio>
-    );
-  }
-}
+const propTypes = {
+  children: PropTypes.element,
+};
 
-let didMountedAutoJoin = false;
+const defaultProps = {
+  children: null,
+};
+
+const AudioContainer = props =>
+  (<Audio {...props}>
+    {props.children}
+  </Audio>
+  );
 
 export default withModalMounter(createContainer(({ mountModal }) => {
   const APP_CONFIG = Meteor.settings.public.app;
 
+  const { autoJoinAudio } = APP_CONFIG;
+
   return {
     init: () => {
       Service.init();
-      if (didMountedAutoJoin) return;
+      if (!autoJoinAudio) return;
       mountModal(<AudioModal handleJoinListenOnly={Service.joinListenOnly} />);
-      didMountedAutoJoin = true;
     },
   };
 }, AudioContainer));
+
+AudioContainer.propTypes = propTypes;
+AudioContainer.defaultProps = defaultProps;

--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -20,6 +20,8 @@ const AudioContainer = props =>
   </Audio>
   );
 
+let didMountedAutoJoin = false;
+
 export default withModalMounter(createContainer(({ mountModal }) => {
   const APP_CONFIG = Meteor.settings.public.app;
 
@@ -28,8 +30,9 @@ export default withModalMounter(createContainer(({ mountModal }) => {
   return {
     init: () => {
       Service.init();
-      if (!autoJoinAudio) return;
+      if (!autoJoinAudio || didMountedAutoJoin) return;
       mountModal(<AudioModal handleJoinListenOnly={Service.joinListenOnly} />);
+      didMountedAutoJoin = true;
     },
   };
 }, AudioContainer));


### PR DESCRIPTION
We were missing the check for the property `autoJoinAudio` inside audio modal, the Audio Modal was always showing, was fix on this PR.