### PR TITLE
Update arrow character used in join audio modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -317,7 +317,7 @@ class AudioModal extends Component {
 
     const showMicrophone = forceListenOnlyAttendee || audioLocked;
 
-    const arrow = isRTL ? '🡸' : '🡺';
+    const arrow = isRTL ? '←' : '→';
     const dialAudioLabel = `${intl.formatMessage(intlMessages.audioDialTitle)} ${arrow}`;
 
     return (


### PR DESCRIPTION
This updates the character used for the arrow icon in the join audio modal. It should now be visible on iOS devices.
