### PR TITLE
[HTML5] STUN/TURN config support for SFU client-side apps and general improvements

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
@@ -1,7 +1,11 @@
 import BaseAudioBridge from './base';
+import { fetchWebRTCMappedStunTurnServers } from '/imports/utils/fetchStunTurnServers';
+import { log } from '/imports/ui/services/api';
 
+const SFU_URL = Meteor.settings.public.kurento.wsUrl;
 const MEDIA = Meteor.settings.public.media;
 const MEDIA_TAG = MEDIA.mediaTag.replace(/#/g, '');
+const GLOBAL_AUDIO_PREFIX = 'GLOBAL_AUDIO_'
 
 export default class KurentoAudioBridge extends BaseAudioBridge {
   constructor(userData) {
@@ -11,11 +15,13 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
       username,
       voiceBridge,
       meetingId,
+      sessionToken,
     } = userData;
 
     this.user = {
       userId,
       name: username,
+      sessionToken
     };
 
     this.internalMeetingID = meetingId;
@@ -27,31 +33,45 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
   }
 
   joinAudio({ isListenOnly }, callback) {
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
       this.callback = callback;
-      const onSuccess = ack => resolve(this.callback({ status: this.baseCallStates.started }));
+      let iceServers = [];
 
-      const onFail = error => resolve(this.callback({
-        status: this.baseCallStates.failed,
-        error: this.baseErrorCodes.CONNECTION_ERROR,
-        bridgeError: error,
-      }));
+      try {
+        iceServers = await fetchWebRTCMappedStunTurnServers(this.user.sessionToken);
+      } catch (error) {
+        log('error', 'SFU audio bridge failed to fetch STUN/TURN info, using default');
+      } finally {
+        console.log("iceServers", iceServers);
+        const options = {
+          wsUrl: SFU_URL,
+          userName: this.user.name,
+          caleeName: `${GLOBAL_AUDIO_PREFIX}${this.voiceBridge}`,
+          iceServers,
+        };
 
-      if (!isListenOnly) {
-        return reject("Invalid bridge option");
+        const onSuccess = ack => resolve(this.callback({ status: this.baseCallStates.started }));
+
+        const onFail = error => resolve(this.callback({
+          status: this.baseCallStates.failed,
+          error: this.baseErrorCodes.CONNECTION_ERROR,
+          bridgeError: error,
+        }));
+
+        if (!isListenOnly) {
+          return reject("Invalid bridge option");
+        }
+
+        window.kurentoJoinAudio(
+          MEDIA_TAG,
+          this.voiceBridge,
+          this.user.userId,
+          this.internalMeetingID,
+          onFail,
+          onSuccess,
+          options
+        );
       }
-
-      window.kurentoJoinAudio(
-        MEDIA_TAG,
-        this.voiceBridge,
-        this.user.userId,
-        this.internalMeetingID,
-        onFail,
-        null,
-        this.user.name,
-        `GLOBAL_AUDIO_${this.voiceBridge}`,
-        onSuccess,
-      );
     });
   }
 

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -1,9 +1,16 @@
 import Users from '/imports/api/users';
 import Auth from '/imports/ui/services/auth';
 import BridgeService from './service';
+import { fetchWebRTCMappedStunTurnServers } from '/imports/utils/fetchStunTurnServers';
+import { log } from '/imports/ui/services/api';
 
-const CHROME_DEFAULT_EXTENSION_KEY = Meteor.settings.public.kurento.chromeDefaultExtensionKey;
-const CHROME_CUSTOM_EXTENSION_KEY = Meteor.settings.public.kurento.chromeExtensionKey;
+const SFU_CONFIG = Meteor.settings.public.kurento;
+const SFU_URL = SFU_CONFIG.wsUrl;
+const CHROME_DEFAULT_EXTENSION_KEY = SFU_CONFIG.chromeDefaultExtensionKey;
+const CHROME_CUSTOM_EXTENSION_KEY = SFU_CONFIG.chromeExtensionKey;
+const CHROME_SCREENSHARE_SOURCES = SFU_CONFIG.chromeScreenshareSources;
+const FIREFOX_SCREENSHARE_SOURCE = SFU_CONFIG.firefoxScreenshareSource;
+const SCREENSHARE_VIDEO_TAG = 'screenshareVideo';
 
 const CHROME_EXTENSION_KEY = CHROME_CUSTOM_EXTENSION_KEY === 'KEY' ? CHROME_DEFAULT_EXTENSION_KEY : CHROME_CUSTOM_EXTENSION_KEY;
 
@@ -13,31 +20,63 @@ const getMeetingId = () => Auth.meetingID;
 
 const getUsername = () => Users.findOne({ userId: getUserId() }).name;
 
+const getSessionToken = () => Auth.sessionToken;
+
 export default class KurentoScreenshareBridge {
-  kurentoWatchVideo() {
-    window.kurentoWatchVideo(
-      'screenshareVideo',
-      BridgeService.getConferenceBridge(),
-      getUserId(),
-      getMeetingId(),
-      null,
-      null,
-    );
+  async kurentoWatchVideo() {
+    let iceServers = [];
+
+    try {
+      iceServers = await fetchWebRTCMappedStunTurnServers(getSessionToken());
+    } catch (error) {
+      log('error', 'Screenshare bridge failed to fetch STUN/TURN info, using default');
+    } finally {
+      const options = {
+        wsUrl: SFU_URL,
+        iceServers,
+      };
+
+      window.kurentoWatchVideo(
+        SCREENSHARE_VIDEO_TAG,
+        BridgeService.getConferenceBridge(),
+        getUserId(),
+        getMeetingId(),
+        null,
+        null,
+        options
+      );
+    };
   }
 
   kurentoExitVideo() {
     window.kurentoExitVideo();
   }
 
-  kurentoShareScreen() {
-    window.kurentoShareScreen(
-      'screenshareVideo',
-      BridgeService.getConferenceBridge(),
-      getUserId(),
-      getMeetingId(),
-      null,
-      CHROME_EXTENSION_KEY,
-    );
+  async kurentoShareScreen() {
+    let iceServers = [];
+    try {
+      iceServers = await fetchWebRTCMappedStunTurnServers(getSessionToken());
+    } catch (error) {
+      log('error', 'Screenshare bridge failed to fetch STUN/TURN info, using default');
+    } finally {
+      const options = {
+        wsUrl: SFU_URL,
+        chromeExtension: CHROME_EXTENSION_KEY,
+        chromeScreenshareSources: CHROME_SCREENSHARE_SOURCES,
+        firefoxScreenshareSource: FIREFOX_SCREENSHARE_SOURCE,
+        iceServers,
+      };
+
+      window.kurentoShareScreen(
+        SCREENSHARE_VIDEO_TAG,
+        BridgeService.getConferenceBridge(),
+        getUserId(),
+        getMeetingId(),
+        null,
+        null,
+        options
+      );
+    }
   }
 
   kurentoExitScreenShare() {

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -37,7 +37,6 @@ const shareScreen = () => {
 }
 
 const unshareScreen = () => {
-  console.log("Exiting screenshare");
   KurentoBridge.kurentoExitScreenShare();
 }
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/container.jsx
@@ -10,5 +10,6 @@ export default withTracker(() => ({
   meetingId: VideoService.meetingId(),
   users: VideoService.getAllUsersVideo(),
   userId: VideoService.userId(),
+  sessionToken: VideoService.sessionToken(),
   enableVideoStats: Meteor.settings.public.kurento.enableVideoStats,
 }))(VideoProviderContainer);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -118,6 +118,10 @@ class VideoService {
     return Auth.meetingID;
   }
 
+  sessionToken() {
+    return Auth.sessionToken;
+  }
+
   isConnected() {
     return this.isConnected;
   }
@@ -147,4 +151,5 @@ export default {
   userId: () => videoService.userId(),
   meetingId: () => videoService.meetingId(),
   getAllUsersVideo: () => videoService.getAllUsersVideo(),
+  sessionToken: () => videoService.sessionToken(),
 };

--- a/bigbluebutton-html5/imports/utils/fetchStunTurnServers.js
+++ b/bigbluebutton-html5/imports/utils/fetchStunTurnServers.js
@@ -1,0 +1,51 @@
+const MEDIA = Meteor.settings.public.media;
+const STUN_TURN_FETCH_URL = MEDIA.stunTurnServersFetchAddress;
+
+const fetchStunTurnServers = function (sessionToken) {
+  const handleStunTurnResponse = ({ stunServers, turnServers }) => {
+    if (!stunServers && !turnServers) {
+      return { error: 404, stun: [], turn: [] };
+    }
+
+    const turnReply = [];
+    _.each(turnServers, (turnEntry) => {
+      const { password, url, username } = turnEntry;
+      turnReply.push({
+        urls: url,
+        password,
+        username,
+      });
+    });
+
+    return {
+      stun: stunServers.map(server => server.url),
+      turn: turnReply,
+    };
+  };
+
+  const url = `${STUN_TURN_FETCH_URL}?sessionToken=${sessionToken}`;
+  return fetch(url, { credentials: 'same-origin' })
+    .then(res => res.json())
+    .then(handleStunTurnResponse)
+    .then((response) => {
+      if (response.error) {
+        return Promise.reject('Could not fetch the stuns/turns servers!');
+      }
+      return response;
+    });
+}
+
+const fetchWebRTCMappedStunTurnServers = function (sessionToken) {
+  return new Promise(async (resolve, reject) => {
+    try {
+      const { stun, turn } = await fetchStunTurnServers(sessionToken);
+      const rtcStuns = stun.map(url => ({ urls: url }));
+      const rtcTurns = turn.map(t => ({ urls: t.urls, credential: t.password, username: t.username }));
+      return resolve(rtcStuns.concat(rtcTurns));
+    } catch (error) {
+      return reject(error);
+    }
+  });
+};
+
+export { fetchStunTurnServers, fetchWebRTCMappedStunTurnServers };

--- a/bigbluebutton-html5/private/config/settings-development.json
+++ b/bigbluebutton-html5/private/config/settings-development.json
@@ -78,10 +78,10 @@
       "chromeExtensionLink": "LINK",
       "chromeScreenshareSources": ["window", "screen"],
       "firefoxScreenshareSource": "window",
-      "enableScreensharing": true,
-      "enableVideo": true,
-      "enableVideoStats": true,
-      "enableListenOnly": true
+      "enableScreensharing": false,
+      "enableVideo": false,
+      "enableVideoStats": false,
+      "enableListenOnly": false
     },
 
     "acl": {

--- a/bigbluebutton-html5/private/config/settings-development.json
+++ b/bigbluebutton-html5/private/config/settings-development.json
@@ -76,10 +76,12 @@
       "chromeDefaultExtensionLink": "https://chrome.google.com/webstore/detail/bigbluebutton-screenshare/akgoaoikmbmhcopjgakkcepdgdgkjfbc",
       "chromeExtensionKey": "KEY",
       "chromeExtensionLink": "LINK",
-      "enableScreensharing": false,
-      "enableVideo": false,
-      "enableVideoStats": false,
-      "enableListenOnly": false
+      "chromeScreenshareSources": ["window", "screen"],
+      "firefoxScreenshareSource": "window",
+      "enableScreensharing": true,
+      "enableVideo": true,
+      "enableVideoStats": true,
+      "enableListenOnly": true
     },
 
     "acl": {

--- a/bigbluebutton-html5/private/config/settings-production.json
+++ b/bigbluebutton-html5/private/config/settings-production.json
@@ -76,6 +76,8 @@
       "chromeDefaultExtensionLink": "https://chrome.google.com/webstore/detail/bigbluebutton-screenshare/akgoaoikmbmhcopjgakkcepdgdgkjfbc",
       "chromeExtensionKey": "KEY",
       "chromeExtensionLink": "LINK",
+      "chromeScreenshareSources": ["window", "screen"],
+      "firefoxScreenshareSource": "window",
       "enableScreensharing": false,
       "enableVideo": false,
       "enableVideoStats": false,

--- a/labs/bbb-webrtc-sfu/lib/audio/AudioManager.js
+++ b/labs/bbb-webrtc-sfu/lib/audio/AudioManager.js
@@ -50,7 +50,7 @@ module.exports = class AudioManager extends BaseManager {
     Logger.debug(this._logPrefix, 'Received message [' + message.id + '] from connection', message.connectionId);
     let session;
 
-    let sessionId = message.voiceBridge.split('-')[0];
+    let sessionId = message.voiceBridge;
     let voiceBridge = sessionId;
     let connectionId = message.connectionId;
 


### PR DESCRIPTION
This PR includes a bunch of minor improvements to the HTML5 client listed below. A separate PR will be opened that adds STUN/TURN config and window sharing to the Flash client.

- Added support to SFU client-side components (screenshare, video and listen only) for fetching the configured STUN/TURN servers in the BBB API. If no ICE servers are configured, they fall back to the default, preconfigured pool of public STUN servers.
- Correctly propagating the SFU URL configuration to the screenshare script
- Made the screensharing options (window, application, tabs) configurable for both Firefox and Chrome. The config parameters are called `chromeScreenshareSources` (an array that can carry `screen`, `window` and `tab` values), and `firefoxScreenshareSource` (a string that can carry `screen`, `window` or `application` values)
- Fixes to the video code related to attaching the stream. There was a rare race condition that could happen where the video tag wouldn't be correctly attached to the peer.
- Minor refactoring to the kurento-extension.js script.