### PR TITLE
Added preffered H264 profile to webcams on SFU

### DIFF
--- a/labs/bbb-webrtc-sfu/config/default.example.yml
+++ b/labs/bbb-webrtc-sfu/config/default.example.yml
@@ -18,6 +18,7 @@ to-akka: "to-akka-apps-redis-channel"
 from-akka: "from-akka-apps-redis-channel"
 common-message-version: "2.x"
 webcam-force-h264: true
+webcam-preferred-h264-profile: "42e01f"
 # Target bitrate (kbps) for webcams. Value 0 leaves it unconstrained.
 webcam-target-bitrate: 300000
 screenshare-force-h264: true

--- a/labs/bbb-webrtc-sfu/lib/video/video.js
+++ b/labs/bbb-webrtc-sfu/lib/video/video.js
@@ -7,6 +7,7 @@ const C = require('../bbb/messages/Constants');
 const Logger = require('../utils/Logger');
 const Messaging = require('../bbb/messages/Messaging');
 const h264_sdp = require('../h264-sdp');
+const PREFERRED_H264_PROFILE = config.get('webcam-preferred-h264-profile');
 const BaseProvider = require('../base/BaseProvider');
 const FORCE_H264 = config.get('webcam-force-h264');
 const WEBCAM_TARGET_BITRATE = config.get('webcam-target-bitrate');
@@ -231,7 +232,7 @@ module.exports = class Video extends BaseProvider {
 
       // Force H264
       if (FORCE_H264) {
-        sdpOffer = h264_sdp.transform(sdpOffer);
+        sdpOffer = h264_sdp.transform(sdpOffer, PREFERRED_H264_PROFILE);
       }
 
       // Start the recording process


### PR DESCRIPTION
Port from the work done to fix Chrome+Windows 10 screensharing garbling problems. Same thing was happening on some webcams (low bandwidth approach coupled with a higher H264 profile that ended up making chrome compress the stream too much).