### PR TITLE
Add `meetingid` GET parameter to endCallbackUrl

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -645,7 +645,9 @@ public class MeetingService implements MessageListener {
       if (metadata.containsKey(endCallbackUrl)) {
         String callbackUrl = metadata.get(endCallbackUrl);
         try {
-            callbackUrl = new URIBuilder(new URI(callbackUrl)).addParameter("recordingmarks", m.haveRecordingMarks() ? "true" : "false").build().toURL().toString();
+            callbackUrl = new URIBuilder(new URI(callbackUrl))
+                    .addParameter("recordingmarks", m.haveRecordingMarks() ? "true" : "false")
+                    .addParameter("meetingid", m.getExternalId()).build().toURL().toString();
         } catch (MalformedURLException e) {
             log.error("Malformed URL in callback url=[{}]", callbackUrl, e);
         } catch (URISyntaxException e) {


### PR DESCRIPTION
We use the external meeting ID in `endCallbackUrl`.