### PR TITLE
Improve RTL layout behaviour and fix its display

### DIFF
--- a/bigbluebutton-client/resources/prod/locales.xml
+++ b/bigbluebutton-client/resources/prod/locales.xml
@@ -15,7 +15,7 @@
 	<locale code="nl_NL" name="Dutch" native="Nederlands"/>
 	<locale code="en_US" name="English" native="English"/>
 	<locale code="et_EE" name="Estonian" native="Eesti"/>
-	<locale code="fa_IR" name="Farsi" native="فارسى"/>
+	<locale code="fa_IR" name="Farsi" native="فارسى" direction="rtl"/>
 	<locale code="fi_FI" name="Finnish" native="Suomi"/>
 	<locale code="fr_FR" name="French" native="Français"/>
 	<locale code="fr_CA" name="French (Canadian)" native="Français (Canadien)"/>

--- a/bigbluebutton-client/src/BigBlueButton.mxml
+++ b/bigbluebutton-client/src/BigBlueButton.mxml
@@ -19,9 +19,10 @@ You should have received a copy of the GNU Lesser General Public License along
 with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 -->
-<mx:Application xmlns:mx="library://ns.adobe.com/flex/mx"
+<BigBlueButtonApplication xmlns:mx="library://ns.adobe.com/flex/mx"
 				xmlns:fx="http://ns.adobe.com/mxml/2009"
 				xmlns:views="*"
+				xmlns="org.bigbluebutton.core.*"
 				xmlns:logging="org.bigbluebutton.common.logging.*"
 				pageTitle="BigBlueButton" 
 				layout="absolute"
@@ -54,4 +55,4 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	
   <views:BigBlueButtonMainContainer id="bbbShell"/>
 
-</mx:Application>
+</BigBlueButtonApplication>

--- a/bigbluebutton-client/src/org/bigbluebutton/core/BigBlueButtonApplication.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/BigBlueButtonApplication.as
@@ -1,0 +1,25 @@
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ *
+ * Copyright (c) 2018 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.bigbluebutton.core {
+	import mx.core.Application;
+
+	[Frame(factoryClass = "org.bigbluebutton.core.managers.SystemManager")]
+	public class BigBlueButtonApplication extends Application {
+	}
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/core/managers/ConfigManager2.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/managers/ConfigManager2.as
@@ -56,9 +56,8 @@ package org.bigbluebutton.core.managers {
 
             var date:Date = new Date();
             var localeReqURL:String = buildRequestURL();
-            trace("::loadConfig [{0}]", [localeReqURL]);
 
-            trace(localeReqURL + " session=[" + sessionToken + "]");
+			LOGGER.debug("loadConfig request={0} session=[{1}]", [localeReqURL, sessionToken]);
 
             var request:URLRequest = new URLRequest(localeReqURL);
             request.method = URLRequestMethod.GET;
@@ -75,21 +74,19 @@ package org.bigbluebutton.core.managers {
         }
 
         private function handleComplete(e:Event):void {
-            trace("handleComplete [{0}]", [new XML(e.target.data)]);
+			LOGGER.debug("handleComplete [{0}]", [new XML(e.target.data)]);
 
             var xml:XML = new XML(e.target.data)
             var dispatcher:Dispatcher = new Dispatcher();
 
             if (xml.returncode == "FAILED") {
-
-               // trace("Getting configXML failed [{0}]", [xml]);
-
+				LOGGER.error("Getting configXML failed [{0}]", [xml]);
                 dispatcher.dispatchEvent(new MeetingNotFoundEvent(xml.response.logoutURL));
             } else {
-              //  trace("Getting configXML passed [{0}]", [xml]);
+                LOGGER.info("Getting configXML passed [{0}]", [xml]);
                 _config = new Config(new XML(e.target.data));
 
-                trace("Initializing logging.");
+                LOGGER.debug("Initializing logging.");
                 LogUtil.initLogging();
 
                 dispatcher.dispatchEvent(new ConfigLoadedEvent());

--- a/bigbluebutton-client/src/org/bigbluebutton/core/managers/PopUpManagerImpl.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/managers/PopUpManagerImpl.as
@@ -1,0 +1,187 @@
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ *
+ * Copyright (c) 2018 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.bigbluebutton.core.managers {
+	import flash.display.DisplayObject;
+	import flash.geom.Point;
+	import flash.geom.Rectangle;
+
+	import mx.core.FlexVersion;
+	import mx.core.IFlexDisplayObject;
+	import mx.core.IInvalidating;
+	import mx.core.UIComponent;
+	import mx.core.mx_internal;
+	import mx.events.Request;
+	import mx.managers.IPopUpManager;
+	import mx.managers.ISystemManager;
+	import mx.managers.PopUpData;
+	import mx.managers.PopUpManagerImpl;
+
+	use namespace mx_internal;
+
+	public class PopUpManagerImpl extends mx.managers.PopUpManagerImpl {
+
+		/**
+		 *  @private
+		 */
+		private static var instance:IPopUpManager;
+
+		/**
+		 *  @private
+		 */
+		public static function getInstance():IPopUpManager {
+			if (!instance)
+				instance = new org.bigbluebutton.core.managers.PopUpManagerImpl();
+
+			return instance;
+		}
+
+		/**
+		 *  Centers a popup window over whatever window was used in the call
+		 *  to the <code>createPopUp()</code> or <code>addPopUp()</code> method.
+		 *
+		 *  <p>Note that the position of the popup window may not
+		 *  change immediately after this call since Flex may wait to measure and layout the
+		 *  popup window before centering it.</p>
+		 *
+		 *  @param The IFlexDisplayObject representing the popup.
+		 *
+		 *  @langversion 3.0
+		 *  @playerversion Flash 9
+		 *  @playerversion AIR 1.1
+		 *  @productversion Flex 3
+		 */
+		override public function centerPopUp(popUp:IFlexDisplayObject):void {
+			if (popUp is IInvalidating)
+				IInvalidating(popUp).validateNow();
+
+			const o:PopUpData = findPopupInfoByOwner(popUp);
+
+			// If we don't find the pop owner or if the owner's parent is not specified or is not on the
+			// stage, then center based on the popUp's current parent.
+			var popUpParent:DisplayObject = (o && o.parent && o.parent.stage) ? o.parent : popUp.parent;
+			if (popUpParent) {
+				//FLEX-28967 : https://issues.apache.org/jira/browse/FLEX-28967. Fix by miroslav.havrlent
+				var systemManager:ISystemManager;
+				if (o != null) {
+					systemManager = o.systemManager;
+				} else if (popUpParent.hasOwnProperty("systemManager")) {
+					systemManager = popUpParent["systemManager"];
+				} else if (popUpParent is ISystemManager) {
+					systemManager = popUpParent as ISystemManager;
+				}
+
+				if (!systemManager)
+					return; // or throw exception maybe ?
+
+				var x:Number;
+				var y:Number;
+				var appWidth:Number;
+				var appHeight:Number;
+				var parentWidth:Number;
+				var parentHeight:Number;
+				var rect:Rectangle;
+				var clippingOffset:Point = new Point();
+				var pt:Point;
+				var isTopLevelRoot:Boolean;
+				var sbRoot:DisplayObject = systemManager.getSandboxRoot();
+
+				var request:Request;
+				if (hasEventListener("isTopLevelRoot")) {
+					request = new Request("isTopLevelRoot", false, true);
+				}
+				if (request && !dispatchEvent(request))
+					isTopLevelRoot = Boolean(request.value);
+				else
+					isTopLevelRoot = systemManager.isTopLevelRoot();
+
+				if (isTopLevelRoot && (FlexVersion.compatibilityVersion < FlexVersion.VERSION_4_6)) {
+					// The sandbox root is the top level root.
+					// The application width is just the screen width.
+					var screen:Rectangle = systemManager.screen;
+					appWidth = screen.width;
+					appHeight = screen.height;
+				} else {
+					rect = systemManager.getVisibleApplicationRect();
+					rect.topLeft = DisplayObject(systemManager).globalToLocal(rect.topLeft);
+					rect.bottomRight = DisplayObject(systemManager).globalToLocal(rect.bottomRight);
+
+					// Offset the top, left of the window to bring it into view.        
+					clippingOffset = rect.topLeft.clone();
+					appWidth = rect.width;
+					appHeight = rect.height;
+				}
+
+				// If parent is a UIComponent, check for clipping between
+				// the object and its SystemManager
+				if (popUpParent is UIComponent) {
+					rect = UIComponent(popUpParent).getVisibleRect();
+					if (UIComponent(popUpParent).systemManager != sbRoot)
+						rect = UIComponent(popUpParent).systemManager.getVisibleApplicationRect(rect);
+					var offset:Point = popUpParent.globalToLocal(rect.topLeft);
+					clippingOffset.x += offset.x;
+					clippingOffset.y += offset.y;
+					parentWidth = rect.width;
+					parentHeight = rect.height;
+				} else {
+					parentWidth = popUpParent.width;
+					parentHeight = popUpParent.height;
+				}
+
+				// The appWidth may smaller than parentWidth if the application is
+				// clipped by the parent application.
+				x = Math.max(0, (Math.min(appWidth, parentWidth) - popUp.width) / 2);
+				y = Math.max(0, (Math.min(appHeight, parentHeight) - popUp.height) / 2);
+
+				// If the layout has been mirrored, then 0,0 is the uppper
+				// right corner; compensate here.
+				// Code removed below, centring a popup does not need RTL layou check
+
+				pt = new Point(clippingOffset.x, clippingOffset.y);
+				pt = popUpParent.localToGlobal(pt);
+				pt = popUp.parent.globalToLocal(pt);
+				popUp.move(Math.round(x) + pt.x, Math.round(y) + pt.y);
+			}
+		}
+
+		/**
+		 *  @private
+		 *  Returns the index position of the PopUpData in the popupInfo array (or -1)
+		 *  for a given popupInfo.owner
+		 */
+		private function findPopupInfoIndexByOwner(owner:Object):int {
+			const n:int = popupInfo.length;
+			for (var i:int = 0; i < n; i++) {
+				var o:PopUpData = popupInfo[i];
+				if (o.owner == owner)
+					return i;
+			}
+			return -1;
+		}
+
+		/**
+		 *  @private
+		 *  Returns the PopUpData (or null) for a given popupInfo.owner
+		 */
+		private function findPopupInfoByOwner(owner:Object):PopUpData {
+			var index:int = findPopupInfoIndexByOwner(owner);
+			return index > -1 ? popupInfo[index] : null;
+		}
+
+	}
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/core/managers/SystemManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/managers/SystemManager.as
@@ -1,0 +1,34 @@
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ *
+ * Copyright (c) 2018 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.bigbluebutton.core.managers {
+	import mx.core.Singleton;
+	import mx.core.mx_internal;
+	import mx.managers.SystemManager;
+
+	use namespace mx_internal;
+
+	public class SystemManager extends mx.managers.SystemManager {
+		override mx_internal function kickOff():void {
+			if (document)
+				return;
+			Singleton.registerClass("mx.managers::IPopUpManager", PopUpManagerImpl);
+			super.kickOff();
+		}
+	}
+}

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/LanguageSelector.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/LanguageSelector.mxml
@@ -42,7 +42,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 
 			private function changeLanguage():void {
-				ResourceUtil.getInstance().setPreferredLocale(selectedItem);
+				ResourceUtil.getInstance().setPreferredLocale(selectedItem.code);
 			}
 		]]>
 	</fx:Script>

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
@@ -109,6 +109,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import mx.core.UIComponent;
 			import mx.events.FlexEvent;
 			
+			import flashx.textLayout.formats.Direction;
+			
 			import flexlib.mdi.effects.effectsLib.MDIVistaEffects;
 			
 			import org.as3commons.lang.StringUtils;
@@ -163,6 +165,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.modules.videoconf.events.ShareCameraRequestEvent;
 			import org.bigbluebutton.util.browser.BrowserCheck;
 			import org.bigbluebutton.util.i18n.ResourceUtil;
+			
+			
+			
+			
 			
 			private static const LOGGER:ILogger = getClassLogger(MainApplicationShell);      
       
@@ -225,6 +231,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
       
 			public function initOptions(e:Event):void {
+				// Set the layout direction at the application start
+				ResourceUtil.getInstance().updateLayoutDirection();
+				
 				brandingOptions = Options.getOptions(BrandingOptions) as BrandingOptions;
 				layoutOptions = Options.getOptions(LayoutOptions) as LayoutOptions;
 				usersOptions = Options.getOptions(UsersOptions) as UsersOptions;
@@ -414,7 +423,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					guestWindow = PopUpUtil.createModalPopUp( FlexGlobals.topLevelApplication as DisplayObject, GuestWindow, false) as GuestWindow;
 					
 					PopUpUtil.lockPosition(guestWindow, function():Point {
-						return new Point(systemManager.screen.width - guestWindow.width - 20, 20);
+						if (ResourceUtil.getInstance().isRTLEnabled() && ResourceUtil.getInstance().getCurrentLanguageDirection() == Direction.RTL) {
+							return new Point(20, 20);
+						} else {
+							return new Point(systemManager.screen.width - guestWindow.width - 20, 20);
+						}
 					});
 					
 					guestWindow.addEventListener(Event.CLOSE, closeGuestWindow);
@@ -856,7 +869,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				var popUp:RecordWindow = PopUpUtil.createModalPopUp(FlexGlobals.topLevelApplication as DisplayObject, RecordWindow, false) as RecordWindow;
 				popUp.setRecordingFlag(e.payload.recording);
 				PopUpUtil.lockPosition(popUp, function():Point {
-					return new Point(parentApplication.width - 150 - popUp.width, y + toolbar.height); 
+					if (ResourceUtil.getInstance().isRTLEnabled() && ResourceUtil.getInstance().getCurrentLanguageDirection() == Direction.RTL) {
+						return new Point(150, y + toolbar.height);
+					} else {
+						return new Point(parentApplication.width - popUp.width - 150, y + toolbar.height); 
+					}
 				});
 			}
 			
@@ -877,9 +894,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
             }
 			
 			private function onLocaleChanged(e:LocaleChangeEvent) : void {
-				if (ResourceUtil.getInstance().isRTLEnabled()) {
-					FlexGlobals.topLevelApplication.setStyle("layoutDirection", ResourceUtil.getInstance().getCurrentLanguageDirection());
-				}
 				PopUpUtil.initAlert();
 			}
 

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
@@ -345,7 +345,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 					// Needs to be improved in case of RTL layout
 					PopUpUtil.lockPosition(logoutWindow, function():Point {
-						return new Point(width - logoutWindow.width - 5, btnLogout.y + btnLogout.height + 5)
+						if (ResourceUtil.getInstance().isRTLEnabled() && ResourceUtil.getInstance().getCurrentLanguageDirection() == Direction.RTL) {
+							return new Point(5, btnLogout.y + btnLogout.height + 5)
+						} else {
+							return new Point(width - logoutWindow.width - 5, btnLogout.y + btnLogout.height + 5)	
+						}
 					});
 				} else {
 					doLogout();

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
@@ -443,6 +443,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				if (!StringUtils.isEmpty(brandingOptions.toolbarColor)) {
 					mainBox.setStyle("backgroundColor", uint("0x" + brandingOptions.toolbarColor.substr(1)));
 				}
+				
+				updateStyle();
 			}
 			
 			private function onDisconnectTest():void{
@@ -460,15 +462,18 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 			
 			private function localeChanged(event:LocaleChangeEvent) : void {
+				updateStyle();
+				initBreakoutRibbon();
+				updateMeetingNameLabel();
+			}
+			
+			private function updateStyle():void {
 				var styleNameExt : String = "";
 				if (ResourceUtil.getInstance().isRTLEnabled() && ResourceUtil.getInstance().getCurrentLanguageDirection() == Direction.RTL) {
 					styleNameExt = "RTL";
 				}
 				
 				btnLogout.styleName = "logoutButtonStyle" + styleNameExt;
-				
-				initBreakoutRibbon();
-				updateMeetingNameLabel();
 			}
 
 			private function openSettings(e:Event = null):void{

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatBox.mxml
@@ -52,10 +52,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		
 		import flash.events.TextEvent;
 		
-		import flashx.textLayout.formats.Direction;
-		
 		import mx.binding.utils.BindingUtils;
 		import mx.events.ScrollEvent;
+		
+		import flashx.textLayout.formats.Direction;
 		
 		import org.as3commons.lang.StringUtils;
 		import org.as3commons.logging.api.ILogger;
@@ -80,7 +80,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		import org.bigbluebutton.modules.chat.events.SendPrivateChatMessageEvent;
 		import org.bigbluebutton.modules.chat.events.SendPublicChatMessageEvent;
 		import org.bigbluebutton.modules.chat.model.ChatConversation;
-		import org.bigbluebutton.modules.chat.model.ChatMessage;
 		import org.bigbluebutton.modules.chat.model.ChatOptions;
 		import org.bigbluebutton.modules.chat.vo.ChatMessageVO;
 		import org.bigbluebutton.modules.polling.events.StartCustomPollEvent;
@@ -167,6 +166,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 //        chatToolbar.registerListeners(chatMessagesList);
         
         chatMessagesList.addEventListener(ChatEvent.RESIZE_CHAT_TOOLBAR, adjustToolbarWidthAccordingToScrollBar);
+		
+		updateStyles();
       }
       
       

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/layout/views/BroadcastButton.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/layout/views/BroadcastButton.mxml
@@ -46,6 +46,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 			private function init():void {
 				refreshRole(UsersUtil.amIModerator());
+				updateStyles();
 			}
 			
 			private function onClick(e:Event):void {
@@ -57,6 +58,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 			
 			private function localeChanged(event:LocaleChangeEvent) : void {
+				updateStyles();
+			}
+			
+			private function updateStyles():void {
 				var styleNameExt : String = "";
 				if (ResourceUtil.getInstance().isRTLEnabled() && ResourceUtil.getInstance().getCurrentLanguageDirection() == Direction.RTL) {
 					styleNameExt = "RTL";

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/SharedNotesWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/sharednotes/views/SharedNotesWindow.mxml
@@ -147,6 +147,8 @@
 
 				typistsTimer.addEventListener(TimerEvent.TIMER, updateTypists);
 				typistsTimer.start();
+				
+				updateStyles();
 			}
 
 			private function updateTypists(e:Event):void {
@@ -578,6 +580,10 @@
 			}
 			
 			private function onLocaleChanged(event:LocaleChangeEvent):void {
+				updateStyles();
+			}
+			
+			private function updateStyles():void {
 				var styleNameExt : String = "";
 				if (ResourceUtil.getInstance().isRTLEnabled() && ResourceUtil.getInstance().getCurrentLanguageDirection() == Direction.RTL) {
 					styleNameExt = "RTL";


### PR DESCRIPTION
- Fix centring popups when `layoutDirection` is RTL. (Fix #5898):
	- Create a custom `SystemManager` defined in `frame` tag to define to `IPopUpManager` inside.
	- Create a custom `PopUpManager` that fixes Flex SDK popup centring.
- Made Persan language display from right to left.
- Improve preferred language detection, look for 'language_COUNTRY' format, then for `language`, and if not found we search for the first locale having the format `language_*`.
- Application layout direction change is moved from `MainApplicationShell` to `ResourceUtil`
- Make `MainApplicationShell` set the `layoutDirection` just after the `configXML` is loaded.
- Handle fixed position pop-ups in RTL mode.
- Improve logging by using the `LOGGER` property instead of `trace` function.

(Tested only on chrome-win-10)