### PR TITLE
Make bbb-webrtc-sfu connect to Kurento using multiple websockets and other assorted improvements

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -464,19 +464,15 @@ class VideoProvider extends Component {
 
       if (this.props.userId === id) {
         this.notifyError(intl.formatMessage(intlClientErrors.sharingError));
-        this.unshareWebcam();
-        this.destroyWebRTCPeer(id);
+        this.stopWebRTCPeer(id);
       } else {
-        const tag = this.webRtcPeers[id].videoTag;
-
         this.stopWebRTCPeer(id);
         this.createWebRTCPeer(id, shareWebcam);
 
-        // We reattach the peer for a real video restart
-        this.attachVideoStream(id);
-
         // Increment reconnect interval
         this.restartTimer[id] = Math.min(2 * this.restartTimer[id], MAX_CAMERA_SHARE_FAILED_WAIT_TIME);
+
+        this.logger('info', `Reconnecting peer ${id} with timer`, this.restartTimer)
       }
     };
   }

--- a/labs/bbb-webrtc-sfu/config/default.example.yml
+++ b/labs/bbb-webrtc-sfu/config/default.example.yml
@@ -1,12 +1,18 @@
+# Websocket URL under which kurento is listening
 kurentoUrl: "ws://HOST/kurento"
+# The external IP of the host where Kurento is located
 kurentoIp: ""
+# The external IP of the host where Red5/BBB is located. Used for the RTMP url
 localIpAddress: ""
 acceptSelfSignedCertificate: false
 redisHost : "127.0.0.1"
 redisPort : "6379"
+# Port under which bbb-webrtc-sfu serves client
 clientPort : "3008"
+# The following UDP port boundary is related to the ports ffmpeg can use to generate the RTMP stream
 minVideoPort: 30000
 maxVideoPort: 33000
+# Timeout (ms) that triggers a failure when no media has reached the server
 mediaFlowTimeoutDuration: 5000
 from-screenshare: "from-screenshare-sfu"
 to-screenshare: "to-screenshare-sfu"
@@ -17,15 +23,24 @@ to-audio: "to-audio-sfu"
 to-akka: "to-akka-apps-redis-channel"
 from-akka: "from-akka-apps-redis-channel"
 common-message-version: "2.x"
+# FORCES H.264 for webcams. Endpoints without H.264 WILL NOT WORK.
+# Disabling it will make the process go untouched and may cause transcoding.
 webcam-force-h264: true
+# Preferred H.264 profile-level-id for webcams. Forces everyone to use CB
 webcam-preferred-h264-profile: "42e01f"
 # Target bitrate (kbps) for webcams. Value 0 leaves it unconstrained.
 webcam-target-bitrate: 300
+# FORCES H.264 for screenshare. Endpoints without H.264 WILL NOT WORK.
+# Disabling it will make the process go untouched and may cause transcoding.
 screenshare-force-h264: true
+# Preferred H.264 profile-level-id for screenshare. Forces everyone to use CB
 screenshare-preferred-h264-profile: "42e01f"
+# Base interval for keyframe requsitions to the screenshare streamer
 screenshareKeyframeInterval: 2
 # Target bitrate (kbps) for screenshare. Value 0 leaves it unconstrained.
 screenshare-target-bitrate: 0
+# Size of the websocket pool SFU uses to connect to Kurento.
+kurento-websocket-pool-size: 7
 
 recordScreenSharing: true
 recordWebcams: false
@@ -36,10 +51,12 @@ recordingFormat: 'mkv'
 
 redisExpireTime: 1209600 # 14 days as per the akka keys
 
+# Used for the listen only bridge. The IP MUST be the one where FS is binded to
 freeswitch:
     ip: 'FREESWITCH_IP'
     port: '5066'
 
+# Log levels, in order of specificity: info, warn, verbose, debug, trace
 log:
     filename: '/var/log/bbb-webrtc-sfu/bbb-webrtc-sfu.log'
     level: 'verbose'

--- a/labs/bbb-webrtc-sfu/lib/audio/audio.js
+++ b/labs/bbb-webrtc-sfu/lib/audio/audio.js
@@ -313,17 +313,4 @@ module.exports = class Audio extends BaseProvider {
     }), C.FROM_AUDIO);
     this.removeUser(connectionId);
   };
-
-  serverState (event) {
-    const { eventTag: { code }  } = { ...event };
-    switch (code) {
-      case C.MEDIA_SERVER_OFFLINE:
-        Logger.error(LOG_PREFIX, "Provider received MEDIA_SERVER_OFFLINE event");
-        this.emit(C.MEDIA_SERVER_OFFLINE, event);
-        break;
-
-      default:
-        Logger.warn(LOG_PREFIX, "Unknown server state", event);
-    }
-  }
 };

--- a/labs/bbb-webrtc-sfu/lib/base/BaseManager.js
+++ b/labs/bbb-webrtc-sfu/lib/base/BaseManager.js
@@ -143,6 +143,11 @@ module.exports = class BaseManager {
   }
 
   _handleError (logPrefix, connectionId, streamId, role, error) {
+    // Setting a default error in case it was unhandled
+    if (error == null) {
+      error = { code: 2200, reason: errors[2200] }
+    }
+
     if (error && this._validateErrorMessage(error)) {
       return error;
     }

--- a/labs/bbb-webrtc-sfu/lib/base/BaseProvider.js
+++ b/labs/bbb-webrtc-sfu/lib/base/BaseProvider.js
@@ -33,6 +33,11 @@ module.exports = class BaseProvider extends EventEmitter {
 
 
   _handleError (logPrefix, error, role, streamId) {
+    // Setting a default error in case it was unhandled
+    if (error == null) {
+      error = { code: 2200, reason: errors[2200] }
+    }
+
     if (this._validateErrorMessage(error)) {
       return error;
     }

--- a/labs/bbb-webrtc-sfu/lib/base/BaseProvider.js
+++ b/labs/bbb-webrtc-sfu/lib/base/BaseProvider.js
@@ -5,12 +5,32 @@ const Logger = require('../utils/Logger');
 const EventEmitter = require('events').EventEmitter;
 const errors = require('../base/errors');
 const config = require('config');
+const LOG_PREFIX = '[base-provider]';
 
 module.exports = class BaseProvider extends EventEmitter {
   constructor () {
     super();
     this.sfuApp = "base";
   }
+
+  serverState (event) {
+    let code = null;
+    const { eventTag } = { ...event };
+    if (eventTag && eventTag.code) {
+      code = eventTag.code;
+    }
+
+    switch (code) {
+      case C.MEDIA_SERVER_OFFLINE:
+        Logger.error(LOG_PREFIX, "Provider received MEDIA_SERVER_OFFLINE event");
+        this.emit(C.MEDIA_SERVER_OFFLINE, event);
+        break;
+
+      default:
+        Logger.warn(LOG_PREFIX, "Unknown server state", event);
+    }
+  }
+
 
   _handleError (logPrefix, error, role, streamId) {
     if (this._validateErrorMessage(error)) {

--- a/labs/bbb-webrtc-sfu/lib/mcs-core/lib/adapters/kurento/kurento.js
+++ b/labs/bbb-webrtc-sfu/lib/mcs-core/lib/adapters/kurento/kurento.js
@@ -224,10 +224,10 @@ module.exports = class MediaServer extends EventEmitter {
         let mediaServer = this._getClientFromPool();
         if (this._mediaElements[elementId]) {
           mediaServer.getMediaobjectById(elementId, (error, element) => {
-            if (error) {
+            if (error || element == null) {
               return reject(this._handleError(error));
             }
-            Logger.warn('[mcs-media] Element', elementId, 'found');
+            Logger.trace('[mcs-media] Element', elementId, 'found');
             return resolve(element);
           });
         } else {

--- a/labs/bbb-webrtc-sfu/lib/mcs-core/lib/constants/Constants.js
+++ b/labs/bbb-webrtc-sfu/lib/mcs-core/lib/constants/Constants.js
@@ -39,6 +39,7 @@ exports.EVENT.MEDIA_STATE.FLOW_IN = "MediaFlowInStateChange"
 exports.EVENT.MEDIA_STATE.ENDOFSTREAM = "EndOfStream"
 exports.EVENT.MEDIA_STATE.ICE = "OnIceCandidate"
 exports.EVENT.SERVER_STATE = "ServerState"
+exports.EVENT.ROOM_EMPTY = "RoomEmpty"
 
 exports.EVENT.RECORDING = {};
 exports.EVENT.RECORDING.STOPPED = 'Stopped';

--- a/labs/bbb-webrtc-sfu/lib/mcs-core/lib/media/MediaController.js
+++ b/labs/bbb-webrtc-sfu/lib/mcs-core/lib/media/MediaController.js
@@ -171,10 +171,8 @@ module.exports = class MediaController {
           case C.MEDIA_TYPE.URI:
             const  { session, answer } = await user.subscribe(params.descriptor, type, source, params);
             this.addMediaSession(session);
-            source.subscribedSessions.push(session.id);
             resolve({answer, sessionId: session.id});
             session.sessionStarted();
-            Logger.info("[mcs-controller] Updated", source.id,  "subscribers list to", source.subscribedSessions);
             break;
           default:
             return reject(this._handleError(C.ERROR.MEDIA_INVALID_TYPE));
@@ -223,7 +221,6 @@ module.exports = class MediaController {
         const answer = await user.startSession(session.id);
         await sourceSession.connect(session._mediaElement);
 
-        sourceSession.subscribedSessions.push(session.id);
         this._mediaSessions[session.id] = session;
 
         resolve(answer);

--- a/labs/bbb-webrtc-sfu/lib/mcs-core/lib/media/MediaController.js
+++ b/labs/bbb-webrtc-sfu/lib/mcs-core/lib/media/MediaController.js
@@ -45,7 +45,7 @@ module.exports = class MediaController {
       let session;
       const room = await this.createRoomMCS(roomId);
       const user = await this.createUserMCS(roomId, type, params);
-      room.setUser(user.id);
+      room.setUser(user);
 
       if (params.sdp) {
         session = user.addSdp(params.sdp);
@@ -306,7 +306,7 @@ module.exports = class MediaController {
     Logger.info("[mcs-controller] Creating new room with ID", roomId);
 
     if (this._rooms[roomId] == null) {
-      this._rooms[roomId] = new Room(roomId);
+      this._rooms[roomId] = new Room(roomId, this.emitter);
     }
 
     return Promise.resolve(this._rooms[roomId]);

--- a/labs/bbb-webrtc-sfu/lib/mcs-core/lib/model/MediaSession.js
+++ b/labs/bbb-webrtc-sfu/lib/mcs-core/lib/model/MediaSession.js
@@ -32,7 +32,7 @@ module.exports = class MediaSession {
     this._options = options;
     this._adapter = options.adapter? options.adapter : C.STRING.KURENTO;
     this._name = options.name? options.name : C.STRING.DEFAULT_NAME;
-    this._MediaServer = MediaSession.getAdapter(this._adapter);
+    this._MediaServer = MediaSession.getAdapter(this._adapter, emitter);
     this.eventQueue = [];
   }
 
@@ -147,14 +147,14 @@ module.exports = class MediaSession {
     }
   }
 
-  static getAdapter (adapter) {
+  static getAdapter (adapter, emitter) {
     let obj = null;
 
     Logger.info("[mcs-media-session] Session is using the", adapter, "adapter");
 
     switch (adapter) {
       case C.STRING.KURENTO:
-        obj = new Kurento(kurentoUrl);
+        obj = new Kurento(kurentoUrl, emitter);
         break;
       case C.STRING.FREESWITCH:
         obj = new Freeswitch();

--- a/labs/bbb-webrtc-sfu/lib/mcs-core/lib/model/Room.js
+++ b/labs/bbb-webrtc-sfu/lib/mcs-core/lib/model/Room.js
@@ -5,11 +5,14 @@
 
 'use strict'
 
+const C = require('../constants/Constants');
+
 module.exports = class Room {
-  constructor(id) {
+  constructor(id, emitter) {
     this._id = id;
     this._users = {};
     this._mcuUsers = {};
+    this.emitter = emitter;
   }
 
   getUser (id) {
@@ -21,6 +24,11 @@ module.exports = class Room {
   }
 
   destroyUser(userId) {
-    this._users[userId] = null;
+    if (this._users[userId]) {
+      delete this._users[userId];
+      if (Object.keys(this._users).length <= 0) {
+        this.emitter.emit(C.EVENT.ROOM_EMPTY, this._id);
+      }
+    }
   }
 }

--- a/labs/bbb-webrtc-sfu/lib/screenshare/screenshare.js
+++ b/labs/bbb-webrtc-sfu/lib/screenshare/screenshare.js
@@ -174,18 +174,6 @@ module.exports = class Screenshare extends BaseProvider {
     }
   }
 
-  serverState (event) {
-    switch (event && event.eventTag) {
-      case C.MEDIA_SERVER_OFFLINE:
-        this._handleError(LOG_PREFIX, err);
-        Logger.error(LOG_PREFIX, "Screenshare provider received MEDIA_SERVER_OFFLINE event");
-        this.emit(C.MEDIA_SERVER_OFFLINE, event);
-        break;
-      default:
-        Logger.warn(LOG_PREFIX, "Unknown server state", event);
-    }
-  }
-
   recordingState(event) {
     const msEvent = event.event;
     Logger.info('[Recording]', msEvent.type, '[', msEvent.state, ']', 'for recording session', event.id, 'for screenshare', this.streamName);

--- a/labs/bbb-webrtc-sfu/lib/video/VideoManager.js
+++ b/labs/bbb-webrtc-sfu/lib/video/VideoManager.js
@@ -73,11 +73,13 @@ module.exports = class VideoManager extends BaseManager {
       case 'start':
         Logger.info(this._logPrefix, 'Received message [' + message.id + '] from connection ' + sessionId);
 
-        if (!video) {
-          video = new Video(this._bbbGW, message.meetingId, message.cameraId, shared, message.connectionId);
-
-          this._sessions[sessionId] = video;
+        if (video) {
+          await this._stopSession(sessionId);
         }
+
+        video = new Video(this._bbbGW, message.meetingId, message.cameraId, shared, message.connectionId);
+
+        this._sessions[sessionId] = video;
 
         try {
           const sdpAnswer = await video.start(message.sdpOffer);

--- a/labs/bbb-webrtc-sfu/lib/video/video.js
+++ b/labs/bbb-webrtc-sfu/lib/video/video.js
@@ -86,20 +86,6 @@ module.exports = class Video extends BaseProvider {
     });
   }
 
-  serverState (event) {
-    const { eventTag: { code }  } = { ...event };
-    switch (code) {
-      case C.MEDIA_SERVER_OFFLINE:
-        Logger.error(LOG_PREFIX, "Video provider received MEDIA_SERVER_OFFLINE event");
-        this.emit(C.MEDIA_SERVER_OFFLINE, event);
-        break;
-
-      default:
-        Logger.warn(LOG_PREFIX, "Unknown server state", event);
-    }
-  }
-
-
   mediaState (event) {
     let msEvent = event.event;
 


### PR DESCRIPTION
- Implemented a websocket pool with configurable size (see `kurento-websocket-pool-size`). SFU will round robin between those websockets when communicating with Kurento. This was done to mitigate some issues we've seen and people have reported about Kurento websockets sometimes ending up unresponsive under high load. Basically, from what I've tested, handling ~50 elements per websocket is a pretty safe bet with Kurento, hence I made the default websocket pool size `7` by assuming a high load ceiling of ~350 streams. Keep in mind each of the processes (audio, video and screenshare) have its own pool, so it should amount to ~21 different and balanced connections.
- Added comments explaining some of the not-so-clear configuration parameters in `bbb-webrtc-sfu`
- Fixed an edge case when Kurento was restarted with SFU up and people using it.