### PR TITLE
Grouping playbacks inside the same recording

### DIFF
--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/domain/Recording.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/domain/Recording.scala
@@ -1,6 +1,7 @@
 package org.bigbluebutton.api2.domain
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
 import java.util.Map
 
 import scala.xml.{Elem, NodeSeq}
@@ -368,6 +369,27 @@ case class RecMetaPlayback(format: String, link: String, processingTime: Int,
 
     <playback>{buffer}</playback>
   }
+
+  // Merged playback formats when responding to get recordings API call
+  def toFormatXml(): Elem = {
+    val buffer = new scala.xml.NodeBuffer
+    val formatElem = <type>{format}</type>
+    val urlElem = <url>{link}</url>
+    val processTimeElem = <processingTime>{processingTime}</processingTime>
+    val lengthElem = <length>{duration / 60000}</length>
+
+    buffer += formatElem
+    buffer += urlElem
+    buffer += processTimeElem
+    buffer += lengthElem
+
+    extensions foreach {ext =>
+      ext.head.child foreach {child =>
+        buffer += child
+      }
+    }
+    <format>{buffer}</format>
+  }
 }
 
 
@@ -388,5 +410,94 @@ case class RecMetaBreakout(parentId: String, sequence: Int, meetingId: String) {
 
   def toMetadataXml(): Elem = {
       <breakout parentMeetingId={parentId} sequence={sequence.toString} meetingId={meetingId}/>
+  }
+}
+
+// A simple mask to merge multiple playback formats of the same recording
+case class RecMetaResponse(
+    id: String,
+    meetingId: String,
+    internalMeetingId: Option[String],
+    meetingName: String,
+    state: String,
+    published: Boolean,
+    startTime: Long,
+    endTime: Long,
+    participants: Int,
+    rawSize: Long,
+    isBreakout: Boolean,
+    meeting: Option[RecMetaMeeting],
+    meta: Option[collection.immutable.Map[String, String]],
+    playbacks: ListBuffer[RecMetaPlayback],
+    breakout: Option[RecMetaBreakout],
+    breakoutRooms: Vector[String]) {
+
+  // Link a new playback if it exists
+  def updateRecMeta(r: RecMeta): RecMetaResponse = {
+    r.playback match {
+      case Some(p) => this.playbacks += p
+      case None =>
+    }
+    this
+  }
+
+  def toXml(): Elem = {
+    def metaToElem(map: scala.collection.immutable.Map[String, String]): Elem = {
+      val buffer = new scala.xml.NodeBuffer
+      map.foreach {case (key, value) =>
+        // Need to escape value otherwise loadString would choke.
+        val m = "<" + key + ">" + xml.Utility.escape(value) + "</" + key + ">"
+        buffer += scala.xml.XML.loadString(m)
+      }
+      <metadata>{buffer}</metadata>
+    }
+
+    def breakoutRoomsToElem(rooms: Vector[String]): Elem = {
+      val buffer = new scala.xml.NodeBuffer
+      rooms foreach(r => buffer += <breakoutRoom>{r}</breakoutRoom>)
+      <breakoutRooms>{buffer}</breakoutRooms>
+    }
+
+    val recordIdElem = <recordID>{id}</recordID>
+    val meetingIdElem = <meetingID>{meetingId}</meetingID>
+    val meetingNameElem = <name>{meetingName}</name>
+
+    val internalId = internalMeetingId match {
+      case Some(intId) => Some(<internalMeetingID>{intId}</internalMeetingID>)
+      case None => None
+    }
+
+    val isBreakoutElem = <isBreakout>{isBreakout}</isBreakout>
+    val publishedElem = <published>{published}</published>
+    val stateElem =  <state>{state}</state>
+    val startTimeElem =  <startTime>{startTime}</startTime>
+    val endTimeElem = <endTime>{endTime}</endTime>
+    val participantsElem = <participants>{participants}</participants>
+
+    val buffer = new scala.xml.NodeBuffer
+    buffer += recordIdElem
+    buffer += meetingIdElem
+    internalId foreach(intId => buffer += intId)
+    buffer += meetingNameElem
+    buffer += isBreakoutElem
+    buffer += publishedElem
+    buffer += stateElem
+    buffer += startTimeElem
+    buffer += endTimeElem
+    buffer += participantsElem
+
+    meta foreach (m => buffer += metaToElem(m))
+    breakout foreach (b => buffer += b.toXml())
+    if (breakoutRooms.nonEmpty) {
+      buffer += breakoutRoomsToElem(breakoutRooms)
+    }
+
+    // Iterate over all formats before include the playback tag
+    val formats = new scala.xml.NodeBuffer
+    playbacks foreach(p => formats += p.toFormatXml())
+    val playbackElem = <playback>{formats}</playback>
+    buffer += playbackElem
+
+    <recording>{buffer}</recording>
   }
 }


### PR DESCRIPTION
Different playbacks of the same recording should now be responded as multiple <format> inside the same <playback> tag