### PR TITLE
Add drag & drop grid for breakout rooms

### DIFF
--- a/bigbluebutton-html5/imports/api/breakouts/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/publishers.js
@@ -2,13 +2,18 @@ import { Meteor } from 'meteor/meteor';
 import Breakouts from '/imports/api/breakouts';
 import Logger from '/imports/startup/server/logger';
 
-function breakouts(credentials) {
+function breakouts(credentials, moderator) {
   const {
     meetingId,
     requesterUserId,
   } = credentials;
-
   Logger.info(`Publishing Breakouts for ${meetingId} ${requesterUserId}`);
+  if (moderator) {
+    const presenterSelector = {
+      parentMeetingId: meetingId,
+    };
+    return Breakouts.find(presenterSelector);
+  }
 
   const selector = {
     $or: [

--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -13,6 +13,7 @@ import Users from '/imports/api/users';
 import Annotations from '/imports/api/annotations';
 import AnnotationsLocal from '/imports/ui/components/whiteboard/service';
 import GroupChat from '/imports/api/group-chat';
+import mapUser from '/imports/ui/services/user/mapUser';
 import { Session } from 'meteor/session';
 import IntlStartup from './intl';
 
@@ -106,7 +107,7 @@ Base.defaultProps = defaultProps;
 
 const SUBSCRIPTIONS_NAME = [
   'users', 'meetings', 'polls', 'presentations',
-  'slides', 'captions', 'breakouts', 'voiceUsers', 'whiteboard-multi-user', 'screenshare',
+  'slides', 'captions', 'voiceUsers', 'whiteboard-multi-user', 'screenshare',
   'group-chat', 'presentation-pods', 'users-settings',
 ];
 
@@ -114,7 +115,7 @@ const BaseContainer = withTracker(() => {
   const { locale } = Settings.application;
   const { credentials, loggedIn } = Auth;
   const { meetingId, requesterUserId } = credentials;
-
+  let breakoutRoomSubscriptionHandler;
   if (!loggedIn) {
     return {
       locale,
@@ -147,6 +148,11 @@ const BaseContainer = withTracker(() => {
   const chatIds = chats.map(chat => chat.chatId);
 
   const groupChatMessageHandler = Meteor.subscribe('group-chat-msg', credentials, chatIds, subscriptionErrorHandler);
+  const User = Users.findOne({ intId: credentials.externUserID });
+  if (User) {
+    const mappedUser = mapUser(User);
+    breakoutRoomSubscriptionHandler = Meteor.subscribe('breakouts', credentials, mappedUser.isModerator, subscriptionErrorHandler);
+  }
 
   const annotationsHandler = Meteor.subscribe('annotations', credentials, {
     onReady: () => {
@@ -171,6 +177,7 @@ const BaseContainer = withTracker(() => {
     subscriptionsReady,
     annotationsHandler,
     groupChatMessageHandler,
+    breakoutRoomSubscriptionHandler,
   };
 })(Base);
 

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -161,8 +161,15 @@ class ActionsDropdown extends Component {
       createBreakoutRoom,
       mountModal,
       meetingName,
+      users,
     } = this.props;
-    mountModal(<BreakoutRoom createBreakoutRoom={createBreakoutRoom} meetingName={meetingName} />);
+
+    mountModal(
+      <BreakoutRoom
+        createBreakoutRoom={createBreakoutRoom}
+        meetingName={meetingName}
+        users={users}
+      />);
   }
 
   render() {

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -25,6 +25,7 @@ class ActionsBar extends React.PureComponent {
       meetingIsBreakout,
       hasBreakoutRoom,
       meetingName,
+      users,
     } = this.props;
 
     const {
@@ -52,6 +53,7 @@ class ActionsBar extends React.PureComponent {
             meetingIsBreakout,
             hasBreakoutRoom,
             meetingName,
+            users,
           }}
           />
         </div>

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
@@ -44,5 +44,6 @@ export default withTracker(({ }) => {
     hasBreakoutRoom: Service.hasBreakoutRoom(),
     meetingName: Service.meetingName(),
     togglePollMenu,
+    users: Service.users(),
   };
 })(ActionsBarContainer);

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -47,11 +47,11 @@ class BreakoutRoom extends Component {
     this.increaseDurationTime = this.increaseDurationTime.bind(this);
     this.decreaseDurationTime = this.decreaseDurationTime.bind(this);
     this.onCreateBreakouts = this.onCreateBreakouts.bind(this);
-
+    this.setFreeJoin = this.setFreeJoin.bind(this);
     this.state = {
       numberOfRooms: MIN_BREAKOUT_ROOMS,
       durationTime: 1,
-      freeJoin: true,
+      freeJoin: false,
     };
   }
 
@@ -73,7 +73,7 @@ class BreakoutRoom extends Component {
       sequence: value,
     }));
 
-    createBreakoutRoom(rooms, durationTime, true);
+    createBreakoutRoom(rooms, durationTime, this.state.freeJoin);
   }
 
   changeNumberOfRooms(event) {
@@ -93,6 +93,10 @@ class BreakoutRoom extends Component {
     this.setState({ durationTime: number < 1 ? 1 : number });
   }
 
+  setFreeJoin(e) {
+    this.setState({ freeJoin: e.target.checked });
+  }
+
   render() {
     const { intl } = this.props;
     return (
@@ -110,7 +114,7 @@ class BreakoutRoom extends Component {
             {intl.formatMessage(intlMessages.breakoutRoomDesc)}
           </p>
           <div className={styles.breakoutSettings}>
-            <label>
+            <label htmlFor="numberOfRooms">
               <p className={styles.labelText}>{intl.formatMessage(intlMessages.numberOfRooms)}</p>
               <select
                 name="numberOfRooms"
@@ -123,7 +127,7 @@ class BreakoutRoom extends Component {
                 }
               </select>
             </label>
-            <label >
+            <label htmlFor="breakoutRoomTime" >
               <p className={styles.labelText}>{intl.formatMessage(intlMessages.duration)}</p>
               <div className={styles.durationArea}>
                 <input
@@ -160,6 +164,17 @@ class BreakoutRoom extends Component {
             </label>
             <p className={styles.randomText}>{intl.formatMessage(intlMessages.randomlyAssign)}</p>
           </div>
+
+          <label htmlFor="freeJoinCheckbox" className={styles.freeJoinLabel}>
+            <input
+              type="checkbox"
+              className={styles.freeJoinCheckbox}
+              onChange={this.setFreeJoin}
+              checked={this.state.freeJoin}
+            />
+            Allow users to choose a breakout room to join
+          </label>
+
         </div>
       </Modal >
     );

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import HoldButton from '/imports/ui/components/presentation/presentation-toolbar/zoom-tool/holdButton/component';
 import { styles } from './styles';
 import Icon from '../../icon/component';
+import cx from 'classnames';
 
 const intlMessages = defineMessages({
   breakoutRoomTitle: {
@@ -67,8 +68,10 @@ class BreakoutRoom extends Component {
     this.renderRoomsGrid = this.renderRoomsGrid.bind(this);
     this.renderBreakoutForm = this.renderBreakoutForm.bind(this);
     this.renderFreeJoinCheck = this.renderFreeJoinCheck.bind(this);
+
     this.state = {
       numberOfRooms: MIN_BREAKOUT_ROOMS,
+      seletedId: '',
       users: [],
       durationTime: 1,
       freeJoin: false,
@@ -169,12 +172,17 @@ class BreakoutRoom extends Component {
       ev.preventDefault();
       const data = ev.dataTransfer.getData('text');
       this.changeUserRoom(data, room);
+      this.setState({ seletedId: '' });
     };
 
     return (
       <div className={styles.boxContainer}>
         <label htmlFor="BreakoutRoom">
-          <p className={styles.freeJoinLabel}>{intl.formatMessage(intlMessages.notAssigned, { 0: this.getUserByRoom(0).length })}</p>
+          <p
+            className={styles.freeJoinLabel}
+          >
+            {intl.formatMessage(intlMessages.notAssigned, { 0: this.getUserByRoom(0).length })}
+          </p>
           <div className={styles.breakoutBox} onDrop={drop(0)} onDragOver={allowDrop} >
             {this.renderUserItemByRoom(0)}
           </div>
@@ -271,17 +279,27 @@ class BreakoutRoom extends Component {
   }
 
   renderUserItemByRoom(room) {
-    const drag = (ev) => {
+    const dragStart = (ev) => {
       ev.dataTransfer.setData('text', ev.target.id);
+      this.setState({ seletedId: ev.target.id });
+    };
+
+    const dragEnd = (ev) => {
+      this.setState({ seletedId: '' });
     };
 
     return this.getUserByRoom(room)
       .map(user => (
         <p
           id={user.userId}
-          className={styles.roomUserItem}
+          className={cx(
+            styles.roomUserItem,
+            this.state.seletedId === user.userId ? styles.selectedItem : null,
+            )
+          }
           draggable
-          onDragStart={drag}
+          onDragStart={dragStart}
+          onDragEnd={dragEnd}
         >
           {user.userName}
         </p>));

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -76,12 +76,8 @@ class BreakoutRoom extends Component {
     createBreakoutRoom(rooms, durationTime, this.state.freeJoin);
   }
 
-  changeNumberOfRooms(event) {
-    this.setState({ numberOfRooms: Number.parseInt(event.target.value, 10) });
-  }
-
-  changeDurationTime(event) {
-    this.setState({ durationTime: Number.parseInt(event.target.value, 10) || '' });
+  setFreeJoin(e) {
+    this.setState({ freeJoin: e.target.checked });
   }
 
   increaseDurationTime() {
@@ -93,8 +89,13 @@ class BreakoutRoom extends Component {
     this.setState({ durationTime: number < 1 ? 1 : number });
   }
 
-  setFreeJoin(e) {
-    this.setState({ freeJoin: e.target.checked });
+  changeDurationTime(event) {
+    this.setState({ durationTime: Number.parseInt(event.target.value, 10) || '' });
+  }
+
+
+  changeNumberOfRooms(event) {
+    this.setState({ numberOfRooms: Number.parseInt(event.target.value, 10) });
   }
 
   render() {

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -35,6 +35,10 @@ const intlMessages = defineMessages({
     id: 'app.createBreakoutRoom.roomName',
     description: 'room intl to name the breakout meetings',
   },
+  freeJoinLabel: {
+    id: 'app.createBreakoutRoom.freeJoin',
+    description: 'free join label',
+  },
 });
 const MIN_BREAKOUT_ROOMS = 2;
 const MAX_BREAKOUT_ROOMS = 8;
@@ -51,7 +55,7 @@ class BreakoutRoom extends Component {
     this.state = {
       numberOfRooms: MIN_BREAKOUT_ROOMS,
       durationTime: 1,
-      freeJoin: false,
+      freeJoin: true,
     };
   }
 
@@ -173,9 +177,8 @@ class BreakoutRoom extends Component {
               onChange={this.setFreeJoin}
               checked={this.state.freeJoin}
             />
-            Allow users to choose a breakout room to join
+            {intl.formatMessage(intlMessages.freeJoinLabel)}
           </label>
-
         </div>
       </Modal >
     );

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -39,6 +39,14 @@ const intlMessages = defineMessages({
     id: 'app.createBreakoutRoom.freeJoin',
     description: 'free join label',
   },
+  roomLabel: {
+    id: 'app.createBreakoutRoom.room',
+    description: 'Room label',
+  },
+  notAssigned: {
+    id: 'app.createBreakoutRoom.notAssigned',
+    description: 'Not assigned label',
+  },
 });
 const MIN_BREAKOUT_ROOMS = 2;
 const MAX_BREAKOUT_ROOMS = 8;
@@ -48,15 +56,34 @@ class BreakoutRoom extends Component {
     super(props);
     this.changeNumberOfRooms = this.changeNumberOfRooms.bind(this);
     this.changeDurationTime = this.changeDurationTime.bind(this);
+    this.changeUserRoom = this.changeUserRoom.bind(this);
     this.increaseDurationTime = this.increaseDurationTime.bind(this);
     this.decreaseDurationTime = this.decreaseDurationTime.bind(this);
     this.onCreateBreakouts = this.onCreateBreakouts.bind(this);
+    this.setRoomUsers = this.setRoomUsers.bind(this);
     this.setFreeJoin = this.setFreeJoin.bind(this);
+    this.getUserByRoom = this.getUserByRoom.bind(this);
+    this.renderUserItemByRoom = this.renderUserItemByRoom.bind(this);
+    this.renderRoomsGrid = this.renderRoomsGrid.bind(this);
+    this.renderBreakoutForm = this.renderBreakoutForm.bind(this);
+    this.renderFreeJoinCheck = this.renderFreeJoinCheck.bind(this);
     this.state = {
       numberOfRooms: MIN_BREAKOUT_ROOMS,
+      users: [],
       durationTime: 1,
-      freeJoin: true,
+      freeJoin: false,
     };
+  }
+
+  componentDidMount() {
+    this.setRoomUsers();
+  }
+
+  componentDidUpdate(prevProps, prevstate) {
+    const { numberOfRooms } = this.state;
+    if (numberOfRooms < prevstate.numberOfRooms) {
+      this.resetUserWhenRoomsChange(numberOfRooms);
+    }
   }
 
   onCreateBreakouts() {
@@ -68,7 +95,7 @@ class BreakoutRoom extends Component {
 
     const { numberOfRooms, durationTime } = this.state;
     const rooms = _.range(1, numberOfRooms + 1).map(value => ({
-      users: [],
+      users: this.getUserByRoom(value).map(u => u.userId),
       name: intl.formatMessage(intlMessages.roomName, {
         0: meetingName,
         1: value,
@@ -80,8 +107,38 @@ class BreakoutRoom extends Component {
     createBreakoutRoom(rooms, durationTime, this.state.freeJoin);
   }
 
+  setRoomUsers() {
+    const { users } = this.props;
+    const roomUsers = users.map(user => ({
+      userId: user.userId,
+      userName: user.name,
+      room: 0,
+    }));
+
+    this.setState({
+      users: roomUsers,
+    });
+  }
+
   setFreeJoin(e) {
     this.setState({ freeJoin: e.target.checked });
+  }
+
+  getUserByRoom(room) {
+    return this.state.users.filter(user => user.room === room);
+  }
+
+  resetUserWhenRoomsChange(rooms) {
+    const { users } = this.state;
+    const filtredUsers = users.filter(u => u.room > rooms);
+    filtredUsers.forEach(u => this.changeUserRoom(u.userId, 0));
+  }
+
+  changeUserRoom(userId, room) {
+    const { users } = this.state;
+    const idxUser = users.findIndex(user => user.userId === userId);
+    users[idxUser].room = room;
+    this.setState({ users });
   }
 
   increaseDurationTime() {
@@ -97,13 +154,142 @@ class BreakoutRoom extends Component {
     this.setState({ durationTime: Number.parseInt(event.target.value, 10) || '' });
   }
 
-
   changeNumberOfRooms(event) {
     this.setState({ numberOfRooms: Number.parseInt(event.target.value, 10) });
   }
 
+  renderRoomsGrid() {
+    const { intl } = this.props;
+
+    const allowDrop = (ev) => {
+      ev.preventDefault();
+    };
+
+    const drop = room => (ev) => {
+      ev.preventDefault();
+      const data = ev.dataTransfer.getData('text');
+      this.changeUserRoom(data, room);
+    };
+
+    return (
+      <div className={styles.boxContainer}>
+        <label htmlFor="BreakoutRoom">
+          <p className={styles.freeJoinLabel}>{intl.formatMessage(intlMessages.notAssigned, { 0: this.getUserByRoom(0).length })}</p>
+          <div className={styles.breakoutBox} onDrop={drop(0)} onDragOver={allowDrop} >
+            {this.renderUserItemByRoom(0)}
+          </div>
+        </label>
+        {
+          _.range(1, this.state.numberOfRooms + 1).map(value =>
+            (
+              <label htmlFor="BreakoutRoom">
+                <p
+                  className={styles.freeJoinLabel}
+                >
+                  {intl.formatMessage(intlMessages.roomLabel, { 0: (value) })}
+                </p>
+                <div className={styles.breakoutBox} onDrop={drop(value)} onDragOver={allowDrop}>
+                  {this.renderUserItemByRoom(value)}
+                </div>
+              </label>))
+        }
+      </div>
+    );
+  }
+
+  renderBreakoutForm() {
+    const { intl } = this.props;
+
+    return (
+      <div className={styles.breakoutSettings}>
+        <label htmlFor="numberOfRooms">
+          <p className={styles.labelText}>{intl.formatMessage(intlMessages.numberOfRooms)}</p>
+          <select
+            name="numberOfRooms"
+            className={styles.inputRooms}
+            value={this.state.numberOfRooms}
+            onChange={this.changeNumberOfRooms}
+          >
+            {
+              _.range(MIN_BREAKOUT_ROOMS, MAX_BREAKOUT_ROOMS + 1).map(item => (<option key={_.uniqueId('value-')}>{item}</option>))
+            }
+          </select>
+        </label>
+        <label htmlFor="breakoutRoomTime" >
+          <p className={styles.labelText}>{intl.formatMessage(intlMessages.duration)}</p>
+          <div className={styles.durationArea}>
+            <input
+              type="number"
+              className={styles.duration}
+              min={MIN_BREAKOUT_ROOMS}
+              value={this.state.durationTime}
+              onChange={this.changeDurationTime}
+            />
+            <span>
+              <HoldButton
+                key="decrease-breakout-time"
+                exec={this.decreaseDurationTime}
+                minBound={MIN_BREAKOUT_ROOMS}
+                value={this.state.durationTime}
+              >
+                <Icon
+                  className={styles.iconsColor}
+                  iconName="substract"
+                />
+              </HoldButton>
+              <HoldButton
+                key="increase-breakout-time"
+                exec={this.increaseDurationTime}
+              >
+                <Icon
+                  className={styles.iconsColor}
+                  iconName="add"
+                />
+              </HoldButton>
+
+            </span>
+          </div>
+        </label>
+        <p className={styles.randomText}>{intl.formatMessage(intlMessages.randomlyAssign)}</p>
+      </div>
+    );
+  }
+
+  renderFreeJoinCheck() {
+    const { intl } = this.props;
+    return (
+      <label htmlFor="freeJoinCheckbox" className={styles.freeJoinLabel}>
+        <input
+          type="checkbox"
+          className={styles.freeJoinCheckbox}
+          onChange={this.setFreeJoin}
+          checked={this.state.freeJoin}
+        />
+        {intl.formatMessage(intlMessages.freeJoinLabel)}
+      </label>
+    );
+  }
+
+  renderUserItemByRoom(room) {
+    const drag = (ev) => {
+      ev.dataTransfer.setData('text', ev.target.id);
+    };
+
+    return this.getUserByRoom(room)
+      .map(user => (
+        <p
+          id={user.userId}
+          className={styles.roomUserItem}
+          draggable
+          onDragStart={drag}
+        >
+          {user.userName}
+        </p>));
+  }
+
   render() {
     const { intl } = this.props;
+
     return (
       <Modal
         title={intl.formatMessage(intlMessages.breakoutRoomTitle)}
@@ -118,67 +304,9 @@ class BreakoutRoom extends Component {
           <p className={styles.subTitle}>
             {intl.formatMessage(intlMessages.breakoutRoomDesc)}
           </p>
-          <div className={styles.breakoutSettings}>
-            <label htmlFor="numberOfRooms">
-              <p className={styles.labelText}>{intl.formatMessage(intlMessages.numberOfRooms)}</p>
-              <select
-                name="numberOfRooms"
-                className={styles.inputRooms}
-                value={this.state.numberOfRooms}
-                onChange={this.changeNumberOfRooms}
-              >
-                {
-                  _.range(MIN_BREAKOUT_ROOMS, MAX_BREAKOUT_ROOMS + 1).map(item => (<option key={_.uniqueId('value-')}>{item}</option>))
-                }
-              </select>
-            </label>
-            <label htmlFor="breakoutRoomTime" >
-              <p className={styles.labelText}>{intl.formatMessage(intlMessages.duration)}</p>
-              <div className={styles.durationArea}>
-                <input
-                  type="number"
-                  className={styles.duration}
-                  min={MIN_BREAKOUT_ROOMS}
-                  value={this.state.durationTime}
-                  onChange={this.changeDurationTime}
-                />
-                <span>
-                  <HoldButton
-                    key="decrease-breakout-time"
-                    exec={this.decreaseDurationTime}
-                    minBound={MIN_BREAKOUT_ROOMS}
-                    value={this.state.durationTime}
-                  >
-                    <Icon
-                      className={styles.iconsColor}
-                      iconName="substract"
-                    />
-                  </HoldButton>
-                  <HoldButton
-                    key="increase-breakout-time"
-                    exec={this.increaseDurationTime}
-                  >
-                    <Icon
-                      className={styles.iconsColor}
-                      iconName="add"
-                    />
-                  </HoldButton>
-
-                </span>
-              </div>
-            </label>
-            <p className={styles.randomText}>{intl.formatMessage(intlMessages.randomlyAssign)}</p>
-          </div>
-
-          <label htmlFor="freeJoinCheckbox" className={styles.freeJoinLabel}>
-            <input
-              type="checkbox"
-              className={styles.freeJoinCheckbox}
-              onChange={this.setFreeJoin}
-              checked={this.state.freeJoin}
-            />
-            {intl.formatMessage(intlMessages.freeJoinLabel)}
-          </label>
+          {this.renderBreakoutForm()}
+          {this.renderFreeJoinCheck()}
+          {this.renderRoomsGrid()}
         </div>
       </Modal >
     );

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.scss
@@ -11,8 +11,9 @@ input[type="number"]::-webkit-outer-spin-button, input[type="number"]::-webkit-i
 .breakoutSettings {
   display: grid;
   grid-template-columns: 2fr 1fr 1fr 1fr; 
-  grid-template-rows: 1fr 1fr;
+  grid-template-rows: 1fr;
   grid-gap: 1rem;
+  margin-bottom: 1rem;
   @include mq($small-only) {
     grid-template-columns: 1fr ;
     grid-template-rows: 1fr 1fr 1fr; 
@@ -74,4 +75,18 @@ input[type="number"]::-webkit-outer-spin-button, input[type="number"]::-webkit-i
   white-space: nowrap;
   margin-bottom: .5rem;
   align-self: flex-end;
+}
+
+.freeJoinCheckbox {
+  width: 1rem;
+  height: 1rem;
+}
+
+.freeJoinLabel {
+  display: flex;
+  align-items: center;
+  font-size: var(--font-size-small);
+  & > * {
+    margin-right: .5rem;
+  }
 }

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.scss
@@ -98,14 +98,25 @@ input[type="number"]::-webkit-outer-spin-button, input[type="number"]::-webkit-i
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   grid-template-rows: 33% 33% 33%;
-  grid-gap: 1rem;
+  grid-gap: 1.5rem 1rem;
+}
+
+.changeToWarn {
+  position: relative;
+  & > .breakoutBox {
+    border-color: var(--color-danger) !important;
+  }
+
+  & > .freeJoinLabel {
+    color: var(--color-danger);
+  }
 }
 
 .breakoutBox {
   @include scrollbox-vertical();
   width: 100%;
   height: 80%;
-  min-height: 5rem;
+  min-height: 4rem;
   max-height: 8rem;
   border: 1px solid var(--color-gray-lighter);
   border-radius: var(--border-radius); 
@@ -114,6 +125,15 @@ input[type="number"]::-webkit-outer-spin-button, input[type="number"]::-webkit-i
 .freeJoinLabel {
   font-size: var(--font-size-small);
   font-weight: bolder;
+}
+
+.leastOneWarn {
+  margin: .25rem;
+  position: absolute;
+  font-size: var(--font-size-small);
+  color: var(--color-danger);
+  font-weight: 200;
+  white-space: nowrap;
 }
 
 .roomUserItem {
@@ -132,4 +152,8 @@ input[type="number"]::-webkit-outer-spin-button, input[type="number"]::-webkit-i
 .selectedItem {
   background-color: var(--color-primary);
   color: var(--color-white)
+}
+
+.dontShow {
+  display: none;
 }

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.scss
@@ -1,4 +1,6 @@
 @import "/imports/ui/stylesheets/variables/_all";
+@import "/imports/ui/stylesheets/mixins/_scrollable";
+
 input[type="number"]::-webkit-outer-spin-button, input[type="number"]::-webkit-inner-spin-button {
   -webkit-appearance: none;
 }
@@ -89,4 +91,36 @@ input[type="number"]::-webkit-outer-spin-button, input[type="number"]::-webkit-i
   & > * {
     margin-right: .5rem;
   }
+}
+
+.boxContainer {
+  height: 50vh;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: 33% 33% 33%;
+  grid-gap: 1rem;
+}
+
+.breakoutBox {
+  @include scrollbox-vertical();
+  width: 100%;
+  height: 80%;
+  min-height: 5rem;
+  max-height: 8rem;
+  border: 1px solid var(--color-gray-lighter);
+  border-radius: var(--border-radius); 
+}
+
+.freeJoinLabel {
+  font-size: var(--font-size-small);
+  font-weight: bolder;
+}
+
+.roomUserItem {
+  width: 10rem;
+  margin-left: .25rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
 }

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.scss
@@ -117,10 +117,19 @@ input[type="number"]::-webkit-outer-spin-button, input[type="number"]::-webkit-i
 }
 
 .roomUserItem {
-  width: 10rem;
-  margin-left: .25rem;
+  width: 11rem;
+  margin: 0;
+  padding-top: .25rem;
+  padding-bottom: .25rem;
+  padding-left: .25rem;
+  margin-right: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   cursor: pointer;
+}
+
+.selectedItem {
+  background-color: var(--color-primary);
+  color: var(--color-white)
 }

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/service.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/service.js
@@ -10,6 +10,7 @@ export default {
   recordSettingsList: () => Meetings.findOne({ meetingId: Auth.meetingID }).recordProp,
   meetingIsBreakout: () => Meetings.findOne({ meetingId: Auth.meetingID }).meetingProp.isBreakout,
   meetingName: () => Meetings.findOne({ meetingId: Auth.meetingID }).meetingProp.name,
+  users: () => Users.find({ connectionStatus: 'online' }).fetch(),
   hasBreakoutRoom: () => Breakouts.find({ parentMeetingId: Auth.meetingID }).fetch().length > 0,
   toggleRecording: () => makeCall('toggleRecording'),
   createBreakoutRoom: (numberOfRooms, durationInMinutes, freeJoin = true, record = false) => makeCall('createBreakoutRoom', numberOfRooms, durationInMinutes, freeJoin, record),

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import cx from 'classnames';
+import Auth from '/imports/ui/services/auth';
 import Icon from '/imports/ui/components/icon/component';
 import BreakoutJoinConfirmation from '/imports/ui/components/breakout-join-confirmation/container';
 import Dropdown from '/imports/ui/components/dropdown/component';
@@ -97,6 +98,10 @@ class NavBar extends Component {
       if (!breakout.users) {
         return;
       }
+
+      const userOnMeeting = breakout.users.filter(u => u.userId === Auth.userID).length;
+
+      if (!userOnMeeting) return;
 
       if (!this.state.didSendBreakoutInvite && !isBreakoutRoom) {
         this.inviteUserToBreakout(breakout);

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -440,6 +440,7 @@
     "app.createBreakoutRoom.generatedURL": "Generated",
     "app.createBreakoutRoom.duration": "Duration {0}",
     "app.createBreakoutRoom.room": "Room {0}",
+    "app.createBreakoutRoom.notAssigned": "Not Assigned ({0})",
     "app.createBreakoutRoom.join": "Join Room",
     "app.createBreakoutRoom.joinAudio": "Join audio",
     "app.createBreakoutRoom.returnAudio": "Return audio",

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -451,5 +451,6 @@
     "app.createBreakoutRoom.endAllBreakouts": "End All Breakout Rooms",
     "app.createBreakoutRoom.roomName": "{0} (Room - {1})",
     "app.createBreakoutRoom.freeJoin": "Allow users to choose a breakout room to join",
+    "app.createBreakoutRoom.leastOneWarnBreakout": "You must place at least one user in a breakout room.",
     "app.createBreakoutRoom.modalDesc": "Complete the steps below to create rooms in your session, To add participants to a room."
 }

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -449,5 +449,6 @@
     "app.createBreakoutRoom.randomlyAssign": "Randomly Assign",
     "app.createBreakoutRoom.endAllBreakouts": "End All Breakout Rooms",
     "app.createBreakoutRoom.roomName": "{0} (Room - {1})",
+    "app.createBreakoutRoom.freeJoin": "Allow users to choose a breakout room to join",
     "app.createBreakoutRoom.modalDesc": "Complete the steps below to create rooms in your session, To add participants to a room."
 }


### PR DESCRIPTION
This PR adds: 
 - Free join checkbox
 - Drag and drop grid to sort users (Desktop only by now)

This PR modifies:
 - The publisher rule for moderator to see all breakouts related with parent meeting.
 - The breakout invitation rule to invite only users on breakout.

Closes #6262, #6261.