### PR TITLE
Cleanup video stream on reconnect

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserBroadcastCamStopMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserBroadcastCamStopMsgHdlr.scala
@@ -18,15 +18,6 @@ trait UserBroadcastCamStopMsgHdlr {
     }
   }
 
-  def handleUserBroadcastCamStopMsg(userId: String): Unit = {
-    for {
-      uvo <- Webcams.findWebcamsForUser(liveMeeting.webcams, userId)
-      _ <- Webcams.removeWebcamBroadcastStream(liveMeeting.webcams, uvo.streamId)
-    } yield {
-      broadcastUserBroadcastCamStoppedEvtMsg(uvo.streamId, userId)
-    }
-  }
-
   def broadcastUserBroadcastCamStoppedEvtMsg(streamId: String, userId: String): Unit = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, props.meetingProp.intId, userId)
     val envelope = BbbCoreEnvelope(UserBroadcastCamStoppedEvtMsg.NAME, routing)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
@@ -19,9 +19,6 @@ trait UserLeaveReqMsgHdlr {
     } yield {
       log.info("User left meeting. meetingId=" + props.meetingProp.intId + " userId=" + u.intId + " user=" + u)
 
-      // stop the webcams of a user leaving
-      handleUserBroadcastCamStopMsg(msg.body.userId)
-
       captionApp2x.handleUserLeavingMsg(msg.body.userId)
       stopAutoStartedRecording()
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -171,7 +171,6 @@ class ReceivedJsonMsgHandlerActor(
       case GetWhiteboardAnnotationsReqMsg.NAME =>
         routeGenericMsg[GetWhiteboardAnnotationsReqMsg](envelope, jsonNode)
       case ClientToServerLatencyTracerMsg.NAME =>
-        log.info("-- trace --" + jsonNode.toString)
         routeGenericMsg[ClientToServerLatencyTracerMsg](envelope, jsonNode)
 
       // Presentation

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
@@ -75,6 +75,10 @@ class AnalyticsActor extends Actor with ActorLogging {
       case m: StartRecordingVoiceConfSysMsg => logMessage(msg)
       case m: StopRecordingVoiceConfSysMsg => logMessage(msg)
       case m: TransferUserToVoiceConfSysMsg => logMessage(msg)
+      case m: UserBroadcastCamStartMsg => logMessage(msg)
+      case m: UserBroadcastCamStopMsg => logMessage(msg)
+      case m: UserBroadcastCamStoppedEvtMsg => logMessage(msg)
+      case m: UserBroadcastCamStartedEvtMsg => logMessage(msg)
 
       // Breakout
       case m: BreakoutRoomEndedEvtMsg => logMessage(msg)

--- a/bbb-video/src/main/java/org/bigbluebutton/app/video/VideoApplication.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/app/video/VideoApplication.java
@@ -45,6 +45,7 @@ import org.springframework.util.StringUtils;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 
 public class VideoApplication extends MultiThreadedApplicationAdapter {
@@ -390,6 +391,7 @@ public class VideoApplication extends MultiThreadedApplicationAdapter {
     	String meetingId = conn.getScope().getName();
     	String streamId = stream.getPublishedName();
 
+			publisher.sendVideoStreamStartedMsg(meetingId, userId, streamId);
 
 			Matcher matcher = RECORD_STREAM_ID_PATTERN.matcher(stream.getPublishedName());
 			addH263PublishedStream(streamId);
@@ -438,6 +440,17 @@ public class VideoApplication extends MultiThreadedApplicationAdapter {
   		String userId = getUserId();
   		String meetingId = conn.getScope().getName();
   		String streamId = stream.getPublishedName();
+
+			try {
+				// Need to extract usrId from streamId (medium-w_npxfdr8lssbq-1526051556133) as
+				// when connection is closed, userId info is gone. We are interested in the
+				// second portion of the streamId (ralam may 11, 2018)
+				String[] splitArray = streamId.split("-");
+				userId = splitArray[1];
+				publisher.sendVideoStreamStoppedMsg(meetingId, userId, streamId);
+			} catch (PatternSyntaxException ex) {
+				log.warn("Cannot split streamId " + streamId);
+			}
 
 			Matcher matcher = RECORD_STREAM_ID_PATTERN.matcher(stream.getPublishedName());
 			removeH263ConverterIfNeeded(streamId);

--- a/bbb-video/src/main/java/org/bigbluebutton/red5/pubsub/MessagePublisher.java
+++ b/bbb-video/src/main/java/org/bigbluebutton/red5/pubsub/MessagePublisher.java
@@ -51,6 +51,40 @@ public class MessagePublisher {
 		sender.send("to-akka-apps-redis-channel", json);
 	}
 
+	public void sendVideoStreamStartedMsg(String meetingId, String userId, String streamId) {
+		BbbClientMsgHeader header = new BbbClientMsgHeader("UserBroadcastCamStartMsg", meetingId, userId);
+		UserBroadcastCamStartMsgBody body = new UserBroadcastCamStartMsgBody(streamId);
+		UserBroadcastCamStartMsg msg = new UserBroadcastCamStartMsg(header, body);
+		Map<String, String> routing = buildRouting();
+		Map<String, Object> envelope = buildEnvelope("UserBroadcastCamStartMsg", routing);
+
+		Map<String, Object> fullmsg = new HashMap<String, Object>();
+		fullmsg.put("envelope", envelope);
+		fullmsg.put("core", msg);
+
+		Gson gson = new Gson();
+		String json = gson.toJson(fullmsg);
+
+		sender.send("to-akka-apps-redis-channel", json);
+	}
+
+	public void sendVideoStreamStoppedMsg(String meetingId, String userId, String streamId) {
+		BbbClientMsgHeader header = new BbbClientMsgHeader("UserBroadcastCamStopMsg", meetingId, userId);
+		UserBroadcastCamStopMsgBody body = new UserBroadcastCamStopMsgBody(streamId);
+		UserBroadcastCamStopMsg msg = new UserBroadcastCamStopMsg(header, body);
+		Map<String, String> routing = buildRouting();
+		Map<String, Object> envelope = buildEnvelope("UserBroadcastCamStopMsg", routing);
+
+		Map<String, Object> fullmsg = new HashMap<String, Object>();
+		fullmsg.put("envelope", envelope);
+		fullmsg.put("core", msg);
+
+		Gson gson = new Gson();
+		String json = gson.toJson(fullmsg);
+
+		sender.send("to-akka-apps-redis-channel", json);
+	}
+
 	// Polling
 	/*
 	public void userSharedWebcamMessage(String meetingId, String userId, String streamId) {

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/UserService.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/UserService.as
@@ -221,11 +221,19 @@ package org.bigbluebutton.main.model.users
 		}
 				
 		public function addStream(e:BroadcastStartedEvent):void {
-      sender.addStream(e.userid, e.stream);
+			// Do not do anything. We are having the server (red5 bbb-video)
+			// send the start stream event. This way, we are sure that the event
+			// is dispatched even if we loose message path if connection is
+			// disconnected (ralam may 11, 2018)
+      //sender.addStream(e.userid, e.stream);
 		}
 		
 		public function removeStream(e:BroadcastStoppedEvent):void {
-      sender.removeStream(e.userid, e.stream);
+			// Do not do anything. We are having the server (red5 bbb-video)
+			// send the stop stream event. This way, we are sure that the event
+			// is dispatched even if we loose message path if connection is
+			// disconnected (ralam may 11, 2018)
+      //sender.removeStream(e.userid, e.stream);
 		}
 		
 		public function emojiStatus(e:EmojiStatusEvent):void {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
@@ -756,9 +756,11 @@ package org.bigbluebutton.modules.users.services
 			logData.streamId = stream;
       LOGGER.info(JSON.stringify(logData));
       
-      LiveMeeting.inst().webcams.remove(stream);
+      var mediaStream: MediaStream = LiveMeeting.inst().webcams.remove(stream);
       
-      sendStreamStoppedEvent(userId, stream);
+			if (mediaStream != null) {
+      	sendStreamStoppedEvent(mediaStream.userId, stream);
+			}
     }
     
     private function sendStreamStoppedEvent(userId: String, streamId: String):void{


### PR DESCRIPTION
Currently, the flash client is the one sending the start/stop webcam stream messages to the server. When the connections to red5 from the client is auto-reconnecting, these messages might not reach the server resulting in multiple or missing webcam displays.

Have bbb-video in red5 instead send the start/stop stream messages. Red5 will detect if the connection with the stream disconnected so it will send the stop stream message.