### PR TITLE
Add property in setting.yml to override default locale

### DIFF
--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -81,7 +81,8 @@ WebApp.connectHandlers.use('/check', (req, res) => {
 WebApp.connectHandlers.use('/locale', (req, res) => {
   const APP_CONFIG = Meteor.settings.public.app;
   const fallback = APP_CONFIG.defaultSettings.application.fallbackLocale;
-  const browserLocale = req.query.locale.split(/[-_]/g);
+  const override = APP_CONFIG.defaultSettings.application.overrideLocale;
+  const browserLocale = override ? override.split(/[-_]/g) : req.query.locale.split(/[-_]/g);
   const localeList = [fallback];
 
   const usableLocales = AVAILABLE_LOCALES

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -29,6 +29,7 @@ public:
         chatAudioAlerts: false
         chatPushAlerts: false
         fallbackLocale: en
+        overrideLocale: 
       audio:
         inputDeviceId: undefined
         outputDeviceId: undefined

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -29,7 +29,7 @@ public:
         chatAudioAlerts: false
         chatPushAlerts: false
         fallbackLocale: en
-        overrideLocale: 
+        overrideLocale: undefined
       audio:
         inputDeviceId: undefined
         outputDeviceId: undefined


### PR DESCRIPTION
This PR adds a property in the settings to provide a way to override the locale used to load the client (was previously detected by the browser).

This came up in a forum thread
https://groups.google.com/forum/#!msg/bigbluebutton-setup/nqvVCYQF11w/6c3vkZ1KAgAJ