### PR TITLE
Recording archive: log when events are are out of order and must be sorted

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/events_archiver.rb
+++ b/record-and-playback/core/lib/recordandplayback/events_archiver.rb
@@ -328,8 +328,14 @@ module BigBlueButton
         # in the file, find the correct spot (it's usually no more than 1 or 2 off).
         # Make sure not to change the relative order of two events with the same timestamp.
         previous_event = recording.last_element_child
+        moved = 0
         while previous_event.name == 'event' && previous_event['timestamp'].to_i > event['timestamp'].to_i
           previous_event = previous_event.previous_element
+          moved += 1
+        end
+        if moved > 0
+          BigBlueButton.logger.info("Reordered event timestamp=#{res[TIMESTAMP]} module=#{res[MODULE]} " \
+                                    "eventname=#{res[EVENTNAME]} by #{moved} positions")
         end
         previous_event.add_next_sibling(event)
 


### PR DESCRIPTION
To help us track down exactly why this is happening - and know when we've
properly fixed it - add some logging.