### PR TITLE
Remove explicit dependency to core-js

### DIFF
--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -21,11 +21,6 @@
     }
   },
   "dependencies": {
-    "//": [
-      "core-js is included with babel-runtime",
-      "but Meteor 1.6.0.1 doesn't see it there for some reason",
-      "need to investigate"
-    ],
     "@babel/runtime": "^7.2.0",
     "@browser-bunyan/server-stream": "^1.5.0",
     "autoprefixer": "~9.3.1",
@@ -35,7 +30,6 @@
     "browser-detect": "^0.2.28",
     "classnames": "^2.2.6",
     "clipboard": "^2.0.4",
-    "core-js": "^2.6.0",
     "eventemitter2": "~5.0.1",
     "fibers": "^3.1.1",
     "flat": "~4.1.0",


### PR DESCRIPTION
As a bonus to removing the explicit dependency, we can now also run `npm audit` without having to make code changes!

Note - there were no changes in package-lock.json this time