### PR TITLE
Don't show manage users option for viewers

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
@@ -203,20 +203,24 @@ class UserParticipants extends Component {
               <div className={styles.container}>
                 <h2 className={styles.smallTitle}>
                   {intl.formatMessage(intlMessages.usersTitle)}
-                &nbsp;(
+                  &nbsp;(
                   {users.length}
-)
-
+                  )
                 </h2>
-                <UserOptionsContainer {...{
-                  users,
-                  muteAllUsers,
-                  muteAllExceptPresenter,
-                  setEmojiStatus,
-                  meeting,
-                  currentUser,
-                }}
-                />
+                {currentUser.isModerator
+                  ? (
+                    <UserOptionsContainer {...{
+                      users,
+                      muteAllUsers,
+                      muteAllExceptPresenter,
+                      setEmojiStatus,
+                      meeting,
+                      currentUser,
+                    }}
+                    />
+                  ) : null
+                }
+
               </div>
             )
             : <hr className={styles.separator} />


### PR DESCRIPTION
This PR hide the manage users option in user list for viewers.
Issue: #6675 