### PR TITLE
Fixing WebRTC screensharing ICE processing (#4932) and limiting Firefox screensharing choices

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/kurento-extension.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-extension.js
@@ -448,7 +448,7 @@ window.getScreenConstraints = function(sendSource, callback) {
     }, chromeExtension);
   }
   else if (isFirefox) {
-    screenConstraints.video.mediaSource= "window";
+    screenConstraints.video.mediaSource= "screen";
 
     console.log("getScreenConstraints for Firefox returns => ");
     console.log(screenConstraints);

--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -448,7 +448,7 @@ window.getScreenConstraints = function(sendSource, callback) {
     }, chromeExtension);
   }
   else if (isFirefox) {
-    screenConstraints.video.mediaSource= "window";
+    screenConstraints.video.mediaSource= "screen";
 
     console.log("getScreenConstraints for Firefox returns => ");
     console.log(screenConstraints);

--- a/labs/bbb-webrtc-sfu/lib/screenshare/screenshare.js
+++ b/labs/bbb-webrtc-sfu/lib/screenshare/screenshare.js
@@ -43,51 +43,51 @@ module.exports = class Screenshare {
   }
 
   onIceCandidate (_candidate) {
+    Logger.debug("[screenshare] onIceCandidate");
     if (this._presenterEndpoint) {
       try {
         this.flushCandidatesQueue(this._presenterEndpoint, this._presenterCandidatesQueue);
         this.mcs.addIceCandidate(this._presenterEndpoint, _candidate);
-      }
-      catch (err)   {
+      } catch (err) {
         Logger.error("[screenshare] ICE candidate could not be added to media controller.", err);
       }
-    }
-    else {
+    } else {
+      Logger.debug("[screenshare] Pushing ICE candidate to presenter queue");
       this._presenterCandidatesQueue.push(_candidate);
     }
   }
 
   onViewerIceCandidate(candidate, callerName) {
+    Logger.debug("[screenshare] onViewerIceCandidate");
     if (this._viewersEndpoint[callerName]) {
       try {
         this.flushCandidatesQueue(this._viewersEndpoint[callerName], this._viewersCandidatesQueue[callerName]);
         this.mcs.addIceCandidate(this._viewersEndpoint[callerName], candidate);
-      }
-      catch (err)   {
+      } catch (err) {
         Logger.error("[screenshare] Viewer ICE candidate could not be added to media controller.", err);
       }
-    }
-    else {
+    } else {
       if (!this._viewersCandidatesQueue[callerName]) {
         this._viewersCandidatesQueue[callerName] = [];
       }
+      Logger.debug("[screenshare] Pushing ICE candidate to viewer queue", callerName);
       this._viewersCandidatesQueue[callerName].push(candidate);
     }
   }
 
-
-
   flushCandidatesQueue (mediaId, queue) {
-    if (this.mediaId) {
+    Logger.debug("[screenshare] flushCandidatesQueue", queue);
+    if (mediaId) {
       try {
         while(queue.length) {
           let candidate = queue.shift();
           this.mcs.addIceCandidate(mediaId, candidate);
         }
-      }
-      catch (err) {
+      } catch (err) {
         Logger.error("[screenshare] ICE candidate could not be added to media controller.", err);
       }
+    } else {
+      Logger.error("[screenshare] No mediaId");
     }
   }
 


### PR DESCRIPTION
This should fix a condition where ICE candidates weren't being correctly processed by the SFU component, which made a presenter unable to start screensharing sometimes or viewers unable to see the shared stream (#4932).

Also limited Firefox WebRTC screenshare options to `screen` only. This is because Firefox can randomly crash while trying to share other applications or windows; in some cases it can even freeze the computer. That doesn't happen with `screen` only.