### PR TITLE
 Do not trigger chapter break recording when meeting is set not to be…

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -524,7 +524,8 @@ class MeetingActor(
     val elapsedInMs = now - lastRecBreakSentOn
     val elapsedInMin = TimeUtil.millisToMinutes(elapsedInMs)
 
-    if (recordingChapterBreakLengthInMinutes > 0 &&
+    if (props.recordProp.record &&
+            recordingChapterBreakLengthInMinutes > 0 &&
       elapsedInMin > recordingChapterBreakLengthInMinutes) {
       lastRecBreakSentOn = now
       val event = MsgBuilder.buildRecordingChapterBreakSysMsg(props.meetingProp.intId, TimeUtil.timeNowInMs())


### PR DESCRIPTION
… recorded

 When chapterBreakLengthInMinutes > 0 in /usr/share/bbb-apps-akka/conf/application.conf, the
 chapter break is triggered even when the meeting isn't set to be recorded.

 Check if meeting is to be recorded before triggering chapter break.