### PR TITLE
Fixed Pencil rendering breaking the html5 client

### DIFF
--- a/bigbluebutton-html5/imports/api/annotations/server/modifiers/addAnnotation.js
+++ b/bigbluebutton-html5/imports/api/annotations/server/modifiers/addAnnotation.js
@@ -82,6 +82,7 @@ function handlePencilUpdate(meetingId, whiteboardId, userId, annotation) {
     meetingId,
     id,
     userId,
+    whiteboardId,
   };
   let baseModifier;
   let chunkSelector;
@@ -169,6 +170,7 @@ function handlePencilUpdate(meetingId, whiteboardId, userId, annotation) {
         id,
         userId,
         meetingId,
+        whiteboardId,
         position,
         annotationType: 'pencil_base',
         numberOfChunks: chunks.length,
@@ -279,6 +281,7 @@ function handlePencilUpdate(meetingId, whiteboardId, userId, annotation) {
         id,
         userId,
         meetingId,
+        whiteboardId,
         position,
         annotationType: 'pencil_base',
         numberOfChunks: _chunks.length,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/pencil/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/pencil/component.jsx
@@ -3,17 +3,16 @@ import PropTypes from 'prop-types';
 import AnnotationHelpers from '../helpers';
 
 export default class PencilDrawComponent extends Component {
-
   static getInitialCoordinates(annotation, slideWidth, slideHeight) {
     const { points } = annotation;
     let i = 2;
     let path = '';
     if (points && points.length >= 2) {
       path = `M${(points[0] / 100) * slideWidth
-        }, ${(points[1] / 100) * slideHeight}`;
+      }, ${(points[1] / 100) * slideHeight}`;
       while (i < points.length) {
         path = `${path} L${(points[i] / 100) * slideWidth
-          }, ${(points[i + 1] / 100) * slideHeight}`;
+        }, ${(points[i + 1] / 100) * slideHeight}`;
         i += 2;
       }
     }
@@ -29,7 +28,7 @@ export default class PencilDrawComponent extends Component {
     let j;
     for (i = 0, j = 0; i < commands.length; i += 1) {
       switch (commands[i]) {
-          // MOVE_TO - consumes 1 pair of values
+        // MOVE_TO - consumes 1 pair of values
         case 1:
           path = `${path} M${(points[j] / 100) * slideWidth} ${(points[j + 1] / 100) * slideHeight}`;
           j += 2;
@@ -45,8 +44,8 @@ export default class PencilDrawComponent extends Component {
           // 1st pair is a control point, second is a coordinate
         case 3:
           path = `${path} Q${(points[j] / 100) * slideWidth}, ${
-              (points[j + 1] / 100) * slideHeight}, ${(points[j + 2] / 100) * slideWidth}, ${
-              (points[j + 3] / 100) * slideHeight}`;
+            (points[j + 1] / 100) * slideHeight}, ${(points[j + 2] / 100) * slideWidth}, ${
+            (points[j + 3] / 100) * slideHeight}`;
           j += 4;
           break;
 
@@ -54,9 +53,9 @@ export default class PencilDrawComponent extends Component {
           // 1st and 2nd are control points, 3rd is an end coordinate
         case 4:
           path = `${path} C${(points[j] / 100) * slideWidth}, ${
-              (points[j + 1] / 100) * slideHeight}, ${(points[j + 2] / 100) * slideWidth}, ${
-              (points[j + 3] / 100) * slideHeight}, ${(points[j + 4] / 100) * slideWidth}, ${
-              (points[j + 5] / 100) * slideHeight}`;
+            (points[j + 1] / 100) * slideHeight}, ${(points[j + 2] / 100) * slideWidth}, ${
+            (points[j + 3] / 100) * slideHeight}, ${(points[j + 4] / 100) * slideWidth}, ${
+            (points[j + 5] / 100) * slideHeight}`;
           j += 6;
           break;
 
@@ -97,6 +96,10 @@ export default class PencilDrawComponent extends Component {
   }
 
   getCoordinates(annotation, slideWidth, slideHeight) {
+    if (annotation.points.length === 0) {
+      return undefined;
+    }
+
     let data;
     // Final message, display smoothes coordinates
     if (annotation.status === 'DRAW_END') {
@@ -124,7 +127,7 @@ export default class PencilDrawComponent extends Component {
 
     while (i < points.length) {
       path = `${path} L${(points[i] / 100) * slideWidth
-        }, ${(points[i + 1] / 100) * slideHeight}`;
+      }, ${(points[i + 1] / 100) * slideHeight}`;
       i += 2;
     }
     path = this.path + path;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-menu-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-menu-item/component.jsx
@@ -8,8 +8,12 @@ export default class ToolbarMenuItem extends Component {
   constructor() {
     super();
 
+    // a flag to keep track of whether the menu item was actually clicked
+    this.clicked = false;
+
     this.handleTouchStart = this.handleTouchStart.bind(this);
     this.handleOnMouseUp = this.handleOnMouseUp.bind(this);
+    this.handleOnMouseDown = this.handleOnMouseDown.bind(this);
     this.setRef = this.setRef.bind(this);
   }
 
@@ -45,7 +49,18 @@ export default class ToolbarMenuItem extends Component {
     onItemClick(objectToReturn);
   }
 
+  handleOnMouseDown() {
+    this.clicked = true;
+  }
+
   handleOnMouseUp() {
+    // checks whether the button was actually clicked
+    // or if a person was drawing and just release their mouse above the menu item
+    if (!this.clicked) {
+      return;
+    }
+    this.clicked = false;
+
     const { objectToReturn, onItemClick } = this.props;
     // if there is a submenu name, then pass it to onClick
     // if not - it's probably "Undo", "Clear All", "Multi-user", etc.
@@ -64,6 +79,7 @@ export default class ToolbarMenuItem extends Component {
           label={this.props.label}
           icon={this.props.icon ? this.props.icon : null}
           customIcon={this.props.customIcon ? this.props.customIcon : null}
+          onMouseDown={this.handleOnMouseDown}
           onMouseUp={this.handleOnMouseUp}
           onBlur={this.props.onBlur}
           className={this.props.className}


### PR DESCRIPTION
The client was breaking because of the race condition between the last pencil message and the "clear annotation" message.
Annotations were cleared, but then the last pencil message was passed through, and the result was an empty `points` array and no `commands` property in the annotation object.

One way to trigger that bug is to start drawing, then move and release your mouse over one of the wb-toolbar buttons.


Changed 3 things here:
- added a whiteboardId to the pensil_base object. This is not going to affect anything, except maybe indexing.
- prevented onMouseUp triggering if there was no onMouseDown (in case if you start drawing an annotation and then release your mouse over one of the whiteboard toolbar's buttons).
- added a check to the PencilDrawComponent, since the above case can still be caused by the Flash clients lagging behind on slow machines. (2.0 only)