### PR TITLE
Fall back to the layout name if a translation could not be found

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/layout/views/LayoutsCombo.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/layout/views/LayoutsCombo.mxml
@@ -21,11 +21,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 <mx:ComboBox xmlns:mx="library://ns.adobe.com/flex/mx" 
 			 xmlns:fx="http://ns.adobe.com/mxml/2009"
 			 xmlns:mate="http://mate.asfusion.com/"
-			toolTip="{ResourceUtil.getInstance().getString('bbb.layout.combo.toolTip')}"
-			prompt="{ResourceUtil.getInstance().getString('bbb.layout.combo.prompt')}"
-			height="{LayoutButton.BUTTON_SIZE}" creationComplete="init()"
-			change="onSelectedItemChanged(event)"
-			disabledColor="{getStyle('color')}" rowCount="10" width="240" >
+			 toolTip="{ResourceUtil.getInstance().getString('bbb.layout.combo.toolTip')}"
+			 prompt="{ResourceUtil.getInstance().getString('bbb.layout.combo.prompt')}"
+			 height="{LayoutButton.BUTTON_SIZE}" creationComplete="init()"
+			 change="onSelectedItemChanged(event)"
+			 disabledColor="{getStyle('color')}" rowCount="10" width="240" >
 	
 	<fx:Declarations>
 		<mate:Listener type="{SwitchedLayoutEvent.SWITCHED_LAYOUT_EVENT}" method="onLayoutChanged" />
@@ -34,69 +34,74 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		<mate:Listener type="{LocaleChangeEvent.LOCALE_CHANGED}" method="localeChanged" />
 		<mate:Listener type="{LayoutEvent.INVALIDATE_LAYOUT_EVENT}" method="invalidateLayout" />
 	</fx:Declarations>
-  
+
 	<fx:Script>
 		<![CDATA[
-      import com.asfusion.mate.events.Dispatcher;
-      
-      import mx.collections.ArrayCollection;
-      
-      import org.as3commons.logging.api.ILogger;
-      import org.as3commons.logging.api.getClassLogger;
-      import org.bigbluebutton.common.events.LocaleChangeEvent;
-      import org.bigbluebutton.core.UsersUtil;
-      import org.bigbluebutton.core.events.LockControlEvent;
-      import org.bigbluebutton.core.events.SwitchedLayoutEvent;
-      import org.bigbluebutton.core.model.LiveMeeting;
-      import org.bigbluebutton.modules.layout.events.ChangeLayoutEvent;
-      import org.bigbluebutton.modules.layout.events.LayoutEvent;
-      import org.bigbluebutton.modules.layout.events.LayoutsReadyEvent;
-      import org.bigbluebutton.modules.layout.model.LayoutModel;
-      import org.bigbluebutton.util.i18n.ResourceUtil;
+			import com.asfusion.mate.events.Dispatcher;
 			
-			private static const LOGGER:ILogger = getClassLogger(LayoutsCombo);      
-      
+			import mx.collections.ArrayCollection;
+			
+			import org.as3commons.lang.StringUtils;
+			import org.as3commons.logging.api.ILogger;
+			import org.as3commons.logging.api.getClassLogger;
+			import org.bigbluebutton.common.events.LocaleChangeEvent;
+			import org.bigbluebutton.core.UsersUtil;
+			import org.bigbluebutton.core.events.LockControlEvent;
+			import org.bigbluebutton.core.events.SwitchedLayoutEvent;
+			import org.bigbluebutton.core.model.LiveMeeting;
+			import org.bigbluebutton.modules.layout.events.ChangeLayoutEvent;
+			import org.bigbluebutton.modules.layout.events.LayoutEvent;
+			import org.bigbluebutton.modules.layout.events.LayoutsReadyEvent;
+			import org.bigbluebutton.modules.layout.model.LayoutModel;
+			import org.bigbluebutton.util.i18n.ResourceUtil;
+
+			private static const LOGGER:ILogger = getClassLogger(LayoutsCombo);
+
 			private var _dispatcher:Dispatcher = new Dispatcher();
-      [Bindable] private var layoutNames:ArrayCollection = new ArrayCollection();
-      
-      private function init():void {
-        dataProvider = layoutNames;
-        populateComboBox();
-        refreshRole(UsersUtil.amIModerator());
-      }
-      
-      private function lockSettingsChanged(e:LockControlEvent):void {
-		  this.enabled = ! LiveMeeting.inst().me.lockedLayout;
-      }
-      
-			private function populateLayoutsList(e:LayoutsReadyEvent):void {
-        populateComboBox();
+
+			[Bindable]
+			private var layoutNames:ArrayCollection = new ArrayCollection();
+			
+			private function init():void {
+				dataProvider = layoutNames;
+				populateComboBox();
+				refreshRole(UsersUtil.amIModerator());
 			}
-      
-      private function populateComboBox():void {
-        layoutNames = new ArrayCollection();         
-        var layouts:Array = LayoutModel.getInstance().getLayoutNames();
-        
-        var idx:int = 0, currentLayoutIndex:int = -1;
-        for each (var lay:Object in layouts) {
-          var translatedName:String = ResourceUtil.getInstance().getString(lay.name)
-          if (translatedName == "undefined") translatedName = lay.name;
-          var item:Object = {index: idx, label: translatedName, localeKey: lay.name, currentLayout: lay.currentLayout };
-          layoutNames.addItem(item);
-          if (lay.currentLayout) {
-            currentLayoutIndex = idx;
-          }
-          idx++;
-        }
-        dataProvider = layoutNames;
-        selectedIndex = currentLayoutIndex;
-        invalidateDisplayList();        
-      }
-						
+			
+			private function lockSettingsChanged(e:LockControlEvent):void {
+				this.enabled = !LiveMeeting.inst().me.lockedLayout;
+			}
+
+			private function populateLayoutsList(e:LayoutsReadyEvent):void {
+				populateComboBox();
+			}
+
+			
+			private function populateComboBox():void {
+				layoutNames = new ArrayCollection();
+				var layouts:Array = LayoutModel.getInstance().getLayoutNames();
+				
+				var idx:int = 0, currentLayoutIndex:int = -1;
+				for each (var lay:Object in layouts) {
+					var translatedName:String = ResourceUtil.getInstance().getString(lay.name)
+					if (StringUtils.isEmpty(translatedName))
+						translatedName = lay.name;
+					var item:Object = {index: idx, label: translatedName, localeKey: lay.name, currentLayout: lay.currentLayout};
+					layoutNames.addItem(item);
+					if (lay.currentLayout) {
+						currentLayoutIndex = idx;
+					}
+					idx++;
+				}
+				dataProvider = layoutNames;
+				selectedIndex = currentLayoutIndex;
+				invalidateDisplayList();
+			}
+
 			private function onLayoutChanged(e:SwitchedLayoutEvent):void {
 				lockSettingsChanged(null);
-        populateComboBox();
-				var idx:int = -1;					
+				populateComboBox();
+				var idx:int = -1;
 				for each (var obj:Object in dataProvider) {
 					if (obj.localeKey == e.layoutID)
 						idx = obj.index;
@@ -108,17 +113,17 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					prompt = dataProvider[idx].label;
 				}
 				invalidateDisplayList();
-				
+
 			}
-			
+
 			private function localeChanged(e:LocaleChangeEvent):void {
 				populateComboBox();
 			}
-			
+
 			private function onSelectedItemChanged(e:Event):void {
 				_dispatcher.dispatchEvent(new ChangeLayoutEvent(e.currentTarget.selectedItem.localeKey));
 			}
-					
+
 			private function invalidateLayout(e:Event):void {
 				selectedIndex = -1;
 				prompt = ResourceUtil.getInstance().getString('bbb.layout.combo.custom');


### PR DESCRIPTION
We kept the layout name retrieval from #4635 and removed the translation in locales.