### PR TITLE
Hide thickness and color buttons in whiteboard toolbar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
@@ -374,7 +374,7 @@ class WhiteboardToolbar extends Component {
 
   renderThicknessItem() {
     const { intl } = this.props;
-    const isDisabled = this.state.annotationSelected.value === 'hand';
+    const isDisabled = this.state.annotationSelected.value === 'pointer';
     return (
       <ToolbarMenuItem
         disabled={isDisabled}
@@ -442,7 +442,7 @@ class WhiteboardToolbar extends Component {
 
   renderColorItem() {
     const { intl } = this.props;
-    const isDisabled = this.state.annotationSelected.value === 'hand';
+    const isDisabled = this.state.annotationSelected.value === 'pointer';
     return (
       <ToolbarMenuItem
         disabled={isDisabled}


### PR DESCRIPTION
- when the pointer tool is selected hide thickness and color button, as it was with the hand tool.