### PR TITLE
Add config option in akka-apps for default multi-user whiteboard state

### DIFF
--- a/akka-bbb-apps/src/main/resources/application.conf
+++ b/akka-bbb-apps/src/main/resources/application.conf
@@ -74,3 +74,7 @@ sharedNotes {
   maxNumberOfNotes = 3
   maxNumberOfUndos = 30
 }
+
+whiteboard {
+  multiUserDefault = false
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
@@ -55,4 +55,6 @@ trait SystemConfiguration {
 
   lazy val maxNumberOfNotes = Try(config.getInt("sharedNotes.maxNumberOfNotes")).getOrElse(3)
   lazy val maxNumberOfUndos = Try(config.getInt("sharedNotes.maxNumberOfUndos")).getOrElse(30)
+
+  lazy val multiUserWhiteboardDefault = Try(config.getBoolean("whiteboard.multiUserDefault")).getOrElse(false)
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
@@ -7,11 +7,12 @@ import scala.collection.immutable.HashMap
 import scala.collection.JavaConverters._
 import org.bigbluebutton.common2.msgs.AnnotationVO
 import org.bigbluebutton.core.apps.whiteboard.Whiteboard
+import org.bigbluebutton.SystemConfiguration
 
-class WhiteboardModel {
+class WhiteboardModel extends SystemConfiguration {
   private var _whiteboards = new HashMap[String, Whiteboard]()
 
-  private var _multiUser = false
+  private var _multiUser = multiUserWhiteboardDefault
 
   private def saveWhiteboard(wb: Whiteboard) {
     _whiteboards += wb.id -> wb


### PR DESCRIPTION
This PR adds a config property "whiteboard.multiUserDefault" to the akka-apps config that determines what the starting state of the multi-user whiteboard is. The default default is "false".