### PR TITLE
Loading screen rotation spins counter-clockwise

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -71,7 +71,7 @@
 
 @keyframes spin {
   from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+  to { transform: rotate(-360deg); }
 }
 
 .connecting {


### PR DESCRIPTION
The arrows for when a webcam is loading now correctly spins counter-clockwise.