### PR TITLE
Additions to video, listen-only and screenshare logging

### DIFF
--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -36,6 +36,7 @@ Kurento = function (
   this.ON_ICE_CANDIDATE_MSG = "iceCandidate";
   this.PING_INTERVAL = 15000;
 
+  window.Logger = this.logger || console;
 
   if (this.wsUrl == null) {
     this.defaultPath = 'bbb-webrtc-sfu';

--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -95,7 +95,7 @@ KurentoManager.prototype.exitScreenShare = function () {
   if (typeof this.kurentoScreenshare !== 'undefined' && this.kurentoScreenshare) {
 
     if (this.kurentoScreenshare.logger !== null) {
-      this.kurentoScreenshare.logger.log('  [exitScreenShare] Exiting screensharing');
+      this.kurentoScreenshare.logger.info('  [exitScreenShare] Exiting screensharing');
     }
 
     if (this.kurentoScreenshare.ws !== null) {
@@ -120,7 +120,7 @@ KurentoManager.prototype.exitVideo = function () {
   if (typeof this.kurentoVideo !== 'undefined' && this.kurentoVideo) {
 
     if (this.kurentoVideo.logger !== null) {
-      this.kurentoVideo.logger.log('  [exitScreenShare] Exiting screensharing viewing');
+      this.kurentoVideo.logger.info('  [exitScreenShare] Exiting screensharing viewing');
     }
 
     if (this.kurentoVideo.ws !== null) {
@@ -141,7 +141,7 @@ KurentoManager.prototype.exitAudio = function () {
   if (typeof this.kurentoAudio !== 'undefined' && this.kurentoAudio) {
 
     if (this.kurentoAudio.logger !== null) {
-      this.kurentoAudio.logger.log('  [exitAudio] Exiting listen only audio');
+      this.kurentoAudio.logger.info('  [exitAudio] Exiting listen only audio');
     }
 
     if (this.kurentoAudio.ws !== null) {
@@ -218,7 +218,7 @@ Kurento.prototype.downscaleResolution = function (oldWidth, oldHeight) {
 Kurento.prototype.init = function () {
   const self = this;
   if ('WebSocket' in window) {
-    this.logger.log('this browser supports websockets');
+    this.logger.info('this browser supports websockets');
     this.ws = new WebSocket(this.wsUrl);
 
     this.ws.onmessage = this.onWSMessage.bind(this);
@@ -234,7 +234,7 @@ Kurento.prototype.init = function () {
       self.pingInterval = setInterval(self.ping.bind(self), self.PING_INTERVAL);
       self.mediaCallback();
     };
-  } else { this.logger.log('this browser does not support websockets'); }
+  } else { this.logger.info('this browser does not support websockets'); }
 };
 
 Kurento.prototype.onWSMessage = function (message) {
@@ -293,7 +293,7 @@ Kurento.prototype.onOfferPresenter = function (error, offerSdp) {
   const self = this;
 
   if (error) {
-    this.logger.log(`Kurento.prototype.onOfferPresenter Error ${error}`);
+    this.logger.info(`Kurento.prototype.onOfferPresenter Error ${error}`);
     this.onFail(error);
     return;
   }
@@ -310,7 +310,7 @@ Kurento.prototype.onOfferPresenter = function (error, offerSdp) {
     vw: this.width,
   };
 
-  this.logger.log("onOfferPresenter sending to screenshare server => ", { sdpOffer: message });
+  this.logger.info("onOfferPresenter sending to screenshare server => ", { sdpOffer: message });
   this.sendMessage(message);
 };
 
@@ -335,7 +335,7 @@ Kurento.prototype.startScreensharing = function () {
     sendSource: 'desktop',
   };
 
-  this.logger.log(" Peer options =>", options);
+  this.logger.info(" Peer options =>", options);
 
   let resolution;
   this.logger.debug(`Screenshare screen dimensions are ${this.width} x ${this.height}`);
@@ -350,13 +350,13 @@ Kurento.prototype.startScreensharing = function () {
 
   this.webRtcPeer = kurentoUtils.WebRtcPeer.WebRtcPeerSendonly(options, (error) => {
     if (error) {
-      this.logger.error("WebRtcPeerSendonly constructor error:", {error: error});
+      this.logger.error("WebRtcPeerSendonly constructor error:", {error});
       this.onFail(error);
       return kurentoManager.exitScreenShare();
     }
 
     this.webRtcPeer.generateOffer(this.onOfferPresenter.bind(this));
-    this.logger.log("Generated peer offer w/ options:", {options: options});
+    this.logger.info("Generated peer offer w/ options:", {options: options});
 
     const localStream = this.webRtcPeer.peerConnection.getLocalStreams()[0];
     localStream.getVideoTracks()[0].onended = function () {
@@ -371,7 +371,7 @@ Kurento.prototype.startScreensharing = function () {
 
 Kurento.prototype.onIceCandidate = function (candidate, role) {
   const self = this;
-  this.logger.log("Local candidate:", {candidate: candidate});
+  this.logger.info("Local candidate:", {candidate});
 
   const message = {
     id: this.ON_ICE_CANDIDATE_MSG,
@@ -421,7 +421,7 @@ Kurento.prototype.viewer = function () {
 Kurento.prototype.onOfferViewer = function (error, offerSdp) {
   const self = this;
   if (error) {
-    this.logger.log(`Kurento.prototype.onOfferViewer Error ${error}`);
+    this.logger.info(`Kurento.prototype.onOfferViewer Error ${error}`);
     return this.onFail();
   }
   const message = {
@@ -434,7 +434,7 @@ Kurento.prototype.onOfferViewer = function (error, offerSdp) {
     sdpOffer: offerSdp,
   };
 
-  this.logger.log("onOfferViewer sending to screenshare server: ", {sdpOffer: message.sdpOffer});
+  this.logger.info("onOfferViewer sending to screenshare server: ", {sdpOffer: message.sdpOffer});
   this.sendMessage(message);
 };
 
@@ -477,7 +477,7 @@ Kurento.prototype.listenOnly = function () {
 
 Kurento.prototype.onListenOnlyIceCandidate = function (candidate) {
   let self = this;
-  this.logger.debug("[onListenOnlyIceCandidate]", {candidate: candidate});
+  this.logger.debug("[onListenOnlyIceCandidate]", {candidate});
 
   var message = {
     id : this.ON_ICE_CANDIDATE_MSG,
@@ -508,7 +508,7 @@ Kurento.prototype.onOfferListenOnly = function (error, offerSdp) {
     internalMeetingId: self.internalMeetingId
   };
 
-  this.logger.debug("[onOfferListenOnly]", {message: message});
+  this.logger.debug("[onOfferListenOnly]", {message});
   this.sendMessage(message);
 };
 
@@ -566,12 +566,12 @@ Kurento.prototype.ping = function () {
 
 Kurento.prototype.sendMessage = function (message) {
   const jsonMessage = JSON.stringify(message);
-  this.logger.log("Sending message:", {message: message});
+  this.logger.info("Sending message:", {message});
   this.ws.send(jsonMessage);
 };
 
 Kurento.prototype.logger = function (obj) {
-  this.logger.log(obj);
+  this.logger.info(obj);
 };
 
 Kurento.prototype.logError = function (obj) {
@@ -583,7 +583,7 @@ Kurento.normalizeCallback = function (callback) {
   if (typeof callback === 'function') {
     return callback;
   }
-  this.logger.log(document.getElementById('BigBlueButton')[callback]);
+  this.logger.info(document.getElementById('BigBlueButton')[callback]);
   return function (args) {
     document.getElementById('BigBlueButton')[callback](args);
   };

--- a/bigbluebutton-html5/client/compatibility/kurento-utils.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-utils.js
@@ -248,7 +248,7 @@ function WebRtcPeer(mode, options, callback) {
         } else {
             candidate = new RTCIceCandidate(iceCandidate);
         }
-        logger.debug('Remote ICE candidate received', iceCandidate);
+        // logger.debug('Remote ICE candidate received', iceCandidate);
         callback = (callback || noop).bind(this);
         addIceCandidate(candidate, callback);
     };
@@ -265,14 +265,14 @@ function WebRtcPeer(mode, options, callback) {
                 offerToReceiveVideo: mode !== 'sendonly' && offerVideo
             };
         var constraints = browserDependantConstraints;
-        logger.debug('constraints: ' + JSON.stringify(constraints));
+        // logger.debug('constraints: ' + JSON.stringify(constraints));
         pc.createOffer(constraints).then(function (offer) {
-            logger.debug('Created SDP offer');
+            // logger.debug('Created SDP offer');
             offer = mangleSdpToAddSimulcast(offer);
             return pc.setLocalDescription(offer);
         }).then(function () {
             var localDescription = pc.localDescription;
-            logger.debug('Local description set', localDescription.sdp);
+            // logger.debug('Local description set', localDescription.sdp);
             if (multistream && usePlanB) {
                 localDescription = interop.toUnifiedPlan(localDescription);
                 logger.debug('offer::origPlanB->UnifiedPlan', dumpSDP(localDescription));
@@ -317,7 +317,7 @@ function WebRtcPeer(mode, options, callback) {
             logger.debug('asnwer::planB', dumpSDP(planBAnswer));
             answer = planBAnswer;
         }
-        logger.debug('SDP answer received, setting remote description');
+        // logger.debug('SDP answer received, setting remote description');
         if (pc.signalingState === 'closed') {
             return callback('PeerConnection is closed');
         }
@@ -337,7 +337,7 @@ function WebRtcPeer(mode, options, callback) {
             logger.debug('offer::planB', dumpSDP(planBOffer));
             offer = planBOffer;
         }
-        logger.debug('SDP offer received, setting remote description');
+        // logger.debug('SDP offer received, setting remote description');
         if (pc.signalingState === 'closed') {
             return callback('PeerConnection is closed');
         }
@@ -347,7 +347,7 @@ function WebRtcPeer(mode, options, callback) {
             return pc.createAnswer();
         }).then(function (answer) {
             answer = mangleSdpToAddSimulcast(answer);
-            logger.debug('Created SDP answer');
+            // logger.debug('Created SDP answer');
             return pc.setLocalDescription(answer);
         }).then(function () {
             var localDescription = pc.localDescription;
@@ -355,7 +355,7 @@ function WebRtcPeer(mode, options, callback) {
                 localDescription = interop.toUnifiedPlan(localDescription);
                 logger.debug('answer::origPlanB->UnifiedPlan', dumpSDP(localDescription));
             }
-            logger.debug('Local description set', localDescription.sdp);
+            // logger.debug('Local description set', localDescription.sdp);
             callback(null, localDescription.sdp);
         }).catch(callback);
     };
@@ -487,7 +487,7 @@ WebRtcPeer.prototype.getRemoteStream = function (index) {
     }
 };
 WebRtcPeer.prototype.dispose = function () {
-    logger.debug('Disposing WebRtcPeer');
+    // logger.debug('Disposing WebRtcPeer');
     var pc = this.peerConnection;
     var dc = this.dataChannel;
     try {

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
@@ -18,7 +18,7 @@ const logFunc = (type, message, options) => {
 
   const topic = options.topic || 'audio';
 
-  logger[type](`[${type}.${topic}] ${message}`, Object.assign(options, {userId, userName, topic}));
+  logger[type]({obj: Object.assign(options, {userId, userName, topic})}, `[${topic}] ${message}`);
 };
 
 const modLogger = {

--- a/bigbluebutton-html5/imports/api/log-client/server/methods/logClient.js
+++ b/bigbluebutton-html5/imports/api/log-client/server/methods/logClient.js
@@ -16,7 +16,7 @@ const logClient = function (type, log, ...args) {
     args[0].validUser = 'notFound';
   }
 
-  const topic = typeof logContents[0] == 'Object' ? logContents[0].topic : null;
+  const topic = typeof logContents == 'Object' ? logContents.topic : null;
 
   if (typeof log === 'string' || log instanceof String) {
     Logger.log(type, `${topic || 'CLIENT'} LOG: ${log}\n`, logContents);

--- a/bigbluebutton-html5/imports/api/log-client/server/methods/logClient.js
+++ b/bigbluebutton-html5/imports/api/log-client/server/methods/logClient.js
@@ -16,10 +16,12 @@ const logClient = function (type, log, ...args) {
     args[0].validUser = 'notFound';
   }
 
+  const topic = typeof logContents[0] == 'Object' ? logContents[0].topic : null;
+
   if (typeof log === 'string' || log instanceof String) {
-    Logger.log(type, `CLIENT LOG: ${log}`, logContents);
+    Logger.log(type, `${topic || 'CLIENT'} LOG: ${log}\n`, logContents);
   } else {
-    Logger.log(type, `CLIENT LOG: ${JSON.stringify(log)}`, logContents);
+    Logger.log(type, `${topic || 'CLIENT'} LOG: ${JSON.stringify(log)}\n`, logContents);
   }
 };
 

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -22,6 +22,25 @@ const getUsername = () => Users.findOne({ userId: getUserId() }).name;
 
 const getSessionToken = () => Auth.sessionToken;
 
+const logFunc = (type, message, options) => {
+  const userId = getUserId();
+  const userName = getUsername();
+
+  log(type, message, Object.assign(options, {userId, userName, topic: options.topic || 'screenshare'}));
+};
+
+const logger = {
+  log: function (message, options = {}) {
+    logFunc('info', message, options);
+  },
+  error: function (message, options = {}) {
+    logFunc('error', message, options);
+  },
+  debug: function (message, options = {}) {
+    logFunc('debug', message, options);
+  },
+};
+
 export default class KurentoScreenshareBridge {
   async kurentoWatchVideo() {
     let iceServers = [];
@@ -29,11 +48,12 @@ export default class KurentoScreenshareBridge {
     try {
       iceServers = await fetchWebRTCMappedStunTurnServers(getSessionToken());
     } catch (error) {
-      log('error', 'Screenshare bridge failed to fetch STUN/TURN info, using default');
+      logger.error('Screenshare bridge failed to fetch STUN/TURN info, using default');
     } finally {
       const options = {
         wsUrl: SFU_URL,
         iceServers,
+        logger
       };
 
       window.kurentoWatchVideo(
@@ -57,7 +77,7 @@ export default class KurentoScreenshareBridge {
     try {
       iceServers = await fetchWebRTCMappedStunTurnServers(getSessionToken());
     } catch (error) {
-      log('error', 'Screenshare bridge failed to fetch STUN/TURN info, using default');
+      logger.error('Screenshare bridge failed to fetch STUN/TURN info, using default');
     } finally {
       const options = {
         wsUrl: SFU_URL,
@@ -65,6 +85,7 @@ export default class KurentoScreenshareBridge {
         chromeScreenshareSources: CHROME_SCREENSHARE_SOURCES,
         firefoxScreenshareSource: FIREFOX_SCREENSHARE_SOURCE,
         iceServers,
+        logger,
       };
 
       window.kurentoShareScreen(

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -2,7 +2,7 @@ import Users from '/imports/api/users';
 import Auth from '/imports/ui/services/auth';
 import BridgeService from './service';
 import { fetchWebRTCMappedStunTurnServers } from '/imports/utils/fetchStunTurnServers';
-import { log } from '/imports/ui/services/api';
+import logger from '/imports/startup/client/logger';
 
 const SFU_CONFIG = Meteor.settings.public.kurento;
 const SFU_URL = SFU_CONFIG.wsUrl;
@@ -26,11 +26,13 @@ const logFunc = (type, message, options) => {
   const userId = getUserId();
   const userName = getUsername();
 
-  log(type, message, Object.assign(options, {userId, userName, topic: options.topic || 'screenshare'}));
+  const topic = options.topic || 'audio';
+
+  logger[type](`[${type}.${topic}] ${message}`, Object.assign(options, {userId, userName, topic}));
 };
 
-const logger = {
-  log: function (message, options = {}) {
+const modLogger = {
+  info: function (message, options = {}) {
     logFunc('info', message, options);
   },
   error: function (message, options = {}) {
@@ -38,6 +40,9 @@ const logger = {
   },
   debug: function (message, options = {}) {
     logFunc('debug', message, options);
+  },
+  warn: (message, options = {}) => {
+    logFunc('warn', message, options);
   },
 };
 
@@ -53,7 +58,7 @@ export default class KurentoScreenshareBridge {
       const options = {
         wsUrl: SFU_URL,
         iceServers,
-        logger
+        logger: modLogger
       };
 
       window.kurentoWatchVideo(
@@ -85,7 +90,7 @@ export default class KurentoScreenshareBridge {
         chromeScreenshareSources: CHROME_SCREENSHARE_SOURCES,
         firefoxScreenshareSource: FIREFOX_SCREENSHARE_SOURCE,
         iceServers,
-        logger,
+        logger: modLogger,
       };
 
       window.kurentoShareScreen(

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -26,9 +26,9 @@ const logFunc = (type, message, options) => {
   const userId = getUserId();
   const userName = getUsername();
 
-  const topic = options.topic || 'audio';
+  const topic = options.topic || 'screenshare';
 
-  logger[type](`[${type}.${topic}] ${message}`, Object.assign(options, {userId, userName, topic}));
+  logger[type]({obj: Object.assign(options, {userId, userName, topic})}, `[${topic}] ${message}`);
 };
 
 const modLogger = {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
-import { log } from '/imports/ui/services/api';
 import { notify } from '/imports/ui/services/notification';
 import VisibilityEvent from '/imports/utils/visibilityEvent';
 import logger from '/imports/startup/client/logger';
@@ -125,9 +124,9 @@ class VideoProvider extends Component {
 
   logger(type, message, options = {}) {
     const {userId, userName} = this.props;
+    const topic = options.topic || 'video';
 
-    log(type, message,
-      Object.assign(options, {userId, userName, topic: options.topic || 'video'}));
+    logger[type](`${type}.${topic}: ${message}`, Object.assign(options, {userId, userName, topic}));
   }
 
   _sendPauseStream(id, role, state) {
@@ -313,7 +312,7 @@ class VideoProvider extends Component {
         }
       });
     } else {
-      log('warn', '[startResponse] Message arrived after the peer was already thrown out, discarding it...');
+      this.logger('warn', '[startResponse] Message arrived after the peer was already thrown out, discarding it...');
     }
   }
 
@@ -381,7 +380,7 @@ class VideoProvider extends Component {
     try {
       iceServers = await fetchWebRTCMappedStunTurnServers(sessionToken);
     } catch (error) {
-      log('error', 'Video provider failed to fetch ice servers, using default');
+      this.logger('error', 'Video provider failed to fetch ice servers, using default');
     } finally {
       const videoConstraints = {
         width: {
@@ -542,7 +541,7 @@ class VideoProvider extends Component {
   attachVideoStream(id) {
     const video = this.videoTags[id];
     if (video == null) {
-      log('warn', 'Peer', id, 'has not been started yet');
+      this.logger('warn', 'Peer', id, 'has not been started yet');
       return;
     }
 
@@ -803,7 +802,7 @@ class VideoProvider extends Component {
         VideoService.joinedVideo();
       }
     } else {
-      log('warn', '[playStart] Message arrived after the peer was already thrown out, discarding it...');
+      this.logger('warn', '[playStart] Message arrived after the peer was already thrown out, discarding it...');
     }
   }
 
@@ -811,7 +810,7 @@ class VideoProvider extends Component {
     const { intl } = this.props;
     const { userId } = this.props;
     const { code, reason } = message;
-    log('debug', 'Received error from SFU:', code, reason, message.streamId, userId);
+    this.logger('debug', 'Received error from SFU:', code, reason, message.streamId, userId);
     if (message.streamId === userId) {
       this.unshareWebcam();
       this.notifyError(intl.formatMessage(intlSFUErrors[code]

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -126,7 +126,7 @@ class VideoProvider extends Component {
     const {userId, userName} = this.props;
     const topic = options.topic || 'video';
 
-    logger[type](`${type}.${topic}: ${message}`, Object.assign(options, {userId, userName, topic}));
+    logger[type]({obj: Object.assign(options, {userId, userName, topic})}, `[${topic}] ${message}`);
   }
 
   _sendPauseStream(id, role, state) {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -123,6 +123,13 @@ class VideoProvider extends Component {
     this.customGetStats = this.customGetStats.bind(this);
   }
 
+  logger(type, message, options = {}) {
+    const {userId, userName} = this.props;
+
+    log(type, message,
+      Object.assign(options, {userId, userName, topic: options.topic || 'video'}));
+  }
+
   _sendPauseStream(id, role, state) {
     this.sendMessage({
       cameraId: id,
@@ -134,7 +141,7 @@ class VideoProvider extends Component {
   }
 
   pauseViewers() {
-    log('debug', 'Calling pause in viewer streams');
+    this.logger('debug', 'Calling pause in viewer streams');
 
     Object.keys(this.webRtcPeers).forEach((id) => {
       if (this.props.userId !== id && this.webRtcPeers[id].started) {
@@ -144,7 +151,7 @@ class VideoProvider extends Component {
   }
 
   unpauseViewers() {
-    log('debug', 'Calling un-pause in viewer streams');
+    this.logger('debug', 'Calling un-pause in viewer streams');
 
     Object.keys(this.webRtcPeers).forEach((id) => {
       if (id !== this.props.userId && this.webRtcPeers[id].started) {
@@ -205,12 +212,11 @@ class VideoProvider extends Component {
     });
 
     // Close websocket connection to prevent multiple reconnects from happening
-    // Don't disconnect socket on unmount to prevent multiple reconnects
     this.ws.close();
   }
 
   onWsOpen() {
-    log('debug', '------ Websocket connection opened.');
+    this.logger('debug', '------ Websocket connection opened.', {topic: 'ws'});
 
     // -- Resend queued messages that happened when socket was not connected
     while (this.wsQueue.length > 0) {
@@ -223,7 +229,7 @@ class VideoProvider extends Component {
   }
 
   onWsClose(error) {
-    log('debug', '------ Websocket connection closed.');
+    this.logger('debug', '------ Websocket connection closed.', {topic: 'ws'});
 
     this.stopWebRTCPeer(this.props.userId);
     clearInterval(this.pingInterval);
@@ -241,7 +247,7 @@ class VideoProvider extends Component {
   onWsMessage(msg) {
     const parsedMessage = JSON.parse(msg.data);
 
-    console.log(parsedMessage);
+    this.logger('debug', `Received new message '${parsedMessage.id}'`, {topic: 'ws', message: parsedMessage});
 
     switch (parsedMessage.id) {
       case 'startResponse':
@@ -261,6 +267,7 @@ class VideoProvider extends Component {
         break;
 
       case 'pong':
+        this.logger('debug', 'Received pong from server', {topic: 'ws'});
         break;
 
       case 'error':
@@ -275,10 +282,10 @@ class VideoProvider extends Component {
 
     if (this.connectedToMediaServer()) {
       const jsonMessage = JSON.stringify(message);
-      log('info', `Sending message: ${jsonMessage}`);
+      this.logger('debug', `Sending message '${message.id}'`, {topic: 'ws', message});
       ws.send(jsonMessage, (error) => {
         if (error) {
-          logger.error(`client: Websocket error "${error}" on message "${jsonMessage.id}"`);
+          this.logger(`client: Websocket error '${error}' on message '${message.id}'`, {topic: 'ws'});
         }
       });
     } else {
@@ -297,12 +304,12 @@ class VideoProvider extends Component {
     const id = message.cameraId;
     const peer = this.webRtcPeers[id];
 
-    log('info', 'SDP answer received from server. Processing ...');
+    this.logger('debug', 'SDP answer received from server. Processing ...', {cameraId: id, sdpAnswer: message.sdpAnswer});
 
     if (peer) {
       peer.processAnswer(message.sdpAnswer, (error) => {
         if (error) {
-          return log('error', JSON.stringify(error));
+          return this.logger('debug', JSON.stringify(error), {cameraId: id});
         }
       });
     } else {
@@ -313,11 +320,13 @@ class VideoProvider extends Component {
   handleIceCandidate(message) {
     const webRtcPeer = this.webRtcPeers[message.cameraId];
 
+    this.logger('debug', 'Received remote ice candidate', {topic: 'ice', candidate: message.candidate})
+
     if (webRtcPeer) {
       if (webRtcPeer.didSDPAnswered) {
         webRtcPeer.addIceCandidate(message.candidate, (err) => {
           if (err) {
-            return log('error', `Error adding candidate: ${err}`);
+            return this.logger('error', `Error adding candidate: ${err}`, {cameraId: message.cameraId});
           }
         });
       } else {
@@ -327,12 +336,12 @@ class VideoProvider extends Component {
         webRtcPeer.iceQueue.push(message.candidate);
       }
     } else {
-      log('warn', '[iceCandidate] Message arrived after the peer was already thrown out, discarding it...');
+      this.logger('warn', ' [iceCandidate] Message arrived after the peer was already thrown out, discarding it...', {cameraId: message.cameraId});
     }
   }
 
   stopWebRTCPeer(id) {
-    log('info', 'Stopping webcam', id);
+    this.logger('info', 'Stopping webcam', {cameraId: id});
     const { userId } = this.props;
     const shareWebcam = id === userId;
 
@@ -357,11 +366,11 @@ class VideoProvider extends Component {
   destroyWebRTCPeer(id) {
     const webRtcPeer = this.webRtcPeers[id];
     if (webRtcPeer) {
-      log('info', 'Stopping WebRTC peer');
+      this.logger('info', 'Stopping WebRTC peer', {cameraId: id});
       webRtcPeer.dispose();
       delete this.webRtcPeers[id];
     } else {
-      log('warn', 'No WebRTC peer to stop (not an error)');
+      this.logger('warn', 'No WebRTC peer to stop (not an error)', {cameraId: id});
     }
   }
 
@@ -428,7 +437,7 @@ class VideoProvider extends Component {
             return this._webRTCOnError(errorGenOffer, id, shareWebcam);
           }
 
-          log('error', `Invoking SDP offer callback function ${location.host}`);
+          this.logger('debug', `Invoking SDP offer callback function ${location.host}`, {cameraId: id, offerSdp});
 
           const message = {
             type: 'video',
@@ -440,7 +449,7 @@ class VideoProvider extends Component {
           };
           this.sendMessage(message);
 
-          this._processIceQueue(peer);
+          this._processIceQueue(peer, id);
 
           peer.didSDPAnswered = true;
         });
@@ -452,7 +461,7 @@ class VideoProvider extends Component {
     const { intl } = this.props;
 
     return () => {
-      log('error', `Camera share has not suceeded in ${CAMERA_SHARE_FAILED_WAIT_TIME} for ${id}`);
+      this.logger('error', `Camera share has not suceeded in ${CAMERA_SHARE_FAILED_WAIT_TIME}`, {cameraId: id});
 
       if (this.props.userId === id) {
         this.notifyError(intl.formatMessage(intlClientErrors.sharingError));
@@ -473,7 +482,7 @@ class VideoProvider extends Component {
     };
   }
 
-  _processIceQueue(peer) {
+  _processIceQueue(peer, cameraId) {
     const { intl } = this.props;
 
     while (peer.iceQueue.length) {
@@ -481,7 +490,7 @@ class VideoProvider extends Component {
       peer.addIceCandidate(candidate, (err) => {
         if (err) {
           this.notifyError(intl.formatMessage(intlClientErrors.iceCandidateError));
-          return console.log(`Error adding candidate: ${err}`);
+          return this.logger('error', `Error adding candidate: ${err}`, {cameraId});
         }
       });
     }
@@ -490,8 +499,8 @@ class VideoProvider extends Component {
   _webRTCOnError(error, id, shareWebcam) {
     const { intl } = this.props;
 
-    log('error', ' WebRTC peerObj create error');
-    log('error', JSON.stringify(error));
+    this.logger('error', ' WebRTC peerObj create error', id);
+    this.logger('error', error, id);
     const errorMessage = intlClientErrors[error.name]
       || intlClientErrors.permissionError;
     this.notifyError(intl.formatMessage(errorMessage));
@@ -502,7 +511,7 @@ class VideoProvider extends Component {
 
     this.stopWebRTCPeer(id);
 
-    return log('error', JSON.stringify(errorMessage));
+    return this.logger('error', errorMessage, {cameraId: id});
   }
 
   _getOnIceCandidateCallback(id, shareWebcam) {
@@ -513,9 +522,11 @@ class VideoProvider extends Component {
       if (!this.restartTimeout[id]) {
         this.restartTimer[id] = this.restartTimer[id] || CAMERA_SHARE_FAILED_WAIT_TIME;
 
-        log('info', `Setting a camera connection restart in ${this.restartTimer[id]}`);
+        this.logger('debug', `Setting a camera connection restart in ${this.restartTimer[id]}`, {cameraId: id});
         this.restartTimeout[id] = setTimeout(this._getWebRTCStartTimeout(id, shareWebcam, peer), this.restartTimer[id]);
       }
+
+      this.logger('debug', 'Generated local ice candidate', {topic: 'ice', candidate})
 
       const message = {
         type: 'video',
@@ -689,14 +700,14 @@ class VideoProvider extends Component {
 
       callback(result);
     }, (exception) => {
-      log('error', `customGetStats() Promise rejected: ${exception.message}`);
+      this.logger('error', `customGetStats() Promise rejected: ${exception.message}`);
       callback(null);
     });
   }
 
   monitorTrackStart(peer, track, local, callback) {
     const that = this;
-    console.log('Starting stats monitoring on', track.id);
+    this.logger('info', 'Starting stats monitoring on', {cameraId: track.id});
     const getStatsInterval = 2000;
 
     const callGetStats = () => {
@@ -721,7 +732,7 @@ class VideoProvider extends Component {
         getStatsInterval,
       );
     } else {
-      console.log('Already monitoring this track');
+      this.logger('info', 'Already monitoring this track');
     }
   }
 
@@ -729,9 +740,9 @@ class VideoProvider extends Component {
     if (this.monitoredTracks[trackId]) {
       clearInterval(this.monitoredTracks[trackId]);
       delete this.monitoredTracks[trackId];
-      console.log(`Track ${trackId} removed`);
+      this.logger('info', `Track ${trackId} removed`);
     } else {
-      console.log(`Track ${trackId} is not monitored`);
+      this.logger('info', `Track ${trackId} is not monitored`);
     }
   }
 
@@ -762,9 +773,9 @@ class VideoProvider extends Component {
   }
 
   handlePlayStop(message) {
-    const id = message.cameraId;
+    const {cameraId} = message;
 
-    log('info', 'Handle play stop for camera', id);
+    this.logger('info', 'Handle play stop for camera', {cameraId});
     this.stopWebRTCPeer(id);
   }
 
@@ -774,7 +785,7 @@ class VideoProvider extends Component {
     const videoTag = this.videoTags[id];
 
     if (peer) {
-      log('info', 'Handle play start for camera', id);
+      this.logger('info', 'Handle play start for camera', {cameraId: id});
 
       // Clear camera shared timeout when camera succesfully starts
       clearTimeout(this.restartTimeout[id]);
@@ -808,6 +819,8 @@ class VideoProvider extends Component {
     } else {
       this.stopWebRTCPeer(message.cameraId);
     }
+
+    this.logger('error', `Handle error ---------------------> ${message.message}`);
   }
 
   notifyError(message) {
@@ -818,17 +831,17 @@ class VideoProvider extends Component {
     const { intl } = this.props;
 
     if (this.connectedToMediaServer()) {
-      log('info', 'Sharing webcam');
+      this.logger('info', 'Sharing webcam');
       this.sharedWebcam = true;
       VideoService.joiningVideo();
     } else {
-      log('debug', 'Error on sharing webcam');
+      this.logger('debug', 'Error on sharing webcam');
       this.notifyError(intl.formatMessage(intlClientErrors.sharingError));
     }
   }
 
   unshareWebcam() {
-    log('info', 'Unsharing webcam');
+    this.logger('info', 'Unsharing webcam');
 
     VideoService.sendUserUnshareWebcam(this.props.userId);
     VideoService.exitedVideo();

--- a/bigbluebutton-html5/imports/ui/components/video-provider/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/container.jsx
@@ -11,5 +11,6 @@ export default withTracker(() => ({
   users: VideoService.getAllUsersVideo(),
   userId: VideoService.userId(),
   sessionToken: VideoService.sessionToken(),
+  userName: VideoService.userName(),
   enableVideoStats: Meteor.settings.public.kurento.enableVideoStats,
 }))(VideoProviderContainer);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -58,7 +58,6 @@ class VideoService {
   }
 
   exitedVideo() {
-    console.warn('exitedVideo');
     this.isSharing = false;
     this.isWaitingResponse = false;
     this.isConnected = false;
@@ -114,6 +113,11 @@ class VideoService {
     return Auth.userID;
   }
 
+  userName() {
+    const currentUser = Users.findOne({ userId: Auth.userID });
+    return currentUser.name;
+  }
+
   meetingId() {
     return Auth.meetingID;
   }
@@ -149,6 +153,7 @@ export default {
   sendUserShareWebcam: stream => videoService.sendUserShareWebcam(stream),
   sendUserUnshareWebcam: stream => videoService.sendUserUnshareWebcam(stream),
   userId: () => videoService.userId(),
+  userName: () => videoService.userName(),
   meetingId: () => videoService.meetingId(),
   getAllUsersVideo: () => videoService.getAllUsersVideo(),
   sessionToken: () => videoService.sessionToken(),

--- a/bigbluebutton-html5/imports/ui/services/api/index.js
+++ b/bigbluebutton-html5/imports/ui/services/api/index.js
@@ -53,7 +53,7 @@ export function log(type = 'error', message, ...args) {
     location: window.location.href,
   };
   const logContents = { ...args };
-  const topic = typeof logContents[0] ? logContents[0].topic : null;
+  const topic = logContents[0] ? logContents[0].topic : null;
 
   const messageOrStack = message.stack || message.message || JSON.stringify(message);
   console.debug(`CLIENT LOG (${topic ? type.toUpperCase() + '.' + topic : type.toUpperCase()}): `, messageOrStack, ...args);

--- a/bigbluebutton-html5/imports/ui/services/api/index.js
+++ b/bigbluebutton-html5/imports/ui/services/api/index.js
@@ -52,9 +52,11 @@ export function log(type = 'error', message, ...args) {
     bbbVersion: Meteor.settings.public.app.bbbServerVersion,
     location: window.location.href,
   };
+  const logContents = { ...args };
+  const topic = typeof logContents[0] ? logContents[0].topic : null;
 
-  const messageOrStack = message.stack || message.message || message.toString();
-  console.debug(`CLIENT LOG (${type.toUpperCase()}): `, messageOrStack, ...args);
+  const messageOrStack = message.stack || message.message || JSON.stringify(message);
+  console.debug(`CLIENT LOG (${topic ? type.toUpperCase() + '.' + topic : type.toUpperCase()}): `, messageOrStack, ...args);
 
   Meteor.call('logClient', type, messageOrStack, {
     clientInfo,


### PR DESCRIPTION
These commits add a few new options to the logging of mostly the media components using webrtc and the  bbb-webrtc-sfu.

Logging messages in these components now have a final object argument that can include a number of options. By default, we include the userId and userName that is calling the logger funcition and a 'topic' that is the name of the component, but can be overriden. New stuff can be added on a call by call basis. Here's some examples:

    CLIENT LOG (DEBUG.ws):  "Received new message 'playStart'" , {
      message: {
        connectionId: 10,
        type: "video",
        role: "share",
        id: "playStart",
        cameraId: "w_29yvkyefydmz",
      },
      topic: "ws",
      userId: "w_29yvkyefydmz",
      userName: "vvvvv",
    }

    CLIENT LOG (INFO.video):  "Handle play start for camera", { 
      cameraId: "w_29yvkyefydmz",
      topic: "video",
      userId: "w_29yvkyefydmz",
      userName: "vvvvv",
    }

    CLIENT LOG (DEBUG.ws):  "Sending message 'ping'" , {
      message: {id: "ping"}
      topic: "ws",
      userId: "w_29yvkyefydmz",
      userName: "vvvvv",
    }

The object parameter can be easily inspected in a browser's console.