### PR TITLE
Modify presentation, chat, and cursor record events to match 2.1 specs

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/AbstractPresentationRecordEvent.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/AbstractPresentationRecordEvent.scala
@@ -20,5 +20,15 @@
 package org.bigbluebutton.core.record.events
 
 trait AbstractPresentationRecordEvent extends RecordEvent {
+  import AbstractPresentationRecordEvent._
+
   setModule("PRESENTATION")
+
+  def setPodId(id: String) {
+    eventMap.put(POD_ID, id)
+  }
+}
+
+object AbstractPresentationRecordEvent {
+  protected final val POD_ID = "podId"
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/CreatePresentationPodRecordEvent.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/CreatePresentationPodRecordEvent.scala
@@ -19,30 +19,16 @@
 
 package org.bigbluebutton.core.record.events
 
-class GotoSlideRecordEvent extends AbstractPresentationRecordEvent {
-  import GotoSlideRecordEvent._
+class CreatePresentationPodRecordEvent extends AbstractPresentationRecordEvent {
+  import CreatePresentationPodRecordEvent._
 
-  setEvent("GotoSlideEvent")
+  setEvent("CreatePresentationPodEvent")
 
-  def setPresentationName(name: String) {
-    eventMap.put(PRES_NAME, name)
-  }
-
-  def setSlide(slide: Integer) {
-    /*
-     * Subtract 1 from the page number to be zero-based to be
-     * compatible with 0.81 and earlier. (ralam Sept 2, 2014)
-     */
-    eventMap.put(SLIDE, Integer.toString(slide - 1))
-  }
-
-  def setId(id: String) {
-    eventMap.put(ID, id)
+  def setOwnerId(name: String) {
+    eventMap.put(OWNER_ID, name)
   }
 }
 
-object GotoSlideRecordEvent {
-  protected final val PRES_NAME = "presentationName"
-  protected final val SLIDE = "slide"
-  protected final val ID = "id"
+object CreatePresentationPodRecordEvent {
+  protected final val OWNER_ID = "ownerId"
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/RemovePresentationPodRecordEvent.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/RemovePresentationPodRecordEvent.scala
@@ -19,30 +19,16 @@
 
 package org.bigbluebutton.core.record.events
 
-class GotoSlideRecordEvent extends AbstractPresentationRecordEvent {
-  import GotoSlideRecordEvent._
+class RemovePresentationPodRecordEvent extends AbstractPresentationRecordEvent {
+  import RemovePresentationPodRecordEvent._
 
-  setEvent("GotoSlideEvent")
+  setEvent("RemovePresentationPodEvent")
 
-  def setPresentationName(name: String) {
-    eventMap.put(PRES_NAME, name)
-  }
-
-  def setSlide(slide: Integer) {
-    /*
-     * Subtract 1 from the page number to be zero-based to be
-     * compatible with 0.81 and earlier. (ralam Sept 2, 2014)
-     */
-    eventMap.put(SLIDE, Integer.toString(slide - 1))
-  }
-
-  def setId(id: String) {
-    eventMap.put(ID, id)
+  def setOwnerId(name: String) {
+    eventMap.put(OWNER_ID, name)
   }
 }
 
-object GotoSlideRecordEvent {
-  protected final val PRES_NAME = "presentationName"
-  protected final val SLIDE = "slide"
-  protected final val ID = "id"
+object RemovePresentationPodRecordEvent {
+  protected final val OWNER_ID = "ownerId"
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/ResizeAndMoveSlideRecordEvent.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/ResizeAndMoveSlideRecordEvent.scala
@@ -24,6 +24,10 @@ class ResizeAndMoveSlideRecordEvent extends AbstractPresentationRecordEvent {
 
   setEvent("ResizeAndMoveSlideEvent")
 
+  def setPresentationName(name: String) {
+    eventMap.put(PRES_NAME, name)
+  }
+
   def setId(id: String) {
     eventMap.put(ID, id)
   }
@@ -46,6 +50,7 @@ class ResizeAndMoveSlideRecordEvent extends AbstractPresentationRecordEvent {
 }
 
 object ResizeAndMoveSlideRecordEvent {
+  protected final val PRES_NAME = "presentationName"
   protected final val ID = "id"
   protected final val X_OFFSET = "xOffset"
   protected final val Y_OFFSET = "yOffset"

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/SetPresenterInPodRecordEvent.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/SetPresenterInPodRecordEvent.scala
@@ -19,30 +19,21 @@
 
 package org.bigbluebutton.core.record.events
 
-class GotoSlideRecordEvent extends AbstractPresentationRecordEvent {
-  import GotoSlideRecordEvent._
+class SetPresenterInPodRecordEvent extends AbstractPresentationRecordEvent {
+  import SetPresenterInPodRecordEvent._
 
-  setEvent("GotoSlideEvent")
+  setEvent("SetPresenterInPodEvent")
 
-  def setPresentationName(name: String) {
-    eventMap.put(PRES_NAME, name)
+  def setPrevPresenterId(userId: String) {
+    eventMap.put(PREV_PRESENTER, userId)
   }
 
-  def setSlide(slide: Integer) {
-    /*
-     * Subtract 1 from the page number to be zero-based to be
-     * compatible with 0.81 and earlier. (ralam Sept 2, 2014)
-     */
-    eventMap.put(SLIDE, Integer.toString(slide - 1))
-  }
-
-  def setId(id: String) {
-    eventMap.put(ID, id)
+  def setNextPresenterId(userId: String) {
+    eventMap.put(NEXT_PRESENTER, userId)
   }
 }
 
-object GotoSlideRecordEvent {
-  protected final val PRES_NAME = "presentationName"
-  protected final val SLIDE = "slide"
-  protected final val ID = "id"
+object SetPresenterInPodRecordEvent {
+  protected final val PREV_PRESENTER = "prevPresenterId"
+  protected final val NEXT_PRESENTER = "nextPresenterId"
 }


### PR DESCRIPTION
RecordEvent Changes
* Updated cursor event to have presentation name and page (matches other whiteboard events)
* Updated Presentation events to all have podId and presentationName
* Added three new recorded events (CreatePresentationPodEvent, RemovePresentationPodEvent, SetPresenterInPodEvent)
* Exchanged SendPublicMessageEvtMsg for GroupChatMessageBroadcastEvtMsg and filtered on chatId == GroupChatApp.MAIN_PUBLIC_CHAT
  * Note: end result is no change for recording processing for chat messages