### PR TITLE
Added onunmute listener to MediaStreamTrack

### DIFF
--- a/bigbluebutton-html5/client/compatibility/kurento-utils.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-utils.js
@@ -528,7 +528,13 @@ WebRtcPeer.prototype.getRemoteStream = function () {
     this.remoteStream = new MediaStream();
     this.peerConnection.getReceivers().forEach((rs) => {
       let track = rs.track;
-      if (track && !track.muted) {
+      if (track) {
+        if (track.muted) {
+          track.onunmute = () => {
+            this.remoteStream.addTrack(track);
+          };
+          return;
+        }
         this.remoteStream.addTrack(track);
       }
     });


### PR DESCRIPTION
Added the `onunmute` listener to WebRTC MediaStreamTracks to detect tracks that turned unmuted after a while. This is a follow up to #6128 that fixes an issue that appeared with viewing screenshare on Firefox and increases overall reliability.