### PR TITLE
Poll updated event - drop requesterId/presenterId and rename event

### DIFF
--- a/bigbluebutton-html5/imports/api/polls/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/polls/server/eventHandlers.js
@@ -7,4 +7,4 @@ import handleUserVoted from './handlers/userVoted';
 RedisPubSub.on('PollShowResultEvtMsg', handlePollPublished);
 RedisPubSub.on('PollStartedEvtMsg', handlePollStarted);
 RedisPubSub.on('PollStoppedEvtMsg', handlePollStopped);
-RedisPubSub.on('UserRespondedToPollEvtMsg', handleUserVoted);
+RedisPubSub.on('PollUpdatedEvtMsg', handleUserVoted);

--- a/bigbluebutton-html5/imports/api/polls/server/handlers/userVoted.js
+++ b/bigbluebutton-html5/imports/api/polls/server/handlers/userVoted.js
@@ -3,11 +3,20 @@ import updateVotes from '../modifiers/updateVotes';
 
 export default function userVoted({ body }, meetingId) {
   const { poll } = body;
-  const { presenterId } = body;
 
   check(meetingId, String);
-  check(poll, Object);
-  check(presenterId, String);
+  check(poll, {
+    id: String,
+    answers: [
+      {
+        id: Number,
+        key: String,
+        numVotes: Number,
+      },
+    ],
+    numRespondents: Number,
+    numResponders: Number,
+  });
 
-  return updateVotes(poll, meetingId, presenterId);
+  return updateVotes(poll, meetingId);
 }

--- a/bigbluebutton-html5/imports/api/polls/server/methods/publishVote.js
+++ b/bigbluebutton-html5/imports/api/polls/server/methods/publishVote.js
@@ -10,6 +10,11 @@ export default function publishVote(credentials, id, pollAnswerId) { // TODO dis
 
   const { meetingId, requesterUserId } = credentials;
 
+  /*
+   We keep an array of people who were in the meeting at the time the poll
+   was started. The poll is published to them only.
+   Once they vote - their ID is removed and they cannot see the poll anymore
+   */
   const currentPoll = Polls.findOne({
     users: requesterUserId,
     meetingId,

--- a/bigbluebutton-html5/imports/api/polls/server/modifiers/updateVotes.js
+++ b/bigbluebutton-html5/imports/api/polls/server/modifiers/updateVotes.js
@@ -3,18 +3,16 @@ import { check } from 'meteor/check';
 import Logger from '/imports/startup/server/logger';
 import flat from 'flat';
 
-export default function updateVotes(poll, meetingId, requesterId) {
+export default function updateVotes(poll, meetingId) {
   check(meetingId, String);
-  check(requesterId, String);
   check(poll, Object);
 
   const {
     id,
     answers,
+    numResponders,
+    numRespondents,
   } = poll;
-
-  const { numResponders } = poll;
-  const { numRespondents } = poll;
 
   check(id, String);
   check(answers, Array);
@@ -24,15 +22,11 @@ export default function updateVotes(poll, meetingId, requesterId) {
 
   const selector = {
     meetingId,
-    requester: requesterId,
     id,
   };
 
   const modifier = {
-    $set: Object.assign(
-      { requester: requesterId },
-      flat(poll, { safe: true }),
-    ),
+    $set: flat(poll, { safe: true }),
   };
 
   const cb = (err) => {


### PR DESCRIPTION
Fixes #4778 

* renamed `UserRespondedToPollEvtMsg` to `PollUpdatedEvtMsg`
* adjusted the code not to expect presenterId to be passed

This was done to adapt the html5 client to changes made in #4776 