### PR TITLE
Add option to force server to use HTTP slide URIs

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -304,6 +304,7 @@ private:
   app:
     captionsChunkLength: 1000
     pencilChunkLength: 100
+    loadSlidesFromHttpAlways: false
   etherpad:
     apikey: ETHERPAD_APIKEY
     version: 1.2.13


### PR DESCRIPTION
The HTML5 server code downloads the slides to determine their width and height, but there are some scenarios where the client needs an HTTPS URL and the server can only access the HTTP endpoint. This PR adds a flag that will turn on the necessary conversion to support this set up.