### PR TITLE
 Add more logging

### DIFF
--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/ConnectionManager.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/ConnectionManager.java
@@ -35,8 +35,11 @@ import org.freeswitch.esl.client.inbound.Client;
 import org.freeswitch.esl.client.inbound.InboundConnectionFailure;
 import org.freeswitch.esl.client.manager.ManagerConnection;
 import org.freeswitch.esl.client.transport.message.EslMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ConnectionManager {
+	private static Logger log = LoggerFactory.getLogger(ConnectionManager.class);
 
 	private static final String EVENT_NAME = "Event-Name";
 
@@ -62,12 +65,12 @@ public class ConnectionManager {
 		try {
 			Client c = manager.getESLClient();
 			if (!c.canSend()) {
-				System.out.println("Attempting to connect to FreeSWITCH ESL");
+				log.info("Attempting to connect to FreeSWITCH ESL");
 				subscribed = false;
 				manager.connect();
 			} else {
 				if (!subscribed) {
-					System.out.println("Subscribing for ESL events.");
+					log.info("Subscribing for ESL events.");
 					c.cancelEventSubscriptions();
 					c.addEventListener(eslEventListener);
 					c.setEventSubscriptions("plain", "all");
@@ -78,19 +81,21 @@ public class ConnectionManager {
 				}
 			}
 		} catch (InboundConnectionFailure e) {
-			System.out.println("Failed to connect to ESL");
+			log.error("Failed to connect to ESL");
 		}
 	}
 
 	public void start() {
-		System.out.println("Starting FreeSWITCH ESL connection manager.");
+		log.info("Starting FreeSWITCH ESL connection manager.");
 		ConnectThread connector = new ConnectThread();
 		connectTask = (ScheduledFuture<ConnectThread>) connExec
 				.scheduleAtFixedRate(connector, 5, 5, TimeUnit.SECONDS);
 	}
 
 	public void stop() {
+		log.info("Stopping FreeSWITCH ESL connection manager.");
 		if (connectTask != null) {
+			log.info("Cancelling connect task.");
 			connectTask.cancel(true);
 		}
 	}

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/DelayedCommandSenderService.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/DelayedCommandSenderService.java
@@ -26,10 +26,12 @@ public class DelayedCommandSenderService {
   }
 
   public void stop() {
+    log.info("Stopping DelayedCommandSenderService.");
     processMessage = false;
   }
 
   public void start() {
+    log.info("Starting DelayedCommandSenderService.");
     try {
       processMessage = true;
 
@@ -38,6 +40,7 @@ public class DelayedCommandSenderService {
           while (processMessage) {
             try {
               DelayedCommand msg = receivedMessages.take();
+              log.info("Scheduling DelayedCommand.");
               if (listener != null) {
                 listener.runDelayedCommand(msg.conferenceCommand);
               }
@@ -54,6 +57,7 @@ public class DelayedCommandSenderService {
   }
 
   public void handleMessage(FreeswitchCommand command, long delayInMillis) {
+    log.info("Queueing DelayedCommand.");
     DelayedCommand dc = new DelayedCommand(command, delayInMillis);
     receivedMessages.add(dc);
   }

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/ESLEventListener.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/ESLEventListener.java
@@ -167,7 +167,7 @@ public class ESLEventListener implements IEslEventListener {
             VoiceConfRunningEvent pt = new VoiceConfRunningEvent(confName, false);
             conferenceEventListener.handleConferenceEvent(pt);
         } else {
-            System.out.println("Unknown conference Action [" + action + "]");
+            log.warn("Unknown conference Action [" + action + "]");
         }
     }
 
@@ -227,7 +227,7 @@ public class ESLEventListener implements IEslEventListener {
         } 
 
         else {
-            System.out.println("Processing UNKNOWN conference Action " + action + "]");
+            log.warn("Processing UNKNOWN conference Action " + action + "]");
         }
     }
 

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/FreeswitchApplication.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/FreeswitchApplication.java
@@ -60,6 +60,7 @@ public class FreeswitchApplication implements  IDelayedCommandListener{
   }
 
   public void runDelayedCommand(FreeswitchCommand command) {
+    log.info("Run DelayedCommand.");
     queueMessage(command);
   }
 


### PR DESCRIPTION
 - FreeSWITCH core dumped and akka-fsesl managed to reconnect. However, commands (mute, unmute, record, etc.) to FS are not reaching FS.
   But events (user joined, left, talking) from FS are received by akka-fsesl. Can't determine where the commands are falling off. These
   extra logging hopefully helps us narrow down if this happens again.

   I wasn't able to reproduce the issue when stopping and restarting FS. Akka-fsesl reconnects and command/events are flowing in both
   directions.