### PR TITLE
Fix lock settings

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/events/BBBEvent.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/events/BBBEvent.as
@@ -76,6 +76,8 @@ package org.bigbluebutton.main.events {
 
 		public static const CANCEL_RECONNECTION_EVENT:String = "CANCEL_RECONNECTION_EVENT";
 		public static const WEBRTC_MONITOR_UPDATE_EVENT:String = "WEBRTC_MONITOR_UPDATE_EVENT";
+		
+		public static const GET_LOCK_SETTINGS_EVENT:String = "GET_LOCK_SETTINGS_EVENT";
 
 		public var message:String;
 		public var payload:Object = new Object();

--- a/bigbluebutton-client/src/org/bigbluebutton/main/maps/ApplicationEventMap.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/maps/ApplicationEventMap.mxml
@@ -100,6 +100,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     <EventHandlers type="{UsersConnectionEvent.CONNECTION_SUCCESS}" >
       <MethodInvoker generator="{UserService}" method="userLoggedIn" arguments="{event}" />
     </EventHandlers>
+		
+    <EventHandlers type="{BBBEvent.GET_LOCK_SETTINGS_EVENT}" >
+      <MethodInvoker generator="{UserService}" method="getLockSettings"/>
+    </EventHandlers>
 	</fx:Declarations>
 
   

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/UserService.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/UserService.as
@@ -80,7 +80,6 @@ package org.bigbluebutton.main.model.users
 			sender.queryForParticipants();
 			sender.queryForRecordingStatus();
 			sender.queryForGuestPolicy();
-			sender.getLockSettings();
 
 			if (!LiveMeeting.inst().meeting.isBreakout) {
 				sender.queryForBreakoutRooms(LiveMeeting.inst().meeting.internalId);
@@ -88,6 +87,10 @@ package org.bigbluebutton.main.model.users
 
 			var loadCommand:SuccessfulLoginEvent = new SuccessfulLoginEvent(SuccessfulLoginEvent.USER_LOGGED_IN);
 			dispatcher.dispatchEvent(loadCommand);
+		}
+		
+		public function getLockSettings() : void {
+			sender.getLockSettings();
 		}
 		
 		public function startService(e:UserServicesEvent):void {

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
@@ -394,7 +394,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			
 			public function sendStartAllModulesEvent():void{
 				var dispatcher:Dispatcher = new Dispatcher();
-				dispatcher.dispatchEvent(new ModuleLoadEvent(ModuleLoadEvent.START_ALL_MODULES));	
+				dispatcher.dispatchEvent(new ModuleLoadEvent(ModuleLoadEvent.START_ALL_MODULES));
+				dispatcher.dispatchEvent(new BBBEvent(BBBEvent.GET_LOCK_SETTINGS_EVENT));
 			}
 			
 			public function guestAllowed(evt:BBBEvent):void {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/layout/managers/LayoutManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/layout/managers/LayoutManager.as
@@ -49,6 +49,7 @@ package org.bigbluebutton.modules.layout.managers
   import org.bigbluebutton.core.UsersUtil;
   import org.bigbluebutton.core.events.SwitchedLayoutEvent;
   import org.bigbluebutton.core.model.LiveMeeting;
+  import org.bigbluebutton.main.events.BBBEvent;
   import org.bigbluebutton.main.model.options.LayoutOptions;
   import org.bigbluebutton.modules.layout.events.LayoutEvent;
   import org.bigbluebutton.modules.layout.events.LayoutFromRemoteEvent;
@@ -89,7 +90,7 @@ package org.bigbluebutton.modules.layout.managers
         applyLayout(currentLayout);
       });
     }
-    
+	
     /**
      *  There's a race condition when the layouts combo doesn't get populated 
      *  with the server's layouts definition. The problem is that sometimes 
@@ -337,8 +338,6 @@ package org.bigbluebutton.modules.layout.managers
 			}
 		}
 		
-		private var firstDisplay : Boolean = true;
-		
 		private function applyLayout(layout:LayoutDefinition):void {
 			//LOGGER.debug("applyLayout");
 			detectContainerChange = false;
@@ -354,10 +353,6 @@ package org.bigbluebutton.modules.layout.managers
 				detectContainerChange = true;
 			}
 			updateCurrentLayout(layout);
-			if (firstDisplay) {
-				firstDisplay = false;
-				setTimeout(lockSettingsChanged, 1000)
-			}
 		}
 
     private function set detectContainerChange(detect:Boolean):void {
@@ -410,9 +405,10 @@ package org.bigbluebutton.modules.layout.managers
 		}
 
 		private function checkPermissionsOverAllWindows():void {
-			if (UsersUtil.amIModerator()) return;
-			for each (var window:MDIWindow in _canvas.windowManager.windowList) {
-				checkPermissionsOverWindow(window);
+			if (!UsersUtil.amIModerator() && _canvas && _canvas.windowManager) {
+				for each (var window:MDIWindow in _canvas.windowManager.windowList) {
+					checkPermissionsOverWindow(window);
+				}
 			}
 		}
 

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/layout/managers/LayoutManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/layout/managers/LayoutManager.as
@@ -27,6 +27,7 @@ package org.bigbluebutton.modules.layout.managers
   import flash.events.TimerEvent;
   import flash.net.FileReference;
   import flash.utils.Timer;
+  import flash.utils.setTimeout;
   
   import mx.controls.Alert;
   import mx.core.FlexGlobals;
@@ -336,6 +337,8 @@ package org.bigbluebutton.modules.layout.managers
 			}
 		}
 		
+		private var firstDisplay : Boolean = true;
+		
 		private function applyLayout(layout:LayoutDefinition):void {
 			//LOGGER.debug("applyLayout");
 			detectContainerChange = false;
@@ -351,6 +354,10 @@ package org.bigbluebutton.modules.layout.managers
 				detectContainerChange = true;
 			}
 			updateCurrentLayout(layout);
+			if (!firstDisplay) {
+				firstDisplay = false;
+				setTimeout(lockSettingsChanged, 250)
+			}
 		}
 
     private function set detectContainerChange(detect:Boolean):void {
@@ -397,8 +404,7 @@ package org.bigbluebutton.modules.layout.managers
 		}
 		
 		private function checkPermissionsOverWindow(window:MDIWindow):void {
-			if (UsersUtil.amIModerator()) return;
-			if (window != null && !LayoutDefinition.ignoreWindow(window)) {
+			if (!UsersUtil.amIModerator() && window != null && !LayoutDefinition.ignoreWindow(window)) {
 				(window as CustomMdiWindow).unlocked = !_locked;
 			}
 		}

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/layout/managers/LayoutManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/layout/managers/LayoutManager.as
@@ -354,9 +354,9 @@ package org.bigbluebutton.modules.layout.managers
 				detectContainerChange = true;
 			}
 			updateCurrentLayout(layout);
-			if (!firstDisplay) {
+			if (firstDisplay) {
 				firstDisplay = false;
-				setTimeout(lockSettingsChanged, 250)
+				setTimeout(lockSettingsChanged, 1000)
 			}
 		}
 

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/layout/views/LayoutsCombo.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/layout/views/LayoutsCombo.mxml
@@ -65,15 +65,15 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         populateComboBox();
         refreshRole(UsersUtil.amIModerator());
       }
-      
-      private function lockSettingsChanged(e:LockControlEvent):void {
-		  this.enabled = ! LiveMeeting.inst().me.lockedLayout;
-      }
-      
-			private function populateLayoutsList(e:LayoutsReadyEvent):void {
-        populateComboBox();
-			}
-      
+
+	  private function lockSettingsChanged(e:LockControlEvent):void {
+		  this.enabled = !LiveMeeting.inst().me.lockedLayout;
+	  }
+
+	  private function populateLayoutsList(e:LayoutsReadyEvent):void {
+		  populateComboBox();
+	  }
+
       private function populateComboBox():void {
         layoutNames = new ArrayCollection();
         var layouts:Array = LayoutModel.getInstance().getLayoutNames();


### PR DESCRIPTION
Fix the following issues
 - [x] Lock layout setting does not apply to late joins #6040
 - [x] Unusable join audio conference button when switching microphone lock and then off. (Wrong config)