### PR TITLE
Fix repeatCount usage in SVG animations

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
@@ -599,7 +599,7 @@ class WhiteboardToolbar extends Component {
                 to={colorSelected.value}
                 begin="indefinite"
                 dur={TRANSITION_DURATION}
-                repeatCount="0"
+                repeatCount="1"
                 fill="freeze"
               />
               <animate
@@ -610,7 +610,7 @@ class WhiteboardToolbar extends Component {
                 to={thicknessSelected.value}
                 begin="indefinite"
                 dur={TRANSITION_DURATION}
-                repeatCount="0"
+                repeatCount="1"
                 fill="freeze"
               />
             </circle>
@@ -692,7 +692,7 @@ class WhiteboardToolbar extends Component {
                 to={colorSelected.value}
                 begin="indefinite"
                 dur={TRANSITION_DURATION}
-                repeatCount="0"
+                repeatCount="1"
                 fill="freeze"
               />
             </rect>


### PR DESCRIPTION
An SVG animation's repeatCount attribute needs to be greater than 0 or 'indefinite' and we were setting it to 0 which resulted in repeated warnings. This changes it to the expected value of 1 so it only runs once.

https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/repeatCount