### PR TITLE
Hide connecting icon when screeshare is loaded.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -6,7 +6,7 @@ export default class ScreenshareComponent extends React.Component {
   constructor() {
     super();
     this.state = {
-      hideConnecting: false,
+      loaded: false,
     };
 
     this.hideConnectingIcon = this.hideConnectingIcon.bind(this);
@@ -24,12 +24,12 @@ export default class ScreenshareComponent extends React.Component {
     this.props.unshareScreen();
   }
   hideConnectingIcon() {
-    this.setState({ hideConnecting: true });
+    this.setState({ loaded: true });
   }
 
   render() {
     return (
-      [(<div className={styles.connecting} hidden={this.state.hideConnecting}/>),
+      [!this.state.loaded ? (<div className={styles.connecting} />) : null,
       (<video id="screenshareVideo" style={{ maxHeight: '100%', width: '100%' }} autoPlay playsInline onLoadedData={this.hideConnectingIcon} />)]
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -3,6 +3,14 @@ import React from 'react';
 import { styles } from './styles';
 
 export default class ScreenshareComponent extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      hideConnecting: false,
+    };
+
+    this.hideConnectingIcon = this.hideConnectingIcon.bind(this);
+  }
   componentDidMount() {
     this.props.presenterScreenshareHasStarted();
   }
@@ -15,11 +23,14 @@ export default class ScreenshareComponent extends React.Component {
     this.props.presenterScreenshareHasEnded();
     this.props.unshareScreen();
   }
+  hideConnectingIcon() {
+    this.setState({ hideConnecting: true });
+  }
 
   render() {
     return (
-      [(<div className={styles.connecting} />),
-      (<video id="screenshareVideo" style={{ maxHeight: '100%', width: '100%' }} autoPlay playsInline />)]
+      [(<div className={styles.connecting} hidden={this.state.hideConnecting}/>),
+      (<video id="screenshareVideo" style={{ maxHeight: '100%', width: '100%' }} autoPlay playsInline onLoadedData={this.hideConnectingIcon} />)]
     );
   }
 }


### PR DESCRIPTION
- Currently, when starts a screen share, the connecting icon is behind the video, so when you share a small screen, the icon appears in the background. In my PR the icon is removed from the screen when video is loaded

Closes issue #5514.

My PR: 
![screemshare-mypr](https://user-images.githubusercontent.com/15806883/40060442-ff196b58-582c-11e8-89aa-86d93198f52c.png)

V2: 
![screenshare-v2](https://user-images.githubusercontent.com/15806883/40060453-0659a464-582d-11e8-9b74-40b365ba23ce.png)

