### PR TITLE
Remove pointless userMap in screenshare view

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import Users from '/imports/api/users/';
 import Auth from '/imports/ui/services/auth';
-import mapUser from '/imports/ui/services/user/mapUser';
 import {
   isVideoBroadcasting, presenterScreenshareHasEnded, unshareScreen,
   presenterScreenshareHasStarted,
@@ -19,9 +18,8 @@ const ScreenshareContainer = (props) => {
 
 export default withTracker(() => {
   const user = Users.findOne({ userId: Auth.userID });
-  const MappedUser = mapUser(user);
   return {
-    isPresenter: MappedUser.isPresenter,
+    isPresenter: user.presenter,
     unshareScreen,
     isVideoBroadcasting,
     presenterScreenshareHasStarted,


### PR DESCRIPTION
Found another pointless use of mapUser that brings in the voice data for no reason.