### PR TITLE
Created property keepEvents at bbb-web to make redis record the event…

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -117,13 +117,7 @@ class BigBlueButtonActor(
       case None =>
         log.info("Create meeting request. meetingId={}", msg.body.props.meetingProp.intId)
 
-        // Check if we are keeping the events
-        var props =  msg.body.props.copy()
-        if (props.recordProp.keepEvents) {
-          val recordProp = msg.body.props.recordProp.copy(record = true)
-          props = msg.body.props.copy(recordProp = recordProp)
-        }
-        val m = RunningMeeting(props, outGW, eventBus)
+        val m = RunningMeeting(msg.body.props, outGW, eventBus)
 
         /** Subscribe to meeting and voice events. **/
         eventBus.subscribe(m.actorRef, m.props.meetingProp.intId)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -117,7 +117,13 @@ class BigBlueButtonActor(
       case None =>
         log.info("Create meeting request. meetingId={}", msg.body.props.meetingProp.intId)
 
-        val m = RunningMeeting(msg.body.props, outGW, eventBus)
+        // Check if we are keeping the events
+        var props =  msg.body.props.copy()
+        if (props.recordProp.keepEvents) {
+          val recordProp = msg.body.props.recordProp.copy(record = true)
+          props = msg.body.props.copy(recordProp = recordProp)
+        }
+        val m = RunningMeeting(props, outGW, eventBus)
 
         /** Subscribe to meeting and voice events. **/
         eventBus.subscribe(m.actorRef, m.props.meetingProp.intId)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/RunningMeeting.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/RunningMeeting.scala
@@ -44,7 +44,8 @@ class RunningMeeting(val props: DefaultProps, outGW: OutMessageGateway,
     liveMeeting.guestsWaiting,
     GuestPolicy(props.usersProp.guestPolicy, SystemUser.ID))
 
-  val outMsgRouter = new OutMsgRouter(props.recordProp.record, outGW)
+  private val recordEvents = props.recordProp.record || props.recordProp.keepEvents
+  val outMsgRouter = new OutMsgRouter(recordEvents, outGW)
 
   val actorRef = context.actorOf(MeetingActor.props(props, eventBus, outMsgRouter, liveMeeting), props.meetingProp.intId)
 

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
@@ -13,7 +13,7 @@ case class BreakoutProps(parentId: String, sequence: Int, freeJoin: Boolean, bre
 
 case class PasswordProp(moderatorPass: String, viewerPass: String)
 
-case class RecordProp(record: Boolean, autoStartRecording: Boolean, allowStartStopRecording: Boolean)
+case class RecordProp(record: Boolean, autoStartRecording: Boolean, allowStartStopRecording: Boolean, keepEvents: Boolean)
 
 case class WelcomeProp(welcomeMsgTemplate: String, welcomeMsg: String, modOnlyMessage: String)
 

--- a/bbb-common-message/src/test/scala/org/bigbluebutton/common2/TestFixtures.scala
+++ b/bbb-common-message/src/test/scala/org/bigbluebutton/common2/TestFixtures.scala
@@ -34,6 +34,7 @@ trait TestFixtures {
   val dialNumber = "613-555-1234"
   val maxUsers = 25
   val muteOnStart = false
+  val keepEvents = false
   val guestPolicy = "ALWAYS_ASK"
   val metadata: collection.immutable.Map[String, String] = Map("foo" -> "bar", "bar" -> "baz", "baz" -> "foo")
 
@@ -46,7 +47,7 @@ trait TestFixtures {
     userInactivityInspectTimerInMinutes = userInactivityInspectTimerInMinutes, userInactivityThresholdInMinutes = userInactivityInspectTimerInMinutes, userActivitySignResponseDelayInMinutes = userActivitySignResponseDelayInMinutes)
   val password = PasswordProp(moderatorPass = moderatorPassword, viewerPass = viewerPassword)
   val recordProp = RecordProp(record = record, autoStartRecording = autoStartRecording,
-    allowStartStopRecording = allowStartStopRecording)
+    allowStartStopRecording = allowStartStopRecording, keepEvents = keepEvents)
   val welcomeProp = WelcomeProp(welcomeMsgTemplate = welcomeMsgTemplate, welcomeMsg = welcomeMsg,
     modOnlyMessage = modOnlyMessage)
   val voiceProp = VoiceProp(telVoice = voiceConfId, voiceConf = voiceConfId, dialNumber = dialNumber, muteOnStart = muteOnStart)

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -518,7 +518,11 @@ public class MeetingService implements MessageListener {
     if (m != null) {
       m.setForciblyEnded(true);
       processRecording(m);
-      if (keepEvents) recordingService.markAsEnded(m.getInternalId());
+      if (keepEvents) {
+        // The creation of the ended tag must occur after the creation of the
+        // recorded tag to avoid concurrency issues at the recording scripts
+        recordingService.markAsEnded(m.getInternalId());
+      }
       destroyMeeting(m.getInternalId());
       meetings.remove(m.getInternalId());
       removeUserSessions(m.getInternalId());

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/RecordingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/RecordingService.java
@@ -126,6 +126,23 @@ public class RecordingService {
         }
     }
 
+    public void markAsEnded(String meetingId) {
+        String done = recordStatusDir + "/../ended/" + meetingId + ".done";
+
+        File doneFile = new File(done);
+        if (!doneFile.exists()) {
+            try {
+                doneFile.createNewFile();
+                if (!doneFile.exists())
+                    log.error("Failed to create " + done + " file.");
+            } catch (IOException e) {
+                log.error("Exception occured when trying to create {} file.", done);
+            }
+        } else {
+            log.error(done + " file already exists.");
+        }
+    }
+
     public List<RecordingMetadata> getRecordingsMetadata(List<String> recordIDs, List<String> states) {
         List<RecordingMetadata> recs = new ArrayList<>();
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
@@ -25,7 +25,8 @@ public interface IBbbWebApiGWApp {
                      Integer userInactivityInspectTimerInMinutes,
                      Integer userInactivityThresholdInMinutes,
                      Integer userActivitySignResponseDelayInMinutes,
-                     Boolean muteOnStart);
+                     Boolean muteOnStart,
+                     Boolean keepEvents);
 
   void registerUser(String meetingID, String internalUserId, String fullname, String role,
                     String externUserID, String authToken, String avatarURL,

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -90,7 +90,8 @@ class BbbWebApiGWApp(
                     userInactivityInspectTimerInMinutes:    java.lang.Integer,
                     userInactivityThresholdInMinutes:       java.lang.Integer,
                     userActivitySignResponseDelayInMinutes: java.lang.Integer,
-                    muteOnStart:                            java.lang.Boolean): Unit = {
+                    muteOnStart:                            java.lang.Boolean,
+                    keepEvents:                             java.lang.Boolean): Unit = {
 
     val meetingProp = MeetingProp(name = meetingName, extId = extMeetingId, intId = meetingId,
       isBreakout = isBreakout.booleanValue())
@@ -107,7 +108,7 @@ class BbbWebApiGWApp(
 
     val password = PasswordProp(moderatorPass = moderatorPass, viewerPass = viewerPass)
     val recordProp = RecordProp(record = recorded.booleanValue(), autoStartRecording = autoStartRecording.booleanValue(),
-      allowStartStopRecording = allowStartStopRecording.booleanValue())
+      allowStartStopRecording = allowStartStopRecording.booleanValue(), keepEvents = keepEvents.booleanValue())
     val breakoutProps = BreakoutProps(parentId = parentMeetingId, sequence = sequence.intValue(), freeJoin = freeJoin.booleanValue(), breakoutRooms = Vector())
     val welcomeProp = WelcomeProp(welcomeMsgTemplate = welcomeMsgTemplate, welcomeMsg = welcomeMsg,
       modOnlyMessage = modOnlyMessage)

--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -355,6 +355,7 @@ if [ $DELETE ]; then
   echo "deleting: $MEETING_ID"
   # Remove the status files first to avoid issues with concurrent
   # recording processing
+  rm -f /var/bigbluebutton/recording/status/ended/$MEETING_ID*
   rm -f /var/bigbluebutton/recording/status/recorded/$MEETING_ID*
   rm -f /var/bigbluebutton/recording/status/archived/$MEETING_ID*
   rm -f /var/bigbluebutton/recording/status/sanity/$MEETING_ID*

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -1,5 +1,5 @@
 import flat from 'flat';
-import { check } from 'meteor/check';
+import { check, Match } from 'meteor/check';
 import Meetings from '/imports/api/meetings';
 import Logger from '/imports/startup/server/logger';
 
@@ -42,11 +42,11 @@ export default function addMeeting(meeting) {
       modOnlyMessage: String,
       welcomeMsgTemplate: String,
     },
-    recordProp: {
+    recordProp: Match.ObjectIncluding({
       allowStartStopRecording: Boolean,
       autoStartRecording: Boolean,
-      record: Boolean,
-    },
+      record: Boolean
+    }),
     password: {
       viewerPass: String,
       moderatorPass: String,

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -185,6 +185,9 @@ webcamsOnlyForModerator=false
 # Mute the meeting on start
 muteOnStart=false
 
+# Saves meeting events even if the meeting is not recorded
+keepEvents=false
+
 #----------------------------------------------------
 # This URL is where the BBB client is accessible. When a user sucessfully
 # enters a name and password, she is redirected here to load the client.

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -44,6 +44,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="registeredUserCleanupTimerTask" ref="registeredUserCleanupTimerTask"/>
         <property name="gw" ref="bbbWebApiGWApp"/>
         <property name="callbackUrlService" ref="callbackUrlService"/>
+        <property name="keepEvents" value="${keepEvents}"/>
     </bean>
 
     <bean id="oldMessageReceivedGW" class="org.bigbluebutton.api2.bus.OldMessageReceivedGW">

--- a/record-and-playback/core/scripts/bigbluebutton.yml
+++ b/record-and-playback/core/scripts/bigbluebutton.yml
@@ -13,6 +13,7 @@ redis_port: 6379
 
 # For PRODUCTION
 log_dir: /var/log/bigbluebutton
+events_dir: /var/bigbluebutton/events
 recording_dir: /var/bigbluebutton/recording
 published_dir: /var/bigbluebutton/published
 playback_host: 127.0.0.1

--- a/record-and-playback/core/scripts/events/events.rb
+++ b/record-and-playback/core/scripts/events/events.rb
@@ -1,0 +1,74 @@
+# Set encoding to utf-8
+# encoding: UTF-8
+#
+# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+#
+# Copyright (c) 2018 BigBlueButton Inc. and by respective authors (see below).
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 3.0 of the License, or (at your option)
+# any later version.
+#
+# BigBlueButton is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+#
+
+require '../lib/recordandplayback'
+require 'logger'
+require 'trollop'
+require 'yaml'
+
+def keep_events(meeting_id, redis_host, redis_port, events_dir, break_timestamp)
+  BigBlueButton.logger.info("Keeping events for #{meeting_id}")
+  redis = BigBlueButton::RedisWrapper.new(redis_host, redis_port)
+  events_archiver = BigBlueButton::RedisEventsArchiver.new redis
+  events_xml = "#{events_dir}/#{meeting_id}/events.xml"
+  events = events_archiver.store_events(meeting_id, events_xml, break_timestamp)
+end
+
+################## START ################################
+
+opts = Trollop::options do
+  opt :meeting_id, "Meeting id with events to keep", type: :string
+  opt :break_timestamp, "Chapter break end timestamp", type: :integer
+end
+Trollop::die :meeting_id, "must be provided" if opts[:meeting_id].nil?
+
+meeting_id = opts[:meeting_id]
+break_timestamp = opts[:break_timestamp]
+
+# This script lives in scripts/archive/steps while bigbluebutton.yml lives in scripts/
+props = YAML::load(File.open('bigbluebutton.yml'))
+recording_dir = props['recording_dir']
+events_dir = props['events_dir']
+redis_host = props['redis_host']
+redis_port = props['redis_port']
+log_dir = props['log_dir']
+
+BigBlueButton.logger = Logger.new("#{log_dir}/events.log", 'daily')
+
+target_dir = "#{events_dir}/#{meeting_id}"
+events_xml = "#{target_dir}/events.xml"
+if not FileTest.directory?(target_dir)
+  FileUtils.mkdir_p target_dir
+  keep_events(meeting_id, redis_host, redis_port, events_dir, break_timestamp)
+  if not File.exist? "#{recording_dir}/status/recorded/#{meeting_id}.done"
+    # if the session was not recorded, it was not archived and the sanity
+    # script won't never run for this particular recording; it means that there's
+    # no script that will remove the keys from redis, so I have to do it here
+    # implementation copied from record-and-playback/core/scripts/sanity/sanity.rb
+    BigBlueButton.logger.info("Deleting keys")
+    redis = BigBlueButton::RedisWrapper.new(redis_host, redis_port)
+    events_archiver = BigBlueButton::RedisEventsArchiver.new redis
+    events_archiver.delete_events(meeting_id)
+  else
+    BigBlueButton.logger.info("Leaving the redis keys to be archived and removed by the sanity script")
+  end
+  FileUtils.rm "#{recording_dir}/status/ended/#{meeting_id}.done"
+end

--- a/record-and-playback/core/scripts/rap-archive-worker.rb
+++ b/record-and-playback/core/scripts/rap-archive-worker.rb
@@ -130,8 +130,8 @@ begin
 
   BigBlueButton.logger.debug("Running rap-archive-worker...")
   
-  keep_events_from_ended_meeting(recording_dir)
   archive_recorded_meetings(recording_dir)
+  keep_events_from_ended_meeting(recording_dir)
 
   BigBlueButton.logger.debug("rap-archive-worker done")
 

--- a/record-and-playback/core/scripts/rap-archive-worker.rb
+++ b/record-and-playback/core/scripts/rap-archive-worker.rb
@@ -92,6 +92,29 @@ def archive_recorded_meetings(recording_dir)
   end
 end
 
+def keep_events_from_ended_meeting(recording_dir)
+  ended_done_files = Dir.glob("#{recording_dir}/status/ended/*.done")
+  ended_done_files.each do |ended_done|
+    ended_done_base = File.basename(ended_done, '.done')
+    meeting_id = nil
+    break_timestamp = nil
+    if match = /^([0-9a-f]+-[0-9]+)$/.match(ended_done_base)
+      meeting_id = match[1]
+    elsif match = /^([0-9a-f]+-[0-9]+)-([0-9]+)$/.match(ended_done_base)
+      meeting_id = match[1]
+      break_timestamp = match[2]
+    else
+      BigBlueButton.logger.warn("Ended done file for #{ended_done_base} has invalid format")
+      next
+    end
+    if !break_timestamp.nil?
+      ret = BigBlueButton.exec_ret("ruby", "events/events.rb", "-m", meeting_id, '-b', break_timestamp)
+    else
+      ret = BigBlueButton.exec_ret("ruby", "events/events.rb", "-m", meeting_id)
+    end
+  end
+end
+
 begin
   props = YAML::load(File.open('bigbluebutton.yml'))
   redis_host = props['redis_host']
@@ -107,6 +130,7 @@ begin
 
   BigBlueButton.logger.debug("Running rap-archive-worker...")
   
+  keep_events_from_ended_meeting(recording_dir)
   archive_recorded_meetings(recording_dir)
 
   BigBlueButton.logger.debug("rap-archive-worker done")

--- a/record-and-playback/deploy.sh
+++ b/record-and-playback/deploy.sh
@@ -40,10 +40,12 @@ function deploy_format() {
 
 deploy_format "presentation"
 
+sudo mkdir -p /var/bigbluebutton/events/
 sudo mkdir -p /var/bigbluebutton/playback/
 sudo mkdir -p /var/bigbluebutton/recording/raw/
 sudo mkdir -p /var/bigbluebutton/recording/process/
 sudo mkdir -p /var/bigbluebutton/recording/publish/
+sudo mkdir -p /var/bigbluebutton/recording/status/ended/
 sudo mkdir -p /var/bigbluebutton/recording/status/recorded/
 sudo mkdir -p /var/bigbluebutton/recording/status/archived/
 sudo mkdir -p /var/bigbluebutton/recording/status/processed/


### PR DESCRIPTION
…s for all meetings

There are some scenarios where we would like to keep the events from all meetings. This is very useful to generate better usage reports for users.

The way we integrated this here is with a new property called `keepEvents` in `bbb-web` that can be enabled/disabled.

When enabled, `bbb-web` and `akka-apps` will use Redis' storage workflow to record events from all meetings (both recordable and not recordable). `bbb-web` will tag the meetings as `ended` and `rap-archive` will take an extra step digesting those events and saving in a separated folder `/var/bigbluebutton/events`. If the meeting was a not recordable meeting nothing else will happen in the recording process.

When `keepEvents` is disabled (it's default value) nothing changes from regular system behavior.