### PR TITLE
Add bitrate config options to cameraProfiles

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -10,8 +10,6 @@ import Modal from '/imports/ui/components/modal/simple/component';
 import browser from 'browser-detect';
 import { styles } from './styles';
 
-
-// const VIDEO_CONSTRAINTS = Meteor.settings.public.kurento.cameraConstraints;
 const CAMERA_PROFILES = Meteor.settings.public.kurento.cameraProfiles;
 
 const propTypes = {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -519,7 +519,7 @@ class VideoProvider extends Component {
       const cameraProfile = CAMERA_PROFILES.find(profile => profile.id === profileId)
         || CAMERA_PROFILES.find(profile => profile.default)
         || CAMERA_PROFILES[0];
-      const { constraints } = cameraProfile;
+      const { constraints, bitrate } = cameraProfile;
       if (Session.get('WebcamDeviceId')) {
         constraints.deviceId = { exact: Session.get('WebcamDeviceId') };
       }
@@ -573,6 +573,7 @@ class VideoProvider extends Component {
             cameraId: id,
             meetingId,
             voiceBridge,
+            bitrate,
           };
           this.sendMessage(message);
           return true;

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -103,6 +103,7 @@ public:
             max: 160
           height:
             max: 120
+        bitrate: 100
       - id: medium
         name: Medium quality
         default: true
@@ -111,6 +112,7 @@ public:
             max: 320
           height:
             max: 240
+        bitrate: 300
       - id: high
         name: High quality
         default: false
@@ -119,6 +121,7 @@ public:
             max: 640
           height:
             max: 480
+        bitrate: 500
       - id: hd
         name: High definition
         default: false
@@ -127,6 +130,7 @@ public:
             max: 1280
           height:
             max: 960
+        bitrate: 800
     enableScreensharing: true
     enableVideo: true
     enableVideoStats: false

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -112,7 +112,7 @@ public:
             max: 320
           height:
             max: 240
-        bitrate: 300
+        bitrate: 200
       - id: high
         name: High quality
         default: false


### PR DESCRIPTION
Sibling: https://github.com/bigbluebutton/bbb-webrtc-sfu/pull/33. The configs are optional, but the SFU PR must be on for them to have any effect.
Testing: fiddle with the settings parameters, check the bandwidth specs on the remote SDP on chrome://webrtc-internals (AS/TIAS fields).

PS.: accidentally commited a commented code removal on preview that was unneeded...