### PR TITLE
Add hint in message form for when chat is locked

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/component.jsx
@@ -104,10 +104,12 @@ const Chat = (props) => {
       <MessageForm
         UnsentMessagesCollection={UnsentMessagesCollection}
         chatId={chatID}
-        disabled={isChatLocked || !isMeteorConnected}
+        connected={isMeteorConnected}
         chatAreaId={ELEMENT_ID}
         chatTitle={title}
         chatName={chatName}
+        disabled={isChatLocked || !isMeteorConnected}
+        locked={isChatLocked}
         minMessageLength={minMessageLength}
         maxMessageLength={maxMessageLength}
         handleSendMessage={actions.handleSendMessage}

--- a/bigbluebutton-html5/imports/ui/components/chat/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/component.jsx
@@ -113,6 +113,7 @@ const Chat = (props) => {
         minMessageLength={minMessageLength}
         maxMessageLength={maxMessageLength}
         handleSendMessage={actions.handleSendMessage}
+        partnerIsLoggedOut={partnerIsLoggedOut}
       />
     </div>
   );

--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
@@ -22,6 +22,7 @@ const propTypes = {
   UnsentMessagesCollection: PropTypes.object.isRequired,
   connected: PropTypes.bool.isRequired,
   locked: PropTypes.bool.isRequired,
+  partnerIsLoggedOut: PropTypes.bool.isRequired,
 };
 
 const defaultProps = {
@@ -87,7 +88,12 @@ class MessageForm extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    const { chatId, connected, locked } = this.props;
+    const {
+      chatId,
+      connected,
+      locked,
+      partnerIsLoggedOut,
+    } = this.props;
     const { message } = this.state;
     const { mobile } = this.BROWSER_RESULTS;
 
@@ -100,7 +106,11 @@ class MessageForm extends PureComponent {
       this.setMessageState();
     }
 
-    if (connected !== prevProps.connected || locked !== prevProps.locked) {
+    if (
+      connected !== prevProps.connected
+      || locked !== prevProps.locked
+      || partnerIsLoggedOut !== prevProps.partnerIsLoggedOut
+    ) {
       this.setMessageHint();
     }
   }
@@ -113,11 +123,29 @@ class MessageForm extends PureComponent {
   }
 
   setMessageHint() {
-    const { connected, disabled, intl } = this.props;
+    const {
+      connected,
+      disabled,
+      intl,
+      locked,
+      partnerIsLoggedOut,
+    } = this.props;
+
+    let chatDisabledHint = null;
+
+    if (disabled && !partnerIsLoggedOut) {
+      if (connected) {
+        if (locked) {
+          chatDisabledHint = messages.errorChatLocked;
+        }
+      } else {
+        chatDisabledHint = messages.errorServerDisconnected;
+      }
+    }
 
     this.setState({
       hasErrors: disabled,
-      error: intl.formatMessage((disabled && connected) ? messages.errorChatLocked : messages.errorServerDisconnected),
+      error: chatDisabledHint ? intl.formatMessage(chatDisabledHint) : null,
     });
   }
 

--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
@@ -20,6 +20,8 @@ const propTypes = {
   chatAreaId: PropTypes.string.isRequired,
   handleSendMessage: PropTypes.func.isRequired,
   UnsentMessagesCollection: PropTypes.object.isRequired,
+  connected: PropTypes.bool.isRequired,
+  locked: PropTypes.bool.isRequired,
 };
 
 const defaultProps = {
@@ -48,6 +50,9 @@ const messages = defineMessages({
   errorServerDisconnected: {
     id: 'app.chat.disconnected',
   },
+  errorChatLocked: {
+    id: 'app.chat.locked',
+  },
 });
 
 const CHAT_ENABLED = Meteor.settings.public.chat.enabled;
@@ -74,6 +79,7 @@ class MessageForm extends PureComponent {
     const { mobile } = this.BROWSER_RESULTS;
 
     this.setMessageState();
+    this.setMessageHint();
 
     if (!mobile) {
       if (this.textarea) this.textarea.focus();
@@ -81,7 +87,7 @@ class MessageForm extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    const { chatId, disabled } = this.props;
+    const { chatId, connected, locked } = this.props;
     const { message } = this.state;
     const { mobile } = this.BROWSER_RESULTS;
 
@@ -94,11 +100,7 @@ class MessageForm extends PureComponent {
       this.setMessageState();
     }
 
-    if (prevProps.disabled !== disabled && disabled) {
-      this.setMessageHint();
-    }
-
-    if (prevProps.disabled !== disabled && !disabled) {
+    if (connected !== prevProps.connected || locked !== prevProps.locked) {
       this.setMessageHint();
     }
   }
@@ -111,10 +113,11 @@ class MessageForm extends PureComponent {
   }
 
   setMessageHint() {
-    const { disabled, intl } = this.props;
+    const { connected, disabled, intl } = this.props;
+
     this.setState({
       hasErrors: disabled,
-      error: intl.formatMessage(messages.errorServerDisconnected),
+      error: intl.formatMessage((disabled && connected) ? messages.errorChatLocked : messages.errorServerDisconnected),
     });
   }
 

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -4,6 +4,7 @@
     "app.chat.errorMinMessageLength": "The message is {0} characters(s) too short",
     "app.chat.errorMaxMessageLength": "The message is {0} characters(s) too long",
     "app.chat.disconnected": "You are disconnected, messages can't be sent",
+    "app.chat.locked": "Chat is locked, messages can't be sent",
     "app.chat.inputLabel": "Message input for chat {0}",
     "app.chat.inputPlaceholder": "Send message to {0}",
     "app.chat.titlePublic": "Public Chat",


### PR DESCRIPTION
Currently we only have a single message for when the chat message form is disabled, but when chat is locked it is showing the an incorrect reason.