### PR TITLE
Adjusts on screenshare button and requested changes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -77,6 +77,28 @@ class ActionsDropdown extends Component {
 
     if (!isUserPresenter) return null;
 
+    function ScreenshareButton(props) {
+      if (Meteor.settings.public.kurento.enableScreensharing) {
+        if (!isVideoBroadcasting()) {
+          return <DropdownListItem
+                   icon="desktop"
+                   label={intl.formatMessage(intlMessages.desktopShareLabel)}
+                   description={intl.formatMessage(intlMessages.desktopShareDesc)}
+                   onClick={handleShareScreen}
+                 />;
+        } else {
+          return <DropdownListItem
+                   icon="desktop"
+                   label={intl.formatMessage(intlMessages.stopDesktopShareLabel)}
+                   description={intl.formatMessage(intlMessages.stopDesktopShareDesc)}
+                   onClick={handleUnshareScreen}
+                 />;
+        }
+      } else {
+        return null;
+      }
+    }
+
     return (
       <Dropdown ref={(ref) => { this._dropdown = ref; }} >
         <DropdownTrigger tabIndex={0} >
@@ -100,18 +122,7 @@ class ActionsDropdown extends Component {
               description={intl.formatMessage(intlMessages.presentationDesc)}
               onClick={this.handlePresentationClick}
             />
-            <DropdownListItem
-              icon="desktop"
-              label={intl.formatMessage(intlMessages.desktopShareLabel)}
-              description={intl.formatMessage(intlMessages.desktopShareDesc)}
-              onClick={handleShareScreen}
-            />
-            <DropdownListItem
-              icon="desktop"
-              label={intl.formatMessage(intlMessages.stopDesktopShareLabel)}
-              description={intl.formatMessage(intlMessages.stopDesktopShareDesc)}
-              onClick={handleUnshareScreen}
-            />
+            <ScreenshareButton />
           </DropdownList>
         </DropdownContent>
       </Dropdown>

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -54,6 +54,11 @@ class ActionsDropdown extends Component {
     this.handlePresentationClick = this.handlePresentationClick.bind(this);
   }
 
+  componentWillMount() {
+    this.presentationItemId = _.uniqueId('action-item-');
+    this.videoItemId = _.uniqueId('action-item-');
+  }
+
   componentWillUpdate(nextProps) {
     const { isUserPresenter: isPresenter } = nextProps;
     const { isUserPresenter: wasPresenter, mountModal } = this.props;
@@ -79,7 +84,7 @@ class ActionsDropdown extends Component {
         icon="presentation"
         label={intl.formatMessage(intlMessages.presentationLabel)}
         description={intl.formatMessage(intlMessages.presentationDesc)}
-        key={_.uniqueId('action-item-')}
+        key={this.presentationItemId}
         onClick={this.handlePresentationClick}
       />),
       (Meteor.settings.public.kurento.enableScreensharing ?
@@ -87,7 +92,7 @@ class ActionsDropdown extends Component {
           icon="desktop"
           label={intl.formatMessage(isVideoBroadcasting ? intlMessages.stopDesktopShareLabel : intlMessages.desktopShareLabel)}
           description={intl.formatMessage(isVideoBroadcasting ? intlMessages.stopDesktopShareDesc : intlMessages.desktopShareDesc)}
-          key={_.uniqueId('action-item-')}
+          key={this.videoItemId}
           onClick={isVideoBroadcasting ? handleUnshareScreen : handleShareScreen }
         />
       : null),

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -66,6 +66,34 @@ class ActionsDropdown extends Component {
     this.props.mountModal(<PresentationUploaderContainer />);
   }
 
+  getAvailableActions() {
+    const {
+      intl,
+      handleShareScreen,
+      handleUnshareScreen,
+      isVideoBroadcasting,
+    } = this.props;
+
+    return _.compact([
+      (<DropdownListItem
+        icon="presentation"
+        label={intl.formatMessage(intlMessages.presentationLabel)}
+        description={intl.formatMessage(intlMessages.presentationDesc)}
+        key={_.uniqueId('action-item-')}
+        onClick={this.handlePresentationClick}
+      />),
+      (Meteor.settings.public.kurento.enableScreensharing ?
+        <DropdownListItem
+          icon="desktop"
+          label={intl.formatMessage(isVideoBroadcasting ? intlMessages.stopDesktopShareLabel : intlMessages.desktopShareLabel)}
+          description={intl.formatMessage(isVideoBroadcasting ? intlMessages.stopDesktopShareDesc : intlMessages.desktopShareDesc)}
+          key={_.uniqueId('action-item-')}
+          onClick={isVideoBroadcasting ? handleUnshareScreen : handleShareScreen }
+        />
+      : null),
+    ]);
+  }
+
   render() {
     const {
       intl,
@@ -74,6 +102,8 @@ class ActionsDropdown extends Component {
       handleUnshareScreen,
       isVideoBroadcasting,
     } = this.props;
+
+    const availableActions = this.getAvailableActions();
 
     if (!isUserPresenter) return null;
 
@@ -94,20 +124,7 @@ class ActionsDropdown extends Component {
         </DropdownTrigger>
         <DropdownContent placement="top left">
           <DropdownList>
-            <DropdownListItem
-              icon="presentation"
-              label={intl.formatMessage(intlMessages.presentationLabel)}
-              description={intl.formatMessage(intlMessages.presentationDesc)}
-              onClick={this.handlePresentationClick}
-            />
-            {Meteor.settings.public.kurento.enableScreensharing ?
-              <DropdownListItem
-                icon="desktop"
-                label={intl.formatMessage(isVideoBroadcasting ? intlMessages.stopDesktopShareLabel : intlMessages.desktopShareLabel)}
-                description={intl.formatMessage(isVideoBroadcasting ? intlMessages.stopDesktopShareDesc : intlMessages.desktopShareDesc)}
-                onClick={isVideoBroadcasting ? handleUnshareScreen : handleShareScreen }
-              />
-            : null}
+            {availableActions}
           </DropdownList>
         </DropdownContent>
       </Dropdown>

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -77,28 +77,6 @@ class ActionsDropdown extends Component {
 
     if (!isUserPresenter) return null;
 
-    function ScreenshareButton(props) {
-      if (Meteor.settings.public.kurento.enableScreensharing) {
-        if (!isVideoBroadcasting()) {
-          return <DropdownListItem
-                   icon="desktop"
-                   label={intl.formatMessage(intlMessages.desktopShareLabel)}
-                   description={intl.formatMessage(intlMessages.desktopShareDesc)}
-                   onClick={handleShareScreen}
-                 />;
-        } else {
-          return <DropdownListItem
-                   icon="desktop"
-                   label={intl.formatMessage(intlMessages.stopDesktopShareLabel)}
-                   description={intl.formatMessage(intlMessages.stopDesktopShareDesc)}
-                   onClick={handleUnshareScreen}
-                 />;
-        }
-      } else {
-        return null;
-      }
-    }
-
     return (
       <Dropdown ref={(ref) => { this._dropdown = ref; }} >
         <DropdownTrigger tabIndex={0} >
@@ -122,7 +100,14 @@ class ActionsDropdown extends Component {
               description={intl.formatMessage(intlMessages.presentationDesc)}
               onClick={this.handlePresentationClick}
             />
-            <ScreenshareButton />
+            {Meteor.settings.public.kurento.enableScreensharing ?
+              <DropdownListItem
+                icon="desktop"
+                label={intl.formatMessage(isVideoBroadcasting ? intlMessages.stopDesktopShareLabel : intlMessages.desktopShareLabel)}
+                description={intl.formatMessage(isVideoBroadcasting ? intlMessages.stopDesktopShareDesc : intlMessages.desktopShareDesc)}
+                onClick={isVideoBroadcasting ? handleUnshareScreen : handleShareScreen }
+              />
+            : null}
           </DropdownList>
         </DropdownContent>
       </Dropdown>

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
@@ -16,6 +16,6 @@ export default withTracker(() => ({
   handleJoinVideo: () => VideoService.joinVideo(),
   handleShareScreen: () => shareScreen(),
   handleUnshareScreen: () => unshareScreen(),
-  isVideoBroadcasting: () => isVideoBroadcasting(),
+  isVideoBroadcasting: isVideoBroadcasting(),
 
 }))(ActionsBarContainer);

--- a/bigbluebutton-html5/imports/ui/components/video-dock/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-dock/component.jsx
@@ -103,11 +103,11 @@ class VideoDock extends Component {
     const ws = this.ws;
     const { users, userId } = this.props;
 
-    for (let i = 0; i < users.length; i++) {
-      if (users[i].has_stream && users[i].userId !== userId) {
-        this.start(users[i].userId, false);
+    users.forEach((user) => {
+      if (user.has_stream && user.userId !== userId) {
+        this.start(user.userId, false);
       }
-    }
+    })
 
     document.addEventListener('joinVideo', this.shareWebcam.bind(this));// TODO find a better way to do this
     document.addEventListener('exitVideo', this.unshareWebcam.bind(this));
@@ -481,7 +481,6 @@ class VideoDock extends Component {
     log('info', 'Handle play start <===================');
 
     if (message.cameraId == this.props.userId) {
-      log('info', "Dae ze caralhow ");
       VideoService.joinedVideo();
     }
   }

--- a/bigbluebutton-html5/imports/ui/components/video-dock/video-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-dock/video-menu/component.jsx
@@ -14,47 +14,36 @@ const intlMessages = defineMessages({
   },
 });
 
-class JoinVideoOptions extends React.Component {
-  render() {
-    const {
-      intl,
-      isWaitingResponse,
-      isConnected,
-      isSharingVideo,
-      handleJoinVideo,
-      handleCloseVideo,
-    } = this.props;
-
-    if (isSharingVideo) {
-        return (
-          <Button
-            onClick={handleCloseVideo}
-            label={intl.formatMessage(intlMessages.leaveVideo)}
-            hideLabel
-            aria-label={intl.formatMessage(intlMessages.leaveVideo)}
-            color={'danger'}
-            icon={'video'}
-            size={'lg'}
-            circle
-            disabled={isWaitingResponse}
-          />
-        );
-    }
-
+const JoinVideoOptions = ({intl, isWaitingResponse, isConnected, isSharingVideo, handleJoinVideo, handleCloseVideo}) => {
+  if (isSharingVideo) {
     return (
       <Button
-        onClick={handleJoinVideo}
-        label={intl.formatMessage(intlMessages.joinVideo)}
+        onClick={handleCloseVideo}
+        label={intl.formatMessage(intlMessages.leaveVideo)}
         hideLabel
-        aria-label={intl.formatMessage(intlMessages.joinVideo)}
-        color={'primary'}
-        icon={'video_off'}
+        aria-label={intl.formatMessage(intlMessages.leaveVideo)}
+        color={'danger'}
+        icon={'video'}
         size={'lg'}
         circle
-        disabled={isWaitingResponse || (!isSharingVideo && isConnected)}
+        disabled={isWaitingResponse}
       />
     );
   }
-};
+
+  return (
+    <Button
+      onClick={handleJoinVideo}
+      label={intl.formatMessage(intlMessages.joinVideo)}
+      hideLabel
+      aria-label={intl.formatMessage(intlMessages.joinVideo)}
+      color={'primary'}
+      icon={'video_off'}
+      size={'lg'}
+      circle
+      disabled={isWaitingResponse || (!isSharingVideo && isConnected)}
+    />
+  );
+}
 
 export default injectIntl(JoinVideoOptions);


### PR DESCRIPTION
Implement changes requested on #4955 after it was merged.
Display either 'start' or 'stop' screenshare button (#4926), only if screensharing is enabled on config file (#4927).