### PR TITLE
Fix refPresentationContainer requestFullscreen is not a function

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/container.jsx
@@ -10,7 +10,7 @@ const SettingsDropdownContainer = props => (
 
 export default withTracker((props) => {
   const isFullscreen = Session.get('isFullscreen');
-  const handleToggleFullscreen = toggleFullScreen;
+  const handleToggleFullscreen = () => toggleFullScreen();
   const BROWSER_RESULTS = browser();
   const isSafari = BROWSER_RESULTS.name === 'safari';
   const noIOSFullscreen = isSafari && BROWSER_RESULTS.versionNumber < 12;

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/service.js
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/service.js
@@ -1,5 +1,5 @@
-const toggleFullScreen = () => {
-  const element = document.documentElement;
+const toggleFullScreen = (ref = null) => {
+  const element = ref || document.documentElement;
 
   if (document.fullscreenElement
     || document.webkitFullscreenElement

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -23,6 +23,18 @@ const intlMessages = defineMessages({
   },
 });
 
+const fullRef = (ref) => {
+  if (ref.requestFullscreen) {
+    ref.requestFullscreen();
+  } else if (ref.mozRequestFullScreen) {
+    ref.mozRequestFullScreen();
+  } else if (ref.webkitRequestFullscreen) {
+    ref.webkitRequestFullscreen();
+  } else if (ref.msRequestFullscreen) {
+    ref.msRequestFullscreen();
+  }
+};
+
 class PresentationArea extends Component {
   constructor() {
     super();
@@ -50,8 +62,8 @@ class PresentationArea extends Component {
   componentDidUpdate(prevProps, prevState) {
     if (prevState.fitToWidth) {
       // When presenter is changed or slide changed we reset fitToWidth
-      if ((prevProps.userIsPresenter && !this.props.userIsPresenter) ||
-          (prevProps.currentSlide.id !== this.props.currentSlide.id)) {
+      if ((prevProps.userIsPresenter && !this.props.userIsPresenter)
+          || (prevProps.currentSlide.id !== this.props.currentSlide.id)) {
         this.setState({
           fitToWidth: false,
         });
@@ -196,16 +208,16 @@ class PresentationArea extends Component {
     const { fitToWidth } = this.state;
     if (userIsPresenter) {
       return fitToWidth;
-    } else {
-      const { width, height, viewBoxWidth, viewBoxHeight } = currentSlide.calculatedData;
-      const slideSizeRatio = width / height;
-      const viewBoxSizeRatio = viewBoxWidth / viewBoxHeight;
-      if (slideSizeRatio !== viewBoxSizeRatio) {
-        return true;
-      } else {
-        return false;
-      }
     }
+    const {
+      width, height, viewBoxWidth, viewBoxHeight,
+    } = currentSlide.calculatedData;
+    const slideSizeRatio = width / height;
+    const viewBoxSizeRatio = viewBoxWidth / viewBoxHeight;
+    if (slideSizeRatio !== viewBoxSizeRatio) {
+      return true;
+    }
+    return false;
   }
 
   zoomChanger(incomingZoom) {
@@ -242,7 +254,6 @@ class PresentationArea extends Component {
       fitToWidth: !fitToWidth,
     });
   }
-
 
   isPresentationAccessible() {
     const { currentSlide } = this.props;
@@ -446,10 +457,6 @@ class PresentationArea extends Component {
 
     const { zoom, fitToWidth } = this.state;
 
-    const fullRef = () => {
-      this.refPresentationContainer.requestFullscreen();
-    };
-
     if (!currentSlide) {
       return null;
     }
@@ -462,7 +469,7 @@ class PresentationArea extends Component {
           podId,
         }}
         isFullscreen={isFullscreen}
-        fullscreenRef={fullRef}
+        fullscreenRef={() => fullRef(this.refPresentationContainer)}
         currentSlideNum={currentSlide.num}
         presentationId={currentSlide.presentationId}
         zoomChanger={this.zoomChanger}
@@ -508,11 +515,9 @@ class PresentationArea extends Component {
     } = this.props;
     if (userIsPresenter) return null;
 
-    const full = () => this.refPresentationContainer.requestFullscreen();
-
     return (
       <FullscreenButton
-        handleFullscreen={full}
+        handleFullscreen={() => fullRef(this.refPresentationContainer)}
         elementName={intl.formatMessage(intlMessages.presentationLabel)}
         dark
         fullscreenButton

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -14,7 +14,7 @@ import { styles } from './styles.scss';
 import MediaService, { shouldEnableSwapLayout } from '../media/service';
 import PresentationCloseButton from './presentation-close-button/component';
 import DownloadPresentationButton from './download-presentation-button/component';
-import FullscreenButton from '/imports/ui/components/video-provider/fullscreen-button/component';
+import FullscreenButtonContainer from '../video-provider/fullscreen-button/container';
 
 const intlMessages = defineMessages({
   presentationLabel: {
@@ -22,18 +22,6 @@ const intlMessages = defineMessages({
     description: 'presentation area element label',
   },
 });
-
-const fullRef = (ref) => {
-  if (ref.requestFullscreen) {
-    ref.requestFullscreen();
-  } else if (ref.mozRequestFullScreen) {
-    ref.mozRequestFullScreen();
-  } else if (ref.webkitRequestFullscreen) {
-    ref.webkitRequestFullscreen();
-  } else if (ref.msRequestFullscreen) {
-    ref.msRequestFullscreen();
-  }
-};
 
 class PresentationArea extends Component {
   constructor() {
@@ -340,7 +328,7 @@ class PresentationArea extends Component {
   // renders the whole presentation area
   renderPresentationArea() {
     const { presentationWidth } = this.state;
-    const { podId, currentSlide } = this.props;
+    const { podId, currentSlide, isFullscreen } = this.props;
     if (!this.isPresentationAccessible()) return null;
 
 
@@ -380,7 +368,7 @@ class PresentationArea extends Component {
       >
         {this.renderPresentationClose()}
         {this.renderPresentationDownload()}
-        {this.renderPresentationFullscreen()}
+        {isFullscreen ? null : this.renderPresentationFullscreen()}
         <TransitionGroup>
           <CSSTransition
             key={slideObj.id}
@@ -469,7 +457,7 @@ class PresentationArea extends Component {
           podId,
         }}
         isFullscreen={isFullscreen}
-        fullscreenRef={() => fullRef(this.refPresentationContainer)}
+        fullscreenRef={this.refPresentationContainer}
         currentSlideNum={currentSlide.num}
         presentationId={currentSlide.presentationId}
         zoomChanger={this.zoomChanger}
@@ -516,11 +504,10 @@ class PresentationArea extends Component {
     if (userIsPresenter) return null;
 
     return (
-      <FullscreenButton
-        handleFullscreen={() => fullRef(this.refPresentationContainer)}
+      <FullscreenButtonContainer
+        fullscreenRef={this.refPresentationContainer}
         elementName={intl.formatMessage(intlMessages.presentationLabel)}
         dark
-        fullscreenButton
       />
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -364,9 +364,14 @@ PresentationToolbar.propTypes = {
   zoomChanger: PropTypes.func.isRequired,
   fitToWidthHandler: PropTypes.func.isRequired,
   fitToWidth: PropTypes.bool.isRequired,
-  fullscreenRef: PropTypes.instanceOf(Element).isRequired,
+  fullscreenRef: PropTypes.instanceOf(Element),
   isFullscreen: PropTypes.bool.isRequired,
   zoom: PropTypes.number.isRequired,
 };
+
+PresentationToolbar.defaultProps = {
+  fullscreenRef: null,
+};
+
 
 export default injectWbResizeEvent(injectIntl(PresentationToolbar));

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -8,7 +8,7 @@ import { HUNDRED_PERCENT, MAX_PERCENT, STEP } from '/imports/utils/slideCalcUtil
 import cx from 'classnames';
 import { styles } from './styles.scss';
 import ZoomTool from './zoom-tool/component';
-import FullscreenButton from '../../video-provider/fullscreen-button/component';
+import FullscreenButtonContainer from '../../video-provider/fullscreen-button/container';
 import Tooltip from '/imports/ui/components/tooltip/component';
 import KEY_CODES from '/imports/utils/keyCodes';
 
@@ -331,8 +331,8 @@ class PresentationToolbar extends Component {
             {
               !isFullscreen
               && (
-                <FullscreenButton
-                  handleFullscreen={fullscreenRef}
+                <FullscreenButtonContainer
+                  fullscreenRef={fullscreenRef}
                   elementName={intl.formatMessage(intlMessages.presentationLabel)}
                   tooltipDistance={tooltipDistance}
                   dark
@@ -364,7 +364,7 @@ PresentationToolbar.propTypes = {
   zoomChanger: PropTypes.func.isRequired,
   fitToWidthHandler: PropTypes.func.isRequired,
   fitToWidth: PropTypes.bool.isRequired,
-  fullscreenRef: PropTypes.func.isRequired,
+  fullscreenRef: PropTypes.instanceOf(Element).isRequired,
   isFullscreen: PropTypes.bool.isRequired,
   zoom: PropTypes.number.isRequired,
 };

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -44,7 +44,9 @@ const PresentationToolbarContainer = (props) => {
 };
 
 export default withTracker((params) => {
-  const { podId, presentationId, fitToWidth } = params;
+  const {
+    podId, presentationId, fitToWidth, fullscreenRef,
+  } = params;
   const data = PresentationToolbarService.getSlideData(podId, presentationId);
 
   const {
@@ -55,6 +57,7 @@ export default withTracker((params) => {
     getSwapLayout: MediaService.getSwapLayout(),
     fitToWidthHandler: params.fitToWidthHandler,
     fitToWidth,
+    fullscreenRef,
     userIsPresenter: PresentationService.isPresenter(podId),
     numberOfSlides,
     zoom: params.zoom,

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import FullscreenButton from '../video-provider/fullscreen-button/component';
+import FullscreenButtonContainer from '../video-provider/fullscreen-button/container';
 import { styles } from './styles';
 
 const intlMessages = defineMessages({
@@ -52,10 +52,11 @@ class ScreenshareComponent extends React.Component {
     };
 
     return (
-      <FullscreenButton
+      <FullscreenButtonContainer
         handleFullscreen={full}
         key={_.uniqueId('fullscreenButton-')}
         elementName={intl.formatMessage(intlMessages.screenShareLabel)}
+        fullscreenRef={this.videoTag}
       />
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/video-provider/fullscreen-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/fullscreen-button/component.jsx
@@ -14,25 +14,28 @@ const intlMessages = defineMessages({
 
 const propTypes = {
   intl: intlShape.isRequired,
-  handleFullscreen: PropTypes.func.isRequired,
+  fullscreenRef: PropTypes.instanceOf(Element),
   dark: PropTypes.bool,
   elementName: PropTypes.string,
   className: PropTypes.string,
+  handleToggleFullScreen: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
   dark: false,
   elementName: '',
   className: '',
+  fullscreenRef: null,
 };
 
 const FullscreenButtonComponent = ({
   intl,
-  handleFullscreen,
   dark,
   elementName,
   tooltipDistance,
   className,
+  fullscreenRef,
+  handleToggleFullScreen,
 }) => {
   const formattedLabel = intl.formatMessage(
     intlMessages.fullscreenButton,
@@ -51,7 +54,7 @@ const FullscreenButtonComponent = ({
         color="default"
         icon="fullscreen"
         size="sm"
-        onClick={handleFullscreen}
+        onClick={() => handleToggleFullScreen(fullscreenRef)}
         label={formattedLabel}
         hideLabel
         className={cx(styles.button, styles.fullScreenButton, className)}

--- a/bigbluebutton-html5/imports/ui/components/video-provider/fullscreen-button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/fullscreen-button/container.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import FullscreenButtonComponent from './component';
+import { toggleFullScreen } from '/imports/ui/components/nav-bar/settings-dropdown/service';
+
+const FullscreenButtonContainer = props => <FullscreenButtonComponent {...props} />;
+
+export default (props) => {
+  const handleToggleFullScreen = ref => toggleFullScreen(ref);
+  return (
+    <FullscreenButtonContainer {...props} {...{ handleToggleFullScreen }} />
+  );
+};

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -14,7 +14,7 @@ import DropdownListItem from '/imports/ui/components/dropdown/list/item/componen
 import Icon from '/imports/ui/components/icon/component';
 import logger from '/imports/startup/client/logger';
 import VideoListItemStats from './video-list-item-stats/component';
-import FullscreenButton from '../../fullscreen-button/component';
+import FullscreenButtonContainer from '../../fullscreen-button/container';
 import { styles } from '../styles';
 
 const intlMessages = defineMessages({
@@ -109,15 +109,12 @@ class VideoListItem extends Component {
 
   renderFullscreenButton() {
     const { user } = this.props;
-    const full = () => {
-      const tag = this.videoTag;
-      if (tag.requestFullscreen) {
-        tag.requestFullscreen();
-      } else if (tag.webkitRequestFullscreen) { // Edge
-        tag.webkitRequestFullscreen();
-      }
-    };
-    return <FullscreenButton handleFullscreen={full} elementName={user.name} />;
+    return (
+      <FullscreenButtonContainer
+        fullscreenRef={this.videoTag}
+        elementName={user.name}
+      />
+    );
   }
 
   render() {


### PR DESCRIPTION
Closes #7279.

Selecting the fullscreen button on the presentation should no longer cause the error to be shown.

In Edge the error was  : `clientLogger: TypeError: Object doesn't support property or method 'requestFullscreen'`. 
