### PR TITLE
Two chat improvements

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/model/ChatMessage.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/model/ChatMessage.as
@@ -20,6 +20,7 @@ package org.bigbluebutton.modules.chat.model {
 	import org.as3commons.lang.StringUtils;
 	import org.bigbluebutton.common.Role;
 	import org.bigbluebutton.core.UsersUtil;
+	import org.bigbluebutton.core.model.users.User2x;
 	import org.bigbluebutton.util.i18n.ResourceUtil;
 	
 	public class ChatMessage {
@@ -43,16 +44,17 @@ package org.bigbluebutton.modules.chat.model {
 	    [Bindable] public var senderTime:String;
 	    */
 		
-		public function get differentLastSenderAndTime():Boolean {
-			return !(lastTime == time) || !sameLastSender;
+		public function sameLastTime():Boolean {
+			return lastTime == time;
 		}
 		
-		public function get sameLastSender() : Boolean {
+		public function sameLastSender():Boolean {
 			return StringUtils.trimToEmpty(senderId) == StringUtils.trimToEmpty(lastSenderId);
 		}
 		
-		public function get isModerator():Boolean {
-			return UsersUtil.getUser(senderId) && UsersUtil.getUser(senderId).role == Role.MODERATOR
+		public function isModerator():Boolean {
+			var user:User2x = UsersUtil.getUser(senderId);
+			return user && user.role == Role.MODERATOR
 		}
 		
 		public function toString() : String {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/AdvancedList.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/AdvancedList.as
@@ -19,9 +19,12 @@
 package org.bigbluebutton.modules.chat.views
 {
   import flash.display.Sprite;
+  import flash.events.Event;
   
   import mx.controls.List;
   import mx.controls.listClasses.IListItemRenderer;
+  import mx.events.CollectionEvent;
+  import mx.events.CollectionEventKind;
   
   import org.as3commons.logging.api.ILogger;
   import org.as3commons.logging.api.getClassLogger;
@@ -65,6 +68,20 @@ package org.bigbluebutton.modules.chat.views
 	
 	public function get verticalScrollAtMax():Boolean {
 		return verticalScrollPosition == maxVerticalScrollPosition;
+	}
+	
+	override protected function collectionChangeHandler(event:Event):void {
+		var previousVScroll:Number = verticalScrollPosition;
+		
+		super.collectionChangeHandler(event);
+		
+		if (event is CollectionEvent) {
+			var cEvent:CollectionEvent = CollectionEvent(event);
+			
+			if (cEvent.kind == CollectionEventKind.REFRESH) {
+				verticalScrollPosition = previousVScroll;
+			}
+		}
 	}
   }
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
@@ -52,10 +52,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		
 		import flash.events.TextEvent;
 		
+		import flashx.textLayout.formats.Direction;
+		
 		import mx.binding.utils.BindingUtils;
 		import mx.events.ScrollEvent;
-		
-		import flashx.textLayout.formats.Direction;
 		
 		import org.as3commons.lang.StringUtils;
 		import org.as3commons.logging.api.ILogger;
@@ -80,6 +80,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		import org.bigbluebutton.modules.chat.events.SendPrivateChatMessageEvent;
 		import org.bigbluebutton.modules.chat.events.SendPublicChatMessageEvent;
 		import org.bigbluebutton.modules.chat.model.ChatConversation;
+		import org.bigbluebutton.modules.chat.model.ChatMessage;
 		import org.bigbluebutton.modules.chat.model.ChatOptions;
 		import org.bigbluebutton.modules.chat.vo.ChatMessageVO;
 		import org.bigbluebutton.modules.polling.events.StartCustomPollEvent;
@@ -247,9 +248,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       private function handleUserLeftEvent(event:UserLeftEvent):void {
         // Handle user leaving so that the user won't be talking to someone not there.
         if (!publicChat && event.userID == chatWithUserID) {
-          displayUserHasLeftMessage();
+          addMessageAndScrollToEnd(createUserHasLeftMessage(), event.userID);
           txtMsgArea.enabled = false;
-          scrollToEndOfMessage(event.userID);
         }
       }
       
@@ -262,14 +262,13 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       private function handleUserJoinedEvent(event:UserJoinedEvent):void {
         // Handle user joining so that the user can start to talk if the person rejoins
         if (!publicChat && event.userID == chatWithUserID) {
-          displayUserHasJoinedMessage();
+          addMessageAndScrollToEnd(createUserHasJoinedMessage(), event.userID);
           txtMsgArea.enabled = true;
-          scrollToEndOfMessage(event.userID);
         }
       }
       
       private var SPACE:String = " ";
-      private function displayUserHasLeftMessage():void {
+      private function createUserHasLeftMessage():ChatMessageVO {
         var msg:ChatMessageVO = new ChatMessageVO();
         msg.fromUserId = SPACE;
         msg.fromUsername = SPACE;
@@ -280,10 +279,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         msg.toUsername = SPACE;
         msg.message = "<b><i>"+ResourceUtil.getInstance().getString('bbb.chat.private.userLeft')+"</b></i>";
         
-        chatMessages.newChatMessage(msg);
+        return msg;
       }
       
-      private function displayUserHasJoinedMessage():void {
+      private function createUserHasJoinedMessage():ChatMessageVO {
         var msg:ChatMessageVO = new ChatMessageVO();
         msg.fromUserId = SPACE;
         msg.fromUsername = SPACE;
@@ -294,7 +293,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         msg.toUsername = SPACE;
         msg.message = "<b><i>"+ResourceUtil.getInstance().getString('bbb.chat.private.userJoined')+"</b></i>";
         
-        chatMessages.newChatMessage(msg);
+        return msg;
       }
       
       public function focusToTextMessageArea():void {
@@ -304,8 +303,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       
       private function handlePublicChatMessageEvent(event:PublicChatMessageEvent):void {
         if (publicChat) {
-          chatMessages.newChatMessage(event.message);
-          scrollToEndOfMessage(event.message.fromUserId);
+          addMessageAndScrollToEnd(event.message, event.message.fromUserId);
         }
       }
       
@@ -327,8 +325,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         if (!publicChat && 
           ( (message.fromUserId == chatWithUserID && UsersUtil.isMe(message.toUserId)) ||
             (message.toUserId == chatWithUserID && UsersUtil.isMe(message.fromUserId)) )) {
-          chatMessages.newChatMessage(event.message);
-          scrollToEndOfMessage(message.fromUserId);
+          addMessageAndScrollToEnd(event.message, event.message.fromUserId);
         }        
       }
       
@@ -353,14 +350,21 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         chatMessages.newChatMessage(msg);
       }
       
-      public function scrollToEndOfMessage(userID:String):void {
+      public function addMessageAndScrollToEnd(message:ChatMessageVO, userId:String):void {
+        // Have to check if the vScroll is max before adding the new message
+        var vScrollMax:Boolean = chatMessagesList.verticalScrollAtMax;
+        chatMessages.newChatMessage(message);
+        scrollToEndOfMessage(userId, vScrollMax);
+      }
+      
+      public function scrollToEndOfMessage(userID:String, precheckedVScroll:Boolean=false):void {
         /**
          * Trigger to force the scrollbar to show the last message.
          */	
 		// @todo : scromm if
 		//			1 - I am the send of the last message
 		//			2 - If the scroll bar is at the bottom most
-		  if (UsersUtil.isMe(userID) || (chatMessagesList.verticalScrollAtMax)) {
+		  if (UsersUtil.isMe(userID) || precheckedVScroll || (chatMessagesList.verticalScrollAtMax)) {
 	        if (scrollTimer != null) scrollTimer.start();
 		  } else if (!scrollTimer.running) {
 			  unreadMessagesBar.visible = unreadMessagesBar.includeInLayout = true;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatMessageRenderer.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatMessageRenderer.mxml
@@ -53,18 +53,27 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			protected function dataChangeHandler(event:FlexEvent):void {
 				// If you remove this some of the chat messages will fail to render
 				validateNow();
+				
+				var sameSender:Boolean = data.sameLastSender();
+				var sameTime:Boolean = data.sameLastTime();
+				var isMod:Boolean = data.isModerator();
+				
+				hbHeader.visible = hbHeader.includeInLayout = !sameSender || !sameTime;
+				lblName.visible = !sameSender;
+				lblName.styleName = (isMod ? 'chatMessageHeaderModerator' : '');
+				moderatorIcon.visible = lblName.visible && isMod;
+				lblTime.visible = !sameSender || !sameTime;
 			}
 		]]>
 	</fx:Script>
 	
   <mx:Canvas width="100%" id="hbHeader" styleName="chatMessageHeader" verticalScrollPolicy="off" horizontalScrollPolicy="off"
-			 visible="{lblName.visible || lblTime.visible}" includeInLayout="{lblName.visible || lblTime.visible}">
-    <mx:Label id="lblName" text="{data.name}" visible="{!data.sameLastSender}"
-			  verticalCenter="0" textAlign="left" left="0" maxWidth="{this.width - lblTime.width - moderatorIcon.width - 22}"
-			  styleName="{data.isModerator ? 'chatMessageHeaderModerator' : ''}"/>
-	<mx:Image id="moderatorIcon" visible="{lblName.visible &amp;&amp; data.isModerator}"
+			 visible="false" includeInLayout="false">
+    <mx:Label id="lblName" text="{data.name}" visible="false"
+			  verticalCenter="0" textAlign="left" left="0" maxWidth="{this.width - lblTime.width - moderatorIcon.width - 22}" />
+	<mx:Image id="moderatorIcon" visible="false"
 			  source="{getStyle('moderatorIcon')}" x="{lblName.width + 4}" verticalCenter="0"/>
-    <mx:Text id="lblTime" visible="{data.differentLastSenderAndTime}" htmlText="{data.time}" textAlign="right"
+    <mx:Text id="lblTime" visible="true" htmlText="{data.time}" textAlign="right"
 			 verticalCenter="0"
              right="4" />
   </mx:Canvas>


### PR DESCRIPTION
This PR has two chat improvements. The first change is and attempt to improve the performance of the chat message rendering by avoiding multiple calls to the same expensive functions. The second change is to fix a bug where if you select a chat message the list will attempt to scroll to show the selected message every time a new message comes in.