### PR TITLE
[Flash Client 2.0] Log unnatural end of screenshare

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/ScreensharePublishWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/ScreensharePublishWindow.mxml
@@ -223,6 +223,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
           cancelBtn.visible = cancelBtn.includeInLayout = true;
           startBtn.visible = startBtn.includeInLayout = false;
           stopBtn.visible = stopBtn.includeInLayout = false;
+
+          var logData:Object = UsersUtil.initLogData();
+          logData.reason = event.reason;
+          logData.tags = ["screenshare"];
+          logData.message = "Unnatural end to screenshare";
+          LOGGER.warn(JSON.stringify(logData));
         } else {
           closeWindow();
         }


### PR DESCRIPTION
This log will help us track instances where the screenshare ended/did not work along with the reason for the behavior.