### PR TITLE
Recording: Remove the red5 race workaround that delays processing

### DIFF
--- a/record-and-playback/core/scripts/rap-archive-worker.rb
+++ b/record-and-playback/core/scripts/rap-archive-worker.rb
@@ -23,9 +23,6 @@ require 'rubygems'
 require 'yaml'
 require 'fileutils'
 
-# Number of seconds to delay archiving (red5 race condition workaround)
-ARCHIVE_DELAY_SECONDS = 120
-
 def archive_recorded_meetings(recording_dir)
   recorded_done_files = Dir.glob("#{recording_dir}/status/recorded/*.done")
 
@@ -42,11 +39,6 @@ def archive_recorded_meetings(recording_dir)
       break_timestamp = match[2]
     else
       BigBlueButton.logger.warn("Recording done file for #{recorded_done_base} has invalid format")
-      next
-    end
-
-    if File.mtime(recorded_done) + ARCHIVE_DELAY_SECONDS > Time.now
-      BigBlueButton.logger.info("Temporarily skipping #{recorded_done_base} for Red5 race workaround")
       next
     end
 


### PR DESCRIPTION
This was added to workaround for red5 taking a while to rewrite the
serialized (.ser) data that it streams to disk back to the .flv format.

The workaround is no longer needed, for two reasons:
* The sanity scripts run the red5 code to generate the .flv from the .ser
  if needed, and
* We're expecting more people to be using WebRTC media in the future anyways

This makes recordings available up to 2 minutes earlier than they would have
been otherwise.

Fixes #6826