### PR TITLE
Change overrideLocale default from undefined to null

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -29,7 +29,7 @@ public:
         chatAudioAlerts: false
         chatPushAlerts: false
         fallbackLocale: en
-        overrideLocale: undefined
+        overrideLocale: null
       audio:
         inputDeviceId: undefined
         outputDeviceId: undefined


### PR DESCRIPTION
Turns out `undefined` actually converts to a string instead of a `null` value. This was causing an issue because the check for the locale is expecting the string to either be a locale or not exist.

Closes #7776