### PR TITLE
Avoid checking for authentication

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
@@ -33,7 +33,7 @@ class ConnectionController {
 
       response.addHeader("Cache-Control", "no-cache")
       response.contentType = 'plain/text'
-      if (userSession != null && userSession.authed) {
+      if (userSession != null) {
         response.setStatus(200)
         response.outputStream << 'authorized'
       } else {


### PR DESCRIPTION
Since the `authed` does not verify an user at server side, we need to remove this check so users that join as `guest=false` can establish websockets connections