### PR TITLE
Fix for voice-only users not appearing in the audio

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/modifiers/addUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/addUser.js
@@ -89,8 +89,9 @@ export default function addUser(meetingId, user) {
     ),
   };
 
-  // Only add an empty VoiceUser if there isn't one already. We want to avoid overwriting good data
-  if (!VoiceUsers.findOne({ meetingId, intId: userId })) {
+  // Only add an empty VoiceUser if there isn't one already and if the user coming in isn't a
+  // dial-in user. We want to avoid overwriting good data
+  if (user.clientType !== 'dial-in-user' && !VoiceUsers.findOne({ meetingId, intId: userId })) {
     addVoiceUser(meetingId, {
       voiceUserId: '',
       intId: userId,


### PR DESCRIPTION
When a voice user comes in for the first time we try to determine if they're voice-only or not. If the user is voice-only we create a User set to 'dial-in-user' for them and then follow up with the creation of a real VoiceUser. As far as I can tell the cause of the issue is that when we create the User with type 'dial-in-user' the addUser code will also trigger the creation of a dummy VoiceUser. The final list of operations is then: dummy VoiceUser, dial-in User, real VoiceUser. It's likely a race condition with the creation of two VoiceUsers with the same ID so this PR removes the race by avoiding the creation of the dummy VoiceUser when the User is a 'dial-in-user'.

The original issue was spotty anyways and would only happen once out of a dozen tries for me, but I couldn't reproduce at all after my change.

This PR should fix #7331 and fix #7136