### PR TITLE
RaP: Don't error on pencil drawings with 0 dataPoints

### DIFF
--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -130,6 +130,12 @@ def svg_render_shape_pencil(g, slide, shape)
   g['shape'] = "pencil#{shape[:shape_unique_id]}"
 
   doc = g.document
+
+  if shape[:data_points].length < 2
+    BigBlueButton.logger.warn("Pencil #{shape[:shape_unique_id]} doesn't have enough points")
+    return
+  end
+
   if shape[:data_points].length == 2
     BigBlueButton.logger.info("Pencil #{shape[:shape_unique_id]}: Drawing single point")
     g['style'] = "stroke:none;fill:##{shape[:color]};visibility:hidden"


### PR DESCRIPTION
In some cases, we get DRAW_END events for pencil shapes from the
html5 client that have no dataPoints. The only thing we can really
do here is detect the issue and ignore the shape.

In some cases, this may result in the shape's intermediate drawing
updates being shown, but it'll disappear when the end event happens.