### PR TITLE
Temporarily disable uploading on Win Firefox 60+

### DIFF
--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -294,6 +294,7 @@ bbb.fileupload.progBarLbl = Progress:
 bbb.fileupload.fileFormatHint = You can upload any Office or Portable Document Format (PDF) document.  For the best result we recommend uploading a PDF.
 bbb.fileupload.letUserDownload = Enable download of presentation
 bbb.fileupload.letUserDownload.tooltip = Check here if you want the other users to download your presentation
+bbb.fileupload.firefox60Warning.temp = This version of Firefox currently has an issue uploading documents (we are working with Mozilla to resolve).  For the moment, please switch to a different browser (we recommend Chrome) to upload your documents.
 bbb.filedownload.title = Download the Presentations
 bbb.filedownload.close.tooltip = Close
 bbb.filedownload.close.accessibilityName = Close file download window

--- a/bigbluebutton-client/resources/config.xml.template
+++ b/bigbluebutton-client/resources/config.xml.template
@@ -110,6 +110,7 @@
 			baseTabIndex="501"
 			maxFileSize="30"
 			enableDownload="true"
+			disableFirefoxF60Upload="true"
 		/>
 
 		<module name="CaptionModule" url="http://HOST/client/CaptionModule.swf?v=VERSION"

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/model/PresentOptions.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/model/PresentOptions.as
@@ -38,6 +38,9 @@ package org.bigbluebutton.modules.present.model {
 
 		[Bindable]
 		public var enableDownload:Boolean = true;
+		
+		[Bindable]
+		public var disableFirefoxF60Upload:Boolean = true;
 
 		public function PresentOptions() {
 			name = "PresentModule";

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/FileUploadWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/FileUploadWindow.mxml
@@ -55,6 +55,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     <![CDATA[
 		import flash.utils.setTimeout;
 		
+		import flashx.textLayout.formats.Direction;
+		
 		import mx.collections.ArrayCollection;
 		import mx.controls.listClasses.IListItemRenderer;
 		import mx.core.mx_internal;
@@ -62,8 +64,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		import mx.events.ListEvent;
 		import mx.managers.PopUpManager;
 		import mx.utils.StringUtil;
-		
-		import flashx.textLayout.formats.Direction;
 		
 		import org.as3commons.lang.StringUtils;
 		import org.as3commons.logging.api.ILogger;
@@ -92,6 +92,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		import org.bigbluebutton.modules.present.model.PresentOptions;
 		import org.bigbluebutton.modules.present.model.Presentation;
 		import org.bigbluebutton.modules.present.model.PresentationModel;
+		import org.bigbluebutton.util.browser.BrowserCheck;
 		import org.bigbluebutton.util.i18n.ResourceUtil;
 		
 		use namespace mx_internal;
@@ -116,7 +117,13 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			updateStyles();
 			
 			// For an unknown reason this popup cannot be centred directly using PopUpUtil
-			PopUpManager.centerPopUp(this)
+			PopUpManager.centerPopUp(this);
+			
+			// All of the code around the "firefox60" state is just a temporary stop gap to mitigate a regression 
+			// in file uploading in Firefox 60+
+			if (presentOptions.disableFirefoxF60Upload && Capabilities.os.indexOf("Windows") != -1 && BrowserCheck.isFirefox() && BrowserCheck.browserMajorVersion >= "60") {
+				currentState = "firefox60";
+			}
 		}
 		
 		private function updateStyles() : void {
@@ -380,6 +387,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		<mx:State name="normal" />
 		<mx:State name="uploading" />
 		<mx:State name="error" />
+		<mx:State name="firefox60" />
 	</mx:states>
 	
 
@@ -405,12 +413,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
                  enabled="false"/>
     </mx:HBox>
 
-    <mx:CheckBox id="letUserDownload" label="{ResourceUtil.getInstance().getString('bbb.fileupload.letUserDownload')}" selected="false" excludeFrom="error"
+    <mx:CheckBox id="letUserDownload" label="{ResourceUtil.getInstance().getString('bbb.fileupload.letUserDownload')}" selected="false" excludeFrom="error, firefox60"
 				 toolTip="{ResourceUtil.getInstance().getString('bbb.fileupload.letUserDownload.tooltip')}"
 				 paddingLeft="5" paddingTop="5" visible="{presentOptions.enableDownload}" includeInLayout="{presentOptions.enableDownload}"/>
 	  
     <mx:VBox id="progressReportBox" width="100%" paddingLeft="10" paddingRight="10" paddingTop="5" paddingBottom="5" verticalAlign="middle"
-			 includeInLayout="true" visible="false" excludeFrom="error">
+			 includeInLayout="true" visible="false" excludeFrom="error, firefox60">
 	  <mx:Text id="progressBarLabel" styleName="presentationUploadProgressBarLabel"
 			   visible="{progressBar.visible}" width="100%" text="{ResourceUtil.getInstance().getString('bbb.fileupload.progBarLbl')}" />
       <mx:ProgressBar id="progressBar" mode="manual"
@@ -423,6 +431,14 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				  label="{ResourceUtil.getInstance().getString('bbb.fileupload.retry')}" click="retryButtonClikcHandler(event)"/>
 	</mx:VBox>
 
+	  <!-- ** Temporary warning due to file upload regression in Firefox 60+ ** -->
+	  <mx:Box width="100%" height="100%" paddingLeft="5" paddingRight="5" includeIn="firefox60">
+		  <mx:Box width="100%" height="100%" styleName="presentationUploadFileFormatHintBoxStyle">
+			  <mx:Text width="100%" id="firefox60WarnLbl" textAlign="center" text="{ResourceUtil.getInstance().getString('bbb.fileupload.firefox60Warning.temp')}" styleName="presentationUploadFileFormatHintTextStyle"/>
+		  </mx:Box>
+	  </mx:Box>
+	  <!-- ******************************************************************** -->
+	  
     <mx:List id="uploadedFilesList" rowCount="{presentationNamesAC.length > 3 ? Math.min(6, presentationNamesAC.length) : 3}" width="100%" styleName="presentationFilesList"
              itemRenderer="org.bigbluebutton.modules.present.ui.views.UploadedPresentationRenderer"
 		     itemRollOver="onItemRollOver(event)" itemRollOut="onItemRollOut(event)"


### PR DESCRIPTION
There's been some sort of regression in Firefox 60+ related to file uploading, see issue #5564. This PR replaces the file select with a warning to use a different browser. Once the problem is fixed or a workaround is discovered we can revert these changes.