### PR TITLE
 - prevent shared notes window from closing as we don't have a way to…

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/AdditionalSharedNotesWindow.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/AdditionalSharedNotesWindow.as
@@ -25,7 +25,7 @@ package org.bigbluebutton.modules.sharednotes.views
 			_noteId = n;
 			_windowName = "AdditionalSharedNotesWindow_" + noteId;
 
-			showCloseButton = UsersUtil.amIModerator();
+			//showCloseButton = UsersUtil.amIModerator();
 			width = 240;
 			height = 240;
 

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/SharedNotesWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/SharedNotesWindow.mxml
@@ -151,7 +151,7 @@
 				if(noteId == "MAIN_NOTE"){
 					btnNew.visible = btnNew.includeInLayout = options.enableMultipleNotes && role == Role.MODERATOR;
 				} else {
-					showCloseButton = role == Role.MODERATOR;
+				//	showCloseButton = role == Role.MODERATOR;
 				}
 			}
 


### PR DESCRIPTION
… re-open them.