### PR TITLE
Set default KEY and LINK for Chrome screenshare extension 

### DIFF
--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -2,21 +2,16 @@ import Users from '/imports/api/users';
 import Auth from '/imports/ui/services/auth';
 import BridgeService from './service';
 
-const CHROME_EXTENSION_KEY = Meteor.settings.public.kurento.chromeExtensionKey;
+const CHROME_DEFAULT_EXTENSION_KEY = Meteor.settings.public.kurento.chromeDefaultExtensionKey;
+const CHROME_CUSTOM_EXTENSION_KEY = Meteor.settings.public.kurento.chromeExtensionKey;
 
-const getUserId = () => {
-  const userID = Auth.userID;
-  return userID;
-}
+const CHROME_EXTENSION_KEY = CHROME_CUSTOM_EXTENSION_KEY === 'KEY' ? CHROME_DEFAULT_EXTENSION_KEY : CHROME_CUSTOM_EXTENSION_KEY;
 
-const getMeetingId = () => {
-  const meetingID = Auth.meetingID;
-  return meetingID;
-}
+const getUserId = () => Auth.userID;
 
-const getUsername = () => {
-  return Users.findOne({ userId: getUserId() }).name;
-}
+const getMeetingId = () => Auth.meetingID;
+
+const getUsername = () => Users.findOne({ userId: getUserId() }).name;
 
 export default class KurentoScreenshareBridge {
   kurentoWatchVideo() {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-dock/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-dock/component.jsx
@@ -1,12 +1,6 @@
 import React, { Component } from 'react';
-import { styles } from '../styles';
 import { defineMessages, injectIntl } from 'react-intl';
-import { log } from '/imports/ui/services/api';
 import { notify } from '/imports/ui/services/notification';
-import { toast } from 'react-toastify';
-import { styles as mediaStyles } from '/imports/ui/components/media/styles';
-import Toast from '/imports/ui/components/toast/component';
-import _ from 'lodash';
 
 import VideoList from '../video-list/component';
 
@@ -29,8 +23,6 @@ class VideoDock extends Component {
   }
 
   componentDidMount() {
-    const { users, userId } = this.props;
-
     document.addEventListener('installChromeExtension', this.installChromeExtension.bind(this));
   }
 
@@ -45,7 +37,11 @@ class VideoDock extends Component {
   installChromeExtension() {
     console.log(intlMessages);
     const { intl } = this.props;
-    const CHROME_EXTENSION_LINK = Meteor.settings.public.kurento.chromeExtensionLink;
+
+    const CHROME_DEFAULT_EXTENSION_LINK = Meteor.settings.public.kurento.chromeDefaultExtensionLink;
+    const CHROME_CUSTOM_EXTENSION_LINK = Meteor.settings.public.kurento.chromeExtensionLink;
+
+    const CHROME_EXTENSION_LINK = CHROME_CUSTOM_EXTENSION_LINK === 'LINK' ? CHROME_DEFAULT_EXTENSION_LINK : CHROME_CUSTOM_EXTENSION_LINK;
 
     this.notifyError(<div>
       {intl.formatMessage(intlMessages.chromeExtensionError)}{' '}
@@ -56,16 +52,23 @@ class VideoDock extends Component {
   }
 
   render() {
-    if (!this.props.socketOpen) {
+    const {
+      socketOpen,
+      users,
+      onStart,
+      onStop,
+    } = this.props;
+
+    if (!socketOpen) {
       // TODO: return something when disconnected
       return null;
     }
 
     return (
       <VideoList
-        users={this.props.users}
-        onMount={this.props.onStart}
-        onUnmount={this.props.onStop}
+        users={users}
+        onMount={onStart}
+        onUnmount={onStop}
       />
     );
   }

--- a/bigbluebutton-html5/private/config/settings-development.json
+++ b/bigbluebutton-html5/private/config/settings-development.json
@@ -58,8 +58,10 @@
 
     "kurento": {
       "wsUrl": "HOST",
-      "chromeExtensionKey": "akgoaoikmbmhcopjgakkcepdgdgkjfbc",
-      "chromeExtensionLink": "https://chrome.google.com/webstore/detail/bigbluebutton-screenshare/akgoaoikmbmhcopjgakkcepdgdgkjfbc",
+      "chromeDefaultExtensionKey": "akgoaoikmbmhcopjgakkcepdgdgkjfbc",
+      "chromeDefaultExtensionLink": "https://chrome.google.com/webstore/detail/bigbluebutton-screenshare/akgoaoikmbmhcopjgakkcepdgdgkjfbc",
+      "chromeExtensionLink": "LINK",
+      "chromeExtensionKey": "KEY",
       "enableScreensharing": false,
       "enableVideo": false
     },

--- a/bigbluebutton-html5/private/config/settings-development.json
+++ b/bigbluebutton-html5/private/config/settings-development.json
@@ -58,8 +58,8 @@
 
     "kurento": {
       "wsUrl": "HOST",
-      "chromeExtensionKey": "KEY",
-      "chromeExtensionLink": "LINK",
+      "chromeExtensionKey": "akgoaoikmbmhcopjgakkcepdgdgkjfbc",
+      "chromeExtensionLink": "https://chrome.google.com/webstore/detail/bigbluebutton-screenshare/akgoaoikmbmhcopjgakkcepdgdgkjfbc",
       "enableScreensharing": false,
       "enableVideo": false
     },

--- a/bigbluebutton-html5/private/config/settings-production.json
+++ b/bigbluebutton-html5/private/config/settings-production.json
@@ -58,8 +58,10 @@
 
     "kurento": {
       "wsUrl": "HOST",
-      "chromeExtensionKey": "akgoaoikmbmhcopjgakkcepdgdgkjfbc",
-      "chromeExtensionLink": "https://chrome.google.com/webstore/detail/bigbluebutton-screenshare/akgoaoikmbmhcopjgakkcepdgdgkjfbc",
+      "chromeDefaultExtensionKey": "akgoaoikmbmhcopjgakkcepdgdgkjfbc",
+      "chromeDefaultExtensionLink": "https://chrome.google.com/webstore/detail/bigbluebutton-screenshare/akgoaoikmbmhcopjgakkcepdgdgkjfbc",
+      "chromeExtensionLink": "LINK",
+      "chromeExtensionKey": "KEY",
       "enableScreensharing": false,
       "enableVideo": false
     },

--- a/bigbluebutton-html5/private/config/settings-production.json
+++ b/bigbluebutton-html5/private/config/settings-production.json
@@ -58,8 +58,8 @@
 
     "kurento": {
       "wsUrl": "HOST",
-      "chromeExtensionKey": "KEY",
-      "chromeExtensionLink": "LINK",
+      "chromeExtensionKey": "akgoaoikmbmhcopjgakkcepdgdgkjfbc",
+      "chromeExtensionLink": "https://chrome.google.com/webstore/detail/bigbluebutton-screenshare/akgoaoikmbmhcopjgakkcepdgdgkjfbc",
       "enableScreensharing": false,
       "enableVideo": false
     },


### PR DESCRIPTION
We now have a BBB screensharing extension for Google Chrome - it whitelists *.bigbluebutton.org domains only and is built from the files in https://github.com/bigbluebutton/screenshare-chrome-extension

 Prefer custom link/key over the default but if no custom ones, fallback to default ones.