### PR TITLE
Adjust lock chat strings to be used as keys

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/notify/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/notify/component.jsx
@@ -12,11 +12,11 @@ const intlMessages = defineMessages({
     id: 'app.userList.userOptions.disableMic',
     description: 'label to disable mic notification',
   },
-  disablePrivChat: {
+  disablePrivateChat: {
     id: 'app.userList.userOptions.disablePrivChat',
     description: 'label to disable private chat notification',
   },
-  disablePubChat: {
+  disablePublicChat: {
     id: 'app.userList.userOptions.disablePubChat',
     description: 'label to disable private chat notification',
   },


### PR DESCRIPTION
Closes #7394 
The strings no longer matched the lock settings props so could not be used as keys

Related to #7138 