### PR TITLE
[AIR] Add background for TopButtons and chat's SendButton

### DIFF
--- a/clients/flash/air-client/src/Default.css
+++ b/clients/flash/air-client/src/Default.css
@@ -311,9 +311,9 @@ settings|SettingsItemRenderer {
 }
 
 .sendButton {
-	color       : PropertyReference("blue500");
+	color       : PropertyReference("bbbWhite");
 	fontFamily  : BBBIcons;
-	borderColor : PropertyReference("blue500");
+	backgroundColor : PropertyReference("bbbBlue");
 	skinClass   : ClassReference("org.bigbluebutton.air.chat.views.skins.SendButtonSkin");
 }
 

--- a/clients/flash/air-client/src/css/hdpi.css
+++ b/clients/flash/air-client/src/css/hdpi.css
@@ -33,10 +33,6 @@
         fontSize: 25.50;
     }
 
-    main|TopToolbarBase {
-        height: 60.00;
-    }
-
     views|NoTabView {
         toolbarHeight: 60.00;
     }
@@ -132,7 +128,6 @@
     }
 
     .sendButton {
-        borderWeight: 1.50;
         diameter: 42.00;
     }
 
@@ -144,6 +139,8 @@
 
     .topButton {
         fontSize: 33.00;
+        height: 57.00;
+        width: 57.00;
     }
 
     .saveButton {
@@ -151,11 +148,11 @@
     }
 
     .topLeftButton {
-        left: 22.50;
+        left: 0;
     }
 
     .topRightButton {
-        right: 22.50;
+        right: 0;
     }
 
     .actionButton {
@@ -192,6 +189,8 @@
 
     .chatIcon, .settingsIcon {
         fontSize: 33.00;
+        width: 33.00;
+        height: 33.00;
     }
 
     .recordIcon {

--- a/clients/flash/air-client/src/css/ldpi.css
+++ b/clients/flash/air-client/src/css/ldpi.css
@@ -33,10 +33,6 @@
         fontSize: 12.750;
     }
 
-    main|TopToolbarBase {
-        height: 30.000;
-    }
-
     views|NoTabView {
         toolbarHeight: 30.000;
     }
@@ -132,7 +128,6 @@
     }
 
     .sendButton {
-        borderWeight: .750;
         diameter: 21.000;
     }
 
@@ -144,6 +139,8 @@
 
     .topButton {
         fontSize: 16.500;
+        height: 28.500;
+        width: 28.500;
     }
 
     .saveButton {
@@ -151,11 +148,11 @@
     }
 
     .topLeftButton {
-        left: 11.250;
+        left: 0;
     }
 
     .topRightButton {
-        right: 11.250;
+        right: 0;
     }
 
     .actionButton {
@@ -192,6 +189,8 @@
 
     .chatIcon, .settingsIcon {
         fontSize: 16.500;
+        width: 16.500;
+        height: 16.500;
     }
 
     .recordIcon {

--- a/clients/flash/air-client/src/css/mdpi.css
+++ b/clients/flash/air-client/src/css/mdpi.css
@@ -33,10 +33,6 @@
         fontSize: 17.0;
     }
 
-    main|TopToolbarBase {
-        height: 40.0;
-    }
-
     views|NoTabView {
         toolbarHeight: 40.0;
     }
@@ -132,7 +128,6 @@
     }
 
     .sendButton {
-        borderWeight: 1.0;
         diameter: 28.0;
     }
 
@@ -144,6 +139,8 @@
 
     .topButton {
         fontSize: 22.0;
+        height: 38.0;
+        width: 38.0;
     }
 
     .saveButton {
@@ -151,11 +148,11 @@
     }
 
     .topLeftButton {
-        left: 15.0;
+        left: 0;
     }
 
     .topRightButton {
-        right: 15.0;
+        right: 0;
     }
 
     .actionButton {
@@ -192,6 +189,8 @@
 
     .chatIcon, .settingsIcon {
         fontSize: 22.0;
+        width: 22.0;
+        height: 22.0;
     }
 
     .recordIcon {

--- a/clients/flash/air-client/src/css/xhdpi.css
+++ b/clients/flash/air-client/src/css/xhdpi.css
@@ -21,10 +21,6 @@
 		fontSize : 34;
 	}
 	
-	main|TopToolbarBase {
-		height : 80;
-	}
-	
 	views|NoTabView {
 		toolbarHeight : 80;
 	}
@@ -120,7 +116,6 @@
 	}
 	
 	.sendButton {
-		borderWeight : 2;
 		diameter     : 56;
 	}
 	
@@ -132,6 +127,8 @@
 	
 	.topButton {
 		fontSize : 44;
+		height   : 76;
+		width    : 76;
 	}
 	
 	.saveButton {
@@ -139,11 +136,11 @@
 	}
 	
 	.topLeftButton {
-		left : 30;
+		left : 0;
 	}
 	
 	.topRightButton {
-		right : 30;
+		right : 0;
 	}
 	
 	.actionButton {
@@ -180,6 +177,8 @@
 	
 	.chatIcon, .settingsIcon {
 		fontSize : 44;
+		width: 44;
+		height: 44;
 	}
 	
 	.recordIcon {

--- a/clients/flash/air-client/src/css/xxhdpi.css
+++ b/clients/flash/air-client/src/css/xxhdpi.css
@@ -33,10 +33,6 @@
         fontSize: 51.0;
     }
 
-    main|TopToolbarBase {
-        height: 120.0;
-    }
-
     views|NoTabView {
         toolbarHeight: 120.0;
     }
@@ -132,7 +128,6 @@
     }
 
     .sendButton {
-        borderWeight: 3.0;
         diameter: 84.0;
     }
 
@@ -144,6 +139,8 @@
 
     .topButton {
         fontSize: 66.0;
+        height: 114.0;
+        width: 114.0;
     }
 
     .saveButton {
@@ -151,11 +148,11 @@
     }
 
     .topLeftButton {
-        left: 45.0;
+        left: 0;
     }
 
     .topRightButton {
-        right: 45.0;
+        right: 0;
     }
 
     .actionButton {
@@ -192,6 +189,8 @@
 
     .chatIcon, .settingsIcon {
         fontSize: 66.0;
+        width: 66.0;
+        height: 66.0;
     }
 
     .recordIcon {

--- a/clients/flash/air-client/src/css/xxxhdpi.css
+++ b/clients/flash/air-client/src/css/xxxhdpi.css
@@ -33,10 +33,6 @@
         fontSize: 68;
     }
 
-    main|TopToolbarBase {
-        height: 160;
-    }
-
     views|NoTabView {
         toolbarHeight: 160;
     }
@@ -132,7 +128,6 @@
     }
 
     .sendButton {
-        borderWeight: 4;
         diameter: 112;
     }
 
@@ -144,6 +139,8 @@
 
     .topButton {
         fontSize: 88;
+        height: 152;
+        width: 152;
     }
 
     .saveButton {
@@ -151,11 +148,11 @@
     }
 
     .topLeftButton {
-        left: 60;
+        left: 0;
     }
 
     .topRightButton {
-        right: 60;
+        right: 0;
     }
 
     .actionButton {
@@ -192,6 +189,8 @@
 
     .chatIcon, .settingsIcon {
         fontSize: 88;
+        width: 88;
+        height: 88;
     }
 
     .recordIcon {

--- a/clients/flash/air-client/src/org/bigbluebutton/air/chat/views/skins/SendButtonSkin.mxml
+++ b/clients/flash/air-client/src/org/bigbluebutton/air/chat/views/skins/SendButtonSkin.mxml
@@ -13,10 +13,9 @@
 	<fx:Script>
 		<![CDATA[
 			override protected function updateDisplayList(unscaledWidth:Number, unscaledHeight:Number):void {
-				border.width = border.height = getStyle("diameter");
+				background.width = background.height = getStyle("diameter");
 				
-				borderStroke.color = getStyle("borderColor");
-				borderStroke.weight = getStyle("borderWeight");
+				backgroundFill.color = getStyle("backgroundColor");
 				
 				labelDisplay.text = getStyle("icon");
 				
@@ -35,10 +34,10 @@
 
 	<!-- layer 7: border - put on top of the fill so it doesn't disappear when scale is less than 1 -->
 	<!--- @private -->
-	<s:Ellipse id="border">
-		<s:stroke>
-			<s:SolidColorStroke id="borderStroke" />
-		</s:stroke>
+	<s:Ellipse id="background">
+		<s:fill>
+			<s:SolidColor id="backgroundFill" />
+		</s:fill>
 	</s:Ellipse>
 
 	<!-- layer 8: text -->

--- a/clients/flash/air-client/src/org/bigbluebutton/air/main/views/skins/TopButtonSkin.mxml
+++ b/clients/flash/air-client/src/org/bigbluebutton/air/main/views/skins/TopButtonSkin.mxml
@@ -10,6 +10,8 @@
 		<![CDATA[
 			override protected function updateDisplayList(w:Number, h:Number):void {
 				super.updateDisplayList(w, h);
+				background.width = getStyle("width");
+				background.height = getStyle("height");
 				
 				icon.setStyle("color", getStyle("iconColor"));
 				icon.text = getStyle("icon");
@@ -24,6 +26,11 @@
 		<s:State name="over" />
 		<s:State name="up" />
 	</s:states>
+	<s:Rect id="background">
+		<s:fill>
+			<s:SolidColor id="backgroundFill" alpha="0" />
+		</s:fill>
+	</s:Rect>
 	<s:Label id="icon"
 			 horizontalCenter="0"
 			 verticalCenter="0" />


### PR DESCRIPTION
The top navigation buttons and chat's send button only had a label and this meant that the area that would register a click was very small. I've added a background to both so that they will register clicks as expected.