### PR TITLE
Improve webcam picker

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/styles.scss
@@ -17,6 +17,10 @@
   display: flex;
 
   width: 30%;
+  @include mq("#{$small-only}") {
+    width: 100%;
+  }
+
   height: 100%;
 
   margin-right: 1.5rem;
@@ -25,6 +29,10 @@
 .content {
   display: flex;
   flex: 3;
+
+  @include mq("#{$small-only}") {
+    flex-direction: column;
+  }
 }
 
 .footer {
@@ -55,6 +63,9 @@
   border-radius: 5px;
   width: 100%;
   height: 8rem;
+  @include mq("#{$small-only}") {
+    height: 100%;
+  }
 }
 
 .row {

--- a/bigbluebutton-html5/imports/ui/components/video-preview/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/styles.scss
@@ -17,7 +17,7 @@
   display: flex;
 
   width: 30%;
-  @include mq("#{$small-only}") {
+  @include mq($small-only) {
     width: 100%;
   }
 
@@ -30,7 +30,7 @@
   display: flex;
   flex: 3;
 
-  @include mq("#{$small-only}") {
+  @include mq($small-only) {
     flex-direction: column;
   }
 }
@@ -63,7 +63,7 @@
   border-radius: 5px;
   width: 100%;
   height: 8rem;
-  @include mq("#{$small-only}") {
+  @include mq($small-only) {
     height: 100%;
   }
 }

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -176,6 +176,7 @@ class VideoProvider extends Component {
 
     window.removeEventListener('online', this.openWs);
     window.removeEventListener('offline', this.onWsClose);
+    window.removeEventListener('beforeunload', this.unshareWebcam);
 
     this.visibility.removeEventListeners();
 


### PR DESCRIPTION
This PR fixes #6251. It improves the mobile UI and makes sure we remove the event listener for `beforeunload`.