### PR TITLE
Display a toast for screensharing not supported by Safari

### DIFF
--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -480,6 +480,9 @@ window.getScreenConstraints = function (sendSource, callback) {
     // now invoking native getUserMedia API
     callback(null, screenConstraints);
   } else if (isSafari) {
+    document.dispatchEvent(new Event('safariScreenshareNotSupported'));
+    return;
+
     screenConstraints.video.mediaSource = 'screen';
 
     console.log('getScreenConstraints for Safari returns => ', screenConstraints);

--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -480,14 +480,16 @@ window.getScreenConstraints = function (sendSource, callback) {
     // now invoking native getUserMedia API
     callback(null, screenConstraints);
   } else if (isSafari) {
+    // At this time (version 11.1), Safari doesn't support screenshare.
     document.dispatchEvent(new Event('safariScreenshareNotSupported'));
     return;
-
+    
+    /*
     screenConstraints.video.mediaSource = 'screen';
-
     console.log('getScreenConstraints for Safari returns => ', screenConstraints);
     // now invoking native getUserMedia API
     callback(null, screenConstraints);
+    */
   }
 };
 

--- a/bigbluebutton-html5/imports/ui/components/media/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/container.jsx
@@ -20,6 +20,10 @@ const intlMessages = defineMessages({
     id: 'app.media.screenshare.end',
     description: 'toast to show when a screenshare has ended',
   },
+  screenshareSafariNotSupportedError: {
+    id: 'app.media.screenshare.safariNotSupported',
+    description: 'Error message for screenshare not supported on Safari',
+  },
   chromeExtensionError: {
     id: 'app.video.chromeExtensionError',
     description: 'Error message for Chrome Extension not installed',
@@ -35,10 +39,12 @@ class MediaContainer extends Component {
     const { willMount } = this.props;
     willMount && willMount();
     document.addEventListener('installChromeExtension', this.installChromeExtension.bind(this));
+    document.addEventListener('safariScreenshareNotSupported', this.safariScreenshareNotSupported.bind(this));
   }
 
   componentWillUnmount() {
     document.removeEventListener('installChromeExtension', this.installChromeExtension.bind(this));
+    document.removeEventListener('safariScreenshareNotSupported', this.safariScreenshareNotSupported.bind(this));
   }
 
   componentWillReceiveProps(nextProps) {
@@ -70,6 +76,11 @@ class MediaContainer extends Component {
       </a>
     </div>, 'error', 'desktop');
   }
+
+  safariScreenshareNotSupported() {
+    const { intl } = this.props;
+    notify(intl.formatMessage(intlMessages.screenshareSafariNotSupportedError), 'error', 'desktop');
+  }  
 
   render() {
     return <Media {...this.props} />;

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -42,6 +42,7 @@
     "app.media.label": "Media",
     "app.media.screenshare.start": "Screenshare has started",
     "app.media.screenshare.end": "Screenshare has ended",
+    "app.media.screenshare.safariNotSupported": "Screenshare is currently not supported by Safari. Please, use Firefox or Google Chrome.",
     "app.meeting.ended": "This session has ended",
     "app.meeting.endedMessage": "You will be forwarded back to the home screen",
     "app.presentation.presentationToolbar.prevSlideLabel": "Previous slide",


### PR DESCRIPTION
When a user tries to share screen on Safari, display a toast saying it's currently not supported by the browser.