### PR TITLE
Fix issue where webcam would randomly drop after starting properly

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -955,12 +955,12 @@ class VideoProvider extends Component {
       const { userId } = this.props;
       this.logger('info', 'Handle play start for camera', 'video_provider_handle_play_start', { cameraId: id });
 
+      peer.started = true;
+
       // Clear camera shared timeout when camera succesfully starts
       clearTimeout(this.restartTimeout[id]);
       delete this.restartTimeout[id];
       delete this.restartTimer[id];
-
-      peer.started = true;
 
       if (!peer.attached) {
         this.attachVideoStream(id);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -656,12 +656,17 @@ class VideoProvider extends Component {
     const peer = this.webRtcPeers[id];
 
     return (candidate) => {
-      // Setup a timeout only when ice first is generated
-      if (!this.restartTimeout[id]) {
+      // Setup a timeout only when ice first is generated and if the peer wasn't
+      // marked as started already (which is done on handlePlayStart after
+      // it was verified that media could circle through the server)
+      const peerHasStarted = peer && peer.started === true;
+      const shouldSetReconnectionTimeout = !this.restartTimeout[id] && !peerHasStarted;
+
+      if (shouldSetReconnectionTimeout) {
         this.restartTimer[id] = this.restartTimer[id] || CAMERA_SHARE_FAILED_WAIT_TIME;
 
         this.logger('debug', `Setting a camera connection restart in ${this.restartTimer[id]}`, 'video_provider_cam_restart', { cameraId: id });
-        this.restartTimeout[id] = setTimeout(this._getWebRTCStartTimeout(id, shareWebcam, peer),
+        this.restartTimeout[id] = setTimeout(this._getWebRTCStartTimeout(id, shareWebcam),
           this.restartTimer[id]);
       }
 


### PR DESCRIPTION
Sometimes webcams would randomly drop 15s after being *correctly* shared. This was due to a race condition on how we set the auto reconnection timers which is currently anchored on local ICE candidates being generated. `handlePlayStart` clears reconnection timers, but sometimes browsers (mainly Firefox) generate new candidates even after the connection was properly established, so it'd re-set the reconnection timer because we weren't checking if the peer had already started.

So I added a check to assert that the peer hasn't started yet when setting the timers. Also made sure the peer is marked as started first thing on `handlePlayStart` (just to be sure).

This tackles the defunct https://github.com/bigbluebutton/bigbluebutton/issues/7518.
The exceptions being thrown on #7672 and #7673 will be handled separetely.