### PR TITLE
Fix #5736

### DIFF
--- a/akka-bbb-transcode/src/main/java/org/bigbluebutton/transcode/core/VideoTranscoder.java
+++ b/akka-bbb-transcode/src/main/java/org/bigbluebutton/transcode/core/VideoTranscoder.java
@@ -303,7 +303,7 @@ public class VideoTranscoder extends UntypedActor implements ProcessMonitorObser
                 ffmpeg = new FFmpegCommand();
                 ffmpeg.setFFmpegPath(FFMPEG_PATH);
                 ffmpeg.setInput(input);
-
+                ffmpeg.setProtocolWhitelist("file,udp,rtp");
                 ffmpeg.setLoglevel("quiet");
                 ffmpeg.setOutput(outputLive);
                 ffmpeg.addRtmpOutputConnectionParameter(meetingId);
@@ -570,7 +570,7 @@ public class VideoTranscoder extends UntypedActor implements ProcessMonitorObser
         if(currentFFmpegRestartNumber == MAX_RESTARTINGS_NUMBER) {
            long timeInterval = System.currentTimeMillis() - lastFFmpegRestartTime;
            if(timeInterval <= MIN_RESTART_TIME) {
-              System.out.println("  > Max number of ffmpeg restartings reached in " + timeInterval + " miliseconds for " + transcoderId + "'s Video Transcoder." + 
+              System.out.println("  > Max number of ffmpeg restartings reached in " + timeInterval + " miliseconds for " + transcoderId + "'s Video Transcoder." +
                         " Not restating it anymore.");
               return true;
            }

--- a/akka-bbb-transcode/src/main/java/org/bigbluebutton/transcode/core/ffmpeg/FFmpegCommand.java
+++ b/akka-bbb-transcode/src/main/java/org/bigbluebutton/transcode/core/ffmpeg/FFmpegCommand.java
@@ -29,6 +29,8 @@ public class FFmpegCommand {
     private int frameRate;
     private String frameSize;
 
+    private String protocolWhitelist;
+
     public FFmpegCommand() {
         this.args = new HashMap();
         this.x264Params = new HashMap();
@@ -80,6 +82,11 @@ public class FFmpegCommand {
         if(probeSize != null && !probeSize.isEmpty()) {
             comm.add("-probesize");
             comm.add(probeSize);
+        }
+
+        if(protocolWhitelist != null && !protocolWhitelist.isEmpty()) {
+            comm.add("-protocol_whitelist");
+            comm.add(protocolWhitelist);
         }
 
         buildRtmpInput();
@@ -321,6 +328,14 @@ public class FFmpegCommand {
 
    public void setFrameSize(String value){
        this.frameSize = value;
+   }
+
+   /**
+    * Sets protocol elements to be whitelisted
+    * @param whitelist
+    */
+   public void setProtocolWhitelist(String whitelist) {
+     this.protocolWhitelist = whitelist;
    }
 
    /**


### PR DESCRIPTION
This adds protocol whitelisting to the ffmpeg line in charge of converting the RTP stream to RTMP (used by WebRTC screensharing). The line explained in #5736 didn't work, but this one should make WebRTC screensharing in flash compatible with ffmpeg >= 3.

This should only be merged when ffmpeg 4 is in place. Protocol whitelisting is not backwards compatible with ffmpeg versions under 3.