### PR TITLE
Fixes for 2.2 merge issues in the client

### DIFF
--- a/bigbluebutton-client/resources/config.xml.template
+++ b/bigbluebutton-client/resources/config.xml.template
@@ -44,7 +44,6 @@
 			enableEmojiStatus="true"
 			enableSettingsButton="true"
 			enableGuestUI="false"
-			moderatorUnmute="true"
 			allowClearRecordingMarks="false"
 			guestSoftMode="false"
 			allowUserLookup="false"

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/model/UsersOptions.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/model/UsersOptions.as
@@ -33,9 +33,6 @@ package org.bigbluebutton.modules.users.model {
 
 		[Bindable]
 		public var enableSettingsButton:Boolean = true;
-		
-		[Bindable]
-		public var moderatorUnmute:Boolean = true;
 
 		[Bindable]
 		public var enableGuestUI:Boolean = false;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
@@ -418,7 +418,7 @@ package org.bigbluebutton.modules.users.services
       var extId: String = user.extId as String;
       var name: String = user.name as String;
       var role: String = user.role as String;
-      var guest: Boolean = user.role as Boolean;
+      var guest: Boolean = user.guest as Boolean;
       var authed: Boolean = user.authed as Boolean;
       var waitingForAcceptance: Boolean = user.waitingForAcceptance as Boolean;
       var emoji: String = user.emoji as String;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/MediaItemRenderer.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/MediaItemRenderer.mxml
@@ -206,14 +206,13 @@
 				if (data != null) {
 					settingsBtn.visible = rolledOver && !UsersUtil.isBreakout() && (amIMod || options.allowUserLookup);
 
-					if ( !data.inVoiceConf || ( options.moderatorUnmute == false && amIMod && !UsersUtil.isMe(data.userId) ) ) {
+					if (!data.inVoiceConf) {
 						muteImg.visible = false;
 						muteImg.includeInLayout = false;
 						muteBtn.visible = false;
 						muteBtn.includeInLayout = true;
 					} else {
 						if (data.listenOnly) {
-							muteImg.source = getStyle("iconSound");
 							muteImg.visible = true;
 							muteImg.includeInLayout = true;
 							muteBtn.visible = false;
@@ -231,7 +230,7 @@
 							}
 						} else {
 							// can no longer unmute others
-							var showMuteBtn:Boolean = rolledOver && (!data.muted || data.me);
+							var showMuteBtn:Boolean = rolledOver && (data.me || (amIMod && !data.muted));
 							muteImg.visible = !showMuteBtn;
 							muteImg.includeInLayout = !showMuteBtn;
 							muteBtn.visible = showMuteBtn;


### PR DESCRIPTION
Fixes in this PR:
* Removed the "moderatorUnmute" option from config.xml because moderators can never unmute other users anymore
* Fixed an issue in the method that processes newly joined users where their "guest" state wasn't being set properly
* Fixed an issue where viewers were shown a button to mute/unmute other users in the user list
* Fixed an issue where moderators could sometimes see no audio icons at all