### PR TITLE
Stop tracks when close preview modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -140,6 +140,7 @@ class VideoPreview extends Component {
 
   handleProceed() {
     const { resolve, closeModal } = this.props;
+    this.stopTracks();
     closeModal();
     if (resolve) resolve();
   }


### PR DESCRIPTION
This PR is to fix the issue #5456 

_In my tests, I don't see the webcam icon after timeout error.
But I see the icon when I close the video preview modal through close button._