### PR TITLE
Fix HTML5 logout

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -182,7 +182,10 @@ class Base extends Component {
     }
 
     if (codeError && !meetingHasEnded) {
-      logger.error({ logCode: 'startup_client_usercouldnotlogin_error' }, `User could not log in HTML5, hit ${codeError}`);
+      // 680 is set for the codeError when the user requests a logout
+      if (codeError !== '680') {
+        logger.error({ logCode: 'startup_client_usercouldnotlogin_error' }, `User could not log in HTML5, hit ${codeError}`);
+      }
       return (<ErrorScreen code={codeError} />);
     }
     // this.props.annotationsHandler.stop();

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -127,7 +127,9 @@ class App extends Component {
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.handleWindowResize, false);
-    navigator.connection.addEventListener('change', this.handleNetworkConnection, false);
+    if (navigator.connection) {
+      navigator.connection.addEventListener('change', this.handleNetworkConnection, false);
+    }
   }
 
   handleWindowResize() {

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -166,7 +166,8 @@ class SettingsDropdown extends PureComponent {
 
   leaveSession() {
     document.dispatchEvent(new Event('exitVideo'));
-    const LOGOUT_CODE = '403';
+    // Set the logout code to 680 because it's not a real code and can be matched on the other side
+    const LOGOUT_CODE = '680';
     makeCall('userLeftMeeting');
     // we don't check askForFeedbackOnLogout here,
     // it is checked in meeting-ended component


### PR DESCRIPTION
There were a couple of regressions introduced in the last couple of days. The first was that the error code being set on logout was changed from 430 to 403 for some reason and that caused the UI to show a message saying that the user had been ejected when they hadn't. The other issue was that the network stats work added a line that removed an event listener on base unmount, but it didn't check to see if the object existed which resulted in a client crash on logout.