### PR TITLE
Revert special api changes made for html5 client

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -21,7 +21,7 @@ const fetchStunTurnServers = (sessionToken) => {
   };
 
   const url = `${STUN_TURN_FETCH_URL}?sessionToken=${sessionToken}`;
-  return fetch(url)
+  return fetch(url, { credentials: 'same-origin' })
     .then(res => res.json())
     .then(handleStunTurnResponse)
     .then((response) => {

--- a/bigbluebutton-html5/imports/startup/client/auth.js
+++ b/bigbluebutton-html5/imports/startup/client/auth.js
@@ -19,7 +19,7 @@ export function joinRouteHandler(nextState, replace, callback) {
   // use enter api to get params for the client
   const url = `/bigbluebutton/api/enter?sessionToken=${sessionToken}`;
 
-  fetch(url)
+  fetch(url, { credentials: 'same-origin' })
     .then(response => response.json())
     .then(({ response }) => {
       const {

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/service.js
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/service.js
@@ -10,7 +10,7 @@ const getBreakoutJoinURL = (breakout) => {
     const user = breakout.users.find(u => u.userId === currentUserId);
 
     if (user) {
-      const urlParams = user.urlParams;
+      const { urlParams } = user;
       return [
         window.origin,
         `html5client/join?sessionToken=${urlParams.sessionToken}`,

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1292,13 +1292,17 @@ class ApiController {
     UserSession us = null;
     Meeting meeting = null;
 
-    if (meetingService.getUserSession(sessionToken) == null)
+    if (!session[sessionToken]) {
       reject = true;
-    else {
-      us = meetingService.getUserSession(sessionToken);
-      meeting = meetingService.getMeeting(us.meetingID);
-      if (meeting == null || meeting.isForciblyEnded()) {
-        reject = true
+    } else {
+      if (meetingService.getUserSession(sessionToken) == null) {
+        reject = true;
+      } else {
+        us = meetingService.getUserSession(sessionToken)
+        meeting = meetingService.getMeeting(us.meetingID);
+        if (meeting == null || meeting.isForciblyEnded()) {
+          reject = true
+        }
       }
     }
 
@@ -1416,13 +1420,17 @@ class ApiController {
       println("Session token = [" + sessionToken + "]")
     }
 
-    if (meetingService.getUserSession(sessionToken) == null)
+    if (!session[sessionToken]) {
       reject = true;
-    else {
-      us = meetingService.getUserSession(sessionToken);
-      meeting = meetingService.getMeeting(us.meetingID);
-      if (meeting == null || meeting.isForciblyEnded()) {
-        reject = true
+    } else {
+      if (meetingService.getUserSession(session[sessionToken]) == null)
+        reject = true;
+      else {
+        us = meetingService.getUserSession(session[sessionToken]);
+        meeting = meetingService.getMeeting(us.meetingID);
+        if (meeting == null || meeting.isForciblyEnded()) {
+          reject = true
+        }
       }
     }
 


### PR DESCRIPTION
in PRs #3983 and #4091 we customized bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy so the apis could be used with the login method of the html5 client of the day. Now that we log in via the same method as the Flash client [but with different redirectUrl] we revert back the customizations.
Also needed to add `{ credentials: 'same-origin' }` to that the client uses the correct JSESSIONID when calling `fetch`. Tnx for the tip @oswaldoacauan @capilkey 