### PR TITLE
Improve codec availability detection in SFU

### DIFF
--- a/labs/bbb-webrtc-sfu/lib/mcs-core/lib/model/SdpSession.js
+++ b/labs/bbb-webrtc-sfu/lib/mcs-core/lib/model/SdpSession.js
@@ -93,7 +93,7 @@ module.exports = class SdpSession extends MediaSession {
   }
 
     _hasAvailableCodec () {
-    return (this._offer.hasAvailableVideoCodec() === this._answer.hasAvailableVideoCodec()) &&
-      (this._offer.hasAvailableAudioCodec() === this._answer.hasAvailableAudioCodec());
+    return (this._offer.hasAvailableVideoCodec() && this._answer.hasAvailableVideoCodec()) ||
+      (this._offer.hasAvailableAudioCodec() && this._answer.hasAvailableAudioCodec());
   }
 }


### PR DESCRIPTION
The check was missing a case where there was no video codec available after the SDP passed through the H264 enforcement filter. It should throw the appropriate error for that case now (`Error 2203`).