### PR TITLE
Breakout rooms - join by following server-provided url to html5 client

### DIFF
--- a/akka-bbb-apps/scala/BreakoutRoom.sc
+++ b/akka-bbb-apps/scala/BreakoutRoom.sc
@@ -17,7 +17,7 @@ object BreakoutRoom {
                                                   //| pter=com.google.gson.Gso
                                                   //| Output exceeds cutoff limit.
 
-  val string = "{\"payload\":{\"redirectJoinUrl\":\"alink\",\"breakoutMeetingId\":\"4455e780b6f62cd5fcf09367aef62d9bc5108375-1479728671031\",\"noRedirectJoinUrl\":\"http://bbb.riadvice.com/bigbluebutton/api/join?fullName\u003dOpera\u0026isBreakout\u003dtrue\u0026meetingID\u003d4455e780b6f62cd5fcf09367aef62d9bc5108375-1479728671031\u0026password\u003dmp\u0026redirect\u003dfalse\u0026userID\u003d6pt0vfeaxdze_1-1\u0026checksum\u003d51c4a1398b88170c25f1a71521bca604e784ab23\",\"parentMeetingId\":\"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1479728593178\",\"userId\":\"6pt0vfeaxdze_1\"},\"header\":{\"name\":\"BreakoutRoomJoinURL\",\"version\":\"0.0.1\",\"current_time\":1479728673586,\"timestamp\":8549632}}"
+  val string = "{\"payload\":{\"redirectJoinUrl\":\"alink\",\"breakoutMeetingId\":\"4455e780b6f62cd5fcf09367aef62d9bc5108375-1479728671031\",\"redirectToHtml5JoinUrl\":\"http://bbb.riadvice.com/bigbluebutton/api/join?fullName\u003dOpera\u0026isBreakout\u003dtrue\u0026meetingID\u003d4455e780b6f62cd5fcf09367aef62d9bc5108375-1479728671031\u0026password\u003dmp\u0026redirect\u003dfalse\u0026userID\u003d6pt0vfeaxdze_1-1\u0026checksum\u003d51c4a1398b88170c25f1a71521bca604e784ab23\",\"parentMeetingId\":\"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1479728593178\",\"userId\":\"6pt0vfeaxdze_1\"},\"header\":{\"name\":\"BreakoutRoomJoinURL\",\"version\":\"0.0.1\",\"current_time\":1479728673586,\"timestamp\":8549632}}"
                                                   //> string  : String = {"payload":{"redirectJoinUrl":"alink","breakoutMeetingId"
                                                   //| :"4455e780b6f62cd5fcf09367aef62d9bc5108375-1479728671031","noRedirectJoinUrl
                                                   //| ":"http://bbb.riadvice.com/bigbluebutton/api/join?fullName=Opera&isBreakout=
@@ -35,5 +35,5 @@ object BreakoutRoom {
   println(brjum.payload.parentMeetingId)          //> 183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1479728593178
   println(brjum.payload.breakoutMeetingId)        //> 4455e780b6f62cd5fcf09367aef62d9bc5108375-1479728671031
   println(brjum.payload.redirectJoinURL)          //> null
-  println(brjum.payload.noRedirectJoinURL)        //> null
+  println(brjum.payload.redirectToHtml5JoinURL)        //> null
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutApp2x.scala
@@ -56,10 +56,11 @@ object BreakoutRoomsUtil {
       "userID" -> urlEncode(userId),
       "isBreakout" -> urlEncode(isBreakout.toString()),
       "meetingID" -> urlEncode(breakoutMeetingId),
-      "password" -> urlEncode(password)
+      "password" -> urlEncode(password),
+      "redirect" -> urlEncode("true")
     )
 
-    (params + ("redirect" -> urlEncode("true")), params + ("redirect" -> urlEncode("false")))
+    (params, params + ("joinViaHtml5" -> urlEncode("true")))
   }
 
   def sortParams(params: collection.immutable.Map[String, String]): SortedSet[String] = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutHdlrHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutHdlrHelpers.scala
@@ -17,37 +17,37 @@ trait BreakoutHdlrHelpers extends SystemConfiguration {
     for {
       user <- Users2x.findWithIntId(liveMeeting.users2x, userId)
       apiCall = "join"
-      (redirectParams, noRedirectParams) = BreakoutRoomsUtil.joinParams(user.name, userId + "-" + roomSequence, true,
+      (redirectParams, redirectToHtml5Params) = BreakoutRoomsUtil.joinParams(user.name, userId + "-" + roomSequence, true,
         externalMeetingId, liveMeeting.props.password.moderatorPass)
       // We generate a first url with redirect -> true
       redirectBaseString = BreakoutRoomsUtil.createBaseString(redirectParams)
       redirectJoinURL = BreakoutRoomsUtil.createJoinURL(bbbWebAPI, apiCall, redirectBaseString,
         BreakoutRoomsUtil.calculateChecksum(apiCall, redirectBaseString, bbbWebSharedSecret))
-      // We generate a second url with redirect -> false
-      noRedirectBaseString = BreakoutRoomsUtil.createBaseString(noRedirectParams)
-      noRedirectJoinURL = BreakoutRoomsUtil.createJoinURL(bbbWebAPI, apiCall, noRedirectBaseString,
-        BreakoutRoomsUtil.calculateChecksum(apiCall, noRedirectBaseString, bbbWebSharedSecret))
+      // We generate a second url with redirect -> true and joinViaHtml5 -> true
+      redirectToHtml5BaseString = BreakoutRoomsUtil.createBaseString(redirectToHtml5Params)
+      redirectToHtml5JoinURL = BreakoutRoomsUtil.createJoinURL(bbbWebAPI, apiCall, redirectToHtml5BaseString,
+        BreakoutRoomsUtil.calculateChecksum(apiCall, redirectToHtml5BaseString, bbbWebSharedSecret))
     } yield {
       sendJoinURLMsg(liveMeeting.props.meetingProp.intId, breakoutId, externalMeetingId,
-        userId, redirectJoinURL, noRedirectJoinURL)
+        userId, redirectJoinURL, redirectToHtml5JoinURL)
     }
   }
 
   def sendJoinURLMsg(meetingId: String, breakoutId: String, externalId: String,
-                     userId: String, redirectJoinURL: String, noRedirectJoinURL: String): Unit = {
+                     userId: String, redirectJoinURL: String, redirectToHtml5JoinURL: String): Unit = {
     def build(meetingId: String, breakoutId: String,
-              userId: String, redirectJoinURL: String, noRedirectJoinURL: String): BbbCommonEnvCoreMsg = {
+              userId: String, redirectJoinURL: String, redirectToHtml5JoinURL: String): BbbCommonEnvCoreMsg = {
       val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, meetingId, userId)
       val envelope = BbbCoreEnvelope(BreakoutRoomJoinURLEvtMsg.NAME, routing)
       val header = BbbClientMsgHeader(BreakoutRoomJoinURLEvtMsg.NAME, meetingId, userId)
 
       val body = BreakoutRoomJoinURLEvtMsgBody(meetingId, breakoutId, externalId,
-        userId, redirectJoinURL, noRedirectJoinURL)
+        userId, redirectJoinURL, redirectToHtml5JoinURL)
       val event = BreakoutRoomJoinURLEvtMsg(header, body)
       BbbCommonEnvCoreMsg(envelope, event)
     }
 
-    val msgEvent = build(meetingId, breakoutId, userId, redirectJoinURL, noRedirectJoinURL)
+    val msgEvent = build(meetingId, breakoutId, userId, redirectJoinURL, redirectToHtml5JoinURL)
     outGW.send(msgEvent)
 
   }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
@@ -8,7 +8,7 @@ package org.bigbluebutton.common2.msgs
   object BreakoutRoomJoinURLEvtMsg { val NAME = "BreakoutRoomJoinURLEvtMsg" }
   case class BreakoutRoomJoinURLEvtMsg(header: BbbClientMsgHeader, body: BreakoutRoomJoinURLEvtMsgBody) extends BbbCoreMsg
   case class BreakoutRoomJoinURLEvtMsgBody(parentId: String, breakoutId: String, externalId: String,
-                                           userId: String, redirectJoinURL: String, noRedirectJoinURL: String)
+                                           userId: String, redirectJoinURL: String, redirectToHtml5JoinURL: String)
 
   // Outgoing messages
   object BreakoutRoomsListEvtMsg { val NAME = "BreakoutRoomsListEvtMsg" }
@@ -69,7 +69,7 @@ package org.bigbluebutton.common2.msgs
 object RequestBreakoutJoinURLRespMsg { val NAME = "RequestBreakoutJoinURLRespMsg" }
 case class RequestBreakoutJoinURLRespMsg(header: BbbClientMsgHeader, body: RequestBreakoutJoinURLRespMsgBody) extends BbbCoreMsg
 case class RequestBreakoutJoinURLRespMsgBody(parentId: String, breakoutId: String,
-                                             userId: String, redirectJoinURL: String, noRedirectJoinURL: String)
+                                             userId: String, redirectJoinURL: String, redirectToHtml5JoinURL: String)
 
 
   object TransferUserToMeetingEvtMsg { val NAME = "TransferUserToMeetingEvtMsg" }

--- a/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutJoinURL.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutJoinURL.js
@@ -4,12 +4,12 @@ import Breakouts from '/imports/api/breakouts';
 
 export default function handleBreakoutJoinURL({ body }) {
   const {
-    noRedirectJoinURL,
+    redirectToHtml5JoinURL,
     userId,
     breakoutId,
   } = body;
 
-  check(noRedirectJoinURL, String);
+  check(redirectToHtml5JoinURL, String);
 
   const selector = {
     breakoutId,
@@ -20,7 +20,7 @@ export default function handleBreakoutJoinURL({ body }) {
       users: userId,
     },
     $set: {
-      noRedirectJoinURL,
+      redirectToHtml5JoinURL,
     },
   };
 

--- a/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutJoinURL.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutJoinURL.js
@@ -8,7 +8,6 @@ export default function handleBreakoutJoinURL({ body }) {
     userId,
     breakoutId,
   } = body;
-  console.error(body);
 
   check(redirectToHtml5JoinURL, String);
 

--- a/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutJoinURL.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutJoinURL.js
@@ -8,6 +8,7 @@ export default function handleBreakoutJoinURL({ body }) {
     userId,
     breakoutId,
   } = body;
+  console.error(body);
 
   check(redirectToHtml5JoinURL, String);
 
@@ -17,10 +18,10 @@ export default function handleBreakoutJoinURL({ body }) {
 
   const modifier = {
     $push: {
-      users: userId,
-    },
-    $set: {
-      redirectToHtml5JoinURL,
+      users: {
+        userId,
+        redirectToHtml5JoinURL,
+      },
     },
   };
 

--- a/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutJoinURL.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutJoinURL.js
@@ -1,17 +1,6 @@
-import xml2js from 'xml2js';
-import url from 'url';
 import { check } from 'meteor/check';
 import Logger from '/imports/startup/server/logger';
 import Breakouts from '/imports/api/breakouts';
-
-const xmlParser = new xml2js.Parser();
-
-const getUrlParams = (urlToParse) => {
-  const options = { parseQueryString: true };
-  const parsedUrl = url.parse(urlToParse, options);
-  return parsedUrl.query;
-};
-
 
 export default function handleBreakoutJoinURL({ body }) {
   const {
@@ -22,61 +11,33 @@ export default function handleBreakoutJoinURL({ body }) {
 
   check(noRedirectJoinURL, String);
 
-  const urlParams = getUrlParams(noRedirectJoinURL);
-
   const selector = {
     breakoutId,
   };
 
-  const res = Meteor.http.call('get', noRedirectJoinURL);
+  const modifier = {
+    $push: {
+      users: userId,
+    },
+    $set: {
+      noRedirectJoinURL,
+    },
+  };
 
-  xmlParser.parseString(res.content, (err, parsedXML) => {
-    if (err) {
-      return Logger.error(`An Error occured when parsing xml response for: ${noRedirectJoinURL}`);
+  const cb = (cbErr, numChanged) => {
+    if (cbErr) {
+      return Logger.error(`Adding breakout to collection: ${cbErr}`);
     }
 
-    const breakout = Breakouts.findOne(selector);
-
-    const { response } = parsedXML;
-    const users = breakout.users;
-
-    const user = {
-      userId,
-      urlParams: {
-        meetingId: response.meeting_id[0],
-        userId: response.user_id[0],
-        authToken: response.auth_token[0],
-        sessionToken: response.session_token[0],
-      },
-    };
-
-    const userExists = users.find(u => user.userId === u.userId);
-
-    if (userExists) {
-      return null;
+    const {
+      insertedId,
+    } = numChanged;
+    if (insertedId) {
+      return Logger.info(`Added breakout id=${breakoutId}`);
     }
 
-    const modifier = {
-      $push: {
-        users: user,
-      },
-    };
+    return Logger.info(`Upserted breakout id=${breakoutId}`);
+  };
 
-    const cb = (cbErr, numChanged) => {
-      if (cbErr) {
-        return Logger.error(`Adding breakout to collection: ${cbErr}`);
-      }
-
-      const {
-        insertedId,
-      } = numChanged;
-      if (insertedId) {
-        return Logger.info(`Added breakout id=${urlParams.meetingID}`);
-      }
-
-      return Logger.info(`Upserted breakout id=${urlParams.meetingID}`);
-    };
-
-    return Breakouts.upsert(selector, modifier, cb);
-  });
+  return Breakouts.upsert(selector, modifier, cb);
 }

--- a/bigbluebutton-html5/imports/api/breakouts/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/publishers.js
@@ -11,17 +11,12 @@ function breakouts(credentials) {
 
   Logger.info(`Publishing Breakouts for ${meetingId} ${requesterUserId}`);
 
-  return Breakouts.find({
-    $or: [
-      { breakoutId: meetingId },
-      { meetingId },
-      {
-        users: {
-          $elemMatch: { userId: requesterUserId },
-        },
-      },
-    ],
-  });
+  const selector = {
+    parentMeetingId: meetingId,
+    users: requesterUserId,
+  };
+
+  return Breakouts.find(selector);
 }
 
 function publish(...args) {

--- a/bigbluebutton-html5/imports/api/breakouts/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/publishers.js
@@ -12,8 +12,13 @@ function breakouts(credentials) {
   Logger.info(`Publishing Breakouts for ${meetingId} ${requesterUserId}`);
 
   const selector = {
-    parentMeetingId: meetingId,
-    users: requesterUserId,
+    $or: [{
+      parentMeetingId: meetingId,
+      'users.userId': requesterUserId,
+    }, {
+      breakoutId: meetingId,
+    },
+    ],
   };
 
   return Breakouts.find(selector);

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/service.js
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/service.js
@@ -1,25 +1,10 @@
-import Auth from '/imports/ui/services/auth';
 import Breakouts from '/imports/api/breakouts';
 
 const getBreakouts = () => Breakouts.find().fetch();
 
-const getBreakoutJoinURL = (breakout) => {
-  const currentUserId = Auth.userID;
-
-  if (breakout.users) {
-    const user = breakout.users.find(u => u.userId === currentUserId);
-
-    if (user) {
-      const { urlParams } = user;
-      return [
-        window.origin,
-        `html5client/join?sessionToken=${urlParams.sessionToken}`,
-      ].join('/');
-    }
-  }
-  return '';
-};
-
+const getBreakoutJoinURL = breakout =>
+  // experimental
+  breakout.noRedirectJoinURL;
 export default {
   getBreakouts,
   getBreakoutJoinURL,

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/service.js
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/service.js
@@ -4,7 +4,7 @@ const getBreakouts = () => Breakouts.find().fetch();
 
 const getBreakoutJoinURL = breakout =>
   // experimental
-  breakout.noRedirectJoinURL;
+  breakout.redirectToHtml5JoinURL;
 export default {
   getBreakouts,
   getBreakoutJoinURL,

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/service.js
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/service.js
@@ -1,10 +1,21 @@
+import Auth from '/imports/ui/services/auth';
 import Breakouts from '/imports/api/breakouts';
 
 const getBreakouts = () => Breakouts.find().fetch();
 
-const getBreakoutJoinURL = breakout =>
-  // experimental
-  breakout.redirectToHtml5JoinURL;
+const getBreakoutJoinURL = (breakout) => {
+  const currentUserId = Auth.userID;
+
+  if (breakout.users) {
+    const user = breakout.users.find(u => u.userId === currentUserId);
+
+    if (user) {
+      return user.redirectToHtml5JoinURL;
+    }
+  }
+  return '';
+};
+
 export default {
   getBreakouts,
   getBreakoutJoinURL,

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -4998,7 +4998,8 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "scss-tokenizer": {
       "version": "0.2.3",
@@ -6147,6 +6148,7 @@
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dev": true,
       "requires": {
         "sax": "1.2.4",
         "xmlbuilder": "9.0.4"
@@ -6155,7 +6157,8 @@
     "xmlbuilder": {
       "version": "9.0.4",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
-      "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8="
+      "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8=",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.1",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -61,8 +61,7 @@
     "string-hash": "~1.1.3",
     "tippy.js": "~2.0.2",
     "winston": "~2.4.0",
-    "winston-daily-rotate-file": "^1.7.2",
-    "xml2js": "~0.4.19"
+    "winston-daily-rotate-file": "^1.7.2"
   },
   "devDependencies": {
     "autoprefixer": "~7.1.6",


### PR DESCRIPTION
As consequence of #5583 we are required to follow a server-provided link (with a set JSESSIONID) in order to call /enter and obtain information from the server.
This PR modifies `akka-apps` component so the breakout url for html5 users is using `redirect=true` and `joinViaHtml5=true`. This url is propagated to HTML5 server side component where it makes its way into Mongo. The url is then utilized on the appropriate clients.
Dropped dependency on `xml2js` as we no longer need to pull xml and construct url ourselves.