### PR TITLE
Fix on getting caption file content type

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/RecordingController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/RecordingController.groovy
@@ -9,7 +9,6 @@ import org.bigbluebutton.api.ApiErrors
 import org.bigbluebutton.api.ApiParams
 import org.apache.commons.lang3.StringUtils
 import org.json.JSONArray
-import org.springframework.web.multipart.commons.CommonsMultipartFile
 import org.apache.commons.lang.LocaleUtils
 
 class RecordingController {
@@ -184,11 +183,7 @@ class RecordingController {
 
     def uploadedCaptionsFile = request.getFile('file')
     if (uploadedCaptionsFile && !uploadedCaptionsFile.empty) {
-      CommonsMultipartFile contentType = uploadedCaptionsFile.contentType
-      def fileContentType = null
-      if (contentType != null) {
-        fileContentType = contentType.getContentType()
-      }
+      def fileContentType = uploadedCaptionsFile.getContentType()
       log.debug("Captions content type: " + fileContentType)
       def origFilename = uploadedCaptionsFile.getOriginalFilename()
       def trackId = recordId + "-" + System.currentTimeMillis()


### PR DESCRIPTION
Avoid casting content type to a CommonsMultipartFile object.

```
2019-07-17T14:21:11.755Z DEBUG o.b.w.c.RecordingController - RecordingController#putRecordingTextTrack
2019-07-17T14:21:11.818Z DEBUG o.b.w.c.RecordingController - Captions for recordID: 4180a696dccc0abae3594ba222e3a97d51301a65-1560279067558
2019-07-17T14:21:11.819Z INFO  o.b.api.ParamsProcessorUtil - CHECKSUM=66494c9ceb83ac523878d4f6582b6620b7d9a512 length=40
2019-07-17T14:21:12.089Z DEBUG o.b.w.c.RecordingController - Captions kind: captions
2019-07-17T14:21:12.089Z DEBUG o.b.w.c.RecordingController - Captions lang: pt_BR
2019-07-17T14:21:12.090Z DEBUG o.b.w.c.RecordingController - Captions locale: pt-BR
2019-07-17T14:21:12.133Z ERROR StackTrace - Full Stack Trace:
org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object 'text/vtt' with class 'java.lang.String' to class 'org.springframework.web.multipart.commons.CommonsMultipartFile'
```

https://docs.spring.io/spring/docs/2.0.x/javadoc-api/org/springframework/web/multipart/MultipartFile.html#getContentType()