### PR TITLE
Delay removing user when leaving

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingAfterReconnectReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingAfterReconnectReqMsgHdlr.scala
@@ -4,6 +4,7 @@ import org.bigbluebutton.common2.msgs.UserJoinMeetingAfterReconnectReqMsg
 import org.bigbluebutton.core.apps.breakout.BreakoutHdlrHelpers
 import org.bigbluebutton.core.apps.voice.UserJoinedVoiceConfEvtMsgHdlr
 import org.bigbluebutton.core.domain.MeetingState2x
+import org.bigbluebutton.core.models.Users2x
 import org.bigbluebutton.core.running.{ BaseMeetingActor, HandlerHelpers, LiveMeeting, OutMsgRouter }
 
 trait UserJoinMeetingAfterReconnectReqMsgHdlr extends HandlerHelpers with BreakoutHdlrHelpers with UserJoinedVoiceConfEvtMsgHdlr {
@@ -13,13 +14,23 @@ trait UserJoinMeetingAfterReconnectReqMsgHdlr extends HandlerHelpers with Breako
   val outGW: OutMsgRouter
 
   def handleUserJoinMeetingAfterReconnectReqMsg(msg: UserJoinMeetingAfterReconnectReqMsg, state: MeetingState2x): MeetingState2x = {
+    log.info("Received user joined after reconnecting. user " + msg.body.userId + " meetingId=" + msg.header.meetingId)
 
-    val newState = userJoinMeeting(outGW, msg.body.authToken, msg.body.clientType, liveMeeting, state)
-    if (liveMeeting.props.meetingProp.isBreakout) {
-      updateParentMeetingWithUsers()
+    Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId) match {
+      case Some(reconnectingUser) =>
+        if (reconnectingUser.userLeftFlag.left) {
+          log.info("Resetting flag that user left meeting. user " + msg.body.userId)
+          // User has reconnected. Just reset it's flag. ralam Oct 23, 2018
+          Users2x.resetUserLeftFlag(liveMeeting.users2x, msg.body.userId)
+        }
+        state
+      case None =>
+        val newState = userJoinMeeting(outGW, msg.body.authToken, msg.body.clientType, liveMeeting, state)
+        if (liveMeeting.props.meetingProp.isBreakout) {
+          updateParentMeetingWithUsers()
+        }
+        newState
     }
-
-    newState
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
@@ -2,7 +2,7 @@ package org.bigbluebutton.core.apps.users
 
 import org.bigbluebutton.common2.msgs.UserJoinMeetingReqMsg
 import org.bigbluebutton.core.apps.breakout.BreakoutHdlrHelpers
-import org.bigbluebutton.core.models.VoiceUsers
+import org.bigbluebutton.core.models.{ Users2x, VoiceUsers }
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.{ BaseMeetingActor, HandlerHelpers, LiveMeeting, OutMsgRouter }
 
@@ -13,17 +13,28 @@ trait UserJoinMeetingReqMsgHdlr extends HandlerHelpers with BreakoutHdlrHelpers 
   val outGW: OutMsgRouter
 
   def handleUserJoinMeetingReqMsg(msg: UserJoinMeetingReqMsg, state: MeetingState2x): MeetingState2x = {
-    val newState = userJoinMeeting(outGW, msg.body.authToken, msg.body.clientType, liveMeeting, state)
+    log.info("Received user joined meeting. user " + msg.body.userId + " meetingId=" + msg.header.meetingId)
 
-    if (liveMeeting.props.meetingProp.isBreakout) {
-      updateParentMeetingWithUsers()
+    Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId) match {
+      case Some(reconnectingUser) =>
+        if (reconnectingUser.userLeftFlag.left) {
+          log.info("Resetting flag that user left meeting. user " + msg.body.userId)
+          // User has reconnected. Just reset it's flag. ralam Oct 23, 2018
+          Users2x.resetUserLeftFlag(liveMeeting.users2x, msg.body.userId)
+        }
+        state
+      case None =>
+        val newState = userJoinMeeting(outGW, msg.body.authToken, msg.body.clientType, liveMeeting, state)
+
+        if (liveMeeting.props.meetingProp.isBreakout) {
+          updateParentMeetingWithUsers()
+        }
+
+        // fresh user joined (not due to reconnection). Clear (pop) the cached voice user
+        VoiceUsers.recoverVoiceUser(liveMeeting.voiceUsers, msg.body.userId)
+
+        newState
     }
-
-    // fresh user joined (not due to reconnection). Clear (pop) the cached voice user
-    VoiceUsers.recoverVoiceUser(liveMeeting.voiceUsers, msg.body.userId)
-
-    newState
   }
-
 }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
@@ -15,7 +15,9 @@ trait UserLeaveReqMsgHdlr {
   def handleUserLeaveReqMsg(msg: UserLeaveReqMsg, state: MeetingState2x): MeetingState2x = {
     Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId) match {
       case Some(reconnectingUser) =>
+        log.info("Received user left meeting. user " + msg.body.userId + " meetingId=" + msg.header.meetingId)
         if (!reconnectingUser.userLeftFlag.left) {
+          log.info("Setting user left flag. user " + msg.body.userId + " meetingId=" + msg.header.meetingId)
           // Just flag that user has left as the user might be reconnecting.
           // An audit will remove this user if it hasn't rejoined after a certain period of time.
           // ralam oct 23, 2018

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
@@ -3,7 +3,7 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.common2.msgs.UserLeaveReqMsg
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models.Users2x
-import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
+import org.bigbluebutton.core.running.{ LiveMeeting, MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core.util.TimeUtil
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
@@ -13,38 +13,17 @@ trait UserLeaveReqMsgHdlr {
   val outGW: OutMsgRouter
 
   def handleUserLeaveReqMsg(msg: UserLeaveReqMsg, state: MeetingState2x): MeetingState2x = {
-    for {
-      u <- Users2x.remove(liveMeeting.users2x, msg.body.userId)
-    } yield {
-      log.info("User left meeting. meetingId=" + props.meetingProp.intId + " userId=" + u.intId + " user=" + u)
-
-      captionApp2x.handleUserLeavingMsg(msg.body.userId)
-      stopRecordingIfAutoStart2x(outGW, liveMeeting, state)
-
-      // send a user left event for the clients to update
-      val userLeftMeetingEvent = MsgBuilder.buildUserLeftMeetingEvtMsg(liveMeeting.props.meetingProp.intId, u.intId)
-      outGW.send(userLeftMeetingEvent)
-
-      if (u.presenter) {
-        automaticallyAssignPresenter(outGW, liveMeeting)
-
-        // request screenshare to end
-        screenshareApp2x.handleScreenshareStoppedVoiceConfEvtMsg(liveMeeting.props.voiceProp.voiceConf, liveMeeting.props.screenshareProps.screenshareConf)
-
-        // request ongoing poll to end
-        handleStopPollReqMsg(u.intId)
-      }
-    }
-
-    if (liveMeeting.props.meetingProp.isBreakout) {
-      updateParentMeetingWithUsers()
-    }
-
-    if (Users2x.numUsers(liveMeeting.users2x) == 0) {
-      val tracker = state.expiryTracker.setLastUserLeftOn(TimeUtil.timeNowInMs())
-      state.update(tracker)
-    } else {
-      state
+    Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId) match {
+      case Some(reconnectingUser) =>
+        if (!reconnectingUser.userLeftFlag.left) {
+          // Just flag that user has left as the user might be reconnecting.
+          // An audit will remove this user if it hasn't rejoined after a certain period of time.
+          // ralam oct 23, 2018
+          Users2x.setUserLeftFlag(liveMeeting.users2x, msg.body.userId)
+        }
+        state
+      case None =>
+        state
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -40,7 +40,7 @@ object Users2x {
 
   def findAllExpiredUserLeftFlags(users: Users2x): Vector[UserState] = {
     users.toVector filter (u => u.userLeftFlag.left && u.userLeftFlag.leftOn != 0 &&
-      System.currentTimeMillis() - u.userLeftFlag.leftOn > 60000)
+      System.currentTimeMillis() - u.userLeftFlag.leftOn > 10000)
   }
 
   def numUsers(users: Users2x): Int = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -18,6 +18,31 @@ object Users2x {
     users.remove(intId)
   }
 
+  def setUserLeftFlag(users: Users2x, intId: String): Option[UserState] = {
+    for {
+      u <- findWithIntId(users, intId)
+    } yield {
+      val newUser = u.copy(userLeftFlag = UserLeftFlag(true, System.currentTimeMillis()))
+      users.save(newUser)
+      newUser
+    }
+  }
+
+  def resetUserLeftFlag(users: Users2x, intId: String): Option[UserState] = {
+    for {
+      u <- findWithIntId(users, intId)
+    } yield {
+      val newUser = u.copy(userLeftFlag = UserLeftFlag(false, 0))
+      users.save(newUser)
+      newUser
+    }
+  }
+
+  def findAllExpiredUserLeftFlags(users: Users2x): Vector[UserState] = {
+    users.toVector filter (u => u.userLeftFlag.left && u.userLeftFlag.leftOn != 0 &&
+      System.currentTimeMillis() - u.userLeftFlag.leftOn > 60000)
+  }
+
   def numUsers(users: Users2x): Int = {
     users.toVector.length
   }
@@ -150,9 +175,11 @@ class Users2x {
   }
 }
 
+case class UserLeftFlag(left: Boolean, leftOn: Long)
+
 case class UserState(intId: String, extId: String, name: String, role: String,
                      guest: Boolean, authed: Boolean, waitingForAcceptance: Boolean, emoji: String, locked: Boolean,
-                     presenter: Boolean, avatar: String, clientType: String)
+                     presenter: Boolean, avatar: String, clientType: String, userLeftFlag: UserLeftFlag)
 
 case class UserIdAndName(id: String, name: String)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -418,7 +418,7 @@ class MeetingActor(
       for {
         u <- Users2x.remove(liveMeeting.users2x, leftUser.intId)
       } yield {
-        log.info("User left meeting. meetingId=" + props.meetingProp.intId + " userId=" + u.intId + " user=" + u)
+        log.info("Removing user from meeting. meetingId=" + props.meetingProp.intId + " userId=" + u.intId + " user=" + u)
 
         captionApp2x.handleUserLeavingMsg(leftUser.intId)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeTestData.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeTestData.scala
@@ -63,7 +63,8 @@ trait FakeTestData {
   def createFakeUser(liveMeeting: LiveMeeting, regUser: RegisteredUser): UserState = {
     UserState(intId = regUser.id, extId = regUser.externId, name = regUser.name, role = regUser.role,
       guest = regUser.guest, authed = regUser.authed, waitingForAcceptance = regUser.waitingForAcceptance,
-      emoji = "none", locked = false, presenter = false, avatar = regUser.avatarURL, clientType = "unknown")
+      emoji = "none", locked = false, presenter = false, avatar = regUser.avatarURL, clientType = "unknown",
+      UserLeftFlag(false, 0))
 
   }
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/core/model/users/VoiceUsers2x.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/model/users/VoiceUsers2x.as
@@ -7,6 +7,10 @@ package org.bigbluebutton.core.model.users
     
     private var _users:ArrayCollection = new ArrayCollection();
     
+    public function getVoiceUsers(): ArrayCollection {
+      return new ArrayCollection(_users.toArray());
+    }
+    
     public function add(nuser: VoiceUser2x):void {
       var index:int = getIndex(nuser.intId);
       if (index != -1) {

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/services/MessageReceiver.as
@@ -22,6 +22,8 @@ package org.bigbluebutton.modules.users.services
   
   import flash.utils.setTimeout;
   
+  import mx.collections.ArrayCollection;
+  
   import org.as3commons.logging.api.ILogger;
   import org.as3commons.logging.api.getClassLogger;
   import org.bigbluebutton.core.BBB;
@@ -216,47 +218,51 @@ package org.bigbluebutton.modules.users.services
     private function handleUserJoinedVoiceConfToClientEvtMsg(msg: Object): void {
       var header: Object = msg.header as Object;
       var body: Object = msg.body as Object;
-      
+      processVoiceUserJoinedEvent(body);
+    }
+    
+    private function processVoiceUserJoinedEvent(vuser:Object):void {
       var vu: VoiceUser2x = new VoiceUser2x();
-      vu.intId = body.intId as String;
-      vu.voiceUserId = body.voiceUserId as String;
-      vu.callerName = body.callerName as String;
-      vu.callerNum = body.callerNum as String;
-      vu.muted = body.muted as Boolean;
-      vu.talking = body.talking as Boolean;
-      vu.callingWith = body.callingWith as String;
-      vu.listenOnly = body.listenOnly as Boolean;
+      vu.intId = vuser.intId as String;
+      vu.voiceUserId = vuser.voiceUserId as String;
+      vu.callerName = vuser.callerName as String;
+      vu.callerNum = vuser.callerNum as String;
+      vu.muted = vuser.muted as Boolean;
+      vu.talking = vuser.talking as Boolean;
+      vu.callingWith = vuser.callingWith as String;
+      vu.listenOnly = vuser.listenOnly as Boolean;
       
       LiveMeeting.inst().voiceUsers.add(vu);
       
       if (UsersUtil.isMe(vu.intId)) {
         LiveMeeting.inst().me.muted = vu.muted;
         LiveMeeting.inst().me.inVoiceConf = true;
-		//Toaster.toast(ResourceUtil.getInstance().getString("bbb.notification.audio.joined"), ToastType.INFO, ToastIcon.AUDIO);
+        //Toaster.toast(ResourceUtil.getInstance().getString("bbb.notification.audio.joined"), ToastType.INFO, ToastIcon.AUDIO);
       }
       
       var bbbEvent:BBBEvent = new BBBEvent(BBBEvent.USER_VOICE_JOINED);
       bbbEvent.payload.userID = vu.intId;            
       globalDispatcher.dispatchEvent(bbbEvent);
-      
     }
     
-    private function handleUserLeftVoiceConfToClientEvtMsg(msg: Object):void {
-      var header: Object = msg.header as Object;
-      var body: Object = msg.body as Object;
-      var intId: String = body.intId as String;
-      
+    private function processVoiceUserLeftEvent(intId:String):void {
       LiveMeeting.inst().voiceUsers.remove(intId);
       
       if (UsersUtil.isMe(intId)) {
         LiveMeeting.inst().me.muted = false;
         LiveMeeting.inst().me.inVoiceConf = false;
-		//Toaster.toast(ResourceUtil.getInstance().getString("bbb.notification.audio.left"), ToastType.INFO, ToastIcon.AUDIO);
+        //Toaster.toast(ResourceUtil.getInstance().getString("bbb.notification.audio.left"), ToastType.INFO, ToastIcon.AUDIO);
       }
       
       var bbbEvent:BBBEvent = new BBBEvent(BBBEvent.USER_VOICE_LEFT);
       bbbEvent.payload.userID = intId;
       globalDispatcher.dispatchEvent(bbbEvent);
+    }
+    private function handleUserLeftVoiceConfToClientEvtMsg(msg: Object):void {
+      var header: Object = msg.header as Object;
+      var body: Object = msg.body as Object;
+      var intId: String = body.intId as String;
+      processVoiceUserLeftEvent(intId);
     }
     
     private function handleUserMutedEvtMsg(msg: Object): void {
@@ -310,20 +316,47 @@ package org.bigbluebutton.modules.users.services
       
     }
     
-    private function handleGetUsersMeetingRespMsg(msg: Object):void {
-      var body: Object = msg.body as Object
-      var users: Array = body.users as Array;
-
-      for (var i:int = 0; i < users.length; i++) {
-        var user:Object = users[i] as Object;
-        processUserJoinedMeetingMsg(user);
+    private function findUserInNewUsers(userId: String, newUsers:Array):Object {
+      for (var i:int = 0; i < newUsers.length; i++) {
+        var user:Object = newUsers[i] as Object;
+        var intId: String = user.intId as String;
+        if (userId == intId) return newUsers.removeAt(i);
       } 
+      return null;
     }
     
-    public function handleUserLeftMeetingEvtMsg(msg:Object):void {     
+    private function handleGetUsersMeetingRespMsg(msg: Object):void {
       var body: Object = msg.body as Object
-      var userId: String = body.intId as String;
+      var newUsers: Array = body.users as Array;
+
+      var oldUsers:Array = UsersUtil.getUsers().toArray();
       
+      for (var i:int = 0; i < oldUsers.length; i++) {
+        var user:User2x = oldUsers[i] as User2x;
+        var newUser:Object = findUserInNewUsers(user.intId, newUsers);
+        if (newUser != null) {
+          // The user is in both old users and new users.
+          // Just need to update this user with the new state.
+          processUserJoinedMeetingMsg(newUser);
+        } else {
+          // The user is in the old users but not in the new one.
+          // The user probably has left the meeting. Remove the user.
+          injectUserLeftEvent(user.intId);
+        }
+      } 
+      
+      if (newUsers.length > 0) {
+        // There are remaining new users that were not in the old users list.
+        // We need to join them into the users list.
+        for (var k:int = 0; k < newUsers.length; k++) {
+          var newUserK:Object = newUsers[k] as Object;
+          processUserJoinedMeetingMsg(newUserK);
+        }
+      }
+      
+    }
+    
+    private function injectUserLeftEvent(userId:String):void {
       var webUser:User2x = UsersUtil.getUser(userId);
       
       if (webUser != null) {
@@ -338,6 +371,12 @@ package org.bigbluebutton.modules.users.services
         joinEvent.userID = userId;
         dispatcher.dispatchEvent(joinEvent);	
       }
+    }
+    
+    public function handleUserLeftMeetingEvtMsg(msg:Object):void {     
+      var body: Object = msg.body as Object
+      var userId: String = body.intId as String;
+      injectUserLeftEvent(userId);
     }
     
     private function handleUserJoinedMeetingEvtMsg(msg:Object):void {
@@ -405,33 +444,68 @@ package org.bigbluebutton.modules.users.services
 
     }
     
+    private function findVoiceUserInNewVoiceUsers(userId: String, newVoiceUsers:Array):Object {
+      for (var i:int = 0; i < newVoiceUsers.length; i++) {
+        var user:Object = newVoiceUsers[i] as Object;
+        var intId: String = user.intId as String;
+        if (userId == intId) return newVoiceUsers.removeAt(i);
+      } 
+      return null;
+    }
+    
     private function handleGetVoiceUsersMeetingRespMsg(msg:Object):void {
       var body: Object = msg.body as Object;
-      var users: Array = body.users as Array;
-
-      for (var i:int = 0; i < users.length; i++) {
-        var user:Object = users[i] as Object;
-        var intId: String = user.intId as String;
-        var voiceUserId: String = user.voiceUserId as String;
-        var callingWith: String = user.callingWith as String;
-        var callerName: String = user.callerName as String;
-        var callerNum: String = user.callerNum as String;
-        var muted: Boolean = user.muted as Boolean;
-        var talking: Boolean = user.talking as Boolean;
-        var listenOnly: Boolean = user.listenOnly as Boolean;
-        
-        var vu: VoiceUser2x = new VoiceUser2x();
-        vu.intId = intId;
-        vu.voiceUserId = voiceUserId;
-        vu.callingWith = callingWith;
-        vu.callerName = callerName;
-        vu.callerNum = callerNum;
-        vu.muted = muted;
-        vu.talking = talking;
-        vu.listenOnly = listenOnly;
-				
-        LiveMeeting.inst().voiceUsers.add(vu);
+      var newVoiceUsers: Array = body.users as Array;
+      
+      var oldVoiceUsers:Array = LiveMeeting.inst().voiceUsers.getVoiceUsers().toArray();
+      
+      for (var i:int = 0; i < oldVoiceUsers.length; i++) {
+        var user:VoiceUser2x = oldVoiceUsers[i] as VoiceUser2x;
+        var newVoiceUser:Object = findVoiceUserInNewVoiceUsers(user.intId, newVoiceUsers);
+        if (newVoiceUser != null) {
+          // The user is in both old users and new users.
+          // Just need to update this user with the new state.
+          processAddVoiceUser(newVoiceUser);
+        } else {
+          // The user is in the old users but not in the new one.
+          // The user probably has left the meeting. Remove the user.
+          processVoiceUserLeftEvent(user.intId);
+        }
+      } 
+      
+      if (newVoiceUsers.length > 0) {
+        // There are remaining new users that were not in the old users list.
+        // We need to join them into the users list.
+        for (var k:int = 0; k < newVoiceUsers.length; k++) {
+          var newUserK:Object = newVoiceUsers[k] as Object;
+          processAddVoiceUser(newUserK);
+        }
       }
+      
+    }
+    
+    private function processAddVoiceUser(user:Object):void {
+
+      var intId: String = user.intId as String;
+      var voiceUserId: String = user.voiceUserId as String;
+      var callingWith: String = user.callingWith as String;
+      var callerName: String = user.callerName as String;
+      var callerNum: String = user.callerNum as String;
+      var muted: Boolean = user.muted as Boolean;
+      var talking: Boolean = user.talking as Boolean;
+      var listenOnly: Boolean = user.listenOnly as Boolean;
+      
+      var vu: VoiceUser2x = new VoiceUser2x();
+      vu.intId = intId;
+      vu.voiceUserId = voiceUserId;
+      vu.callingWith = callingWith;
+      vu.callerName = callerName;
+      vu.callerNum = callerNum;
+      vu.muted = muted;
+      vu.talking = talking;
+      vu.listenOnly = listenOnly;
+      
+      LiveMeeting.inst().voiceUsers.add(vu);      
     }
     
     private function handleGetWebcamStreamsMeetingRespMsg(msg:Object):void {


### PR DESCRIPTION
When we receive a user left message, it might be because the client is reconnecting. Wait a few seconds for the client to reconnect and if it fails to reconnect, then remove the user's from the user's list and notify the other clients.