### PR TITLE
Fix promote demote users

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -148,6 +148,8 @@ class ReceivedJsonMsgHandlerActor(
         routeGenericMsg[UserLeaveReqMsg](envelope, jsonNode)
       case ChangeUserEmojiCmdMsg.NAME =>
         routeGenericMsg[ChangeUserEmojiCmdMsg](envelope, jsonNode)
+      case ChangeUserRoleCmdMsg.NAME =>
+        routeGenericMsg[ChangeUserRoleCmdMsg](envelope, jsonNode)
 
       // Whiteboard
       case SendCursorPositionPubMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -193,6 +193,7 @@ class MeetingActor(
       case m: ChangeUserEmojiCmdMsg          => handleChangeUserEmojiCmdMsg(m)
       case m: EjectUserFromMeetingCmdMsg     => usersApp.handleEjectUserFromMeetingCmdMsg(m)
       case m: GetUsersMeetingReqMsg          => usersApp.handleGetUsersMeetingReqMsg(m)
+      case m: ChangeUserRoleCmdMsg           => usersApp.handleChangeUserRoleCmdMsg(m)
 
       // Whiteboard
       case m: SendCursorPositionPubMsg       => handleSendCursorPositionPubMsg(m)

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
@@ -152,8 +152,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         
         queryForChatHistory();
         
-        chatMessagesList.accessibilityProperties.description = ResourceUtil.getInstance().getString('bbb.accessibility.chat.initialDescription');
-        
+        if (chatMessagesList.accessibilityProperties != null) {
+          chatMessagesList.accessibilityProperties.description = ResourceUtil.getInstance().getString('bbb.accessibility.chat.initialDescription');
+        }
        
         LOGGER.debug(" onCreationComplete. Apply lock settings");
         applyLockSettings();

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
@@ -48,6 +48,7 @@ package org.bigbluebutton.modules.users.services
   import org.bigbluebutton.main.events.UserLeftEvent;
   import org.bigbluebutton.main.model.users.BreakoutRoom;
   import org.bigbluebutton.main.model.users.IMessageListener;
+  import org.bigbluebutton.main.model.users.events.ChangeMyRole;
   import org.bigbluebutton.main.model.users.events.StreamStartedEvent;
   import org.bigbluebutton.main.model.users.events.StreamStoppedEvent;
   import org.bigbluebutton.modules.screenshare.events.WebRTCViewStreamEvent;
@@ -186,6 +187,8 @@ package org.bigbluebutton.modules.users.services
         case "guest_access_denied":
           handleGuestAccessDenied(message);
           break;
+        case "UserRoleChangedEvtMsg":
+          handleUserRoleChangedEvtMsg(message);
       }
     }
     
@@ -805,6 +808,21 @@ package org.bigbluebutton.modules.users.services
       if (UsersUtil.getMyUserID() == map.userId) {
         dispatcher.dispatchEvent(new LogoutEvent(LogoutEvent.MODERATOR_DENIED_ME));
       }
+    }
+
+    public function handleUserRoleChangedEvtMsg(msg:Object):void {
+      var header: Object = msg.header as Object;
+      var body: Object = msg.body as Object;
+      var userId: String = body.userId as String;
+      var role: String = body.role as String;
+
+      LiveMeeting.inst().users.setRoleForUser(userId, role);
+      if (UsersUtil.isMe(userId)) {
+        LiveMeeting.inst().me.role = role;
+        dispatcher.dispatchEvent(new ChangeMyRole(role));
+      }
+
+      dispatcher.dispatchEvent(new UserStatusChangedEvent(userId));
     }
   }
 }


### PR DESCRIPTION
This pull request tries to fix two things, actually.
First is a NPE that was happening at least in Firefox 54 (64-bits, Linux). accessibilityProperties in chatMessagesList could be null when trying to set it's description. I notice this because the copy/save/clear buttons on chat were never being initialized. They were simply missing on my Firefox.
The second thing is some extra code so the promote/demote users would actually work.