### PR TITLE
Block webcam popup opening when locked

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/events/ShortcutEvent.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/events/ShortcutEvent.as
@@ -52,8 +52,6 @@ package org.bigbluebutton.main.events {
 		public static const FOCUS_SHARED_NOTES_WINDOW:String = 'FOCUS_SHARED_NOTES_WINDOW';
 		
 		public static const REMOTE_FOCUS_DESKTOP:String = 'REMOTE_FOCUS_DESKTOP';
-		public static const REMOTE_FOCUS_WEBCAM:String = 'REMOTE_FOCUS_WEBCAM';
-		// Remote focus microphone not necessary; audio options already hog focus
 		
 		public static const REMOTE_OPEN_SHORTCUT_WIN:String = 'REMOTE_OPEN_SHORTCUT_WIN';
 		public static const LOGOUT:String = 'LOGOUT';

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/ToolbarPopupButton.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/views/ToolbarPopupButton.mxml
@@ -153,7 +153,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 			public function remoteClick(e:ShortcutEvent):void{
 				openPublishWindow();
-				dispatchEvent(new ShortcutEvent(ShortcutEvent.REMOTE_FOCUS_WEBCAM));
 			}
 			
 			public function publishingStatus(status:Number, camID:Number = -1):void {
@@ -190,6 +189,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 
 			private function openPublishWindow():void{
+				if (LiveMeeting.inst().me.disableMyCam) {
+					return;
+				}
 				if (browserForcesHTTPS()) {
 					return;
 				}


### PR DESCRIPTION
This PR blocks the webcam popup from opening when the user is locked. It's a fix for issue #4329.