### PR TITLE
Fix outline of disabled buttons and button getting cut off

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/button/styles.scss
@@ -101,7 +101,7 @@
     outline: none;
   }
 
-  &:focus:not([aria-disabled="true"]) {
+  &:focus {
     outline-color: transparent;
     outline-width: 2px;
     outline-style: dotted;

--- a/bigbluebutton-html5/imports/ui/components/video-preview/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/styles.scss
@@ -4,6 +4,11 @@
 
 .actions {
   margin-left: auto;
+  margin-right: 3px;
+
+  :first-child {
+    margin-right: 3px;
+  }
 }
 
 .closeBtn {


### PR DESCRIPTION
This PR makes it so that both disabled and non-disabled buttons will now show the desired focus outline to Chrome users. It also adds some extra spacing to the bottom buttons in the video preview modal so that they don't cut each other off.