### PR TITLE
Fix whiteboard click through

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardCanvas.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardCanvas.as
@@ -76,6 +76,7 @@ package org.bigbluebutton.modules.whiteboard.views {
 			whiteboardToolbar.whiteboardAccessModified(wbModel.multiUser);
 			
 			this.clipContent = true;
+			this.mouseEnabled = false;
 			
 			//create the annotation display container
 			this.addChild(graphicObjectHolder);
@@ -119,12 +120,14 @@ package org.bigbluebutton.modules.whiteboard.views {
 			addEventListener(MouseEvent.MOUSE_DOWN, doMouseDown);
 			addEventListener(MouseEvent.MOUSE_OVER, onMouseOver);
 			addEventListener(MouseEvent.MOUSE_OUT, onMouseOut);
+			mouseEnabled = true;
 		}
 		
 		private function unregisterForMouseEvents():void {
 			removeEventListener(MouseEvent.MOUSE_DOWN, doMouseDown);
 			removeEventListener(MouseEvent.MOUSE_OVER, onMouseOver);
 			removeEventListener(MouseEvent.MOUSE_OUT, onMouseOut);
+			mouseEnabled = false;
 		}
 		
 		private function doMouseUp(event:MouseEvent):void {


### PR DESCRIPTION
In 2.0 the whiteboard was heavily modified and it stopped clicking through annotations or cursors even without a whiteboard tool selected. This PR makes sure that the whiteboard is always click through when it should be.