### PR TITLE
Changed the layout module to use custom names instead of the class name

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/common/IBbbModuleWindow.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/common/IBbbModuleWindow.as
@@ -37,5 +37,10 @@ package org.bigbluebutton.common
 		 * 
 		 */		
 		function getPrefferedPosition():String;
+		
+		/**
+		 * Returns an indentifier to be used by the LayoutModule to position the window.
+		 */
+		function getName():String;
 	}
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/NetworkStatsWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/NetworkStatsWindow.mxml
@@ -75,6 +75,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			public function getPrefferedPosition():String {
 				return MainCanvas.ABSOLUTE;
 			}
+			
+			public function getName():String {
+				return "NetworkStatsWindow";
+			}
 
 			private function onResize():void {}
 

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/broadcast/views/BroadcastWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/broadcast/views/BroadcastWindow.mxml
@@ -119,6 +119,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			public function getPrefferedPosition():String {	
 				return options.position;
 			}
+			
+			public function getName():String {
+				return "BroadcastWindow";
+			}
             
       private function onResize():void {
         if (curStream != null && createComplete) {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/caption/views/CaptionWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/caption/views/CaptionWindow.mxml
@@ -126,6 +126,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				return MainCanvas.POPUP;
 			}
 			
+			public function getName():String {
+				return "CaptionWindow";
+			}
+			
 			private function optionChange(type:int, val:Object):void {
 				switch (type) {
 					case OptionENUM.LOCALE:

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatWindow.mxml
@@ -75,6 +75,14 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         return _windowId;
       }
       
+      public function getPrefferedPosition():String {
+        return MainCanvas.TOP_RIGHT;
+      }
+      
+      public function getName():String {
+        return _windowId;
+	  }
+      
       public function setMainChatId(chatId: String):void {
         _mainChatId = chatId;
       }
@@ -82,10 +90,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       public function setOpenAddTabBox(open:Boolean):void {
         _openAddTabBox = open;
       }
-      
-      public function getPrefferedPosition():String{
-        return MainCanvas.TOP_RIGHT;
-      } 
       
       private function onCreationComplete():void {
         hotkeyCapture();

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/example/ExampleChatWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/example/ExampleChatWindow.mxml
@@ -55,6 +55,10 @@ Notes.mxml is the main view of the SharedNotes application
 				return MainCanvas.POPUP;
 			}
 			
+			public function getName():String {
+				return "ExampleChatWindow";
+			}
+			
 		]]>
 	</fx:Script>
 	

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/layout/model/WindowLayout.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/layout/model/WindowLayout.as
@@ -20,16 +20,17 @@ package org.bigbluebutton.modules.layout.model {
 	import flash.geom.Rectangle;
 	import flash.utils.getQualifiedClassName;
 	
+	import flexlib.mdi.containers.MDICanvas;
+	import flexlib.mdi.containers.MDIWindow;
+	
 	import mx.effects.Move;
 	import mx.effects.Parallel;
 	import mx.effects.Resize;
 	import mx.events.EffectEvent;
 	
-	import flexlib.mdi.containers.MDICanvas;
-	import flexlib.mdi.containers.MDIWindow;
-	
 	import org.as3commons.logging.api.ILogger;
 	import org.as3commons.logging.api.getClassLogger;
+	import org.bigbluebutton.common.IBbbModuleWindow;
 	import org.bigbluebutton.modules.layout.managers.OrderManager;
 
 	public class WindowLayout {
@@ -139,7 +140,6 @@ package org.bigbluebutton.modules.layout.model {
 			var newX:int = Math.floor(this.x * canvas.width);
 			var newY:int = Math.floor(this.y * canvas.height);
 			var newWindowRect:Rectangle = new Rectangle(newX, newY, newWidth, newHeight);
-			var type:String = getType(window);
 
 			window.visible = !this.hidden;
 
@@ -229,8 +229,8 @@ package org.bigbluebutton.modules.layout.model {
 		}
 		
 		static public function getType(obj:Object):String {
-			if (obj.hasOwnProperty("windowName")) {
-				return obj.windowName;
+			if (obj is IBbbModuleWindow) {
+				return (obj as IBbbModuleWindow).getName();
 			} else {
 				var qualifiedClass:String = String(getQualifiedClassName(obj));
 				var pattern:RegExp = /(\w+)::(\w+)/g;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/notes/views/NotesWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/notes/views/NotesWindow.mxml
@@ -38,7 +38,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       public function getPrefferedPosition():String{
         var options:NotesOptions = new NotesOptions();
         return options.position;
-      } 
+      }
+      
+      public function getName():String {
+        return "NotesWindow";
+      }
       
       private function onCreationComplete():void {
         this.title = ResourceUtil.getInstance().getString("bbb.notes.title");

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -71,15 +71,15 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		<![CDATA[
 			import flash.geom.Point;
 			
+			import flashx.textLayout.formats.Direction;
+			
+			import flexlib.mdi.events.MDIWindowEvent;
+			
 			import mx.collections.ArrayCollection;
 			import mx.collections.ArrayList;
 			import mx.controls.Menu;
 			import mx.events.MenuEvent;
 			import mx.managers.PopUpManager;
-			
-			import flashx.textLayout.formats.Direction;
-			
-			import flexlib.mdi.events.MDIWindowEvent;
 			
 			import org.as3commons.lang.StringUtils;
 			import org.as3commons.logging.api.ILogger;
@@ -91,8 +91,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.core.Options;
 			import org.bigbluebutton.core.PopUpUtil;
 			import org.bigbluebutton.core.UsersUtil;
+			import org.bigbluebutton.main.api.JSLog;
 			import org.bigbluebutton.main.events.MadePresenterEvent;
 			import org.bigbluebutton.main.events.ShortcutEvent;
+			import org.bigbluebutton.main.model.users.events.UserAddedToPresenterGroupEvent;
+			import org.bigbluebutton.main.model.users.events.UserRemovedFromPresenterGroupEvent;
 			import org.bigbluebutton.main.views.MainCanvas;
 			import org.bigbluebutton.modules.polling.events.PollShowResultEvent;
 			import org.bigbluebutton.modules.polling.events.PollStartedEvent;
@@ -102,22 +105,20 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.modules.polling.views.PollChoicesModal;
 			import org.bigbluebutton.modules.polling.views.PollResultsModal;
 			import org.bigbluebutton.modules.present.commands.GoToNextPageCommand;
-			import org.bigbluebutton.modules.present.commands.GoToPrevPageCommand;
-			import org.bigbluebutton.modules.present.commands.GoToPageLocalCommand;
 			import org.bigbluebutton.modules.present.commands.GoToPageCommand;
+			import org.bigbluebutton.modules.present.commands.GoToPageLocalCommand;
+			import org.bigbluebutton.modules.present.commands.GoToPrevPageCommand;
 			import org.bigbluebutton.modules.present.events.DisplaySlideEvent;
 			import org.bigbluebutton.modules.present.events.DownloadEvent;
 			import org.bigbluebutton.modules.present.events.ExportEvent;
 			import org.bigbluebutton.modules.present.events.PresentationChangedEvent;
 			import org.bigbluebutton.modules.present.events.PresenterCommands;
 			import org.bigbluebutton.modules.present.events.RemovePresentationEvent;
-			import org.bigbluebutton.modules.present.events.UploadEvent;
-			import org.bigbluebutton.modules.present.events.RequestNewPresentationPodEvent;
 			import org.bigbluebutton.modules.present.events.RequestClosePresentationPodEvent;
-			import org.bigbluebutton.modules.present.events.SetPresenterInPodRespEvent;
+			import org.bigbluebutton.modules.present.events.RequestNewPresentationPodEvent;
 			import org.bigbluebutton.modules.present.events.SetPresenterInPodReqEvent;
-			import org.bigbluebutton.main.model.users.events.UserAddedToPresenterGroupEvent;
-			import org.bigbluebutton.main.model.users.events.UserRemovedFromPresenterGroupEvent;
+			import org.bigbluebutton.modules.present.events.SetPresenterInPodRespEvent;
+			import org.bigbluebutton.modules.present.events.UploadEvent;
 			import org.bigbluebutton.modules.present.model.Page;
 			import org.bigbluebutton.modules.present.model.PresentOptions;
 			import org.bigbluebutton.modules.present.model.PresentationModel;
@@ -127,7 +128,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.modules.whiteboard.views.WhiteboardTextToolbar;
 			import org.bigbluebutton.modules.whiteboard.views.WhiteboardToolbar;
 			import org.bigbluebutton.util.i18n.ResourceUtil;
-			import org.bigbluebutton.main.api.JSLog;
 
 			private static const LOGGER:ILogger = getClassLogger(PresentationWindow);      
       
@@ -420,6 +420,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 			public function getPrefferedPosition():String{
 				return MainCanvas.MIDDLE;
+			}
+			
+			public function getName():String {
+				return podId;
 			}
 						
 			private function onSliderZoom():void {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/ScreensharePublishWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/ScreensharePublishWindow.mxml
@@ -172,6 +172,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       public function getPrefferedPosition():String{
         return MainCanvas.DESKTOP_SHARING_PUBLISH;
       }
+      
+      public function getName():String {
+        return "ScreensharePublishWindow";
+      }
 
       public function handleDisconnectedEvent(event:BBBEvent):void {
           if (event.payload.type == ReconnectionManager.DESKSHARE_CONNECTION) {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/ScreenshareViewWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/ScreenshareViewWindow.mxml
@@ -216,6 +216,10 @@
 			public function getPrefferedPosition():String{
 				return MainCanvas.DESKTOP_SHARING_VIEW;
 			}
+			
+			public function getName():String {
+				return "ScreenshareViewWindow";
+			}
 
             /**
              * Resizes the desktop sharing video to fit to this window

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopPublishWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopPublishWindow.mxml
@@ -188,6 +188,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			public function getPrefferedPosition():String{
 				return MainCanvas.DESKTOP_SHARING_PUBLISH;
 			}
+			
+			public function getName():String {
+				return "ScreensharePublishWindow";
+			}
 
 			/*
 			 * Implement resizeable interface.

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopViewWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopViewWindow.mxml
@@ -265,6 +265,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			public function getPrefferedPosition():String{
 				return MainCanvas.DESKTOP_SHARING_VIEW;
 			}
+			
+			public function getName():String {
+				return "ScreenshareViewWindow";
+			}
 
 			/**
 			 * resizes the desktop sharing video to fit to this window

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/AdditionalSharedNotesWindow.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/AdditionalSharedNotesWindow.as
@@ -18,14 +18,11 @@ package org.bigbluebutton.modules.sharednotes.views
 	{
 		private static const LOGGER:ILogger = getClassLogger(AdditionalSharedNotesWindow);
 
-		private var _windowName:String;
-
 		public function AdditionalSharedNotesWindow(n:String) {
 			super();
 
 			LOGGER.debug("AdditionalSharedNotesWindow: in-constructor additional notes " + n);
 			_noteId = n;
-			_windowName = "AdditionalSharedNotesWindow_" + noteId;
 
 			options = Options.getOptions(SharedNotesOptions) as SharedNotesOptions;
 
@@ -34,8 +31,8 @@ package org.bigbluebutton.modules.sharednotes.views
 			height = 240;
 		}
 
-		public function get windowName():String {
-			return this._windowName;
+		override public function getName():String {
+			return "AdditionalSharedNotesWindow_" + noteId;
 		}
 
 		public function set noteName(name:String):void {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/SharedNotesWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/SharedNotesWindow.mxml
@@ -535,6 +535,10 @@
 			public function getPrefferedPosition():String {
 				return MainCanvas.POPUP;
 			}
+			
+			public function getName():String {
+				return "SharedNotesWindow";
+			}
 
 			override protected function resourcesChanged():void {
 				super.resourcesChanged();

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UsersWindow.mxml
@@ -307,6 +307,10 @@ $Id: $
         return MainCanvas.TOP_LEFT;
       }
       
+      public function getName():String {
+        return "UsersWindow";
+      }
+      
       private function addContextMenuItems():void {
         var contextMenuItems:Array = new Array();
         

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/VideoDock.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/VideoDock.mxml
@@ -74,6 +74,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				return MainCanvas.BOTTOM_LEFT;
 			}
 			
+			public function getName():String {
+				return "VideoDock";
+			}
+			
 			private function hotkeyCapture():void {
 				this.addEventListener(KeyboardEvent.KEY_DOWN, handleKeyDown);
 				ResourceUtil.getInstance().addEventListener(Event.CHANGE, localeChanged); // Listen for locale changing


### PR DESCRIPTION
This PR adds getName() functions to each of the MDIWindows so that we aren't stuck with just using the class name as an identifier in the Layout Module. Most of the windows still use their class names for the returned value, but this will allow us to have identifiers like "ChatWindow[0-n]" and "PresentationWindow[0-n]" inside of the layout definitions.

The ids being used for the Chat and Presentation Windows still needs work as they aren't very human friendly.