### PR TITLE
Disable resizable userlist and chat in mobile views

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -170,7 +170,7 @@ class App extends Component {
           bottomRight: false, bottomLeft: false, topLeft: false }}
         onResize={(e, direction, ref) => {
           const { compactUserList } = this.state;
-          const shouldBeCompact = (e.clientX - ref.offsetLeft) <= USERLIST_COMPACT_WIDTH;
+          const shouldBeCompact = ref.clientWidth <= USERLIST_COMPACT_WIDTH;
           if (compactUserList === shouldBeCompact) return;
           this.setState({ compactUserList: shouldBeCompact });
         }}

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -155,13 +155,26 @@ class App extends Component {
   }
 
   renderUserListResizable() {
+    const { userList } = this.props;
+
+    if (!userList) return null;
+
     return (
       <Resizable
         minWidth="10%"
         maxWidth="20%"
         ref={(node) => { this.resizableUserList = node; }}
-        enable={{ right: true }}
         className={styles.resizableUserList}
+        enable={{
+ top: false,
+right: true,
+bottom: false,
+left: false,
+topRight: false,
+          bottomRight: false,
+bottomLeft: false,
+topLeft: false,
+}}
         onResize={(e, direction, ref) => {
           if (e.clientX - ref.offsetLeft <= 50) this.props.router.push('/');
         }}
@@ -198,7 +211,16 @@ class App extends Component {
         maxWidth="30%"
         ref={(node) => { this.resizableChat = node; }}
         className={styles.resizableChat}
-        enable={{ right: false }}
+        enable={{
+ top: false,
+right: true,
+bottom: false,
+left: false,
+topRight: false,
+          bottomRight: false,
+bottomLeft: false,
+topLeft: false,
+}}
       >
         {this.renderChat()}
       </Resizable>

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -14,6 +14,7 @@ import ChatNotificationContainer from '../chat/notification/container';
 import { styles } from './styles';
 
 const MOBILE_MEDIA = 'only screen and (max-width: 40em)';
+const USERLIST_COMPACT_WIDTH = 50;
 
 const intlMessages = defineMessages({
   userListLabel: {
@@ -89,7 +90,7 @@ class App extends Component {
   handleWindowResize() {
     const { enableResize } = this.state;
     const shouldEnableResize = !window.matchMedia(MOBILE_MEDIA).matches;
-    if (enableResize === shouldEnableResize) return;
+    if(enableResize === shouldEnableResize) return;
 
     this.setState({ enableResize: shouldEnableResize });
   }
@@ -165,18 +166,13 @@ class App extends Component {
         maxWidth="20%"
         ref={(node) => { this.resizableUserList = node; }}
         className={styles.resizableUserList}
-        enable={{
- top: false,
-right: true,
-bottom: false,
-left: false,
-topRight: false,
-          bottomRight: false,
-bottomLeft: false,
-topLeft: false,
-}}
+        enable={{ top: false, right: true, bottom: false, left: false, topRight: false,
+          bottomRight: false, bottomLeft: false, topLeft: false }}
         onResize={(e, direction, ref) => {
-          if (e.clientX - ref.offsetLeft <= 50) this.props.router.push('/');
+          const { compactUserList } = this.state;
+          const shouldBeCompact = (e.clientX - ref.offsetLeft) <= USERLIST_COMPACT_WIDTH;
+          if (compactUserList === shouldBeCompact) return;
+          this.setState({ compactUserList: shouldBeCompact });
         }}
       >
         {this.renderUserList()}
@@ -206,21 +202,13 @@ topLeft: false,
 
     return (
       <Resizable
-        defaultSize={{ width: '22.5%' }}
+        defaultSize={{width: "22.5%"}}
         minWidth="15%"
         maxWidth="30%"
         ref={(node) => { this.resizableChat = node; }}
         className={styles.resizableChat}
-        enable={{
- top: false,
-right: true,
-bottom: false,
-left: false,
-topRight: false,
-          bottomRight: false,
-bottomLeft: false,
-topLeft: false,
-}}
+        enable={{ top: false, right: true, bottom: false, left: false, topRight: false,
+          bottomRight: false, bottomLeft: false, topLeft: false }}
       >
         {this.renderChat()}
       </Resizable>
@@ -293,4 +281,5 @@ topLeft: false,
 
 App.propTypes = propTypes;
 App.defaultProps = defaultProps;
+
 export default injectIntl(App);

--- a/bigbluebutton-html5/imports/ui/components/app/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.scss
@@ -1,6 +1,6 @@
 @import "/imports/ui/stylesheets/variables/_all";
 
-$navbar-height: 65px; // TODO: Change to NavBar real height
+$navbar-height: 63px; // TODO: Change to NavBar real height
 $actionsbar-height: 75px; // TODO: Change to ActionsBar real height
 $bars-padding: $lg-padding-x - .45rem; // -.45 so user-list and chat title is aligned with the presentation title
 
@@ -103,9 +103,6 @@ $bars-padding: $lg-padding-x - .45rem; // -.45 so user-list and chat title is al
 
   @include mq($small-only) {
     padding-top: $navbar-height;
-    padding-top: $navbar-height;
-    height: 100vh;
-    width: 100vw;
   }
 
   @include mq($medium-up) {
@@ -136,9 +133,6 @@ $bars-padding: $lg-padding-x - .45rem; // -.45 so user-list and chat title is al
   @include mq($small-only) {
     z-index: 3;
     padding-top: $navbar-height;
-    padding-top: $navbar-height;
-    height: 100vh;
-    width: 100vw;
   }
 
   @include mq($medium-up) {

--- a/bigbluebutton-html5/imports/ui/components/user-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/component.jsx
@@ -40,15 +40,6 @@ const defaultProps = {
 class UserList extends Component {
   constructor(props) {
     super(props);
-    this.state = {
-      compact: this.props.compact,
-    };
-
-    this.handleToggleCompactView = this.handleToggleCompactView.bind(this);
-  }
-
-  handleToggleCompactView() {
-    this.setState({ compact: !this.state.compact });
   }
 
   render() {

--- a/bigbluebutton-html5/imports/ui/components/user-list/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/container.jsx
@@ -24,7 +24,7 @@ const propTypes = {
   roving: PropTypes.func.isRequired,
 };
 
-const UserListContainer = (props) => <UserList {...props} />;
+const UserListContainer = props => <UserList {...props} />;
 
 UserListContainer.propTypes = propTypes;
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/container.jsx
@@ -24,58 +24,15 @@ const propTypes = {
   roving: PropTypes.func.isRequired,
 };
 
-const UserListContainer = (props) => {
-  const {
-    users,
-    currentUser,
-    openChats,
-    isBreakoutRoom,
-    meeting,
-    getAvailableActions,
-    normalizeEmojiName,
-    isMeetingLocked,
-    isPublicChat,
-    setEmojiStatus,
-    assignPresenter,
-    removeUser,
-    toggleVoice,
-    changeRole,
-    roving,
-    CustomLogoUrl,
-  } = props;
-
-  return (
-    <UserList
-      {...{
-        users,
-        currentUser,
-        openChats,
-        isBreakoutRoom,
-        meeting,
-        getAvailableActions,
-        normalizeEmojiName,
-        isMeetingLocked,
-        isPublicChat,
-        setEmojiStatus,
-        assignPresenter,
-        removeUser,
-        toggleVoice,
-        changeRole,
-        roving,
-        CustomLogoUrl,
-      }
-    }
-    />
-  );
-};
+const UserListContainer = (props) => <UserList {...props} />;
 
 UserListContainer.propTypes = propTypes;
 
-export default withTracker(({ params }) => ({
+export default withTracker(({ chatID, compact }) => ({
   users: Service.getUsers(),
   meeting: Meetings.findOne({}),
   currentUser: Service.getCurrentUser(),
-  openChats: Service.getOpenChats(params.chatID),
+  openChats: Service.getOpenChats(chatID),
   isBreakoutRoom: meetingIsBreakout(),
   getAvailableActions: Service.getAvailableActions,
   normalizeEmojiName: Service.normalizeEmojiName,
@@ -88,4 +45,5 @@ export default withTracker(({ params }) => ({
   changeRole: Service.changeRole,
   roving: Service.roving,
   CustomLogoUrl: Service.getCustomLogoUrl(),
+  compact,
 }))(UserListContainer);


### PR DESCRIPTION
- Disable UserList and Chat components from being resizable in mobile views.
- Prevent NavBar from being hidden on mobile in some cases. Fix #5568 
- Add the userListCompact state in App and pass it down correctly.
- Change the userListCompact state based on the UserList width.
- Remove the action of closing the UserList when the user resize it.

This PR will impact on #5511 