### PR TITLE
Video share button timeout and re-written shouldComponentUpdate method

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-dock/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-dock/component.jsx
@@ -596,13 +596,12 @@ class VideoDock extends Component {
       present[id] = true;
     });
 
-    console.log(users);
     const userIds = Object.keys(users);
 
     for (let i = 0; i < userIds.length; i++) {
       let id = userIds[i];
 
-      // 
+      // If a userId is not present in nextUsers let's stop it
       if (!present[id]) {
         this.stop(id);
         continue;
@@ -610,6 +609,8 @@ class VideoDock extends Component {
 
       console.log(`User ${users[id] ? '' : 'un'}shared webcam ${id}`);
 
+      // If a user stream is true, changed and was shared by other
+      // user we'll start it. If it is false and changed we stop it
       if (users[id]) {
         if (userId !== id) {
           this.start(id, false);

--- a/bigbluebutton-html5/imports/ui/components/video-dock/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-dock/component.jsx
@@ -32,7 +32,7 @@ const intlMessages = defineMessages({
 
 const RECONNECT_WAIT_TIME = 5000;
 const INITIAL_SHARE_WAIT_TIME = 2000;
-const CAMERA_SHARE_FAILED_WAIT_TIME = 15000;
+const CAMERA_SHARE_FAILED_WAIT_TIME = 10000;
 
 class VideoElement extends Component {
   constructor(props) {
@@ -231,8 +231,8 @@ class VideoDock extends Component {
     this.cameraTimeouts[id] = setTimeout(() => {
       log('error', `Camera share has not suceeded in ${CAMERA_SHARE_FAILED_WAIT_TIME}`);
       if (that.myId == id) {
-        this.notifyError(intl.formatMessage(intlMessages.sharingError));
-        that.stop(id);
+        that.notifyError(intl.formatMessage(intlMessages.sharingError));
+        that.unshareWebcam();
       } else {
         that.stop(id);
         that.start(id, shareWebcam);

--- a/bigbluebutton-html5/imports/ui/components/video-dock/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-dock/component.jsx
@@ -130,7 +130,7 @@ class VideoDock extends Component {
     this.ws.addEventListener('close', this.onWsClose);
 
     window.addEventListener('online', this.ws.open.bind(this.ws));
-    window.addEventListener('offline', this.ws.close.bind(this.ws));
+    window.addEventListener('offline', this.onWsClose);
   }
 
   componentWillUnmount () {
@@ -144,8 +144,8 @@ class VideoDock extends Component {
     this.ws.removeEventListener('close', this.onWsClose);
     // Close websocket connection to prevent multiple reconnects from happening
 
-    window.removeEventListener('online', this.ws.open);
-    window.removeEventListener('offline', this.ws.close);
+    window.removeEventListener('online', this.ws.open.bind(this.ws));
+    window.removeEventListener('offline', this.onWsClose);
 
     this.ws.close();
   }


### PR DESCRIPTION
This PR adds some functionalities to the video components:

  * A timeout that will dis-engage the video sharing and the button if the sharing fails.
  * A rewritten version of the shouldComponentUpdate method that actually does the correct thing at all times (we no longer rely on users and nextUsers to be ordered and contain the same number of users)
  * Better handling of reconnect when user is offline
  * Better reconnect of video shared videos that stop flowing for a few moments