### PR TITLE
Sort events when writing the events.xml file

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/events_archiver.rb
+++ b/record-and-playback/core/lib/recordandplayback/events_archiver.rb
@@ -280,8 +280,14 @@ module BigBlueButton
         # in the file, find the correct spot (it's usually no more than 1 or 2 off).
         # Make sure not to change the relative order of two events with the same timestamp.
         previous_event = recording.last_element_child
+        moved = 0
         while previous_event.name == 'event' && previous_event['timestamp'].to_i > event['timestamp'].to_i
           previous_event = previous_event.previous_element
+          moved += 1
+        end
+        if moved > 0
+          BigBlueButton.logger.info("Reordered event timestamp=#{res[TIMESTAMP]} module=#{res[MODULE]} " \
+                                    "eventname=#{res[EVENTNAME]} by #{moved} positions")
         end
         previous_event.add_next_sibling(event)
       end

--- a/record-and-playback/core/scripts/archive/archive.rb
+++ b/record-and-playback/core/scripts/archive/archive.rb
@@ -41,8 +41,7 @@ def archive_events(meeting_id, redis_host, redis_port, raw_archive_dir)
   begin
     redis = BigBlueButton::RedisWrapper.new(redis_host, redis_port)
     events_archiver = BigBlueButton::RedisEventsArchiver.new redis    
-    events = events_archiver.store_events(meeting_id)
-    events_archiver.save_events_to_file("#{raw_archive_dir}/#{meeting_id}", events )
+    events_archiver.store_events(meeting_id, "#{raw_archive_dir}/#{meeting_id}/events.xml")
   rescue => e
     BigBlueButton.logger.warn("Failed to archive events for #{meeting_id}. " + e.to_s)
   end


### PR DESCRIPTION
BigBlueButton can sometimes write events out of order - this particularly
seems to affect the final RecordStatusEvent in a meeting which was ended
while recording was still running. This breaks the recording processing
scripts.

This was fixed in 2.2, but the fix doesn't merge cleanly into 2.0 because
the archiving code was rewriten due to the segment/chapter break feature.
To get the fix here, I've rewritten the store_events on 2.0 to match the
code on 2.2, that way the same sorting function can be used.

For #6035