### PR TITLE
Add a 64-bit check to the Firefox 60+ upload block

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/FileUploadWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/present/ui/views/FileUploadWindow.mxml
@@ -121,7 +121,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 			// All of the code around the "firefox60" state is just a temporary stop gap to mitigate a regression 
 			// in file uploading in Firefox 60+
-			if (presentOptions.disableFirefoxF60Upload && Capabilities.os.indexOf("Windows") != -1 && BrowserCheck.isFirefox() && BrowserCheck.browserMajorVersion >= "60") {
+			if (presentOptions.disableFirefoxF60Upload && Capabilities.os.indexOf("Windows") != -1 &&
+				BrowserCheck.isFirefox() && BrowserCheck.browserMajorVersion >= "60" && BrowserCheck.isWin64()) {
 				currentState = "firefox60";
 			}
 		}

--- a/bigbluebutton-client/src/org/bigbluebutton/util/browser/BrowserCheck.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/util/browser/BrowserCheck.as
@@ -19,7 +19,7 @@
 
 package org.bigbluebutton.util.browser {
 	import flash.external.ExternalInterface;
-
+	
 	import org.as3commons.lang.StringUtils;
 	import org.as3commons.logging.api.ILogger;
 	import org.as3commons.logging.api.getClassLogger;
@@ -71,6 +71,11 @@ package org.bigbluebutton.util.browser {
 
 		public static function isPuffin46AndAbove():Boolean {
 			return browserName.toLowerCase() == "puffin" && String(_fullVersion).substr(0, 3) >= "4.6";
+		}
+		
+		public static function isWin64():Boolean {
+			var platform:String = ExternalInterface.call("window.navigator.platform.toString");
+			return StringUtils.equals(platform, "Win64");
 		}
 
 		private static function getBrowserInfo():void {


### PR DESCRIPTION
The issue (#5564) doesn't happen on 32-bit Windows so this PR adds a check for 64-bit Windows.