### PR TITLE
Added an extra check for the Pencil's DRAW_END message

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/pencil/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/pencil/component.jsx
@@ -96,7 +96,8 @@ export default class PencilDrawComponent extends Component {
   }
 
   getCoordinates(annotation, slideWidth, slideHeight) {
-    if (annotation.points.length === 0) {
+    if ((!annotation || annotation.points.length === 0)
+        || (annotation.status === 'DRAW_END' && !annotation.commands)) {
       return undefined;
     }
 


### PR DESCRIPTION
Even though we couldn't reproduce #5137 - I added an extra check which is supposed to prevent the potential bug with the last Pencil message display.

Most likely it was an edge case where some users had a slow connection and a presenter turned off the multi-user mode and cleared the whiteboard right away whilst some users were still catching up with the updates and were still allowed to send messages.