### PR TITLE
Allowing WebRTC-only screensharing

### DIFF
--- a/labs/bbb-webrtc-sfu/lib/bbb/pubsub/RedisWrapper.js
+++ b/labs/bbb-webrtc-sfu/lib/bbb/pubsub/RedisWrapper.js
@@ -152,6 +152,17 @@ module.exports = class RedisWrapper extends EventEmitter {
     }
   }
 
+  getChannels () {
+    return new Promise((resolve, reject) => {
+      this.redisPub.pubsub('channels', (error, channels) => {
+        if (error) {
+          return reject(error);
+        }
+        return resolve(channels);
+      });
+    });
+  }
+
   /* Private members */
 
   _onMessage (pattern, channel, _message) {

--- a/labs/bbb-webrtc-sfu/lib/bbb/pubsub/bbb-gw.js
+++ b/labs/bbb-webrtc-sfu/lib/bbb/pubsub/bbb-gw.js
@@ -88,7 +88,7 @@ module.exports = class BigBlueButtonGW extends EventEmitter {
           break;
         case C.USER_CAM_BROADCAST_STARTED_2x:
           this.emit(C.USER_CAM_BROADCAST_STARTED_2x, payload[C.STREAM_URL]);
-          break; 
+          break;
         // SCREENSHARE
 
         default:
@@ -129,6 +129,15 @@ module.exports = class BigBlueButtonGW extends EventEmitter {
         Logger.info('Recording key will expire in', EXPIRE_TIME, 'seconds', err);
       });
     });
+  }
+
+  async isChannelAvailable (channel) {
+    const channels = await this.publisher.getChannels();
+    return channels.includes(channel);
+  }
+
+  getChannels () {
+    return this.publisher.getChannels();
   }
 
   setEventEmitter (emitter) {


### PR DESCRIPTION
Few alterations to make WebRTC screensharing possible when Red5/video-broadcast/akka-bbb-transcode aren't installed or running. This should allow a more strict HTML5-only setup.