### PR TITLE
Use bowser for browser detection - 2.0 Edition

### DIFF
--- a/bigbluebutton-client/resources/prod/BigBlueButton.html
+++ b/bigbluebutton-client/resources/prod/BigBlueButton.html
@@ -23,6 +23,7 @@
       }
     </style>
 
+    <script src="lib/bowser.js?v=VERSION" language="javascript"></script>
     <script src="lib/bbb_blinker.js?v=VERSION" language="javascript"></script>
     <script type="text/javascript" src="swfobject/swfobject.js"></script>
 
@@ -148,7 +149,6 @@
     <script src="lib/sip.js?v=VERSION" language="javascript"></script>
 
     <!-- <script src="lib/webrtc_stats_bridge.js?v=VERSION" language="javascript"></script> -->
-    <script src="lib/bowser.js?v=VERSION" language="javascript"></script>
     <script src="lib/bbb_webrtc_bridge_sip.js?v=VERSION" language="javascript"></script>
     <script src="lib/weburl_regex.js?v=VERSION" language="javascript"></script>
     <script src="lib/jsnlog.min.js?v=VERSION" language="javascript"></script>

--- a/bigbluebutton-client/resources/prod/lib/bbb_blinker.js
+++ b/bigbluebutton-client/resources/prod/lib/bbb_blinker.js
@@ -90,6 +90,7 @@ function determineBrowser()
 {
 	var browserName = bowser.name;
 	var fullVersion = bowser.version;
+	var userAgent = navigator.userAgent;
 	
 	// trim the fullVersion string at semicolon/space if present
 	if ((ix=fullVersion.indexOf(";"))!=-1)
@@ -103,7 +104,7 @@ function determineBrowser()
 		majorVersion = parseInt(navigator.appVersion,10);
 	}
 	
-	return [browserName, majorVersion, fullVersion];
+	return [browserName, majorVersion, fullVersion, userAgent];
 }
 
 function toggleFullscreen() {

--- a/bigbluebutton-client/resources/prod/lib/bbb_blinker.js
+++ b/bigbluebutton-client/resources/prod/lib/bbb_blinker.js
@@ -30,7 +30,7 @@ function determineModifier()
 	else if (browser == "Chrome"){
 		modifier = "control+";
 	}
-	else if (browser == "Microsoft Internet Explorer"){
+	else if (browser == "Internet Explorer"){
 		modifier = "control+shift+";
 	}
 	//else if (browser == "Safari"){
@@ -52,7 +52,7 @@ function determineGlobalModifier()
 	else if (browser == "Chrome"){
 		modifier = "control+shift+";
 	}
-	else if (browser == "Microsoft Internet Explorer"){
+	else if (browser == "Internet Explorer"){
 		modifier = "control+alt+";
 	}
 	//else if (browser == "Safari"){
@@ -74,7 +74,7 @@ function determineGlobalAlternateModifier()
 	else if (browser == "Chrome"){
 		modifier = "control+";
 	}
-	else if (browser == "Microsoft Internet Explorer"){
+	else if (browser == "Internet Explorer"){
 		modifier = "control+shift+";
 	}
 	//else if (browser == "Safari"){
@@ -88,64 +88,9 @@ function determineGlobalAlternateModifier()
 
 function determineBrowser()
 {
-	// Browser name extraction code provided by http://www.javascripter.net/faq/browsern.htm
-	var nVer = navigator.appVersion;
-	var nAgt = navigator.userAgent;
-	var browserName  = navigator.appName;
-	var fullVersion  = ''+parseFloat(navigator.appVersion); 
-	var majorVersion = parseInt(navigator.appVersion,10);
-	var nameOffset,verOffset,ix;
-
-	// In Opera, the true version is after "Opera" or after "Version"
-	if ((verOffset=nAgt.indexOf("OPR/"))!=-1) {
-		browserName = "Opera";
-		fullVersion = nAgt.substring(verOffset+4);
-	}
-	// In MSIE, the true version is after "MSIE" in userAgent
-	else if ((verOffset=nAgt.indexOf("MSIE"))!=-1) {
-		browserName = "Microsoft Internet Explorer";
-		fullVersion = nAgt.substring(verOffset+5);
-	}
-	// In Puffin, the true version is after "Puffin" in userAgent
-	else if ((verOffset=nAgt.indexOf("Puffin"))!=-1) {
-		browserName = "Puffin";
-		fullVersion = nAgt.substring(verOffset+7);
-	}
-	// search for Edge before Chrome or Safari because Microsoft
-	// includes Chrome and Safari user agents in Edge's UA
-	// In Microsoft Edge, the true version is the last chunk of the UA
-	// it follows "Edge"
-	else if ((verOffset=nAgt.indexOf("Edge"))!=-1) {
-		browserName = "Edge";
-		// "Edge".length = 4, plus 1 character for the trailing slash
-		fullVersion = nAgt.substring(verOffset+5);
-	}
-	// In Chrome, the true version is after "Chrome" 
-	else if ((verOffset=nAgt.indexOf("Chrome"))!=-1) {
-		browserName = "Chrome";
-		fullVersion = nAgt.substring(verOffset+7);
-	}
-	// In Safari, the true version is after "Safari" or after "Version" 
-	else if ((verOffset=nAgt.indexOf("Safari"))!=-1) {
-		browserName = "Safari";
-		fullVersion = nAgt.substring(verOffset+7);
-		if ((verOffset=nAgt.indexOf("Version"))!=-1) 
-			fullVersion = nAgt.substring(verOffset+8);
-	}
-	// In Firefox, the true version is after "Firefox" 
-	else if ((verOffset=nAgt.indexOf("Firefox"))!=-1) {
-		browserName = "Firefox";
-		fullVersion = nAgt.substring(verOffset+8);
-	}
-	// In most other browsers, "name/version" is at the end of userAgent 
-	else if ( (nameOffset=nAgt.lastIndexOf(' ')+1) < (verOffset=nAgt.lastIndexOf('/')) ) 
-	{
-		 browserName = nAgt.substring(nameOffset,verOffset);
-		 fullVersion = nAgt.substring(verOffset+1);
-		 if (browserName.toLowerCase()==browserName.toUpperCase()) {
-			 browserName = navigator.appName;
-		 }
-	}
+	var browserName = bowser.name;
+	var fullVersion = bowser.version;
+	
 	// trim the fullVersion string at semicolon/space if present
 	if ((ix=fullVersion.indexOf(";"))!=-1)
 		fullVersion=fullVersion.substring(0,ix);

--- a/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/views/MainToolbar.mxml
@@ -250,6 +250,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 				browser.name = BrowserCheck.browserName;
 				browser.majorVersion = BrowserCheck.browserMajorVersion;
 				browser.fullVersion = BrowserCheck.browserFullVersion;
+				browser.userAgent = BrowserCheck.userAgent;
 				
 				var logData:Object = UsersUtil.initLogData();
 				logData.tags = ["initialization"];

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/ScreensharePublishWindow.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/screenshare/view/components/ScreensharePublishWindow.mxml
@@ -49,33 +49,34 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
   <fx:Script>
     <![CDATA[
-			import com.asfusion.mate.events.Dispatcher;
-			
-			import org.as3commons.logging.api.ILogger;
-			import org.as3commons.logging.api.getClassLogger;
-			import org.bigbluebutton.common.events.LocaleChangeEvent;
-			import org.bigbluebutton.core.BBB;
-			import org.bigbluebutton.core.Options;
-			import org.bigbluebutton.core.UsersUtil;
-			import org.bigbluebutton.core.managers.ReconnectionManager;
-			import org.bigbluebutton.main.events.BBBEvent;
-			import org.bigbluebutton.main.events.MadePresenterEvent;
-			import org.bigbluebutton.main.events.ShortcutEvent;
-			import org.bigbluebutton.main.views.MainCanvas;
-			import org.bigbluebutton.modules.screenshare.events.RequestToPauseSharing;
-			import org.bigbluebutton.modules.screenshare.events.RequestToRestartSharing;
-			import org.bigbluebutton.modules.screenshare.events.RequestToStopSharing;
-			import org.bigbluebutton.modules.screenshare.events.ScreenSharePausedEvent;
-			import org.bigbluebutton.modules.screenshare.events.ShareStartEvent;
-			import org.bigbluebutton.modules.screenshare.events.ShareStoppedEvent;
-			import org.bigbluebutton.modules.screenshare.events.ShareWindowEvent;
-			import org.bigbluebutton.modules.screenshare.events.StartShareRequestSuccessEvent;
-			import org.bigbluebutton.modules.screenshare.events.StopSharingButtonEvent;
-			import org.bigbluebutton.modules.screenshare.events.ViewStreamEvent;
-			import org.bigbluebutton.modules.screenshare.model.ScreenshareModel;
-			import org.bigbluebutton.modules.screenshare.model.ScreenshareOptions;
-			import org.bigbluebutton.modules.screenshare.services.red5.Connection;
-			import org.bigbluebutton.util.i18n.ResourceUtil;
+		import com.asfusion.mate.events.Dispatcher;
+		
+		import org.as3commons.logging.api.ILogger;
+		import org.as3commons.logging.api.getClassLogger;
+		import org.bigbluebutton.common.events.LocaleChangeEvent;
+		import org.bigbluebutton.core.BBB;
+		import org.bigbluebutton.core.Options;
+		import org.bigbluebutton.core.UsersUtil;
+		import org.bigbluebutton.core.managers.ReconnectionManager;
+		import org.bigbluebutton.main.events.BBBEvent;
+		import org.bigbluebutton.main.events.MadePresenterEvent;
+		import org.bigbluebutton.main.events.ShortcutEvent;
+		import org.bigbluebutton.main.views.MainCanvas;
+		import org.bigbluebutton.modules.screenshare.events.RequestToPauseSharing;
+		import org.bigbluebutton.modules.screenshare.events.RequestToRestartSharing;
+		import org.bigbluebutton.modules.screenshare.events.RequestToStopSharing;
+		import org.bigbluebutton.modules.screenshare.events.ScreenSharePausedEvent;
+		import org.bigbluebutton.modules.screenshare.events.ShareStartEvent;
+		import org.bigbluebutton.modules.screenshare.events.ShareStoppedEvent;
+		import org.bigbluebutton.modules.screenshare.events.ShareWindowEvent;
+		import org.bigbluebutton.modules.screenshare.events.StartShareRequestSuccessEvent;
+		import org.bigbluebutton.modules.screenshare.events.StopSharingButtonEvent;
+		import org.bigbluebutton.modules.screenshare.events.ViewStreamEvent;
+		import org.bigbluebutton.modules.screenshare.model.ScreenshareModel;
+		import org.bigbluebutton.modules.screenshare.model.ScreenshareOptions;
+		import org.bigbluebutton.modules.screenshare.services.red5.Connection;
+		import org.bigbluebutton.util.browser.BrowserCheck;
+		import org.bigbluebutton.util.i18n.ResourceUtil;
 		
       
       private static const LOGGER:ILogger = getClassLogger(ScreensharePublishWindow);
@@ -127,9 +128,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         } else if (fullOS.indexOf("Linux") != -1) {
           os = "Linux";
         } else {
-          LOGGER.error("Browser not recognized, full value: {0}", [fullOS]);
+          LOGGER.error("OS not recognized, full value: {0}", [fullOS]);
           os = "";
         }
+
+        browser = BrowserCheck.browserName;
 
         windowControls.maximizeRestoreBtn.enabled = false;
 
@@ -542,7 +545,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
           if (os == "Windows") {
             shareTypeBox.visible = true;
             info = "PC";
-            if (browser == "Microsoft Internet Explorer" || browser == "Edge") {
+            if (browser == "Internet Explorer" || browser == "Edge") {
               info += "IE";
             } else if (browser == "Firefox") {
               info += "Firefox";

--- a/bigbluebutton-client/src/org/bigbluebutton/util/browser/BrowserCheck.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/util/browser/BrowserCheck.as
@@ -32,6 +32,8 @@ package org.bigbluebutton.util.browser {
 		private static var _majorVersion:String;
 
 		private static var _fullVersion:String;
+		
+		private static var _userAgent:String;
 
 		// The function below is called in $cinit, while the class is used for the first time.
 		getBrowserInfo();
@@ -51,6 +53,10 @@ package org.bigbluebutton.util.browser {
 
 		public static function get browserFullVersion():String {
 			return _fullVersion;
+		}
+		
+		public static function get userAgent():String {
+			return _userAgent;
 		}
 
 		public static function isChrome():Boolean {
@@ -88,6 +94,7 @@ package org.bigbluebutton.util.browser {
 				_browserName = browserInfo[0];
 				_majorVersion = String(browserInfo[1]);
 				_fullVersion = String(browserInfo[2]);
+				_userAgent = String(browserInfo[3]);
 			} else {
 				_browserName = "unknown";
 				_majorVersion = "0";


### PR DESCRIPTION
This PR updates a JS function that determines browser and version to use bowser for detection as it's more accurate and up to date than the old method. I also discovered that the browser detection in ScreensharePublishWindow used for showing the help images was removed awhile back so I've fixed that also.