### PR TITLE
Remove duplicate "role=alert" prop from toast notification

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/toast/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/toast/component.jsx
@@ -32,7 +32,6 @@ const Toast = ({
 }) => (
   <div
     className={cx(styles.toastContainer, small ? styles.smallToastContainer : null)}
-    role="alert"
   >
     <div className={styles[type]}>
       <div className={cx(styles.icon, small ? styles.smallIcon : null)}>


### PR DESCRIPTION
Fixes toasts not being announced in Firefox & Edge by screen reader (JAWS)