### PR TITLE
Fix WebRTCDesktopViewWindow not being closed properly

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/managers/ViewerWindowManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/managers/ViewerWindowManager.as
@@ -54,8 +54,10 @@ package org.bigbluebutton.modules.screenshare.managers {
         
         public function handleViewWindowCloseEvent():void {
             LOGGER.debug("ViewerWindowManager Received stop viewing command");
-            closeWindow(viewWindow);
-            isViewing = false;
+            if (viewWindow) {
+                closeWindow(viewWindow);
+                isViewing = false;
+            }
         }
         
         private function closeWindow(window:IBbbModuleWindow):void {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/managers/WebRTCViewerWindowManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/managers/WebRTCViewerWindowManager.as
@@ -44,6 +44,7 @@ package org.bigbluebutton.modules.screenshare.managers
 		}
 
 		public function stopViewing():void {
+			LOGGER.debug("Received stop viewing command");
 			if (isViewing) viewWindow.stopViewing();
 		}
 
@@ -54,7 +55,7 @@ package org.bigbluebutton.modules.screenshare.managers
 		}
 
 		public function handleViewWindowCloseEvent():void {
-			LOGGER.debug("ViewerWindowManager Received stop viewing command");
+			LOGGER.debug("Received close view window event");
 			closeWindow(viewWindow);
 			isViewing = false;
 		}
@@ -66,7 +67,7 @@ package org.bigbluebutton.modules.screenshare.managers
 		}
 
 		public function startViewing(rtmp:String, videoWidth:Number, videoHeight:Number):void{
-			LOGGER.debug("ViewerWindowManager::startViewing");
+			LOGGER.debug("startViewing");
 
 			viewWindow = new WebRTCDesktopViewWindow();
 			viewWindow.startVideo(rtmp, videoWidth, videoHeight);

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopViewWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopViewWindow.mxml
@@ -63,7 +63,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.main.events.BBBEvent;
 			import org.bigbluebutton.main.views.MainCanvas;
 			import org.bigbluebutton.modules.screenshare.events.ViewStreamEvent;
-			import org.bigbluebutton.modules.screenshare.events.ViewWindowEvent;
+			import org.bigbluebutton.modules.screenshare.events.WebRTCViewWindowEvent;
 			import org.bigbluebutton.modules.screenshare.model.ScreenshareOptions;
 			import org.bigbluebutton.modules.screenshare.services.red5.WebRTCConnectionEvent;
 			import org.bigbluebutton.util.ConnUtil;
@@ -421,7 +421,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 
 			private function closeWindow():void {
-				dispatchEvent(new ViewWindowEvent(ViewWindowEvent.CLOSE));
+				dispatchEvent(new WebRTCViewWindowEvent(WebRTCViewWindowEvent.CLOSE));
 			}
 
 			override protected function resourcesChanged():void{


### PR DESCRIPTION
The wrong event was being fired by the WebRTCDesktopViewWindow which resulted in it not being closed when the Screenshare Module was shutdown. This PR changes the event from the WindowCloseEvent to the WebRTCWindowCloseEvent.