### PR TITLE
Improve the failed Meteor call log

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/api/index.js
+++ b/bigbluebutton-html5/imports/ui/services/api/index.js
@@ -25,14 +25,20 @@ export function makeCall(name, ...args) {
         resolve(result);
       });
     } else {
-      reject(() => logger.warn({
-        logCode: 'servicesapiindex_makeCall',
-        extraInfo: {
-          attemptForUserInfo: Auth.fullInfo,
-          name,
-          ...args,
-        },
-      }, 'Connection to Meteor was interrupted.'));
+      const failureString = `Call to ${name} failed because Meteor is not connected`;
+      // We don't want to send a log message if the call that failed wasa log message.
+      // Without this you can get into an endless loop of failed logging.
+      if (name !== 'logClient') {
+        logger.warn({
+          logCode: 'servicesapiindex_makeCall',
+          extraInfo: {
+            attemptForUserInfo: Auth.fullInfo,
+            name,
+            ...args,
+          },
+        }, failureString);
+      }
+      reject(failureString);
     }
   });
 }


### PR DESCRIPTION
Changed up the string being logged to tell us specifically which call failed and made the log output correctly. I also had to put in a special case check so that there isn't a potential infinite loop of failed log attempts.