### PR TITLE
[HTML5] - Fixed a logClient function call

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/auth.js
+++ b/bigbluebutton-html5/imports/startup/client/auth.js
@@ -1,5 +1,5 @@
 import Auth from '/imports/ui/services/auth';
-import { logClient } from '/imports/ui/services/api';
+import { log } from '/imports/ui/services/api';
 
 // disconnected and trying to open a new connection
 const STATUS_CONNECTING = 'connecting';
@@ -88,11 +88,7 @@ export function authenticatedRouteHandler(nextState, replace, callback) {
   Auth.authenticate()
     .then(callback)
     .catch((reason) => {
-      logClient('error', {
-        error: reason,
-        method: 'authenticatedRouteHandler',
-        credentialsSnapshot,
-      });
+      log('error', reason);
 
       // make sure users who did not connect are not added to the meeting
       // do **not** use the custom call - it relies on expired data


### PR DESCRIPTION
Got this error in the console:
![logclient_error_1](https://user-images.githubusercontent.com/9299997/32250829-75bcf0da-be64-11e7-9224-fa4bfd7152c0.JPG)

Instead showing me a logout button with the error it was just a black screen.
Checked, it turned out that we forgot to change one of the imports in #4524 

This fixes it.