### PR TITLE
Minimal authentication for SFU and Etherpad connections

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ParamsUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ParamsUtil.java
@@ -1,10 +1,17 @@
 package org.bigbluebutton.api.util;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.commons.lang3.StringUtils;
 
 public class ParamsUtil {
+  private static Logger log = LoggerFactory.getLogger(ParamsUtil.class);
+
   private static final Pattern VALID_ID_PATTERN = Pattern.compile("[a-zA-Z][a-zA-Z0-9- ]*$");
 
   public static final String INVALID_CHARS = ",";
@@ -20,5 +27,24 @@ public class ParamsUtil {
 
   public static boolean containsChar(String text, String chars) {
     return StringUtils.containsAny(text, chars);
+  }
+
+  public static String getSessionToken(String url) {
+    String token = "undefined";
+    try {
+      String decodedURL = URLDecoder.decode(url, "UTF-8");
+      String[] splitedURL = decodedURL.split("\\?");
+      if (splitedURL.length == 2) {
+        String params = splitedURL[1];
+        for (String param : params.split("\\&")) {
+          if (param.startsWith("sessionToken=")) {
+            token = param.split("\\=")[1];
+          }
+        }
+      }
+    } catch (UnsupportedEncodingException e) {
+      log.error(e.toString());
+    }
+    return token;
   }
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ParamsUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ParamsUtil.java
@@ -33,9 +33,9 @@ public class ParamsUtil {
     String token = "undefined";
     try {
       String decodedURL = URLDecoder.decode(url, "UTF-8");
-      String[] splitedURL = decodedURL.split("\\?");
-      if (splitedURL.length == 2) {
-        String params = splitedURL[1];
+      String[] splitURL = decodedURL.split("\\?");
+      if (splitURL.length == 2) {
+        String params = splitURL[1];
         for (String param : params.split("\\&")) {
           if (param.startsWith("sessionToken=")) {
             token = param.split("\\=")[1];

--- a/bigbluebutton-client/resources/prod/lib/kurento-extension.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-extension.js
@@ -55,7 +55,9 @@ Kurento = function (
 
   this.kurentoPort = 'bbb-webrtc-sfu';
   this.hostName = window.location.hostname;
-  this.socketUrl = `wss://${this.hostName}/${this.kurentoPort}`;
+  BBB.getSessionToken(sessionToken => {
+    this.socketUrl = `wss://${this.hostName}/${this.kurentoPort}?sessionToken=${sessionToken}`;
+  });
   this.pingInterval = null;
 
   if (chromeExtension != null) {

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
@@ -74,7 +74,7 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
       } finally {
         logFunc('info', "iceServers", iceServers);
         const options = {
-          wsUrl: SFU_URL,
+          wsUrl: Auth.authenticateURL(SFU_URL),
           userName: this.user.name,
           caleeName: `${GLOBAL_AUDIO_PREFIX}${this.voiceBridge}`,
           iceServers,

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -59,7 +59,7 @@ export default class KurentoScreenshareBridge {
       logger.error({ logCode: 'kurentowatchvideo_fetchstunturninfo_error' }, 'Screenshare bridge failed to fetch STUN/TURN info, using default');
     } finally {
       const options = {
-        wsUrl: SFU_URL,
+        wsUrl: Auth.authenticateURL(SFU_URL),
         iceServers,
         logger: modLogger,
       };
@@ -88,7 +88,7 @@ export default class KurentoScreenshareBridge {
       logger.error({ logCode: 'kurentosharescreen_fetchstunturninfo_error' }, 'Screenshare bridge failed to fetch STUN/TURN info, using default');
     } finally {
       const options = {
-        wsUrl: SFU_URL,
+        wsUrl: Auth.authenticateURL(SFU_URL),
         chromeExtension: CHROME_EXTENSION_KEY,
         chromeScreenshareSources: CHROME_SCREENSHARE_SOURCES,
         firefoxScreenshareSource: FIREFOX_SCREENSHARE_SOURCE,

--- a/bigbluebutton-html5/imports/ui/components/note/service.js
+++ b/bigbluebutton-html5/imports/ui/components/note/service.js
@@ -65,7 +65,7 @@ const getNoteParams = () => {
 const getNoteURL = () => {
   const noteId = generateNoteId();
   const params = getNoteParams();
-  let url = NOTE_CONFIG.url + '/p/' + noteId + '?' + params;
+  const url = Auth.authenticateURL(NOTE_CONFIG.url + '/p/' + noteId + '?' + params);
   return url;
 };
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -8,6 +8,7 @@ import logger from '/imports/startup/client/logger';
 import { Session } from 'meteor/session';
 import browser from 'browser-detect';
 import { tryGenerateIceCandidates } from '../../../utils/safari-webrtc';
+import Auth from '/imports/ui/services/auth';
 
 import VideoService from './service';
 import VideoList from './video-list/component';
@@ -110,7 +111,7 @@ class VideoProvider extends Component {
     };
 
     // Set a valid bbb-webrtc-sfu application server socket in the settings
-    this.ws = new ReconnectingWebSocket(Meteor.settings.public.kurento.wsUrl);
+    this.ws = new ReconnectingWebSocket(Auth.authenticateURL(Meteor.settings.public.kurento.wsUrl));
     this.wsQueue = [];
 
     this.visibility = new VisibilityEvent();

--- a/bigbluebutton-html5/imports/ui/services/auth/index.js
+++ b/bigbluebutton-html5/imports/ui/services/auth/index.js
@@ -242,6 +242,18 @@ class Auth {
       makeCall('validateAuthToken');
     });
   }
+
+  authenticateURL(url) {
+    let authURL = url;
+    if (authURL.indexOf('sessionToken=') === -1) {
+      if (authURL.indexOf('?') !== -1) {
+        authURL = authURL + '&sessionToken=' + this.sessionToken;
+      } else {
+        authURL= authURL + '?sessionToken=' + this.sessionToken;
+      }
+    }
+    return authURL;
+  }
 }
 
 const AuthSingleton = new Auth();

--- a/bigbluebutton-web/bbb-web.nginx
+++ b/bigbluebutton-web/bbb-web.nginx
@@ -60,5 +60,17 @@
 			proxy_request_buffering off;
 
 		}
-       }
 
+		# To check connection authentication, include:
+		#   auth_request /bigbluebutton/connection/checkAuthorization;
+		#   auth_request_set $auth_status $upstream_status;
+		#
+		# and make sure to add sessionToken param in the request URI
+		location = /bigbluebutton/connection/checkAuthorization {
+			internal;
+			proxy_pass               http://127.0.0.1:8080;
+			proxy_pass_request_body  off;
+			proxy_set_header         Content-Length "";
+			proxy_set_header         X-Original-URI $request_uri;
+		}
+	}

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/UrlMappings.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/UrlMappings.groovy
@@ -91,6 +91,10 @@ class UrlMappings {
       action = [POST: 'putRecordingTextTrack']
     }
 
+    "/connection/checkAuthorization"(controller:"connection") {
+      action = [GET:'checkAuthorization']
+    }
+
     "/bigbluebutton/$controller/$action?/$id?(.${format})?" {
       constraints {
         // apply constraints here

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
@@ -1,0 +1,47 @@
+/**
+* BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+*
+* Copyright (c) 2019 BigBlueButton Inc. and by respective authors (see below).
+*
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License as published by the Free Software
+* Foundation; either version 3.0 of the License, or (at your option) any later
+* version.
+*
+* BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License along
+* with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+*
+*/
+package org.bigbluebutton.web.controllers
+
+import org.bigbluebutton.api.MeetingService
+import org.bigbluebutton.api.domain.UserSession
+import org.bigbluebutton.api.util.ParamsUtil
+
+class ConnectionController {
+  MeetingService meetingService
+
+  def checkAuthorization = {
+    try {
+      def uri = request.getHeader("x-original-uri")
+      def sessionToken = ParamsUtil.getSessionToken(uri)
+      UserSession userSession = meetingService.getUserSessionWithAuthToken(sessionToken)
+
+      response.addHeader("Cache-Control", "no-cache")
+      response.contentType = 'plain/text'
+      if (userSession != null && userSession.authed) {
+        response.setStatus(200)
+        response.outputStream << 'authorized'
+      } else {
+        response.setStatus(401)
+        response.outputStream << 'unauthorized'
+      }
+    } catch (IOException e) {
+      log.error("Error while authenticating connection.\n" + e.getMessage())
+    }
+  }
+}


### PR DESCRIPTION
Rebased and resolved #6645 after bbb-web changes.

For this to work we need to change `notes.nginx` for:
```
# https://github.com/ether/etherpad-lite/wiki/How-to-put-Etherpad-Lite-behind-a-reverse-Proxy
location ~ "^\/pad\/p\/(\w+)" {
    rewrite                /pad/(.*) /$1 break;
    rewrite                ^/pad$ /pad/ permanent;
    proxy_pass             http://localhost:9001;
    proxy_pass_header      Server;
    proxy_redirect         / /pad;
    proxy_set_header       Host $host;
    proxy_buffering off;

    auth_request /bigbluebutton/connection/checkAuthorization;
    auth_request_set $auth_status $upstream_status;
}

location /pad {
    rewrite                /pad/(.*) /$1 break;
    rewrite                ^/pad$ /pad/ permanent;
    proxy_pass             http://localhost:9001/;
    proxy_pass_header      Server;
    proxy_redirect         / /pad;
    proxy_set_header       Host $host;
    proxy_buffering off;
}

location /pad/socket.io {
    rewrite /pad/socket.io/(.*) /socket.io/$1 break;
    proxy_pass http://localhost:9001/;
    proxy_redirect         / /pad/;
    proxy_set_header Host $host;
    proxy_buffering off;
    proxy_set_header X-Real-IP $remote_addr;  # http://wiki.nginx.org/HttpProxyModule
    proxy_set_header X-Forwarded-For $remote_addr; # EP logs to show the actual remote IP
    proxy_set_header X-Forwarded-Proto $scheme; # for EP to set secure cookie flag when https is used
    proxy_set_header Host $host;  # pass the host header
    proxy_http_version 1.1;  # recommended with keepalive connections
    # WebSocket proxying - from http://nginx.org/en/docs/http/websocket.html
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "Upgrade";
}

location /static {
    rewrite /static/(.*) /static/$1 break;
    proxy_pass http://localhost:9001/;
    proxy_set_header Host $host;
    proxy_buffering off;
}
```
The first block is the big difference. It will auth_request https://HOSTNAME/pad/p/NOTE_ID

and `webrtc-sfu.nginx` should look like:
```
location /bbb-webrtc-sfu {
        proxy_pass http://127.0.0.1:3008;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "Upgrade";
        proxy_read_timeout 6h;
        proxy_send_timeout 6h;
        client_body_timeout 6h;
        send_timeout 6h;

        auth_request /bigbluebutton/connection/checkAuthorization;
        auth_request_set $auth_status $upstream_status;
}
```

This modifications should unauthorize any connections to this locations that append an invalid sessionToken. Etherpad can be tested by trying to access it outside BBB client. I tested SFU connections by modifying https://github.com/pedrobmarin/bigbluebutton/blob/validate-sfu-conn/bigbluebutton-html5/imports/ui/services/auth/index.js#L246 to send an invalid sessionToken. This should output a 401 exception in console.

And, of course, `web-nginx` should include
```
		location = /bigbluebutton/connection/checkAuthorization {
			internal;
			proxy_pass               http://127.0.0.1:8080;
			proxy_pass_request_body  off;
			proxy_set_header         Content-Length "";
			proxy_set_header         X-Original-URI $request_uri;
		}
```