### PR TITLE
Fix chat message name alignment

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-list/message-list-item/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-list/message-list-item/styles.scss
@@ -75,9 +75,8 @@
   font-weight: 600;
   position: relative;
 
-  > span {
+  :first-child {
     @extend %text-elipsis;
-    padding: .5rem 0;
   }
 }
 


### PR DESCRIPTION
Before it looked like this
![image](https://user-images.githubusercontent.com/1395090/58360609-c0002400-7e57-11e9-8a06-43663cff84e4.png)
and now it looks like this
![image](https://user-images.githubusercontent.com/1395090/58360627-d5754e00-7e57-11e9-81fb-0a3022a9794b.png)

I also found that long names of offline users were clipping like this
![image](https://user-images.githubusercontent.com/1395090/58360661-fb025780-7e57-11e9-80db-ab92fca6c05e.png)
so now they look like this
![image](https://user-images.githubusercontent.com/1395090/58360672-09e90a00-7e58-11e9-868c-468c8b733846.png)
