### PR TITLE
Follow up on the webcam swap/design

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/media/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/component.jsx
@@ -1,8 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import VideoProviderContainer from '/imports/ui/components/video-provider/container';
+import PollingContainer from '/imports/ui/components/polling/container';
+
 import { styles } from './styles';
-import VideoProviderContainer from '../video-provider/container';
 
 const propTypes = {
   children: PropTypes.element.isRequired,
@@ -44,6 +46,7 @@ export default class Media extends Component {
         <div className={!swapLayout ? overlayClassName : contentClassName}>
           { !disableVideo ? <VideoProviderContainer /> : null }
         </div>
+        <PollingContainer />
       </div>
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/media/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/container.jsx
@@ -66,7 +66,7 @@ export default withTracker(() => {
   }
 
   data.isScreensharing = MediaService.isVideoBroadcasting();
-  data.swapLayout = getSwapLayout() && usersVideo.length > 0 && viewParticipantsWebcams;
+  data.swapLayout = getSwapLayout();
   data.disableVideo = !viewParticipantsWebcams;
 
   if (data.swapLayout) {

--- a/bigbluebutton-html5/imports/ui/components/media/service.js
+++ b/bigbluebutton-html5/imports/ui/components/media/service.js
@@ -2,6 +2,9 @@ import Presentations from '/imports/api/presentations';
 import { isVideoBroadcasting } from '/imports/ui/components/screenshare/service';
 import Auth from '/imports/ui/services/auth';
 import Users from '/imports/api/users';
+import Settings from '/imports/ui/services/settings';
+import VideoService from '/imports/ui/components/video-provider/service';
+import PollingService from '/imports/ui/components/polling/service';
 
 const getPresentationInfo = () => {
   const currentPresentation = Presentations.findOne({
@@ -37,9 +40,20 @@ const toggleSwapLayout = () => {
   swapLayout.tracker.changed();
 };
 
+export const shouldEnableSwapLayout = () => {
+  const { viewParticipantsWebcams } = Settings.dataSaving;
+  const usersVideo = VideoService.getAllUsersVideo();
+  const poll = PollingService.mapPolls();
+
+  return usersVideo.length > 0 // prevent swap without any webcams
+  && viewParticipantsWebcams // prevent swap when dataSaving for webcams is enabled
+  && !poll.pollExists; // prevent swap when there is a poll running
+};
+
 export const getSwapLayout = () => {
   swapLayout.tracker.depend();
-  return swapLayout.value;
+
+  return swapLayout.value && shouldEnableSwapLayout();
 };
 
 export default {
@@ -50,4 +64,5 @@ export default {
   isUserPresenter,
   isVideoBroadcasting,
   toggleSwapLayout,
+  shouldEnableSwapLayout,
 };

--- a/bigbluebutton-html5/imports/ui/components/media/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/media/styles.scss
@@ -26,6 +26,7 @@
   order: 1;
   width: 100%;
   border: 5px solid transparent;
+  border-top: 0 !important;
   position: relative;
 
   @include mq($medium-up) {

--- a/bigbluebutton-html5/imports/ui/components/media/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/media/styles.scss
@@ -17,6 +17,7 @@
   justify-content: center;
   overflow: auto;
   width: 100%;
+  position: relative;
 }
 
 .overlay {
@@ -25,6 +26,7 @@
   order: 1;
   width: 100%;
   padding: 0 5px 5px;
+  position: relative;
 
   @include mq($medium-up) {
     padding: 0 10px 10px;

--- a/bigbluebutton-html5/imports/ui/components/media/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/media/styles.scss
@@ -25,11 +25,11 @@
   display: flex;
   order: 1;
   width: 100%;
-  padding: 0 5px 5px;
+  border: 5px solid transparent;
   position: relative;
 
   @include mq($medium-up) {
-    padding: 0 10px 10px;
+    border: 10px solid transparent;
   }
 }
 

--- a/bigbluebutton-html5/imports/ui/components/polling/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/polling/component.jsx
@@ -36,7 +36,7 @@ const Polling = ({ intl, poll, handleVote }) => (
             <Button
               className={styles.pollingButton}
               color="default"
-              size="lg"
+              size="md"
               label={pollAnswer.key}
               onClick={() => handleVote(poll.pollId, pollAnswer)}
               aria-labelledby={`pollAnswerLabel${pollAnswer.key}`}

--- a/bigbluebutton-html5/imports/ui/components/polling/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/polling/styles.scss
@@ -4,7 +4,6 @@
   order: 2;
   width: 100%;
   display: flex;
-  padding: .8rem;
   align-items: center;
   flex-direction: column;
 }

--- a/bigbluebutton-html5/imports/ui/components/polling/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/polling/styles.scss
@@ -6,6 +6,11 @@
   display: flex;
   align-items: center;
   flex-direction: column;
+  padding-bottom: 5px;
+
+  @include mq($medium-up) {
+    padding-bottom: 10px;
+  }
 }
 
 .pollingTitle {

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import WhiteboardOverlayContainer from '/imports/ui/components/whiteboard/whiteboard-overlay/container';
 import WhiteboardToolbarContainer from '/imports/ui/components/whiteboard/whiteboard-toolbar/container';
-import PollingContainer from '/imports/ui/components/polling/container';
 import CursorWrapperContainer from './cursor/cursor-wrapper-container/container';
 import AnnotationGroupContainer from '../whiteboard/annotation-group/container';
 import PresentationToolbarContainer from './presentation-toolbar/container';
@@ -295,7 +294,6 @@ export default class PresentationArea extends Component {
               this.renderWhiteboardToolbar()
             : null }
         </div>
-        <PollingContainer />
         {this.renderPresentationToolbar()}
       </div>
     );

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -155,10 +155,7 @@ export default class PresentationArea extends Component {
         style={{
           width: adjustedSizes.width,
           height: adjustedSizes.height,
-          WebkitTransition: 'width 0.2s', /* Safari */
-          transition: 'width 0.2s',
         }}
-        id="presentationAreaData"
       >
         <TransitionGroup>
           <CSSTransition
@@ -190,7 +187,6 @@ export default class PresentationArea extends Component {
               </defs>
               <g clipPath="url(#viewBox)">
                 <Slide
-                  id="slideComponent"
                   imageUri={imageUri}
                   svgWidth={width}
                   svgHeight={height}
@@ -283,7 +279,7 @@ export default class PresentationArea extends Component {
 
   render() {
     return (
-      <div className={styles.presentationContainer} id="presentationContainer">
+      <div className={styles.presentationContainer}>
         <div
           ref={(ref) => { this.refPresentationArea = ref; }}
           className={styles.presentationArea}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.scss
@@ -18,6 +18,7 @@ $controls-background: $color-white !default;
   box-shadow: 0 0 10px -2px rgba(0, 0, 0, .25);
   align-self: center;
   justify-content: center;
+  z-index: 1;
 
   @include mq("#{$landscape} and (max-height:#{upper-bound($small-range)}), #{$small-only}") {
     transform: scale(.75);

--- a/bigbluebutton-html5/imports/ui/components/presentation/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/presentation/styles.scss
@@ -58,6 +58,9 @@
 .presentationContainer {
   display: flex;
   flex-direction: column;
-  height: 100%;
-  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
 }

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
@@ -94,8 +94,11 @@ class VideoList extends Component {
     const { width: canvasWidth, height: canvasHeight } = this.canvas.getBoundingClientRect();
     const gridGutter = parseInt(window.getComputedStyle(this.grid).getPropertyValue('grid-row-gap'), 10);
 
+
+    const hasFocusedItem = numItems > 2 && focusedId;
+
     // Has a focused item so we need +3 cells
-    if (numItems > 2 && focusedId) {
+    if (hasFocusedItem) {
       numItems += 3;
     }
 
@@ -106,7 +109,7 @@ class VideoList extends Component {
       );
 
       // We need a minimun of 2 rows and columns for the focused
-      const focusedConstraint = focusedId ? testGrid.rows > 1 && testGrid.columns > 1 : true;
+      const focusedConstraint = hasFocusedItem ? testGrid.rows > 1 && testGrid.columns > 1 : true;
       const betterThanCurrent = testGrid.filledArea > currentGrid.filledArea;
 
       return focusedConstraint && betterThanCurrent ? testGrid : currentGrid;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -1,9 +1,11 @@
 @import "/imports/ui/stylesheets/variables/_all";
 
 .videoCanvas {
-  flex: 1;
-  width: 100%;
-  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
   overflow: hidden;
   display: flex;
   align-items: center;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-menu/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-menu/container.jsx
@@ -29,6 +29,8 @@ const JoinVideoOptionsContainer = (props) => {
     isDisabled,
     handleJoinVideo,
     handleCloseVideo,
+    toggleSwapLayout,
+    swapLayoutAllowed,
     baseName,
     intl,
     ...restProps
@@ -38,8 +40,8 @@ const JoinVideoOptionsContainer = (props) => {
       iconPath: `${baseName}/resources/images/video-menu/icon-swap.svg`,
       description: intl.formatMessage(intlMessages.swapCamDesc),
       label: intl.formatMessage(intlMessages.swapCam),
-      disabled: false,
-      click: VideoMenuService.toggleSwapLayout,
+      disabled: !swapLayoutAllowed,
+      click: toggleSwapLayout,
     },
     {
       iconPath: `${baseName}/resources/images/video-menu/icon-webcam-off.svg`,
@@ -58,4 +60,6 @@ export default injectIntl(withTracker(() => ({
   isSharingVideo: VideoMenuService.isSharingVideo(),
   isDisabled: VideoMenuService.isDisabled(),
   videoShareAllowed: VideoMenuService.videoShareAllowed(),
+  toggleSwapLayout: VideoMenuService.toggleSwapLayout,
+  swapLayoutAllowed: VideoMenuService.swapLayoutAllowed(),
 }))(JoinVideoOptionsContainer));

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-menu/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-menu/service.js
@@ -15,7 +15,6 @@ const isSharingVideo = () => {
 
 const videoShareAllowed = () => Settings.dataSaving.viewParticipantsWebcams;
 
-
 const isDisabled = () => {
   const isWaitingResponse = VideoService.isWaitingResponse();
   const isConnected = VideoService.isConnected();
@@ -39,5 +38,6 @@ export default {
   isDisabled,
   baseName,
   toggleSwapLayout: MediaService.toggleSwapLayout,
+  swapLayoutAllowed: MediaService.shouldEnableSwapLayout,
   videoShareAllowed,
 };


### PR DESCRIPTION
This PR is a follow up on #5327.

- Remove the width transition from the presentation since it looks janky while swapping.
- Fix presenter controls not showing in firefox. Fix #5354 
- Fix webcams not resizing properly in some odd cases. Fix #5355 
- Fix wrong calculations while having a focused webcam. 