### PR TITLE
Copyable user info

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/ShortcutHelpWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/ShortcutHelpWindow.mxml
@@ -25,7 +25,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		   xmlns:fx="http://ns.adobe.com/mxml/2009"
 		   xmlns:common="org.bigbluebutton.common.*"
 		   showCloseButton="true"
-		   height="550"
+		   height="500"
 		   width="500"
 		   initialize="init()"
 	       creationComplete="onCreationComplete()"

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UserLookUpWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/UserLookUpWindow.mxml
@@ -26,7 +26,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				implements="org.bigbluebutton.common.IKeyboardClose"
 				show="this.setFocus()"
 				layout="absolute"
-				width="300"
+				width="350"
 				verticalScrollPolicy="off"
 				horizontalScrollPolicy="off"
 				showCloseButton="false">
@@ -68,8 +68,14 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 						   showHeaders="false"
 						   accessibilityName="{ResourceUtil.getInstance().getString('bbb.userLookupWindow.grid.accessibilityName')}" >
 			<views:columns>
-				<mx:DataGridColumn dataField="property" editable="false" sortable="false" />
-				<mx:DataGridColumn dataField="value" editable="false" sortable="false" />
+				<mx:DataGridColumn dataField="property" editable="false" sortable="false" width="110"/>
+				<mx:DataGridColumn dataField="value" editable="false" sortable="false" >
+					<mx:itemRenderer>
+						<fx:Component>
+							<mx:DataGridItemRenderer selectable="true" />
+						</fx:Component>
+					</mx:itemRenderer>
+				</mx:DataGridColumn>
 			</views:columns>
 		</views:BBBDataGrid>
 		<mx:HBox width="100%" horizontalAlign="right">


### PR DESCRIPTION
This PR changes the itemrenderer for the UserLookupWindow's value column to be selectable so that users can copy the text. I also made the window a little wider and made the property column thinner to give maximum space to the values.