### PR TITLE
Welcome msg-drop location of phone icon so it applies to both html5 and flash clients

### DIFF
--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -109,7 +109,7 @@ defaultGuestPolicy=ASK_MODERATOR
 #
 # native2ascii -encoding UTF8 bigbluebutton.properties bigbluebutton.properties
 #
-defaultWelcomeMessage=<br>Welcome to <b>%%CONFNAME%%</b>!<br><br>For help on using BigBlueButton see these (short) <a href="event:http://www.bigbluebutton.org/content/videos"><u>tutorial videos</u></a>.<br><br>To join the audio bridge click the phone button (top center of screen).  Use a headset to avoid causing background noise for others.<br>
+defaultWelcomeMessage=<br>Welcome to <b>%%CONFNAME%%</b>!<br><br>For help on using BigBlueButton see these (short) <a href="event:http://www.bigbluebutton.org/content/videos"><u>tutorial videos</u></a>.<br><br>To join the audio bridge click the phone button.  Use a headset to avoid causing background noise for others.<br>
 defaultWelcomeMessageFooter=This server is running <a href="http://docs.bigbluebutton.org/" target="_blank"><u>BigBlueButton</u></a>.
 
 # Default maximum number of users a meeting can have.


### PR DESCRIPTION
In HTML5 client the phone icon is not in `top center of screen` so the welcome message is confusing. Making it more generic allows the HTML5 client to reuse the message as is.