### PR TITLE
Improve html5 locale fallback selection

### DIFF
--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -21,9 +21,9 @@ WebApp.connectHandlers.use('/check', (req, res) => {
 
 WebApp.connectHandlers.use('/locale', (req, res) => {
   const APP_CONFIG = Meteor.settings.public.app;
-  const defaultLocale = APP_CONFIG.defaultSettings.application.locale;
+  const fallback = APP_CONFIG.defaultSettings.application.fallbackLocale;
   const localeRegion = req.query.locale.split(/[-_]/g);
-  const localeList = [defaultLocale, localeRegion[0]];
+  const localeList = [fallback, localeRegion[0]];
 
   let normalizedLocale = localeRegion[0];
   let messages = {};
@@ -48,11 +48,11 @@ WebApp.connectHandlers.use('/locale', (req, res) => {
 
 WebApp.connectHandlers.use('/locales', (req, res) => {
   const APP_CONFIG = Meteor.settings.public.app;
-  const defaultLocale = APP_CONFIG.defaultSettings.application.locale;
+  const fallback = APP_CONFIG.defaultSettings.application.fallbackLocale;
 
   let availableLocales = [];
 
-  const defaultLocaleFile = `${defaultLocale}.json`;
+  const defaultLocaleFile = `${fallback}.json`;
   const defaultLocalePath = `locales/${defaultLocaleFile}`;
   const localesPath = Assets.absoluteFilePath(defaultLocalePath).replace(defaultLocaleFile, '');
 

--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -29,9 +29,6 @@ WebApp.connectHandlers.use('/locale', (req, res) => {
 
   const usableLocales = AVAILABLE_LOCALES
     .map(file => file.replace('.json', ''))
-    .map(locale => (
-      locale
-    ))
     .reduce((locales, locale) =>
       (locale.match(browserLocale[0]) ? [...locales, locale] : locales), []);
 

--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -25,20 +25,17 @@ WebApp.connectHandlers.use('/locale', (req, res) => {
   const APP_CONFIG = Meteor.settings.public.app;
   const fallback = APP_CONFIG.defaultSettings.application.fallbackLocale;
   const browserLocale = req.query.locale.split(/[-_]/g);
-
   const localeList = [fallback];
-  let regionDefault = null;
-  const usableLocales = [];
 
-  AVAILABLE_LOCALES
+  const usableLocales = AVAILABLE_LOCALES
     .map(file => file.replace('.json', ''))
     .map(locale => (
       locale
     ))
-    .reduce((i, locale) => {
-      if (locale === browserLocale[0]) regionDefault = locale;
-      if (locale.match(browserLocale[0])) usableLocales.push(locale);
-    }, 0);
+    .reduce((locales, locale) =>
+      (locale.match(browserLocale[0]) ? [...locales, locale] : locales), []);
+
+  const regionDefault = usableLocales.find(locale => browserLocale[0] === locale);
 
   if (regionDefault) localeList.push(regionDefault);
   if (!regionDefault && usableLocales[0]) localeList.push(usableLocales[0]);

--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -5,6 +5,8 @@ import fs from 'fs';
 import Logger from './logger';
 import Redis from './redis';
 
+const AVAILABLE_LOCALES = fs.readdirSync('assets/app/locales');
+
 Meteor.startup(() => {
   const APP_CONFIG = Meteor.settings.public.app;
   const env = Meteor.isDevelopment ? 'development' : 'production';
@@ -25,11 +27,10 @@ WebApp.connectHandlers.use('/locale', (req, res) => {
   const browserLocale = req.query.locale.split(/[-_]/g);
 
   const localeList = [fallback];
-  const getAvailableLocales = fs.readdirSync('assets/app/locales');
   let regionDefault = null;
   const usableLocales = [];
 
-  getAvailableLocales
+  AVAILABLE_LOCALES
     .map(file => file.replace('.json', ''))
     .map(locale => (
       locale
@@ -65,10 +66,9 @@ WebApp.connectHandlers.use('/locale', (req, res) => {
 });
 
 WebApp.connectHandlers.use('/locales', (req, res) => {
-  let availableLocales = [];
+  let locales = [];
   try {
-    const getAvailableLocales = fs.readdirSync('assets/app/locales');
-    availableLocales = getAvailableLocales
+    locales = AVAILABLE_LOCALES
       .map(file => file.replace('.json', ''))
       .map(file => file.replace('_', '-'))
       .map(locale => ({
@@ -81,7 +81,7 @@ WebApp.connectHandlers.use('/locales', (req, res) => {
 
   res.setHeader('Content-Type', 'application/json');
   res.writeHead(200);
-  res.end(JSON.stringify(availableLocales));
+  res.end(JSON.stringify(locales));
 });
 
 WebApp.connectHandlers.use('/feedback', (req, res) => {

--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -25,20 +25,19 @@ WebApp.connectHandlers.use('/locale', (req, res) => {
   const browserLocale = req.query.locale.split(/[-_]/g);
 
   const localeList = [fallback];
-  let getAvailableLocales = fs.readdirSync('assets/app/locales');
+  const getAvailableLocales = fs.readdirSync('assets/app/locales');
   let regionDefault = null;
   const usableLocales = [];
 
-  getAvailableLocales = getAvailableLocales
+  getAvailableLocales
     .map(file => file.replace('.json', ''))
     .map(locale => (
       locale
-    ));
-
-  for (let i = 0; i < getAvailableLocales.length; i += 1) {
-    if (getAvailableLocales[i] === browserLocale[0]) regionDefault = getAvailableLocales[i];
-    if (getAvailableLocales[i].match(browserLocale[0])) usableLocales.push(getAvailableLocales[i]);
-  }
+    ))
+    .reduce((i, locale) => {
+      if (locale === browserLocale[0]) regionDefault = locale;
+      if (locale.match(browserLocale[0])) usableLocales.push(locale);
+    }, 0);
 
   if (regionDefault) localeList.push(regionDefault);
   if (!regionDefault && usableLocales[0]) localeList.push(usableLocales[0]);

--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -35,7 +35,7 @@ WebApp.connectHandlers.use('/locale', (req, res) => {
   const regionDefault = usableLocales.find(locale => browserLocale[0] === locale);
 
   if (regionDefault) localeList.push(regionDefault);
-  if (!regionDefault && usableLocales[0]) localeList.push(usableLocales[0]);
+  if (!regionDefault && usableLocales.length) localeList.push(usableLocales[0]);
 
   let normalizedLocale;
   let messages = {};

--- a/bigbluebutton-html5/imports/ui/components/app/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.scss
@@ -3,6 +3,7 @@
 $navbar-height: 65px; // TODO: Change to NavBar real height
 $actionsbar-height: 75px; // TODO: Change to ActionsBar real height
 $bars-padding: $lg-padding-x - .45rem; // -.45 so user-list and chat title is aligned with the presentation title
+$userlist-handle-width: 5px; // 5px so user-list and chat resize handle render as the same size
 
 .main {
   position: relative;
@@ -120,7 +121,7 @@ $bars-padding: $lg-padding-x - .45rem; // -.45 so user-list and chat title is al
 
 .userlistPad {
   background-color: $color-off-white;
-  width: $border-size-large;
+  width: $userlist-handle-width;
 }
 
 .compact {

--- a/bigbluebutton-html5/private/config/settings-development.json
+++ b/bigbluebutton-html5/private/config/settings-development.json
@@ -21,7 +21,7 @@
           "chatAudioNotifications": false,
           "chatPushNotifications": false,
           "fontSize": "16px",
-          "locale": "en"
+          "fallbackLocale": "en"
         },
         "audio": {
           "inputDeviceId": "undefined",

--- a/bigbluebutton-html5/private/config/settings-production.json
+++ b/bigbluebutton-html5/private/config/settings-production.json
@@ -21,7 +21,7 @@
           "chatAudioNotifications": false,
           "chatPushNotifications": false,
           "fontSize": "16px",
-          "locale": "en"
+          "fallbackLocale": "en"
         },
         "audio": {
           "inputDeviceId": "undefined",


### PR DESCRIPTION
Previously, if the browsers locale was set to "ja", the client would default to "en" because it would not find any "ja.json".

Now, it will check for a viable fallback option.

Example : 
![localefallbackorder](https://user-images.githubusercontent.com/22058534/40613659-72a70542-624d-11e8-9f3a-d29bb7d0564c.png)

also adjusts the width of the userlist re-size handle to match that of the chat.
