### PR TITLE
[HTML5] - Meeting title fix

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/container.jsx
@@ -37,7 +37,7 @@ export default withRouter(createContainer(({ location, router }) => {
   });
 
   if (meetingObject != null) {
-    meetingTitle = meetingObject.meetingName;
+    meetingTitle = meetingObject.meetingProp.name;
     meetingRecorded = meetingObject.currentlyBeingRecorded;
   }
 


### PR DESCRIPTION
fixes the meeting title so that it doesn't default to "Default Room Title", when a title is provided.