### PR TITLE
HTML5 - Fix for an incorrectly displayed pop-up in the UserList

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
@@ -96,6 +96,12 @@ const intlMessages = defineMessages({
 
 class UserParticipants extends Component {
 
+  constructor() {
+    super();
+
+    this.getScrollContainerRef = this.getScrollContainerRef.bind(this);
+  }
+
   componentDidMount() {
     if (!this.props.compact) {
       this._usersList.addEventListener('keydown',
@@ -104,6 +110,10 @@ class UserParticipants extends Component {
           this._userItems,
           this.props.users.length));
     }
+  }
+
+  getScrollContainerRef() {
+    return this.refScrollContainer;
   }
 
   render() {
@@ -169,7 +179,10 @@ class UserParticipants extends Component {
       };
 
     return (
-      <div className={styles.participants}>
+      <div
+        className={styles.participants}
+        ref={(ref) => { if (ref != null) { this.refScrollContainer = ref; } }}
+      >
         {
           !compact ?
             <div className={styles.smallTitle} role="banner">
@@ -208,6 +221,7 @@ class UserParticipants extends Component {
                     getAvailableActions={getAvailableActions}
                     normalizeEmojiName={normalizeEmojiName}
                     isMeetingLocked={isMeetingLocked}
+                    getScrollContainerRef={this.getScrollContainerRef}
                   />
                 ))
               }

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
@@ -30,6 +30,7 @@ const propTypes = {
   meeting: PropTypes.shape({}).isRequired,
   isMeetingLocked: PropTypes.func.isRequired,
   normalizeEmojiName: PropTypes.func.isRequired,
+  getScrollContainerRef: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
@@ -105,6 +106,7 @@ class UserListItem extends Component {
       meeting,
       isMeetingLocked,
       normalizeEmojiName,
+      getScrollContainerRef,
     } = this.props;
 
     const actions = this.getUsersActions();
@@ -117,6 +119,7 @@ class UserListItem extends Component {
       actions={actions}
       meeting={meeting}
       isMeetingLocked={isMeetingLocked}
+      getScrollContainerRef={getScrollContainerRef}
     />);
 
     return contents;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
@@ -52,6 +52,7 @@ const propTypes = {
   actions: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   meeting: PropTypes.shape({}).isRequired,
   isMeetingLocked: PropTypes.func.isRequired,
+  getScrollContainerRef: PropTypes.func.isRequired,
 };
 
 
@@ -90,7 +91,7 @@ class UserListContent extends Component {
 
   onActionsShow() {
     const dropdown = findDOMNode(this.dropdown);
-    const scrollContainer = dropdown.parentElement.parentElement;
+    const scrollContainer = this.props.getScrollContainerRef();
     const dropdownTrigger = dropdown.children[0];
 
     this.setState({
@@ -109,7 +110,8 @@ class UserListContent extends Component {
       dropdownVisible: false,
     });
 
-    findDOMNode(this).parentElement.removeEventListener('scroll', this.handleScroll, false);
+    const scrollContainer = this.props.getScrollContainerRef();
+    scrollContainer.removeEventListener('scroll', this.handleScroll, false);
   }
 
   getDropdownMenuParent() {
@@ -131,7 +133,7 @@ class UserListContent extends Component {
       const dropdownTrigger = dropdown.children[0];
       const dropdownContent = dropdown.children[1];
 
-      const scrollContainer = dropdown.parentElement.parentElement;
+      const scrollContainer = this.props.getScrollContainerRef();
 
       const nextState = {
         dropdownVisible: true,


### PR DESCRIPTION
The reference for the scrollContainer changed and as a result the value of the scrollContainer.scrollTop was always 0, which in its turn was breaking the Dropdown offset calculations.
Passed a callback with the ref of the scrollContainer instead of using `parentElement`.