### PR TITLE
[2.1] Close all ChatWindows when module is stopped

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/maps/ChatEventMap.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/maps/ChatEventMap.mxml
@@ -68,7 +68,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     </EventHandlers>
     
     <EventHandlers type="{StopChatModuleEvent.STOP_CHAT_MODULE_EVENT}">        
-      <MethodInvoker generator="{ChatEventMapDelegate}" method="closeChatWindow" />
+      <MethodInvoker generator="{ChatEventMapDelegate}" method="closeChatWindows" />
     </EventHandlers>
     
     <EventHandlers type="{EventConstants.SEND_PUBLIC_CHAT_REQ}">        

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/maps/ChatEventMapDelegate.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/maps/ChatEventMapDelegate.as
@@ -156,11 +156,12 @@ package org.bigbluebutton.modules.chat.maps {
       globalDispatcher.dispatchEvent(event);		
     }
     
-    public function closeChatWindow():void { //Never called
-      var event:CloseWindowEvent = new CloseWindowEvent(CloseWindowEvent.CLOSE_WINDOW_EVENT);
-      //	event.window = _chatWindow;
-      globalDispatcher.dispatchEvent(event);
-      
+    public function closeChatWindows():void { //Never called
+      for each (var window:ChatWindow in _windows) {
+        var event:CloseWindowEvent = new CloseWindowEvent(CloseWindowEvent.CLOSE_WINDOW_EVENT);
+        event.window = window;
+        globalDispatcher.dispatchEvent(event);
+      }
     }
   }
 }


### PR DESCRIPTION
This PR implements closing of the ChatWindows as expected when the ChatModule is stopped (logged out, disconnected, etc).