### PR TITLE
Fixed audio state bug (#5519)

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -311,7 +311,7 @@ export default class SIPBridge extends BaseAudioBridge {
       };
       currentSession.on('terminated', handleSessionTerminated);
 
-      const connectionTerminatedEvents = ['iceConnectionFailed', 'iceConnectionDisconnected'];
+      const connectionTerminatedEvents = ['iceConnectionFailed', 'iceConnectionClosed'];
       const handleConnectionTerminated = (peer) => {
         connectionTerminatedEvents.forEach(e => mediaHandler.off(e, handleConnectionTerminated));
         this.callback({

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -263,6 +263,7 @@ class AudioManager {
         this.notify(this.messages.error[error], true);
         makeCall('failed callStateCallback audio', response);
         console.error('Audio Error:', error, bridgeError);
+        this.exitAudio();
         this.onAudioExit();
       }
     });


### PR DESCRIPTION
Fixes #5519.

Rationale: the `disconnected` ICE connection state is not fatal and may transition either to a valid state (`connected` once again, or `checking` -> `connected`) or a invalid/fatal one (`failed` -> `closed` or `closed`). So I changed the `disconnected` handling in the termination callback to `closed` and let it transition naturally to a final state.

I also added an `exitAudio` call on the manager's error callback. This is because we didn't close the audio/SIP session when a fatal error happened and that'd possibly leave a FreeSWITCH connection dangling or cause further inconsistency problems.