### PR TITLE
Improve the caption UI responsiveness and update frequency

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/caption/views/CaptionWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/caption/views/CaptionWindow.mxml
@@ -32,6 +32,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 	<fx:Declarations>
 		<mate:Listener type="{LocaleChangeEvent.LOCALE_CHANGED}" method="localeChanged" />
 		<mate:Listener type="{ShortcutEvent.FOCUS_CAPTION_WINDOW}" method="focusWindow" />
+		<mate:Listener type="{ChangeMyRole.CHANGE_MY_ROLE_EVENT}" method="roleChanged" />
 	</fx:Declarations>
 
 	<fx:Script>
@@ -45,11 +46,14 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import flexlib.controls.tabBarClasses.SuperTab;
 			
 			import org.as3commons.lang.StringUtils;
+			import org.as3commons.logging.api.ILogger;
+			import org.as3commons.logging.api.getClassLogger;
 			import org.bigbluebutton.common.events.LocaleChangeEvent;
 			import org.bigbluebutton.core.Options;
 			import org.bigbluebutton.core.UsersUtil;
 			import org.bigbluebutton.core.model.users.User2x;
 			import org.bigbluebutton.main.events.ShortcutEvent;
+			import org.bigbluebutton.main.model.users.events.ChangeMyRole;
 			import org.bigbluebutton.main.views.MainCanvas;
 			import org.bigbluebutton.modules.caption.events.RequestTranscriptsEvent;
 			import org.bigbluebutton.modules.caption.model.CaptionOptions;
@@ -57,13 +61,16 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.bigbluebutton.modules.caption.model.Transcripts;
 			import org.bigbluebutton.util.i18n.ResourceUtil;
 			
+			private static const LOGGER:ILogger = getClassLogger(CaptionWindow);
+			
 			[Bindable]
 			private var transcriptsCollection:ArrayCollection;
 			
 			[Bindable]
 			private var currentTranscript:Transcript;
 			
-			private var transcriptsObject:Transcripts;
+			private var activeTranscriptObject:Transcripts;
+			private var originalTranscriptsObject:Transcripts;
 			
 			private var transcriptOwnerChangeWatcher:ChangeWatcher;
 			
@@ -106,7 +113,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 			
 			private function setTranscripts(t:Transcripts):void {
-				transcriptsObject = t;
+				if (originalTranscriptsObject == null) {
+					originalTranscriptsObject = t;
+				}
+				
+				activeTranscriptObject = t;
 				
 				if (UsersUtil.amIModerator()) {
 					transcriptsCollection = new ArrayCollection();
@@ -148,7 +159,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 			
 			private function onLocaleChange(item:Object):void {
-				currentTranscript = transcriptsObject.findLocale(item.locale, item.localeCode);
+				currentTranscript = activeTranscriptObject.findLocale(item.locale, item.localeCode);
 				
 				optionsTab.setCurrentTranscript(currentTranscript);
 				textTab.setCurrentTranscript(currentTranscript);
@@ -210,6 +221,18 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				textTab.setFontSize(int(optionsTab.fontSizeCombo.selectedItem));
 				
 				captionTabs.addChildAt(textTab, 0);
+			}
+			
+			private function roleChanged(e:ChangeMyRole):void {
+				if (originalTranscriptsObject) {
+					// call setTranscripts again to reset the available list
+					setTranscripts(originalTranscriptsObject);
+				}
+				
+				if (currentTranscript) {
+					// call for a fake owner change to revalidate the moderator checking in the text tab
+					textTab.transcriptOwnerIDChange(currentTranscript.ownerID);
+				}
 			}
 			
 			private function localeChanged(e:Event):void{

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/caption/views/TextTab.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/caption/views/TextTab.as
@@ -394,6 +394,14 @@ package org.bigbluebutton.modules.caption.views {
 		}
 		
 		private function sendTextToServer():void {
+			/* Queue up the sending for the next refresh so that all key presses can be handled.
+			 * Avoids an issue where two updates can be triggered at once and get received in the
+			 * wrong order.
+			 */
+			callLater(actuallySendTextToServer);
+		}
+		
+		private function actuallySendTextToServer():void {
 			if (_startIndex >= 0) {
 				var editHistoryEvent:SendEditCaptionHistoryEvent = new SendEditCaptionHistoryEvent(SendEditCaptionHistoryEvent.SEND_EDIT_CAPTION_HISTORY);
 				editHistoryEvent.locale = currentTranscript.locale;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/RoomActionsRenderer.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/RoomActionsRenderer.mxml
@@ -7,7 +7,8 @@
          verticalAlign="middle"
          creationComplete="onCreationCompleteHandler(event)">
   <fx:Declarations>
-    <mate:Listener type="{BreakoutRoomsReadyEvent.BREAKOUT_ROOMS_READY_EVENT}" method="handleBreakoutRoomsReadyEvent" />	
+    <mate:Listener type="{BreakoutRoomsReadyEvent.BREAKOUT_ROOMS_READY_EVENT}" method="handleBreakoutRoomsReadyEvent" />
+    <mate:Listener type="{ChangeMyRole.CHANGE_MY_ROLE_EVENT}" method="roleChanged" />
   </fx:Declarations>
   <fx:Script>
     <![CDATA[
@@ -20,6 +21,7 @@
       import org.bigbluebutton.core.model.LiveMeeting;
       import org.bigbluebutton.main.events.BreakoutRoomEvent;
       import org.bigbluebutton.main.model.users.BreakoutRoom;
+      import org.bigbluebutton.main.model.users.events.ChangeMyRole;
       import org.bigbluebutton.util.i18n.ResourceUtil;
       
       private var globalDispatch:Dispatcher = new Dispatcher();
@@ -39,6 +41,10 @@
       
       private function handleBreakoutRoomsReadyEvent(event: BreakoutRoomsReadyEvent): void {
         breakoutRoomsReady = LiveMeeting.inst().breakoutRooms.breakoutRoomsReady;
+      }
+      
+      private function roleChanged(event: ChangeMyRole):void {
+        moderator = UsersUtil.amIModerator();
       }
       
       private function dataChangeHandler(event:FlexEvent):void {


### PR DESCRIPTION
This PR includes a rate limiter on the caption update sending that makes it so at most one update will be sent every frame. This change will hopefully mitigate an issue where the client would send out multiple updates in the same frame which sometimes resulted in the updates being received in the wrong order. See #6379.

The second update to make it so that the caption UI will update when the user's role is change from/to moderator. Previously the UI would only check the user's role when the window was created resulting in some bad interactions.

The third update that I tagged on is to fix the breakout room action renderer so that it updates when the local user's role changes. This change is very similar to the previous caption change. The action list would always show what it started with instead of updating dynamically.