### PR TITLE
Webrtc call is ready in Edge when completed not connected

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/bbb_webrtc_bridge_sip.js
+++ b/bigbluebutton-client/resources/prod/lib/bbb_webrtc_bridge_sip.js
@@ -536,12 +536,15 @@ function make_call(username, voiceBridge, server, callback, recall, isListenOnly
 	currentSession.mediaHandler.on('iceConnectionConnected', function() {
 		console.log('Received ICE status changed to connected');
 		if (callICEConnected === false) {
-			callICEConnected = true;
-			clearTimeout(iceConnectedTimeout);
-			if (callActive === true) {
-				callback({'status':'started'});
+			// Edge is only ready once the status is 'completed' so we need to skip this step
+			if (!bowser.msedge) {
+				callICEConnected = true;
+				clearTimeout(iceConnectedTimeout);
+				if (callActive === true) {
+					callback({'status':'started'});
+				}
+				clearTimeout(callTimeout);
 			}
-			clearTimeout(callTimeout);
 		}
 	});
 	


### PR DESCRIPTION
The ICE connection has multiple stages and in most browsers the call is ready when the connection state is "connected", but in Edge the call isn't ready until the state is "completed". This PR makes our bridge code ignore the "connected" state update when the browser is Edge.