### PR TITLE
Add proper window identification to PresentationWindows

### DIFF
--- a/bigbluebutton-client/resources/config.xml.template
+++ b/bigbluebutton-client/resources/config.xml.template
@@ -108,6 +108,7 @@
 			baseTabIndex="501"
 			maxFileSize="30"
 			enableDownload="true"
+			maxNumWindows="9"
 		/>
 
 		<module name="CaptionModule" url="http://HOST/client/CaptionModule.swf?v=VERSION"

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/model/PresentOptions.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/model/PresentOptions.as
@@ -38,6 +38,9 @@ package org.bigbluebutton.modules.present.model {
 
 		[Bindable]
 		public var enableDownload:Boolean = true;
+		
+		[Bindable]
+		public var maxNumWindows:uint = 9;
 
 		public function PresentOptions() {
 			name = "PresentModule";

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/model/PresentationWindowManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/model/PresentationWindowManager.as
@@ -1,0 +1,102 @@
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ *
+ * Copyright (c) 2012 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.bigbluebutton.modules.present.model {
+	import org.bigbluebutton.modules.present.ui.views.PresentationWindow;
+
+	public class PresentationWindowManager {
+		private var windows: Array = [];
+		
+		public function PresentationWindowManager() {
+		}
+		
+		public function initCollection(numWindows:int):void {
+			for (var i:int=0; i<numWindows; i++) {
+				windows.push({windowId:"PresentationWindow"+i, podId: "", window: null});
+			}
+		}
+		
+		private function findEmptyWinId():Object {
+			for (var i:int=1; i<windows.length; i++) {
+				if (windows[i].window == null) {
+					return windows[i];
+				}
+			}
+			return null;
+		}
+		
+		public function containsPodId(podId:String):Boolean {
+			for (var i:int=0; i<windows.length; i++) {
+				if (windows[i].podId == podId) {
+					return true;
+				}
+			}
+			return false;
+		}
+		
+		public function findWindowByPodId(podId:String):PresentationWindow {
+			for (var i:int=0; i<windows.length; i++) {
+				if (windows[i].podId == podId) {
+					return windows[i].window;
+				}
+			}
+			return null;
+		}
+		
+		public function findAllWindows():Array {
+			var foundWindows:Array = [];
+			for (var i:int=0; i<windows.length; i++) {
+				if (windows[i].window != null) {
+					foundWindows.push(windows[i].window);
+				}
+			}
+			return foundWindows;
+		}
+		
+		public function addWindow(podId:String, window:PresentationWindow, defaultWin:Boolean):String {
+			var selectedWinId:Object;
+			if (defaultWin) {
+				selectedWinId = windows[0];
+			} else {
+				selectedWinId = findEmptyWinId();
+			}
+			
+			if (selectedWinId != null) {
+				selectedWinId.podId = podId;
+				selectedWinId.window = window;
+				return selectedWinId.windowId;
+			}
+			
+			return null;
+		}
+		
+		public function removeWindow(podId:String):void {
+			for (var i:int=0; i<windows.length; i++) {
+				if (windows[i].podId == podId) {
+					windows[i].podId = "";
+					windows[i].window = null;
+				}
+			}
+		}
+		
+		public function isEmpty():Boolean {
+			return windows.length > 0;
+		}
+	}
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -165,6 +165,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private var pollMenuData:Array;
 			private var pollMenu:Menu;
 
+			private var windowId:String;
+			
 			[Bindable]
 			private var podId: String = "";
 			private var ownerId: String = "";
@@ -228,6 +230,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				this.ownerId = _ownerId;
 				this.currentPresenterInPod = this.ownerId;
 				populatePodDropdown();
+			}
+			
+			public function setWindowId(windowId:String):void {
+				this.windowId = windowId;
 			}
 
 			public function getPodId(): String { return this.podId; }
@@ -446,7 +452,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 			
 			public function getName():String {
-				return podId;
+				return windowId;
 			}
 						
 			private function onSliderZoom():void {


### PR DESCRIPTION
This PR reworks how the PresentationWindows are opened and tracked and also adds consistent identification to them so that they are compatible with layouts.