### PR TITLE
Add support for custom parameters (userdata) in HTML5 client

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -118,6 +118,7 @@ class ActionsDropdown extends Component {
             intlMessages.stopDesktopShareDesc : intlMessages.desktopShareDesc)}
             key={this.videoItemId}
             onClick={isVideoBroadcasting ? handleUnshareScreen : handleShareScreen}
+            id={isVideoBroadcasting ? 'unshare-screen-button' : 'share-screen-button' }
           />
         : null),
       (record && isUserModerator && allowStartStopRecording ?

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -29,8 +29,8 @@ export default class ScreenshareComponent extends React.Component {
 
   render() {
     return (
-      [!this.state.loaded ? (<div className={styles.connecting} />) : null,
-        (<video id="screenshareVideo" style={{ maxHeight: '100%', width: '100%' }} autoPlay playsInline onLoadedData={this.onVideoLoad} />)]
+      [!this.state.loaded ? (<div key="screenshareArea" className={styles.connecting} />) : null,
+        (<video key="screenshareVideo" id="screenshareVideo" style={{ maxHeight: '100%', width: '100%' }} autoPlay playsInline onLoadedData={this.onVideoLoad} />)]
     );
   }
 }

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-menu/component.jsx
@@ -48,6 +48,7 @@ const JoinVideoOptions = ({
           description={item.description}
           onClick={item.click}
           tabIndex={-1}
+          id={item.id}
         >
           <img src={item.iconPath} className={styles.imageSize} alt="video menu icon" />
           <span className={styles.label}>{item.label}</span>

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-menu/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-menu/container.jsx
@@ -42,6 +42,7 @@ const JoinVideoOptionsContainer = (props) => {
       label: intl.formatMessage(intlMessages.swapCam),
       disabled: !swapLayoutAllowed,
       click: toggleSwapLayout,
+      id: 'swap-button',
     },
     {
       iconPath: `${baseName}/resources/images/video-menu/icon-webcam-off.svg`,
@@ -49,6 +50,7 @@ const JoinVideoOptionsContainer = (props) => {
       label: intl.formatMessage(intlMessages[isSharingVideo ? 'leaveVideo' : 'joinVideo']),
       disabled: isDisabled && !isSharingVideo,
       click: isSharingVideo ? handleCloseVideo : handleJoinVideo,
+      id: isSharingVideo ? 'leave-video-button' : 'join-video-button',
     },
   ];
 


### PR DESCRIPTION
Changes necessary for custom implementations to use userdata and metadata parameters from the API correctly.

Also some small additions to the video and screen-share react elements:
  * Add key to scree-nshare video tag to prevent console warnings
  * Add ids to screen-share and video buttons to facilitate dom navigation of pages.  