### PR TITLE
Fix loading slide images in presentation format

### DIFF
--- a/record-and-playback/presentation/playback/presentation/2.0/playback.js
+++ b/record-and-playback/presentation/playback/presentation/2.0/playback.js
@@ -790,7 +790,6 @@ document.addEventListener('playback-ready', function(event) {
       logger.warn("==Unhandled playback-ready event", event.detail);
   }
   if (dataReady && mediaReady && contentReady) {
-    runPopcorn();
     if (firstLoad) {
       // load up the acorn controls
       logger.info("==Loading acorn media player");
@@ -802,6 +801,7 @@ document.addEventListener('playback-ready', function(event) {
         swapVideoPresentation();
       });
 
+      runPopcorn();
       initPopcorn();
     }
   }


### PR DESCRIPTION
The initialization order change to support captions moved the acorn
initialization to after some of the popcorn init had already run. We
have to move that function to run after we create the acorn player
so it references the correct #video element (since acorn replaces/
moves it during init)