### PR TITLE
Add warning to Flash for WebRTC screenshare in FF on Mac

### DIFF
--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -456,6 +456,7 @@ bbb.screenshareView.actualSize = Display actual size
 bbb.screenshareView.minimizeBtn.accessibilityName = Minimize the Screen Sharing View Window
 bbb.screenshareView.maximizeRestoreBtn.accessibilityName = Maximize the Screen Sharing View Window
 bbb.screenshareView.closeBtn.accessibilityName = Close the Screen Sharing View Window
+bbb.screenshareView.warning.ffMacWebRTC = We recommend that you switch to Chrome on Mac for a better screenshare viewing quality.
 bbb.toolbar.phone.toolTip.start = Enable Audio (microphone or listen only)
 bbb.toolbar.phone.toolTip.stop = Disable Audio
 bbb.toolbar.phone.toolTip.mute = Stop listening the conference

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/utils/WebRTCScreenshareUtility.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/utils/WebRTCScreenshareUtility.as
@@ -20,6 +20,7 @@
 package org.bigbluebutton.modules.screenshare.utils
 {
   import flash.external.ExternalInterface;
+  import flash.system.Capabilities;
   
   import org.as3commons.lang.StringUtils;
   import org.as3commons.logging.api.ILogger;
@@ -66,7 +67,11 @@ package org.bigbluebutton.modules.screenshare.utils
 
       // if its firefox go ahead and let webrtc handle it
       if (BrowserCheck.isFirefox()) {
-        webRTCWorksAndConfigured("Firefox, lets try");
+        if (Capabilities.os.indexOf("Mac") >= 0) {
+          cannotUseWebRTC("Firefox on Mac performs poorly fallback to Java");
+        } else {
+          webRTCWorksAndConfigured("Firefox, lets try");
+        }
         return;
 
       // if its chrome we need to check for the extension

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopViewWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopViewWindow.mxml
@@ -67,6 +67,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.modules.screenshare.model.ScreenshareOptions;
 			import org.bigbluebutton.modules.screenshare.services.red5.WebRTCConnectionEvent;
 			import org.bigbluebutton.util.ConnUtil;
+			import org.bigbluebutton.util.browser.BrowserCheck;
 			import org.bigbluebutton.util.i18n.ResourceUtil;
 
 			public static const LOG:String = "Deskshare::DesktopViewWindow - ";
@@ -110,6 +111,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				videoHolder.addEventListener(MouseEvent.MOUSE_OVER, videoHolder_mouseOverHanlder);
 				videoHolder.addEventListener(MouseEvent.MOUSE_OUT, videoHolder_mouseOutHanlder);
 				addEventListener(MDIWindowEvent.RESIZE_END, onResizeEndEvent);
+				
+				if (BrowserCheck.isFirefox() && Capabilities.os.indexOf("Mac") >= 0) {
+					ffMacWarning.visible = ffMacWarning.includeInLayout = true;
+				}
 				
 				resourcesChanged();
 			}
@@ -470,5 +475,16 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			   mouseOver="btnActualSize.alpha = 1"
 			   label="{    btnActualSize.selected ? ResourceUtil.getInstance().getString('bbb.screenshareView.fitToWindow') : ResourceUtil.getInstance().getString('bbb.screenshareView.actualSize')    }"
 			   toolTip="{    btnActualSize.selected ? ResourceUtil.getInstance().getString('bbb.screenshareView.fitToWindow') : ResourceUtil.getInstance().getString('bbb.screenshareView.actualSize')    }"/>
-
+	<mx:Box id="ffMacWarning"
+			visible="false"
+			includeInLayout="false"
+			width="260"
+			styleName="lockSettingsHintBoxStyle"
+			horizontalCenter="0"
+			top="{VIDEO_HEIGHT_PADDING*2+btnActualSize.height}">
+		<mx:Text width="100%"
+				 textAlign="center"
+				 styleName="lockSettingHintTextStyle"
+				 text="{ResourceUtil.getInstance().getString('bbb.screenshareView.warning.ffMacWebRTC')}" />
+	</mx:Box>
 </CustomMdiWindow>


### PR DESCRIPTION
The WebRTC screenshare RTMP stream doesn't display correctly in Firefox on Mac. The stream only seems to show keyframes and not the intermediate steps. This PR adds automatic fallback to Java screenshare if the user is the presenter and displays a recommendation to switch to Chrome if the user is viewing the stream.