### PR TITLE
Add some of the rights management checks

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/PermissionCheck.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/PermissionCheck.scala
@@ -4,7 +4,7 @@ import org.bigbluebutton.core.models.{ Roles, UserState, Users2x }
 import org.bigbluebutton.core.running.OutMsgRouter
 import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
 
-object PermisssionCheck {
+object PermissionCheck {
 
   val MOD_LEVEL = 100
   val AUTHED_LEVEL = 50
@@ -47,7 +47,6 @@ object PermisssionCheck {
 
         println("PERMLEVELCHECK = " + permLevelCheck + " ROLELEVELCHECK=" + roleLevelCheck)
         permLevelCheck && roleLevelCheck
-        false
       case None => false
     }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/BroadcastLayoutMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/BroadcastLayoutMsgHdlr.scala
@@ -4,16 +4,24 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.Layouts
 import org.bigbluebutton.core.running.OutMsgRouter
 import org.bigbluebutton.core2.MeetingStatus2x
+import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.SystemConfiguration
 
-trait BroadcastLayoutMsgHdlr {
+trait BroadcastLayoutMsgHdlr extends SystemConfiguration {
   this: LayoutApp2x =>
 
   val outGW: OutMsgRouter
 
   def handleBroadcastLayoutMsg(msg: BroadcastLayoutMsg): Unit = {
-    Layouts.setCurrentLayout(liveMeeting.layouts, msg.body.layout, msg.header.userId)
+    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val reason = "No permission to broadcast layout to meeting."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW)
+    } else {
+      Layouts.setCurrentLayout(liveMeeting.layouts, msg.body.layout, msg.header.userId)
 
-    sendBroadcastLayoutEvtMsg(msg.header.userId)
+      sendBroadcastLayoutEvtMsg(msg.header.userId)
+    }
   }
 
   def sendBroadcastLayoutEvtMsg(fromUserId: String): Unit = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AddUserToPresenterGroupCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AddUserToPresenterGroupCmdMsgHdlr.scala
@@ -3,6 +3,7 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.{ Roles, Users2x }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
+import org.bigbluebutton.core.apps.PermissionCheck
 
 trait AddUserToPresenterGroupCmdMsgHdlr {
   this: UsersApp =>
@@ -23,15 +24,21 @@ trait AddUserToPresenterGroupCmdMsgHdlr {
       outGW.send(msgEvent)
     }
 
-    val userId = msg.body.userId
-    val requesterId = msg.body.requesterId
+    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val reason = "No permission to add user to presenter group."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW)
+    } else {
+      val userId = msg.body.userId
+      val requesterId = msg.body.requesterId
 
-    for {
-      requester <- Users2x.findWithIntId(liveMeeting.users2x, requesterId)
-    } yield {
-      if (requester.role == Roles.MODERATOR_ROLE) {
-        Users2x.addUserToPresenterGroup(liveMeeting.users2x, userId)
-        broadcastAddUserToPresenterGroup(liveMeeting.props.meetingProp.intId, userId, requesterId)
+      for {
+        requester <- Users2x.findWithIntId(liveMeeting.users2x, requesterId)
+      } yield {
+        if (requester.role == Roles.MODERATOR_ROLE) {
+          Users2x.addUserToPresenterGroup(liveMeeting.users2x, userId)
+          broadcastAddUserToPresenterGroup(liveMeeting.props.meetingProp.intId, userId, requesterId)
+        }
       }
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
@@ -21,7 +21,7 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlrCheckPerm
   override def handleSetLockSettings(msg: ChangeLockSettingsInMeetingCmdMsg): Unit = {
     val isAllowed = PermissionCheck.isAllowed(
       PermissionCheck.MOD_LEVEL,
-      PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.body.setBy
+      PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId
     )
 
     if (applyPermissionCheck && !isAllowed) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
@@ -3,7 +3,7 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.SystemConfiguration
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.api.Permissions
-import org.bigbluebutton.core.apps.PermisssionCheck
+import org.bigbluebutton.core.apps.PermissionCheck
 import org.bigbluebutton.core.running.{ OutMsgRouter }
 import org.bigbluebutton.core.running.MeetingActor
 import org.bigbluebutton.core2.MeetingStatus2x
@@ -19,15 +19,15 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlrCheckPerm
   val outGW: OutMsgRouter
 
   override def handleSetLockSettings(msg: ChangeLockSettingsInMeetingCmdMsg): Unit = {
-    val isAllowed = PermisssionCheck.isAllowed(
-      PermisssionCheck.MOD_LEVEL,
-      PermisssionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.body.setBy
+    val isAllowed = PermissionCheck.isAllowed(
+      PermissionCheck.MOD_LEVEL,
+      PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.body.setBy
     )
 
     if (applyPermissionCheck && !isAllowed) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to change lock settings"
-      PermisssionCheck.ejectUserForFailedPermission(meetingId, msg.body.setBy, reason, outGW)
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.body.setBy, reason, outGW)
     } else {
       super.handleSetLockSettings(msg)
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserEmojiCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserEmojiCmdMsgHdlr.scala
@@ -3,8 +3,10 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.Users2x
 import org.bigbluebutton.core.running.{ BaseMeetingActor, LiveMeeting, OutMsgRouter }
+import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.SystemConfiguration
 
-trait ChangeUserEmojiCmdMsgHdlr {
+trait ChangeUserEmojiCmdMsgHdlr extends SystemConfiguration {
   this: BaseMeetingActor =>
 
   val liveMeeting: LiveMeeting
@@ -12,10 +14,16 @@ trait ChangeUserEmojiCmdMsgHdlr {
 
   def handleChangeUserEmojiCmdMsg(msg: ChangeUserEmojiCmdMsg) {
     log.debug("handling " + msg)
-    for {
-      uvo <- Users2x.setEmojiStatus(liveMeeting.users2x, msg.body.userId, msg.body.emoji)
-    } yield {
-      sendUserEmojiChangedEvtMsg(outGW, liveMeeting.props.meetingProp.intId, msg.body.userId, msg.body.emoji)
+    if (msg.header.userId != msg.body.userId && applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val reason = "No permission to clear chat in meeting."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW)
+    } else {
+      for {
+        uvo <- Users2x.setEmojiStatus(liveMeeting.users2x, msg.body.userId, msg.body.emoji)
+      } yield {
+        sendUserEmojiChangedEvtMsg(outGW, liveMeeting.props.meetingProp.intId, msg.body.userId, msg.body.emoji)
+      }
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
@@ -3,6 +3,7 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.{ Roles, Users2x }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
+import org.bigbluebutton.core.apps.PermissionCheck
 
 trait ChangeUserRoleCmdMsgHdlr {
   this: UsersApp =>
@@ -11,15 +12,21 @@ trait ChangeUserRoleCmdMsgHdlr {
   val outGW: OutMsgRouter
 
   def handleChangeUserRoleCmdMsg(msg: ChangeUserRoleCmdMsg) {
-    for {
-      uvo <- Users2x.changeRole(liveMeeting.users2x, msg.body.userId, msg.body.role)
-    } yield {
-      val userRole = if (uvo.role == Roles.MODERATOR_ROLE) "MODERATOR" else "VIEWER"
+    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val reason = "No permission to change user role in meeting."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW)
+    } else {
+      for {
+        uvo <- Users2x.changeRole(liveMeeting.users2x, msg.body.userId, msg.body.role)
+      } yield {
+        val userRole = if (uvo.role == Roles.MODERATOR_ROLE) "MODERATOR" else "VIEWER"
 
-      val event = buildUserRoleChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.userId,
-        msg.body.changedBy, userRole)
+        val event = buildUserRoleChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.userId,
+          msg.body.changedBy, userRole)
 
-      outGW.send(event)
+        outGW.send(event)
+      }
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectUserFromMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectUserFromMeetingCmdMsgHdlr.scala
@@ -4,6 +4,7 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
+import org.bigbluebutton.core.apps.PermissionCheck
 
 trait EjectUserFromMeetingCmdMsgHdlr {
   this: UsersApp =>
@@ -12,47 +13,53 @@ trait EjectUserFromMeetingCmdMsgHdlr {
   val outGW: OutMsgRouter
 
   def handleEjectUserFromMeetingCmdMsg(msg: EjectUserFromMeetingCmdMsg) {
-    for {
-      user <- Users2x.ejectFromMeeting(liveMeeting.users2x, msg.body.userId)
-    } yield {
-      RegisteredUsers.remove(msg.body.userId, liveMeeting.registeredUsers)
-      val reason = "user ejected by another user"
-      // send a message to client
-      Sender.sendUserEjectedFromMeetingClientEvtMsg(
-        liveMeeting.props.meetingProp.intId,
-        user.intId, msg.body.ejectedBy, reason, outGW
-      )
-
-      log.info("Ejecting user from meeting (client msg).  meetingId=" + liveMeeting.props.meetingProp.intId +
-        " userId=" + msg.body.userId)
-
-      // send a system message to force disconnection
-      Sender.sendUserEjectedFromMeetingSystemMsg(
-        liveMeeting.props.meetingProp.intId,
-        user.intId, msg.body.ejectedBy, outGW
-      )
-
-      log.info("Ejecting user from meeting (system msg).  meetingId=" + liveMeeting.props.meetingProp.intId +
-        " userId=" + msg.body.userId)
-
-      // send a user left event for the clients to update
-      val userLeftMeetingEvent = MsgBuilder.buildUserLeftMeetingEvtMsg(liveMeeting.props.meetingProp.intId, user.intId)
-      outGW.send(userLeftMeetingEvent)
-      log.info("User left meetingId=" + liveMeeting.props.meetingProp.intId + " userId=" + msg.body.userId)
-
+    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val reason = "No permission to eject user from meeting."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW)
+    } else {
       for {
-        vu <- VoiceUsers.findWithIntId(liveMeeting.voiceUsers, msg.body.userId)
+        user <- Users2x.ejectFromMeeting(liveMeeting.users2x, msg.body.userId)
       } yield {
-        val ejectFromVoiceEvent = MsgBuilder.buildEjectUserFromVoiceConfSysMsg(
+        RegisteredUsers.remove(msg.body.userId, liveMeeting.registeredUsers)
+        val reason = "user ejected by another user"
+        // send a message to client
+        Sender.sendUserEjectedFromMeetingClientEvtMsg(
           liveMeeting.props.meetingProp.intId,
-          liveMeeting.props.voiceProp.voiceConf, vu.voiceUserId
+          user.intId, msg.body.ejectedBy, reason, outGW
         )
-        outGW.send(ejectFromVoiceEvent)
-        log.info("Ejecting user from voice.  meetingId=" + liveMeeting.props.meetingProp.intId + " userId=" + vu.intId)
-      }
 
-      if (user.presenter) {
-        automaticallyAssignPresenter(outGW, liveMeeting)
+        log.info("Ejecting user from meeting (client msg).  meetingId=" + liveMeeting.props.meetingProp.intId +
+          " userId=" + msg.body.userId)
+
+        // send a system message to force disconnection
+        Sender.sendUserEjectedFromMeetingSystemMsg(
+          liveMeeting.props.meetingProp.intId,
+          user.intId, msg.body.ejectedBy, outGW
+        )
+
+        log.info("Ejecting user from meeting (system msg).  meetingId=" + liveMeeting.props.meetingProp.intId +
+          " userId=" + msg.body.userId)
+
+        // send a user left event for the clients to update
+        val userLeftMeetingEvent = MsgBuilder.buildUserLeftMeetingEvtMsg(liveMeeting.props.meetingProp.intId, user.intId)
+        outGW.send(userLeftMeetingEvent)
+        log.info("User left meetingId=" + liveMeeting.props.meetingProp.intId + " userId=" + msg.body.userId)
+
+        for {
+          vu <- VoiceUsers.findWithIntId(liveMeeting.voiceUsers, msg.body.userId)
+        } yield {
+          val ejectFromVoiceEvent = MsgBuilder.buildEjectUserFromVoiceConfSysMsg(
+            liveMeeting.props.meetingProp.intId,
+            liveMeeting.props.voiceProp.voiceConf, vu.voiceUserId
+          )
+          outGW.send(ejectFromVoiceEvent)
+          log.info("Ejecting user from voice.  meetingId=" + liveMeeting.props.meetingProp.intId + " userId=" + vu.intId)
+        }
+
+        if (user.presenter) {
+          automaticallyAssignPresenter(outGW, liveMeeting)
+        }
       }
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LockUserInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LockUserInMeetingCmdMsgHdlr.scala
@@ -3,6 +3,7 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.Users2x
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
+import org.bigbluebutton.core.apps.PermissionCheck
 
 trait LockUserInMeetingCmdMsgHdlr {
   this: MeetingActor =>
@@ -21,12 +22,18 @@ trait LockUserInMeetingCmdMsgHdlr {
       BbbCommonEnvCoreMsg(envelope, event)
     }
 
-    for {
-      uvo <- Users2x.setUserLocked(liveMeeting.users2x, msg.body.userId, msg.body.lock)
-    } yield {
-      log.info("Lock user.  meetingId=" + props.meetingProp.intId + " userId=" + uvo.intId + " locked=" + uvo.locked)
-      val event = build(props.meetingProp.intId, uvo.intId, msg.body.lockedBy, uvo.locked)
-      outGW.send(event)
+    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val reason = "No permission to lock user in meeting."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW)
+    } else {
+      for {
+        uvo <- Users2x.setUserLocked(liveMeeting.users2x, msg.body.userId, msg.body.lock)
+      } yield {
+        log.info("Lock user.  meetingId=" + props.meetingProp.intId + " userId=" + uvo.intId + " locked=" + uvo.locked)
+        val event = build(props.meetingProp.intId, uvo.intId, msg.body.lockedBy, uvo.locked)
+        outGW.send(event)
+      }
     }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LockUsersInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LockUsersInMeetingCmdMsgHdlr.scala
@@ -3,6 +3,7 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.Users2x
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
+import org.bigbluebutton.core.apps.PermissionCheck
 
 trait LockUsersInMeetingCmdMsgHdlr {
   this: MeetingActor =>
@@ -21,16 +22,21 @@ trait LockUsersInMeetingCmdMsgHdlr {
       BbbCommonEnvCoreMsg(envelope, event)
     }
 
-    val usersToLock = Users2x.findAll(liveMeeting.users2x).filter(u => !msg.body.except.toSet(u))
-    usersToLock foreach { utl =>
-      for {
-        uvo <- Users2x.setUserLocked(liveMeeting.users2x, utl.intId, msg.body.lock)
-      } yield {
-        log.info("Lock user.  meetingId=" + props.meetingProp.intId + " userId=" + uvo.intId + " locked=" + uvo.locked)
-        val event = build(props.meetingProp.intId, uvo.intId, msg.body.lockedBy, uvo.locked)
-        outGW.send(event)
+    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val reason = "No permission to lock users in meeting."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW)
+    } else {
+      val usersToLock = Users2x.findAll(liveMeeting.users2x).filter(u => !msg.body.except.toSet(u))
+      usersToLock foreach { utl =>
+        for {
+          uvo <- Users2x.setUserLocked(liveMeeting.users2x, utl.intId, msg.body.lock)
+        } yield {
+          log.info("Lock user.  meetingId=" + props.meetingProp.intId + " userId=" + uvo.intId + " locked=" + uvo.locked)
+          val event = build(props.meetingProp.intId, uvo.intId, msg.body.lockedBy, uvo.locked)
+          outGW.send(event)
+        }
       }
     }
-
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LogoutAndEndMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LogoutAndEndMeetingCmdMsgHdlr.scala
@@ -5,6 +5,7 @@ import org.bigbluebutton.core.bus.InternalEventBus
 import org.bigbluebutton.core.domain.{ MeetingEndReason, MeetingState2x }
 import org.bigbluebutton.core.models.{ Roles, Users2x }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
+import org.bigbluebutton.core.apps.PermissionCheck
 
 trait LogoutAndEndMeetingCmdMsgHdlr {
   this: UsersApp =>
@@ -14,14 +15,20 @@ trait LogoutAndEndMeetingCmdMsgHdlr {
   val eventBus: InternalEventBus
 
   def handleLogoutAndEndMeetingCmdMsg(msg: LogoutAndEndMeetingCmdMsg, state: MeetingState2x): Unit = {
-    for {
-      u <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
-    } yield {
-      if (u.role == Roles.MODERATOR_ROLE) {
-        endAllBreakoutRooms(eventBus, liveMeeting, state)
-        log.info("Meeting {} ended by user [{}, {}} when logging out.", liveMeeting.props.meetingProp.intId,
-          u.intId, u.name)
-        sendEndMeetingDueToExpiry(MeetingEndReason.ENDED_AFTER_USER_LOGGED_OUT, eventBus, outGW, liveMeeting)
+    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val reason = "No permission to end meeting on logout."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW)
+    } else {
+      for {
+        u <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
+      } yield {
+        if (u.role == Roles.MODERATOR_ROLE) {
+          endAllBreakoutRooms(eventBus, liveMeeting, state)
+          log.info("Meeting {} ended by user [{}, {}} when logging out.", liveMeeting.props.meetingProp.intId,
+            u.intId, u.name)
+          sendEndMeetingDueToExpiry(MeetingEndReason.ENDED_AFTER_USER_LOGGED_OUT, eventBus, outGW, liveMeeting)
+        }
       }
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/MuteUserCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/MuteUserCmdMsgHdlr.scala
@@ -2,7 +2,7 @@ package org.bigbluebutton.core.apps.users
 
 import org.bigbluebutton.SystemConfiguration
 import org.bigbluebutton.common2.msgs.MuteUserCmdMsg
-import org.bigbluebutton.core.apps.PermisssionCheck
+import org.bigbluebutton.core.apps.PermissionCheck
 import org.bigbluebutton.core.models.VoiceUsers
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.message.senders.MsgBuilder
@@ -22,15 +22,15 @@ trait MuteUserCmdMsgHdlrPermCheck extends MuteUserCmdMsgHdlrDefault with SystemC
   override def handleMuteUserCmdMsg(msg: MuteUserCmdMsg): Unit = {
     println("**************** MuteUserCmdMsgHdlrPermCheck ")
 
-    val isAllowed = PermisssionCheck.isAllowed(
-      PermisssionCheck.MOD_LEVEL,
-      PermisssionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.body.mutedBy
+    val isAllowed = PermissionCheck.isAllowed(
+      PermissionCheck.MOD_LEVEL,
+      PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.body.mutedBy
     )
 
     if (applyPermissionCheck && !isAllowed) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to mute user in meeting."
-      PermisssionCheck.ejectUserForFailedPermission(meetingId, msg.body.mutedBy, reason, outGW)
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.body.mutedBy, reason, outGW)
     } else {
       super.handleMuteUserCmdMsg(msg)
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/MuteUserCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/MuteUserCmdMsgHdlr.scala
@@ -24,10 +24,10 @@ trait MuteUserCmdMsgHdlrPermCheck extends MuteUserCmdMsgHdlrDefault with SystemC
 
     val isAllowed = PermissionCheck.isAllowed(
       PermissionCheck.MOD_LEVEL,
-      PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.body.mutedBy
+      PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId
     )
 
-    if (applyPermissionCheck && !isAllowed) {
+    if (msg.header.userId != msg.body.userId && applyPermissionCheck && !isAllowed) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to mute user in meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.body.mutedBy, reason, outGW)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RemoveUserFromPresenterGroupCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RemoveUserFromPresenterGroupCmdMsgHdlr.scala
@@ -3,6 +3,7 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.{ Roles, Users2x }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
+import org.bigbluebutton.core.apps.PermissionCheck
 
 trait RemoveUserFromPresenterGroupCmdMsgHdlr {
   this: UsersApp =>
@@ -23,15 +24,21 @@ trait RemoveUserFromPresenterGroupCmdMsgHdlr {
       outGW.send(msgEvent)
     }
 
-    val userId = msg.body.userId
-    val requesterId = msg.body.requesterId
+    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val reason = "No permission to remove user from presenter group."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW)
+    } else {
+      val userId = msg.body.userId
+      val requesterId = msg.body.requesterId
 
-    for {
-      requester <- Users2x.findWithIntId(liveMeeting.users2x, requesterId)
-    } yield {
-      if (requester.role == Roles.MODERATOR_ROLE) {
-        Users2x.removeUserFromPresenterGroup(liveMeeting.users2x, userId)
-        broadcastRemoveUserFromPresenterGroup(liveMeeting.props.meetingProp.intId, userId, requesterId)
+      for {
+        requester <- Users2x.findWithIntId(liveMeeting.users2x, requesterId)
+      } yield {
+        if (requester.role == Roles.MODERATOR_ROLE) {
+          Users2x.removeUserFromPresenterGroup(liveMeeting.users2x, userId)
+          broadcastRemoveUserFromPresenterGroup(liveMeeting.props.meetingProp.intId, userId, requesterId)
+        }
       }
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/SetRecordingStatusCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/SetRecordingStatusCmdMsgHdlr.scala
@@ -3,6 +3,7 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.MeetingStatus2x
+import org.bigbluebutton.core.apps.PermissionCheck
 
 trait SetRecordingStatusCmdMsgHdlr {
   this: UsersApp =>
@@ -12,16 +13,23 @@ trait SetRecordingStatusCmdMsgHdlr {
 
   def handleSetRecordingStatusCmdMsg(msg: SetRecordingStatusCmdMsg) {
     log.info("Change recording status. meetingId=" + liveMeeting.props.meetingProp.intId + " recording=" + msg.body.recording)
-    if (liveMeeting.props.recordProp.allowStartStopRecording &&
-      MeetingStatus2x.isRecording(liveMeeting.status) != msg.body.recording) {
-      if (msg.body.recording) {
-        MeetingStatus2x.recordingStarted(liveMeeting.status)
-      } else {
-        MeetingStatus2x.recordingStopped(liveMeeting.status)
-      }
 
-      val event = buildRecordingStatusChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.setBy, msg.body.recording)
-      outGW.send(event)
+    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val reason = "No permission to clear chat in meeting."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW)
+    } else {
+      if (liveMeeting.props.recordProp.allowStartStopRecording &&
+        MeetingStatus2x.isRecording(liveMeeting.status) != msg.body.recording) {
+        if (msg.body.recording) {
+          MeetingStatus2x.recordingStarted(liveMeeting.status)
+        } else {
+          MeetingStatus2x.recordingStopped(liveMeeting.status)
+        }
+
+        val event = buildRecordingStatusChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.setBy, msg.body.recording)
+        outGW.send(event)
+      }
     }
 
     def buildRecordingStatusChangedEvtMsg(meetingId: String, userId: String, recording: Boolean): BbbCommonEnvCoreMsg = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/MuteMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/MuteMeetingCmdMsgHdlr.scala
@@ -19,7 +19,7 @@ trait MuteMeetingCmdMsgHdlrCheckPerm extends MuteMeetingCmdMsgHdlrDefault with S
   override def handleMuteMeetingCmdMsg(msg: MuteMeetingCmdMsg): Unit = {
     val isAllowed = PermissionCheck.isAllowed(
       PermissionCheck.MOD_LEVEL,
-      PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.body.mutedBy
+      PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId
     )
 
     if (applyPermissionCheck && !isAllowed) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/MuteMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/MuteMeetingCmdMsgHdlr.scala
@@ -2,7 +2,7 @@ package org.bigbluebutton.core2.message.handlers
 
 import org.bigbluebutton.SystemConfiguration
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.apps.PermisssionCheck
+import org.bigbluebutton.core.apps.PermissionCheck
 import org.bigbluebutton.core.models.{ VoiceUserState, VoiceUsers }
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core2.MeetingStatus2x
@@ -17,15 +17,15 @@ trait MuteMeetingCmdMsgHdlrCheckPerm extends MuteMeetingCmdMsgHdlrDefault with S
   val outGW: OutMsgRouter
 
   override def handleMuteMeetingCmdMsg(msg: MuteMeetingCmdMsg): Unit = {
-    val isAllowed = PermisssionCheck.isAllowed(
-      PermisssionCheck.MOD_LEVEL,
-      PermisssionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.body.mutedBy
+    val isAllowed = PermissionCheck.isAllowed(
+      PermissionCheck.MOD_LEVEL,
+      PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.body.mutedBy
     )
 
     if (applyPermissionCheck && !isAllowed) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to mute meeting."
-      PermisssionCheck.ejectUserForFailedPermission(meetingId, msg.body.mutedBy, reason, outGW)
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.body.mutedBy, reason, outGW)
     } else {
       super.handleMuteMeetingCmdMsg(msg)
     }


### PR DESCRIPTION
This PR implements some of the rights management checks. Covered are Users, Broadcast Layout, and Clear Chat. I took a different spin on what was already there because I didn't want to write all of the code that would be required to follow the original method.

Original way: https://github.com/bigbluebutton/bigbluebutton/blob/a5ddf0b2038e5fa7935755b2aae59ce88884600d/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/MuteUserCmdMsgHdlr.scala
My way: https://github.com/capilkey/bigbluebutton/blob/ebcf7dc4cca20a999dc2603addf796c0ca96a63b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/chat/ClearPublicChatHistoryPubMsgHdlr.scala
