### PR TITLE
Improve userlist dropdown menu key-board functionality

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/dropdown/list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/list/component.jsx
@@ -63,7 +63,13 @@ export default class DropdownList extends Component {
   handleItemKeyDown(event, callback) {
     const { getDropdownMenuParent } = this.props;
     const { focusedIndex } = this.state;
+
     let nextFocusedIndex = focusedIndex > 0 ? focusedIndex : 0;
+
+    if (focusedIndex === false) {
+      nextFocusedIndex = this.menuRefs.indexOf(document.activeElement);
+    }
+
     const isHorizontal = this.props.horizontal;
     const navigationKeys = {
       previous: KEY_CODES[`ARROW_${isHorizontal ? 'LEFT' : 'UP'}`],

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -319,7 +319,30 @@ const toggleVoice = (userId) => { userId === Auth.userID ? makeCall('toggleSelfV
 
 const changeRole = (userId, role) => { makeCall('changeRole', userId, role); };
 
-const roving = (event, itemCount, changeState) => {
+const roving = (event, itemCount, changeState, getMenuState) => {
+  if (getMenuState && getMenuState() === true) {
+    const menuChildren = document.activeElement.getElementsByTagName('li');
+
+    if ([KEY_CODES.ESCAPE, KEY_CODES.ARROW_LEFT].includes(event.keyCode)) {
+      document.activeElement.click();
+    }
+
+    if ([KEY_CODES.ARROW_UP].includes(event.keyCode)) {
+      menuChildren[menuChildren.length - 1].focus();
+    }
+
+    if ([KEY_CODES.ARROW_DOWN].includes(event.keyCode)) {
+      for (let i = 0; i < menuChildren.length; i += 1) {
+        if (menuChildren[i].hasAttribute('tabIndex')) {
+          menuChildren[i].focus();
+          break;
+        }
+      }
+    }
+
+    return;
+  }
+
   if (this.selectedIndex === undefined) {
     this.selectedIndex = -1;
   }
@@ -350,7 +373,7 @@ const roving = (event, itemCount, changeState) => {
     changeState(this.selectedIndex);
   }
 
-  if ([KEY_CODES.ARROW_RIGHT, KEY_CODES.SPACE].includes(event.keyCode)) {
+  if ([KEY_CODES.ARROW_RIGHT, KEY_CODES.SPACE, KEY_CODES.ENTER].includes(event.keyCode)) {
     document.activeElement.firstChild.click();
   }
 };

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
@@ -98,8 +98,8 @@ class UserParticipants extends Component {
     this.focusUserItem = this.focusUserItem.bind(this);
     this.changeState = this.changeState.bind(this);
     this.getUsers = this.getUsers.bind(this);
-    this.setMenuState = this.setMenuState.bind(this);
-    this.getMenuState = this.getMenuState.bind(this);
+    this.setDropdownOpenState = this.setDropdownOpenState.bind(this);
+    this.getDropdownOpenState = this.getDropdownOpenState.bind(this);
   }
 
   componentDidMount() {
@@ -110,7 +110,7 @@ class UserParticipants extends Component {
           event,
           this.props.users.length,
           this.changeState,
-          this.getMenuState,
+          this.getDropdownOpenState,
         ),
       );
     }
@@ -126,11 +126,11 @@ class UserParticipants extends Component {
     }
   }
 
-  setMenuState(state) {
+  setDropdownOpenState(state) {
     this.setState({ dropdownIsOpen: state });
   }
 
-  getMenuState() {
+  getDropdownOpenState() {
     return this.state.dropdownIsOpen;
   }
 
@@ -225,7 +225,7 @@ class UserParticipants extends Component {
             normalizeEmojiName={normalizeEmojiName}
             isMeetingLocked={isMeetingLocked}
             getScrollContainerRef={this.getScrollContainerRef}
-            setMenuState={this.setMenuState}
+            setDropdownOpenState={this.setDropdownOpenState}
           />
         </div>
       </CSSTransition>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
@@ -111,7 +111,6 @@ class UserParticipants extends Component {
           this.props.users.length,
           this.changeState,
           this.getMenuState,
-          this.setMenuState,
         ),
       );
     }

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
@@ -88,6 +88,7 @@ class UserParticipants extends Component {
 
     this.state = {
       index: -1,
+      dropdownIsOpen: false,
     };
 
     this.userRefs = [];
@@ -97,6 +98,8 @@ class UserParticipants extends Component {
     this.focusUserItem = this.focusUserItem.bind(this);
     this.changeState = this.changeState.bind(this);
     this.getUsers = this.getUsers.bind(this);
+    this.setMenuState = this.setMenuState.bind(this);
+    this.getMenuState = this.getMenuState.bind(this);
   }
 
   componentDidMount() {
@@ -107,6 +110,8 @@ class UserParticipants extends Component {
           event,
           this.props.users.length,
           this.changeState,
+          this.getMenuState,
+          this.setMenuState,
         ),
       );
     }
@@ -120,6 +125,14 @@ class UserParticipants extends Component {
     if (this.state.index !== prevState.index) {
       this.focusUserItem(this.state.index);
     }
+  }
+
+  setMenuState(state) {
+    this.setState({ dropdownIsOpen: state });
+  }
+
+  getMenuState() {
+    return this.state.dropdownIsOpen;
   }
 
   getScrollContainerRef() {
@@ -168,12 +181,12 @@ class UserParticipants extends Component {
       },
       mute: {
         label: () => intl.formatMessage(intlMessages.MuteUserAudioLabel),
-        handler: (user) => toggleVoice(user.id),
+        handler: user => toggleVoice(user.id),
         icon: 'audio_off',
       },
       unmute: {
         label: () => intl.formatMessage(intlMessages.UnmuteUserAudioLabel),
-        handler: (user) => toggleVoice(user.id),
+        handler: user => toggleVoice(user.id),
         icon: 'audio_on',
       },
       promote: {
@@ -213,6 +226,7 @@ class UserParticipants extends Component {
             normalizeEmojiName={normalizeEmojiName}
             isMeetingLocked={isMeetingLocked}
             getScrollContainerRef={this.getScrollContainerRef}
+            setMenuState={this.setMenuState}
           />
         </div>
       </CSSTransition>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
@@ -31,7 +31,7 @@ const propTypes = {
   isMeetingLocked: PropTypes.func.isRequired,
   normalizeEmojiName: PropTypes.func.isRequired,
   getScrollContainerRef: PropTypes.func.isRequired,
-  setMenuState: PropTypes.func.isRequired,
+  setDropdownOpenState: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
@@ -119,7 +119,7 @@ class UserListItem extends Component {
       meeting={meeting}
       isMeetingLocked={isMeetingLocked}
       getScrollContainerRef={getScrollContainerRef}
-      setMenuState={this.props.setMenuState}
+      setDropdownOpenState={this.props.setDropdownOpenState}
     />);
 
     return contents;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
@@ -31,6 +31,7 @@ const propTypes = {
   isMeetingLocked: PropTypes.func.isRequired,
   normalizeEmojiName: PropTypes.func.isRequired,
   getScrollContainerRef: PropTypes.func.isRequired,
+  setMenuState: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
@@ -118,6 +119,7 @@ class UserListItem extends Component {
       meeting={meeting}
       isMeetingLocked={isMeetingLocked}
       getScrollContainerRef={getScrollContainerRef}
+      setMenuState={this.props.setMenuState}
     />);
 
     return contents;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
@@ -53,7 +53,7 @@ const propTypes = {
   meeting: PropTypes.shape({}).isRequired,
   isMeetingLocked: PropTypes.func.isRequired,
   getScrollContainerRef: PropTypes.func.isRequired,
-  setMenuState: PropTypes.func.isRequired,
+  setDropdownOpenState: PropTypes.func.isRequired,
 };
 
 
@@ -111,7 +111,7 @@ class UserListContent extends Component {
     });
 
     scrollContainer.addEventListener('scroll', this.handleScroll, false);
-    this.props.setMenuState(true);
+    this.props.setDropdownOpenState(true);
   }
 
   onActionsHide() {
@@ -123,8 +123,9 @@ class UserListContent extends Component {
     const scrollContainer = this.props.getScrollContainerRef();
     scrollContainer.removeEventListener('scroll', this.handleScroll, false);
 
+    // setTimeout used to prevent race condition with state updates.
     setTimeout(() => {
-      this.props.setMenuState(false);
+      this.props.setDropdownOpenState(false);
     });
   }
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
@@ -118,15 +118,10 @@ class UserListContent extends Component {
     this.setState({
       isActionsOpen: false,
       dropdownVisible: false,
-    });
+    }, () => this.props.setDropdownOpenState(false));
 
     const scrollContainer = this.props.getScrollContainerRef();
     scrollContainer.removeEventListener('scroll', this.handleScroll, false);
-
-    // setTimeout used to prevent race condition with state updates.
-    setTimeout(() => {
-      this.props.setDropdownOpenState(false);
-    });
   }
 
   getDropdownMenuParent() {

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
@@ -53,6 +53,7 @@ const propTypes = {
   meeting: PropTypes.shape({}).isRequired,
   isMeetingLocked: PropTypes.func.isRequired,
   getScrollContainerRef: PropTypes.func.isRequired,
+  setMenuState: PropTypes.func.isRequired,
 };
 
 
@@ -109,6 +110,7 @@ class UserListContent extends Component {
       dropdownDirection: 'top',
     });
 
+    this.props.setMenuState(true);
     scrollContainer.addEventListener('scroll', this.handleScroll, false);
   }
 
@@ -118,6 +120,7 @@ class UserListContent extends Component {
       dropdownVisible: false,
     });
 
+    this.props.setMenuState(false);
     const scrollContainer = this.props.getScrollContainerRef();
     scrollContainer.removeEventListener('scroll', this.handleScroll, false);
   }
@@ -268,7 +271,7 @@ class UserListContent extends Component {
         aria-live="assertive"
         aria-relevant="additions"
       >
-        <DropdownTrigger>
+        <DropdownTrigger open={dropdownVisible}>
           {contents}
         </DropdownTrigger>
         <DropdownContent

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
@@ -199,6 +199,9 @@ class UserListContent extends Component {
     const userItemContentsStyle = {};
 
     userItemContentsStyle[styles.userItemContentsCompact] = compact;
+    userItemContentsStyle[styles.dropdown] = true;
+    userItemContentsStyle[styles.userListItem] = !this.state.isActionsOpen;
+    userItemContentsStyle[styles.usertListItemWithMenu] = this.state.isActionsOpen;
 
     const you = (user.isCurrent) ? intl.formatMessage(messages.you) : '';
 
@@ -263,13 +266,7 @@ class UserListContent extends Component {
         isOpen={this.state.isActionsOpen}
         onShow={this.onActionsShow}
         onHide={this.onActionsHide}
-        className={
-          cx(
-            styles.dropdown,
-            userItemContentsStyle,
-            this.state.isActionsOpen ? styles.usertListItemWithMenu : styles.userListItem,
-          )
-        }
+        className={cx(userItemContentsStyle)}
         autoFocus={false}
         aria-haspopup="true"
         aria-live="assertive"

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
@@ -272,7 +272,7 @@ class UserListContent extends Component {
             styles.dropdown,
             userItemContentsStyle,
             this.state.isActionsOpen ? styles.usertListItemWithMenu : styles.userListItem,
-)
+          )
         }
         autoFocus={false}
         aria-haspopup="true"

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
@@ -271,7 +271,7 @@ class UserListContent extends Component {
         aria-live="assertive"
         aria-relevant="additions"
       >
-        <DropdownTrigger open={dropdownVisible}>
+        <DropdownTrigger>
           {contents}
         </DropdownTrigger>
         <DropdownContent

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
@@ -203,7 +203,6 @@ class UserListContent extends Component {
     const userItemContentsStyle = {};
 
     userItemContentsStyle[styles.userItemContentsCompact] = compact;
-    userItemContentsStyle[styles.active] = isActionsOpen;
 
     const you = (user.isCurrent) ? intl.formatMessage(messages.you) : '';
 
@@ -223,7 +222,7 @@ class UserListContent extends Component {
 
     const contents = (
       <div
-        className={!actions.length ? cx(styles.userListItem, userItemContentsStyle) : null}
+        className={!actions.length ? cx(styles.userListItem) : null}
       >
         <div className={styles.userItemContents}>
           <div className={styles.userAvatar}>
@@ -268,7 +267,13 @@ class UserListContent extends Component {
         isOpen={this.state.isActionsOpen}
         onShow={this.onActionsShow}
         onHide={this.onActionsHide}
-        className={cx(styles.dropdown, styles.userListItem, userItemContentsStyle)}
+        className={
+          cx(
+            styles.dropdown,
+            userItemContentsStyle,
+            this.state.isActionsOpen ? styles.usertListItemWithMenu : styles.userListItem,
+)
+        }
         autoFocus={false}
         aria-haspopup="true"
         aria-live="assertive"

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
@@ -110,8 +110,8 @@ class UserListContent extends Component {
       dropdownDirection: 'top',
     });
 
-    this.props.setMenuState(true);
     scrollContainer.addEventListener('scroll', this.handleScroll, false);
+    this.props.setMenuState(true);
   }
 
   onActionsHide() {
@@ -120,9 +120,12 @@ class UserListContent extends Component {
       dropdownVisible: false,
     });
 
-    this.props.setMenuState(false);
     const scrollContainer = this.props.getScrollContainerRef();
     scrollContainer.removeEventListener('scroll', this.handleScroll, false);
+
+    setTimeout(() => {
+      this.props.setMenuState(false);
+    });
   }
 
   getDropdownMenuParent() {

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/component.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { defineMessages } from 'react-intl';
-import cx from 'classnames';
 import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import UserAvatar from '/imports/ui/components/user-avatar/component';
@@ -221,7 +220,7 @@ class UserListContent extends Component {
 
     const contents = (
       <div
-        className={!actions.length ? cx(styles.userListItem) : null}
+        className={!actions.length ? styles.userListItem : null}
       >
         <div className={styles.userItemContents}>
           <div className={styles.userAvatar}>
@@ -266,7 +265,7 @@ class UserListContent extends Component {
         isOpen={this.state.isActionsOpen}
         onShow={this.onActionsShow}
         onHide={this.onActionsHide}
-        className={cx(userItemContentsStyle)}
+        className={userItemContentsStyle}
         autoFocus={false}
         aria-haspopup="true"
         aria-live="assertive"

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/styles.scss
@@ -71,14 +71,6 @@
   background-color: $list-item-bg-hover;
 }
 
-.userListItemWithMenu {
-
-  @extend %list-item;
-  flex-flow: column;
-  flex-shrink: 0;
-  box-shadow: none !important;
-}
-
 .userListItem {
 
   @extend %list-item;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-list-content/styles.scss
@@ -67,6 +67,18 @@
   outline: none;
 }
 
+.usertListItemWithMenu {
+  background-color: $list-item-bg-hover;
+}
+
+.userListItemWithMenu {
+
+  @extend %list-item;
+  flex-flow: column;
+  flex-shrink: 0;
+  box-shadow: none !important;
+}
+
 .userListItem {
 
   @extend %list-item;


### PR DESCRIPTION
This fixes #5394 

* up / down arrow -> cycle through users in userlist (if menu is closed)
* up / down arrow  -> cycle through open menu options (if menu is open)
* Removes box shadow on the userlist item with an open menu