### PR TITLE
Use Mac mic permission image everywhere, but Windows

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
@@ -611,21 +611,20 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
                 var browserPermissionHelper:BrowserPermissionHelper = PopUpUtil.createModalPopUp(FlexGlobals.topLevelApplication as DisplayObject, BrowserPermissionHelper, false) as BrowserPermissionHelper;
                 if (BrowserCheck.isFirefox()) {
                     if (browserPermissionHelper) {
-						if (Capabilities.os.indexOf("Mac") >= 0){
-							browserPermissionHelper.currentState = "firefoxMicMacOSX";
-						}
-						else {
+						if (Capabilities.os.indexOf("Windows") >= 0) {
 							browserPermissionHelper.currentState = "firefoxMic";
+						} else {
+							browserPermissionHelper.currentState = "firefoxMicMacOSX";
 						}
 						browserPermissionHelper.x = 50;
 						browserPermissionHelper.y = 200;
                     }
                 } else if (BrowserCheck.isChrome()) {
                     if (browserPermissionHelper) {
-						if (Capabilities.os.indexOf("Mac") >= 0){
-							browserPermissionHelper.currentState = "chromeMicMacOSX";
-						} else {
+						if (Capabilities.os.indexOf("Windows") >= 0) {
 							browserPermissionHelper.currentState = "chromeMic";
+						} else {
+							browserPermissionHelper.currentState = "chromeMicMacOSX";
 						}
 						browserPermissionHelper.x = 50;
 						browserPermissionHelper.y = 130;


### PR DESCRIPTION
This PR fixes #5484. 

Before we were using the Windows permission images everywhere, but Mac computers. The problem was that Linux follows the Mac format not the Windows format. This PR makes the Mac images the default.