### PR TITLE
Tiny fixes in chat and notifications

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.scss
@@ -128,9 +128,10 @@ $userlist-handle-width: 5px; // 5px so user-list and chat resize handle render a
   @extend %full-page;
 
   order: 2;
-
+  height: 100%;
   @include mq($small-only) {
     z-index: 3;
+    height: auto;
     top: $navbar-height;
   }
 

--- a/bigbluebutton-html5/imports/ui/services/unread-messages/index.js
+++ b/bigbluebutton-html5/imports/ui/services/unread-messages/index.js
@@ -11,7 +11,7 @@ const PUBLIC_CHAT_USERID = CHAT_CONFIG.public_userid;
 class UnreadMessagesTracker {
   constructor() {
     this._tracker = new Tracker.Dependency();
-    this._unreadChats = Storage.getItem('UNREAD_CHATS') || { [PUBLIC_CHAT_USERID]: (new Date()).getTime() };
+    this._unreadChats = { ...Storage.getItem('UNREAD_CHATS'), [PUBLIC_CHAT_USERID]: (new Date()).getTime() };
     this.get = this.get.bind(this);
   }
 


### PR DESCRIPTION
- Don't notify old messages when reload. Closes #5796.
- Fix chat height in desktop screen.