### PR TITLE
Disable HTML5 waiting screen for guest approve

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/users/server/eventHandlers.js
@@ -17,6 +17,7 @@ RedisPubSub.on('ValidateAuthTokenRespMsg', handleValidateAuthToken);
 RedisPubSub.on('UserEmojiChangedEvtMsg', handleEmojiStatus);
 RedisPubSub.on('SyncGetUsersMeetingRespMsg', handleGetUsers);
 RedisPubSub.on('GuestsWaitingForApprovalEvtMsg', handleGuestsWaitingForApproval);
-RedisPubSub.on('GuestApprovedEvtMsg', handleGuestApproved);
+RedisPubSub.on('GuestsWaitingApprovedEvtMsg', handleGuestApproved);
 RedisPubSub.on('UserEjectedFromMeetingEvtMsg', handleUserEjected);
 RedisPubSub.on('UserRoleChangedEvtMsg', handleChangeRole);
+

--- a/bigbluebutton-html5/imports/api/users/server/handlers/guestApproved.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/guestApproved.js
@@ -5,23 +5,30 @@ import userJoin from '../methods/userJoin';
 
 export default function handleGuestsWaitingForApproval({ header, body }, meetingId) {
   const { userId } = header;
-  const { approved, approvedBy } = body;
+  const { guests, approvedBy } = body;
 
   check(userId, String);
   check(meetingId, String);
-  check(approved, Boolean);
   check(approvedBy, String);
 
-  const selector = {
-    meetingId,
-    userId,
-  };
+  return guests.forEach(item => {
+    const { guest, approved } = item;
 
-  const User = Users.findOne(selector);
+    check(approved, Boolean);
+    check(guest, String);
 
-  if (User && approved) {
-    userJoin(meetingId, userId, User.authToken);
-  }
+    const selector = {
+      meetingId,
+      userId: guest,
+      clientType: "HTML5",
+    };
 
-  return setApprovedStatus(meetingId, userId, approved, approvedBy);
+    const User = Users.findOne(selector);
+
+    if (User && approved) {
+      userJoin(meetingId, guest, User.authToken);
+    }
+
+    setApprovedStatus(meetingId, guest, approved, approvedBy);
+  })
 }

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -69,9 +69,10 @@ export default withRouter(injectIntl(withModalMounter(withTracker(({ router, int
   const currentUser = Users.findOne({ userId: Auth.userID });
   const isMeetingBreakout = meetingIsBreakout();
 
-  if (!currentUser.approved) {
-    baseControls.updateLoadingState(intl.formatMessage(intlMessages.waitingApprovalMessage));
-  }
+  // TODO re-enable to show loading screen while waiting for guest approval
+  // if (!currentUser.approved) {
+  //   baseControls.updateLoadingState(intl.formatMessage(intlMessages.waitingApprovalMessage));
+  // }
 
   // Check if user is removed out of the session
   Users.find({ userId: Auth.userID }).observeChanges({


### PR DESCRIPTION
It will be revisited in BBB 2.2
In 2.0 it is not picking correctly the switch from `approved` from `false` to `true` and is displayed permanently.