### PR TITLE
Added help button to drop-down list

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -103,7 +103,7 @@ class SettingsDropdown extends Component {
     const { fullscreenLabel, fullscreenDesc, fullscreenIcon } = this.checkFullscreen(this.props);
     const { showHelpButton: helpButton } = Meteor.settings.public.app;
 
-    this.menuItems = [(<DropdownListItem
+    this.menuItems =_.compact( [(<DropdownListItem
       key={_.uniqueId('list-item-')}
       icon={fullscreenIcon}
       label={fullscreenLabel}
@@ -124,6 +124,7 @@ class SettingsDropdown extends Component {
         description={intl.formatMessage(intlMessages.aboutDesc)}
         onClick={() => mountModal(<AboutContainer />)}
       />),
+      !helpButton ? null :
       (<DropdownListItem
         key={_.uniqueId('list-item-')}
         icon="help"
@@ -146,16 +147,14 @@ class SettingsDropdown extends Component {
         description={intl.formatMessage(intlMessages.leaveSessionDesc)}
         onClick={() => mountModal(<LogoutConfirmationContainer />)}
       />),
-    ];
+    ])
 
     // Removes fullscreen button if not on Android
     if (!isAndroid) {
       this.menuItems.shift();
     }
 
-    if (!helpButton) {
-      this.menuItems.splice(2, 1);
-    }
+
   }
 
   componentWillReceiveProps(nextProps) {

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -101,7 +101,7 @@ class SettingsDropdown extends Component {
   componentWillMount() {
     const { intl, mountModal, isAndroid } = this.props;
     const { fullscreenLabel, fullscreenDesc, fullscreenIcon } = this.checkFullscreen(this.props);
-    const { isHelpButton: helpButton } = Meteor.settings.public.app;
+    const { showHelpButton: helpButton } = Meteor.settings.public.app;
 
     this.menuItems = [(<DropdownListItem
       key={_.uniqueId('list-item-')}
@@ -126,7 +126,7 @@ class SettingsDropdown extends Component {
       />),
       (<DropdownListItem
         key={_.uniqueId('list-item-')}
-        icon="about"
+        icon="help"
         label={intl.formatMessage(intlMessages.helpLabel)}
         description={intl.formatMessage(intlMessages.helpDesc)}
         onClick={() => window.open('https://bigbluebutton.org/videos/')}

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -101,6 +101,7 @@ class SettingsDropdown extends Component {
   componentWillMount() {
     const { intl, mountModal, isAndroid } = this.props;
     const { fullscreenLabel, fullscreenDesc, fullscreenIcon } = this.checkFullscreen(this.props);
+    const { isHelpButton: helpButton } = Meteor.settings.public.app;
 
     this.menuItems = [(<DropdownListItem
       key={_.uniqueId('list-item-')}
@@ -150,6 +151,10 @@ class SettingsDropdown extends Component {
     // Removes fullscreen button if not on Android
     if (!isAndroid) {
       this.menuItems.shift();
+    }
+
+    if (!helpButton) {
+      this.menuItems.splice(2, 1);
     }
   }
 

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -73,6 +73,14 @@ const intlMessages = defineMessages({
     id: 'app.navBar.settingsDropdown.hotkeysDesc',
     description: 'Describes hotkeys option',
   },
+  helpLabel: {
+    id: 'app.navBar.settingsDropdown.helpLabel',
+    description: 'Help options label',
+  },
+  helpDesc: {
+    id: 'app.navBar.settingsDropdown.helpDesc',
+    description: 'Describes help option',
+  },
 });
 
 const SHORTCUTS_CONFIG = Meteor.settings.public.app.shortcuts;
@@ -118,6 +126,13 @@ class SettingsDropdown extends Component {
       (<DropdownListItem
         key={_.uniqueId('list-item-')}
         icon="about"
+        label={intl.formatMessage(intlMessages.helpLabel)}
+        description={intl.formatMessage(intlMessages.helpDesc)}
+        onClick={() => window.open('https://bigbluebutton.org/videos/')}
+      />),
+      (<DropdownListItem
+        key={_.uniqueId('list-item-')}
+        icon="shortcuts"
         label={intl.formatMessage(intlMessages.hotkeysLabel)}
         description={intl.formatMessage(intlMessages.hotkeysDesc)}
         onClick={() => mountModal(<ShortcutHelpComponent />)}

--- a/bigbluebutton-html5/private/config/settings-development.json
+++ b/bigbluebutton-html5/private/config/settings-development.json
@@ -67,7 +67,8 @@
       "allowHTML5Moderator": true,
       "allowModeratorToUnmuteAudio": true,
       "httpsConnection": false,
-      "connectionTimeout": 60000
+      "connectionTimeout": 60000,
+      "isHelpButton": true
     },
 
     "kurento": {

--- a/bigbluebutton-html5/private/config/settings-development.json
+++ b/bigbluebutton-html5/private/config/settings-development.json
@@ -68,7 +68,7 @@
       "allowModeratorToUnmuteAudio": true,
       "httpsConnection": false,
       "connectionTimeout": 60000,
-      "isHelpButton": true
+      "showHelpButton": true
     },
 
     "kurento": {

--- a/bigbluebutton-html5/private/config/settings-production.json
+++ b/bigbluebutton-html5/private/config/settings-production.json
@@ -68,7 +68,7 @@
       "allowModeratorToUnmuteAudio": true,
       "httpsConnection": true,
       "connectionTimeout": 10000,
-      "isHelpButton": true
+      "showHelpButton": true
     },
 
     "kurento": {

--- a/bigbluebutton-html5/private/config/settings-production.json
+++ b/bigbluebutton-html5/private/config/settings-production.json
@@ -67,7 +67,8 @@
       "allowHTML5Moderator": true,
       "allowModeratorToUnmuteAudio": true,
       "httpsConnection": true,
-      "connectionTimeout": 10000
+      "connectionTimeout": 10000,
+      "isHelpButton": true
     },
 
     "kurento": {

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -97,6 +97,8 @@
     "app.navBar.settingsDropdown.exitFullscreenDesc": "Exit fullscreen mode",
     "app.navBar.settingsDropdown.hotkeysLabel": "Hotkeys",
     "app.navBar.settingsDropdown.hotkeysDesc": "Listing of available hotkeys",
+    "app.navBar.settingsDropdown.helpLabel": "Help",
+    "app.navBar.settingsDropdown.helpDesc": "Links user to video tutorials",
     "app.navBar.userListToggleBtnLabel": "User List Toggle",
     "app.navBar.toggleUserList.ariaLabel": "Users and Messages Toggle",
     "app.navBar.toggleUserList.newMessages": "with new message notification",


### PR DESCRIPTION
Help button that links the user to the tutorial videos has been added to the drop-down list. The placeholder icon that is used for the button is the same icon used for the about button. Currently there is no icon that is a question mark can be used for the help button. #5962 