### PR TITLE
 BBB-web: add allowRequestsWithoutSession=false to handle missing cookie

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -80,6 +80,7 @@ public class ParamsProcessorUtil {
     private String html5ClientUrl;
     private Boolean moderatorsJoinViaHTML5Client;
     private Boolean attendeesJoinViaHTML5Client;
+    private Boolean allowRequestsWithoutSession;
     private String defaultAvatarURL;
     private String defaultConfigURL;
     private String defaultGuestPolicy;
@@ -419,6 +420,10 @@ public class ParamsProcessorUtil {
 
 	public Boolean getModeratorsJoinViaHTML5Client() {
 		return moderatorsJoinViaHTML5Client;
+	}
+
+	public Boolean getAllowRequestsWithoutSession() {
+		return allowRequestsWithoutSession;
 	}
 
 	public String getDefaultConfigXML() {
@@ -773,6 +778,10 @@ public class ParamsProcessorUtil {
 
 	public void setModeratorsJoinViaHTML5Client(Boolean moderatorsJoinViaHTML5Client) {
 		this.moderatorsJoinViaHTML5Client = moderatorsJoinViaHTML5Client;
+	}
+
+	public void setAllowRequestsWithoutSession(Boolean allowRequestsWithoutSession) {
+		this.allowRequestsWithoutSession = allowRequestsWithoutSession;
 	}
 
 	public void setAttendeesJoinViaHTML5Client(Boolean attendeesJoinViaHTML5Client) {

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -201,7 +201,7 @@ bigbluebutton.web.logoutURL=default
 defaultClientUrl=${bigbluebutton.web.serverURL}/client/BigBlueButton.html
 
 # Allow requests without JSESSIONID to be handled (default = false)
-allowRequestsWithoutSession=true
+allowRequestsWithoutSession=false
 
 # Force all attendees to join the meeting using the HTML5 client
 attendeesJoinViaHTML5Client=false

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -200,6 +200,9 @@ bigbluebutton.web.logoutURL=default
 # successfully joining the meeting.
 defaultClientUrl=${bigbluebutton.web.serverURL}/client/BigBlueButton.html
 
+# Allow requests without JSESSIONID to be handled (default = false)
+allowRequestsWithoutSession=true
+
 # Force all attendees to join the meeting using the HTML5 client
 attendeesJoinViaHTML5Client=false
 

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -109,6 +109,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="defaultClientUrl" value="${defaultClientUrl}"/>
         <property name="defaultGuestWaitURL" value="${defaultGuestWaitURL}"/>
         <property name="html5ClientUrl" value="${html5ClientUrl}"/>
+        <property name="allowRequestsWithoutSession" value="${allowRequestsWithoutSession}"/>
         <property name="moderatorsJoinViaHTML5Client" value="${moderatorsJoinViaHTML5Client}"/>
         <property name="attendeesJoinViaHTML5Client" value="${attendeesJoinViaHTML5Client}"/>
         <property name="defaultMeetingDuration" value="${defaultMeetingDuration}"/>

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1419,10 +1419,15 @@ class ApiController {
     Meeting meeting = null;
     UserSession userSession = null;
 
+    Boolean allowEnterWithoutSession = false;
+    // Depending on configuration, allow ENTER requests to proceed without session
+    if (paramsProcessorUtil.getAllowRequestsWithoutSession()) {
+      allowEnterWithoutSession = paramsProcessorUtil.getAllowRequestsWithoutSession();
+    }
+
     String respMessage = "Session " + sessionToken + " not found."
-    if (!session[sessionToken]) {
-      reject = true;
-    } else if (meetingService.getUserSessionWithAuthToken(sessionToken) == null) {
+
+    if (meetingService.getUserSessionWithAuthToken(sessionToken) == null || (!allowEnterWithoutSession && !session[sessionToken])) {
       reject = true;
       respMessage = "Session " + sessionToken + " not found."
     } else {
@@ -1562,9 +1567,13 @@ class ApiController {
       println("Session token = [" + sessionToken + "]")
     }
 
-    if (!session[sessionToken]) {
-      reject = true;
-    } else if (meetingService.getUserSessionWithAuthToken(sessionToken) == null)
+    Boolean allowStunsWithoutSession = false;
+    // Depending on configuration, allow STUNS requests to proceed without session
+    if (paramsProcessorUtil.getAllowRequestsWithoutSession()) {
+      allowStunsWithoutSession = paramsProcessorUtil.getAllowRequestsWithoutSession();
+    }
+
+    if (meetingService.getUserSessionWithAuthToken(sessionToken) == null || (!allowStunsWithoutSession && !session[sessionToken]))
       reject = true;
     else {
       us = meetingService.getUserSessionWithAuthToken(sessionToken);

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1573,9 +1573,9 @@ class ApiController {
       allowStunsWithoutSession = paramsProcessorUtil.getAllowRequestsWithoutSession();
     }
 
-    if (meetingService.getUserSessionWithAuthToken(sessionToken) == null || (!allowStunsWithoutSession && !session[sessionToken]))
+    if (meetingService.getUserSessionWithAuthToken(sessionToken) == null || (!allowStunsWithoutSession && !session[sessionToken])) {
       reject = true;
-    else {
+    } else {
       us = meetingService.getUserSessionWithAuthToken(sessionToken);
       meeting = meetingService.getMeeting(us.meetingID);
       if (meeting == null || meeting.isForciblyEnded()) {


### PR DESCRIPTION
Particularly common in Safari when loading html5 client inside iframe
Closes #6433 
Reasoning - Enter API failed, resulted in no useful data sent to client, unable to authenticate