### PR TITLE
Bulgarian Bug Vol. 3

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -183,23 +183,22 @@ class ApplicationMenu extends BaseMenu {
             </div>
             <div className={styles.col}>
               <label aria-labelledby="changeLangLabel" className={cx(styles.formElement, styles.pullContentRight)}>
-                <select
-                  defaultValue={this.formatLocale(this.state.settings.locale)}
-                  className={styles.select}
-                  onChange={this.handleSelectChange.bind(this, 'locale', availableLocales)}
-                >
-                  <option disabled>
-                    { availableLocales &&
-                        availableLocales.length ?
-                        intl.formatMessage(intlMessages.languageOptionLabel) :
-                        intl.formatMessage(intlMessages.noLocaleOptionLabel) }
-                  </option>
-                  {availableLocales ? availableLocales.map((locale, index) =>
-                    (<option key={index} value={locale.locale}>
-                      {locale.name}
-                    </option>),
-                  ) : null }
-                </select>
+                { availableLocales && availableLocales.length > 0 ?
+                  <select
+                    defaultValue={this.formatLocale(this.state.settings.locale)}
+                    className={styles.select}
+                    onChange={this.handleSelectChange.bind(this, 'locale', availableLocales)}
+                  >
+                    <option disabled>
+                      { intl.formatMessage(intlMessages.languageOptionLabel) }
+                    </option>
+                    { availableLocales.map((locale, index) =>
+                      (<option key={index} value={locale.locale}>
+                        {locale.name}
+                      </option>),
+                    ) }
+                  </select>
+                : null }
               </label>
               <div
                 id="changeLangLabel"


### PR DESCRIPTION
This PR fixes the issue with default language in Settings modal. It was possible to change locales successfully, but the dropdown always had Bulgarian language as the current value.
Change in behaviour: the dropdown is not displayed if the list of available locales is `undefined` (rather than displaying an empty broken dropdown).