### PR TITLE
Fix upload modal and cam unshare bug

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/auth.js
+++ b/bigbluebutton-html5/imports/startup/client/auth.js
@@ -61,7 +61,7 @@ export function joinRouteHandler(nextState, replace, callback) {
 
       replace({ pathname: path });
 
-      callback();
+      return callback();
     });
 }
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -8,6 +8,7 @@ import _ from 'lodash';
 
 import { notify } from '/imports/ui/services/notification';
 import ModalFullscreen from '/imports/ui/components/modal/fullscreen/component';
+import { withModalMounter } from '/imports/ui/components/modal/service';
 import Icon from '/imports/ui/components/icon/component';
 import ButtonBase from '/imports/ui/components/button/base/component';
 import Checkbox from '/imports/ui/components/checkbox/component';
@@ -167,6 +168,7 @@ class PresentationUploader extends Component {
   }
 
   handleConfirm() {
+    const { mountModal } = this.props;
     const presentationsToSave = this.state.presentations
       .filter(p => !p.upload.error && !p.conversion.error);
 
@@ -185,7 +187,7 @@ class PresentationUploader extends Component {
             preventClosing: false,
           });
 
-          return;
+          return mountModal(null);
         }
 
         // if theres error we dont want to close the modal
@@ -213,7 +215,11 @@ class PresentationUploader extends Component {
   }
 
   handleDismiss() {
+    const { mountModal } = this.props;
+
     return new Promise((resolve) => {
+      mountModal(null);
+
       this.setState({
         preventClosing: false,
         disableActions: false,
@@ -518,4 +524,4 @@ class PresentationUploader extends Component {
 PresentationUploader.propTypes = propTypes;
 PresentationUploader.defaultProps = defaultProps;
 
-export default injectIntl(PresentationUploader);
+export default withModalMounter(injectIntl(PresentationUploader));


### PR DESCRIPTION
This PR ensures that the upload modal stays closed after a confirm / dismiss.
Also after sharing a cam, it will remain connected after the user's first route change.