### PR TITLE
Fix mobile screen reader functionality

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -148,7 +148,7 @@ class App extends Component {
   }
 
   renderMedia() {
-    const { media, intl, chatIsOpen } = this.props;
+    const { media, intl, chatIsOpen, userlistIsOpen } = this.props;
 
     if (!media) return null;
 
@@ -156,7 +156,7 @@ class App extends Component {
       <section
         className={styles.media}
         aria-label={intl.formatMessage(intlMessages.mediaLabel)}
-        aria-hidden={chatIsOpen}
+        aria-hidden={userlistIsOpen || chatIsOpen}
       >
         {media}
         {this.renderClosedCaption()}
@@ -165,7 +165,7 @@ class App extends Component {
   }
 
   renderActionsBar() {
-    const { actionsbar, intl, userlistIsOpen } = this.props;
+    const { actionsbar, intl, userlistIsOpen, chatIsOpen } = this.props;
 
     if (!actionsbar) return null;
 
@@ -173,7 +173,7 @@ class App extends Component {
       <section
         className={styles.actionsbar}
         aria-label={intl.formatMessage(intlMessages.actionsBarLabel)}
-        aria-hidden={userlistIsOpen}
+        aria-hidden={userlistIsOpen || chatIsOpen}
       >
         {actionsbar}
       </section>

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -109,7 +109,7 @@ class App extends Component {
   }
 
   renderUserList() {
-    const { intl } = this.props;
+    const { intl, chatIsOpen } = this.props;
     let { userList } = this.props;
     const { compactUserList } = this.state;
 
@@ -125,6 +125,7 @@ class App extends Component {
       <div
         className={cx(styles.userList, userListStyle)}
         aria-label={intl.formatMessage(intlMessages.userListLabel)}
+        aria-hidden={chatIsOpen}
       >
         {userList}
       </div>
@@ -147,7 +148,7 @@ class App extends Component {
   }
 
   renderMedia() {
-    const { media, intl } = this.props;
+    const { media, intl, chatIsOpen } = this.props;
 
     if (!media) return null;
 
@@ -155,6 +156,7 @@ class App extends Component {
       <section
         className={styles.media}
         aria-label={intl.formatMessage(intlMessages.mediaLabel)}
+        aria-hidden={chatIsOpen}
       >
         {media}
         {this.renderClosedCaption()}
@@ -163,7 +165,7 @@ class App extends Component {
   }
 
   renderActionsBar() {
-    const { actionsbar, intl } = this.props;
+    const { actionsbar, intl, userlistIsOpen } = this.props;
 
     if (!actionsbar) return null;
 
@@ -171,6 +173,7 @@ class App extends Component {
       <section
         className={styles.actionsbar}
         aria-label={intl.formatMessage(intlMessages.actionsBarLabel)}
+        aria-hidden={userlistIsOpen}
       >
         {actionsbar}
       </section>

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -102,6 +102,8 @@ export default withRouter(injectIntl(withModalMounter(withTracker(({ router, int
   return {
     closedCaption: getCaptionsStatus() ? <ClosedCaptionsContainer /> : null,
     fontSize: getFontSize(),
+    userlistIsOpen: window.location.pathname.includes('users'),
+    chatIsOpen: window.location.pathname.includes('chat'),
   };
 })(AppContainer))));
 

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -285,7 +285,7 @@ class AudioModal extends Component {
 
     if (this.skipAudioOptions()) {
       return (
-        <span className={styles.connecting}>
+        <span className={styles.connecting} role="alert">
           { !isEchoTest ?
             intl.formatMessage(intlMessages.connecting) :
             intl.formatMessage(intlMessages.connectingEchoTest)

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/styles.scss
@@ -32,6 +32,7 @@
 .audioOptions {
   margin-top: auto;
   margin-bottom: auto;
+  display: flex;
 }
 
 .overlay {

--- a/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
@@ -70,8 +70,6 @@ class Dropdown extends Component {
   }
 
   componentWillUpdate(nextProps, nextState) {
-    //if (nextState.isOpen) return screenreaderTrap.trap(this.dropdown);
-    //if (!nextState.isOpen) return screenreaderTrap.untrap();
     return nextState.isOpen ? screenreaderTrap.trap(this.dropdown) : screenreaderTrap.untrap();
   }
 

--- a/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
@@ -70,8 +70,9 @@ class Dropdown extends Component {
   }
 
   componentWillUpdate(nextProps, nextState) {
-    if (nextState.isOpen) return screenreaderTrap.trap(this.dropdown);
-    if (!nextState.isOpen) return screenreaderTrap.untrap();
+    //if (nextState.isOpen) return screenreaderTrap.trap(this.dropdown);
+    //if (!nextState.isOpen) return screenreaderTrap.untrap();
+    return nextState.isOpen ? screenreaderTrap.trap(this.dropdown) : screenreaderTrap.untrap();
   }
 
 

--- a/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
@@ -4,6 +4,7 @@ import { findDOMNode } from 'react-dom';
 import cx from 'classnames';
 import { defineMessages, injectIntl } from 'react-intl';
 import Button from '/imports/ui/components/button/component';
+import screenreaderTrap from 'makeup-screenreader-trap';
 import { styles } from './styles';
 import DropdownTrigger from './trigger/component';
 import DropdownContent from './content/component';
@@ -67,6 +68,12 @@ class Dropdown extends Component {
     this.handleToggle = this.handleToggle.bind(this);
     this.handleWindowClick = this.handleWindowClick.bind(this);
   }
+
+  componentWillUpdate(nextProps, nextState) {
+    if (nextState.isOpen) return screenreaderTrap.trap(this.dropdown);
+    if (!nextState.isOpen) return screenreaderTrap.untrap();
+  }
+
 
   componentDidUpdate(prevProps, prevState) {
     if (this.state.isOpen && !prevState.isOpen) {
@@ -145,6 +152,7 @@ class Dropdown extends Component {
         aria-relevant={otherProps['aria-relevant']}
         aria-haspopup={otherProps['aria-haspopup']}
         aria-label={otherProps['aria-label']}
+        ref={(node) => { this.dropdown = node; }}
         tabIndex={-1}
       >
         {trigger}

--- a/bigbluebutton-html5/imports/ui/components/dropdown/list/title/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/list/title/component.jsx
@@ -17,9 +17,8 @@ export default class DropdownListTitle extends Component {
     const { className, description } = this.props;
 
     return (
-      <li className={cx(styles.title, className)} aria-describedby={this.labelID} aria-hidden={true}>
+      <li className={cx(styles.title, className)} aria-hidden>
         {this.props.children}
-        <div id={this.labelID} aria-label={description} />
       </li>
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/dropdown/list/title/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/list/title/component.jsx
@@ -17,7 +17,7 @@ export default class DropdownListTitle extends Component {
     const { className, description } = this.props;
 
     return (
-      <li className={cx(styles.title, className)} aria-describedby={this.labelID}>
+      <li className={cx(styles.title, className)} aria-describedby={this.labelID} aria-hidden={true}>
         {this.props.children}
         <div id={this.labelID} aria-label={description} />
       </li>

--- a/bigbluebutton-html5/imports/ui/components/dropdown/trigger/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/trigger/component.jsx
@@ -59,8 +59,8 @@ export default class DropdownTrigger extends Component {
       ...restProps,
       onClick: this.handleClick,
       onKeyDown: this.handleKeyDown,
-      'aria-haspopup': true,
       className: cx(children.props.className, className),
+      'aria-expanded': this.props.dropdownIsOpen,
     });
 
     return TriggerComponentBounded;

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -185,6 +185,10 @@ class ApplicationMenu extends BaseMenu {
               </div>
             </div>
             <div className={styles.col}>
+              <div
+                id="changeLangLabel"
+                aria-label={intl.formatMessage(intlMessages.ariaLanguageLabel)}
+              />
               <label
                 aria-labelledby="changeLangLabel"
                 className={cx(styles.formElement, styles.pullContentRight)}
@@ -194,6 +198,7 @@ class ApplicationMenu extends BaseMenu {
                     defaultValue={this.state.settings.locale}
                     className={styles.select}
                     onChange={this.handleSelectChange.bind(this, 'locale', availableLocales)}
+                    label="testing"
                   >
                     <option disabled>{intl.formatMessage(intlMessages.languageOptionLabel)}</option>
                     {availableLocales.map((locale, index) => (
@@ -204,10 +209,6 @@ class ApplicationMenu extends BaseMenu {
                   </select>
                 ) : null}
               </label>
-              <div
-                id="changeLangLabel"
-                aria-label={intl.formatMessage(intlMessages.ariaLanguageLabel)}
-              />
             </div>
           </div>
           <hr className={styles.separator} />

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -198,7 +198,6 @@ class ApplicationMenu extends BaseMenu {
                     defaultValue={this.state.settings.locale}
                     className={styles.select}
                     onChange={this.handleSelectChange.bind(this, 'locale', availableLocales)}
-                    label="testing"
                   >
                     <option disabled>{intl.formatMessage(intlMessages.languageOptionLabel)}</option>
                     {availableLocales.map((locale, index) => (

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
@@ -242,6 +242,7 @@ class UserListContent extends Component {
             meeting={meeting}
             isMeetingLocked={isMeetingLocked}
             userAriaLabel={userAriaLabel}
+            isActionsOpen={isActionsOpen}
           />}
           {<UserIcons
             user={user}

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-name/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-name/component.jsx
@@ -56,6 +56,7 @@ const UserName = (props) => {
     isMeetingLocked,
     meeting,
     userAriaLabel,
+    isActionsOpen,
   } = props;
 
   if (compact) {
@@ -80,7 +81,7 @@ const UserName = (props) => {
   }
 
   return (
-    <div className={styles.userName} role="button" aria-label={userAriaLabel}>
+    <div className={styles.userName} role="button" aria-label={userAriaLabel} aria-expanded={isActionsOpen}>
       <span className={styles.userNameMain}>
         {user.name} <i>{(user.isCurrent) ? `(${intl.formatMessage(messages.you)})` : ''}</i>
       </span>

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -836,6 +836,11 @@
         "array-find-index": "1.0.2"
       }
     },
+    "custom-event-polyfill": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/custom-event-polyfill/-/custom-event-polyfill-0.3.0.tgz",
+      "integrity": "sha1-mYB4Ob5i7bRGtkWDLg2A6tb6GIg="
+    },
     "cycle": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
@@ -3034,6 +3039,14 @@
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
+      }
+    },
+    "makeup-screenreader-trap": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/makeup-screenreader-trap/-/makeup-screenreader-trap-0.0.5.tgz",
+      "integrity": "sha512-I2rb0Prijbz3eyko3sZY10tjF5ZLUol2mpbRbl/XJCLUybMZCr5c0iKg4N+pGsCONPWITvcfIS/qtEGQUOYUmQ==",
+      "requires": {
+        "custom-event-polyfill": "0.3.0"
       }
     },
     "map-obj": {

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -23,15 +23,15 @@
     }
   },
   "dependencies": {
-    "babel-runtime": "~6.26.0",
     "//": [
       "core-js is included with babel-runtime",
       "but Meteor 1.6.0.1 doesn't see it there for some reason",
       "need to investigate"
     ],
-    "core-js": "~2.5.3",
+    "babel-runtime": "~6.26.0",
     "classnames": "~2.2.5",
     "clipboard": "~1.7.1",
+    "core-js": "~2.5.3",
     "eventemitter2": "~4.1.2",
     "flat": "~4.0.0",
     "hiredis": "~0.5.0",
@@ -39,6 +39,7 @@
     "immutability-helper": "~2.4.0",
     "langmap": "0.0.16",
     "lodash": "~4.17.4",
+    "makeup-screenreader-trap": "0.0.5",
     "meteor-node-stubs": "~0.3.2",
     "node-sass": "~4.5.3",
     "probe-image-size": "~3.1.0",

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -95,7 +95,7 @@
     "app.navBar.settingsDropdown.leaveSessionDesc": "Leave the meeting",
     "app.navBar.settingsDropdown.exitFullscreenDesc": "Exit fullscreen mode",
     "app.navBar.userListToggleBtnLabel": "User List Toggle",
-    "app.navBar.toggleUserList.ariaLabel": "Users and Conversations Toggle",
+    "app.navBar.toggleUserList.ariaLabel": "Users and Messages Toggle",
     "app.navBar.toggleUserList.newMessages": "with new message notification",
     "app.navBar.recording": "This session is being recorded",
     "app.navBar.recording.on": "Recording",


### PR DESCRIPTION
This PR fixes how the mobile screen reader interacts with the html5 client.

* mobile SR no longer has access to elements behind the current view.
* adds makeup-screenreader-trap package.
* adds aria-expanded to dropdown menus.
* SR alerts the audio modal connecting text.
* other minor bug fixes.