### PR TITLE
Forcing H264 in HTML5 video

### DIFF
--- a/labs/bbb-webrtc-sfu/lib/video/video.js
+++ b/labs/bbb-webrtc-sfu/lib/video/video.js
@@ -5,6 +5,7 @@ const kurentoUrl = config.get('kurentoUrl');
 const MCSApi = require('../mcs-core/lib/media/MCSApiStub');
 const C = require('../bbb/messages/Constants');
 const Logger = require('../utils/Logger');
+const h264_sdp = require('../h264-sdp');
 
 var sharedWebcams = {};
 
@@ -117,6 +118,9 @@ module.exports = class Video {
   async start (sdpOffer, callback) {
     Logger.info("[video] Starting video instance for", this.id);
     let sdpAnswer;
+
+    // Force H264
+    sdpOffer = h264_sdp.transform(sdpOffer);
 
     try {
       this.userId = await this.mcs.join(this.meetingId, 'SFU', {});


### PR DESCRIPTION
This forces H264 in HTML5 video through SDP mangling.
It should avoid high CPU usage in Kurento in cases where people enter with Chrome/Firefox (opting for VP8) and with Safari/iOS in the same meeting (opting for H264), which makes Kurento transcode video between parties.