### PR TITLE
Fix regression from #7606

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/handlers/userJoined.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/userJoined.js
@@ -5,7 +5,6 @@ import addUser from '../modifiers/addUser';
 export default function handleUserJoined({ body }, meetingId) {
   const user = body;
 
-  user.moderator = user.moderator || false;
   check(user, Object);
 
   return addUser(meetingId, user);

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/addUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/addUser.js
@@ -30,7 +30,6 @@ export default function addUser(meetingId, user) {
     guestStatus: String,
     emoji: String,
     presenter: Boolean,
-    moderator: Boolean,
     locked: Boolean,
     avatar: String,
     clientType: String,

--- a/bigbluebutton-html5/imports/startup/server/redis.js
+++ b/bigbluebutton-html5/imports/startup/server/redis.js
@@ -69,7 +69,7 @@ class MeetingMessageQueue {
     };
 
     const onError = (reason) => {
-      this.debug(`${eventName}: ${reason.stack ? reason.stack : reason}`);
+      Logger.error(`${eventName}: ${reason.stack ? reason.stack : reason}`);
       callNext();
     };
 
@@ -109,7 +109,7 @@ class RedisPubSub {
     const redisConf = Meteor.settings.private.redis;
     const { password, port } = redisConf;
 
-    if (!!password) {
+    if (password) {
       this.pub = Redis.createClient({ host, port, password });
       this.sub = Redis.createClient({ host, port, password });
       this.pub.auth(password);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/many-users-notify/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/many-users-notify/container.jsx
@@ -5,14 +5,18 @@ import Users from '/imports/api/users/';
 import LockViewersService from '/imports/ui/components/lock-viewers/service';
 import ManyUsersComponent from './component';
 
+const USER_CONFIG = Meteor.settings.public.user;
+const ROLE_MODERATOR = USER_CONFIG.role_moderator;
+const ROLE_VIEWER = USER_CONFIG.role_viewer;
+
 export default withTracker(() => ({
   viewersInWebcam: Users.find({
     meetingId: Auth.meetingID,
     hasStream: true,
-    moderator: false,
+    role: ROLE_VIEWER,
     presenter: false,
   }).count(),
-  currentUserIsModerator: Users.findOne({ userId: Auth.userID }).moderator,
+  currentUserIsModerator: Users.findOne({ userId: Auth.userID }).role === ROLE_MODERATOR,
   lockSettings: Meetings.findOne({ meetingId: Auth.meetingID }).lockSettingsProps,
   webcamOnlyForModerator: Meetings.findOne({
     meetingId: Auth.meetingID,


### PR DESCRIPTION
There was a new property mysteriously being checked for in #7606 when trying to add a new User. The new property was "moderator" which doesn't exist in the User data model in any other components. Adding this check broke a few other message handlers because they use the proper data model and didn't conform to the changes made in #7606. I rolled back the check and did proper data fetching to only user properties that should exist.

While doing this I discovered that any exceptions thrown during redis message handling were being caught and silenced so we had no way of detecting this regression until we noticed that functionality was broken. I changed the exception handling to always log as an error so we can detect these regressions much easier in the future.

Fixes #7697