### PR TITLE
Fix Safari issue with processing ICE candidates for video

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -353,6 +353,9 @@ class VideoProvider extends Component {
         if (error) {
           return this.logger('debug', JSON.stringify(error), { cameraId: id });
         }
+
+        peer.didSDPAnswered = true;
+        this._processIceQueue(peer, id);
       });
     } else {
       this.logger('warn', '[startResponse] Message arrived after the peer was already thrown out, discarding it...');
@@ -508,9 +511,7 @@ class VideoProvider extends Component {
           };
           this.sendMessage(message);
 
-          this._processIceQueue(peer, id);
 
-          peer.didSDPAnswered = true;
         });
       });
       if (this.webRtcPeers[id].peerConnection) {


### PR DESCRIPTION
- Wait for SDP to be processed before adding candidates to peer on video
This was done to go around an issue reporting with webkit implementations that happened when we tried to add ICE candidates to the peer before the SDP was processed.
```
ERROR: clientLogger: [video] Error adding candidate: TypeError: Can only call RTCPeerConnection.addIceCandidate on instances of RTCPeerConnection https://..
```