### PR TITLE
Modify clientLog notation for easier parse-edit

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -243,17 +243,9 @@ public:
       - pencil
       - hand
   clientLog:
-    server:
-      enabled: true
-      level: info
-    console:
-      enabled: false
-      level: debug
-    external:
-      enabled: false
-      level: info
-      url: https://LOG_HOST/html5Log
-      method: POST
+    server: { enabled: true, level: info }
+    console: { enabled: true, level: debug }
+    external: { enabled: false, level: info, url: https://LOG_HOST/html5Log, method: POST }
 private:
   app:
     captionsChunkLength: 1000


### PR DESCRIPTION
The structure remains the same. Only the notation is modified for easier parsing/editing via tools like Ansible. With the previous notation it was not straightforward how to match  log type with log level or enabled flag