### PR TITLE
Improved getDisplayMedia detection

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/kurento-extension.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-extension.js
@@ -2,7 +2,8 @@ const isFirefox = typeof window.InstallTrigger !== 'undefined';
 const isOpera = !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0;
 const isChrome = !!window.chrome && !isOpera;
 const isSafari = navigator.userAgent.indexOf('Safari') >= 0 && !isChrome;
-const hasDisplayMedia = typeof navigator.getDisplayMedia === 'function';
+const hasDisplayMedia = (typeof navigator.getDisplayMedia === 'function'
+  || typeof navigator.mediaDevices.getDisplayMedia === 'function');
 const kurentoHandler = null;
 const SEND_ROLE = "send";
 const RECV_ROLE = "recv";

--- a/bigbluebutton-client/resources/prod/lib/kurento-utils.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-utils.js
@@ -410,16 +410,24 @@ function WebRtcPeer(mode, options, callback) {
                     return callback(error);
                 constraints = [mediaConstraints];
                 constraints.unshift(constraints_);
-                if (typeof navigator.getDisplayMedia === 'function') {
-                    navigator.getDisplayMedia(recursive.apply(undefined, constraints)).then(stream => {
-                        stream.getTracks()[0].applyConstraints(constraints[0].optional).then(() => {
+                let gDMCallback = function(stream) {
+                    stream.getTracks()[0].applyConstraints(constraints[0].optional)
+                        .then(() => {
                             videoStream = stream;
                             start();
                         }).catch(() => {
-                          videoStream = stream;
-                          start();
+                            videoStream = stream;
+                            start();
                         });
-                    }).catch(callback);
+                }
+                if (typeof navigator.getDisplayMedia === 'function') {
+                    navigator.getDisplayMedia(recursive.apply(undefined, constraints))
+                        .then(gDMCallback)
+                        .catch(callback);
+                } else if (typeof navigator.mediaDevices.getDisplayMedia === 'function') {
+                    navigator.mediaDevices.getDisplayMedia(recursive.apply(undefined, constraints))
+                        .then(gDMCallback)
+                        .catch(callback);
                 } else {
                     getMedia(recursive.apply(undefined, constraints));
                 }

--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -3,7 +3,8 @@ const isOpera = !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0;
 const isChrome = !!window.chrome && !isOpera;
 const isSafari = navigator.userAgent.indexOf('Safari') >= 0 && !isChrome;
 const isElectron = navigator.userAgent.toLowerCase().indexOf(' electron/') > -1;
-const hasDisplayMedia = typeof navigator.getDisplayMedia === 'function';
+const hasDisplayMedia = (typeof navigator.getDisplayMedia === 'function'
+  || typeof navigator.mediaDevices.getDisplayMedia === 'function');
 const kurentoHandler = null;
 
 Kurento = function (

--- a/bigbluebutton-html5/client/compatibility/kurento-utils.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-utils.js
@@ -446,16 +446,24 @@ function WebRtcPeer(mode, options, callback) {
                     return callback(error);
                 constraints = [mediaConstraints];
                 constraints.unshift(constraints_);
-                if (typeof navigator.getDisplayMedia === 'function') {
-                    navigator.getDisplayMedia(recursive.apply(undefined, constraints)).then(stream => {
-                        stream.getTracks()[0].applyConstraints(constraints[0].optional).then(() => {
+                let gDMCallback = function(stream) {
+                    stream.getTracks()[0].applyConstraints(constraints[0].optional)
+                        .then(() => {
                             videoStream = stream;
                             start();
                         }).catch(() => {
-                          videoStream = stream;
-                          start();
+                            videoStream = stream;
+                            start();
                         });
-                    }).catch(callback);
+                }
+                if (typeof navigator.getDisplayMedia === 'function') {
+                    navigator.getDisplayMedia(recursive.apply(undefined, constraints))
+                        .then(gDMCallback)
+                        .catch(callback);
+                } else if (typeof navigator.mediaDevices.getDisplayMedia === 'function') {
+                    navigator.mediaDevices.getDisplayMedia(recursive.apply(undefined, constraints))
+                        .then(gDMCallback)
+                        .catch(callback);
                 } else {
                     getMedia(recursive.apply(undefined, constraints));
                 }


### PR DESCRIPTION
Ported a fraction of #6599 that improves `getDisplayMedia` detection and usage.
This was done because Chrome folks decided to move it from the `navigator` scope to `navigator.mediaDevices` on 72, and Edge still relies on the `navigator` scope.