### PR TITLE
[WIP] Redirect to HTML5 instead of offering it as an option

### DIFF
--- a/bigbluebutton-client/resources/prod/BigBlueButton.html
+++ b/bigbluebutton-client/resources/prod/BigBlueButton.html
@@ -163,24 +163,26 @@
       }
     </script>
     <script type="text/javascript">
-      window.onload = function() {
-        let checkRequest = $.ajax({
-           dataType: 'json',
-           url: '/html5client/check'
-        });
-        checkRequest.done(function(data) {
-          if(typeof data.html5clientStatus !== "undefined" && data.html5clientStatus === "running" && document.getElementById('html5Section') != null) {
-            document.getElementById('html5Section').style.display='inherit';
-          }
-        });
-        
+      window.onload = function () {
+        // prefer the Flash client if Flash is available on the system
+        const preferFlashClient = swfobject.getFlashPlayerVersion().major !== 0;
+
+        if (!preferFlashClient) {
+          const checkRequest = $.ajax({
+            dataType: 'json',
+            url: '/html5client/check',
+          });
+
+          checkRequest.done(function (data) {
+            if (data.html5clientStatus && data.html5clientStatus === 'running') {
+              // Navigate to HTML5 login
+              document.location.pathname = '/html5client/join';
+            }
+          });
+        }
+
         if (fillContent) fillContent();
       };
-
-      function html5() {
-        // Navigate to HTML5 login
-        document.location.pathname = "/html5client/join";
-      }
     </script>
   </head>
 
@@ -201,10 +203,6 @@
           <a href="http://www.adobe.com/go/getflashplayer">
             <img src="get_flash_player.gif" alt="Get Adobe Flash player" />
           </a>
-          <div id="html5Section" style="display:none">
-            <p>OR</p>
-            <button type="button" onclick="html5();"><h3>Launch the HTML5 client instead</h3></button>
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Instead of showing a button for the user to click on, go straight into the meeting via HTML5 client.
Relies on `swfobject.getFlashPlayerVersion().major`