### PR TITLE
 Have only one ESL listener

### DIFF
--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/ConnectionManager.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/ConnectionManager.java
@@ -61,6 +61,12 @@ public class ConnectionManager {
 		this.manager = connManager;
 		this.eslEventListener = eventListener;
 		this.conferenceEventListener = confListener;
+		// Set up listener here. Before it was inside connect()
+		// but on auto-reconnect, another listener is added
+		// increasing the number of listeners causing duplicate
+		// messages to akka-apps (ralam Oct 10, 2019)
+		Client c = manager.getESLClient();
+		c.addEventListener(eslEventListener);
 	}
 
 	private void connect() {
@@ -75,7 +81,6 @@ public class ConnectionManager {
 				if (!subscribed) {
 					log.info("Subscribing for ESL events.");
 					c.cancelEventSubscriptions();
-					c.addEventListener(eslEventListener);
 					c.setEventSubscriptions("plain", "all");
 					//c.addEventFilter(EVENT_NAME, "heartbeat");
 					c.addEventFilter(EVENT_NAME, "custom");


### PR DESCRIPTION
 - on auto-reconnect when FS restarts, the auto-reconnect add another
   listener to the ESL client resulting in multiple handlers of ESL events
   and multiple messages to akka-apps. This resulted in multiple recordings
   of audio when the first user joins as akka-apps receives 2 user join events.