### PR TITLE
Added indexes for the html5 Mongo collections

### DIFF
--- a/bigbluebutton-html5/imports/api/2.0/annotations/index.js
+++ b/bigbluebutton-html5/imports/api/2.0/annotations/index.js
@@ -1,1 +1,19 @@
-export default new Mongo.Collection('annotations');
+import { Meteor } from 'meteor/meteor';
+
+const Annotations = new Mongo.Collection('annotations');
+
+if (Meteor.isServer) {
+  // types of queries for the annotations:
+  // 1. meetingId, whiteboardId
+  // 2. meetingId, whiteboardId, userId
+  // 3. meetingId, id, userId
+  // 4. meetingId, whiteboardId, id
+  // These 2 indexes seem to cover all of the cases
+  // Either mongo uses a whole or a part of the compound index
+  // Or it uses 'id' and then matches other fields
+
+  Annotations._ensureIndex({ id: 1 });
+  Annotations._ensureIndex({ meetingId: 1, whiteboardId: 1, userId: 1 });
+}
+
+export default Annotations;

--- a/bigbluebutton-html5/imports/api/2.0/breakouts/index.js
+++ b/bigbluebutton-html5/imports/api/2.0/breakouts/index.js
@@ -1,1 +1,14 @@
-export default new Mongo.Collection('breakouts2x');
+import { Meteor } from 'meteor/meteor';
+
+const Breakouts = new Mongo.Collection('breakouts2x');
+
+if (Meteor.isServer) {
+  // types of queries for the breakouts:
+  // 1. breakoutId ( handleJoinUrl, roomStarted, clearBreakouts )
+  // 2. parentMeetingId ( updateTimeRemaining )
+
+  Breakouts._ensureIndex({ breakoutId: 1 });
+  Breakouts._ensureIndex({ parentMeetingId: 1 });
+}
+
+export default Breakouts;

--- a/bigbluebutton-html5/imports/api/2.0/captions/index.js
+++ b/bigbluebutton-html5/imports/api/2.0/captions/index.js
@@ -1,1 +1,14 @@
-export default new Mongo.Collection('captions2x');
+import { Meteor } from 'meteor/meteor';
+
+const Captions = new Mongo.Collection('captions2x');
+
+if (Meteor.isServer) {
+  // types of queries for the captions:
+  // 1. meetingId, locale, 'captionHistory.index' (History)
+  // 2. meetingId, locale (Owner update, Caption update, addCaption)
+  // 3. meetingId ( clear Captions)
+
+  Captions._ensureIndex({ meetingId: 1, locale: 1 });
+}
+
+export default Captions;

--- a/bigbluebutton-html5/imports/api/2.0/chat/index.js
+++ b/bigbluebutton-html5/imports/api/2.0/chat/index.js
@@ -1,1 +1,19 @@
-export default new Mongo.Collection('chat2x');
+import { Meteor } from 'meteor/meteor';
+
+const Chat = new Mongo.Collection('chat2x');
+
+if (Meteor.isServer) {
+  // types of queries for the chat:
+  // 1. meetingId, toUsername (publishers)
+  // 2. meetingId, fromUserId (publishers)
+  // 3. meetingId, toUserId (publishers)
+  // 4. meetingId, fromTime, fromUserId, toUserId (addChat)
+  // 5. meetingId (clearChat)
+  // 6. meetingId, fromUserId, toUserId (clearSystemMessages)
+
+  Chat._ensureIndex({ meetingId: 1, toUsername: 1 });
+  Chat._ensureIndex({ meetingId: 1, fromUserId: 1 });
+  Chat._ensureIndex({ meetingId: 1, toUserId: 1 });
+}
+
+export default Chat;

--- a/bigbluebutton-html5/imports/api/2.0/cursor/index.js
+++ b/bigbluebutton-html5/imports/api/2.0/cursor/index.js
@@ -1,1 +1,13 @@
-export default new Mongo.Collection('cursor2x');
+import { Meteor } from 'meteor/meteor';
+
+const Cursor = new Mongo.Collection('cursor2x');
+
+if (Meteor.isServer) {
+  // types of queries for the cursor:
+  // 1. meetingId (clear)
+  // 2. meetingId, userId
+
+  Cursor._ensureIndex({ meetingId: 1, userId: 1 });
+}
+
+export default Cursor;

--- a/bigbluebutton-html5/imports/api/2.0/meetings/index.js
+++ b/bigbluebutton-html5/imports/api/2.0/meetings/index.js
@@ -1,1 +1,12 @@
-export default new Mongo.Collection('meetings2x');
+import { Meteor } from 'meteor/meteor';
+
+const Meetings = new Mongo.Collection('meetings2x');
+
+if (Meteor.isServer) {
+  // types of queries for the meetings:
+  // 1. meetingId
+
+  Meetings._ensureIndex({ meetingId: 1 });
+}
+
+export default Meetings;

--- a/bigbluebutton-html5/imports/api/2.0/polls/index.js
+++ b/bigbluebutton-html5/imports/api/2.0/polls/index.js
@@ -1,1 +1,12 @@
-export default new Mongo.Collection('polls2x');
+import { Meteor } from 'meteor/meteor';
+
+const Polls = new Mongo.Collection('polls2x');
+
+if (Meteor.isServer) {
+  // We can have just one active poll per meeting
+  // makes no sense to index it by anything other than meetingId
+
+  Polls._ensureIndex({ meetingId: 1 });
+}
+
+export default Polls;

--- a/bigbluebutton-html5/imports/api/2.0/presentations/index.js
+++ b/bigbluebutton-html5/imports/api/2.0/presentations/index.js
@@ -1,1 +1,13 @@
-export default new Mongo.Collection('presentations2x');
+import { Meteor } from 'meteor/meteor';
+
+const Presentations = new Mongo.Collection('presentations2x');
+
+if (Meteor.isServer) {
+  // types of queries for the presentations:
+  // 1. meetingId, id
+  // 2. meetingId
+
+  Presentations._ensureIndex({ meetingId: 1, id: 1 });
+}
+
+export default Presentations;

--- a/bigbluebutton-html5/imports/api/2.0/screenshare/index.js
+++ b/bigbluebutton-html5/imports/api/2.0/screenshare/index.js
@@ -1,1 +1,12 @@
-export default new Mongo.Collection('screenshare');
+import { Meteor } from 'meteor/meteor';
+
+const Screenshare = new Mongo.Collection('screenshare');
+
+if (Meteor.isServer) {
+  // types of queries for the screenshare:
+  // 1. meetingId
+
+  Screenshare._ensureIndex({ meetingId: 1 });
+}
+
+export default Screenshare;

--- a/bigbluebutton-html5/imports/api/2.0/slides/index.js
+++ b/bigbluebutton-html5/imports/api/2.0/slides/index.js
@@ -1,1 +1,14 @@
-export default new Mongo.Collection('slides2x');
+import { Meteor } from 'meteor/meteor';
+
+const Slides = new Mongo.Collection('slides2x');
+
+if (Meteor.isServer) {
+  // types of queries for the slides:
+  // 1. meetingId
+  // 2. meetingId, presentationId
+  // 3. meetingId, presentationId, id
+
+  Slides._ensureIndex({ meetingId: 1, presentationId: 1, id: 1 });
+}
+
+export default Slides;

--- a/bigbluebutton-html5/imports/api/2.0/users/index.js
+++ b/bigbluebutton-html5/imports/api/2.0/users/index.js
@@ -1,1 +1,13 @@
-export default new Mongo.Collection('users2x');
+import { Meteor } from 'meteor/meteor';
+
+const Users = new Mongo.Collection('users2x');
+
+if (Meteor.isServer) {
+  // types of queries for the users:
+  // 1. meetingId
+  // 2. meetingId, userId
+
+  Users._ensureIndex({ meetingId: 1, userId: 1 });
+}
+
+export default Users;

--- a/bigbluebutton-html5/imports/api/2.0/voice-users/index.js
+++ b/bigbluebutton-html5/imports/api/2.0/voice-users/index.js
@@ -1,1 +1,14 @@
-export default new Mongo.Collection('voiceUsers');
+import { Meteor } from 'meteor/meteor';
+
+const VoiceUsers = new Mongo.Collection('voiceUsers');
+
+if (Meteor.isServer) {
+  // types of queries for the voice users:
+  // 1. intId
+  // 2. meetingId, intId
+
+  VoiceUsers._ensureIndex({ intId: 1 });
+  VoiceUsers._ensureIndex({ meetingId: 1, intId: 1 });
+}
+
+export default VoiceUsers;

--- a/bigbluebutton-html5/imports/api/2.0/whiteboard-multi-user/index.js
+++ b/bigbluebutton-html5/imports/api/2.0/whiteboard-multi-user/index.js
@@ -1,1 +1,12 @@
-export default new Mongo.Collection('whiteboard-multi-user');
+import { Meteor } from 'meteor/meteor';
+
+const WhiteboardMultiUser = new Mongo.Collection('whiteboard-multi-user');
+
+if (Meteor.isServer) {
+  // types of queries for the whiteboard-multi-user:
+  // 1. meetingId
+
+  WhiteboardMultiUser._ensureIndex({ meetingId: 1 });
+}
+
+export default WhiteboardMultiUser;


### PR DESCRIPTION
- All of the collections are indexed by `meetingId` (either separately or as a part of the compound index). That speeds up Meteor publishing the data for parallel meetings and cleaning the collections times, depending on the number of parallel meetings we have.

Cases where we need more than one index for the collection:
- Breakouts and VoiceUsers have queries using just `breakoutId` and `intId` accordingly, no `meetingId`, so we have to have a separate index for those cases.
- Chat is indexed by `toUsername`, `fromUserId`, and `toUserId`, as well as `meetingId`, which seems to cover most of the cases with publishing and adding the data.
- Annotations collection has a few different common queries, `id` and `meetingId, whiteboardId, userId` cover all the cases. (see the comments in the code)

Note: There is no need to keep a separate `meetingId` index. If you have 2 indexes, one `meetingId` and second `meetingId, id` and fetch the data by `meetingId` only - Mongo will use a part of the second, compound index, not the first `meetingId` one.