### PR TITLE
Do not send UserLeftVoice on UserLeave - fix for audio state issue on reconnect

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
@@ -2,7 +2,7 @@ package org.bigbluebutton.core.apps.users
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.domain.{ MeetingExpiryTracker, MeetingState2x }
-import org.bigbluebutton.core.models.{ Users2x, VoiceUserState, VoiceUsers }
+import org.bigbluebutton.core.models.Users2x
 import org.bigbluebutton.core.running.{ LiveMeeting, MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core.util.TimeUtil
 import org.bigbluebutton.core2.MeetingStatus2x
@@ -37,26 +37,6 @@ trait UserLeaveReqMsgHdlr {
 
         // request ongoing poll to end
         handleStopPollReqMsg(u.intId)
-      }
-
-      def broadcastEvent(vu: VoiceUserState): Unit = {
-        val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId,
-          vu.intId)
-        val envelope = BbbCoreEnvelope(UserLeftVoiceConfToClientEvtMsg.NAME, routing)
-        val header = BbbClientMsgHeader(UserLeftVoiceConfToClientEvtMsg.NAME, liveMeeting.props.meetingProp.intId, vu.intId)
-
-        val body = UserLeftVoiceConfToClientEvtMsgBody(voiceConf = liveMeeting.props.voiceProp.voiceConf, intId = vu.intId, voiceUserId = vu.voiceUserId)
-
-        val event = UserLeftVoiceConfToClientEvtMsg(header, body)
-        val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
-        outGW.send(msgEvent)
-      }
-
-      for {
-        user <- VoiceUsers.findWithIntId(liveMeeting.voiceUsers, msg.body.userId)
-      } yield {
-        VoiceUsers.removeWithIntId(liveMeeting.voiceUsers, user.intId)
-        broadcastEvent(user)
       }
     }
 


### PR DESCRIPTION
The problem was that if the Flash client reconnects during a meeting but the audio connection remains intact, akka-apps would still tell all clients that the user has left audio.
Removing this logic fixes the issue.
