### PR TITLE
HTML5 - fix for the bug with the current Slide being unset

### DIFF
--- a/bigbluebutton-html5/imports/api/2.0/slides/server/modifiers/changeCurrentSlide.js
+++ b/bigbluebutton-html5/imports/api/2.0/slides/server/modifiers/changeCurrentSlide.js
@@ -47,7 +47,7 @@ export default function changeCurrentSlide(meetingId, presentationId, slideId) {
   const newSlide = Slides.findOne(newCurrent.selector);
 
   // if the oldCurrent and newCurrent have the same ids
-  if ((oldSlide && newSlide) && (oldSlide._id === newSlide._id)) {
+  if (oldSlide && newSlide && (oldSlide._id === newSlide._id)) {
     return;
   }
 

--- a/bigbluebutton-html5/imports/api/2.0/slides/server/modifiers/changeCurrentSlide.js
+++ b/bigbluebutton-html5/imports/api/2.0/slides/server/modifiers/changeCurrentSlide.js
@@ -46,6 +46,11 @@ export default function changeCurrentSlide(meetingId, presentationId, slideId) {
   const oldSlide = Slides.findOne(oldCurrent.selector);
   const newSlide = Slides.findOne(newCurrent.selector);
 
+  // if the oldCurrent and newCurrent have the same ids
+  if ((oldSlide && newSlide) && (oldSlide._id === newSlide._id)) {
+    return;
+  }
+
   if (newSlide) {
     Slides.update(newSlide._id, newCurrent.modifier, newCurrent.callback);
   }


### PR DESCRIPTION
Our current algorithm for changing the slide is simple:
1. Fetch an old slide based on the property `current: true`
2. Fetch a new slide based on the received `id`.
3. Update the new slide object with the `current: true`
4. Update the old slide object with the `current: false`.

The problem is when you have high latency or just click very fast - you can easily send 2 requests with the same slide id. And after the first request is processed we receive the second one. Following our algorithm we fetch old and new slides, but that's the same object. So we set the slide to `current: true`, and then set exactly the same object to `current: false`. And the slide just disappears from the html5 client, as if there is no presentation.

Added a check to prevent that scenario.