### PR TITLE
Fix same name files failing in upload.

### DIFF
--- a/bigbluebutton-html5/imports/api/presentation-upload-token/server/handlers/presentationUploadTokenPass.js
+++ b/bigbluebutton-html5/imports/api/presentation-upload-token/server/handlers/presentationUploadTokenPass.js
@@ -27,6 +27,7 @@ export default function handlePresentationUploadTokenPass({ body, header }, meet
     filename,
     authzToken,
     failed: false,
+    used: false,
   };
 
   const cb = (err) => {

--- a/bigbluebutton-html5/imports/api/presentation-upload-token/server/methods.js
+++ b/bigbluebutton-html5/imports/api/presentation-upload-token/server/methods.js
@@ -1,6 +1,8 @@
 import { Meteor } from 'meteor/meteor';
 import requestPresentationUploadToken from './methods/requestPresentationUploadToken';
+import setUsedToken from './methods/setUsedToken';
 
 Meteor.methods({
   requestPresentationUploadToken,
+  setUsedToken,
 });

--- a/bigbluebutton-html5/imports/api/presentation-upload-token/server/methods/setUsedToken.js
+++ b/bigbluebutton-html5/imports/api/presentation-upload-token/server/methods/setUsedToken.js
@@ -1,0 +1,26 @@
+import PresentationUploadToken from '/imports/api/presentation-upload-token';
+import Logger from '/imports/startup/server/logger';
+import { check } from 'meteor/check';
+
+export default function setUsedToken(credentials, authzToken) {
+  const { meetingId, requesterUserId, requesterToken } = credentials;
+  check(meetingId, String);
+  check(requesterUserId, String);
+  check(requesterToken, String);
+
+  const payload = {
+    $set: {
+      used: true,
+    },
+  };
+  const cb = (err) => {
+    if (err) {
+      Logger.error(`Unable to set token as used : ${err}`);
+      return;
+    }
+
+    Logger.info(`Token: ${authzToken} have been setted as used in meeting=${meetingId}`);
+  };
+
+  return PresentationUploadToken.update({ authzToken }, payload, cb);
+}

--- a/bigbluebutton-html5/imports/api/presentation-upload-token/server/methods/setUsedToken.js
+++ b/bigbluebutton-html5/imports/api/presentation-upload-token/server/methods/setUsedToken.js
@@ -22,5 +22,9 @@ export default function setUsedToken(credentials, authzToken) {
     Logger.info(`Token: ${authzToken} have been setted as used in meeting=${meetingId}`);
   };
 
-  return PresentationUploadToken.update({ authzToken }, payload, cb);
+  return PresentationUploadToken.update({
+    meetingId,
+    userId: requesterUserId,
+    authzToken,
+  }, payload, cb);
 }

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/service.js
@@ -131,7 +131,7 @@ const requestPresentationUploadToken = (
     }
 
     if (PresentationToken.failed) {
-      reject({ code: 401, message: 'requestPresentationUploadToken failed' });
+      reject({ code: 401, message: `requestPresentationUploadToken token ${PresentationToken} failed` });
     }
   });
 });

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/service.js
@@ -131,7 +131,7 @@ const requestPresentationUploadToken = (
     }
 
     if (PresentationToken.failed) {
-      reject({ code: 401, message: `requestPresentationUploadToken token ${PresentationToken} failed` });
+      reject({ code: 401, message: `requestPresentationUploadToken token ${PresentationToken.authzToken} failed` });
     }
   });
 });


### PR DESCRIPTION
Issue causes: 
- The client does a location query to get the token, using the same parameters, that way when files with same name are uploaded the find returns the old token, instead of waiting for the message from the server.

Solution:
- I've added a `used` field which is set to true when the upload is started.

Closes #7519.