### PR TITLE
Recording events archiver: fix syntax errors

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/events_archiver.rb
+++ b/record-and-playback/core/lib/recordandplayback/events_archiver.rb
@@ -328,7 +328,7 @@ module BigBlueButton
         # in the file, find the correct spot (it's usually no more than 1 or 2 off).
         # Make sure not to change the relative order of two events with the same timestamp.
         previous_event = recording.last_element_child
-        while prev_event.name == 'event' && prev_event['timestamp'].to_i > event['timestamp'].to_i
+        while previous_event.name == 'event' && previous_event['timestamp'].to_i > event['timestamp'].to_i
           previous_event = previous_event.previous_element
         end
         previous_event.add_next_sibling(event)


### PR DESCRIPTION
I had renamed prev_event to previous_event, but missed a couple of spots.