### PR TITLE
Fix private chat for viewers and allow private chat with moderators

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateGroupChatReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateGroupChatReqMsgHdlr.scala
@@ -26,7 +26,14 @@ trait CreateGroupChatReqMsgHdlr extends SystemConfiguration {
       if (user.role != Roles.MODERATOR_ROLE) {
         if (msg.body.access == GroupChatAccess.PRIVATE) {
           val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
-          chatLocked = user.locked && permissions.disablePrivChat
+          val modMembers = msg.body.users.filter(userId => Users2x.findWithIntId(liveMeeting.users2x, userId) match {
+            case Some(user) => user.role == Roles.MODERATOR_ROLE
+            case None       => false
+          })
+          // don't lock creation of private chats that involve a moderator
+          if (modMembers.length == 0) {
+            chatLocked = user.locked && permissions.disablePrivChat
+          }
         } else {
           chatLocked = true
         }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
@@ -28,7 +28,14 @@ trait SendGroupChatMessageMsgHdlr {
       if (user.role != Roles.MODERATOR_ROLE && user.locked) {
         val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
         if (groupChat.access == GroupChatAccess.PRIVATE) {
-          chatLocked = permissions.disablePrivChat
+          val modMembers = groupChat.users.filter(cu => Users2x.findWithIntId(liveMeeting.users2x, cu.id) match {
+            case Some(user) => user.role == Roles.MODERATOR_ROLE
+            case None       => false
+          })
+          // don't lock private chats that involve a moderator
+          if (modMembers.length == 0) {
+            chatLocked = permissions.disablePrivChat
+          }
         } else {
           chatLocked = permissions.disablePubChat
         }

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatOptionsTab.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatOptionsTab.mxml
@@ -217,10 +217,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 			}
 			
 			private function refreshListStatus():void {
-				
-				if (UsersUtil.amIModerator() || UsersUtil.amIPresenter()) return; // Settings only affect viewers.
-				
-				usersList.enabled = ! LiveMeeting.inst().me.disableMyPrivateChat;
+				if (LiveMeeting.inst().me.disableMyPrivateChat) {
+					handler.enableModeratorsFilter();
+				} else {
+					handler.disableModeratorsFilter();
+				}
+				users = removeMe(handler.users);
 			}
 			
 			public function sendSaveEvent():void{

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatTab.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatTab.mxml
@@ -69,6 +69,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		import org.bigbluebutton.core.events.LockControlEvent;
 		import org.bigbluebutton.core.events.UserStatusChangedEvent;
 		import org.bigbluebutton.core.model.LiveMeeting;
+		import org.bigbluebutton.core.model.users.User2x;
 		import org.bigbluebutton.main.events.BBBEvent;
 		import org.bigbluebutton.main.events.ShortcutEvent;
 		import org.bigbluebutton.main.events.UserJoinedEvent;
@@ -87,13 +88,13 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		import org.bigbluebutton.modules.chat.model.ChatOptions;
 		import org.bigbluebutton.modules.chat.model.GroupChat;
 		import org.bigbluebutton.modules.chat.vo.ChatMessageVO;
+		import org.bigbluebutton.modules.chat.vo.GroupChatUser;
 		import org.bigbluebutton.modules.polling.events.StartCustomPollEvent;
 		import org.bigbluebutton.util.i18n.ResourceUtil;
 		
       private static const LOGGER:ILogger = getClassLogger(ChatTab);
       
       public var publicChat:Boolean = false;
-      public var chatWithUserID:String;
       public var chatWithUsername:String
       public var chatId: String = null;
       public var parentWindowId:String = null;
@@ -609,7 +610,18 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 		if (publicChat) {
           txtMsgArea.enabled = sendBtn.enabled = !LiveMeeting.inst().me.disableMyPublicChat;
         } else {
-          txtMsgArea.enabled = sendBtn.enabled = !LiveMeeting.inst().me.disableMyPrivateChat || LiveMeeting.inst().users.getUser(chatWithUserID).role == Role.MODERATOR;
+          var chattingWithMod:Boolean = false;
+          var gc:GroupChat = LiveMeeting.inst().chats.getGroupChat(chatId);
+          for (var i:int = 0; i < gc.users.length; i++) {
+            var chatUser:GroupChatUser = gc.users[i] as GroupChatUser;
+            if (chatUser.id != UsersUtil.getMyUserID()) {
+              var user:User2x = UsersUtil.getUser(chatUser.id);
+              if (user && user.role == Role.MODERATOR) {
+                chattingWithMod = true;
+              }
+            }
+          }
+          txtMsgArea.enabled = sendBtn.enabled = !LiveMeeting.inst().me.disableMyPrivateChat || chattingWithMod;
         }
       }
       

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatView.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/chat/views/ChatView.mxml
@@ -340,7 +340,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         var chatBox:ChatTab = new ChatTab();
         
         chatBox.name = groupChatId;
-        chatBox.chatWithUserID = groupChatId;
         chatBox.parentWindowId = windowId;
         chatBox.tabIndexer.startIndex = tabIndexer.startIndex + 10;
 				chatBox.chatMessages = new ChatConversation(groupChatId);

--- a/bigbluebutton-html5/imports/ui/components/chat/service.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/service.js
@@ -20,6 +20,8 @@ const PRIVATE_CHAT_TYPE = CHAT_CONFIG.type_private;
 const PUBLIC_CHAT_USER_ID = CHAT_CONFIG.system_userid;
 const PUBLIC_CHAT_CLEAR = CHAT_CONFIG.system_messages_keys.chat_clear;
 
+const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
+
 const ScrollCollection = new Mongo.Collection(null);
 
 const UnsentMessagesCollection = new Mongo.Collection(null);
@@ -135,11 +137,14 @@ const isChatLocked = (receiverID) => {
   const user = Users.findOne({ userId: Auth.userID });
 
   if (meeting.lockSettingsProp !== undefined) {
-    const isPubChatLocked = meeting.lockSettingsProp.disablePubChat;
-    const isPrivChatLocked = meeting.lockSettingsProp.disablePrivChat;
-
-    return mapUser(user).isLocked
-      && ((isPublic && isPubChatLocked) || (!isPublic && isPrivChatLocked));
+    if (mapUser(user).isLocked) {
+      if (isPublic) {
+        return meeting.lockSettingsProp.disablePubChat;
+      }
+      const receivingUser = Users.findOne({ userId: receiverID });
+      const receiverIsMod = receivingUser && receivingUser.role === ROLE_MODERATOR;
+      return !receiverIsMod && meeting.lockSettingsProp.disablePrivChat;
+    }
   }
 
   return false;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
@@ -226,7 +226,7 @@ class UserDropdown extends PureComponent {
     const enablePrivateChat = currentUser.isModerator
       ? allowedToChatPrivately
       : allowedToChatPrivately
-      && (!(user.locked && disablePrivChat)
+      && (!(currentUser.isLocked && disablePrivChat)
         || hasPrivateChatBetweenUsers(currentUser, user)
         || user.isModerator);
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
@@ -226,7 +226,9 @@ class UserDropdown extends PureComponent {
     const enablePrivateChat = currentUser.isModerator
       ? allowedToChatPrivately
       : allowedToChatPrivately
-      && (!disablePrivChat || (disablePrivChat && hasPrivateChatBetweenUsers(currentUser, user)));
+      && (!(user.locked && disablePrivChat)
+        || hasPrivateChatBetweenUsers(currentUser, user)
+        || user.isModerator);
 
     if (showNestedOptions) {
       if (allowedToChangeStatus) {


### PR DESCRIPTION
This PR fixes a couple of issues related to private chat for viewer users. The detection for whether or not the input box is enabled was broken and was throwing an exception. This meant that the input was always enabled and would sometimes allow viewers to get on the wrong side of the permission checks and get ejected. This PR also restores extra private chat functionality so that a viewer can start and respond to a private chat involving a moderator. ~~I've only covered the Flash client side of this work, but the HTML5 side can easily be added after this has been merged.~~ Both clients allow viewers to private chat with moderators.