### PR TITLE
Fix randomly assign problem in breakout rooms

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -353,9 +353,13 @@ class BreakoutRoom extends PureComponent {
     const { users } = this.state;
 
     const idxUser = users.findIndex(user => user.userId === userId);
-    users[idxUser].room = room;
+
+    const usersCopy = [...users];
+
+    usersCopy[idxUser].room = room;
+
     this.setState({
-      users,
+      users: usersCopy,
       valid: this.getUserByRoom(0).length !== users.length,
     });
   }


### PR DESCRIPTION
The problem was caused because of `PureComponent` shallow comparison, the users list in state are not changing his reference.