### PR TITLE
Fix audio in ios Webview

### DIFF
--- a/bigbluebutton-html5/client/compatibility/sip.js
+++ b/bigbluebutton-html5/client/compatibility/sip.js
@@ -11564,6 +11564,13 @@ MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
     self.ready = false;
     methodName = self.hasOffer('remote') ? 'createAnswer' : 'createOffer';
 
+    if(constraints.offerToReceiveAudio) {
+      //Needed for Safari on webview
+      try {
+        pc.addTransceiver('audio');
+      } catch (e) {}
+    }
+
     return SIP.Utils.promisify(pc, methodName, true)(constraints)
       .catch(function methodError(e) {
         self.emit('peerConnection-' + methodName + 'Failed', e);
@@ -11611,7 +11618,9 @@ MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
     try {
       streams = [].concat(streams);
       streams.forEach(function (stream) {
-        this.peerConnection.addStream(stream);
+        try {
+          this.peerConnection.addStream(stream);
+        } catch (e) {}
       }, this);
     } catch(e) {
       this.logger.error('error adding stream');

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -259,10 +259,8 @@ export default class SIPBridge extends BaseAudioBridge {
         },
       },
       RTCConstraints: {
-        mandatory: {
-          OfferToReceiveAudio: true,
-          OfferToReceiveVideo: false,
-        },
+        offerToReceiveAudio: true,
+        offerToReceiveVideo: false,
       },
     };
 
@@ -295,9 +293,9 @@ export default class SIPBridge extends BaseAudioBridge {
           });
         }
 
-        const mappedCause = cause in this.errorCodes ?
-          this.errorCodes[cause] :
-          this.baseErrorCodes.GENERIC_ERROR;
+        const mappedCause = cause in this.errorCodes
+          ? this.errorCodes[cause]
+          : this.baseErrorCodes.GENERIC_ERROR;
 
         return this.callback({
           status: this.baseCallStates.failed,

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/ios-webview-audio-polyfills.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/ios-webview-audio-polyfills.js
@@ -1,0 +1,100 @@
+const iosWebviewAudioPolyfills = function () {
+  function shimRemoteStreamsAPI(window) {
+    if (!('getRemoteStreams' in window.RTCPeerConnection.prototype)) {
+      window.RTCPeerConnection.prototype.getRemoteStreams = function () {
+        return this._remoteStreams ? this._remoteStreams : [];
+      };
+    }
+    if (!('onaddstream' in window.RTCPeerConnection.prototype)) {
+      Object.defineProperty(window.RTCPeerConnection.prototype, 'onaddstream', {
+        get: function get() {
+          return this._onaddstream;
+        },
+        set: function set(f) {
+          const _this3 = this;
+
+          if (this._onaddstream) {
+            this.removeEventListener('addstream', this._onaddstream);
+            this.removeEventListener('track', this._onaddstreampoly);
+          }
+          this.addEventListener('addstream', this._onaddstream = f);
+          this.addEventListener('track', this._onaddstreampoly = function (e) {
+            e.streams.forEach((stream) => {
+              if (!_this3._remoteStreams) {
+                _this3._remoteStreams = [];
+              }
+              if (_this3._remoteStreams.includes(stream)) {
+                return;
+              }
+              _this3._remoteStreams.push(stream);
+              const event = new Event('addstream');
+              event.stream = stream;
+              _this3.dispatchEvent(event);
+            });
+          });
+        },
+      });
+      const origSetRemoteDescription = window.RTCPeerConnection.prototype.setRemoteDescription;
+      window.RTCPeerConnection.prototype.setRemoteDescription = function () {
+        const pc = this;
+        if (!this._onaddstreampoly) {
+          this.addEventListener('track', this._onaddstreampoly = function (e) {
+            e.streams.forEach((stream) => {
+              if (!pc._remoteStreams) {
+                pc._remoteStreams = [];
+              }
+              if (pc._remoteStreams.indexOf(stream) >= 0) {
+                return;
+              }
+              pc._remoteStreams.push(stream);
+              const event = new Event('addstream');
+              event.stream = stream;
+              pc.dispatchEvent(event);
+            });
+          });
+        }
+        return origSetRemoteDescription.apply(pc, arguments);
+      };
+    }
+  }
+
+  function shimCallbacksAPI(window) {
+    const prototype = window.RTCPeerConnection.prototype;
+    const createOffer = prototype.createOffer;
+    const setLocalDescription = prototype.setLocalDescription;
+    const setRemoteDescription = prototype.setRemoteDescription;
+
+    prototype.createOffer = function (successCallback, failureCallback) {
+      const options = arguments.length >= 2 ? arguments[2] : arguments[0];
+      const promise = createOffer.apply(this, [options]);
+      if (!failureCallback) {
+        return promise;
+      }
+      promise.then(successCallback, failureCallback);
+      return Promise.resolve();
+    };
+
+    prototype.setLocalDescription = function withCallback(description, successCallback, failureCallback) {
+      const promise = setLocalDescription.apply(this, [description]);
+      if (!failureCallback) {
+        return promise;
+      }
+      promise.then(successCallback, failureCallback);
+      return Promise.resolve();
+    };
+
+    prototype.setRemoteDescription = function withCallback(description, successCallback, failureCallback) {
+      const promise = setRemoteDescription.apply(this, [description]);
+      if (!failureCallback) {
+        return promise;
+      }
+      promise.then(successCallback, failureCallback);
+      return Promise.resolve();
+    };
+  }
+
+  shimCallbacksAPI(window);
+  shimRemoteStreamsAPI(window);
+};
+
+export default iosWebviewAudioPolyfills;


### PR DESCRIPTION
This PR adds:
- Fix audio in ios Webview choosing the option "Listen Only"
- Stop asking for microphone permission when user choose "Listen Only" (in Safari)
- Add file "ios-webview-audio-polyfills.js", that's based on "https://github.com/webrtc/adapter/" library, containing only the necessary part of the library for this fix.
- Fix parameters used on webrtc (some parts of the code was different from what's in webRTC documentation). 