### PR TITLE
Change audio error code log property

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -355,7 +355,7 @@ class AudioManager {
         logger.error({
           logCode: 'audio_failure',
           extraInfo: {
-            error,
+            errorCode: error,
             cause: bridgeError,
           },
         }, 'Audio Error');


### PR DESCRIPTION
Other client logs have started to attach extraInfo.error properties and they've been using Objects instead of the Strings that the audio failures use. This type mismatch causes log aggregators to throw a fit. I moved the audio error codes to a different property so they can be parsed again. 