### PR TITLE
Stop external video sharing when current presenter leaves

### DIFF
--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/startWatchingExternalVideo.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/startWatchingExternalVideo.js
@@ -4,15 +4,13 @@ import Logger from '/imports/startup/server/logger';
 import Meetings from '/imports/api/meetings';
 import RedisPubSub from '/imports/startup/server/redis';
 
-export default function startStream(credentials, options) {
+export default function startWatchingExternalVideo(credentials, options) {
   const REDIS_CONFIG = Meteor.settings.private.redis;
   const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
   const EVENT_NAME = 'StartExternalVideoMsg';
 
   const { meetingId, requesterUserId } = credentials;
   const { externalVideoUrl } = options;
-
-  Logger.info(' user sharing a new youtube video: ', credentials);
 
   check(meetingId, String);
   check(requesterUserId, String);
@@ -21,6 +19,8 @@ export default function startStream(credentials, options) {
   Meetings.update({ meetingId }, { $set: { externalVideoUrl } });
 
   const payload = { externalVideoUrl };
+
+  Logger.info(`User id=${requesterUserId} sharing a youtube video: ${externalVideoUrl} for meeting ${meetingId}`);
 
   return RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);
 }

--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/stopWatchingExternalVideo.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/stopWatchingExternalVideo.js
@@ -4,20 +4,20 @@ import Logger from '/imports/startup/server/logger';
 import Meetings from '/imports/api/meetings';
 import RedisPubSub from '/imports/startup/server/redis';
 
-export default function startStream(credentials) {
+export default function stopStream(credentials) {
   const REDIS_CONFIG = Meteor.settings.private.redis;
   const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
   const EVENT_NAME = 'StopExternalVideoMsg';
 
   const { meetingId, requesterUserId } = credentials;
 
-  Logger.info(' user sharing a new youtube video: ', credentials);
-
   check(meetingId, String);
   check(requesterUserId, String);
 
   Meetings.update({ meetingId }, { $set: { externalVideoUrl: null } });
   const payload = {};
+
+  Logger.info(`User id=${requesterUserId} stoped sharing a youtube video for meeting=${meetingId}`);
 
   RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);
 }

--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/stopWatchingExternalVideo.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/stopWatchingExternalVideo.js
@@ -17,7 +17,7 @@ export default function stopWatchingExternalVideo(credentials) {
   Meetings.update({ meetingId }, { $set: { externalVideoUrl: null } });
   const payload = {};
 
-  Logger.info(`User id=${requesterUserId} stoped sharing a youtube video for meeting=${meetingId}`);
+  Logger.info(`User id=${requesterUserId} stopped sharing a youtube video for meeting=${meetingId}`);
 
   RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);
 }

--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/stopWatchingExternalVideo.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/stopWatchingExternalVideo.js
@@ -4,7 +4,7 @@ import Logger from '/imports/startup/server/logger';
 import Meetings from '/imports/api/meetings';
 import RedisPubSub from '/imports/startup/server/redis';
 
-export default function stopStream(credentials) {
+export default function stopWatchingExternalVideo(credentials) {
   const REDIS_CONFIG = Meteor.settings.private.redis;
   const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
   const EVENT_NAME = 'StopExternalVideoMsg';

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
@@ -1,6 +1,7 @@
 import { check } from 'meteor/check';
 import Users from '/imports/api/users';
 import Logger from '/imports/startup/server/logger';
+import stopWatchingExternalVideo from '/imports/api/external-videos/server/methods/stopWatchingExternalVideo';
 
 const clearAllSessions = (sessionUserId) => {
   const serverSessions = Meteor.server.sessions;
@@ -12,6 +13,15 @@ const clearAllSessions = (sessionUserId) => {
 export default function removeUser(meetingId, userId) {
   check(meetingId, String);
   check(userId, String);
+
+  const userToRemove = Users.findOne({ userId });
+
+  if (userToRemove) {
+    const { presenter } = userToRemove;
+    if (presenter) {
+      stopWatchingExternalVideo({ meetingId, requesterUserId: userId });
+    }
+  }
 
   const selector = {
     meetingId,

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/container.jsx
@@ -16,10 +16,11 @@ const ExternalVideoContainer = props => (
   </ExternalVideo>
 );
 
-export default injectIntl(withTracker(({ params, intl }) => {
+export default injectIntl(withTracker(({ params, intl, isPresenter }) => {
   const title = intl.formatMessage(intlMessages.title);
 
   return {
     title,
+    isPresenter,
   };
 })(ExternalVideoContainer));


### PR DESCRIPTION
When the current presenter is sharing an external video and he leaves, the sharing video is stopped.

_Issue: #6596_ 