### PR TITLE
Allow negative cursor updates to publish

### DIFF
--- a/bigbluebutton-html5/imports/api/cursor/server/methods/publishCursorUpdate.js
+++ b/bigbluebutton-html5/imports/api/cursor/server/methods/publishCursorUpdate.js
@@ -21,10 +21,15 @@ export default function publishCursorUpdate(credentials, payload) {
     whiteboardId: String,
   });
 
-  const { whiteboardId } = payload;
+  const {
+    whiteboardId,
+    xPercent,
+    yPercent,
+  } = payload;
 
   const allowed = isPodPresenter(meetingId, whiteboardId, requesterUserId)
-    || getMultiUserStatus(meetingId, whiteboardId);
+    || getMultiUserStatus(meetingId, whiteboardId)
+    || (xPercent < 0 && yPercent < 0);
   if (!allowed) {
     throw new Meteor.Error('not-allowed', `User ${requesterUserId} is not allowed to move the cursor`);
   }


### PR DESCRIPTION
The updates might get rejected by akka-apps if they're sent late, but the user won't get kicked for cursor updates so it's not major.

Fixes #7890 