### PR TITLE
Remove force debug in LoadingScreenMediator

### DIFF
--- a/clients/flash/air-client/src/org/bigbluebutton/air/main/views/LoadingScreenMediator.as
+++ b/clients/flash/air-client/src/org/bigbluebutton/air/main/views/LoadingScreenMediator.as
@@ -2,13 +2,12 @@ package org.bigbluebutton.air.main.views {
 	
 	import flash.desktop.NativeApplication;
 	import flash.events.InvokeEvent;
-	import flash.system.Capabilities;
 	
 	import mx.core.FlexGlobals;
 	
 	import org.bigbluebutton.air.common.PageEnum;
-	import org.bigbluebutton.air.main.models.IUISession;
 	import org.bigbluebutton.air.main.commands.JoinMeetingSignal;
+	import org.bigbluebutton.air.main.models.IUISession;
 	import org.bigbluebutton.air.main.models.IUserSession;
 	
 	import robotlegs.bender.bundles.mvcs.Mediator;
@@ -36,17 +35,10 @@ package org.bigbluebutton.air.main.views {
 			NativeApplication.nativeApplication.addEventListener(InvokeEvent.INVOKE, onInvokeEvent);
 			uiSession.loadingChangeSignal.add(onLoadingChange);
 			onLoadingChange(uiSession.loading, uiSession.loadingMessage);
-			
-			// If we are in the Flash Builder debugger the InvokeEvent will never be fired
-			if (Capabilities.isDebugger) {
-				//var url:String = "bigbluebutton://test-install.blindsidenetworks.com/bigbluebutton/api/join?fullName=AIR&meetingID=Demo+Meeting&password=mp&redirect=false&checksum=3fdf56e9915c1031c3ea012b4ec8823cedd7c272";
-				var url:String = "bigbluebutton://test-install.blindsidenetworks.com/bigbluebutton/api/join?fullName=User+2021828&meetingID=Demo+Meeting&password=ap&redirect=true&checksum=8751963df96437c7d435eac8124e4fb3ec147115";
-				joinRoom(url);
-			}
 		}
 		
 		private function onInvokeEvent(invocation:InvokeEvent):void {
-			if (invocation.arguments.length > 0 && !Capabilities.isDebugger) {
+			if (invocation.arguments.length > 0) {
 				var url:String = invocation.arguments[0].toString();
 				if (url.lastIndexOf("://") != -1) {
 					if (userSession.mainConnection)


### PR DESCRIPTION
We should use this configuration. I will add it to the documentation later.

![flash_mobile_debug](https://user-images.githubusercontent.com/4991088/36993171-63f84128-20ad-11e8-890c-732183f2ace7.png)
