### PR TITLE
fix toast

### DIFF
--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -10,7 +10,7 @@
     }
 
     body {
-      position: absolute;
+      position: fixed;
       height: 100%;
       font-family: 'Source Sans Pro', Arial, sans-serif;
       font-size: 1rem; /* 16px */

--- a/bigbluebutton-html5/imports/ui/components/app/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.scss
@@ -12,9 +12,8 @@
 }
 
 .main {
-  position: fixed;
+  position: relative;
   height: 100%;
-  width: 100%;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
#5918 cause ToastContainer hide behind ModalContainer.
Details: ToastContainer create a fixed div with z-index 9999 inside `.main`, ModalContainer create a fixed div with z-index 1000 outside `.main`. When `.main` is relative, toast is in the front, when `.main` is fixed, the modal is in the front. https://developers.google.com/web/updates/2012/09/Stacking-Changes-Coming-to-position-fixed-elements