### PR TITLE
Replace double quotes in audio name with single quotes

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/bbb_webrtc_bridge_sip.js
+++ b/bigbluebutton-client/resources/prod/lib/bbb_webrtc_bridge_sip.js
@@ -80,6 +80,8 @@ function callIntoConference(voiceBridge, callback, isListenOnly, stunTurn = null
 			} else {
 				voiceBridge = conferenceVoiceBridge;
 			}
+			callerIdName = callerIdName.replace(/"/g, "'");
+
 			console.log(callerIdName);
 			webrtc_call(callerIdName, voiceBridge, callback, isListenOnly);
 		});

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -102,7 +102,7 @@ export default class SIPBridge extends BaseAudioBridge {
       isListenOnly ? `LISTENONLY-${name}` : name,
     ].join('-');
 
-    this.user.callerIdName = callerIdName;
+    this.user.callerIdName = callerIdName.replace(/"/g, "'");
     this.callOptions = options;
 
     return fetchStunTurnServers(sessionToken)


### PR DESCRIPTION
If a user had a quote in their name (commonly used for nicknames) they were unable to join audio because sip.js would reject it. This PR replaces any instance of " with ' in the user name which will get around the block without greatly changing semantics.