### PR TITLE
Show lock image if webcamsOnlyForModerator is enabled

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/MediaItemRenderer.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/MediaItemRenderer.mxml
@@ -25,14 +25,14 @@
 	xmlns:mate="http://mate.asfusion.com/"
 	verticalScrollPolicy="off" horizontalScrollPolicy="off"
 	creationComplete="onCreationComplete()" > 
-	
+
 	<fx:Declarations>
 		<mate:Listener type="{UsersRollEvent.USER_ROLL_OVER}" method="onRollOver" />
 		<mate:Listener type="{UsersRollEvent.USER_ROLL_OUT}" method="onRollOut" />
 		<mate:Listener type="{ChangeMyRole.CHANGE_MY_ROLE_EVENT}" method="onChangeMyRole"/>
 		<mate:Listener type="{BBBEvent.CHANGE_WEBCAMS_ONLY_FOR_MODERATOR}" method="onChangeWebcamsOnlyForModerator"/>
 	</fx:Declarations>
-	
+
 	<fx:Script>
 		<![CDATA[
 			import flash.filters.BitmapFilterQuality;
@@ -59,10 +59,14 @@
 			import org.bigbluebutton.modules.users.model.UsersOptions;
 			import org.bigbluebutton.util.i18n.ResourceUtil;
 			
-			private var moderator:Boolean = false;
 			[Bindable]
 			private var rolledOver:Boolean = false;
 			
+			[Bindable]
+			private var webcamsOnlyForModerator:Boolean;
+			
+			private var moderator:Boolean = false;
+
 			private var rolledOverMute:Boolean = false;
 			private var rolledOverLock:Boolean = false;
 			
@@ -118,6 +122,8 @@
 			}
 			
 			private function onChangeWebcamsOnlyForModerator(e:BBBEvent):void {
+				webcamsOnlyForModerator = LiveMeeting.inst().meeting.webcamsOnlyForModerator;
+
 				if (data != null) {
 					updateButtons();
 				}
@@ -187,8 +193,6 @@
 
 				var ls:LockSettingsVO = UsersUtil.getLockSettings();
 				
-				var webcamsOnlyForModerator:Boolean = LiveMeeting.inst().meeting.webcamsOnlyForModerator;
-
 				if (data != null) {
 					settingsBtn.visible = rolledOver && !data.me && !UsersUtil.isBreakout();
 
@@ -290,8 +294,7 @@
 							}
 						}
 
-
-						if (data.locked && !data.presenter && ls.isAnythingLocked()) {
+						if (data.locked && !data.presenter && ls.isAnythingLocked() || (!data.presenter && webcamsOnlyForModerator)) {
 							lockImg.source = getStyle("iconLock");
 						} else {
 							lockImg.source = null;


### PR DESCRIPTION
Show lock image if webcamsOnlyForModerator is enabled, however it is not possible to unlock this feature. Improve #5067