### PR TITLE
Allow unlocked viewers to unmute when meeting is locked

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/MuteUserCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/MuteUserCmdMsgHdlr.scala
@@ -33,7 +33,7 @@ trait MuteUserCmdMsgHdlr extends RightsManagementTrait {
         requester <- Users2x.findWithIntId(liveMeeting.users2x, msg.header.userId)
         u <- VoiceUsers.findWithIntId(liveMeeting.voiceUsers, msg.body.userId)
       } yield {
-        if (requester.role != Roles.MODERATOR_ROLE && permissions.disableMic && u.muted &&
+        if (requester.role != Roles.MODERATOR_ROLE && permissions.disableMic && requester.locked && u.muted &&
           msg.body.userId == msg.header.userId) {
           // unmuting self while not moderator and mic disabled. Do not allow.
         } else {


### PR DESCRIPTION
Previously an unlocked viewer couldn't unmute when the microphones were locked in a meeting. I just had to add an additional check for the user's personal lock state.

Issue was reported in https://github.com/bigbluebutton/bigbluebutton/pull/7005