### PR TITLE
Globally catch any unhandled exception

### DIFF
--- a/bigbluebutton-client/branding/default/style/css/V2Theme.css
+++ b/bigbluebutton-client/branding/default/style/css/V2Theme.css
@@ -570,6 +570,14 @@ views|ClientStatusItemRenderer {
 	paddingTop : 0;
 }
 
+.statusCopyStyle {
+	paddingBottom : 6;
+	paddingLeft   : 6;
+	paddingRight  : 6;
+	paddingTop    : 6;
+	fontSize      : 12;
+}
+
 .statusTimeStyle {
 	fontSize   : 10;
 	paddingTop : 0;
@@ -670,19 +678,19 @@ chat|ChatMessageRenderer {
 }
 
 .unreadMessagesBar {
-	backgroundColor            : #1070D7;
-	cornerRadius               : 4;
-	borderStyle                : none;
-	color                      : #FFFFFF;
-	fontSize                   : 13;	
+	backgroundColor : #1070D7;
+	cornerRadius    : 4;
+	borderStyle     : none;
+	color           : #FFFFFF;
+	fontSize        : 13;
 }
 
 .unreadMessagesBarText {
-	textAlign : center;
+	textAlign     : center;
 	paddingBottom : 6;
-	paddingTop : 6;
-	paddingLeft : 12;
-	paddingRight : 12;
+	paddingTop    : 6;
+	paddingLeft   : 12;
+	paddingRight  : 12;
 }
 
 /*
@@ -1790,7 +1798,7 @@ toast|ToastMessageRenderer {
 	iconSuccess                : Embed(source="assets/swf/v2_skin.swf", symbol="Icon_Notification_Success");
 	iconError                  : Embed(source="assets/swf/v2_skin.swf", symbol="Icon_Notification_Error");
 	iconWarning                : Embed(source="assets/swf/v2_skin.swf", symbol="Icon_Notification_Warning");
-	
+
 	iconAudio                  : Embed(source="assets/swf/v2_skin.swf", symbol="Icon_Notification_Audio");
 	iconDesktop                : Embed(source="assets/swf/v2_skin.swf", symbol="Icon_Notification_Desktop");
 }

--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -891,6 +891,11 @@ bbb.notification.recording.stopped = This session is not being recorded anymore
 
 bbb.langSelector.default=Default language
 
+bbb.error.catch.title = An unxpected error was prevented
+bbb.error.catch.message = Error ID {0} occured
+bbb.error.catch.copy = Copy error
+bbb.error.catch.copy.accessibilityName = Copy error to clipboard
+
 bbb.alert.cancel = Cancel
 bbb.alert.ok = OK
 bbb.alert.no = No

--- a/bigbluebutton-client/resources/config.xml.template
+++ b/bigbluebutton-client/resources/config.xml.template
@@ -18,7 +18,7 @@
             showRecordingNotification="true" logoutOnStopRecording="false"
             askForFeedbackOnLogout="false"/>
     <breakoutRooms enabled="true" record="false" privateChateEnabled="true"/>
-    <logging enabled="true" logTarget="trace" level="info" format="{dateUTC} {timeUTC} :: {name} :: [{logLevel}] {message}" uri="http://HOST/log" logPattern=".*"/>
+    <logging enabled="true" logTarget="trace" level="info" format="{dateUTC} {timeUTC} :: {name} :: [{logLevel}] {message}" uri="http://HOST/log" logPattern=".*" reportErrorsInUI="false"/>
     <lock disableCam="false" disableMic="false" disablePrivateChat="false"
           disablePublicChat="false" lockedLayout="false" lockOnJoin="true" lockOnJoinConfigurable="false"/>
 

--- a/bigbluebutton-client/src/BigBlueButton.mxml
+++ b/bigbluebutton-client/src/BigBlueButton.mxml
@@ -22,6 +22,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 <mx:Application xmlns:mx="library://ns.adobe.com/flex/mx"
 				xmlns:fx="http://ns.adobe.com/mxml/2009"
 				xmlns:views="*"
+				xmlns:logging="org.bigbluebutton.common.logging.*"
 				pageTitle="BigBlueButton" 
 				layout="absolute"
 				preinitialize="init()"
@@ -36,13 +37,21 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 	<fx:Script>
 		<![CDATA[
-			import org.bigbluebutton.common.LogUtil;
+			import org.bigbluebutton.common.logging.LogUtil;
 
 			private function init():void {
 				LogUtil.initLogging(true);
 			}
 		]]>
 	</fx:Script>
+	
+	<fx:Declarations>
+		<logging:GlobalExceptionHandler preventDefault="true">
+			<logging:LogHandlerAction/>
+			<logging:DisplayWarningAction />
+		</logging:GlobalExceptionHandler>	
+	</fx:Declarations>
+	
   <views:BigBlueButtonMainContainer id="bbbShell"/>
 
 </mx:Application>

--- a/bigbluebutton-client/src/org/bigbluebutton/common/logging/DisplayWarningAction.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/common/logging/DisplayWarningAction.as
@@ -20,15 +20,23 @@ package org.bigbluebutton.common.logging {
 	import com.adobe.crypto.SHA256;
 	import com.asfusion.mate.events.Dispatcher;
 
+	import org.bigbluebutton.core.Options;
 	import org.bigbluebutton.main.events.ClientStatusEvent;
+	import org.bigbluebutton.main.model.options.LoggingOptions;
 	import org.bigbluebutton.util.i18n.ResourceUtil;
 
 	public class DisplayWarningAction implements GlobalExceptionHandlerAction {
 
 		private var dispatcher:Dispatcher = new Dispatcher();
 
+		private var loggingOptions:LoggingOptions;
+
+		public function DisplayWarningAction():void {
+			loggingOptions = Options.getOptions(LoggingOptions) as LoggingOptions;
+		}
+
 		public function handle(error:Object):void {
-			if (error is Error) {
+			if (loggingOptions.reportErrorsInUI && error is Error) {
 				var errorObj:Error = error as Error;
 				var errorId:String = SHA256.hash(errorObj.getStackTrace()).substr(0, 8);
 				var fullMessage:String = "Error ID : " + errorObj.errorID + "\nUnique ID : " + errorId + "\nMessage : " + errorObj.message + "\n" + errorObj.getStackTrace();

--- a/bigbluebutton-client/src/org/bigbluebutton/common/logging/DisplayWarningAction.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/common/logging/DisplayWarningAction.as
@@ -1,0 +1,39 @@
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ *
+ * Copyright (c) 2018 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.bigbluebutton.common.logging {
+	import com.adobe.crypto.SHA256;
+	import com.asfusion.mate.events.Dispatcher;
+
+	import org.bigbluebutton.main.events.ClientStatusEvent;
+	import org.bigbluebutton.util.i18n.ResourceUtil;
+
+	public class DisplayWarningAction implements GlobalExceptionHandlerAction {
+
+		private var dispatcher:Dispatcher = new Dispatcher();
+
+		public function handle(error:Object):void {
+			if (error is Error) {
+				var errorObj:Error = error as Error;
+				var errorId:String = SHA256.hash(errorObj.getStackTrace()).substr(0, 8);
+				var fullMessage:String = "Error ID : " + errorObj.errorID + "\nUnique ID : " + errorId + "\nMessage : " + errorObj.message + "\n" + errorObj.getStackTrace();
+				dispatcher.dispatchEvent(new ClientStatusEvent(ClientStatusEvent.GLOBAL_EXCEPTION, ResourceUtil.getInstance().getString('bbb.error.catch.title', [errorId]), ResourceUtil.getInstance().getString('bbb.error.catch.message', [errorId]), fullMessage));
+			}
+		}
+	}
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/common/logging/GlobalExceptionHandler.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/common/logging/GlobalExceptionHandler.as
@@ -1,0 +1,54 @@
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ *
+ * Copyright (c) 2018 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.bigbluebutton.common.logging {
+	import flash.display.LoaderInfo;
+	import flash.events.UncaughtErrorEvent;
+
+	import mx.managers.ISystemManager;
+
+	[Mixin]
+	[DefaultProperty("handlerActions")]
+	public class GlobalExceptionHandler {
+
+		private static var loaderInfo:LoaderInfo;
+
+		[ArrayElementType("org.bigbluebutton.common.logging.GlobalExceptionHandlerAction")]
+		public var handlerActions:Array;
+
+		public var preventDefault:Boolean;
+
+		public static function init(sm:ISystemManager):void {
+			loaderInfo = sm.loaderInfo;
+		}
+
+		public function GlobalExceptionHandler() {
+			loaderInfo.uncaughtErrorEvents.addEventListener(UncaughtErrorEvent.UNCAUGHT_ERROR, uncaughtErrorHandler);
+		}
+
+		private function uncaughtErrorHandler(event:UncaughtErrorEvent):void {
+			for each (var action:GlobalExceptionHandlerAction in handlerActions) {
+				action.handle(event.error);
+			}
+
+			if (preventDefault == true) {
+				event.preventDefault();
+			}
+		}
+	}
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/common/logging/GlobalExceptionHandlerAction.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/common/logging/GlobalExceptionHandlerAction.as
@@ -1,0 +1,24 @@
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ *
+ * Copyright (c) 2018 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.bigbluebutton.common.logging {
+
+	public interface GlobalExceptionHandlerAction {
+		function handle(error:Object):void;
+	}
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/common/logging/LogHandlerAction.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/common/logging/LogHandlerAction.as
@@ -1,0 +1,38 @@
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ *
+ * Copyright (c) 2018 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.bigbluebutton.common.logging {
+	import com.adobe.crypto.SHA256;
+	
+	import flash.events.UncaughtErrorEvent;
+	
+	import org.as3commons.logging.api.ILogger;
+	import org.as3commons.logging.api.getClassLogger;
+
+	public class LogHandlerAction implements GlobalExceptionHandlerAction {
+		private static const LOGGER:ILogger = getClassLogger(UncaughtErrorEvent);
+
+		public function handle(error:Object):void {
+			if (error is Error) {
+				var errorObj:Error = error as Error;
+
+				LOGGER.fatal("\nError ID : {0}\nUnique ID : {1}\nMessage : {2}\n{3}", [errorObj.errorID, SHA256.hash(errorObj.getStackTrace()).substr(0, 8), errorObj.message, errorObj.getStackTrace()]);
+			}
+		}
+	}
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/common/logging/LogUtil.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/common/logging/LogUtil.as
@@ -16,7 +16,7 @@
  * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
  *
  */
-package org.bigbluebutton.common {
+package org.bigbluebutton.common.logging {
 
 	import org.as3commons.logging.api.LOGGER_FACTORY;
 	import org.as3commons.logging.setup.LevelTargetSetup;

--- a/bigbluebutton-client/src/org/bigbluebutton/core/managers/ConfigManager2.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/managers/ConfigManager2.as
@@ -31,7 +31,7 @@ package org.bigbluebutton.core.managers {
     
     import org.as3commons.logging.api.ILogger;
     import org.as3commons.logging.api.getClassLogger;
-    import org.bigbluebutton.common.LogUtil;
+    import org.bigbluebutton.common.logging.LogUtil;
     import org.bigbluebutton.core.BBB;
     import org.bigbluebutton.core.model.Config;
     import org.bigbluebutton.main.events.ConfigLoadedEvent;

--- a/bigbluebutton-client/src/org/bigbluebutton/main/events/ClientStatusEvent.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/events/ClientStatusEvent.as
@@ -26,6 +26,7 @@ package org.bigbluebutton.main.events
 		public static const SUCCESS_MESSAGE_EVENT:String = "SUCCESS_MESSAGE_EVENT";
 		public static const WARNING_MESSAGE_EVENT:String = "WARNING_MESSAGE_EVENT";
 		public static const FAIL_MESSAGE_EVENT:String = "FAIL_MESSAGE_EVENT";
+		public static const GLOBAL_EXCEPTION:String = "GLOBAL_EXCEPTION";
 		
 		public var title:String;
 		public var message:String;

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/options/LoggingOptions.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/options/LoggingOptions.as
@@ -38,6 +38,9 @@ package org.bigbluebutton.main.model.options {
 
 		[Bindable]
 		public var uri:String = "";
+		
+		[Bindable]
+		public var reportErrorsInUI:Boolean = false;
 
 		public function LoggingOptions() {
 			name = "logging";

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/ClientStatusItemRenderer.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/ClientStatusItemRenderer.mxml
@@ -4,6 +4,7 @@
 		 verticalScrollPolicy="off" horizontalScrollPolicy="off" verticalAlign="middle">
 	<fx:Script>
 		<![CDATA[
+			import org.bigbluebutton.util.i18n.ResourceUtil;
 			override public function set data(value:Object):void {
 				super.data = value;
 				
@@ -19,6 +20,10 @@
 					case "fail":
 						typeImg.source = getStyle("iconFail");
 						break
+					case "error":
+						typeImg.source = getStyle("iconFail");
+						copyButton.visible = copyButton.includeInLayout = true;
+						break
 				}
 				titleLbl.text = value.title;
 				if (value.occurrences > 1) {
@@ -29,12 +34,23 @@
 				
 				validateNow();
 			}
+			
+			protected function copyButton_clickHandler(event:MouseEvent):void{
+				System.setClipboard(data.logCode);
+			}
+			
 		]]>
 	</fx:Script>
 	<mx:Image id="typeImg" width="34" height="34" />
 	<mx:VBox width="100%" verticalGap="0">
 		<mx:Label id="titleLbl" width="100%" styleName="statusTitleStyle"/>
 		<mx:Text id="messageTxt" width="100%" styleName="statusMessageStyle"/>
+		<mx:Button id="copyButton" styleName="statusCopyStyle"
+				   label="{ResourceUtil.getInstance().getString('bbb.error.catch.copy')}"
+				   accessibilityName="{ResourceUtil.getInstance().getString('bbb.error.catch.copy.accessibilityName')}"
+				   toolTip="{ResourceUtil.getInstance().getString('bbb.error.catch.copy.accessibilityName')}"
+				   visible="false" includeInLayout="false"
+				   click="copyButton_clickHandler(event)" />	
 	</mx:VBox>
 	<mx:VBox height="100%" verticalAlign="bottom">
 		<mx:Label id="timeLbl" width="100%" styleName="statusTimeStyle"/>

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/WarningButton.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/WarningButton.mxml
@@ -32,6 +32,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		<mate:Listener type="{ClientStatusEvent.SUCCESS_MESSAGE_EVENT}" method="handleSuccessMessageEvent" />
 		<mate:Listener type="{ClientStatusEvent.WARNING_MESSAGE_EVENT}" method="handleWarningMessageEvent" />
 		<mate:Listener type="{ClientStatusEvent.FAIL_MESSAGE_EVENT}" method="handleFailMessageEvent" />
+		<mate:Listener type="{ClientStatusEvent.GLOBAL_EXCEPTION}" method="handleGlobalExceptionEvent" />
 	</fx:Declarations>
 	
 	<fx:Script>
@@ -47,6 +48,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.as3commons.logging.api.ILogger;
 			import org.as3commons.logging.api.getClassLogger;
 			import org.bigbluebutton.core.PopUpUtil;
+			import org.bigbluebutton.main.events.BBBEvent;
 			import org.bigbluebutton.main.events.ClientStatusEvent;
 			import org.bigbluebutton.util.i18n.ResourceUtil;
 			
@@ -76,6 +78,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				handleMessageEvent("fail", e);
 			}
 			
+			private function handleGlobalExceptionEvent(e:ClientStatusEvent):void {
+				handleMessageEvent("error", e);
+			}
+			
 			private function handleMessageEvent(type:String, e:ClientStatusEvent):void {
 				var index:Number = getMessageIndex(type, e.title, e.message);
 				var obj:Object;
@@ -87,6 +93,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 						type: type,
 						title: e.title,
 						message: e.message,
+						logCode: e.logCode,
 						occurrences: 1
 					};
 				}
@@ -98,12 +105,14 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				messages.push(obj);
 				showNotification();
 
-				var logData:Object = {};
-				logData.type = "ClientNotification";
-				logData.logCode = e.logCode;
-				logData.message = e.message;
-				logData.title = e.title;
-				LOGGER.warn(JSON.stringify(logData));
+				if (type != "error") {
+					var logData:Object = {};
+					logData.type = "ClientNotification";
+					logData.logCode = e.logCode;
+					logData.message = e.message;
+					logData.title = e.title;
+					LOGGER.warn(JSON.stringify(logData));
+				}
 			}
 			
 			private function showNotification():void {


### PR DESCRIPTION
Catch any unhandled and copy it to clipboard for better bug reporting. Those type of errors will be logged as `fatal`, they are also marked with unique ID, hashed from their stack-trace.

![global_exception_handle](https://user-images.githubusercontent.com/4991088/41115129-762b4438-6a7e-11e8-8b20-0f9dc5da4cc0.gif)
