### PR TITLE
Restore breakout name in invitation modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/service.js
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/service.js
@@ -67,7 +67,7 @@ const getNumUsersByBreakoutId = breakoutId => Users.find({
 
 const getBreakoutByUserId = userId => Breakouts.find({ 'users.userId': userId }).fetch();
 
-const getBreakoutByUser = user => Breakouts.findOne({ users: user }, { fields: { breakoutId: 1 } });
+const getBreakoutByUser = user => Breakouts.findOne({ users: user });
 
 const getUsersFromBreakouts = breakoutsArray => breakoutsArray
   .map(breakout => breakout.users)


### PR DESCRIPTION
We were too aggressive in our field pruning and remove information that was still needed.

Fixes #8094