### PR TITLE
[HTML5] - logoutRouteHandler Fix

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/auth.js
+++ b/bigbluebutton-html5/imports/startup/client/auth.js
@@ -29,15 +29,14 @@ export function joinRouteHandler(nextState, replace, callback) {
 
 export function logoutRouteHandler(nextState, replace, callback) {
   Auth.logout()
-    .then((logoutURL) => {
-      let formattedURL;
+    .then((logoutURL = window.location.origin) => {
       const protocolPattern = /^((http|https):\/\/)/;
 
-      if (!protocolPattern.test(logoutURL)) {
-        formattedURL = `http://${logoutURL}`;
-      }
+      window.location.href =
+        protocolPattern.test(logoutURL) ?
+          logoutURL :
+          `http://${logoutURL}`;
 
-      window.location.href = formattedURL || window.location.origin;
       callback();
     })
     .catch(() => {

--- a/bigbluebutton-html5/imports/startup/client/auth.js
+++ b/bigbluebutton-html5/imports/startup/client/auth.js
@@ -30,7 +30,14 @@ export function joinRouteHandler(nextState, replace, callback) {
 export function logoutRouteHandler(nextState, replace, callback) {
   Auth.logout()
     .then((logoutURL) => {
-      window.location = logoutURL || window.location.origin;
+      let formattedURL;
+      const protocolPattern = /^((http|https):\/\/)/;
+
+      if (!protocolPattern.test(logoutURL)) {
+        formattedURL = `http://${logoutURL}`;
+      }
+
+      window.location.href = formattedURL || window.location.origin;
       callback();
     })
     .catch(() => {

--- a/bigbluebutton-html5/imports/startup/client/auth.js
+++ b/bigbluebutton-html5/imports/startup/client/auth.js
@@ -27,7 +27,7 @@ export function joinRouteHandler(nextState, replace, callback) {
     });
 }
 
-export function logoutRouteHandler(nextState, replace, callback) {
+export function logoutRouteHandler(nextState, replace) {
   Auth.logout()
     .then((logoutURL = window.location.origin) => {
       const protocolPattern = /^((http|https):\/\/)/;
@@ -36,12 +36,9 @@ export function logoutRouteHandler(nextState, replace, callback) {
         protocolPattern.test(logoutURL) ?
           logoutURL :
           `http://${logoutURL}`;
-
-      callback();
     })
     .catch(() => {
       replace({ pathname: '/error/500' });
-      callback();
     });
 }
 


### PR DESCRIPTION
Checks to see if the provided logoutURL string has http or https. If it doesn't we add and set window.location.href to the newly formatted URL string.

The bug was a result of setting window.location, which appended the logoutURL to the main application URL instead of replacing it.