### PR TITLE
Fix problem with clear chat when popup alerts are enabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/alert/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/alert/component.jsx
@@ -204,7 +204,7 @@ class ChatAlert extends PureComponent {
                 const reducedMessage = Service
                   .reduceAndMapGroupMessages(pendingNotificationsByChat[chatId].slice(-5)).pop();
 
-                if (!reducedMessage) return null;
+                if (!reducedMessage || !reducedMessage.sender) return null;
 
                 const content = this
                   .createMessage(reducedMessage.sender.name, reducedMessage.content);


### PR DESCRIPTION
The problem was caused because the system messages don't have a sender.