### PR TITLE
Add monitor for memory usage in nodejs html5

### DIFF
--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -24,13 +24,13 @@ Meteor.startup(() => {
   const memoryMonitoringSettings = Meteor.settings.private.memoryMonitoring;
   if (memoryMonitoringSettings.stat.enabled) {
     memwatch.on('stats', (stats) => {
-      Logger.debug('memwatch stats', stats);
+      Logger.info('memwatch stats', stats);
     });
   }
 
   if (memoryMonitoringSettings.leak.enabled) {
     memwatch.on('leak', (info) => {
-      Logger.debug('memwatch leak', info);
+      Logger.info('memwatch leak', info);
     });
   }
 

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -656,6 +656,14 @@
       "integrity": "sha1-g4qZLan51zfg9LLbC+YrsJ3Qxeg=",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -2215,6 +2223,11 @@
       "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
       "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
       "dev": true
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "fill-range": {
       "version": "4.0.0",
@@ -3937,6 +3950,15 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
+    },
+    "memwatch-next": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/memwatch-next/-/memwatch-next-0.3.0.tgz",
+      "integrity": "sha1-IREFD5qQbgqi1ypOwPAInHhyb48=",
+      "requires": {
+        "bindings": "^1.2.1",
+        "nan": "^2.3.2"
+      }
     },
     "meow": {
       "version": "3.7.0",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -47,6 +47,7 @@
     "langmap": "0.0.16",
     "lodash": "^4.17.15",
     "makeup-screenreader-trap": "0.0.5",
+    "memwatch-next": "^0.3.0",
     "meteor-node-stubs": "^0.4.1",
     "node-sass": "^4.12.0",
     "postcss-nested": "4.1.0",

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -355,9 +355,9 @@ private:
     level: info
   memoryMonitoring:
     stat:
-      enabled: true
+      enabled: false
     leak:
-      enabled: true
+      enabled: false
   minBrowserVersions:
     - browser: chrome
       version: 59

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -353,6 +353,11 @@ private:
     - DoLatencyTracerMsg
   serverLog:
     level: info
+  memoryMonitoring:
+    stat:
+      enabled: true
+    leak:
+      enabled: true
   minBrowserVersions:
     - browser: chrome
       version: 59


### PR DESCRIPTION

From https://github.com/marcominetti/node-memwatch
![Screenshot from 2019-09-09 14-47-23](https://user-images.githubusercontent.com/6312397/64557963-c59f4e00-d310-11e9-8b6a-f6f5b358dcaa.png)


The `info object` will look something like:


```
{ 
  start: Fri, 29 Jun 2012 14:12:13 GMT,
  end: Fri, 29 Jun 2012 14:12:33 GMT,
  growth: 67984,
  reason: 'heap growth over 5 consecutive GCs (20s) - 11.67 mb/hr' 
}
```



The `stats` data will look something like this:

```
{
  "num_full_gc": 17,
  "num_inc_gc": 8,
  "heap_compactions": 8,
  "estimated_base": 2592568,
  "current_base": 2592568,
  "min": 2499912,
  "max": 2592568,
  "usage_trend": 0
}
```

