### PR TITLE
Attempt to fix annotation clipping

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/SlideView.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/SlideView.mxml
@@ -32,6 +32,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		   creationComplete="onCreationComplete()"
 		   verticalScrollPolicy="off"
 		   horizontalScrollPolicy="off"
+		   clipContent="true"
 		   styleName="presentationSlideViewStyle"
 		   xmlns:views="org.bigbluebutton.modules.present.views.*">
 
@@ -84,8 +85,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       private var pageCache:ArrayCollection = new ArrayCollection();
       
 			private function onCreationComplete():void {
-				slideLoader.width = this.width;
-				slideLoader.height = this.height;
+				//slideLoader.width = this.width;
+				//slideLoader.height = this.height;
 				
 				this.setChildIndex(thumbnailView, this.numChildren - 1);
 				
@@ -299,7 +300,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         if (page != null && page.swfData != null) {   
           LOGGER.debug("Positioning page [{0}]", [page.id]);
           slideModel.saveViewedRegion(page.xOffset, page.yOffset, page.widthRatio, page.heightRatio);
-          slideModel.calculateViewportNeededForRegion(page.xOffset, page.yOffset, page.widthRatio, page.heightRatio);
+          slideModel.calculateViewportNeededForRegion(page.widthRatio, page.heightRatio);
           slideModel.displayViewerRegion(page.xOffset, page.yOffset, page.widthRatio, page.heightRatio);
           slideModel.calculateViewportXY();
           slideModel.displayPresenterView();

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/models/SlideViewModel.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/models/SlideViewModel.as
@@ -139,7 +139,7 @@ package org.bigbluebutton.modules.present.ui.views.models
 		
 		public function adjustSlideAfterParentResized():void {			
 			if (fitToPage) {
-				calculateViewportNeededForRegion(_viewedRegionX, _viewedRegionY, _viewedRegionW, _viewedRegionH);
+				calculateViewportNeededForRegion(_viewedRegionW, _viewedRegionH);
 				displayViewerRegion(_viewedRegionX, _viewedRegionY, _viewedRegionW, _viewedRegionH);
 				calculateViewportXY();
 				displayPresenterView();
@@ -213,29 +213,37 @@ package org.bigbluebutton.modules.present.ui.views.models
 			viewportW = parentW;
 			viewportH = parentH;
 			
+			/*
+			* For some reason when the viewport values are both whole numbers the clipping doesn't 
+			* function. When the second part of the width/height pair is rounded up and then 
+			* reduced by 0.5 the clipping always seems to happen. This was a long standing, bug 
+			* and if you try to remove the Math.ceil and "-0.5" you better know what you're doing.
+			*             - Chad (Aug 30, 2017)
+			*/
+			
 			if (fitToPage) {
 				// If the height is smaller than the width, we use the height as the base to determine the size of the slide.
-				if (parentH < parentW) {					
+				if (parentH < parentW) {
 					viewportH = parentH;
-					viewportW = ((pageOrigW * viewportH)/pageOrigH);					
+					viewportW = Math.ceil((pageOrigW * viewportH)/pageOrigH)-0.5;
 					if (parentW < viewportW) {
 						viewportW = parentW;
-						viewportH = ((pageOrigH * viewportW)/pageOrigW);
+						viewportH = Math.ceil((pageOrigH * viewportW)/pageOrigW)-0.5;
 					}
 				} else {
 					viewportW = parentW;
-					viewportH = (viewportW/pageOrigW) * pageOrigH;
+					viewportH = Math.ceil((viewportW/pageOrigW) * pageOrigH)-0.5;
 					if (parentH < viewportH) {
 						viewportH = parentH;
-						viewportW = ((pageOrigW * viewportH)/pageOrigH);
-					}												
-				}					
+						viewportW = Math.ceil((pageOrigW * viewportH)/pageOrigH)-0.5;
+					}
+				}
 			} else {
-				viewportH = (viewportW/pageOrigW)*pageOrigH;
-				if (viewportH > parentH) 
+				viewportH = Math.ceil((viewportW/pageOrigW)*pageOrigH)-0.5;
+				if (viewportH > parentH)
 					viewportH = parentH;
-			}		
-		}	
+			}
+		}
 			
 		public function printViewedRegion():void {
 //			LogUtil.debug("Region [" + viewedRegionW + "," + viewedRegionH + "] [" + viewedRegionX + "," + viewedRegionY + "]");			
@@ -304,27 +312,35 @@ package org.bigbluebutton.modules.present.ui.views.models
 			_viewedRegionH = regionH;
 		}
 		
-		public function calculateViewportNeededForRegion(x:Number, y:Number, regionW:Number, regionH:Number):void {			
+		public function calculateViewportNeededForRegion(regionW:Number, regionH:Number):void {
 			var vrwp:Number = pageOrigW * (regionW/HUNDRED_PERCENT);
 			var vrhp:Number = pageOrigH * (regionH/HUNDRED_PERCENT);
 			
+			/*
+			* For some reason when the viewport values are both whole numbers the clipping doesn't 
+			* function. When the second part of the width/height pair is rounded up and then 
+			* reduced by 0.5 the clipping always seems to happen. This was a long standing, bug 
+			* and if you try to remove the Math.ceil and "-0.5" you better know what you're doing.
+			*             - Chad (Aug 30, 2017)
+			*/
+			
 			if (parentW < parentH) {
 				viewportW = parentW;
-				viewportH = (vrhp/vrwp)*parentW;				 
+				viewportH = Math.ceil((vrhp/vrwp)*parentW)-0.5;
 				if (parentH < viewportH) {
 					viewportH = parentH;
-					viewportW = ((vrwp * viewportH)/vrhp);
-//					LogUtil.debug("calc viewport ***** resizing [" + viewportW + "," + viewportH + "] [" + parentW + "," + parentH + "," + fitToPage + "] [" + pageOrigW + "," + pageOrigH + "]");
+					viewportW = Math.ceil((vrwp * viewportH)/vrhp)-0.5;
 				}
 			} else {
 				viewportH = parentH;
-				viewportW = (vrwp/vrhp)*parentH;
+				viewportW = Math.ceil((vrwp/vrhp)*parentH)-0.5;
 				if (parentW < viewportW) {
 					viewportW = parentW;
-					viewportH = ((vrhp * viewportW)/vrwp);
-//					LogUtil.debug("calc viewport resizing [" + viewportW + "," + viewportH + "] [" + parentW + "," + parentH + "," + fitToPage + "] [" + pageOrigW + "," + pageOrigH + "]");
+					viewportH = Math.ceil((vrhp * viewportW)/vrwp)-0.5;
 				}
 			}
+			
+			LOGGER.debug("calc viewport ***** resizing [" + viewportW + "," + viewportH + "] [" + parentW + "," + parentH + "," + fitToPage + "] [" + pageOrigW + "," + pageOrigH + "]");
 		}
 	}
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardCanvas.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardCanvas.as
@@ -76,18 +76,18 @@ package org.bigbluebutton.modules.whiteboard.views {
 			
 			whiteboardToolbar.whiteboardAccessModified(wbModel.multiUser);
 			
+			this.clipContent = true;
+			
 			//create the annotation display container
 			this.addChild(graphicObjectHolder);
 			graphicObjectHolder.x = 0;
 			graphicObjectHolder.y = 0;
-			graphicObjectHolder.clipContent = true;
 			graphicObjectHolder.tabFocusEnabled = false;
 			
 			//create the cursor display container
 			this.addChild(cursorObjectHolder);
 			cursorObjectHolder.x = 0;
 			cursorObjectHolder.y = 0;
-			cursorObjectHolder.clipContent = true;
 			cursorObjectHolder.tabFocusEnabled = false;
 			
 			wbModel.addEventListener(WhiteboardUpdateReceived.NEW_ANNOTATION, onNewAnnotationEvent);


### PR DESCRIPTION
Annotation clipping hasn't worked correctly for many versions. What I could figure out is that if the viewport width or height (whichever was the second one calculated) was a whole number the clipping would always fail, and if the second side calculated was a decimal number > n.5 or < n.5 it would sometimes fail to clip. By setting the viewports second side to always end in ".5" the clipping always seems to work. I have no idea why it works or even why it didn't work before.