### PR TITLE
Sort events when writing the events.xml file

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/events_archiver.rb
+++ b/record-and-playback/core/lib/recordandplayback/events_archiver.rb
@@ -323,7 +323,15 @@ module BigBlueButton
             end
           end
         end
-        recording << event
+
+        # Handle out of order events - if this event has an earlier timestamp than the last event
+        # in the file, find the correct spot (it's usually no more than 1 or 2 off).
+        # Make sure not to change the relative order of two events with the same timestamp.
+        previous_event = recording.last_element_child
+        while prev_event.name == 'event' && prev_event['timestamp'].to_i > event['timestamp'].to_i
+          previous_event = previous_event.previous_element
+        end
+        previous_event.add_next_sibling(event)
 
         # Stop reading events if we've reached the recording break for this
         # segment


### PR DESCRIPTION
BigBlueButton can sometimes write events out of order - this particularly
seems to affect the final RecordStatusEvent in a meeting which was ended
while recording was still running. This breaks the recording processing
scripts.

As a workaround, sort the events as they're being written into the events.xml
file. We have the following properties:

* The input data is already mostly sorted
* Items in the wrong position will be no more than a couple spots off from where
  they should be
* We should not change the relative order of events with the same timestamp.

The best algorithm to use here is a simple insertion sort. When adding each new
event to the XML structure, it scans backwards through existing events until it
finds the correct position.

For #6035