### PR TITLE
[HTML5 Client] Production Logging to Console

### DIFF
--- a/bigbluebutton-html5/imports/startup/server/logger.js
+++ b/bigbluebutton-html5/imports/startup/server/logger.js
@@ -20,16 +20,14 @@ Meteor.startup(() => {
   const LOG_CONFIG = Meteor.settings.private.log || {};
   const { level } = LOG_CONFIG;
 
-  // console logging in production
-  if (Meteor.isProduction) {
-    Logger.add(Winston.transports.Console, {
-      prettyPrint: false,
-      humanReadableUnhandledException: true,
-      colorize: true,
-      handleExceptions: true,
-      level
-    });
-  }
+  // console logging
+  Logger.add(Winston.transports.Console, {
+    prettyPrint: false,
+    humanReadableUnhandledException: true,
+    colorize: true,
+    handleExceptions: true,
+    level,
+  });
 
 });
 

--- a/bigbluebutton-html5/imports/startup/server/logger.js
+++ b/bigbluebutton-html5/imports/startup/server/logger.js
@@ -18,46 +18,19 @@ Logger.configure({
 
 Meteor.startup(() => {
   const LOG_CONFIG = Meteor.settings.private.log || {};
-  let { filename } = LOG_CONFIG;
   const { level } = LOG_CONFIG;
 
-  // console logging
-  if (Meteor.isDevelopment) {
+  // console logging in production
+  if (Meteor.isProduction) {
     Logger.add(Winston.transports.Console, {
       prettyPrint: false,
       humanReadableUnhandledException: true,
       colorize: true,
       handleExceptions: true,
-      level,
+      level
     });
   }
 
-  // file logging
-  if (filename) {
-    // no file rotation
-    if (Meteor.isDevelopment) {
-      const path = Npm.require('path');
-      filename = path.join(process.env.PWD, filename);
-
-      Logger.add(Winston.transports.File, {
-        filename,
-        prettyPrint: true,
-        level,
-        prepend: true,
-      });
-    }
-
-    // daily file rotation
-    if (Meteor.isProduction) {
-      Winston.transports.DailyRotateFile = Npm.require('winston-daily-rotate-file');
-      Logger.add(Winston.transports.DailyRotateFile, {
-        filename,
-        datePattern: '.yyyy-MM-dd',
-        prepend: false,
-        level,
-      });
-    }
-  }
 });
 
 export default Logger;

--- a/bigbluebutton-html5/private/config/settings-development.json
+++ b/bigbluebutton-html5/private/config/settings-development.json
@@ -346,7 +346,6 @@
 
 
     "log": {
-      "filename": "/log/development.log",
       "level": "info"
     }
   }

--- a/bigbluebutton-html5/private/config/settings-production.json
+++ b/bigbluebutton-html5/private/config/settings-production.json
@@ -345,7 +345,6 @@
     },
 
     "log": {
-      "filename": "/var/log/bigbluebutton/html5/html5client.log",
       "level": "warn"
     }
   }


### PR DESCRIPTION
This PR adds console logging in production + removes daily rotation logs and logging to file in development.
The console logs were tested in the package mode and it was confirmed that `systemctl` picks logging from HTML5 client.