### PR TITLE
Remove screensharing option from Safari by UA checks (#8142)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/desktop-share/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/desktop-share/component.jsx
@@ -104,6 +104,7 @@ const isMobileBrowser = (BROWSER_RESULTS ? BROWSER_RESULTS.mobile : false)
   || (BROWSER_RESULTS && BROWSER_RESULTS.os
     ? BROWSER_RESULTS.os.includes('Android') // mobile flag doesn't always work
     : false);
+const isSafari = BROWSER_RESULTS.name === 'safari';
 
 const DesktopShare = ({
   intl,
@@ -152,7 +153,12 @@ const DesktopShare = ({
   const vDescr = isVideoBroadcasting
     ? intlMessages.stopDesktopShareDesc : intlMessages.desktopShareDesc;
 
-  return (screenSharingCheck && !isMobileBrowser && amIPresenter
+  const shouldAllowScreensharing = screenSharingCheck
+    && !isMobileBrowser
+    && amIPresenter
+    && !isSafari;
+
+  return (shouldAllowScreensharing
     ? (
       <Button
         className={cx(styles.button, isVideoBroadcasting || styles.btn)}


### PR DESCRIPTION
Making screensharing work on Safari 13 needs more time and testing since it involves moving some sensitive code around, so we're just disabling it for the next beta release.
Temporarily addresses #8142.