### PR TITLE
Change webcam resolution to 640x480 if using iOS

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -155,14 +155,9 @@ class VideoPreview extends Component {
       const webcams = [];
 
       // set webcam
-      if (webcamDeviceId) {
-        changeWebcam(webcamDeviceId);
-        this.setState({ webcamDeviceId });
-        isInitialDeviceSet = true;
-      }
       devices.forEach((device) => {
         if (device.kind === 'videoinput') {
-          if (!isInitialDeviceSet) {
+          if (!isInitialDeviceSet || (webcamDeviceId && webcamDeviceId === device.deviceId)) {
             changeWebcam(device.deviceId);
             this.setState({ webcamDeviceId: device.deviceId });
             isInitialDeviceSet = true;
@@ -174,6 +169,14 @@ class VideoPreview extends Component {
       }
 
       constraints.video.deviceId = { exact: this.state.webcamDeviceId };
+
+      const iOS = ['iPad', 'iPhone', 'iPod'].indexOf(navigator.platform) >= 0;
+      
+      if (iOS) {
+        constraints.video.width = { max: 640 };
+        constraints.video.height = { max: 480 };
+      }
+
       navigator.mediaDevices.getUserMedia(constraints).then((stream) => {
         // display the preview
         this.video.srcObject = stream;


### PR DESCRIPTION
This Pr adds:

- Change webcam resolution to 640x480 if using iOS (It is necessary because iOS cannot give 320x240)
- Guarantee the `constraints.video.deviceId` is in devices list of `enumerateDevices` (sometimes the `webcamDeviceId` was an invalid Id in iOS tests)

This PR solves the #6947 issue.