### PR TITLE
Fix exception in presentation uploader

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -196,7 +196,8 @@ class PresentationUploader extends Component {
   }
 
   static getDerivedStateFromProps(props, state) {
-    if (props.presentations[0].isCurrent && state.disableConfirm) {
+    const firstPres = props.presentations[0];
+    if (firstPres && firstPres.isCurrent && state.disableConfirm) {
       return {
         disableConfirm: !state.disableConfirm,
       };


### PR DESCRIPTION
There was an exception thrown if you opened the modal before the default presentation had been converted. I've added an extra check to make sure the first presentation exists.

After this PR the modal will open, but it won't update when the default presentation finally converts because the presentations are being cached on modal open for some reason. I'm pretty sure that issue has been around for a long time though. The state of the confirm button is also very odd and inconsistent.

Fixes https://github.com/bigbluebutton/bigbluebutton/issues/7666