### PR TITLE
Reset rolledOver when user itemrenderers are used for a different user

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/MediaItemRenderer.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/MediaItemRenderer.mxml
@@ -91,8 +91,16 @@
 				BindingUtils.bindSetter(updateButtons, viewingStreamInd, "visible");
 			}
 
+			override public function set data(value:Object):void {
+				//reset rolledOver when the data changes because onRollOut wont be called if the row moves
+				if (data == null || value == null || data.userId != value.userId) {
+					rolledOver = false;
+				}
+				
+				super.data = value;
+			}
+			
 			private function dataChangeHandler(e:Event):void {
-				//rest rolledOver when the data changes because onRollOut wont be called if the row moves
 				if (data != null) {
 					updateButtons();
 					validateNow();

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/StatusItemRenderer.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/StatusItemRenderer.mxml
@@ -84,6 +84,15 @@
   				validateNow();
   			}
   			
+			override public function set data(value:Object):void {
+				//reset rolledOver when the data changes because onRollOut wont be called if the row moves
+				if (data == null || value == null || data.userId != value.userId) {
+					rolledOver = false;
+				}
+				
+				super.data = value;
+			}
+			
   			private function dataChangeHandler(e:Event):void {
   				if (data != null) {
   					updateButtons(); //reassess data state on change


### PR DESCRIPTION
This PR adds checks to the Status and Media ItemRenderers to detect when they are recycled and applied to a different user.