### PR TITLE
Add indication that join breakout room btn opens new window

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/component.jsx
@@ -81,7 +81,7 @@ class BreakoutJoinConfirmation extends Component {
           value={this.state.selectValue}
           onChange={this.handleSelectChange}
         >
-          {breakouts.map(({ name, breakoutId }) => (<option key={breakoutId} value={breakoutId} >{name}</option>))}
+          {breakouts.map(({ name, breakoutId }) => (<option key={breakoutId} value={breakoutId}>{name}</option>))}
         </select>
       </div>
     );
@@ -94,8 +94,9 @@ class BreakoutJoinConfirmation extends Component {
         title={intl.formatMessage(intlMessages.title)}
         confirm={{
           callback: this.handleJoinBreakoutConfirmation,
-          label: intl.formatMessage(intlMessages.confirmLabel),
+          label: 'Join room',
           description: intl.formatMessage(intlMessages.confirmDesc),
+          icon: 'popout_window',
         }}
         dismiss={{
           label: intl.formatMessage(intlMessages.dismissLabel),

--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/component.jsx
@@ -20,7 +20,7 @@ const intlMessages = defineMessages({
     description: 'Join breakout confim message',
   },
   confirmLabel: {
-    id: 'app.breakoutJoinConfirmation.confirmLabel',
+    id: 'app.createBreakoutRoom.join',
     description: 'Join confirmation button label',
   },
   confirmDesc: {
@@ -94,7 +94,7 @@ class BreakoutJoinConfirmation extends Component {
         title={intl.formatMessage(intlMessages.title)}
         confirm={{
           callback: this.handleJoinBreakoutConfirmation,
-          label: 'Join room',
+          label: intl.formatMessage(intlMessages.confirmLabel),
           description: intl.formatMessage(intlMessages.confirmDesc),
           icon: 'popout_window',
         }}

--- a/bigbluebutton-html5/imports/ui/components/modal/fullscreen/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/modal/fullscreen/component.jsx
@@ -23,6 +23,10 @@ const intlMessages = defineMessages({
     id: 'app.modal.confirm.description',
     description: 'Disregards changes and closes the modal',
   },
+  newTabLabel: {
+    id: 'app.modal.newTab',
+    description: 'aria label used to indicate opening a new window',
+  },
 });
 
 const propTypes = {
@@ -67,6 +71,12 @@ class ModalFullscreen extends PureComponent {
       ...otherProps
     } = this.props;
 
+    const popoutIcon = confirm.icon === 'popout_window';
+    let confirmAriaLabel = `${confirm.label || intl.formatMessage(intlMessages.modalDone)} `;
+    if (popoutIcon) {
+      confirmAriaLabel = `${confirmAriaLabel} ${intl.formatMessage(intlMessages.newTabLabel)}`;
+    }
+
     return (
       <ModalBase
         isOpen={modalisOpen || preventClosing}
@@ -89,12 +99,14 @@ class ModalFullscreen extends PureComponent {
             <Button
               data-test="modalConfirmButton"
               color="primary"
-              className={styles.confirm}
-              label={intl.formatMessage(intlMessages.modalDone)}
-              aria-label={`${intl.formatMessage(intlMessages.modalDone)} ${title}`}
+              className={popoutIcon ? cx(styles.confirm, styles.popout) : styles.confirm}
+              label={confirm.label}
+              aria-label={confirmAriaLabel}
               disabled={confirm.disabled}
               onClick={this.handleAction.bind(this, 'confirm')}
               aria-describedby="modalConfirmDescription"
+              icon={confirm.icon || null}
+              iconRight={popoutIcon}
             />
           </div>
         </header>

--- a/bigbluebutton-html5/imports/ui/components/modal/fullscreen/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/modal/fullscreen/styles.scss
@@ -50,6 +50,13 @@
   @extend %btn;
 }
 
+.popout {
+  > i {
+    bottom: 2px;
+    left: .75rem;
+  }
+}
+
 .dismiss {
 }
 

--- a/bigbluebutton-html5/imports/ui/components/modal/simple/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/modal/simple/component.jsx
@@ -20,7 +20,7 @@ const intlMessages = defineMessages({
 const propTypes = {
   title: PropTypes.string,
   dismiss: PropTypes.shape({
-    callback: PropTypes.func
+    callback: PropTypes.func,
   }),
 };
 
@@ -61,7 +61,7 @@ class ModalSimple extends Component {
         isOpen={modalisOpen}
         className={cx(className, styles.modal)}
         onRequestClose={closeModel}
-        contentLabel={title}
+        contentLabel={title || contentLabel}
         {...otherProps}
       >
         <header className={hideBorder ? styles.headerNoBorder : styles.header}>

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -405,6 +405,7 @@
     "app.modal.close": "Close",
     "app.modal.close.description": "Disregards changes and closes the modal",
     "app.modal.confirm": "Done",
+    "app.modal.newTab": "(opens new tab)",
     "app.modal.confirm.description": "Saves changes and closes the modal",
     "app.dropdown.close": "Close",
     "app.error.400": "Bad Request",

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -339,7 +339,6 @@
     "app.audioNotificaion.reconnectingAsListenOnly": "Microphone has been locked for viewers, you are being connected as listen only",
     "app.breakoutJoinConfirmation.title": "Join breakout room",
     "app.breakoutJoinConfirmation.message": "Do you want to join",
-    "app.breakoutJoinConfirmation.confirmLabel": "Join",
     "app.breakoutJoinConfirmation.confirmDesc": "Join you to the breakout room",
     "app.breakoutJoinConfirmation.dismissLabel": "Cancel",
     "app.breakoutJoinConfirmation.dismissDesc": "Closes and rejects joining the breakout room",


### PR DESCRIPTION
Makes the Join room button show that it opens a new window
![image](https://user-images.githubusercontent.com/22058534/58346258-6e8c7080-7e28-11e9-8a58-dc8ff96be36c.png)

Also fixes the modals all showing "Done" as their confirm label.

