### PR TITLE
Fix recording presentation playback - slides loading

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video.rb
@@ -287,6 +287,9 @@ module BigBlueButton
 
           info[:width] = info[:video][:width].to_i
           info[:height] = info[:video][:height].to_i
+
+          # Check for corrupt/undecodable video streams
+          return {} if info[:video][:pix_fmt].nil?
           return {} if info[:width] == 0 or info[:height] == 0
 
           info[:sample_aspect_ratio] = Rational(1, 1)

--- a/record-and-playback/presentation/playback/presentation/2.0/playback.js
+++ b/record-and-playback/presentation/playback/presentation/2.0/playback.js
@@ -790,7 +790,6 @@ document.addEventListener('playback-ready', function(event) {
       logger.warn("==Unhandled playback-ready event", event.detail);
   }
   if (dataReady && mediaReady && contentReady) {
-    runPopcorn();
     if (firstLoad) {
       // load up the acorn controls
       logger.info("==Loading acorn media player");
@@ -802,6 +801,7 @@ document.addEventListener('playback-ready', function(event) {
         swapVideoPresentation();
       });
 
+      runPopcorn();
       initPopcorn();
     }
   }


### PR DESCRIPTION
This also includes a fix from 2.2 that checks for more invalid video files.