### PR TITLE
Fix not clearing pods and token when removing a meeting

### DIFF
--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/clearGroupChatMsg.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/clearGroupChatMsg.js
@@ -9,7 +9,7 @@ export default function clearGroupChatMsg(meetingId, chatId) {
   const CHAT_CLEAR_MESSAGE = CHAT_CONFIG.system_messages_keys.chat_clear;
 
   if (chatId) {
-    GroupChatMsg.remove({ meetingId, chatId }, Logger.info(`Cleared GroupChat (${meetingId}, ${chatId})`));
+    GroupChatMsg.remove({ meetingId, chatId }, Logger.info(`Cleared GroupChatMsg (${meetingId}, ${chatId})`));
 
     const clearMsg = {
       color: '0',
@@ -26,8 +26,8 @@ export default function clearGroupChatMsg(meetingId, chatId) {
   }
 
   if (meetingId) {
-    return GroupChatMsg.remove({ meetingId }, Logger.info(`Cleared GroupChat (${meetingId})`));
+    return GroupChatMsg.remove({ meetingId }, Logger.info(`Cleared GroupChatMsg (${meetingId})`));
   }
 
-  return GroupChatMsg.remove({}, Logger.info('Cleared GroupChat (all)'));
+  return GroupChatMsg.remove({}, Logger.info('Cleared GroupChatMsg (all)'));
 }

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/removeMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/removeMeeting.js
@@ -8,14 +8,15 @@ import clearAnnotations from '/imports/api/annotations/server/modifiers/clearAnn
 import clearSlides from '/imports/api/slides/server/modifiers/clearSlides';
 import clearPolls from '/imports/api/polls/server/modifiers/clearPolls';
 import clearCaptions from '/imports/api/captions/server/modifiers/clearCaptions';
-import clearPresentations from '/imports/api/presentations/server/modifiers/clearPresentations';
+import clearPresentationPods from '/imports/api/presentation-pods/server/modifiers/clearPresentationPods';
 import clearVoiceUsers from '/imports/api/voice-users/server/modifiers/clearVoiceUsers';
+
 
 export default function removeMeeting(meetingId) {
   return Meetings.remove({ meetingId }, () => {
     clearCaptions(meetingId);
     clearGroupChat(meetingId);
-    clearPresentations(meetingId);
+    clearPresentationPods(meetingId);
     clearBreakouts(meetingId);
     clearPolls(meetingId);
     clearAnnotations(meetingId);

--- a/bigbluebutton-html5/imports/api/presentation-pods/server/modifiers/clearPresentationPods.js
+++ b/bigbluebutton-html5/imports/api/presentation-pods/server/modifiers/clearPresentationPods.js
@@ -1,0 +1,23 @@
+import PresentationPods from '/imports/api/presentation-pods';
+import Logger from '/imports/startup/server/logger';
+import clearPresentations from '/imports/api/presentations/server/modifiers/clearPresentations';
+import clearPresentationUploadToken from '/imports/api/presentation-upload-token/server/modifiers/clearPresentationUploadToken';
+
+export default function clearPresentationPods(meetingId) {
+  if (meetingId) {
+    return PresentationPods.remove(
+      { meetingId },
+      () => {
+        clearPresentations(meetingId);
+        clearPresentationUploadToken(meetingId);
+        Logger.info(`Cleared Presentations Pods (${meetingId})`);
+      },
+    );
+  }
+
+  return PresentationPods.remove({}, () => {
+    clearPresentations();
+    clearPresentationUploadToken();
+    Logger.info('Cleared Presentations Pods (all)');
+  });
+}

--- a/bigbluebutton-html5/imports/api/presentation-pods/server/modifiers/removePresentationPod.js
+++ b/bigbluebutton-html5/imports/api/presentation-pods/server/modifiers/removePresentationPod.js
@@ -2,6 +2,7 @@ import { check } from 'meteor/check';
 import PresentationPods from '/imports/api/presentation-pods';
 import Logger from '/imports/startup/server/logger';
 import clearPresentations from '/imports/api/presentations/server/modifiers/clearPresentations';
+import clearPresentationUploadToken from '/imports/api/presentation-upload-token/server/modifiers/clearPresentationUploadToken';
 
 export default function removePresentationPod(meetingId, podId) {
   check(meetingId, String);
@@ -21,6 +22,7 @@ export default function removePresentationPod(meetingId, podId) {
     if (podId) {
       Logger.info(`Removed presentation pod id=${podId} meeting=${meetingId}`);
       clearPresentations(meetingId, podId);
+      clearPresentationUploadToken(meetingId, podId);
     }
   };
 

--- a/bigbluebutton-html5/imports/api/presentation-upload-token/server/modifiers/clearPresentationUploadToken.js
+++ b/bigbluebutton-html5/imports/api/presentation-upload-token/server/modifiers/clearPresentationUploadToken.js
@@ -1,0 +1,21 @@
+import PresentationUploadToken from '/imports/api/presentation-upload-token';
+import Logger from '/imports/startup/server/logger';
+
+export default function clearPresentationUploadToken(meetingId, podId) {
+  if (meetingId && podId) {
+    return PresentationUploadToken.remove(
+      { meetingId, podId },
+      Logger.info(`Cleared Presentations Upload Token (${meetingId}, ${podId})`),
+    );
+  }
+
+  if (meetingId) {
+    return PresentationUploadToken.remove(
+      { meetingId },
+      Logger.info(`Cleared Presentations Upload Token (${meetingId})`),
+    );
+  }
+
+  // clearing presentations for the whole server
+  return PresentationUploadToken.remove({}, Logger.info('Cleared Presentations Upload Token (all)'));
+}

--- a/bigbluebutton-html5/imports/api/presentations/server/modifiers/clearPresentations.js
+++ b/bigbluebutton-html5/imports/api/presentations/server/modifiers/clearPresentations.js
@@ -6,14 +6,14 @@ export default function clearPresentations(meetingId, podId) {
   if (meetingId && podId) {
     return Presentations.remove(
       { meetingId, podId },
-      Logger.info(`Cleared Presentations for the podId=${podId} and meetingId=${meetingId}`),
+      Logger.info(`Cleared Presentations (${meetingId}, ${podId})`),
     );
 
   // clearing presentations for the whole meeting
   } else if (meetingId) {
     return Presentations.remove(
       { meetingId },
-      Logger.info(`Cleared Presentations for the meetingId=${meetingId}`),
+      Logger.info(`Cleared Presentations (${meetingId})`),
     );
   }
 


### PR DESCRIPTION
This PR fixes presentation pods and presentation upload token collections not being cleared correctly when a pod is removed or a presentation. I also fixed the log message when removing GroupChatMsg.