### PR TITLE
Remove clear credentials that cause new client subscriptions.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -4,7 +4,6 @@ import { defineMessages, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import Auth from '/imports/ui/services/auth';
 import Users from '/imports/api/users';
-import mapUser from '/imports/ui/services/user/mapUser';
 import Breakouts from '/imports/api/breakouts';
 import Meetings from '/imports/api/meetings';
 
@@ -69,8 +68,6 @@ const AppContainer = (props) => {
 
 export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) => {
   const currentUser = Users.findOne({ userId: Auth.userID });
-  const currentUserIsLocked = mapUser(currentUser).isLocked;
-  const meeting = Meetings.findOne({ meetingId: Auth.meetingID });
   const isMeetingBreakout = meetingIsBreakout();
 
   if (!currentUser.approved) {
@@ -92,7 +89,7 @@ export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) 
   Meetings.find({ meetingId: Auth.meetingID }).observeChanges({
     removed() {
       if (isMeetingBreakout) {
-        Auth.clearCredentials().then(window.close);
+        window.close();
       } else {
         endMeeting('410');
       }
@@ -102,7 +99,7 @@ export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) 
   // Close the window when the current breakout room ends
   Breakouts.find({ breakoutId: Auth.meetingID }).observeChanges({
     removed() {
-      Auth.clearCredentials().then(window.close);
+      window.close();
     },
   });
 

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
@@ -167,7 +167,11 @@ class MeetingEnded extends React.PureComponent {
       <div className={styles.parent}>
         <div className={styles.modal}>
           <div className={styles.content}>
-            <h1 className={styles.title}>{intl.formatMessage(intlMessage[code])}</h1>
+            <h1 className={styles.title}>
+              {
+                intl.formatMessage(intlMessage[code] || intlMessage[430])
+              }
+            </h1>
             <div className={styles.text}>
               {this.shouldShowFeedback
                 ? intl.formatMessage(intlMessage.subtitle)

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
@@ -163,6 +163,9 @@ class MeetingEnded extends React.PureComponent {
     } = this.state;
 
     const noRating = selected <= 0;
+
+    logger.info({ feedback: code, logCode: 'meeting_ended_code' }, code);
+
     return (
       <div className={styles.parent}>
         <div className={styles.modal}>


### PR DESCRIPTION
`Auth.clearCredentials` was changing the properties for `null` and the base uses these properties to do `Meteor.subscriptions` and when a property is changed the meteor remakes the subcritions passing the null values to the publishers.

Closes #6925.