### PR TITLE
[HTML5 Client] Include bowser.js in html5 client for browser detection in webrtc

### DIFF
--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -44,6 +44,7 @@
 </head>
 <body style="background-color: #06172A">
   <div id="app" role="document"></div>
+  <script src="/client/lib/bowser.js"></script>
   <script src="/client/lib/sip.js"></script>
   <script src="/client/lib/bbb_webrtc_bridge_sip.js"></script>
   <script src="/client/lib/bbblogger.js"></script>


### PR DESCRIPTION
In /client/lib/bbb_webrtc_bridge_sip.js we now check for browser type via `bowser`. In order to be able to use `/client/lib/bbb_webrtc_bridge_sip.js` we need to load `bowser.js` too. Without this we cannot join the audio bridge