### PR TITLE
Provide option to join via html5 over flash client

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -70,6 +70,9 @@ public class ParamsProcessorUtil {
     private String defaultServerUrl;
     private int defaultNumDigitsForTelVoice;
     private String defaultClientUrl;
+    private String html5ClientUrl;
+    private Boolean moderatorsJoinViaHTML5Client;
+    private Boolean attendeesJoinViaHTML5Client;
     private String defaultAvatarURL;
     private String defaultConfigURL;
     private String defaultGuestPolicy;
@@ -489,7 +492,19 @@ public class ParamsProcessorUtil {
 	public String getDefaultClientUrl() {
 		return defaultClientUrl;
 	}
-	
+
+	public String getHTML5ClientUrl() {
+		return html5ClientUrl;
+	}
+
+	public Boolean getAttendeesJoinViaHTML5Client() {
+		return attendeesJoinViaHTML5Client;
+	}
+
+	public Boolean getModeratorsJoinViaHTML5Client() {
+		return moderatorsJoinViaHTML5Client;
+	}
+
 	public String getDefaultConfigXML() {
 		defaultConfigXML = getConfig(defaultConfigURL);
 		
@@ -806,6 +821,18 @@ public class ParamsProcessorUtil {
 
 	public void setDefaultClientUrl(String defaultClientUrl) {
 		this.defaultClientUrl = defaultClientUrl;
+	}
+
+	public void setHtml5ClientUrl(String html5ClientUrl) {
+		this.html5ClientUrl = html5ClientUrl;
+	}
+
+	public void setModeratorsJoinViaHTML5Client(Boolean moderatorsJoinViaHTML5Client) {
+		this.moderatorsJoinViaHTML5Client = moderatorsJoinViaHTML5Client;
+	}
+
+	public void setAttendeesJoinViaHTML5Client(Boolean attendeesJoinViaHTML5Client) {
+		this.attendeesJoinViaHTML5Client = attendeesJoinViaHTML5Client;
 	}
 
 	public void setDefaultMeetingDuration(int defaultMeetingDuration) {

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -164,10 +164,20 @@ bigbluebutton.web.serverURL=http://192.168.246.131
 # If "default", it returns to bigbluebutton.web.serverURL
 bigbluebutton.web.logoutURL=default
 
-# The url of the BigBlueButton client. User's will be redirected here when
+# The url of the BigBlueButton client. Users will be redirected here when
 # successfully joining the meeting.
 defaultClientUrl=${bigbluebutton.web.serverURL}/client/BigBlueButton.html
-#defaultClientUrl=http://192.168.0.235/3rd-party.html
+
+# Force all attendees to join the meeting using the HTML5 client
+attendeesJoinViaHTML5Client=false
+
+# Force all moderators to join the meeting using the HTML5 client
+moderatorsJoinViaHTML5Client=false
+
+# The url of the BigBlueButton HTML5 client. Users will be redirected here when
+# successfully joining the meeting.
+html5ClientUrl=${bigbluebutton.web.serverURL}/html5client/join
+
 
 # The default avatar image to display if nothing is passed on the JOIN API (avatarURL)
 # call. This avatar is displayed if the user isn't sharing the webcam and

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -122,6 +122,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="defaultServerUrl" value="${bigbluebutton.web.serverURL}"/>
         <property name="defaultNumDigitsForTelVoice" value="${defaultNumDigitsForTelVoice}"/>
         <property name="defaultClientUrl" value="${defaultClientUrl}"/>
+        <property name="html5ClientUrl" value="${html5ClientUrl}"/>
+        <property name="moderatorsJoinViaHTML5Client" value="${moderatorsJoinViaHTML5Client}"/>
+        <property name="attendeesJoinViaHTML5Client" value="${attendeesJoinViaHTML5Client}"/>
         <property name="defaultMeetingDuration" value="${defaultMeetingDuration}"/>
         <property name="disableRecordingDefault" value="${disableRecordingDefault}"/>
         <property name="autoStartRecording" value="${autoStartRecording}"/>

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -263,6 +263,11 @@ class ApiController {
       authenticated = Boolean.parseBoolean(params.auth)
     }
 
+    Boolean joinViaHtml5 = false;
+    if (!StringUtils.isEmpty(params.joinViaHtml5)) {
+      joinViaHtml5 = Boolean.parseBoolean(params.joinViaHtml5)
+    }
+
     // Do we have a name for the user joining? If none, complain.
     if(!StringUtils.isEmpty(params.fullName)) {
       params.fullName = StringUtils.strip(params.fullName);
@@ -504,6 +509,7 @@ class ApiController {
     boolean redirectClient = true;
     String clientURL = paramsProcessorUtil.getDefaultClientUrl();
 
+    // server-wide configuration:
     // Depending on configuration, prefer the HTML5 client over Flash for moderators
     if (paramsProcessorUtil.getModeratorsJoinViaHTML5Client() && role == ROLE_MODERATOR) {
       clientURL = paramsProcessorUtil.getHTML5ClientUrl();
@@ -514,6 +520,16 @@ class ApiController {
       clientURL = paramsProcessorUtil.getHTML5ClientUrl();
     }
 
+    // single client join configuration:
+    // Depending on configuration, prefer the HTML5 client over Flash client
+    if (joinViaHtml5) {
+      clientURL = paramsProcessorUtil.getHTML5ClientUrl();
+    } else {
+      if(!StringUtils.isEmpty(params.clientURL)){
+        clientURL = params.clientURL;
+      }
+    }
+
     if(! StringUtils.isEmpty(params.redirect)) {
       try{
         redirectClient = Boolean.parseBoolean(params.redirect);
@@ -522,9 +538,6 @@ class ApiController {
       }
     }
 
-    if(!StringUtils.isEmpty(params.clientURL)){
-      clientURL = params.clientURL;
-    }
 
     if (redirectClient){
       String destUrl = clientURL + "?sessionToken=" + sessionToken

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -504,6 +504,16 @@ class ApiController {
     boolean redirectClient = true;
     String clientURL = paramsProcessorUtil.getDefaultClientUrl();
 
+    // Depending on configuration, prefer the HTML5 client over Flash for moderators
+    if (paramsProcessorUtil.getModeratorsJoinViaHTML5Client() && role == ROLE_MODERATOR) {
+      clientURL = paramsProcessorUtil.getHTML5ClientUrl();
+    }
+
+    // Depending on configuration, prefer the HTML5 client over Flash for attendees
+    if (paramsProcessorUtil.getAttendeesJoinViaHTML5Client() && role == ROLE_ATTENDEE) {
+      clientURL = paramsProcessorUtil.getHTML5ClientUrl();
+    }
+
     if(! StringUtils.isEmpty(params.redirect)) {
       try{
         redirectClient = Boolean.parseBoolean(params.redirect);


### PR DESCRIPTION
Add configuration to control what client (HTML5 vs Flash) the users join a meeting with:

- *optional:  on join parameter*

 `joinViaHtml5=true` (per client join)
![screenshot from 2017-12-04 15-31-16](https://user-images.githubusercontent.com/6312397/33574780-54ed0354-d908-11e7-9136-26b1d9cb4545.png)

Explanation: if you pass `joinViaHtml5=true` your user will join in the HTML5 client

- *optional  bigbluebutton.properties parameters:*

```
attendeesJoinViaHTML5Client=false
moderatorsJoinViaHTML5Client=false
```
Explanation: if you set `attendeesJoinViaHTML5Client=true` all attendees will join in the HTML5 client
if you set `moderatorsJoinViaHTML5Client=true` all moderators will join in the HTML5 client