### PR TITLE
RaP: Store rendered audio temp file in target directory, not archive_dir

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/generators/audio_processor.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/audio_processor.rb
@@ -43,10 +43,12 @@ module BigBlueButton
       audio_edl = BigBlueButton::Events.edl_match_recording_marks_audio(audio_edl, archive_dir)
       BigBlueButton::EDL::Audio.dump(audio_edl)
 
+      target_dir = File.dirname(file_basename)
       audio_dir = "#{archive_dir}/audio"
       events_xml = "#{archive_dir}/events.xml"
 
-      @audio_file = BigBlueButton::EDL::Audio.render(audio_edl, "#{audio_dir}/recording")
+      @audio_file = BigBlueButton::EDL::Audio.render(
+        audio_edl, File.join(target_dir, 'recording'))
 
       ogg_format = {
         :extension => 'ogg',


### PR DESCRIPTION
The archive_dir can be the raw recording directory in some recording
formats - including, hopefully, presentation at some point (to avoid the
extra copy)