### PR TITLE
Handle incorrect presentationId passed from client

### DIFF
--- a/bigbluebutton-html5/imports/api/presentations/server/methods/setPresentation.js
+++ b/bigbluebutton-html5/imports/api/presentations/server/methods/setPresentation.js
@@ -18,17 +18,22 @@ export default function setPresentation(credentials, presentationId, podId) {
     meetingId,
     id: presentationId,
     podId,
-    current: true,
   });
 
-  if (currentPresentation && currentPresentation.id === presentationId) {
-    return Promise.resolve();
+  if (currentPresentation) {
+    if (currentPresentation.current) {
+      return Promise.resolve();
+    }
+
+    const payload = {
+      presentationId,
+      podId,
+    };
+
+    return RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);
   }
 
-  const payload = {
-    presentationId,
-    podId,
-  };
-
-  return RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);
+  // did not find presentation with such id. abandon
+  // return Promise.resolve(); // will close the uploading modal
+  throw new Meteor.Error('presentation-not-found', `Did not find a presentation with id ${presentationId} in method setPresentation`);
 }


### PR DESCRIPTION
Closes https://github.com/bigbluebutton/bigbluebutton/issues/7516

To test:
substitute
      `return setPresentation(currentPresentation.id, podId);`

for
      ```return setPresentation(`${currentPresentation.id}______`, podId);```

in `presentation-uploader/service.js`