### PR TITLE
Fix log errors on webcam draggable

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/media/webcam-draggable-overlay/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/webcam-draggable-overlay/component.jsx
@@ -89,16 +89,16 @@ class WebcamDraggable extends Component {
     if (mediaContainer) {
       const mediaContainerRect = mediaContainer.getBoundingClientRect();
       const {
-        top, left, width, height,
+        top, left, newWidth, newHeight,
       } = mediaContainerRect;
 
-      if (mediaState.width === 0 || mediaState.height === 0) {
+      if ((mediaState.width === 0 || mediaState.height === 0) && (newWidth > 0 && newHeight > 0)) {
         webcamDraggableDispatch(
           {
             type: 'setMediaSize',
             value: {
-              width,
-              height,
+              newWidth,
+              newHeight,
             },
           },
         );
@@ -107,8 +107,8 @@ class WebcamDraggable extends Component {
       return {
         top,
         left,
-        width,
-        height,
+        newWidth,
+        newHeight,
       };
     }
     return false;
@@ -162,7 +162,7 @@ class WebcamDraggable extends Component {
 
   handleWebcamDragStop(e, position) {
     const { webcamDraggableDispatch, singleWebcam } = this.props;
-    const targetClassname = e.target.className;
+    const targetClassname = JSON.stringify(e.target.className);
     const { x, y } = position;
 
     if (targetClassname && targetClassname.includes('Top')) {


### PR DESCRIPTION
This PR fixes that errors

Race condition
```
Uncaught TypeError: targetClassname.includes is not a function
    at WebcamDraggable.handleWebcamDragStop (component.jsx:168)
    at Object.Draggable._this.onDragStop [as onStop] (modules.js?hash=0e5f549658b3f98d9d35f6eae2a01dd3458212ef:84094)
    at HTMLDocument.DraggableCore._this.handleDragStop (modules.js?hash=0e5f549658b3f98d9d35f6eae2a01dd3458212ef:83793)
handleWebcamDragStop @ component.jsx:168
Draggable._this.onDragStop @ modules.js?hash=0e5f549658b3f98d9d35f6eae2a01dd3458212ef:84094
DraggableCore._this.handleDragStop @ modules.js?hash=0e5f549658b3f98d9d35f6eae2a01dd3458212ef:83793
```

![image](https://user-images.githubusercontent.com/9675166/62496384-289c4300-b7af-11e9-8bf8-88cf83618b65.png)
> _happens when the client is presenter (has the bottom presentation toolbar) and resizes the screen in such a way that the presentation can't be viewed_