### PR TITLE
[2.2][Flash] Fixed Chrome extension-based screensharing with latest adapter

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/kurento-extension.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-extension.js
@@ -660,9 +660,14 @@ window.getScreenConstraints = function (sendSource, callback) {
 
         kurentoManager.kurentoScreenshare.extensionInstalled = true;
 
-        // this statement sets gets 'sourceId" and sets "chromeMediaSourceId"
-        screenConstraints.video.chromeMediaSource = { exact: [sendSource] };
-        screenConstraints.video.chromeMediaSourceId = sourceId;
+        // Re-wrap the video constraints into the mandatory object (latest adapter)
+        screenConstraints.video = {}
+        screenConstraints.video.mandatory = {};
+        screenConstraints.video.mandatory.maxFrameRate = 10;
+        screenConstraints.video.mandatory.maxHeight = kurentoManager.kurentoScreenshare.vid_max_height;
+        screenConstraints.video.mandatory.maxWidth = kurentoManager.kurentoScreenshare.vid_max_width;
+        screenConstraints.video.mandatory.chromeMediaSource = sendSource;
+        screenConstraints.video.mandatory.chromeMediaSourceId = sourceId;
         screenConstraints.optional = optionalConstraints;
 
         console.log('getScreenConstraints for Chrome returns => ', screenConstraints);


### PR DESCRIPTION
Ported another fraction of #6599. Must be merged when  #6609 is merged, else Chrome extension-based screensharing on Flash will break.