### PR TITLE
Add a timeout to WebRTCScreensharePublishWin startup

### DIFF
--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -449,6 +449,7 @@ bbb.screensharePublish.WebRTCPrivateBrowsingWarning.label = It seems you may be 
 bbb.screensharePublish.WebRTCExtensionInstallButton.label = Click here to install
 bbb.screensharePublish.WebRTC.starting = Starting Screen Sharing
 bbb.screensharePublish.sharingMessage= This is your screen being shared
+bbb.screensharePublish.streamTimeout.label = Timeout hit waiting for stream to start.
 bbb.screenshareView.title = Screen Sharing
 bbb.screenshareView.fitToWindow = Fit to Window
 bbb.screenshareView.actualSize = Display actual size

--- a/bigbluebutton-client/resources/prod/lib/kurento-extension.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-extension.js
@@ -367,9 +367,12 @@ Kurento.prototype.startScreensharing = function () {
     this.webRtcPeer = kurentoUtils.WebRtcPeer.WebRtcPeerSendonly(options, (error) => {
       if (error) {
         console.log(`WebRtcPeerSendonly constructor error ${JSON.stringify(error, null, 2)}`);
-        //this.onFail(error);
+        console.log({error});
+        this.onFail(error);
         return kurentoManager.exitScreenShare();
       }
+
+      this.onSuccess();
 
       this.webRtcPeer.generateOffer(this.onOfferPresenter.bind(this));
       console.log(`Generated peer offer w/ options ${JSON.stringify(options)}`);
@@ -589,6 +592,9 @@ Kurento.prototype.logError = function (obj) {
   console.error(obj);
 };
 
+Kurento.prototype.logSuccess = function (obj) {
+  console.log(obj);
+};
 
 Kurento.normalizeCallback = function (callback) {
   if (typeof callback === 'function') {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopPublishWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopPublishWindow.mxml
@@ -95,6 +95,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private var streamHeight:Number = 100;
 			private var streamWidth:Number = 100;
 			private var globalDispatcher:Dispatcher = new Dispatcher();
+			
+			private var red5StreamTimeout:Timer = new Timer(30000, 1);
 
 			[Bindable] private var dsOptions:ScreenshareOptions;
 			
@@ -220,8 +222,29 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 							displayFail();
 						}
 						LOGGER.info(JSON.stringify(logData));
+						
+						red5StreamTimeout.stop();
 					};
+					var onSuccess:Function = function():void {
+						var logData:Object = UsersUtil.initLogData();
+						logData.tags = ["webrtc-screenshare"];
+						logData.logCode = "webrtc-sending-offer";
+						LOGGER.info(JSON.stringify(logData));
+						
+						// start timeout timer
+						red5StreamTimeout.addEventListener(TimerEvent.TIMER_COMPLETE, function():void {
+							var logData:Object = UsersUtil.initLogData();
+							logData.tags = ["webrtc-screenshare"];
+							logData.logCode = "webrtc-stream-timeout";
+							logData.reason = "Timeout hit waiting for the red5 stream to start";
+							LOGGER.info(JSON.stringify(logData));
+							
+							displayFail(ResourceUtil.getInstance().getString("bbb.screensharePublish.streamTimeout.label"));
+						});
+						red5StreamTimeout.start();
+					}
 					ExternalInterface.addCallback("onFail", onFail);
+					ExternalInterface.addCallback("onSuccess", onSuccess);
 					
 					var voiceBridge:String = UsersUtil.getVoiceBridge();
 					var myUserId:String = UsersUtil.getMyUserID();
@@ -234,7 +257,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 						myUserId,
 						internalMeetingID,
 						"onFail",
-						dsOptions.chromeExtensionKey);
+						dsOptions.chromeExtensionKey,
+						"",
+						"",
+						"onSuccess");
 					
 				}
 			}
@@ -275,7 +301,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					dispatchEvent(streamEvent);
 				}
 				streaming = false;
-				//closeWindow();
+				closeWindow();
 			}
 
 			public function stopSharingEvent(evt:StopSharingButtonEvent):void{
@@ -284,6 +310,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 
 			public function startVideo(rtmp:String, videoWidth:Number, videoHeight:Number):void {
+				red5StreamTimeout.stop();
+				
 				setCurrentState("dispFullRegionControlBar");
 				var myArray :Array = rtmp.split('/');
 				var meetingUrl:String = rtmp.substring(0, rtmp.lastIndexOf('/'));


### PR DESCRIPTION
Currently if an error occurs while trying to start the WebRTC screenshare in the Flash client, the user won't always be notified. This PR adds a simple 30s timeout to try and catch unhandled errors and inform the user that screenshare is likely not going to work.