### PR TITLE
presentation playback: Make setMediaSync a no-op if there's no deskshare

### DIFF
--- a/record-and-playback/presentation/playback/presentation/2.0/playback.js
+++ b/record-and-playback/presentation/playback/presentation/2.0/playback.js
@@ -383,6 +383,10 @@ function loadDeskshare() {
 };
 
 function setMediaSync() {
+  if (!hasDeskshare) {
+    return;
+  }
+
   // Master video
   primaryMedia = Popcorn("#video");
   // Slave videos


### PR DESCRIPTION
Previously the setMediaSync function was only called after the deskshare
loaded, but by moving it to run after all media loaded, it now runs even
on recordings that didn't have deskshare. Make it do nothing (return early)
in that case.