### PR TITLE
Fix for switching back to fit-to-page

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -264,8 +264,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				fitSlideToWindowMaintainingAspectRatio();
 			}
 			
-			[Bindable] private var fitToPage:Boolean = true;
-			
 			private function fitSlideToWindowMaintainingAspectRatio():void {
 				if (this.minimized) return;
 				
@@ -482,9 +480,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				resourcesChanged();
 			}
 			
-			private function onFitToPage(ftp:Boolean):void {				
-				fitToPage = ftp;
-				slideView.switchToFitToPage(fitToPage);
+			private function onFitToPage(ftp:Boolean):void {
+				slideView.switchToFitToPage(ftp);
 				fitSlideToWindowMaintainingAspectRatio();				
 			}
 			

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/SlideView.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/SlideView.mxml
@@ -242,6 +242,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 			public function switchToFitToPage(ftp:Boolean):void {
 				slideModel.switchToFitToPage(ftp);
+				slideModel.onMove(0, 0); // fake a move to reset some values
 				onZoomSlide(100);
 			}
 			

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/models/SlideViewModel.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/models/SlideViewModel.as
@@ -158,6 +158,9 @@ package org.bigbluebutton.modules.present.ui.views.models
 			LOGGER.debug("switchToFitToPage");
 			
 			this.fitToPage = ftp;
+			
+			saveViewedRegion(0,0,100,100);
+			
 			calculateViewportSize();
 			calculateViewportXY();			
 		}


### PR DESCRIPTION
This PR sets the viewed region back to 100% width and height when switching back to fit-to-page which is enough to get it working again.

This fixes https://github.com/bigbluebutton/bigbluebutton/issues/4339