### PR TITLE
Make whiteboard toolbar accessible via keyboard

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -242,22 +242,20 @@ class ApplicationMenu extends BaseMenu {
           <div className={styles.row}>
             <div className={styles.col} aria-hidden="true">
               <div className={styles.formElement}>
-                <label className={styles.label}>
+                <label
+                  className={styles.label}
+                  htmlFor="langSelector"
+                  aria-label={intl.formatMessage(intlMessages.ariaLanguageLabel)}
+                >
                   {intl.formatMessage(intlMessages.languageLabel)}
                 </label>
               </div>
             </div>
             <div className={styles.col}>
-              <div
-                id="changeLangLabel"
-                aria-label={intl.formatMessage(intlMessages.ariaLanguageLabel)}
-              />
-              <label
-                aria-labelledby="changeLangLabel"
-                className={cx(styles.formElement, styles.pullContentRight)}
-              >
+              <span className={cx(styles.formElement, styles.pullContentRight)}>
                 {availableLocales && availableLocales.length > 0 ? (
                   <select
+                    id="langSelector"
                     defaultValue={this.state.settings.locale}
                     lang={this.state.settings.locale}
                     className={styles.select}
@@ -271,7 +269,7 @@ class ApplicationMenu extends BaseMenu {
                     ))}
                   </select>
                 ) : null}
-              </label>
+              </span>
             </div>
           </div>
           <hr className={styles.separator} />

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
@@ -295,8 +295,10 @@ class WhiteboardToolbar extends Component {
   // open a submenu
   displaySubMenu(listName) {
     const { currentSubmenuOpen } = this.state;
+
     this.setState({
       currentSubmenuOpen: currentSubmenuOpen === listName ? '' : listName,
+      onBlurEnabled: false,
     });
   }
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-menu-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-menu-item/component.jsx
@@ -69,24 +69,36 @@ export default class ToolbarMenuItem extends Component {
   }
 
   render() {
+    const {
+      disabled,
+      label,
+      icon,
+      customIcon,
+      onBlur,
+      className,
+      children,
+    } = this.props;
+
     return (
-      <div className={styles.buttonWrapper} hidden={this.props.disabled}>
+      <div className={styles.buttonWrapper} hidden={disabled}>
         <Button
           hideLabel
           role="button"
           color="default"
           size="md"
-          label={this.props.label}
-          icon={this.props.icon ? this.props.icon : null}
-          customIcon={this.props.customIcon ? this.props.customIcon : null}
+          label={label}
+          icon={icon || null}
+          customIcon={customIcon || null}
           onMouseDown={this.handleOnMouseDown}
           onMouseUp={this.handleOnMouseUp}
-          onBlur={this.props.onBlur}
-          className={this.props.className}
+          onKeyPress={this.handleOnMouseDown}
+          onKeyUp={this.handleOnMouseUp}
+          onBlur={onBlur}
+          className={className}
           setRef={this.setRef}
-          disabled={this.props.disabled}
+          disabled={disabled}
         />
-        {this.props.children}
+        {children}
       </div>
     );
   }
@@ -109,6 +121,7 @@ ToolbarMenuItem.propTypes = {
   customIcon: PropTypes.node,
   label: PropTypes.string.isRequired,
   className: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
 };
 
 ToolbarMenuItem.defaultProps = {
@@ -117,4 +130,5 @@ ToolbarMenuItem.defaultProps = {
   customIcon: null,
   onBlur: null,
   children: null,
+  disabled: false,
 };

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-submenu-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-submenu-item/component.jsx
@@ -69,6 +69,7 @@ export default class ToolbarSubmenuItem extends Component {
           icon={icon}
           customIcon={customIcon}
           onMouseUp={this.handleOnMouseUp}
+          onKeyPress={this.handleOnMouseUp}
           className={className}
           setRef={this.setRef}
         />

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-submenu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-submenu/component.jsx
@@ -130,12 +130,47 @@ class ToolbarSubmenu extends Component {
     this.handleMouseEnter = this.handleMouseEnter.bind(this);
     this.handleMouseLeave = this.handleMouseLeave.bind(this);
     this.onItemClick = this.onItemClick.bind(this);
+    this.findCurrentElement = this.findCurrentElement.bind(this);
   }
 
   componentDidMount() {
-    const { handleMouseEnter } = this.props;
+    const { handleMouseEnter, objectSelected, type } = this.props;
+
     if (handleMouseEnter) {
       handleMouseEnter();
+
+      if (type === 'annotations') {
+        this.submenuItems.childNodes.forEach((element) => {
+          const node = this.findCurrentElement(element.childNodes[0]);
+          const classname = node.getAttribute('class');
+          if (classname) {
+            const name = classname.split('-');
+            if (name[name.length - 1] === objectSelected.icon) {
+              element.firstChild.focus();
+            }
+          }
+        });
+      }
+
+      if (type === 'thickness') {
+        this.submenuItems.childNodes.forEach((element) => {
+          const node = this.findCurrentElement(element.childNodes[0]);
+          const radius = node.getAttribute('r');
+          if (radius === objectSelected.value.toString()) {
+            element.firstChild.focus();
+          }
+        });
+      }
+
+      if (type === 'color') {
+        this.submenuItems.childNodes.forEach((element) => {
+          const node = this.findCurrentElement(element.childNodes[0]);
+          const fill = node.getAttribute('fill');
+          if (fill === objectSelected.value) {
+            element.firstChild.focus();
+          }
+        });
+      }
     }
   }
 
@@ -145,6 +180,12 @@ class ToolbarSubmenu extends Component {
     if (onItemClick) {
       onItemClick(objectToReturn);
     }
+  }
+
+  findCurrentElement(node) {
+    if (node.nodeName === 'BUTTON') return this.findCurrentElement(node.childNodes[0]);
+    if (node.nodeName === 'svg') return node.firstChild;
+    return node;
   }
 
   handleMouseEnter() {
@@ -194,6 +235,7 @@ class ToolbarSubmenu extends Component {
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
         className={ToolbarSubmenu.getWrapperClassNames(type)}
+        ref={(node) => { this.submenuItems = node; }}
       >
         {objectsToRender ? objectsToRender.map(obj => (
           <ToolbarSubmenuItem

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-submenu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-submenu/component.jsx
@@ -132,21 +132,32 @@ class ToolbarSubmenu extends Component {
     this.onItemClick = this.onItemClick.bind(this);
   }
 
+  componentDidMount() {
+    const { handleMouseEnter } = this.props;
+    if (handleMouseEnter) {
+      handleMouseEnter();
+    }
+  }
+
   onItemClick(objectToReturn) {
-    if (this.props.onItemClick) {
-      this.props.onItemClick(objectToReturn);
+    const { onItemClick } = this.props;
+
+    if (onItemClick) {
+      onItemClick(objectToReturn);
     }
   }
 
   handleMouseEnter() {
-    if (this.props.handleMouseEnter) {
-      this.props.handleMouseEnter();
+    const { handleMouseEnter } = this.props;
+    if (handleMouseEnter) {
+      handleMouseEnter();
     }
   }
 
   handleMouseLeave() {
-    if (this.props.handleMouseLeave) {
-      this.props.handleMouseLeave();
+    const { handleMouseLeave } = this.props;
+    if (handleMouseLeave) {
+      handleMouseLeave();
     }
   }
 
@@ -232,11 +243,8 @@ ToolbarSubmenu.propTypes = {
       icon: PropTypes.string.isRequired,
     }),
   ]).isRequired,
-  label: PropTypes.string.isRequired,
   customIcon: PropTypes.bool.isRequired,
-
   intl: intlShape.isRequired,
-
 };
 
 export default injectIntl(ToolbarSubmenu);


### PR DESCRIPTION
This PR allows the items on the whiteboard toolbar to be activated via they keyboard. Also fixes the screen reader not announcing the aria-label on the language select element in the application settings.

![whiteboard-toolbar-access](https://user-images.githubusercontent.com/22058534/58499744-c0960480-814e-11e9-9a01-c5874a03a1c2.gif)
