### PR TITLE
Enable kurento screenshare recording, disable red5 video-broadcast ss recording

### DIFF
--- a/labs/bbb-webrtc-sfu/config/default.example.yml
+++ b/labs/bbb-webrtc-sfu/config/default.example.yml
@@ -18,7 +18,7 @@ to-akka: "to-akka-apps-redis-channel"
 webcam-force-h264: true
 screenshare-force-h264: true
 
-recordScreenSharing: false
+recordScreenSharing: true
 recordWebcams: false
 recordingBasePath: "file:///var/kurento"
 

--- a/video-broadcast/src/main/webapp/WEB-INF/red5-web.xml
+++ b/video-broadcast/src/main/webapp/WEB-INF/red5-web.xml
@@ -50,7 +50,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 	<bean id="web.handler" class="org.bigbluebutton.app.videobroadcast.VideoApplication">
 		<property name="packetTimeout" value="10000"/>
-		<property name="recordVideoStream" value="true"/>
+		<property name="recordVideoStream" value="false"/>
 		<property name="eventRecordingService" ref="redisRecorder"/>
 	</bean>
 


### PR DESCRIPTION
From now on webrtc screenshare [via Kurento] will only be recorded by Kurento and red5's video-broadcast app will be used only for streaming live to potential Flash client meeting viewers