### PR TITLE
baseErrorCodes not defined

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -469,7 +469,8 @@ export default class SIPBridge extends BaseAudioBridge {
     return new Promise((resolve, reject) => {
       let { hostname } = this;
 
-      this.activeSession = new SIPSession(this.user, this.userData, this.protocol, hostname, this.baseCallStates);
+      this.activeSession = new SIPSession(this.user, this.userData, this.protocol,
+        hostname, this.baseCallStates, this.baseErrorCodes);
 
       const callback = (message) => {
         if (message.status === this.baseCallStates.failed) {
@@ -492,7 +493,8 @@ export default class SIPBridge extends BaseAudioBridge {
 
           if (shouldTryReconnect) {
             const fallbackExtension = this.activeSession.inEchoTest ? extension : undefined;
-            this.activeSession = new SIPSession(this.user, this.userData, this.protocol, hostname, this.baseCallStates);
+            this.activeSession = new SIPSession(this.user, this.userData, this.protocol,
+              hostname, this.baseCallStates, this.baseErrorCodes);
             this.activeSession.joinAudio({ isListenOnly, extension: fallbackExtension, inputStream }, callback)
               .then((value) => {
                 resolve(value);

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -17,12 +17,13 @@ const CALL_CONNECT_TIMEOUT = 15000;
 const ICE_NEGOTIATION_TIMEOUT = 20000;
 
 class SIPSession {
-  constructor(user, userData, protocol, hostname, baseCallStates) {
+  constructor(user, userData, protocol, hostname, baseCallStates, baseErrorCodes) {
     this.user = user;
     this.userData = userData;
     this.protocol = protocol;
     this.hostname = hostname;
     this.baseCallStates = baseCallStates;
+    this.baseErrorCodes = baseErrorCodes;
   }
 
   static parseDTMF(message) {


### PR DESCRIPTION
We have been encountering errors on demo:
```
Jun 24 12:49:24 demo.bigbluebutton.org systemd_start.sh[6224]: error: CLIENT LOG: TypeError: Cannot read property 'CONNECTION_ERROR' of undefined
Jun 24 12:49:24 demo.bigbluebutton.org systemd_start.sh[6224]:     at UA.h (https://demo.bigbluebutton.org/html5client/cbb07aeb6e882508c69f5f6639a9c987d13b0fb7.js?meteor_js_resource=true:125:1059312)
Jun 24 12:49:24 demo.bigbluebutton.org systemd_start.sh[6224]:     at UA.EventEmitter.emit (https://demo.bigbluebutton.org/html5client/compatibility/sip.js?v=553:112:17)
Jun 24 12:49:24 demo.bigbluebutton.org systemd_start.sh[6224]:     at UA.onTransportError (https://demo.bigbluebutton.org/html5client/compatibility/sip.js?v=553:9110:8) ...
```

because baseErrorCodes was not defined