### PR TITLE
Fix microphone failure detection

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -503,7 +503,7 @@ class VideoPreview extends Component {
                 ? (
                   <select
                     id="setCam"
-                    value={webcamDeviceId}
+                    value={webcamDeviceId || ''}
                     className={styles.select}
                     onChange={this.handleSelectWebcam.bind(this)}
                   >
@@ -528,7 +528,7 @@ class VideoPreview extends Component {
                 ? (
                   <select
                     id="setQuality"
-                    value={selectedProfile}
+                    value={selectedProfile || ''}
                     className={styles.select}
                     onChange={this.handleSelectProfile.bind(this)}
                   >

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -423,12 +423,19 @@ class AudioManager {
       return Promise.resolve(inputDevice);
     };
 
-    const handleChangeInputDeviceError = () => new Promise((reject) => {
-      reject({
+    const handleChangeInputDeviceError = (error) => {
+      logger.error({
+        logCode: 'audiomanager_error_getting_device',
+        extraInfo: {
+          errorName: error.name,
+          errorMessage: error.message,
+        },
+      }, `Error getting microphone - {${error.name}: ${error.message}}`);
+      return Promise.reject({
         type: 'MEDIA_ERROR',
         message: this.messages.error.MEDIA_ERROR,
       });
-    });
+    };
 
     if (!deviceId) {
       return this.bridge.setDefaultInputDevice()


### PR DESCRIPTION
The function that was handling errors thrown when retrieving a microphone wasn't working and the code would continue on an error. This lead to the issue being hidden farther into the code. It should be using a proper Promise rejection now.

I also added a log message with the cause so we can track how many times people have issues with their microphones and which specific cause they run into.

There's also a one line fix for a warning when the video preview modal was opened.