### PR TITLE
Decouple whiteboard from presentation

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/NetConnectionDelegate.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/NetConnectionDelegate.as
@@ -29,6 +29,8 @@ package org.bigbluebutton.main.model.users
 	import flash.net.Responder;
 	import flash.utils.Timer;
 	
+	import mx.utils.ObjectUtil;
+	
 	import org.as3commons.logging.api.ILogger;
 	import org.as3commons.logging.api.getClassLogger;
 	import org.bigbluebutton.core.BBB;
@@ -112,7 +114,7 @@ package org.bigbluebutton.main.model.users
                 _messageListeners[notify].onMessage(messageName, message);
               }
             } catch(error:Error) {
-              LOGGER.error("Exception dispatched by a MessageListener, error: " + error.message);
+              LOGGER.error("Exception dispatched by a MessageListener, error: " + error.message + ", while trying to process " + ObjectUtil.toString(message));
             }
           } else {
             LOGGER.debug("Message name is undefined");

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/events/ExportEvent.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/events/ExportEvent.as
@@ -18,10 +18,10 @@
  */
 package org.bigbluebutton.modules.present.events {
 	import flash.events.Event;
-
+	
 	import org.bigbluebutton.modules.present.model.PresentationModel;
 	import org.bigbluebutton.modules.present.ui.views.models.SlideViewModel;
-	import org.bigbluebutton.modules.whiteboard.views.WhiteboardCanvas;
+	import org.bigbluebutton.modules.whiteboard.views.IWhiteboardOverlay;
 
 	public class ExportEvent extends Event {
 		public static const OPEN_EXPORT_WINDOW:String = "OPEN_EXPORT_WINDOW";
@@ -42,7 +42,7 @@ package org.bigbluebutton.modules.present.events {
 
 		public var presentationModel:PresentationModel;
 
-		public var whiteboardCanvas:WhiteboardCanvas
+		public var whiteboardCanvas:IWhiteboardOverlay;
 
 		public function ExportEvent(type:String) {
 			super(type, true, false);

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/FileExportWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/FileExportWindow.mxml
@@ -65,7 +65,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.modules.present.ui.views.models.SlideViewModel;
 			import org.bigbluebutton.modules.whiteboard.models.Annotation;
 			import org.bigbluebutton.modules.whiteboard.models.AnnotationType;
-			import org.bigbluebutton.modules.whiteboard.views.WhiteboardCanvas;
+			import org.bigbluebutton.modules.whiteboard.views.IWhiteboardOverlay;
 			import org.bigbluebutton.util.i18n.ResourceUtil;
 
 			public var firstPage:int;
@@ -78,7 +78,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 			public var presentationModel:PresentationModel;
 
-			public var whiteboardCanvas:WhiteboardCanvas;
+			public var whiteboardCanvas:IWhiteboardOverlay;
 
 			private var _pdf:PDF;
 

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/PresentationWindow.mxml
@@ -71,17 +71,18 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		<![CDATA[
 			import flash.geom.Point;
 			
+			import flashx.textLayout.formats.Direction;
+			
+			import flexlib.mdi.events.MDIWindowEvent;
+			
 			import mx.collections.ArrayCollection;
 			import mx.controls.Button;
 			import mx.controls.Menu;
 			import mx.core.FlexGlobals;
+			import mx.core.UIComponent;
 			import mx.events.MenuEvent;
 			import mx.managers.PopUpManager;
 			import mx.utils.StringUtil;
-			
-			import flashx.textLayout.formats.Direction;
-			
-			import flexlib.mdi.events.MDIWindowEvent;
 			
 			import org.as3commons.lang.StringUtils;
 			import org.as3commons.logging.api.ILogger;
@@ -127,7 +128,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.modules.present.model.PresentationModel;
 			import org.bigbluebutton.modules.present.model.PresentationPodManager;
 			import org.bigbluebutton.modules.whiteboard.events.RequestNewCanvasEvent;
-			import org.bigbluebutton.modules.whiteboard.views.WhiteboardCanvas;
+			import org.bigbluebutton.modules.whiteboard.views.IWhiteboardOverlay;
+			import org.bigbluebutton.modules.whiteboard.views.IWhiteboardToolbar;
 			import org.bigbluebutton.modules.whiteboard.views.WhiteboardTextToolbar;
 			import org.bigbluebutton.modules.whiteboard.views.WhiteboardToolbar;
 			import org.bigbluebutton.util.i18n.ResourceUtil;
@@ -182,7 +184,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private var noticeSoundClass:Class;
 			private var noticeSound:Sound = new noticeSoundClass() as Sound;
 
-			private var whiteboardOverlay:WhiteboardCanvas = null;
+			private var whiteboardOverlay:IWhiteboardOverlay = null;
 
 			[Bindable]
 			private var podDropdownVisible:Boolean = false;
@@ -1101,19 +1103,19 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				}
 			}
 
-			public function receiveToolbars(wt:WhiteboardToolbar, wtt:WhiteboardTextToolbar):void {
+			public function receiveToolbars(wt:IWhiteboardToolbar, wtt:IWhiteboardToolbar):void {
 				var addUIEvent:AddUIComponentToMainCanvas = new AddUIComponentToMainCanvas(AddUIComponentToMainCanvas.ADD_COMPONENT);
-				addUIEvent.component = wt;
+				addUIEvent.component = wt as UIComponent;
 				globalDispatcher.dispatchEvent(addUIEvent);
 				wt.positionToolbar(this);
 				
 				var addTextToolbarEvent:AddUIComponentToMainCanvas = new AddUIComponentToMainCanvas(AddUIComponentToMainCanvas.ADD_COMPONENT);
-				addTextToolbarEvent.component = wtt;
+				addTextToolbarEvent.component = wtt as UIComponent;
 				globalDispatcher.dispatchEvent(addTextToolbarEvent);
 				wtt.positionToolbar(this);
 			}
 
-			public function receiveCanvas(wc:WhiteboardCanvas):void {
+			public function receiveCanvas(wc:IWhiteboardOverlay):void {
 				whiteboardOverlay = wc;
 
 				addWhiteboardCanvasToSlideView();

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/SlideView.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/SlideView.mxml
@@ -63,7 +63,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.modules.present.model.PresentationPodManager;
 			import org.bigbluebutton.modules.present.ui.views.models.SlideCalcUtil;
 			import org.bigbluebutton.modules.present.ui.views.models.SlideViewModel;
-			import org.bigbluebutton.modules.whiteboard.views.WhiteboardCanvas;
+			import org.bigbluebutton.modules.whiteboard.views.IWhiteboardOverlay;
 			import org.bigbluebutton.util.i18n.ResourceUtil;
 
 			private static const LOGGER:ILogger = getClassLogger(SlideView);      
@@ -72,7 +72,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			public static const ZOOM_STEP:int = 5;
 			public static const THUMBNAILS_CLOSED:String = "ThumbnailsClosed";
 			
-			private var whiteboardCanvas:WhiteboardCanvas;
+			private var whiteboardOverlay:IWhiteboardOverlay;
 										
 			private var dispatcher:Dispatcher = new Dispatcher();
 						
@@ -353,8 +353,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					slideLoader.source = page.swfData;
 					LOGGER.debug("Displaying page [{0}]", [e.pageId]);
 					//positionPage(page);
-					if (whiteboardCanvas != null) {
-						whiteboardCanvas.displayWhiteboardById(page.id);
+					if (whiteboardOverlay != null) {
+						whiteboardOverlay.displayWhiteboardById(page.id);
 					}
 
 					//slideLoader.accessibilityProperties.description = "Slide text start:  " + e.slideText + "    Slide text end";
@@ -417,26 +417,26 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				dispatcher.dispatchEvent(dispEvent);
 			}
 			
-			public function acceptOverlayCanvas(_podId: String, overlay:WhiteboardCanvas):void{
+			public function acceptOverlayCanvas(_podId: String, overlay:IWhiteboardOverlay):void{
 				if (_podId != this.podId || PresentationPodManager.getInstance().getPod(_podId) == null) {
 					return;
 				}
 
-				whiteboardCanvas = overlay;
+				whiteboardOverlay = overlay;
 
 				var currPage:Page = PresentationPodManager.getInstance().getPod(_podId).getCurrentPage();
 				if (currPage != null) {
-					whiteboardCanvas.displayWhiteboardById(currPage.id);
+					whiteboardOverlay.displayWhiteboardById(currPage.id);
 				}
 
-				this.addChildAt(whiteboardCanvas, this.getChildIndex(thumbnailView));
+				this.addChildAt((whiteboardOverlay as DisplayObject), this.getChildIndex(thumbnailView));
 				fitSlideToLoader();
-				whiteboardCanvas.addEventListener(MouseEvent.MOUSE_DOWN, handleWhiteboardCanvasClick);
+				(whiteboardOverlay as IEventDispatcher).addEventListener(MouseEvent.MOUSE_DOWN, handleWhiteboardCanvasClick);
 				slideLoader.addEventListener(MouseEvent.MOUSE_DOWN, handleWhiteboardCanvasClick);
 			}
 			
 			public function removeOverlayCanvas():void {
-				whiteboardCanvas = null;
+				whiteboardOverlay = null;
 			}
 			
 			private function handleWhiteboardCanvasClick(e:MouseEvent):void {
@@ -444,16 +444,16 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 			
 			public function moveCanvas(x:Number, y:Number):void{
-				if (whiteboardCanvas != null) {
-					whiteboardCanvas.moveCanvas(x * SlideCalcUtil.MYSTERY_NUM, y * SlideCalcUtil.MYSTERY_NUM);
+				if (whiteboardOverlay != null) {
+					whiteboardOverlay.moveCanvas(x * SlideCalcUtil.MYSTERY_NUM, y * SlideCalcUtil.MYSTERY_NUM);
 				}
 			}
 			
 			public function zoomCanvas(width:Number, height:Number):void{
 				moveCanvas(slideLoader.x, slideLoader.y);
-				if (whiteboardCanvas != null) {
+				if (whiteboardOverlay != null) {
 					//LogUtil.debug("Zooming Canvas " + width + " " + height);
-					whiteboardCanvas.zoomCanvas(width, height);
+					whiteboardOverlay.zoomCanvas(width, height);
 				}
 			}
 			

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/IWhiteboardOverlay.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/IWhiteboardOverlay.as
@@ -18,8 +18,13 @@
  */
 
 package org.bigbluebutton.modules.whiteboard.views {
-	public interface IWhiteboardReceiver {
-		function receiveToolbars(wt:IWhiteboardToolbar, wtt:IWhiteboardToolbar):void;
-		function receiveCanvas(wc:IWhiteboardOverlay):void;
+	import flash.display.DisplayObject;
+
+	public interface IWhiteboardOverlay {
+		function presenterChange(amIPresenter:Boolean, presenterId:String):void;
+		function displayWhiteboardById(wbId:String):void;
+		function moveCanvas(x:Number, y:Number):void;
+		function zoomCanvas(width:Number, height:Number):void;
+		function getGraphicByName(childName:String):DisplayObject;
 	}
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/IWhiteboardToolbar.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/IWhiteboardToolbar.as
@@ -18,8 +18,9 @@
  */
 
 package org.bigbluebutton.modules.whiteboard.views {
-	public interface IWhiteboardReceiver {
-		function receiveToolbars(wt:IWhiteboardToolbar, wtt:IWhiteboardToolbar):void;
-		function receiveCanvas(wc:IWhiteboardOverlay):void;
+	import flexlib.mdi.containers.MDIWindow;
+
+	public interface IWhiteboardToolbar {
+		function positionToolbar(container:MDIWindow):void;
 	}
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardCanvas.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardCanvas.as
@@ -43,7 +43,7 @@ package org.bigbluebutton.modules.whiteboard.views {
 	import org.bigbluebutton.modules.whiteboard.models.AnnotationType;
 	import org.bigbluebutton.modules.whiteboard.models.WhiteboardModel;
 	
-	public class WhiteboardCanvas extends Canvas {
+	public class WhiteboardCanvas extends Canvas implements IWhiteboardOverlay {
 		private var whiteboardModel:WhiteboardModel;
 		private var canvasModel:WhiteboardCanvasModel;
 		private var canvasDisplayModel:WhiteboardCanvasDisplayModel;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardTextToolbar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardTextToolbar.mxml
@@ -20,9 +20,13 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 -->
 
-<mx:HBox xmlns="flexlib.containers.*" xmlns:mx="library://ns.adobe.com/flex/mx" xmlns:fx="http://ns.adobe.com/mxml/2009"
-	xmlns:mate="http://mate.asfusion.com/" visible="false"
-	xmlns:views="org.bigbluebutton.modules.whiteboard.views.*">
+<mx:HBox xmlns="flexlib.containers.*"
+		 xmlns:mx="library://ns.adobe.com/flex/mx"
+		 xmlns:fx="http://ns.adobe.com/mxml/2009"
+		 xmlns:mate="http://mate.asfusion.com/"
+		 xmlns:views="org.bigbluebutton.modules.whiteboard.views.*"
+		 implements="org.bigbluebutton.modules.whiteboard.views.IWhiteboardToolbar"
+		 visible="false">
 	
 	<fx:Declarations>
 		<mate:Listener type="{WhiteboardButtonEvent.DISABLE_WHITEBOARD}" method="disableTextToolbar" />

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardToolbar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardToolbar.mxml
@@ -27,6 +27,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     xmlns:wbBtns="org.bigbluebutton.modules.whiteboard.views.buttons.*"
 	xmlns:common="org.bigbluebutton.common.*"
     xmlns:mate="http://mate.asfusion.com/"
+    implements="org.bigbluebutton.modules.whiteboard.views.IWhiteboardToolbar"
     creationComplete="onCreationComplete()"
     visible="{showWhiteboardToolbar}" 
     includeInLayout="{showWhiteboardToolbar}"


### PR DESCRIPTION
The PresentationWindow and SlideView in the PresentationModule imported the WhiteboardCanvas directly which resulted in the PresentationModule being bigger than it needs to be and removing the ability to build the WhiteboardModule on its own. This PR adds two interfaces so all the PresentationModule needs to include is those small interfaces instead of most of the WhiteboardModule.