### PR TITLE
SFU correctly throwing connection error on KMS misconfig

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/kurento-extension.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-extension.js
@@ -29,7 +29,7 @@ Kurento = function (
   this.webRtcPeer = null;
   this.mediaCallback = null;
 
-  this.voiceBridge = `${voiceBridge}-SCREENSHARE`;
+  this.voiceBridge = voiceBridge;
   this.internalMeetingId = internalMeetingId;
 
   this.userId = userId;

--- a/labs/bbb-webrtc-sfu/lib/mcs-core/lib/adapters/kurento.js
+++ b/labs/bbb-webrtc-sfu/lib/mcs-core/lib/adapters/kurento.js
@@ -32,11 +32,13 @@ module.exports = class MediaServer extends EventEmitter {
           this._mediaServer = await this._getMediaServerClient(this._serverUri);
           Logger.info("[mcs-media] Retrieved media server client => " + this._mediaServer);
           this._monitorConnectionState();
-          resolve();
+          return resolve();
         }
+        resolve();
       }
       catch (err) {
         this._handleError(err);
+        this.emit(C.ERROR.MEDIA_SERVER_OFFLINE);
         reject(err);
       }
     });

--- a/labs/bbb-webrtc-sfu/lib/mcs-core/lib/adapters/kurento.js
+++ b/labs/bbb-webrtc-sfu/lib/mcs-core/lib/adapters/kurento.js
@@ -25,17 +25,21 @@ module.exports = class MediaServer extends EventEmitter {
     return instance;
   }
 
-  async init () {
-    try {
-      if (!this._mediaServer) {
-        this._mediaServer = await this._getMediaServerClient(this._serverUri);
-        Logger.info("[mcs-media] Retrieved media server client => " + this._mediaServer);
-        this._monitorConnectionState();
+  init () {
+    return new Promise(async (resolve, reject) => {
+      try {
+        if (!this._mediaServer) {
+          this._mediaServer = await this._getMediaServerClient(this._serverUri);
+          Logger.info("[mcs-media] Retrieved media server client => " + this._mediaServer);
+          this._monitorConnectionState();
+          resolve();
+        }
       }
-    }
-    catch (err) {
-      this._handleError(err);
-    }
+      catch (err) {
+        this._handleError(err);
+        reject(err);
+      }
+    });
   }
 
   _getMediaServerClient (serverUri) {

--- a/labs/bbb-webrtc-sfu/lib/screenshare/ScreenshareManager.js
+++ b/labs/bbb-webrtc-sfu/lib/screenshare/ScreenshareManager.js
@@ -70,8 +70,8 @@ module.exports = class ScreenshareManager extends BaseManager {
 
           Logger.info(this._logPrefix, "Sending startResponse to peer", sessionId, "for connection", session._id);
         }
-        catch (err) {
-          Logger.error(this._logPrefix, err);
+        catch (error) {
+          Logger.error(this._logPrefix, error);
           this._bbbGW.publish(JSON.stringify({
             connectionId: connectionId,
             type: C.SCREENSHARE_APP,
@@ -119,7 +119,7 @@ module.exports = class ScreenshareManager extends BaseManager {
 
       default:
         this._bbbGW.publish(JSON.stringify({
-          connectionId: session._id? session._id : 'none',
+          connectionId: (session && session._id) ? session._id : 'none',
           id : 'error',
           message: 'Invalid message ' + message
         }), C.FROM_SCREENSHARE);


### PR DESCRIPTION
When KMS is misconfigured in the SFU component, it should throw a `Connection error` on the first attempt to connect.
Also landed a quick fix for Flash<->HTML5 interop that was broken on #5842, while I don't open the Flash equivalent of that one.