### PR TITLE
Drop metadata configs; use userdata configs for autoSwap

### DIFF
--- a/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
+++ b/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
@@ -1,4 +1,3 @@
-import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 import addUserSetting from '/imports/api/users-settings/server/modifiers/addUserSetting';
 
@@ -30,6 +29,9 @@ export default function addUserSettings(credentials, meetingId, userId, settings
       'multiUserPenOnly',
       'presenterTools',
       'multiUserTools',
+      'autoSwapLayout',
+      'autoShareWebcam',
+      'hidePresentation',
     ];
     if (!handledHTML5Parameters.includes(key)) {
       return acc;

--- a/bigbluebutton-html5/imports/startup/client/auth.js
+++ b/bigbluebutton-html5/imports/startup/client/auth.js
@@ -1,5 +1,4 @@
 import Auth from '/imports/ui/services/auth';
-import SessionStorage from '/imports/ui/services/storage/session';
 import { setCustomLogoUrl } from '/imports/ui/components/user-list/service';
 import { log, makeCall } from '/imports/ui/services/api';
 import deviceInfo from '/imports/utils/deviceInfo';
@@ -7,7 +6,6 @@ import logger from '/imports/startup/client/logger';
 
 // disconnected and trying to open a new connection
 const STATUS_CONNECTING = 'connecting';
-const METADATA_KEY = 'metadata';
 
 export function joinRouteHandler(nextState, replace, callback) {
   const { sessionToken } = nextState.location.query;
@@ -27,7 +25,7 @@ export function joinRouteHandler(nextState, replace, callback) {
     .then(response => response.json())
     .then(({ response }) => {
       const {
-        returncode, meetingID, internalUserID, authToken, logoutUrl, customLogoURL, metadata,
+        returncode, meetingID, internalUserID, authToken, logoutUrl, customLogoURL,
         externUserID, fullname, confname, customdata,
       } = response;
 
@@ -38,33 +36,9 @@ export function joinRouteHandler(nextState, replace, callback) {
 
       setCustomLogoUrl(customLogoURL);
 
-      const metakeys = metadata.length
-        ? metadata.reduce((acc, meta) => {
-          const key = Object.keys(meta).shift();
-
-          const handledHTML5Parameters = [
-            'html5autoswaplayout', 'html5autosharewebcam', 'html5hidepresentation',
-          ];
-          if (handledHTML5Parameters.indexOf(key) === -1) {
-            return acc;
-          }
-
-          /* this reducer transforms array of objects in a single object and
-           forces the metadata a be boolean value */
-          let value = meta[key];
-          try {
-            value = JSON.parse(meta[key]);
-          } catch (e) {
-            log('error', `Caught: ${e.message}`);
-          }
-          return { ...acc, [key]: value };
-        }, {}) : {};
-
       if (customdata.length) {
         makeCall('addUserSettings', meetingID, internalUserID, customdata);
       }
-
-      SessionStorage.setItem(METADATA_KEY, metakeys);
 
       Auth.set(
         meetingID, internalUserID, authToken, logoutUrl,

--- a/bigbluebutton-html5/imports/ui/components/media/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/container.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
-import SessionStorage from '/imports/ui/services/storage/session';
 import Settings from '/imports/ui/services/settings';
 import { defineMessages, injectIntl } from 'react-intl';
 import { notify } from '/imports/ui/services/notification';
@@ -11,6 +10,9 @@ import MediaService, { getSwapLayout } from './service';
 import PresentationPodsContainer from '../presentation-pod/container';
 import ScreenshareContainer from '../screenshare/container';
 import DefaultContent from '../presentation/default-content/component';
+
+const LAYOUT_CONFIG = Meteor.settings.public.layout;
+const KURENTO_CONFIG = Meteor.settings.public.kurento;
 
 const intlMessages = defineMessages({
   screenshareStarted: {
@@ -66,8 +68,8 @@ class MediaContainer extends Component {
   installChromeExtension() {
     const { intl } = this.props;
 
-    const CHROME_DEFAULT_EXTENSION_LINK = Meteor.settings.public.kurento.chromeDefaultExtensionLink;
-    const CHROME_CUSTOM_EXTENSION_LINK = Meteor.settings.public.kurento.chromeExtensionLink;
+    const CHROME_DEFAULT_EXTENSION_LINK = KURENTO_CONFIG.chromeDefaultExtensionLink;
+    const CHROME_CUSTOM_EXTENSION_LINK = KURENTO_CONFIG.chromeExtensionLink;
     const CHROME_EXTENSION_LINK = CHROME_CUSTOM_EXTENSION_LINK === 'LINK' ? CHROME_DEFAULT_EXTENSION_LINK : CHROME_CUSTOM_EXTENSION_LINK;
 
     notify(<div>
@@ -92,7 +94,7 @@ export default withTracker(() => {
   const { dataSaving } = Settings;
   const { viewParticipantsWebcams, viewScreenshare } = dataSaving;
 
-  const hidePresentation = SessionStorage.getItem('metadata').html5hidepresentation || false;
+  const hidePresentation = getFromUserSettings('hidePresentation', LAYOUT_CONFIG.hidePresentation) || false;
   const data = {
     children: <DefaultContent />,
   };
@@ -121,8 +123,8 @@ export default withTracker(() => {
     data.hideOverlay = hidePresentation;
   }
 
-  const enableVideo = getFromUserSettings('enableVideo', Meteor.settings.public.kurento.enableVideo);
-  const autoShareWebcam = SessionStorage.getItem('metadata').html5autosharewebcam || false;
+  const enableVideo = getFromUserSettings('enableVideo', KURENTO_CONFIG.enableVideo);
+  const autoShareWebcam = getFromUserSettings('autoShareWebcam', KURENTO_CONFIG.autoShareWebcam) || false;
 
   if (enableVideo && autoShareWebcam) {
     data.willMount = VideoService.joinVideo;

--- a/bigbluebutton-html5/imports/ui/components/media/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/container.jsx
@@ -94,7 +94,7 @@ export default withTracker(() => {
   const { dataSaving } = Settings;
   const { viewParticipantsWebcams, viewScreenshare } = dataSaving;
 
-  const hidePresentation = getFromUserSettings('hidePresentation', LAYOUT_CONFIG.hidePresentation) || false;
+  const hidePresentation = getFromUserSettings('hidePresentation', LAYOUT_CONFIG.hidePresentation);
   const data = {
     children: <DefaultContent />,
   };
@@ -124,7 +124,7 @@ export default withTracker(() => {
   }
 
   const enableVideo = getFromUserSettings('enableVideo', KURENTO_CONFIG.enableVideo);
-  const autoShareWebcam = getFromUserSettings('autoShareWebcam', KURENTO_CONFIG.autoShareWebcam) || false;
+  const autoShareWebcam = getFromUserSettings('autoShareWebcam', KURENTO_CONFIG.autoShareWebcam);
 
   if (enableVideo && autoShareWebcam) {
     data.willMount = VideoService.joinVideo;

--- a/bigbluebutton-html5/imports/ui/components/media/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/container.jsx
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import Settings from '/imports/ui/services/settings';
-import { defineMessages, injectIntl } from 'react-intl';
+import { defineMessages, injectIntl, intlShape } from 'react-intl';
+import PropTypes from 'prop-types';
 import { notify } from '/imports/ui/services/notification';
 import VideoService from '/imports/ui/components/video-provider/service';
 import getFromUserSettings from '/imports/ui/services/users-settings';
@@ -13,6 +14,11 @@ import DefaultContent from '../presentation/default-content/component';
 
 const LAYOUT_CONFIG = Meteor.settings.public.layout;
 const KURENTO_CONFIG = Meteor.settings.public.kurento;
+
+const propTypes = {
+  isScreensharing: PropTypes.bool.isRequired,
+  intl: intlShape.isRequired,
+};
 
 const intlMessages = defineMessages({
   screenshareStarted: {
@@ -40,14 +46,11 @@ const intlMessages = defineMessages({
 class MediaContainer extends Component {
   componentWillMount() {
     const { willMount } = this.props;
-    willMount && willMount();
+    if (willMount) {
+      willMount();
+    }
     document.addEventListener('installChromeExtension', this.installChromeExtension.bind(this));
     document.addEventListener('safariScreenshareNotSupported', this.safariScreenshareNotSupported.bind(this));
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('installChromeExtension', this.installChromeExtension.bind(this));
-    document.removeEventListener('safariScreenshareNotSupported', this.safariScreenshareNotSupported.bind(this));
   }
 
   componentWillReceiveProps(nextProps) {
@@ -65,6 +68,11 @@ class MediaContainer extends Component {
     }
   }
 
+  componentWillUnmount() {
+    document.removeEventListener('installChromeExtension', this.installChromeExtension.bind(this));
+    document.removeEventListener('safariScreenshareNotSupported', this.safariScreenshareNotSupported.bind(this));
+  }
+
   installChromeExtension() {
     const { intl } = this.props;
 
@@ -72,12 +80,15 @@ class MediaContainer extends Component {
     const CHROME_CUSTOM_EXTENSION_LINK = KURENTO_CONFIG.chromeExtensionLink;
     const CHROME_EXTENSION_LINK = CHROME_CUSTOM_EXTENSION_LINK === 'LINK' ? CHROME_DEFAULT_EXTENSION_LINK : CHROME_CUSTOM_EXTENSION_LINK;
 
-    notify(<div>
-      {intl.formatMessage(intlMessages.chromeExtensionError)}{' '}
-      <a href={CHROME_EXTENSION_LINK} target="_blank">
-        {intl.formatMessage(intlMessages.chromeExtensionErrorLink)}
-      </a>
-    </div>, 'error', 'desktop');
+    const chromeErrorElement = (
+      <div>
+        {intl.formatMessage(intlMessages.chromeExtensionError)}{' '}
+        <a href={CHROME_EXTENSION_LINK} target="_blank">
+          {intl.formatMessage(intlMessages.chromeExtensionErrorLink)}
+        </a>
+      </div>
+    );
+    notify(chromeErrorElement, 'error', 'desktop');
   }
 
   safariScreenshareNotSupported() {
@@ -130,5 +141,6 @@ export default withTracker(() => {
     data.willMount = VideoService.joinVideo;
   }
 
+  MediaContainer.propTypes = propTypes;
   return data;
 })(injectIntl(MediaContainer));

--- a/bigbluebutton-html5/imports/ui/components/media/service.js
+++ b/bigbluebutton-html5/imports/ui/components/media/service.js
@@ -1,4 +1,3 @@
-import SessionStorage from '/imports/ui/services/storage/session';
 import Presentations from '/imports/api/presentations';
 import { isVideoBroadcasting } from '/imports/ui/components/screenshare/service';
 import Auth from '/imports/ui/services/auth';
@@ -7,6 +6,9 @@ import Settings from '/imports/ui/services/settings';
 import VideoService from '/imports/ui/components/video-provider/service';
 import PollingService from '/imports/ui/components/polling/service';
 import getFromUserSettings from '/imports/ui/services/users-settings';
+
+const LAYOUT_CONFIG = Meteor.settings.public.layout;
+const KURENTO_CONFIG = Meteor.settings.public.kurento;
 
 const getPresentationInfo = () => {
   const currentPresentation = Presentations.findOne({
@@ -25,11 +27,11 @@ function shouldShowWhiteboard() {
 }
 
 function shouldShowScreenshare() {
-  return isVideoBroadcasting() && getFromUserSettings('enableScreensharing', Meteor.settings.public.kurento.enableScreensharing);
+  return isVideoBroadcasting() && getFromUserSettings('enableScreensharing', KURENTO_CONFIG.enableScreensharing);
 }
 
 function shouldShowOverlay() {
-  return getFromUserSettings('enableVideo', Meteor.settings.public.kurento.enableVideo);
+  return getFromUserSettings('enableVideo', KURENTO_CONFIG.enableVideo);
 }
 
 const swapLayout = {
@@ -54,8 +56,8 @@ export const shouldEnableSwapLayout = () => {
 
 export const getSwapLayout = () => {
   swapLayout.tracker.depend();
-  const metaAutoSwapLayout = SessionStorage.getItem('metadata').html5autoswaplayout || false;
-  return metaAutoSwapLayout || (swapLayout.value && shouldEnableSwapLayout());
+  const autoSwapLayout = getFromUserSettings('autoSwapLayout', LAYOUT_CONFIG.autoSwapLayout);
+  return autoSwapLayout || (swapLayout.value && shouldEnableSwapLayout());
 };
 
 export default {

--- a/bigbluebutton-html5/imports/ui/components/presentation/default-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/default-content/component.jsx
@@ -1,175 +1,33 @@
-import React, { Component } from 'react';
-import { FormattedMessage, FormattedDate } from 'react-intl';
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import { styles } from './styles.scss';
-import Button from '../../button/component';
 
-export default class DefaultContent extends Component {
-  static handleClick() {
-    console.log('dummy handler');
-  }
-
-  render() {
-    return (
-      <TransitionGroup>
-        <CSSTransition
-          classNames={{
-            appear: styles.appear,
-            appearActive: styles.appearActive,
-          }}
-          appear
-          enter={false}
-          exit={false}
-          timeout={{ enter: 400 }}
-          className={styles.contentWrapper}
-        >
-          <div className={styles.contentRatio}>
-            <div className={styles.content}>
-              <div className={styles.defaultContent}>
-                <p>
-                  <FormattedMessage
-                    id="app.home.greeting"
-                    description="Message to greet the user."
-                    defaultMessage="Welcome {0}! Your presentation will begin shortly..."
-                    values={{ 0: 'James Bond' }}
-                  />
-                  <br />
-                  Today is {' '}<FormattedDate value={Date.now()} />
-                  <br />
-                  Here is some button examples
-                  <br />
-                </p>
-                <p>
-                  <Button
-                    label="Small"
-                    onClick={DefaultContent.handleClick}
-                    size="sm"
-                  />&nbsp;
-                  <Button
-                    label="Medium"
-                    onClick={DefaultContent.handleClick}
-                  />&nbsp;
-                  <Button
-                    label="Large"
-                    onClick={DefaultContent.handleClick}
-                    size="lg"
-                  />
-                </p>
-                <p>
-                  <Button
-                    label="Default"
-                    onClick={DefaultContent.handleClick}
-                  />&nbsp;
-                  <Button
-                    label="Primary"
-                    onClick={DefaultContent.handleClick}
-                    color="primary"
-                  />&nbsp;
-                  <Button
-                    label="Danger"
-                    onClick={DefaultContent.handleClick}
-                    color="danger"
-                  />&nbsp;
-                  <Button
-                    label="Success"
-                    onClick={DefaultContent.handleClick}
-                    color="success"
-                  />
-                </p>
-                <p>
-                  <Button
-                    label="Default"
-                    onClick={DefaultContent.handleClick}
-                    ghost
-                  />&nbsp;
-                  <Button
-                    label="Primary"
-                    onClick={DefaultContent.handleClick}
-                    color="primary"
-                    ghost
-                  />&nbsp;
-                  <Button
-                    label="Danger"
-                    onClick={DefaultContent.handleClick}
-                    color="danger"
-                    ghost
-                  />&nbsp;
-                  <Button
-                    label="Success"
-                    onClick={DefaultContent.handleClick}
-                    color="success"
-                    ghost
-                  />
-                </p>
-                <p>
-                  <Button
-                    label="With Icon"
-                    onClick={DefaultContent.handleClick}
-                    icon="add"
-                  />&nbsp;
-                  <Button
-                    label="Ghost With Icon"
-                    onClick={DefaultContent.handleClick}
-                    color="primary"
-                    icon="add"
-                    ghost
-                  />&nbsp;
-                  <Button
-                    label="Icon Right"
-                    onClick={DefaultContent.handleClick}
-                    color="danger"
-                    icon="add"
-                    ghost
-                    iconRight
-                  />&nbsp;
-                  <Button
-                    label="Icon Right"
-                    onClick={DefaultContent.handleClick}
-                    color="success"
-                    icon="add"
-                    iconRight
-                  />
-                </p>
-                <p>
-                  <Button
-                    label="Medium"
-                    onClick={DefaultContent.handleClick}
-                    color="primary"
-                    icon="unmute"
-                    ghost
-                    circle
-                  />&nbsp;
-                  <Button
-                    label="Large"
-                    onClick={DefaultContent.handleClick}
-                    color="danger"
-                    icon="unmute"
-                    size="lg"
-                    ghost
-                    circle
-                  /><br />
-                  <Button
-                    label="Small"
-                    onClick={DefaultContent.handleClick}
-                    icon="unmute"
-                    size="sm"
-                    circle
-                  />&nbsp;
-                  <Button
-                    label="Icon Right"
-                    onClick={DefaultContent.handleClick}
-                    color="success"
-                    icon="unmute"
-                    size="sm"
-                    iconRight
-                    circle
-                  />
-                </p>
-              </div>
-            </div>
-          </div>
-        </CSSTransition>
-      </TransitionGroup>
-    );
-  }
-}
+export default () => (
+  <TransitionGroup>
+    <CSSTransition
+      classNames={{
+          appear: styles.appear,
+          appearActive: styles.appearActive,
+        }}
+      appear
+      enter={false}
+      exit={false}
+      timeout={{ enter: 400 }}
+      className={styles.contentWrapper}
+    >
+      <div className={styles.content}>
+        <div className={styles.defaultContent}>
+          <p>
+            <FormattedMessage
+              id="app.home.greeting"
+              description="Message to greet the user."
+              defaultMessage="Your presentation will begin shortly..."
+            />
+            <br />
+          </p>
+        </div>
+      </div>
+    </CSSTransition>
+  </TransitionGroup>
+);

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -98,6 +98,7 @@ public:
     enableVideo: false
     enableVideoStats: false
     enableListenOnly: false
+    autoShareWebcam: false
   acl:
     viewer:
       subscriptions:
@@ -170,6 +171,9 @@ public:
     path_route: users/chat/
     system_messages_keys:
       chat_clear: PUBLIC_CHAT_CLEAR
+  layout:
+    autoSwapLayout: false
+    hidePresentation: false
   media:
     WebRTCHangupRetryInterval: 2000
     vertoServerAddress: HOST

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -1,5 +1,5 @@
 {
-    "app.home.greeting": "Welcome {0}! Your presentation will begin shortly...",
+    "app.home.greeting": "Your presentation will begin shortly...",
     "app.chat.submitLabel": "Send Message",
     "app.chat.errorMinMessageLength": "The message is {0} characters(s) too short",
     "app.chat.errorMaxMessageLength": "The message is {0} characters(s) too long",


### PR DESCRIPTION
Given that we use `userdata-` parameters in the html5 client, this pull request switches the existing meatadata parameters to userdata alternatives.
Test by passing the following block in the `customParameters` field in API MATE
```
joinViaHtml5=true
userdata-autoSwapLayout=true
userdata-autoShareWebcam=true
userdata-hidePresentation=true
```