### PR TITLE
Handling the case when browser detection package fails.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/desktop-share/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/desktop-share/component.jsx
@@ -34,8 +34,10 @@ const intlMessages = defineMessages({
 });
 
 const BROWSER_RESULTS = browser();
-const isMobileBrowser = BROWSER_RESULTS.mobile ||
-  BROWSER_RESULTS.os.includes('Android'); // mobile flag doesn't always work
+const isMobileBrowser = (BROWSER_RESULTS ? BROWSER_RESULTS.mobile : false) ||
+  (BROWSER_RESULTS && BROWSER_RESULTS.os ?
+    BROWSER_RESULTS.os.includes('Android') : // mobile flag doesn't always work
+    false);
 const screenSharingCheck = Meteor.settings.public.kurento.enableScreensharing;
 
 const DesktopShare = ({

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -81,8 +81,12 @@ class App extends Component {
 
     const BROWSER_RESULTS = browser();
     const body = document.getElementsByTagName('body')[0];
-    body.classList.add(`browser-${BROWSER_RESULTS.name}`);
-    body.classList.add(`os-${BROWSER_RESULTS.os.split(' ').shift().toLowerCase()}`);
+    if (BROWSER_RESULTS && BROWSER_RESULTS.name) {
+      body.classList.add(`browser-${BROWSER_RESULTS.name}`);
+    }
+    if (BROWSER_RESULTS && BROWSER_RESULTS.os) {
+      body.classList.add(`os-${BROWSER_RESULTS.os.split(' ').shift().toLowerCase()}`);
+    }
 
     this.handleWindowResize();
     window.addEventListener('resize', this.handleWindowResize, false);

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/container.jsx
@@ -53,7 +53,7 @@ export default class SettingsDropdownContainer extends Component {
     const handleToggleFullscreen = toggleFullScreen;
     const isFullScreen = this.state.isFullScreen;
     const result = browser();
-    const isAndroid = result.os.includes('Android');
+    const isAndroid = (result && result.os) ? result.os.includes('Android') : false;
 
     return (
       <SettingsDropdown


### PR DESCRIPTION
When you run the client in headless Chrome, it is possible to get `undefined` values from `browser-detect`. This PR allows client to work well in that situation (browser detection defaults to desktop).