### PR TITLE
Bump AIR version from 28 to 29

### DIFF
--- a/clients/flash/air-client/src/Main-app.xml
+++ b/clients/flash/air-client/src/Main-app.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
-<application xmlns="http://ns.adobe.com/air/application/28.0">
+<application xmlns="http://ns.adobe.com/air/application/29.0">
 
 <!-- Adobe AIR Application Descriptor File Template.
 


### PR DESCRIPTION
AIR 28 has a bug where you can't use URL app invocation. This PR bumps the AIR version to 29 so the app can launch again.