### PR TITLE
Make Chat Pods layout compatible

### DIFF
--- a/bigbluebutton-client/resources/prod/layout.xml
+++ b/bigbluebutton-client/resources/prod/layout.xml
@@ -3,8 +3,8 @@
   <layout name="bbb.layout.name.defaultlayout" default="true">
     <window name="UsersWindow" width="0.19" height="0.645714285714286" x="0.0078125" y="0.014285714285714" />
     <window name="VideoDock" width="0.19" height="0.303616071428571" x="0.0078125" y="0.682098214285714" />
-    <window name="PresentationWindow" width="0.5575" height="0.971428571428571" x="0.205625" y="0.014285714285714" />
-    <window name="ChatWindow" width="0.22125" height="0.971428571428571" x="0.7709375" y="0.014285714285714" />
+    <window name="PresentationWindow0" width="0.5575" height="0.971428571428571" x="0.205625" y="0.014285714285714" />
+    <window name="ChatWindow0" width="0.22125" height="0.971428571428571" x="0.7709375" y="0.014285714285714" />
     <window name="SharedNotesWindow" hidden="true" />
     <window name="BroadcastWindow" hidden="true" />
     <window name="CaptionWindow" hidden="true" />
@@ -12,9 +12,9 @@
   <layout name="bbb.layout.name.closedcaption">
     <window name="UsersWindow" width="0.19" height="0.645714285714286" x="0.0078125" y="0.014285714285714" />
     <window name="VideoDock" width="0.19" height="0.303616071428571" x="0.0078125" y="0.682098214285714" />
-    <window name="PresentationWindow" width="0.5575" height="0.539560439560439" x="0.205625" y="0.014285714285714" />
+    <window name="PresentationWindow0" width="0.5575" height="0.539560439560439" x="0.205625" y="0.014285714285714" />
     <window name="CaptionWindow" width="0.5575" height="0.409769917582418" x="0.205625" y="0.575944368131867" />
-    <window name="ChatWindow" width="0.22125" height="0.971428571428571" x="0.7709375" y="0.014285714285714" />
+    <window name="ChatWindow0" width="0.22125" height="0.971428571428571" x="0.7709375" y="0.014285714285714" />
     <window name="SharedNotesWindow" hidden="true" />
     <window name="BroadcastWindow" hidden="true" />
   </layout>
@@ -22,23 +22,23 @@
     <window name="VideoDock" width="1" height="1" x="0" y="0" order="0"/>
     <window name="SharedNotesWindow" hidden="true" />
     <window name="BroadcastWindow" hidden="true" />
-    <window name="ChatWindow" hidden="true"  />
-    <window name="PresentationWindow" hidden="true"  />
+    <window name="ChatWindow0" hidden="true"  />
+    <window name="PresentationWindow0" hidden="true"  />
     <window name="UsersWindow" hidden="true" />
     <window name="CaptionWindow" hidden="true"  />
   </layout>
   <layout name="bbb.layout.name.webcamsfocus">
     <window name="VideoDock" width="0.649206313314037" height="0.971428571428571" x="0.0078125" y="0.014285714285714" />
-    <window name="ChatWindow" width="0.335168686685963" height="0.478571428571429" x="0.664831313314037" y="0.014285714285714" />
-    <window name="PresentationWindow" width="0.335168686685963" height="0.478571428571429" x="0.664831313314037" y="0.507142857142857" />
+    <window name="ChatWindow0" width="0.335168686685963" height="0.478571428571429" x="0.664831313314037" y="0.014285714285714" />
+    <window name="PresentationWindow0" width="0.335168686685963" height="0.478571428571429" x="0.664831313314037" y="0.507142857142857" />
     <window name="CaptionWindow" hidden="true"  />
     <window name="BroadcastWindow" hidden="true" />
     <window name="UsersWindow" hidden="true"  />
     <window name="SharedNotesWindow" hidden="true" />
   </layout>
   <layout name="bbb.layout.name.presentfocus">
-    <window name="PresentationWindow" width="0.649206313314037" height="0.971428571428571" x="0.0078125" y="0.014285714285714" />
-    <window name="ChatWindow" width="0.335168686685963" height="0.478571428571429" x="0.664831313314037" y="0.014285714285714" />
+    <window name="PresentationWindow0" width="0.649206313314037" height="0.971428571428571" x="0.0078125" y="0.014285714285714" />
+    <window name="ChatWindow0" width="0.335168686685963" height="0.478571428571429" x="0.664831313314037" y="0.014285714285714" />
     <window name="VideoDock" width="0.335168686685963" height="0.478571428571429" x="0.664831313314037" y="0.507142857142857" />
     <window name="CaptionWindow" hidden="true" />
     <window name="SharedNotesWindow" hidden="true" />
@@ -46,8 +46,8 @@
     <window name="UsersWindow" hidden="true" />
   </layout>
   <layout name="bbb.layout.name.presentandusers">
-    <window name="PresentationWindow" width="0.649206313314037" height="0.971428571428571" x="0.0078125" y="0.014285714285714" />
-    <window name="ChatWindow" width="0.335168686685963" height="0.478571428571429" x="0.664831313314037" y="0.014285714285714" />
+    <window name="PresentationWindow0" width="0.649206313314037" height="0.971428571428571" x="0.0078125" y="0.014285714285714" />
+    <window name="ChatWindow0" width="0.335168686685963" height="0.478571428571429" x="0.664831313314037" y="0.014285714285714" />
     <window name="UsersWindow" width="0.335168686685963" height="0.478571428571429" x="0.664831313314037" y="0.507142857142857" />
     <window name="CaptionWindow" hidden="true" />
     <window name="SharedNotesWindow" hidden="true" />
@@ -56,8 +56,8 @@
   </layout>
   <layout name="bbb.layout.name.lectureassistant">
     <window name="UsersWindow" width="0.19" height="0.971428571428571" x="0.0078125" y="0.014285714285714" />
-    <window name="ChatWindow" width="0.5575" height="0.971428571428571" x="0.205625" y="0.014285714285714" />
-    <window name="PresentationWindow" width="0.22125" height="0.478571428571429" x="0.7709375" y="0.014285714285714" />
+    <window name="ChatWindow0" width="0.5575" height="0.971428571428571" x="0.205625" y="0.014285714285714" />
+    <window name="PresentationWindow0" width="0.22125" height="0.478571428571429" x="0.7709375" y="0.014285714285714" />
     <window name="VideoDock" width="0.22125" height="0.478571428571429" x="0.7709375" y="0.507142857142857" />
     <window name="SharedNotesWindow" hidden="true" />
     <window name="BroadcastWindow" hidden="true" />
@@ -66,25 +66,25 @@
   <layout name="bbb.layout.name.lecture">
     <window name="UsersWindow" width="0.19" height="0.645714285714286" x="0.0078125" y="0.014285714285714" order="3"/>
     <window name="SharedNotesWindow" width="0.19" height="0.303616071428571" x="0.0078125" y="0.682098214285714" order="4"/>
-    <window name="PresentationWindow" width="0.5575" height="0.971428571428571" x="0.205625" y="0.014285714285714" />
-    <window name="ChatWindow" width="0.22125" height="0.478571428571429" x="0.7709375" y="0.014285714285714" order="2"/>
+    <window name="PresentationWindow0" width="0.5575" height="0.971428571428571" x="0.205625" y="0.014285714285714" />
+    <window name="ChatWindow0" width="0.22125" height="0.478571428571429" x="0.7709375" y="0.014285714285714" order="2"/>
     <window name="VideoDock" width="0.22125" height="0.478571428571429" x="0.7709375" y="0.507142857142857" order="0"/>
     <window name="BroadcastWindow" hidden="true"/>
     <window name="CaptionWindow" hidden="true"/>
   </layout>
   <layout name="bbb.layout.name.lecture" role="presenter">
-    <window name="PresentationWindow" maximized="true" />
+    <window name="PresentationWindow0" maximized="true" />
     <window name="SharedNotesWindow" hidden="true" />
     <window name="BroadcastWindow" hidden="true"/>
-    <window name="ChatWindow" hidden="true" />
+    <window name="ChatWindow0" hidden="true" />
     <window name="UsersWindow" hidden="true" />
     <window name="VideoDock" hidden="true" />
     <window name="CaptionWindow" hidden="true" />
   </layout>
   <layout name="bbb.layout.name.lecture" role="moderator">
     <window name="UsersWindow" width="0.19" height="0.971428571428571" x="0.0078125" y="0.014285714285714" />
-    <window name="ChatWindow" width="0.5575" height="0.971428571428571" x="0.205625" y="0.014285714285714" />
-    <window name="PresentationWindow" width="0.22125" height="0.478571428571429" x="0.7709375" y="0.014285714285714" />
+    <window name="ChatWindow0" width="0.5575" height="0.971428571428571" x="0.205625" y="0.014285714285714" />
+    <window name="PresentationWindow0" width="0.22125" height="0.478571428571429" x="0.7709375" y="0.014285714285714" />
     <window name="VideoDock" width="0.22125" height="0.478571428571429" x="0.7709375" y="0.507142857142857" />
     <window name="SharedNotesWindow" hidden="true" />
     <window name="BroadcastWindow" hidden="true" />
@@ -93,8 +93,8 @@
   <layout name="bbb.layout.name.sharednotes">
     <window name="UsersWindow" width="0.19" height="0.611428571428572" x="0.0078125" y="0.014285714285714" order="3"/>
     <window name="SharedNotesWindow" width="0.19" height="0.337901785714285" x="0.0078125" y="0.647812500000000" order="4"/>
-    <window name="PresentationWindow" width="0.5575" height="0.971428571428571" x="0.205625" y="0.014285714285714" />
-    <window name="ChatWindow" width="0.22125" height="0.611428571428572" x="0.7709375" y="0.014285714285714" order="2"/>
+    <window name="PresentationWindow0" width="0.5575" height="0.971428571428571" x="0.205625" y="0.014285714285714" />
+    <window name="ChatWindow0" width="0.22125" height="0.611428571428572" x="0.7709375" y="0.014285714285714" order="2"/>
     <window name="VideoDock" width="0.22125" height="0.337901785714285" x="0.7709375" y="0.647812500000000" order="0"/>
     <window name="BroadcastWindow" hidden="true"/>
     <window name="CaptionWindow" hidden="true"/>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/maps/GroupChatBoxMapper.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/maps/GroupChatBoxMapper.as
@@ -1,11 +1,11 @@
 package org.bigbluebutton.modules.chat.maps
 {
-  public class GroubChatBoxMapper
+  public class GroupChatBoxMapper
   {
     private var _chatBoxId: String;
     private var _chatBoxOpen: Boolean = false;
     
-    public function GroubChatBoxMapper(chatBoxId: String)
+    public function GroupChatBoxMapper(chatBoxId: String)
     {
       _chatBoxId = chatBoxId;
     }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/maps/GroupChatWindowMapper.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/maps/GroupChatWindowMapper.as
@@ -1,10 +1,12 @@
 package org.bigbluebutton.modules.chat.maps
 {
+  import mx.collections.ArrayCollection;
+
   public class GroupChatWindowMapper
   {
     private var _gcWinId: String;
     
-    private var _chatBoxes:Array = [];
+    private var _chatBoxes:ArrayCollection = new ArrayCollection();
     
     public function GroupChatWindowMapper(gcWinId: String)
     {
@@ -19,12 +21,17 @@ package org.bigbluebutton.modules.chat.maps
       return _chatBoxes.length == 0;
     }
     
-    public function addChatBox(box: GroubChatBoxMapper):void {
-      _chatBoxes[box.chatBoxId] = box;
+    public function addChatBox(box: GroupChatBoxMapper):void {
+      _chatBoxes.addItem(box);
     }
     
-    public function removeChatBox(id: String):void {
-      delete _chatBoxes[id];
+    public function removeChatBox(id: String):void { // never called
+      for (var i:int=0; i<_chatBoxes.length; i++) {
+        var box:GroupChatBoxMapper = _chatBoxes.getItemAt(i) as GroupChatBoxMapper;
+        if (box.chatBoxId == id) {
+          _chatBoxes.removeItemAt(i);
+        }
+      }
     }
     
     public function getNumChatBoxes():int {


### PR DESCRIPTION
This PR makes the ChatWindow names more human readable (ChatWindow{n}) and reworks the opening procedure so that it is sequential.