### PR TITLE
Add a new message RecordStatusResetSysMsg to be handled and saved in events.xml

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RecordAndClearPreviousMarkersCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RecordAndClearPreviousMarkersCmdMsgHdlr.scala
@@ -5,6 +5,7 @@ import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core.util.TimeUtil
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait RecordAndClearPreviousMarkersCmdMsgHdlr {
   this: UsersApp =>
@@ -34,6 +35,8 @@ trait RecordAndClearPreviousMarkersCmdMsgHdlr {
       val tracker = state.recordingTracker.resetTimer(TimeUtil.timeNowInMs())
       val event = buildRecordingStatusChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.setBy, msg.body.recording)
       outGW.send(event)
+
+      outGW.send(MsgBuilder.buildRecordStatusResetSysMsg(liveMeeting.props.meetingProp.intId, msg.body.recording, msg.body.setBy))
 
       state.update(tracker)
     } else {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/RecordStatusResetEvent.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/RecordStatusResetEvent.scala
@@ -1,0 +1,39 @@
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ *
+ * Copyright (c) 2017 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.bigbluebutton.core.record.events
+
+class RecordStatusResetEvent extends AbstractParticipantRecordEvent {
+  import RecordStatusResetEvent._
+
+  setEvent("RecordStatusReset")
+
+  def setUserId(userId: String) {
+    eventMap.put(USER_ID, userId)
+  }
+
+  def setRecordingStatus(status: Boolean) {
+    eventMap.put(STATUS, status.toString)
+  }
+}
+
+object RecordStatusResetEvent {
+  protected final val USER_ID = "userId"
+  protected final val STATUS = "status"
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -156,6 +156,16 @@ object MsgBuilder {
     BbbCommonEnvCoreMsg(envelope, event)
   }
 
+  def buildRecordStatusResetSysMsg(meetingId: String, recording: Boolean, setBy: String): BbbCommonEnvCoreMsg = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.SYSTEM, meetingId, setBy)
+    val envelope = BbbCoreEnvelope(RecordStatusResetSysMsg.NAME, routing)
+    val body = RecordStatusResetSysMsgBody(recording, setBy)
+    val header = BbbCoreHeaderWithMeetingId(RecordStatusResetSysMsg.NAME, meetingId)
+    val event = RecordStatusResetSysMsg(header, body)
+
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
+
   def buildDisconnectAllClientsSysMsg(meetingId: String, reason: String): BbbCommonEnvCoreMsg = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.SYSTEM, meetingId, "not-used")
     val envelope = BbbCoreEnvelope(DisconnectAllClientsSysMsg.NAME, routing)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
@@ -90,6 +90,7 @@ class RedisRecorderActor(val system: ActorSystem)
 
       // Meeting
       case m: RecordingStatusChangedEvtMsg          => handleRecordingStatusChangedEvtMsg(m)
+      case m: RecordStatusResetSysMsg               => handleRecordStatusResetSysMsg(m)
       case m: WebcamsOnlyForModeratorChangedEvtMsg  => handleWebcamsOnlyForModeratorChangedEvtMsg(m)
       case m: EndAndKickAllSysMsg                   => handleEndAndKickAllSysMsg(m)
 
@@ -401,6 +402,15 @@ class RedisRecorderActor(val system: ActorSystem)
 
   private def handleRecordingStatusChangedEvtMsg(msg: RecordingStatusChangedEvtMsg) {
     val ev = new RecordStatusRecordEvent()
+    ev.setMeetingId(msg.header.meetingId)
+    ev.setUserId(msg.body.setBy)
+    ev.setRecordingStatus(msg.body.recording)
+
+    record(msg.header.meetingId, ev.toMap)
+  }
+  
+  private def handleRecordStatusResetSysMsg(msg: RecordStatusResetSysMsg) {
+    val ev = new RecordStatusResetEvent()
     ev.setMeetingId(msg.header.meetingId)
     ev.setUserId(msg.body.setBy)
     ev.setRecordingStatus(msg.body.recording)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/SystemMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/SystemMsgs.scala
@@ -86,6 +86,10 @@ case class EndAndKickAllSysMsg(header: BbbCoreHeaderWithMeetingId,
                                       body: EndAndKickAllSysMsgBody) extends BbbCoreMsg
 case class EndAndKickAllSysMsgBody(meetingId: String)
 
+object RecordStatusResetSysMsg {val NAME = "RecordStatusResetSysMsg"}
+case class RecordStatusResetSysMsg(header: BbbCoreHeaderWithMeetingId,
+                                      body: RecordStatusResetSysMsgBody) extends BbbCoreMsg
+case class RecordStatusResetSysMsgBody(recording: Boolean, setBy: String)
 
 object SyncGetMeetingInfoRespMsg { val NAME = "SyncGetMeetingInfoRespMsg"}
   case class SyncGetMeetingInfoRespMsg(header: BbbCoreBaseHeader,


### PR DESCRIPTION
Update for #5534

On @kepstin request this update handle the new record and clear previous marker events and saves it into the following format in `events.xml`
```xml
  <event timestamp="539744812" module="PARTICIPANT" eventname="RecordStatusReset">
    <userId>w_nlw1bcznkpys</userId>
  </event>
```