### PR TITLE
 - set meeting inactivity check to zero as default which disables the…

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/domain/MeetingInactivityTracker.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/domain/MeetingInactivityTracker.scala
@@ -25,7 +25,11 @@ case class MeetingInactivityTracker(
   }
 
   def isMeetingInactive(nowInMs: Long): Boolean = {
-    warningSent && (nowInMs - lastActivityTimestampInMs) > maxInactivityTimeoutInMs
+    if (maxInactivityTimeoutInMs > 0) {
+      warningSent && (nowInMs - lastActivityTimestampInMs) > maxInactivityTimeoutInMs
+    } else {
+      false
+    }
   }
 
   def timeLeftInMs(nowInMs: Long): Long = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -623,8 +623,11 @@ class MeetingActor(
 
   def processUserInactivityAudit(): Unit = {
     val now = TimeUtil.timeNowInMs()
-    // Time to do a new check?
-    if (now > lastUserInactivityInspectSentOn + expiryTracker.userInactivityInspectTimerInMs) {
+
+    // Check if user is inactive. We only do the check is user inactivity
+    // is not disabled (0).
+    if ((expiryTracker.userInactivityInspectTimerInMs > 0) &&
+            (now > lastUserInactivityInspectSentOn + expiryTracker.userInactivityInspectTimerInMs)) {
       lastUserInactivityInspectSentOn = now
       checkInactiveUsers = true
       warnPotentiallyInactiveUsers()

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -141,8 +141,9 @@ defaultMaxUsers=0
 defaultMeetingDuration=0
 
 # Number of minutes elapse of no activity before
-# ending the meeting
-maxInactivityTimeoutMinutes=120
+# ending the meeting. Default zero (0) to disable
+# check.
+maxInactivityTimeoutMinutes=0
 
 # Number of minutes to logout client if user
 # isn't responsive

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -162,7 +162,7 @@ meetingExpireIfNoUserJoinedInMinutes=5
 meetingExpireWhenLastUserLeftInMinutes=1
 
 # User inactivity audit timer interval.
-userInactivityInspectTimerInMinutes=120
+userInactivityInspectTimerInMinutes=0
 
 # Number of minutes to consider a user inactive.
 # iSend warning message to client to check if really inactive.


### PR DESCRIPTION
… check. When set to zero, the meeting won't end due to inactivity.