### PR TITLE
Handle recordings that have an unmatched DeskshareStartedEvent

### DIFF
--- a/record-and-playback/core/spec/recordandplayback/deskshare_generator_spec.rb
+++ b/record-and-playback/core/spec/recordandplayback/deskshare_generator_spec.rb
@@ -36,17 +36,6 @@ module BigBlueButton
         se.size.should == 2       
       end
 
-      it "should match the 2 webcam events" do
-        dir = "resources/raw"
-        events_xml = "#{dir}/webcam-events.xml"
-        start = BigBlueButton::Events.get_start_video_events(events_xml)
-        start.size.should == 2       
-        stop = BigBlueButton::Events.get_stop_video_events(events_xml)
-        stop.size.should == 2
-        matched = BigBlueButton::Events.match_start_and_stop_video_events(start, stop)
-        matched.size.should == 2
-      end
-      
       it "should get the 2 deskshare start events" do
         dir = "resources/raw/974a4b8c-5bf7-4382-b4cd-eb26af7dfcc2"
         events_xml = "#{dir}/events.xml"


### PR DESCRIPTION
The previous code looked for stop events and tried to find their associated start event. This obviously doesn't work if there was no stop event. But if there was a start event, we need to show the deskshare… so rework to code to try to find the matching stop to each start instead, and use the end of the meeting if no matching stop was found.

Fixes #4394 