### PR TITLE
[HTML5] Added target bitrate option for WebRTC screenshare and webcam

### DIFF
--- a/bigbluebutton-html5/private/config/settings-development.json
+++ b/bigbluebutton-html5/private/config/settings-development.json
@@ -79,6 +79,14 @@
       "chromeExtensionLink": "LINK",
       "chromeScreenshareSources": ["window", "screen"],
       "firefoxScreenshareSource": "window",
+      "cameraConstraints": {
+        "width": {
+          "max": 640
+        },
+        "height": {
+          "max": 480
+        }
+      },
       "enableScreensharing": false,
       "enableVideo": false,
       "enableVideoStats": false,
@@ -344,9 +352,9 @@
       }
     },
     "clientLog": [
-      { 
-        "target": "server", 
-        "level": "info" 
+      {
+        "target": "server",
+        "level": "info"
       }
     ]
   },
@@ -378,7 +386,6 @@
         "DoLatencyTracerMsg"
       ]
     },
-
 
     "serverLog": {
       "level": "info"

--- a/bigbluebutton-html5/private/config/settings-production.json
+++ b/bigbluebutton-html5/private/config/settings-production.json
@@ -79,6 +79,14 @@
       "chromeExtensionLink": "LINK",
       "chromeScreenshareSources": ["window", "screen"],
       "firefoxScreenshareSource": "window",
+      "cameraConstraints": {
+        "width": {
+          "max": 640
+        },
+        "height": {
+          "max": 480
+        }
+      },
       "enableScreensharing": false,
       "enableVideo": false,
       "enableVideoStats": false,
@@ -344,9 +352,9 @@
       }
     },
     "clientLog": [
-      { 
-        "target": "server", 
-        "level": "info" 
+      {
+        "target": "server",
+        "level": "info"
       }
     ]
   },

--- a/labs/bbb-webrtc-sfu/config/default.example.yml
+++ b/labs/bbb-webrtc-sfu/config/default.example.yml
@@ -18,9 +18,13 @@ to-akka: "to-akka-apps-redis-channel"
 from-akka: "from-akka-apps-redis-channel"
 common-message-version: "2.x"
 webcam-force-h264: true
+# Target bitrate (kbps) for webcams. Value 0 leaves it unconstrained.
+webcam-target-bitrate: 300000
 screenshare-force-h264: true
 screenshare-preferred-h264-profile: "42e01f"
 screenshareKeyframeInterval: 2
+# Target bitrate (kbps) for screenshare. Value 0 leaves it unconstrained.
+screenshare-target-bitrate: 0
 
 recordScreenSharing: true
 recordWebcams: false

--- a/labs/bbb-webrtc-sfu/config/default.example.yml
+++ b/labs/bbb-webrtc-sfu/config/default.example.yml
@@ -19,7 +19,7 @@ from-akka: "from-akka-apps-redis-channel"
 common-message-version: "2.x"
 webcam-force-h264: true
 # Target bitrate (kbps) for webcams. Value 0 leaves it unconstrained.
-webcam-target-bitrate: 300000
+webcam-target-bitrate: 300
 screenshare-force-h264: true
 screenshare-preferred-h264-profile: "42e01f"
 screenshareKeyframeInterval: 2

--- a/labs/bbb-webrtc-sfu/lib/audio/audio.js
+++ b/labs/bbb-webrtc-sfu/lib/audio/audio.js
@@ -255,7 +255,7 @@ module.exports = class Audio extends BaseProvider {
       return Promise.resolve();
     }
     catch (err) {
-      reject(this._handleError(LOG_PREFIX, err, "recv", this.userId));
+      throw (this._handleError(LOG_PREFIX, err, "recv", this.userId));
     }
   };
 

--- a/labs/bbb-webrtc-sfu/lib/mcs-core/lib/model/SdpSession.js
+++ b/labs/bbb-webrtc-sfu/lib/mcs-core/lib/model/SdpSession.js
@@ -60,13 +60,19 @@ module.exports = class SdpSession extends MediaSession {
           return reject(this._handleError(C.ERROR.MEDIA_NO_AVAILABLE_CODEC));
         }
 
+        const { targetBitrate } = this._options;
+
+        if (answer && targetBitrate && targetBitrate !== '0') {
+          this._answer.addBandwidth('video', targetBitrate);
+        }
+
         if (this._type !== 'WebRtcEndpoint') {
           this._offer.replaceServerIpv4(kurentoIp);
-          return resolve(answer);
+          return resolve(this._answer? this._answer._plainSdp : null);
         }
 
         await this._MediaServer.gatherCandidates(this._mediaElement);
-        resolve(answer);
+        resolve(this._answer._plainSdp);
       }
       catch (err) {
         return reject(this._handleError(err));

--- a/labs/bbb-webrtc-sfu/lib/mcs-core/lib/utils/SdpWrapper.js
+++ b/labs/bbb-webrtc-sfu/lib/mcs-core/lib/utils/SdpWrapper.js
@@ -54,6 +54,20 @@ module.exports = class SdpWrapper {
     return this._mediaCapabilities.hasAvailableAudioCodec;
   }
 
+  addBandwidth (type, bw) {
+    // Bandwidth format
+    // { type: 'TIAS or AS', limit: 2048000 }
+    for(var ml of this._jsonSdp.media) {
+      if(ml.type === type ) {
+        ml['bandwidth'] = [];
+        ml.bandwidth.push({ type: 'TIAS', limit: (bw >>> 0) * 1000 });
+        ml.bandwidth.push({ type: 'AS', limit: bw });
+      }
+    }
+
+    this._plainSdp = transform.write(this._jsonSdp);
+  }
+
   /**
    * Given a SDP, test if there is an audio description in it
    * @return {boolean}    true if there is more than one video description, else false

--- a/labs/bbb-webrtc-sfu/lib/screenshare/screenshare.js
+++ b/labs/bbb-webrtc-sfu/lib/screenshare/screenshare.js
@@ -21,6 +21,7 @@ const kurentoIp = config.get('kurentoIp');
 const localIpAddress = config.get('localIpAddress');
 const FORCE_H264 = config.get('screenshare-force-h264');
 const PREFERRED_H264_PROFILE = config.get('screenshare-preferred-h264-profile');
+const SCREENSHARE_TARGET_BITRATE = config.get('screenshare-target-bitrate');
 const SHOULD_RECORD = config.get('recordScreenSharing');
 const KEYFRAME_INTERVAL = config.get('screenshareKeyframeInterval');
 const LOG_PREFIX = "[screenshare]";
@@ -274,7 +275,7 @@ module.exports = class Screenshare extends BaseProvider {
   _startPresenter (sdpOffer) {
     return new Promise(async (resolve, reject) => {
       try {
-        const retSource = await this.mcs.publish(this.mcsUserId, this._meetingId, 'WebRtcEndpoint', {descriptor: sdpOffer});
+        const retSource = await this.mcs.publish(this.mcsUserId, this._meetingId, 'WebRtcEndpoint', {descriptor: sdpOffer, targetBitrate: SCREENSHARE_TARGET_BITRATE });
 
         this._presenterEndpoint = retSource.sessionId;
         sharedScreens[this._voiceBridge] = this._presenterEndpoint;

--- a/labs/bbb-webrtc-sfu/lib/video/video.js
+++ b/labs/bbb-webrtc-sfu/lib/video/video.js
@@ -9,6 +9,7 @@ const Messaging = require('../bbb/messages/Messaging');
 const h264_sdp = require('../h264-sdp');
 const BaseProvider = require('../base/BaseProvider');
 const FORCE_H264 = config.get('webcam-force-h264');
+const WEBCAM_TARGET_BITRATE = config.get('webcam-target-bitrate');
 const SHOULD_RECORD = config.get('recordWebcams');
 const LOG_PREFIX = "[video]";
 
@@ -259,7 +260,7 @@ module.exports = class Video extends BaseProvider {
     return new Promise(async (resolve, reject) => {
       try {
         if (this.shared) {
-          let { answer, sessionId } = await this.mcs.publish(this.userId, this.meetingId, type, { descriptor });
+          let { answer, sessionId } = await this.mcs.publish(this.userId, this.meetingId, type, { descriptor, targetBitrate: WEBCAM_TARGET_BITRATE });
           this.mediaId = sessionId;
           sharedWebcams[this.id] = this.mediaId;
           return resolve(answer);


### PR DESCRIPTION
This PR adds a target bitrate option for both WebRTC webcams and screenshare. This can be configured in `bbb-webrtc-sfu`'s `config/default.yml`. See the `default.example.yml` file for an example. The new parameters are:
  - `webcam-target-bitrate`: webcam target bitrate in kbps. Set it to `0` for unconstrained. Default 300 kbps.
  - `screenshare-target-bitrate`: screenshare target bitrate in kbps. Set it to `0` for unconstrained. Default is unconstrained.

Be aware that the target bitrate will act as an ideal bitrate, but it might still be lower than that because we still use a REMB approach where the bitrate is scaled down to fit the worst connection in the conference.

Also added in this PR:
  - Made the WebRTC camera constraints configurable. We can now set them (in the WebRTC spec format) in the settings-development/production.json files. The configuration property is `kurento.cameraConstraints`. I removed the FPS constraints because the new target bitrate option already takes care of it, and it should (hopefully) diminish a few of the incompatibility issues with mobile devices (e.g. #5765), while also providing a smoother video.
  - Fixed exceptions found in `handlePlayStop` and `stopWebRTC` methods.