### PR TITLE
Trying to fix WebRTC video tag attachment

### DIFF
--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -136,11 +136,11 @@ KurentoManager.prototype.exitAudio = function () {
       this.kurentoAudio.ws.close();
     }
 
-    this.kurentoAudio.dispose();
-    this.kurentoAudio = null;
-  }
+    if (this.kurentoAudio.pingInterval) {
+      clearInterval(this.kurentoAudio.pingInterval);
+    }
 
-  if (this.kurentoAudio) {
+    this.kurentoAudio.dispose();
     this.kurentoAudio = null;
   }
 };


### PR DESCRIPTION
This PR is an attempt to fix the tag attachment race condition that happens in the WebRTC video component. Seems good based on the tests I ran, but we need to keep on watch to see if it happens again.
 It also adds some other minor fixes:
  - Correctly checking peer availability in the client on SFU responses
  - Cleaning SFU listen only ping/pong interval on exit