### PR TITLE
 - end breakout rooms when parent meeting ends

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutRoomEndedInternalMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutRoomEndedInternalMsgHdlr.scala
@@ -11,6 +11,8 @@ trait BreakoutRoomEndedInternalMsgHdlr {
   val outGW: OutMsgRouter
 
   def handleBreakoutRoomEndedInternalMsg(msg: BreakoutRoomEndedInternalMsg, state: MeetingState2x): MeetingState2x = {
+    log.info("Received breakout room ended. breakoutId={}", msg.meetingId)
+
     // send out BreakoutRoomEndedEvtMsg to inform clients the breakout has ended
     outGW.send(MsgBuilder.buildBreakoutRoomEndedEvtMsg(liveMeeting.props.meetingProp.intId, "not-used",
       msg.meetingId))

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LogoutAndEndMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LogoutAndEndMeetingCmdMsgHdlr.scala
@@ -2,7 +2,7 @@ package org.bigbluebutton.core.apps.users
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.InternalEventBus
-import org.bigbluebutton.core.domain.MeetingEndReason
+import org.bigbluebutton.core.domain.{ MeetingEndReason, MeetingState2x }
 import org.bigbluebutton.core.models.{ Roles, Users2x }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 
@@ -13,11 +13,12 @@ trait LogoutAndEndMeetingCmdMsgHdlr {
   val outGW: OutMsgRouter
   val eventBus: InternalEventBus
 
-  def handleLogoutAndEndMeetingCmdMsg(msg: LogoutAndEndMeetingCmdMsg) {
+  def handleLogoutAndEndMeetingCmdMsg(msg: LogoutAndEndMeetingCmdMsg, state: MeetingState2x): Unit = {
     for {
       u <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
     } yield {
       if (u.role == Roles.MODERATOR_ROLE) {
+        endAllBreakoutRooms(eventBus, liveMeeting, state)
         log.info("Meeting {} ended by user [{}, {}} when logging out.", liveMeeting.props.meetingProp.intId,
           u.intId, u.name)
         sendEndMeetingDueToExpiry(MeetingEndReason.ENDED_AFTER_USER_LOGGED_OUT, eventBus, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -2,9 +2,9 @@ package org.bigbluebutton.core.running
 
 import org.bigbluebutton.SystemConfiguration
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.api.{ BreakoutRoomEndedInternalMsg, DestroyMeetingInternalMsg }
+import org.bigbluebutton.core.api.{ BreakoutRoomEndedInternalMsg, DestroyMeetingInternalMsg, EndBreakoutRoomInternalMsg }
 import org.bigbluebutton.core.bus.{ BigBlueButtonEvent, InternalEventBus }
-import org.bigbluebutton.core.domain.{ MeetingState2x }
+import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core2.message.senders.{ MsgBuilder, UserJoinedMeetingEvtMsgBuilder }
@@ -148,6 +148,18 @@ trait HandlerHelpers extends SystemConfiguration {
   def ejectAllUsersFromVoiceConf(outGW: OutMsgRouter, liveMeeting: LiveMeeting): Unit = {
     val event = MsgBuilder.buildEjectAllFromVoiceConfMsg(liveMeeting.props.meetingProp.intId, liveMeeting.props.voiceProp.voiceConf)
     outGW.send(event)
+  }
+
+  def endAllBreakoutRooms(eventBus: InternalEventBus, liveMeeting: LiveMeeting, state: MeetingState2x): MeetingState2x = {
+    for {
+      model <- state.breakout
+    } yield {
+      model.rooms.values.foreach { room =>
+        eventBus.publish(BigBlueButtonEvent(room.id, EndBreakoutRoomInternalMsg(liveMeeting.props.breakoutProps.parentId, room.id)))
+      }
+    }
+
+    state.update(None)
   }
 
   def sendEndMeetingDueToExpiry(reason: String, eventBus: InternalEventBus, outGW: OutMsgRouter, liveMeeting: LiveMeeting): Unit = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -173,7 +173,7 @@ class MeetingActor(
     state = state.update(tracker)
 
     msg.core match {
-      case m: EndMeetingSysCmdMsg => handleEndMeeting(m)
+      case m: EndMeetingSysCmdMsg => handleEndMeeting(m, state)
 
       // Users
       case m: ValidateAuthTokenReqMsg =>
@@ -187,7 +187,7 @@ class MeetingActor(
       case m: UserJoinedVoiceConfEvtMsg => handleUserJoinedVoiceConfEvtMsg(m)
       case m: MeetingActivityResponseCmdMsg =>
         state = usersApp.handleMeetingActivityResponseCmdMsg(m, state)
-      case m: LogoutAndEndMeetingCmdMsg      => usersApp.handleLogoutAndEndMeetingCmdMsg(m)
+      case m: LogoutAndEndMeetingCmdMsg      => usersApp.handleLogoutAndEndMeetingCmdMsg(m, state)
       case m: SetRecordingStatusCmdMsg       => usersApp.handleSetRecordingStatusCmdMsg(m)
       case m: GetRecordingStatusReqMsg       => usersApp.handleGetRecordingStatusReqMsg(m)
       case m: ChangeUserEmojiCmdMsg          => handleChangeUserEmojiCmdMsg(m)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingExpiryTrackerHelper.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingExpiryTrackerHelper.scala
@@ -20,6 +20,7 @@ trait MeetingExpiryTrackerHelper extends HandlerHelpers {
       for {
         expireReason <- reason
       } yield {
+        endAllBreakoutRooms(eventBus, liveMeeting, state)
         sendEndMeetingDueToExpiry(expireReason, eventBus, outGW, liveMeeting)
       }
     }
@@ -38,6 +39,7 @@ trait MeetingExpiryTrackerHelper extends HandlerHelpers {
     if (!state.inactivityTracker.hasRecentActivity(nowInMs)) {
       if (state.inactivityTracker.isMeetingInactive(nowInMs)) {
         val expireReason = MeetingEndReason.ENDED_DUE_TO_INACTIVITY
+        endAllBreakoutRooms(eventBus, liveMeeting, state)
         sendEndMeetingDueToExpiry(expireReason, eventBus, outGW, liveMeeting)
         (state, Some(expireReason))
       } else {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
@@ -67,6 +67,10 @@ class AnalyticsActor extends Actor with ActorLogging {
       case m: MeetingInactivityWarningEvtMsg => logMessage(msg)
       case m: StartRecordingVoiceConfSysMsg => logMessage(msg)
       case m: TransferUserToVoiceConfSysMsg => logMessage(msg)
+
+      // Breakout
+      case m: BreakoutRoomEndedEvtMsg => logMessage(msg)
+
       case _ => // ignore message
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/SendTimeRemainingUpdateHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/SendTimeRemainingUpdateHdlr.scala
@@ -29,8 +29,11 @@ trait SendTimeRemainingUpdateHdlr {
         BbbCommonEnvCoreMsg(envelope, event)
       }
 
-      val event = buildMeetingTimeRemainingUpdateEvtMsg(liveMeeting.props.meetingProp.intId, timeRemaining.toInt)
-      outGW.send(event)
+      if (timeRemaining > 0) {
+        val event = buildMeetingTimeRemainingUpdateEvtMsg(liveMeeting.props.meetingProp.intId, timeRemaining.toInt)
+        outGW.send(event)
+      }
+
     }
 
     state

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/meeting/EndMeetingSysCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/meeting/EndMeetingSysCmdMsgHdlr.scala
@@ -2,7 +2,7 @@ package org.bigbluebutton.core2.message.handlers.meeting
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.InternalEventBus
-import org.bigbluebutton.core.domain.MeetingEndReason
+import org.bigbluebutton.core.domain.{ MeetingEndReason, MeetingState2x }
 import org.bigbluebutton.core.running.{ BaseMeetingActor, HandlerHelpers, LiveMeeting, OutMsgRouter }
 
 trait EndMeetingSysCmdMsgHdlr extends HandlerHelpers {
@@ -12,7 +12,8 @@ trait EndMeetingSysCmdMsgHdlr extends HandlerHelpers {
   val outGW: OutMsgRouter
   val eventBus: InternalEventBus
 
-  def handleEndMeeting(msg: EndMeetingSysCmdMsg) {
+  def handleEndMeeting(msg: EndMeetingSysCmdMsg, state: MeetingState2x): Unit = {
+    endAllBreakoutRooms(eventBus, liveMeeting, state)
     log.info("Meeting {} ended by from API.", msg.body.meetingId)
     sendEndMeetingDueToExpiry(MeetingEndReason.ENDED_FROM_API, eventBus, outGW, liveMeeting)
   }


### PR DESCRIPTION
 - send breakout ended event
 - do not send negative time remaining updates