### PR TITLE
Fixes hanging Flash on tab switch in Firefox 55-56

### DIFF
--- a/bigbluebutton-client/resources/prod/BigBlueButton.html
+++ b/bigbluebutton-client/resources/prod/BigBlueButton.html
@@ -25,6 +25,20 @@
 
     <script src="lib/bbb_blinker.js?v=VERSION" language="javascript"></script>
     <script type="text/javascript" src="swfobject/swfobject.js"></script>
+
+    <script type="text/javascript">
+      // Workaround Flash hang in Firefox 55 / 56
+      // See https://bugzilla.mozilla.org/show_bug.cgi?id=1360666
+      document.addEventListener('visibilitychange', function() {
+        if ((navigator.userAgent.indexOf("Firefox/55") != -1) || (navigator.userAgent.indexOf("Firefox/56") != -1)) {
+          if(document.visibilityState == 'visible') {
+            document.getElementById("content").style.height = "99%";
+            setTimeout(function(){ document.getElementById("content").style.height = "100%"; }, 500);
+          }
+        }
+      });
+    </script>
+
     <script type="text/javascript">
       // Check for Firefox 41.0.1/2 to workaround Flash hang
       // See https://bugzilla.mozilla.org/show_bug.cgi?id=1210665

--- a/bigbluebutton-client/resources/prod/BigBlueButton.html
+++ b/bigbluebutton-client/resources/prod/BigBlueButton.html
@@ -30,7 +30,8 @@
       // Workaround Flash hang in Firefox 55 / 56
       // See https://bugzilla.mozilla.org/show_bug.cgi?id=1360666
       document.addEventListener('visibilitychange', function() {
-        if ((navigator.userAgent.indexOf("Firefox/55") != -1) || (navigator.userAgent.indexOf("Firefox/56") != -1)) {
+        if (((navigator.userAgent.indexOf("Firefox/55") != -1) || (navigator.userAgent.indexOf("Firefox/56") != -1))
+          && (navigator.userAgent.indexOf("Win64; x64") == -1) ) {
           if(document.visibilityState == 'visible') {
             document.getElementById("content").style.height = "99%";
             setTimeout(function(){ document.getElementById("content").style.height = "100%"; }, 500);

--- a/bigbluebutton-client/resources/prod/BigBlueButton.html
+++ b/bigbluebutton-client/resources/prod/BigBlueButton.html
@@ -29,14 +29,21 @@
     <script type="text/javascript">
       // Workaround Flash hang in Firefox 55 / 56
       // See https://bugzilla.mozilla.org/show_bug.cgi?id=1360666
-      document.addEventListener('visibilitychange', function() {
-        if (((navigator.userAgent.indexOf("Firefox/55") != -1) || (navigator.userAgent.indexOf("Firefox/56") != -1))
-          && (navigator.userAgent.indexOf("Win64; x64") == -1) ) {
-          if(document.visibilityState == 'visible') {
-            document.getElementById("content").style.height = "99%";
-            setTimeout(function(){ document.getElementById("content").style.height = "100%"; }, 500);
+
+      // if it's Windows
+      if (navigator.userAgent.indexOf("Windows") != -1
+        // if it's Firefox 55 or 56
+        && (navigator.userAgent.indexOf("Firefox/55") != -1 || navigator.userAgent.indexOf("Firefox/56") != -1)
+        // if there is no 64-bit signature
+        && (navigator.userAgent.indexOf("Win64; x64") == -1)) {
+
+          // resizing the content block on visibility change, to make Flash responsive again
+          document.addEventListener('visibilitychange', function() {
+            if(document.visibilityState == 'visible') {
+              document.getElementById("content").style.height = "99%";
+              setTimeout(function(){ document.getElementById("content").style.height = "100%"; }, 500);
+            }
           }
-        }
       });
     </script>
 

--- a/bigbluebutton-client/resources/prod/BigBlueButton.html
+++ b/bigbluebutton-client/resources/prod/BigBlueButton.html
@@ -43,8 +43,8 @@
               document.getElementById("content").style.height = "99%";
               setTimeout(function(){ document.getElementById("content").style.height = "100%"; }, 500);
             }
-          }
-      });
+          });
+      }
     </script>
 
     <script type="text/javascript">


### PR DESCRIPTION
Workaround for this bug:
https://bugzilla.mozilla.org/show_bug.cgi?id=1360666

Resizing the Flash content for half a sec makes Flash responsive again.