### PR TITLE
Add context to manage locksettings

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/container.jsx
@@ -3,6 +3,7 @@ import { withTracker } from 'meteor/react-meteor-data';
 import { withModalMounter } from '/imports/ui/components/modal/service';
 import AudioManager from '/imports/ui/services/audio-manager';
 import { makeCall } from '/imports/ui/services/api';
+import lockContextContainer from '/imports/ui/components/lock-viewers/context/container';
 import AudioControls from './component';
 import AudioModalContainer from '../audio-modal/container';
 import Service from '../service';
@@ -31,9 +32,9 @@ const processToggleMuteFromOutside = (e) => {
   }
 };
 
-export default withModalMounter(withTracker(({ mountModal }) => ({
+export default lockContextContainer(withModalMounter(withTracker(({ mountModal, userLocks }) => ({
   processToggleMuteFromOutside: arg => processToggleMuteFromOutside(arg),
-  showMute: Service.isConnected() && !Service.isListenOnly() && !Service.isEchoTest() && !Service.audioLocked(),
+  showMute: Service.isConnected() && !Service.isListenOnly() && !Service.isEchoTest() && !userLocks.userMic,
   muted: Service.isConnected() && !Service.isListenOnly() && Service.isMuted(),
   inAudio: Service.isConnected() && !Service.isEchoTest(),
   listenOnly: Service.isConnected() && Service.isListenOnly(),
@@ -43,4 +44,4 @@ export default withModalMounter(withTracker(({ mountModal }) => ({
   handleToggleMuteMicrophone: () => Service.toggleMuteMicrophone(),
   handleJoinAudio: () => (Service.isConnected() ? Service.joinListenOnly() : mountModal(<AudioModalContainer />)),
   handleLeaveAudio: () => Service.exitAudio(),
-}))(AudioControlsContainer));
+}))(AudioControlsContainer)));

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -6,6 +6,7 @@ import getFromUserSettings from '/imports/ui/services/users-settings';
 import AudioModal from './component';
 import Meetings from '/imports/api/meetings';
 import Auth from '/imports/ui/services/auth';
+import lockContextContainer from '/imports/ui/components/lock-viewers/context/container';
 import Service from '../service';
 
 const AudioModalContainer = props => <AudioModal {...props} />;
@@ -13,7 +14,7 @@ const AudioModalContainer = props => <AudioModal {...props} />;
 const APP_CONFIG = Meteor.settings.public.app;
 
 
-export default withModalMounter(withTracker(({ mountModal }) => {
+export default lockContextContainer(withModalMounter(withTracker(({ mountModal, userLocks }) => {
   const listenOnlyMode = getFromUserSettings('listenOnlyMode', APP_CONFIG.listenOnlyMode);
   const forceListenOnly = getFromUserSettings('forceListenOnly', APP_CONFIG.forceListenOnly);
   const skipCheck = getFromUserSettings('skipCheck', APP_CONFIG.skipCheck);
@@ -75,7 +76,7 @@ export default withModalMounter(withTracker(({ mountModal }) => {
     formattedDialNum,
     formattedTelVoice,
     combinedDialInNum,
-    audioLocked: Service.audioLocked(),
+    audioLocked: userLocks.userMic,
     joinFullAudioImmediately: !listenOnlyMode && skipCheck,
     joinFullAudioEchoTest: !listenOnlyMode && !skipCheck,
     forceListenOnlyAttendee: listenOnlyMode && forceListenOnly && !Service.isUserModerator(),
@@ -83,4 +84,4 @@ export default withModalMounter(withTracker(({ mountModal }) => {
     isMobileNative: navigator.userAgent.toLowerCase().includes('bbbnative'),
     isIEOrEdge: browser().name === 'edge' || browser().name === 'ie',
   });
-})(AudioModalContainer));
+})(AudioModalContainer)));

--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -78,7 +78,7 @@ export default lockContextContainer(withModalMounter(injectIntl(withTracker(({ m
   const APP_CONFIG = Meteor.settings.public.app;
   const KURENTO_CONFIG = Meteor.settings.public.kurento;
   const autoJoin = getFromUserSettings('autoJoin', APP_CONFIG.autoJoin);
-  const { userWebcam } = userLocks;
+  const { userWebcam, userMic } = userLocks;
   const openAudioModal = () => new Promise((resolve) => {
     mountModal(<AudioModalContainer resolve={resolve} />);
   });
@@ -87,7 +87,7 @@ export default lockContextContainer(withModalMounter(injectIntl(withTracker(({ m
     if (userWebcam) return resolve();
     mountModal(<VideoPreviewContainer resolve={resolve} />);
   });
-  if (userWebcam
+  if (userMic
     && Service.isConnected()
     && !Service.isListenOnly()
     && !Service.isMuted()) {

--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -8,6 +8,7 @@ import Breakouts from '/imports/api/breakouts';
 import { notify } from '/imports/ui/services/notification';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import VideoPreviewContainer from '/imports/ui/components/video-preview/container';
+import lockContextContainer from '/imports/ui/components/lock-viewers/context/container';
 import Service from './service';
 import AudioModalContainer from './audio-modal/container';
 
@@ -73,19 +74,20 @@ class AudioContainer extends React.Component {
 
 let didMountAutoJoin = false;
 
-export default withModalMounter(injectIntl(withTracker(({ mountModal, intl }) => {
+export default lockContextContainer(withModalMounter(injectIntl(withTracker(({ mountModal, intl, userLocks }) => {
   const APP_CONFIG = Meteor.settings.public.app;
   const KURENTO_CONFIG = Meteor.settings.public.kurento;
-
   const autoJoin = getFromUserSettings('autoJoin', APP_CONFIG.autoJoin);
+  const { userWebcam } = userLocks;
   const openAudioModal = () => new Promise((resolve) => {
     mountModal(<AudioModalContainer resolve={resolve} />);
   });
 
   const openVideoPreviewModal = () => new Promise((resolve) => {
+    if (userWebcam) return resolve();
     mountModal(<VideoPreviewContainer resolve={resolve} />);
   });
-  if (Service.audioLocked()
+  if (userWebcam
     && Service.isConnected()
     && !Service.isListenOnly()
     && !Service.isMuted()) {
@@ -144,4 +146,4 @@ export default withModalMounter(injectIntl(withTracker(({ mountModal, intl }) =>
       }
     },
   };
-})(AudioContainer)));
+})(AudioContainer))));

--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -30,17 +30,6 @@ const init = (messages, intl) => {
   AudioManager.init(userData);
 };
 
-const audioLocked = () => {
-  const userId = Auth.userID;
-  const User = mapUser(Users.findOne({ userId }));
-
-  const Meeting = Meetings.findOne({ meetingId: Auth.meetingID });
-  const lockSetting = Meeting.lockSettingsProps;
-  const audioLock = lockSetting ? lockSetting.disableMic : false;
-
-  return audioLock && User.isLocked;
-};
-
 const currentUser = () => mapUser(Users.findOne({ intId: Auth.userID }));
 
 export default {
@@ -66,6 +55,5 @@ export default {
   isEchoTest: () => AudioManager.isEchoTest,
   error: () => AudioManager.error,
   isUserModerator: () => Users.findOne({ userId: Auth.userID }).moderator,
-  audioLocked,
   currentUser,
 };

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/context/consumer.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/context/consumer.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import lockContext from './context';
 
 
-const contextProvider = Component => props => (
+const contextConsumer = Component => props => (
   <lockContext.Consumer>
     { contexts => <Component {...props} {...contexts} />}
   </lockContext.Consumer>
 );
 
-export default contextProvider;
+export default contextConsumer;

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/context/consumer.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/context/consumer.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import lockContext from './context';
+
+
+const contextProvider = Component => props => (
+  <lockContext.Consumer>
+    { contexts => <Component {...props} {...contexts} />}
+  </lockContext.Consumer>
+);
+
+export default contextProvider;

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/context/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/context/container.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { withTracker } from 'meteor/react-meteor-data';
+import Meetings from '/imports/api/meetings';
+import Users from '/imports/api/users';
+import Auth from '/imports/ui/services/auth';
+import mapUser from '/imports/ui/services/user/mapUser';
+import { DataStruct } from './context';
+import { withLockContext } from './withContext';
+
+
+const lockContextContainer = component => withTracker(() => {
+  const lockSetting = new DataStruct();
+  const Meeting = Meetings.findOne({ meetingId: Auth.meetingID });
+  const User = Users.findOne({ userId: Auth.userID });
+  const mappedUser = mapUser(User);
+  const userIsLocked = mappedUser.isLocked;
+  const lockSettings = Meeting.lockSettingsProps;
+
+  lockSetting.isLocked = userIsLocked;
+  lockSetting.lockSettings = lockSettings;
+  lockSetting.userLocks.userWebcam = userIsLocked && lockSettings.disableCam;
+  lockSetting.userLocks.userMic = userIsLocked && lockSettings.disableMic;
+  lockSetting.userLocks.userNote = userIsLocked && lockSettings.disableNote;
+  lockSetting.userLocks.userPrivateChat = userIsLocked && lockSettings.disablePrivateChat;
+  lockSetting.userLocks.userPublicChat = userIsLocked && lockSettings.disablePublicChat;
+  lockSetting.userLocks.userLockOnJoin = userIsLocked && lockSettings.lockOnJoin;
+  lockSetting.userLocks.userLockedLayout = userIsLocked && lockSettings.lockedLayout;
+  lockSetting.userLocks.userOnJoinConfigurable = userIsLocked
+  && lockSettings.lockOnJoinConfigurable;
+
+  return lockSetting;
+})(withLockContext(component));
+
+export default lockContextContainer;

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/context/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/context/container.jsx
@@ -4,12 +4,12 @@ import Meetings from '/imports/api/meetings';
 import Users from '/imports/api/users';
 import Auth from '/imports/ui/services/auth';
 import mapUser from '/imports/ui/services/user/mapUser';
-import { DataStruct } from './context';
+import { LockStruct } from './context';
 import { withLockContext } from './withContext';
 
 
 const lockContextContainer = component => withTracker(() => {
-  const lockSetting = new DataStruct();
+  const lockSetting = new LockStruct();
   const Meeting = Meetings.findOne({ meetingId: Auth.meetingID });
   const User = Users.findOne({ userId: Auth.userID });
   const mappedUser = mapUser(User);
@@ -23,10 +23,7 @@ const lockContextContainer = component => withTracker(() => {
   lockSetting.userLocks.userNote = userIsLocked && lockSettings.disableNote;
   lockSetting.userLocks.userPrivateChat = userIsLocked && lockSettings.disablePrivateChat;
   lockSetting.userLocks.userPublicChat = userIsLocked && lockSettings.disablePublicChat;
-  lockSetting.userLocks.userLockOnJoin = userIsLocked && lockSettings.lockOnJoin;
   lockSetting.userLocks.userLockedLayout = userIsLocked && lockSettings.lockedLayout;
-  lockSetting.userLocks.userOnJoinConfigurable = userIsLocked
-  && lockSettings.lockOnJoinConfigurable;
 
   return lockSetting;
 })(withLockContext(component));

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/context/context.js
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/context/context.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+export function DataStruct() {
+  return ({
+    isLocked: false,
+    lockSettings: {
+      disableCam: false,
+      disableMic: false,
+      disableNote: false,
+      disablePrivateChat: false,
+      disablePublicChat: false,
+      lockOnJoin: true,
+      lockOnJoinConfigurable: false,
+      lockedLayout: false,
+    },
+    userLocks: {
+      userWebcam: false,
+      userMic: false,
+      userNote: false,
+      userPrivateChat: false,
+      userPublicChat: false,
+      userLockOnJoin: false,
+      userOnJoinConfigurable: false,
+      userLockedLayout: false,
+    },
+  });
+}
+
+const lockContext = React.createContext(new DataStruct());
+
+export default lockContext;

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/context/context.js
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/context/context.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export function DataStruct() {
+export function LockStruct() {
   return ({
     isLocked: false,
     lockSettings: {
@@ -19,13 +19,11 @@ export function DataStruct() {
       userNote: false,
       userPrivateChat: false,
       userPublicChat: false,
-      userLockOnJoin: false,
-      userOnJoinConfigurable: false,
       userLockedLayout: false,
     },
   });
 }
 
-const lockContext = React.createContext(new DataStruct());
+const lockContext = React.createContext(new LockStruct());
 
 export default lockContext;

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/context/provider.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/context/provider.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import lockContext from './context';
+
+
+const contextProvider = props => (
+  <lockContext.Provider value={props}>
+    { props.children }
+  </lockContext.Provider>
+);
+
+export default contextProvider;

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/context/withContext.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/context/withContext.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import LockProvider from './provider';
+import LockConsumer from './consumer';
+
+const withProvider = Component => props => (
+  <LockProvider {...props}>
+    <Component />
+  </LockProvider>
+);
+
+const withConsumer = Component => LockConsumer(Component);
+
+const withLockContext = Component => withProvider(withConsumer(Component));
+
+export {
+  withProvider,
+  withConsumer,
+  withLockContext,
+};

--- a/bigbluebutton-html5/imports/ui/services/user/mapUser.js
+++ b/bigbluebutton-html5/imports/ui/services/user/mapUser.js
@@ -34,7 +34,7 @@ const mapUser = (user) => {
     externalUserId: user.extId,
   };
 
-  mappedUser.isLocked = user.locked && !(mappedUser.isPresenter || mappedUser.isModerator);
+  mappedUser.isLocked = user.locked && !mappedUser.isModerator;
 
   return mappedUser;
 };


### PR DESCRIPTION
This PR intend to add a context ([context Api](https://reactjs.org/docs/context.html)) to consolidate the lock settings data.

Problem:
 Whenever we want to make sure that the lock settings are applied, we repeat the same step, take the meeting and the user, and compare `user.isLocked` && `meeting.lockSettingsProps.<Any lock>`, the idea of this context is inject lock data as props in wrapped component and simplify his verification and be able to access it data  regardless the deepness of component.

Way to use:
	To use this context, simply import the container into `/imports/ui/components/lock-viewers/context/container.jsx` and encapsulate the target component, such as the context use a provider component, the children must be a component for work properly.
	Any component deeper than the children, doesn't need receive the data via prop, just import the `/imports/ui/components/lock-viewers/context/withContext.jsx` that inject the `context.consumer` to access the data.