### PR TITLE
Show bite out of avatar when not in audio

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-avatar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-avatar/component.jsx
@@ -7,11 +7,12 @@ import { styles } from './styles';
 const propTypes = {
   children: PropTypes.node.isRequired,
   moderator: PropTypes.bool.isRequired,
-  presenter: PropTypes.bool.isRequired,
-  talking: PropTypes.bool.isRequired,
-  muted: PropTypes.bool.isRequired,
-  listenOnly: PropTypes.bool.isRequired,
-  voice: PropTypes.bool.isRequired,
+  presenter: PropTypes.bool,
+  talking: PropTypes.bool,
+  muted: PropTypes.bool,
+  listenOnly: PropTypes.bool,
+  voice: PropTypes.bool,
+  noVoice: PropTypes.bool,
   color: PropTypes.string,
   className: PropTypes.string,
 };
@@ -23,6 +24,7 @@ const defaultProps = {
   muted: false,
   listenOnly: false,
   voice: false,
+  noVoice: false,
   color: '#000',
   className: null,
 };
@@ -36,36 +38,38 @@ const UserAvatar = ({
   listenOnly,
   color,
   voice,
+  noVoice,
   className,
 }) => (
 
-    <div
-      aria-hidden="true"
-      data-test="userAvatar"
-      className={cx(styles.avatar, {
-        [styles.moderator]: moderator,
-        [styles.presenter]: presenter,
-        [styles.muted]: muted,
-        [styles.listenOnly]: listenOnly,
-        [styles.voice]: voice,
-      }, className)}
-      style={{
-        backgroundColor: color,
-        color, // We need the same color on both for the border
-      }}
-    >
+  <div
+    aria-hidden="true"
+    data-test="userAvatar"
+    className={cx(styles.avatar, {
+      [styles.moderator]: moderator,
+      [styles.presenter]: presenter,
+      [styles.muted]: muted,
+      [styles.listenOnly]: listenOnly,
+      [styles.voice]: voice,
+      [styles.noVoice]: noVoice && !listenOnly,
+    }, className)}
+    style={{
+      backgroundColor: color,
+      color, // We need the same color on both for the border
+    }}
+  >
 
-      <div className={cx({
-        [styles.talking]: (talking && !muted),
-      })}
-      />
+    <div className={cx({
+      [styles.talking]: (talking && !muted),
+    })}
+    />
 
 
-      <div className={styles.content}>
-        {children}
-      </div>
+    <div className={styles.content}>
+      {children}
     </div>
-  );
+  </div>
+);
 
 UserAvatar.propTypes = propTypes;
 UserAvatar.defaultProps = defaultProps;

--- a/bigbluebutton-html5/imports/ui/components/user-avatar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-avatar/styles.scss
@@ -119,6 +119,13 @@
   }
 }
 
+.noVoice {
+  &:after {
+    content: "";
+    background-color: var(--color-off-white);
+  }
+}
+
 .muted {
   &:after {
     content: "\00a0\e932\00a0";
@@ -134,7 +141,8 @@
 
 .listenOnly,
 .muted,
-.voice {
+.voice,
+.noVoice {
   @include indicatorStyles();
 }
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
@@ -457,6 +457,7 @@ class UserDropdown extends PureComponent {
         muted={user.isMuted}
         listenOnly={user.isListenOnly}
         voice={user.isVoiceUser}
+        noVoice={!user.isVoiceUser}
         color={user.color}
       >
         {isVoiceOnly ? iconVoiceOnlyUser : iconUser}


### PR DESCRIPTION
This PR adds an empty space to the user avatar where the audio icon is displayed when the user isn't in audio. The goal is to make it more clear that something is missing. For the moment, I think we want to just try it out and see what we think. The issue is #7053.

![image](https://user-images.githubusercontent.com/1395090/54845205-2f6a6380-4caf-11e9-8c30-d922a1d2f49c.png)