### PR TITLE
Edit css to prevent disappearing close btn background

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/dropdown/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/styles.scss
@@ -78,7 +78,8 @@ $dropdown-caret-height: 8px;
   font-size: $font-size-large * 1.1;
   width: calc(100% - #{($line-height-computed * 2)});
   left: $line-height-computed;
-  box-shadow: 0 0 0 2rem #fff;
+  box-shadow: 0 0 0 2rem $color-white !important;
+  border: $color-white !important;
 
   @include mq($small-only) {
     display: block;


### PR DESCRIPTION
Fixes issue #4972
Now when you hold down the close button, the background no longer disappears.

![close-btn-with-bg](https://user-images.githubusercontent.com/22058534/35053886-68403e42-fb79-11e7-8e0a-234f33aef071.png)
