### PR TITLE
Hide Mic and Camera buttons when userAgent is Mobile App

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -265,13 +265,14 @@ class AudioModal extends Component {
       forceListenOnlyAttendee,
       skipCheck,
       audioLocked,
+      isMobileNative,
     } = this.props;
 
     const showMicrophone = forceListenOnlyAttendee || audioLocked;
 
     return (
       <span className={styles.audioOptions}>
-        {!showMicrophone
+        {!showMicrophone && !isMobileNative
           ? (
             <Button
               className={styles.audioBtn}

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -62,5 +62,6 @@ export default withModalMounter(withTracker(({ mountModal }) => {
     joinFullAudioEchoTest: !listenOnlyMode && !skipCheck,
     forceListenOnlyAttendee: listenOnlyMode && forceListenOnly && !Service.isUserModerator(),
     isIOSChrome: browser().name === 'crios',
+    isMobileNative: navigator.userAgent.toLowerCase().includes('bbbnative'),
   });
 })(AudioModalContainer));

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/container.jsx
@@ -15,12 +15,13 @@ const JoinVideoOptionsContainer = (props) => {
     baseName,
     intl,
     mountModal,
+    isMobileNative,
     ...restProps
   } = props;
 
   const mountPreview = () => { mountModal(<VideoPreviewContainer />); };
 
-  return <JoinVideoButton {...{ handleJoinVideo: mountPreview, handleCloseVideo, isSharingVideo, isDisabled, ...restProps }} />;
+  return !isMobileNative && <JoinVideoButton {...{ handleJoinVideo: mountPreview, handleCloseVideo, isSharingVideo, isDisabled, ...restProps }} />;
 };
 
 export default withModalMounter(injectIntl(withTracker(() => ({
@@ -28,4 +29,5 @@ export default withModalMounter(injectIntl(withTracker(() => ({
   isSharingVideo: VideoButtonService.isSharingVideo(),
   isDisabled: VideoButtonService.isDisabled(),
   videoShareAllowed: VideoButtonService.videoShareAllowed(),
+  isMobileNative: navigator.userAgent.toLowerCase().includes('bbbnative'),
 }))(JoinVideoOptionsContainer)));


### PR DESCRIPTION
The mobile APP does not support Microfone and share Camera (for now).
So it is necessary to hide this options to avoid errors in application.

This PR adds:
- Verifies if the userAgent contains "bbbnative" and set isMobileNative
- Does not render Mic button if isMobileNative is true
- Does not render Camera button if isMobileNative is true

_The APP is including the string bbbnative in the userAgent string to make this verification possible_