### PR TITLE
[HTML5] Fix for the default locale in the Settings modal's selector (a.k.a. "Bulgarian bug").

### DIFF
--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -21,7 +21,7 @@ WebApp.connectHandlers.use('/check', (req, res, next) => {
 
 WebApp.connectHandlers.use('/locale', (req, res) => {
   const APP_CONFIG = Meteor.settings.public.app;
-  const defaultLocale = APP_CONFIG.defaultLocale;
+  const defaultLocale = APP_CONFIG.defaultSettings.application.locale;
   const localeRegion = req.query.locale.split('-');
   let messages = {};
   const locales = [defaultLocale, localeRegion[0]];

--- a/bigbluebutton-html5/private/config/public/app.yaml
+++ b/bigbluebutton-html5/private/config/public/app.yaml
@@ -13,10 +13,10 @@ app:
   skipCheck: false
 
   # Default global variables
-  appName: "BigBlueButton HTML5 Client"
-  bbbServerVersion: "1.1-beta"
-  copyright: "©2017 BigBlueButton Inc."
-  html5ClientBuild: "HTML5_CLIENT_VERSION"
+  appName: 'BigBlueButton HTML5 Client'
+  bbbServerVersion: '1.1-beta'
+  copyright: '©2017 BigBlueButton Inc.'
+  html5ClientBuild: 'HTML5_CLIENT_VERSION'
   lockOnJoin: true
 
   # Name displayed in the brower URL
@@ -27,18 +27,18 @@ app:
     application:
       chatAudioNotifications: false
       chatPushNotifications: false
-      fontSize: "16px"
-      locale: "en"
+      fontSize: '16px'
+      locale: 'en'
     audio:
       inputDeviceId: undefined
       outputDeviceId: undefined
     video:
       viewParticipantsWebcams: true
     cc:
-      backgroundColor: "#FFFFFF"
-      fontColor: "#000000"
+      backgroundColor: '#FFFFFF'
+      fontColor: '#000000'
       enabled: false
-      fontFamily: "Calibri"
+      fontFamily: 'Calibri'
       fontSize: '16px'
       # locale: undefined
       takeOwnership: false

--- a/bigbluebutton-html5/private/config/public/app.yaml
+++ b/bigbluebutton-html5/private/config/public/app.yaml
@@ -22,13 +22,13 @@ app:
   # Name displayed in the brower URL
   basename: '/html5client'
 
-  defaultLocale: 'en'
   #default settings for session storage
   defaultSettings:
     application:
       chatAudioNotifications: false
       chatPushNotifications: false
       fontSize: "16px"
+      locale: "en"
     audio:
       inputDeviceId: undefined
       outputDeviceId: undefined


### PR DESCRIPTION
This PR makes sure the Settings modal uses the system's default locale. It also moves the `locale` setting under the `defaultSettings` in `app.yaml`.