### PR TITLE
Fixed incorrect error toast on screenshare presenter exit

### DIFF
--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -97,6 +97,10 @@ KurentoManager.prototype.exitScreenShare = function () {
       this.kurentoScreenshare.logger.info('  [exitScreenShare] Exiting screensharing');
     }
 
+    if(this.kurentoScreenshare.webRtcPeer) {
+      this.kurentoScreenshare.webRtcPeer.peerConnection.oniceconnectionstatechange = null;
+    }
+
     if (this.kurentoScreenshare.ws !== null) {
       this.kurentoScreenshare.ws.onclose = function () {};
       this.kurentoScreenshare.ws.close();


### PR DESCRIPTION
- Removed ICE state change listener on screenshare presenter exit

Sometimes an ICE connection error toast would pop when exiting screensharing because the listener wasn't correctly removed for the presenter.