### PR TITLE
 - try fixing this error

### DIFF
--- a/akka-bbb-transcode/build.sbt
+++ b/akka-bbb-transcode/build.sbt
@@ -1,4 +1,5 @@
 enablePlugins(JavaServerAppPackaging)
+enablePlugins(SystemdPlugin)
 
 name := "bbb-transcode-akka"
 


### PR DESCRIPTION
/mnt/tmp/bbb-transcode-akka_2.2.0_xenial_m22/build.sbt:134: error: object ServerLoader is not a member of package com.typesafe.sbt.packager.archetypes
serverLoading in Debian := com.typesafe.sbt.packager.archetypes.ServerLoader.Systemd