### PR TITLE
Create RTCPeerConnection with sdpSemantics:plan-b for Chrome unified-plan

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/sip.js
+++ b/bigbluebutton-client/resources/prod/lib/sip.js
@@ -6665,6 +6665,9 @@ InviteClientContext.prototype = {
                 }*/
               },
               function onFailure (e) {
+                if (e && e.message) {
+                  session.logger.warn(e.message);
+                }
                 session.logger.warn(e);
                 session.acceptAndTerminate(response, 488, 'Not Acceptable Here');
                 session.failed(response, SIP.C.causes.BAD_MEDIA_DESCRIPTION);
@@ -11445,7 +11448,8 @@ MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
     }
 
     var connConfig = {
-      iceServers: servers
+      iceServers: servers,
+      sdpSemantics:'plan-b'
     };
 
     if (config.rtcpMuxPolicy) {


### PR DESCRIPTION
Chrome is introducing a new "unified plan" for their WebRTC SDP and in Chrome 72 they are going to be making it the default format. Our webrtc library and FreeSWITCH aren't set up to handle the format change yet so this PR creates the RTCPeerConnection in "plan-b" mode (legacy way) as a stop gap until we can be compatible with the new SDP format and WebRTC APIs.

Other browsers and older versions of Chrome should just ignore the new property and will continue to function the same as they have in the past.

See #6414 for the original issue.
For information on the differences between the unified plan and plan-b refer to: https://docs.google.com/document/d/1-ZfikoUtoJa9k-GZG1daN0BU3IjIanQ_JSscHxQesvU