### PR TITLE
Fetch fullInfo from Auth every time instead of caching

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/logger.js
+++ b/bigbluebutton-html5/imports/startup/client/logger.js
@@ -17,11 +17,12 @@ import { nameFromLevel } from '@browser-bunyan/levels';
 // Call the logger by doing a function call with the level name, I.e, logger.warn('Hi on warn')
 
 const LOG_CONFIG = Meteor.settings.public.clientLog || { console: { enabled: true, level: 'info' } };
-const { fullInfo } = Auth;
 
 // Custom stream that logs to an end-point
 class ServerLoggerStream extends ServerStream {
   write(rec) {
+    const { fullInfo } = Auth;
+
     this.rec = rec;
     if (fullInfo.meetingId != null) {
       this.rec.clientInfo = fullInfo;
@@ -33,6 +34,8 @@ class ServerLoggerStream extends ServerStream {
 // Custom stream to log to the meteor server
 class MeteorStream {
   write(rec) {
+    const { fullInfo } = Auth;
+
     this.rec = rec;
     if (fullInfo.meetingId != null) {
       Meteor.call('logClient', nameFromLevel[this.rec.level], this.rec.msg, fullInfo);


### PR DESCRIPTION
The fullInfo from Auth was being fetched once and then reused for every log message sent out. Caching this way meant that Auth wasn't filled with the correct information on a user's first load and all of the log messages couldn't be identified. This PR changes logging to fetch the fullInfo from Auth every time a log is sent out which will mean that the results are always accurate at the time of log creation.