### PR TITLE
[HTML5] Attempt to fix SIP.js listen only permission problems

### DIFF
--- a/bigbluebutton-html5/client/compatibility/sip.js
+++ b/bigbluebutton-html5/client/compatibility/sip.js
@@ -11572,11 +11572,7 @@ MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
       })
       .then(function onSetLocalDescriptionSuccess() {
         var deferred = SIP.Utils.defer();
-        if (pc.iceGatheringState === 'complete' && (pc.iceConnectionState === 'connected' || pc.iceConnectionState === 'completed')) {
-          deferred.resolve();
-        } else {
-          self.onIceCompleted.promise.then(deferred.resolve);
-        }
+        self.onIceCompleted.promise.then(deferred.resolve);
         return deferred.promise;
       })
       .then(function readySuccess () {


### PR DESCRIPTION
Rationale: the negotiation failed because SIP.js was resolving the local description without properly waiting for ICE completion, so the generated SDP would end up without any ICE candidate and FreeSWITCH would reject the call. The permissioning thing was more of a side effect that freed the stuck ICE candidate, so it ended up work. We now only resolve the local description when ICE gathering was properly completed and processed.