### PR TITLE
Improve client annotation edit

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
@@ -108,7 +108,7 @@ class WhiteboardModel {
     //println("!usersAnnotations.isEmpty: " + (!usersAnnotations.isEmpty) + ", usersAnnotations.head.id == annotation.id: " + (usersAnnotations.head.id == annotation.id));
     if (!usersAnnotations.isEmpty && usersAnnotations.head.id == annotation.id) {
       var dimensions: List[Int] = List[Int]()
-      annotation.annotationInfo.get("points").foreach(d => {
+      annotation.annotationInfo.get("dimensions").foreach(d => {
         d match {
           case d2: List[_] => dimensions = d2.asInstanceOf[List[Int]]
         }
@@ -124,11 +124,18 @@ class WhiteboardModel {
           }
         })
 
+        var newPoints: List[Float] = List[Float]()
+        annotation.annotationInfo.get("points").foreach(a => {
+          a match {
+            case a2: List[_] => newPoints = convertListNumbersToFloat(a2)
+          }
+        }) //newPoints = a.asInstanceOf[ArrayList[Float]])
+
         //println("oldPoints.size(): " + oldPoints.size());
 
         //val oldPointsJava: java.util.List[java.lang.Float] = oldPoints.asJava.asInstanceOf[java.util.List[java.lang.Float]]
         //println("****class = " + oldPointsJava.getClass())
-        val pathData = BezierWrapper.lineSimplifyAndCurve(oldPoints.asJava.asInstanceOf[java.util.List[java.lang.Float]], dimensions(0), dimensions(1))
+        val pathData = BezierWrapper.lineSimplifyAndCurve((oldPoints ::: newPoints).asJava.asInstanceOf[java.util.List[java.lang.Float]], dimensions(0), dimensions(1))
         //println("Path data: pointssize " + pathData.points.size() + " commandssize " + pathData.commands.size())
 
         val updatedAnnotationData = annotation.annotationInfo + ("points" -> pathData.points.asScala.toList) + ("commands" -> pathData.commands.asScala.toList)

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/WhiteboardCanvasModel.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/WhiteboardCanvasModel.as
@@ -84,6 +84,12 @@ package org.bigbluebutton.modules.whiteboard
       }
     }
 
+    public function stopDrawing(mouseX:Number, mouseY:Number): void {
+      for (var ob:int = 0; ob < drawListeners.length; ob++) {
+        (drawListeners[ob] as IDrawListener).stopDrawing(mouseX, mouseY);
+      }
+    }
+
     public function setGraphicType(type:String):void {
       //LogUtil.debug("!!! Set graphic type = " + type);
       wbTool.graphicType = type;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/EllipseAnnotation.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/EllipseAnnotation.as
@@ -26,17 +26,13 @@ package org.bigbluebutton.modules.whiteboard.business.shapes
 		private var _type:String = AnnotationType.ELLIPSE;
 		private var _shape:Array;
 		private var _color:uint;
-		private var _fillColor:uint;
 		private var _thickness:Number;
-		private var _fill:Boolean;
-		private var _transparent:Boolean;
 		
-		public function EllipseAnnotation(segment:Array, color:uint, thickness:Number, trans:Boolean)
+		public function EllipseAnnotation(segment:Array, color:uint, thickness:Number)
 		{
 			_shape = segment;
 			_color = color;
 			_thickness = thickness;
-			_transparent = trans;
 		}
 		
 		private function optimize(segment:Array):Array {
@@ -62,7 +58,6 @@ package org.bigbluebutton.modules.whiteboard.business.shapes
 			ao["thickness"] = _thickness;
 			ao["id"] = _id;
 			ao["status"] = _status;
-			ao["transparency"] = _transparent;
 
       if (wbId != null) {
         ao["whiteboardId"] = wbId;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/LineAnnotation.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/LineAnnotation.as
@@ -26,17 +26,13 @@ package org.bigbluebutton.modules.whiteboard.business.shapes
 		private var _type:String = AnnotationType.LINE;
 		private var _shape:Array;
 		private var _color:uint;
-		private var _fillColor:uint;
 		private var _thickness:Number;
-		private var _fill:Boolean;
-		private var _transparent:Boolean;
 		
-		public function LineAnnotation(segment:Array, color:uint, thickness:Number, trans:Boolean)
+		public function LineAnnotation(segment:Array, color:uint, thickness:Number)
 		{
 			_shape = segment;
 			_color = color;
 			_thickness = thickness;
-			_transparent = trans;
 		}
 		
 		private function optimize(segment:Array):Array {
@@ -63,7 +59,6 @@ package org.bigbluebutton.modules.whiteboard.business.shapes
 			ao["thickness"] = _thickness;
 			ao["id"] = _id;
 			ao["status"] = _status;
-			ao["transparency"] = _transparent;
 
       if (wbId != null) {
         ao["whiteboardId"] = wbId;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/Pencil.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/Pencil.as
@@ -21,13 +21,10 @@ package org.bigbluebutton.modules.whiteboard.business.shapes
 	import org.bigbluebutton.modules.whiteboard.models.Annotation;
 	import org.bigbluebutton.modules.whiteboard.models.AnnotationStatus;
 
-	/**
-	 * The Pencil class. Extends a DrawObject 
-	 * @author dzgonjan
-	 * 
-	 */	
 	public class Pencil extends DrawObject
 	{
+		private var numPointsDrawn:uint = 0;
+		
 		public function Pencil(id:String, type:String, status:String, userId:String) {
 			super(id, type, status, userId);
 		}
@@ -72,6 +69,8 @@ package org.bigbluebutton.modules.whiteboard.business.shapes
 				//setup for the next line command
 				graphics.moveTo(denormalize(points[0], _parentWidth), denormalize(points[1], _parentHeight));
 			}
+			
+			numPointsDrawn = points.length;
 			
 			this.alpha = 1;
 		}
@@ -123,7 +122,11 @@ package org.bigbluebutton.modules.whiteboard.business.shapes
 				_ao = a.annotation;
 				
 				graphics.lineStyle(denormalize(_ao.thickness, _parentWidth), _ao.color);
-				graphics.lineTo(denormalize(newPoints[newPoints.length-2], _parentWidth), denormalize(newPoints[newPoints.length-1], _parentHeight));
+				for (var i:int=numPointsDrawn; i<newPoints.length;){
+					graphics.lineTo(denormalize(newPoints[i++], _parentWidth), denormalize(newPoints[i++], _parentHeight));
+				}
+				
+				numPointsDrawn = newPoints.length;
 			} else {
 				_ao = a.annotation;
 				makeGraphic();

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/PencilDrawAnnotation.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/PencilDrawAnnotation.as
@@ -24,34 +24,38 @@ package org.bigbluebutton.modules.whiteboard.business.shapes
     public class PencilDrawAnnotation extends DrawAnnotation
     {
         private var _type:String = AnnotationType.PENCIL;
-        private var _shape:Array;
+        private var _points:Array;
         private var _color:uint;
-        private var _fillColor:uint;
         private var _thickness:Number;
-        private var _fill:Boolean;
-        private var _transparent:Boolean;
+        private var _dimensions:Array;
 
         
-        public function PencilDrawAnnotation(segment:Array, color:uint, thickness:Number, trans:Boolean)
+        public function PencilDrawAnnotation(segment:Array, color:uint, thickness:Number)
         {
-            _shape = segment;
+            _points = segment;
             _color = color;
             _thickness = thickness;
-            _transparent = trans;
         }
-               
+        
+        public function addDimensions(dimensions:Array):void {
+            _dimensions = dimensions;
+        }
+        
         override public function createAnnotation(wbId:String):Annotation {
             var ao:Object = new Object();
             ao["type"] = _type;
-            ao["points"] = _shape;
+            ao["points"] = _points;
             ao["color"] = _color;
             ao["thickness"] = _thickness;
             ao["id"] = _id;
             ao["status"] = _status;
-            ao["transparency"] = _transparent;
 
+            if (_dimensions) {
+                ao["dimensions"] = _dimensions;
+            }
+            
             if (wbId != null) {
-              ao["whiteboardId"] = wbId;
+                ao["whiteboardId"] = wbId;
             }
                       
             return new Annotation(_id, _type, ao);

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/RectangleAnnotation.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/RectangleAnnotation.as
@@ -26,17 +26,13 @@ package org.bigbluebutton.modules.whiteboard.business.shapes
 		private var _type:String = AnnotationType.RECTANGLE;
 		private var _shape:Array;
 		private var _color:uint;
-		private var _fillColor:uint;
 		private var _thickness:Number;
-		private var _fill:Boolean;
-		private var _transparent:Boolean;
 		
-		public function RectangleAnnotation(segment:Array, color:uint, thickness:Number, trans:Boolean)
+		public function RectangleAnnotation(segment:Array, color:uint, thickness:Number)
 		{
 			_shape = segment;
 			_color = color;
 			_thickness = thickness;
-			_transparent = trans;
 		}
 		
 		private function optimize(segment:Array):Array {
@@ -62,12 +58,10 @@ package org.bigbluebutton.modules.whiteboard.business.shapes
 			ao["thickness"] = _thickness;
 			ao["id"] = _id;
 			ao["status"] = _status;
-			ao["transparency"] = _transparent;
 			
       if (wbId != null) {
         ao["whiteboardId"] = wbId;
       }
-      
       
 			return new Annotation(_id, _type, ao);
 		}

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/ShapeFactory.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/ShapeFactory.as
@@ -74,24 +74,24 @@ package org.bigbluebutton.modules.whiteboard.business.shapes
         return null;
     }
         
-    private function createAnnotation(type:String, shape:Array, color:uint, thickness:Number, fill:Boolean, fillColor:uint, trans:Boolean):DrawAnnotation{
+    private function createAnnotation(type:String, shape:Array, color:uint, thickness:Number):DrawAnnotation{
             if (type == AnnotationType.PENCIL){
-                return new PencilDrawAnnotation(shape, color, thickness, trans);
+                return new PencilDrawAnnotation(shape, color, thickness);
             } else if (type == AnnotationType.RECTANGLE){
-        return new RectangleAnnotation(shape, color, thickness, trans);
+        return new RectangleAnnotation(shape, color, thickness);
       } else if (type == AnnotationType.ELLIPSE){
-        return new EllipseAnnotation(shape, color, thickness, trans);
+        return new EllipseAnnotation(shape, color, thickness);
       } else if (type == AnnotationType.LINE){
-        return new LineAnnotation(shape, color, thickness, trans);
+        return new LineAnnotation(shape, color, thickness);
       } else if (type == AnnotationType.TRIANGLE){
-        return new TriangleAnnotation(shape, color, thickness, trans);
+        return new TriangleAnnotation(shape, color, thickness);
       }
             
             return null;
         }
             
-    public function createDrawObject(type:String, segment:Array, color:uint, thickness:uint, fill:Boolean, fillColor:uint, transparency:Boolean):DrawAnnotation {
-      return createAnnotation(type, segment, color, normalize(thickness, _parentWidth), fill, fillColor, transparency);
+    public function createDrawObject(type:String, segment:Array, color:uint, thickness:uint):DrawAnnotation {
+      return createAnnotation(type, segment, color, normalize(thickness, _parentWidth));
     }
     
     public function normalizePoint(x:Number, y:Number):Point {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/TriangleAnnotation.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/TriangleAnnotation.as
@@ -26,17 +26,13 @@ package org.bigbluebutton.modules.whiteboard.business.shapes
 		private var _type:String = AnnotationType.TRIANGLE;
 		private var _shape:Array;
 		private var _color:uint;
-		private var _fillColor:uint;
 		private var _thickness:Number;
-		private var _fill:Boolean;
-		private var _transparent:Boolean;
 		
-		public function TriangleAnnotation(segment:Array, color:uint, thickness:Number, trans:Boolean)
+		public function TriangleAnnotation(segment:Array, color:uint, thickness:Number)
 		{
 			_shape = segment;
 			_color = color;
 			_thickness = thickness;
-			_transparent = trans;
 		}
 		
 		private function optimize(segment:Array):Array {
@@ -62,7 +58,6 @@ package org.bigbluebutton.modules.whiteboard.business.shapes
 			ao["thickness"] = _thickness;
 			ao["id"] = _id;
 			ao["status"] = _status;
-			ao["transparency"] = _transparent;
       
       if (wbId != null) {
         ao["whiteboardId"] = wbId;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/CursorPositionListener.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/CursorPositionListener.as
@@ -24,7 +24,7 @@ package org.bigbluebutton.modules.whiteboard.views {
 			_lastXPosition = -1;
 			_lastYPosition = 1;
 			
-			_timer = new Timer(100);
+			_timer = new Timer(50);
 			_timer.addEventListener(TimerEvent.TIMER, onTimerInterval);
 		}
 		

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/IDrawListener.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/IDrawListener.as
@@ -25,5 +25,6 @@ package org.bigbluebutton.modules.whiteboard.views
         function onMouseDown(mouseX:Number, mouseY:Number, tool:WhiteboardTool, wbId:String):void;
         function onMouseMove(mouseX:Number, mouseY:Number, tool:WhiteboardTool):void;
         function onMouseUp(mouseX:Number, mouseY:Number, tool:WhiteboardTool):void;
+        function stopDrawing(mouseX:Number, mouseY:Number):void;
     }
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/TextDrawListener.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/TextDrawListener.as
@@ -117,6 +117,15 @@ package org.bigbluebutton.modules.whiteboard.views {
                 sendTextToServer(AnnotationStatus.DRAW_START, tobj);
             }
         }
+        
+        public function stopDrawing(mouseX:Number, mouseY:Number):void {
+            feedback.clear();
+            if (_wbCanvas.contains(feedback)) {
+              _wbCanvas.removeGraphic(feedback);
+            }
+            
+            _mousedDown = false;
+        }
 
         private function sendTextToServer(status:String, tobj:TextDrawAnnotation):void {
             if (status == AnnotationStatus.DRAW_START) {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardCanvas.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardCanvas.as
@@ -150,6 +150,13 @@ package org.bigbluebutton.modules.whiteboard.views {
 			canvasModel.doMouseMove(mousePoint.x, mousePoint.y);
 		}
 		
+		private function stopDrawing():void {
+			var mousePoint:Point = getMouseXY();
+			
+			canvasDisplayModel.doMouseDown(mousePoint.x, mousePoint.y);
+			canvasModel.stopDrawing(mousePoint.x, mousePoint.y);
+		}
+		
 		public function changeColor(color:uint):void {
 			canvasModel.changeColor(color);
 		}
@@ -238,7 +245,11 @@ package org.bigbluebutton.modules.whiteboard.views {
 		}
 		
 		private function getMouseXY():Point {
-			return new Point(Math.min(Math.max(parent.mouseX, 0), parent.width-1) - this.x, Math.min(Math.max(parent.mouseY, 0), parent.height-1) - this.y);
+			if (parent) {
+				return new Point(Math.min(Math.max(parent.mouseX, 0), parent.width-1) - this.x, Math.min(Math.max(parent.mouseY, 0), parent.height-1) - this.y);
+			} else {
+				return new Point(0, 0);
+			}
 		}
 		
 		private function presenterChange(amIPresenter:Boolean, presenterId:String):void {
@@ -293,6 +304,8 @@ package org.bigbluebutton.modules.whiteboard.views {
 		}
 		
 		public function displayWhiteboardById(wbId:String):void {
+			stopDrawing();
+			
 			currentWhiteboardId = wbId;
 			canvasDisplayModel.changeWhiteboard(wbId);
 			whiteboardToolbar.whiteboardIdSet();
@@ -342,6 +355,8 @@ package org.bigbluebutton.modules.whiteboard.views {
 		
 		private function onDisableWhiteboardEvent(e:WhiteboardButtonEvent):void {
 			e.stopPropagation();
+			
+			stopDrawing();
 			
 			removeCursor()
 			

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardToolbar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardToolbar.mxml
@@ -334,13 +334,13 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
    
 	<!--mx:Spacer height="2"/-->
   <mx:VBox backgroundColor="#FFFFFF" horizontalAlign="center">
-    <mx:Image source="{getStyle('iconWhiteboardThick')}" horizontalAlign="center" width="40"/>
+    <mx:Image source="{getStyle('iconWhiteboardThick')}" horizontalAlign="center" width="{BUTTON_SIZE}"/>
     <mx:VSlider height="50" id="sld" change="changeThickness(event)"
                 toolTip="{ResourceUtil.getInstance().getString('bbb.highlighter.toolbar.thickness.accessibilityName')}" 
                 minimum="1" maximum="30" 
                 useHandCursor="true" value="3" showDataTip="true" snapInterval="1" dataTipOffset="0" labelOffset="0" 
                 accessibilityName="{ResourceUtil.getInstance().getString('bbb.highlighter.toolbar.thickness.accessibilityName')}" />
-    <mx:Image source="{getStyle('iconWhiteboardThin')}" horizontalAlign="center" width="40"/>
+    <mx:Image source="{getStyle('iconWhiteboardThin')}" horizontalAlign="center" width="{BUTTON_SIZE}"/>
   </mx:VBox>
 
 	<mx:Button id="multiUserBtn" enabled="false" visible="false" click="changeMultiUser()" width="{BUTTON_SIZE}" height="{BUTTON_SIZE}" styleName="{multiUser ? 'multiUserWhiteboardOnButtonStyle' : 'multiUserWhiteboardOffButtonStyle'}"/> 

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/models/WhiteboardTool.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/models/WhiteboardTool.as
@@ -30,12 +30,21 @@ package org.bigbluebutton.modules.whiteboard.views.models
         public var graphicType:String = WhiteboardConstants.TYPE_SHAPE;
         public var toolType:String = AnnotationType.PENCIL;
         public var drawColor:uint = 0x000000;
-        public var fillColor:uint = 0x000000;
         public var thickness:uint = 1;       
         public var _fontStyle:String = "_sans";
         public var _fontSize:Number = 18;
-        public var _textText:String = "Hello BBB!";        
-        public var fillOn:Boolean = false;
-        public var transparencyOn:Boolean = false;
+        
+        public static function copy(tool:WhiteboardTool):WhiteboardTool {
+            var newTool:WhiteboardTool = new WhiteboardTool();
+            if (tool) {
+                newTool.graphicType = tool.graphicType;
+                newTool.toolType = tool.toolType;
+                newTool.drawColor = tool.drawColor;
+                newTool.thickness = tool.thickness;
+                newTool._fontStyle = tool._fontStyle;
+                newTool._fontSize = tool._fontSize;
+            }
+            return newTool;
+        }
     }
 }


### PR DESCRIPTION
The core of this PR is throttling of the whiteboard updates that the client sends out to one update every 50ms. In my tests this translates to 1-10 pairs of pencil coordinates being bundled together in an update. I've also included a fix for the DRAW_END so that when drawing is disabled (multiuser turned off, lost presenter, page change) the final DRAW_END is sent as expected so the pencil will smooth and the text will close. I've also increased the cursor position update to once every 50ms which should cause the annotations and the cursor to sync up.

The throttling of annotation updates caused a change in the pencil's DRAW_END properties. The canvas dimensions that used to be sent in the points have been moved to a new property "dimensions" and any left over coordinates are included in the "points" property. This didn't trgger any changes on the message sent from akka-apps.