### PR TITLE
Reliably check mod status for clearing chat

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-dropdown/component.jsx
@@ -71,7 +71,7 @@ class ChatDropdown extends PureComponent {
   }
 
   getAvailableActions() {
-    const { intl, isMeteorConnected } = this.props;
+    const { intl, isMeteorConnected, amIModerator } = this.props;
 
     const clearIcon = 'delete';
     const saveIcon = 'download';
@@ -103,7 +103,7 @@ class ChatDropdown extends PureComponent {
         label={intl.formatMessage(intlMessages.copy)}
         key={this.actionsKey[1]}
       />,
-      ChatService.amIModerator && isMeteorConnected ? (
+      amIModerator && isMeteorConnected ? (
         <DropdownListItem
           data-test="chatClear"
           icon={clearIcon}

--- a/bigbluebutton-html5/imports/ui/components/chat/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/component.jsx
@@ -40,6 +40,7 @@ const Chat = (props) => {
     UnsentMessagesCollection,
     minMessageLength,
     maxMessageLength,
+    amIModerator,
   } = props;
 
   const HIDE_CHAT_AK = shortcuts.hidePrivateChat;
@@ -86,7 +87,7 @@ const Chat = (props) => {
                 accessKey={CLOSE_CHAT_AK}
               />
             )
-            : <ChatDropdown isMeteorConnected={isMeteorConnected} />
+            : <ChatDropdown isMeteorConnected={isMeteorConnected} amIModerator={amIModerator}/>
         }
       </header>
       <MessageList

--- a/bigbluebutton-html5/imports/ui/components/chat/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/container.jsx
@@ -5,6 +5,7 @@ import { Session } from 'meteor/session';
 import Auth from '/imports/ui/services/auth';
 import Chat from './component';
 import ChatService from './service';
+import UserService from '../user-list/service';
 
 const CHAT_CONFIG = Meteor.settings.public.chat;
 const PUBLIC_CHAT_KEY = CHAT_CONFIG.public_id;
@@ -154,6 +155,7 @@ export default injectIntl(withTracker(({ intl }) => {
     partnerIsLoggedOut,
     isChatLocked,
     isMeteorConnected,
+    amIModerator: UserService.isUserModerator(Auth.userID),
     actions: {
       handleClosePrivateChat: ChatService.closePrivateChat,
     },

--- a/bigbluebutton-html5/imports/ui/components/chat/service.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/service.js
@@ -323,7 +323,6 @@ export default {
   reduceAndMapGroupMessages,
   getPublicGroupMessages,
   getPrivateGroupMessages,
-  amIModerator: UserService.isUserModerator(Auth.userID),
   getUser,
   getWelcomeProp,
   getScrollPosition,


### PR DESCRIPTION
Fixes #8064 
The check for moderator was coming from the Service and was not going through a `withTracker` watcher, so the clearChat option would be hidden if the user role was changed or initially picked too early