### PR TITLE
 - fix exception

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/managers/WebRTCDeskshareManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/managers/WebRTCDeskshareManager.as
@@ -20,7 +20,9 @@
 package org.bigbluebutton.modules.screenshare.managers
 {
 	import com.asfusion.mate.events.Dispatcher;
+	
 	import flash.external.ExternalInterface;
+	
 	import org.as3commons.lang.StringUtils;
 	import org.as3commons.logging.api.ILogger;
 	import org.as3commons.logging.api.getClassLogger;
@@ -30,6 +32,7 @@ package org.bigbluebutton.modules.screenshare.managers
 	import org.bigbluebutton.main.events.MadePresenterEvent;
 	import org.bigbluebutton.modules.phone.models.WebRTCAudioStatus;
 	import org.bigbluebutton.modules.screenshare.events.DeskshareToolbarEvent;
+	import org.bigbluebutton.modules.screenshare.events.IsSharingScreenEvent;
 	import org.bigbluebutton.modules.screenshare.events.ShareStartedEvent;
 	import org.bigbluebutton.modules.screenshare.events.UseJavaModeCommand;
 	import org.bigbluebutton.modules.screenshare.events.WebRTCPublishWindowChangeState;
@@ -296,8 +299,7 @@ package org.bigbluebutton.modules.screenshare.managers
 			dispatcher.dispatchEvent(new WebRTCViewStreamEvent(WebRTCViewStreamEvent.START));
 		}
 
-		/*public function handleIsSharingScreenEvent(event: IsSharingScreenEvent):void {*/
-		public function handleIsSharingScreenEvent():void {
+		public function handleIsSharingScreenEvent(event: IsSharingScreenEvent):void {
 			if (UsersUtil.amIPresenter()) {
 			} else {
 				/*handleStreamStartEvent(ScreenshareModel.getInstance().streamId, event.width, event.height);*/


### PR DESCRIPTION
---------------------------------------------------------
- ERROR: Wrong number of arguments supplied when calling method handleIsSharingScreenEvent
- EVENT TYPE: "IsSharingScreenEvent.IS_SCREENSHARING" (screenshare is sharing screen event)
- TAG: MethodInvoker
- GENERATOR: WebRTCDeskshareManager
- METHOD: handleIsSharingScreenEvent
- FILE: WebRTCDeskshareEventMap
- 1 ARGUMENT SUPPLIED: [Event type="screenshare is sharing screen event" bubbles=true cancelable=false eventPhase=2]
- STACK TRACE: ArgumentError: Error #1063: Argument count mismatch on org.bigbluebutton.modules.screenshare.managers::WebRTCDeskshareManager/handleIsSharingScreenEvent(). Expected 0, got 1.
	at Function/http://adobe.com/AS3/2006/builtin::apply()
	at com.asfusion.mate.core::MethodCaller/call()[/Users/nahuel/Documents/Flex Builder 3/MateDevelopment/src/com/asfusion/mate/core/MethodCaller.as:90]
	at com.asfusion.mate.actions.builders::MethodInvoker/run()[/Users/nahuel/Documents/Flex Builder 3/MateDevelopment/src/com/asfusion/mate/actions/builders/MethodInvoker.as:113]
	at com.asfusion.mate.actions::AbstractAction/trigger()[/Users/nahuel/Documents/Flex Builder 3/MateDevelopment/src/com/asfusion/mate/actions/AbstractAction.as:61]
	at com.asfusion.mate.actionLists::AbstractHandlers/runSequence()[/Users/nahuel/Documents/Flex Builder 3/MateDevelopment/src/com/asfusion/mate/actionLists/AbstractHandlers.as:331]
	at com.asfusion.mate.actionLists::EventHandlers/fireEvent()[/Users/nahuel/Documents/Flex Builder 3/MateDevelopment/src/com/asfusion/mate/actionLists/EventHandlers.as:257]
	at flash.events::EventDispatcher/dispatchEventFunction()
	at flash.events::EventDispatcher/dispatchEvent()
	at mx.core::UIComponent/dispatchEvent()[/Users/aharui/release4.13.0/frameworks/projects/framework/src/mx/core/UIComponent.as:13682]
	at com.asfusion.mate.core::GlobalDispatcher/dispatchEvent()[/Users/nahuel/Documents/Flex Builder 3/MateDevelopment/src/com/asfusion/mate/core/GlobalDispatcher.as:110]
	at com.asfusion.mate.events::Dispatcher/dispatchEvent()[/Users/nahuel/Documents/Flex Builder 3/MateDevelopment/src/com/asfusion/mate/events/Dispatcher.as:240]
	at org.bigbluebutton.modules.screenshare.services::MessageReceiver/handleIsSharingScreenRequestResponse()[/tmp/bbb-client_2.0.0_xenial_m02/src/org/bigbluebutton/modules/screenshare/services/MessageReceiver.as:146]
	at org.bigbluebutton.modules.screenshare.services::MessageReceiver/onMessage()[/tmp/bbb-client_2.0.0_xenial_m02/src/org/bigbluebutton/modules/screenshare/services/MessageReceiver.as:52]
	at org.bigbluebutton.modules.screenshare.services.red5::Connection/notifyListeners()[/tmp/bbb-client_2.0.0_xenial_m02/src/org/bigbluebutton/modules/screenshare/services/red5/Connection.as:101]
	at org.bigbluebutton.modules.screenshare.services.red5::Connection/onMessageFromServer()[/tmp/bbb-client_2.0.0_xenial_m02/src/org/bigbluebutton/modules/screenshare/services/red5/Connection.as:110]
---------------------------------------------------------

---------------------------------------------------------
MATE Error: Invalid number of arguments, turn on the debugger for more information
EventType:screenshare is sharing screen event. Error was found in a EventHandlers list in file WebRTCDeskshareEventMap
---------------------------------------------------------