### PR TITLE
Cleanup old bbb-webrtc-sfu logs

### DIFF
--- a/bigbluebutton-config/cron.daily/bigbluebutton
+++ b/bigbluebutton-config/cron.daily/bigbluebutton
@@ -70,6 +70,7 @@ find /opt/freeswitch/var/log/freeswitch -type f -mtime +$log_history -delete
 find /var/log/red5 -type f -mtime +$log_history -delete
 [[ -d /var/log/tomcat7 ]] && find /var/log/tomcat7 -type f -mtime +$log_history -delete
 find /var/log/bigbluebutton -type f -mtime +$log_history -delete
+find /var/log/bbb-webrtc-sfu -type f -mtime +$log_history -delete
 find /var/log/kurento-media-server -name "*.pid*.log" -type f -mtime +$log_history -delete
 
 #


### PR DESCRIPTION
The bbb-webrtc-sfu logs are getting rotated, but the old logs just accumulate. Add the directory to the bigbluebutton cron.daily so they get removed.