### PR TITLE
Added option to use modal component without header border

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import ModalBase from '/imports/ui/components/modal/base/component';
+import Modal from '/imports/ui/components/modal/simple/component';
 import Button from '/imports/ui/components/button/component';
 import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import { styles } from './styles';
@@ -8,6 +8,7 @@ import PermissionsOverlay from '../permissions-overlay/component';
 import AudioSettings from '../audio-settings/component';
 import EchoTest from '../echo-test/component';
 import Help from '../help/component';
+
 
 const propTypes = {
   intl: intlShape.isRequired,
@@ -392,10 +393,11 @@ class AudioModal extends Component {
     return (
       <span>
         {showPermissionsOvelay ? <PermissionsOverlay /> : null}
-        <ModalBase
+        <Modal
           overlayClassName={styles.overlay}
           className={styles.modal}
           onRequestClose={this.closeModal}
+          hideBorder
         >
           {!this.skipAudioOptions() ?
 
@@ -410,22 +412,13 @@ class AudioModal extends Component {
                   intl.formatMessage(intlMessages.audioChoiceLabel)}
                 </h3>
             }
-              <Button
-                data-test="modalBaseCloseButton"
-                className={styles.closeBtn}
-                label={intl.formatMessage(intlMessages.closeLabel)}
-                icon="close"
-                size="md"
-                hideLabel
-                onClick={this.closeModal}
-              />
             </header>
             : null
           }
           <div className={styles.content}>
             {this.renderContent()}
           </div>
-        </ModalBase>
+        </Modal>
       </span>
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/styles.scss
@@ -118,6 +118,7 @@
   text-align: center;
   font-weight: 400;
   font-size: 1.3rem;
+  color: var(--color-background);
   white-space: normal;
 
   @include mq($small-only) {

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
@@ -1,9 +1,8 @@
 import React, { Component } from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
-import Button from '/imports/ui/components/button/component';
 import Toggle from '/imports/ui/components/switch/component';
 import cx from 'classnames';
-import ModalBase from '/imports/ui/components/modal/base/component';
+import Modal from '/imports/ui/components/modal/simple/component';
 import { styles } from './styles';
 
 const intlMessages = defineMessages({
@@ -75,24 +74,16 @@ class LockViewersComponent extends Component {
     const { intl, meeting } = this.props;
 
     return (
-      <ModalBase
+      <Modal
         overlayClassName={styles.overlay}
         className={styles.modal}
         onRequestClose={this.closeModal}
+        hideBorder
       >
 
         <div className={styles.container}>
           <div className={styles.header}>
             <div className={styles.title}>{intl.formatMessage(intlMessages.lockViewersTitle)}</div>
-            <Button
-              data-test="modalBaseCloseButton"
-              className={styles.closeBtn}
-              label={intl.formatMessage(intlMessages.closeLabel)}
-              icon="close"
-              size="md"
-              hideLabel
-              onClick={this.closeModal}
-            />
           </div>
           <div className={styles.description}>
             {`${intl.formatMessage(intlMessages.lockViewersDescription)}`}
@@ -243,7 +234,7 @@ class LockViewersComponent extends Component {
             </div>
           </div>
         </div>
-      </ModalBase>
+      </Modal>
     );
   }
 }

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/styles.scss
@@ -9,7 +9,6 @@
 }
 
 .title {
-  position: relative;
   left: var(--title-position-left);
   color: var(--color-gray-dark);
   font-weight: bold;
@@ -24,6 +23,7 @@
 
 .container {
   margin: var(--modal-margin);
+  margin-top: 0;
   margin-bottom: var(--lg-padding-x);
 }
 

--- a/bigbluebutton-html5/imports/ui/components/modal/simple/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/modal/simple/component.jsx
@@ -51,7 +51,7 @@ class ModalSimple extends Component {
         contentLabel={title}
         {...otherProps}
       >
-        {hideBorder ? <header className={styles.headerNoBorder}>
+        <header className={hideBorder ? styles.headerNoBorder : styles.header}>
           <h1 className={styles.title}>{title}</h1>
           <Button
             className={styles.dismiss}
@@ -62,18 +62,7 @@ class ModalSimple extends Component {
             onClick={this.handleDismiss}
             aria-describedby="modalDismissDescription"
           />
-        </header> : <header className={styles.header}>
-            <h1 className={styles.title}>{title}</h1>
-            <Button
-              className={styles.dismiss}
-              label={dismiss.label}
-              icon="close"
-              circle
-              hideLabel
-              onClick={this.handleDismiss}
-              aria-describedby="modalDismissDescription"
-            />
-          </header>}
+        </header>
         <div className={styles.content}>
           {this.props.children}
         </div>

--- a/bigbluebutton-html5/imports/ui/components/modal/simple/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/modal/simple/component.jsx
@@ -6,7 +6,7 @@ import ModalBase, { withModalState } from '../base/component';
 import { styles } from './styles';
 
 const propTypes = {
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   dismiss: PropTypes.shape({
     callback: PropTypes.func,
     label: PropTypes.string.isRequired,
@@ -36,6 +36,7 @@ class ModalSimple extends Component {
   render() {
     const {
       title,
+      hideBorder,
       dismiss,
       className,
       modalisOpen,
@@ -50,18 +51,29 @@ class ModalSimple extends Component {
         contentLabel={title}
         {...otherProps}
       >
-        <header className={styles.header}>
+        {hideBorder ? <header className={styles.headerNoBorder}>
           <h1 className={styles.title}>{title}</h1>
           <Button
             className={styles.dismiss}
             label={dismiss.label}
-            icon={'close'}
+            icon="close"
             circle
             hideLabel
             onClick={this.handleDismiss}
-            aria-describedby={'modalDismissDescription'}
+            aria-describedby="modalDismissDescription"
           />
-        </header>
+        </header> : <header className={styles.header}>
+            <h1 className={styles.title}>{title}</h1>
+            <Button
+              className={styles.dismiss}
+              label={dismiss.label}
+              icon="close"
+              circle
+              hideLabel
+              onClick={this.handleDismiss}
+              aria-describedby="modalDismissDescription"
+            />
+          </header>}
         <div className={styles.content}>
           {this.props.children}
         </div>

--- a/bigbluebutton-html5/imports/ui/components/modal/simple/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/modal/simple/styles.scss
@@ -15,16 +15,14 @@
   padding: var(--line-height-computed) 0;
 }
 
-.header {
+.headerNoBorder, .header {
   display: flex;
-  padding: calc(var(--line-height-computed) / 2) 0;
-  border-bottom: var(--border-size) solid var(--color-gray-lighter);
   flex-shrink: 0;
 }
 
-.headerNoBorder {
-  display: flex;
-  flex-shrink: 0;
+.header {
+   padding: calc(var(--line-height-computed) / 2) 0;
+   border-bottom: var(--border-size) solid var(--color-gray-lighter);
 }
 
 .title {

--- a/bigbluebutton-html5/imports/ui/components/modal/simple/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/modal/simple/styles.scss
@@ -22,6 +22,11 @@
   flex-shrink: 0;
 }
 
+.headerNoBorder {
+  display: flex;
+  flex-shrink: 0;
+}
+
 .title {
   @extend %text-elipsis;
   flex: 1;

--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import Button from '/imports/ui/components/button/component';
-import ModalBase from '/imports/ui/components/modal/base/component';
 import { notify } from '/imports/ui/services/notification';
 import logger from '/imports/startup/client/logger';
+import Modal from '/imports/ui/components/modal/simple/component';
 import { styles } from './styles';
 
 const VIDEO_CONSTRAINTS = Meteor.settings.public.kurento.cameraConstraints;
@@ -175,82 +175,69 @@ class VideoPreview extends Component {
     } = this.props;
 
     return (
-      <span>
-        <ModalBase
-          overlayClassName={styles.overlay}
-          className={styles.modal}
-          onRequestClose={this.handleProceed}
-        >
-          <header
-            className={styles.header}
-          >
+      <Modal
+        overlayClassName={styles.overlay}
+        className={styles.modal}
+        onRequestClose={this.handleProceed}
+        hideBorder
+      >
+        <div className={styles.title}>
+          {intl.formatMessage(intlMessages.webcamSettingsTitle)}
+        </div>
+        <div className={styles.content}>
+          <div className={styles.col}>
+            <video
+              id="preview"
+              className={styles.preview}
+              ref={(ref) => { this.video = ref; }}
+              autoPlay
+              playsInline
+            />
+          </div>
+          <div className={styles.options}>
+            <label className={styles.label}>
+              {intl.formatMessage(intlMessages.cameraLabel)}
+            </label>
+            {this.state.availableWebcams && this.state.availableWebcams.length > 0 ? (
+              <select
+                value={this.state.webcamDeviceId}
+                className={styles.select}
+                onChange={this.handleSelectWebcam.bind(this)}
+              >
+                <option disabled>
+                  {intl.formatMessage(intlMessages.webcamOptionLabel)}
+                </option>
+                {this.state.availableWebcams.map((webcam, index) => (
+                  <option key={index} value={webcam.deviceId}>
+                    {webcam.label}
+                  </option>
+                  ))}
+              </select>
+              ) :
+              <select
+                className={styles.select}
+              >
+                <option disabled>
+                  {intl.formatMessage(intlMessages.webcamNotFoundLabel)}
+                </option>
+              </select>}
+          </div>
+        </div>
+        <div className={styles.footer}>
+          <div className={styles.actions}>
             <Button
-              className={styles.closeBtn}
-              label={intl.formatMessage(intlMessages.closeLabel)}
-              icon="close"
-              size="md"
-              hideLabel
+              label={intl.formatMessage(intlMessages.cancelLabel)}
               onClick={this.handleProceed}
             />
-          </header>
-          <h3 className={styles.title}>
-            {intl.formatMessage(intlMessages.webcamSettingsTitle)}
-          </h3>
-          <div className={styles.content}>
-            <div className={styles.col}>
-              <video
-                id="preview"
-                className={styles.preview}
-                ref={(ref) => { this.video = ref; }}
-                autoPlay
-                playsInline
-              />
-            </div>
-            <div className={styles.options}>
-              <label className={styles.label}>
-                {intl.formatMessage(intlMessages.cameraLabel)}
-              </label>
-              {this.state.availableWebcams && this.state.availableWebcams.length > 0 ? (
-                <select
-                  value={this.state.webcamDeviceId}
-                  className={styles.select}
-                  onChange={this.handleSelectWebcam.bind(this)}
-                >
-                  <option disabled>
-                    {intl.formatMessage(intlMessages.webcamOptionLabel)}
-                  </option>
-                  {this.state.availableWebcams.map((webcam, index) => (
-                    <option key={index} value={webcam.deviceId}>
-                      {webcam.label}
-                    </option>
-                  ))}
-                </select>
-              ) :
-                <select
-                  className={styles.select}
-                >
-                  <option disabled>
-                    {intl.formatMessage(intlMessages.webcamNotFoundLabel)}
-                  </option>
-                </select>}
-            </div>
+            <Button
+              color="primary"
+              label={intl.formatMessage(intlMessages.startSharingLabel)}
+              onClick={() => this.handleStartSharing()}
+              disabled={this.state.isStartSharingDisabled}
+            />
           </div>
-          <div className={styles.footer}>
-            <div className={styles.actions}>
-              <Button
-                label={intl.formatMessage(intlMessages.cancelLabel)}
-                onClick={this.handleProceed}
-              />
-              <Button
-                color="primary"
-                label={intl.formatMessage(intlMessages.startSharingLabel)}
-                onClick={() => this.handleStartSharing()}
-                disabled={this.state.isStartSharingDisabled}
-              />
-            </div>
-          </div>
-        </ModalBase>
-      </span>
+        </div>
+      </Modal>
     );
   }
 }

--- a/bigbluebutton-html5/imports/ui/components/video-preview/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/styles.scss
@@ -73,6 +73,8 @@
 }
 
 .title {
+  display: block;
+  color: var(--color-background);
   font-size: 1.4rem;
   text-align: center;
 }


### PR DESCRIPTION
The modal component can now be used for various  different modal designed with the hideBorder option. With the hideBorder property set to true, there is no need to individually modify modalBase for each component , thus now all modals will have a consistent structure with one another. #6016 