### PR TITLE
RaP: Improve check for record events in archive, sanity scripts

### DIFF
--- a/record-and-playback/core/scripts/archive/archive.rb
+++ b/record-and-playback/core/scripts/archive/archive.rb
@@ -106,15 +106,23 @@ end
 
 def archive_has_recording_marks?(meeting_id, raw_archive_dir)
   BigBlueButton.logger.info("Fetching the recording marks for #{meeting_id}.")
-  has_recording_marks = true
-  begin
-    record_events = BigBlueButton::Events.get_record_status_events("#{raw_archive_dir}/#{meeting_id}/events.xml")
-    BigBlueButton.logger.info("record_events:\n#{BigBlueButton.hash_to_str(record_events)}")
-    has_recording_marks = (not record_events.empty?)
-  rescue => e
-    BigBlueButton.logger.warn("Failed to fetch the recording marks for #{meeting_id}. " + e.to_s)
+
+  # No recording events at all
+  record_events = BigBlueButton::Events.get_record_status_events("#{raw_archive_dir}/#{meeting_id}/events.xml")
+  BigBlueButton.logger.info("record_events:\n#{BigBlueButton.hash_to_str(record_events)}")
+  if record_events.empty?
+    return false
   end
-  has_recording_marks
+
+  # Recorded section of meeting has 0 length
+  duration = BigBlueButton::Events.get_recording_length("#{raw_archive_dir}/#{meeting_id}/events.xml")
+  BigBlueButton.logger.info("record duration: #{duration}")
+  if duration == 0
+    return false
+  end
+
+  # There's recording events, process it
+  return true
 end
 
 

--- a/record-and-playback/core/scripts/sanity/sanity.rb
+++ b/record-and-playback/core/scripts/sanity/sanity.rb
@@ -128,6 +128,13 @@ def check_deskshare_files(raw_dir, meeting_id)
     end
 end
 
+def check_recording_events(raw_dir, meeting_id)
+  duration = BigBlueButton::Events.get_recording_length("#{raw_dir}/#{meeting_id}/events.xml")
+  if duration == 0
+    raise Exception, "Duration of recorded portion of meeting is 0. You must edit the RecordStatusEvent events in #{raw_dir}/#{meeting_id}/events.xml before this meeting can be processed."
+  end
+end
+
 
 opts = Trollop::options do
   opt :meeting_id, "Meeting id to archive", :default => '58f4a6b3-cd07-444d-8564-59116cb53974', :type => String
@@ -150,6 +157,8 @@ begin
 	BigBlueButton.logger.info("Starting sanity check for recording #{meeting_id}.")
 	BigBlueButton.logger.info("Checking events.xml")
 	check_events_xml(raw_archive_dir,meeting_id)
+        BigBlueButton.logger.info("Checking recording events")
+        check_recording_events(raw_archive_dir, meeting_id)
 	BigBlueButton.logger.info("Checking audio")
 	check_audio_files(raw_archive_dir,meeting_id)
     BigBlueButton.logger.info("Checking webcam videos")


### PR DESCRIPTION
There's some cases where you can get 0-duration recordings due to
recording event placement (e.g. a single recording event is the last
event in the events.xml). Detect these cases, and treat them like
no recording marks in the archive script (it will stop the recording
from being automatically processed).

I've also adjusted the sanity script to detect these cases and error
out. The recording processing scripts cannot handle 0-length recordings,
you have to manually edit the events. I've added a message to the
sanity log about this.