### PR TITLE
Stop voice conf recording when meeting ends

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -4,6 +4,7 @@ import org.bigbluebutton.SystemConfiguration
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.api.{ BreakoutRoomEndedInternalMsg, DestroyMeetingInternalMsg, EndBreakoutRoomInternalMsg }
 import org.bigbluebutton.core.apps.users.UsersApp
+import org.bigbluebutton.core.apps.voice.VoiceApp
 import org.bigbluebutton.core.bus.{ BigBlueButtonEvent, InternalEventBus }
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models._
@@ -197,6 +198,9 @@ trait HandlerHelpers extends SystemConfiguration {
   }
 
   def ejectAllUsersFromVoiceConf(outGW: OutMsgRouter, liveMeeting: LiveMeeting): Unit = {
+    // Force stopping of voice recording if voice conf is being recorded.
+    VoiceApp.stopRecordingVoiceConference(liveMeeting, outGW)
+
     val event = MsgBuilder.buildEjectAllFromVoiceConfMsg(liveMeeting.props.meetingProp.intId, liveMeeting.props.voiceProp.voiceConf)
     outGW.send(event)
   }
@@ -235,6 +239,9 @@ trait HandlerHelpers extends SystemConfiguration {
         new BreakoutRoomEndedInternalMsg(meetingId)
       ))
     }
+
+    // Force stopping of voice recording if voice conf is being recorded.
+    VoiceApp.stopRecordingVoiceConference(liveMeeting, outGW)
 
     val event = MsgBuilder.buildEjectAllFromVoiceConfMsg(meetingId, liveMeeting.props.voiceProp.voiceConf)
     outGW.send(event)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/meeting/DestroyMeetingSysCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/meeting/DestroyMeetingSysCmdMsgHdlr.scala
@@ -1,6 +1,7 @@
 package org.bigbluebutton.core2.message.handlers.meeting
 
 import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.apps.voice.VoiceApp
 import org.bigbluebutton.core.running.{ BaseMeetingActor, LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
@@ -26,6 +27,9 @@ trait DestroyMeetingSysCmdMsgHdlr {
 
     // Eject all users using the client.
     outGW.send(MsgBuilder.buildEndAndKickAllSysMsg(liveMeeting.props.meetingProp.intId, "not-used"))
+
+    // Force stopping of voice recording if voice conf is being recorded.
+    VoiceApp.stopRecordingVoiceConference(liveMeeting, outGW)
 
     // Eject all users from the voice conference
     outGW.send(MsgBuilder.buildEjectAllFromVoiceConfMsg(

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/FreeswitchApplication.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/FreeswitchApplication.java
@@ -168,7 +168,9 @@ public class FreeswitchApplication implements  IDelayedCommandListener{
           EjectAllUsersCommand cmd = (EjectAllUsersCommand) command;
           manager.ejectAll(cmd);
 
-          CheckIfConfIsRunningCommand command = new CheckIfConfIsRunningCommand(cmd.getRoom(), cmd.getRequesterId());
+          CheckIfConfIsRunningCommand command = new CheckIfConfIsRunningCommand(cmd.getRoom(),
+                  cmd.getRequesterId(),
+                  delayedCommandSenderService);
           delayedCommandSenderService.handleMessage(command, 5000);
         } else if (command instanceof TransferUserToMeetingCommand) {
           TransferUserToMeetingCommand cmd = (TransferUserToMeetingCommand) command;

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/FreeswitchApplication.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/FreeswitchApplication.java
@@ -170,7 +170,7 @@ public class FreeswitchApplication implements  IDelayedCommandListener{
 
           CheckIfConfIsRunningCommand command = new CheckIfConfIsRunningCommand(cmd.getRoom(),
                   cmd.getRequesterId(),
-                  delayedCommandSenderService);
+                  delayedCommandSenderService, 0);
           delayedCommandSenderService.handleMessage(command, 5000);
         } else if (command instanceof TransferUserToMeetingCommand) {
           TransferUserToMeetingCommand cmd = (TransferUserToMeetingCommand) command;

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/actions/CheckIfConfIsRunningCommand.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/actions/CheckIfConfIsRunningCommand.java
@@ -38,10 +38,14 @@ import java.util.regex.Matcher;
 public class CheckIfConfIsRunningCommand extends FreeswitchCommand {
     private static Logger log = LoggerFactory.getLogger(CheckIfConfIsRunningCommand.class);
     private DelayedCommandSenderService delayedCommandSenderService;
+    private Integer forceEjectCount = 0;
 
-    public CheckIfConfIsRunningCommand(String room, String requesterId, DelayedCommandSenderService delayedCommandSenderService) {
+    public CheckIfConfIsRunningCommand(String room, String requesterId,
+                                       DelayedCommandSenderService delayedCommandSenderService,
+                                       Integer forceEjectCount) {
             super(room, requesterId);
             this.delayedCommandSenderService = delayedCommandSenderService;
+            this.forceEjectCount = forceEjectCount;
     }
     
     @Override
@@ -85,36 +89,40 @@ public class CheckIfConfIsRunningCommand extends FreeswitchCommand {
 
             Integer numUsers =  confXML.getConferenceList().size();
             if (numUsers > 0) {
-
                 log.info("Check conference response: " + responseBody);
                 log.warn("WARNING! Failed to eject all users from conf={},numUsers={}.", room, numUsers);
-                for(ConferenceMember member : confXML.getConferenceList()) {
-                    if ("caller".equals(member.getMemberType())) {
-                        //Foreach found member in conference create a JoinedEvent
-                        String callerId = member.getCallerId();
-                        String callerIdName = member.getCallerIdName();
-                        String voiceUserId = callerIdName;
-                        String uuid = member.getUUID();
-                        log.info("WARNING! User possibly stuck in conference. uuid=" + uuid
-                                + ",caller=" + callerIdName + ",callerId=" + callerId + ",conf=" + room);
+                if (forceEjectCount <= 5) {
+                    for (ConferenceMember member : confXML.getConferenceList()) {
+                        if ("caller".equals(member.getMemberType())) {
+                            //Foreach found member in conference create a JoinedEvent
+                            String callerId = member.getCallerId();
+                            String callerIdName = member.getCallerIdName();
+                            String voiceUserId = callerIdName;
+                            String uuid = member.getUUID();
+                            log.info("WARNING! User possibly stuck in conference. uuid=" + uuid
+                                    + ",caller=" + callerIdName + ",callerId=" + callerId + ",conf=" + room);
 
-                        // We have stubborn users that cannot be ejected from the voice conference.
-                        // This results in the voice conference hanging around for potentially a long time.
-                        // Force ejection by killing their uuid. (ralam Oct 1, 2019)
-                        ForceEjectUserCommand forceEjectUserCommand = new ForceEjectUserCommand(getRoom(),
-                                member.getId().toString(),
-                                member.getUUID());
-                        delayedCommandSenderService.handleMessage(forceEjectUserCommand, 5000L);
+                            // We have stubborn users that cannot be ejected from the voice conference.
+                            // This results in the voice conference hanging around for potentially a long time.
+                            // Force ejection by killing their uuid. (ralam Oct 1, 2019)
+                            ForceEjectUserCommand forceEjectUserCommand = new ForceEjectUserCommand(getRoom(),
+                                    member.getId().toString(),
+                                    member.getUUID());
+                            delayedCommandSenderService.handleMessage(forceEjectUserCommand, 5000L);
 
-                    } else if ("recording_node".equals(member.getMemberType())) {
+                        } else if ("recording_node".equals(member.getMemberType())) {
 
+                        }
                     }
+                    // Check again if the conference is still running after ejecting the users. (ralam Oct. 1, 2019)
+                    CheckIfConfIsRunningCommand command = new CheckIfConfIsRunningCommand(getRoom(),
+                            getRequesterId(),
+                            delayedCommandSenderService,
+                            forceEjectCount + 1);
+                    delayedCommandSenderService.handleMessage(command, 10000);
+                } else {
+                    log.warn("Failed to eject users for voice conf " + getRoom() + " after " + forceEjectCount + " tries.");
                 }
-                // Check again if the conference is still running after ejecting the users. (ralam Oct. 1, 2019)
-                CheckIfConfIsRunningCommand command = new CheckIfConfIsRunningCommand(getRoom(),
-                        getRequesterId(),
-                        delayedCommandSenderService);
-                delayedCommandSenderService.handleMessage(command, 10000);
             } else {
                 log.info("INFO! Successfully ejected all users from conference {}.", room);
             }

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/actions/ForceEjectUserCommand.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/actions/ForceEjectUserCommand.java
@@ -1,0 +1,38 @@
+package org.bigbluebutton.freeswitch.voice.freeswitch.actions;
+
+import com.google.gson.Gson;
+import org.bigbluebutton.freeswitch.voice.events.ConferenceEventListener;
+import org.freeswitch.esl.client.transport.message.EslMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ForceEjectUserCommand extends FreeswitchCommand {
+    private static Logger log = LoggerFactory.getLogger(ForceEjectUserCommand.class);
+
+    private final String voiceConf;
+    private final String userId;
+    private final String uuid;
+
+    public ForceEjectUserCommand(String voiceConf, String userId, String uuid) {
+        super(voiceConf, userId);
+        this.voiceConf = voiceConf;
+        this.userId = userId;
+        this.uuid = uuid;
+    }
+    @Override
+    public String getCommand() {
+        return "uuid_kill " + uuid;
+    }
+
+    @Override
+    public String getCommandArgs() {
+        log.debug("Force eject user " + userId + " from conf " + voiceConf + " by uuid_kill " + uuid);
+        return "";
+    }
+
+    public void handleResponse(EslMessage response, ConferenceEventListener eventListener) {
+        Gson gson = new Gson();
+        log.info(gson.toJson(response.getBodyLines()));
+
+    }
+}


### PR DESCRIPTION
We are seeing issue where voice recording continues after the meeting ends resulting in very large wav files.

The reason is that when we eject the users from the voice conference when the meeting ends, some users are not ejected. Somehow, freeswitch cannot find the userid even if listing the conference users shows the user.

To fix:

We try to stop the recording then the meeting ends by sending a stop recording command to freeswitch.

If the users cannot be ejected using the "kick all" command, we kill the channel instead by using "uuid_kill" command.

