### PR TITLE
Fix flash stream regex

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
@@ -64,7 +64,7 @@ package org.bigbluebutton.modules.users.services
     public var onAllowedToJoin:Function = null;
     private static var globalDispatcher:Dispatcher = new Dispatcher();
 
-    private static var flashWebcamPattern:RegExp = /^([A-z0-9]+)-([A-z0-9]+)-([A-z0-9]+)$/;
+    private static var flashWebcamPattern:RegExp = /^([A-z0-9]+)-([A-z0-9]+)-([A-z0-9]+)(-recorded)?$/;
     
     public function MessageReceiver() {
       BBB.initConnectionManager().addMessageListener(this);

--- a/bigbluebutton-html5/imports/api/video/server/handlers/userSharedHtml5Webcam.js
+++ b/bigbluebutton-html5/imports/api/video/server/handlers/userSharedHtml5Webcam.js
@@ -6,7 +6,7 @@ export default function handleUserSharedHtml5Webcam({ header, body }, meetingId 
   const isValidStream = Match.Where((stream) => {
     check(stream, String);
     // Checking if the stream name is a flash one
-    const regexp = /^([A-z0-9]+)-([A-z0-9]+)-([A-z0-9]+)$/;
+    const regexp = /^([A-z0-9]+)-([A-z0-9]+)-([A-z0-9]+)(-recorded)?$/;
     return !regexp.test(stream);
   });
 

--- a/bigbluebutton-html5/imports/api/video/server/handlers/userUnsharedHtml5Webcam.js
+++ b/bigbluebutton-html5/imports/api/video/server/handlers/userUnsharedHtml5Webcam.js
@@ -6,7 +6,7 @@ export default function handleUserUnsharedHtml5Webcam({ header, body }, meetingI
   const isValidStream = Match.Where((stream) => {
     check(stream, String);
     // Checking if the stream name is a flash one
-    const regexp = /^([A-z0-9]+)-([A-z0-9]+)-([A-z0-9]+)$/;
+    const regexp = /^([A-z0-9]+)-([A-z0-9]+)-([A-z0-9]+)(-recorded)?$/;
     return !regexp.test(stream);
   });
 


### PR DESCRIPTION
Fix the regex that checks the Flash stream id by adding the option "-recorded" to the pattern, making sure recorded streams are matched too.