### PR TITLE
Fixed locked user to have the same height as a default user

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-name/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-name/styles.scss
@@ -18,7 +18,6 @@
   transition: all 0.3s;
   font-weight: 400;
   color: $color-gray-dark;
-  padding: .5rem 0;
 }
 
 .userNameSub {


### PR DESCRIPTION

![userlist locked](https://user-images.githubusercontent.com/32152296/45388620-821fe000-b5e7-11e8-9c0f-08a87040d50d.PNG)
There is now correct spacing between locked users and default users in the userlist. #6015 