### PR TITLE
Show 'Default' in Speakers list when browser is Safari

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/device-selector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/device-selector/component.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import logger from '/imports/startup/client/logger';
 import { styles } from '../audio-modal/styles';
+import browser from 'browser-detect';
 
 const propTypes = {
   kind: PropTypes.oneOf(['audioinput', 'audiooutput', 'videoinput']),
@@ -66,6 +67,7 @@ class DeviceSelector extends Component {
     const {
       kind, className, ...props
     } = this.props;
+
     const { options, value } = this.state;
 
     return (
@@ -86,7 +88,12 @@ class DeviceSelector extends Component {
                 {option.label}
               </option>
             )) :
-            <option value="not-found">{`no ${kind} found`}</option>
+            (
+              (kind == 'audiooutput' && browser().name == 'safari') ?
+                <option value="not-found">Default</option>
+              :
+                <option value="not-found">{`no ${kind} found`}</option>
+            )
         }
       </select>
     );


### PR DESCRIPTION
Like we discussed in #6590, Safari can't obtain the list of output audio devices.
This PR verify when browser is Safari and populate the `Speakers list` with only one option: "Default"

**Before**
![outputlist-before](https://user-images.githubusercontent.com/5660191/52339823-4998fc80-29f5-11e9-8a03-eb03c8d00388.png)

**After**
![outputlist-after](https://user-images.githubusercontent.com/5660191/52339829-4d2c8380-29f5-11e9-8203-2e3cd882c320.png)