### PR TITLE
Break captions

### DIFF
--- a/record-and-playback/presentation/playback/presentation/2.0/playback.js
+++ b/record-and-playback/presentation/playback/presentation/2.0/playback.js
@@ -790,6 +790,7 @@ document.addEventListener('playback-ready', function(event) {
       logger.warn("==Unhandled playback-ready event", event.detail);
   }
   if (dataReady && mediaReady && contentReady) {
+    runPopcorn();
     if (firstLoad) {
       // load up the acorn controls
       logger.info("==Loading acorn media player");
@@ -801,7 +802,6 @@ document.addEventListener('playback-ready', function(event) {
         swapVideoPresentation();
       });
 
-      runPopcorn();
       initPopcorn();
     }
   }

--- a/record-and-playback/presentation/playback/presentation/2.0/playback.js
+++ b/record-and-playback/presentation/playback/presentation/2.0/playback.js
@@ -531,6 +531,16 @@ function loadPlayback() {
     loadAudio();
   }
 
+  // load up the acorn controls
+  logger.info("==Loading acorn media player");
+  $('#video').acornMediaPlayer({
+    theme: 'bigbluebutton',
+    volumeSlider: 'vertical'
+  });
+  $('#video').on("swap", function() {
+    swapVideoPresentation();
+  });
+
   if (hasDeskshare) {
     loadDeskshare();
   } else {
@@ -792,16 +802,6 @@ document.addEventListener('playback-ready', function(event) {
   if (dataReady && mediaReady && contentReady) {
     runPopcorn();
     if (firstLoad) {
-      // load up the acorn controls
-      logger.info("==Loading acorn media player");
-      $('#video').acornMediaPlayer({
-        theme: 'bigbluebutton',
-        volumeSlider: 'vertical'
-      });
-      $('#video').on("swap", function() {
-        swapVideoPresentation();
-      });
-
       initPopcorn();
     }
   }


### PR DESCRIPTION
Revert the changes to fix caption loading, because the change in the order of initialization has broken a bunch of other stuff like loading presentation pages and syncing deskshare video.