### PR TITLE
Display open userlist on meeting join

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/auth.js
+++ b/bigbluebutton-html5/imports/startup/client/auth.js
@@ -1,6 +1,7 @@
 import Auth from '/imports/ui/services/auth';
 import { setCustomLogoUrl } from '/imports/ui/components/user-list/service';
 import { log } from '/imports/ui/services/api';
+import deviceType from '/imports/utils/deviceType';
 
 // disconnected and trying to open a new connection
 const STATUS_CONNECTING = 'connecting';
@@ -27,19 +28,10 @@ export function joinRouteHandler(nextState, replace, callback) {
 
       Auth.set(meetingID, internalUserID, authToken, logoutUrl, sessionToken);
 
-      let path = '/';
-
-      const MAX_PHONE_SHORT_SIDE = 480;
-
-      const smallSide = window.screen.width < window.screen.height
-        ? window.screen.width
-        : window.screen.height;
-
-      const isPhone = smallSide <= MAX_PHONE_SHORT_SIDE;
-
-      if (!isPhone) path += 'users';
+      const path = deviceType().isPhone ? '/' : '/users';
 
       replace({ pathname: path });
+
       callback();
     });
 }

--- a/bigbluebutton-html5/imports/startup/client/auth.js
+++ b/bigbluebutton-html5/imports/startup/client/auth.js
@@ -26,7 +26,18 @@ export function joinRouteHandler(nextState, replace, callback) {
       setCustomLogoUrl(customLogoURL);
 
       Auth.set(meetingID, internalUserID, authToken, logoutUrl, sessionToken);
-      replace({ pathname: '/' });
+
+      const MAX_PHONE_VIEWPORT = 480;
+      const hasPhoneDimensions = (
+        (window.screen.width <= MAX_PHONE_VIEWPORT && window.screen.width < window.screen.height)
+        ||
+        (window.screen.height <= MAX_PHONE_VIEWPORT && window.screen.width > window.screen.height)
+      );
+
+      const path = (('ontouchstart' in window || navigator.msMaxTouchPoints) && hasPhoneDimensions)
+        ? '/' : '/users';
+
+      replace({ pathname: path });
       callback();
     });
 }

--- a/bigbluebutton-html5/imports/startup/client/auth.js
+++ b/bigbluebutton-html5/imports/startup/client/auth.js
@@ -28,8 +28,16 @@ export function joinRouteHandler(nextState, replace, callback) {
       Auth.set(meetingID, internalUserID, authToken, logoutUrl, sessionToken);
 
       let path = '/';
-      const smallSide = window.matchMedia('(orientation: portrait)') ? 'width' : 'height';
-      if (!matchMedia(`only screen and (max-${smallSide}: 480px)`).matches) path += 'users';
+
+      const MAX_PHONE_SHORT_SIDE = 480;
+
+      const smallSide = window.screen.width < window.screen.height
+        ? window.screen.width
+        : window.screen.height;
+
+      const isPhone = smallSide <= MAX_PHONE_SHORT_SIDE;
+
+      if (!isPhone) path += 'users';
 
       replace({ pathname: path });
       callback();

--- a/bigbluebutton-html5/imports/startup/client/auth.js
+++ b/bigbluebutton-html5/imports/startup/client/auth.js
@@ -27,15 +27,9 @@ export function joinRouteHandler(nextState, replace, callback) {
 
       Auth.set(meetingID, internalUserID, authToken, logoutUrl, sessionToken);
 
-      const MAX_PHONE_VIEWPORT = 480;
-      const hasPhoneDimensions = (
-        (window.screen.width <= MAX_PHONE_VIEWPORT && window.screen.width < window.screen.height)
-        ||
-        (window.screen.height <= MAX_PHONE_VIEWPORT && window.screen.width > window.screen.height)
-      );
-
-      const path = (('ontouchstart' in window || navigator.msMaxTouchPoints) && hasPhoneDimensions)
-        ? '/' : '/users';
+      let path = '/';
+      const smallSide = window.matchMedia('(orientation: portrait)') ? 'width' : 'height';
+      if (!matchMedia(`only screen and (max-${smallSide}: 480px)`).matches) path += 'users';
 
       replace({ pathname: path });
       callback();

--- a/bigbluebutton-html5/imports/utils/deviceType.js
+++ b/bigbluebutton-html5/imports/utils/deviceType.js
@@ -1,4 +1,6 @@
 const deviceType = () => {
+  // Listing of Device Viewport sizes, Updated : March 25th, 2018
+  // http://mediag.com/news/popular-screen-resolutions-designing-for-all/
   const MAX_PHONE_SHORT_SIDE = 480;
 
   const smallSide = window.screen.width < window.screen.height

--- a/bigbluebutton-html5/imports/utils/deviceType.js
+++ b/bigbluebutton-html5/imports/utils/deviceType.js
@@ -1,0 +1,14 @@
+const deviceType = () => {
+  const MAX_PHONE_SHORT_SIDE = 480;
+
+  const smallSide = window.screen.width < window.screen.height
+    ? window.screen.width
+    : window.screen.height;
+
+  return {
+    isPhone: smallSide <= MAX_PHONE_SHORT_SIDE,
+  };
+};
+
+export default deviceType;
+


### PR DESCRIPTION
when a user joins a meeting from a desktop / tablet the userlist is open.
If they join from a mobile phone, the userlist renders as closed.

fixes issue #5217 