### PR TITLE
Fix HTML5 server logger initialization

### DIFF
--- a/bigbluebutton-html5/imports/startup/server/logger.js
+++ b/bigbluebutton-html5/imports/startup/server/logger.js
@@ -1,26 +1,26 @@
 import { Meteor } from 'meteor/meteor';
 import { createLogger, format, transports } from 'winston';
 
+const LOG_CONFIG = Meteor.settings.private.serverLog || {};
+const { level } = LOG_CONFIG;
+
 const Logger = createLogger({
+  level,
   format: format.combine(
     format.colorize({ level: true }),
     format.splat(),
     format.simple(),
   ),
-});
-
-Meteor.startup(() => {
-  const LOG_CONFIG = Meteor.settings.private.serverLog || {};
-  const { level } = LOG_CONFIG;
-
-  // console logging
-  Logger.add(new transports.Console(), {
-    prettyPrint: false,
-    humanReadableUnhandledException: true,
-    colorize: true,
-    handleExceptions: true,
-    level,
-  });
+  transports: [
+    // console logging
+    new transports.Console({
+      prettyPrint: false,
+      humanReadableUnhandledException: true,
+      colorize: true,
+      handleExceptions: true,
+      level,
+    }),
+  ],
 });
 
 export default Logger;


### PR DESCRIPTION
In order to actually set the log level in Winston it needs to be set in the logger and in the transport. We were only setting the log level in the transport so it was useless.