### PR TITLE
Display recordings raw size and playbacks sizes at getRecordings API …

### DIFF
--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/domain/Recording.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/domain/Recording.scala
@@ -243,7 +243,7 @@ case class RecMeta(id: String, meetingId: String, internalMeetingId: Option[ Str
     val startTimeElem =  <startTime>{startTime}</startTime>
     val endTimeElem = <endTime>{endTime}</endTime>
     val participantsElem = <participants>{participants}</participants>
-
+    val rawSizeElem = <rawSize>{rawSize}</rawSize>
 
     val buffer = new scala.xml.NodeBuffer
     buffer += recordIdElem
@@ -256,6 +256,7 @@ case class RecMeta(id: String, meetingId: String, internalMeetingId: Option[ Str
     buffer += startTimeElem
     buffer += endTimeElem
     buffer += participantsElem
+    buffer += rawSizeElem
 
     meta foreach (m => buffer += metaToElem(m))
     breakout foreach (b => buffer += b.toXml())
@@ -285,6 +286,7 @@ case class RecMeta(id: String, meetingId: String, internalMeetingId: Option[ Str
     buffer += startTimeElem
     buffer += endTimeElem
     buffer += participantsElem
+    buffer += rawSizeElem
 
     meeting foreach { m =>
       buffer += m.toMetadataXml()
@@ -320,8 +322,6 @@ case class RecMeta(id: String, meetingId: String, internalMeetingId: Option[ Str
 
     dataMetrics foreach(p => buffer += p.toMetadataXml())
 
-    buffer += rawSizeElem
-
     <recording>{buffer}</recording>
   }
 }
@@ -346,11 +346,13 @@ case class RecMetaPlayback(format: String, link: String, processingTime: Int,
     val urlElem = <url>{link}</url>
     val processTimeElem = <processingTime>{processingTime}</processingTime>
     val lengthElem = <length>{duration / 60000}</length>
+    val sizeElem = <size>{size}</size>
 
     buffer += formatElem
     buffer += urlElem
     buffer += processTimeElem
     buffer += lengthElem
+    buffer += sizeElem
 
     extensions foreach {ext =>
       ext.head.child foreach {child =>
@@ -369,12 +371,13 @@ case class RecMetaPlayback(format: String, link: String, processingTime: Int,
     val urlElem = <link>{link}</link>
     val processTimeElem = <processing_time>{processingTime}</processing_time>
     val lengthElem = <duration>{duration}</duration>
+    val sizeElem = <size>{size}</size>
 
     buffer += formatElem
     buffer += urlElem
     buffer += processTimeElem
     buffer += lengthElem
-
+    buffer += sizeElem
 
     extensions foreach {ext =>
       buffer += ext.head
@@ -390,11 +393,13 @@ case class RecMetaPlayback(format: String, link: String, processingTime: Int,
     val urlElem = <url>{link}</url>
     val processTimeElem = <processingTime>{processingTime}</processingTime>
     val lengthElem = <length>{duration / 60000}</length>
+    val sizeElem = <size>{size}</size>
 
     buffer += formatElem
     buffer += urlElem
     buffer += processTimeElem
     buffer += lengthElem
+    buffer += sizeElem
 
     extensions foreach {ext =>
       ext.head.child foreach {child =>
@@ -530,6 +535,7 @@ case class RecMetaResponse(
     val startTimeElem =  <startTime>{startTime}</startTime>
     val endTimeElem = <endTime>{endTime}</endTime>
     val participantsElem = <participants>{participants}</participants>
+    val rawSizeElem = <rawSize>{rawSize}</rawSize>
 
     val buffer = new scala.xml.NodeBuffer
     buffer += recordIdElem
@@ -542,6 +548,7 @@ case class RecMetaResponse(
     buffer += startTimeElem
     buffer += endTimeElem
     buffer += participantsElem
+    buffer += rawSizeElem
 
     meta foreach (m => buffer += metaToElem(m))
     breakout foreach (b => buffer += b.toXml())
@@ -551,7 +558,13 @@ case class RecMetaResponse(
 
     // Iterate over all formats before include the playback tag
     val formats = new scala.xml.NodeBuffer
-    playbacks foreach(p => formats += p.toFormatXml())
+    var size = 0L
+    playbacks foreach(p => {
+      size += p.size
+      formats += p.toFormatXml()
+    })
+    val sizeElem = <size>{size}</size>
+    buffer += sizeElem
     val playbackElem = <playback>{formats}</playback>
     buffer += playbackElem
 


### PR DESCRIPTION
…call

Finished including `size` and `rawSize` at `getRecordings` response. Not sure why this wasn't running already, maybe some conflict with old recordings metadata.

The result should look like this:
```
<response>
  <returncode>SUCCESS</returncode>
  <recordings>
    <recording>
      <recordID>75c142af99138540c4a0d8a1f6130a9aaa8aae34-1544097896376</recordID>
      <meetingID>random-1626728</meetingID>
      <internalMeetingID>75c142af99138540c4a0d8a1f6130a9aaa8aae34-1544097896376</internalMeetingID>
      <name>random-1626728</name>
      <isBreakout>false</isBreakout>
      <published>true</published>
      <state>published</state>
      <startTime>1544097896376</startTime>
      <endTime>1544097944364</endTime>
      <participants>1</participants>
      <rawSize>2808123</rawSize>
      <metadata>
        <isBreakout>false</isBreakout>
        <meetingName>random-1626728</meetingName>
        <meetingId>random-1626728</meetingId>
      </metadata>
      <size>287808</size>
      <playback>
        <format>
          <type>podcast</type>
          <url>http://127.0.0.1/podcast/75c142af99138540c4a0d8a1f6130a9aaa8aae34-1544097896376/audio.ogg</url>
          <processingTime>0</processingTime>
          <length>0</length>
          <size>86236</size>
        </format>
        <format>
          <type>presentation</type>
          <url>http://127.0.0.1/playback/presentation/2.0/playback.html?meetingId=75c142af99138540c4a0d8a1f6130a9aaa8aae34-1544097896376</url>
          <processingTime>7683</processingTime>
          <length>0</length>
          <size>201572</size>
          <preview>
            <images>
              <image alt="Welcome To BigBlueButton" height="136" width="176">http://127.0.0.1/presentation/75c142af99138540c4a0d8a1f6130a9aaa8aae34-1544097896376/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1544097896450/thumbnails/thumb-1.png</image>
              <image alt="This slide left blank for whiteboard" height="136" width="176">http://127.0.0.1/presentation/75c142af99138540c4a0d8a1f6130a9aaa8aae34-1544097896376/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1544097896450/thumbnails/thumb-2.png</image>
              <image alt="This slide left blank for whiteboard" height="136" width="176">http://127.0.0.1/presentation/75c142af99138540c4a0d8a1f6130a9aaa8aae34-1544097896376/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1544097896450/thumbnails/thumb-3.png</image>
            </images>
          </preview>
        </format>
      </playback>
      <data></data>
    </recording>
  </recordings>
</response>
```

Where `size` inside each one of the playbacks is it's the published directory size. The `size` value outside the playbacks is the sum of all playbacks sizes and `rawSize` is the size of the recording raw directory.

If a recording doesn't have this attributes in it's metadata, the API will fill those values with zero:
```
<response>
  <returncode>SUCCESS</returncode>
  <recordings>
    <recording>
      <recordID>047ea337e871698078c084f148a851ce6360cf8e-1544040180142</recordID>
      <meetingID>random-7850147</meetingID>
      <internalMeetingID>047ea337e871698078c084f148a851ce6360cf8e-1544040180142</internalMeetingID>
      <name>random-7850147</name>
      <isBreakout>false</isBreakout>
      <published>true</published>
      <state>published</state>
      <startTime>1544040180142</startTime>
      <endTime>1544040216856</endTime>
      <participants>1</participants>
      <rawSize>0</rawSize>
      <metadata>
        <meetingId>random-7850147</meetingId>
        <meetingName>random-7850147</meetingName>
        <isBreakout>false</isBreakout>
      </metadata>
      <size>0</size>
      <playback>
        <format>
          <type>podcast</type>
          <url>http://127.0.0.1/podcast/047ea337e871698078c084f148a851ce6360cf8e-1544040180142/audio.ogg</url>
          <processingTime>0</processingTime>
          <length>0</length>
          <size>0</size>
        </format>
        <format>
          <type>presentation</type>
          <url>http://127.0.0.1/playback/presentation/2.0/playback.html?meetingId=047ea337e871698078c084f148a851ce6360cf8e-1544040180142</url>
          <processingTime>8036</processingTime>
          <length>0</length>
          <size>0</size>
          <preview>
            <images>
              <image alt="Welcome To BigBlueButton" height="136" width="176">http://127.0.0.1/presentation/047ea337e871698078c084f148a851ce6360cf8e-1544040180142/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1544040180210/thumbnails/thumb-1.png</image>
              <image alt="This slide left blank for whiteboard" height="136" width="176">http://127.0.0.1/presentation/047ea337e871698078c084f148a851ce6360cf8e-1544040180142/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1544040180210/thumbnails/thumb-2.png</image>
              <image alt="This slide left blank for whiteboard" height="136" width="176">http://127.0.0.1/presentation/047ea337e871698078c084f148a851ce6360cf8e-1544040180142/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1544040180210/thumbnails/thumb-3.png</image>
            </images>
          </preview>
        </format>
      </playback>
      <data></data>
    </recording>
  </recordings>
</response>
```