### PR TITLE
Fixed full audio exit when SFU listen only is enabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -171,7 +171,7 @@ class AudioManager {
   exitAudio() {
     if (!this.isConnected) return Promise.resolve();
 
-    const bridge  = USE_KURENTO? this.listenOnlyBridge : this.bridge;
+    const bridge  = (USE_KURENTO && this.isListenOnly) ? this.listenOnlyBridge : this.bridge;
 
     this.isHangingUp = true;
     this.isEchoTest = false;


### PR DESCRIPTION
Full audio exit was broken when SFU listen only was enabled because I was mishandling the way I fetched the SFU bridge.