### PR TITLE
Limited screensharing FPS to 5-10, resolution to screen size and fixed chrome extension prompt

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/kurento-extension.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-extension.js
@@ -418,18 +418,28 @@ window.getScreenConstraints = function(sendSource, callback) {
   let chromeMediaSourceId = sendSource;
   let screenConstraints = {video: {}};
 
+  // Limiting FPS to a range of 5-10 (5 ideal)
+  screenConstraints.video.frameRate = {ideal: 5, max: 10};
+
+  // Limiting max resolution to screen size
+  screenConstraints.video.height = {max: window.screen.height};
+  screenConstraints.video.width = {max: window.screen.width};
+
   if(isChrome) {
     getChromeScreenConstraints ((constraints) => {
-      if(!constraints){
+      if (!constraints) {
         document.dispatchEvent(new Event("installChromeExtension"));
         return;
       }
-      extensionInstalled = true;
+
       let sourceId = constraints.streamId;
+
+      kurentoManager.kurentoScreenshare.extensionInstalled = true;
 
       // this statement sets gets 'sourceId" and sets "chromeMediaSourceId"
       screenConstraints.video.chromeMediaSource = { exact: [sendSource]};
       screenConstraints.video.chromeMediaSourceId = sourceId;
+
       console.log("getScreenConstraints for Chrome returns => ");
       console.log(screenConstraints);
       // now invoking native getUserMedia API
@@ -439,8 +449,6 @@ window.getScreenConstraints = function(sendSource, callback) {
   }
   else if (isFirefox) {
     screenConstraints.video.mediaSource= "window";
-    screenConstraints.video.width= {max: "1280"};
-    screenConstraints.video.height = {max:  "720"};
 
     console.log("getScreenConstraints for Firefox returns => ");
     console.log(screenConstraints);
@@ -449,8 +457,6 @@ window.getScreenConstraints = function(sendSource, callback) {
   }
   else if(isSafari) {
     screenConstraints.video.mediaSource= "screen";
-    screenConstraints.video.width= {max: window.screen.width};
-    screenConstraints.video.height = {max:  window.screen.vid_height};
 
     console.log("getScreenConstraints for Safari returns => ");
     console.log(screenConstraints);

--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -418,13 +418,28 @@ window.getScreenConstraints = function(sendSource, callback) {
   let chromeMediaSourceId = sendSource;
   let screenConstraints = {video: {}};
 
+  // Limiting FPS to a range of 5-10 (5 ideal)
+  screenConstraints.video.frameRate = {ideal: 5, max: 10};
+
+  // Limiting max resolution to screen size
+  screenConstraints.video.height = {max: window.screen.height};
+  screenConstraints.video.width = {max: window.screen.width};
+
   if(isChrome) {
     getChromeScreenConstraints ((constraints) => {
+      if (!constraints) {
+        document.dispatchEvent(new Event("installChromeExtension"));
+        return;
+      }
+
       let sourceId = constraints.streamId;
+
+      kurentoManager.kurentoScreenshare.extensionInstalled = true;
 
       // this statement sets gets 'sourceId" and sets "chromeMediaSourceId"
       screenConstraints.video.chromeMediaSource = { exact: [sendSource]};
       screenConstraints.video.chromeMediaSourceId = sourceId;
+
       console.log("getScreenConstraints for Chrome returns => ");
       console.log(screenConstraints);
       // now invoking native getUserMedia API
@@ -434,8 +449,6 @@ window.getScreenConstraints = function(sendSource, callback) {
   }
   else if (isFirefox) {
     screenConstraints.video.mediaSource= "window";
-    screenConstraints.video.width= {max: "1280"};
-    screenConstraints.video.height = {max:  "720"};
 
     console.log("getScreenConstraints for Firefox returns => ");
     console.log(screenConstraints);
@@ -444,8 +457,6 @@ window.getScreenConstraints = function(sendSource, callback) {
   }
   else if(isSafari) {
     screenConstraints.video.mediaSource= "screen";
-    screenConstraints.video.width= {max: window.screen.width};
-    screenConstraints.video.height = {max:  window.screen.vid_height};
 
     console.log("getScreenConstraints for Safari returns => ");
     console.log(screenConstraints);


### PR DESCRIPTION
While investigating the FPS/resolution constraints, I also found why the chrome extension prompt wasn't being shown in the HTML5 client (#5073). So I fixed it, could you take a look @jfsiebel?

How to test the FPS modifications: share your screen, either in Flash or HTML5, Chrome or Firefox, and see if the FPS seems noticeably reduced (should be something between 5-10 FPS).

How to test the Chrome extension fix: configure a proper extension with its store link and key, uninstall it (if installed) and try sharing your screen in the HTML5 client on Chrome. A notification should pop out recommending the installation of the extension, alongside with the configured store link.