### PR TITLE
Fix error handling when client parts fail to load

### DIFF
--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -5,6 +5,8 @@ bbb.mainshell.statusProgress.cannotConnectServer = Sorry, we cannot connect to t
 bbb.mainshell.copyrightLabel2 = (c) 2018 <a href='event:http://www.bigbluebutton.org/' target='_blank'><u>BigBlueButton Inc.</u></a> (build {0})
 bbb.mainshell.logBtn.toolTip = Open Log Window
 bbb.mainshell.meetingNotFound = Meeting Not Found
+bbb.mainshell.configXMLFailed = Failed to fetch config.xml
+bbb.mainshell.enterAPIFailed = Failed to fetch enter API
 bbb.mainshell.invalidAuthToken = Invalid Authentication Token
 bbb.mainshell.resetLayoutBtn.toolTip = Reset Layout
 bbb.mainshell.notification.tunnelling = Tunnelling

--- a/bigbluebutton-client/src/org/bigbluebutton/core/managers/ConfigManager2.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/managers/ConfigManager2.as
@@ -86,7 +86,7 @@ package org.bigbluebutton.core.managers {
 
             var dispatcher:Dispatcher = new Dispatcher();
             
-            if (xml && xml.contains("config") && xml.config.contains("modules")) {
+            if (xml && xml.modules.length() > 0) {
                 LOGGER.info("Getting configXML passed [{0}]", [xml]);
                 _config = new Config(new XML(e.target.data));
 

--- a/bigbluebutton-client/src/org/bigbluebutton/main/events/MeetingNotFoundEvent.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/events/MeetingNotFoundEvent.as
@@ -6,12 +6,12 @@ package org.bigbluebutton.main.events
   {
     public static const MEETING_NOT_FOUND:String = "meeting not found event";
     
-    public var logoutUrl:String;
+    public var reason:String;
     
-    public function MeetingNotFoundEvent(logoutTo:String)
+    public function MeetingNotFoundEvent(reason:String)
     {
       super(MEETING_NOT_FOUND, true, false);
-      logoutUrl = logoutTo;
+      this.reason = reason;
     }
   }
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/modules/EnterApiService.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/modules/EnterApiService.as
@@ -9,10 +9,12 @@ package org.bigbluebutton.main.model.modules
   import flash.net.URLRequest;
   import flash.net.URLRequestMethod;
   import flash.net.URLVariables;
+  
   import org.as3commons.logging.api.ILogger;
   import org.as3commons.logging.api.getClassLogger;
   import org.bigbluebutton.core.UsersUtil;
   import org.bigbluebutton.main.events.MeetingNotFoundEvent;
+  import org.bigbluebutton.util.i18n.ResourceUtil;
   
   public class EnterApiService
   {
@@ -70,7 +72,7 @@ package org.bigbluebutton.main.model.modules
         LOGGER.info(JSON.stringify(logData));
 
         var dispatcher:Dispatcher = new Dispatcher();
-        dispatcher.dispatchEvent(new MeetingNotFoundEvent(result.response.logoutURL));			
+        dispatcher.dispatchEvent(new MeetingNotFoundEvent(ResourceUtil.getInstance().getString('bbb.mainshell.enterAPIFailed')));
       } else if (returncode == 'SUCCESS') {
 
           

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/JoinService.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/JoinService.as
@@ -34,6 +34,7 @@ package org.bigbluebutton.main.model.users
   import org.bigbluebutton.core.UsersUtil;
   import org.bigbluebutton.main.events.MeetingNotFoundEvent;
   import org.bigbluebutton.main.model.users.events.ConnectionFailedEvent;
+  import org.bigbluebutton.util.i18n.ResourceUtil;
   
   public class JoinService
   {  
@@ -127,7 +128,7 @@ package org.bigbluebutton.main.model.users
         LOGGER.info(JSON.stringify(logData));
         
         var dispatcher:Dispatcher = new Dispatcher();
-        dispatcher.dispatchEvent(new MeetingNotFoundEvent(result.response.logoutURL));			
+        dispatcher.dispatchEvent(new MeetingNotFoundEvent(ResourceUtil.getInstance().getString('bbb.mainshell.enterAPIFailed')));
       } else if (returncode == 'SUCCESS') {
         logData.logCode = "enter_api_succeeded"; 
         LOGGER.info(JSON.stringify(logData));

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/LoadingBar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/LoadingBar.mxml
@@ -99,6 +99,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private function tunnelingFailed(e:PortTestEvent):void {
 				loadingbarLabel.text = ResourceUtil.getInstance().getString('bbb.mainshell.statusProgress.cannotConnectServer');
 			}
+			
+			public function loadingFailed(message:String):void {
+				loadingbarLabel.text = message;
+			}
 		]]>
 	</fx:Script>
 

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/LoggedOutWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/LoggedOutWindow.mxml
@@ -156,6 +156,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 					case ConnectionFailedEvent.USER_LOGGED_OUT:
 						message = ResourceUtil.getInstance().getString('bbb.logout.usercommand');
 						break;
+					default:
+						message = reason;
 				}
 				if (message && UsersUtil.isBreakout()) {
 					message += "\n" + ResourceUtil.getInstance().getString('bbb.logour.breakoutRoomClose');

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainApplicationShell.mxml
@@ -677,32 +677,24 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 
             private function handleMeetingNotFoundEvent(e:MeetingNotFoundEvent):void {
-                showlogoutWindow(ResourceUtil.getInstance().getString('bbb.mainshell.meetingNotFound'));
+                mdiCanvas.removeAllPopUps();
+                removeToolBars();
+                progressBar.loadingFailed(e.reason);
             }
 
             private function showlogoutWindow(reason:String):void {
-                if (layoutOptions != null && layoutOptions.showLogoutWindow) {
-                    if (UsersUtil.iAskedToLogout()) {
-                        handleExitApplicationEvent();
-                        return;
-                    }
+                if ((layoutOptions != null && !layoutOptions.showLogoutWindow) || UsersUtil.iAskedToLogout()) {
+                    mdiCanvas.removeAllPopUps();
+                    removeToolBars();
+                    
+                    handleExitApplicationEvent();
+                } else {
                     var loggedOutWindow:LoggedOutWindow = PopUpUtil.createModalPopUp(FlexGlobals.topLevelApplication as DisplayObject, LoggedOutWindow, true) as LoggedOutWindow;
                     if (loggedOutWindow) {
                         loggedOutWindow.setReason(reason);
                         mdiCanvas.removeAllPopUps();
                         removeToolBars();
                     }
-                } else {
-                    mdiCanvas.removeAllPopUps();
-                    removeToolBars();
-                    var pageHost:String = FlexGlobals.topLevelApplication.url.split("/")[0];
-                    var pageURL:String = FlexGlobals.topLevelApplication.url.split("/")[2];
-                    LOGGER.debug("SingOut to [{0}//{1}/bigbluebutton/api/signOut]", [pageHost, pageURL]);
-                    var request:URLRequest = new URLRequest(pageHost + "//" + pageURL + "/bigbluebutton/api/signOut");
-                    var urlLoader:URLLoader = new URLLoader();
-                    urlLoader.addEventListener(Event.COMPLETE, handleLogoutComplete);
-                    urlLoader.addEventListener(IOErrorEvent.IO_ERROR, handleLogoutError);
-                    urlLoader.load(request);
                 }
             }
 
@@ -729,24 +721,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
                     ExternalInterface.call("window.close");
                 }
             }
-
-			private function redirectToLogoutUrl ():void {
-        		var logoutURL:String = BBB.getLogoutURL();
-				var request:URLRequest = new URLRequest(logoutURL);
-
-				navigateToURL(request, '_self');
-			}
-			
-
-			private function handleLogoutError(e:Event):void {
-
-				redirectToLogoutUrl();
-			}
-			
-			private function handleLogoutComplete(e:Event):void {	
-
-				redirectToLogoutUrl();
-			}
 			
 			private function attemptReconnect(e:ConnectionFailedEvent):void{
 				handleLogout(e);


### PR DESCRIPTION
If the config.xml, or enter API, couldn't be loaded the client would sit on the loading bar and sometimes throw and exception. This PR simplifies the error handling and reports the error to the user rather than just showing nothing. In previous versions the client would automatically fetch the default logout URL (api/signOut), but at some point that stopped returning a URL.