### PR TITLE
[Flash] disable the webrtc audio stats

### DIFF
--- a/bigbluebutton-client/resources/prod/BigBlueButton.html
+++ b/bigbluebutton-client/resources/prod/BigBlueButton.html
@@ -147,7 +147,7 @@
     <script src="lib/adapter.js?v=VERSION" language="javascript"></script>
     <script src="lib/sip.js?v=VERSION" language="javascript"></script>
 
-    <script src="lib/webrtc_stats_bridge.js?v=VERSION" language="javascript"></script>
+    <!-- <script src="lib/webrtc_stats_bridge.js?v=VERSION" language="javascript"></script> -->
     <script src="lib/bowser.js?v=VERSION" language="javascript"></script>
     <script src="lib/bbb_webrtc_bridge_sip.js?v=VERSION" language="javascript"></script>
     <script src="lib/weburl_regex.js?v=VERSION" language="javascript"></script>

--- a/bigbluebutton-client/resources/prod/lib/bbb_webrtc_bridge_sip.js
+++ b/bigbluebutton-client/resources/prod/lib/bbb_webrtc_bridge_sip.js
@@ -12,15 +12,15 @@ function webRTCCallback(message) {
 			if (message.errorcode !== 1004) {
 				message.cause = null;
 			}
-			monitorTracksStop();
+			//monitorTracksStop();
 			BBB.webRTCCallFailed(inEchoTest, message.errorcode, message.cause);
 			break;
 		case 'ended':
-			monitorTracksStop();
+			//monitorTracksStop();
 			BBB.webRTCCallEnded(inEchoTest);
 			break;
 		case 'started':
-			monitorTracksStart();
+			//monitorTracksStart();
 			BBB.webRTCCallStarted(inEchoTest);
 			break;
 		case 'connecting':


### PR DESCRIPTION
The WebRTC audio stats weren't being used and were just cluttering up the console output. I've disabled them to clear the console up.

Fixes #6175