### PR TITLE
Add check for logClient to obtain meetingId for media calls

### DIFF
--- a/bigbluebutton-html5/imports/api/log-client/server/methods/logClient.js
+++ b/bigbluebutton-html5/imports/api/log-client/server/methods/logClient.js
@@ -1,13 +1,14 @@
 import Logger from '/imports/startup/server/logger';
 import Users from '/imports/api/users';
 
-const logClient = function (type, log, fullInfo) {
+const logClient = function (type, log, fullInfo = {}) {
   const SERVER_CONN_ID = this.connection.id;
   const User = Users.findOne({ connectionId: SERVER_CONN_ID });
   const logContents = { fullInfo };
 
   if (User) {
-    if (User.meetingId === fullInfo.credentials.meetingId) {
+    if ((fullInfo.credentials && User.meetingId === fullInfo.credentials.meetingId) ||
+      ((fullInfo.meetingId && User.meetingId === fullInfo.meetingId))) {
       logContents.validUser = 'valid';
     } else {
       logContents.validUser = 'invalid';

--- a/bigbluebutton-html5/imports/api/users/server/handlers/guestApproved.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/guestApproved.js
@@ -11,7 +11,7 @@ export default function handleGuestsWaitingForApproval({ header, body }, meeting
   check(meetingId, String);
   check(approvedBy, String);
 
-  return guests.forEach(item => {
+  return guests.forEach((item) => {
     const { guest, approved } = item;
 
     check(approved, Boolean);
@@ -20,7 +20,7 @@ export default function handleGuestsWaitingForApproval({ header, body }, meeting
     const selector = {
       meetingId,
       userId: guest,
-      clientType: "HTML5",
+      clientType: 'HTML5',
     };
 
     const User = Users.findOne(selector);
@@ -30,5 +30,5 @@ export default function handleGuestsWaitingForApproval({ header, body }, meeting
     }
 
     setApprovedStatus(meetingId, guest, approved, approvedBy);
-  })
+  });
 }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -168,7 +168,6 @@ WhiteboardMultiUser.find({ meetingId: Auth.meetingID }).observeChanges({
 
 Users.find({ userId: Auth.userID }).observeChanges({
   changed(id, { presenter }) {
-    console.log(presenter);
     if (presenter === false) clearFakeAnnotations();
   },
 });


### PR DESCRIPTION
Prior to this we could see `Error invoking Method 'logClient': Internal server error [500]` when webcams/screenshare were active