### PR TITLE
Move legacy browser versions into settings.yml

### DIFF
--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -4,10 +4,12 @@ import Langmap from 'langmap';
 import Users from '/imports/api/users';
 import fs from 'fs';
 import './settings';
+import { lookup as lookupUserAgent } from 'useragent';
 import Logger from './logger';
 import Redis from './redis';
+import setMinBrowserVersions from './minBrowserVersion';
 
-var parse = Npm.require('url').parse;
+const parse = Npm.require('url').parse;
 
 const AVAILABLE_LOCALES = fs.readdirSync('assets/app/locales');
 
@@ -26,9 +28,9 @@ Meteor.startup(() => {
     BrowserPolicy.content.allowOriginForAll(CDN_URL);
     WebAppInternals.setBundledJsCssPrefix(CDN_URL + APP_CONFIG.basename);
 
-    var fontRegExp = /\.(eot|ttf|otf|woff|woff2)$/;
+    const fontRegExp = /\.(eot|ttf|otf|woff|woff2)$/;
 
-    WebApp.rawConnectHandlers.use('/', function(req, res, next) {
+    WebApp.rawConnectHandlers.use('/', (req, res, next) => {
       if (fontRegExp.test(req._parsedUrl.pathname)) {
         res.setHeader('Access-Control-Allow-Origin', '*');
         res.setHeader('Vary', 'Origin');
@@ -38,6 +40,8 @@ Meteor.startup(() => {
       return next();
     });
   }
+
+  setMinBrowserVersions();
 
   Logger.warn(`SERVER STARTED.\nENV=${env},\nnodejs version=${process.version}\nCDN=${CDN_URL}\n`, APP_CONFIG);
 });
@@ -139,6 +143,19 @@ WebApp.connectHandlers.use('/feedback', (req, res) => {
   }));
 });
 
+WebApp.connectHandlers.use('/useragent', (req, res) => {
+  const userAgent = req.headers['user-agent'];
+  let response = 'No user agent found in header';
+  if (userAgent) {
+    response = lookupUserAgent(req.headers['user-agent']).toString();
+  }
+
+  Logger.info(`The requesting user agent is ${response}`);
+
+  // res.setHeader('Content-Type', 'application/json');
+  res.writeHead(200);
+  res.end(response);
+});
 
 export const eventEmitter = Redis.emitter;
 

--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -147,7 +147,7 @@ WebApp.connectHandlers.use('/useragent', (req, res) => {
   const userAgent = req.headers['user-agent'];
   let response = 'No user agent found in header';
   if (userAgent) {
-    response = lookupUserAgent(req.headers['user-agent']).toString();
+    response = lookupUserAgent(userAgent).toString();
   }
 
   Logger.info(`The requesting user agent is ${response}`);

--- a/bigbluebutton-html5/imports/startup/server/minBrowserVersion.js
+++ b/bigbluebutton-html5/imports/startup/server/minBrowserVersion.js
@@ -1,0 +1,19 @@
+import { Meteor } from 'meteor/meteor';
+import { setMinimumBrowserVersions } from 'meteor/modern-browsers';
+
+const setMinBrowserVersions = () => {
+  const { minBrowserVersions } = Meteor.settings.private;
+
+  const versions = {};
+
+  minBrowserVersions.forEach((elem) => {
+    let { version } = elem;
+    if (version === 'Infinity') version = Infinity;
+
+    versions[elem.browser] = version;
+  });
+
+  setMinimumBrowserVersions(versions, 'bbb-min');
+};
+
+export default setMinBrowserVersions;

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -68,6 +68,7 @@
     "redis": "~2.8.0",
     "string-hash": "~1.1.3",
     "tippy.js": "^3.4.1",
+    "useragent": "^2.3.0",
     "winston": "^3.2.1",
     "yaml": "^1.3.2"
   },

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -295,3 +295,22 @@ private:
     - DoLatencyTracerMsg
   serverLog:
     level: info
+  minBrowserVersions:
+    - browser: chrome
+      version: 59
+    - browser: firefox
+      version: 52
+    - browser: firefoxMobile
+      version: 52
+    - browser: edge
+      version: 17
+    - browser: ie
+      version: Infinity
+    - browser: mobileSafari
+      version: [11, 1]
+    - browser: opera
+      version: 46
+    - browser: safari
+      version: [11, 1]
+    - browser: electron
+      version: [0, 36]

--- a/bigbluebutton-html5/server/main.js
+++ b/bigbluebutton-html5/server/main.js
@@ -29,20 +29,3 @@ import '/imports/api/guest-users/server';
 import '/imports/api/log-client/server';
 import '/imports/api/common/server/helpers';
 import '/imports/startup/server/logger';
-
-import { setMinimumBrowserVersions } from 'meteor/modern-browsers';
-
-// common restriction is support for WebRTC functions
-
-// WebRTC stats might require FF 55/CH 67 (or 66)
-
-setMinimumBrowserVersions({
-  chrome: 59,
-  firefox: 52,
-  edge: 17,
-  ie: Infinity,
-  mobileSafari: [11, 1],
-  opera: 46,
-  safari: [11, 1],
-  electron: [0, 36],
-}, 'service workers');


### PR DESCRIPTION
This PR moves the legacy browser versions into settings.yml which will make configuration changes easier. I also added an endpoint for the app at "/html5client/useragent" that will return back the browser information that Meteor will detect for the user. This will be helpful down the road if there's a browser that is showing the legacy content when it shouldn't.

I also added "firefoxMobile" to the list because it was getting incorrectly flagged as unsupported. This will address one part of #5765.