### PR TITLE
Improved Chrome WebRTC screenshare constraints

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/kurento-extension.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-extension.js
@@ -434,6 +434,17 @@ window.getScreenConstraints = function (sendSource, callback) {
       // this statement sets gets 'sourceId" and sets "chromeMediaSourceId"
       screenConstraints.video.chromeMediaSource = { exact: [sendSource] };
       screenConstraints.video.chromeMediaSourceId = sourceId;
+      screenConstraints.optional = [
+        { googCpuOveruseDetection: true },
+        { googCpuOveruseEncodeUsage: true },
+        { googCpuUnderuseThreshold: 55 },
+        { googCpuOveruseThreshold: 85 },
+        { googPayloadPadding: true },
+        { googScreencastMinBitrate: 400 },
+        { googHighStartBitrate: true },
+        { googHighBitrate: true },
+        { googVeryHighBitrate: true }
+      ];
 
       console.log('getScreenConstraints for Chrome returns => ', screenConstraints);
       // now invoking native getUserMedia API

--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -434,6 +434,17 @@ window.getScreenConstraints = function (sendSource, callback) {
       // this statement sets gets 'sourceId" and sets "chromeMediaSourceId"
       screenConstraints.video.chromeMediaSource = { exact: [sendSource] };
       screenConstraints.video.chromeMediaSourceId = sourceId;
+      screenConstraints.optional = [
+        { googCpuOveruseDetection: true },
+        { googCpuOveruseEncodeUsage: true },
+        { googCpuUnderuseThreshold: 55 },
+        { googCpuOveruseThreshold: 85 },
+        { googPayloadPadding: true },
+        { googScreencastMinBitrate: 400 },
+        { googHighStartBitrate: true },
+        { googHighBitrate: true },
+        { googVeryHighBitrate: true }
+      ];
 
       console.log('getScreenConstraints for Chrome returns => ', screenConstraints);
       // now invoking native getUserMedia API


### PR DESCRIPTION
I further specified Chrome's constraints with google-specific optimizations. The quality is fairly better now. There's an increase on used bandwidth, but that's the tradeoff.
Firefox seems fairly good with no changes, but I've seen some cases where it throttles the stream and don't raises the quality back up. Firefox optimizations will probably come in another PR.