### PR TITLE
Aligned the dropdown's close button on small screens

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/dropdown/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/styles.scss
@@ -82,6 +82,7 @@ $dropdown-caret-height: 8px;
 
   @include mq($small-only) {
     display: block;
+    bottom: 0.8rem;
   }
 }
 


### PR DESCRIPTION
Now it properly covers the other actions bar buttons. Fixes #4954 