### PR TITLE
Show a call out when a user doesn't join audio

### DIFF
--- a/bigbluebutton-client/branding/default/style/css/org/bigbluebutton/skins/ToolTipSkin.as
+++ b/bigbluebutton-client/branding/default/style/css/org/bigbluebutton/skins/ToolTipSkin.as
@@ -183,10 +183,12 @@ package org.bigbluebutton.skins {
 
 					// top pointer
 					g.beginFill(borderColor, backgroundAlpha);
-					g.moveTo(9, 11);
-					g.lineTo(15, 0);
-					g.lineTo(21, 11);
-					g.moveTo(10, 11);
+					
+					g.moveTo(w / 2 - 6, 13);
+					g.lineTo(w / 2, 2);
+					g.lineTo(w / 2 + 6, 13);
+					g.moveTo(w / 2 - 6, 13);
+					
 					g.endFill();
 
 					filters = [new DropShadowFilter(2, 90, 0, 0.4)];

--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -452,6 +452,7 @@ bbb.toolbar.phone.toolTip.stop = Disable Audio
 bbb.toolbar.phone.toolTip.mute = Stop listening the conference
 bbb.toolbar.phone.toolTip.unmute = Start listening the conference
 bbb.toolbar.phone.toolTip.nomic = No microphone detected
+bbb.toolbar.phone.callout.didntjoin = Click here to join the audio
 bbb.toolbar.deskshare.toolTip.start = Open Screen Share Publish Window
 bbb.toolbar.deskshare.toolTip.stop = Stop Sharing Your Screen
 bbb.toolbar.sharednotes.toolTip = Open Shared Notes

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/AudioSelectionWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/AudioSelectionWindow.mxml
@@ -115,7 +115,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private function onCancelClicked():void {
 				LOGGER.debug("AudioSelectionWindow - Close clicked");
 				var dispatcher:Dispatcher = new Dispatcher();
-				dispatcher.dispatchEvent(new AudioSelectionWindowEvent(AudioSelectionWindowEvent.CLOSED_AUDIO_SELECTION));
+				dispatcher.dispatchEvent(new AudioSelectionWindowEvent(AudioSelectionWindowEvent.CLOSED_AUDIO_SELECTION, true));
 				
 				PopUpUtil.removePopUp(this);
 			}

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/FlashMicSettings.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/FlashMicSettings.mxml
@@ -257,7 +257,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         cleanUp();
         stopEchoTest();
         var dispatcher:Dispatcher = new Dispatcher();
-        dispatcher.dispatchEvent(new AudioSelectionWindowEvent(AudioSelectionWindowEvent.CLOSED_AUDIO_SELECTION));
+        dispatcher.dispatchEvent(new AudioSelectionWindowEvent(AudioSelectionWindowEvent.CLOSED_AUDIO_SELECTION, true));
         PopUpUtil.removePopUp(this);
       }
       

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/phone/events/AudioSelectionWindowEvent.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/phone/events/AudioSelectionWindowEvent.as
@@ -7,9 +7,12 @@ package org.bigbluebutton.modules.phone.events
 		public static const SHOW_AUDIO_SELECTION:String = 'SHOW_AUDIO_SELECTION';
 		public static const CLOSED_AUDIO_SELECTION:String = 'CLOSED_AUDIO_SELECTION';
 		
-		public function AudioSelectionWindowEvent(type:String, bubbles:Boolean=false, cancelable:Boolean=false)
+		public var closedWithoutJoin:Boolean = false;
+		
+		public function AudioSelectionWindowEvent(type:String, closedWithoutJoin:Boolean=false)
 		{
-			super(type, bubbles, cancelable);
+			super(type, false, false);
+			this.closedWithoutJoin = closedWithoutJoin;
 		}
 	}
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/WebRTCCallManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/WebRTCCallManager.as
@@ -290,7 +290,7 @@ package org.bigbluebutton.modules.phone.managers
         });
         popUpDelayTimer.start();
       } else {
-        dispatcher.dispatchEvent(new AudioSelectionWindowEvent(AudioSelectionWindowEvent.CLOSED_AUDIO_SELECTION));
+        dispatcher.dispatchEvent(new AudioSelectionWindowEvent(AudioSelectionWindowEvent.CLOSED_AUDIO_SELECTION, true));
       }
     }
     

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/phone/views/components/ToolbarButton.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/phone/views/components/ToolbarButton.mxml
@@ -24,6 +24,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
            styleName="voiceConfDefaultButtonStyle" click="startPhone()"
 	mouseOver = "mouseOverHandler(event)"
 	mouseOut = "mouseOutHandler(event)"
+	move="handleMove()"
 	creationComplete="onCreationComplete()"
 	height="30"
 	width="40"
@@ -41,25 +42,28 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	</fx:Declarations>  
 	<fx:Script>
 		<![CDATA[
-      import com.asfusion.mate.events.Dispatcher;
-      
-      import org.as3commons.logging.api.ILogger;
-      import org.as3commons.logging.api.getClassLogger;
-      import org.bigbluebutton.core.Options;
-      import org.bigbluebutton.core.model.LiveMeeting;
-      import org.bigbluebutton.main.events.BBBEvent;
-      import org.bigbluebutton.main.events.ShortcutEvent;
-      import org.bigbluebutton.main.views.MainToolbar;
-      import org.bigbluebutton.modules.phone.events.AudioSelectionWindowEvent;
-      import org.bigbluebutton.modules.phone.events.FlashEchoTestStoppedEvent;
-      import org.bigbluebutton.modules.phone.events.FlashJoinedListenOnlyVoiceConferenceEvent;
-      import org.bigbluebutton.modules.phone.events.FlashJoinedVoiceConferenceEvent;
-      import org.bigbluebutton.modules.phone.events.FlashLeftVoiceConferenceEvent;
-      import org.bigbluebutton.modules.phone.events.JoinVoiceConferenceCommand;
-      import org.bigbluebutton.modules.phone.events.LeaveVoiceConferenceCommand;
-      import org.bigbluebutton.modules.phone.events.WebRTCCallEvent;
-      import org.bigbluebutton.modules.phone.models.PhoneOptions;
-      import org.bigbluebutton.util.i18n.ResourceUtil;
+			import com.asfusion.mate.events.Dispatcher;
+			
+			import mx.controls.ToolTip;
+			import mx.managers.ToolTipManager;
+			
+			import org.as3commons.logging.api.ILogger;
+			import org.as3commons.logging.api.getClassLogger;
+			import org.bigbluebutton.core.Options;
+			import org.bigbluebutton.core.model.LiveMeeting;
+			import org.bigbluebutton.main.events.BBBEvent;
+			import org.bigbluebutton.main.events.ShortcutEvent;
+			import org.bigbluebutton.main.views.MainToolbar;
+			import org.bigbluebutton.modules.phone.events.AudioSelectionWindowEvent;
+			import org.bigbluebutton.modules.phone.events.FlashEchoTestStoppedEvent;
+			import org.bigbluebutton.modules.phone.events.FlashJoinedListenOnlyVoiceConferenceEvent;
+			import org.bigbluebutton.modules.phone.events.FlashJoinedVoiceConferenceEvent;
+			import org.bigbluebutton.modules.phone.events.FlashLeftVoiceConferenceEvent;
+			import org.bigbluebutton.modules.phone.events.JoinVoiceConferenceCommand;
+			import org.bigbluebutton.modules.phone.events.LeaveVoiceConferenceCommand;
+			import org.bigbluebutton.modules.phone.events.WebRTCCallEvent;
+			import org.bigbluebutton.modules.phone.models.PhoneOptions;
+			import org.bigbluebutton.util.i18n.ResourceUtil;
 			
 			private static const LOGGER:ILogger = getClassLogger(ToolbarButton);      
       
@@ -69,6 +73,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			public const DEFAULT_STATE:Number = 0;
 			public const ACTIVE_STATE:Number = 1;
 			private var _currentState:Number = DEFAULT_STATE;
+			
+			private var notificationTimer:Timer;
+			private var notification:ToolTip;
 			
 			[Bindable] public var phoneOptions:PhoneOptions;
 			
@@ -134,6 +141,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 				phoneOptions = Options.getOptions(PhoneOptions) as PhoneOptions;
 
+				notificationTimer = new Timer(30000, 1); // 30 second timer
+				notificationTimer.addEventListener(TimerEvent.TIMER, hideNotification);
+				
 				// when the button is added to the stage display the audio selection window if auto join is true
 				if (phoneOptions.autoJoin) {
 					if (phoneOptions.skipCheck || LiveMeeting.inst().me.disableMyMic) {
@@ -149,6 +159,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 						LOGGER.debug("Sending Show Audio Selection command");
 						dispatcher.dispatchEvent(new AudioSelectionWindowEvent(AudioSelectionWindowEvent.SHOW_AUDIO_SELECTION));
 					}
+				} else {
+					showNotification();
 				}
 			}
 
@@ -161,13 +173,17 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         LOGGER.debug("onUserJoinedConference enabled=[{0}] selected=[{1}]", [enabled, selected]);
         _currentState = ACTIVE_STATE;
         this.styleName = "voiceConfActiveButtonStyle";
-        this.toolTip = ResourceUtil.getInstance().getString('bbb.toolbar.phone.toolTip.stop');	        
+        this.toolTip = ResourceUtil.getInstance().getString('bbb.toolbar.phone.toolTip.stop');
+        
+        hideNotification();
       }
       
       private function onUserJoinedListenOnlyConference():void {
         LOGGER.debug("onUserJoinedListenOnlyConference enabled=[" + enabled + "] selected=[" + selected + "]");
 
         resetButtonState();
+        
+        hideNotification();
       }
 
       private function onUserLeftConference():void {
@@ -241,6 +257,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         		this.styleName = "voiceConfDefaultButtonStyle";
 				this.toolTip = ResourceUtil.getInstance().getString('bbb.toolbar.phone.toolTip.start');
 				joinDefaultListenOnlyMode();
+				
+				if (event.closedWithoutJoin) {
+					showNotification();
+				}
 			}
 				
 			//For whatever reason the tooltip does not update when localization is changed dynamically. Overrideing it here
@@ -258,6 +278,34 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 			private function joinVoiceFocusHead(e:BBBEvent):void{
 				this.setFocus();
+			}
+			
+			private function showNotification():void {
+				if (parent.visible) {
+					visible = includeInLayout = true;
+					
+					if (notificationTimer.running) notificationTimer.reset();
+					notificationTimer.start();
+					
+					if (!notification) {
+						notification = ToolTipManager.createToolTip(ResourceUtil.getInstance().getString('bbb.toolbar.phone.callout.didntjoin'), 100, 100, "errorTipBelow", this) as ToolTip;
+						handleMove();
+					}
+				}
+			}
+			
+			private function handleMove():void {
+				if (notification) {
+					var location:Point = localToGlobal(new Point(0,0));
+					notification.move(location.x - notification.width/2 + this.width/2, location.y + this.height);
+				}
+			}
+			
+			private function hideNotification(e:Event=null):void {
+				if (notification) {
+					ToolTipManager.destroyToolTip(notification);
+					notification = null;
+				}
 			}
 		]]>
 	</fx:Script>

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/Pencil.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/business/shapes/Pencil.as
@@ -30,7 +30,7 @@ package org.bigbluebutton.modules.whiteboard.business.shapes
 		}
 		
 		override protected function makeGraphic():void {
-			if (status == AnnotationStatus.DRAW_END && (_ao.points.length > 2)) {
+			if (status == AnnotationStatus.DRAW_END && _ao.points.length > 2 && _ao.commands) {
 				drawFinishedLine();
 			} else {
 				drawSimpleLine();


### PR DESCRIPTION
Sometimes the user will close the audio selection window without reading it and then not know how to join the audio. This PR creates a tooltip with the text "Click here to join the audio" and points to the join audio button if the audio modals are closed without joining. The call out will also be shown if meeting has "autoJoin" turned off in the config.xml.

Fixes issue #5441.

![image](https://user-images.githubusercontent.com/1395090/39656898-52b5d256-4fd1-11e8-9409-6d86344a0ba4.png)
