### PR TITLE
Sending an extra message for guest management in Meteor

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RegisterUserReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RegisterUserReqMsgHdlr.scala
@@ -42,6 +42,9 @@ trait RegisterUserReqMsgHdlr {
         val event = MsgBuilder.buildGuestsWaitingForApprovalEvtMsg(meetingId, m.intId, guests)
         outGW.send(event)
       }
+      // Meteor should only listen for this single message
+      val event = MsgBuilder.buildGuestsWaitingForApprovalEvtMsg(meetingId, "nodeJSapp", guests)
+      outGW.send(event)
     }
 
     def addGuestToWaitingForApproval(guest: GuestWaiting, guestsWaitingList: GuestsWaiting): Unit = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RegisterUserReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RegisterUserReqMsgHdlr.scala
@@ -37,7 +37,7 @@ trait RegisterUserReqMsgHdlr {
     outGW.send(event)
 
     def notifyModeratorsOfGuestWaiting(guests: Vector[GuestWaiting], users: Users2x, meetingId: String): Unit = {
-      val mods = Users2x.findAll(users).filter(p => p.role == Roles.MODERATOR_ROLE)
+      val mods = Users2x.findAll(users).filter(p => p.role == Roles.MODERATOR_ROLE && p.clientType == ClientType.FLASH)
       mods foreach { m =>
         val event = MsgBuilder.buildGuestsWaitingForApprovalEvtMsg(meetingId, m.intId, guests)
         outGW.send(event)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -281,6 +281,11 @@ object Roles {
   val AUTHENTICATED_ROLE = "AUTHENTICATED"
 }
 
+object ClientType {
+  val FLASH = "FLASH"
+  val HTML5 = "HTML5"
+}
+
 object SystemUser {
   val ID = "SYSTEM"
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/guests/GuestsWaitingApprovedMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/guests/GuestsWaitingApprovedMsgHdlr.scala
@@ -33,7 +33,7 @@ trait GuestsWaitingApprovedMsgHdlr extends HandlerHelpers with RightsManagementT
   }
 
   def notifyModeratorsOfGuestsApproval(guests: Vector[GuestApprovedVO], approvedBy: String): Unit = {
-    val mods = Users2x.findAll(liveMeeting.users2x).filter(p => p.role == Roles.MODERATOR_ROLE)
+    val mods = Users2x.findAll(liveMeeting.users2x).filter(p => p.role == Roles.MODERATOR_ROLE && p.clientType == ClientType.FLASH)
     val meetingId = liveMeeting.props.meetingProp.intId
     mods foreach { m =>
       val event = MsgBuilder.buildGuestsWaitingApprovedEvtMsg(meetingId, m.intId, guests, approvedBy)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/guests/GuestsWaitingApprovedMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/guests/GuestsWaitingApprovedMsgHdlr.scala
@@ -34,12 +34,13 @@ trait GuestsWaitingApprovedMsgHdlr extends HandlerHelpers with RightsManagementT
 
   def notifyModeratorsOfGuestsApproval(guests: Vector[GuestApprovedVO], approvedBy: String): Unit = {
     val mods = Users2x.findAll(liveMeeting.users2x).filter(p => p.role == Roles.MODERATOR_ROLE)
+    val meetingId = liveMeeting.props.meetingProp.intId
     mods foreach { m =>
-      val event = MsgBuilder.buildGuestsWaitingApprovedEvtMsg(
-        liveMeeting.props.meetingProp.intId,
-        m.intId, guests, approvedBy
-      )
+      val event = MsgBuilder.buildGuestsWaitingApprovedEvtMsg(meetingId, m.intId, guests, approvedBy)
       outGW.send(event)
     }
+    // Meteor should only listen for this single message
+    val event = MsgBuilder.buildGuestsWaitingApprovedEvtMsg(meetingId, "nodeJSapp", guests, approvedBy)
+    outGW.send(event)
   }
 }

--- a/bigbluebutton-html5/imports/api/guest-users/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/guest-users/server/eventHandlers.js
@@ -1,6 +1,7 @@
 import RedisPubSub from '/imports/startup/server/redis';
+import { processForHTML5ServerOnly } from '/imports/api/common/server/helpers';
 import handleGuestApproved from './handlers/guestApproved';
 import handleGuestsWaitingForApproval from './handlers/guestsWaitingForApproval';
 
-RedisPubSub.on('GuestsWaitingForApprovalEvtMsg', handleGuestsWaitingForApproval);
-RedisPubSub.on('GuestsWaitingApprovedEvtMsg', handleGuestApproved);
+RedisPubSub.on('GuestsWaitingForApprovalEvtMsg', processForHTML5ServerOnly(handleGuestsWaitingForApproval));
+RedisPubSub.on('GuestsWaitingApprovedEvtMsg', processForHTML5ServerOnly(handleGuestApproved));

--- a/bigbluebutton-html5/imports/api/guest-users/server/handlers/guestApproved.js
+++ b/bigbluebutton-html5/imports/api/guest-users/server/handlers/guestApproved.js
@@ -1,13 +1,15 @@
 import { check } from 'meteor/check';
 import setGuestStatus from '../modifiers/setGuestStatus';
 
-export default function handleGuestsWaitingForApproval({ header, body }, meetingId) {
+export default function handleGuestApproved({ header, body }, meetingId) {
   const { userId } = header;
-  const { approvedBy, guests } = body;
-
   check(userId, String);
+  if (userId !== 'nodeJSapp') { return false; }
+
+  const { approvedBy, guests } = body;
   check(meetingId, String);
   check(approvedBy, String);
+  check(guests, Array);
 
   return guests.forEach(guest => setGuestStatus(meetingId, guest.guest, guest.status, approvedBy));
 }

--- a/bigbluebutton-html5/imports/api/guest-users/server/handlers/guestApproved.js
+++ b/bigbluebutton-html5/imports/api/guest-users/server/handlers/guestApproved.js
@@ -1,11 +1,7 @@
 import { check } from 'meteor/check';
 import setGuestStatus from '../modifiers/setGuestStatus';
 
-export default function handleGuestApproved({ header, body }, meetingId) {
-  const { userId } = header;
-  check(userId, String);
-  if (userId !== 'nodeJSapp') { return false; }
-
+export default function handleGuestApproved({ body }, meetingId) {
   const { approvedBy, guests } = body;
   check(meetingId, String);
   check(approvedBy, String);

--- a/bigbluebutton-html5/imports/api/guest-users/server/handlers/guestsWaitingForApproval.js
+++ b/bigbluebutton-html5/imports/api/guest-users/server/handlers/guestsWaitingForApproval.js
@@ -9,9 +9,15 @@ const COLOR_LIST = [
   '#0d47a1', '#0277bd', '#01579b',
 ];
 
-export default function handleGuestsWaitingForApproval({ body }, meetingId) {
+export default function handleGuestsWaitingForApproval({ header, body }, meetingId) {
+  const { userId } = header;
+  check(userId, String);
+  if (userId !== 'nodeJSapp') { return false; }
+
   const { guests } = body;
   check(guests, Array);
+  check(meetingId, String);
+
   const cb = (err, numChanged) => {
     if (err) {
       return Logger.error(`Adding guest user to collection: ${err}`);

--- a/bigbluebutton-html5/imports/api/guest-users/server/handlers/guestsWaitingForApproval.js
+++ b/bigbluebutton-html5/imports/api/guest-users/server/handlers/guestsWaitingForApproval.js
@@ -9,10 +9,7 @@ const COLOR_LIST = [
   '#0d47a1', '#0277bd', '#01579b',
 ];
 
-export default function handleGuestsWaitingForApproval({ header, body }, meetingId) {
-  const { userId } = header;
-  check(userId, String);
-  if (userId !== 'nodeJSapp') { return false; }
+export default function handleGuestsWaitingForApproval({ body }, meetingId) {
 
   const { guests } = body;
   check(guests, Array);

--- a/bigbluebutton-html5/imports/api/guest-users/server/handlers/guestsWaitingForApproval.js
+++ b/bigbluebutton-html5/imports/api/guest-users/server/handlers/guestsWaitingForApproval.js
@@ -10,7 +10,6 @@ const COLOR_LIST = [
 ];
 
 export default function handleGuestsWaitingForApproval({ body }, meetingId) {
-
   const { guests } = body;
   check(guests, Array);
   check(meetingId, String);


### PR DESCRIPTION
This should handle #6987 

Right now Meteor is listening and processing all `GuestsWaitingForApprovalEvtMsg` and `GuestsWaitingApprovedEvtMsg` messages.

This way `akka-apps` will always send a message addressed to Meteor and Meteor can filter what it is supposed to process or not.