### PR TITLE
Fix broken locales on load

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/intl.jsx
+++ b/bigbluebutton-html5/imports/startup/client/intl.jsx
@@ -1,8 +1,43 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { IntlProvider } from 'react-intl';
+import { IntlProvider, addLocaleData } from 'react-intl';
 import Settings from '/imports/ui/services/settings';
 import LoadingScreen from '/imports/ui/components/loading-screen/component';
+
+// currently supported locales.
+import en from 'react-intl/locale-data/en';
+import uk from 'react-intl/locale-data/uk';
+import zh from 'react-intl/locale-data/zh';
+import ru from 'react-intl/locale-data/ru';
+import de from 'react-intl/locale-data/de';
+import fr from 'react-intl/locale-data/fr';
+import pt from 'react-intl/locale-data/pt';
+import fa from 'react-intl/locale-data/fa';
+import tr from 'react-intl/locale-data/tr';
+import ja from 'react-intl/locale-data/ja';
+import km from 'react-intl/locale-data/km';
+import es from 'react-intl/locale-data/es';
+import id from 'react-intl/locale-data/id';
+import el from 'react-intl/locale-data/el';
+import it from 'react-intl/locale-data/it';
+
+addLocaleData([
+  ...en,
+  ...uk,
+  ...zh,
+  ...ru,
+  ...de,
+  ...fr,
+  ...pt,
+  ...fa,
+  ...tr,
+  ...ja,
+  ...km,
+  ...es,
+  ...id,
+  ...el,
+  ...it,
+]);
 
 const propTypes = {
   locale: PropTypes.string,
@@ -29,14 +64,18 @@ class IntlStartup extends Component {
   }
 
   componentWillMount() {
-    this.fetchLocalizedMessages(this.props.locale);
+    const { locale } = this.props;
+    this.fetchLocalizedMessages(locale);
   }
 
   componentWillUpdate(nextProps) {
-    if (!this.state.fetching
-      && this.state.normalizedLocale
-      && nextProps.locale.toLowerCase() !== this.state.normalizedLocale.toLowerCase()) {
-      this.fetchLocalizedMessages(nextProps.locale);
+    const { fetching, normalizedLocale } = this.state;
+    const { locale } = nextProps;
+
+    if (!fetching
+      && normalizedLocale
+      && locale.toLowerCase() !== normalizedLocale.toLowerCase()) {
+      this.fetchLocalizedMessages(locale);
     }
   }
 
@@ -69,9 +108,12 @@ class IntlStartup extends Component {
   }
 
   render() {
-    return this.state.fetching ? <LoadingScreen /> : (
-      <IntlProvider locale={DEFAULT_LANGUAGE} messages={this.state.messages}>
-        {this.props.children}
+    const { fetching, normalizedLocale, messages } = this.state;
+    const { children } = this.props;
+
+    return fetching ? <LoadingScreen /> : (
+      <IntlProvider locale={normalizedLocale} messages={messages}>
+        {children}
       </IntlProvider>
     );
   }

--- a/bigbluebutton-html5/imports/startup/client/intl.jsx
+++ b/bigbluebutton-html5/imports/startup/client/intl.jsx
@@ -20,6 +20,8 @@ import es from 'react-intl/locale-data/es';
 import id from 'react-intl/locale-data/id';
 import el from 'react-intl/locale-data/el';
 import it from 'react-intl/locale-data/it';
+import bg from 'react-intl/locale-data/bg';
+
 
 addLocaleData([
   ...en,
@@ -37,6 +39,7 @@ addLocaleData([
   ...id,
   ...el,
   ...it,
+  ...bg,
 ]);
 
 const propTypes = {


### PR DESCRIPTION
Uses `addLocaleData` to register the available locale data module's with the locale data registry. Closes #6406