### PR TITLE
Add friendly iteration on audio settings retry

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -97,6 +97,7 @@ class AudioModal extends Component {
 
     this.handleGoToAudioOptions = this.handleGoToAudioOptions.bind(this);
     this.handleGoToAudioSettings = this.handleGoToAudioSettings.bind(this);
+    this.handleRetryGoToEchoTest = this.handleRetryGoToEchoTest.bind(this);
     this.handleGoToEchoTest = this.handleGoToEchoTest.bind(this);
     this.handleJoinMicrophone = this.handleJoinMicrophone.bind(this);
     this.handleJoinListenOnly = this.handleJoinListenOnly.bind(this);
@@ -167,6 +168,19 @@ class AudioModal extends Component {
         content: 'settings',
       });
     });
+  }
+
+  handleRetryGoToEchoTest() {
+    const { joinFullAudioImmediately } = this.props;
+
+    this.setState({
+      hasError: false,
+      content: null,
+    });
+
+    if (joinFullAudioImmediately) return this.joinMicrophone();
+
+    return this.handleGoToEchoTest();
   }
 
   handleGoToEchoTest() {
@@ -317,7 +331,7 @@ class AudioModal extends Component {
     return (
       <AudioSettings
         handleBack={this.handleGoToAudioOptions}
-        handleRetry={this.handleGoToEchoTest}
+        handleRetry={this.handleRetryGoToEchoTest}
         joinEchoTest={this.joinEchoTest}
         exitAudio={this.exitAudio}
         changeInputDevice={this.changeInputDevice}


### PR DESCRIPTION
Currently when you click in retry there is no indication that something is happening.
![before-pr](https://user-images.githubusercontent.com/2110278/39195520-689fa4ca-47b6-11e8-8a9d-5ee9464a7f70.gif)

Now when you click in retry the user is informed that something is happening.
![after-pr](https://user-images.githubusercontent.com/2110278/39195519-688bf678-47b6-11e8-9a22-980736faf5be.gif)

