### PR TITLE
Wait until the media is ready before initializing the acorn player.

### DIFF
--- a/record-and-playback/presentation/playback/presentation/2.0/playback.js
+++ b/record-and-playback/presentation/playback/presentation/2.0/playback.js
@@ -531,16 +531,6 @@ function loadPlayback() {
     loadAudio();
   }
 
-  // load up the acorn controls
-  logger.info("==Loading acorn media player");
-  $('#video').acornMediaPlayer({
-    theme: 'bigbluebutton',
-    volumeSlider: 'vertical'
-  });
-  $('#video').on("swap", function() {
-    swapVideoPresentation();
-  });
-
   if (hasDeskshare) {
     loadDeskshare();
   } else {
@@ -802,6 +792,16 @@ document.addEventListener('playback-ready', function(event) {
   if (dataReady && mediaReady && contentReady) {
     runPopcorn();
     if (firstLoad) {
+      // load up the acorn controls
+      logger.info("==Loading acorn media player");
+      $('#video').acornMediaPlayer({
+        theme: 'bigbluebutton',
+        volumeSlider: 'vertical'
+      });
+      $('#video').on("swap", function() {
+        swapVideoPresentation();
+      });
+
       initPopcorn();
     }
   }


### PR DESCRIPTION
Previously, the acorn player was being initialized before the asynchronous
load of captions information completed, meaning that the acorn player didn't
know there were caption tracks, and the CC selector control wasn't available.

Fixes #6463