### PR TITLE
Delete control characters from all recording event properties

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/events_archiver.rb
+++ b/record-and-playback/core/lib/recordandplayback/events_archiver.rb
@@ -318,13 +318,10 @@ module BigBlueButton
               # The slidesInfo value is XML serialized info, just insert it
               # directly into the event
               event << v
-            elsif (res[MODULE] == 'CHAT' and res[EVENTNAME] == 'PublicChatEvent' and k == 'message') ||
-                  (res[MODULE] == 'WHITEBOARD' and res[EVENTNAME] == 'AddShapeEvent' and k == 'text')
-              # Apply a cleanup that removes certain ranges of special
-              # characters from user-provided text
-              event << events_doc.create_element(k, v.tr("\x00-\x09\x0B\x0C\x0E-\x19\x7F",''))
             else
-              event << events_doc.create_element(k, v)
+              # Apply a cleanup that removes certain ranges of special
+              # control characters from user-provided text
+              event << events_doc.create_element(k, v.tr("\x00-\x08\x0B\x0C\x0E-\x1F\x7F",''))
             end
           end
         end


### PR DESCRIPTION
Found another case where the html5 client was passing through control
characters, in the original presentation name field.

Rather than play whack-a-mole with different fields which may eventually
get poorly sanitized user data, apply the control character filtering
to all properties.

Adjust the character range to do the following:
* Allow horizontal tab (0x09), it's not problematic.
* Disallow control characters in the range 0x1A-0x1F. Probably missed by accident.