### PR TITLE
Improvements to Safari WebRTC interop and SFU listen only

### DIFF
--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -476,12 +476,8 @@ Kurento.prototype.setAudio = function (tag) {
 
 Kurento.prototype.listenOnly = function () {
   var self = this;
-  const remoteVideo = document.getElementById(this.renderTag);
-  remoteVideo.muted = true;
   if (!this.webRtcPeer) {
     var options = {
-      audioStream: this.inputStream,
-      remoteVideo,
       onicecandidate : this.onListenOnlyIceCandidate.bind(this),
       mediaConstraints: {
         audio: true,

--- a/bigbluebutton-html5/client/compatibility/kurento-utils.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-utils.js
@@ -38,11 +38,13 @@ function noop(error) {
         logger.error(error);
 }
 function trackStop(track) {
-    track.stop && track.stop();
+    track && track.stop && track.stop();
 }
 function streamStop(stream) {
-    stream.getTracks().forEach(trackStop);
+    let track = stream.track;
+    trackStop(track);
 }
+
 var dumpSDP = function (description) {
     if (typeof description === 'undefined' || description === null) {
         return '';
@@ -67,7 +69,9 @@ function bufferizeCandidates(pc, onerror) {
             break;
         case 'stable':
             if (pc.remoteDescription) {
-                pc.addIceCandidate(candidate, callback, callback);
+                pc.addIceCandidate(candidate).then(callback).catch(err => {
+                    callback(err);
+                });
                 break;
             }
         default:
@@ -228,7 +232,7 @@ function WebRtcPeer(mode, options, callback) {
                 candidategatheringdone = true;
         }
     });
-    pc.ontrack = options.onaddstream;
+    pc.onaddtrack = options.onaddstream;
     pc.onnegotiationneeded = options.onnegotiationneeded;
     this.on('newListener', function (event, listener) {
         if (event === 'icecandidate' || event === 'candidategatheringdone') {
@@ -300,7 +304,8 @@ function WebRtcPeer(mode, options, callback) {
             }).then(() => { remoteVideo.muted = false; played = true; attempt = 0;});
           }
         }
-        var stream = pc.getRemoteStreams()[0];
+
+        let stream = self.getRemoteStream();
 
         remoteVideo.oncanplaythrough = function() {
           playVideo();
@@ -338,10 +343,10 @@ function WebRtcPeer(mode, options, callback) {
         if (pc.signalingState === 'closed') {
             return callback('PeerConnection is closed');
         }
-        pc.setRemoteDescription(answer, function () {
+        pc.setRemoteDescription(answer).then(function () {
             setRemoteVideo();
             callback();
-        }, callback);
+        }).catch(callback);
     };
     this.processOffer = function (sdpOffer, callback) {
         callback = callback.bind(this);
@@ -398,10 +403,10 @@ function WebRtcPeer(mode, options, callback) {
             self.showLocalVideo();
         }
         if (videoStream) {
-            pc.addStream(videoStream);
+            videoStream.getTracks().forEach(track => pc.addTrack(track, videoStream));
         }
         if (audioStream) {
-            pc.addStream(audioStream);
+            audioStream.getTracks().forEach(track => pc.addTrack(track, audioStream));
         }
         var browser = parser.getBrowser();
         if (mode === 'sendonly' && (browser.name === 'Chrome' || browser.name === 'Chromium') && browser.major === 39) {
@@ -459,23 +464,28 @@ function createEnableDescriptor(type) {
         get: function () {
             if (!this.peerConnection)
                 return;
-            var streams = this.peerConnection.getLocalStreams();
-            if (!streams.length)
+
+            var senders = this.peerConnection.getSenders();
+            if (!senders.length)
                 return;
-            for (var i = 0, stream; stream = streams[i]; i++) {
-                var tracks = stream[method]();
-                for (var j = 0, track; track = tracks[j]; j++)
-                    if (!track.enabled)
-                        return false;
-            }
+
+            senders.forEach(sender => {
+                let track = sender.track;
+                if (!track.enabled && track.kind === type) {
+                    return false;
+                }
+            });
             return true;
         },
         set: function (value) {
             function trackSetEnable(track) {
                 track.enabled = value;
             }
-            this.peerConnection.getLocalStreams().forEach(function (stream) {
-                stream[method]().forEach(trackSetEnable);
+            this.peerConnection.getSenders().forEach(function (stream) {
+                let track = stream.track;
+                if (track.kind === type) {
+                    trackSetEnable(track);
+                }
             });
         }
     };
@@ -493,15 +503,37 @@ Object.defineProperties(WebRtcPeer.prototype, {
     'audioEnabled': createEnableDescriptor('Audio'),
     'videoEnabled': createEnableDescriptor('Video')
 });
-WebRtcPeer.prototype.getLocalStream = function (index) {
-    if (this.peerConnection) {
-        return this.peerConnection.getLocalStreams()[index || 0];
-    }
+WebRtcPeer.prototype.getLocalStream = function () {
+  if (this.localStream) {
+    return this.localStream;
+  }
+
+  if (this.peerConnection) {
+    this.localStream = new MediaStream();
+    this.peerConnection.getSenders().forEach((ls) => {
+      let track = ls.track;
+      if (track && !track.muted) {
+        this.localStream.addTrack(track);
+      }
+    });
+    return this.localStream;
+  }
 };
-WebRtcPeer.prototype.getRemoteStream = function (index) {
-    if (this.peerConnection) {
-        return this.peerConnection.getRemoteStreams()[index || 0];
-    }
+WebRtcPeer.prototype.getRemoteStream = function () {
+  if (this.remoteStream) {
+    return this.remoteStream;
+  }
+
+  if (this.peerConnection) {
+    this.remoteStream = new MediaStream();
+    this.peerConnection.getReceivers().forEach((rs) => {
+      let track = rs.track;
+      if (track && !track.muted) {
+        this.remoteStream.addTrack(track);
+      }
+    });
+    return this.remoteStream;
+  }
 };
 WebRtcPeer.prototype.dispose = function () {
     // logger.debug('Disposing WebRtcPeer');
@@ -516,7 +548,13 @@ WebRtcPeer.prototype.dispose = function () {
         if (pc) {
             if (pc.signalingState === 'closed')
                 return;
-            pc.getLocalStreams().forEach(streamStop);
+            pc.getSenders().forEach(streamStop);
+            if (this.remoteStream) {
+                this.remoteStream = null;
+            }
+            if (this.localStream) {
+                this.localStream = null;
+            }
             pc.close();
         }
     } catch (err) {

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
@@ -62,10 +62,6 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
     this.voiceBridge = voiceBridge;
   }
 
-  exitAudio(listenOnly) {
-    window.kurentoExitAudio();
-  }
-
   joinAudio({ isListenOnly, inputStream }, callback) {
     return new Promise(async (resolve, reject) => {
       this.callback = callback;
@@ -86,7 +82,18 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
           inputStream,
         };
 
-        const onSuccess = ack => resolve(this.callback({ status: this.baseCallStates.started }));
+        const onSuccess = ack => {
+          const { webRtcPeer } = window.kurentoManager.kurentoAudio;
+          if (webRtcPeer) {
+            const audioTag = document.getElementById(MEDIA_TAG);
+            const stream = webRtcPeer.getRemoteStream();
+            audioTag.pause();
+            audioTag.srcObject = stream;
+            audioTag.muted = false;
+            audioTag.play();
+          }
+          resolve(this.callback({ status: this.baseCallStates.started }));
+        };
 
         const onFail = error => {
           const { reason } = error;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -407,11 +407,12 @@ class VideoProvider extends Component {
         options.configuration.iceServers = iceServers;
       }
 
-      let WebRtcPeerObj = window.kurentoUtils.WebRtcPeer.WebRtcPeerRecvonly;
-
+      let WebRtcPeerObj;
       if (shareWebcam) {
         WebRtcPeerObj = window.kurentoUtils.WebRtcPeer.WebRtcPeerSendonly;
         this.shareWebcam();
+      } else {
+        WebRtcPeerObj = window.kurentoUtils.WebRtcPeer.WebRtcPeerRecvonly;
       }
 
       this.webRtcPeers[id] = new WebRtcPeerObj(options, (error) => {

--- a/labs/bbb-webrtc-sfu/lib/base/BaseManager.js
+++ b/labs/bbb-webrtc-sfu/lib/base/BaseManager.js
@@ -64,6 +64,12 @@ module.exports = class BaseManager {
     }
   }
 
+  _deleteIceQueue (sessionId) {
+    if (this._iceQueues[sessionId]) {
+      delete this._iceQueues[sessionId];
+    }
+  }
+
   _killConnectionSessions (connectionId) {
     const keys = Object.keys(this._sessions);
     keys.forEach((sessionId) => {


### PR DESCRIPTION
This PR includes the following:
  - Revamped the `kurento-utils` library to get rid of deprecated WebRTC API calls. We should be now up to spec, with an exception to chrome screenshare constraints. This was done because Safari 12 disable the legacy API support by default, which was making video and audio a bit unreliable on Safari. Safari 11 does support the updated spec AFAIK.
  - Improvements to video reliability on Safari (Mac/iOS).
  - Added a forced microphone permission request on Safari when trying to join listen only. This is related to WebKit ICE gathering policies, as said in the following: https://webkit.org/blog/7763/a-closer-look-into-webrtc/
  - Transitioned SFU listen only to use `MediaStream` instead of using the HTML audio tag directly. This should improve its robustness.
  - Added an ICE queue for the audio impl. on bbb-webrtc-sfu for increased reliability on ICE exchanges.

This needs a good batch of testing due to the nature of the changes. I've tested with the following:
  - Desktop: Chrome 69, 70, 71. Safari 12. Firefox 61, 62 and Nightly. 
  - Mobile: iPad/Safari (12), iPhone/Safari(12), Chrome (69)/Android 8, Chrome 69 (Android 5.1), Chrome 69 (Android 6), Firefox for Android Nightly (64, Android 8).