### PR TITLE
Add auto-reconnect to SFU listen only (#6994)

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
@@ -7,6 +7,7 @@ const SFU_URL = Meteor.settings.public.kurento.wsUrl;
 const MEDIA = Meteor.settings.public.media;
 const MEDIA_TAG = MEDIA.mediaTag.replace(/#/g, '');
 const GLOBAL_AUDIO_PREFIX = 'GLOBAL_AUDIO_';
+const RECONNECT_TIMEOUT_MS = 15000;
 
 export default class KurentoAudioBridge extends BaseAudioBridge {
   constructor(userData) {
@@ -32,6 +33,8 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
 
     this.internalMeetingID = meetingId;
     this.voiceBridge = voiceBridge;
+    this.reconnectOngoing = false;
+    this.hasSuccessfullyStarted = false;
   }
 
   joinAudio({ isListenOnly, inputStream }, callback) {
@@ -58,6 +61,8 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
 
         const onSuccess = () => {
           const { webRtcPeer } = window.kurentoManager.kurentoAudio;
+
+          this.hasSuccessfullyStarted = true;
           if (webRtcPeer) {
             const audioTag = document.getElementById(MEDIA_TAG);
             const stream = webRtcPeer.getRemoteStream();
@@ -73,21 +78,67 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
               }, 'Could not play audio tag, emit mediaTagPlayFailed event');
             });
           }
+
+          if (this.reconnectOngoing) {
+            this.reconnectOngoing = false;
+            clearTimeout(this.reconnectTimeout);
+          }
+
+
           resolve(this.callback({ status: this.baseCallStates.started }));
         };
 
         const onFail = (error) => {
-          let reason = 'Undefined';
-          if (error) {
-            reason = error.reason || error.id || error;
-          }
-          this.callback({
-            status: this.baseCallStates.failed,
-            error: this.baseErrorCodes.CONNECTION_ERROR,
-            bridgeError: reason,
-          });
+          // Listen only connected successfully already and dropped mid-call.
+          // Try to reconnect ONCE (binded to reconnectOngoing flag)
+          if (this.hasSuccessfullyStarted && !this.reconnectOngoing) {
+            logger.error({
+              logCode: 'sfuaudiobridge_listen_only_error_reconnect',
+              extraInfo: { error },
+            }, `Listen only failed for an ongoing session, try to reconnect`);
+            window.kurentoExitAudio();
+            this.callback({ status: this.baseCallStates.reconnecting });
+            this.reconnectOngoing = true;
+            // Set up a reconnectionTimeout in case the server is unresponsive
+            // for some reason. If it gets triggered, end the session and stop
+            // trying to reconnect
+            this.reconnectTimeout = setTimeout(() => {
+              this.callback({
+                status: this.baseCallStates.failed,
+                error: this.baseErrorCodes.CONNECTION_ERROR,
+              });
+              this.reconnectOngoing = false;
+              this.hasSuccessfullyStarted = false;
+              window.kurentoExitAudio();
+            }, RECONNECT_TIMEOUT_MS);
+            window.kurentoJoinAudio(
+              MEDIA_TAG,
+              this.voiceBridge,
+              this.user.userId,
+              this.internalMeetingID,
+              onFail,
+              onSuccess,
+              options,
+            );
+          } else {
+            // Already tried reconnecting once OR the user handn't succesfully
+            // connected firsthand. Just finish the session and reject with error
+            this.reconnectOngoing = false;
+            this.hasSuccessfullyStarted = false;
+            window.kurentoExitAudio();
 
-          reject(reason);
+            let reason = 'Undefined';
+            if (error) {
+              reason = error.reason || error.id || error;
+            }
+            this.callback({
+              status: this.baseCallStates.failed,
+              error: this.baseErrorCodes.CONNECTION_ERROR,
+              bridgeError: reason,
+            });
+
+            reject(reason);
+          }
         };
 
         if (!isListenOnly) {
@@ -126,6 +177,7 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
 
   exitAudio() {
     return new Promise((resolve) => {
+      this.hasSuccessfullyStarted = false;
       window.kurentoExitAudio();
       return resolve(this.callback({ status: this.baseCallStates.ended }));
     });


### PR DESCRIPTION
Addresses #6994.

Triggered if it fails during a successfully negotiated listen only session (for any reason). Tries to reconnect **once**. Reuses the beep warning and the reconnecting toast done in the client audio manager to notify the user it's trying to reconnect.
There's a 15s timer on the reconnection attempt in case the server is unresponsive for some reason.