### PR TITLE
Remove the Chrome extension check for versions >= 72

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/NetConnectionDelegate.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/NetConnectionDelegate.as
@@ -752,9 +752,9 @@ package org.bigbluebutton.main.model.users
 									logData.logCode = "reconnect_attempt_failed";
 									LOGGER.info(JSON.stringify(logData));
 									
-                    var attemptFailedEvent:BBBEvent = new BBBEvent(BBBEvent.RECONNECT_CONNECTION_ATTEMPT_FAILED_EVENT);
-                    attemptFailedEvent.payload.type = ReconnectionManager.BIGBLUEBUTTON_CONNECTION;
-                    dispatcher.dispatchEvent(attemptFailedEvent);
+                    var attemptFailedEvent1:BBBEvent = new BBBEvent(BBBEvent.RECONNECT_CONNECTION_ATTEMPT_FAILED_EVENT);
+                    attemptFailedEvent1.payload.type = ReconnectionManager.BIGBLUEBUTTON_CONNECTION;
+                    dispatcher.dispatchEvent(attemptFailedEvent1);
                 } else {
                     reconnecting = true;
                     LiveMeeting.inst().me.authTokenValid = false;
@@ -787,9 +787,9 @@ package org.bigbluebutton.main.model.users
                 logData.logCode = "reconnect_attempt_failed";
                 LOGGER.info(JSON.stringify(logData));
                 
-                var attemptFailedEvent:BBBEvent = new BBBEvent(BBBEvent.RECONNECT_CONNECTION_ATTEMPT_FAILED_EVENT);
-                attemptFailedEvent.payload.type = ReconnectionManager.BIGBLUEBUTTON_CONNECTION;
-                dispatcher.dispatchEvent(attemptFailedEvent);
+                var attemptFailedEvent2:BBBEvent = new BBBEvent(BBBEvent.RECONNECT_CONNECTION_ATTEMPT_FAILED_EVENT);
+                attemptFailedEvent2.payload.type = ReconnectionManager.BIGBLUEBUTTON_CONNECTION;
+                dispatcher.dispatchEvent(attemptFailedEvent2);
             } else {
                 logData.reason = reason;
                 logData.app = "apps";

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/utils/WebRTCScreenshareUtility.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/utils/WebRTCScreenshareUtility.as
@@ -76,20 +76,23 @@ package org.bigbluebutton.modules.screenshare.utils
 
       // if its chrome we need to check for the extension
       } else if (BrowserCheck.isChrome()) {
-        WebRTCScreenshareUtility.extensionLink = options.chromeExtensionLink;
+        // We only need to check for the extension for Chrome versions before 72
+        if (BrowserCheck.browserMajorVersion < '72') {
+          WebRTCScreenshareUtility.extensionLink = options.chromeExtensionLink;
         
-        // if theres no extension link-- users cant download-- fail
-        if (StringUtils.isEmpty(options.chromeExtensionLink)) {
-          cannotUseWebRTC("No extensionLink in config.xml");
-          return;
-        }
+          // if theres no extension link-- users cant download-- fail
+          if (StringUtils.isEmpty(options.chromeExtensionLink)) {
+            cannotUseWebRTC("No extensionLink in config.xml");
+            return;
+          }
         
-        WebRTCScreenshareUtility.chromeExtensionKey = options.chromeExtensionKey;
+          WebRTCScreenshareUtility.chromeExtensionKey = options.chromeExtensionKey;
 
-        // if theres no key we cannot connect to the extension-- fail
-        if (StringUtils.isEmpty(WebRTCScreenshareUtility.chromeExtensionKey)) {
-          cannotUseWebRTC("No chromeExtensionKey in config.xml");
-          return;
+          // if theres no key we cannot connect to the extension-- fail
+          if (StringUtils.isEmpty(WebRTCScreenshareUtility.chromeExtensionKey)) {
+            cannotUseWebRTC("No chromeExtensionKey in config.xml");
+            return;
+          }
         }
 
         // connect to the webrtc code to attempt a connection with the extension


### PR DESCRIPTION
This PR adjusts the check for an Chrome screenshare extension key so that it only checks when the browser version is less than 72.

I also included a fix to a warning when building the NetConnectionDelegate about duplicate variable definitions in the same scope.