### PR TITLE
Chrome plan-b support applied to 2.2 cherry-picked from 2.0

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/sip.js
+++ b/bigbluebutton-client/resources/prod/lib/sip.js
@@ -6665,6 +6665,9 @@ InviteClientContext.prototype = {
                 }*/
               },
               function onFailure (e) {
+                if (e && e.message) {
+                  session.logger.warn(e.message);
+                }
                 session.logger.warn(e);
                 session.acceptAndTerminate(response, 488, 'Not Acceptable Here');
                 session.failed(response, SIP.C.causes.BAD_MEDIA_DESCRIPTION);
@@ -11445,7 +11448,8 @@ MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
     }
 
     var connConfig = {
-      iceServers: servers
+      iceServers: servers,
+      sdpSemantics:'plan-b'
     };
 
     if (config.rtcpMuxPolicy) {

--- a/bigbluebutton-html5/client/compatibility/sip.js
+++ b/bigbluebutton-html5/client/compatibility/sip.js
@@ -6665,6 +6665,9 @@ InviteClientContext.prototype = {
                 }*/
               },
               function onFailure (e) {
+                if (e && e.message) {
+                  session.logger.warn(e.message);
+                }
                 session.logger.warn(e);
                 session.acceptAndTerminate(response, 488, 'Not Acceptable Here');
                 session.failed(response, SIP.C.causes.BAD_MEDIA_DESCRIPTION);
@@ -11445,7 +11448,8 @@ MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
     }
 
     var connConfig = {
-      iceServers: servers
+      iceServers: servers,
+      sdpSemantics:'plan-b'
     };
 
     if (config.rtcpMuxPolicy) {


### PR DESCRIPTION
These commits are cherry-picked from #6435 and #6436 to apply the Chrome unified plan workaround to 2.2 code.