### PR TITLE
Convert playback length to minutes when writing to XML.

### DIFF
--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/domain/Recording.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/domain/Recording.scala
@@ -329,7 +329,7 @@ case class RecMetaPlayback(format: String, link: String, processingTime: Int,
     val formatElem = <type>{format}</type>
     val urlElem = <url>{link}</url>
     val processTimeElem = <processingTime>{processingTime}</processingTime>
-    val lengthElem = <length>{duration}</length>
+    val lengthElem = <length>{duration / 60000}</length>
 
     buffer += formatElem
     buffer += urlElem


### PR DESCRIPTION
In BigBlueButton 1.1 the length property displayed in minutes. To keep consistent with that (to prevent applications using the API from displaying incorrect values) we should also convert the length to minutes in BigBlueButton 2.0.