### PR TITLE
Recording fixes for BBB 2.0

### DIFF
--- a/record-and-playback/presentation/playback/presentation/2.0/playback.css
+++ b/record-and-playback/presentation/playback/presentation/2.0/playback.css
@@ -54,6 +54,10 @@ html, .acorn-controls {
   min-width: 310px;
 }
 
+p {
+  font-size: inherit;
+}
+
 
 /* Swappable components have different settings depending on where they are */
 #main-section #presentation-area {

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -368,7 +368,7 @@ def svg_render_shape_poll(g, slide, shape)
 
   result = JSON.load(shape[:result])
   num_responders = shape[:num_responders]
-  presentation = shape[:presentation]
+  presentation = slide[:presentation]
   max_num_votes = result.map{ |r| r['num_votes'] }.max
 
   dat_file = "#{$process_dir}/poll_result#{poll_id}.dat"


### PR DESCRIPTION
This fixes a couple minor issues in the recording presentation and playback:

- The font size of text shapes wasn't correct
- Poll images weren't put into the presentation subdirectories, and the filenames contained a `//` from an empty path component.