### PR TITLE
Send audo alert for new messages when in another tab or browser minimized

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/alert/audio-alert/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/alert/audio-alert/component.jsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 
 const propTypes = {
   play: PropTypes.bool.isRequired,
 };
 
-class ChatAudioAlert extends React.Component {
+class ChatAudioAlert extends Component {
   constructor(props) {
     super(props);
     this.audio = new Audio(`${Meteor.settings.public.app.cdn + Meteor.settings.public.app.basename}/resources/sounds/notify.mp3`);

--- a/bigbluebutton-html5/imports/ui/components/chat/alert/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/alert/component.jsx
@@ -173,11 +173,18 @@ class ChatAlert extends PureComponent {
       pendingNotificationsByChat,
     } = this.state;
 
-    const shouldPlay = Object.keys(pendingNotificationsByChat).length > 0;
+    const notCurrentTabOrMinimized = document.hidden;
+
+    const shouldPlayChatAlert = notCurrentTabOrMinimized
+      || Object.keys(pendingNotificationsByChat).length > 0;
 
     return (
       <Fragment>
-        {!audioAlertDisabled ? <ChatAudioAlert play={shouldPlay} /> : null}
+        {
+          !audioAlertDisabled && notCurrentTabOrMinimized
+            ? <ChatAudioAlert play={shouldPlayChatAlert} />
+            : null
+        }
         {
           !pushAlertDisabled
             ? Object.keys(pendingNotificationsByChat)

--- a/bigbluebutton-html5/imports/ui/components/chat/alert/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/alert/container.jsx
@@ -3,7 +3,6 @@ import { withTracker } from 'meteor/react-meteor-data';
 import UserListService from '/imports/ui/components/user-list/service';
 import Settings from '/imports/ui/services/settings';
 import ChatAlert from './component';
-import ChatService from '/imports/ui/components/chat/service.js';
 import Auth from '/imports/ui/services/auth';
 import Users from '/imports/api/users';
 
@@ -14,7 +13,7 @@ const ChatAlertContainer = props => (
 export default withTracker(() => {
   const AppSettings = Settings.application;
   const activeChats = UserListService.getActiveChats();
-  const loginTime = Users.findOne({ userId: Auth.userID }).loginTime;
+  const { loginTime } = Users.findOne({ userId: Auth.userID }, { fields: { loginTime: 1 } });
   return {
     audioAlertDisabled: !AppSettings.chatAudioAlerts,
     pushAlertDisabled: !AppSettings.chatPushAlerts,


### PR DESCRIPTION
If the user have audio alerts enabled in settings, the alert will play even if the user is in other tab or with the browser minimized. It uses [Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API).