### PR TITLE
Fixed webcam fullscreen display position

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/UserGraphicHolder.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/UserGraphicHolder.mxml
@@ -41,6 +41,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     <fx:Script>
         <![CDATA[
 			import com.asfusion.mate.events.Dispatcher;
+
+			import org.as3commons.logging.api.ILogger;
+			import org.as3commons.logging.api.getClassLogger;
 			
 			import mx.core.UIComponent;
 			
@@ -61,6 +64,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.modules.videoconf.events.AddStaticComponent;
 			import org.bigbluebutton.modules.videoconf.model.VideoConfOptions;
 			import org.bigbluebutton.util.i18n.ResourceUtil;
+
+            private static const LOGGER:ILogger = getClassLogger(UserGraphicHolder);
 
             private var videoOptions:VideoConfOptions;
             
@@ -91,10 +96,23 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
             }
 
             protected function onCreationComplete():void {
-                // There must be a better way!
-                _newParent = parent.parent.parent.parent.parent;
+                _newParent = getBBBDisplayObjectContainer();
                 fullScreenIcon.source = getStyle("iconFullScreen");
 				closeIcon.source = getStyle("iconClose");
+            }
+
+            private function getBBBDisplayObjectContainer():DisplayObjectContainer {
+                var p:DisplayObjectContainer = parent;
+                var displayName:String = "";
+                while (p) {
+                    displayName = p.name;
+                    if (displayName.indexOf("BigBlueButton") >= 0) {
+                        return p;
+                    }
+                    p = p.parent;
+                }
+                LOGGER.warn("Could not get the correct DisplayObjectContainer");
+                return parent;
             }
 
             private function handleUserJoinedEvent(event:UserJoinedEvent):void {
@@ -377,6 +395,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
                     _newParent.addChildAt(this, 0);
 
+                    this.move(0, 0);
                     this.percentHeight = 100;
                     this.percentWidth = 100;
 


### PR DESCRIPTION
UserGraphicHolder is keeping the move applied at the GraphicWrapper when the fullscreen is turned on. Just setting move to origin to fix it. Also refactored the parent selector so he selects the DisplayObjectContainer named BigBlueButton. Looks like to be a unique and static property to search for.