### PR TITLE
Fix a problem with ejected user when private chat is locked.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/component.jsx
@@ -66,6 +66,7 @@ class UserList extends PureComponent {
       showBranding,
       hasBreakoutRoom,
       getUsersId,
+      hasPrivateChatBetweenUsers,
     } = this.props;
 
     return (
@@ -101,6 +102,7 @@ class UserList extends PureComponent {
           getEmoji,
           hasBreakoutRoom,
           getUsersId,
+          hasPrivateChatBetweenUsers,
         }
       }
         />}

--- a/bigbluebutton-html5/imports/ui/components/user-list/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/container.jsx
@@ -55,4 +55,5 @@ export default withTracker(({ chatID, compact }) => ({
   getEmojiList: Service.getEmojiList(),
   getEmoji: Service.getEmoji(),
   showBranding: getFromUserSettings('displayBrandingArea', Meteor.settings.public.app.branding.displayBrandingArea),
+  hasPrivateChatBetweenUsers: Service.hasPrivateChatBetweenUsers,
 }))(UserListContainer);

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -428,10 +428,11 @@ const roving = (event, itemCount, changeState) => {
   }
 };
 
-const getGroupChatPrivate = (sender, receiver) => {
-  const privateChat = GroupChat.findOne({ users: { $all: [receiver.id, sender.id] } });
+const hasPrivateChatBetweenUsers = (sender, receiver) => GroupChat
+  .findOne({ users: { $all: [receiver.id, sender.id] } });
 
-  if (!privateChat) {
+const getGroupChatPrivate = (sender, receiver) => {
+  if (!hasPrivateChatBetweenUsers(sender, receiver)) {
     makeCall('createGroupChat', receiver);
   }
 };
@@ -465,4 +466,5 @@ export default {
   isUserModerator,
   getEmojiList: () => EMOJI_STATUSES,
   getEmoji: () => Users.findOne({ userId: Auth.userID }).emoji,
+  hasPrivateChatBetweenUsers,
 };

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
@@ -67,6 +67,7 @@ class UserContent extends PureComponent {
       forcePollOpen,
       hasBreakoutRoom,
       getUsersId,
+      hasPrivateChatBetweenUsers,
     } = this.props;
 
     return (
@@ -119,6 +120,7 @@ class UserContent extends PureComponent {
             getEmoji,
             getGroupChatPrivate,
             getUsersId,
+            hasPrivateChatBetweenUsers,
           }}
         />
       </div>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
@@ -125,6 +125,7 @@ class UserParticipants extends Component {
       getEmojiList,
       getEmoji,
       users,
+      hasPrivateChatBetweenUsers,
     } = this.props;
 
     let index = -1;
@@ -159,6 +160,7 @@ class UserParticipants extends Component {
               toggleVoice,
               changeRole,
               getGroupChatPrivate,
+              hasPrivateChatBetweenUsers,
             }}
             userId={u}
             getScrollContainerRef={this.getScrollContainerRef}

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
@@ -46,9 +46,10 @@ class UserListItem extends PureComponent {
       removeUser,
       setEmojiStatus,
       toggleVoice,
+      hasPrivateChatBetweenUsers,
     } = this.props;
 
-    const { meetingId } = meeting;
+    const { meetingId, lockSettingsProp } = meeting;
 
     const contents = (<UserDropdown
       {...{
@@ -66,11 +67,13 @@ class UserListItem extends PureComponent {
         isBreakoutRoom,
         isMeetingLocked,
         meetingId,
+        lockSettingsProp,
         normalizeEmojiName,
         removeUser,
         setEmojiStatus,
         toggleVoice,
         user,
+        hasPrivateChatBetweenUsers,
       }}
     />);
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
@@ -194,6 +194,8 @@ class UserDropdown extends PureComponent {
       removeUser,
       toggleVoice,
       changeRole,
+      lockSettingsProp,
+      hasPrivateChatBetweenUsers,
     } = this.props;
 
     const { showNestedOptions } = this.state;
@@ -212,6 +214,13 @@ class UserDropdown extends PureComponent {
       allowedToDemote,
       allowedToChangeStatus,
     } = actionPermissions;
+
+    const { disablePrivChat } = lockSettingsProp;
+
+    const enablePrivateChat = currentUser.isModerator
+      ? allowedToChatPrivately
+      : allowedToChatPrivately
+      && (!disablePrivChat || (disablePrivChat && hasPrivateChatBetweenUsers(currentUser, user)));
 
     if (showNestedOptions) {
       if (allowedToChangeStatus) {
@@ -246,7 +255,7 @@ class UserDropdown extends PureComponent {
       ));
     }
 
-    if (allowedToChatPrivately) {
+    if (enablePrivateChat) {
       actions.push(this.makeDropdownItem(
         'openChat',
         intl.formatMessage(messages.ChatLabel),


### PR DESCRIPTION
This PR fix a problem with some users getting ejected after try to initiate a private chat when private chat is locked. Update the UI when private chat is locked to only show this action when the users already had a private chat conversation.(only affect viewers, moderators still see the action every time)

Issue: #6434 