### PR TITLE
Presentation Pod Cleanup

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/GetAllPresentationPodsReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/GetAllPresentationPodsReqMsgHdlr.scala
@@ -1,11 +1,10 @@
 package org.bigbluebutton.core.apps.presentationpod
 
-import org.bigbluebutton.common2.domain.{ PresentationPodVO, PresentationVO }
+import org.bigbluebutton.common2.domain.PresentationPodVO
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.PermissionCheck
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.domain.MeetingState2x
-import org.bigbluebutton.core.models.PresentationPod
 import org.bigbluebutton.core.running.LiveMeeting
 
 trait GetAllPresentationPodsReqMsgHdlr {
@@ -31,12 +30,10 @@ trait GetAllPresentationPodsReqMsgHdlr {
         BbbCommonEnvCoreMsg(envelope, event)
       }
 
-      val requesterId = msg.body.requesterId
-
       val pods = PresentationPodsApp.getAllPresentationPodsInMeeting(state)
 
       val podsVO = pods.map(pod => PresentationPodsApp.translatePresentationPodToVO(pod))
-      val event = buildGetAllPresentationPodsRespMsg(podsVO, requesterId)
+      val event = buildGetAllPresentationPodsRespMsg(podsVO, msg.header.userId)
 
       bus.outGW.send(event)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/GetPresentationInfoReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/GetPresentationInfoReqMsgHdlr.scala
@@ -31,7 +31,7 @@ trait GetPresentationInfoReqMsgHdlr {
         BbbCommonEnvCoreMsg(envelope, event)
       }
 
-      val requesterId = msg.body.userId
+      val requesterId = msg.header.userId
       val podId = msg.body.podId
 
       for {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationPodsApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationPodsApp.scala
@@ -7,19 +7,14 @@ import org.bigbluebutton.core.util.RandomStringGenerator
 
 object PresentationPodsApp {
 
-  def createPresentationPod(ownerId: String): PresentationPod = {
-    PresentationPodFactory.create(ownerId)
+  def createPresentationPod(creatorId: String): PresentationPod = {
+    PresentationPodFactory.create(creatorId)
   }
 
-  def createDefaultPresentationPod(ownerId: String): PresentationPod = {
-    PresentationPodFactory.createDefaultPod(ownerId)
+  def createDefaultPresentationPod(state: MeetingState2x): MeetingState2x = {
+    val podManager = state.presentationPodManager.addPod(PresentationPodFactory.createDefaultPod())
+    state.update(podManager)
   }
-
-  //    def createDefaultPresentationPod(state: MeetingState2x): MeetingState2x = {
-  //      val defaultPresPod = PresentationPodFactory.create("the-owner-id")
-  //      val podManager = state.presentationPodManager.addPod(defaultPresPod)
-  //      state.update(podManager)
-  //    }
 
   def removePresentationPod(state: MeetingState2x, podId: String): MeetingState2x = {
     val podManager = state.presentationPodManager.removePod(podId)
@@ -27,13 +22,7 @@ object PresentationPodsApp {
   }
 
   def getPresentationPod(state: MeetingState2x, podId: String): Option[PresentationPod] = {
-    if (getNumberOfPresentationPods(state) == 0) {
-      val defPod = createDefaultPresentationPod("") // ownerId is to be assigned later
-      state.presentationPodManager.addPod(defPod)
-      Some(defPod)
-    } else {
-      state.presentationPodManager.getPod(podId)
-    }
+    state.presentationPodManager.getPod(podId)
   }
 
   def getAllPresentationPodsInMeeting(state: MeetingState2x): Vector[PresentationPod] = {
@@ -47,7 +36,7 @@ object PresentationPodsApp {
     val presentationVOs = presentationObjects.values.map(p => PresentationVO(p.id, p.name, p.current,
       p.pages.values.toVector, p.downloadable)).toVector
 
-    PresentationPodVO(pod.id, pod.ownerId, pod.currentPresenter, presentationVOs)
+    PresentationPodVO(pod.id, pod.currentPresenter, presentationVOs)
   }
 
   def updatePresentationPod(state: MeetingState2x, pod: PresentationPod): MeetingState2x = {
@@ -65,15 +54,6 @@ object PresentationPodsApp {
       updatedPod <- pod.setCurrentPresentation(nextCurrentPresId)
     } yield {
       updatedPod
-    }
-  }
-
-  // add ownerId to default presentation pod -- in some cases we add it before first user is available
-  def changeOwnershipOfDefaultPod(state: MeetingState2x, newOwnerId: String): Option[PresentationPod] = {
-    for {
-      defPod <- getPresentationPod(state, "DEFAULT_PRESENTATION_POD")
-    } yield {
-      defPod.copy(ownerId = newOwnerId)
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPagePubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPagePubMsgHdlr.scala
@@ -43,11 +43,10 @@ trait SetCurrentPagePubMsgHdlr {
 
       val newState = for {
         pod <- PresentationPodsApp.getPresentationPod(state, podId)
-        presentationToModify <- pod.getPresentation(presentationId)
         updatedPod <- pod.setCurrentPage(presentationId, pageId)
       } yield {
 
-        if (Users2x.userIsInPresenterGroup(liveMeeting.users2x, userId) || userId.equals(pod.ownerId)) {
+        if (pod.currentPresenter == userId) {
           broadcastSetCurrentPageEvtMsg(pod.id, presentationId, pageId, userId)
 
           val pods = state.presentationPodManager.addPod(updatedPod)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/PresentationPods.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/PresentationPods.scala
@@ -6,17 +6,15 @@ import org.bigbluebutton.core.util.RandomStringGenerator
 object PresentationPodFactory {
   private def genId(): String = System.currentTimeMillis() + "-" + RandomStringGenerator.randomAlphanumericString(8)
 
-  def create(ownerId: String): PresentationPod = {
-    val currentPresenter = ownerId
-    PresentationPod(genId(), ownerId, currentPresenter, Map.empty)
+  def create(creatorId: String): PresentationPod = {
+    val currentPresenter = creatorId
+    PresentationPod(genId(), currentPresenter, Map.empty)
   }
 
-  def createDefaultPod(ownerId: String): PresentationPod = {
-    val currentPresenter = ownerId
-
+  def createDefaultPod(): PresentationPod = {
     // we hardcode the podId of the default presentation pod for the purposes of having bbb-web know the podId
     // in advance (so we can fully process default.pdf)
-    PresentationPod("DEFAULT_PRESENTATION_POD", ownerId, currentPresenter, Map.empty)
+    PresentationPod("DEFAULT_PRESENTATION_POD", "", Map.empty)
   }
 }
 
@@ -41,7 +39,7 @@ case class PresentationInPod(id: String, name: String, current: Boolean = false,
 
 }
 
-case class PresentationPod(id: String, ownerId: String, currentPresenter: String,
+case class PresentationPod(id: String, currentPresenter: String,
                            presentations: collection.immutable.Map[String, PresentationInPod]) {
   def addPresentation(presentation: PresentationInPod): PresentationPod = {
     println(s" 1 PresentationPods::addPresentation  ${presentation.id}  presName=${presentation.name}   current=${presentation.current} ")
@@ -104,7 +102,7 @@ case class PresentationPod(id: String, ownerId: String, currentPresenter: String
     val b = s"printPod (${presentations.values.size}):"
     var d = ""
     presentations.values.foreach(p => d += s"\nPRES_ID=${p.id} NAME=${p.name} CURRENT=${p.current}\n")
-    b.concat(s"PODID=$id  OWNERID=$ownerId  CURRENTPRESENTER=$currentPresenter PRESENTATIONS={{{$d}}}\n")
+    b.concat(s"PODID=$id CURRENTPRESENTER=$currentPresenter PRESENTATIONS={{{$d}}}\n")
   }
 
   def resizePage(presentationId: String, pageId: String,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/CreatePresentationPodRecordEvent.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/CreatePresentationPodRecordEvent.scala
@@ -24,11 +24,11 @@ class CreatePresentationPodRecordEvent extends AbstractPresentationRecordEvent {
 
   setEvent("CreatePresentationPodEvent")
 
-  def setOwnerId(name: String) {
-    eventMap.put(OWNER_ID, name)
+  def setCurrentPresenter(name: String) {
+    eventMap.put(CURRENT_PRESENTER, name)
   }
 }
 
 object CreatePresentationPodRecordEvent {
-  protected final val OWNER_ID = "ownerId"
+  protected final val CURRENT_PRESENTER = "currentPresenter"
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/RemovePresentationPodRecordEvent.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/RemovePresentationPodRecordEvent.scala
@@ -20,15 +20,5 @@
 package org.bigbluebutton.core.record.events
 
 class RemovePresentationPodRecordEvent extends AbstractPresentationRecordEvent {
-  import RemovePresentationPodRecordEvent._
-
   setEvent("RemovePresentationPodEvent")
-
-  def setOwnerId(name: String) {
-    eventMap.put(OWNER_ID, name)
-  }
-}
-
-object RemovePresentationPodRecordEvent {
-  protected final val OWNER_ID = "ownerId"
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/SetPresenterInPodRecordEvent.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/SetPresenterInPodRecordEvent.scala
@@ -24,16 +24,11 @@ class SetPresenterInPodRecordEvent extends AbstractPresentationRecordEvent {
 
   setEvent("SetPresenterInPodEvent")
 
-  def setPrevPresenterId(userId: String) {
-    eventMap.put(PREV_PRESENTER, userId)
-  }
-
   def setNextPresenterId(userId: String) {
     eventMap.put(NEXT_PRESENTER, userId)
   }
 }
 
 object SetPresenterInPodRecordEvent {
-  protected final val PREV_PRESENTER = "prevPresenterId"
   protected final val NEXT_PRESENTER = "nextPresenterId"
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -153,7 +153,7 @@ class MeetingActor(
   log.debug("NUM GROUP CHATS = " + state.groupChats.findAllPublicChats().length)
 
   // Create a default Presentation Pod
-  //  state = PresentationPodsApp.createDefaultPresentationPod(state)
+  state = PresentationPodsApp.createDefaultPresentationPod(state)
   log.debug("NUM Presentation Pods = " + state.presentationPodManager.getNumberOfPods())
 
   /*******************************************************************/

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
@@ -179,7 +179,7 @@ class RedisRecorderActor(val system: ActorSystem)
     val ev = new CreatePresentationPodRecordEvent()
     ev.setMeetingId(msg.header.meetingId)
     ev.setPodId(msg.body.podId)
-    ev.setOwnerId(msg.body.ownerId)
+    ev.setCurrentPresenter(msg.body.currentPresenterId)
 
     record(msg.header.meetingId, ev.toMap)
   }
@@ -188,7 +188,6 @@ class RedisRecorderActor(val system: ActorSystem)
     val ev = new RemovePresentationPodRecordEvent()
     ev.setMeetingId(msg.header.meetingId)
     ev.setPodId(msg.body.podId)
-    ev.setOwnerId(msg.body.ownerId)
 
     record(msg.header.meetingId, ev.toMap)
   }
@@ -197,7 +196,6 @@ class RedisRecorderActor(val system: ActorSystem)
     val ev = new SetPresenterInPodRecordEvent()
     ev.setMeetingId(msg.header.meetingId)
     ev.setPodId(msg.body.podId)
-    ev.setPrevPresenterId(msg.body.prevPresenterId)
     ev.setNextPresenterId(msg.body.nextPresenterId)
 
     record(msg.header.meetingId, ev.toMap)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Presentation.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Presentation.scala
@@ -7,5 +7,5 @@ case class PageVO(id: String, num: Int, thumbUri: String = "", swfUri: String,
   txtUri: String, svgUri: String, current: Boolean = false, xOffset: Double = 0,
   yOffset: Double = 0, widthRatio: Double = 100D, heightRatio: Double = 100D)
 
-case class PresentationPodVO(id: String, ownerId: String, currentPresenter: String,
+case class PresentationPodVO(id: String, currentPresenter: String,
                            presentations: Vector[PresentationVO])

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PresentationPodsMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PresentationPodsMsgs.scala
@@ -6,15 +6,15 @@ import org.bigbluebutton.common2.domain.{PresentationPodVO, PresentationVO}
 // ------------ client to akka-apps ------------
 object CreateNewPresentationPodPubMsg { val NAME = "CreateNewPresentationPodPubMsg"}
 case class CreateNewPresentationPodPubMsg(header: BbbClientMsgHeader, body: CreateNewPresentationPodPubMsgBody) extends StandardMsg
-case class CreateNewPresentationPodPubMsgBody(ownerId: String)
+case class CreateNewPresentationPodPubMsgBody()
 
 object RemovePresentationPodPubMsg { val NAME = "RemovePresentationPodPubMsg"}
 case class RemovePresentationPodPubMsg(header: BbbClientMsgHeader, body: RemovePresentationPodPubMsgBody) extends StandardMsg
-case class RemovePresentationPodPubMsgBody(requesterId: String, podId: String)
+case class RemovePresentationPodPubMsgBody(podId: String)
 
 object GetPresentationInfoReqMsg { val NAME = "GetPresentationInfoReqMsg"}
 case class GetPresentationInfoReqMsg(header: BbbClientMsgHeader, body: GetPresentationInfoReqMsgBody) extends StandardMsg
-case class GetPresentationInfoReqMsgBody(userId: String, podId: String)
+case class GetPresentationInfoReqMsgBody(podId: String)
 
 object PresentationUploadTokenReqMsg { val NAME = "PresentationUploadTokenReqMsg"}
 case class PresentationUploadTokenReqMsg(header: BbbClientMsgHeader, body: PresentationUploadTokenReqMsgBody) extends StandardMsg
@@ -22,7 +22,7 @@ case class PresentationUploadTokenReqMsgBody(podId: String, filename: String)
 
 object GetAllPresentationPodsReqMsg { val NAME = "GetAllPresentationPodsReqMsg"}
 case class GetAllPresentationPodsReqMsg(header: BbbClientMsgHeader, body: GetAllPresentationPodsReqMsgBody) extends StandardMsg
-case class GetAllPresentationPodsReqMsgBody(requesterId: String)
+case class GetAllPresentationPodsReqMsgBody()
 
 object SetCurrentPagePubMsg { val NAME = "SetCurrentPagePubMsg"}
 case class SetCurrentPagePubMsg(header: BbbClientMsgHeader, body: SetCurrentPagePubMsgBody) extends StandardMsg
@@ -30,7 +30,7 @@ case class SetCurrentPagePubMsgBody(podId: String, presentationId: String, pageI
 
 object SetPresenterInPodReqMsg { val NAME = "SetPresenterInPodReqMsg"}
 case class SetPresenterInPodReqMsg(header: BbbClientMsgHeader, body: SetPresenterInPodReqMsgBody) extends StandardMsg
-case class SetPresenterInPodReqMsgBody(podId: String, prevPresenterId: String, nextPresenterId: String)
+case class SetPresenterInPodReqMsgBody(podId: String, nextPresenterId: String)
 
 object RemovePresentationPubMsg { val NAME = "RemovePresentationPubMsg"}
 case class RemovePresentationPubMsg(header: BbbClientMsgHeader, body: RemovePresentationPubMsgBody) extends StandardMsg
@@ -80,11 +80,11 @@ case class PresentationConversionCompletedSysPubMsgBody(podId: String, messageKe
 // ------------ akka-apps to client ------------
 object CreateNewPresentationPodEvtMsg { val NAME = "CreateNewPresentationPodEvtMsg"}
 case class CreateNewPresentationPodEvtMsg(header: BbbClientMsgHeader, body: CreateNewPresentationPodEvtMsgBody) extends StandardMsg
-case class CreateNewPresentationPodEvtMsgBody(ownerId: String, podId: String)
+case class CreateNewPresentationPodEvtMsgBody(currentPresenterId: String, podId: String)
 
 object RemovePresentationPodEvtMsg { val NAME = "RemovePresentationPodEvtMsg"}
 case class RemovePresentationPodEvtMsg(header: BbbClientMsgHeader, body: RemovePresentationPodEvtMsgBody) extends StandardMsg
-case class RemovePresentationPodEvtMsgBody( ownerId: String, podId: String)
+case class RemovePresentationPodEvtMsgBody(podId: String)
 
 object GetPresentationInfoRespMsg { val NAME = "GetPresentationInfoRespMsg"}
 case class GetPresentationInfoRespMsg(header: BbbClientMsgHeader, body: GetPresentationInfoRespMsgBody) extends BbbCoreMsg
@@ -124,7 +124,7 @@ case class SetCurrentPageEvtMsgBody(podId: String, presentationId: String, pageI
 
 object SetPresenterInPodRespMsg { val NAME = "SetPresenterInPodRespMsg"}
 case class SetPresenterInPodRespMsg(header: BbbClientMsgHeader, body: SetPresenterInPodRespMsgBody) extends StandardMsg
-case class SetPresenterInPodRespMsgBody(podId: String, prevPresenterId: String, nextPresenterId: String)
+case class SetPresenterInPodRespMsgBody(podId: String, nextPresenterId: String)
 
 object RemovePresentationEvtMsg { val NAME = "RemovePresentationEvtMsg"}
 case class RemovePresentationEvtMsg(header: BbbClientMsgHeader, body: RemovePresentationEvtMsgBody) extends BbbCoreMsg

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/business/PresentProxy.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/business/PresentProxy.as
@@ -46,14 +46,12 @@ package org.bigbluebutton.modules.present.business
 	import org.bigbluebutton.modules.present.events.RequestPresentationInfoPodEvent;
 	import org.bigbluebutton.modules.present.events.SetPresenterInPodReqEvent;
 	import org.bigbluebutton.modules.present.events.UploadEvent;
-	import org.bigbluebutton.modules.present.managers.PresentationSlides;
 	import org.bigbluebutton.modules.present.model.Page;
 	import org.bigbluebutton.modules.present.model.Presentation;
 	import org.bigbluebutton.modules.present.model.PresentationModel;
 	import org.bigbluebutton.modules.present.model.PresentationPodManager;
 	import org.bigbluebutton.modules.present.services.PresentationService;
 	import org.bigbluebutton.modules.present.services.messages.PageChangeVO;
-	import org.bigbluebutton.modules.present.services.messaging.MessageReceiver;
 	import org.bigbluebutton.modules.present.services.messaging.MessageSender;
 	
 	public class PresentProxy {
@@ -64,9 +62,7 @@ package org.bigbluebutton.modules.present.business
 		private var room:String;
 		private var userid:Number;
 		private var uploadService:FileUploadService;
-		private var slides:PresentationSlides;
 		private var sender:MessageSender;
-		private var _messageReceiver:MessageReceiver;
     
 		private var podManager: PresentationPodManager;
 		private var service: PresentationService;
@@ -76,7 +72,6 @@ package org.bigbluebutton.modules.present.business
 
 			podManager = PresentationPodManager.getInstance();
 
-			slides = new PresentationSlides();
 			sender = new MessageSender();
 			service = new PresentationService();
 		}
@@ -222,23 +217,6 @@ package org.bigbluebutton.modules.present.business
 			var req:URLRequest = new URLRequest(downloadUri);
 			navigateToURL(req,"_blank");
 		}
-				
-		/**
-		 * Loads a presentation from the server. creates a new PresentationService class 
-		 * 
-		 */		
-		public function loadPresentation(e:UploadEvent) : void
-		{
-			var presentationName:String = e.presentationName;
-			LOGGER.debug("PresentProxy::loadPresentation: presentationName={0}", [presentationName]);
-			var fullUri : String = host + "/bigbluebutton/presentation/" + conference + "/" + room + "/" + presentationName+"/slides";	
-			var slideUri:String = host + "/bigbluebutton/presentation/" + conference + "/" + room + "/" + presentationName;
-			
-			LOGGER.debug("PresentationApplication::loadPresentation()... {0}", [fullUri]);
-//			var service:PresentationService = new PresentationService();
-//			service.load(fullUri, slides, slideUri);
-			LOGGER.debug('number of slides={0}', [slides.size()]);
-		}
 
 		/**
 		 * It may take a few seconds for the process to complete on the server, so we allow for some time 
@@ -279,7 +257,7 @@ package org.bigbluebutton.modules.present.business
 		 * 
 		 */
 		public function handleRequestNewPresentationPod(e: RequestNewPresentationPodEvent): void {
-			sender.requestNewPresentationPod(e.requesterId);
+			sender.requestNewPresentationPod();
 		}
 
 		/**
@@ -288,11 +266,11 @@ package org.bigbluebutton.modules.present.business
 		 * 
 		 */
 		public function handleRequestClosePresentationPod(e: RequestClosePresentationPodEvent): void {
-			sender.requestClosePresentationPod(e.requesterId, e.podId);
+			sender.requestClosePresentationPod(e.podId);
 		}
 
 		public function handleSetPresenterInPodReqEvent(e: SetPresenterInPodReqEvent): void {
-			sender.handleSetPresenterInPodReqEvent(e.podId, e.prevPresenterId, e.nextPresenterId);
+			sender.handleSetPresenterInPodReqEvent(e.podId, e.nextPresenterId);
 		}
 
 	}

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/events/NewPresentationPodCreated.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/events/NewPresentationPodCreated.as
@@ -6,12 +6,12 @@ package org.bigbluebutton.modules.present.events {
         public static const PRESENTATION_NEW_POD_CREATED:String = "NewPresentationPodCreated";
 
         public var podId:String;
-        public var ownerId:String;
+        public var presenterId:String;
 
-        public function NewPresentationPodCreated(_podId:String, _ownerId:String) {
+        public function NewPresentationPodCreated(podId:String, presenterId:String) {
             super(PRESENTATION_NEW_POD_CREATED, true, false);
-            this.podId = _podId;
-            this.ownerId = _ownerId;
+            this.podId = podId;
+            this.presenterId = presenterId;
         }
     }
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/events/PresentationPodRemoved.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/events/PresentationPodRemoved.as
@@ -6,12 +6,10 @@ package org.bigbluebutton.modules.present.events {
         public static const PRESENTATION_POD_REMOVED:String = "PresentationPodRemoved";
 
         public var podId:String;
-        public var ownerId:String;
 
-        public function PresentationPodRemoved(_podId:String, _ownerId:String) {
+        public function PresentationPodRemoved(podId:String) {
             super(PRESENTATION_POD_REMOVED, true, false);
-            this.podId = _podId;
-            this.ownerId = _ownerId;
+            this.podId = podId;
         }
     }
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/events/RequestNewPresentationPodEvent.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/events/RequestNewPresentationPodEvent.as
@@ -25,10 +25,8 @@ import flash.events.Event;
     public class RequestNewPresentationPodEvent extends Event {
         public static const REQUEST_NEW_PRES_POD:String = "REQUEST_NEW_PRES_POD";
 
-        public var requesterId: String;
-
-        public function RequestNewPresentationPodEvent(type:String) {
-            super(type, true, false);
+        public function RequestNewPresentationPodEvent() {
+            super(REQUEST_NEW_PRES_POD, true, false);
         }
 
     }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/events/SetPresenterInPodReqEvent.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/events/SetPresenterInPodReqEvent.as
@@ -26,14 +26,12 @@ package org.bigbluebutton.modules.present.events
         public static const SET_PRESENTER_IN_POD_REQ:String = "SET_PRESENTER_IN_POD_REQ";
 
         public var podId: String;
-        public var prevPresenterId: String;
         public var nextPresenterId: String;
 
-        public function SetPresenterInPodReqEvent(podId :String, prevPresenterId: String, nextPresenterId: String) {
+        public function SetPresenterInPodReqEvent(podId :String, nextPresenterId: String) {
             super(SET_PRESENTER_IN_POD_REQ, true, false);
             this.podId = podId;
             this.nextPresenterId = nextPresenterId;
-            this.prevPresenterId = prevPresenterId;
         }
 
     }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/events/SetPresenterInPodRespEvent.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/events/SetPresenterInPodRespEvent.as
@@ -6,13 +6,11 @@ package org.bigbluebutton.modules.present.events
     public static const SET_PRESENTER_IN_POD_RESP:String = "SET_PRESENTER_IN_POD_RESP";
 
     public var podId: String;
-    public var prevPresenterId: String;
     public var nextPresenterId: String;
 
-    public function SetPresenterInPodRespEvent(podId: String, prevPresenterId: String, nextPresenterId: String) {
+    public function SetPresenterInPodRespEvent(podId: String, nextPresenterId: String) {
       super(SET_PRESENTER_IN_POD_RESP, true, false);
       this.podId = podId;
-      this.prevPresenterId = prevPresenterId;
       this.nextPresenterId = nextPresenterId;
     }
   }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/managers/PresentManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/managers/PresentManager.as
@@ -60,7 +60,7 @@ package org.bigbluebutton.modules.present.managers
 		}
 
 		public function handleStartModuleEvent(e:PresentModuleEvent):void{
-			if (winManager.isEmpty()) {
+			if (!winManager.isEmpty()) { 
 				return;
 			}
 			
@@ -77,50 +77,37 @@ package org.bigbluebutton.modules.present.managers
 
 		public function handleAddPresentationPod(e: NewPresentationPodCreated): void {
 			var podId: String = e.podId;
-			var ownerId: String = e.ownerId;
+			var presenterId: String = e.presenterId;
 
-			if (podId == PresentationPodManager.DEFAULT_POD_ID && winManager.containsPodId(podId)) {
-				// update model
-				podsManager.updateOwnershipOfDefaultPod(ownerId);
-				var defWindow: PresentationWindow = winManager.findWindowByPodId(PresentationPodManager.DEFAULT_POD_ID);
-				defWindow.setOwnerId(ownerId);
-			} else {
-				if (StringUtils.isEmpty(ownerId)) {
-					podsManager.requestDefaultPresentationPod();
-				}
-				if(winManager.containsPodId(podId)) {
-					// remove pod and replace with the updated version
-					handlePresentationPodRemovedHelper(podId, ownerId);
-				}
+			if(winManager.containsPodId(podId)) {
+				// remove pod and replace with the updated version
+				handlePresentationPodRemovedHelper(podId);
+			}
 
-				var newWindow:PresentationWindow = new PresentationWindow();
-				newWindow.onPodCreated(podId, ownerId);
-				newWindow.visible = true;
-				newWindow.showControls = presentOptions.showWindowControls;
+			var newWindow:PresentationWindow = new PresentationWindow();
+			newWindow.onPodCreated(podId, presenterId);
 
-				var selectedWinId:String = winManager.addWindow(podId, newWindow, podId == PresentationPodManager.DEFAULT_POD_ID);
+			var selectedWinId:String = winManager.addWindow(podId, newWindow, podId == PresentationPodManager.DEFAULT_POD_ID);
 
-				if (selectedWinId != null) {
-					newWindow.setWindowId(selectedWinId);
+			if (selectedWinId != null) {
+				newWindow.setWindowId(selectedWinId);
 
-					var openEvent:OpenWindowEvent = new OpenWindowEvent(OpenWindowEvent.OPEN_WINDOW_EVENT);
-					openEvent.window = newWindow;
-					globalDispatcher.dispatchEvent(openEvent);
+				var openEvent:OpenWindowEvent = new OpenWindowEvent(OpenWindowEvent.OPEN_WINDOW_EVENT);
+				openEvent.window = newWindow;
+				globalDispatcher.dispatchEvent(openEvent);
 
-					podsManager.handleAddPresentationPod(podId, ownerId);
-				}
+				podsManager.handleAddPresentationPod(podId);
 			}
 		}
 
 		public function handlePresentationPodRemoved(e: PresentationPodRemoved): void {
 			var podId: String = e.podId;
-			var ownerId: String = e.ownerId;
 
-			handlePresentationPodRemovedHelper(podId, ownerId);
+			handlePresentationPodRemovedHelper(podId);
 		}
 
-		private function handlePresentationPodRemovedHelper(podId: String, ownerId: String): void {
-			podsManager.handlePresentationPodRemoved(podId, ownerId);
+		private function handlePresentationPodRemovedHelper(podId: String): void {
+			podsManager.handlePresentationPodRemoved(podId);
 
 			var destroyWindow:PresentationWindow = winManager.findWindowByPodId(podId);
 			if (destroyWindow != null) {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/model/PresentationModel.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/model/PresentationModel.as
@@ -13,15 +13,9 @@ package org.bigbluebutton.modules.present.model
 
     private var _presentations:ArrayCollection = new ArrayCollection();
     private var _podId: String = "";
-    private var _ownerId: String = "";
 
-    public function PresentationModel(podId: String, ownerId: String) {
-      initialize(podId, ownerId);
-    }
-    
-    private function initialize(podId: String, ownerId: String):void {
-        this._podId = podId;
-        this._ownerId = ownerId;
+    public function PresentationModel(podId: String) {
+		_podId = podId;
     }
     
     private function whichPageIsCurrent(presId: String): String {
@@ -44,14 +38,6 @@ package org.bigbluebutton.modules.present.model
     
     public function getPodId(): String {
         return this._podId;
-    }
-
-    public function getOwnerId(): String {
-        return this._ownerId;
-    }
-    
-    public function setOwnerId(ownerId: String): void {
-        this._ownerId = ownerId;
     }
 
     public function addPresentation(p: Presentation):void {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/model/PresentationPodManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/model/PresentationPodManager.as
@@ -56,14 +56,7 @@ package org.bigbluebutton.modules.present.model {
             this.presentationService = service;
         }
         
-        public function requestDefaultPresentationPod(): void {
-            var event:RequestNewPresentationPodEvent = new RequestNewPresentationPodEvent(RequestNewPresentationPodEvent.REQUEST_NEW_PRES_POD);
-            event.requesterId = UsersUtil.getMyUserID();
-            globalDispatcher.dispatchEvent(event);
-        }
-        
         public function getPod(podId: String): PresentationModel {
-            var resultingPod: PresentationModel = null;
             for (var i:int = 0; i < _presentationPods.length; i++) {
                 var pod: PresentationModel = _presentationPods.getItemAt(i) as PresentationModel;
 
@@ -71,15 +64,15 @@ package org.bigbluebutton.modules.present.model {
                     return pod;
                 }
             }
-            return resultingPod;
+            return null;
         }
 
         public function getDefaultPresentationPod(): PresentationModel {
             var pod: PresentationModel = getPod(DEFAULT_POD_ID);
-            return pod || null;
+            return pod;
         }
 
-        public function handleAddPresentationPod(podId: String, ownerId: String): void {
+        public function handleAddPresentationPod(podId: String): void {
             for (var i:int = 0; i < _presentationPods.length; i++) {
                 var pod: PresentationModel = _presentationPods.getItemAt(i) as PresentationModel;
                 if (pod.getPodId() == podId) {
@@ -87,11 +80,11 @@ package org.bigbluebutton.modules.present.model {
                 }
             }
 
-            var newPod: PresentationModel = new PresentationModel(podId, ownerId);
+            var newPod: PresentationModel = new PresentationModel(podId);
             _presentationPods.addItem(newPod);
         }
         
-        public function handlePresentationPodRemoved(podId: String, ownerId: String): void {
+        public function handlePresentationPodRemoved(podId: String): void {
             for (var i:int = 0; i < _presentationPods.length; i++) {
                 var pod: PresentationModel = _presentationPods.getItemAt(i) as PresentationModel;
 
@@ -115,23 +108,11 @@ package org.bigbluebutton.modules.present.model {
         public function handleGetAllPodsResp(podsAC: ArrayCollection): void {
             for (var j:int = 0; j < podsAC.length; j++) {
                 var podVO: PresentationPodVO = podsAC.getItemAt(j) as PresentationPodVO;
-                var newPod: PresentationModel = new PresentationModel(podVO.id, podVO.ownerId);
 
-                globalDispatcher.dispatchEvent(new NewPresentationPodCreated(newPod.getPodId(), newPod.getOwnerId()));
+                globalDispatcher.dispatchEvent(new NewPresentationPodCreated(podVO.id, podVO.currentPresenter));
 
                 var presentationsToAdd:ArrayCollection = podVO.getPresentations();
                 presentationService.addPresentations(podVO.id, presentationsToAdd);
-            }
-
-            if (podsAC.length == 0) { // If there are no pods, request the creation of a default one
-                requestDefaultPresentationPod();
-            }
-        }
-
-        public function updateOwnershipOfDefaultPod(ownerId: String): void {
-            var pod: PresentationModel = getDefaultPresentationPod();
-            if (pod != null) {
-                pod.setOwnerId(ownerId);
             }
         }
 

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/model/PresentationWindowManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/model/PresentationWindowManager.as
@@ -96,7 +96,7 @@ package org.bigbluebutton.modules.present.model {
 		}
 		
 		public function isEmpty():Boolean {
-			return windows.length > 0;
+			return windows.length == 0;
 		}
 	}
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/services/messages/PresentationPodVO.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/services/messages/PresentationPodVO.as
@@ -4,15 +4,14 @@ import mx.collections.ArrayCollection;
 
     public class PresentationPodVO {
         private var _id:String;
-        private var _ownerId:String;
         private var _currentPresenter:String;
         private var _authorizedPresenters:ArrayCollection;
         private var _presentations:ArrayCollection;
 
-        public function PresentationPodVO(id: String, ownerId: String, currentPresenter: String,
-                                          authorizedPresenters: ArrayCollection, presentations: ArrayCollection) {
+        public function PresentationPodVO(id: String, currentPresenter: String,
+                                          authorizedPresenters: ArrayCollection,
+                                          presentations: ArrayCollection) {
             _id = id;
-            _ownerId = ownerId;
             _currentPresenter = currentPresenter;
             _authorizedPresenters = authorizedPresenters;
             _presentations = presentations;
@@ -22,11 +21,7 @@ import mx.collections.ArrayCollection;
             return _id;
         }
 
-        public function get ownerId():String {
-            return _ownerId;
-        }
-
-        public function currentPresenter():String {
+        public function get currentPresenter():String {
             return _currentPresenter;
         }
 

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/services/messaging/MessageReceiver.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/services/messaging/MessageReceiver.as
@@ -225,8 +225,8 @@ package org.bigbluebutton.modules.present.services.messaging
         presentationVOs.addItem(authPresArray[m] as String);
       }  
 
-      var podVO:PresentationPodVO = new PresentationPodVO(presentationPod.id, presentationPod.ownerId,
-                presentationPod.currentPresenter, authorizedPresenters, presentationVOs);
+      var podVO:PresentationPodVO = new PresentationPodVO(presentationPod.id, presentationPod.currentPresenter,
+                                                          authorizedPresenters, presentationVOs);
       return podVO;
     }
     
@@ -298,15 +298,14 @@ package org.bigbluebutton.modules.present.services.messaging
     }
 
     private function handleCreateNewPresentationPodEvtMsg(msg:Object): void {
-      var ownerId: String = msg.body.ownerId;
+      var currentPresenterId: String = msg.body.currentPresenterId;
       var podId: String = msg.body.podId;
-      dispatcher.dispatchEvent(new NewPresentationPodCreated(podId, ownerId));
+      dispatcher.dispatchEvent(new NewPresentationPodCreated(podId, currentPresenterId));
     }
 
     private function handleRemovePresentationPodEvtMsg(msg:Object): void {
-      var ownerId: String = msg.body.ownerId;
       var podId: String = msg.body.podId;
-      dispatcher.dispatchEvent(new PresentationPodRemoved(podId, ownerId));
+      dispatcher.dispatchEvent(new PresentationPodRemoved(podId));
     }
 
     private function handleGetAllPresentationPodsRespMsg(msg: Object): void {
@@ -325,9 +324,8 @@ package org.bigbluebutton.modules.present.services.messaging
 
     private function handleSetPresenterInPodRespMsg(msg: Object): void {
       var podId: String = msg.body.podId as String;
-      var prevPresenterId: String = msg.body.prevPresenterId as String;
       var nextPresenterId: String = msg.body.nextPresenterId as String;
-      dispatcher.dispatchEvent(new SetPresenterInPodRespEvent(podId, prevPresenterId, nextPresenterId));
+      dispatcher.dispatchEvent(new SetPresenterInPodRespEvent(podId, nextPresenterId));
     }
   }
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/services/messaging/MessageSender.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/services/messaging/MessageSender.as
@@ -77,7 +77,7 @@ package org.bigbluebutton.modules.present.services.messaging
     public function getPresentationInfo(podId: String):void {
       var message:Object = {
         header: {name: "GetPresentationInfoReqMsg", meetingId: UsersUtil.getInternalMeetingID(), userId: UsersUtil.getMyUserID()},
-        body: {userId: "", podId: podId}
+        body: {podId: podId}
       };
       
       var _nc:ConnectionManager = BBB.initConnectionManager();
@@ -91,7 +91,7 @@ package org.bigbluebutton.modules.present.services.messaging
     public function requestAllPodsEvent():void {
       var message:Object = {
         header: {name: "GetAllPresentationPodsReqMsg", meetingId: UsersUtil.getInternalMeetingID(), userId: UsersUtil.getMyUserID()},
-        body: {requesterId: UsersUtil.getMyUserID()}
+        body: {}
       };
       
       var _nc:ConnectionManager = BBB.initConnectionManager();
@@ -133,7 +133,7 @@ package org.bigbluebutton.modules.present.services.messaging
     public function requestNewPresentationPod():void {
       var message:Object = {
         header: {name: "CreateNewPresentationPodPubMsg", meetingId: UsersUtil.getInternalMeetingID(), userId: UsersUtil.getMyUserID()},
-        body: {ownerId: ""}
+        body: {}
       };
 
       var _nc:ConnectionManager = BBB.initConnectionManager();
@@ -147,7 +147,7 @@ package org.bigbluebutton.modules.present.services.messaging
     public function requestClosePresentationPod(podId: String):void {
       var message:Object = {
         header: {name: "RemovePresentationPodPubMsg", meetingId: UsersUtil.getInternalMeetingID(), userId: UsersUtil.getMyUserID()},
-        body: {requesterId: "", podId: podId}
+        body: {podId: podId}
       };
 
       var _nc:ConnectionManager = BBB.initConnectionManager();
@@ -161,7 +161,7 @@ package org.bigbluebutton.modules.present.services.messaging
     public function handleSetPresenterInPodReqEvent(podId: String, nextPresenterId: String):void {
       var message:Object = {
         header: {name: "SetPresenterInPodReqMsg", meetingId: UsersUtil.getInternalMeetingID(), userId: UsersUtil.getMyUserID()},
-        body: { podId: podId, prevPresenterId: "", nextPresenterId: nextPresenterId }
+        body: {podId: podId, nextPresenterId: nextPresenterId}
       };
 
       var _nc:ConnectionManager = BBB.initConnectionManager();

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/services/messaging/MessageSender.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/services/messaging/MessageSender.as
@@ -77,7 +77,7 @@ package org.bigbluebutton.modules.present.services.messaging
     public function getPresentationInfo(podId: String):void {
       var message:Object = {
         header: {name: "GetPresentationInfoReqMsg", meetingId: UsersUtil.getInternalMeetingID(), userId: UsersUtil.getMyUserID()},
-        body: {userId: UsersUtil.getMyUserID(), podId: podId}
+        body: {userId: "", podId: podId}
       };
       
       var _nc:ConnectionManager = BBB.initConnectionManager();
@@ -130,10 +130,10 @@ package org.bigbluebutton.modules.present.services.messaging
       );
     }
 
-    public function requestNewPresentationPod(requesterId: String):void {
+    public function requestNewPresentationPod():void {
       var message:Object = {
         header: {name: "CreateNewPresentationPodPubMsg", meetingId: UsersUtil.getInternalMeetingID(), userId: UsersUtil.getMyUserID()},
-        body: {ownerId: requesterId}
+        body: {ownerId: ""}
       };
 
       var _nc:ConnectionManager = BBB.initConnectionManager();
@@ -144,10 +144,10 @@ package org.bigbluebutton.modules.present.services.messaging
       );
     }
 
-    public function requestClosePresentationPod(requesterId: String, podId: String):void {
+    public function requestClosePresentationPod(podId: String):void {
       var message:Object = {
         header: {name: "RemovePresentationPodPubMsg", meetingId: UsersUtil.getInternalMeetingID(), userId: UsersUtil.getMyUserID()},
-        body: {requesterId: requesterId, podId: podId}
+        body: {requesterId: "", podId: podId}
       };
 
       var _nc:ConnectionManager = BBB.initConnectionManager();
@@ -158,10 +158,10 @@ package org.bigbluebutton.modules.present.services.messaging
       );
     }
 
-    public function handleSetPresenterInPodReqEvent(podId: String, prevPresenterId: String, nextPresenterId: String):void {
+    public function handleSetPresenterInPodReqEvent(podId: String, nextPresenterId: String):void {
       var message:Object = {
         header: {name: "SetPresenterInPodReqMsg", meetingId: UsersUtil.getInternalMeetingID(), userId: UsersUtil.getMyUserID()},
-        body: { podId: podId, prevPresenterId: prevPresenterId, nextPresenterId: nextPresenterId }
+        body: { podId: podId, prevPresenterId: "", nextPresenterId: nextPresenterId }
       };
 
       var _nc:ConnectionManager = BBB.initConnectionManager();

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -308,6 +308,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					becomePresenter();
 				}
 				
+				//send new presenter to the whiteboard canvas
+				if (whiteboardOverlay != null) {
+					whiteboardOverlay.presenterChange(amITheCurrentPodPresenter(), currentPresenterInPod);
+				}
+				
 				populatePodDropdown();
 			}
 
@@ -651,7 +656,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         if(whiteboardOverlay != null) {
           LOGGER.debug("addWhiteboardCanvasToSlideView: Adding whiteboard canvas to SlideView");
           slideView.acceptOverlayCanvas(this.podId, whiteboardOverlay);
-		}
+          
+          whiteboardOverlay.presenterChange(amITheCurrentPodPresenter(), currentPresenterInPod);
+        }
       }
 			
 			override protected function resourcesChanged():void{

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -164,7 +164,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private var windowId:String;
 			
 			[Bindable] private var podId: String = "";
-			private var ownerId: String = "";
 			[Bindable] private var currentPresenterInPod: String = "";
 			[Bindable] private var currentPresenterUsername: String = "";
 			
@@ -182,6 +181,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 			private function init():void{
 				presentOptions = Options.getOptions(PresentOptions) as PresentOptions;
+				
+				showControls = presentOptions.showWindowControls;
 			}
 
 			private function amITheCurrentPodPresenter(): Boolean {
@@ -229,10 +230,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				return item.type == "user" || item.type == "action";
 			}
 
-			public function onPodCreated(_podId: String, _ownerId: String):void {
-				this.podId = _podId;
-				this.ownerId = _ownerId;
-				this.currentPresenterInPod = this.ownerId;
+			public function onPodCreated(podId: String, presenterId: String):void {
+				this.podId = podId;
+				this.currentPresenterInPod = presenterId;
 				this.currentPresenterUsername = UsersUtil.getUserName(this.currentPresenterInPod);
 				populatePodDropdown();
 
@@ -248,13 +248,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 			public function getPodId(): String { return this.podId; }
 
-			public function getOwnerId(): String { return this.ownerId; }
-			public function setOwnerId(newOwnerId: String): void {
-				this.ownerId = newOwnerId;
-				// trigger update
-				onPodCreated(this.podId, this.ownerId);
-			}
-
 			private function onPresentationPodControlsChange(e:Event):void {
 				if(presentationPodControls.selectedItem != null && presentationPodControls.selectedItem.hasOwnProperty('handler')) {
 					presentationPodControls.selectedItem.handler();
@@ -263,10 +256,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 
 			private function newPresentationWindowHandler(): void {
-				var event:RequestNewPresentationPodEvent = new RequestNewPresentationPodEvent(RequestNewPresentationPodEvent.REQUEST_NEW_PRES_POD);
-
-				event.requesterId = UsersUtil.getMyUserID();
-				localDispatcher.dispatchEvent(event);
+				localDispatcher.dispatchEvent(new RequestNewPresentationPodEvent());
 			}
 
 			private function closePresentationWindowHandler(): void {
@@ -286,26 +276,21 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 
 			private function setPresenterInPodHelper(nextPresenterId: String): void {
-				var prevPresenterId: String = this.ownerId;
-				if (!StringUtils.isEmpty(this.currentPresenterInPod)) {
-					prevPresenterId = this.currentPresenterInPod;
-				}
-				localDispatcher.dispatchEvent(new SetPresenterInPodReqEvent(this.podId, prevPresenterId, nextPresenterId));
+				localDispatcher.dispatchEvent(new SetPresenterInPodReqEvent(this.podId, nextPresenterId));
 			}
 
 			private function handleSetPresenterInPodRespEvent(event: SetPresenterInPodRespEvent): void {
 				if (event.podId != this.podId) {
 					return;
 				}
-
-				this.currentPresenterInPod = event.nextPresenterId as String;
+				
+				this.currentPresenterInPod = event.nextPresenterId;
 				this.currentPresenterUsername = UsersUtil.getUserName(this.currentPresenterInPod);
-				if (UsersUtil.getMyUserID() == event.prevPresenterId) {
-					becomeViewer();
-				}
 
-				if (UsersUtil.getMyUserID() == event.nextPresenterId) {
+				if (amITheCurrentPodPresenter()) {
 					becomePresenter();
+				} else {
+					becomeViewer();
 				}
 				
 				//send new presenter to the whiteboard canvas

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -237,7 +237,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				populatePodDropdown();
 
 				// make me currentPodPresenter
-				if (StringUtils.isEmpty(this.currentPresenterInPod) || StringUtils.isEmpty(this.currentPresenterUsername)) {
+				if ((StringUtils.isEmpty(this.currentPresenterInPod) || StringUtils.isEmpty(this.currentPresenterUsername)) && UsersUtil.amIModerator()) {
 					setPresenterInPodHelper(UsersUtil.getMyUserID());
 				}
 			}

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/SlideView.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/SlideView.mxml
@@ -367,19 +367,18 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 			private function amITheCurrentPodPresenter(): Boolean {
 				return UsersUtil.getMyUserID() == this.currentPresenterInPod;
-                        }
+			}
 			
-      public function becomeViewer(amIThePresenterInThePod:Boolean, currentPresenterInPod: String):void {
-        removeEventListener(MouseEvent.MOUSE_WHEEL, onMouseWheelZoomEvent);
-        this.removeEventListener(MouseEvent.MOUSE_DOWN, onMouseDown);
-        if (whiteboardCanvas != null && currentPresenterInPod != null) {
-          whiteboardCanvas.presenterChange(amIThePresenterInThePod, currentPresenterInPod);
-        }
-        pagePositionBroadcaster.reset();
-        
-        endDrag();
-      }
-      
+			public function becomeViewer(amIThePresenterInThePod:Boolean, currentPresenterInPod: String):void {
+
+				removeEventListener(MouseEvent.MOUSE_WHEEL, onMouseWheelZoomEvent);
+				this.removeEventListener(MouseEvent.MOUSE_DOWN, onMouseDown);
+				
+				pagePositionBroadcaster.reset();
+				
+				endDrag();
+			}
+			
 			public function becomePresenter(amIThePresenterInThePod:Boolean, currentPresenterInPod: String):void {
 				// need to calculate slide zoom percentage left by a previous presenter
 				/**
@@ -391,9 +390,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				addEventListener(MouseEvent.MOUSE_WHEEL, onMouseWheelZoomEvent);
 				this.addEventListener(MouseEvent.MOUSE_DOWN, onMouseDown);
 				notifyOthersOfZoomEvent();
-				if (whiteboardCanvas != null) {
-					whiteboardCanvas.presenterChange(amIThePresenterInThePod, currentPresenterInPod);
-				}
 			}
 
 			private function noSlideContentLoaded():Boolean {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardTextToolbar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardTextToolbar.mxml
@@ -108,8 +108,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 			
 			private function closeMenus() : void {
-				ctextpik.close();
-				textSizeMenu.close();
+				if (ctextpik) ctextpik.close();
+				if (textSizeMenu) textSizeMenu.close();
 			}
 			
 			public function syncPropsWith(tobj:TextObject):void {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardToolbar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardToolbar.mxml
@@ -169,7 +169,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		
 			public function presenterChange(amIPresenter:Boolean): void {
 				this.isPresenter = amIPresenter;
-				multiUserBtn.enabled = multiUserBtn.visible = multiUserBtn.includeInLayout = amIPresenter;
+				
+				if (multiUserBtn != null) {
+					multiUserBtn.enabled = multiUserBtn.visible = multiUserBtn.includeInLayout = amIPresenter;
+				}
 				checkVisibility();
 
 				if (!amIPresenter) {


### PR DESCRIPTION
This PR cleans up the presentation pod code on the client and server by removing some unnecessary and unused properties and functions. I've removed ownerId from the pods, prevPresenterId from presenter switch, and a bunch of userIds that shouldn't be in the body of messages.

I wasn't able to test uploading because at the moment that doesn't work on my VM for (I think) an unrelated reason.