### PR TITLE
Show presentation and whiteboard controls after auto swap back

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
-import { getSwapLayout } from '/imports/ui/components/media/service';
+import { getSwapLayout, shouldEnableSwapLayout } from '/imports/ui/components/media/service';
 import { notify } from '/imports/ui/services/notification';
 import PresentationAreaService from './service';
 import PresentationArea from './component';
@@ -13,6 +13,7 @@ const PresentationAreaContainer = ({ presentationPodIds, mountPresentationArea, 
 export default withTracker(({ podId }) => {
   const currentSlide = PresentationAreaService.getCurrentSlide(podId);
   const presentationIsDownloadable = PresentationAreaService.isPresentationDownloadable(podId);
+  const layoutSwapped = getSwapLayout() && shouldEnableSwapLayout();
 
   let slidePosition;
   if (currentSlide) {
@@ -26,9 +27,9 @@ export default withTracker(({ podId }) => {
     currentSlide,
     slidePosition,
     downloadPresentationUri: PresentationAreaService.downloadPresentationUri(podId),
-    userIsPresenter: PresentationAreaService.isPresenter(podId) && !getSwapLayout(),
+    userIsPresenter: PresentationAreaService.isPresenter(podId) && !layoutSwapped,
     multiUser: PresentationAreaService.getMultiUserStatus(currentSlide && currentSlide.id)
-      && !getSwapLayout(),
+      && !layoutSwapped,
     presentationIsDownloadable,
     mountPresentationArea: !!currentSlide,
     currentPresentation: PresentationAreaService.getCurrentPresentation(podId),

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -9,10 +9,10 @@ import PresentationToolbarService from './service';
 const PresentationToolbarContainer = (props) => {
   const {
     userIsPresenter,
-    getSwapLayout,
+    layoutSwapped,
   } = props;
 
-  if (userIsPresenter && !getSwapLayout) {
+  if (userIsPresenter && !layoutSwapped) {
     // Only show controls if user is presenter and layout isn't swapped
 
     return (
@@ -31,7 +31,7 @@ export default withTracker((params) => {
   } = params;
 
   return {
-    getSwapLayout: MediaService.getSwapLayout(),
+    layoutSwapped: MediaService.getSwapLayout() && MediaService.shouldEnableSwapLayout(),
     userIsPresenter: PresentationService.isPresenter(podId),
     numberOfSlides: PresentationToolbarService.getNumberOfSlides(podId, presentationId),
     nextSlide: PresentationToolbarService.nextSlide,


### PR DESCRIPTION
The code was looking at the swap layout property only, but there's a second function that determines if a swap layout should be obeyed. This PR adds the check to the second function.

Fixes #7870