### PR TITLE
Update bbb-conf to now call apply-config.sh (if available)

### DIFF
--- a/bigbluebutton-config/bin/apply-config.template
+++ b/bigbluebutton-config/bin/apply-config.template
@@ -1,0 +1,76 @@
+#!/bin/bash -e
+
+# This is a template for apply-config.sh, which if created will be automatically called by
+# bbb-conf when you do
+#
+#   bbb-conf --restart
+#   bbb-conf --seitp ... 
+#
+# To use this template, copy it to apply-config.sh and make it executable
+#
+#  cp apply-config.template apply-config.sh
+#  chmod +x apply-config.sh
+#
+# You can then uncomment some of the built-in configuration options or add your own.
+#
+
+
+if LANG=c ifconfig | grep -q 'venet0:0'; then
+  # IP detection for OpenVZ environment
+  IP=$(ifconfig | grep -v '127.0.0.1' | grep -E "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | tail -1 | cut -d: -f2 | awk '{ print $1}')
+else
+  IP=$(hostname -I | sed 's/ .*//g')
+fi
+
+if [ -f /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties ]; then
+  SERVLET_DIR=/usr/share/bbb-web
+else
+  SERVLET_DIR=/var/lib/tomcat7/webapps/bigbluebutton
+fi
+
+PROTOCOL=http
+if [ -f $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties ]; then
+  SERVER_URL=$(cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties | sed -n '/^bigbluebutton.web.serverURL/{s/.*\///;p}')
+  if cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties | grep bigbluebutton.web.serverURL | grep -q https; then
+    PROTOCOL=https
+  fi
+fi
+
+HOST=$(cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties | grep -v '#' | sed -n '/^bigbluebutton.web.serverURL/{s/.*\///;p}')
+
+
+#
+# Enable Looging of the HTML5 client for debugging
+#
+enableHTML5ClientLog() {
+  echo "  - enable HTML5 client log"
+
+  HTML5_CONFIG=/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml
+  yq w -i $HTML5_CONFIG public.clientLog.external.enabled true
+  yq w -i $HTML5_CONFIG public.clientLog.external.url     "$PROTOCOL://$HOST/html5log"
+
+  cat > /etc/bigbluebutton/nginx/html5-client-log.nginx << HERE
+location /html5log {
+	access_log /var/log/nginx/html5-client.log postdata;
+	echo_read_request_body;
+}
+HERE
+
+  cat > /etc/nginx/conf.d/html5-client-log.conf << HERE
+log_format postdata '\$remote_addr [\$time_iso8601] \$request_body';
+HERE
+ 
+  # We need nginx-full to enable postdata log_format 
+  if ! dpkg -l | grep -q nginx-full; then
+    apt-get install -y nginx-full
+  fi
+
+  #
+  # You can monitor the live HTML5 client logs with the command
+  #
+  #   tail -f /var/log/nginx/html5-client.log | sed -u 's/\\x22/"/g' | sed -u 's/\\x5C//g' 
+}
+
+
+#enableHTML5ClientLog
+

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -74,11 +74,10 @@ if [ "$(id -u)" != "0" ]; then
 fi
 
 if [ ! -f /etc/bigbluebutton/bigbluebutton-release ]; then
-	echo "#"
+	echo 
 	echo "# BigBlueButton does not appear to be installed.  Could not"
-	echo "# locate:"
-	echo "#"
-	echo "# /usr/share/red5/webapps/bigbluebutton/WEB-INF/red5-web.xml"
+	echo "# locate: /etc/bigbluebutton/bigbluebutton-release"
+	echo 
 	exit 1
 fi
 
@@ -96,19 +95,36 @@ SERVLET_CONTAINER=tomcat7
 TOMCAT_DIR=/var/lib/$SERVLET_CONTAINER
 LTI_DIR=$TOMCAT_DIR/webapps/lti
 
-if dpkg -l | grep bbb-web | grep -q 2.2; then
+if [ -f /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties ]; then
   SERVLET_DIR=/usr/share/bbb-web
 else
-  SERVLET_DIR=/var/lib/$SERVLET_CONTAINER/webapps/bigbluebutton
+  SERVLET_DIR=/var/lib/tomcat7/webapps/bigbluebutton
 fi
+
+PROTOCOL=HTTP
+if [ -f $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties ]; then
+  SERVER_URL=$(cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties | sed -n '/^bigbluebutton.web.serverURL/{s/.*\///;p}')
+  if cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties | grep bigbluebutton.web.serverURL | grep -q https; then
+    PROTOCOL=HTTPS
+  fi
+fi
+
 
 FREESWITCH_VARS=/opt/freeswitch/conf/vars.xml
 FREESWITCH_EXTERNAL=/opt/freeswitch/conf/sip_profiles/external.xml
 FREESWITCH_PID=/opt/freeswitch/run/freeswitch.pid
 FREESWITCH_EVENT_SOCKET=/opt/freeswitch/conf/autoload_configs/event_socket.conf.xml
 
-HTML5_CONFIG=/usr/share/meteor/bundle/programs/server/assets/app/config/settings-production.json
-HTML5_CONFIG_NEW=/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml
+RECORD_CONFIG=/usr/local/bigbluebutton/core/scripts/bigbluebutton.yml
+
+HTML5_CONFIG_OLD=/usr/share/meteor/bundle/programs/server/assets/app/config/settings-production.json
+HTML5_CONFIG=/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml
+
+KURENTO_CONFIG=/usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml
+
+BBB_WEB_CONFIG=$SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties
+
+SIP_CONFIG=/etc/bigbluebutton/nginx/sip.nginx
 
 BBB_USER=bigbluebutton
 
@@ -151,14 +167,6 @@ if [ ! -f /var/www/bigbluebutton/client/conf/config.xml ]; then
 	exit 1
 fi
 
-if cat /var/www/bigbluebutton/client/conf/config.xml | grep "ChatModule" | grep -q https; then
-	PROTOCOL_HTTP=https
-	PROTOCOL_RTMP=rtmp
-else
-	PROTOCOL_HTTP=http
-	PROTOCOL_RTMP=rtmp
-fi
-
 #
 # We're going to give ^bigbluebutton.web.logoutURL a default value (if undefined) so bbb-conf does not give a warning
 #
@@ -174,14 +182,10 @@ VOICE_CONFERENCE="bbb-voice-freeswitch.xml"
 # Determine IP so it works on multilingual installations
 #
 
-
 if LANG=c ifconfig | grep -q 'venet0:0'; then
-        # IP detection for OpenVZ environment
-        echo "yes"
-        IP=$(ifconfig | grep -v '127.0.0.1' | grep -E "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | tail -1 | cut -d: -f2 | awk '{ print $1}')
+  IP=$(ifconfig | grep -v '127.0.0.1' | grep -E "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | tail -1 | cut -d: -f2 | awk '{ print $1}')
 else
-        # IP detection for et* and en* networks
-IP=$(echo "$(LANG=c ifconfig  | awk -v RS="" '{gsub (/\n[ ]*inet /," ")}1' | grep ^et.* | grep addr: | head -n1 | sed 's/.*addr://g' | sed 's/ .*//g')$(LANG=c ifconfig  | awk -v RS="" '{gsub (/\n[ ]*inet /," ")}1' | grep ^en.* | grep addr: | head -n1 | sed 's/.*addr://g' | sed 's/ .*//g')$(LANG=c ifconfig  | awk -v RS="" '{gsub (/\n[ ]*inet /," ")}1' | grep ^wl.* | grep addr: | head -n1 | sed 's/.*addr://g' | sed 's/ .*//g')$(LANG=c ifconfig  | awk -v RS="" '{gsub (/\n[ ]*inet /," ")}1' | grep ^bo.* | grep addr: | head -n1 | sed 's/.*addr://g' | sed 's/ .*//g')$(LANG=c ifconfig  | awk -v RS="" '{gsub (/\n[ ]*inet /," ")}1' | grep ^em.* | grep addr: | head -n1 | sed 's/.*addr://g' | sed 's/ .*//g')$(LANG=c ifconfig  | awk -v RS="" '{gsub (/\n[ ]*inet /," ")}1' | grep ^p.p.* | grep addr: | head -n1 | sed 's/.*addr://g' | sed 's/ .*//g')"  | head -n1)
+  IP=$(hostname -I | cut -f1 -d' ')
 fi
 
 if [ -z "$IP" ]; then
@@ -385,7 +389,8 @@ start_bigbluebutton () {
         # Apply any local configuration options (if exists)
         #
         if [ -x /etc/bigbluebutton/bbb-conf/apply-config.sh ]; then
-                echo -n "Applying updates in /etc/bigbluebutton/bbb-conf/apply-config.sh: "
+		echo
+                echo "Applying updates in /etc/bigbluebutton/bbb-conf/apply-config.sh: "
                 /etc/bigbluebutton/bbb-conf/apply-config.sh
                 echo
         fi
@@ -567,62 +572,6 @@ display_bigbluebutton_status () {
         /etc/init.d/${SERVLET_CONTAINER} status
     fi
 }
-
-#
-# Depreciated -- WebRTC is always enabled by default
-#
-enable_webrtc(){
-	# Set server ip address in FreeSWITCH
-	sed -i "s@<X-PRE-PROCESS cmd=\"set\" data=\"local_ip_v4=.*\"/>@<X-PRE-PROCESS cmd=\"set\" data=\"local_ip_v4=$IP\"/>@g"  $FREESWITCH_VARS
-
-	# Set server ip address in red5 sip app. For flash client.
-	sed -i "s/bbb.sip.app.ip=.*/bbb.sip.app.ip=$IP/g" /usr/share/red5/webapps/sip/WEB-INF/bigbluebutton-sip.properties
-	sed -i "s/freeswitch.ip=.*/freeswitch.ip=$IP/g" /usr/share/red5/webapps/sip/WEB-INF/bigbluebutton-sip.properties
-
-	# Enable WebRTC in the client
-	sed -i "s@useWebRTCIfAvailable=\".*\"@useWebRTCIfAvailable=\"true\"@g" /var/www/bigbluebutton/client/conf/config.xml
-
-	# Enable port 5066 in FreeSWITCH
-	sed -i 's/^.*<!--<param name="ws-binding"  value=":5066"\/>-->.*$/\t<param name="ws-binding"  value=":5066"\/>/g' $FREESWITCH_EXTERNAL
-
-        PROTOCOL=$(cat /etc/bigbluebutton/nginx/sip.nginx |  sed -n '/proxy_pass/{s/.*proxy_pass [ ]*//;s/:.*//;p}')
-        PORT=5066
-        if [[ $PROTOCOL == "https" ]]; then
-                PORT=7443
-        fi
-        sed -i "s/proxy_pass .*/proxy_pass $PROTOCOL:\/\/$IP:$PORT;/g" /etc/bigbluebutton/nginx/sip.nginx
-
-	echo 
-	echo "WebRTC audio enabled.  To apply settings to your server, do"
-	echo 
-	echo "  $SUDO bbb-conf --clean"
-	echo 
-}
-
-disable_webrtc(){
-	# Set 127.0.0.1 in FreeSWITCH
-	sed -i "s@<X-PRE-PROCESS cmd=\"set\" data=\"local_ip_v4=.*\"/>@<X-PRE-PROCESS cmd=\"set\" data=\"local_ip_v4=127.0.0.1\"/>@g"  $FREESWITCH_VARS
-
-	# Set 127.0.0.1 in red5 sip app. For flash client.
-	sed -i "s/bbb.sip.app.ip=.*/bbb.sip.app.ip=127.0.0.1/g" /usr/share/red5/webapps/sip/WEB-INF/bigbluebutton-sip.properties
-	sed -i "s/freeswitch.ip=.*/freeswitch.ip=127.0.0.1/g" /usr/share/red5/webapps/sip/WEB-INF/bigbluebutton-sip.properties
-
-	# Disable WebRTC in the client
-        sed -i "s@useWebRTCIfAvailable=\".*\"@useWebRTCIfAvailable=\"false\"@g" /var/www/bigbluebutton/client/conf/config.xml
-
-	# Disable port 5066 in FreeSWITCH
-	sed -i 's/^.*<param name="ws-binding"  value=":5066"\/>.*$/\t<!--<param name="ws-binding"  value=":5066"\/>-->/g' $FREESWITCH_EXTERNAL
-
-        PROTOCOL=$(cat /etc/bigbluebutton/nginx/sip.nginx |  sed -n '/proxy_pass/{s/.*proxy_pass [ ]*//;s/:.*//;p}')
-        sed -i "s/proxy_pass .*/proxy_pass $PROTOCOL:\/\/127.0.0.1:5066;/g" /etc/bigbluebutton/nginx/sip.nginx
-
-	echo 
-	echo "WebRTC audio disabled.  To apply settings to your server, do"
-	echo 
-	echo "  $SUDO bbb-conf --clean"
-	echo 
-}
-
 
 if [ $# -eq 0 ]; then
 	usage
@@ -1014,8 +963,8 @@ check_configuration() {
 			echo 
 		fi
 
-	if [ -f $HTML5_CONFIG ]; then 
-          if grep \"enableListenOnly\".*true $HTML5_CONFIG > /dev/null; then
+	if [ -f $HTML5_CONFIG_OLD ]; then 
+          if grep \"enableListenOnly\".*true $HTML5_CONFIG_OLD > /dev/null; then
             if ! grep -q ws-binding $FREESWITCH_EXTERNAL ;  then
                 echo "# Warning: You have enabled listen-only audio via Kurento"
                 echo "# but FreeSWITCH is not listening on port 5066.  You should edit "
@@ -1066,7 +1015,7 @@ check_configuration() {
                 echo "# is not owned by $BBB_USER"
         fi
 
-        if [ $PROTOCOL_HTTP == "https" ]; then
+        if [ $PROTOCOL == "https" ]; then
             if ! grep jnlpUrl /usr/share/red5/webapps/screenshare/WEB-INF/screenshare.properties | grep -q https; then
                 echo "# Warning: Detected the value for jnlpUrl is not configured for HTTPS"
                 echo "#    /usr/share/red5/webapps/screenshare/WEB-INF/screenshare.properties"
@@ -1363,7 +1312,7 @@ check_state() {
         COUNT=0
         while [ $COUNT -lt 20 ]; do
           let COUNT=COUNT+1
-	  timeout 1s wget $PROTOCOL_HTTP://$BBB_WEB/bigbluebutton/api -O - --quiet | grep -q SUCCESS
+	  timeout 1s wget $PROTOCOL://$BBB_WEB/bigbluebutton/api -O - --quiet | grep -q SUCCESS
 	  if [ $? -eq 0 ]; then
             let COUNT=30
           else
@@ -1373,10 +1322,10 @@ check_state() {
         done
 	echo
 
-        if ! wget $PROTOCOL_HTTP://$BBB_WEB/bigbluebutton/api -O - --quiet | grep -q SUCCESS; then
+        if ! wget $PROTOCOL://$BBB_WEB/bigbluebutton/api -O - --quiet | grep -q SUCCESS; then
                 echo "# Error: Could not connect to the configured hostname/IP address"
                 echo "#"
-                echo "#    $PROTOCOL_HTTP://$BBB_WEB/"
+                echo "#    $PROTOCOL://$BBB_WEB/"
                 echo "#"
                 echo "# If your BigBlueButton server is behind a firewall, see FAQ."
                 echo
@@ -1626,26 +1575,9 @@ if [ $CHECK ]; then
 	echo "                            Memory: $MEM MB"
 
 	echo
-	echo "/var/www/bigbluebutton/client/conf/config.xml (bbb-client)"
-	PORT_IP=$(cat /var/www/bigbluebutton/client/conf/config.xml | sed -n '/porttest /{s/.*host="//;s/".*//;p}')
-	echo "  		Port test (tunnel): $PORT_IP"
-
-	RED5_IP=$(cat /var/www/bigbluebutton/client/conf/config.xml | sed -n '/uri.*video/{s/.*rtmp[s]*:\/\///;s/\/.*//;p}')
-	WEBRTC_ENABLED_CLIENT=$(grep -i useWebrtcIfAvailable /var/www/bigbluebutton/client/conf/config.xml | cut -d '"' -f2)
-	echo "                              red5: $RED5_IP"
-	echo "              useWebrtcIfAvailable: $WEBRTC_ENABLED_CLIENT"
-
-        if grep -q ws-binding $FREESWITCH_EXTERNAL; then
-          WEBRTC_SOCKET=$($SUDO cat $FREESWITCH_EXTERNAL | sed -n '/ws-binding/{s/.*value="//;s/".*//;p}')
-        fi
-        if grep -q wss-binding $FREESWITCH_EXTERNAL; then
-          WEBRTC_SOCKET=$($SUDO cat $FREESWITCH_EXTERNAL | sed -n '/wss-binding/{s/.*value="//;s/".*//;p}')
-        fi
-	echo
-	echo "$FREESWITCH_EXTERNAL (FreeSWITCH)"
-	echo "                         websocket: $WEBRTC_SOCKET"	
-	WEBRTC_ENABLED=$(grep -i useWebrtcIfAvailable /var/www/bigbluebutton/client/conf/config.xml | cut -d '"' -f2)
-	echo "                    WebRTC enabled: $WEBRTC_ENABLED"	
+	echo "$BBB_WEB_CONFIG (bbb-web)"
+	echo "                              URL: $(cat $BBB_WEB_CONFIG | grep -v '#' | sed -n '/^bigbluebutton.web.serverURL/{s/.*=//;p}')"
+	echo "                defaultGuestPolicy: $(cat $BBB_WEB_CONFIG | grep -v '#' | sed -n '/^defaultGuestPolicy/{s/.*=//;p}')"
 
 	echo
 	echo "/etc/nginx/sites-available/bigbluebutton (nginx)"
@@ -1657,14 +1589,31 @@ if [ $CHECK ]; then
         if cat /etc/nginx/sites-available/bigbluebutton | grep -v '#' | sed -n '/listen/{s/.*listen[ ]*//;s/;//;p}' | grep ssl > /dev/null; then
           echo "                              port: 443 ssl"
         fi
-
 	BBB_CLIENT_DOC_ROOT=$(cat /etc/bigbluebutton/nginx/client.nginx | grep -v '#' | grep \/client -A 1 | head -n 2 | grep root | sed -n '{s/[ \t]*root[ ]*//;s/;//;p}')
 	echo "                    bbb-client dir: $BBB_CLIENT_DOC_ROOT"
 
-	BBB_WEB_IP=$(cat ${SERVLET_DIR}//WEB-INF/classes/bigbluebutton.properties | grep -v '#' | sed -n '/^bigbluebutton.web.serverURL/{s/.*\///;p}')
 	echo
-	echo "${SERVLET_DIR}/WEB-INF/classes/bigbluebutton.properties (bbb-web)"
-	echo "                      bbb-web host: $BBB_WEB_IP"
+	echo "/var/www/bigbluebutton/client/conf/config.xml (bbb-client)"
+	PORT_IP=$(cat /var/www/bigbluebutton/client/conf/config.xml | sed -n '/porttest /{s/.*host="//;s/".*//;p}')
+	echo "  		Port test (tunnel): $PORT_IP"
+
+	RED5_IP=$(cat /var/www/bigbluebutton/client/conf/config.xml | sed -n '/uri.*video/{s/.*rtmp[s]*:\/\///;s/\/.*//;p}')
+	WEBRTC_ENABLED_CLIENT=`xmlstarlet sel -t -m "config/modules/module[@name='PhoneModule']" -v @useWebRTCIfAvailable /var/www/bigbluebutton/client/conf/config.xml`
+	echo "                              red5: $RED5_IP"
+	echo "              useWebrtcIfAvailable: $WEBRTC_ENABLED_CLIENT"
+
+	echo
+	echo "$FREESWITCH_VARS (FreeSWITCH)"
+	echo "                       local_ip_v4: $(xmlstarlet sel -t -m '//X-PRE-PROCESS[@cmd="set" and starts-with(@data, "local_ip_v4=")]' -v @data $FREESWITCH_VARS | sed 's/local_ip_v4=//g')"
+	echo "                   external_rtp_ip: $(xmlstarlet sel -t -m '//X-PRE-PROCESS[@cmd="set" and starts-with(@data, "external_rtp_ip=")]' -v @data $FREESWITCH_VARS | sed 's/external_rtp_ip=//g')"
+	echo "                   external_sip_ip: $(xmlstarlet sel -t -m '//X-PRE-PROCESS[@cmd="set" and starts-with(@data, "external_sip_ip=")]' -v @data $FREESWITCH_VARS | sed 's/external_sip_ip=//g')"
+
+	echo
+	echo "$FREESWITCH_EXTERNAL (FreeSWITCH)"
+	echo "                        ext-rtp-ip: $(xmlstarlet sel -t -m 'profile/settings/param[@name="ext-rtp-ip"]' -v @value $FREESWITCH_EXTERNAL)"
+	echo "                        ext-sip-ip: $(xmlstarlet sel -t -m 'profile/settings/param[@name="ext-sip-ip"]' -v @value $FREESWITCH_EXTERNAL)"
+	echo "                        ws-binding: $(xmlstarlet sel -t -m 'profile/settings/param[@name="ws-binding"]' -v @value $FREESWITCH_EXTERNAL)"
+	echo "                       wss-binding: $(xmlstarlet sel -t -m 'profile/settings/param[@name="wss-binding"]' -v @value $FREESWITCH_EXTERNAL)"
 
 	if [ -f ${SERVLET_DIR}/demo/bbb_api_conf.jsp ]; then
 		BBB_WEB_URL=$(cat ${SERVLET_DIR}//WEB-INF/classes/bigbluebutton.properties | grep -v '#' | sed -n '/^bigbluebutton.web.serverURL/{s/.*\///;p}')
@@ -1687,37 +1636,40 @@ if [ $CHECK ]; then
 		echo "                      client check: $CHECK_URL"
 	fi
 
-	CONFERENCING_MODULE="FreeSWITCH"
-
-	echo
-	echo "/usr/share/red5/webapps/bigbluebutton/WEB-INF/red5-web.xml (red5)"
-	echo "                  voice conference: $CONFERENCING_MODULE"
-
-	if [ -f /usr/local/bigbluebutton/core/scripts/bigbluebutton.yml ]; then
-		PLAYBACK_IP=$(cat /usr/local/bigbluebutton/core/scripts/bigbluebutton.yml | grep -v '#' | sed -n '/^playback_host/{s/.*:[ ]*//;s/;//;p}' | tail -n 1)
+	if [ -f $RECORD_CONFIG ]; then
 		echo
-		echo "/usr/local/bigbluebutton/core/scripts/bigbluebutton.yml (record and playback)"
-		echo "                     playback host: $PLAYBACK_IP"
+		echo "$RECORD_CONFIG (record and playback)"
+		echo "                     playback_host: $(yq r $RECORD_CONFIG playback_host)"
+		echo "                 playback_protocol: $(yq r $RECORD_CONFIG playback_protocol)"
                 echo "                            ffmpeg: $(ffmpeg -version 2>/dev/null | grep ffmpeg | cut -d ' ' -f3 | sed 's/--.*//g' | tr -d '\n')"
 	fi
 
-        if [ -f /usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml ]; then
-	        KURENTO_URL=$(yq r /usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml kurento[0].url)
-                KURENTO_IP=$(yq r /usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml kurento[0].ip)
-                KURENTO_LOCAL_IP=$(yq r /usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml localIpAddress)
-                KURENTO_RECORD_SCREEN_SHARING=$(yq r /usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml recordScreenSharing)
-                KURENTO_RECORD_WEBCAMS=$(yq r /usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml recordWebcams)
-
+        if [ -f $SIP_CONFIG ]; then
                 echo
-                echo "/usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml (Kurento)"
-                echo "                        kurentoUrl: $KURENTO_URL"
-                echo "                         kurentoIp: $KURENTO_IP"
-                echo "                    localIpAddress: $KURENTO_LOCAL_IP"
-                echo "               recordScreenSharing: $KURENTO_RECORD_SCREEN_SHARING"
-                echo "                     recordWebcams: $KURENTO_RECORD_WEBCAMS"
-                echo "                              Node: $(node -v)"
-                echo "                           mongoDB: $(/usr/bin/mongod --version | grep "db version" | sed 's/db version //g')"
+                echo "$SIP_CONFIG (sip.nginx)"
+                echo "                        proxy_pass: $(cat $SIP_CONFIG | grep proxy_pass | sed 's/.*proxy_pass //g' | sed 's/;//'g )"
         fi
+
+        if [ -f $KURENTO_CONFIG ]; then
+                echo
+                echo "$KURENTO_CONFIG (Kurento SFU)"
+                echo "                        kurento.ip: $(yq r $KURENTO_CONFIG kurento[0].ip)"
+                echo "                       kurento.url: $(yq r $KURENTO_CONFIG kurento[0].url)"
+                echo "                    localIpAddress: $(yq r $KURENTO_CONFIG localIpAddress)"
+                echo "               recordScreenSharing: $(yq r $KURENTO_CONFIG recordScreenSharing)"
+                echo "                     recordWebcams: $(yq r $KURENTO_CONFIG recordWebcams)"
+                echo "                  codec_video_main: $(yq r $KURENTO_CONFIG conference-media-specs.codec_video_main)"
+                echo "               codec_video_content: $(yq r $KURENTO_CONFIG conference-media-specs.codec_video_content)"
+        fi
+
+	if [ -f $HTML5_CONFIG ]; then
+                echo
+                echo "/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml (HTML5 client)"
+                echo "                             build: $(yq r $HTML5_CONFIG public.app.html5ClientBuild)"
+                echo "                        kurentoUrl: $(yq r $HTML5_CONFIG public.kurento.wsUrl)"
+                echo "                  enableListenOnly: $(yq r $HTML5_CONFIG public.kurento.enableListenOnly)"
+	fi
+
 
 	check_state
 	echo
@@ -1887,7 +1839,7 @@ if [ -n "$HOST" ]; then
 	chromeExtensionLinkURL=$(cat /var/www/bigbluebutton/client/conf/config.xml | sed -n '/chromeExtensionLink/{s/.*https*:\/\///;s/\/.*//;p}')
 	
 	echo "Assigning $HOST for http[s]:// in /var/www/bigbluebutton/client/conf/config.xml"
-	$SUDO sed -i "s/http[s]*:\/\/\([^\"\/]*\)\([\"\/]\)/$PROTOCOL_HTTP:\/\/$HOST\2/g" \
+	$SUDO sed -i "s/http[s]*:\/\/\([^\"\/]*\)\([\"\/]\)/$PROTOCOL:\/\/$HOST\2/g" \
 		/var/www/bigbluebutton/client/conf/config.xml
 
 	if ! echo "$chromeExtensionLinkURL" | grep -q '""'; then
@@ -1903,15 +1855,15 @@ if [ -n "$HOST" ]; then
 	#
 	echo "Assigning $HOST for web application URL in ${SERVLET_DIR}/WEB-INF/classes/bigbluebutton.properties"
 
-	$SUDO sed -i "s/bigbluebutton.web.serverURL=http[s]*:\/\/.*/bigbluebutton.web.serverURL=$PROTOCOL_HTTP:\/\/$HOST/g" \
+	$SUDO sed -i "s/bigbluebutton.web.serverURL=http[s]*:\/\/.*/bigbluebutton.web.serverURL=$PROTOCOL:\/\/$HOST/g" \
 				${SERVLET_DIR}/WEB-INF/classes/bigbluebutton.properties
 
 	$SUDO sed -i "s/screenshareRtmpServer=.*/screenshareRtmpServer=$HOST/g" \
 				${SERVLET_DIR}/WEB-INF/classes/bigbluebutton.properties
 
 	change_var_value /usr/share/red5/webapps/screenshare/WEB-INF/screenshare.properties streamBaseUrl rtmp://$HOST/screenshare
-	change_var_value /usr/share/red5/webapps/screenshare/WEB-INF/screenshare.properties jnlpUrl $PROTOCOL_HTTP://$HOST/screenshare
-	change_var_value /usr/share/red5/webapps/screenshare/WEB-INF/screenshare.properties jnlpFile $PROTOCOL_HTTP://$HOST/screenshare/screenshare.jnlp
+	change_var_value /usr/share/red5/webapps/screenshare/WEB-INF/screenshare.properties jnlpUrl $PROTOCOL://$HOST/screenshare
+	change_var_value /usr/share/red5/webapps/screenshare/WEB-INF/screenshare.properties jnlpFile $PROTOCOL://$HOST/screenshare/screenshare.jnlp
 
 	if ! grep -q server_names_hash_bucket_size /etc/nginx/nginx.conf; then
 		$SUDO sed -i "s/gzip  on;/gzip  on;\n    server_names_hash_bucket_size  64;/g" /etc/nginx/nginx.conf
@@ -1923,7 +1875,7 @@ if [ -n "$HOST" ]; then
         echo "Assigning $HOST for web application URL in /usr/share/bbb-apps-akka/conf/application.conf"
 
         if [ -f /usr/share/bbb-apps-akka/conf/application.conf ]; then
-                sed -i  "s/bbbWebAPI[ ]*=[ ]*\"[^\"]*\"/bbbWebAPI=\"${PROTOCOL_HTTP}:\/\/$HOST\/bigbluebutton\/api\"/g" \
+                sed -i  "s/bbbWebAPI[ ]*=[ ]*\"[^\"]*\"/bbbWebAPI=\"${PROTOCOL}:\/\/$HOST\/bigbluebutton\/api\"/g" \
                         /usr/share/bbb-apps-akka/conf/application.conf
                 sed -i "s/deskshareip[ ]*=[ ]*\"[^\"]*\"/deskshareip=\"$HOST\"/g" \
                         /usr/share/bbb-apps-akka/conf/application.conf
@@ -1938,7 +1890,7 @@ if [ -n "$HOST" ]; then
         #
         if [ -f ${TOMCAT_DIR}/webapps/demo/bbb_api_conf.jsp ]; then
                 echo "Assigning $HOST for api demos in ${TOMCAT_DIR}/webapps/demo/bbb_api_conf.jsp"
-                $SUDO sed -i "s/BigBlueButtonURL = \"http[s]*:\/\/\([^\"\/]*\)\([\"\/]\)/BigBlueButtonURL = \"$PROTOCOL_HTTP:\/\/$HOST\2/g" \
+                $SUDO sed -i "s/BigBlueButtonURL = \"http[s]*:\/\/\([^\"\/]*\)\([\"\/]\)/BigBlueButtonURL = \"$PROTOCOL:\/\/$HOST\2/g" \
                         ${TOMCAT_DIR}/webapps/demo/bbb_api_conf.jsp
         fi
 
@@ -1986,19 +1938,19 @@ if [ -n "$HOST" ]; then
         #
         # Update HTML5 client
         #
-	if [ -f $HTML5_CONFIG ]; then
+	if [ -f $HTML5_CONFIG_OLD ]; then
         	WS=$(cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties | grep -v '#' | sed -n '/^bigbluebutton.web.serverURL/{s/.*=//;p}' | sed 's/https/wss/g' | sed s'/http/ws/g')
-        	sed -i "s|\"wsUrl.*|\"wsUrl\": \"$WS/bbb-webrtc-sfu\",|g" $HTML5_CONFIG
+        	sed -i "s|\"wsUrl.*|\"wsUrl\": \"$WS/bbb-webrtc-sfu\",|g" $HTML5_CONFIG_OLD
 
 		if [ -f /usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml ]; then
 		  change_yml_value /usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml kurentoUrl "ws://$HOST:8888/kurento"
 		fi
 	fi
 
-	if [ -f $HTML5_CONFIG_NEW ]; then
+	if [ -f $HTML5_CONFIG ]; then
         	WS=$(cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties | grep -v '#' | sed -n '/^bigbluebutton.web.serverURL/{s/.*=//;p}' | sed 's/https/wss/g' | sed s'/http/ws/g')
 
-		change_yml_value $HTML5_CONFIG_NEW wsUrl "$WS/bbb-webrtc-sfu"
+		change_yml_value $HTML5_CONFIG wsUrl "$WS/bbb-webrtc-sfu"
 
 		if [ -f /usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml ]; then
 		  change_yml_value /usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml kurentoUrl "ws://$HOST:8888/kurento"


### PR DESCRIPTION
This pull request 
   * Refactors some of bbb-conf to use xmlstarlet and yq for more reliable extraction of data
   * adds `apply-config.template` to `/etc/bigbluebutton/bbb-conf` to serve as a template for `apply-config.sh`

System administrators can use `apply-config.sh` to automatically apply local configuration changes when updating packages followed by `bbb-conf --setip` or `bbb-conf --restart`.