### PR TITLE
Correct the userlist gear visibility

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/MediaItemRenderer.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/MediaItemRenderer.mxml
@@ -204,7 +204,7 @@
 				var amIMod:Boolean = UsersUtil.amIModerator();
 				
 				if (data != null) {
-					settingsBtn.visible = rolledOver && !UsersUtil.isBreakout() && (amIMod || options.allowUserLookup);
+					settingsBtn.visible = rolledOver && !UsersUtil.isBreakout() && ((amIMod && !data.me) || options.allowUserLookup);
 
 					if (!data.inVoiceConf) {
 						muteImg.visible = false;


### PR DESCRIPTION
The gear in the user list was being shown to moderators when they moused over their own row and "allowUserLookup" was false. In that scenario there's nothing in the menu so it looks like the button does nothing. This PR makes sure the gear button is only shown to moderators when it isn't their own row.