### PR TITLE
Show audio modal when microphone is locked

### DIFF
--- a/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
+++ b/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
@@ -17,7 +17,7 @@ export default function addUserSettings(credentials, meetingId, userId, settings
       'forceListenOnly',
       'skipCheck',
       'clientTitle',
-      'lockOnJoin', // NOT IMPLEMENTED YET
+      'lockOnJoin',
       'askForFeedbackOnLogout',
       // BRANDING
       'displayBrandingArea',

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -194,7 +194,7 @@ class App extends Component {
 
   render() {
     const {
-      customStyle, customStyleUrl, micsLocked, openPanel,
+      customStyle, customStyleUrl, openPanel,
     } = this.props;
 
     return (
@@ -211,7 +211,7 @@ class App extends Component {
         </section>
         <PollingContainer />
         <ModalContainer />
-        {micsLocked ? null : <AudioContainer />}
+        <AudioContainer />
         <ToastContainer />
         <ChatAlertContainer />
         {customStyleUrl ? <link rel="stylesheet" type="text/css" href={customStyleUrl} /> : null}

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -116,7 +116,6 @@ export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) 
     chatIsOpen: Session.equals('openPanel', 'chat'),
     openPanel: Session.get('openPanel'),
     userListIsOpen: !Session.equals('openPanel', ''),
-    micsLocked: (currentUserIsLocked && meeting.lockSettingsProp.disableMic),
   };
 })(AppContainer)));
 

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/container.jsx
@@ -44,12 +44,7 @@ export default withModalMounter(withTracker(({ mountModal }) => ({
   glow: Service.isTalking() && !Service.isMuted(),
   handleToggleMuteMicrophone: () => Service.toggleMuteMicrophone(),
   handleJoinAudio: () => {
-    const meeting = Meetings.findOne({ meetingId: Auth.meetingID });
-    const currentUser = Users.findOne({ userId: Auth.userID });
-    const currentUserIsLocked = mapUser(currentUser).isLocked;
-    const micsLocked = (currentUserIsLocked && meeting.lockSettingsProp.disableMic);
-
-    return micsLocked ? Service.joinListenOnly() : mountModal(<AudioModalContainer />);
+    return Service.isConnected() ? Service.joinListenOnly() : mountModal(<AudioModalContainer />);
   },
   handleLeaveAudio: () => Service.exitAudio(),
 }))(AudioControlsContainer));

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -129,6 +129,7 @@ class AudioModal extends Component {
       joinFullAudioImmediately,
       joinFullAudioEchoTest,
       forceListenOnlyAttendee,
+      audioLocked,
     } = this.props;
 
     if (joinFullAudioImmediately) {
@@ -139,7 +140,7 @@ class AudioModal extends Component {
       this.handleGoToEchoTest();
     }
 
-    if (forceListenOnlyAttendee) {
+    if (forceListenOnlyAttendee || audioLocked) {
       this.handleJoinListenOnly();
     }
   }
@@ -266,9 +267,11 @@ class AudioModal extends Component {
       audioLocked,
     } = this.props;
 
+    const showMicrophone = forceListenOnlyAttendee || audioLocked;
+
     return (
       <span className={styles.audioOptions}>
-        {!forceListenOnlyAttendee
+        {!showMicrophone
           ? (
             <Button
               className={styles.audioBtn}

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
@@ -50,10 +50,6 @@ const intlMessages = defineMessages({
     id: 'app.lock-viewers.PrivateChatLable',
     description: 'description for close button',
   },
-  layoutLable: {
-    id: 'app.lock-viewers.Layout',
-    description: 'description for close button',
-  },
 });
 
 class LockViewersComponent extends React.PureComponent {
@@ -193,28 +189,6 @@ class LockViewersComponent extends React.PureComponent {
                       toggleLockSettings(meeting);
                     }}
                     ariaLabel={intl.formatMessage(intlMessages.privateChatLable)}
-                  />
-                </div>
-              </div>
-            </div>
-            <div className={styles.row}>
-              <div className={styles.col} aria-hidden="true">
-                <div className={styles.formElement}>
-                  <div className={styles.label}>
-                    {intl.formatMessage(intlMessages.layoutLable)}
-                  </div>
-                </div>
-              </div>
-              <div className={styles.col}>
-                <div className={cx(styles.formElement, styles.pullContentRight)}>
-                  <Toggle
-                    icons={false}
-                    defaultChecked={meeting.lockSettingsProp.lockedLayout}
-                    onChange={() => {
-                      meeting.lockSettingsProp.lockedLayout = !meeting.lockSettingsProp.lockedLayout;
-                      toggleLockSettings(meeting);
-                    }}
-                    ariaLabel={intl.formatMessage(intlMessages.layoutLable)}
                   />
                 </div>
               </div>


### PR DESCRIPTION
Show the audio model when microphone is locked in meeting, and fix a problem while connecting to listen only when microphone is locked, and remove lock layout from lock options.

Issue: #6574