### PR TITLE
Fix some bugs at BBB HTML5 client

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-list/styles.scss
@@ -25,6 +25,7 @@
   margin-right: auto;
   padding-right: var(--md-padding-x);
   padding-top: 0;
+  width: 100%;
   &:after {
     content: "";
     display: block;

--- a/bigbluebutton-html5/imports/ui/components/chat/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/chat/styles.scss
@@ -52,6 +52,7 @@
   flex-direction: row;
   align-items: left;
   flex-shrink: 0;
+  margin-bottom: 1rem;
 
   a {
     @include elementFocus(var(--color-primary));
@@ -75,6 +76,7 @@
     margin-top: 0;
     padding-top: 0;
     border-top: 0;
+    padding-bottom: 0;
   }
 }
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.scss
@@ -31,7 +31,7 @@
 
       &:hover,
       &:focus {
-        background-color: var(--color-gray-light);
+        background-color: transparentize(#8B9AA8, .85);
       }
 
       th,


### PR DESCRIPTION
- Fix opacity on presentation uploader. Fix #6402.
- Fix scroll disappearing with long messages. The scroll disappearing because it's no width defined, hence, the message list uses the content size. Fix #6443. 
- Add margin bottom in title of the chat. Fix #4903 (Partial). 