### PR TITLE
Fix microphone lock affecting moderators

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/context/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/context/container.jsx
@@ -11,7 +11,7 @@ const lockContextContainer = component => withTracker(() => {
   const lockSetting = new LockStruct();
   const Meeting = Meetings.findOne({ meetingId: Auth.meetingID });
   const User = Users.findOne({ userId: Auth.userID });
-  const userIsLocked = User.locked && User.role === ROLE_MODERATOR;
+  const userIsLocked = User.locked && User.role !== ROLE_MODERATOR;
   const lockSettings = Meeting.lockSettingsProps;
 
   lockSetting.isLocked = userIsLocked;


### PR DESCRIPTION
When microphone lock was activated the moderators couldn't join with microphone and the lock wasn't affecting attendees. 