### PR TITLE
Use an SVG for the recording icon

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/component.jsx
@@ -81,6 +81,29 @@ class RecordingIndicator extends PureComponent {
       document.activeElement.blur();
     };
 
+    const recordingIndicatorIcon = (
+      <span className={styles.recordingIndicatorIcon}>
+        <svg xmlns="http://www.w3.org/2000/svg" height="100%" version="1" viewBox="0 0 20 20">
+          <g stroke="#FFF" fill="#FFF" strokeLinecap="square">
+            <circle
+              fill="none"
+              strokeWidth="1"
+              r="9"
+              cx="10"
+              cy="10"
+            />
+            <circle
+              stroke={recording ? '#F00' : '#FFF'}
+              fill={recording ? '#F00' : '#FFF'}
+              r="4"
+              cx="10"
+              cy="10"
+            />
+          </g>
+        </svg>
+      </span>
+    );
+
     const showButton = amIModerator && allowStartStopRecording;
 
     const recordMeetingButton = (
@@ -93,9 +116,7 @@ class RecordingIndicator extends PureComponent {
         onClick={recordingToggle}
         onKeyPress={recordingToggle}
       >
-        <span
-          className={recording ? styles.recordingIndicatorON : styles.recordingIndicatorOFF}
-        />
+        {recordingIndicatorIcon}
 
         <div className={styles.presentationTitle}>
           {recording
@@ -137,14 +158,10 @@ class RecordingIndicator extends PureComponent {
                 : intlMessages.notificationRecordingStop)}`}
               className={styles.recordingStatusViewOnly}
             >
+              {recordingIndicatorIcon}
 
-              <span
-                className={recording ? styles.recordingIndicatorON : styles.recordingIndicatorOFF}
-              />
-
-              <div className={styles.presentationTitle}>
-                {recording ? humanizeSeconds(time) : null}
-              </div>
+              {recording
+                ? <div className={styles.presentationTitle}>{humanizeSeconds(time)}</div> : null}
             </div>
           </Tooltip>
         )}

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/styles.scss
@@ -91,56 +91,10 @@
   display: flex;
 }
 
-%recordingIndicator {
-  border: var(--border-size-small) solid var(--color-white) !important;
-  border-radius: 50%;
-  span {
-    border: none;
-    box-shadow: none;
-    background-color: transparent !important;
-  }
-  position: relative;
-  display: inline-block;
-  padding: 0 !important;
+.recordingIndicatorIcon {
   width: var(--font-size-large);
   height: var(--font-size-large);
-  border-radius: 50%;
-  &:after {
-    content: '';
-    width: calc(var(--font-size-large) / 2);
-    height: calc(var(--font-size-large) / 2);
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    margin-top: calc((var(--font-size-large) / -4));
-    margin-left: calc((var(--font-size-large) / -4));
-    border-radius: 50%;
-  }
-}
-
-.recordingIndicatorON {
-  @extend %recordingIndicator;
-  &:after {
-    border: var(--border-size) solid transparent;
-    background-color: var(--color-danger);
-  }
-}
-
-.recordingIndicatorOFF {
-  @extend %recordingIndicator;
-  &:after {
-    background-color: var(--color-white);
-  }
-}
-
-.isRecordingCircle {
-  border: var(--border-size-small) solid var(--color-white) !important;
-  border-radius: 50%;
-  span {
-    border: none;
-    box-shadow: none;
-    background-color: transparent !important;
-  }
+  font-size: var(--font-size-base);
 }
 
 .recordingIndicator {


### PR DESCRIPTION
Previously the recording icon was made with CSS and it didn't always render well in all browsers. This PR changes the icon to be an SVG instead which seems to scale better from my tests.

Old:
![image](https://user-images.githubusercontent.com/1395090/63628260-81eed980-c5d9-11e9-8a28-e7143550cfdb.png)
![image](https://user-images.githubusercontent.com/1395090/63628283-a0ed6b80-c5d9-11e9-9f54-865174e3fdcd.png)

New:
![image](https://user-images.githubusercontent.com/1395090/63628248-700d3680-c5d9-11e9-912e-c5e6a9fe8aeb.png)
![image](https://user-images.githubusercontent.com/1395090/63628299-ba8eb300-c5d9-11e9-87fc-7eaac859d4d7.png)