### PR TITLE
Recording: Strip control characters in whiteboard text events

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/events_archiver.rb
+++ b/record-and-playback/core/lib/recordandplayback/events_archiver.rb
@@ -314,10 +314,11 @@ module BigBlueButton
               # The slidesInfo value is XML serialized info, just insert it
               # directly into the event
               event << v
-            elsif res[MODULE] == 'CHAT' and res[EVENTNAME] == 'PublicChatEvent' and k == 'message'
+            elsif (res[MODULE] == 'CHAT' and res[EVENTNAME] == 'PublicChatEvent' and k == 'message') ||
+                  (res[MODULE] == 'WHITEBOARD' and res[EVENTNAME] == 'AddShapeEvent' and k == 'text')
               # Apply a cleanup that removes certain ranges of special
-              # characters from chat messages
-              event << events_doc.create_element(k, v.tr("\u0000-\u001f\u007f\u2028",''))
+              # characters from user-provided text
+              event << events_doc.create_element(k, v.tr("\x00-\x09\x0B\x0C\x0E-\x19\x7F",''))
             else
               event << events_doc.create_element(k, v)
             end


### PR DESCRIPTION
Sometimes when text is pasted into the whiteboard text tool from
external apps, it'll include control characters that mess up later
recording processing scripts.

Run the same cleanup as already used for chat messages on the whiteboard
text as well.

The cleanup has been adjusted to allow newline and tab characters. They
won't really cause issues in chat, and newlines (at a minimum) are
required for the whiteboard.

This is a workaround for #7356