### PR TITLE
Check if mediaDevices exists before checking for gDM availability

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/kurento-extension.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-extension.js
@@ -3,7 +3,7 @@ const isOpera = !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0;
 const isChrome = !!window.chrome && !isOpera;
 const isSafari = navigator.userAgent.indexOf('Safari') >= 0 && !isChrome;
 const hasDisplayMedia = (typeof navigator.getDisplayMedia === 'function'
-  || typeof navigator.mediaDevices.getDisplayMedia === 'function');
+  || (navigator.mediaDevices && typeof navigator.mediaDevices.getDisplayMedia === 'function'));
 const kurentoHandler = null;
 const SEND_ROLE = "send";
 const RECV_ROLE = "recv";

--- a/bigbluebutton-client/resources/prod/lib/kurento-utils.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-utils.js
@@ -424,7 +424,7 @@ function WebRtcPeer(mode, options, callback) {
                     navigator.getDisplayMedia(recursive.apply(undefined, constraints))
                         .then(gDMCallback)
                         .catch(callback);
-                } else if (typeof navigator.mediaDevices.getDisplayMedia === 'function') {
+                } else if (navigator.mediaDevices && typeof navigator.mediaDevices.getDisplayMedia === 'function') {
                     navigator.mediaDevices.getDisplayMedia(recursive.apply(undefined, constraints))
                         .then(gDMCallback)
                         .catch(callback);

--- a/bigbluebutton-html5/client/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-extension.js
@@ -4,7 +4,7 @@ const isChrome = !!window.chrome && !isOpera;
 const isSafari = navigator.userAgent.indexOf('Safari') >= 0 && !isChrome;
 const isElectron = navigator.userAgent.toLowerCase().indexOf(' electron/') > -1;
 const hasDisplayMedia = (typeof navigator.getDisplayMedia === 'function'
-  || typeof navigator.mediaDevices.getDisplayMedia === 'function');
+  || (navigator.mediaDevices && typeof navigator.mediaDevices.getDisplayMedia === 'function'));
 const kurentoHandler = null;
 
 Kurento = function (

--- a/bigbluebutton-html5/client/compatibility/kurento-utils.js
+++ b/bigbluebutton-html5/client/compatibility/kurento-utils.js
@@ -475,7 +475,7 @@ function WebRtcPeer(mode, options, callback) {
                     navigator.getDisplayMedia(recursive.apply(undefined, constraints))
                         .then(gDMCallback)
                         .catch(callback);
-                } else if (typeof navigator.mediaDevices.getDisplayMedia === 'function') {
+                } else if (navigator.mediaDevices && typeof navigator.mediaDevices.getDisplayMedia === 'function') {
                     navigator.mediaDevices.getDisplayMedia(recursive.apply(undefined, constraints))
                         .then(gDMCallback)
                         .catch(callback);


### PR DESCRIPTION
The Safari webview decided not to provide the mediaDevices scope and that broke things.