### PR TITLE
Skip userLeaving when meeting is gone.

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/methods/userLeaving.js
+++ b/bigbluebutton-html5/imports/api/users/server/methods/userLeaving.js
@@ -3,6 +3,7 @@ import { check } from 'meteor/check';
 import RedisPubSub from '/imports/startup/server/redis';
 import Logger from '/imports/startup/server/logger';
 import Users from '/imports/api/users';
+import Meetings from '/imports/api/meetings';
 
 export default function userLeaving(credentials, userId, connectionId) {
   const REDIS_CONFIG = Meteor.settings.private.redis;
@@ -15,19 +16,22 @@ export default function userLeaving(credentials, userId, connectionId) {
   check(requesterUserId, String);
   check(userId, String);
 
+  const meeting = Meetings.findOne({ meetingId });
+  if (!meeting) return false;
+
   const selector = {
     meetingId,
     userId,
   };
 
-  const User = Users.findOne(selector);
+  const user = Users.findOne(selector);
 
-  if (!User) {
+  if (!user) {
     throw new Meteor.Error('user-not-found', `Could not find ${userId} in ${meetingId}: cannot complete userLeaving`);
   }
 
   // If the current user connection is not the same that triggered the leave we skip
-  if (User.connectionId !== connectionId) {
+  if (user.connectionId !== connectionId) {
     return false;
   }
 


### PR DESCRIPTION
- Verify that the meeting exists before execute userleaving, if there is no meeting just ignore the function.
Closes #5692.