### PR TITLE
Fix autoplay of deskshare video in presentation playback format

### DIFF
--- a/record-and-playback/presentation/playback/presentation/2.0/acornmediaplayer/jquery.acornmediaplayer.js
+++ b/record-and-playback/presentation/playback/presentation/2.0/acornmediaplayer/jquery.acornmediaplayer.js
@@ -223,8 +223,7 @@
 				if(!acorn.$self.prop('paused')) {
 					acorn.$self.trigger('pause');
 				} else {
-					//acorn.$self.trigger('play');
-					acorn.$self[0].play();
+					acorn.$self.trigger('play');
 				}
 				
 				// We return false to stop the followup click event on tablets


### PR DESCRIPTION
This reverts a bbb-specific customization made in the jquery.acornmediaplayer.js
file: it's restored to what the upstream player did. I can't find any explanation
for why this change was made in the first place? Reverting it doesn't seem to
cause any playback issues (Popcorn still works, in particular).