### PR TITLE
Fix compatibility in some old browser

### DIFF
--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -634,7 +634,7 @@ window.getScreenConstraints = function (sendSource, callback) {
         },
         (response) => {
           resolve(response);
-        },
+        }
       );
     });
   };


### PR DESCRIPTION
Trailing comma in function arguments does not allowed until ECMAScript 2017