### PR TITLE
Move slide positions into their own collection

### DIFF
--- a/bigbluebutton-html5/imports/api/presentation-pods/server/utils/isPodPresenter.js
+++ b/bigbluebutton-html5/imports/api/presentation-pods/server/utils/isPodPresenter.js
@@ -1,4 +1,4 @@
-import Slides from '/imports/api/slides';
+import { Slides } from '/imports/api/slides';
 import PresentationPods from '/imports/api/presentation-pods';
 
 export default function isPodPresenter(meetingId, whiteboardId, userId) {

--- a/bigbluebutton-html5/imports/api/presentations/server/modifiers/addPresentation.js
+++ b/bigbluebutton-html5/imports/api/presentations/server/modifiers/addPresentation.js
@@ -3,7 +3,6 @@ import { check } from 'meteor/check';
 import Presentations from '/imports/api/presentations';
 import Logger from '/imports/startup/server/logger';
 import flat from 'flat';
-
 import addSlide from '/imports/api/slides/server/modifiers/addSlide';
 import setCurrentPresentation from './setCurrentPresentation';
 
@@ -18,17 +17,13 @@ const getSlideText = async (url) => {
 };
 
 const addSlides = (meetingId, podId, presentationId, slides) => {
-  const slidesAdded = [];
-
   slides.forEach(async (slide) => {
     const content = await getSlideText(slide.txtUri);
 
     Object.assign(slide, { content });
 
-    slidesAdded.push(addSlide(meetingId, podId, presentationId, slide));
+    addSlide(meetingId, podId, presentationId, slide);
   });
-
-  return slidesAdded;
 };
 
 export default function addPresentation(meetingId, podId, presentation) {

--- a/bigbluebutton-html5/imports/api/slides/index.js
+++ b/bigbluebutton-html5/imports/api/slides/index.js
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 
 const Slides = new Mongo.Collection('slides');
-const SlidePositions = new Mongo.Collection('slidePositions');
+const SlidePositions = new Mongo.Collection('slide-positions');
 
 if (Meteor.isServer) {
   // types of queries for the slides:

--- a/bigbluebutton-html5/imports/api/slides/index.js
+++ b/bigbluebutton-html5/imports/api/slides/index.js
@@ -1,6 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 
 const Slides = new Mongo.Collection('slides');
+const SlidePositions = new Mongo.Collection('slidePositions');
 
 if (Meteor.isServer) {
   // types of queries for the slides:
@@ -15,6 +16,10 @@ if (Meteor.isServer) {
   Slides._ensureIndex({
     meetingId: 1, podId: 1, presentationId: 1, id: 1,
   });
+
+  SlidePositions._ensureIndex({
+    meetingId: 1, podId: 1, presentationId: 1, id: 1,
+  });
 }
 
-export default Slides;
+export { Slides, SlidePositions };

--- a/bigbluebutton-html5/imports/api/slides/server/helpers.js
+++ b/bigbluebutton-html5/imports/api/slides/server/helpers.js
@@ -1,9 +1,13 @@
 
 const calculateSlideData = (slideData) => {
-  const { width, height, xOffset, yOffset, widthRatio, heightRatio } = slideData;
+  const {
+    width, height, xOffset, yOffset, widthRatio, heightRatio,
+  } = slideData;
 
   // calculating viewBox and offsets for the current presentation
   return {
+    width,
+    height,
     x: ((-xOffset * 2) * width) / 100,
     y: ((-yOffset * 2) * height) / 100,
     viewBoxWidth: (width * widthRatio) / 100,

--- a/bigbluebutton-html5/imports/api/slides/server/methods/switchSlide.js
+++ b/bigbluebutton-html5/imports/api/slides/server/methods/switchSlide.js
@@ -1,5 +1,5 @@
 import Presentations from '/imports/api/presentations';
-import Slides from '/imports/api/slides';
+import { Slides } from '/imports/api/slides';
 import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 import RedisPubSub from '/imports/startup/server/redis';

--- a/bigbluebutton-html5/imports/api/slides/server/methods/zoomSlide.js
+++ b/bigbluebutton-html5/imports/api/slides/server/methods/zoomSlide.js
@@ -1,5 +1,5 @@
 import Presentations from '/imports/api/presentations';
-import Slides from '/imports/api/slides';
+import { Slides } from '/imports/api/slides';
 import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 import RedisPubSub from '/imports/startup/server/redis';

--- a/bigbluebutton-html5/imports/api/slides/server/modifiers/addSlidePositions.js
+++ b/bigbluebutton-html5/imports/api/slides/server/modifiers/addSlidePositions.js
@@ -1,0 +1,60 @@
+import { SlidePositions } from '/imports/api/slides';
+import Logger from '/imports/startup/server/logger';
+import { check } from 'meteor/check';
+import flat from 'flat';
+
+export default function addSlidePositions(
+  meetingId,
+  podId,
+  presentationId,
+  slideId,
+  slidePosition,
+) {
+  check(meetingId, String);
+  check(podId, String);
+  check(presentationId, String);
+  check(slideId, String);
+
+  check(slidePosition, {
+    width: Number,
+    height: Number,
+    x: Number,
+    y: Number,
+    viewBoxWidth: Number,
+    viewBoxHeight: Number,
+  });
+
+  const selector = {
+    meetingId,
+    podId,
+    presentationId,
+    id: slideId,
+  };
+
+  const modifier = {
+    $set: Object.assign(
+      { meetingId },
+      { podId },
+      { presentationId },
+      { id: slideId },
+      flat(slidePosition),
+      { safe: true },
+    ),
+  };
+
+  const cb = (err, numChanged) => {
+    if (err) {
+      return Logger.error(`Adding slide position to collection: ${err}`);
+    }
+
+    const { insertedId } = numChanged;
+
+    if (insertedId) {
+      return Logger.info(`Added slide position id=${slideId} pod=${podId} presentation=${presentationId}`);
+    }
+
+    return Logger.info(`Upserted slide position id=${slideId} pod=${podId} presentation=${presentationId}`);
+  };
+
+  return SlidePositions.upsert(selector, modifier, cb);
+}

--- a/bigbluebutton-html5/imports/api/slides/server/modifiers/changeCurrentSlide.js
+++ b/bigbluebutton-html5/imports/api/slides/server/modifiers/changeCurrentSlide.js
@@ -1,5 +1,5 @@
 import { check } from 'meteor/check';
-import Slides from '/imports/api/slides';
+import { Slides } from '/imports/api/slides';
 import Logger from '/imports/startup/server/logger';
 
 export default function changeCurrentSlide(meetingId, podId, presentationId, slideId) {

--- a/bigbluebutton-html5/imports/api/slides/server/modifiers/clearSlides.js
+++ b/bigbluebutton-html5/imports/api/slides/server/modifiers/clearSlides.js
@@ -1,12 +1,20 @@
-import Slides from '/imports/api/slides';
+import { Slides, SlidePositions } from '/imports/api/slides';
 import Logger from '/imports/startup/server/logger';
 
 export default function clearSlides(meetingId) {
   if (meetingId) {
+    SlidePositions.remove({ meetingId }, () => {
+      Logger.info(`Cleared SlidePositions (${meetingId})`);
+    });
+
     return Slides.remove({ meetingId }, () => {
       Logger.info(`Cleared Slides (${meetingId})`);
     });
   }
+
+  SlidePositions.remove({}, () => {
+    Logger.info('Cleared SlidePositions (all)');
+  });
 
   return Slides.remove({}, () => {
     Logger.info('Cleared Slides (all)');

--- a/bigbluebutton-html5/imports/api/slides/server/modifiers/clearSlidesPresentation.js
+++ b/bigbluebutton-html5/imports/api/slides/server/modifiers/clearSlidesPresentation.js
@@ -1,4 +1,4 @@
-import Slides from '/imports/api/slides';
+import { Slides, SlidePositions } from '/imports/api/slides';
 import Logger from '/imports/startup/server/logger';
 import { check } from 'meteor/check';
 import clearAnnotations from '/imports/api/annotations/server/modifiers/clearAnnotations';
@@ -23,6 +23,8 @@ export default function clearSlidesPresentation(meetingId, presentationId) {
 
     return Logger.info(`Removed Slides where presentationId=${presentationId}`);
   };
+
+  SlidePositions.remove(selector);
 
   return Slides.remove(selector, cb);
 }

--- a/bigbluebutton-html5/imports/api/slides/server/modifiers/resizeSlide.js
+++ b/bigbluebutton-html5/imports/api/slides/server/modifiers/resizeSlide.js
@@ -1,5 +1,5 @@
 import { check } from 'meteor/check';
-import Slides from '/imports/api/slides';
+import { SlidePositions } from '/imports/api/slides';
 import Logger from '/imports/startup/server/logger';
 import calculateSlideData from '/imports/api/slides/server/helpers';
 
@@ -23,44 +23,43 @@ export default function resizeSlide(meetingId, slide) {
     id: pageId,
   };
 
-  const modifier = {
-    $set: {
-      widthRatio,
-      heightRatio,
-      xOffset,
-      yOffset,
-    },
-  };
-
   // fetching the current slide data
   // and pre-calculating the width, height, and vieBox coordinates / sizes
   // to reduce the client-side load
-  const Slide = Slides.findOne(selector);
-  const slideData = {
-    width: Slide.calculatedData.width,
-    height: Slide.calculatedData.height,
-    xOffset,
-    yOffset,
-    widthRatio,
-    heightRatio,
-  };
-  const calculatedData = calculateSlideData(slideData);
-  calculatedData.imageUri = Slide.calculatedData.imageUri;
-  calculatedData.width = Slide.calculatedData.width;
-  calculatedData.height = Slide.calculatedData.height;
-  modifier.$set.calculatedData = calculatedData;
+  const SlidePosition = SlidePositions.findOne(selector);
 
-  const cb = (err, numChanged) => {
-    if (err) {
-      return Logger.error(`Resizing slide id=${pageId}: ${err}`);
-    }
+  if (SlidePosition) {
+    const {
+      width,
+      height,
+    } = SlidePosition;
 
-    if (numChanged) {
-      return Logger.debug(`Resized slide id=${pageId}`);
-    }
+    const slideData = {
+      width,
+      height,
+      xOffset,
+      yOffset,
+      widthRatio,
+      heightRatio,
+    };
+    const calculatedData = calculateSlideData(slideData);
 
-    return Logger.info(`No slide found with id=${pageId}`);
-  };
+    const modifier = {
+      $set: calculatedData,
+    };
 
-  return Slides.update(selector, modifier, cb);
+    const cb = (err, numChanged) => {
+      if (err) {
+        return Logger.error(`Resizing slide positions id=${pageId}: ${err}`);
+      }
+
+      if (numChanged) {
+        return Logger.debug(`Resized slide positions id=${pageId}`);
+      }
+
+      return Logger.info(`No slide positions found with id=${pageId}`);
+    };
+
+    return SlidePositions.update(selector, modifier, cb);
+  }
 }

--- a/bigbluebutton-html5/imports/api/slides/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/slides/server/publishers.js
@@ -1,4 +1,4 @@
-import Slides from '/imports/api/slides';
+import { Slides, SlidePositions } from '/imports/api/slides';
 import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 import Logger from '/imports/startup/server/logger';
@@ -21,3 +21,22 @@ function publish(...args) {
 }
 
 Meteor.publish('slides', publish);
+
+function slidePositions(credentials) {
+  const { meetingId, requesterUserId, requesterToken } = credentials;
+
+  check(meetingId, String);
+  check(requesterUserId, String);
+  check(requesterToken, String);
+
+  Logger.debug(`Publishing SlidePositions for ${meetingId} ${requesterUserId} ${requesterToken}`);
+
+  return SlidePositions.find({ meetingId });
+}
+
+function publishPositions(...args) {
+  const boundSlidePositions = slidePositions.bind(this);
+  return boundSlidePositions(...args);
+}
+
+Meteor.publish('slide-positions', publishPositions);

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -56,8 +56,12 @@ class PresentationArea extends PureComponent {
     const { prevProps } = state;
     const stateChange = { prevProps: props };
 
-    if (props.userIsPresenter && (!prevProps || !prevProps.userIsPresenter) && props.currentSlide) {
-      const potentialZoom = 100 * 100 / props.currentSlide.widthRatio;
+    if (props.userIsPresenter
+      && (!prevProps || !prevProps.userIsPresenter)
+      && props.currentSlide
+      && props.slidePosition) {
+      let potentialZoom = 100 / (props.slidePosition.viewBoxWidth / props.slidePosition.width);
+      potentialZoom = Math.max(HUNDRED_PERCENT, Math.min(MAX_PERCENT, potentialZoom));
       stateChange.zoom = potentialZoom;
     }
 
@@ -185,14 +189,15 @@ class PresentationArea extends PureComponent {
     const {
       userIsPresenter,
       currentSlide,
+      slidePosition,
     } = this.props;
 
-    if (!currentSlide || !currentSlide.calculatedData) {
+    if (!currentSlide || !slidePosition) {
       return { width: 0, height: 0 };
     }
 
-    const originalWidth = currentSlide.calculatedData.width;
-    const originalHeight = currentSlide.calculatedData.height;
+    const originalWidth = slidePosition.width;
+    const originalHeight = slidePosition.height;
     const viewBoxWidth = viewBoxDimensions.width;
     const viewBoxHeight = viewBoxDimensions.height;
 
@@ -255,9 +260,12 @@ class PresentationArea extends PureComponent {
   }
 
   isPresentationAccessible() {
-    const { currentSlide } = this.props;
-    // sometimes tomcat publishes the slide url, but the actual file is not accessible (why?)
-    return currentSlide && currentSlide.calculatedData;
+    const {
+      currentSlide,
+      slidePosition,
+    } = this.props;
+    // sometimes tomcat publishes the slide url, but the actual file is not accessible
+    return currentSlide && slidePosition;
   }
 
   updateLocalPosition(x, y, width, height, zoom) {
@@ -293,6 +301,7 @@ class PresentationArea extends PureComponent {
       multiUser,
       podId,
       currentSlide,
+      slidePosition,
     } = this.props;
 
     const {
@@ -308,7 +317,7 @@ class PresentationArea extends PureComponent {
     const {
       width,
       height,
-    } = slideObj.calculatedData;
+    } = slidePosition;
 
     return (
       <PresentationOverlayContainer
@@ -358,6 +367,7 @@ class PresentationArea extends PureComponent {
     const {
       podId,
       currentSlide,
+      slidePosition,
       userIsPresenter,
     } = this.props;
 
@@ -373,8 +383,11 @@ class PresentationArea extends PureComponent {
     const {
       width,
       height,
+    } = slidePosition;
+
+    const {
       imageUri,
-    } = currentSlide.calculatedData;
+    } = currentSlide;
 
     let viewBoxPosition;
 
@@ -385,8 +398,8 @@ class PresentationArea extends PureComponent {
       };
     } else {
       viewBoxPosition = {
-        x: currentSlide.calculatedData.x,
-        y: currentSlide.calculatedData.y,
+        x: slidePosition.x,
+        y: slidePosition.y,
       };
     }
 
@@ -545,7 +558,7 @@ class PresentationArea extends PureComponent {
     const {
       userIsPresenter,
       multiUser,
-      currentSlide,
+      slidePosition,
     } = this.props;
 
     const {
@@ -564,8 +577,8 @@ class PresentationArea extends PureComponent {
       };
     } else {
       viewBoxDimensions = {
-        width: currentSlide.calculatedData.viewBoxWidth,
-        height: currentSlide.calculatedData.viewBoxHeight,
+        width: slidePosition.viewBoxWidth,
+        height: slidePosition.viewBoxHeight,
       };
     }
 
@@ -646,21 +659,17 @@ PresentationArea.propTypes = {
   currentSlide: PropTypes.shape({
     presentationId: PropTypes.string.isRequired,
     current: PropTypes.bool.isRequired,
-    heightRatio: PropTypes.number.isRequired,
-    widthRatio: PropTypes.number.isRequired,
-    xOffset: PropTypes.number.isRequired,
-    yOffset: PropTypes.number.isRequired,
     num: PropTypes.number.isRequired,
     id: PropTypes.string.isRequired,
-    calculatedData: PropTypes.shape({
-      x: PropTypes.number.isRequired,
-      y: PropTypes.number.isRequired,
-      height: PropTypes.number.isRequired,
-      width: PropTypes.number.isRequired,
-      viewBoxWidth: PropTypes.number.isRequired,
-      viewBoxHeight: PropTypes.number.isRequired,
-      imageUri: PropTypes.string.isRequired,
-    }),
+    imageUri: PropTypes.string.isRequired,
+  }),
+  slidePosition: PropTypes.shape({
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired,
+    height: PropTypes.number.isRequired,
+    width: PropTypes.number.isRequired,
+    viewBoxWidth: PropTypes.number.isRequired,
+    viewBoxHeight: PropTypes.number.isRequired,
   }),
   // current multi-user status
   multiUser: PropTypes.bool.isRequired,
@@ -668,4 +677,5 @@ PresentationArea.propTypes = {
 
 PresentationArea.defaultProps = {
   currentSlide: undefined,
+  slidePosition: undefined,
 };

--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -13,8 +13,18 @@ const PresentationAreaContainer = ({ presentationPodIds, mountPresentationArea, 
 export default withTracker(({ podId }) => {
   const currentSlide = PresentationAreaService.getCurrentSlide(podId);
   const presentationIsDownloadable = PresentationAreaService.isPresentationDownloadable(podId);
+
+  let slidePosition = {};
+  if (currentSlide) {
+    const {
+      presentationId,
+      id: slideId,
+    } = currentSlide;
+    slidePosition = PresentationAreaService.getSlidePosition(podId, presentationId, slideId);
+  }
   return {
     currentSlide,
+    slidePosition,
     downloadPresentationUri: PresentationAreaService.downloadPresentationUri(podId),
     userIsPresenter: PresentationAreaService.isPresenter(podId) && !getSwapLayout(),
     multiUser: PresentationAreaService.getMultiUserStatus(currentSlide && currentSlide.id)

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-overlay/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-overlay/container.jsx
@@ -10,14 +10,11 @@ const PresentationOverlayContainer = ({ children, ...rest }) => (
   </PresentationOverlay>
 );
 
-export default withTracker(({ podId, currentSlideNum, slide }) => {
+export default withTracker(() => {
   const drawSettings = WhiteboardToolbarService.getCurrentDrawSettings();
   const tool = drawSettings ? drawSettings.whiteboardAnnotationTool : '';
 
   return {
-    slide,
-    podId,
-    currentSlideNum,
     annotationTool: tool,
   };
 })(PresentationOverlayContainer);

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -28,24 +28,12 @@ export default withTracker((params) => {
   const {
     podId,
     presentationId,
-    fitToWidth,
-    fullscreenRef,
-    zoom,
-    zoomChanger,
-    currentSlideNum,
-    fitToWidthHandler,
   } = params;
 
   return {
     getSwapLayout: MediaService.getSwapLayout(),
-    fitToWidthHandler,
-    fitToWidth,
-    fullscreenRef,
     userIsPresenter: PresentationService.isPresenter(podId),
     numberOfSlides: PresentationToolbarService.getNumberOfSlides(podId, presentationId),
-    zoom,
-    zoomChanger,
-    currentSlideNum,
     nextSlide: PresentationToolbarService.nextSlide,
     previousSlide: PresentationToolbarService.previousSlide,
     skipToSlide: PresentationToolbarService.skipToSlide,

--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -1,7 +1,7 @@
 import WhiteboardMultiUser from '/imports/api/whiteboard-multi-user/';
 import PresentationPods from '/imports/api/presentation-pods';
 import Presentations from '/imports/api/presentations';
-import Slides from '/imports/api/slides';
+import { Slides, SlidePositions } from '/imports/api/slides';
 import Users from '/imports/api/users';
 import Auth from '/imports/ui/services/auth';
 
@@ -52,6 +52,12 @@ const getCurrentSlide = (podId) => {
     },
   });
 };
+
+const getSlidePosition = (podId, presentationId, slideId) => SlidePositions.findOne({
+  podId,
+  presentationId,
+  id: slideId,
+});
 
 const currentSlidHasContent = () => {
   const currentSlide = getCurrentSlide('DEFAULT_PRESENTATION_POD');
@@ -173,6 +179,7 @@ const getMultiUserStatus = (whiteboardId) => {
 
 export default {
   getCurrentSlide,
+  getSlidePosition,
   isPresenter,
   isPresentationDownloadable,
   downloadPresentationUri,

--- a/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
@@ -14,7 +14,7 @@ const CHAT_ENABLED = CHAT_CONFIG.enabled;
 const PUBLIC_GROUP_CHAT_ID = CHAT_CONFIG.public_group_id;
 const PUBLIC_CHAT_TYPE = CHAT_CONFIG.type_public;
 const SUBSCRIPTIONS = [
-  'users', 'meetings', 'polls', 'presentations', 'slides', 'captions',
+  'users', 'meetings', 'polls', 'presentations', 'slides', 'slide-positions', 'captions',
   'voiceUsers', 'whiteboard-multi-user', 'screenshare', 'group-chat',
   'presentation-pods', 'users-settings', 'guestUser', 'users-infos', 'note',
   'network-information', 'ping-pong',

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -199,7 +199,7 @@ public:
     echoTestNumber: '9196'
   presentation:
     defaultPresentationFile: default.pdf
-    panZoomThrottle: 200
+    panZoomThrottle: 32
     uploadEndpoint: "/bigbluebutton/presentation/upload"
     uploadSizeMin: 0
     uploadSizeMax: 50000000


### PR DESCRIPTION
The slide position updates frequently when panning or zooming and it was causing the whole Slide record to be sent to every client multiple times per second. The Slide record is very heavy with a lot of text and it was very inefficient. This PR leaves the mostly static properties of the slide in Slide and creates a new collection for just the slide positions.

Normally when there's a new collection it needs a bunch of filler around and a separate directory for it in the file structure, but I chose to keep the new collection inside of the api/slides directory because creation and destruction is directly tied together. They're basically one collection, but are only split for performance reasons.