### PR TITLE
[Akka-apps 2.0] Drop camera for leaving user Fix for #4191

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/StopPollReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/StopPollReqMsgHdlr.scala
@@ -9,7 +9,7 @@ trait StopPollReqMsgHdlr {
 
   val outGW: OutMsgRouter
 
-  def broadcastEvent(requesterId: String, stoppedPollId: String): Unit = {
+  def broadcastPollStoppedEvtMsg(requesterId: String, stoppedPollId: String): Unit = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, props.meetingProp.intId, requesterId)
     val envelope = BbbCoreEnvelope(PollStoppedEvtMsg.NAME, routing)
     val header = BbbClientMsgHeader(PollStoppedEvtMsg.NAME, props.meetingProp.intId, requesterId)
@@ -24,7 +24,7 @@ trait StopPollReqMsgHdlr {
     for {
       stoppedPollId <- Polls.handleStopPollReqMsg(msg.header.userId, liveMeeting)
     } yield {
-      broadcastEvent(msg.header.userId, stoppedPollId)
+      broadcastPollStoppedEvtMsg(msg.header.userId, stoppedPollId)
     }
   }
 
@@ -32,7 +32,7 @@ trait StopPollReqMsgHdlr {
     for {
       stoppedPollId <- Polls.handleStopPollReqMsg(requesterId, liveMeeting)
     } yield {
-      broadcastEvent(requesterId, stoppedPollId)
+      broadcastPollStoppedEvtMsg(requesterId, stoppedPollId)
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
@@ -19,6 +19,9 @@ trait UserLeaveReqMsgHdlr {
     } yield {
       log.info("User left meeting. meetingId=" + props.meetingProp.intId + " userId=" + u.intId + " user=" + u)
 
+      // stop the webcams of a user leaving
+      handleUserBroadcastCamStopMsg(msg.body.userId)
+
       captionApp2x.handleUserLeavingMsg(msg.body.userId)
       stopAutoStartedRecording()
 


### PR DESCRIPTION
Fix for #4191 
We now remove the webcam from a user who is leaving the meeting (due to refresh or reconnect). On page refresh we start with a clean slate and the webcam will not be re-shared automatically. On reconnect the webcam will be automatically shared if it was shared prior to the reconnect.
