### PR TITLE
 - move public chat save, copy, and clean into chat options box for accessibility

### DIFF
--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -599,7 +599,7 @@ bbb.accessibility.chat.chatBox.navigatedLatest = You have navigated to the lates
 bbb.accessibility.chat.chatBox.navigatedLatestRead = You have navigated to the most recent message you have read.
 bbb.accessibility.chat.chatwindow.input = Chat input
 bbb.accessibility.chat.chatwindow.audibleChatNotification = Audible Chat Notification
-
+bbb.accessibility.chat.chatwindow.publicChatOptions = Public Chat Options
 bbb.accessibility.chat.initialDescription = Please use the arrow keys to navigate through chat messages.
 
 bbb.accessibility.notes.notesview.input = Notes input

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/AddChatTabBox.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/AddChatTabBox.mxml
@@ -39,6 +39,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
           import com.asfusion.mate.events.Dispatcher;
           
           import mx.collections.ArrayCollection;
+          import mx.controls.Alert;
+          import mx.events.CloseEvent;
           
           import org.as3commons.logging.api.ILogger;
           import org.as3commons.logging.api.getClassLogger;
@@ -53,6 +55,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
           import org.bigbluebutton.main.model.users.events.ChangeMyRole;
           import org.bigbluebutton.modules.chat.events.ChatNoiseEnabledEvent;
           import org.bigbluebutton.modules.chat.events.ChatOptionsEvent;
+          import org.bigbluebutton.modules.chat.events.ChatToolbarButtonEvent;
           import org.bigbluebutton.modules.chat.model.ChatOptions;
           import org.bigbluebutton.util.i18n.ResourceUtil;
             
@@ -63,7 +66,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
             [Bindable] private var fontSizes:Array = ['8', '10', '12', '14', '16', '18'];
             
             [Bindable] public var chatOptions:ChatOptions;		
-            
+          [Bindable] private var clrBtnVisible:Boolean = false;
+          
+          private var globalDispatcher:Dispatcher = new Dispatcher();
+          
           private var handler: ChatWindowEventHandler = new ChatWindowEventHandler();
           
           private function handleUserLeftEvent(event: UserLeftEvent): void {
@@ -76,6 +82,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
           }
           
             private function onCreationComplete():void{
+              clrBtnVisible = UsersUtil.amIModerator();
+              
               handler.populateAllUsers()
                 users = handler.users;
                 chatOptions = Options.getOptions(ChatOptions) as ChatOptions;
@@ -151,6 +159,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
           }
 
           private function refreshRole(e:ChangeMyRole):void {
+            clearBtn.visible = clearBtn.enabled = clearBtn.includeInLayout = clrBtnVisible = UsersUtil.amIModerator();
               refreshListStatus();
           }
 
@@ -161,6 +170,28 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
             usersList.enabled = ! LiveMeeting.inst().me.disableMyPrivateChat;
           }
             
+          public function sendSaveEvent():void{
+            var saveEvent:ChatToolbarButtonEvent = new ChatToolbarButtonEvent(ChatToolbarButtonEvent.SAVE_CHAT_TOOLBAR_EVENT);
+            globalDispatcher.dispatchEvent(saveEvent);
+          }
+          
+          public function sendCopyEvent():void{
+            var copyEvent:ChatToolbarButtonEvent = new ChatToolbarButtonEvent(ChatToolbarButtonEvent.COPY_CHAT_TOOLBAR_EVENT);
+            globalDispatcher.dispatchEvent(copyEvent);
+          }
+          
+          public function sendClearEvent():void{
+            var clearChatHistoryAlert:Alert = Alert.show(ResourceUtil.getInstance().getString('bbb.chat.clearBtn.alert.text'),
+              ResourceUtil.getInstance().getString('bbb.chat.clearBtn.alert.title'),
+              Alert.YES | Alert.NO, null, handleClearChatHistoryAlert, null, Alert.YES);
+          }
+          
+          private function handleClearChatHistoryAlert(e:CloseEvent):void {
+            if (e.detail == Alert.YES) {
+              var clearEvent:ChatToolbarButtonEvent = new ChatToolbarButtonEvent(ChatToolbarButtonEvent.CLEAR_PUBLIC_CHAT_TOOLBAR_EVENT);
+              globalDispatcher.dispatchEvent(clearEvent);
+            }
+          }
         ]]>
     </fx:Script>
     
@@ -186,7 +217,41 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
                      selectedIndex="1" toolTip="{ResourceUtil.getInstance().getString('bbb.chat.cmbFontSize.toolTip')}" />
     </mx:HBox>
 	<mx:HBox width="100%">
-		<mx:Label styleName="chatOptionsLabel" text="{ResourceUtil.getInstance().getString('bbb.accessibility.chat.chatwindow.audibleChatNotification')}" width="100%"/>
+		<mx:Label styleName="chatOptionsLabel" 
+              text="{ResourceUtil.getInstance().getString('bbb.accessibility.chat.chatwindow.audibleChatNotification')}" 
+              width="100%"/>
 		<mx:CheckBox id="chatNoiseCheckBox" change="changeChatNoise()" />
 	</mx:HBox>
+  <mx:HBox width="100%">
+    <mx:Label styleName="publicChatOptionsLabel" 
+              text="{ResourceUtil.getInstance().getString('bbb.accessibility.chat.chatwindow.publicChatOptions')}" 
+              width="100%"/>
+    <mx:Button id="saveBtn"
+               styleName="chatSaveButtonStyle"
+               width="22"
+               height="22"
+               toolTip="{ResourceUtil.getInstance().getString('bbb.chat.saveBtn.toolTip')}"
+               click="sendSaveEvent()"
+               accessibilityName="{ResourceUtil.getInstance().getString('bbb.chat.saveBtn.accessibilityName')}"/>
+    
+    <mx:Button id="copyBtn"
+               styleName="chatCopyButtonStyle"
+               width="22"
+               height="22"
+               toolTip="{ResourceUtil.getInstance().getString('bbb.chat.copyBtn.toolTip')}"
+               click="sendCopyEvent()"
+               accessibilityName="{ResourceUtil.getInstance().getString('bbb.chat.copyBtn.accessibilityName')}"/>
+    
+    <mx:Button id="clearBtn"
+               styleName="chatClearButtonStyle"
+               width="22"
+               height="22"
+               visible = "{clrBtnVisible}"
+               enabled = "{clrBtnVisible}"
+               includeInLayout = "{clrBtnVisible}"
+               toolTip="{ResourceUtil.getInstance().getString('bbb.chat.clearBtn.toolTip')}"
+               click="sendClearEvent()"
+               accessibilityName="{ResourceUtil.getInstance().getString('bbb.chat.clearBtn.accessibilityName')}"/>
+  </mx:HBox>
+
 </mx:VBox>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
@@ -159,7 +159,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         LOGGER.debug(" onCreationComplete. Apply lock settings");
         applyLockSettings();
         
-        chatToolbar.registerListeners(chatMessagesList);
+//        chatToolbar.registerListeners(chatMessagesList);
         
         chatMessagesList.addEventListener(ChatEvent.RESIZE_CHAT_TOOLBAR, adjustToolbarWidthAccordingToScrollBar);
       }
@@ -611,12 +611,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         const paddingHeight:int = 5;
         const paddingWidth:int = 5;
         
-        chatToolbar.x = (chatMessagesCanvas.width - chatToolbar.width) - 20;
-        chatToolbar.y = 10;
+//        chatToolbar.x = (chatMessagesCanvas.width - chatToolbar.width) - 20;
+//        chatToolbar.y = 10;
         
-        if (!publicChat) {
-          chatToolbar.publicChat = false;
-        }
+//        if (!publicChat) {
+//          chatToolbar.publicChat = false;
+//        }
       }
     ]]>
     
@@ -633,7 +633,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
                          dataProvider="{chatMessages.messages}"
                          styleName="chatMessageListStyle"
                          accessibilityName="{ResourceUtil.getInstance().getString('bbb.chat.messageList')}" />
-      <chat:ChatToolbar id="chatToolbar" />
+      <!--chat:ChatToolbar id="chatToolbar" /-->
     </mx:Canvas>
   </mx:VBox>
   <mx:HBox id="chatCtrlBar" width="100%" height="60" styleName="chatControlBarStyle" verticalScrollPolicy="off"

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatView.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatView.mxml
@@ -120,8 +120,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				return chatBox;
 			}
 
+      private function getPublicChatBox():ChatBox {
+        return publicBox;
+      }
+      
 			private function dispatchSaveChatEvent(e:Event):void {
-				var chatBox:ChatBox = getVisibleChatBox();
+				var chatBox:ChatBox = getPublicChatBox();
 				var saveEvent:ChatSaveEvent = new ChatSaveEvent(ChatSaveEvent.SAVE_CHAT_EVENT);
 
 				if (chatBox.chatWithUsername == null || chatBox.chatWithUsername == "") {
@@ -135,7 +139,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 
 			private function dispatchCopyChatEvent(e:Event):void {
-				var chatBox:ChatBox = getVisibleChatBox();
+				var chatBox:ChatBox = getPublicChatBox();
 				var copyEvent:ChatCopyEvent = new ChatCopyEvent(ChatCopyEvent.COPY_CHAT_EVENT);
 
 				copyEvent.chatMessages = chatBox.getChatMessages();


### PR DESCRIPTION
- save, copy, and clear only applies to public chat