### PR TITLE
Skip saving viewParticipantsWebcams in collection

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/settings/index.js
+++ b/bigbluebutton-html5/imports/ui/services/settings/index.js
@@ -57,11 +57,12 @@ class Settings {
 
   save() {
     Object.keys(this).forEach((k) => {
-      if (k === '_dataSaving') {
-        const { value: { viewParticipantsWebcams } } = this[k];
-
-        makeCall('userChangedSettings', 'viewParticipantsWebcams', viewParticipantsWebcams);
-      }
+      // if (k === '_dataSaving') {
+      //   const { value: { viewParticipantsWebcams } } = this[k];
+      //
+      //   makeCall('userChangedSettings', 'viewParticipantsWebcams', viewParticipantsWebcams);
+      // }
+      // TODO https://github.com/bigbluebutton/bigbluebutton/issue/7774
 
       Storage.setItem(`settings${k}`, this[k].value);
     });


### PR DESCRIPTION

To be revisited -- currently it causes issues with calling `makeCall` before Meteor is fully connected
// side note: do we need this value in the collection?