### PR TITLE
Improved audio connect and transfer

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -1,5 +1,3 @@
-import VoiceUsers from '/imports/api/voice-users';
-import { Tracker } from 'meteor/tracker';
 import browser from 'browser-detect';
 import BaseAudioBridge from './base';
 import logger from '/imports/startup/client/logger';
@@ -12,7 +10,6 @@ const CALL_HANGUP_TIMEOUT = MEDIA.callHangupTimeout;
 const CALL_HANGUP_MAX_RETRIES = MEDIA.callHangupMaximumRetries;
 const ICE_NEGOTIATION_FAILED = ['iceConnectionFailed'];
 const CALL_CONNECT_TIMEOUT = 15000;
-const CALL_CONNECT_NOTIFICATION_TIMEOUT = 1000;
 const ICE_NEGOTIATION_TIMEOUT = 20000;
 
 export default class SIPBridge extends BaseAudioBridge {
@@ -37,6 +34,14 @@ export default class SIPBridge extends BaseAudioBridge {
 
     this.protocol = window.document.location.protocol;
     this.hostname = window.document.location.hostname;
+  }
+
+  static parseDTMF(message) {
+    const parse = message.match(/Signal=(.)/);
+    if (parse && parse.length === 2) {
+      return parse[1];
+    }
+    return '';
   }
 
   joinAudio({ isListenOnly, extension, inputStream }, managerCallback) {
@@ -84,47 +89,29 @@ export default class SIPBridge extends BaseAudioBridge {
 
   transferCall(onTransferSuccess) {
     return new Promise((resolve, reject) => {
-      let trackerControl = null;
-      let transferAttemptCount = 0;
-
       const timeout = setInterval(() => {
-        // There's a bug with FS and FF where the connection can take awhile to negotiate. I'm
-        // adding retries if they're on that to mitigate the issue. Refer to the following bug 
-        // for more info, https://freeswitch.org/jira/browse/FS-11661.
-        if (browser().name === 'firefox' && transferAttemptCount < 3) {
-          transferAttemptCount++;
-          this.currentSession.dtmf(1);
-        } else {
-          clearInterval(timeout);
-          trackerControl.stop();
-          logger.error({ logCode: 'sip_js_transfer_timed_out' }, 'Timeout on transfering from echo test to conference');
-          this.callback({
-            status: this.baseCallStates.failed,
-            error: 1008,
-            bridgeError: 'Timeout on call transfer',
-          });
-          reject(this.baseErrorCodes.REQUEST_TIMEOUT);
-        }
+        clearInterval(timeout);
+        logger.error({ logCode: 'sip_js_transfer_timed_out' }, 'Timeout on transfering from echo test to conference');
+        this.callback({
+          status: this.baseCallStates.failed,
+          error: 1008,
+          bridgeError: 'Timeout on call transfer',
+        });
+        reject(this.baseErrorCodes.REQUEST_TIMEOUT);
       }, CALL_TRANSFER_TIMEOUT);
 
       // This is is the call transfer code ask @chadpilkey
       this.currentSession.dtmf(1);
 
-      Tracker.autorun((c) => {
-        trackerControl = c;
-        const selector = { meetingId: this.userData.meetingId, intId: this.userData.userId };
-        const query = VoiceUsers.find(selector);
-
-        query.observeChanges({
-          changed: (id, fields) => {
-            if (fields.joined) {
-              clearInterval(timeout);
-              onTransferSuccess();
-              c.stop();
-              resolve();
-            }
-          },
-        });
+      this.currentSession.on('dtmf', (event) => {
+        if (event.body && (typeof event.body === 'string')) {
+          const key = SIPBridge.parseDTMF(event.body);
+          if (key === '7') {
+            clearInterval(timeout);
+            onTransferSuccess();
+            resolve();
+          }
+        }
       });
     });
   }
@@ -271,6 +258,7 @@ export default class SIPBridge extends BaseAudioBridge {
       const { mediaHandler } = currentSession;
 
       this.connectionCompleted = false;
+      this.inEcho = false;
 
       let connectionCompletedEvents = ['iceConnectionCompleted', 'iceConnectionConnected'];
       // Edge sends a connected first and then a completed, but the call isn't ready until
@@ -279,6 +267,13 @@ export default class SIPBridge extends BaseAudioBridge {
       if (browser().name === 'edge') {
         connectionCompletedEvents = ['iceConnectionCompleted'];
       }
+
+      const checkIfCallReady = () => {
+        if (this.connectionCompleted && this.inEcho) {
+          this.callback({ status: this.baseCallStates.started });
+          resolve();
+        }
+      };
 
       // Sometimes FreeSWITCH just won't respond with anything and hangs. This timeout is to
       // avoid that issue
@@ -322,15 +317,8 @@ export default class SIPBridge extends BaseAudioBridge {
         clearTimeout(iceNegotiationTimeout);
         connectionCompletedEvents.forEach(e => mediaHandler.off(e, handleConnectionCompleted));
         this.connectionCompleted = true;
-        // We have to delay notifying that the call is connected because it is sometimes not
-        // actually ready and if the user says "Yes they can hear themselves" too quickly the
-        // B-leg transfer will fail
-        const that = this;
-        const notificationTimeout = (browser().name === 'firefox' ? CALL_CONNECT_NOTIFICATION_TIMEOUT : 0);
-        setTimeout(() => {
-          that.callback({ status: that.baseCallStates.started });
-          resolve();
-        }, notificationTimeout);
+
+        checkIfCallReady();
       };
       connectionCompletedEvents.forEach(e => mediaHandler.on(e, handleConnectionCompleted));
 
@@ -361,6 +349,11 @@ export default class SIPBridge extends BaseAudioBridge {
       currentSession.on('terminated', handleSessionTerminated);
 
       const handleIceNegotiationFailed = (peer) => {
+        if (this.connectionCompleted) {
+          logger.error({ logCode: 'sipjs_ice_failed_after' }, 'ICE connection failed after success');
+        } else {
+          logger.error({ logCode: 'sipjs_ice_failed_before' }, 'ICE connection failed before success');
+        }
         clearTimeout(callTimeout);
         clearTimeout(iceNegotiationTimeout);
         ICE_NEGOTIATION_FAILED.forEach(e => mediaHandler.off(e, handleIceNegotiationFailed));
@@ -386,6 +379,18 @@ export default class SIPBridge extends BaseAudioBridge {
         */
       };
       ['iceConnectionClosed'].forEach(e => mediaHandler.on(e, handleIceConnectionTerminated));
+
+      const inEchoDTMF = (event) => {
+        if (event.body && typeof event.body === 'string') {
+          const dtmf = SIPBridge.parseDTMF(event.body);
+          if (dtmf === '0') {
+            this.inEcho = true;
+            checkIfCallReady();
+          }
+        }
+        currentSession.off('dtmf', inEchoDTMF);
+      };
+      currentSession.on('dtmf', inEchoDTMF);
 
       this.currentSession = currentSession;
     });


### PR DESCRIPTION
This PR changes how the client determines when it's in the echo test and when the transfer to the conference is successful. The new method is to have the FreeSWITCH dialplan send back DTMF INFO messages so that we don't have to rely on guessing or the server components. 

In order for this to work there are some dialplan changes required. The first two files already exist and need to be changed and the third file is new.

/opt/freeswitch/conf/dialplan/default/bbb_conference.xml
```xml
<include>
    <extension name="bbb_conferences_ws">
      <condition field="${bbb_authorized}" expression="true" break="on-false"/>
      <condition field="${sip_via_protocol}" expression="^wss?$"/>
      <condition field="destination_number" expression="^(\d{5,6})$">
        <action application="set" data="jitterbuffer_msec=20:400"/>
        <action application="answer"/>
        <action application="set" data="dtmf_type=info"/>
        <action application="send_dtmf" data="0"/>
        <action application="conference" data="$1@cdquality"/>
      </condition>
    </extension>
    <extension name="bbb_conferences">
      <condition field="${bbb_authorized}" expression="true" break="on-false"/>
      <condition field="destination_number" expression="^(\d{5,6})$">
        <action application="set" data="jitterbuffer_msec=20:400"/>
        <action application="answer"/>
        <action application="conference" data="$1@cdquality"/>
      </condition>
    </extension>
</include>
```

/opt/freeswitch/conf/dialplan/default/bbb_echo_test.xml
```xml
<include>
  <extension name="bbb_echo_test_direct">
    <condition field="${bbb_authorized}" expression="true" break="on-false"/>
    <condition field="destination_number" expression="^9196$|^9196(\d{5,6})$">
      <action application="set" data="vbridge=$1"/>
      <action application="answer"/>
      <action application="set" data="bbb_from_echo=true"/>
      <action application="set" data="dtmf_type=info"/>
      <action application="send_dtmf" data="0"/>
      <action application="bind_digit_action" data="direct_from_echo,1,exec:execute_extension,ECHO_TO_CONFERENCE XML default"/>
      <action application="sleep" data="500"/>
      <action application="echo"/>
    </condition>
  </extension>
</include>
```

/opt/freeswitch/conf/dialplan/default/bbb_echo_to_conference.xml
```xml
<include>
  <extension name="ECHO_TO_CONFERENCE">
    <condition field="${bbb_from_echo}" expression="true" break="on-false"/>
    <condition field="destination_number" expression="^(ECHO_TO_CONFERENCE)$">
      <action application="set" data="jitterbuffer_msec=20:400"/>
      <action application="answer"/>
      <action application="set" data="dtmf_type=info"/>
      <action application="send_dtmf" data="7"/>
      <action application="conference" data="${vbridge}@cdquality"/>
    </condition>
  </extension>
</include>
```

Thanks to @hostbbb for the assist on the dialplan changes.