### PR TITLE
More assertive annotation and cursor clearing

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/WhiteboardCanvasDisplayModel.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/WhiteboardCanvasDisplayModel.as
@@ -145,13 +145,23 @@ package org.bigbluebutton.modules.whiteboard
       textUpdateListener.canvasMouseDown();
       
       //LogUtil.debug("**** CanvasDisplay changePage. Clearing page *****");
-      clearBoard();
+      
+      // forcefully clear all annotations and cursors on whiteboard change
+      _annotationsMap = new Object();
+      wbCanvas.removeAllGraphics();
+      
+      clearCursors();
       
       var annotations:Array = whiteboardModel.getAnnotations(wbId);
       //LogUtil.debug("**** CanvasDisplay changePage [" + annotations.length + "] *****");
       for (var i:int = 0; i < annotations.length; i++) {
         createGraphic(annotations[i], true);
       }
+    }
+    
+    public function clearCursors():void {
+      _cursors = new Object();
+      wbCanvas.removeAllCursorChildren();
     }
     
 		public function drawCursor(userId:String, xPercent:Number, yPercent:Number):void {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardCanvas.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/whiteboard/views/WhiteboardCanvas.as
@@ -26,10 +26,15 @@ package org.bigbluebutton.modules.whiteboard.views {
 	import flash.events.MouseEvent;
 	import flash.geom.Point;
 	
+	import melomel.core.UI;
+	
 	import mx.containers.Canvas;
+	import mx.core.IChildList;
 	import mx.managers.CursorManager;
 	
 	import org.bigbluebutton.core.UsersUtil;
+	import org.bigbluebutton.core.model.LiveMeeting;
+	import org.bigbluebutton.core.model.users.User2x;
 	import org.bigbluebutton.main.events.SwitchedPresenterEvent;
 	import org.bigbluebutton.main.events.UserLeftEvent;
 	import org.bigbluebutton.modules.whiteboard.WhiteboardCanvasDisplayModel;
@@ -268,6 +273,13 @@ package org.bigbluebutton.modules.whiteboard.views {
 			else trace("Does not contain");
 		}
 		
+		public function removeAllGraphics():void {
+			var children:IChildList = this.graphicObjectHolder.rawChildren;
+			while (children.numChildren != 0) {
+				children.removeChildAt(children.numChildren - 1);
+			}
+		}
+		
 		public function addGraphic(child:DisplayObject):void {
 			this.graphicObjectHolder.rawChildren.addChild(child);
 		}
@@ -282,6 +294,13 @@ package org.bigbluebutton.modules.whiteboard.views {
 		
 		public function removeCursorChild(cursor:DisplayObject):void {
 			if (doesContainCursor(cursor)) this.cursorObjectHolder.rawChildren.removeChild(cursor);
+		}
+		
+		public function removeAllCursorChildren():void {
+			var children:IChildList = this.cursorObjectHolder.rawChildren;
+			while (children.numChildren != 0) {
+				children.removeChildAt(children.numChildren - 1);
+			}
 		}
 		
 		public function textToolbarSyncProxy(tobj:TextObject):void {
@@ -341,11 +360,20 @@ package org.bigbluebutton.modules.whiteboard.views {
 			//if (e.whiteboardId == currentWhiteboardId) {
 			whiteboardToolbar.whiteboardAccessModified(e.multiUser);
 			canvasModel.multiUserChange(e.multiUser);
+			
+			if (!e.multiUser) {
+				canvasDisplayModel.clearCursors();
+			}
 			//}
 		}
 		
 		private function onReceivedCursorPosition(e:WhiteboardCursorEvent):void {
-			canvasDisplayModel.drawCursor(e.userId, e.xPercent, e.yPercent);
+			var user:User2x = UsersUtil.getUser(e.userId);
+			
+			// only draw the cursor if the user exists and it's in multiuser mode or they are the presenter
+			if (user && (LiveMeeting.inst().whiteboardModel.multiUser || user.presenter)) {
+				canvasDisplayModel.drawCursor(e.userId, e.xPercent, e.yPercent);
+			}
 		}
 		
 		private function onEnableWhiteboardEvent(e:WhiteboardButtonEvent):void {
@@ -360,7 +388,7 @@ package org.bigbluebutton.modules.whiteboard.views {
 			
 			stopDrawing();
 			
-			removeCursor()
+			removeCursor();
 			
 			this.whiteboardEnabled = false;
 			setWhiteboardInteractable();


### PR DESCRIPTION
This PR makes the clearing of annotations and cursors on whiteboard change and cursor clearing on multiuser being turned off more assertive. Previously only annotations that were known were cleared and cursors were only cleared if the other client sent a new cursor coordinate. This would sometimes result in orphaned annotations and cursors. The new forceful clears should hopefully clear up both problems.