### PR TITLE
2.0 shared notes fixes

### DIFF
--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -530,6 +530,7 @@ bbb.sharedNotes.redo.toolTip = Redo modification
 bbb.sharedNotes.toolbar.toolTip = Text formatting toolbar
 bbb.sharedNotes.additionalNotes.closeWarning.title = Closing shared notes
 bbb.sharedNotes.additionalNotes.closeWarning.message = This action will destroy the notes on this window for everyone, and there's no way to undo. Are you sure you want to close these notes?
+bbb.sharedNotes.pastewarning.title = Shared Notes Paste Warning
 bbb.settings.deskshare.instructions = Choose Allow on the prompt that pops up to check that desktop sharing is working properly for you
 bbb.settings.deskshare.start = Check Desktop Sharing
 bbb.settings.voice.volume = Microphone Activity

--- a/bigbluebutton-client/resources/config.xml.template
+++ b/bigbluebutton-client/resources/config.xml.template
@@ -130,6 +130,8 @@
 			toolbarVisibleByDefault="false"
 			showToolbarButton="true"
 			fontSize="12"
+			maxPasteLength="1024"
+			maxNoteLenght="5120"
 		/>
 
 <!--

--- a/bigbluebutton-client/src/org/bigbluebutton/core/model/users/User2x.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/model/users/User2x.as
@@ -6,7 +6,7 @@ package org.bigbluebutton.core.model.users
     public var intId: String;
     public var extId: String;
     public var name: String;
-    public var role: String;
+    [Bindable] public var role: String;
     public var guest: Boolean;
     public var authed: Boolean;
     public var waitingForAcceptance: Boolean;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/SharedNotesOptions.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/SharedNotesOptions.as
@@ -18,6 +18,12 @@ package org.bigbluebutton.modules.sharednotes {
 		[Bindable]
 		public var fontSize:int = 10;
 
+		[Bindable]
+		public var maxPasteLength:int = 1024;
+
+		[Bindable]
+		public var maxNoteLength:int = 10240;
+
 		public function SharedNotesOptions() {
 			name = "SharedNotesModule";
 		}

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/AdditionalSharedNotesWindow.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/AdditionalSharedNotesWindow.as
@@ -28,8 +28,6 @@ package org.bigbluebutton.modules.sharednotes.views
 			showCloseButton = UsersUtil.amIModerator();
 			width = 240;
 			height = 240;
-
-			closeBtn.addEventListener(MouseEvent.CLICK, onCloseBtnClick);
 		}
 
 		public function get windowName():String {
@@ -46,6 +44,7 @@ package org.bigbluebutton.modules.sharednotes.views
 			LOGGER.debug("AdditionalSharedNotesWindow: [2] in-constructor additional notes " + noteId);
 
 			btnNew.visible = btnNew.includeInLayout = false;
+			closeBtn.addEventListener(MouseEvent.CLICK, onCloseBtnClick);
 		}
 
 		private function onCloseBtnClick(e:MouseEvent):void {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/SharedNotesWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/SharedNotesWindow.mxml
@@ -209,10 +209,11 @@
 							_document = result;
 //							LOGGER.debug("SharedNotes: patching local with server modifications");
 							richTextEditor.patch(e.patch);
+							/* This code is forcing resync and causing more problems then resolving
 							if (possiblePatchError()) {
 								syncNote();
 								return;
-							}
+							}*/
 						}
 						_lastPatch = e.patchId;
 						updateUndoRedoButtons(e.undo, e.redo);

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/SharedNotesWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/SharedNotesWindow.mxml
@@ -145,6 +145,8 @@
 				richTextEditor.bulletButton.visible = false;
 				richTextEditor.bulletButton.height = 0;
 				richTextEditor.bulletButton.width = 0;
+
+				richTextEditor.textArea.maxChars = options.maxNoteLength;
 			}
 
 			private function updateRoleDependentProperties(role:String):void {
@@ -422,6 +424,10 @@
 				return true;
 			}
 
+			public function throwPasteWarning(pasteLength:int):void {
+				Alert.show(ResourceUtil.getInstance().getString("bbb.caption.transcript.pastewarning.text", [options.maxPasteLength, pasteLength]), ResourceUtil.getInstance().getString("bbb.sharedNotes.pastewarning.title"), Alert.OK);
+			}
+
 			protected function btnToolbar_clickHandler(event:MouseEvent):void {
 				richTextEditor.showControlBar = !richTextEditor.showControlBar;
 			}
@@ -491,6 +497,10 @@
 						enabled="false" visible="true"/>
 			</mx:HBox>
 			<mx:HBox width="100%" horizontalAlign="right" paddingTop="0">
+				<mx:Label id="charRemain"
+						includeInLayout="true"
+						visible="{(options.maxNoteLength - richTextEditor.text.length) &lt; (options.maxNoteLength / 8)}"
+						text="{options.maxNoteLength - richTextEditor.text.length}"/>
 				<mx:Button id="btnNew"
 						styleName="sharedNotesNewButtonStyle"
 						width="26"

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/components/SharedNotesRichTextEditor.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/components/SharedNotesRichTextEditor.mxml
@@ -991,6 +991,17 @@
     private var shiftPressed:Boolean = false;
     private var ctrlPressed:Boolean = false;
     private var preventTextInput:Boolean = false;
+    private var _maxPasteLength:int = 1024;
+
+    public function set maxPasteLength(value:int):void
+    {
+        _maxPasteLength = value;
+    }
+
+    public function get maxPasteLength():int
+    {
+        return _maxPasteLength;
+    }
 
     public function restoreVerticalScroll(oldVerticalScroll:Number):void
     {
@@ -1215,6 +1226,12 @@
     private function onTextInput(e:TextEvent):void
     {
         if (e.text.length > 0) refreshSelection = true;
+
+        if (e.text.length > maxPasteLength)
+        {
+            e.preventDefault();
+            parentDocument.throwPasteWarning(e.text.length);
+        }
 
         if (preventTextInput) e.preventDefault();
     }


### PR DESCRIPTION
Included some extra limitations in the notes (max length and max paste length). I'm not sure what will be the use case of this feature but if you guys need bigger notes you can set those values in client's config.xml.

Had to remove an old workaround we did for extra synchronization. I'll need more time to rethink that but I believe the notes can be used as they are to more testing.