### PR TITLE
Add checks before operating with tooltips

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/tooltip/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/tooltip/component.jsx
@@ -152,6 +152,8 @@ class Tooltip extends Component {
     const {
       children,
       className,
+      title,
+      tooltipDistance,
       ...restProps
     } = this.props;
 

--- a/bigbluebutton-html5/imports/ui/components/tooltip/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/tooltip/component.jsx
@@ -140,16 +140,18 @@ class Tooltip extends Component {
   }
 
   handleEscapeHide(e) {
-    if (e.keyCode !== ESCAPE) return;
-    this.tooltip.tooltips[0].hide();
+    if (this.tooltip
+      && e.keyCode === ESCAPE
+      && this.tooltip.tooltips
+      && this.tooltip.tooltips[0]) {
+      this.tooltip.tooltips[0].hide();
+    }
   }
 
   render() {
     const {
       children,
       className,
-      title,
-      tooltipDistance,
       ...restProps
     } = this.props;
 


### PR DESCRIPTION
Was seeing logs like

```
[{"name":"clientLogger","level":50,"logCode":"startup_error","levelName":"error","msg":"TypeError: Cannot read property '0' of undefinedn    at k.handleEscapeHide (https://____________.com/html5client/9dfe674c161537255e5a566f150dc06b872bc725.js?meteor_js_resource=true:125:819887)","time":"2019-04-18T15:52:02.400Z"
```