### PR TITLE
Try to improve Kurento listen-only error reporting

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
@@ -89,7 +89,10 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
         };
 
         const onFail = (error) => {
-          const { reason } = error;
+          let reason = 'Undefined';
+          if (error) {
+            reason = error.reason || error.id || error;
+          }
           this.callback({
             status: this.baseCallStates.failed,
             error: this.baseErrorCodes.CONNECTION_ERROR,


### PR DESCRIPTION
I was looking through the logs sent by the client and all of the Kurento listen-only errors get turned into generic CONNECTION_ERRORs. The reason is supposed to be mapped to bridgeError which is supposed to mapped to cause in the log, but reason is almost always undefined. I looked through the client code and there are at least four different error formats that can be passed back to the onFail handler.
* Error with reason
* Error with id
* String
* Nothing