### PR TITLE
Fix Clear All status icons

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/handlers/emojiStatus.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/emojiStatus.js
@@ -27,9 +27,7 @@ export default function handleEmojiStatus({ body }, meetingId) {
     }
 
     if (numChanged) {
-      Logger.info(`Assigned user emoji status${
-        emoji} id=${userId} meeting=${meetingId}`,
-      );
+      Logger.info(`Assigned user emoji status ${emoji} id=${userId} meeting=${meetingId}`);
     }
   };
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -368,12 +368,12 @@ const normalizeEmojiName = emoji => (
   emoji in EMOJI_STATUSES ? EMOJI_STATUSES[emoji] : emoji
 );
 
-const setEmojiStatus = (data) => {
-  const statusAvailable = (Object.keys(EMOJI_STATUSES).includes(data));
+const setEmojiStatus = (userId, emoji) => {
+  const statusAvailable = (Object.keys(EMOJI_STATUSES).includes(emoji));
 
   return statusAvailable
-    ? makeCall('setEmojiStatus', Auth.userID, data)
-    : makeCall('setEmojiStatus', data, 'none');
+    ? makeCall('setEmojiStatus', Auth.userID, emoji)
+    : makeCall('setEmojiStatus', userId, 'none');
 };
 
 const assignPresenter = (userId) => { makeCall('assignPresenter', userId); };

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
@@ -272,7 +272,7 @@ class UserDropdown extends PureComponent {
       statuses.map(status => actions.push(this.makeDropdownItem(
         status,
         intl.formatMessage({ id: `app.actionsBar.emojiMenu.${status}Label` }),
-        () => { handleEmojiChange(status); this.resetMenuState(); },
+        () => { handleEmojiChange(user.id, status); this.resetMenuState(); },
         getEmojiList[status],
       )));
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/container.jsx
@@ -37,7 +37,7 @@ const UserOptionsContainer = withTracker((props) => {
   } = props;
 
   const toggleStatus = () => {
-    users.forEach(id => setEmojiStatus(id, 'none'));
+    users.forEach(user => setEmojiStatus(user.userId, 'none'));
     notify(
       intl.formatMessage(intlMessages.clearStatusMessage), 'info', 'clear_status',
     );


### PR DESCRIPTION
The problem was caused by a wrong parameter being passed down to the function.