### PR TITLE
Fix HTML5 server exceptions

### DIFF
--- a/bigbluebutton-html5/imports/api/log-client/server/methods/logClient.js
+++ b/bigbluebutton-html5/imports/api/log-client/server/methods/logClient.js
@@ -1,7 +1,7 @@
 import Logger from '/imports/startup/server/logger';
 import Users from '/imports/api/users';
 
-const logClient = function (type, logDescription, logCode = 'was_not_provided', extraInfo, userInfo = {}) {
+const logClient = function (type, logDescription, logCode = 'was_not_provided', extraInfo = {}, userInfo = {}) {
   const SERVER_CONN_ID = this.connection.id;
   const User = Users.findOne({ connectionId: SERVER_CONN_ID });
   const logContents = {

--- a/bigbluebutton-html5/imports/api/polls/server/methods/publishVote.js
+++ b/bigbluebutton-html5/imports/api/polls/server/methods/publishVote.js
@@ -25,6 +25,7 @@ export default function publishVote(credentials, id, pollAnswerId) { // TODO dis
   check(meetingId, String);
   check(requesterUserId, String);
   check(pollAnswerId, Number);
+  check(currentPoll, Object);
   check(currentPoll.meetingId, String);
 
   const payload = {

--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -152,6 +152,14 @@ WebApp.connectHandlers.use('/feedback', (req, res) => {
       authToken,
     });
 
+    if (!user) {
+      Logger.error(`Feedback failed, user with id=${userId} wasn't found`);
+      res.setHeader('Content-Type', 'application/json');
+      res.writeHead(500);
+      res.end(JSON.stringify({ status: 'ok' }));
+      return;
+    }
+
     const feedback = {
       userName: user.name,
       ...body,


### PR DESCRIPTION
This PR contains fixes for three different server exceptions that I found in the logs. 

The first was an exception if no `extraInfo` parameter was included in a log. The second was an exception when a poll response was attempted, but no poll could be found. The third was an exception when /feeback was called, but the user couldn't be found.