### PR TITLE
Handle dial-in users in HTML5

### DIFF
--- a/bigbluebutton-html5/imports/api/voice-users/server/handlers/joinVoiceUser.js
+++ b/bigbluebutton-html5/imports/api/voice-users/server/handlers/joinVoiceUser.js
@@ -1,5 +1,7 @@
 import { check } from 'meteor/check';
 
+import Logger from '/imports/startup/server/logger';
+import Users from '/imports/api/users';
 import addVoiceUser from '../modifiers/addVoiceUser';
 
 export default function handleJoinVoiceUser({ body }, meetingId) {
@@ -7,6 +9,74 @@ export default function handleJoinVoiceUser({ body }, meetingId) {
   voiceUser.joined = true;
 
   check(meetingId, String);
+  check(voiceUser, {
+    voiceConf: String,
+    intId: String,
+    voiceUserId: String,
+    callerName: String,
+    callerNum: String,
+    muted: Boolean,
+    talking: Boolean,
+    callingWith: String,
+    listenOnly: Boolean,
+    joined: Boolean,
+  });
+
+  const {
+    intId,
+    callerName,
+  } = voiceUser;
+
+  if (intId.toString().startsWith('v_')) {
+    /* voice-only user - called into the conference */
+
+    const selector = {
+      meetingId,
+      userId: intId,
+    };
+
+    const USER_CONFIG = Meteor.settings.public.user;
+    const ROLE_VIEWER = USER_CONFIG.role_viewer;
+
+    const modifier = {
+      $set: {
+        meetingId,
+        connectionStatus: 'online',
+        roles: [ROLE_VIEWER.toLowerCase()],
+        sortName: callerName.trim().toLowerCase(),
+        color: '#ffffff', // TODO
+        intId,
+        extId: intId, // TODO
+        name: callerName,
+        role: ROLE_VIEWER.toLowerCase(),
+        guest: false,
+        authed: true,
+        waitingForAcceptance: false,
+        emoji: 'none',
+        presenter: false,
+        locked: false, // TODO
+        avatar: '',
+      },
+    };
+
+    const cb = (err, numChanged) => {
+      if (err) {
+        return Logger.error(`Adding call-in user to VoiceUser collection: ${err}`);
+      }
+
+      const { insertedId } = numChanged;
+      if (insertedId) {
+        return Logger.info(`Added a call-in user id=${intId} meeting=${meetingId}`);
+      }
+
+      return Logger.info(`Upserted a call-in user id=${intId} meeting=${meetingId}`);
+    };
+
+    Users.upsert(selector, modifier, cb);
+  } else {
+
+    /* there is a corresponding web user in Users collection -- no need to add new one */
+  }
 
   return addVoiceUser(meetingId, voiceUser);
 }

--- a/bigbluebutton-html5/imports/api/voice-users/server/handlers/leftVoiceUser.js
+++ b/bigbluebutton-html5/imports/api/voice-users/server/handlers/leftVoiceUser.js
@@ -1,11 +1,20 @@
 import { check } from 'meteor/check';
 
-import removeVoiceUser from '../modifiers/removeVoiceUser';
+import removeVoiceUser from '/imports/api/voice-users/server/modifiers/removeVoiceUser';
+import removeUser from '/imports/api/users/server/modifiers/removeUser';
 
 export default function handleVoiceUpdate({ body }, meetingId) {
   const voiceUser = body;
 
   check(meetingId, String);
+  check(voiceUser, {
+    voiceConf: String,
+    intId: String,
+    voiceUserId: String,
+  });
 
+  const { intId } = voiceUser;
+
+  removeUser(meetingId, intId);
   return removeVoiceUser(meetingId, voiceUser);
 }

--- a/bigbluebutton-html5/imports/api/voice-users/server/methods.js
+++ b/bigbluebutton-html5/imports/api/voice-users/server/methods.js
@@ -2,10 +2,12 @@ import { Meteor } from 'meteor/meteor';
 import mapToAcl from '/imports/startup/mapToAcl';
 import listenOnlyToggle from './methods/listenOnlyToggle';
 import muteToggle from './methods/muteToggle';
+import ejectUserFromVoice from './methods/ejectUserFromVoice';
 
-Meteor.methods(mapToAcl(['methods.listenOnlyToggle', 'methods.toggleSelfVoice', 'methods.toggleVoice',
-], {
+Meteor.methods(mapToAcl(['methods.listenOnlyToggle', 'methods.toggleSelfVoice',
+  'methods.toggleVoice', 'methods.ejectUserFromVoice'], {
   listenOnlyToggle,
   toggleSelfVoice: (credentials) => { muteToggle(credentials, credentials.requesterUserId); },
   toggleVoice: muteToggle,
+  ejectUserFromVoice,
 }));

--- a/bigbluebutton-html5/imports/api/voice-users/server/methods/ejectUserFromVoice.js
+++ b/bigbluebutton-html5/imports/api/voice-users/server/methods/ejectUserFromVoice.js
@@ -1,0 +1,22 @@
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+import RedisPubSub from '/imports/startup/server/redis';
+
+export default function ejectUserFromVoice(credentials, userId) {
+  const REDIS_CONFIG = Meteor.settings.redis;
+  const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
+  const EVENT_NAME = 'EjectUserFromVoiceCmdMsg';
+
+  const { requesterUserId, meetingId } = credentials;
+
+  check(meetingId, String);
+  check(requesterUserId, String);
+  check(userId, String);
+
+  const payload = {
+    userId,
+    ejectedBy: requesterUserId,
+  };
+
+  return RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);
+}

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -211,9 +211,10 @@ const getOpenChats = (chatID) => {
     .sort(sortChats);
 };
 
+const isVoiceOnlyUser = userId => userId.toString().startsWith('v_');
+
 const getAvailableActions = (currentUser, user, router, isBreakoutRoom) => {
-  const isDialInUser = user.id.toString().startsWith('v_')
-                      || user.isPhoneUser;
+  const isDialInUser = isVoiceOnlyUser(user.id) || user.isPhoneUser;
 
   const hasAuthority = currentUser.isModerator || user.isCurrent;
 
@@ -296,7 +297,13 @@ const setEmojiStatus = (userId) => { makeCall('setEmojiStatus', userId, 'none');
 
 const assignPresenter = (userId) => { makeCall('assignPresenter', userId); };
 
-const kickUser = (userId) => { makeCall('kickUser', userId); };
+const kickUser = (userId) => {
+  if (isVoiceOnlyUser(userId)) {
+    makeCall('ejectUserFromVoice', userId);
+  } else {
+    makeCall('kickUser', userId);
+  }
+};
 
 const toggleVoice = (userId) => { makeCall('toggleVoice', userId); };
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -212,26 +212,44 @@ const getOpenChats = (chatID) => {
 };
 
 const getAvailableActions = (currentUser, user, router, isBreakoutRoom) => {
+  const isDialInUser = user.id.toString().startsWith('v_')
+                      || user.isPhoneUser;
+
   const hasAuthority = currentUser.isModerator || user.isCurrent;
-  const allowedToChatPrivately = !user.isCurrent;
+
+  const allowedToChatPrivately = !user.isCurrent && !isDialInUser;
+
   const allowedToMuteAudio = hasAuthority
                             && user.isVoiceUser
                             && !user.isMuted
                             && !user.isListenOnly;
+
   const allowedToUnmuteAudio = hasAuthority
                               && user.isVoiceUser
                               && !user.isListenOnly
                               && user.isMuted
                               && (ALLOW_MODERATOR_TO_UNMUTE_AUDIO || user.isCurrent);
-  const allowedToResetStatus = hasAuthority && user.emoji.status !== EMOJI_STATUSES.none;
+
+  const allowedToResetStatus = hasAuthority
+      && user.emoji.status !== EMOJI_STATUSES.none
+      && !isDialInUser;
 
   // if currentUser is a moderator, allow kicking other users
   const allowedToKick = currentUser.isModerator && !user.isCurrent && !isBreakoutRoom;
 
-  const allowedToSetPresenter = currentUser.isModerator && !user.isPresenter;
+  const allowedToSetPresenter = currentUser.isModerator
+      && !user.isPresenter
+      && !isDialInUser;
 
-  const allowedToPromote = currentUser.isModerator && !user.isCurrent && !user.isModerator;
-  const allowedToDemote = currentUser.isModerator && !user.isCurrent && user.isModerator;
+  const allowedToPromote = currentUser.isModerator
+      && !user.isCurrent
+      && !user.isModerator
+      && !isDialInUser;
+
+  const allowedToDemote = currentUser.isModerator
+      && !user.isCurrent
+      && user.isModerator
+      && !isDialInUser;
 
   return {
     allowedToChatPrivately,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/component.jsx
@@ -32,53 +32,9 @@ const listTransition = {
 };
 
 const intlMessages = defineMessages({
-  usersTitle: {
-    id: 'app.userList.usersTitle',
-    description: 'Title for the Header',
-  },
   messagesTitle: {
     id: 'app.userList.messagesTitle',
     description: 'Title for the messages list',
-  },
-  participantsTitle: {
-    id: 'app.userList.participantsTitle',
-    description: 'Title for the Users list',
-  },
-  toggleCompactView: {
-    id: 'app.userList.toggleCompactView.label',
-    description: 'Toggle user list view mode',
-  },
-  ChatLabel: {
-    id: 'app.userList.menu.chat.label',
-    description: 'Save the changes and close the settings menu',
-  },
-  ClearStatusLabel: {
-    id: 'app.userList.menu.clearStatus.label',
-    description: 'Clear the emoji status of this user',
-  },
-  MakePresenterLabel: {
-    id: 'app.userList.menu.makePresenter.label',
-    description: 'Set this user to be the presenter in this meeting',
-  },
-  KickUserLabel: {
-    id: 'app.userList.menu.kickUser.label',
-    description: 'Forcefully remove this user from the meeting',
-  },
-  MuteUserAudioLabel: {
-    id: 'app.userList.menu.muteUserAudio.label',
-    description: 'Forcefully mute this user',
-  },
-  UnmuteUserAudioLabel: {
-    id: 'app.userList.menu.unmuteUserAudio.label',
-    description: 'Forcefully unmute this user',
-  },
-  PromoteUserLabel: {
-    id: 'app.userList.menu.promoteUser.label',
-    description: 'Forcefully promote this viewer to a moderator',
-  },
-  DemoteUserLabel: {
-    id: 'app.userList.menu.demoteUser.label',
-    description: 'Forcefully demote this moderator to a viewer',
   },
 });
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
@@ -48,18 +48,6 @@ const intlMessages = defineMessages({
     id: 'app.userList.usersTitle',
     description: 'Title for the Header',
   },
-  messagesTitle: {
-    id: 'app.userList.messagesTitle',
-    description: 'Title for the messages list',
-  },
-  participantsTitle: {
-    id: 'app.userList.participantsTitle',
-    description: 'Title for the Users list',
-  },
-  toggleCompactView: {
-    id: 'app.userList.toggleCompactView.label',
-    description: 'Toggle user list view mode',
-  },
   ChatLabel: {
     id: 'app.userList.menu.chat.label',
     description: 'Save the changes and close the settings menu',

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
@@ -25,7 +25,7 @@ const propTypes = {
   }).isRequired,
   userActions: PropTypes.shape({}).isRequired,
   router: PropTypes.shape({}).isRequired,
-  isBreakoutRoom: PropTypes.bool.isRequired,
+  isBreakoutRoom: PropTypes.bool,
   getAvailableActions: PropTypes.func.isRequired,
   meeting: PropTypes.shape({}).isRequired,
   isMeetingLocked: PropTypes.func.isRequired,
@@ -34,12 +34,10 @@ const propTypes = {
 };
 
 const defaultProps = {
-  shouldShowActions: false,
   isBreakoutRoom: false,
 };
 
 class UserListItem extends Component {
-
   static createAction(action, ...options) {
     return (
       <UserAction

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
@@ -201,13 +201,15 @@ class UserListContent extends Component {
       ? intl.formatMessage(messages.presenter)
       : '';
 
-    const userAriaLabel = intl.formatMessage(messages.userAriaLabel,
+    const userAriaLabel = intl.formatMessage(
+      messages.userAriaLabel,
       {
         0: user.name,
         1: presenter,
         2: you,
         3: user.emoji.status,
-      });
+      },
+    );
 
     const contents = (
       <div

--- a/bigbluebutton-html5/private/config/public/acl.yaml
+++ b/bigbluebutton-html5/private/config/public/acl.yaml
@@ -31,6 +31,7 @@ acl:
       - 'toggleVoice'
       - 'clearPublicChatHistory'
       - 'changeRole'
+      - 'ejectUserFromVoice'
   presenter:
     methods:
       - 'assignPresenter'

--- a/bigbluebutton-html5/private/config/server/redis.yaml
+++ b/bigbluebutton-html5/private/config/server/redis.yaml
@@ -12,3 +12,4 @@ redis:
     - 'from-akka-apps-wb-redis-channel'
   ignored:
     - 'CheckAlivePongSysMsg'
+    - 'DoLatencyTracerMsg'


### PR DESCRIPTION
Fixes #4457 

Adjustments coming:
* Make call-in/dial-in users visually different than web users #4786 (design required, aiming for 2.1)
* Voice users are not sent over to html5 server on meteor start #4784 (aiming for 2.0)
* Locking the microphone control in a meeting does not have effect on dial-in users #4787 (changes must be done on BBB)