### PR TITLE
Set HTML5 client as presenter in default pod

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/handlers/presenterAssigned.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/presenterAssigned.js
@@ -1,10 +1,13 @@
 import Users from '/imports/api/users';
+import PresentationPods from '/imports/api/presentation-pods';
 import changeRole from '/imports/api/users/server/modifiers/changeRole';
+import assignPresenter from '../methods/assignPresenter';
 
-export default function handlePresenterAssigned({ body }, meetingId) {
+export default function handlePresenterAssigned(credentials, meetingId) {
   const USER_CONFIG = Meteor.settings.public.user;
   const ROLE_PRESENTER = USER_CONFIG.role_presenter;
 
+  const { body } = credentials;
   const { presenterId, assignedBy } = body;
 
   changeRole(ROLE_PRESENTER, true, presenterId, meetingId, assignedBy);
@@ -15,11 +18,32 @@ export default function handlePresenterAssigned({ body }, meetingId) {
     presenter: true,
   };
 
+  const defaultPodSelector = {
+    podId: 'DEFAULT_PRESENTATION_POD',
+  };
+
   const prevPresenter = Users.findOne(selector);
 
   // no previous presenters
   if (!prevPresenter) {
-    return true;
+    const currentDefaultPodPresenter = PresentationPods.findOne(defaultPodSelector);
+
+    const { currentPresenterId } = currentDefaultPodPresenter;
+
+    const fakeCredentials = {
+      meetingId,
+      requesterUserId: assignedBy,
+    };
+
+    if (currentDefaultPodPresenter.currentPresenterId !== '') {
+      const oldPresenter = Users.findOne({ userId: currentPresenterId });
+
+      if (oldPresenter.connectionStatus === 'offline') {
+        return assignPresenter(fakeCredentials, presenterId);
+      }
+      return true;
+    }
+    return assignPresenter(fakeCredentials, presenterId);
   }
 
   return changeRole(ROLE_PRESENTER, false, prevPresenter.userId, meetingId, assignedBy);


### PR DESCRIPTION
When HTML5 moderator user enter he takes control over default pod as presenter, fixing the drawing bug and cases when a flash moderator takes pod control.