### PR TITLE
Fixed Text Shape for the desktop FF 57 and 58, disabled spellCheck

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/text/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/text/component.jsx
@@ -60,7 +60,7 @@ export default class TextDrawComponent extends Component {
     // that's why we have a separate case for iOS - we don't focus here automatically
     // but we focus on the next "tap" invoked by a user
     const iOS = ['iPad', 'iPhone', 'iPod'].indexOf(navigator.platform) >= 0;
-    const Android = ['Android'].indexOf(navigator.platform) >= 0;
+    const Android = navigator.userAgent.toLowerCase().indexOf('android') > -1;
 
     // unsupported Firefox condition (not iOS though) can be removed when FF 59 is released
     // see https://bugzilla.mozilla.org/show_bug.cgi?id=1409113

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/text/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/text/component.jsx
@@ -60,13 +60,14 @@ export default class TextDrawComponent extends Component {
     // that's why we have a separate case for iOS - we don't focus here automatically
     // but we focus on the next "tap" invoked by a user
     const iOS = ['iPad', 'iPhone', 'iPod'].indexOf(navigator.platform) >= 0;
+    const Android = ['Android'].indexOf(navigator.platform) >= 0;
 
     // unsupported Firefox condition (not iOS though) can be removed when FF 59 is released
     // see https://bugzilla.mozilla.org/show_bug.cgi?id=1409113
     const unsupportedFirefox = navigator.userAgent.indexOf('Firefox/57') !== -1
                             || navigator.userAgent.indexOf('Firefox/58') !== -1;
 
-    if (iOS || unsupportedFirefox) { return; }
+    if (iOS || (Android && unsupportedFirefox)) { return; }
 
     if (this.props.isActive && this.props.annotation.status !== DRAW_END) {
       this.handleFocus();
@@ -183,6 +184,7 @@ export default class TextDrawComponent extends Component {
             onChange={this.onChangeHandler}
             onBlur={this.handleOnBlur}
             style={styles}
+            spellCheck="false"
           />
         </foreignObject>
       </g>


### PR DESCRIPTION
#4734 introduced a workaround for the Firefox 57 and 58 for Android, to support the text shape functionality.

But I forgot to add Android detection there, just checked if it was Firefox.
As a result textarea is not focused on desktops in FF 57 and 58 by default, and it's waiting for the second "touchstart" event to move focus there. Which you can't do, if you are using the mouse only.

This fixes it.

And disabled a default spell check for the text shape.