### PR TITLE
[HTML5] Change default resolution for webcams to 320x240

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -93,9 +93,9 @@ public:
     firefoxScreenshareSource: window
     cameraConstraints:
       width:
-        max: 640
+        max: 320
       height:
-        max: 480
+        max: 240
     enableScreensharing: false
     enableVideo: true
     enableVideoStats: false


### PR DESCRIPTION
- This was done to mitigate packet loss and flickering and better abide to our default configured bitrate (300kbps).
This goes alongside updates to bbb-webrtc-sfu and kurento-media-server to increase reliablity and diminish stream artifacts.
I'll probably revisit this resolution change once I can correctly identify the source of corrupted frames, but I really think we should
maintain this as 320x240 for the time being. 640x480 would only be feasible if we increased our default bitrate config to 500kbps.