### PR TITLE
Avoid client crash when in multi whiteboard mode and when publishing polls

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/media/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/media/styles.scss
@@ -35,7 +35,12 @@
 }
 
 .hideOverlay {
-  display: none;
+  visibility: hidden;
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  height: 1px; width: 1px;
+  margin: -1px; padding: 0; border: 0;
 }
 
 .floatingOverlay {


### PR DESCRIPTION
Avoid `NS_ERROR_FAILURE` in Firefox which leads to client crash and solves a problem when presenter publish a poll and a viewer is with presentation close.

- _Poll issue: #6710_
- _Multi whiteboard issue: #6857_

The problem was that Firefox can't handle `getBBox()` of element that are `display: none`, the solution was set the elements to use `visibility: hidden` instead.

In the example below it's possible to observe this behaviour:
https://jsfiddle.net/dekkard/b0t5mbea/

### How to try to reproduce the error:
You will need 2 or more users
Enable multi whiteboard
Start drawing or leaving the presentation area with the cursor and then close the presentation. (The problem should only occurs on Firefox)(The exception don't occurs often)