### PR TITLE
Filter delayed messages

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/PermissionCheck.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/PermissionCheck.scala
@@ -26,6 +26,8 @@ trait RightsManagementTrait extends SystemConfiguration {
   }
 
   def filterPresentationMessage(users: Users2x, userId: String): Boolean = {
+    // Check if the message are delayed presentation messages from the previous presenter
+    // after a switch presenter has been made. ralam nov 22, 2017
     users.purgeOldPresenters()
     val now = System.currentTimeMillis()
     users.findOldPresenter(userId) match {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/PermissionCheck.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/PermissionCheck.scala
@@ -19,11 +19,7 @@ trait RightsManagementTrait extends SystemConfiguration {
    */
   def permissionFailed(permissionLevel: Int, roleLevel: Int, users: Users2x, userId: String): Boolean = {
     if (applyPermissionCheck) {
-      if (PermissionCheck.isDelayedMessage(users, userId)) {
-        false
-      } else {
-        !PermissionCheck.isAllowed(permissionLevel, roleLevel, users, userId)
-      }
+      !PermissionCheck.isAllowed(permissionLevel, roleLevel, users, userId)
     } else {
       false
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/PermissionCheck.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/PermissionCheck.scala
@@ -24,6 +24,15 @@ trait RightsManagementTrait extends SystemConfiguration {
       false
     }
   }
+
+  def filterPresentationMessage(users: Users2x, userId: String): Boolean = {
+    users.purgeOldPresenters()
+    val now = System.currentTimeMillis()
+    users.findOldPresenter(userId) match {
+      case Some(op) => now - op.changedPresenterOn < 5000
+      case None     => false
+    }
+  }
 }
 
 object PermissionCheck {
@@ -87,12 +96,4 @@ object PermissionCheck {
     users.removeOldPresenter(userId)
   }
 
-  def isDelayedMessage(users: Users2x, userId: String): Boolean = {
-    users.purgeOldPresenters()
-    val now = System.currentTimeMillis()
-    users.findOldPresenter(userId) match {
-      case Some(op) => now - op.notPresenterOn < 5000
-      case None     => false
-    }
-  }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
@@ -12,6 +12,7 @@ class WhiteboardModel {
   private var _whiteboards = new HashMap[String, Whiteboard]()
 
   private var _multiUser = false
+  private var changedModeOn = System.currentTimeMillis()
 
   private def saveWhiteboard(wb: Whiteboard) {
     _whiteboards += wb.id -> wb
@@ -217,11 +218,14 @@ class WhiteboardModel {
 
   def modifyWhiteboardAccess(multiUser: Boolean) {
     _multiUser = multiUser
+    changedModeOn = System.currentTimeMillis()
   }
 
-  def getWhiteboardAccess(): Boolean = {
+  def isMultiUser(): Boolean = {
     _multiUser
   }
+
+  def getChangedModeOn: Long = changedModeOn
 
   def cleansePointsInAnnotation(ann: AnnotationVO): AnnotationVO = {
     var updatedAnnotationInfo = ann.annotationInfo

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -1,20 +1,20 @@
 package org.bigbluebutton.core.apps.breakout
 
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.apps.BreakoutModel
+import org.bigbluebutton.core.apps.{ BreakoutModel, PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.domain.{ BreakoutRoom2x, MeetingState2x }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core.running.MeetingActor
-import org.bigbluebutton.core.apps.PermissionCheck
 
-trait CreateBreakoutRoomsCmdMsgHdlr {
+trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
 
   val liveMeeting: LiveMeeting
   val outGW: OutMsgRouter
 
   def handleCreateBreakoutRoomsCmdMsg(msg: CreateBreakoutRoomsCmdMsg, state: MeetingState2x): MeetingState2x = {
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to create breakout room for meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EndAllBreakoutRoomsMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EndAllBreakoutRoomsMsgHdlr.scala
@@ -5,15 +5,15 @@ import org.bigbluebutton.core.api.EndBreakoutRoomInternalMsg
 import org.bigbluebutton.core.bus.BigBlueButtonEvent
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait EndAllBreakoutRoomsMsgHdlr {
+trait EndAllBreakoutRoomsMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
 
   val outGW: OutMsgRouter
 
   def handleEndAllBreakoutRoomsMsg(msg: EndAllBreakoutRoomsMsg, state: MeetingState2x): MeetingState2x = {
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to end breakout rooms for meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/RequestBreakoutJoinURLReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/RequestBreakoutJoinURLReqMsgHdlr.scala
@@ -3,15 +3,15 @@ package org.bigbluebutton.core.apps.breakout
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait RequestBreakoutJoinURLReqMsgHdlr extends BreakoutHdlrHelpers {
+trait RequestBreakoutJoinURLReqMsgHdlr extends BreakoutHdlrHelpers with RightsManagementTrait {
   this: MeetingActor =>
 
   val outGW: OutMsgRouter
 
   def handleRequestBreakoutJoinURLReqMsg(msg: RequestBreakoutJoinURLReqMsg, state: MeetingState2x): MeetingState2x = {
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.GUEST_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to request breakout room URL for meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/TransferUserToMeetingRequestHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/TransferUserToMeetingRequestHdlr.scala
@@ -1,19 +1,18 @@
 package org.bigbluebutton.core.apps.breakout
 
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.apps.BreakoutModel
+import org.bigbluebutton.core.apps.{ BreakoutModel, PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.domain.MeetingState2x
-import org.bigbluebutton.core.models.{ VoiceUsers }
+import org.bigbluebutton.core.models.VoiceUsers
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
-import org.bigbluebutton.core.apps.PermissionCheck
 
-trait TransferUserToMeetingRequestHdlr {
+trait TransferUserToMeetingRequestHdlr extends RightsManagementTrait {
   this: MeetingActor =>
 
   val outGW: OutMsgRouter
 
   def handleTransferUserToMeetingRequestMsg(msg: TransferUserToMeetingRequestMsg, state: MeetingState2x): MeetingState2x = {
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to transfer user to voice breakout."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/caption/CaptionApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/caption/CaptionApp2x.scala
@@ -4,11 +4,10 @@ import akka.actor.ActorContext
 import akka.event.Logging
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.MessageBus
-import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
-import org.bigbluebutton.SystemConfiguration
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.running.{ LiveMeeting }
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-class CaptionApp2x(implicit val context: ActorContext) extends SystemConfiguration {
+class CaptionApp2x(implicit val context: ActorContext) extends RightsManagementTrait {
   val log = Logging(context.system, getClass)
 
   def getCaptionHistory(liveMeeting: LiveMeeting): Map[String, TranscriptVO] = {
@@ -46,7 +45,7 @@ class CaptionApp2x(implicit val context: ActorContext) extends SystemConfigurati
       bus.outGW.send(msgEvent)
     }
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)
       && isUserCaptionOwner(liveMeeting, msg.header.userId, msg.body.locale)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to edit caption history in meeting."
@@ -87,7 +86,7 @@ class CaptionApp2x(implicit val context: ActorContext) extends SystemConfigurati
       bus.outGW.send(msgEvent)
     }
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to change caption owners."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/chat/ClearPublicChatHistoryPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/chat/ClearPublicChatHistoryPubMsgHdlr.scala
@@ -1,14 +1,13 @@
 package org.bigbluebutton.core.apps.chat
 
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.apps.ChatModel
+import org.bigbluebutton.core.apps.{ ChatModel, PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.running.{ LiveMeeting, LogHelper }
 import org.bigbluebutton.SystemConfiguration
-import org.bigbluebutton.core.apps.PermissionCheck
 import org.bigbluebutton.core.domain.MeetingState2x
 
-trait ClearPublicChatHistoryPubMsgHdlr extends LogHelper with SystemConfiguration {
+trait ClearPublicChatHistoryPubMsgHdlr extends LogHelper with RightsManagementTrait {
 
   def handle(msg: ClearPublicChatHistoryPubMsg, state: MeetingState2x,
              liveMeeting: LiveMeeting, bus: MessageBus): MeetingState2x = {
@@ -23,7 +22,7 @@ trait ClearPublicChatHistoryPubMsgHdlr extends LogHelper with SystemConfiguratio
       bus.outGW.send(msgEvent)
     }
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to clear chat in meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
@@ -35,7 +35,10 @@ trait SendGroupChatMessageMsgHdlr {
       }
     }
 
-    if (applyPermissionCheck && chatLocked) {
+    // Check if this message was sent while the lock settings was being changed.
+    val isDelayedMessage = System.currentTimeMillis() - MeetingStatus2x.getPermissionsChangedOn(liveMeeting.status) < 5000
+
+    if (applyPermissionCheck && chatLocked && !isDelayedMessage) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to send a message to this group chat."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/BroadcastLayoutMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/BroadcastLayoutMsgHdlr.scala
@@ -4,16 +4,15 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.Layouts
 import org.bigbluebutton.core.running.OutMsgRouter
 import org.bigbluebutton.core2.MeetingStatus2x
-import org.bigbluebutton.core.apps.PermissionCheck
-import org.bigbluebutton.SystemConfiguration
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait BroadcastLayoutMsgHdlr extends SystemConfiguration {
+trait BroadcastLayoutMsgHdlr extends RightsManagementTrait {
   this: LayoutApp2x =>
 
   val outGW: OutMsgRouter
 
   def handleBroadcastLayoutMsg(msg: BroadcastLayoutMsg): Unit = {
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to broadcast layout to meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/GetCurrentPollReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/GetCurrentPollReqMsgHdlr.scala
@@ -26,12 +26,10 @@ trait GetCurrentPollReqMsgHdlr {
     val pollVO = Polls.handleGetCurrentPollReqMsg(state, msgIn.header.userId, liveMeeting)
 
     pollVO match {
-      case Some(poll) => {
+      case Some(poll) =>
         broadcastEvent(msgIn, true, pollVO)
-      }
-      case None => {
+      case None =>
         broadcastEvent(msgIn, false, None)
-      }
     }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/HidePollResultReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/HidePollResultReqMsgHdlr.scala
@@ -3,11 +3,10 @@ package org.bigbluebutton.core.apps.polls
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.models.Polls
-import org.bigbluebutton.core.running.{ LiveMeeting }
-import org.bigbluebutton.SystemConfiguration
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.running.LiveMeeting
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait HidePollResultReqMsgHdlr extends SystemConfiguration {
+trait HidePollResultReqMsgHdlr extends RightsManagementTrait {
   this: PollApp2x =>
 
   def handle(msg: HidePollResultReqMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
@@ -23,7 +22,7 @@ trait HidePollResultReqMsgHdlr extends SystemConfiguration {
       bus.outGW.send(msgEvent)
     }
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to hide poll result."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/ShowPollResultReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/ShowPollResultReqMsgHdlr.scala
@@ -6,10 +6,9 @@ import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models.Polls
 import org.bigbluebutton.core.running.LiveMeeting
-import org.bigbluebutton.core.apps.PermissionCheck
-import org.bigbluebutton.SystemConfiguration
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait ShowPollResultReqMsgHdlr extends SystemConfiguration {
+trait ShowPollResultReqMsgHdlr extends RightsManagementTrait {
   this: PollApp2x =>
 
   def handle(msg: ShowPollResultReqMsg, state: MeetingState2x, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
@@ -36,7 +35,7 @@ trait ShowPollResultReqMsgHdlr extends SystemConfiguration {
       bus.outGW.send(annotationMsgEvent)
     }
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to show poll results."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/StartCustomPollReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/StartCustomPollReqMsgHdlr.scala
@@ -6,10 +6,9 @@ import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models.Polls
 import org.bigbluebutton.core.running.LiveMeeting
-import org.bigbluebutton.core.apps.PermissionCheck
-import org.bigbluebutton.SystemConfiguration
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait StartCustomPollReqMsgHdlr extends SystemConfiguration {
+trait StartCustomPollReqMsgHdlr extends RightsManagementTrait {
   this: PollApp2x =>
 
   def handle(msg: StartCustomPollReqMsg, state: MeetingState2x, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
@@ -24,7 +23,7 @@ trait StartCustomPollReqMsgHdlr extends SystemConfiguration {
       bus.outGW.send(msgEvent)
     }
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to start custom poll."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/StartPollReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/StartPollReqMsgHdlr.scala
@@ -6,10 +6,9 @@ import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models.Polls
 import org.bigbluebutton.core.running.LiveMeeting
-import org.bigbluebutton.core.apps.PermissionCheck
-import org.bigbluebutton.SystemConfiguration
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait StartPollReqMsgHdlr extends SystemConfiguration {
+trait StartPollReqMsgHdlr extends RightsManagementTrait {
   this: PollApp2x =>
 
   def handle(msg: StartPollReqMsg, state: MeetingState2x, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
@@ -25,7 +24,7 @@ trait StartPollReqMsgHdlr extends SystemConfiguration {
       bus.outGW.send(msgEvent)
     }
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to start poll."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/StopPollReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/StopPollReqMsgHdlr.scala
@@ -5,10 +5,9 @@ import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models.Polls
 import org.bigbluebutton.core.running.LiveMeeting
-import org.bigbluebutton.core.apps.PermissionCheck
-import org.bigbluebutton.SystemConfiguration
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait StopPollReqMsgHdlr extends SystemConfiguration {
+trait StopPollReqMsgHdlr extends RightsManagementTrait {
   this: PollApp2x =>
 
   def broadcastPollStoppedEvtMsg(requesterId: String, stoppedPollId: String, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
@@ -23,7 +22,7 @@ trait StopPollReqMsgHdlr extends SystemConfiguration {
   }
 
   def handle(msg: StopPollReqMsg, state: MeetingState2x, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to stop poll."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/CreateNewPresentationPodPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/CreateNewPresentationPodPubMsgHdlr.scala
@@ -1,20 +1,19 @@
 package org.bigbluebutton.core.apps.presentationpod
 
-import org.bigbluebutton.SystemConfiguration
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models.PresentationPod
 import org.bigbluebutton.core.running.LiveMeeting
 
-trait CreateNewPresentationPodPubMsgHdlr extends SystemConfiguration {
+trait CreateNewPresentationPodPubMsgHdlr extends RightsManagementTrait {
   this: PresentationPodHdlrs =>
 
   def handle(msg: CreateNewPresentationPodPubMsg, state: MeetingState2x,
              liveMeeting: LiveMeeting, bus: MessageBus): MeetingState2x = {
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(
+    if (permissionFailed(
       PermissionCheck.MOD_LEVEL,
       PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId
     )) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/GetAllPresentationPodsReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/GetAllPresentationPodsReqMsgHdlr.scala
@@ -2,18 +2,18 @@ package org.bigbluebutton.core.apps.presentationpod
 
 import org.bigbluebutton.common2.domain.PresentationPodVO
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.LiveMeeting
 
-trait GetAllPresentationPodsReqMsgHdlr {
+trait GetAllPresentationPodsReqMsgHdlr extends RightsManagementTrait {
   this: PresentationPodHdlrs =>
 
   def handle(msg: GetAllPresentationPodsReqMsg, state: MeetingState2x,
              liveMeeting: LiveMeeting, bus: MessageBus): MeetingState2x = {
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.GUEST_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to get all presentation pods from meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/GetPresentationInfoReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/GetPresentationInfoReqMsgHdlr.scala
@@ -2,18 +2,18 @@ package org.bigbluebutton.core.apps.presentationpod
 
 import org.bigbluebutton.common2.domain.PresentationVO
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.LiveMeeting
 
-trait GetPresentationInfoReqMsgHdlr {
+trait GetPresentationInfoReqMsgHdlr extends RightsManagementTrait {
   this: PresentationPodHdlrs =>
 
   def handle(msg: GetPresentationInfoReqMsg, state: MeetingState2x,
              liveMeeting: LiveMeeting, bus: MessageBus): MeetingState2x = {
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.GUEST_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission get presentation info from meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationUploadTokenReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationUploadTokenReqMsgHdlr.scala
@@ -65,7 +65,8 @@ trait PresentationUploadTokenReqMsgHdlr extends RightsManagementTrait {
     log.info("handlePresentationUploadTokenReqMsg" + liveMeeting.props.meetingProp.intId +
       " userId=" + msg.header.userId + " filename=" + msg.body.filename)
 
-    if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (filterPresentationMessage(liveMeeting.users2x, msg.header.userId) &&
+      permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to request presentation upload token."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationUploadTokenReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationUploadTokenReqMsgHdlr.scala
@@ -5,9 +5,9 @@ import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models.Users2x
 import org.bigbluebutton.core.running.LiveMeeting
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait PresentationUploadTokenReqMsgHdlr {
+trait PresentationUploadTokenReqMsgHdlr extends RightsManagementTrait {
   this: PresentationPodHdlrs =>
 
   def handle(msg: PresentationUploadTokenReqMsg, state: MeetingState2x,
@@ -65,7 +65,7 @@ trait PresentationUploadTokenReqMsgHdlr {
     log.info("handlePresentationUploadTokenReqMsg" + liveMeeting.props.meetingProp.intId +
       " userId=" + msg.header.userId + " filename=" + msg.body.filename)
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to request presentation upload token."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/RemovePresentationPodPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/RemovePresentationPodPubMsgHdlr.scala
@@ -12,7 +12,8 @@ trait RemovePresentationPodPubMsgHdlr extends RightsManagementTrait {
   def handle(msg: RemovePresentationPodPubMsg, state: MeetingState2x,
              liveMeeting: LiveMeeting, bus: MessageBus): MeetingState2x = {
 
-    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (filterPresentationMessage(liveMeeting.users2x, msg.header.userId) &&
+      permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to remove presentation pod from meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/RemovePresentationPodPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/RemovePresentationPodPubMsgHdlr.scala
@@ -1,18 +1,18 @@
 package org.bigbluebutton.core.apps.presentationpod
 
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.LiveMeeting
 
-trait RemovePresentationPodPubMsgHdlr {
+trait RemovePresentationPodPubMsgHdlr extends RightsManagementTrait {
   this: PresentationPodHdlrs =>
 
   def handle(msg: RemovePresentationPodPubMsg, state: MeetingState2x,
              liveMeeting: LiveMeeting, bus: MessageBus): MeetingState2x = {
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to remove presentation pod from meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/RemovePresentationPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/RemovePresentationPubMsgHdlr.scala
@@ -14,7 +14,8 @@ trait RemovePresentationPubMsgHdlr extends RightsManagementTrait {
     liveMeeting: LiveMeeting, bus: MessageBus
   ): MeetingState2x = {
 
-    if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (filterPresentationMessage(liveMeeting.users2x, msg.header.userId) &&
+      permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to remove presentation from meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/RemovePresentationPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/RemovePresentationPubMsgHdlr.scala
@@ -1,12 +1,12 @@
 package org.bigbluebutton.core.apps.presentationpod
 
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.LiveMeeting
 
-trait RemovePresentationPubMsgHdlr {
+trait RemovePresentationPubMsgHdlr extends RightsManagementTrait {
   this: PresentationPodHdlrs =>
 
   def handle(
@@ -14,7 +14,7 @@ trait RemovePresentationPubMsgHdlr {
     liveMeeting: LiveMeeting, bus: MessageBus
   ): MeetingState2x = {
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to remove presentation from meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/ResizeAndMovePagePubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/ResizeAndMovePagePubMsgHdlr.scala
@@ -5,9 +5,9 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.LiveMeeting
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait ResizeAndMovePagePubMsgHdlr {
+trait ResizeAndMovePagePubMsgHdlr extends RightsManagementTrait {
   this: PresentationPodHdlrs =>
 
   def handle(msg: ResizeAndMovePagePubMsg, state: MeetingState2x,
@@ -31,7 +31,7 @@ trait ResizeAndMovePagePubMsgHdlr {
       bus.outGW.send(msgEvent)
     }
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to resize and move page."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/ResizeAndMovePagePubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/ResizeAndMovePagePubMsgHdlr.scala
@@ -31,7 +31,8 @@ trait ResizeAndMovePagePubMsgHdlr extends RightsManagementTrait {
       bus.outGW.send(msgEvent)
     }
 
-    if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (filterPresentationMessage(liveMeeting.users2x, msg.header.userId) &&
+      permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to resize and move page."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPagePubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPagePubMsgHdlr.scala
@@ -15,7 +15,8 @@ trait SetCurrentPagePubMsgHdlr extends RightsManagementTrait {
     liveMeeting: LiveMeeting, bus: MessageBus
   ): MeetingState2x = {
 
-    if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (filterPresentationMessage(liveMeeting.users2x, msg.header.userId) &&
+      permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to set current presentation page."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPagePubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPagePubMsgHdlr.scala
@@ -1,13 +1,12 @@
 package org.bigbluebutton.core.apps.presentationpod
 
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.LiveMeeting
-import org.bigbluebutton.core.models.Users2x
 
-trait SetCurrentPagePubMsgHdlr {
+trait SetCurrentPagePubMsgHdlr extends RightsManagementTrait {
 
   this: PresentationPodHdlrs =>
 
@@ -16,7 +15,7 @@ trait SetCurrentPagePubMsgHdlr {
     liveMeeting: LiveMeeting, bus: MessageBus
   ): MeetingState2x = {
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to set current presentation page."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPresentationPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPresentationPubMsgHdlr.scala
@@ -14,7 +14,8 @@ trait SetCurrentPresentationPubMsgHdlr extends RightsManagementTrait {
     liveMeeting: LiveMeeting, bus: MessageBus
   ): MeetingState2x = {
 
-    if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (filterPresentationMessage(liveMeeting.users2x, msg.header.userId) &&
+      permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to change current presentation."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPresentationPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPresentationPubMsgHdlr.scala
@@ -1,12 +1,12 @@
 package org.bigbluebutton.core.apps.presentationpod
 
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.LiveMeeting
 
-trait SetCurrentPresentationPubMsgHdlr {
+trait SetCurrentPresentationPubMsgHdlr extends RightsManagementTrait {
   this: PresentationPodHdlrs =>
 
   def handle(
@@ -14,7 +14,7 @@ trait SetCurrentPresentationPubMsgHdlr {
     liveMeeting: LiveMeeting, bus: MessageBus
   ): MeetingState2x = {
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to change current presentation."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetPresenterInPodReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetPresenterInPodReqMsgHdlr.scala
@@ -1,13 +1,13 @@
 package org.bigbluebutton.core.apps.presentationpod
 
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.core.models.Users2x
 
-trait SetPresenterInPodReqMsgHdlr {
+trait SetPresenterInPodReqMsgHdlr extends RightsManagementTrait {
   this: PresentationPodHdlrs =>
 
   def handle(
@@ -15,7 +15,7 @@ trait SetPresenterInPodReqMsgHdlr {
     liveMeeting: LiveMeeting, bus: MessageBus
   ): MeetingState2x = {
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to set presenter in presentation pod."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetPresenterInPodReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetPresenterInPodReqMsgHdlr.scala
@@ -44,6 +44,11 @@ trait SetPresenterInPodReqMsgHdlr extends RightsManagementTrait {
       } yield {
 
         if (Users2x.userIsInPresenterGroup(liveMeeting.users2x, nextPresenterId)) {
+
+          if (pod.currentPresenter != "") {
+            liveMeeting.users2x.addOldPresenter(pod.currentPresenter)
+          }
+
           val updatedPod = pod.setCurrentPresenter(nextPresenterId)
 
           broadcastSetPresenterInPodRespMsg(pod.id, nextPresenterId, requesterId)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/sharednotes/ClearSharedNotePubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/sharednotes/ClearSharedNotePubMsgHdlr.scala
@@ -2,11 +2,10 @@ package org.bigbluebutton.core.apps.sharednotes
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.MessageBus
-import org.bigbluebutton.core.running.{ LiveMeeting }
-import org.bigbluebutton.core.apps.PermissionCheck
-import org.bigbluebutton.SystemConfiguration
+import org.bigbluebutton.core.running.LiveMeeting
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait ClearSharedNotePubMsgHdlr extends SystemConfiguration {
+trait ClearSharedNotePubMsgHdlr extends RightsManagementTrait {
   this: SharedNotesApp2x =>
 
   def handle(msg: ClearSharedNotePubMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
@@ -22,7 +21,7 @@ trait ClearSharedNotePubMsgHdlr extends SystemConfiguration {
       bus.outGW.send(msgEvent)
     }
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to clear shared notes in meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/sharednotes/CreateSharedNoteReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/sharednotes/CreateSharedNoteReqMsgHdlr.scala
@@ -2,11 +2,10 @@ package org.bigbluebutton.core.apps.sharednotes
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.MessageBus
-import org.bigbluebutton.core.running.{ LiveMeeting }
-import org.bigbluebutton.core.apps.PermissionCheck
-import org.bigbluebutton.SystemConfiguration
+import org.bigbluebutton.core.running.LiveMeeting
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait CreateSharedNoteReqMsgHdlr extends SystemConfiguration {
+trait CreateSharedNoteReqMsgHdlr extends RightsManagementTrait {
   this: SharedNotesApp2x =>
 
   def handle(msg: CreateSharedNoteReqMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
@@ -22,7 +21,7 @@ trait CreateSharedNoteReqMsgHdlr extends SystemConfiguration {
       bus.outGW.send(msgEvent)
     }
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to create new shared note."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/sharednotes/DestroySharedNoteReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/sharednotes/DestroySharedNoteReqMsgHdlr.scala
@@ -2,11 +2,10 @@ package org.bigbluebutton.core.apps.sharednotes
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.MessageBus
-import org.bigbluebutton.core.running.{ LiveMeeting }
-import org.bigbluebutton.core.apps.PermissionCheck
-import org.bigbluebutton.SystemConfiguration
+import org.bigbluebutton.core.running.LiveMeeting
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait DestroySharedNoteReqMsgHdlr extends SystemConfiguration {
+trait DestroySharedNoteReqMsgHdlr extends RightsManagementTrait {
   this: SharedNotesApp2x =>
 
   def handle(msg: DestroySharedNoteReqMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
@@ -22,7 +21,7 @@ trait DestroySharedNoteReqMsgHdlr extends SystemConfiguration {
       bus.outGW.send(msgEvent)
     }
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to destory shared note."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AddUserToPresenterGroupCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AddUserToPresenterGroupCmdMsgHdlr.scala
@@ -3,9 +3,9 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.{ Roles, Users2x }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait AddUserToPresenterGroupCmdMsgHdlr {
+trait AddUserToPresenterGroupCmdMsgHdlr extends RightsManagementTrait {
   this: UsersApp =>
 
   val liveMeeting: LiveMeeting
@@ -13,7 +13,7 @@ trait AddUserToPresenterGroupCmdMsgHdlr {
 
   def handleAddUserToPresenterGroupCmdMsg(msg: AddUserToPresenterGroupCmdMsg) {
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to add user to presenter group."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AssignPresenterReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AssignPresenterReqMsgHdlr.scala
@@ -3,9 +3,9 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.{ UserState, Users2x }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait AssignPresenterReqMsgHdlr {
+trait AssignPresenterReqMsgHdlr extends RightsManagementTrait {
   this: UsersApp =>
 
   val liveMeeting: LiveMeeting
@@ -45,7 +45,7 @@ trait AssignPresenterReqMsgHdlr {
       outGW.send(msgEventAssign)
     }
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to change presenter in meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
@@ -1,86 +1,66 @@
 package org.bigbluebutton.core.apps.users
 
-import org.bigbluebutton.SystemConfiguration
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.api.Permissions
-import org.bigbluebutton.core.apps.PermissionCheck
-import org.bigbluebutton.core.running.{ OutMsgRouter }
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
+import org.bigbluebutton.core.running.OutMsgRouter
 import org.bigbluebutton.core.running.MeetingActor
 import org.bigbluebutton.core2.MeetingStatus2x
 
-trait ChangeLockSettingsInMeetingCmdMsgHdlrDefault {
-  def handleSetLockSettings(msg: ChangeLockSettingsInMeetingCmdMsg): Unit = {}
-}
-
-trait ChangeLockSettingsInMeetingCmdMsgHdlrCheckPerm
-    extends ChangeLockSettingsInMeetingCmdMsgHdlrDefault with SystemConfiguration {
+trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
 
   val outGW: OutMsgRouter
 
-  override def handleSetLockSettings(msg: ChangeLockSettingsInMeetingCmdMsg): Unit = {
-    val isAllowed = PermissionCheck.isAllowed(
-      PermissionCheck.MOD_LEVEL,
-      PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId
-    )
+  def handleSetLockSettings(msg: ChangeLockSettingsInMeetingCmdMsg): Unit = {
 
-    if (applyPermissionCheck && !isAllowed) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to change lock settings"
-      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.body.setBy, reason, outGW, liveMeeting)
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)
     } else {
-      super.handleSetLockSettings(msg)
-    }
-  }
-}
-
-trait ChangeLockSettingsInMeetingCmdMsgHdlr extends ChangeLockSettingsInMeetingCmdMsgHdlrCheckPerm {
-  this: MeetingActor =>
-
-  val outGW: OutMsgRouter
-
-  override def handleSetLockSettings(msg: ChangeLockSettingsInMeetingCmdMsg): Unit = {
-    val settings = Permissions(
-      disableCam = msg.body.disableCam,
-      disableMic = msg.body.disableMic,
-      disablePrivChat = msg.body.disablePrivChat,
-      disablePubChat = msg.body.disablePubChat,
-      lockedLayout = msg.body.lockedLayout,
-      lockOnJoin = msg.body.lockOnJoin,
-      lockOnJoinConfigurable = msg.body.lockOnJoinConfigurable
-    )
-
-    if (!MeetingStatus2x.permissionsEqual(liveMeeting.status, settings) || !MeetingStatus2x.permisionsInitialized(liveMeeting.status)) {
-      MeetingStatus2x.initializePermissions(liveMeeting.status)
-
-      MeetingStatus2x.setPermissions(liveMeeting.status, settings)
-
-      val routing = Routing.addMsgToClientRouting(
-        MessageTypes.BROADCAST_TO_MEETING,
-        props.meetingProp.intId,
-        msg.body.setBy
-      )
-      val envelope = BbbCoreEnvelope(
-        LockSettingsInMeetingChangedEvtMsg.NAME,
-        routing
-      )
-      val body = LockSettingsInMeetingChangedEvtMsgBody(
-        disableCam = settings.disableCam,
-        disableMic = settings.disableMic,
-        disablePrivChat = settings.disablePrivChat,
-        disablePubChat = settings.disablePubChat,
-        lockedLayout = settings.lockedLayout,
-        lockOnJoin = settings.lockOnJoin,
-        lockOnJoinConfigurable = settings.lockOnJoinConfigurable,
-        msg.body.setBy
-      )
-      val header = BbbClientMsgHeader(
-        LockSettingsInMeetingChangedEvtMsg.NAME,
-        props.meetingProp.intId,
-        msg.body.setBy
+      val settings = Permissions(
+        disableCam = msg.body.disableCam,
+        disableMic = msg.body.disableMic,
+        disablePrivChat = msg.body.disablePrivChat,
+        disablePubChat = msg.body.disablePubChat,
+        lockedLayout = msg.body.lockedLayout,
+        lockOnJoin = msg.body.lockOnJoin,
+        lockOnJoinConfigurable = msg.body.lockOnJoinConfigurable
       )
 
-      outGW.send(BbbCommonEnvCoreMsg(envelope, LockSettingsInMeetingChangedEvtMsg(header, body)))
+      if (!MeetingStatus2x.permissionsEqual(liveMeeting.status, settings) || !MeetingStatus2x.permisionsInitialized(liveMeeting.status)) {
+        MeetingStatus2x.initializePermissions(liveMeeting.status)
+
+        MeetingStatus2x.setPermissions(liveMeeting.status, settings)
+
+        val routing = Routing.addMsgToClientRouting(
+          MessageTypes.BROADCAST_TO_MEETING,
+          props.meetingProp.intId,
+          msg.body.setBy
+        )
+        val envelope = BbbCoreEnvelope(
+          LockSettingsInMeetingChangedEvtMsg.NAME,
+          routing
+        )
+        val body = LockSettingsInMeetingChangedEvtMsgBody(
+          disableCam = settings.disableCam,
+          disableMic = settings.disableMic,
+          disablePrivChat = settings.disablePrivChat,
+          disablePubChat = settings.disablePubChat,
+          lockedLayout = settings.lockedLayout,
+          lockOnJoin = settings.lockOnJoin,
+          lockOnJoinConfigurable = settings.lockOnJoinConfigurable,
+          msg.body.setBy
+        )
+        val header = BbbClientMsgHeader(
+          LockSettingsInMeetingChangedEvtMsg.NAME,
+          props.meetingProp.intId,
+          msg.body.setBy
+        )
+
+        outGW.send(BbbCommonEnvCoreMsg(envelope, LockSettingsInMeetingChangedEvtMsg(header, body)))
+      }
     }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserEmojiCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserEmojiCmdMsgHdlr.scala
@@ -3,10 +3,9 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.Users2x
 import org.bigbluebutton.core.running.{ BaseMeetingActor, LiveMeeting, OutMsgRouter }
-import org.bigbluebutton.core.apps.PermissionCheck
-import org.bigbluebutton.SystemConfiguration
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait ChangeUserEmojiCmdMsgHdlr extends SystemConfiguration {
+trait ChangeUserEmojiCmdMsgHdlr extends RightsManagementTrait {
   this: BaseMeetingActor =>
 
   val liveMeeting: LiveMeeting
@@ -14,7 +13,7 @@ trait ChangeUserEmojiCmdMsgHdlr extends SystemConfiguration {
 
   def handleChangeUserEmojiCmdMsg(msg: ChangeUserEmojiCmdMsg) {
     log.debug("handling " + msg)
-    if (msg.header.userId != msg.body.userId && applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (msg.header.userId != msg.body.userId && permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to clear chat in meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserEmojiCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserEmojiCmdMsgHdlr.scala
@@ -12,10 +12,9 @@ trait ChangeUserEmojiCmdMsgHdlr extends RightsManagementTrait {
   val outGW: OutMsgRouter
 
   def handleChangeUserEmojiCmdMsg(msg: ChangeUserEmojiCmdMsg) {
-    log.debug("handling " + msg)
     if (msg.header.userId != msg.body.userId && permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
-      val reason = "No permission to clear chat in meeting."
+      val reason = "No permission to clear change user emoji status."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)
     } else {
       for {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
@@ -3,16 +3,16 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.{ Roles, Users2x }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait ChangeUserRoleCmdMsgHdlr {
+trait ChangeUserRoleCmdMsgHdlr extends RightsManagementTrait {
   this: UsersApp =>
 
   val liveMeeting: LiveMeeting
   val outGW: OutMsgRouter
 
   def handleChangeUserRoleCmdMsg(msg: ChangeUserRoleCmdMsg) {
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to change user role in meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectUserFromMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectUserFromMeetingCmdMsgHdlr.scala
@@ -4,9 +4,9 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait EjectUserFromMeetingCmdMsgHdlr {
+trait EjectUserFromMeetingCmdMsgHdlr extends RightsManagementTrait {
   this: UsersApp =>
 
   val liveMeeting: LiveMeeting
@@ -17,7 +17,7 @@ trait EjectUserFromMeetingCmdMsgHdlr {
     val userId = msg.body.userId
     val ejectedBy = msg.body.ejectedBy
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(
+    if (permissionFailed(
       PermissionCheck.MOD_LEVEL,
       PermissionCheck.VIEWER_LEVEL,
       liveMeeting.users2x,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LockUserInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LockUserInMeetingCmdMsgHdlr.scala
@@ -3,9 +3,9 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.Users2x
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait LockUserInMeetingCmdMsgHdlr {
+trait LockUserInMeetingCmdMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
 
   val outGW: OutMsgRouter
@@ -22,7 +22,7 @@ trait LockUserInMeetingCmdMsgHdlr {
       BbbCommonEnvCoreMsg(envelope, event)
     }
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to lock user in meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LockUsersInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LockUsersInMeetingCmdMsgHdlr.scala
@@ -3,9 +3,9 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.Users2x
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait LockUsersInMeetingCmdMsgHdlr {
+trait LockUsersInMeetingCmdMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
 
   val outGW: OutMsgRouter
@@ -22,7 +22,7 @@ trait LockUsersInMeetingCmdMsgHdlr {
       BbbCommonEnvCoreMsg(envelope, event)
     }
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to lock users in meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LogoutAndEndMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LogoutAndEndMeetingCmdMsgHdlr.scala
@@ -5,9 +5,9 @@ import org.bigbluebutton.core.bus.InternalEventBus
 import org.bigbluebutton.core.domain.{ MeetingEndReason, MeetingState2x }
 import org.bigbluebutton.core.models.{ Roles, Users2x }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait LogoutAndEndMeetingCmdMsgHdlr {
+trait LogoutAndEndMeetingCmdMsgHdlr extends RightsManagementTrait {
   this: UsersApp =>
 
   val liveMeeting: LiveMeeting
@@ -15,7 +15,7 @@ trait LogoutAndEndMeetingCmdMsgHdlr {
   val eventBus: InternalEventBus
 
   def handleLogoutAndEndMeetingCmdMsg(msg: LogoutAndEndMeetingCmdMsg, state: MeetingState2x): Unit = {
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to end meeting on logout."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/MuteUserCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/MuteUserCmdMsgHdlr.scala
@@ -14,7 +14,7 @@ trait MuteUserCmdMsgHdlr extends RightsManagementTrait {
   val outGW: OutMsgRouter
 
   def handleMuteUserCmdMsg(msg: MuteUserCmdMsg) {
-    if (permissionFailed(
+    if (msg.body.userId != msg.header.userId && permissionFailed(
       PermissionCheck.MOD_LEVEL,
       PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId
     )) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/MuteUserCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/MuteUserCmdMsgHdlr.scala
@@ -2,64 +2,42 @@ package org.bigbluebutton.core.apps.users
 
 import org.bigbluebutton.SystemConfiguration
 import org.bigbluebutton.common2.msgs.MuteUserCmdMsg
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.models.VoiceUsers
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
-trait MuteUserCmdMsgHdlrDefault {
-  def handleMuteUserCmdMsg(msg: MuteUserCmdMsg): Unit = {
-    println("**************** MuteUserCmdMsgHdlrDefault ")
-  }
-}
-
-trait MuteUserCmdMsgHdlrPermCheck extends MuteUserCmdMsgHdlrDefault with SystemConfiguration {
+trait MuteUserCmdMsgHdlr extends RightsManagementTrait {
   this: UsersApp =>
 
   val liveMeeting: LiveMeeting
   val outGW: OutMsgRouter
 
-  override def handleMuteUserCmdMsg(msg: MuteUserCmdMsg): Unit = {
-    println("**************** MuteUserCmdMsgHdlrPermCheck ")
-
-    val isAllowed = PermissionCheck.isAllowed(
+  def handleMuteUserCmdMsg(msg: MuteUserCmdMsg) {
+    if (permissionFailed(
       PermissionCheck.MOD_LEVEL,
       PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId
-    )
-
-    if (msg.header.userId != msg.body.userId && applyPermissionCheck && !isAllowed) {
+    )) {
       val meetingId = liveMeeting.props.meetingProp.intId
-      val reason = "No permission to mute user in meeting."
-      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.body.mutedBy, reason, outGW, liveMeeting)
+      val reason = "No permission to mute user."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)
     } else {
-      super.handleMuteUserCmdMsg(msg)
-    }
-  }
-}
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val voiceConf = liveMeeting.props.voiceProp.voiceConf
 
-trait MuteUserCmdMsgHdlr extends MuteUserCmdMsgHdlrDefault {
-  this: UsersApp =>
-
-  val liveMeeting: LiveMeeting
-  val outGW: OutMsgRouter
-
-  override def handleMuteUserCmdMsg(msg: MuteUserCmdMsg) {
-    println("**************** MuteUserCmdMsgHdlr ")
-
-    val meetingId = liveMeeting.props.meetingProp.intId
-    val voiceConf = liveMeeting.props.voiceProp.voiceConf
-
-    log.info("Received mute user request. meetingId=" + meetingId + " userId="
-      + msg.body.userId)
-    for {
-      u <- VoiceUsers.findWithIntId(liveMeeting.voiceUsers, msg.body.userId)
-    } yield {
-      if (u.muted != msg.body.mute) {
-        log.info("Send mute user request. meetingId=" + meetingId + " userId=" + u.intId + " user=" + u)
-        val event = MsgBuilder.buildMuteUserInVoiceConfSysMsg(meetingId, voiceConf,
-          u.voiceUserId, msg.body.mute)
-        outGW.send(event)
+      log.info("Received mute user request. meetingId=" + meetingId + " userId="
+        + msg.body.userId)
+      for {
+        u <- VoiceUsers.findWithIntId(liveMeeting.voiceUsers, msg.body.userId)
+      } yield {
+        if (u.muted != msg.body.mute) {
+          log.info("Send mute user request. meetingId=" + meetingId + " userId=" + u.intId + " user=" + u)
+          val event = MsgBuilder.buildMuteUserInVoiceConfSysMsg(meetingId, voiceConf,
+            u.voiceUserId, msg.body.mute)
+          outGW.send(event)
+        }
       }
     }
+
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RemoveUserFromPresenterGroupCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RemoveUserFromPresenterGroupCmdMsgHdlr.scala
@@ -3,9 +3,9 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.{ Roles, Users2x }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait RemoveUserFromPresenterGroupCmdMsgHdlr {
+trait RemoveUserFromPresenterGroupCmdMsgHdlr extends RightsManagementTrait {
   this: UsersApp =>
 
   val liveMeeting: LiveMeeting
@@ -13,7 +13,12 @@ trait RemoveUserFromPresenterGroupCmdMsgHdlr {
 
   def handleRemoveUserFromPresenterGroupCmdMsg(msg: RemoveUserFromPresenterGroupCmdMsg) {
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(
+      PermissionCheck.MOD_LEVEL,
+      PermissionCheck.VIEWER_LEVEL,
+      liveMeeting.users2x,
+      msg.header.userId
+    )) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to remove user from presenter group."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/SetRecordingStatusCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/SetRecordingStatusCmdMsgHdlr.scala
@@ -3,9 +3,9 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.MeetingStatus2x
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait SetRecordingStatusCmdMsgHdlr {
+trait SetRecordingStatusCmdMsgHdlr extends RightsManagementTrait {
   this: UsersApp =>
 
   val liveMeeting: LiveMeeting
@@ -14,7 +14,7 @@ trait SetRecordingStatusCmdMsgHdlr {
   def handleSetRecordingStatusCmdMsg(msg: SetRecordingStatusCmdMsg) {
     log.info("Change recording status. meetingId=" + liveMeeting.props.meetingProp.intId + " recording=" + msg.body.recording)
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to clear chat in meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
@@ -144,8 +144,7 @@ class UsersApp(
     with RemoveUserFromPresenterGroupCmdMsgHdlr
     with GetPresenterGroupReqMsgHdlr
     with EjectUserFromMeetingCmdMsgHdlr
-    with MuteUserCmdMsgHdlr
-    with MuteUserCmdMsgHdlrPermCheck {
+    with MuteUserCmdMsgHdlr {
 
   val log = Logging(context.system, getClass)
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ClearWhiteboardPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ClearWhiteboardPubMsgHdlr.scala
@@ -1,12 +1,11 @@
 package org.bigbluebutton.core.apps.whiteboard
 
-import org.bigbluebutton.core.running.{ LiveMeeting }
+import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.MessageBus
-import org.bigbluebutton.core.apps.PermissionCheck
-import org.bigbluebutton.SystemConfiguration
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait ClearWhiteboardPubMsgHdlr extends SystemConfiguration {
+trait ClearWhiteboardPubMsgHdlr extends RightsManagementTrait {
   this: WhiteboardApp2x =>
 
   def handle(msg: ClearWhiteboardPubMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
@@ -22,7 +21,7 @@ trait ClearWhiteboardPubMsgHdlr extends SystemConfiguration {
       bus.outGW.send(msgEvent)
     }
 
-    if (!getWhiteboardAccess(liveMeeting) && applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (!getWhiteboardAccess(liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to clear the whiteboard."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ClearWhiteboardPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ClearWhiteboardPubMsgHdlr.scala
@@ -21,7 +21,7 @@ trait ClearWhiteboardPubMsgHdlr extends RightsManagementTrait {
       bus.outGW.send(msgEvent)
     }
 
-    if (!getWhiteboardAccess(liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (filterWhiteboardMessage(liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to clear the whiteboard."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/GetWhiteboardAccessReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/GetWhiteboardAccessReqMsgHdlr.scala
@@ -20,6 +20,6 @@ trait GetWhiteboardAccessReqMsgHdlr {
       bus.outGW.send(msgEvent)
     }
 
-    broadcastEvent(msg, getWhiteboardAccess(liveMeeting))
+    broadcastEvent(msg, liveMeeting.wbModel.isMultiUser())
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ModifyWhiteboardAccessPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ModifyWhiteboardAccessPubMsgHdlr.scala
@@ -1,12 +1,12 @@
 package org.bigbluebutton.core.apps.whiteboard
 
-import org.bigbluebutton.core.running.{ LiveMeeting }
+import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.MessageBus
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.SystemConfiguration
 
-trait ModifyWhiteboardAccessPubMsgHdlr extends SystemConfiguration {
+trait ModifyWhiteboardAccessPubMsgHdlr extends RightsManagementTrait {
   this: WhiteboardApp2x =>
 
   def handle(msg: ModifyWhiteboardAccessPubMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
@@ -22,7 +22,7 @@ trait ModifyWhiteboardAccessPubMsgHdlr extends SystemConfiguration {
       bus.outGW.send(msgEvent)
     }
 
-    if (!getWhiteboardAccess(liveMeeting) && applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (!getWhiteboardAccess(liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to modify access to the whiteboard."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ModifyWhiteboardAccessPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ModifyWhiteboardAccessPubMsgHdlr.scala
@@ -22,7 +22,7 @@ trait ModifyWhiteboardAccessPubMsgHdlr extends RightsManagementTrait {
       bus.outGW.send(msgEvent)
     }
 
-    if (!getWhiteboardAccess(liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (filterWhiteboardMessage(liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to modify access to the whiteboard."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendCursorPositionPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendCursorPositionPubMsgHdlr.scala
@@ -21,7 +21,7 @@ trait SendCursorPositionPubMsgHdlr extends RightsManagementTrait {
       bus.outGW.send(msgEvent)
     }
 
-    if (!getWhiteboardAccess(liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (filterWhiteboardMessage(liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to send your cursor position."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendCursorPositionPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendCursorPositionPubMsgHdlr.scala
@@ -1,12 +1,11 @@
 package org.bigbluebutton.core.apps.whiteboard
 
-import org.bigbluebutton.core.running.{ LiveMeeting }
+import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.MessageBus
-import org.bigbluebutton.SystemConfiguration
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait SendCursorPositionPubMsgHdlr extends SystemConfiguration {
+trait SendCursorPositionPubMsgHdlr extends RightsManagementTrait {
   this: WhiteboardApp2x =>
 
   def handle(msg: SendCursorPositionPubMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
@@ -22,7 +21,7 @@ trait SendCursorPositionPubMsgHdlr extends SystemConfiguration {
       bus.outGW.send(msgEvent)
     }
 
-    if (!getWhiteboardAccess(liveMeeting) && applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (!getWhiteboardAccess(liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to send your cursor position."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendWhiteboardAnnotationPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendWhiteboardAnnotationPubMsgHdlr.scala
@@ -21,7 +21,7 @@ trait SendWhiteboardAnnotationPubMsgHdlr extends RightsManagementTrait {
       bus.outGW.send(msgEvent)
     }
 
-    if (!getWhiteboardAccess(liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (filterWhiteboardMessage(liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to send a whiteboard annotation."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendWhiteboardAnnotationPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendWhiteboardAnnotationPubMsgHdlr.scala
@@ -1,12 +1,11 @@
 package org.bigbluebutton.core.apps.whiteboard
 
-import org.bigbluebutton.core.running.{ LiveMeeting }
+import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.MessageBus
-import org.bigbluebutton.core.apps.PermissionCheck
-import org.bigbluebutton.SystemConfiguration
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait SendWhiteboardAnnotationPubMsgHdlr extends SystemConfiguration {
+trait SendWhiteboardAnnotationPubMsgHdlr extends RightsManagementTrait {
   this: WhiteboardApp2x =>
 
   def handle(msg: SendWhiteboardAnnotationPubMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
@@ -22,7 +21,7 @@ trait SendWhiteboardAnnotationPubMsgHdlr extends SystemConfiguration {
       bus.outGW.send(msgEvent)
     }
 
-    if (!getWhiteboardAccess(liveMeeting) && applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (!getWhiteboardAccess(liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to send a whiteboard annotation."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SyncWhiteboardAccessRespMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SyncWhiteboardAccessRespMsgHdlr.scala
@@ -20,6 +20,6 @@ trait SyncWhiteboardAccessRespMsgHdlr {
       bus.outGW.send(msgEvent)
     }
 
-    broadcastEvent(getWhiteboardAccess(liveMeeting))
+    broadcastEvent(liveMeeting.wbModel.isMultiUser())
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/UndoWhiteboardPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/UndoWhiteboardPubMsgHdlr.scala
@@ -21,7 +21,7 @@ trait UndoWhiteboardPubMsgHdlr extends RightsManagementTrait {
       bus.outGW.send(msgEvent)
     }
 
-    if (!getWhiteboardAccess(liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (filterWhiteboardMessage(liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to undo an annotation."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/UndoWhiteboardPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/UndoWhiteboardPubMsgHdlr.scala
@@ -1,12 +1,11 @@
 package org.bigbluebutton.core.apps.whiteboard
 
-import org.bigbluebutton.core.running.{ LiveMeeting }
+import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.MessageBus
-import org.bigbluebutton.core.apps.PermissionCheck
-import org.bigbluebutton.SystemConfiguration
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait UndoWhiteboardPubMsgHdlr extends SystemConfiguration {
+trait UndoWhiteboardPubMsgHdlr extends RightsManagementTrait {
   this: WhiteboardApp2x =>
 
   def handle(msg: UndoWhiteboardPubMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
@@ -22,7 +21,7 @@ trait UndoWhiteboardPubMsgHdlr extends SystemConfiguration {
       bus.outGW.send(msgEvent)
     }
 
-    if (!getWhiteboardAccess(liveMeeting) && applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (!getWhiteboardAccess(liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to undo an annotation."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/WhiteboardApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/WhiteboardApp2x.scala
@@ -62,7 +62,10 @@ class WhiteboardApp2x(implicit val context: ActorContext)
     liveMeeting.wbModel.modifyWhiteboardAccess(multiUser)
   }
 
-  def getWhiteboardAccess(liveMeeting: LiveMeeting): Boolean = {
-    liveMeeting.wbModel.getWhiteboardAccess()
+  def filterWhiteboardMessage(liveMeeting: LiveMeeting): Boolean = {
+    // Need to check if the wb mode change from multi-user to single-user. Give 5sec allowance to
+    // allow delayed messages to be handled as clients may have been sending messages while the wb
+    // mode was changed. (ralam nov 22, 2017)
+    if (!liveMeeting.wbModel.isMultiUser() && liveMeeting.wbModel.getChangedModeOn > 5000) true else false
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -30,7 +30,7 @@ object Users2x {
     for {
       u <- findWithIntId(users, intId)
     } yield {
-      val newUserState = modify(u)(_.role).setTo(newRole)
+      val newUserState = modify(u)(_.role).setTo(newRole).modify(_.roleChangedOn).setTo(System.currentTimeMillis())
       users.save(newUserState)
       newUserState
     }
@@ -208,7 +208,7 @@ case class OldPresenter(userId: String, notPresenterOn: Long)
 
 case class UserState(intId: String, extId: String, name: String, role: String,
                      guest: Boolean, authed: Boolean, guestStatus: String, emoji: String, locked: Boolean,
-                     presenter: Boolean, avatar: String)
+                     presenter: Boolean, avatar: String, roleChangedOn: Long = System.currentTimeMillis())
 
 case class UserIdAndName(id: String, name: String)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -197,14 +197,14 @@ class Users2x {
   def purgeOldPresenters(): Unit = {
     val now = System.currentTimeMillis()
     oldPresenterGroup.values.foreach { op =>
-      if (now - op.notPresenterOn < 5000) {
+      if (now - op.changedPresenterOn < 5000) {
         oldPresenterGroup -= op.userId
       }
     }
   }
 }
 
-case class OldPresenter(userId: String, notPresenterOn: Long)
+case class OldPresenter(userId: String, changedPresenterOn: Long)
 
 case class UserState(intId: String, extId: String, name: String, role: String,
                      guest: Boolean, authed: Boolean, guestStatus: String, emoji: String, locked: Boolean,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -183,19 +183,16 @@ class MeetingActor(
     case msg: SendTimeRemainingAuditInternalMsg =>
       state = handleSendTimeRemainingUpdate(msg, state)
       state = handleSendBreakoutTimeRemainingMsg(msg, state)
-    case msg: BreakoutRoomCreatedInternalMsg =>
-      state = handleBreakoutRoomCreatedInternalMsg(msg, state)
-    case msg: SendBreakoutUsersAuditInternalMsg => handleSendBreakoutUsersUpdateInternalMsg(msg)
-    case msg: BreakoutRoomUsersUpdateInternalMsg =>
-      state = handleBreakoutRoomUsersUpdateInternalMsg(msg, state)
-    case msg: EndBreakoutRoomInternalMsg => handleEndBreakoutRoomInternalMsg(msg)
-    case msg: BreakoutRoomEndedInternalMsg =>
-      state = handleBreakoutRoomEndedInternalMsg(msg, state)
+    case msg: BreakoutRoomCreatedInternalMsg     => state = handleBreakoutRoomCreatedInternalMsg(msg, state)
+    case msg: SendBreakoutUsersAuditInternalMsg  => handleSendBreakoutUsersUpdateInternalMsg(msg)
+    case msg: BreakoutRoomUsersUpdateInternalMsg => state = handleBreakoutRoomUsersUpdateInternalMsg(msg, state)
+    case msg: EndBreakoutRoomInternalMsg         => handleEndBreakoutRoomInternalMsg(msg)
+    case msg: BreakoutRoomEndedInternalMsg       => state = handleBreakoutRoomEndedInternalMsg(msg, state)
 
     // Screenshare
-    case msg: DeskShareGetDeskShareInfoRequest => handleDeskShareGetDeskShareInfoRequest(msg)
+    case msg: DeskShareGetDeskShareInfoRequest   => handleDeskShareGetDeskShareInfoRequest(msg)
 
-    case _                                     => // do nothing
+    case _                                       => // do nothing
   }
 
   private def handleBbbCommonEnvCoreMsg(msg: BbbCommonEnvCoreMsg): Unit = {
@@ -206,61 +203,51 @@ class MeetingActor(
       case m: EndMeetingSysCmdMsg => handleEndMeeting(m, state)
 
       // Users
-      case m: ValidateAuthTokenReqMsg =>
-        state = usersApp.handleValidateAuthTokenReqMsg(m, state)
-      case m: UserJoinMeetingReqMsg =>
-        state = handleUserJoinMeetingReqMsg(m, state)
-      case m: UserJoinMeetingAfterReconnectReqMsg =>
-        state = handleUserJoinMeetingAfterReconnectReqMsg(m, state)
-      case m: UserLeaveReqMsg =>
-        state = handleUserLeaveReqMsg(m, state)
-      case m: UserBroadcastCamStartMsg  => handleUserBroadcastCamStartMsg(m)
-      case m: UserBroadcastCamStopMsg   => handleUserBroadcastCamStopMsg(m)
+      case m: ValidateAuthTokenReqMsg => state = usersApp.handleValidateAuthTokenReqMsg(m, state)
+      case m: UserJoinMeetingReqMsg => state = handleUserJoinMeetingReqMsg(m, state)
+      case m: UserJoinMeetingAfterReconnectReqMsg => state = handleUserJoinMeetingAfterReconnectReqMsg(m, state)
+      case m: UserLeaveReqMsg => state = handleUserLeaveReqMsg(m, state)
+      case m: UserBroadcastCamStartMsg => handleUserBroadcastCamStartMsg(m)
+      case m: UserBroadcastCamStopMsg => handleUserBroadcastCamStopMsg(m)
       case m: UserJoinedVoiceConfEvtMsg => handleUserJoinedVoiceConfEvtMsg(m)
-      case m: MeetingActivityResponseCmdMsg =>
-        state = usersApp.handleMeetingActivityResponseCmdMsg(m, state)
-      case m: LogoutAndEndMeetingCmdMsg     => usersApp.handleLogoutAndEndMeetingCmdMsg(m, state)
-      case m: SetRecordingStatusCmdMsg      => usersApp.handleSetRecordingStatusCmdMsg(m)
-      case m: GetRecordingStatusReqMsg      => usersApp.handleGetRecordingStatusReqMsg(m)
-      case m: ChangeUserEmojiCmdMsg         => handleChangeUserEmojiCmdMsg(m)
-      case m: EjectUserFromMeetingCmdMsg    => usersApp.handleEjectUserFromMeetingCmdMsg(m)
-      case m: GetUsersMeetingReqMsg         => usersApp.handleGetUsersMeetingReqMsg(m)
-      case m: ChangeUserRoleCmdMsg          => usersApp.handleChangeUserRoleCmdMsg(m)
+      case m: MeetingActivityResponseCmdMsg => state = usersApp.handleMeetingActivityResponseCmdMsg(m, state)
+      case m: LogoutAndEndMeetingCmdMsg => usersApp.handleLogoutAndEndMeetingCmdMsg(m, state)
+      case m: SetRecordingStatusCmdMsg => usersApp.handleSetRecordingStatusCmdMsg(m)
+      case m: GetRecordingStatusReqMsg => usersApp.handleGetRecordingStatusReqMsg(m)
+      case m: ChangeUserEmojiCmdMsg => handleChangeUserEmojiCmdMsg(m)
+      case m: EjectUserFromMeetingCmdMsg => usersApp.handleEjectUserFromMeetingCmdMsg(m)
+      case m: GetUsersMeetingReqMsg => usersApp.handleGetUsersMeetingReqMsg(m)
+      case m: ChangeUserRoleCmdMsg => usersApp.handleChangeUserRoleCmdMsg(m)
       case m: AddUserToPresenterGroupCmdMsg => usersApp.handleAddUserToPresenterGroupCmdMsg(m)
-      case m: RemoveUserFromPresenterGroupCmdMsg =>
-        usersApp.handleRemoveUserFromPresenterGroupCmdMsg(m)
-      case m: GetPresenterGroupReqMsg        => usersApp.handleGetPresenterGroupReqMsg(m)
+      case m: RemoveUserFromPresenterGroupCmdMsg => usersApp.handleRemoveUserFromPresenterGroupCmdMsg(m)
+      case m: GetPresenterGroupReqMsg => usersApp.handleGetPresenterGroupReqMsg(m)
 
       // Whiteboard
-      case m: SendCursorPositionPubMsg       => wbApp.handle(m, liveMeeting, msgBus)
-      case m: ClearWhiteboardPubMsg          => wbApp.handle(m, liveMeeting, msgBus)
-      case m: UndoWhiteboardPubMsg           => wbApp.handle(m, liveMeeting, msgBus)
-      case m: ModifyWhiteboardAccessPubMsg   => wbApp.handle(m, liveMeeting, msgBus)
-      case m: GetWhiteboardAccessReqMsg      => wbApp.handle(m, liveMeeting, msgBus)
+      case m: SendCursorPositionPubMsg => wbApp.handle(m, liveMeeting, msgBus)
+      case m: ClearWhiteboardPubMsg => wbApp.handle(m, liveMeeting, msgBus)
+      case m: UndoWhiteboardPubMsg => wbApp.handle(m, liveMeeting, msgBus)
+      case m: ModifyWhiteboardAccessPubMsg => wbApp.handle(m, liveMeeting, msgBus)
+      case m: GetWhiteboardAccessReqMsg => wbApp.handle(m, liveMeeting, msgBus)
       case m: SendWhiteboardAnnotationPubMsg => wbApp.handle(m, liveMeeting, msgBus)
       case m: GetWhiteboardAnnotationsReqMsg => wbApp.handle(m, liveMeeting, msgBus)
+
       case m: ClientToServerLatencyTracerMsg => handleClientToServerLatencyTracerMsg(m)
 
       // Poll
-      case m: StartPollReqMsg                => pollApp.handle(m, state, liveMeeting, msgBus) // passing state but not modifying it
-      case m: StartCustomPollReqMsg          => pollApp.handle(m, state, liveMeeting, msgBus) // passing state but not modifying it
-      case m: StopPollReqMsg                 => pollApp.handle(m, state, liveMeeting, msgBus) // passing state but not modifying it
-      case m: ShowPollResultReqMsg           => pollApp.handle(m, state, liveMeeting, msgBus) // passing state but not modifying it
-      case m: HidePollResultReqMsg           => pollApp.handle(m, liveMeeting, msgBus)
-      case m: GetCurrentPollReqMsg           => pollApp.handle(m, state, liveMeeting, msgBus) // passing state but not modifying it
-      case m: RespondToPollReqMsg            => pollApp.handle(m, liveMeeting, msgBus)
+      case m: StartPollReqMsg => pollApp.handle(m, state, liveMeeting, msgBus) // passing state but not modifying it
+      case m: StartCustomPollReqMsg => pollApp.handle(m, state, liveMeeting, msgBus) // passing state but not modifying it
+      case m: StopPollReqMsg => pollApp.handle(m, state, liveMeeting, msgBus) // passing state but not modifying it
+      case m: ShowPollResultReqMsg => pollApp.handle(m, state, liveMeeting, msgBus) // passing state but not modifying it
+      case m: HidePollResultReqMsg => pollApp.handle(m, liveMeeting, msgBus)
+      case m: GetCurrentPollReqMsg => pollApp.handle(m, state, liveMeeting, msgBus) // passing state but not modifying it
+      case m: RespondToPollReqMsg => pollApp.handle(m, liveMeeting, msgBus)
 
       // Breakout
-      case m: BreakoutRoomsListMsg =>
-        state = handleBreakoutRoomsListMsg(m, state)
-      case m: CreateBreakoutRoomsCmdMsg =>
-        state = handleCreateBreakoutRoomsCmdMsg(m, state)
-      case m: EndAllBreakoutRoomsMsg =>
-        state = handleEndAllBreakoutRoomsMsg(m, state)
-      case m: RequestBreakoutJoinURLReqMsg =>
-        state = handleRequestBreakoutJoinURLReqMsg(m, state)
-      case m: TransferUserToMeetingRequestMsg =>
-        state = handleTransferUserToMeetingRequestMsg(m, state)
+      case m: BreakoutRoomsListMsg => state = handleBreakoutRoomsListMsg(m, state)
+      case m: CreateBreakoutRoomsCmdMsg => state = handleCreateBreakoutRoomsCmdMsg(m, state)
+      case m: EndAllBreakoutRoomsMsg => state = handleEndAllBreakoutRoomsMsg(m, state)
+      case m: RequestBreakoutJoinURLReqMsg => state = handleRequestBreakoutJoinURLReqMsg(m, state)
+      case m: TransferUserToMeetingRequestMsg => state = handleTransferUserToMeetingRequestMsg(m, state)
 
       // Voice
       case m: UserLeftVoiceConfEvtMsg => handleUserLeftVoiceConfEvtMsg(m)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -68,7 +68,6 @@ class MeetingActor(
     with UserDisconnectedFromGlobalAudioMsgHdlr
     with MuteAllExceptPresentersCmdMsgHdlr
     with MuteMeetingCmdMsgHdlr
-    with MuteMeetingCmdMsgHdlrCheckPerm
     with IsMeetingMutedReqMsgHdlr
 
     with EjectUserFromVoiceCmdMsgHdlr

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/MeetingStatus2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/MeetingStatus2x.scala
@@ -47,7 +47,11 @@ object MeetingStatus2x {
   def initializeAudioSettings(status: MeetingStatus2x) = status.audioSettingsInited = true
   def permissionsEqual(status: MeetingStatus2x, other: Permissions): Boolean = status.permissions == other
   def getPermissions(status: MeetingStatus2x): Permissions = status.permissions
-  def setPermissions(status: MeetingStatus2x, p: Permissions) = status.permissions = p
+  def setPermissions(status: MeetingStatus2x, p: Permissions) = {
+    status.permissions = p
+    status.permissionsChangedOn = System.currentTimeMillis()
+  }
+  def getPermissionsChangedOn(status: MeetingStatus2x): Long = status.permissionsChangedOn
   def meetingHasEnded(status: MeetingStatus2x) = status.meetingEnded = true
   def hasMeetingEnded(status: MeetingStatus2x): Boolean = status.meetingEnded
   def timeNowInMinutes(status: MeetingStatus2x): Long = TimeUnit.NANOSECONDS.toMinutes(System.nanoTime())
@@ -60,6 +64,7 @@ class MeetingStatus2x {
   private var recordingVoice = false
   private var audioSettingsInited = false
   private var permissionsInited = false
+  private var permissionsChangedOn: Long = System.currentTimeMillis()
   private var permissions = new Permissions()
   private var recording = false
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/EjectUserFromVoiceCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/EjectUserFromVoiceCmdMsgHdlr.scala
@@ -4,9 +4,9 @@ import org.bigbluebutton.common2.msgs.EjectUserFromVoiceCmdMsg
 import org.bigbluebutton.core.models.VoiceUsers
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core2.message.senders.MsgBuilder
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait EjectUserFromVoiceCmdMsgHdlr {
+trait EjectUserFromVoiceCmdMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
 
   val outGW: OutMsgRouter
@@ -14,7 +14,7 @@ trait EjectUserFromVoiceCmdMsgHdlr {
   def handleEjectUserFromVoiceCmdMsg(msg: EjectUserFromVoiceCmdMsg) {
     log.info("Received eject user request. meetingId=" + msg.header.meetingId + " userId=" + msg.body.userId)
 
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to eject the voice user."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/MuteAllExceptPresentersCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/MuteAllExceptPresentersCmdMsgHdlr.scala
@@ -4,15 +4,15 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.{ UserState, Users2x, VoiceUserState, VoiceUsers }
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core2.MeetingStatus2x
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait MuteAllExceptPresentersCmdMsgHdlr {
+trait MuteAllExceptPresentersCmdMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
 
   val outGW: OutMsgRouter
 
   def handleMuteAllExceptPresentersCmdMsg(msg: MuteAllExceptPresentersCmdMsg) {
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to mute all except presenters."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/MuteMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/MuteMeetingCmdMsgHdlr.scala
@@ -1,85 +1,66 @@
 package org.bigbluebutton.core2.message.handlers
 
-import org.bigbluebutton.SystemConfiguration
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.models.{ VoiceUserState, VoiceUsers }
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core2.MeetingStatus2x
 
-trait MuteMeetingCmdMsgHdlrDefault {
-  def handleMuteMeetingCmdMsg(msg: MuteMeetingCmdMsg): Unit = {}
-}
-
-trait MuteMeetingCmdMsgHdlrCheckPerm extends MuteMeetingCmdMsgHdlrDefault with SystemConfiguration {
+trait MuteMeetingCmdMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
 
   val outGW: OutMsgRouter
 
-  override def handleMuteMeetingCmdMsg(msg: MuteMeetingCmdMsg): Unit = {
-    val isAllowed = PermissionCheck.isAllowed(
-      PermissionCheck.MOD_LEVEL,
-      PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId
-    )
+  def handleMuteMeetingCmdMsg(msg: MuteMeetingCmdMsg): Unit = {
 
-    if (applyPermissionCheck && !isAllowed) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to mute meeting."
-      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.body.mutedBy, reason, outGW, liveMeeting)
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)
     } else {
-      super.handleMuteMeetingCmdMsg(msg)
-    }
-  }
-}
+      def build(meetingId: String, userId: String, muted: Boolean, mutedBy: String): BbbCommonEnvCoreMsg = {
+        val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
+        val envelope = BbbCoreEnvelope(MeetingMutedEvtMsg.NAME, routing)
+        val header = BbbClientMsgHeader(MeetingMutedEvtMsg.NAME, meetingId, userId)
 
-trait MuteMeetingCmdMsgHdlr extends MuteMeetingCmdMsgHdlrDefault {
-  this: MeetingActor =>
+        val body = MeetingMutedEvtMsgBody(muted, mutedBy)
+        val event = MeetingMutedEvtMsg(header, body)
 
-  val outGW: OutMsgRouter
-
-  override def handleMuteMeetingCmdMsg(msg: MuteMeetingCmdMsg): Unit = {
-
-    def build(meetingId: String, userId: String, muted: Boolean, mutedBy: String): BbbCommonEnvCoreMsg = {
-      val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
-      val envelope = BbbCoreEnvelope(MeetingMutedEvtMsg.NAME, routing)
-      val header = BbbClientMsgHeader(MeetingMutedEvtMsg.NAME, meetingId, userId)
-
-      val body = MeetingMutedEvtMsgBody(muted, mutedBy)
-      val event = MeetingMutedEvtMsg(header, body)
-
-      BbbCommonEnvCoreMsg(envelope, event)
-    }
-
-    def muteUserInVoiceConf(vu: VoiceUserState, mute: Boolean): Unit = {
-      val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, props.meetingProp.intId, vu.intId)
-      val envelope = BbbCoreEnvelope(MuteUserInVoiceConfSysMsg.NAME, routing)
-      val header = BbbCoreHeaderWithMeetingId(MuteUserInVoiceConfSysMsg.NAME, props.meetingProp.intId)
-
-      val body = MuteUserInVoiceConfSysMsgBody(props.voiceProp.voiceConf, vu.voiceUserId, mute)
-      val event = MuteUserInVoiceConfSysMsg(header, body)
-      val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
-
-      outGW.send(msgEvent)
-
-    }
-
-    if (msg.body.mute != MeetingStatus2x.isMeetingMuted(liveMeeting.status)) {
-      if (msg.body.mute) {
-        MeetingStatus2x.muteMeeting(liveMeeting.status)
-      } else {
-        MeetingStatus2x.unmuteMeeting(liveMeeting.status)
+        BbbCommonEnvCoreMsg(envelope, event)
       }
 
-      val muted = MeetingStatus2x.isMeetingMuted(liveMeeting.status)
-      val meetingMutedEvent = build(props.meetingProp.intId, msg.body.mutedBy, muted, msg.body.mutedBy)
+      def muteUserInVoiceConf(vu: VoiceUserState, mute: Boolean): Unit = {
+        val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, props.meetingProp.intId, vu.intId)
+        val envelope = BbbCoreEnvelope(MuteUserInVoiceConfSysMsg.NAME, routing)
+        val header = BbbCoreHeaderWithMeetingId(MuteUserInVoiceConfSysMsg.NAME, props.meetingProp.intId)
 
-      outGW.send(meetingMutedEvent)
+        val body = MuteUserInVoiceConfSysMsgBody(props.voiceProp.voiceConf, vu.voiceUserId, mute)
+        val event = MuteUserInVoiceConfSysMsg(header, body)
+        val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
 
-      VoiceUsers.findAll(liveMeeting.voiceUsers) foreach { vu =>
-        if (!vu.listenOnly) {
-          muteUserInVoiceConf(vu, muted)
+        outGW.send(msgEvent)
+
+      }
+
+      if (msg.body.mute != MeetingStatus2x.isMeetingMuted(liveMeeting.status)) {
+        if (msg.body.mute) {
+          MeetingStatus2x.muteMeeting(liveMeeting.status)
+        } else {
+          MeetingStatus2x.unmuteMeeting(liveMeeting.status)
+        }
+
+        val muted = MeetingStatus2x.isMeetingMuted(liveMeeting.status)
+        val meetingMutedEvent = build(props.meetingProp.intId, msg.body.mutedBy, muted, msg.body.mutedBy)
+
+        outGW.send(meetingMutedEvent)
+
+        VoiceUsers.findAll(liveMeeting.voiceUsers) foreach { vu =>
+          if (!vu.listenOnly) {
+            muteUserInVoiceConf(vu, muted)
+          }
         }
       }
     }
+
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/guests/GuestsWaitingApprovedMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/guests/GuestsWaitingApprovedMsgHdlr.scala
@@ -5,16 +5,16 @@ import org.bigbluebutton.core.apps.users.UsersApp
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core.running.{ BaseMeetingActor, HandlerHelpers, LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.message.senders.MsgBuilder
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 
-trait GuestsWaitingApprovedMsgHdlr extends HandlerHelpers {
+trait GuestsWaitingApprovedMsgHdlr extends HandlerHelpers with RightsManagementTrait {
   this: BaseMeetingActor =>
 
   val liveMeeting: LiveMeeting
   val outGW: OutMsgRouter
 
   def handleGuestsWaitingApprovedMsg(msg: GuestsWaitingApprovedMsg): Unit = {
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to approve or deny guests in meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/guests/SetGuestPolicyMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/guests/SetGuestPolicyMsgHdlr.scala
@@ -3,18 +3,18 @@ package org.bigbluebutton.core2.message.handlers.guests
 import org.bigbluebutton.common2.msgs.SetGuestPolicyCmdMsg
 import org.bigbluebutton.core.models.{ GuestPolicy, GuestPolicyType, GuestsWaiting }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
-import org.bigbluebutton.core2.message.senders.{ MsgBuilder }
-import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core2.message.senders.MsgBuilder
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.running.MeetingActor
 
-trait SetGuestPolicyMsgHdlr {
+trait SetGuestPolicyMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
 
   val liveMeeting: LiveMeeting
   val outGW: OutMsgRouter
 
   def handleSetGuestPolicyMsg(msg: SetGuestPolicyCmdMsg): Unit = {
-    if (applyPermissionCheck && !PermissionCheck.isAllowed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to set guest policy in meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)


### PR DESCRIPTION
- when switching presenter, there might be delayed messages coming from the old presenter that when we apply the permission check for the delayed message results in ejecting the old presenter from the meeting. Handle delayed messages without applying permissions check just like the default behaviour of no rights management.