### PR TITLE
Handle properly audio state on reconnect

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingAfterReconnectReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingAfterReconnectReqMsgHdlr.scala
@@ -1,0 +1,34 @@
+package org.bigbluebutton.core.apps.users
+
+import org.bigbluebutton.common2.msgs.UserJoinMeetingAfterReconnectReqMsg
+import org.bigbluebutton.core.apps.breakout.BreakoutHdlrHelpers
+import org.bigbluebutton.core.apps.voice.UserJoinedVoiceConfEvtMsgHdlr
+import org.bigbluebutton.core.domain.MeetingState2x
+import org.bigbluebutton.core.models.VoiceUsers
+import org.bigbluebutton.core.running.{ BaseMeetingActor, HandlerHelpers, LiveMeeting, OutMsgRouter }
+
+trait UserJoinMeetingAfterReconnectReqMsgHdlr extends HandlerHelpers with BreakoutHdlrHelpers with UserJoinedVoiceConfEvtMsgHdlr {
+  this: BaseMeetingActor =>
+
+  val liveMeeting: LiveMeeting
+  val outGW: OutMsgRouter
+
+  def handleUserJoinMeetingAfterReconnectReqMsg(msg: UserJoinMeetingAfterReconnectReqMsg, state: MeetingState2x): MeetingState2x = {
+    val newState = userJoinMeeting(outGW, msg.body.authToken, liveMeeting, state)
+
+    if (liveMeeting.props.meetingProp.isBreakout) {
+      updateParentMeetingWithUsers()
+    }
+
+    // recover voice user
+    for {
+      vu <- VoiceUsers.recoverVoiceUser(liveMeeting.voiceUsers, msg.body.userId)
+    } yield {
+      handleUserJoinedVoiceConfEvtMsg(liveMeeting.props.voiceProp.voiceConf, vu.intId, vu.voiceUserId, vu.callingWith, vu.callerName, vu.callerNum, vu.muted, vu.talking)
+    }
+
+    newState
+  }
+
+}
+

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
@@ -2,6 +2,7 @@ package org.bigbluebutton.core.apps.users
 
 import org.bigbluebutton.common2.msgs.UserJoinMeetingReqMsg
 import org.bigbluebutton.core.apps.breakout.BreakoutHdlrHelpers
+import org.bigbluebutton.core.models.VoiceUsers
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.{ BaseMeetingActor, HandlerHelpers, LiveMeeting, OutMsgRouter }
 
@@ -17,6 +18,9 @@ trait UserJoinMeetingReqMsgHdlr extends HandlerHelpers with BreakoutHdlrHelpers 
     if (liveMeeting.props.meetingProp.isBreakout) {
       updateParentMeetingWithUsers()
     }
+
+    // fresh user joined (not due to reconnection). Clear (pop) the cached voice user
+    VoiceUsers.recoverVoiceUser(liveMeeting.voiceUsers, msg.body.userId)
 
     newState
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
@@ -45,7 +45,7 @@ trait UserLeaveReqMsgHdlr {
         val envelope = BbbCoreEnvelope(UserLeftVoiceConfToClientEvtMsg.NAME, routing)
         val header = BbbClientMsgHeader(UserLeftVoiceConfToClientEvtMsg.NAME, liveMeeting.props.meetingProp.intId, vu.intId)
 
-        val body = UserLeftVoiceConfToClientEvtMsgBody(voiceConf = liveMeeting.props.voiceProp.voiceConf, intId = vu.intId, voiceUserId = vu.intId)
+        val body = UserLeftVoiceConfToClientEvtMsgBody(voiceConf = liveMeeting.props.voiceProp.voiceConf, intId = vu.intId, voiceUserId = vu.voiceUserId)
 
         val event = UserLeftVoiceConfToClientEvtMsg(header, body)
         val msgEvent = BbbCommonEnvCoreMsg(envelope, event)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/VoiceUsers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/VoiceUsers.scala
@@ -25,6 +25,10 @@ object VoiceUsers {
     users.toVector.find(u => u.intId == intId)
   }
 
+  def recoverVoiceUser(users: VoiceUsers, intId: String): Option[VoiceUserState] = {
+    users.removeFromCache(intId)
+  }
+
   def userMuted(users: VoiceUsers, voiceUserId: String, muted: Boolean): Option[VoiceUserState] = {
     for {
       u <- findWithVoiceUserId(users, voiceUserId)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -62,6 +62,8 @@ class ReceivedJsonMsgHandlerActor(
         route[RegisterUserReqMsg](meetingManagerChannel, envelope, jsonNode)
       case UserJoinMeetingReqMsg.NAME =>
         routeGenericMsg[UserJoinMeetingReqMsg](envelope, jsonNode)
+      case UserJoinMeetingAfterReconnectReqMsg.NAME =>
+        routeGenericMsg[UserJoinMeetingAfterReconnectReqMsg](envelope, jsonNode)
       case GetAllMeetingsReqMsg.NAME =>
         route[GetAllMeetingsReqMsg](meetingManagerChannel, envelope, jsonNode)
       case DestroyMeetingSysCmdMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -63,6 +63,7 @@ class MeetingActor(
     with PermisssionCheck
     with UserBroadcastCamStartMsgHdlr
     with UserJoinMeetingReqMsgHdlr
+    with UserJoinMeetingAfterReconnectReqMsgHdlr
     with UserBroadcastCamStopMsgHdlr
     with UserConnectedToGlobalAudioMsgHdlr
     with UserDisconnectedFromGlobalAudioMsgHdlr
@@ -180,6 +181,8 @@ class MeetingActor(
         state = usersApp.handleValidateAuthTokenReqMsg(m, state)
       case m: UserJoinMeetingReqMsg =>
         state = handleUserJoinMeetingReqMsg(m, state)
+      case m: UserJoinMeetingAfterReconnectReqMsg =>
+        state = handleUserJoinMeetingAfterReconnectReqMsg(m, state)
       case m: UserLeaveReqMsg =>
         state = handleUserLeaveReqMsg(m, state)
       case m: UserBroadcastCamStartMsg  => handleUserBroadcastCamStartMsg(m)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMgs.scala
@@ -238,6 +238,14 @@ object UserJoinMeetingReqMsg { val NAME = "UserJoinMeetingReqMsg" }
 case class UserJoinMeetingReqMsg(header: BbbClientMsgHeader, body: UserJoinMeetingReqMsgBody) extends StandardMsg
 case class UserJoinMeetingReqMsgBody(userId: String, authToken: String)
 
+/**
+  * Sent from Flash client to rejoin meeting after reconnection
+  */
+object UserJoinMeetingAfterReconnectReqMsg { val NAME = "UserJoinMeetingAfterReconnectReqMsg" }
+case class UserJoinMeetingAfterReconnectReqMsg(header: BbbClientMsgHeader, body: UserJoinMeetingAfterReconnectReqMsgBody) extends StandardMsg
+case class UserJoinMeetingAfterReconnectReqMsgBody(userId: String, authToken: String)
+
+
 object UserLeaveReqMsg { val NAME = "UserLeaveReqMsg" }
 case class UserLeaveReqMsg(header: BbbClientMsgHeader, body: UserLeaveReqMsgBody) extends StandardMsg
 case class UserLeaveReqMsgBody(userId: String, sessionId: String)

--- a/bigbluebutton-client/src/org/bigbluebutton/core/events/TokenValidReconnectEvent.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/events/TokenValidReconnectEvent.as
@@ -1,0 +1,16 @@
+package org.bigbluebutton.core.events
+{
+import flash.events.Event;
+
+public class TokenValidReconnectEvent extends Event
+{
+    public static const TOKEN_VALID_RECONNECT_EVENT:String = "auth token valid reconnect event";
+
+    public function TokenValidReconnectEvent()
+    {
+        super(TOKEN_VALID_RECONNECT_EVENT, true, false);
+    }
+
+}
+
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/UserService.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/UserService.as
@@ -29,6 +29,7 @@ package org.bigbluebutton.main.model.users
 	import org.bigbluebutton.core.UsersUtil;
 	import org.bigbluebutton.core.events.LockControlEvent;
 	import org.bigbluebutton.core.events.TokenValidEvent;
+	import org.bigbluebutton.core.events.TokenValidReconnectEvent;
 	import org.bigbluebutton.core.events.VoiceConfEvent;
 	import org.bigbluebutton.core.managers.ConnectionManager;
 	import org.bigbluebutton.core.model.LiveMeeting;
@@ -148,7 +149,11 @@ package org.bigbluebutton.main.model.users
     public function tokenValidEventHandler(event: TokenValidEvent): void {
       sender.joinMeeting();
     }
-    
+
+    public function tokenValidReconnectEventHandler(event: TokenValidReconnectEvent): void {
+      sender.joinMeetingAfterReconnect();
+    }
+
 	public function logoutEndMeeting():void{
 		if (this.isModerator()) {
 			var myUserId: String = UsersUtil.getMyUserID();
@@ -187,6 +192,7 @@ package org.bigbluebutton.main.model.users
 				reconnecting = false;
 			} else {
         onAllowedToJoin();
+
       }
 		}
 

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/maps/UsersMainEventMap.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/maps/UsersMainEventMap.mxml
@@ -27,6 +27,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       
       import org.bigbluebutton.core.events.LockControlEvent;
       import org.bigbluebutton.core.events.TokenValidEvent;
+      import org.bigbluebutton.core.events.TokenValidReconnectEvent;
       import org.bigbluebutton.core.events.VoiceConfEvent;
       import org.bigbluebutton.main.events.BBBEvent;
       import org.bigbluebutton.main.events.BreakoutRoomEvent;
@@ -115,7 +116,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     <EventHandlers type="{TokenValidEvent.TOKEN_VALID_EVENT}" >
       <MethodInvoker generator="{UserService}" method="tokenValidEventHandler" arguments="{event}" />
     </EventHandlers>
-        
+
+	<EventHandlers type="{TokenValidReconnectEvent.TOKEN_VALID_RECONNECT_EVENT}" >
+		<MethodInvoker generator="{UserService}" method="tokenValidReconnectEventHandler" arguments="{event}" />
+	</EventHandlers>
+
 	  <EventHandlers type="{ChangeRoleEvent.CHANGE_ROLE_EVENT}" >
 	    <MethodInvoker generator="{UserService}" method="changeRole" arguments="{event}" />
 	  </EventHandlers>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageSender.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageSender.as
@@ -73,11 +73,29 @@ package org.bigbluebutton.modules.users.services
       }, function(status:String):void { // status - On error occurred
         var logData:Object = UsersUtil.initLogData();
         logData.tags = ["apps"];
-        logData.message = "Error occurred assigning a presenter.";
+        logData.message = "Error occurred when user joining.";
         LOGGER.info(JSON.stringify(logData));
       }, JSON.stringify(message));
     }
-    
+
+    public function joinMeetingAfterReconnect(): void {
+      LOGGER.info("Sending JOIN MEETING AFTER RECONNECT message");
+
+      var message:Object = {
+        header: {name: "UserJoinMeetingAfterReconnectReqMsg", meetingId: UsersUtil.getInternalMeetingID(), userId: UsersUtil.getMyUserID()},
+        body: {userId: UsersUtil.getMyUserID(), authToken: LiveMeeting.inst().me.authToken}
+      };
+
+      var _nc:ConnectionManager = BBB.initConnectionManager();
+      _nc.sendMessage2x(function(result:String):void { // On successful result
+      }, function(status:String):void { // status - On error occurred
+          var logData:Object = UsersUtil.initLogData();
+          logData.tags = ["apps"];
+          logData.message = "Error occurred when user joining after reconnect.";
+          LOGGER.info(JSON.stringify(logData));
+      }, JSON.stringify(message));
+    }
+
     public function assignPresenter(newPresenterUserId:String, newPresenterName:String, assignedBy:String):void {
       var message:Object = {
         header: {name: "AssignPresenterReqMsg", meetingId: UsersUtil.getInternalMeetingID(), userId: UsersUtil.getMyUserID()},


### PR DESCRIPTION
Added a separate event to distinguish user join on reconnect from fresh user join. Using this piece of information we drop any matching voice users from akka-apps' voice user cache OR we recover them
Fix for #4229 