### PR TITLE
Only process chat msgs when requested from html5

### DIFF
--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/eventHandlers.js
@@ -2,8 +2,9 @@ import RedisPubSub from '/imports/startup/server/redis';
 import handleGroupChatsMsgs from './handlers/groupChatsMsgs';
 import handleGroupChatMsgBroadcast from './handlers/groupChatMsgBroadcast';
 import handleClearPublicGroupChat from './handlers/clearPublicGroupChat';
+import { processForHTML5ServerOnly } from '/imports/api/common/server/helpers';
 
-RedisPubSub.on('GetGroupChatMsgsRespMsg', handleGroupChatsMsgs);
+RedisPubSub.on('GetGroupChatMsgsRespMsg', processForHTML5ServerOnly(handleGroupChatsMsgs));
 RedisPubSub.on('GroupChatMessageBroadcastEvtMsg', handleGroupChatMsgBroadcast);
 RedisPubSub.on('ClearPublicChatHistoryEvtMsg', handleClearPublicGroupChat);
 RedisPubSub.on('SyncGetGroupChatMsgsRespMsg', handleGroupChatsMsgs);

--- a/bigbluebutton-html5/imports/api/group-chat/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/group-chat/server/eventHandlers.js
@@ -2,8 +2,9 @@ import RedisPubSub from '/imports/startup/server/redis';
 import handleGroupChats from './handlers/groupChats';
 import handleGroupChatCreated from './handlers/groupChatCreated';
 import handleGroupChatDestroyed from './handlers/groupChatDestroyed';
+import { processForHTML5ServerOnly } from '/imports/api/common/server/helpers';
 
-RedisPubSub.on('GetGroupChatsRespMsg', handleGroupChats);
+RedisPubSub.on('GetGroupChatsRespMsg', processForHTML5ServerOnly(handleGroupChats));
 RedisPubSub.on('GroupChatCreatedEvtMsg', handleGroupChatCreated);
 RedisPubSub.on('GroupChatDestroyedEvtMsg', handleGroupChatDestroyed);
 RedisPubSub.on('SyncGetGroupChatsRespMsg', handleGroupChats);

--- a/bigbluebutton-html5/imports/api/voice-users/server/modifiers/updateVoiceUser.js
+++ b/bigbluebutton-html5/imports/api/voice-users/server/modifiers/updateVoiceUser.js
@@ -33,7 +33,7 @@ export default function updateVoiceUser(meetingId, voiceUser) {
       return Logger.error(`Update voiceUser=${intId}: ${err}`);
     }
 
-    return true;
+    return Logger.debug(`Update voiceUser=${intId} meeting=${meetingId}`);
   };
 
   return VoiceUsers.update(selector, modifier, cb);

--- a/bigbluebutton-html5/imports/api/voice-users/server/modifiers/updateVoiceUser.js
+++ b/bigbluebutton-html5/imports/api/voice-users/server/modifiers/updateVoiceUser.js
@@ -33,7 +33,7 @@ export default function updateVoiceUser(meetingId, voiceUser) {
       return Logger.error(`Update voiceUser=${intId}: ${err}`);
     }
 
-    return Logger.info(`Update voiceUser=${intId} meeting=${meetingId}`);
+    return true;
   };
 
   return VoiceUsers.update(selector, modifier, cb);


### PR DESCRIPTION
Prior to this change, every time a Flash client user joined the meeting, the entire chat history would be resent via redis (to the Flash user) but html5 server side would also pick it up and re-process.
