### PR TITLE
Clean up user roles

### DIFF
--- a/bigbluebutton-html5/imports/api/breakouts/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/publishers.js
@@ -3,6 +3,8 @@ import Breakouts from '/imports/api/breakouts';
 import Users from '/imports/api/users';
 import Logger from '/imports/startup/server/logger';
 
+const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
+
 function breakouts(credentials, moderator = false) {
   const {
     meetingId,
@@ -12,7 +14,7 @@ function breakouts(credentials, moderator = false) {
 
   if (moderator) {
     const User = Users.findOne({ userId: requesterUserId });
-    if (!!User && User.moderator) {
+    if (!!User && User.role === ROLE_MODERATOR) {
       const presenterSelector = {
         $or: [
           { parentMeetingId: meetingId },

--- a/bigbluebutton-html5/imports/api/meetings/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/publishers.js
@@ -4,6 +4,8 @@ import Meetings from '/imports/api/meetings';
 import Users from '/imports/api/users';
 import Logger from '/imports/startup/server/logger';
 
+const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
+
 function meetings(credentials, isModerator = false) {
   const { meetingId, requesterUserId, requesterToken } = credentials;
 
@@ -21,7 +23,7 @@ function meetings(credentials, isModerator = false) {
 
   if (isModerator) {
     const User = Users.findOne({ userId: requesterUserId });
-    if (!!User && User.moderator) {
+    if (!!User && User.role === ROLE_MODERATOR) {
       selector.$or.push({
         'meetingProp.isBreakout': true,
         'breakoutProps.parentId': meetingId,

--- a/bigbluebutton-html5/imports/api/users/server/handlers/changeRole.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/changeRole.js
@@ -1,27 +1,11 @@
 import { check } from 'meteor/check';
-import Users from '/imports/api/users';
 import changeRole from '/imports/api/users/server/modifiers/changeRole';
 
 export default function handleChangeRole(payload, meetingId) {
-  const USER_CONFIG = Meteor.settings.public.user;
-  const ROLE_MODERATOR = USER_CONFIG.role_moderator;
-  const ROLE_VIEWER = USER_CONFIG.role_viewer;
-
   check(payload.body, Object);
   check(meetingId, String);
 
   const { userId, role, changedBy } = payload.body;
 
-  const selector = {
-    meetingId,
-    userId,
-  };
-
-  const user = Users.findOne(selector);
-
-  if (role === ROLE_VIEWER && user.role === ROLE_MODERATOR) {
-    changeRole(ROLE_MODERATOR, false, userId, meetingId, changedBy);
-  }
-
-  return changeRole(role, true, userId, meetingId, changedBy);
+  return changeRole(role, userId, meetingId, changedBy);
 }

--- a/bigbluebutton-html5/imports/api/users/server/handlers/presenterAssigned.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/presenterAssigned.js
@@ -1,15 +1,12 @@
 import Users from '/imports/api/users';
 import PresentationPods from '/imports/api/presentation-pods';
-import changeRole from '/imports/api/users/server/modifiers/changeRole';
+import changePresenter from '/imports/api/users/server/modifiers/changePresenter';
 import setPresenterInPodReqMsg from '/imports/api/presentation-pods/server/methods/setPresenterInPodReqMsg';
 
 export default function handlePresenterAssigned({ body }, meetingId) {
-  const USER_CONFIG = Meteor.settings.public.user;
-  const ROLE_PRESENTER = USER_CONFIG.role_presenter;
-
   const { presenterId, assignedBy } = body;
 
-  changeRole(ROLE_PRESENTER, true, presenterId, meetingId, assignedBy);
+  changePresenter(true, presenterId, meetingId, assignedBy);
 
   const selector = {
     meetingId,
@@ -49,5 +46,5 @@ export default function handlePresenterAssigned({ body }, meetingId) {
     return true;
   }
 
-  return changeRole(ROLE_PRESENTER, false, prevPresenter.userId, meetingId, assignedBy);
+  return changePresenter(false, prevPresenter.userId, meetingId, assignedBy);
 }

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/changePresenter.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/changePresenter.js
@@ -1,7 +1,7 @@
 import Logger from '/imports/startup/server/logger';
 import Users from '/imports/api/users';
 
-export default function changeRole(role, userId, meetingId, changedBy) {
+export default function changePresenter(presenter, userId, meetingId, changedBy) {
   const selector = {
     meetingId,
     userId,
@@ -9,7 +9,7 @@ export default function changeRole(role, userId, meetingId, changedBy) {
 
   const modifier = {
     $set: {
-      role,
+      presenter,
     },
   };
 
@@ -19,7 +19,7 @@ export default function changeRole(role, userId, meetingId, changedBy) {
     }
 
     if (numChanged) {
-      return Logger.info(`Changed user role=${role} id=${userId} meeting=${meetingId}`
+      return Logger.info(`Changed presenter=${presenter} id=${userId} meeting=${meetingId}`
       + `${changedBy ? ` changedBy=${changedBy}` : ''}`);
     }
 

--- a/bigbluebutton-html5/imports/api/users/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/users/server/publishers.js
@@ -6,6 +6,8 @@ import Logger from '/imports/startup/server/logger';
 
 import userLeaving from './methods/userLeaving';
 
+const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
+
 Meteor.publish('current-user', function currentUserPub(credentials) {
   const { meetingId, requesterUserId, requesterToken } = credentials;
 
@@ -58,7 +60,7 @@ function users(credentials, isModerator = false) {
 
   if (isModerator) {
     const User = Users.findOne({ userId: requesterUserId });
-    if (!!User && User.moderator) {
+    if (!!User && User.role === ROLE_MODERATOR) {
       selector.$or.push({
         'breakoutProps.isBreakoutUser': true,
         'breakoutProps.parentId': meetingId,

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -12,6 +12,8 @@ import HoldButton from '/imports/ui/components/presentation/presentation-toolbar
 import SortList from './sort-user-list/component';
 import styles from './styles';
 
+const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
+
 const intlMessages = defineMessages({
   breakoutRoomTitle: {
     id: 'app.createBreakoutRoom.title',
@@ -265,7 +267,7 @@ class BreakoutRoom extends Component {
     while (viewers.length > 0) {
       // We cycle through the rooms picking one user for each room so that the rooms
       // will have an equal number of people in each one
-      for (let i = 1; i <= numberOfRooms && viewers.length > 0; i++) {
+      for (let i = 1; i <= numberOfRooms && viewers.length > 0; i += 1) {
         // Select a random user for the room
         const userIdx = Math.floor(Math.random() * (viewers.length));
         this.changeUserRoom(viewers[userIdx].userId, i);
@@ -293,7 +295,7 @@ class BreakoutRoom extends Component {
       .map(user => ({
         userId: user.userId,
         userName: user.name,
-        isModerator: user.moderator,
+        isModerator: user.role === ROLE_MODERATOR,
         room: 0,
       }));
 

--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -4,6 +4,8 @@ import AudioManager from '/imports/ui/services/audio-manager';
 import Meetings from '/imports/api/meetings';
 import mapUser from '/imports/ui/services/user/mapUser';
 
+const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
+
 const init = (messages, intl) => {
   AudioManager.setAudioMessages(messages, intl);
   if (AudioManager.initialized) return;
@@ -54,6 +56,6 @@ export default {
   outputDeviceId: () => AudioManager.outputDeviceId,
   isEchoTest: () => AudioManager.isEchoTest,
   error: () => AudioManager.error,
-  isUserModerator: () => Users.findOne({ userId: Auth.userID }).moderator,
+  isUserModerator: () => Users.findOne({ userId: Auth.userID }).role === ROLE_MODERATOR,
   currentUser,
 };

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -14,6 +14,7 @@ import KEY_CODES from '/imports/utils/keyCodes';
 
 const CHAT_CONFIG = Meteor.settings.public.chat;
 const PUBLIC_GROUP_CHAT_ID = CHAT_CONFIG.public_group_id;
+const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 
 // session for closed chat list
 const CLOSED_CHAT_LIST_KEY = 'closedChatList';
@@ -288,7 +289,7 @@ const areUsersUnmutable = () => {
     return meeting.usersProp.allowModsToUnmuteUsers;
   }
   return false;
-}
+};
 
 const getAvailableActions = (currentUser, user, isBreakoutRoom) => {
   const isDialInUser = isVoiceOnlyUser(user.id) || user.isPhoneUser;
@@ -463,7 +464,7 @@ const getGroupChatPrivate = (sender, receiver) => {
 
 const isUserModerator = (userId) => {
   const u = Users.findOne({ userId });
-  return u ? u.moderator : false;
+  return u ? u.role === ROLE_MODERATOR : false;
 };
 
 const toggleUserLock = (userId, lockStatus) => {

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -75,7 +75,6 @@ public:
         descId: openStatus
     branding:
       displayBrandingArea: false
-    allowHTML5Moderator: true
     httpsConnection: false
     connectionTimeout: 60000
     showHelpButton: true
@@ -233,7 +232,6 @@ public:
   user:
     role_moderator: MODERATOR
     role_viewer: VIEWER
-    role_presenter: PRESENTER
   whiteboard:
     annotations:
       status:


### PR DESCRIPTION
This PR builds on PR #7557 

There was a lot of weird stuff being done with user roles that didn't match how every other BBB component does roles. The biggest issue was "presenter" status being misinterpreted as role (which it definitely is not). There was also duplicate of the role value into two different properties that might or might not exist. These two problems caused a lot of confusion in the code with properties that sometimes existed and sometimes didn't and inefficiencies with extra data fetching that wasn't needed.