### PR TITLE
Relax presentation resize bounds to accommodate fit-to-width

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentation/PresentationApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentation/PresentationApp2x.scala
@@ -64,8 +64,8 @@ class PresentationApp2x(
     // Force coordinate that are out-of-bounds inside valid values
     // 0.25D is 400% zoom
     // 100D-checkedWidth is the maximum the page can be moved over
-    val checkedWidth = Math.min(Math.max(widthRatio, 25D), 100D) //if (widthRatio <= 100D) widthRatio else 100D
-    val checkedHeight = Math.min(Math.max(heightRatio, 25D), 100D)
+    val checkedWidth = Math.min(widthRatio, 100D) //if (widthRatio <= 100D) widthRatio else 100D
+    val checkedHeight = Math.min(heightRatio, 100D)
     val checkedXOffset = Math.min(xOffset, 0D)
     val checkedYOffset = Math.min(yOffset, 0D)
 


### PR DESCRIPTION
I had put in bounds checks for the presentation resize values and they work fine with fit-to-page because the width and height values should always be between the same values (100% - 25%). With fit-to-width though the height can be much smaller than 25% so I've just removed the lower bounds checks altogether.