### PR TITLE
[HTML5] Fix inconsistency inside the ACL, #4310

### DIFF
--- a/bigbluebutton-html5/imports/api/acl/Acl.js
+++ b/bigbluebutton-html5/imports/api/acl/Acl.js
@@ -56,7 +56,11 @@ export class Acl {
       let permissions = {};
 
       roles.forEach((role) => {
-        permissions = deepMerge(permissions, this.config[role]);
+        // There is a big issue here, if we just send the content from the this.config
+        // inside the deepMerge, we change both permissions and the config.
+        // Couldn't find a better way to prevent the changing.
+        // The problems occurs in the `sources.shift()`.
+        permissions = deepMerge(permissions, JSON.parse(JSON.stringify(this.config[role])));
       });
 
       return permissions;
@@ -66,6 +70,6 @@ export class Acl {
 
   static containsRole(user) {
     return Match.test(user, Object) &&
-        Match.test(user.roles, Array);
+      Match.test(user.roles, Array);
   }
 }

--- a/bigbluebutton-html5/imports/utils/deepMerge.js
+++ b/bigbluebutton-html5/imports/utils/deepMerge.js
@@ -1,30 +1,31 @@
 import { Match } from 'meteor/check';
 
-export default function deepMerge(origin, ...sources) {
-  if (!sources.length) return origin;
+export default function deepMerge(merge, ...sources) {
+  if (!sources.length) return merge;
 
   const source = sources.shift();
-  let modOrigin = origin;
 
-  if (Match.test(origin, Array)) {
+  let merged = merge;
+
+  if (Match.test(merged, Array)) {
     if (Match.test(source, Array)) {
-      origin.push(...source);
+      merged.push(...source);
     } else {
-      origin.push(source);
+      merged.push(source);
     }
-  } else if (Match.test(origin, Object)) {
+  } else if (Match.test(merged, Object)) {
     if (Match.test(source, Object)) {
       Object.keys(source).forEach((key) => {
-        if (!origin[key]) {
-          modOrigin[key] = source[key];
+        if (!merged[key]) {
+          merged[key] = source[key];
         } else {
-          deepMerge(modOrigin[key], source[key]);
+          deepMerge(merged[key], source[key]);
         }
       });
     }
   } else {
-    modOrigin = source;
+    merged = source;
   }
 
-  return deepMerge(modOrigin, ...sources);
+  return deepMerge(merged, ...sources);
 }


### PR DESCRIPTION
While merging inside, using the previously code, the deepMerge function change the state of the **this.config** object, making the following result appear:

If we merge **presenter** and **viewer**, the result would be correct, but the **this.config** is messed up, it change its internal objects to the result of the functions.

This occurs because of the `sources.shift()`, which change both references, i try the following codes to prevent this from happening, but no one work.

```
const acl = {
  "viewer": {
    "subscriptions": [
      "users",
      "cursor",
      "screenshare",
      "meetings",
      "polls",
      "chat",
      "presentations",
      "annotations",
      "slides",
      "captions",
      "breakouts",
      "voiceUsers"
    ],
    "methods": [
      "listenOnlyToggle",
      "userLogout",
      "setEmojiStatus",
      "toggleSelfVoice",
      "publishVote",
      "sendChat"
    ]
  },
  "moderator": {
    "methods": [
      "assignPresenter",
      "kickUser",
      "toggleVoice",
      "clearPublicChatHistory"
    ]
  },
  "presenter": {
    "methods": [
      "assignPresenter",
      "switchSlide"
    ]
  }
}
```

```
function testFunction(...roles){
  const newArray = new Array(...roles)
  console.log(newArray.shift().subscriptions.shift());
}
testFunction(acl['viewer']);

console.log(acl);
```

```
function testFunction(...roles){
  const newArray = roles.map(e => e);
  console.log(newArray.shift().subscriptions.shift());
}

testFunction(acl['viewer']);

console.log(acl);
```

```
function testFunction(...roles){
  const shiftRole = [...roles].shift();
  const testObj = Object.assign({}, shiftRole);
  console.log(testObj.subscriptions.shift());
}

testFunction(acl['viewer']);

console.log(acl);
```

If you pay attention to the **console.log**, the **user** disappear from **acl.viewer.subscriptions** on all cases, but if we do using **JSON.parse(JSON.stringify(acl['viewer']))** , the function don't mess with the acl stuff.

If anyone know a better way to fix this, please post on this PR!
