### PR TITLE
Change unsafe Users upserts to updates

### DIFF
--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/changeUserLock.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/changeUserLock.js
@@ -13,6 +13,7 @@ export default function changeUserLock(meetingId, payload) {
   const { userId, locked, lockedBy } = payload;
 
   const selector = {
+    meetingId,
     userId,
   };
 
@@ -34,5 +35,5 @@ export default function changeUserLock(meetingId, payload) {
     return Logger.info(`User's userId=${userId} lock status was changed to: ${locked} by user userId=${lockedBy}`);
   };
 
-  return Users.upsert(selector, modifier, cb);
+  return Users.update(selector, modifier, cb);
 }

--- a/bigbluebutton-html5/imports/api/ping-pong/server/methods/ping.js
+++ b/bigbluebutton-html5/imports/api/ping-pong/server/methods/ping.js
@@ -1,6 +1,6 @@
-import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 import Users from '/imports/api/users';
+import Logger from '/imports/startup/server/logger';
 
 export default function ping(credentials) {
   const { meetingId, requesterUserId, requesterToken } = credentials;
@@ -9,13 +9,22 @@ export default function ping(credentials) {
   check(requesterUserId, String);
   check(requesterToken, String);
 
-
-  return Users.upsert({
+  const selector = {
     meetingId,
     userId: requesterUserId,
-  }, {
+  };
+
+  const modifier = {
     $set: {
       lastPing: Date.now(),
     },
-  });
+  };
+
+  const cb = (err) => {
+    if (err) {
+      return Logger.error(`Error updating lastPing for ${requesterUserId}: ${err}`);
+    }
+  };
+
+  return Users.update(selector, modifier, cb);
 }

--- a/bigbluebutton-html5/imports/api/video/server/modifiers/sharedWebcam.js
+++ b/bigbluebutton-html5/imports/api/video/server/modifiers/sharedWebcam.js
@@ -13,21 +13,19 @@ export default function sharedWebcam(meetingId, userId) {
 
   const modifier = {
     $set: {
-      meetingId,
-      userId,
       hasStream: true,
     },
   };
 
   const cb = (err, numChanged) => {
     if (err) {
-      return Logger.error(`Adding user to collection: ${err}`);
+      return Logger.error(`Error setting hasStream to true: ${err}`);
     }
 
     if (numChanged) {
-      return Logger.info(`Upserted user id=${userId} meeting=${meetingId}`);
+      return Logger.info(`Updated hasStream for user id=${userId} meeting=${meetingId}`);
     }
   };
 
-  return Users.upsert(selector, modifier, cb);
+  return Users.update(selector, modifier, cb);
 }

--- a/bigbluebutton-html5/imports/api/video/server/modifiers/unsharedWebcam.js
+++ b/bigbluebutton-html5/imports/api/video/server/modifiers/unsharedWebcam.js
@@ -13,21 +13,19 @@ export default function unsharedWebcam(meetingId, userId) {
 
   const modifier = {
     $set: {
-      meetingId,
-      userId,
       hasStream: false,
     },
   };
 
   const cb = (err, numChanged) => {
     if (err) {
-      return Logger.error(`Adding user to collection: ${err}`);
+      return Logger.error(`Error setting hasStream to false: ${err}`);
     }
 
     if (numChanged) {
-      return Logger.info(`Upserted user id=${userId} meeting=${meetingId}`);
+      return Logger.info(`Updated hasStream for user id=${userId} meeting=${meetingId}`);
     }
   };
 
-  return Users.upsert(selector, modifier, cb);
+  return Users.update(selector, modifier, cb);
 }


### PR DESCRIPTION
There were four instances where the Users collection could be upserted with partial User objects and it might have been resulting in invalid User objects getting to the client.