### PR TITLE
Fix locale initialization

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/bigbluebutton.js
+++ b/bigbluebutton-client/resources/prod/lib/bigbluebutton.js
@@ -1,7 +1,7 @@
 $(function () {
 	setTimeout(function(){
 		   $('#BigBlueButton').focus();
-	},1000);
+	},2000);
 });
 
 function startFlashFocus() {


### PR DESCRIPTION
This PR fixes the locale initialization when the browser suggests a locale we don't have. Previously this would result in the client not starting up and it would sit on a white screen.

I also tacked on an increase to the timeout before focusing the Flash content because sometimes it can take longer to become active.