### PR TITLE
Improving WebRTC screenshare quality on chrome + windows

### DIFF
--- a/labs/bbb-webrtc-sfu/config/default.example.yml
+++ b/labs/bbb-webrtc-sfu/config/default.example.yml
@@ -19,6 +19,7 @@ from-akka: "from-akka-apps-redis-channel"
 common-message-version: "2.x"
 webcam-force-h264: true
 screenshare-force-h264: true
+screenshare-preferred-h264-profile: "42e01f"
 screenshareKeyframeInterval: 2
 
 recordScreenSharing: true

--- a/labs/bbb-webrtc-sfu/lib/screenshare/screenshare.js
+++ b/labs/bbb-webrtc-sfu/lib/screenshare/screenshare.js
@@ -18,6 +18,7 @@ const config = require('config');
 const kurentoIp = config.get('kurentoIp');
 const localIpAddress = config.get('localIpAddress');
 const FORCE_H264 = config.get('screenshare-force-h264');
+const PREFERRED_H264_PROFILE = config.get('screenshare-preferred-h264-profile');
 const EventEmitter = require('events').EventEmitter;
 const Logger = require('../utils/Logger');
 const SHOULD_RECORD = config.get('recordScreenSharing');
@@ -220,9 +221,9 @@ module.exports = class Screenshare extends EventEmitter {
 
   start (sessionId, connectionId, sdpOffer, callerName, role) {
     return new Promise(async (resolve, reject) => {
-      // Force H264 on Firefox and Chrome
+      // Forces H264 with a possible preferred profile
       if (FORCE_H264) {
-        sdpOffer = h264_sdp.transform(sdpOffer);
+        sdpOffer = h264_sdp.transform(sdpOffer, PREFERRED_H264_PROFILE);
       }
 
       // Start the recording process
@@ -313,10 +314,6 @@ module.exports = class Screenshare extends EventEmitter {
     return new Promise(async (resolve, reject) => {
       Logger.info("[screenshare] Starting viewer", callerName, "for voiceBridge", this._voiceBridge);
       let sdpAnswer;
-
-      if (FORCE_H264) {
-        sdpOffer = h264_sdp.transform(sdpOffer);
-      }
 
       this._viewersCandidatesQueue[callerName] = [];
 


### PR DESCRIPTION
Rationale: The problem resides in our low-bandwidth approach coupled with the profile Chrome uses on Windows with hardware acceleration on. The profile is a bit higher than normal, which triggers an aggressive compression in the browser to fit the stream into the available bandwidth, resulting in a garbled joke.  So I devised a workaround by including an option to prefer a specific H264 profile for screenshare procedures, which is the baseline profile that Firefox uses by default and that Chrome uses with hardware acceleration off. If the configured profile is non-existant in the SDP, the negotiation is unchanged and things should work as before.