### PR TITLE
 - check if we have successfully ejected all users from the voice con…

### DIFF
--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/ConnectionManager.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/ConnectionManager.java
@@ -119,6 +119,24 @@ public class ConnectionManager {
 		}
 	}
 
+	public void checkIfConfIsRunningCommand(CheckIfConfIsRunningCommand command) {
+    Client c = manager.getESLClient();
+    if (c.canSend()) {
+      EslMessage response = c.sendSyncApiCommand(command.getCommand(),
+        command.getCommandArgs());
+      command.handleResponse(response, conferenceEventListener);
+    }
+  }
+
+	public void checkIfConferenceIsRecording(ConferenceCheckRecordCommand ccrc) {
+		Client c = manager.getESLClient();
+		if (c.canSend()) {
+			EslMessage response = c.sendSyncApiCommand(ccrc.getCommand(),
+				ccrc.getCommandArgs());
+			ccrc.handleResponse(response, conferenceEventListener);
+		}
+	}
+
 	public void mute(MuteUserCommand mpc) {
 		Client c = manager.getESLClient();
 		if (c.canSend()) {

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/DelayedCommandSenderService.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/DelayedCommandSenderService.java
@@ -1,0 +1,60 @@
+package org.bigbluebutton.freeswitch.voice.freeswitch;
+
+import org.bigbluebutton.freeswitch.voice.freeswitch.actions.DelayedCommand;
+import org.bigbluebutton.freeswitch.voice.freeswitch.actions.FreeswitchCommand;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.DelayQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+public class DelayedCommandSenderService {
+  private static Logger log = LoggerFactory.getLogger(DelayedCommandSenderService.class);
+
+  private BlockingQueue<DelayedCommand> receivedMessages = new DelayQueue<DelayedCommand>();
+
+  private volatile boolean processMessage = false;
+
+  private final Executor msgProcessorExec = Executors.newSingleThreadExecutor();
+
+  private IDelayedCommandListener listener;
+
+  public void setDelayedCommandListener(IDelayedCommandListener listener) {
+    this.listener = listener;
+  }
+
+  public void stop() {
+    processMessage = false;
+  }
+
+  public void start() {
+    try {
+      processMessage = true;
+
+      Runnable messageProcessor = new Runnable() {
+        public void run() {
+          while (processMessage) {
+            try {
+              DelayedCommand msg = receivedMessages.take();
+              if (listener != null) {
+                listener.runDelayedCommand(msg.conferenceCommand);
+              }
+            } catch (InterruptedException e) {
+              log.error("Error while taking received message from queue.");
+            }
+          }
+        }
+      };
+      msgProcessorExec.execute(messageProcessor);
+    } catch (Exception e) {
+      log.error("Error subscribing to channels: " + e);
+    }
+  }
+
+  public void handleMessage(FreeswitchCommand command, long delayInMillis) {
+    DelayedCommand dc = new DelayedCommand(command, delayInMillis);
+    receivedMessages.add(dc);
+  }
+}

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/IDelayedCommandListener.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/IDelayedCommandListener.java
@@ -1,0 +1,7 @@
+package org.bigbluebutton.freeswitch.voice.freeswitch;
+
+import org.bigbluebutton.freeswitch.voice.freeswitch.actions.FreeswitchCommand;
+
+public interface IDelayedCommandListener {
+  public void runDelayedCommand(FreeswitchCommand command);
+}

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/actions/CheckIfConfIsRunningCommand.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/actions/CheckIfConfIsRunningCommand.java
@@ -1,0 +1,96 @@
+/**
+* BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+* 
+* Copyright (c) 2012 BigBlueButton Inc. and by respective authors (see below).
+*
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License as published by the Free Software
+* Foundation; either version 3.0 of the License, or (at your option) any later
+* version.
+* 
+* BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License along
+* with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+*
+*/
+package org.bigbluebutton.freeswitch.voice.freeswitch.actions;
+
+import org.apache.commons.lang3.StringUtils;
+import org.bigbluebutton.freeswitch.voice.events.ConferenceEventListener;
+import org.bigbluebutton.freeswitch.voice.freeswitch.response.XMLResponseConferenceListParser;
+import org.freeswitch.esl.client.transport.message.EslMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class CheckIfConfIsRunningCommand extends FreeswitchCommand {
+    private static Logger log = LoggerFactory.getLogger(CheckIfConfIsRunningCommand.class);
+
+    public CheckIfConfIsRunningCommand(String room, String requesterId) {
+            super(room, requesterId);
+    }
+    
+    @Override
+    public String getCommandArgs() {
+        return getRoom() + SPACE + "xml_list";
+    }
+    
+    public void handleResponse(EslMessage response, ConferenceEventListener eventListener) {
+
+        //Test for Known Conference
+
+        String firstLine = response.getBodyLines().get(0);
+
+        log.info("Check conference response: " + firstLine);
+        //E.g. Conference 85115 not found
+        
+        if(!firstLine.startsWith("<?xml")) {
+            log.info("INFO! Successfully ejected all users from conference {}.", room);
+            return;
+        }
+
+
+        XMLResponseConferenceListParser confXML = new XMLResponseConferenceListParser();
+
+        //get a factory
+        SAXParserFactory spf = SAXParserFactory.newInstance();
+        try {
+
+            //get a new instance of parser
+            SAXParser sp = spf.newSAXParser();
+
+            //Hack turning body lines back into string then to ByteStream.... BLAH!
+            
+            String responseBody = StringUtils.join(response.getBodyLines(), "\n");
+
+            //http://mark.koli.ch/2009/02/resolving-orgxmlsaxsaxparseexception-content-is-not-allowed-in-prolog.html
+            //This Sux!
+            responseBody = responseBody.trim().replaceFirst("^([\\W]+)<","<");
+
+            ByteArrayInputStream bs = new ByteArrayInputStream(responseBody.getBytes());
+            sp.parse(bs, confXML);
+
+            if (confXML.getConferenceList().size() > 0) {
+                log.warn("WARNING! Failed to eject all users from conference {}.", room);
+            } else {
+                log.info("INFO! Successfully ejected all users from conference {}.", room);
+            }
+        }catch(SAXException se) {
+//            System.out.println("Cannot parse repsonce. ", se);
+        }catch(ParserConfigurationException pce) {
+//            System.out.println("ParserConfigurationException. ", pce);
+        }catch (IOException ie) {
+//        	System.out.println("Cannot parse repsonce. IO Exception. ", ie);
+        }
+    }
+
+}

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/actions/ConferenceCheckRecordCommand.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/actions/ConferenceCheckRecordCommand.java
@@ -1,0 +1,26 @@
+package org.bigbluebutton.freeswitch.voice.freeswitch.actions;
+
+import org.bigbluebutton.freeswitch.voice.events.ConferenceEventListener;
+import org.freeswitch.esl.client.transport.message.EslMessage;
+
+import java.util.Iterator;
+
+public class ConferenceCheckRecordCommand extends FreeswitchCommand {
+
+  public ConferenceCheckRecordCommand(String room, String requesterId) {
+    super(room, requesterId);
+  }
+
+  @Override
+  public String getCommandArgs() {
+    return room + " chkrecord";
+  }
+
+  public void handleResponse(EslMessage response, ConferenceEventListener eventListener) {
+
+    Iterator iterator = response.getBodyLines().iterator();
+    while(iterator.hasNext()) {
+      System.out.println(iterator.next());
+    }
+  }
+}

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/actions/DelayedCommand.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/actions/DelayedCommand.java
@@ -1,0 +1,26 @@
+package org.bigbluebutton.freeswitch.voice.freeswitch.actions;
+
+import java.util.concurrent.Delayed;
+import java.util.concurrent.TimeUnit;
+
+public class DelayedCommand implements Delayed {
+  public final FreeswitchCommand conferenceCommand;
+  public final long callTime;
+
+
+  public DelayedCommand(FreeswitchCommand conferenceCommand, long delayInMillis) {
+    this.conferenceCommand = conferenceCommand;
+    this.callTime = System.currentTimeMillis() + delayInMillis;
+  }
+
+  @Override
+  public long getDelay(TimeUnit unit) {
+    long diff = callTime - System.currentTimeMillis();
+    return unit.convert(diff, TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  public int compareTo(Delayed o) {
+    return new Long(this.callTime - ((DelayedCommand) o).callTime).intValue();
+  }
+}


### PR DESCRIPTION
…ference.

We have noticed that sometimes ejecting all users from the voice conference when meeting ends that FS won't be able to eject some users. This might be that the channel is stuck resulting in the voice conference not being cleaned up properly. This would check if users are ejected properly and log the result for us to track.