### PR TITLE
Added client-logger settings to production

### DIFF
--- a/bigbluebutton-html5/private/config/settings-production.json
+++ b/bigbluebutton-html5/private/config/settings-production.json
@@ -341,7 +341,10 @@
           }
         ]
       }
-    }
+    },
+    "log": [
+      { "target": "server", "level": "info" }
+    ]
   },
 
   "private": {


### PR DESCRIPTION
The client logger can now be configured on the production settings #5604 