### PR TITLE
Fix three bugs in 2.1

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateGroupChatReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateGroupChatReqMsgHdlr.scala
@@ -23,12 +23,12 @@ trait CreateGroupChatReqMsgHdlr extends SystemConfiguration {
     for {
       user <- Users2x.findWithIntId(liveMeeting.users2x, msg.header.userId)
     } yield {
-      if (user.role != Roles.MODERATOR_ROLE && user.locked) {
-        val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
+      if (user.role != Roles.MODERATOR_ROLE) {
         if (msg.body.access == GroupChatAccess.PRIVATE) {
-          chatLocked = permissions.disablePrivChat
+          val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
+          chatLocked = user.locked && permissions.disablePrivChat
         } else {
-          chatLocked = permissions.disablePubChat
+          chatLocked = true
         }
       }
     }

--- a/bigbluebutton-client/src/org/bigbluebutton/core/UsersUtil.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/UsersUtil.as
@@ -331,16 +331,18 @@ package org.bigbluebutton.core
     }
     
     public static function lockSettingsNotInitialized():void {
-      var lockOptions:LockOptions = Options.getOptions(LockOptions) as LockOptions;
-      var lockSettings:LockSettingsVO = new LockSettingsVO(lockOptions.disableCam, lockOptions.disableMic,
-        lockOptions.disablePrivateChat, lockOptions.disablePublicChat,
-        lockOptions.lockedLayout, lockOptions.lockOnJoin,
-        lockOptions.lockOnJoinConfigurable);
-      var event:LockControlEvent = new LockControlEvent(LockControlEvent.SAVE_LOCK_SETTINGS);
-      event.payload = lockSettings.toMap();
-      
-      var dispatcher:Dispatcher = new Dispatcher();
-      dispatcher.dispatchEvent(event);
+      if (amIModerator()) {
+        var lockOptions:LockOptions = Options.getOptions(LockOptions) as LockOptions;
+        var lockSettings:LockSettingsVO = new LockSettingsVO(lockOptions.disableCam, lockOptions.disableMic,
+          lockOptions.disablePrivateChat, lockOptions.disablePublicChat,
+          lockOptions.lockedLayout, lockOptions.lockOnJoin,
+          lockOptions.lockOnJoinConfigurable);
+        var event:LockControlEvent = new LockControlEvent(LockControlEvent.SAVE_LOCK_SETTINGS);
+        event.payload = lockSettings.toMap();
+        
+        var dispatcher:Dispatcher = new Dispatcher();
+        dispatcher.dispatchEvent(event);
+      }
     }
     
     public static function getBreakoutRoom(id: String): BreakoutRoom {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatOptionsTab.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatOptionsTab.mxml
@@ -74,7 +74,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       [Bindable] private var fontSizes:Array = ['8', '10', '12', '14', '16', '18'];
       
       [Bindable] public var chatOptions:ChatOptions;		
-      [Bindable] private var clrBtnVisible:Boolean = false;
+      [Bindable] private var amIModerator:Boolean = false;
       
       private var globalDispatcher:Dispatcher = new Dispatcher();
       
@@ -109,7 +109,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       }
       
       private function onCreationComplete():void{
-        clrBtnVisible = UsersUtil.amIModerator();
+        amIModerator = UsersUtil.amIModerator();
         
 		handler.populateAllUsers()
 		handler.populateAllGroupChats()
@@ -205,7 +205,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       }
       
       private function refreshRole(e:ChangeMyRole):void {
-        clearBtn.visible = clearBtn.enabled = clearBtn.includeInLayout = clrBtnVisible = UsersUtil.amIModerator();
+        amIModerator = UsersUtil.amIModerator();
         refreshListStatus();
       }
       
@@ -260,8 +260,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
   </fx:Declarations>
   
 	<mx:HBox id="newGroupChatBox" width="100%" verticalAlign="middle"
-			 visible="{chatOptions.groupEnabled &amp;&amp; groupChats.length &lt; chatOptions.maxNumWindows}"
-			 includeInLayout="{chatOptions.groupEnabled &amp;&amp; groupChats.length &lt; chatOptions.maxNumWindows}">
+			 visible="{chatOptions.groupEnabled &amp;&amp; groupChats.length &lt; chatOptions.maxNumWindows &amp;&amp; amIModerator}"
+			 includeInLayout="{chatOptions.groupEnabled &amp;&amp; groupChats.length &lt; chatOptions.maxNumWindows &amp;&amp; amIModerator}">
 		<mx:Label text="{ResourceUtil.getInstance().getString('bbb.chat.newChat.label')}"/>
 		<mx:TextInput id="newChatNameInput" width="100%"/>
 		<mx:Button id="createChatGroupBtn" label="{ResourceUtil.getInstance().getString('bbb.chat.newChat.create')}"
@@ -326,9 +326,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
                styleName="chatClearButtonStyle"
                width="22"
                height="22"
-               visible = "{clrBtnVisible}"
-               enabled = "{clrBtnVisible}"
-               includeInLayout = "{clrBtnVisible}"
+               visible = "{amIModerator}"
+               enabled = "{amIModerator}"
+               includeInLayout = "{amIModerator}"
                toolTip="{ResourceUtil.getInstance().getString('bbb.chat.clearBtn.toolTip')}"
                click="sendClearEvent()"
                accessibilityName="{ResourceUtil.getInstance().getString('bbb.chat.clearBtn.accessibilityName')}"/>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/layout/managers/LayoutManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/layout/managers/LayoutManager.as
@@ -399,6 +399,7 @@ package org.bigbluebutton.modules.layout.managers
 
 		private function checkPermissionsOverAllWindows():void {
 			if (UsersUtil.amIModerator()) return;
+			if (_canvas == null || _canvas.windowManager == null) return;
 			for each (var window:MDIWindow in _canvas.windowManager.windowList) {
 				checkPermissionsOverWindow(window);
 			}


### PR DESCRIPTION
This PR fixes three minor bugs in 2.1.
* stops viewers from being able to create new public chat pods
* fixes a race condition in the LayoutManager on client load
* stops viewer clients from trying to initialize the lock settings on client load