### PR TITLE
Prevent subscribing every 10s when recording

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -232,7 +232,7 @@ const BaseContainer = withTracker(() => {
     userSubscriptionHandler,
     breakoutRoomSubscriptionHandler,
     animations,
-    meetingExist: !!Meetings.findOne({ meetingId }),
+    meetingExist: !!Meetings.find({ meetingId }).count(),
     User,
     meteorIsConnected: Meteor.status().connected,
   };


### PR DESCRIPTION
This PR fix the problem with subscribing every 10s to collections when recording is active, also solve a problem with text tool, reported in #6796.

_Issue: #6723_