### PR TITLE
Whiteboard fixes and improvements

### DIFF
--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -1,5 +1,5 @@
 <head>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <style>
     html {
       box-sizing: border-box;

--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -128,11 +128,11 @@ const BaseContainer = withRouter(withTracker(({ params, router }) => {
   const annotationsHandler = Meteor.subscribe('annotations', credentials, {
     onReady: () => {
       AnnotationsLocal.remove({});
-      Annotations.find({}, { reactive: false }).forEach(a => {
+      Annotations.find({}, { reactive: false }).forEach((a) => {
         try {
-          AnnotationsLocal.insert(a)
+          AnnotationsLocal.insert(a);
         } catch (e) {
-            // who cares.
+          // who cares.
         }
       });
       annotationsHandler.stop();

--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -109,6 +109,7 @@ const BaseContainer = withRouter(withTracker(({ params, router }) => {
   const { credentials, loggedIn } = Auth;
 
   if (!loggedIn) {
+    console.log('cai aqui');
     return {
       locale,
       subscriptionsReady: false,
@@ -127,6 +128,7 @@ const BaseContainer = withRouter(withTracker(({ params, router }) => {
 
   const annotationsHandler = Meteor.subscribe('annotations', credentials, {
     onReady: () => {
+      AnnotationsLocal.remove({});
       Annotations.find({}, { reactive: false }).forEach(a => {
         try {
           AnnotationsLocal.insert(a)

--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -109,7 +109,6 @@ const BaseContainer = withRouter(withTracker(({ params, router }) => {
   const { credentials, loggedIn } = Auth;
 
   if (!loggedIn) {
-    console.log('cai aqui');
     return {
       locale,
       subscriptionsReady: false,

--- a/bigbluebutton-html5/imports/ui/components/cursor/presentation-overlay/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/cursor/presentation-overlay/component.jsx
@@ -92,6 +92,7 @@ export default class PresentationOverlay extends Component {
   }
 
   handleTouchMove(event) {
+    event.preventDefault();
     const { clientX, clientY } = event.changedTouches[0];
 
     this.currentClientX = clientX;

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-overlay/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-overlay/component.jsx
@@ -189,6 +189,8 @@ export default class PresentationOverlay extends Component {
         y="0"
         width={this.props.slideWidth}
         height={this.props.slideHeight}
+        // maximun value of z-index to prevent other things from overlapping
+        style={{ zIndex: 2 ** 31 - 1 }}
       >
         <div
           onTouchStart={this.handleTouchStart}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-overlay/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-overlay/component.jsx
@@ -97,6 +97,8 @@ export default class PresentationOverlay extends Component {
   }
 
   handleTouchMove(event) {
+    event.preventDefault();
+
     const { clientX, clientY } = event.changedTouches[0];
 
     this.currentClientX = clientX;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -131,6 +131,9 @@ const proccessAnnotationsQueue = () => {
 };
 
 export function sendAnnotation(annotation) {
+  // Prevent sending annotations while disconnected
+  if (!Meteor.status().connected) return;
+
   annotationsQueue.push(annotation);
   if (!annotationsSenderIsRunning) setTimeout(proccessAnnotationsQueue, annotationsBufferTimeMin);
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -66,7 +66,7 @@ function handleRemovedAnnotation({
   }
 
   if (shapeId) {
-    query.id = shapeId;
+    query.id = { $in: [shapeId, `${shapeId}-fake`] };
   }
 
   Annotations.remove(query);

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/pencil-draw-listener/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/pencil-draw-listener/component.jsx
@@ -214,6 +214,7 @@ export default class PencilDrawListener extends Component {
       width: '100%',
       height: '100%',
       touchAction: 'none',
+      zIndex: 2 ** 31 - 1, // maximun value of z-index to prevent other things from overlapping
       cursor: `url('${baseName}/resources/images/whiteboard-cursor/pencil.png') 2 22, default`,
     };
     return (

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/pencil-draw-listener/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/pencil-draw-listener/component.jsx
@@ -102,6 +102,7 @@ export default class PencilDrawListener extends Component {
   }
 
   handleTouchMove(event) {
+    event.preventDefault();
     const { clientX, clientY } = event.changedTouches[0];
     this.commonDrawMoveHandler(clientX, clientY);
   }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/shape-draw-listener/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/shape-draw-listener/component.jsx
@@ -133,6 +133,7 @@ export default class ShapeDrawListener extends Component {
   }
 
   handleTouchMove(event) {
+    event.preventDefault();
     const { clientX, clientY } = event.changedTouches[0];
     this.commonDrawMoveHandler(clientX, clientY);
   }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/shape-draw-listener/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/shape-draw-listener/component.jsx
@@ -285,6 +285,7 @@ export default class ShapeDrawListener extends Component {
       width: '100%',
       height: '100%',
       touchAction: 'none',
+      zIndex: 2 ** 31 - 1, // maximun value of z-index to prevent other things from overlapping
       cursor: `url('${baseName}/resources/images/whiteboard-cursor/${tool !== 'rectangle' ? tool : 'square'}.png'), default`,
     };
     return (

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/text-draw-listener/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/text-draw-listener/component.jsx
@@ -374,6 +374,7 @@ export default class TextDrawListener extends Component {
       width: '100%',
       height: '100%',
       touchAction: 'none',
+      zIndex: 2 ** 31 - 1, // maximun value of z-index to prevent other things from overlapping
       cursor: `url('${baseName}/resources/images/whiteboard-cursor/text.png'), default`,
     };
     return (

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/text-draw-listener/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/text-draw-listener/component.jsx
@@ -151,6 +151,7 @@ export default class TextDrawListener extends Component {
   }
 
   handleTouchMove(event) {
+    event.preventDefault();
     const { clientX, clientY } = event.changedTouches[0];
     this.commonDrawMoveHandler(clientX, clientY);
   }


### PR DESCRIPTION
This PR is a follow-up on #5594 and implements/fix the following:

- Prevent disconnected users from drawing locally
- Fix most linter errors introduced in #5594
- Fix the undo action not interacting correctly with text shapes (#5618)
- Fix scrolling while drawing in Apple devices, needs more testing (#5672)
- Fix local shapes not being removed after the user lost the drawing permission (#5677)
- Fix some reconnect interactions with the local shapes (#5671)
- Fix not being able to draw in some areas of the presentation (#5768 and #5778)
- Fix cursor not showing while on top of some areas of the presentation (#5768 and #5778)