### PR TITLE
Block WebRTC on Edge

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/bbb_webrtc_bridge_sip.js
+++ b/bigbluebutton-client/resources/prod/lib/bbb_webrtc_bridge_sip.js
@@ -565,7 +565,12 @@ function webrtc_hangup(callback) {
 }
 
 function isWebRTCAvailable() {
-	return SIP.WebRTC.isSupported();
+	var browserInfo = determineBrowser();
+	if (browserInfo[0] === "Edge") {
+		return false;
+	else {
+		return SIP.WebRTC.isSupported();
+	}
 }
 
 function getCallStatus() {


### PR DESCRIPTION
While Edge does support WebRTC now, the way it is supported is incompatible with the library we use. This PR makes it so the client always thinks WebRTC is not supported on Edge and can be removed once the library is updated.

See the issue here, https://github.com/bigbluebutton/bigbluebutton/issues/4384.