### PR TITLE
Hide poll waiting message on publish

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
@@ -142,7 +142,7 @@ class LiveResult extends Component {
         return user;
       });
 
-      waiting = respondedCount !== userAnswers.length;
+      waiting = respondedCount !== userAnswers.length && currentPoll;
     }
 
     return (


### PR DESCRIPTION
This PR fixes the case where a poll is published but the waiting message / animation does not disappear.

 The issue was reported on slack. 
* Polling still says [Waiting for results ... (with animation)] even after I published the poll results