### PR TITLE
RaP: Fix error message when shared notes could not be archived.

### DIFF
--- a/record-and-playback/core/lib/recordandplayback.rb
+++ b/record-and-playback/core/lib/recordandplayback.rb
@@ -160,7 +160,7 @@ module BigBlueButton
         http.head(uri.request_uri)
       }
       unless response.is_a? Net::HTTPSuccess
-        raise "File not available: #{respose.message}"
+        raise "File not available: #{response.message}"
       end
     end
 


### PR DESCRIPTION
It used to print:
```
Failed to download file: undefined local variable or method `respose' for BigBlueButton:Module
Did you mean?  response
```
because the incorrect variable name was used in the error message.

There was no effect other than the message in the log, since the shared notes
couldn't be archived anyways, and the only thing the exception did was ...
prevent the shared notes from being archived.