### PR TITLE
Add commons-compress dependency to pres-checker project

### DIFF
--- a/bigbluebutton-web/pres-checker/build.gradle
+++ b/bigbluebutton-web/pres-checker/build.gradle
@@ -20,13 +20,14 @@ repositories {
 }
 
 dependencies {
-    compile 'org.apache.poi:poi:4.0.0@jar'
-    compile 'org.apache.poi:poi-ooxml:4.0.0@jar'
-    compile 'org.apache.poi:poi-ooxml-schemas:4.0.0@jar'
-    compile 'commons-io:commons-io:2.6@jar'
-    compile 'org.apache.commons:commons-lang3:3.8.1@jar'
-    compile 'org.apache.commons:commons-collections4:4.2@jar'
-    compile 'org.apache.xmlbeans:xmlbeans:3.0.2@jar'
+    compile 'org.apache.poi:poi:4.0.0'
+    compile 'org.apache.poi:poi-ooxml:4.0.0'
+    compile 'org.apache.poi:poi-ooxml-schemas:4.0.0'
+    compile 'commons-io:commons-io:2.6'
+    compile 'org.apache.commons:commons-lang3:3.8.1'
+    compile 'org.apache.commons:commons-collections4:4.2'
+    compile 'org.apache.xmlbeans:xmlbeans:3.0.2'
+    compile 'org.apache.commons:commons-compress:1.18'
 }
 
 jar {

--- a/bigbluebutton-web/pres-checker/build.sh
+++ b/bigbluebutton-web/pres-checker/build.sh
@@ -1,3 +1,3 @@
 gradle clean
 gradle jar
-cp build/lib/*.jar lib
+cp build/libs/*.jar lib


### PR DESCRIPTION
Used classes from `commons-compress` seems to not be provided in POI 4.

This PR fixes the following issue when running the presentation checker.

```
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/commons/compress/archivers/zip/ZipArchiveOutputStream
        at org.apache.poi.openxml4j.opc.OPCPackage.open(OPCPackage.java:298)
        at org.apache.poi.ooxml.util.PackageHelper.open(PackageHelper.java:37)
        at org.apache.poi.xslf.usermodel.XMLSlideShow.<init>(XMLSlideShow.java:109)
        at org.bigbluebutton.prescheck.Main.check(Main.java:38)
        at org.bigbluebutton.prescheck.Main.main(Main.java:24)
Caused by: java.lang.ClassNotFoundException: org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
        at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        ... 5 more
```