### PR TITLE
More responsive and less noisy initial connection watcher

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
@@ -25,7 +25,6 @@ class JoinHandler extends Component {
   constructor(props) {
     super(props);
     this.fetchToken = this.fetchToken.bind(this);
-    this.numFetchTokenRetries = 0;
 
     this.state = {
       joined: false,
@@ -34,7 +33,51 @@ class JoinHandler extends Component {
 
   componentDidMount() {
     this._isMounted = true;
-    this.fetchToken();
+
+    if (!this.firstJoinTime) {
+      this.firstJoinTime = new Date();
+    }
+    Tracker.autorun((c) => {
+      const {
+        connected,
+        status,
+      } = Meteor.status();
+
+      logger.debug(`Initial connection status change. status: ${status}, connected: ${connected}`);
+      if (connected) {
+        c.stop();
+
+        const msToConnect = (new Date() - this.firstJoinTime) / 1000;
+        const secondsToConnect = parseFloat(msToConnect).toFixed(2);
+
+        logger.info({
+          logCode: 'joinhandler_component_initial_connection_time',
+          extraInfo: {
+            attemptForUserInfo: Auth.fullInfo,
+            timeToConnect: secondsToConnect,
+          },
+        }, `Connection to Meteor took ${secondsToConnect}s`);
+
+        this.firstJoinTime = undefined;
+        this.fetchToken();
+      } else if (status === 'failed') {
+        c.stop();
+
+        const msToConnect = (new Date() - this.firstJoinTime) / 1000;
+        const secondsToConnect = parseFloat(msToConnect).toFixed(2);
+        logger.info({
+          logCode: 'joinhandler_component_initial_connection_failed',
+          extraInfo: {
+            attemptForUserInfo: Auth.fullInfo,
+            timeToConnect: secondsToConnect,
+          },
+        }, `Connection to Meteor failed, took ${secondsToConnect}s`);
+
+        JoinHandler.setError('400');
+        Session.set('errorMessageDescription', 'Failed to connect to server');
+        this.firstJoinTime = undefined;
+      }
+    });
   }
 
   componentWillUnmount() {
@@ -44,21 +87,6 @@ class JoinHandler extends Component {
   async fetchToken() {
     if (!this._isMounted) return;
 
-    if (!Meteor.status().connected) {
-      if (this.numFetchTokenRetries % 9) {
-        logger.error({
-          logCode: 'joinhandler_component_fetchToken_not_connected',
-          extraInfo: {
-            attemptForUserInfo: Auth.fullInfo,
-            numFetchTokenRetries: this.numFetchTokenRetries,
-          },
-        }, 'Meteor was not connected, retry in a few moments');
-      }
-      this.numFetchTokenRetries += 1;
-
-      setTimeout(() => this.fetchToken(), 200);
-      return;
-    }
     const urlParams = new URLSearchParams(window.location.search);
     const sessionToken = urlParams.get('sessionToken');
 


### PR DESCRIPTION
This PR changes the code that tracks the initial connection to Meteor. We used to check the connection status every 200ms and this code changes it to use a Tracker which is much more responsive. I also added an exit case when the connection fails. We can also now track the time it took someone to connect in an easier manner and see how long people take on average.

I thought about adding a ~5s timeout also, but some people take 15s or more to connect so a timeout is difficult.