### PR TITLE
Invert toggle colours in the lock settings

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
@@ -151,6 +151,8 @@ class LockViewersComponent extends Component {
 
     const { lockSettingsProps, usersProp } = this.state;
 
+    const invertColors = true;
+
     return (
       <Modal
         overlayClassName={styles.overlay}
@@ -193,6 +195,7 @@ class LockViewersComponent extends Component {
                     }}
                     ariaLabel={intl.formatMessage(intlMessages.webcamLabel)}
                     showToggleLabel={showToggleLabel}
+                    invertColors={invertColors}
                   />
                 </div>
               </div>
@@ -216,6 +219,7 @@ class LockViewersComponent extends Component {
                     }}
                     ariaLabel={intl.formatMessage(intlMessages.otherViewersWebcamLabel)}
                     showToggleLabel={showToggleLabel}
+                    invertColors={invertColors}
                   />
                 </div>
               </div>
@@ -239,6 +243,7 @@ class LockViewersComponent extends Component {
                     }}
                     ariaLabel={intl.formatMessage(intlMessages.microphoneLable)}
                     showToggleLabel={showToggleLabel}
+                    invertColors={invertColors}
                   />
                 </div>
               </div>
@@ -265,6 +270,7 @@ class LockViewersComponent extends Component {
                         }}
                         ariaLabel={intl.formatMessage(intlMessages.publicChatLabel)}
                         showToggleLabel={showToggleLabel}
+                        invertColors={invertColors}
                       />
                     </div>
                   </div>
@@ -288,6 +294,7 @@ class LockViewersComponent extends Component {
                         }}
                         ariaLabel={intl.formatMessage(intlMessages.privateChatLable)}
                         showToggleLabel={showToggleLabel}
+                        invertColors={invertColors}
                       />
                     </div>
                   </div>
@@ -316,6 +323,7 @@ class LockViewersComponent extends Component {
                         }}
                         ariaLabel={intl.formatMessage(intlMessages.notesLabel)}
                         showToggleLabel={showToggleLabel}
+                        invertColors={invertColors}
                       />
                     </div>
                   </div>
@@ -342,6 +350,7 @@ class LockViewersComponent extends Component {
                     }}
                     ariaLabel={intl.formatMessage(intlMessages.userListLabel)}
                     showToggleLabel={showToggleLabel}
+                    invertColors={invertColors}
                   />
                 </div>
               </div>

--- a/bigbluebutton-html5/imports/ui/components/switch/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/switch/component.jsx
@@ -17,6 +17,7 @@ const intlMessages = defineMessages({
 
 const defaultProps = {
   showToggleLabel: true,
+  invertColors: false,
 };
 
 class Switch extends Toggle {
@@ -30,13 +31,20 @@ class Switch extends Toggle {
       ariaLabel,
       ariaDesc,
       showToggleLabel,
+      invertColors,
+      disabled,
       ...inputProps
     } = this.props;
 
+    const {
+      checked,
+      hasFocus,
+    } = this.state;
+
     const classes = cx('react-toggle', {
-      'react-toggle--checked': this.state.checked,
-      'react-toggle--focus': this.state.hasFocus,
-      'react-toggle--disabled': this.props.disabled,
+      'react-toggle--checked': checked,
+      'react-toggle--focus': hasFocus,
+      'react-toggle--disabled': disabled,
     }, className);
 
     return (
@@ -47,7 +55,12 @@ class Switch extends Toggle {
         onTouchMove={this.handleTouchMove}
         onTouchEnd={this.handleTouchEnd}
       >
-        <div className="react-toggle-track" aria-hidden="true">
+        <div
+          className={cx('react-toggle-track',
+            invertColors && styles.invertBackground,
+            checked && styles.checked)}
+          aria-hidden="true"
+        >
           <div className="react-toggle-track-check">
             {showToggleLabel ? intl.formatMessage(intlMessages.on) : null}
           </div>
@@ -65,6 +78,7 @@ class Switch extends Toggle {
           className="react-toggle-screenreader-only"
           type="checkbox"
           tabIndex="0"
+          disabled={disabled}
           aria-label={ariaLabel}
           aria-describedby={ariaDescribedBy}
         />

--- a/bigbluebutton-html5/imports/ui/components/switch/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/switch/styles.scss
@@ -11,3 +11,10 @@
         outline-style: solid;
     }
 }
+
+.invertBackground {
+    background-color: #008081 !important;
+    &.checked {
+        background-color: #DF2721 !important;
+    }
+}


### PR DESCRIPTION
This PR inverts the colours of the lock settings toggles so that unchecked is green and checked is red.