### PR TITLE
Fixes for some spacing issues in the client

### DIFF
--- a/bigbluebutton-client/branding/default/style/css/V2Theme.css
+++ b/bigbluebutton-client/branding/default/style/css/V2Theme.css
@@ -164,7 +164,7 @@ phonecomponents|MuteMeButton {
 }
 
 .topBoxStyle {
-	paddingTop    : 6;
+	paddingTop    : 0;
 	paddingBottom : 0;
 	paddingLeft   : 8;
 	paddingRight  : 8;

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
@@ -170,7 +170,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			[Bindable] private var toolbarHeight:Number = DEFAULT_TOOLBAR_HEIGHT;
 			[Bindable] private var showFooterOpt:Boolean = true;
 			[Bindable] private var _showFooter:Boolean = true;
-			[Bindable] private var footerHeight:Number = 60;
+			[Bindable] private var footerHeight:Number = 50;
 			
 			[Bindable] private var isTunneling:Boolean = false;
 			

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
@@ -525,7 +525,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 						   tabIndices="{[recordBtn, webRTCAudioStatus, shortcutKeysBtn, helpBtn, btnLogout]}"/>
 	</fx:Declarations>
 
-	<mx:VBox id="mainBox" styleName="toolbarMainBox" width="100%" horizontalScrollPolicy="off" verticalAlign="top">
+	<mx:VBox id="mainBox" styleName="toolbarMainBox" width="100%" horizontalScrollPolicy="off" verticalAlign="top" verticalGap="0">
 		<!-- Breakout room  Ribbon-->
 		<mx:HBox id="banner" visible="false" includeInLayout="false" styleName="bannerStyle" width="100%" height="30">
 			<mx:Label id="bannerLabel" width="100%" textAlign="center"/>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/layout/views/LayoutsCombo.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/layout/views/LayoutsCombo.mxml
@@ -25,7 +25,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			 prompt="{ResourceUtil.getInstance().getString('bbb.layout.combo.prompt')}"
 			 height="{LayoutButton.BUTTON_SIZE}" creationComplete="init()"
 			 change="onSelectedItemChanged(event)"
-			 rowCount="10" width="240" >
+			 rowCount="15" width="240" >
 	
 	<fx:Declarations>
 		<mate:Listener type="{SwitchedLayoutEvent.SWITCHED_LAYOUT_EVENT}" method="onLayoutChanged" />


### PR DESCRIPTION
I removed a 6 pixel padding on the top of the main toolbar that made it unbalanced and 10 pixels from the bottom control bar because it didn't need all that space. I also increased the number of layouts visible in the combobox from 10 to 15.