### PR TITLE
Improve format of callbacks on collection document removal (to address exception)

### DIFF
--- a/bigbluebutton-html5/imports/api/breakouts/server/modifiers/clearBreakouts.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/modifiers/clearBreakouts.js
@@ -7,8 +7,12 @@ export default function clearBreakouts(breakoutId) {
       breakoutId,
     };
 
-    return Breakouts.remove(selector);
+    return Breakouts.remove(selector, () => {
+      Logger.info(`Cleared Breakouts (${breakoutId})`);
+    });
   }
 
-  return Breakouts.remove({}, Logger.info('Cleared Breakouts (all)'));
+  return Breakouts.remove({}, () => {
+    Logger.info('Cleared Breakouts (all)');
+  });
 }

--- a/bigbluebutton-html5/imports/api/captions/server/modifiers/clearCaptions.js
+++ b/bigbluebutton-html5/imports/api/captions/server/modifiers/clearCaptions.js
@@ -3,8 +3,12 @@ import Logger from '/imports/startup/server/logger';
 
 export default function clearCaptions(meetingId) {
   if (meetingId) {
-    return Captions.remove({ meetingId }, Logger.info(`Cleared Captions (${meetingId})`));
+    return Captions.remove({ meetingId }, () => {
+      Logger.info(`Cleared Captions (${meetingId})`);
+    });
   }
 
-  return Captions.remove({}, Logger.info('Cleared Captions (all)'));
+  return Captions.remove({}, () => {
+    Logger.info('Cleared Captions (all)');
+  });
 }

--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/clearGroupChatMsg.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/clearGroupChatMsg.js
@@ -9,7 +9,9 @@ export default function clearGroupChatMsg(meetingId, chatId) {
   const CHAT_CLEAR_MESSAGE = CHAT_CONFIG.system_messages_keys.chat_clear;
 
   if (chatId) {
-    GroupChatMsg.remove({ meetingId, chatId }, Logger.info(`Cleared GroupChatMsg (${meetingId}, ${chatId})`));
+    GroupChatMsg.remove({ meetingId, chatId }, () => {
+      Logger.info(`Cleared GroupChatMsg (${meetingId}, ${chatId})`);
+    });
 
     const clearMsg = {
       color: '0',
@@ -26,8 +28,12 @@ export default function clearGroupChatMsg(meetingId, chatId) {
   }
 
   if (meetingId) {
-    return GroupChatMsg.remove({ meetingId }, Logger.info(`Cleared GroupChatMsg (${meetingId})`));
+    return GroupChatMsg.remove({ meetingId }, () => {
+      Logger.info(`Cleared GroupChatMsg (${meetingId})`);
+    });
   }
 
-  return GroupChatMsg.remove({}, Logger.info('Cleared GroupChatMsg (all)'));
+  return GroupChatMsg.remove({}, () => {
+    Logger.info('Cleared GroupChatMsg (all)');
+  });
 }

--- a/bigbluebutton-html5/imports/api/group-chat/server/modifiers/clearGroupChat.js
+++ b/bigbluebutton-html5/imports/api/group-chat/server/modifiers/clearGroupChat.js
@@ -4,5 +4,7 @@ import clearGroupChatMsg from '/imports/api/group-chat-msg/server/modifiers/clea
 
 export default function clearGroupChat(meetingId) {
   clearGroupChatMsg(meetingId);
-  return GroupChat.remove({ meetingId }, Logger.info(`Cleared GroupChat (${meetingId})`));
+  return GroupChat.remove({ meetingId }, () => {
+    Logger.info(`Cleared GroupChat (${meetingId})`);
+  });
 }

--- a/bigbluebutton-html5/imports/api/polls/server/modifiers/clearPolls.js
+++ b/bigbluebutton-html5/imports/api/polls/server/modifiers/clearPolls.js
@@ -3,8 +3,12 @@ import Logger from '/imports/startup/server/logger';
 
 export default function clearPolls(meetingId) {
   if (meetingId) {
-    return Polls.remove({ meetingId }, Logger.info(`Cleared Polls (${meetingId})`));
+    return Polls.remove({ meetingId }, () => {
+      Logger.info(`Cleared Polls (${meetingId})`);
+    });
   }
 
-  return Polls.remove({}, Logger.info('Cleared Polls (all)'));
+  return Polls.remove({}, () => {
+    Logger.info('Cleared Polls (all)');
+  });
 }

--- a/bigbluebutton-html5/imports/api/presentation-upload-token/server/modifiers/clearPresentationUploadToken.js
+++ b/bigbluebutton-html5/imports/api/presentation-upload-token/server/modifiers/clearPresentationUploadToken.js
@@ -3,19 +3,19 @@ import Logger from '/imports/startup/server/logger';
 
 export default function clearPresentationUploadToken(meetingId, podId) {
   if (meetingId && podId) {
-    return PresentationUploadToken.remove(
-      { meetingId, podId },
-      Logger.info(`Cleared Presentations Upload Token (${meetingId}, ${podId})`),
-    );
+    return PresentationUploadToken.remove({ meetingId, podId }, () => {
+      Logger.info(`Cleared Presentations Upload Token (${meetingId}, ${podId})`);
+    });
   }
 
   if (meetingId) {
-    return PresentationUploadToken.remove(
-      { meetingId },
-      Logger.info(`Cleared Presentations Upload Token (${meetingId})`),
-    );
+    return PresentationUploadToken.remove({ meetingId }, () => {
+      Logger.info(`Cleared Presentations Upload Token (${meetingId})`);
+    });
   }
 
   // clearing presentations for the whole server
-  return PresentationUploadToken.remove({}, Logger.info('Cleared Presentations Upload Token (all)'));
+  return PresentationUploadToken.remove({}, () => {
+    Logger.info('Cleared Presentations Upload Token (all)');
+  });
 }

--- a/bigbluebutton-html5/imports/api/presentations/server/modifiers/clearPresentations.js
+++ b/bigbluebutton-html5/imports/api/presentations/server/modifiers/clearPresentations.js
@@ -4,19 +4,20 @@ import Logger from '/imports/startup/server/logger';
 export default function clearPresentations(meetingId, podId) {
   // clearing presentations for 1 pod
   if (meetingId && podId) {
-    return Presentations.remove(
-      { meetingId, podId },
-      Logger.info(`Cleared Presentations (${meetingId}, ${podId})`),
-    );
+    return Presentations.remove({ meetingId, podId }, () => {
+      Logger.info(`Cleared Presentations (${meetingId}, ${podId})`);
+    });
+  }
 
   // clearing presentations for the whole meeting
-  } else if (meetingId) {
-    return Presentations.remove(
-      { meetingId },
-      Logger.info(`Cleared Presentations (${meetingId})`),
-    );
+  if (meetingId) {
+    return Presentations.remove({ meetingId }, () => {
+      Logger.info(`Cleared Presentations (${meetingId})`);
+    });
   }
 
   // clearing presentations for the whole server
-  return Presentations.remove({}, Logger.info('Cleared Presentations (all)'));
+  return Presentations.remove({}, () => {
+    Logger.info('Cleared Presentations (all)');
+  });
 }

--- a/bigbluebutton-html5/imports/api/slides/server/modifiers/clearSlides.js
+++ b/bigbluebutton-html5/imports/api/slides/server/modifiers/clearSlides.js
@@ -3,8 +3,12 @@ import Logger from '/imports/startup/server/logger';
 
 export default function clearSlides(meetingId) {
   if (meetingId) {
-    return Slides.remove({ meetingId }, Logger.info(`Cleared Slides (${meetingId})`));
+    return Slides.remove({ meetingId }, () => {
+      Logger.info(`Cleared Slides (${meetingId})`);
+    });
   }
 
-  return Slides.remove({}, Logger.info('Cleared Slides (all)'));
+  return Slides.remove({}, () => {
+    Logger.info('Cleared Slides (all)');
+  });
 }

--- a/bigbluebutton-html5/imports/api/users-settings/server/modifiers/clearUsersSettings.js
+++ b/bigbluebutton-html5/imports/api/users-settings/server/modifiers/clearUsersSettings.js
@@ -2,5 +2,7 @@ import UserSettings from '/imports/api/users-settings';
 import Logger from '/imports/startup/server/logger';
 
 export default function clearUsersSettings(meetingId) {
-  return UserSettings.remove({ meetingId }, Logger.info(`Cleared User Settings (${meetingId})`));
+  return UserSettings.remove({ meetingId }, () => {
+    Logger.info(`Cleared User Settings (${meetingId})`);
+  });
 }

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/clearUsers.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/clearUsers.js
@@ -3,10 +3,14 @@ import Users from '/imports/api/users/index';
 
 const clearUsers = (meetingId) => {
   if (meetingId) {
-    return Users.remove({ meetingId }, Logger.info(`Cleared Users (${meetingId})`));
+    return Users.remove({ meetingId }, () => {
+      Logger.info(`Cleared Users (${meetingId})`);
+    });
   }
 
-  return Users.remove({}, Logger.info('Cleared Users (all)'));
+  return Users.remove({}, () => {
+    Logger.info('Cleared Users (all)');
+  });
 };
 
 export default clearUsers;

--- a/bigbluebutton-html5/imports/api/voice-users/server/modifiers/clearVoiceUsers.js
+++ b/bigbluebutton-html5/imports/api/voice-users/server/modifiers/clearVoiceUsers.js
@@ -3,8 +3,12 @@ import VoiceUsers from '/imports/api/voice-users';
 
 export default function clearVoiceUser(meetingId) {
   if (meetingId) {
-    return VoiceUsers.remove({ meetingId }, Logger.info(`Cleared Users (${meetingId})`));
+    return VoiceUsers.remove({ meetingId }, () => {
+      Logger.info(`Cleared Users (${meetingId})`);
+    });
   }
 
-  return VoiceUsers.remove({}, Logger.info('Cleared Users (all)'));
+  return VoiceUsers.remove({}, () => {
+    Logger.info('Cleared Users (all)');
+  });
 }


### PR DESCRIPTION
Before:
```
I20181213-20:07:38.589(0)? info: Cleared GroupChatMsg (183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1544731618269)
I20181213-20:07:38.590(0)? info: Cleared GroupChat (183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1544731618269)
I20181213-20:07:38.597(0)? Exception in callback of async function: TypeError: callback is not a function
I20181213-20:07:38.598(0)?     at packages/mongo/collection.js:729:7
I20181213-20:07:38.599(0)?     at runWithEnvironment (packages/meteor.js:1356:24)
I20181213-20:07:38.600(0)?     at packages/meteor.js:1369:14
I20181213-20:07:38.601(0)?     at packages/mongo/mongo_driver.js:331:7
I20181213-20:07:38.601(0)?     at runWithEnvironment (packages/meteor.js:1356:24)
I20181213-20:07:38.602(0)? Exception in callback of async function: TypeError: callback is not a function
I20181213-20:07:38.602(0)?     at packages/mongo/collection.js:729:7
I20181213-20:07:38.602(0)?     at runWithEnvironment (packages/meteor.js:1356:24)
I20181213-20:07:38.602(0)?     at packages/meteor.js:1369:14
I20181213-20:07:38.603(0)?     at packages/mongo/mongo_driver.js:331:7
I20181213-20:07:38.603(0)?     at runWithEnvironment (packages/meteor.js:1356:24)
I20181213-20:07:38.603(0)? Exception in callback of async function: TypeError: callback is not a function
I20181213-20:07:38.603(0)?     at packages/mongo/collection.js:729:7
I20181213-20:07:38.603(0)?     at runWithEnvironment (packages/meteor.js:1356:24)
I20181213-20:07:38.603(0)?     at packages/meteor.js:1369:14
I20181213-20:07:38.604(0)?     at packages/mongo/mongo_driver.js:331:7
I20181213-20:07:38.604(0)?     at runWithEnvironment (packages/meteor.js:1356:24)
I20181213-20:07:38.604(0)? info: Cleared Polls (183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1544731618269)
```

After:
![screenshot from 2018-12-14 15-18-18](https://user-images.githubusercontent.com/6312397/50025485-bb376a00-ffb3-11e8-8311-b7a1e56b6a31.png)

Closes #6396 