### PR TITLE
Raised max resolution for webcam constraints

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -288,7 +288,7 @@ class VideoProvider extends Component {
       },
       height: {
         min: 180,
-        max: 360,
+        max: 480,
       },
     };
 


### PR DESCRIPTION
We can't force 16:9. Some browsers don't work well with this, and mobiles get an `overconstrained` error.
Fixes #5358 