### PR TITLE
Include missing classes in AIR client

### DIFF
--- a/clients/flash/common-library/src/main/actionscript/org/bigbluebutton/lib/chat/commands/RequestWelcomeMessageCommand.as
+++ b/clients/flash/common-library/src/main/actionscript/org/bigbluebutton/lib/chat/commands/RequestWelcomeMessageCommand.as
@@ -1,0 +1,15 @@
+package org.bigbluebutton.lib.chat.commands {
+	import org.bigbluebutton.lib.chat.services.IChatMessageService;
+	
+	import robotlegs.bender.bundles.mvcs.Command;
+	
+	public class RequestWelcomeMessageCommand extends Command {
+		
+		[Inject]
+		public var chatService:IChatMessageService;
+		
+		override public function execute():void {
+			chatService.sendWelcomeMessage();
+		}
+	}
+}

--- a/clients/flash/common-library/src/main/actionscript/org/bigbluebutton/lib/chat/commands/RequestWelcomeMessageSignal.as
+++ b/clients/flash/common-library/src/main/actionscript/org/bigbluebutton/lib/chat/commands/RequestWelcomeMessageSignal.as
@@ -1,0 +1,9 @@
+package org.bigbluebutton.lib.chat.commands {
+	import org.osflash.signals.Signal;
+	
+	public class RequestWelcomeMessageSignal extends Signal {
+		public function RequestWelcomeMessageSignal() {
+			super();
+		}
+	}
+}


### PR DESCRIPTION
I forgot to include the RequestWelcomeMessageSignal and RequestWelcomeMessageCommand classes that I created. 