### PR TITLE
[Flash 2.0] - Display join audio window if back from breakout room.

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/core/model/Me.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/model/Me.as
@@ -52,7 +52,8 @@ package org.bigbluebutton.core.model
     public var authTokenValid: Boolean = false;
     public var waitingForApproval: Boolean;
     
-    
+	public var breakoutEjectFromAudio : Boolean = false;
+	
     private var _role:String =  "viewer";   
     public function get role():String {
       return _role.toUpperCase();
@@ -84,7 +85,7 @@ package org.bigbluebutton.core.model
     public function myCamSettings():ArrayCollection {
       return _myCamSettings;
     }
-    
+	
     public function applyLockSettings():void {
       var lockSettings:LockSettingsVO = UsersUtil.getLockSettings();
       var amNotModerator:Boolean = !UsersUtil.amIModerator();

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/BreakoutRoom.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/BreakoutRoom.as
@@ -61,6 +61,15 @@ package org.bigbluebutton.main.model.users {
       removeUser(user.id);
       users.addItem(user);
     }
+	
+	public function hasUserWithId(userId:String) : Boolean {
+		for (var i : int = 0; i < users.length; i++) {
+			if (BreakoutUser(users.getItemAt(i)).id.indexOf(userId) > -1 ) {
+				return true;
+			}
+		}
+		return false;
+	}
     
     public function removeUser(id: String): void {
       for (var i: int = 0; i < users.length; i++) {

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
@@ -150,10 +150,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.modules.phone.events.WebRTCEchoTestEvent;
 			import org.bigbluebutton.modules.phone.events.WebRTCMediaEvent;
 			import org.bigbluebutton.modules.phone.models.PhoneOptions;
-			import org.bigbluebutton.util.browser.BrowserCheck;
 			import org.bigbluebutton.modules.users.model.UsersOptions;
 			import org.bigbluebutton.modules.users.views.BreakoutRoomSettings;
 			import org.bigbluebutton.modules.videoconf.events.ShareCameraRequestEvent;
+			import org.bigbluebutton.util.browser.BrowserCheck;
 			import org.bigbluebutton.util.i18n.ResourceUtil;
 			
 			private static const LOGGER:ILogger = getClassLogger(MainApplicationShell);      

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/phone/views/components/ToolbarButton.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/phone/views/components/ToolbarButton.mxml
@@ -113,6 +113,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 
 			private function joinAudio():void {
+				LiveMeeting.inst().me.breakoutEjectFromAudio = false;
 
 				if (phoneOptions.skipCheck || disableMyMic || defaultListenOnlyMode) {
 					var command:JoinVoiceConferenceCommand = new JoinVoiceConferenceCommand();

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
@@ -812,7 +812,10 @@ package org.bigbluebutton.modules.users.services
       var breakoutId: String = body.breakoutId as String;
       
 	  // Display audio join window
-	  if (LiveMeeting.inst().me.breakoutEjectFromAudio && LiveMeeting.inst().breakoutRooms.getBreakoutRoom(breakoutId).hasUserWithId(LiveMeeting.inst().me.id)) {
+	  if (LiveMeeting.inst().me.breakoutEjectFromAudio &&
+		  LiveMeeting.inst().breakoutRooms.getBreakoutRoom(breakoutId).hasUserWithId(LiveMeeting.inst().me.id) &&
+		  !LiveMeeting.inst().me.inVoiceConf
+	  ) {
 	  	  LiveMeeting.inst().me.breakoutEjectFromAudio = false;
 		  dispatcher.dispatchEvent(new AudioSelectionWindowEvent(AudioSelectionWindowEvent.SHOW_AUDIO_SELECTION));
 	  }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
@@ -51,6 +51,7 @@ package org.bigbluebutton.modules.users.services
   import org.bigbluebutton.main.model.users.events.ChangeMyRole;
   import org.bigbluebutton.main.model.users.events.StreamStartedEvent;
   import org.bigbluebutton.main.model.users.events.StreamStoppedEvent;
+  import org.bigbluebutton.modules.phone.events.AudioSelectionWindowEvent;
   import org.bigbluebutton.modules.screenshare.events.WebRTCViewStreamEvent;
   import org.bigbluebutton.modules.users.events.MeetingMutedEvent;
   
@@ -810,6 +811,12 @@ package org.bigbluebutton.modules.users.services
       var body: Object = msg.body as Object;
       var breakoutId: String = body.breakoutId as String;
       
+	  // Display audio join window
+	  if (LiveMeeting.inst().me.breakoutEjectFromAudio && LiveMeeting.inst().breakoutRooms.getBreakoutRoom(breakoutId).hasUserWithId(LiveMeeting.inst().me.id)) {
+	  	  LiveMeeting.inst().me.breakoutEjectFromAudio = false;
+		  dispatcher.dispatchEvent(new AudioSelectionWindowEvent(AudioSelectionWindowEvent.SHOW_AUDIO_SELECTION));
+	  }
+	  
       switchUserFromBreakoutToMainVoiceConf(breakoutId);
       var breakoutRoom: BreakoutRoom = LiveMeeting.inst().breakoutRooms.getBreakoutRoom(breakoutId);
       LiveMeeting.inst().breakoutRooms.removeBreakoutRoom(breakoutId);

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/JoinBreakoutRoomWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/JoinBreakoutRoomWindow.mxml
@@ -31,10 +31,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	<fx:Script>
 		<![CDATA[
 			import com.asfusion.mate.events.Dispatcher;
-
+			
 			import flash.net.navigateToURL;
-
+			
 			import org.bigbluebutton.core.PopUpUtil;
+			import org.bigbluebutton.core.model.LiveMeeting;
 			import org.bigbluebutton.modules.phone.events.LeaveVoiceConferenceCommand;
 			import org.bigbluebutton.modules.videoconf.events.StopBroadcastEvent;
 			import org.bigbluebutton.util.i18n.ResourceUtil;
@@ -49,6 +50,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 
 			protected function joinButtonClickHandler(event:MouseEvent):void {
+				if (LiveMeeting.inst().me.inVoiceConf) {
+					LiveMeeting.inst().me.breakoutEjectFromAudio = true;
+				} else {
+					LiveMeeting.inst().me.breakoutEjectFromAudio = false;
+
+				}
 				dispatcher.dispatchEvent(new LeaveVoiceConferenceCommand());
 				dispatcher.dispatchEvent(new StopBroadcastEvent());
 				navigateToURL(new URLRequest(this.joinUrl), "_blank");


### PR DESCRIPTION
If the user was disconnected from Audio to join a breakout room, the audio selection window is displayed once the user is back to the main room.