### PR TITLE
Configurable available shortcuts

### DIFF
--- a/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
+++ b/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
@@ -21,6 +21,8 @@ export default function addUserSettings(credentials, meetingId, userId, settings
       'askForFeedbackOnLogout',
       // BRANDING
       'displayBrandingArea',
+      // SHORTCUTS
+      'shortcuts',
       // KURENTO
       'enableScreensharing',
       'enableVideo',

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -9,6 +9,7 @@ import DropdownList from '/imports/ui/components/dropdown/list/component';
 import DropdownListItem from '/imports/ui/components/dropdown/list/item/component';
 import PresentationUploaderContainer from '/imports/ui/components/presentation/presentation-uploader/container';
 import { withModalMounter } from '/imports/ui/components/modal/service';
+import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
 import { styles } from '../styles';
 
 const propTypes = {
@@ -55,9 +56,6 @@ const intlMessages = defineMessages({
     description: 'stop recording option',
   },
 });
-
-const SHORTCUTS_CONFIG = Meteor.settings.public.app.shortcuts;
-const OPEN_ACTIONS_AK = SHORTCUTS_CONFIG.openActions.accesskey;
 
 class ActionsDropdown extends Component {
   constructor(props) {
@@ -123,6 +121,7 @@ class ActionsDropdown extends Component {
       intl,
       isUserPresenter,
       isUserModerator,
+      shortcuts: OPEN_ACTIONS_AK,
     } = this.props;
 
     const availableActions = this.getAvailableActions();
@@ -156,4 +155,4 @@ class ActionsDropdown extends Component {
 
 ActionsDropdown.propTypes = propTypes;
 
-export default withModalMounter(injectIntl(ActionsDropdown));
+export default withShortcutHelper(withModalMounter(injectIntl(ActionsDropdown)), 'openActions');

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { defineMessages, intlShape, injectIntl } from 'react-intl';
 import Button from '/imports/ui/components/button/component';
+import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
 import { styles } from './styles';
 
 const intlMessages = defineMessages({
@@ -41,11 +42,6 @@ const defaultProps = {
   unmute: false,
 };
 
-const SHORTCUTS_CONFIG = Meteor.settings.public.app.shortcuts;
-const JOIN_AUDIO_AK = SHORTCUTS_CONFIG.joinAudio.accesskey;
-const LEAVE_AUDIO_AK = SHORTCUTS_CONFIG.leaveAudio.accesskey;
-const MUTE_UNMUTE_AK = SHORTCUTS_CONFIG.toggleMute.accesskey;
-
 const AudioControls = ({
   handleToggleMuteMicrophone,
   handleJoinAudio,
@@ -56,6 +52,7 @@ const AudioControls = ({
   glow,
   join,
   intl,
+  shortcuts,
 }) => (
   <span className={styles.container}>
     {mute ?
@@ -70,7 +67,7 @@ const AudioControls = ({
         icon={unmute ? 'mute' : 'unmute'}
         size="lg"
         circle
-        accessKey={MUTE_UNMUTE_AK}
+        accessKey={shortcuts.toggleMute}
       /> : null}
     <Button
       className={styles.button}
@@ -83,11 +80,11 @@ const AudioControls = ({
       icon={join ? 'audio_off' : 'audio_on'}
       size="lg"
       circle
-      accessKey={join ? LEAVE_AUDIO_AK : JOIN_AUDIO_AK}
+      accessKey={join ? shortcuts.leaveAudio : shortcuts.joinAudio}
     />
   </span>);
 
 AudioControls.propTypes = propTypes;
 AudioControls.defaultProps = defaultProps;
 
-export default injectIntl(AudioControls);
+export default withShortcutHelper(injectIntl(AudioControls), ['joinAudio', 'leaveAudio', 'toggleMute']);

--- a/bigbluebutton-html5/imports/ui/components/chat/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/component.jsx
@@ -4,11 +4,11 @@ import { defineMessages, injectIntl } from 'react-intl';
 import injectWbResizeEvent from '/imports/ui/components/presentation/resize-wrapper/component';
 import Button from '/imports/ui/components/button/component';
 import { Session } from 'meteor/session';
+import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
 import { styles } from './styles';
 import MessageForm from './message-form/component';
 import MessageList from './message-list/component';
 import ChatDropdown from './chat-dropdown/component';
-import Icon from '../icon/component';
 
 const ELEMENT_ID = 'chat-messages';
 
@@ -22,10 +22,6 @@ const intlMessages = defineMessages({
     description: 'aria-label for hiding chat button',
   },
 });
-
-const SHORTCUTS_CONFIG = Meteor.settings.public.app.shortcuts;
-const HIDE_CHAT_AK = SHORTCUTS_CONFIG.hidePrivateChat.accesskey;
-const CLOSE_CHAT_AK = SHORTCUTS_CONFIG.closePrivateChat.accesskey;
 
 const Chat = (props) => {
   const {
@@ -42,7 +38,11 @@ const Chat = (props) => {
     maxMessageLength,
     actions,
     intl,
+    shortcuts,
   } = props;
+
+  const HIDE_CHAT_AK = shortcuts.hidePrivateChat;
+  const CLOSE_CHAT_AK = shortcuts.closePrivateChat;
 
   return (
     <div
@@ -108,7 +108,7 @@ const Chat = (props) => {
   );
 };
 
-export default injectWbResizeEvent(injectIntl(Chat));
+export default withShortcutHelper(injectWbResizeEvent(injectIntl(Chat)), ['hidePrivateChat', 'closePrivateChat']);
 
 const propTypes = {
   chatID: PropTypes.string.isRequired,

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -10,6 +10,7 @@ import DropdownContent from '/imports/ui/components/dropdown/content/component';
 import DropdownList from '/imports/ui/components/dropdown/list/component';
 import DropdownListItem from '/imports/ui/components/dropdown/list/item/component';
 import { withModalMounter } from '/imports/ui/components/modal/service';
+import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
 import { defineMessages, injectIntl } from 'react-intl';
 import { styles } from './styles.scss';
 import Button from '../button/component';
@@ -44,19 +45,18 @@ const intlMessages = defineMessages({
 });
 
 const propTypes = {
-  presentationTitle: PropTypes.string.isRequired,
-  hasUnreadMessages: PropTypes.bool.isRequired,
-  beingRecorded: PropTypes.object.isRequired,
+  presentationTitle: PropTypes.string,
+  hasUnreadMessages: PropTypes.bool,
+  beingRecorded: PropTypes.object,
+  shortcuts: PropTypes.string,
 };
 
 const defaultProps = {
   presentationTitle: 'Default Room Title',
   hasUnreadMessages: false,
   beingRecorded: false,
+  shortcuts: '',
 };
-
-const SHORTCUTS_CONFIG = Meteor.settings.public.app.shortcuts;
-const TOGGLE_USERLIST_AK = SHORTCUTS_CONFIG.toggleUserList.accesskey;
 
 const openBreakoutJoinConfirmation = (breakout, breakoutName, mountModal) =>
   mountModal(<BreakoutJoinConfirmation
@@ -82,7 +82,6 @@ class NavBar extends Component {
   componentDidUpdate(oldProps) {
     const {
       breakouts,
-      getBreakoutJoinURL,
       isBreakoutRoom,
       mountModal,
     } = this.props;
@@ -174,7 +173,11 @@ class NavBar extends Component {
 
   render() {
     const {
-      hasUnreadMessages, beingRecorded, isExpanded, intl,
+      hasUnreadMessages,
+      beingRecorded,
+      isExpanded,
+      intl,
+      shortcuts: TOGGLE_USERLIST_AK,
     } = this.props;
 
     const recordingMessage = beingRecorded.recording ? 'recordingIndicatorOn' : 'recordingIndicatorOff';
@@ -223,4 +226,4 @@ class NavBar extends Component {
 
 NavBar.propTypes = propTypes;
 NavBar.defaultProps = defaultProps;
-export default withModalMounter(injectIntl(NavBar));
+export default withShortcutHelper(withModalMounter(injectIntl(NavBar)), 'toggleUserList');

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -3,12 +3,9 @@ import { defineMessages, injectIntl } from 'react-intl';
 import cx from 'classnames';
 import _ from 'lodash';
 import { withModalMounter } from '/imports/ui/components/modal/service';
-
-
 import LogoutConfirmationContainer from '/imports/ui/components/logout-confirmation/container';
 import AboutContainer from '/imports/ui/components/about/container';
 import SettingsMenuContainer from '/imports/ui/components/settings/container';
-
 import Button from '/imports/ui/components/button/component';
 import Dropdown from '/imports/ui/components/dropdown/component';
 import DropdownTrigger from '/imports/ui/components/dropdown/trigger/component';
@@ -17,6 +14,7 @@ import DropdownList from '/imports/ui/components/dropdown/list/component';
 import DropdownListItem from '/imports/ui/components/dropdown/list/item/component';
 import DropdownListSeparator from '/imports/ui/components/dropdown/list/separator/component';
 import ShortcutHelpComponent from '/imports/ui/components/shortcut-help/component';
+import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
 
 import { styles } from '../styles';
 
@@ -82,9 +80,6 @@ const intlMessages = defineMessages({
     description: 'Describes help option',
   },
 });
-
-const SHORTCUTS_CONFIG = Meteor.settings.public.app.shortcuts;
-const OPEN_OPTIONS_AK = SHORTCUTS_CONFIG.openOptions.accesskey;
 
 class SettingsDropdown extends Component {
   constructor(props) {
@@ -210,7 +205,10 @@ class SettingsDropdown extends Component {
   }
 
   render() {
-    const { intl } = this.props;
+    const {
+      intl,
+      shortcuts: OPEN_OPTIONS_AK,
+    } = this.props;
 
     return (
       <Dropdown
@@ -245,4 +243,4 @@ class SettingsDropdown extends Component {
   }
 }
 
-export default withModalMounter(injectIntl(SettingsDropdown));
+export default withShortcutHelper(withModalMounter(injectIntl(SettingsDropdown)), 'openOptions');

--- a/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
@@ -1,9 +1,11 @@
-import React, { Component } from 'react';
-import { defineMessages, injectIntl } from 'react-intl';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import browser from 'browser-detect';
 import Modal from '/imports/ui/components/modal/simple/component';
 import _ from 'lodash';
 import { styles } from './styles';
+import withShortcutHelper from './service';
 
 const intlMessages = defineMessages({
   title: {
@@ -72,60 +74,69 @@ const intlMessages = defineMessages({
   },
 });
 
-const SHORTCUTS_CONFIG = Meteor.settings.public.app.shortcuts;
+const ShortcutHelpComponent = (props) => {
+  const { intl, shortcuts } = props;
+  const { name } = browser();
 
-class ShortcutHelpComponent extends Component {
-  render() {
-    const { intl } = this.props;
-    const shortcuts = Object.values(SHORTCUTS_CONFIG);
-    const { name } = browser();
+  let accessMod = null;
 
-    let accessMod = null;
-
-    switch (name) {
-      case 'chrome':
-      case 'edge':
-        accessMod = 'Alt';
-        break;
-      case 'firefox':
-        accessMod = 'Alt + Shift';
-        break;
-      case 'safari':
-      case 'crios':
-      case 'fxios':
-        accessMod = 'Control + Alt';
-        break;
-    }
-
-    return (
-      <Modal
-        title={intl.formatMessage(intlMessages.title)}
-        dismiss={{
-          label: intl.formatMessage(intlMessages.closeLabel),
-          description: intl.formatMessage(intlMessages.closeDesc),
-        }}
-      >
-        { !accessMod ? <p>{intl.formatMessage(intlMessages.accessKeyNotAvailable)}</p> :
-        <span>
-          <table className={styles.shortcutTable}>
-            <tbody>
-              <tr>
-                <th>{intl.formatMessage(intlMessages.comboLabel)}</th>
-                <th>{intl.formatMessage(intlMessages.functionLabel)}</th>
-              </tr>
-              {shortcuts.map(shortcut => (
-                <tr key={_.uniqueId('hotkey-item-')}>
-                  <td className={styles.keyCell}>{`${accessMod} + ${shortcut.accesskey}`}</td>
-                  <td className={styles.descCell}>{intl.formatMessage(intlMessages[`${shortcut.descId}`])}</td>
-                </tr>
-                  ))}
-            </tbody>
-          </table>
-        </span>
-        }
-      </Modal>
-    );
+  switch (name) {
+    case 'chrome':
+    case 'edge':
+      accessMod = 'Alt';
+      break;
+    case 'firefox':
+      accessMod = 'Alt + Shift';
+      break;
+    case 'safari':
+    case 'crios':
+    case 'fxios':
+      accessMod = 'Control + Alt';
+      break;
+    default:
+      break;
   }
-}
 
-export default injectIntl(ShortcutHelpComponent);
+  return (
+    <Modal
+      title={intl.formatMessage(intlMessages.title)}
+      dismiss={{
+        label: intl.formatMessage(intlMessages.closeLabel),
+        description: intl.formatMessage(intlMessages.closeDesc),
+      }}
+    >
+      {!accessMod ? <p>{intl.formatMessage(intlMessages.accessKeyNotAvailable)}</p> :
+      <span>
+        <table className={styles.shortcutTable}>
+          <tbody>
+            <tr>
+              <th>{intl.formatMessage(intlMessages.comboLabel)}</th>
+              <th>{intl.formatMessage(intlMessages.functionLabel)}</th>
+            </tr>
+            {shortcuts.map(shortcut => (
+              <tr key={_.uniqueId('hotkey-item-')}>
+                <td className={styles.keyCell}>{`${accessMod} + ${shortcut.accesskey}`}</td>
+                <td className={styles.descCell}>{intl.formatMessage(intlMessages[`${shortcut.descId}`])}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </span>
+      }
+    </Modal>
+  );
+};
+
+ShortcutHelpComponent.defaultProps = {
+  intl: intlShape,
+};
+
+ShortcutHelpComponent.propTypes = {
+  intl: intlShape,
+  shortcuts: PropTypes.arrayOf(PropTypes.shape({
+    accesskey: PropTypes.string.isRequired,
+    descId: PropTypes.string.isRequired,
+  })).isRequired,
+};
+
+export default withShortcutHelper(injectIntl(ShortcutHelpComponent));

--- a/bigbluebutton-html5/imports/ui/components/shortcut-help/service.jsx
+++ b/bigbluebutton-html5/imports/ui/components/shortcut-help/service.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import getFromUserSettings from '/imports/ui/services/users-settings';
+
+const BASE_SHORTCUTS = Meteor.settings.public.app.shortcuts;
+
+const withShortcutHelper = (WrappedComponent, param) => (props) => {
+  const ENABLED_SHORTCUTS = getFromUserSettings('shortcuts', null);
+
+  let shortcuts = Object.values(BASE_SHORTCUTS);
+
+  if (ENABLED_SHORTCUTS) {
+    shortcuts = Object.values(BASE_SHORTCUTS)
+      .filter(el => ENABLED_SHORTCUTS.includes(el.descId));
+  }
+
+  if (param !== undefined) {
+    if (!Array.isArray(param)) {
+      shortcuts = shortcuts
+        .filter(el => el.descId === param)
+        .map(el => el.accesskey)
+        .pop();
+    } else {
+      shortcuts = shortcuts
+        .filter(el => param.includes(el.descId))
+        .reduce((acc, current) => {
+          acc[current.descId] = current.accesskey;
+          return acc;
+        }, {});
+    }
+  }
+
+  return (
+    <WrappedComponent {...props} shortcuts={shortcuts} />
+  );
+};
+
+export default withShortcutHelper;

--- a/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { defineMessages, injectIntl } from 'react-intl';
 import { Session } from 'meteor/session';
+import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
 import { styles } from './styles';
 import ChatAvatar from './chat-avatar/component';
 import ChatIcon from './chat-icon/component';
@@ -23,9 +24,6 @@ const intlMessages = defineMessages({
   },
 });
 
-const SHORTCUTS_CONFIG = Meteor.settings.public.app.shortcuts;
-const TOGGLE_CHAT_PUB_AK = SHORTCUTS_CONFIG.togglePublicChat.accesskey;
-
 const propTypes = {
   chat: PropTypes.shape({
     id: PropTypes.string.isRequired,
@@ -39,10 +37,12 @@ const propTypes = {
   }).isRequired,
   tabIndex: PropTypes.number.isRequired,
   isPublicChat: PropTypes.func.isRequired,
+  shortcuts: PropTypes.string,
 };
 
 const defaultProps = {
   openChat: '',
+  shortcuts: '',
 };
 
 const toggleChatOpen = () => {
@@ -57,6 +57,7 @@ const ChatListItem = (props) => {
     intl,
     tabIndex,
     isPublicChat,
+    shortcuts: TOGGLE_CHAT_PUB_AK,
   } = props;
 
   const isCurrentChat = chat.id === openChat;
@@ -109,4 +110,4 @@ const ChatListItem = (props) => {
 ChatListItem.propTypes = propTypes;
 ChatListItem.defaultProps = defaultProps;
 
-export default injectIntl(ChatListItem);
+export default withShortcutHelper(injectIntl(ChatListItem), 'togglePublicChat');


### PR DESCRIPTION
This PR creates a HOC for components that have a shortcut and a custom parameter to define which shortcut will be available.
## Usage ##
`userdata-shortcuts=["openOptions", "toggleMute"]`
## Available shortcuts list ##
- openOptions
- toggleUserList
- toggleMute
- joinAudio
- leaveAudio
- togglePublicChat
- hidePrivateChat
- closePrivateChat
- openActions
- openStatus