### PR TITLE
UI improvements to Closed Captions (part 2)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -13,8 +13,6 @@ import { withModalMounter } from '/imports/ui/components/modal/service';
 import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
 import { styles } from '../styles';
 import ExternalVideoModal from '/imports/ui/components/external-video-player/modal/container';
-import CaptionsWriterMenu from '/imports/ui/components/captions/writer-menu/container';
-import CaptionsService from '/imports/ui/components/captions/service';
 
 const propTypes = {
   isUserPresenter: PropTypes.bool.isRequired,
@@ -72,14 +70,6 @@ const intlMessages = defineMessages({
     id: 'app.actionsBar.actionsDropdown.takePresenterDesc',
     description: 'Description of take presenter role option',
   },
-  captionsLabel: {
-    id: 'app.actionsBar.actionsDropdown.captionsLabel',
-    description: 'Captions menu toggle label',
-  },
-  captionsDesc: {
-    id: 'app.actionsBar.actionsDropdown.captionsDesc',
-    description: 'Captions menu toggle description',
-  },
   startExternalVideoLabel: {
     id: 'app.actionsBar.actionsDropdown.shareExternalVideo',
     description: 'Start sharing external video button',
@@ -96,12 +86,10 @@ class ActionsDropdown extends Component {
 
     this.presentationItemId = _.uniqueId('action-item-');
     this.pollId = _.uniqueId('action-item-');
-    this.captionsId = _.uniqueId('action-item-');
     this.takePresenterId = _.uniqueId('action-item-');
 
     this.handlePresentationClick = this.handlePresentationClick.bind(this);
     this.handleExternalVideoClick = this.handleExternalVideoClick.bind(this);
-    this.handleCaptionsClick = this.handleCaptionsClick.bind(this);
   }
 
   componentWillUpdate(nextProps) {
@@ -127,8 +115,6 @@ class ActionsDropdown extends Component {
       pollBtnDesc,
       presentationLabel,
       presentationDesc,
-      captionsLabel,
-      captionsDesc,
       takePresenter,
       takePresenterDesc,
     } = intlMessages;
@@ -163,17 +149,6 @@ class ActionsDropdown extends Component {
             onClick={() => handleTakePresenter()}
           />
         )),
-      (CaptionsService.isCaptionsEnabled()
-        ? (
-          <DropdownListItem
-            icon="closed_caption"
-            label={formatMessage(captionsLabel)}
-            description={formatMessage(captionsDesc)}
-            key={this.captionsId}
-            onClick={this.handleCaptionsClick}
-          />
-        ) : null
-      ),
       (isUserPresenter
         ? (
           <DropdownListItem
@@ -204,11 +179,6 @@ class ActionsDropdown extends Component {
   handleExternalVideoClick() {
     const { mountModal } = this.props;
     mountModal(<ExternalVideoModal />);
-  }
-
-  handleCaptionsClick() {
-    const { mountModal } = this.props;
-    mountModal(<CaptionsWriterMenu />);
   }
 
   handlePresentationClick() {

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/captions/reader-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/captions/reader-menu/component.jsx
@@ -84,8 +84,10 @@ class ReaderMenu extends PureComponent {
       fontSize,
     } = props.getCaptionsSettings();
 
+    const { ownedLocales } = this.props;
+
     this.state = {
-      locale: null,
+      locale: (ownedLocales && ownedLocales[0]) ? ownedLocales[0].locale : null,
       backgroundColor,
       fontColor,
       fontFamily,
@@ -186,6 +188,7 @@ class ReaderMenu extends PureComponent {
       locale,
     } = this.state;
 
+    const defaultLocale = locale || DEFAULT_VALUE;
     return (
       <Modal
         overlayClassName={styles.overlay}
@@ -201,7 +204,7 @@ class ReaderMenu extends PureComponent {
           <select
             className={styles.select}
             onChange={this.handleLocaleChange}
-            defaultValue={DEFAULT_VALUE}
+            defaultValue={defaultLocale}
           >
             <option
               disabled

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/captions/reader-menu/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/captions/reader-menu/styles.scss
@@ -47,7 +47,7 @@
 }
 
 .selectLanguage {
-  text-align: center;
+  text-align: end;
 }
 
 .col {

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -73,6 +73,12 @@ class ActionsBar extends React.PureComponent {
               parseCurrentSlideContent,
             }}
           />
+          {isCaptionsAvailable
+            ? (
+              <CaptionsButtonContainer {...{ intl }} />
+            )
+            : null
+          }
         </div>
         <div
           className={
@@ -98,12 +104,6 @@ class ActionsBar extends React.PureComponent {
             screenshareDataSavingSetting,
           }}
           />
-          {isCaptionsAvailable
-            ? (
-              <CaptionsButtonContainer {...{ intl }} />
-            )
-            : null
-        }
         </div>
         <div className={styles.right}>
           {isLayoutSwapped

--- a/bigbluebutton-html5/imports/ui/components/captions/writer-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/writer-menu/component.jsx
@@ -8,6 +8,7 @@ import Button from '/imports/ui/components/button/component';
 import { styles } from './styles';
 
 const DEFAULT_VALUE = 'select';
+
 const DEFAULT_KEY = -1;
 
 const intlMessages = defineMessages({
@@ -18,6 +19,10 @@ const intlMessages = defineMessages({
   title: {
     id: 'app.captions.menu.title',
     description: 'Title for the closed captions menu',
+  },
+  subtitle: {
+    id: 'app.captions.menu.subtitle',
+    description: 'Subtitle for the closed captions writer menu',
   },
   start: {
     id: 'app.captions.menu.start',
@@ -53,7 +58,15 @@ const propTypes = {
 class WriterMenu extends PureComponent {
   constructor(props) {
     super(props);
-    this.state = { locale: null };
+    const { availableLocales, intl } = this.props;
+
+    const candidate = availableLocales.filter(
+      l => l.locale.substring(0, 2) === intl.locale.substring(0, 2),
+    );
+
+    this.state = {
+      locale: candidate && candidate[0] ? candidate[0].locale : null,
+    };
 
     this.handleChange = this.handleChange.bind(this);
     this.handleStart = this.handleStart.bind(this);
@@ -82,7 +95,7 @@ class WriterMenu extends PureComponent {
     } = this.props;
 
     const { locale } = this.state;
-
+    const defaultLocale = locale || DEFAULT_VALUE;
     return (
       <Modal
         overlayClassName={styles.overlay}
@@ -97,6 +110,9 @@ class WriterMenu extends PureComponent {
           </h3>
         </header>
         <div className={styles.content}>
+          <label>
+            {intl.formatMessage(intlMessages.subtitle)}
+          </label>
           <label
             aria-hidden
             htmlFor="captionsLangSelector"
@@ -106,7 +122,7 @@ class WriterMenu extends PureComponent {
             id="captionsLangSelector"
             className={styles.select}
             onChange={this.handleChange}
-            defaultValue={DEFAULT_VALUE}
+            defaultValue={defaultLocale}
           >
             <option disabled key={DEFAULT_KEY} value={DEFAULT_VALUE}>
               {intl.formatMessage(intlMessages.select)}

--- a/bigbluebutton-html5/imports/ui/components/captions/writer-menu/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/captions/writer-menu/styles.scss
@@ -10,12 +10,10 @@
 }
 
 .content {
-  flex-grow: 1;
+  align-items: center;
   display: flex;
-  justify-content: center;
-  margin-top: auto;
-  margin-bottom: auto;
-  padding: 3rem 0 0.5rem 0;
+  flex-direction: column;
+  padding: .3rem 0 0.5rem 0;
 }
 
 .captionsOptions {
@@ -43,7 +41,7 @@
   border-radius: var(--border-size);
   border-bottom: 0.1rem solid var(--color-gray-lighter);
   color: var(--color-gray-label);
-  width: 50%;
+  width: 40%;
   height: 1.75rem;
   padding: 1px;
 
@@ -71,13 +69,12 @@
 }
 
 .startBtn {
-  display: flex;
   align-self: center;
   margin: 0;
   width: 40%;
   display: block;
   position: absolute;
-  bottom:   20px;
+  bottom: 20px;
   color: var(--color-white) !important;
   background-color: var(--color-link) !important;
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -13,6 +13,7 @@ import LockViewersContainer from '/imports/ui/components/lock-viewers/container'
 import BreakoutRoom from '/imports/ui/components/actions-bar/create-breakout-room/container';
 import CaptionsService from '/imports/ui/components/captions/service';
 import CaptionsWriterMenu from '/imports/ui/components/captions/writer-menu/container';
+import DropdownListSeparator from '/imports/ui/components/dropdown/list/separator/component';
 import { styles } from './styles';
 
 const propTypes = {
@@ -234,6 +235,16 @@ class UserOptions extends PureComponent {
           onClick={toggleMuteAllUsersExceptPresenter}
         />) : null
       ),
+      (isUserModerator
+        ? (
+          <DropdownListItem
+            icon="download"
+            label={intl.formatMessage(intlMessages.saveUserNames)}
+            key={this.saveUsersNameId}
+            onClick={this.onSaveUserNames}
+          />
+        )
+        : null),
       (<DropdownListItem
         key={this.lockId}
         icon="lock"
@@ -241,6 +252,7 @@ class UserOptions extends PureComponent {
         description={intl.formatMessage(intlMessages.lockViewersDesc)}
         onClick={() => mountModal(<LockViewersContainer />)}
       />),
+      (<DropdownListSeparator key={_.uniqueId('list-separator-')} />),
       (canCreateBreakout
         ? (
           <DropdownListItem
@@ -270,16 +282,6 @@ class UserOptions extends PureComponent {
             description={intl.formatMessage(intlMessages.captionsDesc)}
             key={this.captionsId}
             onClick={this.handleCaptionsClick}
-          />
-        )
-        : null),
-      (isUserModerator
-        ? (
-          <DropdownListItem
-            icon="download"
-            label={intl.formatMessage(intlMessages.saveUserNames)}
-            key={this.saveUsersNameId}
-            onClick={this.onSaveUserNames}
           />
         )
         : null),

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -117,7 +117,7 @@ class UserOptions extends PureComponent {
     this.lockId = _.uniqueId('list-item-');
     this.createBreakoutId = _.uniqueId('list-item-');
     this.saveUsersNameId = _.uniqueId('list-item-');
-    this.captionsId = _.uniqueId('action-item-');
+    this.captionsId = _.uniqueId('list-item-');
 
     this.onActionsShow = this.onActionsShow.bind(this);
     this.onActionsHide = this.onActionsHide.bind(this);

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -11,6 +11,8 @@ import DropdownList from '/imports/ui/components/dropdown/list/component';
 import DropdownListItem from '/imports/ui/components/dropdown/list/item/component';
 import LockViewersContainer from '/imports/ui/components/lock-viewers/container';
 import BreakoutRoom from '/imports/ui/components/actions-bar/create-breakout-room/container';
+import CaptionsService from '/imports/ui/components/captions/service';
+import CaptionsWriterMenu from '/imports/ui/components/captions/writer-menu/container';
 import { styles } from './styles';
 
 const propTypes = {
@@ -90,6 +92,14 @@ const intlMessages = defineMessages({
     id: 'app.actionsBar.actionsDropdown.saveUserNames',
     description: 'Save user name feature description',
   },
+  captionsLabel: {
+    id: 'app.actionsBar.actionsDropdown.captionsLabel',
+    description: 'Captions menu toggle label',
+  },
+  captionsDesc: {
+    id: 'app.actionsBar.actionsDropdown.captionsDesc',
+    description: 'Captions menu toggle description',
+  },
 });
 
 class UserOptions extends PureComponent {
@@ -106,10 +116,12 @@ class UserOptions extends PureComponent {
     this.lockId = _.uniqueId('list-item-');
     this.createBreakoutId = _.uniqueId('list-item-');
     this.saveUsersNameId = _.uniqueId('list-item-');
+    this.captionsId = _.uniqueId('action-item-');
 
     this.onActionsShow = this.onActionsShow.bind(this);
     this.onActionsHide = this.onActionsHide.bind(this);
     this.handleCreateBreakoutRoomClick = this.handleCreateBreakoutRoomClick.bind(this);
+    this.handleCaptionsClick = this.handleCaptionsClick.bind(this);
     this.onCreateBreakouts = this.onCreateBreakouts.bind(this);
     this.onInvitationUsers = this.onInvitationUsers.bind(this);
     this.renderMenuItems = this.renderMenuItems.bind(this);
@@ -165,6 +177,11 @@ class UserOptions extends PureComponent {
         }}
       />,
     );
+  }
+
+  handleCaptionsClick() {
+    const { mountModal } = this.props;
+    mountModal(<CaptionsWriterMenu />);
   }
 
   renderMenuItems() {
@@ -242,6 +259,17 @@ class UserOptions extends PureComponent {
             label={intl.formatMessage(intlMessages.invitationItem)}
             key={this.createBreakoutId}
             onClick={this.onInvitationUsers}
+          />
+        )
+        : null),
+      (isUserModerator && CaptionsService.isCaptionsEnabled()
+        ? (
+          <DropdownListItem
+            icon="closed_caption"
+            label={intl.formatMessage(intlMessages.captionsLabel)}
+            description={intl.formatMessage(intlMessages.captionsDesc)}
+            key={this.captionsId}
+            onClick={this.handleCaptionsClick}
           />
         )
         : null),

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
@@ -89,7 +89,7 @@ class WhiteboardToolbar extends Component {
       // variables to keep current selected draw settings
       annotationSelected,
       prevAnnotationSelected: annotationSelected,
-      thicknessSelected: { value: 2 },
+      thicknessSelected: { value: 1 },
       colorSelected: { value: '#ff0000' },
       fontSizeSelected: { value: 20 },
 

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -26,6 +26,7 @@
     "app.captions.menu.ariaStartDesc": "Opens captions editor and closes the modal",
     "app.captions.menu.select": "Select available language",
     "app.captions.menu.ariaSelect": "Captions language",
+    "app.captions.menu.subtitle": "Please select a language and styles for closed captions within your session.",
     "app.captions.menu.title": "Closed captions",
     "app.captions.menu.fontSize": "Size",
     "app.captions.menu.fontColor": "Text color",


### PR DESCRIPTION
Closes #7586
![Screenshot from 2019-06-20 11-05-06](https://user-images.githubusercontent.com/6312397/59860524-00ff3180-934d-11e9-8c6a-fb0c476c1dc0.png)

Implements all the suggestions from @tylercopeland from 7586

Also sets the default thickness for whiteboard to 1