### PR TITLE
Sends a ejectUserFromVoice after removing a user

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -297,9 +297,20 @@ export default class SIPBridge extends BaseAudioBridge {
         });
       };
 
+      const handleConnectionTerminated = peer => this.callback({
+        status: this.baseCallStates.failed,
+        error: this.baseErrorCodes.CONNECTION_ERROR,
+        bridgeError: peer,
+      });
+
       currentSession.on('terminated', handleSessionTerminated);
       currentSession.mediaHandler.on('iceConnectionCompleted', handleConnectionCompleted);
       currentSession.mediaHandler.on('iceConnectionConnected', handleConnectionCompleted);
+
+
+      currentSession.mediaHandler.on('iceConnectionFailed', handleConnectionTerminated);
+      currentSession.mediaHandler.on('iceConnectionDisconnected', handleConnectionTerminated);
+      currentSession.mediaHandler.on('iceConnectionClosed', handleConnectionTerminated);
 
       this.currentSession = currentSession;
     });

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -269,17 +269,18 @@ export default class SIPBridge extends BaseAudioBridge {
 
   setupEventHandlers(currentSession) {
     return new Promise((resolve) => {
-      this.connectionCompleted = false;
+      const { mediaHandler } = currentSession;
 
+      const connectionCompletedEvents = ['iceConnectionCompleted', 'iceConnectionConnected'];
       const handleConnectionCompleted = () => {
-        if (this.connectionCompleted) return;
+        connectionCompletedEvents.forEach(e => mediaHandler.off(e, handleConnectionCompleted));
         this.callback({ status: this.baseCallStates.started });
         this.connectionCompleted = true;
         resolve();
       };
+      connectionCompletedEvents.forEach(e => mediaHandler.on(e, handleConnectionCompleted));
 
       const handleSessionTerminated = (message, cause) => {
-        this.connectionCompleted = false;
         if (!message && !cause) {
           return this.callback({
             status: this.baseCallStates.ended,
@@ -296,21 +297,18 @@ export default class SIPBridge extends BaseAudioBridge {
           bridgeError: cause,
         });
       };
-
-      const handleConnectionTerminated = peer => this.callback({
-        status: this.baseCallStates.failed,
-        error: this.baseErrorCodes.CONNECTION_ERROR,
-        bridgeError: peer,
-      });
-
       currentSession.on('terminated', handleSessionTerminated);
-      currentSession.mediaHandler.on('iceConnectionCompleted', handleConnectionCompleted);
-      currentSession.mediaHandler.on('iceConnectionConnected', handleConnectionCompleted);
 
-
-      currentSession.mediaHandler.on('iceConnectionFailed', handleConnectionTerminated);
-      currentSession.mediaHandler.on('iceConnectionDisconnected', handleConnectionTerminated);
-      currentSession.mediaHandler.on('iceConnectionClosed', handleConnectionTerminated);
+      const connectionTerminatedEvents = ['iceConnectionFailed', 'iceConnectionDisconnected'];
+      const handleConnectionTerminated = (peer) => {
+        connectionTerminatedEvents.forEach(e => mediaHandler.off(e, handleConnectionTerminated));
+        this.callback({
+          status: this.baseCallStates.failed,
+          error: this.baseErrorCodes.CONNECTION_ERROR,
+          bridgeError: peer,
+        });
+      };
+      connectionTerminatedEvents.forEach(e => mediaHandler.on(e, handleConnectionTerminated));
 
       this.currentSession = currentSession;
     });

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
@@ -1,7 +1,7 @@
 import { check } from 'meteor/check';
 import Users from '/imports/api/users';
 import Logger from '/imports/startup/server/logger';
-import removeVoiceUser from '/imports/api/voice-users/server/modifiers/removeVoiceUser';
+import ejectUserFromVoice from '/imports/api/voice-users/server/methods/ejectUserFromVoice';
 
 const CLIENT_TYPE_HTML = 'HTML5';
 
@@ -31,12 +31,6 @@ export default function removeUser(meetingId, userId) {
     },
   };
 
-  removeVoiceUser(meetingId, {
-    voiceConf: '',
-    voiceUserId: '',
-    intId: userId,
-  });
-
   const cb = (err) => {
     if (err) {
       return Logger.error(`Removing user from collection: ${err}`);
@@ -44,6 +38,11 @@ export default function removeUser(meetingId, userId) {
 
     const sessionUserId = `${meetingId}-${userId}`;
     clearAllSessions(sessionUserId);
+
+    ejectUserFromVoice({
+      requesterUserId: userId,
+      meetingId,
+    }, userId);
 
     return Logger.info(`Removed ${CLIENT_TYPE_HTML} user id=${userId} meeting=${meetingId}`);
   };


### PR DESCRIPTION
This PR implements a `ejectUserFromVoice` after the user is "removed" instead of just updating our local voice collection when a user left the meeting,

This PR also implement and improve the current event handlers for iceConnection state changes.

This is a attempt to fix #5183.