### PR TITLE
Stop HTML5 ejecting from voice on reconnect and fix voice user creation

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/modifiers/addUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/addUser.js
@@ -1,6 +1,7 @@
 import { check } from 'meteor/check';
 import Logger from '/imports/startup/server/logger';
 import Users from '/imports/api/users';
+import VoiceUsers from '/imports/api/voice-users/';
 
 import stringHash from 'string-hash';
 import flat from 'flat';
@@ -68,7 +69,7 @@ export default function addUser(meetingId, user) {
   const ROLE_VIEWER = USER_CONFIG.role_viewer;
   const APP_CONFIG = Meteor.settings.public.app;
   const ALLOW_HTML5_MODERATOR = APP_CONFIG.allowHTML5Moderator;
-  const GUEST_ALWAYS_ACCEPT = "ALWAYS_ACCEPT";
+  const GUEST_ALWAYS_ACCEPT = 'ALWAYS_ACCEPT';
 
   // override moderator status of html5 client users, depending on a system flag
   const dummyUser = Users.findOne(selector);
@@ -100,18 +101,21 @@ export default function addUser(meetingId, user) {
     ),
   };
 
-  addVoiceUser(meetingId, {
-    voiceUserId: '',
-    intId: userId,
-    callerName: user.name,
-    callerNum: '',
-    muted: false,
-    talking: false,
-    callingWith: '',
-    listenOnly: false,
-    voiceConf: '',
-    joined: false,
-  });
+  // Only add an empty VoiceUser if there isn't one already. We want to avoid overwriting good data
+  if (!VoiceUsers.findOne({ meetingId, intId: userId })) {
+    addVoiceUser(meetingId, {
+      voiceUserId: '',
+      intId: userId,
+      callerName: user.name,
+      callerNum: '',
+      muted: false,
+      talking: false,
+      callingWith: '',
+      listenOnly: false,
+      voiceConf: '',
+      joined: false,
+    });
+  }
 
   const cb = (err, numChanged) => {
     if (err) {

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
@@ -1,7 +1,6 @@
 import { check } from 'meteor/check';
 import Users from '/imports/api/users';
 import Logger from '/imports/startup/server/logger';
-import ejectUserFromVoice from '/imports/api/voice-users/server/methods/ejectUserFromVoice';
 
 const clearAllSessions = (sessionUserId) => {
   const serverSessions = Meteor.server.sessions;
@@ -36,11 +35,6 @@ export default function removeUser(meetingId, userId) {
 
     const sessionUserId = `${meetingId}-${userId}`;
     clearAllSessions(sessionUserId);
-
-    ejectUserFromVoice({
-      requesterUserId: userId,
-      meetingId,
-    }, userId);
 
     return Logger.info(`Removed user id=${userId} meeting=${meetingId}`);
   };


### PR DESCRIPTION
The HTML5 server was automatically ejecting Voice Users when their paired User was removed. This is incorrect because on a reconnect the User might leave and rejoin, but that person's WebRTC audio connection will likely survive. See #6176. I've fixed the problem by removing the ejection code as it should never have been there in the first place.

The other problem that was uncovered by the kick fix is that when a User joins and the addUser server code is run it will create an empty VoiceUser record for the newly joined person. The empty VoiceUser is upserted  so it was overwriting good VoiceUser data when it shouldn't. I added a check so that the empty record will only be created if there isn't a row already.