### PR TITLE
Don't recommend Firefox or Chrome for WebRTC when Puffin is being used

### DIFF
--- a/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/WebRTCCallManager.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/modules/phone/managers/WebRTCCallManager.as
@@ -26,6 +26,7 @@ package org.bigbluebutton.modules.phone.managers
   import org.bigbluebutton.modules.phone.models.WebRTCAudioStatus;
   import org.bigbluebutton.modules.phone.models.WebRTCModel;
   import org.bigbluebutton.util.i18n.ResourceUtil;
+  import org.bigbluebutton.util.browser.BrowserCheck;
 
   public class WebRTCCallManager
   {
@@ -47,7 +48,9 @@ package org.bigbluebutton.modules.phone.managers
       options = Options.getOptions(PhoneOptions) as PhoneOptions;
       
       // only show the warning if the admin has enabled WebRTC
-      if (options.useWebRTCIfAvailable && !isWebRTCSupported()) {
+      // and don't show it in Puffin Browser, because it is used
+      // when no other browsers are available
+      if (options.useWebRTCIfAvailable && !isWebRTCSupported() && !BrowserCheck.isPuffin()) {
         dispatcher.dispatchEvent(new ClientStatusEvent(ClientStatusEvent.WARNING_MESSAGE_EVENT, 
           ResourceUtil.getInstance().getString("bbb.clientstatus.webrtc.title"), 
           ResourceUtil.getInstance().getString("bbb.clientstatus.webrtc.message"),

--- a/bigbluebutton-client/src/org/bigbluebutton/util/browser/BrowserCheck.as
+++ b/bigbluebutton-client/src/org/bigbluebutton/util/browser/BrowserCheck.as
@@ -76,6 +76,10 @@ package org.bigbluebutton.util.browser {
 			return _browserName.toLowerCase() == "edge";
 		}
 
+		public static function isPuffin():Boolean {
+			return _browserName.toLowerCase() == "puffin";
+		}
+
 		public static function isPuffinBelow46():Boolean {
 			return _browserName.toLowerCase() == "puffin" && String(_fullVersion).substr(0, 3) < "4.6";
 		}


### PR DESCRIPTION
People use Puffin Browser only when they are on a mobile device and have to use
BBB flash client. They cannot use a browser with WebRTC support,
in our case, we in Dumalogiya temporarily disabled HTML5 version
due to problems with sharing webcams across HTML5 and Flash clients and we are
not ready to fully migrate to HTML5 client because it e.g. lacks support
of changing window layouts. So, we want to avoid showing this warning in Puffin Browser.

P.S. I did not try to build Flash client after this change. Hope it builds. It's difficult to do because building and deploying of BBB is not automated and debian specs are not published.