### PR TITLE
Don't crash playback if text is not available for a slide.

### DIFF
--- a/record-and-playback/presentation/playback/presentation/0.9.0/lib/writing.js
+++ b/record-and-playback/presentation/playback/presentation/0.9.0/lib/writing.js
@@ -782,7 +782,11 @@ function setPresentationTextFromJSON(images, presentationText) {
       var imgTxt = images[m].getAttribute("text").split("/"); // Text format: presentation/PRESENTATION_ID/textfiles/SLIDE_ID.txt
       var presentationId = imgTxt[1];
       var slideId = imgTxt[3].split(".")[0];
-      slidePlainText[imgId] = $('<div/>').text(presentationText[presentationId][slideId]).html();
+      if (presentationText[presentationId] && presentationText[presentationId][slideId]) {
+        slidePlainText[imgId] = $('<div/>').text(presentationText[presentationId][slideId]).html();
+      } else {
+        slidePlainText[imgId] = $('<div/>')
+      }
     }
   }
 }

--- a/record-and-playback/presentation/playback/presentation/2.0/lib/writing.js
+++ b/record-and-playback/presentation/playback/presentation/2.0/lib/writing.js
@@ -754,7 +754,11 @@ function setPresentationTextFromJSON(images, presentationText) {
       var imgTxt = images[m].getAttribute("text").split("/"); // Text format: presentation/PRESENTATION_ID/textfiles/SLIDE_ID.txt
       var presentationId = imgTxt[1];
       var slideId = imgTxt[3].split(".")[0];
-      slidePlainText[imgId] = $('<div/>').text(presentationText[presentationId][slideId]).html();
+      if (presentationText[presentationId] && presentationText[presentationId][slideId]) {
+        slidePlainText[imgId] = $('<div/>').text(presentationText[presentationId][slideId]).html();
+      } else {
+        slidePlainText[imgId] = $('<div/>')
+      }
     }
   }
 }


### PR DESCRIPTION
This happens when the slide is a plain image, for example.
Fixes #4425