### PR TITLE
Revert "Fix error when user is not moderator"

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/modifiers/addUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/addUser.js
@@ -58,10 +58,10 @@ export default function addUser(meetingId, user) {
   let userRole = user.role;
 
   if (
-    dummyUser
-    && dummyUser.clientType === 'HTML5'
-    && userRole === ROLE_MODERATOR
-    && !ALLOW_HTML5_MODERATOR
+    dummyUser &&
+    dummyUser.clientType === 'HTML5' &&
+    userRole === ROLE_MODERATOR &&
+    !ALLOW_HTML5_MODERATOR
   ) {
     userRole = ROLE_VIEWER;
   }
@@ -110,8 +110,6 @@ export default function addUser(meetingId, user) {
 
     if (userRole === ROLE_MODERATOR) {
       changeRole(ROLE_MODERATOR, true, userId, meetingId);
-    } else {
-      changeRole(ROLE_MODERATOR, false, userId, meetingId);
     }
 
     if (Meeting.usersProp.guestPolicy === GUEST_ALWAYS_ACCEPT) {


### PR DESCRIPTION
Reverts bigbluebutton/bigbluebutton#6729

Reverting as this change causes viewers in a meeting to obtain privileges (and to look like) moderators

With line `changeRole(ROLE_MODERATOR, false, userId, meetingId);`
![screenshot from 2019-02-11 17-08-39](https://user-images.githubusercontent.com/6312397/52597332-aabf3680-2e20-11e9-91b4-587b37906074.png)

Without it:
![screenshot from 2019-02-11 17-08-57](https://user-images.githubusercontent.com/6312397/52597331-aabf3680-2e20-11e9-8ef9-aed2f2cfa7da.png)
