### PR TITLE
Make Flash WebRTC screenshare use RTMPS when available

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopPublishWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopPublishWindow.mxml
@@ -309,13 +309,17 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				stopSharing();
 			}
 
-			public function startVideo(rtmp:String, videoWidth:Number, videoHeight:Number):void {
+			public function startVideo(streamURL:String, videoWidth:Number, videoHeight:Number):void {
 				red5StreamTimeout.stop();
 				
 				setCurrentState("dispFullRegionControlBar");
-				var myArray :Array = rtmp.split('/');
-				var meetingUrl:String = rtmp.substring(0, rtmp.lastIndexOf('/'));
-				stream = rtmp.substring(rtmp.lastIndexOf('/')+1, rtmp.length);
+				
+				var videoURLPattern:RegExp = /(?P<protocol>.+):\/\/(?P<server>[^\/]+)\/(?P<app>[^\/]+\/[^\/]+)\/(?P<stream>[^\/]+)/;
+				var videoURLResult:Array = videoURLPattern.exec(streamURL);
+				var protocolPattern:RegExp = /(?P<protocol>.+):\/\/(?P<server>[^\/]+)\/(?P<app>[^\/]+)/;
+				var protocolURLResult:Array = protocolPattern.exec(dsOptions.uri);
+				
+				stream = videoURLResult.stream;
 				
 				var logData:Object = UsersUtil.initLogData();
 				logData.tags = ["webrtc-screenshare"];
@@ -325,10 +329,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 				connection = new NetConnection();
 				
-				var pattern:RegExp = /(?P<protocol>.+):\/\/(?P<server>[^\/]+)\/(?P<app>.+)/;
-				var result:Array = pattern.exec(meetingUrl);
+				var useRTMPS: Boolean = protocolURLResult.protocol == ConnUtil.RTMPS;
 				
-				var useRTMPS: Boolean = result.protocol == ConnUtil.RTMPS;
 				var ssAppUrl: String = null;
 				
 				var hostName:String = BBB.initConnectionManager().hostToUse;
@@ -342,7 +344,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					}
 					
 					
-					ssAppUrl = tunnelProtocol + "://" + hostName + "/" + result.app;
+					ssAppUrl = tunnelProtocol + "://" + hostName + "/" + videoURLResult.app;
 					LOGGER.debug("WEBRTC SSHARE CONNECT tunnel = TRUE " + "url=" +  ssAppUrl);
 				} else {
 					var nativeProtocol: String = ConnUtil.RTMP;
@@ -351,7 +353,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 						nativeProtocol = ConnUtil.RTMPS;
 					}
 					
-					ssAppUrl = nativeProtocol + "://" + hostName + "/" + result.app;
+					ssAppUrl = nativeProtocol + "://" + hostName + "/" + videoURLResult.app;
 					LOGGER.debug("WEBRTC SSHARE CONNECT tunnel = FALSE " + "url=" +  ssAppUrl);
 				}
 				

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopViewWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/WebRTCDesktopViewWindow.mxml
@@ -26,7 +26,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	xmlns:common="org.bigbluebutton.common.*"
 	xmlns:ss="org.bigbluebutton.modules.screenshare.view.components.*"
 	width="600" height="400"
-	initialize="init()"
 	layout="absolute"
 	creationComplete="onCreationComplete()"
 	verticalScrollPolicy="off"
@@ -90,11 +89,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 			[Bindable] private var baseIndex:int;
 
-			[Bindable] private var dsOptions:ScreenshareOptions;
-			
-			private function init():void {
-				dsOptions = Options.getOptions(ScreenshareOptions) as ScreenshareOptions;
-			}
+			[Bindable] private var dsOptions:ScreenshareOptions = Options.getOptions(ScreenshareOptions) as ScreenshareOptions;
 			
 			private function resizeVideoCanvas():void {
 				videoCanvas.width = this.width - VIDEO_WIDTH_PADDING;
@@ -147,17 +142,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				// values will be in the meta data
 				streamWidth = width;
 				streamHeight = height;
-
-				var myArray :Array = rtmp.split('/');
-				// myArray.forEach ( function ( item:*, i:int, arr:Array) : void { JSLog.debug("^^^^" + i +"aa=" + item, logData); } );
-
-				streamID = myArray[5]; // Grab the streamID from the end of the rtmp string
-				var videoURL:String = rtmp.substring(0, rtmp.lastIndexOf('/'));
-
-				connect(videoURL);
+				
+				connect(rtmp);
 			}
 
-			public function connect(rtmpUrl: String):void {
+			public function connect(streamURL: String):void {
 				if (nc) {
 					nc.removeEventListener(NetStatusEvent.NET_STATUS, netStatusHandler);
 					nc.removeEventListener(SecurityErrorEvent.SECURITY_ERROR, securityErrorHandler);
@@ -165,24 +154,26 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				
 				nc = new NetConnection();
 				
-				var pattern:RegExp = /(?P<protocol>.+):\/\/(?P<server>[^\/]+)\/(?P<app>.+)/;
-				var result:Array = pattern.exec(rtmpUrl);
+				var videoURLPattern:RegExp = /(?P<protocol>.+):\/\/(?P<server>[^\/]+)\/(?P<app>[^\/]+\/[^\/]+)\/(?P<stream>[^\/]+)/;
+				var videoURLResult:Array = videoURLPattern.exec(streamURL);
+				var protocolPattern:RegExp = /(?P<protocol>.+):\/\/(?P<server>[^\/]+)\/(?P<app>[^\/]+)/;
+				var protocolURLResult:Array = protocolPattern.exec(dsOptions.uri);
 				
-				var useRTMPS: Boolean = result.protocol == ConnUtil.RTMPS;
+				streamID = videoURLResult.stream;
+				
+				var useRTMPS: Boolean = protocolURLResult.protocol == ConnUtil.RTMPS;
 				var ssAppUrl: String = null;
 				
 				var hostName:String = BBB.initConnectionManager().hostToUse;
 				
 				if (BBB.initConnectionManager().isTunnelling) {
 					var tunnelProtocol: String = ConnUtil.RTMPT;
-				
 					if (useRTMPS) {
 						nc.proxyType = ConnUtil.PROXY_NONE;
 						tunnelProtocol = ConnUtil.RTMPS;
 					}
 					
-					
-					ssAppUrl = tunnelProtocol + "://" + hostName + "/" + result.app;
+					ssAppUrl = tunnelProtocol + "://" + hostName + "/" + videoURLResult.app;
 					LOGGER.debug("WEBRTC SSHARE CONNECT tunnel = TRUE " + "url=" +  ssAppUrl);
 				} else {
 					var nativeProtocol: String = ConnUtil.RTMP;
@@ -191,7 +182,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 						nativeProtocol = ConnUtil.RTMPS;
 					}
 				
-					ssAppUrl = nativeProtocol + "://" + hostName + "/" + result.app;
+					ssAppUrl = nativeProtocol + "://" + hostName + "/" + videoURLResult.app;
 					LOGGER.debug("WEBRTC SSHARE CONNECT tunnel = FALSE " + "url=" +  ssAppUrl);
 				}
 				


### PR DESCRIPTION
Previously if your config.xml had RTMPS for all other red5 connections the WebRTC screenshare URL would still be RTMP. This PR makes it so that the screenshare connections inherit the protocol used in the config.xml.

Resolves #6078.