### PR TITLE
Fixed a problem with the default locale selection in Edge

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/settings/index.js
+++ b/bigbluebutton-html5/imports/ui/services/settings/index.js
@@ -32,7 +32,7 @@ class Settings {
     });
 
     // Sets default locale to browser locale
-    defaultValues.application.locale = navigator.languages[0] ||
+    defaultValues.application.locale = navigator.languages ? navigator.languages[0] : false ||
                                        navigator.language ||
                                        defaultValues.application.locale;
 


### PR DESCRIPTION
Currently html5 login completely fails in Edge, all users can see is a dark screen.
`navigator.languages` is undefined there, it tries to extract [0] from `undefined` and fails.
This fixes it.