### PR TITLE
Fixes exception in meteor log when the meeting is ended

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
@@ -125,9 +125,12 @@ class MeetingEnded extends React.PureComponent {
       return;
     }
 
+    const { fullname } = Auth.credentials;
+
     const message = {
       rating: selected,
       userId: Auth.userID,
+      userName: fullname,
       authToken: Auth.token,
       meetingId: Auth.meetingID,
       comment: MeetingEnded.getComment(),


### PR DESCRIPTION
The mentioned exception happens when the meeting is ended and "feedback" is enabled.

When the meeting is ended all the users are removed from mongo. If the user takes too long (10~15 seconds or more) to answer the feedback question it's not possible to authenticate the user anymore.

It means that we can't make sure that the feedback is reliable. Now, those feedbacks will be tagged as "[unconfirmed]".

Closes #7751 