### PR TITLE
Revert "Make it so that cameras use the full space of the video window"

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -69,7 +69,7 @@ $audio-indicator-fs: 75%;
   position: relative;
   height: 100%;
   width: 100%;
-  object-fit: cover;
+  object-fit: contain;
   border-radius: 5px;
 }
 


### PR DESCRIPTION
The issue is that we still record the full stream from the webcams even if we only show parts of it to optimize UI during the live session