### PR TITLE
Fix WebRTC screenshare RTMP URL regular expression

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopPublishWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopPublishWindow.mxml
@@ -325,7 +325,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 				connection = new NetConnection();
 				
-				var pattern:RegExp = /(?P<protocol>.+):\/\/(?P<server>.+)\/(?P<app>.+)/;
+				var pattern:RegExp = /(?P<protocol>.+):\/\/(?P<server>[^\/]+)\/(?P<app>.+)/;
 				var result:Array = pattern.exec(meetingUrl);
 				
 				var useRTMPS: Boolean = result.protocol == ConnUtil.RTMPS;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopViewWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopViewWindow.mxml
@@ -165,7 +165,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				
 				nc = new NetConnection();
 				
-				var pattern:RegExp = /(?P<protocol>.+):\/\/(?P<server>.+)\/(?P<app>.+)/;
+				var pattern:RegExp = /(?P<protocol>.+):\/\/(?P<server>[^\/]+)\/(?P<app>.+)/;
 				var result:Array = pattern.exec(rtmpUrl);
 				
 				var useRTMPS: Boolean = result.protocol == ConnUtil.RTMPS;


### PR DESCRIPTION
The regex was greedily combining some of the app portion into the server portion. It's been edited to be more explicit.