### PR TITLE
[Flash Client 2.0] Add log for invalid or failed presentation conversion

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/FileUploadWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/FileUploadWindow.mxml
@@ -243,14 +243,26 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       }
 
       private function handleOfficeDocumentConversionFailed(e:OfficeDocConvertFailedEvent):void {
+        var logData:Object = UsersUtil.initLogData();
+        logData.tags = ["presentation-conversion"];
+        logData.filename = fileToUpload.name;
+        logData.message = "Presentation conversion failed";
+        LOGGER.warn(JSON.stringify(logData));
+
         enableClosing();
         displayAlert(ResourceUtil.getInstance().getString('bbb.presentation.error.document.convert.failed'));
       }
-		
-		private function handleOfficeDocumentConversionInvalid(e:OfficeDocConvertInvalidEvent):void {
-			enableClosing();
-			displayAlert(ResourceUtil.getInstance().getString('bbb.presentation.error.document.convert.invalid'));
-		}
+
+      private function handleOfficeDocumentConversionInvalid(e:OfficeDocConvertInvalidEvent):void {
+        var logData:Object = UsersUtil.initLogData();
+        logData.tags = ["presentation-conversion"];
+        logData.filename = fileToUpload.name;
+        logData.message = "Presentation conversion invalid";
+        LOGGER.warn(JSON.stringify(logData));
+
+        enableClosing();
+        displayAlert(ResourceUtil.getInstance().getString('bbb.presentation.error.document.convert.failed'));
+      }
 
       private function handleOfficeDocumentConversionSuccess(e:OfficeDocConvertSuccessEvent):void {
 		buildProgressLabel(ResourceUtil.getInstance().getString('bbb.presentation.document.converted'));


### PR DESCRIPTION
These logs will help identifying presentation conversion issues

Note, the label switch from 'invalid' to 'failed' is intentional - we want to have the same user-facing message