### PR TITLE
Improve client annotation editing speed

### DIFF
--- a/bigbluebutton-client/branding/default/style/css/V2Theme.css
+++ b/bigbluebutton-client/branding/default/style/css/V2Theme.css
@@ -1607,9 +1607,9 @@ whiteboard|WhiteboardTextToolbar {
 }
 
 .multiUserWhiteboardOnButtonStyle {
-	icon : Embed(source="assets/swf/v2_skin.swf", symbol="Icon_Whiteboard");
+	icon : Embed(source="assets/swf/v2_skin.swf", symbol="Icon_Multi_Whiteboard");
 }
 
 .multiUserWhiteboardOffButtonStyle {
-	icon : Embed(source="assets/swf/v2_skin.swf", symbol="Icon_Multi_Whiteboard");
+	icon : Embed(source="assets/swf/v2_skin.swf", symbol="Icon_Whiteboard");
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/ShapeFactory.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/ShapeFactory.as
@@ -54,7 +54,7 @@ package org.bigbluebutton.modules.whiteboard.business.shapes
       return _parentHeight;
     }
         
-    public function makeGraphicObject(a:Annotation, whiteboardModel:WhiteboardModel):GraphicObject{
+    public function makeGraphicObject(a:Annotation):GraphicObject{
         if (a.type == AnnotationType.PENCIL) {
             return new Pencil(a.id, a.type, a.status, a.userId);
         } else if (a.type == AnnotationType.RECTANGLE) {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/models/Whiteboard.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/models/Whiteboard.as
@@ -9,6 +9,7 @@ package org.bigbluebutton.modules.whiteboard.models
     private var _id:String;
     private var _historyLoaded:Boolean = false;
     private var _annotations:ArrayCollection = new ArrayCollection();
+    private var _annotationsMap:Object = new Object();
     
     public function Whiteboard(id:String) {
       _id = id;
@@ -28,10 +29,12 @@ package org.bigbluebutton.modules.whiteboard.models
     
     public function addAnnotation(annotation:Annotation):void {
       _annotations.addItem(annotation);
+      _annotationsMap[annotation.id] = annotation;
     }
     
     public function addAnnotationAt(annotation:Annotation, index:int):void {
       _annotations.addItemAt(annotation, index);
+      _annotationsMap[annotation.id] = annotation;
     }
     
     public function updateAnnotation(annotation:Annotation):void {
@@ -48,42 +51,40 @@ package org.bigbluebutton.modules.whiteboard.models
     }
     
     public function undo(id:String):Annotation {
-      for (var i:int = _annotations.length-1; i >= 0; i--) {
-        if ((_annotations.getItemAt(i) as Annotation).id == id) {
-          return (_annotations.removeItemAt(i) as Annotation);
-        }
+      if (_annotationsMap.propertyIsEnumerable(id)) {
+        var annotation:Annotation = _annotationsMap[id];
+        delete _annotationsMap[id];
+        _annotations.removeItem(annotation);
+        return annotation;
+      } else {
+        return null;
       }
-      return null;
     }
     
     public function clearAll():void {
       _annotations.removeAll();
+      _annotationsMap = new Object();
     }
     
     public function clear(userId:String):void {
-      for (var i:int = _annotations.length-1; i >= 0; i--) {
-        if ((_annotations.getItemAt(i) as Annotation).userId == userId) {
-          _annotations.removeItemAt(i);
+      for each (var annotation:Annotation in _annotationsMap) {
+        if (annotation.userId == userId) {
+          delete _annotationsMap[annotation.id]
+          _annotations.removeItem(annotation);
         }
       }
     }
     
     public function getAnnotations():Array {
-      var a:Array = new Array();
-      for (var i:int = 0; i < _annotations.length; i++) {
-        a.push(_annotations.getItemAt(i) as Annotation);
-      }
-      return a;
+      return _annotations.toArray();
     }
     
     public function getAnnotation(id:String):Annotation {
-      for (var i:int = _annotations.length-1; i >= 0; i--) {
-        if ((_annotations.getItemAt(i) as Annotation).id == id) {
-          return _annotations.getItemAt(i) as Annotation;
-        }
+      if (_annotationsMap.propertyIsEnumerable(id)) {
+        return _annotationsMap[id];
+      } else {
+        return null;
       }
-      
-      return null;
     }
   }
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardToolbar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardToolbar.mxml
@@ -84,7 +84,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private var _hideToolbarTimer:Timer = new Timer(500, 1);
 
       private function onCreationComplete():void {
-        multiUserBtn.enabled = multiUserBtn.visible = UsersUtil.amIPresenter();
+        multiUserBtn.enabled = multiUserBtn.visible = multiUserBtn.includeInLayout = UsersUtil.amIPresenter();
         
         setToolType(WhiteboardConstants.TYPE_ZOOM, null);
         _hideToolbarTimer.addEventListener(TimerEvent.TIMER, onHideToolbarTimerComplete);
@@ -153,12 +153,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 						
 			private function presenterMode(e:MadePresenterEvent):void {
-        multiUserBtn.enabled = multiUserBtn.visible = true;
+        multiUserBtn.enabled = multiUserBtn.visible = multiUserBtn.includeInLayout = true;
 				checkVisibility();
 			}
 			
 			private function viewerMode(e:MadePresenterEvent):void {
-        multiUserBtn.enabled = multiUserBtn.visible = false;
+        multiUserBtn.enabled = multiUserBtn.visible = multiUserBtn.includeInLayout = false;
 				checkToolReset();
 				checkVisibility();
 			}


### PR DESCRIPTION
This PR changes the annotation storage from an array to a hash map. This change will hopefully decrease the run times when editing shapes drastically resulting in better performance when multiuser editing is turned on.

This PR also includes a fix for the multiuser button icons being reversed and the button taking up display space when invisible.