### PR TITLE
Fix duplicate user fetch and chat list bugs

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -319,25 +319,24 @@ const curatedVoiceUser = (intId) => {
   };
 };
 
-const getAvailableActions = (subjectUser) => {
+const getAvailableActions = (subjectUser, subjectVoiceUser) => {
   const isBreakoutRoom = meetingIsBreakout();
   const isDialInUser = isVoiceOnlyUser(subjectUser.userId) || subjectUser.phone_user;
   const amIModerator = isUserModerator(Auth.userID);
   const amISubjectUser = isMe(subjectUser.userId);
-  const isSubjectUserModerator = isUserModerator(subjectUser.userId);
+  const isSubjectUserModerator = subjectUser.role === ROLE_MODERATOR;
 
   const hasAuthority = amIModerator || amISubjectUser;
   const allowedToChatPrivately = !amISubjectUser && !isDialInUser;
-  const voiceUser = curatedVoiceUser(subjectUser.userId);
   const allowedToMuteAudio = hasAuthority
-    && voiceUser.isVoiceUser
-    && !voiceUser.isMuted
-    && !voiceUser.isListenOnly;
+    && subjectVoiceUser.isVoiceUser
+    && !subjectVoiceUser.isMuted
+    && !subjectVoiceUser.isListenOnly;
 
   const allowedToUnmuteAudio = hasAuthority
-    && voiceUser.isVoiceUser
-    && !voiceUser.isListenOnly
-    && voiceUser.isMuted
+    && subjectVoiceUser.isVoiceUser
+    && !subjectVoiceUser.isListenOnly
+    && subjectVoiceUser.isMuted
     && (amISubjectUser || areUsersUnmutable());
 
   const allowedToResetStatus = hasAuthority

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -139,9 +139,9 @@ const sortChatsByName = (a, b) => {
     return -1;
   } if (a.name.toLowerCase() > b.name.toLowerCase()) {
     return 1;
-  } if (a.id.toLowerCase() > b.id.toLowerCase()) {
+  } if (a.userId.toLowerCase() > b.userId.toLowerCase()) {
     return -1;
-  } if (a.id.toLowerCase() < b.id.toLowerCase()) {
+  } if (a.userId.toLowerCase() < b.userId.toLowerCase()) {
     return 1;
   }
 
@@ -253,15 +253,15 @@ const getActiveChats = (chatID) => {
   activeChats.forEach((op) => {
     // When a new private chat message is received, ensure the conversation view is restored.
     if (op.unreadCounter > 0) {
-      if (_.indexOf(currentClosedChats, op.id) > -1) {
-        Storage.setItem(CLOSED_CHAT_LIST_KEY, _.without(currentClosedChats, op.id));
+      if (_.indexOf(currentClosedChats, op.userId) > -1) {
+        Storage.setItem(CLOSED_CHAT_LIST_KEY, _.without(currentClosedChats, op.userId));
       }
     }
 
     // Compare activeChats with session and push it into filteredChatList
     // if one of the activeChat is not in session.
     // It will pass to activeChats.
-    if (_.indexOf(currentClosedChats, op.id) < 0) {
+    if (_.indexOf(currentClosedChats, op.userId) < 0) {
       filteredChatList.push(op);
     }
   });

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
@@ -202,6 +202,7 @@ class UserDropdown extends PureComponent {
       intl,
       currentUser, // TODO remove
       user,
+      voiceUser,
       getAvailableActions,
       getGroupChatPrivate,
       handleEmojiChange,
@@ -222,7 +223,7 @@ class UserDropdown extends PureComponent {
     } = this.props;
     const { showNestedOptions } = this.state;
 
-    const actionPermissions = getAvailableActions(user);
+    const actionPermissions = getAvailableActions(user, voiceUser);
     const actions = [];
 
     const {


### PR DESCRIPTION
This is a followup to #8030.

When the client tries to determine what actions are available for each row in the user list it was doing duplicate requests for that row's User and VoiceUser objects even though the information was already present in the component. I've changed the getAvailableActions() function use the information we already have.

I also found some bugs with the chat list. If there were private chats active with two users with the same name the sort would throw an exception. There was also an issue where if you closed the private chat it wouldn't hide it like intended and it also wouldn't restore it if a new message came in.