### PR TITLE
RaP: Convert aspect ratio numbers to int before checking value

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video.rb
@@ -293,6 +293,8 @@ module BigBlueButton
           if !info[:video][:sample_aspect_ratio].nil? and
               info[:video][:sample_aspect_ratio] != 'N/A'
             aspect_x, aspect_y = info[:video][:sample_aspect_ratio].split(':')
+            aspect_x = aspect_x.to_i
+            aspect_y = aspect_y.to_i
             if aspect_x != 0 and aspect_y != 0
               info[:sample_aspect_ratio] = Rational(aspect_x, aspect_y)
             end


### PR DESCRIPTION
The checks for 0 numerator or denominator were failing due to
type mismatch