### PR TITLE
Set default tool to pan and add corner triangle

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
@@ -72,11 +72,10 @@ class WhiteboardToolbar extends Component {
     super(props);
 
     const { annotations } = this.props;
-    const isMobile = browser().mobile;
 
     let annotationSelected = {
-      icon: isMobile ? 'hand' : 'pen_tool',
-      value: isMobile ? 'hand' : 'pencil',
+      icon: 'hand',
+      value: 'hand',
     };
 
     if (!annotations.some(el => el.value === annotationSelected.value) && annotations.length > 0) {
@@ -243,8 +242,9 @@ class WhiteboardToolbar extends Component {
   panOff(event) {
     const { target, which } = event;
     const isInputArea = target.nodeName === 'TEXTAREA' || target.nodeName === 'INPUT';
+    const { panMode } = this.state;
 
-    if (isInputArea) return;
+    if (isInputArea || !panMode) return;
 
     const { prevAnnotationSelected } = this.state;
 
@@ -451,6 +451,7 @@ class WhiteboardToolbar extends Component {
           objectToReturn="annotationList"
           onBlur={this.closeSubMenu}
           className={cx(styles.toolbarButton, currentSubmenuOpen === 'annotationList' ? styles.toolbarActive : null)}
+          showCornerTriangle
         >
           {currentSubmenuOpen === 'annotationList' && annotations.length > 1
             ? (
@@ -482,6 +483,7 @@ class WhiteboardToolbar extends Component {
         objectToReturn="fontSizeList"
         onBlur={this.closeSubMenu}
         className={cx(styles.toolbarButton, currentSubmenuOpen === 'fontSizeList' ? styles.toolbarActive : null)}
+        showCornerTriangle
       >
         {currentSubmenuOpen === 'fontSizeList'
           ? (
@@ -543,6 +545,7 @@ class WhiteboardToolbar extends Component {
         onBlur={this.closeSubMenu}
         className={cx(styles.toolbarButton, currentSubmenuOpen === 'thicknessList' ? styles.toolbarActive : null)}
         customIcon={this.renderThicknessItemIcon()}
+        showCornerTriangle
       >
         {currentSubmenuOpen === 'thicknessList'
           ? (
@@ -644,6 +647,7 @@ class WhiteboardToolbar extends Component {
         onBlur={this.closeSubMenu}
         className={cx(styles.toolbarButton, currentSubmenuOpen === 'colorList' ? styles.toolbarActive : null)}
         customIcon={this.renderColorItemIcon()}
+        showCornerTriangle
       >
         {currentSubmenuOpen === 'colorList'
           ? (

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/styles.scss
@@ -115,7 +115,7 @@
     right: var(--toolbar-item-triangle-padding);
 
     border-left-color: transparent;
-    border-right-color: var(--toolbar-item-triangle-padding);
+    border-right-color: var(--toolbar-list-color);
   }
 }
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/styles.scss
@@ -15,6 +15,7 @@
   --toolbar-list-bg-focus: #c6c6c6;
   --toolbar-list-color: var(--color-gray);
   --toolbar-item-outline-offset: -.19rem;
+  --toolbar-item-triangle-padding: 2px;
 }
 
 .toolbarContainer {
@@ -94,6 +95,28 @@
   height: var(--toolbar-button-height);
   min-height: var(--toolbar-button-height);
   position: relative;
+}
+
+.cornerTriangle::before {
+  content: '';
+  position: absolute;
+  border-color: transparent;
+  border-style: solid;
+  z-index: 100;
+  border-radius: 0;
+  border-width: 0.35em;
+  bottom: var(--toolbar-item-triangle-padding);
+  left: var(--toolbar-item-triangle-padding);
+  border-left-color: var(--toolbar-list-color);
+  border-bottom-color: var(--toolbar-list-color);
+
+  [dir="rtl"] & {
+    left: auto;
+    right: var(--toolbar-item-triangle-padding);
+
+    border-left-color: transparent;
+    border-right-color: var(--toolbar-item-triangle-padding);
+  }
 }
 
 .toolbarButton {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-menu-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-menu-item/component.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Button from '/imports/ui/components/button/component';
 import _ from 'lodash';
+import cx from 'classnames';
 import { styles } from '../styles';
 
 export default class ToolbarMenuItem extends Component {
@@ -77,10 +78,14 @@ export default class ToolbarMenuItem extends Component {
       onBlur,
       className,
       children,
+      showCornerTriangle,
     } = this.props;
 
     return (
-      <div className={styles.buttonWrapper} hidden={disabled}>
+      <div
+        className={cx(styles.buttonWrapper, !showCornerTriangle || styles.cornerTriangle)}
+        hidden={disabled}
+      >
         <Button
           hideLabel
           role="button"
@@ -122,6 +127,7 @@ ToolbarMenuItem.propTypes = {
   label: PropTypes.string.isRequired,
   className: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
+  showCornerTriangle: PropTypes.bool,
 };
 
 ToolbarMenuItem.defaultProps = {
@@ -131,4 +137,5 @@ ToolbarMenuItem.defaultProps = {
   onBlur: null,
   children: null,
   disabled: false,
+  showCornerTriangle: false,
 };


### PR DESCRIPTION
This PR adds a corner triangle to the whiteboard toolbar buttons that have sub-menus so it's easier for the user to tell that there's something more there. It also sets the default tool back to the hand so there's less accidental drawing. I also found an issue with the functionality where you press the spacebar to pan. If you pressed and released Space while pan was selected it would change you to a different tool.

![image](https://user-images.githubusercontent.com/1395090/59473888-682f5a00-8e12-11e9-843a-43d5640bee03.png)

Fixes #7587