### PR TITLE
 - change red5 screenshare log format

### DIFF
--- a/bbb-screenshare/app/src/main/webapp/WEB-INF/classes/logback-screenshare.xml
+++ b/bbb-screenshare/app/src/main/webapp/WEB-INF/classes/logback-screenshare.xml
@@ -11,7 +11,7 @@
 
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>%d{ISO8601} [%thread] %-5level %logger{35} - %msg%n</pattern>
+		<pattern>%d{"yyyy-MM-dd HH:mm:ss,SSSXXX"} [%thread] %-5level %logger{35} - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Change red5 screenshare log format to be the same as other red5 logs.