### PR TITLE
Fixes podcast undefined method xpath errors

### DIFF
--- a/record-and-playback/podcast/scripts/process/podcast.rb
+++ b/record-and-playback/podcast/scripts/process/podcast.rb
@@ -114,7 +114,7 @@ if not FileTest.directory?(target_dir)
     end
 
     participants = recording.at_xpath("participants")
-    participants.content = BigBlueButton::Events.get_num_participants("#{raw_archive_dir}/events.xml")
+    participants.content = BigBlueButton::Events.get_num_participants(@doc)
 
     ## Remove empty meta
     metadata.search('//recording/meta').each do |meta|

--- a/record-and-playback/podcast/scripts/publish/podcast.rb
+++ b/record-and-playback/podcast/scripts/publish/podcast.rb
@@ -70,7 +70,8 @@ begin
       BigBlueButton.logger.info("copying: #{process_dir}/audio.ogg to -> #{target_dir}")
       FileUtils.cp("#{process_dir}/audio.ogg", target_dir)
 
-      recording_time = BigBlueButton::Events.get_recording_length("#{raw_archive_dir}/events.xml")
+      @doc = Nokogiri::XML(File.open("#{raw_archive_dir}/events.xml"))
+      recording_time = BigBlueButton::Events.get_recording_length(@doc)
 
       BigBlueButton.logger.info("Creating metadata.xml")
 


### PR DESCRIPTION
@kepstin , not sure if you guys still uses this, but I was testing something else and found those,
at process:
```
E, [2018-12-06T12:10:23.833143 #4062] ERROR -- : undefined method `xpath' for #<String:0x00000001c8d3f8>
E, [2018-12-06T12:10:23.833291 #4062] ERROR -- : /usr/local/bigbluebutton/core/lib/recordandplayback/generators/events.rb:34:in `get_num_participants'
E, [2018-12-06T12:10:23.833322 #4062] ERROR -- : process/podcast.rb:117:in `<main>'
```
and at publish:
```
E, [2018-12-06T12:35:20.280856 #5160] ERROR -- : undefined method `xpath' for #<String:0x00000001a199a0>
E, [2018-12-06T12:35:20.280902 #5160] ERROR -- : /usr/local/bigbluebutton/core/lib/recordandplayback/generators/events.rb:474:in `get_record_status_events'
E, [2018-12-06T12:35:20.280930 #5160] ERROR -- : /usr/local/bigbluebutton/core/lib/recordandplayback/generators/events.rb:484:in `get_start_and_stop_rec_events'
E, [2018-12-06T12:35:20.280957 #5160] ERROR -- : /usr/local/bigbluebutton/core/lib/recordandplayback/generators/events.rb:541:in `get_recording_length'
E, [2018-12-06T12:35:20.280983 #5160] ERROR -- : publish/podcast.rb:73:in `<main>'
```