### PR TITLE
Preserving WebRTC screenshare aspect ratio in video-broadcast

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/kurento-extension.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-extension.js
@@ -33,6 +33,8 @@ Kurento = function (
   // of multiple screens the total area shared becomes too large
   this.vid_max_width = 1920;
   this.vid_max_height = 1080;
+  this.width = window.screen.width;
+  this.height = window.screen.height;
 
   // TODO properly generate a uuid
   this.sessid = Math.random().toString();
@@ -219,16 +221,13 @@ Kurento.prototype.onOfferPresenter = function (error, offerSdp) {
     return;
   }
 
-  const track = this.webRtcPeer.getLocalStream().getVideoTracks()[0];
-  const settings = track.getSettings();
-  let { width, height } = settings;
-  console.debug("Screenshare track dimensions are", width, "x", height);
+  console.debug("Screenshare screen dimensions are", this.width, "x", this.height);
 
-  if (width > this.vid_max_width || height > this.vid_max_height) {
-    resolution = this.downscaleResolution(width, height);
-    width = resolution.width;
-    height = resolution.height;
-    console.debug("Screenshare track dimensions have been resized to", width, "x", height);
+  if (this.width > this.vid_max_width || this.height > this.vid_max_height) {
+    resolution = this.downscaleResolution(this.width, this.height);
+    this.width = resolution.width;
+    this.height = resolution.height;
+    console.debug("Screenshare track dimensions have been resized to", this.width, "x", this.height);
   }
 
   const message = {
@@ -239,8 +238,8 @@ Kurento.prototype.onOfferPresenter = function (error, offerSdp) {
     voiceBridge: self.voiceBridge,
     callerName: self.caller_id_name,
     sdpOffer: offerSdp,
-    vh: height,
-    vw: width,
+    vh: this.height,
+    vw: this.width,
   };
 
   console.log(`onOfferPresenter sending to screenshare server => ${JSON.stringify(message, null, 2)}`);
@@ -522,7 +521,6 @@ window.getChromeScreenConstraints = function (callback, extensionId) {
     extensionId, {
       getStream: true,
       sources: [
-        'window',
         'screen',
       ],
     },

--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -33,6 +33,8 @@ Kurento = function (
   // of multiple screens the total area shared becomes too large
   this.vid_max_width = 1920;
   this.vid_max_height = 1080;
+  this.width = window.screen.width;
+  this.height = window.screen.height;
 
   // TODO properly generate a uuid
   this.sessid = Math.random().toString();
@@ -219,16 +221,13 @@ Kurento.prototype.onOfferPresenter = function (error, offerSdp) {
     return;
   }
 
-  const track = this.webRtcPeer.getLocalStream().getVideoTracks()[0];
-  const settings = track.getSettings();
-  let { width, height } = settings;
-  console.debug("Screenshare track dimensions are", width, "x", height);
+  console.debug("Screenshare screen dimensions are", this.width, "x", this.height);
 
-  if (width > this.vid_max_width || height > this.vid_max_height) {
-    resolution = this.downscaleResolution(width, height);
-    width = resolution.width;
-    height = resolution.height;
-    console.debug("Screenshare track dimensions have been resized to", width, "x", height);
+  if (this.width > this.vid_max_width || this.height > this.vid_max_height) {
+    resolution = this.downscaleResolution(this.width, this.height);
+    this.width = resolution.width;
+    this.height = resolution.height;
+    console.debug("Screenshare track dimensions have been resized to", this.width, "x", this.height);
   }
 
   const message = {
@@ -239,8 +238,8 @@ Kurento.prototype.onOfferPresenter = function (error, offerSdp) {
     voiceBridge: self.voiceBridge,
     callerName: self.caller_id_name,
     sdpOffer: offerSdp,
-    vh: height,
-    vw: width,
+    vh: this.height,
+    vw: this.width,
   };
 
   console.log(`onOfferPresenter sending to screenshare server => ${JSON.stringify(message, null, 2)}`);
@@ -522,7 +521,6 @@ window.getChromeScreenConstraints = function (callback, extensionId) {
     extensionId, {
       getStream: true,
       sources: [
-        'window',
         'screen',
       ],
     },

--- a/labs/bbb-webrtc-sfu/lib/bbb/pubsub/bbb-gw.js
+++ b/labs/bbb-webrtc-sfu/lib/bbb/pubsub/bbb-gw.js
@@ -57,6 +57,7 @@ module.exports = class BigBlueButtonGW extends EventEmitter {
     let header;
     let payload;
     let msg = (typeof message !== 'object')?JSON.parse(message):message;
+    let meetingId;
 
     // Trying to parse both message types, 1x and 2x
     if (msg.header) {
@@ -72,19 +73,23 @@ module.exports = class BigBlueButtonGW extends EventEmitter {
       switch (header.name) {
         // interoperability with 1.1
         case C.START_TRANSCODER_REPLY:
-          this.emit(C.START_TRANSCODER_REPLY, payload);
+          meetingId = payload[C.MEETING_ID];
+          this.emit(C.START_TRANSCODER_REPLY+meetingId, payload);
           break;
         case C.STOP_TRANSCODER_REPLY:
-          this.emit(C.STOP_TRANSCODER_REPLY, payload);
+          meetingId = payload[C.MEETING_ID];
+          this.emit(C.STOP_TRANSCODER_REPLY+meetingId, payload);
           break;
           // 2x messages
         case C.START_TRANSCODER_RESP_2x:
-          payload[C.MEETING_ID_2x] = header[C.MEETING_ID_2x];
-          this.emit(C.START_TRANSCODER_RESP_2x, payload);
+          meetingId = header[C.MEETING_ID_2x];
+          payload[C.MEETING_ID_2x] = meetingId;
+          this.emit(C.START_TRANSCODER_RESP_2x+meetingId, payload);
           break;
         case C.STOP_TRANSCODER_RESP_2x:
-          payload[C.MEETING_ID_2x] = header[C.MEETING_ID_2x];
-          this.emit(C.STOP_TRANSCODER_RESP_2x, payload);
+          meetingId = header[C.MEETING_ID_2x];
+          payload[C.MEETING_ID_2x] = meetingId;
+          this.emit(C.STOP_TRANSCODER_RESP_2x+meetingId, payload);
           break;
         case C.USER_CAM_BROADCAST_STARTED_2x:
           this.emit(C.USER_CAM_BROADCAST_STARTED_2x, payload[C.STREAM_URL]);

--- a/labs/bbb-webrtc-sfu/lib/screenshare/screenshare.js
+++ b/labs/bbb-webrtc-sfu/lib/screenshare/screenshare.js
@@ -328,7 +328,7 @@ module.exports = class Screenshare extends EventEmitter {
 
         if (isTranscoderAvailable) {
           // Interoperability: capturing 1.1 stop_transcoder_reply messages
-          this._BigBlueButtonGW.on(C.STOP_TRANSCODER_REPLY, async (payload) => {
+          this._BigBlueButtonGW.once(C.STOP_TRANSCODER_REPLY+this._meetingId, async (payload) => {
             let meetingId = payload[C.MEETING_ID];
             if(this._meetingId === meetingId) {
               await this._stopRtmpBroadcast(meetingId);
@@ -337,7 +337,7 @@ module.exports = class Screenshare extends EventEmitter {
           });
 
           // Capturing stop transcoder responses from the 2x model
-          this._BigBlueButtonGW.on(C.STOP_TRANSCODER_RESP_2x, async (payload) => {
+          this._BigBlueButtonGW.once(C.STOP_TRANSCODER_RESP_2x+this._meetingId, async (payload) => {
             Logger.info(payload);
             let meetingId = payload[C.MEETING_ID_2x];
             if(this._meetingId === meetingId) {
@@ -372,14 +372,14 @@ module.exports = class Screenshare extends EventEmitter {
       // Checking if transcoder is avaiable; if so, transposes the stream to RTMP
       if (isTranscoderAvailable) {
         // Interoperability: capturing 1.1 start_transcoder_reply messages
-        this._BigBlueButtonGW.on(C.START_TRANSCODER_REPLY, (payload) => {
+        this._BigBlueButtonGW.once(C.START_TRANSCODER_REPLY+this._meetingId, (payload) => {
           let meetingId = payload[C.MEETING_ID];
           let output = payload["params"].output;
           this._startRtmpBroadcast(meetingId, output);
         });
 
         // Capturing stop transcoder responses from the 2x model
-        this._BigBlueButtonGW.on(C.START_TRANSCODER_RESP_2x, (payload) => {
+        this._BigBlueButtonGW.once(C.START_TRANSCODER_RESP_2x+this._meetingId, (payload) => {
           let meetingId = payload[C.MEETING_ID_2x];
           let output = payload["params"].output;
           this._startRtmpBroadcast(meetingId, output);
@@ -414,15 +414,13 @@ module.exports = class Screenshare extends EventEmitter {
 
   _startRtmpBroadcast (meetingId, output) {
     Logger.info("[screenshare] _startRtmpBroadcast for meeting", + meetingId);
-    if (this._meetingId === meetingId) {
-      let timestamp = now.format('hhmmss');
-      this._streamUrl = MediaHandler.generateStreamUrl(localIpAddress, meetingId, output);
-      let dsrbstam = Messaging.generateScreenshareRTMPBroadcastStartedEvent2x(this._voiceBridge,
-          this._voiceBridge, this._streamUrl, this._vw, this._vh, timestamp);
+    let timestamp = now.format('hhmmss');
+    this._streamUrl = MediaHandler.generateStreamUrl(localIpAddress, meetingId, output);
+    let dsrbstam = Messaging.generateScreenshareRTMPBroadcastStartedEvent2x(this._voiceBridge,
+      this._voiceBridge, this._streamUrl, this._vw, this._vh, timestamp);
 
-      this._BigBlueButtonGW.publish(dsrbstam, C.FROM_VOICE_CONF_SYSTEM_CHAN, function(error) {});
-      this._rtmpBroadcastStarted = true;
-    }
+    this._BigBlueButtonGW.publish(dsrbstam, C.FROM_VOICE_CONF_SYSTEM_CHAN, function(error) {});
+    this._rtmpBroadcastStarted = true;
   }
 
   _onRtpMediaNotFlowing() {

--- a/labs/bbb-webrtc-sfu/lib/screenshare/screenshare.js
+++ b/labs/bbb-webrtc-sfu/lib/screenshare/screenshare.js
@@ -329,21 +329,16 @@ module.exports = class Screenshare extends EventEmitter {
         if (isTranscoderAvailable) {
           // Interoperability: capturing 1.1 stop_transcoder_reply messages
           this._BigBlueButtonGW.once(C.STOP_TRANSCODER_REPLY+this._meetingId, async (payload) => {
-            let meetingId = payload[C.MEETING_ID];
-            if(this._meetingId === meetingId) {
-              await this._stopRtmpBroadcast(meetingId);
-              return resolve();
-            }
+            const meetingId = payload[C.MEETING_ID];
+            await this._stopRtmpBroadcast(meetingId);
+            return resolve();
           });
 
           // Capturing stop transcoder responses from the 2x model
           this._BigBlueButtonGW.once(C.STOP_TRANSCODER_RESP_2x+this._meetingId, async (payload) => {
-            Logger.info(payload);
-            let meetingId = payload[C.MEETING_ID_2x];
-            if(this._meetingId === meetingId) {
-              await this._stopRtmpBroadcast(meetingId);
-              return resolve();
-            }
+            const meetingId = payload[C.MEETING_ID_2x];
+            await this._stopRtmpBroadcast(meetingId);
+            return resolve();
           });
 
           this._BigBlueButtonGW.publish(strm, C.TO_BBB_TRANSCODE_SYSTEM_CHAN, function(error) {});


### PR DESCRIPTION
This improves the resolution handling for screensharing by reducing the max resolution to a factor of 1080p while preserving the original track's aspect ratio. I also fixed a bug with the `rtmpBroadcast` message sending in the SFU component that was messing with the width/height being sent to video-broadcast.

A careful round of testing on this would be welcome.