### PR TITLE
[HTML5 Client] Fix for locales containing `_`

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -116,6 +116,11 @@ class ApplicationMenu extends BaseMenu {
     this.handleUpdateSettings('application', obj.settings);
   }
 
+  // Adjust the locale format to be able to display the locale names properly in the client
+  formatLocale(locale) {
+    return locale.split('-').map((val, idx) => (idx == 1 ? val.toUpperCase() : val)).join('_');
+  }
+
   render() {
     const {
       availableLocales,
@@ -182,7 +187,7 @@ class ApplicationMenu extends BaseMenu {
             <div className={styles.col}>
                 <label aria-labelledby="changeLangLabel" className={cx(styles.formElement, styles.pullContentRight)}>
                   <select
-                    defaultValue={this.state.settings.locale}
+                    defaultValue={this.formatLocale(this.state.settings.locale)}
                     className={styles.select}
                     onChange={this.handleSelectChange.bind(this, 'locale', availableLocales)}
                   >


### PR DESCRIPTION
This PR fixes the issue with the locale names that contain `_`: they were not able to change properly and, as a result, such locale names were not properly displayed in the Settings modal when shown as current language. Basically, we had formatting from `es-es` to `es_ES`, but didn't do it another way around when needed.