### PR TITLE
Maintain array of user roles so they are unique

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/modifiers/changeRole.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/changeRole.js
@@ -10,8 +10,7 @@ export default function changeRole(role, status, userId, meetingId, changedBy) {
     userId,
   };
 
-  const action = status ? '$push' : '$pop';
-
+  const action = status ? '$addToSet' : '$pull';
   const user = Users.findOne(selector);
 
   const modifier = {


### PR DESCRIPTION
Closes #6004 
Closes #6107 
Improvements on the way we maintain a user's array of current roles (used for ACL): allowed items are `viewer`, `moderator`, `presenter`
The bugs resolved had to do with discrepancy between ACL item and UI or duplicated items in array
