### PR TITLE
 Prevent long chat message to make the chat area of the client to be resized

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-list/message-list-item/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-list/message-list-item/styles.scss
@@ -51,6 +51,7 @@
   flex: 1;
   display: flex;
   flex-flow: column;
+  overflow-x: hidden;
   width: calc(100% - 1.7rem);
 }
 


### PR DESCRIPTION
Fix for #5641 