### PR TITLE
Fix fitToWidth label toggle / button alignment

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -95,14 +95,14 @@ const propTypes = {
   handleToggleFullscreen: PropTypes.func.isRequired,
   mountModal: PropTypes.func.isRequired,
   isFullScreen: PropTypes.bool,
-  isAndroid: PropTypes.bool,
+  noIOSFullscreen: PropTypes.bool,
   amIModerator: PropTypes.bool,
   shortcuts: PropTypes.string,
 };
 
 const defaultProps = {
   isFullScreen: false,
-  isAndroid: false,
+  noIOSFullscreen: true,
   amIModerator: false,
   shortcuts: '',
 };
@@ -135,7 +135,7 @@ class SettingsDropdown extends PureComponent {
     const {
       intl,
       isFullScreen,
-      isAndroid,
+      noIOSFullscreen,
       handleToggleFullscreen,
     } = this.props;
 
@@ -149,7 +149,8 @@ class SettingsDropdown extends PureComponent {
       fullscreenIcon = 'exit_fullscreen';
     }
 
-    if (!isAndroid) return null;
+    if (noIOSFullscreen) return null;
+
     return (
       <DropdownListItem
         key="list-item-fullscreen"

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/container.jsx
@@ -56,15 +56,19 @@ export default class SettingsDropdownContainer extends PureComponent {
 
     const handleToggleFullscreen = toggleFullScreen;
     const { isFullScreen } = this.state;
-    const result = browser();
-    const isAndroid = (result && result.os) ? result.os.includes('Android') : false;
+
+    const BROWSER_RESULTS = browser();
+    const isSafari = BROWSER_RESULTS.name === 'safari';
+    const noIOSFullscreen = isSafari && BROWSER_RESULTS.versionNumber < 12;
 
     return (
       <SettingsDropdown
-        handleToggleFullscreen={handleToggleFullscreen}
-        isFullScreen={isFullScreen}
-        isAndroid={isAndroid}
-        amIModerator={amIModerator}
+        {...{
+          handleToggleFullscreen,
+          isFullScreen,
+          noIOSFullscreen,
+          amIModerator,
+        }}
       />
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -381,7 +381,7 @@ class PresentationArea extends Component {
       isFullscreen: propIsFullscreen,
     } = this.props;
 
-    const { zoom } = this.state;
+    const { zoom, fitToWidth } = this.state;
 
     const fullRef = () => this.refPresentationContainer.requestFullscreen();
 
@@ -391,12 +391,15 @@ class PresentationArea extends Component {
 
     return (
       <PresentationToolbarContainer
+        {...{
+          fitToWidth,
+          zoom,
+          podId,
+        }}
         isFullscreen={propIsFullscreen}
         fullscreenRef={fullRef}
-        podId={podId}
         currentSlideNum={currentSlide.num}
         presentationId={currentSlide.presentationId}
-        zoom={zoom}
         zoomChanger={this.zoomChanger}
         fitToWidthHandler={this.fitToWidthHandler}
       />

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -8,8 +8,6 @@ import { HUNDRED_PERCENT, MAX_PERCENT, STEP } from '/imports/utils/slideCalcUtil
 import { styles } from './styles.scss';
 import ZoomTool from './zoom-tool/component';
 import FullscreenButton from '../../video-provider/fullscreen-button/component';
-import DownloadPresentationButton from '/imports/ui/components/presentation/download-presentation-button/component';
-
 
 const intlMessages = defineMessages({
   previousSlideLabel: {
@@ -27,6 +25,10 @@ const intlMessages = defineMessages({
   fitToWidth: {
     id: 'app.presentation.presentationToolbar.fitToWidth',
     description: 'button for fit to width',
+  },
+  fitToPage: {
+    id: 'app.presentation.presentationToolbar.fitToPage',
+    description: 'button label for fit to width',
   },
   presentationLabel: {
     id: 'app.presentationUploder.title',
@@ -188,6 +190,7 @@ class PresentationToolbar extends Component {
       currentSlideNum,
       numberOfSlides,
       fitToWidthHandler,
+      fitToWidth,
       actions,
       intl,
       zoom,
@@ -198,9 +201,9 @@ class PresentationToolbar extends Component {
     const BROWSER_RESULTS = browser();
     const isMobileBrowser = BROWSER_RESULTS.mobile
       || BROWSER_RESULTS.os.includes('Android');
-    
+
     const tooltipDistance = 35;
-    
+
     return (
       <div id="presentationToolbarWrapper" className={styles.presentationToolbarWrapper}>
         {PresentationToolbar.renderAriaLabelsDescs()}
@@ -277,7 +280,10 @@ class PresentationToolbar extends Component {
               size="md"
               circle={false}
               onClick={fitToWidthHandler}
-              label={intl.formatMessage(intlMessages.fitToWidth)}
+              label={fitToWidth
+                ? intl.formatMessage(intlMessages.fitToPage)
+                : intl.formatMessage(intlMessages.fitToWidth)
+              }
               hideLabel
               className={styles.skipSlide}
               tooltipDistance={tooltipDistance}
@@ -327,6 +333,12 @@ PresentationToolbar.propTypes = {
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
+  zoomChanger: PropTypes.func.isRequired,
+  fitToWidthHandler: PropTypes.func.isRequired,
+  fitToWidth: PropTypes.bool.isRequired,
+  fullscreenRef: PropTypes.func.isRequired,
+  isFullscreen: PropTypes.bool.isRequired,
+  zoom: PropTypes.number.isRequired,
 };
 
 export default injectWbResizeEvent(injectIntl(PresentationToolbar));

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -18,6 +18,7 @@ const PresentationToolbarContainer = (props) => {
     getSwapLayout,
     isFullscreen,
     fullscreenRef,
+    fitToWidth,
   } = props;
 
   if (userIsPresenter && !getSwapLayout) {
@@ -34,6 +35,7 @@ const PresentationToolbarContainer = (props) => {
           zoom,
           zoomChanger,
           fitToWidthHandler,
+          fitToWidth,
         }}
       />
     );
@@ -42,7 +44,7 @@ const PresentationToolbarContainer = (props) => {
 };
 
 export default withTracker((params) => {
-  const { podId, presentationId } = params;
+  const { podId, presentationId, fitToWidth } = params;
   const data = PresentationToolbarService.getSlideData(podId, presentationId);
 
   const {
@@ -52,6 +54,7 @@ export default withTracker((params) => {
   return {
     getSwapLayout: MediaService.getSwapLayout(),
     fitToWidthHandler: params.fitToWidthHandler,
+    fitToWidth,
     userIsPresenter: PresentationService.isPresenter(podId),
     numberOfSlides,
     zoom: params.zoom,

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.scss
@@ -126,6 +126,12 @@
   }
 }
 
+.itemAction {
+  div > i {
+    margin-top: .25rem;
+  }
+}
+
 .itemAction,
 .itemAction > i {
   display: inline-block;

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -94,6 +94,7 @@
     "app.presentation.presentationToolbar.zoomReset": "Reset Zoom",
     "app.presentation.presentationToolbar.zoomIndicator": "Current zoom percentage",
     "app.presentation.presentationToolbar.fitToWidth": "Fit to width",
+    "app.presentation.presentationToolbar.fitToPage": "Fit to page",
     "app.presentation.presentationToolbar.goToSlide": "Slide {0}",
     "app.presentationUploder.title": "Presentation",
     "app.presentationUploder.message": "As a presenter in BigBlueButton, you have the ability of uploading any office document or PDF file.  We recommend PDF file for best results.",


### PR DESCRIPTION
Closes #6973 and #6907.

Also display's the fullscreen button in the options menu for Safari 12, partially closing #6936.  