### PR TITLE
 - track if user joins within a certain period of time. 

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
@@ -19,6 +19,8 @@ trait SystemConfiguration extends RedisConfiguration {
   lazy val expireLastUserLeft = Try(config.getInt("expire.lastUserLeft")).getOrElse(60) // 1 minute
   lazy val expireNeverJoined = Try(config.getInt("expire.neverJoined")).getOrElse(5 * 60) // 5 minutes
 
+  lazy val maxRegUserToJoinTime = Try(config.getInt("expire.maxRegUserToJoin")).getOrElse(5 * 60) // 5 minutes
+
   lazy val analyticsChannel = Try(config.getString("eventBus.analyticsChannel")).getOrElse("analytics-channel")
   lazy val meetingManagerChannel = Try(config.getString("eventBus.meetingManagerChannel")).getOrElse("MeetingManagerChannel")
   lazy val outMessageChannel = Try(config.getString("eventBus.outMessageChannel")).getOrElse("OutgoingMessageChannel")

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
@@ -7,7 +7,18 @@ object RegisteredUsers {
   def create(userId: String, extId: String, name: String, roles: String,
              token: String, avatar: String, guest: Boolean, authenticated: Boolean,
              guestStatus: String): RegisteredUser = {
-    new RegisteredUser(userId, extId, name, roles, token, avatar, guest, authenticated, guestStatus)
+    new RegisteredUser(userId,
+      extId,
+      name,
+      roles,
+      token,
+      avatar,
+      guest,
+      authenticated,
+      guestStatus,
+      System.currentTimeMillis(),
+      false,
+      false)
   }
 
   def findWithToken(token: String, users: RegisteredUsers): Option[RegisteredUser] = {
@@ -16,6 +27,10 @@ object RegisteredUsers {
 
   def findWithUserId(id: String, users: RegisteredUsers): Option[RegisteredUser] = {
     users.toVector.find(ru => id == ru.id)
+  }
+
+  def findUsersNotJoined(users: RegisteredUsers):Vector[RegisteredUser] = {
+    users.toVector.filter(u => u.joined == false && u.markAsJoinTimedOut == false)
   }
 
   def getRegisteredUserWithToken(token: String, userId: String, regUsers: RegisteredUsers): Option[RegisteredUser] = {
@@ -31,14 +46,6 @@ object RegisteredUsers {
       ru <- RegisteredUsers.findWithToken(token, regUsers)
       user <- isSameUserId(ru, userId)
     } yield user
-  }
-
-  def updateRegUser(uvo: UserVO, users: RegisteredUsers) {
-    for {
-      ru <- RegisteredUsers.findWithUserId(uvo.id, users)
-      regUser = new RegisteredUser(uvo.id, uvo.externalId, uvo.name, uvo.role, ru.authToken,
-        uvo.avatarURL, uvo.guest, uvo.authed, uvo.guestStatus)
-    } yield users.save(regUser)
   }
 
   def add(users: RegisteredUsers, user: RegisteredUser): Vector[RegisteredUser] = {
@@ -63,6 +70,17 @@ object RegisteredUsers {
     u
   }
 
+  def updateUserJoin(users: RegisteredUsers, user: RegisteredUser): RegisteredUser = {
+    val u = user.copy(joined = true)
+    users.save(u)
+    u
+  }
+
+  def markAsUserFailedToJoin(users: RegisteredUsers, user: RegisteredUser): RegisteredUser = {
+    val u = user.copy(markAsJoinTimedOut = true)
+    users.save(u)
+    u
+  }
 }
 
 class RegisteredUsers {
@@ -84,7 +102,16 @@ class RegisteredUsers {
   }
 }
 
-case class RegisteredUser(id: String, externId: String, name: String, role: String,
-                          authToken: String, avatarURL: String, guest: Boolean,
-                          authed: Boolean, guestStatus: String)
+case class RegisteredUser(id: String,
+                          externId: String,
+                          name: String,
+                          role: String,
+                          authToken: String,
+                          avatarURL: String,
+                          guest: Boolean,
+                          authed: Boolean,
+                          guestStatus: String,
+                          registeredOn: Long,
+                          joined: Boolean,
+                          markAsJoinTimedOut: Boolean)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -26,12 +26,22 @@ trait HandlerHelpers extends SystemConfiguration {
     outGW.send(event)
   }
 
+  def trackUserJoin(outGW: OutMsgRouter,
+                    liveMeeting: LiveMeeting,
+                    regUser: RegisteredUser): Unit = {
+    if (!regUser.joined) {
+      RegisteredUsers.updateUserJoin(liveMeeting.registeredUsers, regUser)
+    }
+  }
+
   def userJoinMeeting(outGW: OutMsgRouter, authToken: String, clientType: String,
                       liveMeeting: LiveMeeting, state: MeetingState2x): MeetingState2x = {
 
     val nu = for {
       regUser <- RegisteredUsers.findWithToken(authToken, liveMeeting.registeredUsers)
     } yield {
+      trackUserJoin(outGW, liveMeeting, regUser)
+
       UserState(
         intId = regUser.id,
         extId = regUser.externId,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -506,7 +506,7 @@ class MeetingActor(
     setRecordingChapterBreak()
 
     processUserInactivityAudit()
-
+    flagRegisteredUsersWhoHasNotJoined()
     checkIfNeetToEndMeetingWhenNoAuthedUsers(liveMeeting)
   }
 
@@ -654,6 +654,21 @@ class MeetingActor(
       if (!respondedOntIme) {
         UsersApp.ejectUserFromMeeting(outGW, liveMeeting, u.intId, SystemUser.ID, "User inactive for too long.", EjectReasonCode.USER_INACTIVITY)
         Sender.sendDisconnectClientSysMsg(liveMeeting.props.meetingProp.intId, u.intId, SystemUser.ID, EjectReasonCode.USER_INACTIVITY, outGW)
+      }
+    }
+  }
+
+  def flagRegisteredUsersWhoHasNotJoined(): Unit = {
+    val users = RegisteredUsers.findUsersNotJoined(liveMeeting.registeredUsers)
+    users foreach{ u =>
+      val now = System.currentTimeMillis()
+      if (now - u.registeredOn > TimeUtil.secondsToMillis(maxRegUserToJoinTime)) {
+        RegisteredUsers.markAsUserFailedToJoin(liveMeeting.registeredUsers, u)
+        val event = MsgBuilder.buildRegisteredUserJoinTimeoutMsg(
+          liveMeeting.props.meetingProp.intId,
+          u.id,
+          u.name)
+        outGW.send(event)
       }
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/util/TimeUtil.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/util/TimeUtil.scala
@@ -20,6 +20,10 @@ object TimeUtil {
     TimeUnit.MINUTES.toSeconds(minutes)
   }
 
+  def secondsToMillis(seconds: Long): Long = {
+    TimeUnit.SECONDS.toMillis(seconds)
+  }
+
   def timeNowInMinutes(): Long = TimeUnit.NANOSECONDS.toMinutes(System.nanoTime())
   def timeNowInSeconds(): Long = TimeUnit.NANOSECONDS.toSeconds(System.nanoTime())
   def timeNowInMs(): Long = TimeUnit.NANOSECONDS.toMillis(System.nanoTime())

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
@@ -31,6 +31,7 @@ class AnalyticsActor extends Actor with ActorLogging {
 
     msg.core match {
       case m: RegisterUserReqMsg => logMessage(msg)
+      case m: RegisteredUserJoinTimeoutMsg => logMessage(msg)
       case m: UserRegisteredRespMsg => logMessage(msg)
       case m: DisconnectAllClientsSysMsg => logMessage(msg)
       case m: DisconnectClientSysMsg => logMessage(msg)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -317,4 +317,13 @@ object MsgBuilder {
 
     BbbCommonEnvCoreMsg(envelope, event)
   }
+
+  def buildRegisteredUserJoinTimeoutMsg(meetingId: String, userId: String, name: String): BbbCommonEnvCoreMsg = {
+    val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
+    val envelope = BbbCoreEnvelope(RegisteredUserJoinTimeoutMsg.NAME, routing)
+    val header = BbbCoreHeaderWithMeetingId(RegisteredUserJoinTimeoutMsg.NAME, meetingId)
+    val body = RegisteredUserJoinTimeoutMsgBody(meetingId, userId, name)
+    val event = RegisteredUserJoinTimeoutMsg(header, body)
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
 }

--- a/akka-bbb-apps/src/universal/conf/application.conf
+++ b/akka-bbb-apps/src/universal/conf/application.conf
@@ -39,6 +39,7 @@ expire {
   # time in seconds
   lastUserLeft = 60
   neverJoined = 300
+  maxRegUserToJoin = 300
 }
 
 services {

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMgs.scala
@@ -18,6 +18,11 @@ case class UserRegisteredRespMsg(header: BbbCoreHeaderWithMeetingId,
                               body: UserRegisteredRespMsgBody) extends BbbCoreMsg
 case class UserRegisteredRespMsgBody(meetingId: String, userId: String, name: String, role: String)
 
+object RegisteredUserJoinTimeoutMsg { val NAME = "RegisteredUserJoinTimeoutMsg" }
+case class RegisteredUserJoinTimeoutMsg(header: BbbCoreHeaderWithMeetingId,
+                                 body: RegisteredUserJoinTimeoutMsgBody) extends BbbCoreMsg
+case class RegisteredUserJoinTimeoutMsgBody(meetingId: String, userId: String, name: String)
+
 object ValidateAuthTokenReqMsg {
   val NAME = "ValidateAuthTokenReqMsg"
 


### PR DESCRIPTION
Sometimes, nodejs takes most of the CPU that users takes a long time to load the client and join. This way, we can detect if there are a number of users failing to join the meeting.