### PR TITLE
Add detection for a stalled connection with FF62+ and Win 10

### DIFF
--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -2,7 +2,7 @@ bbb.mainshell.locale.version = 0.9.0
 bbb.mainshell.statusProgress.connecting = Connecting to the server
 bbb.mainshell.statusProgress.loading = Loading
 bbb.mainshell.statusProgress.cannotConnectServer = Sorry, we cannot connect to the server.
-bbb.mainshell.statusProgress.connectingTimeout = Unable to establish a secure connection, try switching to Chrome.
+bbb.mainshell.statusProgress.connectingTimeout = Unable to establish a connection, try switching to Chrome or Edge.
 bbb.mainshell.copyrightLabel2 = (c) 2018 <a href='event:http://www.bigbluebutton.org/' target='_blank'><u>BigBlueButton Inc.</u></a> (build {0})
 bbb.mainshell.logBtn.toolTip = Open Log Window
 bbb.mainshell.meetingNotFound = Meeting Not Found

--- a/bigbluebutton-client/locale/en_US/bbbResources.properties
+++ b/bigbluebutton-client/locale/en_US/bbbResources.properties
@@ -2,6 +2,7 @@ bbb.mainshell.locale.version = 0.9.0
 bbb.mainshell.statusProgress.connecting = Connecting to the server
 bbb.mainshell.statusProgress.loading = Loading
 bbb.mainshell.statusProgress.cannotConnectServer = Sorry, we cannot connect to the server.
+bbb.mainshell.statusProgress.connectingTimeout = Unable to establish a secure connection, try switching to Chrome.
 bbb.mainshell.copyrightLabel2 = (c) 2018 <a href='event:http://www.bigbluebutton.org/' target='_blank'><u>BigBlueButton Inc.</u></a> (build {0})
 bbb.mainshell.logBtn.toolTip = Open Log Window
 bbb.mainshell.meetingNotFound = Meeting Not Found

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/PortTest.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/PortTest.as
@@ -180,6 +180,13 @@ package org.bigbluebutton.main.model
 			} catch( e : ArgumentError ) {
 				// Invalid parameters.
 				status = "ERROR: " + e.message;
+				
+				var logData2:Object = UsersUtil.initLogData();
+				logData2.uri = this.baseURI;
+				logData2.tags = ["initialization", "port-test", "connection"];
+				logData2.logCode = "port_test_connect_error";
+				logData2.message = e.message;
+				LOGGER.error(JSON.stringify(logData2));
 			}	
 		}
 		
@@ -250,7 +257,7 @@ package org.bigbluebutton.main.model
 
         if ( statusCode == "NetConnection.Connect.Success" ) {
             status = "SUCCESS";
-						logData.uri = this.baseURI;
+            logData.uri = this.baseURI;
             logData.logCode = "port_test_connected";
             LOGGER.info(JSON.stringify(logData));
 
@@ -258,14 +265,18 @@ package org.bigbluebutton.main.model
         } else if ( statusCode == "NetConnection.Connect.Rejected" ||
                     statusCode == "NetConnection.Connect.Failed" || 
                     statusCode == "NetConnection.Connect.Closed" ) {
-            logData.statusCode = statusCode;            
-						logData.uri = this.baseURI;
-						logData.logCode = "port_test_connect_failed";
+            logData.statusCode = statusCode;
+            logData.uri = this.baseURI;
+            logData.logCode = "port_test_connect_failed";
             LOGGER.info(JSON.stringify(logData));
 
             status = "FAILED";
             _connectionListener(status, tunnel, hostname, port, application);
-            
+        } else {
+            logData.statusCode = statusCode;
+            logData.uri = this.baseURI;
+            logData.logCode = "port_test_connect_unknown_status";
+            LOGGER.info(JSON.stringify(logData));
         }
         
         closeConnection();

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/modules/ModulesProxy.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/modules/ModulesProxy.as
@@ -104,7 +104,7 @@ package org.bigbluebutton.main.model.modules
 
 		public function portTestFailed(e:PortTestEvent):void {
 			if (!e.tunnel) {
-				if (e.hostname == getPortTestHost() && !StringUtils.isEmpty(getPortTestAlternateHost())) {
+				if (e.hostname == getPortTestHost() && !StringUtils.isEmpty(getPortTestAlternateHost()) && getPortTestAlternateHost() != getPortTestHost()) {
 					// try the alternate host
 					portTestProxy.connect(false /*tunnel*/, getPortTestAlternateHost(), "", getPortTestApplication(), getPortTestTimeout());
 				} else {

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/LoadingBar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/LoadingBar.mxml
@@ -22,7 +22,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 <mx:VBox xmlns:mate="http://mate.asfusion.com/"
 		 xmlns:fx="http://ns.adobe.com/mxml/2009"
-		 xmlns:mx="library://ns.adobe.com/flex/mx">
+		 xmlns:mx="library://ns.adobe.com/flex/mx"
+		 creationComplete="onCreationComplete()">
 
 	<fx:Declarations>
 		<mate:Listener type="{ModuleLoadEvent.MODULE_LOADING_STARTED}"
@@ -44,8 +45,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			import org.as3commons.logging.api.ILogger;
 			import org.as3commons.logging.api.getClassLogger;
 			import org.bigbluebutton.core.BBB;
+			import org.bigbluebutton.core.UsersUtil;
 			import org.bigbluebutton.main.events.ModuleLoadEvent;
 			import org.bigbluebutton.main.events.PortTestEvent;
+			import org.bigbluebutton.util.ConnUtil;
+			import org.bigbluebutton.util.browser.BrowserCheck;
 			import org.bigbluebutton.util.i18n.ResourceUtil;
 
 			private static const LOGGER:ILogger = getClassLogger(LoadingBar);
@@ -55,11 +59,19 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private var numModules:int = 0;
 
 			private var portUpdateStr:String = 'Connecting to the server';
+			
+			private var portTestTimeout:Timer = new Timer(10000, 1);
 
+			private function onCreationComplete():void {
+				portTestTimeout.addEventListener(TimerEvent.TIMER, loadingUpdateTimeout);
+			}
+			
 			private function moduleLoadingStarted(e:ModuleLoadEvent):void {
 				numModules = BBB.getConfigManager().config.numberOfModules();
 				loadingbarLabel.text = ResourceUtil.getInstance().getString('bbb.mainshell.statusProgress.loading');
 				this.visible = true;
+				
+				portTestTimeout.stop();
 			}
 
 			private function moduleLoadProgress(e:ModuleLoadEvent):void {
@@ -88,6 +100,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			private function testRTMP(e:PortTestEvent):void {
 				//- Cannot get locale string this early in loading process
 				loadingbarLabel.text = portUpdateStr; //ResourceUtil.getInstance().getString('bbb.mainshell.statusProgress.connecting');
+				
+				portTestTimeout.start();
 			}
 
 			private function testRTMPupdate(e:PortTestEvent):void {
@@ -98,10 +112,31 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 			private function tunnelingFailed(e:PortTestEvent):void {
 				loadingbarLabel.text = ResourceUtil.getInstance().getString('bbb.mainshell.statusProgress.cannotConnectServer');
+				
+				portTestTimeout.stop();
 			}
 			
 			public function loadingFailed(message:String):void {
 				loadingbarLabel.text = message;
+				
+				portTestTimeout.stop();
+			}
+			
+			private function loadingUpdateTimeout(e:TimerEvent):void {
+				// Have to figure out the protocol first
+				var hostname:String = BBB.initConnectionManager().portTestHost;
+				var pattern:RegExp = /(?P<protocol>.+):\/\/(?P<server>.+)/;
+				var result:Array = pattern.exec(hostname);
+				
+				if (Capabilities.os == "Windows 10" && BrowserCheck.isFirefox() && BrowserCheck.browserMajorVersion >= "62" && result.protocol == ConnUtil.RTMPS) {
+					loadingbarLabel.text = ResourceUtil.getInstance().getString("bbb.mainshell.statusProgress.connectingTimeout");
+					
+					var logData:Object = UsersUtil.initLogData();
+					logData.tags = ["initialization", "loading-bar", "connection"];
+					logData.message = "Timeout expired while waiting for the port test";
+					logData.logCode = "loading_bar_timeout_hit";
+					LOGGER.info(JSON.stringify(logData));
+				}
 			}
 		]]>
 	</fx:Script>


### PR DESCRIPTION
In some scenarios with FF 62+, Win 10, and RTMPS the connection will stall without any warnings or other messages. This PR adds a 10s timer that will show a recommendation to try Chrome when the conditions are met.

I also added some extra log messages to some edge cases in the port test logic that previously didn't have any.