### PR TITLE
Prevent duplicate tab ghost user

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/methods/userLeaving.js
+++ b/bigbluebutton-html5/imports/api/users/server/methods/userLeaving.js
@@ -35,6 +35,7 @@ export default function userLeaving(credentials, userId) {
     const modifier = {
       $set: {
         validated: null,
+        ejected: true,
       },
     };
 


### PR DESCRIPTION
This prevents a user being turned into a ghost if a duplicate tab is closed.
Now if a duplicated tab is closed, the user is removed from any remaining open tabs.

fixes #5066 