### PR TITLE
Initial work to handle unconfigured chromeExtensionLink.

### DIFF
--- a/bigbluebutton-html5/private/config/settings-development.json
+++ b/bigbluebutton-html5/private/config/settings-development.json
@@ -59,7 +59,7 @@
     "kurento": {
       "wsUrl": "HOST",
       "chromeExtensionKey": "KEY",
-      "chromeExtensionLink": "LINK",
+      "chromeExtensionLink": "javascript:alert('Missing kurento.chromeExtensionLink config')",
       "enableScreensharing": false,
       "enableVideo": false
     },

--- a/bigbluebutton-html5/private/config/settings-production.json
+++ b/bigbluebutton-html5/private/config/settings-production.json
@@ -59,7 +59,7 @@
     "kurento": {
       "wsUrl": "HOST",
       "chromeExtensionKey": "KEY",
-      "chromeExtensionLink": "LINK",
+      "chromeExtensionLink": "javascript:alert('Missing kurento.chromeExtensionLink config')",
       "enableScreensharing": false,
       "enableVideo": false
     },


### PR DESCRIPTION
- Change the default chromeExtensionLink key to a javascript alert when it is unconfigured to issue an onscreen alert when user tries to open the link.

Initial fix for #5345.