### PR TITLE
Change client error formatting

### DIFF
--- a/bigbluebutton-html5/client/main.jsx
+++ b/bigbluebutton-html5/client/main.jsx
@@ -11,16 +11,19 @@ import Subscriptions from '/imports/ui/components/subscriptions/component';
 Meteor.startup(() => {
   // Logs all uncaught exceptions to the client logger
   window.addEventListener('error', (e) => {
-    const { stack } = e.error;
-    let message = e.error.toString();
+    let message = e.message || e.error.toString();
+
+    // Chrome will add on "Uncaught" to the start of the message for some reason. This
+    // will strip that so the errors can hopefully be grouped better.
+    if (message) message = message.replace(/^Uncaught/, '').trim();
+
+    let { stack } = e.error;
 
     // Checks if stack includes the message, if not add the two together.
-    if (stack.includes(message)) {
-      message = stack;
-    } else {
-      message += `\n${stack}`;
+    if (!stack.includes(message)) {
+      stack = `${message}\n${stack}`;
     }
-    logger.error({ logCode: 'startup_error' }, message);
+    logger.error({ logCode: 'startup_error', stackTrace: stack }, message);
   });
 
   // TODO make this a Promise


### PR DESCRIPTION
The errors in the client were getting logged with the full stack trace as the message which meant that you couldn't group exceptions because the stack has the domain in it. This PR makes the log message just the error message which should allow for grouping and determining which errors happen more frequently. I also decided to strip "Uncaught" from the start of any messages because Chrome likes to add that on and it doesn't add anything in our case. The full stack will be available in the `stackTrace` parameter for viewing afterwards.