### PR TITLE
 Return some data metrics on get recordings api

### DIFF
--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/domain/Recording.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/domain/Recording.scala
@@ -101,6 +101,16 @@ object RecMeta {
     }
   }
 
+  def getDataMetrics(metaXml: Elem): Option[RecMetaDataMetrics] = {
+    val data = metaXml \ "data"
+    if (data.isEmpty) None
+    else {
+      val format = getText(data, "format", "unknown")
+      val link = getText(data, "link", "unknown")
+      Some(RecMetaDataMetrics(format, link))
+    }
+  }
+
   def getExtensions(playbackXml: NodeSeq): Option[NodeSeq] = {
     val extensions = playbackXml \ "extensions"
     if (extensions.isEmpty) None
@@ -135,6 +145,7 @@ object RecMeta {
     val meeting = getMeeting(metaXml)
     val meta = getMeta(metaXml)
     val playback = getPlayback(metaXml)
+    val dataMetrics = getDataMetrics(metaXml)
     val breakout = getBreakout(metaXml)
     val breakoutRooms = getBreakoutRooms(metaXml)
 
@@ -168,7 +179,7 @@ object RecMeta {
 
     Some(RecMeta(id, meetingId, internalMeetingId, meetingName, state, published,
       startTime, endTime, participants, rawSize, isBreakout,
-      meeting, meta, playback, breakout, breakoutRooms))
+      meeting, meta, playback, dataMetrics, breakout, breakoutRooms))
   }
 }
 
@@ -176,7 +187,7 @@ case class RecMeta(id: String, meetingId: String, internalMeetingId: Option[ Str
                    meetingName: String, state: String, published: Boolean, startTime: Long, endTime: Long,
                    participants: Int, rawSize: Long, isBreakout: Boolean, meeting: Option[RecMetaMeeting],
                    meta: Option[collection.immutable.Map[String, String]], playback: Option[RecMetaPlayback],
-                   breakout: Option[RecMetaBreakout], breakoutRooms: Vector[String]) {
+                   dataMetrics: Option[RecMetaDataMetrics], breakout: Option[RecMetaBreakout], breakoutRooms: Vector[String]) {
 
   def setState(state: String): RecMeta = this.copy(state = state)
   def setPublished(publish: Boolean): RecMeta = this.copy(published = publish)
@@ -253,6 +264,8 @@ case class RecMeta(id: String, meetingId: String, internalMeetingId: Option[ Str
     }
     playback foreach(p => buffer += p.toXml())
 
+    dataMetrics foreach(p => buffer += p.toXml())
+
     <recording>{buffer}</recording>
   }
 
@@ -304,6 +317,8 @@ case class RecMeta(id: String, meetingId: String, internalMeetingId: Option[ Str
     }
 
     playback foreach(p => buffer += p.toMetadataXml())
+
+    dataMetrics foreach(p => buffer += p.toMetadataXml())
 
     buffer += rawSizeElem
 
@@ -390,6 +405,43 @@ case class RecMetaPlayback(format: String, link: String, processingTime: Int,
   }
 }
 
+case class RecMetaDataMetrics(format: String, link: String) {
+  def toXml(): Elem = {
+
+    val formatElem = <type>{format}</type>
+    val urlElem = <url>{link}</url>
+
+    val buffer = new scala.xml.NodeBuffer
+    buffer += formatElem
+    buffer += urlElem
+
+    <data><format>{buffer}</format></data>
+  }
+
+  def toMetadataXml(): Elem = {
+
+    val formatElem = <format>{format}</format>
+    val urlElem = <link>{link}</link>
+
+    val buffer = new scala.xml.NodeBuffer
+    buffer += formatElem
+    buffer += urlElem
+
+
+    <data>{buffer}</data>
+  }
+
+  // Merged data formats when responding to get recordings API call
+  def toFormatXml(): Elem = {
+    val buffer = new scala.xml.NodeBuffer
+    val formatElem = <type>{format}</type>
+    val urlElem = <url>{link}</url>
+    buffer += formatElem
+    buffer += urlElem
+
+    <format>{buffer}</format>
+  }
+}
 
 case class RecMetaImage(width: String, height: String, alt: String, link: String)
 
@@ -429,6 +481,7 @@ case class RecMetaResponse(
     meeting: Option[RecMetaMeeting],
     meta: Option[collection.immutable.Map[String, String]],
     playbacks: ListBuffer[RecMetaPlayback],
+    data: ListBuffer[RecMetaDataMetrics],
     breakout: Option[RecMetaBreakout],
     breakoutRooms: Vector[String]) {
 
@@ -436,6 +489,10 @@ case class RecMetaResponse(
   def updateRecMeta(r: RecMeta): RecMetaResponse = {
     r.playback match {
       case Some(p) => this.playbacks += p
+      case None =>
+    }
+    r.dataMetrics match {
+      case Some(p) => this.data += p
       case None =>
     }
     this
@@ -497,6 +554,12 @@ case class RecMetaResponse(
     playbacks foreach(p => formats += p.toFormatXml())
     val playbackElem = <playback>{formats}</playback>
     buffer += playbackElem
+
+    // Iterate over all formats before include the data tag
+    val dataFormats = new scala.xml.NodeBuffer
+    data foreach(p => dataFormats += p.toFormatXml())
+    val dataFormatElem = <data>{dataFormats}</data>
+    buffer += dataFormatElem
 
     <recording>{buffer}</recording>
   }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/util/RecMetaXmlHelper.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/util/RecMetaXmlHelper.scala
@@ -123,6 +123,10 @@ class RecMetaXmlHelper extends RecordingServiceGW with LogHelper {
             case Some(p) => ListBuffer(p)
             case None => ListBuffer()
           },
+          recMeta.dataMetrics match {
+            case Some(p) => ListBuffer(p)
+            case None => ListBuffer()
+          },
           recMeta.breakout,
           recMeta.breakoutRooms
       )


### PR DESCRIPTION
This PR adds extra data on the get recording api response.

```
<recording>
...
<playback>
  <format>
    <type>podcast</type>
    <url>
      https://example.com/podcast/fffc312304296c2f0287e2e5e98b79c4e3379692-1538487285527/audio.ogg
    </url>
    <processingTime>0</processingTime>
    <length>7</length>
  </format>
</playback>
<data>
  <format>
    <type>metrics</type>
    <url>
      https://example.com/metrics/fffc312304296c2f0287e2e5e98b79c4e3379692-1538487285527/data.json
    </url>
  </format>
</data>
</recording>
```
