### PR TITLE
 - remove null values from whiteboard shapes

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendWhiteboardAnnotationPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendWhiteboardAnnotationPubMsgHdlr.scala
@@ -21,6 +21,45 @@ trait SendWhiteboardAnnotationPubMsgHdlr extends RightsManagementTrait {
       bus.outGW.send(msgEvent)
     }
 
+    def sanitizeAnnotation(annotation: AnnotationVO): AnnotationVO = {
+      // Remove null values by wrapping value with Option
+      val shape = annotation.annotationInfo.collect {
+        case (key, value: Any) => key -> Option(value)
+      }
+
+      // Unwrap the value wrapped as Option
+      val shape2 = shape.collect {
+        case (key, Some(value)) => key -> value
+      }
+
+      annotation.copy(annotationInfo = shape2)
+    }
+
+    // For testing
+    def testInsertSomeNoneValues(annotation: AnnotationVO): AnnotationVO = {
+      //val c = annotation.annotationInfo + ("AR" -> "", "AZ" -> None, "foo" -> null)
+      val c = annotation.annotationInfo + ("AR" -> null, "AZ" -> null, "foo" -> null)
+      annotation.copy(annotationInfo = c)
+    }
+
+    // For testing
+    def printAnnotationShape(annotationInfo: scala.collection.immutable.Map[String, Any], annotation: AnnotationVO): AnnotationVO = {
+      println("************* Printing Shape annotation *************")
+      annotationInfo.foreach { an =>
+        println("*** key=" + an._1 + ",  value=" + an._2)
+      }
+      println("************* Printing Shape annotation *************")
+      annotation
+    }
+
+    // For testing
+    def printAnnotationInfo(annotation: AnnotationVO): AnnotationVO = {
+      annotation.annotationInfo.foreach { an =>
+        println(">>> key=" + an._1 + ", value=" + an._2)
+      }
+      annotation
+    }
+
     def excludedWbMsg(annotation: AnnotationVO): Boolean = {
       WhiteboardKeyUtil.PENCIL_TYPE == annotation.annotationType &&
         (WhiteboardKeyUtil.DRAW_END_STATUS == annotation.status ||
@@ -38,7 +77,20 @@ trait SendWhiteboardAnnotationPubMsgHdlr extends RightsManagementTrait {
       // eject user unnecessarily when switching from multi-user to single user. (ralam feb 7, 2018)
       // PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
     } else {
-      val annotation = sendWhiteboardAnnotation(msg.body.annotation, liveMeeting)
+      //val dirtyAnn = testInsertSomeNoneValues(msg.body.annotation)
+      //println(">>>>>>>>>>>>> Printing Dirty annotation >>>>>>>>>>>>>>")
+      //val dirtyAnn2 = printAnnotationInfo(dirtyAnn)
+      //println(">>>>>>>>>>>>> Printed Dirty annotation  >>>>>>>>>>>>>>")
+
+      // Sometimes, we get null values for some of our whiteboard shapes. We need to
+      // weed these out so as not to cause any problems to other components. We've
+      // seen where the null values killed the RecorderActor when trying to write to redis.
+      // ralam april 11, 2019
+      val sanitizedShape = sanitizeAnnotation(msg.body.annotation)
+      //println("============= Printing Sanitized annotation ============")
+      //printAnnotationInfo(sanitizedShape)
+      //println("============= Printed Sanitized annotation  ============")
+      val annotation = sendWhiteboardAnnotation(sanitizedShape, liveMeeting)
       broadcastEvent(msg, annotation)
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/AddShapeWhiteboardRecordEvent.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/AddShapeWhiteboardRecordEvent.scala
@@ -61,6 +61,20 @@ class AddShapeWhiteboardRecordEvent extends AbstractWhiteboardRecordEvent {
         }
       } else {
         eventMap.put(f._1, f._2.toString)
+        // Sometimes, we get null values for some of our whiteboard shapes. We need to
+        // weed these out so as not to cause any problems to other components. We've
+        // seen where the null values killed the RecorderActor when trying to write to redis.
+        // We've modified this in SendWhiteboardAnnotationPubMsgHdlr but keeping here in case
+        // we also need to clean here.
+        //
+        // ralam april 11, 2019
+        //        f._1 match {
+        //          case f1: String =>
+        //            f._2 match {
+        //              case Some(f2) => eventMap.put(f._1, f2.toString)
+        //              case _        => // discard
+        //            }
+        //        }
       }
     })
   }


### PR DESCRIPTION
Sometimes, we get null values for some of our whiteboard shapes. We need to
weed these out so as not to cause any problems to other components. We've
seen where the null values killed the RecorderActor when trying to write to redis.

This PR looks through all values for each whiteboard shape coming in from the client and remove those with null values.