### PR TITLE
Set default value for idChatOpen

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/authenticated-handler/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/authenticated-handler/component.jsx
@@ -5,6 +5,8 @@ import Auth from '/imports/ui/services/auth';
 import LoadingScreen from '/imports/ui/components/loading-screen/component';
 
 const STATUS_CONNECTING = 'connecting';
+const CHAT_CONFIG = Meteor.settings.public.chat;
+const PUBLIC_CHAT_ID = CHAT_CONFIG.public_id;
 
 class AuthenticatedHandler extends Component {
   static setError(codeError) {
@@ -82,7 +84,7 @@ class AuthenticatedHandler extends Component {
     } = this.state;
 
     Session.set('isChatOpen', false);
-    Session.set('idChatOpen', 'public');
+    Session.set('idChatOpen', PUBLIC_CHAT_ID);
     Session.set('isMeetingEnded', false);
     Session.set('isPollOpen', false);
     Session.set('breakoutRoomIsOpen', false);

--- a/bigbluebutton-html5/imports/ui/components/authenticated-handler/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/authenticated-handler/component.jsx
@@ -82,7 +82,7 @@ class AuthenticatedHandler extends Component {
     } = this.state;
 
     Session.set('isChatOpen', false);
-    Session.set('idChatOpen', '');
+    Session.set('idChatOpen', 'public');
     Session.set('isMeetingEnded', false);
     Session.set('isPollOpen', false);
     Session.set('breakoutRoomIsOpen', false);

--- a/bigbluebutton-html5/imports/ui/components/chat/service.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/service.js
@@ -196,7 +196,7 @@ const updateScrollPosition =
   );
 
 const updateUnreadMessage = (timestamp) => {
-  const chatID = Session.get('idChatOpen');
+  const chatID = Session.get('idChatOpen') || PUBLIC_CHAT_ID;
   const isPublic = chatID === PUBLIC_CHAT_ID;
   const chatType = isPublic ? PUBLIC_GROUP_CHAT_ID : chatID;
   return UnreadMessages.update(chatType, timestamp);


### PR DESCRIPTION
Set `public` as default value for Session property `idChatOpen` in order to prevent some unexpected behaviour from Chat component and fix a problem with unread messages counter and scroll. It's a follow up from #6440.