### PR TITLE
[AIR] Stop the active poll when the result is shown

### DIFF
--- a/clients/flash/air-client/src/org/bigbluebutton/air/poll/services/PollMessageReceiver.as
+++ b/clients/flash/air-client/src/org/bigbluebutton/air/poll/services/PollMessageReceiver.as
@@ -16,6 +16,8 @@ package org.bigbluebutton.air.poll.services {
 				case "PollStoppedEvtMsg":
 					handlePollStopped(message);
 					break;
+				case "PollShowResultEvtMsg":
+					handlePollShowResult(message);
 				default:
 					break;
 			}
@@ -36,6 +38,12 @@ package org.bigbluebutton.air.poll.services {
 		}
 		
 		public function handlePollStopped(msg:Object):void {
+			meetingData.polls.removeCurrentPoll();
+		}
+		
+		public function handlePollShowResult(msg:Object):void {
+			// This is sent when the presenter publishes the poll result and contains pollId and
+			// the voting results. For now just remove the active poll
 			meetingData.polls.removeCurrentPoll();
 		}
 	}


### PR DESCRIPTION
This PR handles an additional poll stop scenario that occurs when the presenter publishes the poll instead of just closing it.