### PR TITLE
Remove <recording> tag around the getRecordings response.

### DIFF
--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/util/RecMetaXmlHelper.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/util/RecMetaXmlHelper.scala
@@ -76,8 +76,7 @@ class RecMetaXmlHelper extends RecordingServiceGW with LogHelper {
           <message>There are no recordings for the meeting(s).</message>
         </response>
       val p = new scala.xml.PrettyPrinter(80, 4)
-
-      p.format(<recording>{resp}</recording>)
+      p.format(resp)
     } else {
       val buffer = new scala.xml.NodeBuffer
       recMeta foreach(rm => buffer += rm.toXml())
@@ -87,7 +86,7 @@ class RecMetaXmlHelper extends RecordingServiceGW with LogHelper {
           <recordings>{buffer}</recordings>
         </response>
       val p = new scala.xml.PrettyPrinter(80, 4)
-      p.format(<recording>{resp}</recording>)
+      p.format(resp)
     }
   }
 }


### PR DESCRIPTION
This was causing some errors in applications using the BigBlueButton API. It has been changed to match the format of the other responses.