### PR TITLE
Add RTMP fallback for IPv4-only hostname to the client

### DIFF
--- a/bigbluebutton-client/resources/config.xml.template
+++ b/bigbluebutton-client/resources/config.xml.template
@@ -4,7 +4,7 @@
     <version>VERSION</version>
     <help url="http://HOST/help.html"/>
     <javaTest url="http://HOST/testjava.html"/>
-    <porttest host="rtmp://HOST" application="video/portTest" timeout="10000"/>
+    <porttest host="rtmp://HOST" ipv4FallbackHost="" application="video/portTest" timeout="10000"/>
     <bwMon server="rtmp://HOST" application="video/bwTest"/>
     <application uri="rtmp://HOST/bigbluebutton" host="http://HOST/bigbluebutton/api/enter" reconnWaitTime="2000"/>
     <language userSelectionEnabled="true" rtlEnabled="false"/>

--- a/bigbluebutton-client/src/org/bigbluebutton/core/managers/ConnectionManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/managers/ConnectionManager.as
@@ -32,7 +32,8 @@ package org.bigbluebutton.core.managers {
 				private var _screenshareConnId:String = "";
 				private var _appsConnId:String = "";
 
-        private var _isTunnelling:Boolean = false;
+				private var _isTunnelling:Boolean = false;
+				private var _hostToUse:String = "";
 
 				private var portTestOptions : PortTestOptions;
 				
@@ -101,12 +102,24 @@ package org.bigbluebutton.core.managers {
 					_isTunnelling = tunnel;
 				}
 				
+				public function useHost(host:String):void {
+					_hostToUse = host;
+				}
+				
 				public function get isTunnelling():Boolean {
 					return _isTunnelling;
 				}
 				
+				public function get hostToUse():String {
+					return _hostToUse;
+				}
+				
 				public function get portTestHost():String {
 					return portTestOptions.host;
+				}
+				
+				public function get portTestIpv4FallbackHost():String {
+					return portTestOptions.ipv4FallbackHost;
 				}
 				
 				public function get portTestApplication():String {

--- a/bigbluebutton-client/src/org/bigbluebutton/core/services/BandwidthMonitor.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/services/BandwidthMonitor.as
@@ -99,6 +99,9 @@ package org.bigbluebutton.core.services
 					
 					var bwMonUrl: String;
 					var useRTMPS: Boolean = result.protocol == ConnUtil.RTMPS;
+					
+					var hostName:String = BBB.initConnectionManager().hostToUse;
+					
 					if (BBB.initConnectionManager().isTunnelling) {
 						var tunnelProtocol: String = ConnUtil.RTMPT;
 						
@@ -108,7 +111,7 @@ package org.bigbluebutton.core.services
 						}
 						
 						
-						bwMonUrl = tunnelProtocol + "://" + result.server + "/" + bwMonOption.application;
+						bwMonUrl = tunnelProtocol + "://" + hostName + "/" + bwMonOption.application;
 						LOGGER.debug("BW MON CONNECT tunnel = TRUE " + "url=" +  bwMonUrl);
 					} else {
 						var nativeProtocol: String = ConnUtil.RTMP;
@@ -117,7 +120,7 @@ package org.bigbluebutton.core.services
 							nativeProtocol = ConnUtil.RTMPS;
 						}
 						
-						bwMonUrl = nativeProtocol + "://" + result.server + "/" + bwMonOption.application;
+						bwMonUrl = nativeProtocol + "://" + hostName + "/" + bwMonOption.application;
 						LOGGER.debug("BBB MON CONNECT tunnel = FALSE " + "url=" +  bwMonUrl);
 					}
 					

--- a/bigbluebutton-client/src/org/bigbluebutton/main/maps/ApplicationEventMap.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/maps/ApplicationEventMap.mxml
@@ -44,11 +44,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		</EventHandlers>
 	
 		<EventHandlers type="{PortTestEvent.PORT_TEST_SUCCESS}" >
-			<MethodInvoker generator="{ModulesProxy}" method="portTestSuccess" arguments="{event.tunnel}" />
+			<MethodInvoker generator="{ModulesProxy}" method="portTestSuccess" arguments="{event}" />
 		</EventHandlers>
 		
 		<EventHandlers type="{PortTestEvent.PORT_TEST_FAILED}" >
-			<MethodInvoker generator="{ModulesProxy}" method="testRTMPT" arguments="{event.tunnel}" />
+			<MethodInvoker generator="{ModulesProxy}" method="portTestFailed" arguments="{event}" />
 		</EventHandlers>
 	
 	  <EventHandlers type="{SuccessfulLoginEvent.USER_LOGGED_IN}" >

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/modules/ModulesProxy.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/modules/ModulesProxy.as
@@ -18,10 +18,12 @@
 */
 package org.bigbluebutton.main.model.modules
 {
+	import org.as3commons.lang.StringUtils;
 	import org.as3commons.logging.api.ILogger;
 	import org.as3commons.logging.api.getClassLogger;
 	import org.bigbluebutton.core.BBB;
 	import org.bigbluebutton.core.UsersUtil;
+	import org.bigbluebutton.main.events.PortTestEvent;
 	import org.bigbluebutton.main.model.PortTestProxy;
 	
 	public class ModulesProxy {
@@ -43,14 +45,20 @@ package org.bigbluebutton.main.model.modules
 			return _user.username;
 		}
 
-		public function portTestSuccess(tunnel:Boolean):void {
+		public function portTestSuccess(e:PortTestEvent):void {
             var logData:Object = UsersUtil.initLogData();
             logData.tags = ["initialization"];
-            logData.tunnel = tunnel;
+            logData.tunnel = e.tunnel;
+            logData.hostname = e.hostname;
             logData.logCode = "port_test_done";
             LOGGER.info(JSON.stringify(logData));
                 
-						BBB.initConnectionManager().useProtocol(tunnel);
+            BBB.initConnectionManager().useProtocol(e.tunnel);
+            
+            var pattern:RegExp = /(?P<protocol>.+):\/\/(?P<server>.+)/;
+            var result:Array = pattern.exec(e.hostname);
+            BBB.initConnectionManager().useHost(result.server);
+            
 			modulesManager.startUserServices();
 		}
 						
@@ -60,6 +68,10 @@ package org.bigbluebutton.main.model.modules
 		
 		public function getPortTestHost():String {
 			return BBB.initConnectionManager().portTestHost;
+		}
+		
+		public function getPortTestAlternateHost():String {
+			return BBB.initConnectionManager().portTestIpv4FallbackHost;
 		}
 		
 		public function getPortTestApplication():String {
@@ -82,10 +94,15 @@ package org.bigbluebutton.main.model.modules
 			portTestProxy.connect(false /*tunnel*/, getPortTestHost(), "", getPortTestApplication(), getPortTestTimeout());
 		}
 
-		public function testRTMPT(tunnel:Boolean):void {
-			if (!tunnel) {
-				// Try to test using rtmpt as rtmp failed.
-				portTestProxy.connect(true /*tunnel*/, getPortTestHost(), "", getPortTestApplication(), getPortTestTimeout());
+		public function portTestFailed(e:PortTestEvent):void {
+			if (!e.tunnel) {
+				if (e.hostname == getPortTestHost() && !StringUtils.isEmpty(getPortTestAlternateHost())) {
+					// try the alternate host
+					portTestProxy.connect(false /*tunnel*/, getPortTestAlternateHost(), "", getPortTestApplication(), getPortTestTimeout());
+				} else {
+					// Try to test using rtmpt as rtmp failed.
+					portTestProxy.connect(true /*tunnel*/, getPortTestHost(), "", getPortTestApplication(), getPortTestTimeout());
+				}
 			} else {
 				modulesDispatcher.sendTunnelingFailedEvent(getPortTestHost(), getPortTestApplication());
 			}

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/options/PortTestOptions.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/options/PortTestOptions.as
@@ -23,6 +23,9 @@ package org.bigbluebutton.main.model.options {
 
 		[Bindable]
 		public var host:String = "";
+		
+		[Bindable]
+		public var ipv4FallbackHost:String = "";
 
 		[Bindable]
 		public var application:String = "";

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/NetConnectionDelegate.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/NetConnectionDelegate.as
@@ -19,6 +19,7 @@
 package org.bigbluebutton.main.model.users
 {
 	import com.asfusion.mate.events.Dispatcher;
+	
 	import flash.events.AsyncErrorEvent;
 	import flash.events.IOErrorEvent;
 	import flash.events.NetStatusEvent;
@@ -28,6 +29,7 @@ package org.bigbluebutton.main.model.users
 	import flash.net.ObjectEncoding;
 	import flash.net.Responder;
 	import flash.utils.Timer;
+	
 	import org.as3commons.logging.api.ILogger;
 	import org.as3commons.logging.api.getClassLogger;
 	import org.bigbluebutton.core.BBB;
@@ -415,6 +417,8 @@ package org.bigbluebutton.main.model.users
 
 								var useRTMPS: Boolean = result.protocol == ConnUtil.RTMPS;
 								
+								var hostName:String = BBB.initConnectionManager().hostToUse;
+								
 								if (BBB.initConnectionManager().isTunnelling) {
 									var tunnelProtocol: String = ConnUtil.RTMPT;
 								
@@ -423,7 +427,7 @@ package org.bigbluebutton.main.model.users
 										tunnelProtocol = ConnUtil.RTMPS;
 									}
 								
-									bbbAppsUrl = tunnelProtocol + "://" + result.server + "/" + result.app + "/" + intMeetingId;
+									bbbAppsUrl = tunnelProtocol + "://" + hostName + "/" + result.app + "/" + intMeetingId;
 									//LOGGER.debug("BBB APPS CONNECT tunnel = TRUE " + "url=" +  bbbAppsUrl);
 								} else {
 									var nativeProtocol: String = ConnUtil.RTMP;
@@ -432,7 +436,7 @@ package org.bigbluebutton.main.model.users
 										nativeProtocol = ConnUtil.RTMPS;
 									}
 								
-									bbbAppsUrl = nativeProtocol + "://" + result.server + "/" + result.app + "/" + intMeetingId;
+									bbbAppsUrl = nativeProtocol + "://" + hostName + "/" + result.app + "/" + intMeetingId;
 									//LOGGER.debug("BBB APPS CONNECT tunnel = FALSE " + "url=" +  bbbAppsUrl);
 								
                 }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/ConnectionManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/ConnectionManager.as
@@ -94,6 +94,8 @@ package org.bigbluebutton.modules.phone.managers {
 					
 				netConnection = new NetConnection();
 				
+				var hostName:String = BBB.initConnectionManager().hostToUse;
+				
 				if (BBB.initConnectionManager().isTunnelling) {
 					var tunnelProtocol: String = ConnUtil.RTMPT;
 					
@@ -102,7 +104,7 @@ package org.bigbluebutton.modules.phone.managers {
 						tunnelProtocol = ConnUtil.RTMPS;
 					}
 						
-					uri = tunnelProtocol + "://" + result.server + "/" + result.app;
+					uri = tunnelProtocol + "://" + hostName + "/" + result.app;
 				} else {
 					var nativeProtocol: String = ConnUtil.RTMP;
 					if (useRTMPS) {
@@ -110,7 +112,7 @@ package org.bigbluebutton.modules.phone.managers {
 						nativeProtocol = ConnUtil.RTMPS;
 					}
 					
-					uri = nativeProtocol + "://" + result.server + "/" + result.app;
+					uri = nativeProtocol + "://" + hostName + "/" + result.app;
 				}
 								
 				netConnection.objectEncoding = ObjectEncoding.AMF3;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/services/red5/Connection.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/services/red5/Connection.as
@@ -65,6 +65,8 @@ package org.bigbluebutton.modules.screenshare.services.red5 {
 			
 				var useRTMPS: Boolean = result.protocol == ConnUtil.RTMPS;
 				
+				var hostName:String = BBB.initConnectionManager().hostToUse;
+				
 				if (BBB.initConnectionManager().isTunnelling) {
 					var tunnelProtocol: String = ConnUtil.RTMPT;
 				
@@ -73,7 +75,7 @@ package org.bigbluebutton.modules.screenshare.services.red5 {
 						tunnelProtocol = ConnUtil.RTMPS;
 					}
 					
-					ssAppUrl = tunnelProtocol + "://" + result.server + "/" + result.app + "/" + UsersUtil.getInternalMeetingID();
+					ssAppUrl = tunnelProtocol + "://" + hostName + "/" + result.app + "/" + UsersUtil.getInternalMeetingID();
 
 				} else {
 					var nativeProtocol: String = ConnUtil.RTMP;
@@ -82,7 +84,7 @@ package org.bigbluebutton.modules.screenshare.services.red5 {
 						nativeProtocol = ConnUtil.RTMPS;
 					}
 				
-					ssAppUrl = nativeProtocol + "://" + result.server + "/" + result.app + "/" + UsersUtil.getInternalMeetingID();
+					ssAppUrl = nativeProtocol + "://" + hostName + "/" + result.app + "/" + UsersUtil.getInternalMeetingID();
 
 				}
 				

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopPublishWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopPublishWindow.mxml
@@ -325,11 +325,13 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 				connection = new NetConnection();
 				
-				var pattern:RegExp = /(?P<protocol>.+):\/\/(?P<serverAndApp>.+)/;
+				var pattern:RegExp = /(?P<protocol>.+):\/\/(?P<server>.+)\/(?P<app>.+)/;
 				var result:Array = pattern.exec(meetingUrl);
 				
 				var useRTMPS: Boolean = result.protocol == ConnUtil.RTMPS;
 				var ssAppUrl: String = null;
+				
+				var hostName:String = BBB.initConnectionManager().hostToUse;
 				
 				if (BBB.initConnectionManager().isTunnelling) {
 					var tunnelProtocol: String = ConnUtil.RTMPT;
@@ -340,7 +342,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					}
 					
 					
-					ssAppUrl = tunnelProtocol + "://" + result.serverAndApp;
+					ssAppUrl = tunnelProtocol + "://" + hostName + "/" + result.app;
 					LOGGER.debug("WEBRTC SSHARE CONNECT tunnel = TRUE " + "url=" +  ssAppUrl);
 				} else {
 					var nativeProtocol: String = ConnUtil.RTMP;
@@ -349,7 +351,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 						nativeProtocol = ConnUtil.RTMPS;
 					}
 					
-					ssAppUrl = nativeProtocol + "://" + result.serverAndApp;
+					ssAppUrl = nativeProtocol + "://" + hostName + "/" + result.app;
 					LOGGER.debug("WEBRTC SSHARE CONNECT tunnel = FALSE " + "url=" +  ssAppUrl);
 				}
 				

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopViewWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopViewWindow.mxml
@@ -46,11 +46,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 	<fx:Script>
 		<![CDATA[
-			import flexlib.mdi.events.MDIWindowEvent;
-			
 			import mx.core.ScrollPolicy;
 			import mx.core.UIComponent;
 			import mx.utils.ObjectUtil;
+			
+			import flexlib.mdi.events.MDIWindowEvent;
 			
 			import org.as3commons.logging.api.ILogger;
 			import org.as3commons.logging.api.getClassLogger;
@@ -165,11 +165,13 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				
 				nc = new NetConnection();
 				
-				var pattern:RegExp = /(?P<protocol>.+):\/\/(?P<serverAndApp>.+)/;
+				var pattern:RegExp = /(?P<protocol>.+):\/\/(?P<server>.+)\/(?P<app>.+)/;
 				var result:Array = pattern.exec(rtmpUrl);
 				
 				var useRTMPS: Boolean = result.protocol == ConnUtil.RTMPS;
 				var ssAppUrl: String = null;
+				
+				var hostName:String = BBB.initConnectionManager().hostToUse;
 				
 				if (BBB.initConnectionManager().isTunnelling) {
 					var tunnelProtocol: String = ConnUtil.RTMPT;
@@ -180,7 +182,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					}
 					
 					
-					ssAppUrl = tunnelProtocol + "://" + result.serverAndApp;
+					ssAppUrl = tunnelProtocol + "://" + hostName + "/" + result.app;
 					LOGGER.debug("WEBRTC SSHARE CONNECT tunnel = TRUE " + "url=" +  ssAppUrl);
 				} else {
 					var nativeProtocol: String = ConnUtil.RTMP;
@@ -189,7 +191,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 						nativeProtocol = ConnUtil.RTMPS;
 					}
 				
-					ssAppUrl = nativeProtocol + "://" + result.serverAndApp;
+					ssAppUrl = nativeProtocol + "://" + hostName + "/" + result.app;
 					LOGGER.debug("WEBRTC SSHARE CONNECT tunnel = FALSE " + "url=" +  ssAppUrl);
 				}
 				

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/business/VideoProxy.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/videoconf/business/VideoProxy.as
@@ -85,8 +85,10 @@ package org.bigbluebutton.modules.videoconf.business
 				var pattern:RegExp = /(?P<protocol>.+):\/\/(?P<server>.+)\/(?P<app>.+)/;
 				var result:Array = pattern.exec(options.uri);
 				
-				
 				var useRTMPS: Boolean = result.protocol == ConnUtil.RTMPS;
+				
+				var hostName:String = BBB.initConnectionManager().hostToUse;
+				
 				if (BBB.initConnectionManager().isTunnelling) {
 					var tunnelProtocol: String = ConnUtil.RTMPT;
 				
@@ -95,7 +97,7 @@ package org.bigbluebutton.modules.videoconf.business
 						tunnelProtocol = ConnUtil.RTMPS;
 					}
 				
-					videoConnUrl = tunnelProtocol + "://" + result.server + "/" + result.app;
+					videoConnUrl = tunnelProtocol + "://" + hostName + "/" + result.app;
 
 				} else {
 					var nativeProtocol: String = ConnUtil.RTMP;
@@ -104,7 +106,7 @@ package org.bigbluebutton.modules.videoconf.business
 						nativeProtocol = ConnUtil.RTMPS;
 					}
 				
-					videoConnUrl = nativeProtocol + "://" + result.server + "/" + result.app;
+					videoConnUrl = nativeProtocol + "://" + hostName + "/" + result.app;
 
 				}
 				

--- a/bigbluebutton-client/src/org/red5/flash/bwcheck/app/BandwidthDetectionApp.as
+++ b/bigbluebutton-client/src/org/red5/flash/bwcheck/app/BandwidthDetectionApp.as
@@ -61,6 +61,9 @@ package org.red5.flash.bwcheck.app
 			nc = new NetConnection();
 			
 			var useRTMPS: Boolean = result.protocol == ConnUtil.RTMPS;
+			
+			var hostName:String = BBB.initConnectionManager().hostToUse;
+			
 			if (BBB.initConnectionManager().isTunnelling) {
 				var tunnelProtocol: String = ConnUtil.RTMPT;
 				
@@ -69,7 +72,7 @@ package org.red5.flash.bwcheck.app
 					tunnelProtocol = ConnUtil.RTMPS;
 				}
 				
-				bwMonUrl = tunnelProtocol + "://" + result.server + "/" + bwMonOption.application;
+				bwMonUrl = tunnelProtocol + "://" + hostName + "/" + bwMonOption.application;
 				trace("******* BW MON CONNECT tunnel = TRUE " + "url=" +  bwMonUrl);
 			} else {
 				var nativeProtocol: String = ConnUtil.RTMP;
@@ -78,7 +81,7 @@ package org.red5.flash.bwcheck.app
 					nativeProtocol = ConnUtil.RTMPS;
 				}
 				
-				bwMonUrl = nativeProtocol + "://" + result.server + "/" + bwMonOption.application;
+				bwMonUrl = nativeProtocol + "://" + hostName + "/" + bwMonOption.application;
 				trace("******* BBB MON CONNECT tunnel = FALSE " + "url=" +  bwMonUrl);
 			}
 


### PR DESCRIPTION
This PR addresses #6059. I've added an optional fallback host property (ipv4FallbackHost) to the <porttest> section of config.xml and if the property isn't blank the client will try the fallback host before trying to tunnel. The only change required to apply this yourself is a domain that only has IPv4 resolution and then to set the value of the property to "rtmp://ipv4host.com".  One fallout from this is that the module RTMP URIs will not longer use the hostname contained in their values, but we never really supported messing with them anyways.