### PR TITLE
Switch from flash based fullscreen to html5 api based

### DIFF
--- a/bigbluebutton-client/resources/prod/BigBlueButton.html
+++ b/bigbluebutton-client/resources/prod/BigBlueButton.html
@@ -4,7 +4,7 @@
     <title></title>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
     <style type="text/css" media="screen">
-      html, body, #content    { height:100%; }
+      html, body, #content    { height:100%; width: 100%; }
       body                                    { margin:0; padding:0; overflow:hidden; }
       #altContent                             { /* style alt content */ }
       .visually-hidden {

--- a/bigbluebutton-client/resources/prod/lib/bbb_blinker.js
+++ b/bigbluebutton-client/resources/prod/lib/bbb_blinker.js
@@ -164,13 +164,15 @@ function determineBrowser()
 }
 
 function toggleFullscreen() {
-	// are we currently in full-screen mode?
-	if (document.fullscreenElement ||
-		document.webkitFullscreenElement ||
-		document.mozFullScreenElement ||
-		document.msFullscreenElement) {
 
-		// exit full-screen
+	function isFullscreen() {
+		return !!(document.fullscreenElement ||
+			document.webkitFullscreenElement ||
+			document.mozFullScreenElement ||
+			document.msFullscreenElement);
+	}
+
+	function exitFullscreen() {
 		if (document.exitFullscreen) {
 			document.exitFullscreen();
 		} else if (document.webkitExitFullscreen) {
@@ -180,10 +182,11 @@ function toggleFullscreen() {
 		} else if (document.msExitFullscreen) {
 			document.msExitFullscreen();
 		}
-	} else {
+	}
+
+	function setFullscreen() {
 		var htmlElement = document.getElementById("content");
 
-		// go full-screen
 		if (htmlElement.requestFullscreen) {
 			htmlElement.requestFullscreen();
 		} else if (htmlElement.webkitRequestFullscreen) {
@@ -193,5 +196,32 @@ function toggleFullscreen() {
 		} else if (htmlElement.msRequestFullscreen) {
 			htmlElement.msRequestFullscreen();
 		}
+	}
+
+	function FShandler() {
+		var isNowFullscreen = isFullscreen();
+		var swfObj = swfobject.getObjectById("BigBlueButton");
+		if (swfObj) {
+			swfObj.fullscreenToggled(isNowFullscreen);
+		}
+	}
+
+	// remove old listeners
+	document.removeEventListener("fullscreenchange", FShandler);
+	document.removeEventListener("webkitfullscreenchange", FShandler);
+	document.removeEventListener("mozfullscreenchange", FShandler);
+	document.removeEventListener("MSFullscreenChange", FShandler);
+
+	// add listeners
+	document.addEventListener("fullscreenchange", FShandler);
+	document.addEventListener("webkitfullscreenchange", FShandler);
+	document.addEventListener("mozfullscreenchange", FShandler);
+	document.addEventListener("MSFullscreenChange", FShandler);
+
+	// are we currently in full-screen mode?
+	if (isFullscreen()) {
+		exitFullscreen();
+	} else {
+		setFullscreen()
 	}
 }

--- a/bigbluebutton-client/resources/prod/lib/bbb_blinker.js
+++ b/bigbluebutton-client/resources/prod/lib/bbb_blinker.js
@@ -162,3 +162,36 @@ function determineBrowser()
 	
 	return [browserName, majorVersion, fullVersion];
 }
+
+function toggleFullscreen() {
+	// are we currently in full-screen mode?
+	if (document.fullscreenElement ||
+		document.webkitFullscreenElement ||
+		document.mozFullScreenElement ||
+		document.msFullscreenElement) {
+
+		// exit full-screen
+		if (document.exitFullscreen) {
+			document.exitFullscreen();
+		} else if (document.webkitExitFullscreen) {
+			document.webkitExitFullscreen();
+		} else if (document.mozCancelFullScreen) {
+			document.mozCancelFullScreen();
+		} else if (document.msExitFullscreen) {
+			document.msExitFullscreen();
+		}
+	} else {
+		var htmlElement = document.getElementById("content");
+
+		// go full-screen
+		if (htmlElement.requestFullscreen) {
+			htmlElement.requestFullscreen();
+		} else if (htmlElement.webkitRequestFullscreen) {
+			htmlElement.webkitRequestFullscreen();
+		} else if (htmlElement.mozRequestFullScreen) {
+			htmlElement.mozRequestFullScreen();
+		} else if (htmlElement.msRequestFullscreen) {
+			htmlElement.msRequestFullscreen();
+		}
+	}
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/core/events/FullscreenToggledEvent.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/events/FullscreenToggledEvent.as
@@ -1,0 +1,35 @@
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ * 
+ * Copyright (c) 2017 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ * 
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.bigbluebutton.core.events
+{
+  import flash.events.Event;
+
+  public class FullscreenToggledEvent extends Event
+  {
+    public static const IS_FULLSCREEN_TOGGLED:String = "is fullscreen toggled event";
+
+    public var isNowFullscreen: Boolean;
+
+    public function FullscreenToggledEvent(isNowFullscreen: Boolean)
+    {
+      super(IS_FULLSCREEN_TOGGLED, false, false);
+      this.isNowFullscreen = isNowFullscreen;
+    }
+  }
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/main/api/ExternalApiCallbacks.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/api/ExternalApiCallbacks.as
@@ -36,6 +36,7 @@ package org.bigbluebutton.main.api
   import org.bigbluebutton.core.events.GetMyUserInfoRequestEvent;
   import org.bigbluebutton.core.events.IsUserPublishingCamRequest;
   import org.bigbluebutton.core.events.VoiceConfEvent;
+  import org.bigbluebutton.core.events.FullscreenToggledEvent;
   import org.bigbluebutton.core.vo.CameraSettingsVO;
   import org.bigbluebutton.main.events.BBBEvent;
   import org.bigbluebutton.main.model.users.events.EmojiStatusEvent;
@@ -95,6 +96,7 @@ package org.bigbluebutton.main.api
         ExternalInterface.addCallback("displayPresentationRequest", handleDisplayPresentationRequest);
         ExternalInterface.addCallback("deletePresentationRequest", handleDeletePresentationRequest);
         ExternalInterface.addCallback("queryListsOfPresentationsRequest", handleQueryListsOfPresentationsRequest);
+        ExternalInterface.addCallback("fullscreenToggled", handleFullscreenToggled);
 
         ExternalInterface.addCallback("webRTCCallStarted", handleWebRTCCallStarted);
         ExternalInterface.addCallback("webRTCCallConnecting", handleWebRTCCallConnecting);
@@ -216,7 +218,10 @@ package org.bigbluebutton.main.api
     private function handleAmISharingCameraRequestAsync():void {
       _dispatcher.dispatchEvent(new AmISharingWebcamQueryEvent());
     }
-    
+
+    private function handleFullscreenToggled(isNowFullscreen: Boolean):void {
+      _dispatcher.dispatchEvent(new FullscreenToggledEvent(isNowFullscreen));
+    }
 
     private function handleAmIPresenterRequestSync():Boolean {
       return UsersUtil.amIPresenter();

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
@@ -54,6 +54,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		<mate:Listener type="{ConnectionFailedEvent.CONNECTION_REJECTED}" method="attemptReconnect"  />
 		<mate:Listener type="{ExitApplicationEvent.EXIT_APPLICATION}" method="handleExitApplicationEvent" />
 		<mate:Listener type="{ConfigLoadedEvent.CONFIG_LOADED_EVENT}" method="initOptions"  />
+		<mate:Listener type="{FullscreenToggledEvent.IS_FULLSCREEN_TOGGLED}" method="handleFullscreenToggleState"  />
 		<mate:Listener type="{FlashMicSettingsEvent.FLASH_MIC_SETTINGS}" method="handleFlashMicSettingsEvent"  />
 		<mate:Listener type="{WebRTCEchoTestEvent.WEBRTC_ECHO_TEST_CONNECTING}" method="handleWebRTCEchoTestConnectingEvent"  />
 		<mate:Listener type="{WebRTCMediaEvent.WEBRTC_MEDIA_REQUEST}" method="handleWebRTCMediaRequestEvent"  />
@@ -121,6 +122,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.core.events.NewGuestWaitingEvent;
 			import org.bigbluebutton.core.events.RoundTripLatencyReceivedEvent;
 			import org.bigbluebutton.core.events.SwitchedLayoutEvent;
+			import org.bigbluebutton.core.events.FullscreenToggledEvent;
 			import org.bigbluebutton.core.vo.LockSettingsVO;
 			import org.bigbluebutton.main.events.AppVersionEvent;
 			import org.bigbluebutton.main.events.BBBEvent;
@@ -442,7 +444,15 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				
 				scWindow.focusHead();
 			}
-			
+
+			private function handleFullscreenToggleState(event: FullscreenToggledEvent): void {
+				if (event.isNowFullscreen) {
+						fullScreenBtn.styleName = "exitFullScreenButton";
+					} else {
+						fullScreenBtn.styleName = "fullScreenButton";
+					}
+			}
+
 			private function toggleFullScreen():void{
 				LOGGER.debug("Toggling fullscreen");
 				if (ExternalInterface.available) {

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
@@ -173,8 +173,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 			[Bindable] private var copyrightText:String;
 
-			private var _hideToolbarsTimer:Timer;
-
 			public function get mode():String {
 				return _mode;
 			}
@@ -203,10 +201,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private var widthWatch:ChangeWatcher;
 			private var heightWatch:ChangeWatcher;
 			private var resizeExecuting:Boolean = false;
-			
-			private const THRESHOLD_AREA_SHOW_TOOLBARS:int = 5;
-			private const HIDE_TOOLBARS_EFFECT_DURATION:int = 500;
-			private const HIDE_TOOLBARS_DELAY:int = 1000;
 
       private var _respTimer:ResponsivenessTimer;
       
@@ -257,9 +251,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 			protected function initializeShell():void {	
 				globalDispatcher = new Dispatcher();
-				
-				_hideToolbarsTimer = new Timer(HIDE_TOOLBARS_DELAY, 1);
-				_hideToolbarsTimer.addEventListener(TimerEvent.TIMER, onHideToolbarsTimerComplete);
 
 				copyrightLabel2.addEventListener(FlexEvent.UPDATE_COMPLETE, updateCopyrightLabelDimensions);
 			}
@@ -306,80 +297,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					guestManagement.setGuestPolicy(guestPolicy);
 					guestManagement.addToSettings();
 				}
-			}
-
-			private function set showToolbar(visible:Boolean):void {
-				if (!showToolbarOpt) return;
-
-				if (visible) {
-					if (enlargeToolbar.isPlaying) return;
-					if (shrinkToolbar.isPlaying) shrinkToolbar.end();
-
-					enlargeToolbar.heightFrom = toolbar.height;
-					if (enlargeToolbar.heightFrom != enlargeToolbar.heightTo) {
-						_showToolbar = true;
-						enlargeToolbar.play([toolbar]);
-					}
-				} else {
-					if (shrinkToolbar.isPlaying) return;
-					if (enlargeToolbar.isPlaying) enlargeToolbar.end();
-
-					shrinkToolbar.heightFrom = toolbar.height;
-					if (shrinkToolbar.heightFrom != shrinkToolbar.heightTo) {
-						_showToolbar = true;
-						shrinkToolbar.play([toolbar]);
-					}
-				}
-			}
-
-
-			private function onToolbarEffectEnd():void {
-				_showToolbar = showToolbarOpt && (toolbar.height > 0);
-				calculateCanvasHeight();
-			}
-
-			private function set showFooter(visible:Boolean):void {
-				if (!showFooterOpt) return;
-
-				if (visible) {
-					if (enlargeControlBar.isPlaying) return;
-					if (shrinkControlBar.isPlaying) shrinkControlBar.end();
-
-					enlargeControlBar.heightFrom = controlBar.height;
-					if (enlargeControlBar.heightFrom != enlargeControlBar.heightTo) {
-						_showFooter = true;
-						enlargeControlBar.play([controlBar]);
-					}
-				} else {
-					if (shrinkControlBar.isPlaying) return;
-					if (enlargeControlBar.isPlaying) enlargeControlBar.end();
-
-					shrinkControlBar.heightFrom = controlBar.height;
-					if (shrinkControlBar.heightFrom != shrinkControlBar.heightTo) {
-						_showFooter = true;
-						shrinkControlBar.play([controlBar]);
-					}
-				}
-			}
-
-			private function onControlBarEffectEnd():void {
-				_showFooter = showFooterOpt && (controlBar.height > 0);
-				calculateCanvasHeight();
-			}
-
-			private function onHideToolbarsTimerComplete(event:TimerEvent):void {
-				showToolbar = showFooter = false;
-			}
-
-			private function hideToolbars():void {
-				// Temporarily disabling toolbar hiding on fullscreen to address animation delays
-				// _hideToolbarsTimer.reset();
-				// _hideToolbarsTimer.start();
-			}
-
-			private function showToolbars():void {
-				_hideToolbarsTimer.reset();
-				showToolbar = showFooter = true;
 			}
 
 			private function updateCopyrightLabelDimensions(e:Event = null):void {
@@ -967,13 +884,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		]]>
 	</fx:Script>
 
-	<fx:Declarations>
-		<mx:Resize id="shrinkControlBar" duration="{HIDE_TOOLBARS_EFFECT_DURATION}" heightFrom="{footerHeight}" heightTo="0" effectEnd="onControlBarEffectEnd()" />
-		<mx:Resize id="enlargeControlBar" duration="{HIDE_TOOLBARS_EFFECT_DURATION}" heightFrom="0" heightTo="{footerHeight}" effectEnd="onControlBarEffectEnd()" />
-		<mx:Resize id="shrinkToolbar" target="{toolbar}" duration="{HIDE_TOOLBARS_EFFECT_DURATION}" heightFrom="{toolbarHeight}" heightTo="0" effectEnd="onToolbarEffectEnd()" />
-		<mx:Resize id="enlargeToolbar" duration="{HIDE_TOOLBARS_EFFECT_DURATION}" heightFrom="0" heightTo="{toolbarHeight}" effectEnd="onToolbarEffectEnd()" />
-	</fx:Declarations>
-	
 	<fx:Declarations>
 		<common:TabIndexer id="tabIndexer" startIndex="100000"
 						   tabIndices="{[warningBtn, langSelector, logBtn]}"/>

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
@@ -89,7 +89,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import com.asfusion.mate.events.Dispatcher;
 			
 			import flash.events.Event;
-			import flash.events.FullScreenEvent;
 			import flash.events.IOErrorEvent;
 			import flash.events.TextEvent;
 			import flash.geom.Point;
@@ -262,12 +261,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				_hideToolbarsTimer = new Timer(HIDE_TOOLBARS_DELAY, 1);
 				_hideToolbarsTimer.addEventListener(TimerEvent.TIMER, onHideToolbarsTimerComplete);
 
-				if (stage == null) {
-					addEventListener(Event.ADDED_TO_STAGE, initFullScreen);
-				} else {
-					initFullScreen();
-				}
-
 				copyrightLabel2.addEventListener(FlexEvent.UPDATE_COMPLETE, updateCopyrightLabelDimensions);
 			}
 			
@@ -312,23 +305,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					guestManagement = new GuestManagement();
 					guestManagement.setGuestPolicy(guestPolicy);
 					guestManagement.addToSettings();
-				}
-			}
-
-			private function isFullScreen():Boolean {
-				return stage.displayState == StageDisplayState.FULL_SCREEN ||
-						stage.displayState == StageDisplayState.FULL_SCREEN_INTERACTIVE;
-			}
-
-			private function mouseMoveHandler(e:MouseEvent):void {
-				if (isFullScreen()) {
-					if (e.stageY <= THRESHOLD_AREA_SHOW_TOOLBARS || e.stageY > this.height - THRESHOLD_AREA_SHOW_TOOLBARS) {
-						showToolbars();
-					} else if (e.stageY >= toolbar.height && e.stageY <= this.height - controlBar.height) {
-						hideToolbars();
-					}
-				} else {
-					showToolbars();
 				}
 			}
 
@@ -415,12 +391,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					copyrightLabel2.width += Math.min(spacer.width, copyrightLabel2.measuredWidth - copyrightLabel2.width);
 				}
 			}
-		
-			protected function initFullScreen(e:Event = null):void {
-				stage.addEventListener(FullScreenEvent.FULL_SCREEN, fullScreenHandler);
-				stage.addEventListener(MouseEvent.MOUSE_MOVE, mouseMoveHandler);
-			}
-			
+
 			private var sendStartModulesEvent:Boolean = true;
 			
 			// We have to calculate the canvas height manually because if you set it to a 
@@ -484,19 +455,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					waitWindow = null;
 				}
 			}
-
-			private function fullScreenHandler(evt:FullScreenEvent):void {
-				dispState = stage.displayState + " (fullScreen=" + evt.fullScreen.toString() + ")";
-				if (evt.fullScreen) {
-					LOGGER.debug("Switching to full screen");
-					fullScreenBtn.styleName = "exitFullScreenButton"
-					hideToolbars();
-				} else {
-					LOGGER.debug("Switching to normal screen");
-					fullScreenBtn.styleName = "fullScreenButton"
-					showToolbars();
-				}
-			}			
 
 			private function closeGuestWindow(e:Event = null):void {
 				if(guestWindow != null) {
@@ -569,26 +527,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 			
 			private function toggleFullScreen():void{
-				LOGGER.debug("Toggling fullscreen, current mode: " + stage.displayState);
-	   			try {
-					switch (stage.displayState) {
-						case StageDisplayState.FULL_SCREEN:
-						case StageDisplayState.FULL_SCREEN_INTERACTIVE:
-							LOGGER.debug("Full screen mode, switching to normal screen mode");
-							// If already in full screen mode, switch to normal mode.
-							stage.displayState = StageDisplayState.NORMAL;
-							break;
-						default:
-							LOGGER.debug("Normal screen mode, switching to full screen mode");
-							// If not in full screen mode, switch to full screen mode.
-							stage.displayState = StageDisplayState.FULL_SCREEN_INTERACTIVE;
-							break;
-					}
-				} catch (err:SecurityError) {
-					// ignore
+				LOGGER.debug("Toggling fullscreen");
+				if (ExternalInterface.available) {
+					ExternalInterface.call("toggleFullscreen");
 				}
-	   		}	
-	   		
+	   		}
+
 	   		private function handleOpenWindowEvent(event:OpenWindowEvent):void {
 				// this is a terrible place for these checks because this function runs 4 times on startup
 				if (BBB.initConnectionManager().isTunnelling) {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatWindow.mxml
@@ -56,7 +56,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private var _yPosition:int;
 			private var keyCombos:Object;
 			private var disp:Dispatcher = new Dispatcher();
-			private var dispState:String;
 			[Bindable] public var chatOptions:ChatOptions;
 			
 			public function getPrefferedPosition():String{
@@ -64,10 +63,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			} 
 			
 			private function onCreationComplete():void {
-				/* Set up full screen handler. */
-				FlexGlobals.topLevelApplication.stage.addEventListener(FullScreenEvent.FULL_SCREEN, fullScreenHandler);
-				dispState = FlexGlobals.topLevelApplication.stage.displayState;
-				
 				hotkeyCapture();
 				titleBarOverlay.tabIndex = chatOptions.baseTabIndex;
 				
@@ -128,20 +123,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					focusManager.setFocus(titleBarOverlay);
 				}
 			}
-			
-			private function fullScreenHandler(evt:FullScreenEvent):void {
-/*				dispState = FlexGlobals.topLevelApplication.stage.displayState + " (fullScreen=" + evt.fullScreen.toString() + ")";
-				if (evt.fullScreen) {
-					txtMsg.text = "Chat not enabled in full screen mode";
-					txtMsg.enabled = false;
-					sendBtn.enabled = false;
-				} else {
-					txtMsg.text = "";
-					txtMsg.enabled = true;
-					sendBtn.enabled = true;
-				}
-*/			}		
-			
+
 			override protected function resourcesChanged():void{
 				super.resourcesChanged();
 				this.title = ResourceUtil.getInstance().getString("bbb.chat.title");


### PR DESCRIPTION
This pull request replaces the existing fullscreen toggle (based on Flash) with HTML5 API one (same as when you press F11 in the browser)

After this pull request is merged FireFox on Linux will not be able to trigger pop-ups (upload presentation, etc). This is already the case now if we switch to full screen mode via browser controls (F11)

I have also removed some code related to animations related to Flash based fullscreen toggle. Kept some tightly coupled code (e.x. showToolbar due to its usage on calculating positioning). Advice is welcome on the right approach - remove all / keep all / current state. @capilkey @GhaziTriki @fcecagno 

Note also the related #4330 