### PR TITLE
[HTML5] Avatar indicator bug's

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-avatar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-avatar/component.jsx
@@ -43,7 +43,7 @@ const UserAvatar = ({
       [styles.presenter]: presenter,
       [styles.muted]: muted,
       [styles.listenOnly]: listenOnly,
-      [styles.talking]: talking,
+      [styles.talking]: (talking && !muted),
       [styles.voice]: voice,
     }, className)}
     style={{

--- a/bigbluebutton-html5/imports/ui/services/user/mapUser.js
+++ b/bigbluebutton-html5/imports/ui/services/user/mapUser.js
@@ -22,7 +22,7 @@ const mapUser = (user) => {
     isPresenter: user.presenter,
     isModerator: user.role === ROLE_MODERATOR,
     isCurrent: user.userId === userId,
-    isVoiceUser: !!voiceUser,
+    isVoiceUser: voiceUser.joined,
     isMuted: voiceUser ? voiceUser.muted : false,
     isTalking: voiceUser ? voiceUser.talking : false,
     isListenOnly: voiceUser ? voiceUser.listenOnly : false,


### PR DESCRIPTION
this will fix 2 bugs,

1) the user-list-item's avatar displaying the voice -user indicator icon for all user.

2) when a voice-user is talking, a ring around the avatar is rendered. If the voice-user is muted while talking, the isTalking ring indicator stays rendered to the screen; instead of disappearing.