### PR TITLE
Fix check for heapdump enabled

### DIFF
--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -28,7 +28,7 @@ Meteor.startup(() => {
     memwatch.on('stats', (stats) => {
       let heapDumpTriggered = false;
 
-      if (memoryMonitoringSettings.heapdump) {
+      if (memoryMonitoringSettings.heapdump.enabled) {
         heapDumpTriggered = (stats.current_base / 1048576) > heapDumpMbThreshold;
       }
       Logger.info('memwatch stats', { ...stats, heapDumpEnabled: memoryMonitoringSettings.heapdump.enabled, heapDumpTriggered });


### PR DESCRIPTION
The value in settings is `heapdump.enabled: true`, but the code was doing a truthy check on just `heapdump` so it was always enabled if memwatch.stats was enabled.