### PR TITLE
Comply audio lock setting.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -273,6 +273,7 @@ class AudioModal extends Component {
       listenOnlyMode,
       forceListenOnlyAttendee,
       skipCheck,
+      audioLocked,
     } = this.props;
 
     return (
@@ -284,6 +285,7 @@ class AudioModal extends Component {
             icon="unmute"
             circle
             size="jumbo"
+            disabled={audioLocked}
             onClick={skipCheck ? this.handleJoinMicrophone : this.handleGoToEchoTest}
           />
           : null}

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -53,6 +53,7 @@ export default withModalMounter(withTracker(({ mountModal }) =>
     showPermissionsOvelay: Service.isWaitingPermissions(),
     listenOnlyMode,
     skipCheck,
+    audioLocked: Service.audioLocked(),
     joinFullAudioImmediately: !listenOnlyMode && skipCheck,
     joinFullAudioEchoTest: !listenOnlyMode && !skipCheck,
     forceListenOnlyAttendee: listenOnlyMode && forceListenOnly && !Service.isUserModerator(),

--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -4,6 +4,7 @@ import { withModalMounter } from '/imports/ui/components/modal/service';
 import { injectIntl, defineMessages } from 'react-intl';
 import _ from 'lodash';
 import Breakouts from '/imports/api/breakouts';
+import { notify } from '/imports/ui/services/notification';
 import Service from './service';
 import AudioModalContainer from './audio-modal/container';
 
@@ -48,6 +49,10 @@ const intlMessages = defineMessages({
     id: 'app.audioNotification.audioFailedError1007',
     description: 'ice negociation error messsage',
   },
+  reconectingAsListener: {
+    id: 'app.audioNotificaion.reconnectingAsListenOnly',
+    description: 'ice negociation error messsage',
+  },
 });
 
 
@@ -77,6 +82,11 @@ export default withModalMounter(injectIntl(withTracker(({ mountModal, intl }) =>
     null,
     <AudioModalContainer />,
   );
+  if (Service.audioLocked() && Service.isConnected() && !Service.isListenOnly()) {
+    Service.exitAudio();
+    notify(intl.formatMessage(intlMessages.reconectingAsListener), 'info', 'audio_on');
+    Service.joinListenOnly();
+  }
 
   Breakouts.find().observeChanges({
     removed() {

--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -2,6 +2,7 @@ import Users from '/imports/api/users';
 import Auth from '/imports/ui/services/auth';
 import AudioManager from '/imports/ui/services/audio-manager';
 import Meetings from '/imports/api/meetings';
+import mapUser from '/imports/ui/services/user/mapUser';
 
 const init = (messages) => {
   AudioManager.setAudioMessages(messages);
@@ -29,6 +30,16 @@ const init = (messages) => {
   AudioManager.init(userData);
 };
 
+const audioLocked = () => {
+  const userId = Auth.userID;
+  const User = mapUser(Users.findOne({ userId }));
+
+  const Meeting = Meetings.findOne({ meetingId: Auth.meetingID });
+  const audioLock = Meeting.lockSettingsProp.disableMic;
+
+  return audioLock && User.isLocked;
+};
+
 export default {
   init,
   exitAudio: () => AudioManager.exitAudio(),
@@ -52,4 +63,5 @@ export default {
   isEchoTest: () => AudioManager.isEchoTest,
   error: () => AudioManager.error,
   isUserModerator: () => Users.findOne({ userId: Auth.userID }).moderator,
+  audioLocked,
 };

--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -35,7 +35,8 @@ const audioLocked = () => {
   const User = mapUser(Users.findOne({ userId }));
 
   const Meeting = Meetings.findOne({ meetingId: Auth.meetingID });
-  const audioLock = Meeting.lockSettingsProp.disableMic;
+  const lockSetting = Meeting.lockSettingProps;
+  const audioLock = lockSetting ? lockSetting.disableMic : false;
 
   return audioLock && User.isLocked;
 };

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -236,6 +236,7 @@
     "app.audioNotification.audioFailedMessage": "Your audio connection failed to connect",
     "app.audioNotification.mediaFailedMessage": "getUserMicMedia failed, Only secure origins are allowed",
     "app.audioNotification.closeLabel": "Close",
+    "app.audioNotificaion.reconnectingAsListenOnly": "Audio has been locked for moderators only, you are being connected as listen only",
     "app.breakoutJoinConfirmation.title": "Join Breakout Room",
     "app.breakoutJoinConfirmation.message": "Do you want to join",
     "app.breakoutJoinConfirmation.confirmLabel": "Join",


### PR DESCRIPTION
- When audio lock setting is enable viewers are connected as listen only.
- When to open the audio modal, only the listen only is enabled to join.

Closes #5833.