### PR TITLE
Better client logs on user join/subscription

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -82,7 +82,7 @@ class Base extends Component {
     // this.props.annotationsHandler.stop();
 
     if (subscriptionsReady) {
-      logger.info('Client loaded successfully');
+      logger.info('Subscriptions are ready');
     }
 
     return (<AppContainer {...this.props} baseControls={stateControls} />);

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -9,6 +9,7 @@ import browser from 'browser-detect';
 import BreakoutRoomContainer from '/imports/ui/components/breakout-room/container';
 import PollingContainer from '/imports/ui/components/polling/container';
 import PollContainer from '/imports/ui/components/poll/container';
+import logger from '/imports/startup/client/logger';
 import ToastContainer from '../toast/container';
 import ModalContainer from '../modal/container';
 import NotificationsBarContainer from '../notifications-bar/container';
@@ -95,6 +96,8 @@ class App extends Component {
 
     this.handleWindowResize();
     window.addEventListener('resize', this.handleWindowResize, false);
+
+    logger.info('Client loaded successfully');
   }
 
   componentWillUnmount() {

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -6,7 +6,6 @@ import Auth from '/imports/ui/services/auth';
 import Users from '/imports/api/users';
 import Breakouts from '/imports/api/breakouts';
 import Meetings from '/imports/api/meetings';
-import logger from '/imports/startup/client/logger';
 
 import ClosedCaptionsContainer from '/imports/ui/components/closed-captions/container';
 import getFromUserSettings from '/imports/ui/services/users-settings';
@@ -76,8 +75,6 @@ export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) 
   if (!currentUser.approved) {
     baseControls.updateLoadingState(intl.formatMessage(intlMessages.waitingApprovalMessage));
   }
-
-  logger.info('User joined meeting and subscribed to data successfully');
 
   // Check if user is removed out of the session
   Users.find({ userId: Auth.userID }).observeChanges({


### PR DESCRIPTION
Improvements to the client logs appearing on user join/subscription.

No more `User joined meeting and subscribed to data successfully` logs when opening/closing userlist / public chat or changing status.