### PR TITLE
 - when using rtmps, firefox and ie clients doesn't log out when the …

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/NetConnectionDelegate.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/NetConnectionDelegate.as
@@ -776,9 +776,12 @@ package org.bigbluebutton.main.model.users
 										LOGGER.info(JSON.stringify(logData));
 
                     LOGGER.info(JSON.stringify(logData));
-                    reason = ConnectionFailedEvent.USER_EJECTED_FROM_MEETING;
-                    var cfe:ConnectionFailedEvent = new ConnectionFailedEvent(reason);
-                    dispatcher.dispatchEvent(cfe);
+										// Let the logout happen when receiving the user ejected message instead
+										// of here. Firefox and IE isn't closing the connection when using RTMPS
+										// which doesn't trigger this event. (ralam july 17, 2018)
+                 //   reason = ConnectionFailedEvent.USER_EJECTED_FROM_MEETING;
+                 //   var cfe:ConnectionFailedEvent = new ConnectionFailedEvent(reason);
+                 //   dispatcher.dispatchEvent(cfe);
                 } else {
 										logData.reason = reason;
 										logData.app = "apps";

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
@@ -59,6 +59,7 @@ package org.bigbluebutton.modules.users.services
   import org.bigbluebutton.main.model.users.BreakoutRoom;
   import org.bigbluebutton.main.model.users.IMessageListener;
   import org.bigbluebutton.main.model.users.events.ChangeMyRole;
+  import org.bigbluebutton.main.model.users.events.ConnectionFailedEvent;
   import org.bigbluebutton.main.model.users.events.LookUpUserResultEvent;
   import org.bigbluebutton.main.model.users.events.StreamStartedEvent;
   import org.bigbluebutton.main.model.users.events.StreamStoppedEvent;
@@ -571,6 +572,14 @@ package org.bigbluebutton.modules.users.services
       logData.logCode = "received_user_ejected";
 			logData.userId = userId;
       LOGGER.debug(JSON.stringify(logData));
+			
+			// Let the logout happen when receiving the user ejected message instead
+			// of when the connection is closed in NetConnectionDelegate. 
+			// Firefox and IE isn't closing the connection when using RTMPS
+			// which doesn't trigger this event. (ralam july 17, 2018)			
+			var reason:String = ConnectionFailedEvent.USER_EJECTED_FROM_MEETING;
+			var cfe:ConnectionFailedEvent = new ConnectionFailedEvent(reason);
+			dispatcher.dispatchEvent(cfe);
     }
     
     private function handleUserLocked(msg:Object):void {


### PR DESCRIPTION
…user is ejected from the meeting.

   The client relies on the connection being closed by red5 when the user is ejected which triggers
   the client to logout. Hoever, when using rtmps, the connection doesn't close therefore not logging
   out the client.