### PR TITLE
flushOnClose option for Browser Bunyan

### DIFF
--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -111,9 +111,9 @@
       "integrity": "sha1-oFIwOuXRofm2Pus6lElaL0KfSDE="
     },
     "@browser-bunyan/server-stream": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@browser-bunyan/server-stream/-/server-stream-1.5.0.tgz",
-      "integrity": "sha512-u/ixWjnIESdF1LOtn/yh4Fe7wTAoGmhcdBk3cb4bmI+s1Pr9f5bUoHD8wbQlbok2sQw5TpQbPPh6r5IdfJFbcQ=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@browser-bunyan/server-stream/-/server-stream-1.5.1.tgz",
+      "integrity": "sha512-xR0/+hDq8HcLIo/edgN95Lkq4iEfrWsYxvfTnF/d8QwN0REmcDWcs8RmrWnmWrM+SElvBl3Lq5RcImMo+AYqSw=="
     },
     "@iamstarkov/listr-update-renderer": {
       "version": "0.4.1",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -28,10 +28,11 @@
     }
   },
   "dependencies": {
-    "axios": "^0.19.0",
     "@babel/runtime": "^7.3.1",
-    "@browser-bunyan/server-stream": "^1.5.0",
+    "@browser-bunyan/server-stream": "^1.5.1",
+    "@jitsi/sdp-interop": "0.1.14",
     "autoprefixer": "~9.3.1",
+    "axios": "^0.19.0",
     "babel-plugin-react-remove-properties": "~0.2.5",
     "babel-runtime": "~6.26.0",
     "browser-bunyan": "^1.5.0",
@@ -68,7 +69,6 @@
     "react-youtube": "^7.9.0",
     "reconnecting-websocket": "~v4.1.10",
     "redis": "~2.8.0",
-    "@jitsi/sdp-interop": "0.1.14",
     "sdp-transform": "2.7.0",
     "string-hash": "~1.1.3",
     "tippy.js": "^3.4.1",

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -313,7 +313,7 @@ public:
   clientLog:
     server: { enabled: true, level: info }
     console: { enabled: true, level: debug }
-    external: { enabled: false, level: info, url: https://LOG_HOST/html5Log, method: POST, throttleInterval: 400 }
+    external: { enabled: false, level: info, url: https://LOG_HOST/html5Log, method: POST, throttleInterval: 400, flushOnClose: true }
 private:
   app:
     host: 127.0.0.1


### PR DESCRIPTION
Update Browser Bunyan and enable `flushOnClose` for the `external` target (issue #6923).