### PR TITLE
Fix user avatar image sizing

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/UserAvatar.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/UserAvatar.as
@@ -3,6 +3,8 @@ package org.bigbluebutton.modules.videoconf.views
     import flash.display.Loader;
     import flash.events.Event;
     import flash.net.URLRequest;
+    
+    import mx.core.UIComponent;
 
     public class UserAvatar extends UserGraphic {
 
@@ -18,14 +20,17 @@ package org.bigbluebutton.modules.videoconf.views
           _completed = false;
 
           _imageLoader.contentLoaderInfo.addEventListener(Event.COMPLETE, onLoadingComplete);
-          addChild(_imageLoader);
+          
           var request:URLRequest = new URLRequest(avatarUrl);
           _imageLoader.load(request);
       }
 
       private function onLoadingComplete(event:Event):void {
           _completed = true;
+          addChild(_imageLoader);
           setOriginalDimensions(_imageLoader.width, _imageLoader.height);
+          if (parent && parent is UIComponent) 
+            UIComponent(parent).invalidateDisplayList();
       }
 
       override protected function updateDisplayList(unscaledWidth:Number, unscaledHeight:Number):void {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/UserGraphic.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/UserGraphic.as
@@ -62,12 +62,12 @@ package org.bigbluebutton.modules.videoconf.views
                 object_height = unscaledHeight;
                 object_width = Math.ceil(unscaledHeight * aspectRatio);
                 object_y = BORDER_THICKNESS;
-                object_x = Math.floor((unscaledWidth - object.width) / 2);
+                object_x = Math.floor((unscaledWidth - object_width) / 2);
             } else {
                 object_width = unscaledWidth;
                 object_height = Math.ceil(unscaledWidth / aspectRatio);
                 object_x = BORDER_THICKNESS;
-                object_y = Math.floor((unscaledHeight - object.height) / 2);
+                object_y = Math.floor((unscaledHeight - object_height) / 2);
             }
 
             object.x = object_x;


### PR DESCRIPTION
There were two issues with the User Avatar sizing. The first issue is that the video dock doesn't know the size of the image before loading so the aspect ratio of the latest avatar was always incorrect. I've added a call to invalidate the Video Dock container size once the image is loaded and the dimensions are known so the correct values are picked up. The second issue was that sizing for the inner object (image or webcam) was calculating the x or y values with the inner object's width or height instead of the new width or height. Using the wrong property resulted in the inner object always having it's position a little off. I've switched the algorithm to use the new value instead of the old one and it has fixed the positioning issue.

Relevant issues are #3605 and #3770.