### PR TITLE
Fixed exceptions thrown during meeting destruction and presenter assignment 

### DIFF
--- a/bigbluebutton-html5/imports/api/meetings/server/handlers/meetingDestruction.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/handlers/meetingDestruction.js
@@ -1,7 +1,9 @@
 import RedisPubSub from '/imports/startup/server/redis';
 import { check } from 'meteor/check';
 
-export default function handleMeetingDestruction(_, meetingId) {
+export default function handleMeetingDestruction({ body }) {
+  check(body, Object);
+  const { meetingId } = body;
   check(meetingId, String);
 
   return RedisPubSub.destroyMeetingQueue(meetingId);

--- a/bigbluebutton-html5/imports/api/users/server/handlers/presenterAssigned.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/presenterAssigned.js
@@ -16,5 +16,12 @@ export default function handlePresenterAssigned({ body }, meetingId) {
   };
 
   const prevPresenter = Users.findOne(selector);
+
+  // no previous presenters
+  if (!prevPresenter) {
+    // return value is sponsored by eslint
+    return true;
+  }
+
   return changeRole(ROLE_PRESENTER, false, prevPresenter.userId, meetingId, assignedBy);
 }

--- a/bigbluebutton-html5/imports/api/users/server/handlers/presenterAssigned.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/presenterAssigned.js
@@ -19,7 +19,6 @@ export default function handlePresenterAssigned({ body }, meetingId) {
 
   // no previous presenters
   if (!prevPresenter) {
-    // return value is sponsored by eslint
     return true;
   }
 


### PR DESCRIPTION
It turned out that "meetings" collections wasn't cleared on meeting destruction, since there was an error that prevented the code from being executed.

Also, there was another exception thrown when we tried to change the role of the previous presenter, but there was no presenters before.

Both are fixed here.