### PR TITLE
Fix recording status not update in nav bar.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -83,9 +83,6 @@ class NavBar extends Component {
     this.props.toggleUserList();
   }
 
-  shouldComponentUpdate(nextProps) {
-    return nextProps.breakouts.length !== this.props.breakouts.length;
-  }
   componentDidUpdate(oldProps) {
     const {
       breakouts,


### PR DESCRIPTION
currently recording status not update when start/stop a meeting recording.