### PR TITLE
Fix deskshare media sync when deskshare loads before webcam/audio

### DIFF
--- a/record-and-playback/presentation/playback/presentation/2.0/lib/writing.js
+++ b/record-and-playback/presentation/playback/presentation/2.0/lib/writing.js
@@ -1017,6 +1017,7 @@ document.addEventListener('media-ready', function(event) {
   }
   if ((audioReady || (videoReady && captionsReady)) && deskshareReady) {
     logger.info("==All medias can be played");
+    setMediaSync();
     linkChatToMedia();
     document.dispatchEvent(new CustomEvent('playback-ready', {'detail': 'media'}));
   }

--- a/record-and-playback/presentation/playback/presentation/2.0/playback.js
+++ b/record-and-playback/presentation/playback/presentation/2.0/playback.js
@@ -574,7 +574,6 @@ function checkLoadedMedia() {
 function checkLoadedDeskshare() {
   let deskshare = $('#deskshare-video')[0];
   if (isMediaReady(deskshare)) {
-    setMediaSync();
     document.dispatchEvent(new CustomEvent('media-ready', {'detail': 'deskshare'}));
   } else {
     setTimeout(checkLoadedDeskshare, 250);


### PR DESCRIPTION
If the secondary media loaded before the main media, it would run the
"setMediaSync" function before the main media player was setup. As a
side-effect of setting up the main media player, all of the event handlers
added by the setMediaSync function are detached, and so the secondary
media never starts playing.

Move the call to setMediaSync to after the media-ready events for all
media have fired, so that it can reliably attach the event handlers.