### PR TITLE
Protect against no slide position

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -575,10 +575,15 @@ class PresentationArea extends PureComponent {
         width: localPosition.width,
         height: localPosition.height,
       };
-    } else {
+    } else if (slidePosition) {
       viewBoxDimensions = {
         width: slidePosition.viewBoxWidth,
         height: slidePosition.viewBoxHeight,
+      };
+    } else {
+      viewBoxDimensions = {
+        width: 0,
+        height: 0,
       };
     }
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -14,7 +14,7 @@ export default withTracker(({ podId }) => {
   const currentSlide = PresentationAreaService.getCurrentSlide(podId);
   const presentationIsDownloadable = PresentationAreaService.isPresentationDownloadable(podId);
 
-  let slidePosition = {};
+  let slidePosition;
   if (currentSlide) {
     const {
       presentationId,


### PR DESCRIPTION
This PR protects against the case where there's no slide position (race condition, file deleted on the server). If the fallback is hit, the presentation area will look like the following.

![image](https://user-images.githubusercontent.com/1395090/62315658-ccaa8500-b463-11e9-92e8-c208e9081b9f.png)

Fixes #7873