### PR TITLE
Add support for getDisplayMedia on Chrome and Edge

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/kurento-extension.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-extension.js
@@ -618,6 +618,23 @@ window.getScreenConstraints = function (sendSource, callback) {
   screenConstraints.video.height = { max: kurentoManager.kurentoScreenshare.vid_max_height };
   screenConstraints.video.width = { max: kurentoManager.kurentoScreenshare.vid_max_width };
 
+  const getDisplayMediaConstraints = function () {
+    // The fine-grained constraints (e.g.: frameRate) are supposed to go into
+    // the MediaStream because getDisplayMedia does not support them,
+    // so they're passed differently
+    kurentoManager.kurentoScreenshare.extensionInstalled = true;
+    optionalConstraints.width = { max: kurentoManager.kurentoScreenshare.vid_max_width };
+    optionalConstraints.height = { max: kurentoManager.kurentoScreenshare.vid_max_height };
+    optionalConstraints.frameRate = { ideal: 5, max: 10 };
+
+    let gDPConstraints = {
+      video: true,
+      optional: optionalConstraints
+    }
+
+    return gDPConstraints;
+  };
+
   const optionalConstraints = [
     { googCpuOveruseDetection: true },
     { googCpuOveruseEncodeUsage: true },
@@ -652,21 +669,7 @@ window.getScreenConstraints = function (sendSource, callback) {
         callback(null, screenConstraints);
       }, chromeExtension);
     } else {
-      // Falls back to getDisplayMedia if the browser supports it
-      // The fine-grained constraints (e.g.: frameRate) are supposed to go into
-      // the MediaStream because getDisplayMedia does not support them,
-      // so they're passed differently
-      kurentoManager.kurentoScreenshare.extensionInstalled = true;
-      optionalConstraints.width = { max: kurentoManager.kurentoScreenshare.vid_max_width };
-      optionalConstraints.height = { max: kurentoManager.kurentoScreenshare.vid_max_height };
-      optionalConstraints.frameRate = { ideal: 5, max: 10 };
-
-      screenConstraints = {
-        video: true,
-        optional: optionalConstraints
-      }
-
-      callback(null, screenConstraints);
+      return callback(null, getDisplayMediaConstraints());
     }
   } else if (isFirefox) {
     screenConstraints.video.mediaSource = 'window';
@@ -674,12 +677,15 @@ window.getScreenConstraints = function (sendSource, callback) {
     console.log('getScreenConstraints for Firefox returns => ', screenConstraints);
     // now invoking native getUserMedia API
     callback(null, screenConstraints);
-  } else if (isSafari) {
+  } else if (isSafari && !hasDisplayMedia) {
     screenConstraints.video.mediaSource = 'screen';
 
     console.log('getScreenConstraints for Safari returns => ', screenConstraints);
     // now invoking native getUserMedia API
     callback(null, screenConstraints);
+  } else if (hasDisplayMedia) {
+    // Falls back to getDisplayMedia if the browser supports it
+    return callback(null, getDisplayMediaConstraints());
   }
 };
 

--- a/bigbluebutton-client/resources/prod/lib/kurento-extension.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-extension.js
@@ -2,6 +2,7 @@ const isFirefox = typeof window.InstallTrigger !== 'undefined';
 const isOpera = !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0;
 const isChrome = !!window.chrome && !isOpera;
 const isSafari = navigator.userAgent.indexOf('Safari') >= 0 && !isChrome;
+const hasDisplayMedia = typeof navigator.getDisplayMedia === 'function';
 const kurentoHandler = null;
 const SEND_ROLE = "send";
 const RECV_ROLE = "recv";
@@ -610,44 +611,63 @@ Kurento.normalizeCallback = function (callback) {
 
 // this function explains how to use above methods/objects
 window.getScreenConstraints = function (sendSource, callback) {
-  const screenConstraints = { video: {}, audio: false };
+  let screenConstraints = { video: {}, audio: false };
 
   // Limiting FPS to a range of 5-10 (5 ideal)
   screenConstraints.video.frameRate = { ideal: 5, max: 10 };
-
   screenConstraints.video.height = { max: kurentoManager.kurentoScreenshare.vid_max_height };
   screenConstraints.video.width = { max: kurentoManager.kurentoScreenshare.vid_max_width };
 
+  const optionalConstraints = [
+    { googCpuOveruseDetection: true },
+    { googCpuOveruseEncodeUsage: true },
+    { googCpuUnderuseThreshold: 55 },
+    { googCpuOveruseThreshold: 100 },
+    { googPayloadPadding: true },
+    { googScreencastMinBitrate: 600 },
+    { googHighStartBitrate: true },
+    { googHighBitrate: true },
+    { googVeryHighBitrate: true },
+  ];
+
   if (isChrome) {
-    getChromeScreenConstraints((constraints) => {
-      if (!constraints) {
-        document.dispatchEvent(new Event('installChromeExtension'));
-        return;
+    if (!hasDisplayMedia) {
+      getChromeScreenConstraints((constraints) => {
+        if (!constraints) {
+          document.dispatchEvent(new Event('installChromeExtension'));
+          return;
+        }
+
+        const sourceId = constraints.streamId;
+
+        kurentoManager.kurentoScreenshare.extensionInstalled = true;
+
+        // this statement sets gets 'sourceId" and sets "chromeMediaSourceId"
+        screenConstraints.video.chromeMediaSource = { exact: [sendSource] };
+        screenConstraints.video.chromeMediaSourceId = sourceId;
+        screenConstraints.optional = optionalConstraints;
+
+        console.log('getScreenConstraints for Chrome returns => ', screenConstraints);
+        // now invoking native getUserMedia API
+        callback(null, screenConstraints);
+      }, chromeExtension);
+    } else {
+      // Falls back to getDisplayMedia if the browser supports it
+      // The fine-grained constraints (e.g.: frameRate) are supposed to go into
+      // the MediaStream because getDisplayMedia does not support them,
+      // so they're passed differently
+      kurentoManager.kurentoScreenshare.extensionInstalled = true;
+      optionalConstraints.width = { max: kurentoManager.kurentoScreenshare.vid_max_width };
+      optionalConstraints.height = { max: kurentoManager.kurentoScreenshare.vid_max_height };
+      optionalConstraints.frameRate = { ideal: 5, max: 10 };
+
+      screenConstraints = {
+        video: true,
+        optional: optionalConstraints
       }
 
-      const sourceId = constraints.streamId;
-
-      kurentoManager.kurentoScreenshare.extensionInstalled = true;
-
-      // this statement sets gets 'sourceId" and sets "chromeMediaSourceId"
-      screenConstraints.video.chromeMediaSource = { exact: [sendSource] };
-      screenConstraints.video.chromeMediaSourceId = sourceId;
-      screenConstraints.optional = [
-        { googCpuOveruseDetection: true },
-        { googCpuOveruseEncodeUsage: true },
-        { googCpuUnderuseThreshold: 55 },
-        { googCpuOveruseThreshold: 100},
-        { googPayloadPadding: true },
-        { googScreencastMinBitrate: 600 },
-        { googHighStartBitrate: true },
-        { googHighBitrate: true },
-        { googVeryHighBitrate: true }
-      ];
-
-      console.log('getScreenConstraints for Chrome returns => ', screenConstraints);
-      // now invoking native getUserMedia API
       callback(null, screenConstraints);
-    }, chromeExtension);
+    }
   } else if (isFirefox) {
     screenConstraints.video.mediaSource = 'window';
 
@@ -734,6 +754,10 @@ window.checkIfIncognito = function(isIncognito, isNotIncognito = function () {})
 
 window.checkChromeExtInstalled = function (callback, chromeExtensionId) {
   callback = Kurento.normalizeCallback(callback);
+
+  if (hasDisplayMedia) {
+    return callback(true);
+  }
 
   if (typeof chrome === "undefined" || !chrome || !chrome.runtime) {
     // No API, so no extension for sure

--- a/bigbluebutton-client/resources/prod/lib/kurento-utils.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-utils.js
@@ -410,7 +410,16 @@ function WebRtcPeer(mode, options, callback) {
                     return callback(error);
                 constraints = [mediaConstraints];
                 constraints.unshift(constraints_);
-                getMedia(recursive.apply(undefined, constraints));
+                if (typeof navigator.getDisplayMedia === 'function') {
+                    navigator.getDisplayMedia(recursive.apply(undefined, constraints)).then(stream => {
+                        stream.getTracks()[0].applyConstraints(constraints[0].optional).then(() => {
+                            videoStream = stream;
+                            start();
+                        }).catch(callback);
+                    }).catch(callback);
+                } else {
+                    getMedia(recursive.apply(undefined, constraints));
+                }
             }, guid);
         }
     } else {
@@ -1045,7 +1054,7 @@ module.exports = function(stream, options) {
   harker.setInterval = function(i) {
     interval = i;
   };
-  
+
   harker.stop = function() {
     running = false;
     harker.emit('volume_change', -100, threshold);
@@ -1063,12 +1072,12 @@ module.exports = function(stream, options) {
   // and emit events if changed
   var looper = function() {
     setTimeout(function() {
-    
+
       //check if stop has been called
       if(!running) {
         return;
       }
-      
+
       var currentVolume = getMaxVolume(analyser, fftBins);
 
       harker.emit('volume_change', currentVolume, threshold);

--- a/bigbluebutton-client/resources/prod/lib/kurento-utils.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-utils.js
@@ -415,7 +415,10 @@ function WebRtcPeer(mode, options, callback) {
                         stream.getTracks()[0].applyConstraints(constraints[0].optional).then(() => {
                             videoStream = stream;
                             start();
-                        }).catch(callback);
+                        }).catch(() => {
+                          videoStream = stream;
+                          start();
+                        });
                     }).catch(callback);
                 } else {
                     getMedia(recursive.apply(undefined, constraints));

--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -3,6 +3,7 @@ const isOpera = !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0;
 const isChrome = !!window.chrome && !isOpera;
 const isSafari = navigator.userAgent.indexOf('Safari') >= 0 && !isChrome;
 const isElectron = navigator.userAgent.toLowerCase().indexOf(' electron/') > -1;
+const hasDisplayMedia = typeof navigator.getDisplayMedia === 'function';
 const kurentoHandler = null;
 
 Kurento = function (
@@ -620,7 +621,7 @@ Kurento.normalizeCallback = function (callback) {
 
 // this function explains how to use above methods/objects
 window.getScreenConstraints = function (sendSource, callback) {
-  const screenConstraints = { video: {}, audio: false };
+  let screenConstraints = { video: {}, audio: false };
 
   // Limiting FPS to a range of 5-10 (5 ideal)
   screenConstraints.video.frameRate = { ideal: 5, max: 10 };
@@ -669,25 +670,43 @@ window.getScreenConstraints = function (sendSource, callback) {
   }
 
   if (isChrome) {
-    const extensionKey = kurentoManager.getChromeExtensionKey();
-    getChromeScreenConstraints(extensionKey).then((constraints) => {
-      if (!constraints) {
-        document.dispatchEvent(new Event('installChromeExtension'));
-        return;
+    if (!hasDisplayMedia) {
+      const extensionKey = kurentoManager.getChromeExtensionKey();
+      getChromeScreenConstraints(extensionKey).then((constraints) => {
+        if (!constraints) {
+          document.dispatchEvent(new Event('installChromeExtension'));
+          return;
+        }
+
+        const sourceId = constraints.streamId;
+
+        kurentoManager.kurentoScreenshare.extensionInstalled = true;
+
+        // this statement sets gets 'sourceId" and sets "chromeMediaSourceId"
+        screenConstraints.video.chromeMediaSource = { exact: [sendSource] };
+        screenConstraints.video.chromeMediaSourceId = sourceId;
+        screenConstraints.optional = optionalConstraints;
+
+        console.log('getScreenConstraints for Chrome returns => ', screenConstraints);
+        return callback(null, screenConstraints);
+      });
+    } else {
+      // Falls back to getDisplayMedia if the browser supports it
+      // The fine-grained constraints (e.g.: frameRate) are supposed to go into
+      // the MediaStream because getDisplayMedia does not support them,
+      // so they're passed differently
+      kurentoManager.kurentoScreenshare.extensionInstalled = true;
+      optionalConstraints.width = { max: kurentoManager.kurentoScreenshare.vid_max_width };
+      optionalConstraints.height = { max: kurentoManager.kurentoScreenshare.vid_max_height };
+      optionalConstraints.frameRate = { ideal: 5, max: 10 };
+
+      screenConstraints = {
+        video: true,
+        optional: optionalConstraints
       }
 
-      const sourceId = constraints.streamId;
-
-      kurentoManager.kurentoScreenshare.extensionInstalled = true;
-
-      // this statement sets gets 'sourceId" and sets "chromeMediaSourceId"
-      screenConstraints.video.chromeMediaSource = { exact: [sendSource] };
-      screenConstraints.video.chromeMediaSourceId = sourceId;
-      screenConstraints.optional = optionalConstraints;
-
-      console.log('getScreenConstraints for Chrome returns => ', screenConstraints);
       return callback(null, screenConstraints);
-    });
+    }
   }
 
   if (isFirefox) {

--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -644,6 +644,23 @@ window.getScreenConstraints = function (sendSource, callback) {
     });
   };
 
+  const getDisplayMediaConstraints = function () {
+    // The fine-grained constraints (e.g.: frameRate) are supposed to go into
+    // the MediaStream because getDisplayMedia does not support them,
+    // so they're passed differently
+    kurentoManager.kurentoScreenshare.extensionInstalled = true;
+    optionalConstraints.width = { max: kurentoManager.kurentoScreenshare.vid_max_width };
+    optionalConstraints.height = { max: kurentoManager.kurentoScreenshare.vid_max_height };
+    optionalConstraints.frameRate = { ideal: 5, max: 10 };
+
+    let gDPConstraints = {
+      video: true,
+      optional: optionalConstraints
+    }
+
+    return gDPConstraints;
+  };
+
   const optionalConstraints = [
     { googCpuOveruseDetection: true },
     { googCpuOveruseEncodeUsage: true },
@@ -691,21 +708,7 @@ window.getScreenConstraints = function (sendSource, callback) {
         return callback(null, screenConstraints);
       });
     } else {
-      // Falls back to getDisplayMedia if the browser supports it
-      // The fine-grained constraints (e.g.: frameRate) are supposed to go into
-      // the MediaStream because getDisplayMedia does not support them,
-      // so they're passed differently
-      kurentoManager.kurentoScreenshare.extensionInstalled = true;
-      optionalConstraints.width = { max: kurentoManager.kurentoScreenshare.vid_max_width };
-      optionalConstraints.height = { max: kurentoManager.kurentoScreenshare.vid_max_height };
-      optionalConstraints.frameRate = { ideal: 5, max: 10 };
-
-      screenConstraints = {
-        video: true,
-        optional: optionalConstraints
-      }
-
-      return callback(null, screenConstraints);
+      return callback(null, getDisplayMediaConstraints());
     }
   }
 
@@ -717,9 +720,14 @@ window.getScreenConstraints = function (sendSource, callback) {
     return callback(null, screenConstraints);
   }
 
+  // Falls back to getDisplayMedia if the browser supports it
+  if (hasDisplayMedia) {
+    return callback(null, getDisplayMediaConstraints());
+  }
+
   if (isSafari) {
     // At this time (version 11.1), Safari doesn't support screenshare.
-    document.dispatchEvent(new Event('safariScreenshareNotSupported'));
+    return document.dispatchEvent(new Event('safariScreenshareNotSupported'));
   }
 };
 

--- a/bigbluebutton-html5/client/compatibility/kurento-utils.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-utils.js
@@ -432,7 +432,16 @@ function WebRtcPeer(mode, options, callback) {
                     return callback(error);
                 constraints = [mediaConstraints];
                 constraints.unshift(constraints_);
-                getMedia(recursive.apply(undefined, constraints));
+                if (typeof navigator.getDisplayMedia === 'function') {
+                    navigator.getDisplayMedia(recursive.apply(undefined, constraints)).then(stream => {
+                        stream.getTracks()[0].applyConstraints(constraints[0].optional).then(() => {
+                            videoStream = stream;
+                            start();
+                        }).catch(callback);
+                    }).catch(callback);
+                } else {
+                    getMedia(recursive.apply(undefined, constraints));
+                }
             }, guid);
         }
     } else {

--- a/bigbluebutton-html5/client/compatibility/kurento-utils.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-utils.js
@@ -437,7 +437,10 @@ function WebRtcPeer(mode, options, callback) {
                         stream.getTracks()[0].applyConstraints(constraints[0].optional).then(() => {
                             videoStream = stream;
                             start();
-                        }).catch(callback);
+                        }).catch(() => {
+                          videoStream = stream;
+                          start();
+                        });
                     }).catch(callback);
                 } else {
                     getMedia(recursive.apply(undefined, constraints));


### PR DESCRIPTION
This adds support for the new `navigator.getDisplayMedia` call on Google Chrome (edit: and Edge) which doesn't demand an extension for screensharing. This PR is backwards compatible with extension sharing: if the user is using an older version of Chrome, it'll fallback to the `chooseDesktopMedia` based screensharing.

This has been applied to both Flash and HTML5 clients. The advanced constraints we used (`goog*`) to better control quality and performance aren't supported by gDM, but I left them there in case they get supported in the future. The `frameRate`, `width` and `height` constraints aren't supported by gDM too, so I had to work around that by applying then manually as optional constraints to the `MediaStreamTrack` generated by the call.

Another thing that isn't supported yet by gDM is the specification of the display sources (`window`, `screen`, `tab`), so all three of them are enabled by default. We'll have to wait until Chrome implements the `displaySources` and `logicalSources` constraints according to the spec (or something along that line).