### PR TITLE
Unmute viewers

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/MuteUserCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/MuteUserCmdMsgHdlr.scala
@@ -14,7 +14,8 @@ trait MuteUserCmdMsgHdlr extends RightsManagementTrait {
   val outGW: OutMsgRouter
 
   def handleMuteUserCmdMsg(msg: MuteUserCmdMsg) {
-    if (msg.body.userId != msg.header.userId && (msg.body.mute == false || permissionFailed(
+    val unmuteDisabled = !liveMeeting.props.usersProp.unmuteViewers && msg.body.mute == false
+    if (msg.body.userId != msg.header.userId && (unmuteDisabled || permissionFailed(
       PermissionCheck.MOD_LEVEL,
       PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId
     ))) {

--- a/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
+++ b/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
@@ -40,6 +40,7 @@ trait AppsTestFixtures {
   val dialNumber = "613-555-1234"
   val maxUsers = 25
   val guestPolicy = "ALWAYS_ASK"
+  val unmuteViewers = false
 
   val red5DeskShareIPTestFixture = "127.0.0.1"
   val red5DeskShareAppTestFixtures = "red5App"
@@ -59,7 +60,7 @@ trait AppsTestFixtures {
     modOnlyMessage = modOnlyMessage)
   val voiceProp = VoiceProp(telVoice = voiceConfId, voiceConf = voiceConfId, dialNumber = dialNumber, muteOnStart = muteOnStart)
   val usersProp = UsersProp(maxUsers = maxUsers, webcamsOnlyForModerator = webcamsOnlyForModerator,
-    guestPolicy = guestPolicy)
+    guestPolicy = guestPolicy, unmuteViewers = unmuteViewers)
   val metadataProp = new MetadataProp(metadata)
 
   val defaultProps = DefaultProps(meetingProp, breakoutProps, durationProps, password, recordProp, welcomeProp, voiceProp,

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
@@ -19,7 +19,7 @@ case class WelcomeProp(welcomeMsgTemplate: String, welcomeMsg: String, modOnlyMe
 
 case class VoiceProp(telVoice: String, voiceConf: String, dialNumber: String, muteOnStart: Boolean)
 
-case class UsersProp(maxUsers: Int, webcamsOnlyForModerator: Boolean, guestPolicy: String)
+case class UsersProp(maxUsers: Int, webcamsOnlyForModerator: Boolean, guestPolicy: String, unmuteViewers: Boolean)
 
 case class MetadataProp(metadata: collection.immutable.Map[String, String])
 

--- a/bbb-common-message/src/test/scala/org/bigbluebutton/common2/TestFixtures.scala
+++ b/bbb-common-message/src/test/scala/org/bigbluebutton/common2/TestFixtures.scala
@@ -34,6 +34,7 @@ trait TestFixtures {
   val dialNumber = "613-555-1234"
   val maxUsers = 25
   val muteOnStart = false
+  val unmuteViewers = false
   val keepEvents = false
   val guestPolicy = "ALWAYS_ASK"
   val metadata: collection.immutable.Map[String, String] = Map("foo" -> "bar", "bar" -> "baz", "baz" -> "foo")
@@ -52,7 +53,7 @@ trait TestFixtures {
     modOnlyMessage = modOnlyMessage)
   val voiceProp = VoiceProp(telVoice = voiceConfId, voiceConf = voiceConfId, dialNumber = dialNumber, muteOnStart = muteOnStart)
   val usersProp = UsersProp(maxUsers = maxUsers, webcamsOnlyForModerator = webcamsOnlyForModerator,
-    guestPolicy = guestPolicy)
+    guestPolicy = guestPolicy, unmuteViewers = unmuteViewers)
   val metadataProp = new MetadataProp(metadata)
   val screenshareProps = ScreenshareProps(screenshareConf = "FixMe!", red5ScreenshareIp = "fixMe!",
     red5ScreenshareApp = "fixMe!")

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -43,6 +43,7 @@ public class ApiParams {
     public static final String MODERATOR_ONLY_MESSAGE = "moderatorOnlyMessage";
     public static final String MODERATOR_PW = "moderatorPW";
     public static final String MUTE_ON_START = "muteOnStart";
+    public static final String UNMUTE_VIEWERS = "unmuteViewers";
     public static final String NAME = "name";
     public static final String PARENT_MEETING_ID = "parentMeetingID";
     public static final String PASSWORD = "password";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -315,7 +315,7 @@ public class MeetingService implements MessageListener {
             m.getDialNumber(), m.getMaxUsers(), m.getMaxInactivityTimeoutMinutes(), m.getWarnMinutesBeforeMax(),
             m.getMeetingExpireIfNoUserJoinedInMinutes(), m.getmeetingExpireWhenLastUserLeftInMinutes(),
             m.getUserInactivityInspectTimerInMinutes(), m.getUserInactivityThresholdInMinutes(),
-            m.getUserActivitySignResponseDelayInMinutes(), m.getMuteOnStart(), keepEvents);
+            m.getUserActivitySignResponseDelayInMinutes(), m.getMuteOnStart(), m.getUnmuteViewers(), keepEvents);
   }
 
   private String formatPrettyDate(Long timestamp) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -90,6 +90,7 @@ public class ParamsProcessorUtil {
     private boolean allowStartStopRecording;
     private boolean webcamsOnlyForModerator;
     private boolean defaultMuteOnStart = false;
+    private boolean defaultUnmuteViewers = false;
 
     private String defaultConfigXML = null;
 
@@ -391,6 +392,13 @@ public class ParamsProcessorUtil {
         }
 
 		meeting.setMuteOnStart(muteOnStart);
+
+        Boolean unmuteViewers = defaultUnmuteViewers;
+        if (!StringUtils.isEmpty(params.get(ApiParams.UNMUTE_VIEWERS))) {
+            unmuteViewers = Boolean.parseBoolean(params.get(ApiParams.UNMUTE_VIEWERS));
+        }
+        meeting.setUnmuteViewers(unmuteViewers);
+
         return meeting;
     }
 	
@@ -888,6 +896,13 @@ public class ParamsProcessorUtil {
 		return defaultMuteOnStart;
 	}
 
+	public void setUnmuteViewers(Boolean value) {
+		defaultUnmuteViewers = value;
+	}
+
+	public Boolean getUnmuteViewers() {
+		return defaultUnmuteViewers;
+	}
 
 	public List<String> decodeIds(String encodeid) {
 		ArrayList<String> ids=new ArrayList<>();

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -78,6 +78,7 @@ public class Meeting {
 	private String customLogoURL = "";
 	private String customCopyright = "";
 	private Boolean muteOnStart = false;
+	private Boolean unmuteViewers = false;
 
 	private Integer maxInactivityTimeoutMinutes = 120;
 	private Integer warnMinutesBeforeMax = 5;
@@ -422,6 +423,14 @@ public class Meeting {
 
 	public Boolean getMuteOnStart() {
     	return muteOnStart;
+	}
+
+	public void setUnmuteViewers(Boolean value) {
+		unmuteViewers = value;
+	}
+
+	public Boolean getUnmuteViewers() {
+		return unmuteViewers;
 	}
 
 	public void userJoined(User user) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
@@ -26,6 +26,7 @@ public interface IBbbWebApiGWApp {
                      Integer userInactivityThresholdInMinutes,
                      Integer userActivitySignResponseDelayInMinutes,
                      Boolean muteOnStart,
+                     Boolean unmuteViewers,
                      Boolean keepEvents);
 
   void registerUser(String meetingID, String internalUserId, String fullname, String role,

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -97,6 +97,7 @@ class BbbWebApiGWApp(
                     userInactivityThresholdInMinutes:       java.lang.Integer,
                     userActivitySignResponseDelayInMinutes: java.lang.Integer,
                     muteOnStart:                            java.lang.Boolean,
+                    unmuteViewers:                          java.lang.Boolean,
                     keepEvents:                             java.lang.Boolean): Unit = {
 
     val meetingProp = MeetingProp(name = meetingName, extId = extMeetingId, intId = meetingId,
@@ -121,7 +122,7 @@ class BbbWebApiGWApp(
       modOnlyMessage = modOnlyMessage)
     val voiceProp = VoiceProp(telVoice = voiceBridge, voiceConf = voiceBridge, dialNumber = dialNumber, muteOnStart = muteOnStart.booleanValue())
     val usersProp = UsersProp(maxUsers = maxUsers.intValue(), webcamsOnlyForModerator = webcamsOnlyForModerator.booleanValue(),
-      guestPolicy = guestPolicy)
+      guestPolicy = guestPolicy, unmuteViewers = unmuteViewers.booleanValue())
     val metadataProp = MetadataProp(mapAsScalaMap(metadata).toMap)
     val screenshareProps = ScreenshareProps(
       screenshareConf = voiceBridge + screenshareConfSuffix,

--- a/bigbluebutton-client/src/org/bigbluebutton/core/model/Meeting.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/model/Meeting.as
@@ -16,6 +16,7 @@ package org.bigbluebutton.core.model
     public var allowStartStopRecording:Boolean = true;
     public var webcamsOnlyForModerator:Boolean = false;
     public var metadata:Object = null;
+    public var unmuteViewers:Boolean = false;
     public var muteOnStart:Boolean = false;
 	public var logoutTimer:int=0;
 	public var bannerColor:String = "";

--- a/bigbluebutton-client/src/org/bigbluebutton/core/model/MeetingBuilder.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/core/model/MeetingBuilder.as
@@ -15,6 +15,7 @@ package org.bigbluebutton.core.model
     internal var modOnlyMessage:String;
     internal var allowStartStopRecording: Boolean;
     internal var metadata: Object;
+    internal var unmuteViewers: Boolean;
 	internal var muteOnStart:Boolean;
     
     public function MeetingBuilder(id: String, name: String) {
@@ -74,6 +75,11 @@ package org.bigbluebutton.core.model
     
     public function withMetadata(value: Object):MeetingBuilder {
       metadata = value;
+      return this;
+    }
+
+    public function withUnmuteViewers(value: Boolean):MeetingBuilder {
+      unmuteViewers = value;
       return this;
     }
 	

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/EnterApiResponse.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/EnterApiResponse.as
@@ -30,6 +30,7 @@ package org.bigbluebutton.main.model.users
     public var allowStartStopRecording: Boolean;
     public var metadata: Object = new Object();
     public var modOnlyMessage: String;
+    public var unmuteViewers:Boolean = false;
 		public var muteOnStart:Boolean = false;
   }
 }

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/JoinService.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/JoinService.as
@@ -179,6 +179,7 @@ package org.bigbluebutton.main.model.users
 				apiResponse.bannerColor = result.response.bannerColor;
 				apiResponse.bannerText = result.response.bannerText;
 				
+				apiResponse.unmuteViewers = result.response.unmuteViewers as Boolean;
 				apiResponse.muteOnStart = result.response.muteOnStart as Boolean;
 				apiResponse.customLogo = result.response.customLogoURL;
 				apiResponse.customCopyright = result.response.customCopyright;

--- a/bigbluebutton-client/src/org/bigbluebutton/main/model/users/UserService.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/main/model/users/UserService.as
@@ -140,6 +140,7 @@ package org.bigbluebutton.main.model.users
 		LiveMeeting.inst().meeting.bannerColor = result.bannerColor;
 		LiveMeeting.inst().meeting.bannerText = result.bannerText;
 
+        LiveMeeting.inst().meeting.unmuteViewers = result.unmuteViewers;
         LiveMeeting.inst().meeting.muteOnStart = result.muteOnStart;
 				LiveMeeting.inst().meetingStatus.isMeetingMuted = result.muteOnStart;
         LiveMeeting.inst().meeting.customLogo = result.customLogo;

--- a/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/MediaItemRenderer.mxml
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/users/views/MediaItemRenderer.mxml
@@ -66,6 +66,8 @@
 			
 			[Bindable]
 			private var webcamsOnlyForModerator:Boolean;
+
+			private var unmuteViewers:Boolean = false;
 			
 			private var moderator:Boolean = false;
 
@@ -91,6 +93,8 @@
 				BindingUtils.bindSetter(updateButtons, userLockedInd, "visible");
 				BindingUtils.bindSetter(updateButtons, hasStreamInd, "visible");
 				BindingUtils.bindSetter(updateButtons, viewingStreamInd, "visible");
+
+				unmuteViewers = LiveMeeting.inst().meeting.unmuteViewers;
 			}
 
 			override public function set data(value:Object):void {
@@ -193,7 +197,7 @@
 				
 				var e:VoiceConfEvent = new VoiceConfEvent(VoiceConfEvent.MUTE_USER);
 				e.userid = data.userId;
-				e.mute = data.me ? !data.muted : true;
+				e.mute = (data.me || unmuteViewers) ? !data.muted : true;
 				dispatchEvent(e);
 			}
 			
@@ -246,8 +250,9 @@
 								muteImg.filters = [];
 							}
 						} else {
-							// can no longer unmute others
-							var showMuteBtn:Boolean = rolledOver && (data.me || (amIMod && !data.muted));
+							// can only unmute viewers when unmuteViewers is set on create
+							var unmute:Boolean = unmuteViewers && amIMod && (data.role == Role.VIEWER);
+							var showMuteBtn:Boolean = rolledOver && (data.me || (amIMod && (!data.muted || unmute)));
 							muteImg.visible = !showMuteBtn;
 							muteImg.includeInLayout = !showMuteBtn;
 							muteBtn.visible = showMuteBtn;

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -24,6 +24,7 @@ export default function addMeeting(meeting) {
       webcamsOnlyForModerator: Boolean,
       guestPolicy: String,
       maxUsers: Number,
+      unmuteViewers: Boolean,
     },
     durationProps: {
       createdTime: Number,

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -281,10 +281,20 @@ const isMeetingLocked = (id) => {
   return isLocked;
 };
 
+const areViewersUnmutable = () => {
+  const meeting = Meetings.findOne({ meetingId: Auth.meetingID });
+  if (meeting.usersProp) {
+    return meeting.usersProp.unmuteViewers;
+  }
+  return false;
+}
+
 const getAvailableActions = (currentUser, user, isBreakoutRoom) => {
   const isDialInUser = isVoiceOnlyUser(user.id) || user.isPhoneUser;
 
   const hasAuthority = currentUser.isModerator || user.isCurrent;
+
+  const unmuteViewer = !user.isModerator && areViewersUnmutable();
 
   const allowedToChatPrivately = !user.isCurrent && !isDialInUser;
 
@@ -297,7 +307,7 @@ const getAvailableActions = (currentUser, user, isBreakoutRoom) => {
     && user.isVoiceUser
     && !user.isListenOnly
     && user.isMuted
-    && user.isCurrent;
+    && (user.isCurrent || unmuteViewer);
 
   const allowedToResetStatus = hasAuthority
     && user.emoji.status !== EMOJI_STATUSES.none

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -191,6 +191,10 @@ webcamsOnlyForModerator=false
 # Mute the meeting on start
 muteOnStart=false
 
+# Unmute users
+# Gives moderators permisson to unmute other users
+unmuteViewers=false
+
 # Saves meeting events even if the meeting is not recorded
 keepEvents=false
 

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -131,6 +131,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="maxPresentationFileUpload" value="${maxFileSizeUpload}"/>
         <property name="clientLogoutTimerInMinutes" value="${clientLogoutTimerInMinutes}"/>
         <property name="muteOnStart" value="${muteOnStart}"/>
+        <property name="unmuteViewers" value="${unmuteViewers}"/>
     </bean>
 
     <import resource="doc-conversion.xml"/>

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1514,6 +1514,7 @@ class ApiController {
             customLogoURL meeting.getCustomLogoURL()
             customCopyright meeting.getCustomCopyright()
             muteOnStart meeting.getMuteOnStart()
+            unmuteViewers meeting.getUnmuteViewers()
             logoutUrl us.logoutUrl
             defaultLayout us.defaultLayout
             avatarURL us.avatarURL


### PR DESCRIPTION
Added `unmuteViewers` to the `create` meeting API call.

When `true`, moderators should be able to unmute viewers.

Tries to resolve #6814 and #7092