### PR TITLE
Fix chromeExtensionLink restore in bbb-conf

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -1793,23 +1793,24 @@ if [ -n "$HOST" ]; then
 	echo "Assigning $HOST for servername in /etc/nginx/sites-available/bigbluebutton"
 	sudo sed -i "s/server_name  .*/server_name  $HOST;/g" /etc/nginx/sites-available/bigbluebutton
 
-        #
-        # Update configuration for BigBlueButton client (and preserve hostname for chromeExtensionLink if exists)
-        #
+	#
+	# Update configuration for BigBlueButton client (and preserve hostname for chromeExtensionLink if exists)
+	#
 
-        echo "Assigning $HOST for http[s]:// in /var/www/bigbluebutton/client/conf/config.xml"
-        sudo sed -i "s/http[s]*:\/\/\([^\"\/]*\)\([\"\/]\)/$PROTOCOL_HTTP:\/\/$HOST\2/g" \
-	        /var/www/bigbluebutton/client/conf/config.xml
+	# Extract the chrome store URL before updating config.xml. We will be able to restore it.
 	chromeExtensionLinkURL=$(cat /var/www/bigbluebutton/client/conf/config.xml | sed -n '/chromeExtensionLink/{s/.*https*:\/\///;s/\/.*//;p}')
+	
+	echo "Assigning $HOST for http[s]:// in /var/www/bigbluebutton/client/conf/config.xml"
+	sudo sed -i "s/http[s]*:\/\/\([^\"\/]*\)\([\"\/]\)/$PROTOCOL_HTTP:\/\/$HOST\2/g" \
+		/var/www/bigbluebutton/client/conf/config.xml
 
-        if ! echo "$chromeExtensionLinkURL" | grep -q '""'; then
-          sudo sed -i "s/chromeExtensionLink=\"https:\/\/[^\/]*/chromeExtensionLink=\"https:\/\/$chromeExtensionLinkURL/g" \
-                /var/www/bigbluebutton/client/conf/config.xml
-        fi
+	if ! echo "$chromeExtensionLinkURL" | grep -q '""'; then
+		sudo sed -i "s/chromeExtensionLink=\"https:\/\/[^\/]*/chromeExtensionLink=\"https:\/\/$chromeExtensionLinkURL/g" \
+			/var/www/bigbluebutton/client/conf/config.xml
+	fi
 
-
-        echo "Assigning $HOST for publishURI in /var/www/bigbluebutton/client/conf/config.xml"
-        sudo sed -i "s/publishURI=\"[^\"]*\"/publishURI=\"$HOST\"/" /var/www/bigbluebutton/client/conf/config.xml
+	echo "Assigning $HOST for publishURI in /var/www/bigbluebutton/client/conf/config.xml"
+	sudo sed -i "s/publishURI=\"[^\"]*\"/publishURI=\"$HOST\"/" /var/www/bigbluebutton/client/conf/config.xml
 
 	#
 	# Update configuration for BigBlueButton web app


### PR DESCRIPTION
Fixed #5967. Storing `chromeExtensionLink` happens now before applying the first change oto `config.xml`.