### PR TITLE
Fix broken view styles displayed on error, on meetingEnd and for removed users

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/error-screen/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/error-screen/component.jsx
@@ -1,9 +1,9 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
 import Button from '/imports/ui/components/button/component';
 import { withRouter } from 'react-router';
-import styles from './styles.scss';
+import { styles } from './styles';
 
 const intlMessages = defineMessages({
   500: {
@@ -34,7 +34,7 @@ const defaultProps = {
   code: 500,
 };
 
-class ErrorScreen extends Component {
+class ErrorScreen extends React.PureComponent {
   render() {
     const {
       intl, code, children, router,

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { withRouter } from 'react-router';
 import { defineMessages, injectIntl } from 'react-intl';
 import Button from '/imports/ui/components/button/component';
-import styles from './styles.scss';
+import { styles } from './styles';
 
 const intlMessage = defineMessages({
   410: {


### PR DESCRIPTION
This allows the previously defined styles to render as expected.

fixes issue #4969 