### PR TITLE
Bump audio leave log level

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -310,7 +310,7 @@ class AudioManager {
         this.onAudioJoin();
         resolve(STARTED);
       } else if (status === ENDED) {
-        logger.debug({ logCode: 'audio_ended' }, 'Audio ended without issue');
+        logger.info({ logCode: 'audio_ended' }, 'Audio ended without issue');
         this.onAudioExit();
       } else if (status === FAILED) {
         const errorKey = this.messages.error[error] || this.messages.error.GENERIC_ERROR;


### PR DESCRIPTION
The log that says that that some left the audio was lower priority than all of the other audio log levels.