### PR TITLE
Improvements to SFU listen only error handling

### DIFF
--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -253,7 +253,7 @@ Kurento.prototype.onWSMessage = function (message) {
       this.onSuccess(parsedMessage.success);
       break;
     case 'webRTCAudioError':
-      this.onFail(parsedMessage.error);
+      this.onFail(parsedMessage);
       break;
     case 'pong':
       break;

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
@@ -88,11 +88,16 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
 
         const onSuccess = ack => resolve(this.callback({ status: this.baseCallStates.started }));
 
-        const onFail = error => resolve(this.callback({
-          status: this.baseCallStates.failed,
-          error: this.baseErrorCodes.CONNECTION_ERROR,
-          bridgeError: error,
-        }));
+        const onFail = error => {
+          const { reason } = error;
+          this.callback({
+            status: this.baseCallStates.failed,
+            error: this.baseErrorCodes.CONNECTION_ERROR,
+            bridgeError: reason,
+          })
+
+          reject(reason);
+        };
 
         if (!isListenOnly) {
           return reject("Invalid bridge option");

--- a/labs/bbb-webrtc-sfu/lib/audio/audio.js
+++ b/labs/bbb-webrtc-sfu/lib/audio/audio.js
@@ -155,53 +155,56 @@ module.exports = class Audio extends BaseProvider {
     }
   }
 
-  async start (sessionId, connectionId, sdpOffer, caleeName, userId, userName, callback) {
-    Logger.info(LOG_PREFIX, "Starting audio instance for", this.id);
-    let sdpAnswer;
+  start (sessionId, connectionId, sdpOffer, caleeName, userId, userName) {
+    return new Promise(async (resolve, reject) => {
+      Logger.info(LOG_PREFIX, "Starting audio instance for", this.id);
+      let sdpAnswer;
 
-    // Storing the user data to be used by the pub calls
-    let user = {userId: userId, userName: userName};
-    this.addUser(connectionId, user);
+      // Storing the user data to be used by the pub calls
+      let user = {userId: userId, userName: userName};
+      this.addUser(connectionId, user);
 
-    try {
-      if (!this.sourceAudioStarted) {
-        this.userId = await this.mcs.join(this.voiceBridge, 'SFU', {});
-        Logger.info(LOG_PREFIX, "MCS join for", this.id, "returned", this.userId);
+      try {
+        if (!this.sourceAudioStarted) {
+          this.userId = await this.mcs.join(this.voiceBridge, 'SFU', {});
+          Logger.info(LOG_PREFIX, "MCS join for", this.id, "returned", this.userId);
 
-        const ret = await this.mcs.publish(this.userId,
+          const ret = await this.mcs.publish(this.userId,
             this.voiceBridge,
             'RtpEndpoint',
             {descriptor: sdpOffer, adapter: 'Freeswitch', name: caleeName});
 
-        this.sourceAudio = ret.sessionId;
-        this.mcs.on('MediaEvent' + this.sourceAudio, this.mediaState.bind(this));
-        this.sourceAudioStarted = true;
+          this.sourceAudio = ret.sessionId;
+          this.mcs.on('MediaEvent' + this.sourceAudio, this.mediaState.bind(this));
+          this.mcs.on('ServerState' + this.sourceAudio, this.serverState.bind(this));
+          this.sourceAudioStarted = true;
 
-        Logger.info(LOG_PREFIX, "MCS publish for user", this.userId, "returned", this.sourceAudio);
-      }
+          Logger.info(LOG_PREFIX, "MCS publish for user", this.userId, "returned", this.sourceAudio);
+        }
 
-      const retSubscribe  = await this.mcs.subscribe(this.userId,
+        const retSubscribe  = await this.mcs.subscribe(this.userId,
           this.sourceAudio,
           'WebRtcEndpoint',
           {descriptor: sdpOffer, adapter: 'Kurento'});
 
-      this.audioEndpoints[connectionId] = retSubscribe.sessionId;
+        this.audioEndpoints[connectionId] = retSubscribe.sessionId;
 
-      sdpAnswer = retSubscribe.answer;
-      this.flushCandidatesQueue(connectionId);
+        sdpAnswer = retSubscribe.answer;
+        this.flushCandidatesQueue(connectionId);
 
-      this.mcs.on('MediaEvent' + retSubscribe.sessionId, (event) => {
-        this.mediaStateWebRtc(event, connectionId)
-      });
+        this.mcs.on('MediaEvent' + retSubscribe.sessionId, (event) => {
+          this.mediaStateWebRtc(event, connectionId)
+        });
 
-      Logger.info(LOG_PREFIX, "MCS subscribe for user", this.userId, "returned", retSubscribe.sessionId);
+        Logger.info(LOG_PREFIX, "MCS subscribe for user", this.userId, "returned", retSubscribe.sessionId);
 
-      return callback(null, sdpAnswer);
-    }
-    catch (err) {
-      return callback(this._handleError(LOG_PREFIX, err, "recv", userId));
-    }
-  };
+        return resolve(sdpAnswer);
+      }
+      catch (err) {
+        return reject(this._handleError(LOG_PREFIX, err, "recv", userId));
+      }
+    });
+  }
 
   async stopListener(id) {
     const listener = this.audioEndpoints[id];
@@ -310,4 +313,17 @@ module.exports = class Audio extends BaseProvider {
     }), C.FROM_AUDIO);
     this.removeUser(connectionId);
   };
+
+  serverState (event) {
+    const { eventTag: { code }  } = { ...event };
+    switch (code) {
+      case C.MEDIA_SERVER_OFFLINE:
+        Logger.error(LOG_PREFIX, "Provider received MEDIA_SERVER_OFFLINE event");
+        this.emit(C.MEDIA_SERVER_OFFLINE, event);
+        break;
+
+      default:
+        Logger.warn(LOG_PREFIX, "Unknown server state", event);
+    }
+  }
 };

--- a/labs/bbb-webrtc-sfu/lib/mcs-core/lib/adapters/freeswitch/freeswitch.js
+++ b/labs/bbb-webrtc-sfu/lib/mcs-core/lib/adapters/freeswitch/freeswitch.js
@@ -24,6 +24,10 @@ module.exports = class Freeswitch extends EventEmitter {
       this._sessions = {};
       this._rtpConverters = {};
       this._Kurento = new Kurento(config.get('kurentoUrl'));
+      this._Kurento.on(C.ERROR.MEDIA_SERVER_OFFLINE, () => {
+        this.emit(C.ERROR.MEDIA_SERVER_OFFLINE);
+      });
+
       instance = this;
     }
 


### PR DESCRIPTION
Includes:
  - Listen only correctly detects Kurento shutting down/crashing and meeting maintains a consistent state
  - Correctly propagating an error to the client when KMS is misconfigured or down
  - Fixed any "forever reconnecting" problem we had before (corrected client-side error handling on SFU audio bridge and implemented a max retry for the ICE gathering/joinListenOnly promise race)