### PR TITLE
Fix default locale selector

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/LanguageSelector.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/LanguageSelector.mxml
@@ -42,7 +42,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 
 			private function changeLanguage():void {
-				ResourceUtil.getInstance().setPreferredLocale(selectedItem);
+				ResourceUtil.getInstance().setPreferredLocale(selectedItem.code);
 			}
 		]]>
 	</fx:Script>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatView.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatView.mxml
@@ -284,7 +284,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       }
       
       private function getTabIndexFor(chatBox:ChatTab):int {
-        return chatTabs.getChildIndex(chatBox);
+        if (chatBox)
+          return chatTabs.getChildIndex(chatBox);
+        else
+          return -1;
       }
       
       private function onTabNavChange():void{

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/services/ScreenshareService.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/services/ScreenshareService.as
@@ -73,7 +73,7 @@ package org.bigbluebutton.modules.screenshare.services {
         }
         
         public function disconnect():void {
-            conn.disconnect();
+            if (conn) conn.disconnect();
         }
         
         public function checkIfPresenterIsSharingScreen():void {


### PR DESCRIPTION
The ResourceUtil initialization was broken and didn't complete fully when the default locale from the browser was the same as the master locale (en_US). I added a skip over the resource loading because it already exists and faked that it had been loaded. The selector now switches to "English" on load like it used to and the first line shows "Default Locale" like it used to.

I also included two one liners that avoid null exceptions that I hit doing other things.