### PR TITLE
Update webhooks module to support new messages in 2.0.

### DIFF
--- a/bbb-webhooks/application.coffee
+++ b/bbb-webhooks/application.coffee
@@ -1,3 +1,5 @@
+redis = require("redis")
+
 config = require("./config")
 Hook = require("./hook")
 IDMapping = require("./id_mapping")
@@ -10,6 +12,10 @@ WebServer = require("./web_server")
 module.exports = class Application
 
   constructor: ->
+    # one for pub/sub, another to read/write data
+    config.redis.pubSubClient = redis.createClient()
+    config.redis.client = redis.createClient()
+    
     @webHooks = new WebHooks()
     @webServer = new WebServer()
 

--- a/bbb-webhooks/callback_emitter.coffee
+++ b/bbb-webhooks/callback_emitter.coffee
@@ -82,6 +82,6 @@ module.exports = class CallbackEmitter extends EventEmitter
 simplifiedEvent = (event) ->
   try
     eventJs = JSON.parse(event)
-    "event: { name: #{eventJs.header?.name}, timestamp: #{eventJs.header?.timestamp} }"
+    "event: { name: #{eventJs.envelope?.name}, timestamp: #{eventJs.envelope?.timestamp} }"
   catch e
     "event: #{event}"

--- a/bbb-webhooks/config.coffee
+++ b/bbb-webhooks/config.coffee
@@ -14,37 +14,42 @@ config.server.port or= 3005
 
 # Web hooks configs
 config.hooks or= {}
-config.hooks.pchannel or= "bigbluebutton:*"
-config.hooks.meetingsChannel or= "bigbluebutton:from-bbb-apps:meeting"
+
+# Channels to subscribe to.
+config.hooks.channels or= {
+  mainChannel: 'from-akka-apps-redis-channel',
+  rapChannel: 'bigbluebutton:from-rap'
+}
 
 # Filters to the events we want to generate callback calls for
 config.hooks.events or= [
-  { channel: "bigbluebutton:from-bbb-apps:meeting", name: "meeting_created_message" },
-  { channel: "bigbluebutton:from-bbb-apps:meeting", name: "meeting_destroyed_event" },
-  { channel: "bigbluebutton:from-bbb-apps:users", name: "user_joined_message" },
-  { channel: "bigbluebutton:from-bbb-apps:users", name: "user_left_message" },
-  { channel: "bigbluebutton:from-bbb-apps:users", name: "user_listening_only" },
-  { channel: "bigbluebutton:from-bbb-apps:users", name: "user_joined_voice_message" },
-  { channel: "bigbluebutton:from-bbb-apps:users", name: "user_left_voice_message" },
-  { channel: "bigbluebutton:from-bbb-apps:users", name: "user_shared_webcam_message" },
-  { channel: "bigbluebutton:from-bbb-apps:users", name: "user_unshared_webcam_message" },
-  { channel: "bigbluebutton:from-rap", name: "sanity_started" },
-  { channel: "bigbluebutton:from-rap", name: "sanity_ended" },
-  { channel: "bigbluebutton:from-rap", name: "archive_started" },
-  { channel: "bigbluebutton:from-rap", name: "archive_ended" },
-  { channel: "bigbluebutton:from-rap", name: "post_archive_started" },
-  { channel: "bigbluebutton:from-rap", name: "post_archive_ended" },
-  { channel: "bigbluebutton:from-rap", name: "process_started" },
-  { channel: "bigbluebutton:from-rap", name: "process_ended" },
-  { channel: "bigbluebutton:from-rap", name: "post_process_started" },
-  { channel: "bigbluebutton:from-rap", name: "post_process_ended" },
-  { channel: "bigbluebutton:from-rap", name: "publish_started" },
-  { channel: "bigbluebutton:from-rap", name: "publish_ended" },
-  { channel: "bigbluebutton:from-rap", name: "post_publish_started" },
-  { channel: "bigbluebutton:from-rap", name: "post_publish_ended" },
-  { channel: "bigbluebutton:from-rap", name: "unpublished" },
-  { channel: "bigbluebutton:from-rap", name: "published" },
-  { channel: "bigbluebutton:from-rap", name: "deleted" }
+  { channel: config.hooks.channels.mainChannel, name: "MeetingCreatedEvtMsg" },
+  { channel: config.hooks.channels.mainChannel, name: "MeetingEndedEvtMsg" },
+  { channel: config.hooks.channels.mainChannel, name: "UserJoinedMeetingEvtMsg" },
+  { channel: config.hooks.channels.mainChannel, name: "UserLeftMeetingEvtMsg" },
+  { channel: config.hooks.channels.mainChannel, name: "UserJoinedVoiceConfToClientEvtMsg" },
+  { channel: config.hooks.channels.mainChannel, name: "UserLeftVoiceConfToClientEvtMsg" },
+  { channel: config.hooks.channels.mainChannel, name: "UserMutedVoiceEvtMsg" },
+  { channel: config.hooks.channels.mainChannel, name: "UserBroadcastCamStartedEvtMsg" },
+  { channel: config.hooks.channels.mainChannel, name: "UserBroadcastCamStoppedEvtMsg" },
+  { channel: config.hooks.channels.mainChannel, name: "RecordingStatusChangedEvtMsg" },
+  { channel: config.hooks.channels.rapChannel, name: "sanity_started" },
+  { channel: config.hooks.channels.rapChannel, name: "sanity_ended" },
+  { channel: config.hooks.channels.rapChannel, name: "archive_started" },
+  { channel: config.hooks.channels.rapChannel, name: "archive_ended" },
+  { channel: config.hooks.channels.rapChannel, name: "post_archive_started" },
+  { channel: config.hooks.channels.rapChannel, name: "post_archive_ended" },
+  { channel: config.hooks.channels.rapChannel, name: "process_started" },
+  { channel: config.hooks.channels.rapChannel, name: "process_ended" },
+  { channel: config.hooks.channels.rapChannel, name: "post_process_started" },
+  { channel: config.hooks.channels.rapChannel, name: "post_process_ended" },
+  { channel: config.hooks.channels.rapChannel, name: "publish_started" },
+  { channel: config.hooks.channels.rapChannel, name: "publish_ended" },
+  { channel: config.hooks.channels.rapChannel, name: "post_publish_started" },
+  { channel: config.hooks.channels.rapChannel, name: "post_publish_ended" },
+  { channel: config.hooks.channels.rapChannel, name: "unpublished" },
+  { channel: config.hooks.channels.rapChannel, name: "published" },
+  { channel: config.hooks.channels.rapChannel, name: "deleted" }
 ]
 
 # Retry intervals for failed attempts for perform callback calls.

--- a/bbb-webhooks/config_local.coffee.example
+++ b/bbb-webhooks/config_local.coffee.example
@@ -10,16 +10,24 @@ config.bbb.sharedSecret = "33e06642a13942004fd83b3ba6e4104a"
 config.server = {}
 config.server.port = 3005
 
+# Web hooks configs
+config.hooks = {}
+
+# Channels to subscribe to.
+config.hooks.channels = {
+  mainChannel: 'from-akka-apps-redis-channel',
+  rapChannel: 'bigbluebutton:from-rap'
+}
+
 # Callbacks will be triggered for all the events in this list and only for these events.
 # You only need to specify it if you want events that are not used by default or
 # if you want to restrict the events used. See `config.coffee` for the default list.
 #
-# config.hooks = {}
 # config.hooks.events = [
-#   { channel: "bigbluebutton:from-bbb-apps:meeting", name: "meeting_created_message" },
-#   { channel: "bigbluebutton:from-bbb-apps:meeting", name: "meeting_destroyed_event" },
-#   { channel: "bigbluebutton:from-bbb-apps:users", name: "user_joined_message" },
-#   { channel: "bigbluebutton:from-bbb-apps:users", name: "user_left_message" }
+#   { channel: config.hooks.channels.mainChannel, name: "MeetingCreatedEvtMsg" },
+#   { channel: config.hooks.channels.mainChannel, name: "MeetingEndedEvtMsg" },
+#   { channel: config.hooks.channels.mainChannel, name: "UserJoinedMeetingEvtMsg" },
+#   { channel: config.hooks.channels.mainChannel, name: "UserLeftMeetingEvtMsg" }
 # ]
 
 module.exports = config

--- a/bbb-webhooks/hook.coffee
+++ b/bbb-webhooks/hook.coffee
@@ -36,7 +36,7 @@ module.exports = class Hook
     @externalMeetingID = null
     @queue = []
     @emitter = null
-    @redisClient = redis.createClient()
+    @redisClient = config.redis.client
 
   save: (callback) ->
     @redisClient.hmset config.redis.keys.hook(@id), @toRedis(), (error, reply) =>
@@ -180,7 +180,7 @@ module.exports = class Hook
   # Gets all hooks from redis to populate the local database.
   # Calls `callback()` when done.
   @resync = (callback) ->
-    client = redis.createClient()
+    client = config.redis.client
     tasks = []
 
     client.smembers config.redis.keys.hooks, (error, hooks) =>

--- a/bbb-webhooks/id_mapping.coffee
+++ b/bbb-webhooks/id_mapping.coffee
@@ -32,7 +32,7 @@ module.exports = class IDMapping
     @externalMeetingID = null
     @internalMeetingID = null
     @lastActivity = null
-    @redisClient = redis.createClient()
+    @redisClient = config.redis.client
 
   save: (callback) ->
     @redisClient.hmset config.redis.keys.mapping(@id), @toRedis(), (error, reply) =>
@@ -137,7 +137,7 @@ module.exports = class IDMapping
   # Gets all mappings from redis to populate the local database.
   # Calls `callback()` when done.
   @resync = (callback) ->
-    client = redis.createClient()
+    client = config.redis.client
     tasks = []
 
     client.smembers config.redis.keys.mappings, (error, mappings) =>

--- a/bbb-webhooks/web_hooks.coffee
+++ b/bbb-webhooks/web_hooks.coffee
@@ -33,22 +33,24 @@ module.exports = class WebHooks
       try
         message = JSON.parse(message)
         if message?
-          id = message.payload?.meeting_id
+          id = @_findMeetingId(message)
           IDMapping.reportActivity(id)
 
           # First treat meeting events to add/remove ID mappings
-          if message.header?.name is "meeting_created_message"
+          if message.envelope?.name is "MeetingCreatedEvtMsg"
             Logger.info "WebHooks: got create message on meetings channel [#{channel}]", message
-            IDMapping.addOrUpdateMapping message.payload?.meeting_id, message.payload?.external_meeting_id, (error, result) ->
-              # has to be here, after the meeting was created, otherwise create calls won't generate
-              # callback calls for meeting hooks
-              processMessage()
+            meetingProp = message.core?.body?.props?.meetingProp
+            if meetingProp
+              IDMapping.addOrUpdateMapping meetingProp.intId, meetingProp.extId, (error, result) ->
+                # has to be here, after the meeting was created, otherwise create calls won't generate
+                # callback calls for meeting hooks
+                processMessage()
 
           # TODO: Temporarily commented because we still need the mapping for recording events,
           #   after the meeting ended.
-          # else if message.header?.name is "meeting_destroyed_event"
+          # else if message.envelope?.name is "MeetingEndedEvtMessage"
           #   Logger.info "WebHooks: got destroy message on meetings channel [#{channel}]", message
-          #   IDMapping.removeMapping message.payload?.meeting_id, (error, result) ->
+          #   IDMapping.removeMapping @_findMeetingId(message), (error, result) ->
           #     processMessage()
 
           else
@@ -57,17 +59,40 @@ module.exports = class WebHooks
       catch e
         Logger.error "WebHooks: error processing the message", message, ":", e
 
-    @subscriberEvents.psubscribe config.hooks.pchannel
+    # Subscribe to the neccesary channels.
+    for k, channel of config.hooks.channels
+      @subscriberEvents.psubscribe channel
 
   # Returns whether the message read from redis should generate a callback
   # call or not.
   _filterMessage: (channel, message) ->
+    messageName = @_messageNameFromChannel(channel, message)
     for event in config.hooks.events
-      if channel? and message.header?.name? and
-         event.channel.match(channel) and event.name.match(message.header?.name)
+      if channel? and messageName? and
+         event.channel.match(channel) and event.name.match(messageName)
           return true
-    false
+    false  
 
+  # BigBlueButton 2.0 changed where the message name is located, but it didn't
+  # change for the Record and Playback events. Thus, we need to handle both.
+  _messageNameFromChannel: (channel, message) ->
+    if channel == 'bigbluebutton:from-rap'
+      return message.header?.name
+    message.envelope?.name
+
+  # Find the meetingId in the message.
+  # This is neccesary because the new message in BigBlueButton 2.0 have 
+  # their meetingId in different locations.
+  _findMeetingId: (message) ->
+    # Various 2.0 meetingId locations.
+    return message.envelope.routing.meetingId if message.envelope?.routing?.meetingId?
+    return message.header.body.meetingId if message.header?.body?.meetingId?
+    return message.core.body.meetingId if message.core?.body?.meetingId?
+    return message.core.body.props.meetingProp.intId if message.core?.body?.props?.meetingProp?.intId?
+    # Record and Playback 1.1 meeting_id location.
+    return message.payload.meeting_id if message.payload?.meeting_id?
+    return undefined
+    
   # Processes an event received from redis. Will get all hook URLs that
   # should receive this event and start the process to perform the callback.
   _processEvent: (message) ->
@@ -78,7 +103,11 @@ module.exports = class WebHooks
 
     # filter the hooks that need to receive this event
     # only global hooks or hooks for this specific meeting
-    idFromMessage = message.payload?.meeting_id
+    
+    # All the messages have the meetingId in different locations now.
+    # Depending on the event, it could appear within header, core or envelope.
+    # It always appears in atleast one, so we just need to search for it.
+    idFromMessage = @_findMeetingId(message)
     if idFromMessage?
       eMeetingID = IDMapping.getExternalMeetingID(idFromMessage)
       hooks = hooks.concat(Hook.findByExternalMeetingIDSync(eMeetingID))

--- a/bbb-webhooks/web_hooks.coffee
+++ b/bbb-webhooks/web_hooks.coffee
@@ -13,7 +13,7 @@ Logger = require("./logger")
 module.exports = class WebHooks
 
   constructor: ->
-    @subscriberEvents = redis.createClient()
+    @subscriberEvents = config.redis.pubSubClient
 
   start: ->
     @_subscribeToEvents()


### PR DESCRIPTION
With all the changes to the messages BigBlueButton 2.0, it broke the webhooks module. I've gone through and updated it to handle the new messages properly. Since the messages don't use the `bigbluebutton:*` scope for channel names anymore, it's just listening for the messages on two separate channels (`from-akka-apps-redis-channel` for basic events, and `bigbluebutton:from-rap` for the record and playback updates).

I've also included a couple of fixes by @daronco (see #4180) that fix an issue with the webhooks module not properly cleaning up it's connections.

A BigBlueButton 1.1 server will not work with this version of the webhooks, this is strictly for 2.0 only. Anyone using 1.1 will have to use the webhooks from the `v1.1.x-release` branch (it's been updated with the redis connection fixes included in this PR). It might be worth mapping the 2.0 message format to the 1.1 message format in the interest of backwards compatibility.