### PR TITLE
Make it so that cameras use the full space of the video window

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -69,7 +69,7 @@ $audio-indicator-fs: 75%;
   position: relative;
   height: 100%;
   width: 100%;
-  object-fit: contain;
+  object-fit: cover;
   border-radius: 5px;
 }
 


### PR DESCRIPTION
This is just a small CSS change to crop the cameras to cover the entire video rectangle. This does not change anything about the webrtc stream size or bandwidth, but in my opinion looks prettier and uses the interface more appropriately.

Here's a picture of how it looks:
![selection_045](https://user-images.githubusercontent.com/33211/45709862-6d00ff00-bb5b-11e8-8363-ee3a4bd249cb.png)
