### PR TITLE
Fix webhooks

### DIFF
--- a/bbb-webhooks/callback_emitter.js
+++ b/bbb-webhooks/callback_emitter.js
@@ -19,8 +19,7 @@ module.exports = class CallbackEmitter extends EventEmitter {
     this.callbackURL = callbackURL;
     this.message = message;
     this.nextInterval = 0;
-    this.timestap = 0;
-    this.permanent = false;
+    this.timestamp = 0;
     this.permanent = permanent;
   }
 
@@ -47,9 +46,9 @@ module.exports = class CallbackEmitter extends EventEmitter {
 
           // no intervals anymore, time to give up
           } else {
-            this.nextInterval = !this.permanent ? 0 : config.hooks.permanentIntervalReset; // Reset interval to permanent hooks
+            this.nextInterval = config.hooks.permanentIntervalReset; // Reset interval to permanent hooks
             if(this.permanent){
-              this._scheduleNext(interval);
+              this._scheduleNext(this.nextInterval);
             }
             else {
               return this.emit("stopped");
@@ -63,7 +62,7 @@ module.exports = class CallbackEmitter extends EventEmitter {
 
   _emitMessage(callback) {
     let data,requestOptions;
-    
+
     if (config.bbb.auth2_0) {
       // Send data as a JSON
       data = "[" + this.message + "]";

--- a/bbb-webhooks/config.js
+++ b/bbb-webhooks/config.js
@@ -29,7 +29,7 @@ if (!config.hooks.permanentURLs) { config.hooks.permanentURLs = []; }
 // How many messages will be enqueued to be processed at the same time
 if (config.hooks.queueSize  == null) { config.hooks.queueSize = 10000; }
 // Allow permanent hooks to receive raw message, which is the message straight from BBB
-if (config.hooks.defaultGetRaw  == null) { config.hooks.defaultGetRaw = false; }
+if (config.hooks.getRaw  == null) { config.hooks.getRaw = true; }
 // If set to higher than 1, will send events on the format:
 // "event=[{event1},{event2}],timestamp=000" or "[{event1},{event2}]" (based on using auth2_0 or not)
 // when there are more than 1 event on the queue at the moment of processing the queue.

--- a/bbb-webhooks/config.js
+++ b/bbb-webhooks/config.js
@@ -42,7 +42,7 @@ config.hooks.retryIntervals = [
 ];
 
 // Reset permanent interval when exceeding maximum attemps
-config.hooks.permanentURLsIntervalReset = 8;
+config.hooks.permanentIntervalReset = 8;
 
 // Mappings of internal to external meeting IDs
 config.mappings = {};

--- a/bbb-webhooks/config.js
+++ b/bbb-webhooks/config.js
@@ -29,7 +29,7 @@ if (!config.hooks.permanentURLs) { config.hooks.permanentURLs = []; }
 // How many messages will be enqueued to be processed at the same time
 if (config.hooks.queueSize  == null) { config.hooks.queueSize = 10000; }
 // Allow permanent hooks to receive raw message, which is the message straight from BBB
-if (config.hooks.getRaw  == null) { config.hooks.getRaw = true; }
+if (config.hooks.defaultGetRaw  == null) { config.hooks.defaultGetRaw = false; }
 // If set to higher than 1, will send events on the format:
 // "event=[{event1},{event2}],timestamp=000" or "[{event1},{event2}]" (based on using auth2_0 or not)
 // when there are more than 1 event on the queue at the moment of processing the queue.

--- a/bbb-webhooks/config_local.js.example
+++ b/bbb-webhooks/config_local.js.example
@@ -23,7 +23,7 @@ config.server.port = 3005;
 // IP where permanent hook will post data (more than 1 URL means more than 1 permanent hook)
 //config.hooks.permanentURLs = [ { url: "request.catcher.url", getRaw: false }, { url: "another.request.catcher.url", getRaw: true } ]
 
-// Determine default behaviour when getRaw isn't defined while registering the hook
-//config.hooks.defaultGetRaw = false;
+// Allow global hook to receive all events with raw data
+//config.hooks.getRaw = false;
 
 module.exports = config;

--- a/bbb-webhooks/config_local.js.example
+++ b/bbb-webhooks/config_local.js.example
@@ -6,7 +6,7 @@ const config = {};
 config.bbb = {};
 config.bbb.sharedSecret = "mysharedsecret";
 // Whether to use Auth2.0 or not, Auth2.0 sends the sharedSecret whithin an Authorization header as a bearer
-config.bbb.auth2_0 = false
+config.bbb.auth2_0 = false;
 
 // The port in which the API server will run.
 config.server = {};
@@ -21,9 +21,9 @@ config.server.port = 3005;
 //}
 
 // IP where permanent hook will post data (more than 1 URL means more than 1 permanent hook)
-//config.hooks.permanentURLs = ["request.catcher.url", "another.request.catcher.url"]
+//config.hooks.permanentURLs = [ { url: "request.catcher.url", getRaw: false }, { url: "another.request.catcher.url", getRaw: true } ]
 
-// Allow global hook to receive all events with raw data
-//config.hooks.getRaw = false;
+// Determine default behaviour when getRaw isn't defined while registering the hook
+//config.hooks.defaultGetRaw = false;
 
 module.exports = config;

--- a/bbb-webhooks/hook.js
+++ b/bbb-webhooks/hook.js
@@ -168,11 +168,11 @@ module.exports = class Hook {
       hook.callbackURL = callbackURL;
       hook.externalMeetingID = meetingID;
       hook.getRaw = getRaw;
-      hook.permanent = config.hooks.permanentURLs.some( url => {
-        return url === callbackURL
+      hook.permanent = config.hooks.permanentURLs.some( obj => {
+        return obj.url === callbackURL
       });
       if (hook.permanent) {
-        hook.id = config.hooks.permanentURLs.indexOf(callbackURL) + 1;
+        hook.id = config.hooks.permanentURLs.map(obj => obj.url).indexOf(callbackURL) + 1;
         nextID = config.hooks.permanentURLs.length + 1;
       } else {
         hook.id = nextID++;

--- a/bbb-webhooks/messageMapping.js
+++ b/bbb-webhooks/messageMapping.js
@@ -93,7 +93,7 @@ module.exports = class MessageMapping {
         },
         "user":{
           "internal-user-id": msgHeader.userId,
-          "external-user-id": extId,
+          "external-user-id": extId ? extId : "",
           "sharing-mic": msgBody.muted,
           "name": msgBody.name,
           "role": msgBody.role,

--- a/bbb-webhooks/test/test.js
+++ b/bbb-webhooks/test/test.js
@@ -14,7 +14,7 @@ Logger.remove(winston.transports.Console);
 describe('bbb-webhooks tests', () => {
   before( (done) => {
     config.hooks.queueSize = 10;
-    config.hooks.permanentURLs = ["http://wh.requestcatcher.com"];
+    config.hooks.permanentURLs = [ { url: "http://wh.requestcatcher.com", getRaw: true } ];
     application = new Application();
     application.start( () => {
       done();
@@ -110,7 +110,7 @@ describe('bbb-webhooks tests', () => {
       .expect('Content-Type', /text\/xml/)
       .expect(200, (res) => {
         const hooks = Hook.allGlobalSync();
-        if (hooks && hooks[0].callbackURL == config.hooks.permanentURLs[0]) {
+        if (hooks && hooks[0].callbackURL == config.hooks.permanentURLs[0].url) {
           done();
         }
         else {
@@ -221,7 +221,7 @@ describe('bbb-webhooks tests', () => {
       const hooks = Hook.allGlobalSync();
       const hook = hooks[0];
 
-      const getpost = nock(config.hooks.permanentURLs[0])
+      const getpost = nock(config.hooks.permanentURLs[0].url)
                       .filteringRequestBody( (body) => {
                         let parsed = JSON.parse(body)
                         return parsed[0].data.id ? "mapped" : "not mapped";
@@ -262,7 +262,7 @@ describe('bbb-webhooks tests', () => {
                       .reply(200, () => {
                         done();
                       });
-      const permanent = nock(config.hooks.permanentURLs[0])
+      const permanent = nock(config.hooks.permanentURLs[0].url)
                         .post("/")
                         .reply(200)
       config.redis.client.publish("test-channel", JSON.stringify(Helpers.rawMessage));
@@ -280,7 +280,7 @@ describe('bbb-webhooks tests', () => {
       const hooks = Hook.allGlobalSync();
       const hook = hooks[0];
       hook.enqueue("multiMessage2")
-      const getpost = nock(config.hooks.permanentURLs[0])
+      const getpost = nock(config.hooks.permanentURLs[0].url)
                       .filteringPath( (path) => {
                         return path.split('?')[0];
                       })

--- a/bbb-webhooks/web_hooks.js
+++ b/bbb-webhooks/web_hooks.js
@@ -142,7 +142,7 @@ module.exports = class WebHooks {
     });
 
     const sendRaw = hooks.some(hook => { return hook.getRaw });
-    if (sendRaw) {
+    if (sendRaw && config.hooks.getRaw) {
       this._processRaw(raw);
     }
   }

--- a/bbb-webhooks/web_hooks.js
+++ b/bbb-webhooks/web_hooks.js
@@ -39,7 +39,7 @@ module.exports = class WebHooks {
         let messageMapped = new MessageMapping();
         messageMapped.mapMessage(JSON.parse(message));
         message = messageMapped.mappedObject;
-        if (!_.isEmpty(message) && !config.hooks.getRaw) {
+        if (!_.isEmpty(message)) {
           const intId = message.data.attributes.meeting["internal-meeting-id"];
           IDMapping.reportActivity(intId);
 
@@ -67,8 +67,6 @@ module.exports = class WebHooks {
             default:
               processMessage();
           }
-        } else {
-          this._processRaw(raw);
         }
       } catch (e) {
         Logger.error("[WebHooks] error processing the message:", JSON.stringify(raw), ":", e);

--- a/bbb-webhooks/web_server.js
+++ b/bbb-webhooks/web_server.js
@@ -52,7 +52,7 @@ module.exports = class WebServer {
     if (getRaw){
       getRaw = JSON.parse(getRaw.toLowerCase());
     } else {
-      getRaw = config.hooks.defaultGetRaw;
+      getRaw = false;
     }
 
     if (callbackURL == null) {

--- a/bbb-webhooks/web_server.js
+++ b/bbb-webhooks/web_server.js
@@ -49,10 +49,11 @@ module.exports = class WebServer {
     const callbackURL = urlObj.query["callbackURL"];
     const meetingID = urlObj.query["meetingID"];
     let getRaw = urlObj.query["getRaw"];
-    if(getRaw){
+    if (getRaw){
       getRaw = JSON.parse(getRaw.toLowerCase());
+    } else {
+      getRaw = config.hooks.defaultGetRaw;
     }
-    else getRaw = false
 
     if (callbackURL == null) {
       respondWithXML(res, config.api.responses.missingParamCallbackURL);
@@ -73,7 +74,7 @@ module.exports = class WebServer {
   // Create a permanent hook. Permanent hooks can't be deleted via API and will try to emit a message until it succeed
   createPermanents(callback) {
     for (let i = 0; i < config.hooks.permanentURLs.length; i++) {
-      Hook.addSubscription(config.hooks.permanentURLs[i], null, config.hooks.getRaw, function(error, hook) {
+      Hook.addSubscription(config.hooks.permanentURLs[i].url, null, config.hooks.permanentURLs[i].getRaw, function(error, hook) {
         if (error != null) { // there probably won't be any errors here
           Logger.info("[WebServer] duplicated permanent hook", error);
         } else if (hook != null) {


### PR DESCRIPTION
There are two formats of webhooks we support: the raw format, when you pass getRaw=true on the hooks/create call, send to the callback the original (raw) event received on Redis; and the processed format, when you pass getRaw=false or do not pass anything on the hooks/create call, send the callback in a simpler and more structured format. When config.hooks.getRaw=true and the registered hook was getRaw=false, the callback wouldn't be called.
Also, include a commit that we missed in the previous PR.

@daronco @kmyokoyama please review.