### PR TITLE
Add permissionLayout location for Safari

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/permissions-overlay/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/permissions-overlay/component.jsx
@@ -30,6 +30,10 @@ class PermissionsOverlay extends Component {
         top: '210px',
         left: '605px',
       },
+      Safari: {
+        top: '100px',
+        left: '100px',
+      },
     };
 
     const browser = window.bowser.name;


### PR DESCRIPTION
Prior to this change the echo test in Safari on iOS 11 would result in blank screen - the UI would not render at all due to not specifying how/where Safari should render it. Adding specification for Safari resolved the issue