### PR TITLE
Remove auto-join voice handler on auto-reconnect

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingAfterReconnectReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingAfterReconnectReqMsgHdlr.scala
@@ -14,20 +14,24 @@ trait UserJoinMeetingAfterReconnectReqMsgHdlr extends HandlerHelpers with Breako
   val outGW: OutMsgRouter
 
   def handleUserJoinMeetingAfterReconnectReqMsg(msg: UserJoinMeetingAfterReconnectReqMsg, state: MeetingState2x): MeetingState2x = {
-    val newState = userJoinMeeting(outGW, msg.body.authToken, liveMeeting, state)
+    /**
+     * val newState = userJoinMeeting(outGW, msg.body.authToken, liveMeeting, state)
+     *
+     * if (liveMeeting.props.meetingProp.isBreakout) {
+     * updateParentMeetingWithUsers()
+     * }
+     *
+     * // recover voice user
+     * for {
+     * vu <- VoiceUsers.recoverVoiceUser(liveMeeting.voiceUsers, msg.body.userId)
+     * } yield {
+     * handleUserJoinedVoiceConfEvtMsg(liveMeeting.props.voiceProp.voiceConf, vu.intId, vu.voiceUserId, vu.callingWith, vu.callerName, vu.callerNum, vu.muted, vu.talking)
+     * }
+     *
+     * newState
+     */
 
-    if (liveMeeting.props.meetingProp.isBreakout) {
-      updateParentMeetingWithUsers()
-    }
-
-    // recover voice user
-    for {
-      vu <- VoiceUsers.recoverVoiceUser(liveMeeting.voiceUsers, msg.body.userId)
-    } yield {
-      handleUserJoinedVoiceConfEvtMsg(liveMeeting.props.voiceProp.voiceConf, vu.intId, vu.voiceUserId, vu.callingWith, vu.callerName, vu.callerNum, vu.muted, vu.talking)
-    }
-
-    newState
+    state
   }
 
 }


### PR DESCRIPTION
I think the issue the code removed was trying to fix has been fixed in another commit.

The issue was https://github.com/bigbluebutton/bigbluebutton/issues/4229

The commit is 

https://github.com/bigbluebutton/bigbluebutton/commit/a6fb90e9c8f7647f35fdc1215040b37ae7cfbb02#diff-b0f61d648e5756b5fe9065652166bb9c

