### PR TITLE
Backport of getDisplayMedia support (#6490) and Chrome screenshare fixes

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/kurento-extension.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-extension.js
@@ -632,6 +632,23 @@ window.getScreenConstraints = function (sendSource, callback) {
   screenConstraints.video.height = { max: kurentoManager.kurentoScreenshare.vid_max_height };
   screenConstraints.video.width = { max: kurentoManager.kurentoScreenshare.vid_max_width };
 
+  const getDisplayMediaConstraints = function () {
+    // The fine-grained constraints (e.g.: frameRate) are supposed to go into
+    // the MediaStream because getDisplayMedia does not support them,
+    // so they're passed differently
+    kurentoManager.kurentoScreenshare.extensionInstalled = true;
+    optionalConstraints.width = { max: kurentoManager.kurentoScreenshare.vid_max_width };
+    optionalConstraints.height = { max: kurentoManager.kurentoScreenshare.vid_max_height };
+    optionalConstraints.frameRate = { ideal: 5, max: 10 };
+
+    let gDPConstraints = {
+      video: true,
+      optional: optionalConstraints
+    }
+
+    return gDPConstraints;
+  };
+
   const optionalConstraints = [
     { googCpuOveruseDetection: true },
     { googCpuOveruseEncodeUsage: true },
@@ -666,21 +683,7 @@ window.getScreenConstraints = function (sendSource, callback) {
         callback(null, screenConstraints);
       }, chromeExtension);
     } else {
-      // Falls back to getDisplayMedia if the browser supports it
-      // The fine-grained constraints (e.g.: frameRate) are supposed to go into
-      // the MediaStream because getDisplayMedia does not support them,
-      // so they're passed differently
-      kurentoManager.kurentoScreenshare.extensionInstalled = true;
-      optionalConstraints.width = { max: kurentoManager.kurentoScreenshare.vid_max_width };
-      optionalConstraints.height = { max: kurentoManager.kurentoScreenshare.vid_max_height };
-      optionalConstraints.frameRate = { ideal: 5, max: 10 };
-
-      screenConstraints = {
-        video: true,
-        optional: optionalConstraints
-      }
-
-      callback(null, screenConstraints);
+      return callback(null, getDisplayMediaConstraints());
     }
   } else if (isFirefox) {
     screenConstraints.video.mediaSource = 'window';
@@ -688,12 +691,15 @@ window.getScreenConstraints = function (sendSource, callback) {
     console.log('getScreenConstraints for Firefox returns => ', screenConstraints);
     // now invoking native getUserMedia API
     callback(null, screenConstraints);
-  } else if (isSafari) {
+  } else if (isSafari && !hasDisplayMedia) {
     screenConstraints.video.mediaSource = 'screen';
 
     console.log('getScreenConstraints for Safari returns => ', screenConstraints);
     // now invoking native getUserMedia API
     callback(null, screenConstraints);
+  } else if (hasDisplayMedia) {
+    // Falls back to getDisplayMedia if the browser supports it
+    return callback(null, getDisplayMediaConstraints());
   }
 };
 

--- a/bigbluebutton-client/resources/prod/lib/kurento-extension.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-extension.js
@@ -673,9 +673,14 @@ window.getScreenConstraints = function (sendSource, callback) {
 
         kurentoManager.kurentoScreenshare.extensionInstalled = true;
 
-        // this statement sets gets 'sourceId" and sets "chromeMediaSourceId"
-        screenConstraints.video.chromeMediaSource = { exact: [sendSource] };
-        screenConstraints.video.chromeMediaSourceId = sourceId;
+        // Re-wrap the video constraints into the mandatory object (latest adapter)
+        screenConstraints.video = {}
+        screenConstraints.video.mandatory = {};
+        screenConstraints.video.mandatory.maxFrameRate = 10;
+        screenConstraints.video.mandatory.maxHeight = kurentoManager.kurentoScreenshare.vid_max_height;
+        screenConstraints.video.mandatory.maxWidth = kurentoManager.kurentoScreenshare.vid_max_width;
+        screenConstraints.video.mandatory.chromeMediaSource = sendSource;
+        screenConstraints.video.mandatory.chromeMediaSourceId = sourceId;
         screenConstraints.optional = optionalConstraints;
 
         console.log('getScreenConstraints for Chrome returns => ', screenConstraints);

--- a/bigbluebutton-client/resources/prod/lib/kurento-extension.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-extension.js
@@ -2,7 +2,8 @@ const isFirefox = typeof window.InstallTrigger !== 'undefined';
 const isOpera = !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0;
 const isChrome = !!window.chrome && !isOpera;
 const isSafari = navigator.userAgent.indexOf('Safari') >= 0 && !isChrome;
-const hasDisplayMedia = typeof navigator.getDisplayMedia === 'function';
+const hasDisplayMedia = (typeof navigator.getDisplayMedia === 'function'
+  || typeof navigator.mediaDevices.getDisplayMedia === 'function');
 const kurentoHandler = null;
 const SEND_ROLE = "send";
 const RECV_ROLE = "recv";

--- a/bigbluebutton-client/resources/prod/lib/kurento-utils.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-utils.js
@@ -410,7 +410,16 @@ function WebRtcPeer(mode, options, callback) {
                     return callback(error);
                 constraints = [mediaConstraints];
                 constraints.unshift(constraints_);
-                getMedia(recursive.apply(undefined, constraints));
+                if (typeof navigator.getDisplayMedia === 'function') {
+                    navigator.getDisplayMedia(recursive.apply(undefined, constraints)).then(stream => {
+                        stream.getTracks()[0].applyConstraints(constraints[0].optional).then(() => {
+                            videoStream = stream;
+                            start();
+                        }).catch(callback);
+                    }).catch(callback);
+                } else {
+                    getMedia(recursive.apply(undefined, constraints));
+                }
             }, guid);
         }
     } else {
@@ -1045,7 +1054,7 @@ module.exports = function(stream, options) {
   harker.setInterval = function(i) {
     interval = i;
   };
-  
+
   harker.stop = function() {
     running = false;
     harker.emit('volume_change', -100, threshold);
@@ -1063,12 +1072,12 @@ module.exports = function(stream, options) {
   // and emit events if changed
   var looper = function() {
     setTimeout(function() {
-    
+
       //check if stop has been called
       if(!running) {
         return;
       }
-      
+
       var currentVolume = getMaxVolume(analyser, fftBins);
 
       harker.emit('volume_change', currentVolume, threshold);

--- a/bigbluebutton-client/resources/prod/lib/kurento-utils.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-utils.js
@@ -415,7 +415,10 @@ function WebRtcPeer(mode, options, callback) {
                         stream.getTracks()[0].applyConstraints(constraints[0].optional).then(() => {
                             videoStream = stream;
                             start();
-                        }).catch(callback);
+                        }).catch(() => {
+                          videoStream = stream;
+                          start();
+                        });
                     }).catch(callback);
                 } else {
                     getMedia(recursive.apply(undefined, constraints));

--- a/bigbluebutton-client/resources/prod/lib/kurento-utils.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-utils.js
@@ -410,16 +410,24 @@ function WebRtcPeer(mode, options, callback) {
                     return callback(error);
                 constraints = [mediaConstraints];
                 constraints.unshift(constraints_);
-                if (typeof navigator.getDisplayMedia === 'function') {
-                    navigator.getDisplayMedia(recursive.apply(undefined, constraints)).then(stream => {
-                        stream.getTracks()[0].applyConstraints(constraints[0].optional).then(() => {
+                let gDMCallback = function(stream) {
+                    stream.getTracks()[0].applyConstraints(constraints[0].optional)
+                        .then(() => {
                             videoStream = stream;
                             start();
                         }).catch(() => {
-                          videoStream = stream;
-                          start();
+                            videoStream = stream;
+                            start();
                         });
-                    }).catch(callback);
+                }
+                if (typeof navigator.getDisplayMedia === 'function') {
+                    navigator.getDisplayMedia(recursive.apply(undefined, constraints))
+                        .then(gDMCallback)
+                        .catch(callback);
+                } else if (typeof navigator.mediaDevices.getDisplayMedia === 'function') {
+                    navigator.mediaDevices.getDisplayMedia(recursive.apply(undefined, constraints))
+                        .then(gDMCallback)
+                        .catch(callback);
                 } else {
                     getMedia(recursive.apply(undefined, constraints));
                 }

--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -639,6 +639,23 @@ window.getScreenConstraints = function (sendSource, callback) {
     });
   };
 
+  const getDisplayMediaConstraints = function () {
+    // The fine-grained constraints (e.g.: frameRate) are supposed to go into
+    // the MediaStream because getDisplayMedia does not support them,
+    // so they're passed differently
+    kurentoManager.kurentoScreenshare.extensionInstalled = true;
+    optionalConstraints.width = { max: kurentoManager.kurentoScreenshare.vid_max_width };
+    optionalConstraints.height = { max: kurentoManager.kurentoScreenshare.vid_max_height };
+    optionalConstraints.frameRate = { ideal: 5, max: 10 };
+
+    let gDPConstraints = {
+      video: true,
+      optional: optionalConstraints
+    }
+
+    return gDPConstraints;
+  };
+
   const optionalConstraints = [
     { googCpuOveruseDetection: true },
     { googCpuOveruseEncodeUsage: true },
@@ -674,21 +691,7 @@ window.getScreenConstraints = function (sendSource, callback) {
         return callback(null, screenConstraints);
       });
     } else {
-      // Falls back to getDisplayMedia if the browser supports it
-      // The fine-grained constraints (e.g.: frameRate) are supposed to go into
-      // the MediaStream because getDisplayMedia does not support them,
-      // so they're passed differently
-      kurentoManager.kurentoScreenshare.extensionInstalled = true;
-      optionalConstraints.width = { max: kurentoManager.kurentoScreenshare.vid_max_width };
-      optionalConstraints.height = { max: kurentoManager.kurentoScreenshare.vid_max_height };
-      optionalConstraints.frameRate = { ideal: 5, max: 10 };
-
-      screenConstraints = {
-        video: true,
-        optional: optionalConstraints
-      }
-
-      return callback(null, screenConstraints);
+      return callback(null, getDisplayMediaConstraints());
     }
   }
 
@@ -700,9 +703,14 @@ window.getScreenConstraints = function (sendSource, callback) {
     return callback(null, screenConstraints);
   }
 
+  // Falls back to getDisplayMedia if the browser supports it
+  if (hasDisplayMedia) {
+    return callback(null, getDisplayMediaConstraints());
+  }
+
   if (isSafari) {
     // At this time (version 11.1), Safari doesn't support screenshare.
-    document.dispatchEvent(new Event('safariScreenshareNotSupported'));
+    return document.dispatchEvent(new Event('safariScreenshareNotSupported'));
   }
 };
 

--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -2,7 +2,8 @@ const isFirefox = typeof window.InstallTrigger !== 'undefined';
 const isOpera = !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0;
 const isChrome = !!window.chrome && !isOpera;
 const isSafari = navigator.userAgent.indexOf('Safari') >= 0 && !isChrome;
-const hasDisplayMedia = typeof navigator.getDisplayMedia === 'function';
+const hasDisplayMedia = (typeof navigator.getDisplayMedia === 'function'
+  || typeof navigator.mediaDevices.getDisplayMedia === 'function');
 const kurentoHandler = null;
 
 Kurento = function (

--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -2,6 +2,7 @@ const isFirefox = typeof window.InstallTrigger !== 'undefined';
 const isOpera = !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0;
 const isChrome = !!window.chrome && !isOpera;
 const isSafari = navigator.userAgent.indexOf('Safari') >= 0 && !isChrome;
+const hasDisplayMedia = typeof navigator.getDisplayMedia === 'function';
 const kurentoHandler = null;
 
 Kurento = function (
@@ -615,7 +616,7 @@ Kurento.normalizeCallback = function (callback) {
 
 // this function explains how to use above methods/objects
 window.getScreenConstraints = function (sendSource, callback) {
-  const screenConstraints = { video: {}, audio: false };
+  let screenConstraints = { video: {}, audio: false };
 
   // Limiting FPS to a range of 5-10 (5 ideal)
   screenConstraints.video.frameRate = { ideal: 5, max: 10 };
@@ -638,36 +639,57 @@ window.getScreenConstraints = function (sendSource, callback) {
     });
   };
 
+  const optionalConstraints = [
+    { googCpuOveruseDetection: true },
+    { googCpuOveruseEncodeUsage: true },
+    { googCpuUnderuseThreshold: 55 },
+    { googCpuOveruseThreshold: 100 },
+    { googPayloadPadding: true },
+    { googScreencastMinBitrate: 600 },
+    { googHighStartBitrate: true },
+    { googHighBitrate: true },
+    { googVeryHighBitrate: true },
+  ];
+
+
   if (isChrome) {
-    const extensionKey = kurentoManager.getChromeExtensionKey();
-    getChromeScreenConstraints(extensionKey).then((constraints) => {
-      if (!constraints) {
-        document.dispatchEvent(new Event('installChromeExtension'));
-        return;
+    if (!hasDisplayMedia) {
+      const extensionKey = kurentoManager.getChromeExtensionKey();
+      getChromeScreenConstraints(extensionKey).then((constraints) => {
+        if (!constraints) {
+          document.dispatchEvent(new Event('installChromeExtension'));
+          return;
+        }
+
+        const sourceId = constraints.streamId;
+
+        kurentoManager.kurentoScreenshare.extensionInstalled = true;
+
+        // this statement sets gets 'sourceId" and sets "chromeMediaSourceId"
+        screenConstraints.video.chromeMediaSource = { exact: [sendSource] };
+        screenConstraints.video.chromeMediaSourceId = sourceId;
+        screenConstraints.optional = optionalConstraints;
+
+        console.log('getScreenConstraints for Chrome returns => ', screenConstraints);
+        return callback(null, screenConstraints);
+      });
+    } else {
+      // Falls back to getDisplayMedia if the browser supports it
+      // The fine-grained constraints (e.g.: frameRate) are supposed to go into
+      // the MediaStream because getDisplayMedia does not support them,
+      // so they're passed differently
+      kurentoManager.kurentoScreenshare.extensionInstalled = true;
+      optionalConstraints.width = { max: kurentoManager.kurentoScreenshare.vid_max_width };
+      optionalConstraints.height = { max: kurentoManager.kurentoScreenshare.vid_max_height };
+      optionalConstraints.frameRate = { ideal: 5, max: 10 };
+
+      screenConstraints = {
+        video: true,
+        optional: optionalConstraints
       }
 
-      const sourceId = constraints.streamId;
-
-      kurentoManager.kurentoScreenshare.extensionInstalled = true;
-
-      // this statement sets gets 'sourceId" and sets "chromeMediaSourceId"
-      screenConstraints.video.chromeMediaSource = { exact: [sendSource] };
-      screenConstraints.video.chromeMediaSourceId = sourceId;
-      screenConstraints.optional = [
-        { googCpuOveruseDetection: true },
-        { googCpuOveruseEncodeUsage: true },
-        { googCpuUnderuseThreshold: 55 },
-        { googCpuOveruseThreshold: 100 },
-        { googPayloadPadding: true },
-        { googScreencastMinBitrate: 600 },
-        { googHighStartBitrate: true },
-        { googHighBitrate: true },
-        { googVeryHighBitrate: true },
-      ];
-
-      console.log('getScreenConstraints for Chrome returns => ', screenConstraints);
       return callback(null, screenConstraints);
-    });
+    }
   }
 
   if (isFirefox) {

--- a/bigbluebutton-html5/client/compatibility/kurento-utils.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-utils.js
@@ -432,16 +432,24 @@ function WebRtcPeer(mode, options, callback) {
                     return callback(error);
                 constraints = [mediaConstraints];
                 constraints.unshift(constraints_);
-                if (typeof navigator.getDisplayMedia === 'function') {
-                    navigator.getDisplayMedia(recursive.apply(undefined, constraints)).then(stream => {
-                        stream.getTracks()[0].applyConstraints(constraints[0].optional).then(() => {
+                let gDMCallback = function(stream) {
+                    stream.getTracks()[0].applyConstraints(constraints[0].optional)
+                        .then(() => {
                             videoStream = stream;
                             start();
                         }).catch(() => {
-                          videoStream = stream;
-                          start();
+                            videoStream = stream;
+                            start();
                         });
-                    }).catch(callback);
+                }
+                if (typeof navigator.getDisplayMedia === 'function') {
+                    navigator.getDisplayMedia(recursive.apply(undefined, constraints))
+                        .then(gDMCallback)
+                        .catch(callback);
+                } else if (typeof navigator.mediaDevices.getDisplayMedia === 'function') {
+                    navigator.mediaDevices.getDisplayMedia(recursive.apply(undefined, constraints))
+                        .then(gDMCallback)
+                        .catch(callback);
                 } else {
                     getMedia(recursive.apply(undefined, constraints));
                 }

--- a/bigbluebutton-html5/client/compatibility/kurento-utils.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-utils.js
@@ -432,7 +432,16 @@ function WebRtcPeer(mode, options, callback) {
                     return callback(error);
                 constraints = [mediaConstraints];
                 constraints.unshift(constraints_);
-                getMedia(recursive.apply(undefined, constraints));
+                if (typeof navigator.getDisplayMedia === 'function') {
+                    navigator.getDisplayMedia(recursive.apply(undefined, constraints)).then(stream => {
+                        stream.getTracks()[0].applyConstraints(constraints[0].optional).then(() => {
+                            videoStream = stream;
+                            start();
+                        }).catch(callback);
+                    }).catch(callback);
+                } else {
+                    getMedia(recursive.apply(undefined, constraints));
+                }
             }, guid);
         }
     } else {

--- a/bigbluebutton-html5/client/compatibility/kurento-utils.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-utils.js
@@ -437,7 +437,10 @@ function WebRtcPeer(mode, options, callback) {
                         stream.getTracks()[0].applyConstraints(constraints[0].optional).then(() => {
                             videoStream = stream;
                             start();
-                        }).catch(callback);
+                        }).catch(() => {
+                          videoStream = stream;
+                          start();
+                        });
                     }).catch(callback);
                 } else {
                     getMedia(recursive.apply(undefined, constraints));


### PR DESCRIPTION
- Backported #6490 from 2.2 to support extension-less screensharing via getDisplayMedia
- Fixed an issue with Chrome extension-based screensharing with the latest adapter.