### PR TITLE
Fixed recording stop in SFU

### DIFF
--- a/labs/bbb-webrtc-sfu/lib/mcs-core/lib/media/MediaController.js
+++ b/labs/bbb-webrtc-sfu/lib/mcs-core/lib/media/MediaController.js
@@ -292,6 +292,11 @@ module.exports = class MediaController {
       Logger.error("[mcs-controller] Subscribe failed with an error", err);
       return Promise.reject(err);
     }
+    finally {
+      if (typeof err === 'undefined' && session) {
+        session.sessionStarted();
+      }
+    }
   }
 
   async addIceCandidate (mediaId, candidate) {


### PR DESCRIPTION
There was a routine that marks a media session as started missing in the mcs-core lib, so recordings weren't being correctly stopped.