### PR TITLE
Fix exception when the PollingModule is commented out

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -161,7 +161,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private function onCreationComplete():void{
 				//check for the polling module in config.xml
 				var vxml:XML = BBB.getConfigForModule("PollingModule");
-				if (vxml == null) navigationControls.removeChild(pollStartBtn);
+				if (vxml == null) fileAndPollControls.removeChild(pollStartBtn);
 				
 				setControlBarState("presenter");
 				


### PR DESCRIPTION
The parent of the pollStartBtn was changed and when the PollingModule was commented out the attempt to hide the pollStartBtn threw an exception.

The issue was reported here, https://groups.google.com/forum/?fromgroups=#!topic/bigbluebutton-dev/IR6M4-JiBbI