### PR TITLE
Make user-list avatar the same width as chat avatar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/styles.scss
@@ -101,7 +101,7 @@
 }
 
 .userAvatar {
-  flex: 0 0 2.2rem;
+  flex: 0 0 2.25rem;
 }
 
 .userItemContents {


### PR DESCRIPTION
Before this the user-list avatar was 30.8x32 and the chat avatar was 31.5x32. After this PR the user-list avatar is also 31.5x32.