### PR TITLE
[HTML5] Fixed WebRTC Screenshare isVideoBroadcasting check

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -13,8 +13,9 @@ const isVideoBroadcasting = () => {
     return false;
   }
 
+  const hasStream = ds.screenshare.stream ? true : false;
   // TODO commented out isPresenter to enable screen viewing to the presenter
-  return ds.screenshare.stream; // && !PresentationService.isPresenter();
+  return hasStream; // && !PresentationService.isPresenter();
 }
 
 // if remote screenshare has been ended disconnect and hide the video stream


### PR DESCRIPTION
It was firing an exception because the output was expected to be a `boolean` literal on the actions-bar component, but it was actually returning a string with the `rtmp` url.