### PR TITLE
Added Unified Plan <-> Plan B translation for Safari endpoints

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -187,7 +187,7 @@ export default class SIPBridge extends BaseAudioBridge {
 
       // Second UA check to get all Safari browsers to enable Unified Plan <-> PlanB
       // translation
-      const isSafari = true //browser().name === 'safari';
+      const isSafari = browser().name === 'safari';
 
       logger.debug('Creating the user agent');
 

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -184,7 +184,6 @@ export default class SIPBridge extends BaseAudioBridge {
       const isSafariWebview = ((browserUA.indexOf('iphone') > -1
         || browserUA.indexOf('ipad') > -1) && browserUA.indexOf('safari') == -1);
 
-
       // Second UA check to get all Safari browsers to enable Unified Plan <-> PlanB
       // translation
       const isSafari = browser().name === 'safari';

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -2,6 +2,7 @@ import browser from 'browser-detect';
 import BaseAudioBridge from './base';
 import logger from '/imports/startup/client/logger';
 import { fetchStunTurnServers } from '/imports/utils/fetchStunTurnServers';
+import { isUnifiedPlan, toUnifiedPlan, toPlanB} from '/imports/utils/sdpUtils';
 
 const MEDIA = Meteor.settings.public.media;
 const MEDIA_TAG = MEDIA.mediaTag;
@@ -34,6 +35,11 @@ export default class SIPBridge extends BaseAudioBridge {
 
     this.protocol = window.document.location.protocol;
     this.hostname = window.document.location.hostname;
+
+    // SDP conversion utilitary methods to be used inside SIP.js
+    window.isUnifiedPlan = isUnifiedPlan;
+    window.toUnifiedPlan = toUnifiedPlan;
+    window.toPlanB = toPlanB;
   }
 
   static parseDTMF(message) {
@@ -171,6 +177,18 @@ export default class SIPBridge extends BaseAudioBridge {
 
       let userAgentConnected = false;
 
+      // WebView safari needs a transceiver to be added. Made it a SIP.js hack.
+      // Don't like the UA picking though, we should straighten everything to user
+      // transceivers - prlanzarin 2019/05/21
+      const browserUA = window.navigator.userAgent.toLocaleLowerCase();
+      const isSafariWebview = ((browserUA.indexOf('iphone') > -1
+        || browserUA.indexOf('ipad') > -1) && browserUA.indexOf('safari') == -1);
+
+
+      // Second UA check to get all Safari browsers to enable Unified Plan <-> PlanB
+      // translation
+      const isSafari = true //browser().name === 'safari';
+
       logger.debug('Creating the user agent');
 
       let userAgent = new window.SIP.UA({
@@ -183,6 +201,8 @@ export default class SIPBridge extends BaseAudioBridge {
         userAgentString: 'BigBlueButton',
         stunServers: stun,
         turnServers: turn,
+        hackPlanBUnifiedPlanTranslation: isSafari,
+        hackAddAudioTransceiver: isSafariWebview,
       });
 
       userAgent.removeAllListeners('connected');

--- a/bigbluebutton-html5/imports/utils/sdpUtils.js
+++ b/bigbluebutton-html5/imports/utils/sdpUtils.js
@@ -16,6 +16,7 @@ const isUnifiedPlan = (sdp) => {
   }
 
   logger.info({ logCode: 'sdp_utils_is_unified_plan' }, 'SDP looks like Unified Plan');
+
   return true;
 }
 

--- a/bigbluebutton-html5/imports/utils/sdpUtils.js
+++ b/bigbluebutton-html5/imports/utils/sdpUtils.js
@@ -1,0 +1,51 @@
+import Interop from '@jitsi/sdp-interop'
+import transform from 'sdp-transform'
+import logger from '/imports/startup/client/logger';
+
+// sdp-interop library for unified-plan <-> plan-b translation
+const interop = new Interop.Interop();
+
+// Some heuristics to determine if the input SDP is Unified Plan
+const isUnifiedPlan = (sdp) => {
+  const parsedSDP = transform.parse(sdp);
+  if (parsedSDP.media.length <= 3 && parsedSDP.media.every((m) => {
+    return ['video', 'audio', 'data'].indexOf(m.mid) !== -1;
+  })) {
+    logger.info({ logCode: 'sdp_utils_not_unified_plan' }, 'SDP does not look like Unified Plan');
+    return false;
+  }
+
+  logger.info({ logCode: 'sdp_utils_is_unified_plan' }, 'SDP looks like Unified Plan');
+  return true;
+}
+
+// Some heuristics to determine if the input SDP is Plan B
+const isPlanB = (sdp) => {
+  const parsedSDP = transform.parse(sdp);
+  if (parsedSDP.media.length > 3 || !parsedSDP.media.every((m) => {
+    return ['video', 'audio', 'data'].indexOf(m.mid) !== -1;
+  })) {
+    logger.info({ logCode: 'sdp_utils_not_plan_b' }, 'SDP does not look like Plan B');
+    return false;
+  }
+
+  logger.info({ logCode: 'sdp_utils_is_plan_b' }, 'SDP looks like Plan B');
+
+  return true;
+}
+
+
+// Specific method for translating FS SDPs from Plan B to Unified Plan (vice-versa)
+const toPlanB = (unifiedPlanSDP) => {
+  const planBSDP = interop.toPlanB(unifiedPlanSDP);
+  logger.info({ logCode: 'sdp_utils_unified_plan_to_plan_b' }, `Converted Unified Plan to Plan B ${JSON.stringify(planBSDP)}`);
+  return planBSDP;
+}
+
+const toUnifiedPlan = (planBSDP) => {
+  const unifiedPlanSDP = interop.toUnifiedPlan(planBSDP);
+  logger.info({ logCode: 'sdp_utils_plan_b_to_unified_plan' }, `Converted Plan B to Unified Plan ${JSON.stringify(unifiedPlanSDP)}`);
+  return unifiedPlanSDP;
+}
+
+export { interop, isUnifiedPlan, toPlanB, toUnifiedPlan };

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -66,6 +66,8 @@
     "react-youtube": "^7.9.0",
     "reconnecting-websocket": "~v4.1.10",
     "redis": "~2.8.0",
+    "@jitsi/sdp-interop": "0.1.14",
+    "sdp-transform": "2.7.0",
     "string-hash": "~1.1.3",
     "tippy.js": "^3.4.1",
     "useragent": "^2.3.0",

--- a/bigbluebutton-html5/public/compatibility/sip.js
+++ b/bigbluebutton-html5/public/compatibility/sip.js
@@ -11626,7 +11626,7 @@ MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
 
         if (window.isUnifiedPlan(sdp) &&
           self.session.ua.configuration.hackPlanBUnifiedPlanTranslation) {
-          sdpWrapper.sdp = window.toPlanB(sdpWrapper.sdp);
+          sdpWrapper = window.toPlanB(sdpWrapper);
         }
 
         self.emit('getDescription', sdpWrapper);


### PR DESCRIPTION
* Built upon the work @capilkey had done on translating the audio SDPs on SIP.js. The problem here is that FreeSWITCH does not support Unified Plan yet and Safari is rolling out version where Plan B is completely disabled. This PR adds the capability to translate audio SDPs between both versions. Currently it's only restricted to Safari endpoints
* Added two new hacks to our SIP.js: 
  - `hackPlanBUnifiedPlanTranslation`: enables the SDP translation. UA parameter.
  - `hackAddAudioTransceiver`: there was some code inside SIP.js that we added to create `transceivers`
for Safari endpoints that ran inside WebView. It wasn't restricted to those, so along with `offerToReceiveAudio` it was duplicating audio streams in Chrome/Firefox/Edgium. Added the hack so we can control when it should be added or not. UA parameter.
* Added two new deps: `@jitsi/sdp-interop` and `sdp-transform`.
* Added new utilitary file `sdpUtils.js` to centralize SDP munging calls and whatnots. Probably will revisit this in the future with a proper SDP munging library.
* Added logs for when the translation is actually used.
* Tested on: Chrome 74 (Win, Linux, Android); Firefox 66 (Win, Linux, Mobile); Safari 12.3 (iOS only, don't have Desktop to try it out); and Edge/Chromium. Also tested forcing both `unified-plan` and `plan-b` in the `sdpSemantics` PC config for all the aforementioned.

I tested this a bunch. Still needs all the testing we can get, though, because I'm particularly worried about the `transceiver` restriction I added.
