### PR TITLE
Fix auto swap race condition

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -10,32 +10,6 @@ import CaptionsButtonContainer from '/imports/ui/components/actions-bar/captions
 import PresentationOptionsContainer from './presentation-options/component';
 
 class ActionsBar extends PureComponent {
-  componentDidUpdate(prevProps) {
-    const { isThereCurrentPresentation: prevIsThereCurrPresentation } = prevProps;
-    const {
-      isThereCurrentPresentation,
-      getSwapLayout,
-      toggleSwapLayout,
-      isSharingVideo,
-      isVideoBroadcasting,
-    } = this.props;
-
-    //  TODO: THIS BREAKS AUTO SWAP BIGLY AND SHOULD BE FIXED IN MEDIA CONTAINER
-    //    if (!isThereCurrentPresentation && !isSharingVideo && !isVideoBroadcasting) {
-    //      if (!getSwapLayout()) {
-    //        toggleSwapLayout();
-    //      }
-    //    }
-
-    //    if (!prevIsThereCurrPresentation
-    //      && isThereCurrentPresentation
-    //      && !isSharingVideo
-    //      && !isVideoBroadcasting) {
-    //      if (getSwapLayout()) {
-    //        toggleSwapLayout();
-    //      }
-    //    }
-  }
 
   render() {
     const {
@@ -62,10 +36,10 @@ class ActionsBar extends PureComponent {
       isMeteorConnected,
       isPollingEnabled,
       isThereCurrentPresentation,
+      allowExternalVideo,
     } = this.props;
 
     const actionBarClasses = {};
-    const { enabled: enableExternalVideo } = Meteor.settings.public.externalVideoPlayer;
 
     actionBarClasses[styles.centerWithActions] = amIPresenter;
     actionBarClasses[styles.center] = true;
@@ -77,7 +51,7 @@ class ActionsBar extends PureComponent {
             amIPresenter,
             amIModerator,
             isPollingEnabled,
-            allowExternalVideo: enableExternalVideo,
+            allowExternalVideo,
             handleTakePresenter,
             intl,
             isSharingVideo,

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -20,20 +20,21 @@ class ActionsBar extends PureComponent {
       isVideoBroadcasting,
     } = this.props;
 
-    if (!isThereCurrentPresentation && !isSharingVideo && !isVideoBroadcasting) {
-      if (!getSwapLayout()) {
-        toggleSwapLayout();
-      }
-    }
+    //  TODO: THIS BREAKS AUTO SWAP BIGLY AND SHOULD BE FIXED IN MEDIA CONTAINER
+    //    if (!isThereCurrentPresentation && !isSharingVideo && !isVideoBroadcasting) {
+    //      if (!getSwapLayout()) {
+    //        toggleSwapLayout();
+    //      }
+    //    }
 
-    if (!prevIsThereCurrPresentation
-      && isThereCurrentPresentation
-      && !isSharingVideo
-      && !isVideoBroadcasting) {
-      if (getSwapLayout()) {
-        toggleSwapLayout();
-      }
-    }
+    //    if (!prevIsThereCurrPresentation
+    //      && isThereCurrentPresentation
+    //      && !isSharingVideo
+    //      && !isVideoBroadcasting) {
+    //      if (getSwapLayout()) {
+    //        toggleSwapLayout();
+    //      }
+    //    }
   }
 
   render() {

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
@@ -51,5 +51,5 @@ export default withTracker(() => ({
   isPollingEnabled: POLLING_ENABLED,
   isThereCurrentPresentation: Presentations.findOne({ meetingId: Auth.meetingID, current: true },
     { fields: {} }),
-  getSwapLayout,
+  allowExternalVideo: Meteor.settings.public.externalVideoPlayer.enabled,
 }))(injectIntl(ActionsBarContainer));

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/modal/component.jsx
@@ -60,14 +60,12 @@ class ExternalVideoModal extends Component {
     const {
       startWatching,
       closeModal,
-      toggleLayout,
       isSwapped,
     } = this.props;
 
     const { url } = this.state;
 
     startWatching(url.trim());
-    if (isSwapped) toggleLayout();
     closeModal();
   }
 

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/modal/component.jsx
@@ -60,7 +60,6 @@ class ExternalVideoModal extends Component {
     const {
       startWatching,
       closeModal,
-      isSwapped,
     } = this.props;
 
     const { url } = this.state;

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/modal/container.jsx
@@ -3,7 +3,6 @@ import { withTracker } from 'meteor/react-meteor-data';
 import { withModalMounter } from '/imports/ui/components/modal/service';
 import ExternalVideoModal from './component';
 import { startWatching, getVideoUrl } from '../service';
-import mediaService from '/imports/ui/components/media/service';
 
 const ExternalVideoModalContainer = props => <ExternalVideoModal {...props} />;
 
@@ -13,6 +12,4 @@ export default withModalMounter(withTracker(({ mountModal }) => ({
   },
   startWatching,
   videoUrl: getVideoUrl(),
-  toggleLayout: mediaService.toggleSwapLayout,
-  isSwapped: mediaService.getSwapLayout(),
 }))(ExternalVideoModalContainer));

--- a/bigbluebutton-html5/imports/ui/components/media/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/container.jsx
@@ -105,6 +105,7 @@ export default withModalMounter(withTracker(() => {
   const { dataSaving } = Settings;
   const { viewParticipantsWebcams, viewScreenshare } = dataSaving;
   const hidePresentation = getFromUserSettings('hidePresentation', LAYOUT_CONFIG.hidePresentation);
+  const { current_presentation: hasPresentation } = MediaService.getPresentationInfo();
   const data = {
     children: <DefaultContent />,
     audioModalIsOpen: Session.get('audioModalIsOpen'),
@@ -130,7 +131,7 @@ export default withModalMounter(withTracker(() => {
   }
 
   data.isScreensharing = MediaService.isVideoBroadcasting();
-  data.swapLayout = getSwapLayout() && shouldEnableSwapLayout();
+  data.swapLayout = (getSwapLayout() || !hasPresentation) && shouldEnableSwapLayout();
   data.disableVideo = !viewParticipantsWebcams;
 
   if (data.swapLayout) {

--- a/bigbluebutton-html5/imports/ui/components/media/service.js
+++ b/bigbluebutton-html5/imports/ui/components/media/service.js
@@ -62,10 +62,13 @@ export const shouldEnableSwapLayout = () => {
   const { viewParticipantsWebcams } = Settings.dataSaving;
   const usersVideo = VideoService.getAllWebcamUsers();
   const poll = PollingService.mapPolls();
+  const { current_presentation: hasPresentation } = getPresentationInfo();
 
   return usersVideo.length > 0 // prevent swap without any webcams
   && viewParticipantsWebcams // prevent swap when dataSaving for webcams is enabled
-  && !poll.pollExists; // prevent swap when there is a poll running
+  && !poll.pollExists // prevent swap when there is a poll running
+  && !shouldShowScreenshare() // and when there's screenshare
+  && !shouldShowExternalVideo() // or there's an external video
 };
 
 export const getSwapLayout = () => {


### PR DESCRIPTION
There was some code in actions-bar/component that toggled the presentation/video swap when there was no presentation and an external video or screenshare. This was there to ensure that having a video and no presentation would show a big webcam area (the 'swapped' version), but with external video or screenshare you would correctly see the media and the cameras. Unfortunately this caused race conditions with the autoSwap custom data parameters and 50% of the times the auto swap would not work.

So this attempts to fix the problems with swap and empty presentations while still keeping the autoSwap flag functional. I also think that it keeps the code more contained to the media component without the need of including implementaiton details in unrelated components.