### PR TITLE
Handle out of order inserts at the start of a caption stream.

### DIFF
--- a/record-and-playback/core/scripts/utils/gen_webvtt
+++ b/record-and-playback/core/scripts/utils/gen_webvtt
@@ -72,8 +72,11 @@ class Caption:
 
             if i < len(self.timestamps) and timestamp > self.timestamps[i]:
                 timestamp = self._del_timestamps[i]
-                if timestamp is None and i > 0:
-                    timestamp = self.timestamps[i-1]
+                if timestamp is None:
+                    if i > 0:
+                        timestamp = self.timestamps[i-1]
+                    else:
+                        timestamp = self.timestamps[i]
                 logger.debug("Out of order timestamps, using ts: %d", timestamp)
 
         self._del_timestamps[i:j] = [del_timestamp] * len(text)


### PR DESCRIPTION
If you're inserting at position 0 (and there was no previous deleted text
from that position), you can't use the timestamp from the previous character
position, since there's no previous character. Use the timestamp of the
following character instead.