### PR TITLE
 Eject users by force from FreeSWITCH

### DIFF
--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/ConnectionManager.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/ConnectionManager.java
@@ -159,6 +159,15 @@ public class ConnectionManager {
 		}
 	}
 
+	public void forceEjectUser(ForceEjectUserCommand ccrc) {
+		Client c = manager.getESLClient();
+		if (c.canSend()) {
+			EslMessage response = c.sendSyncApiCommand(ccrc.getCommand(),
+					ccrc.getCommandArgs());
+			ccrc.handleResponse(response, conferenceEventListener);
+		}
+	}
+
 	public void checkIfConferenceIsRecording(ConferenceCheckRecordCommand ccrc) {
 		Client c = manager.getESLClient();
 		if (c.canSend()) {

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/FreeswitchApplication.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/FreeswitchApplication.java
@@ -188,6 +188,8 @@ public class FreeswitchApplication implements  IDelayedCommandListener{
           manager.checkIfConferenceIsRecording((ConferenceCheckRecordCommand) command);
         } else if (command instanceof CheckIfConfIsRunningCommand) {
           manager.checkIfConfIsRunningCommand((CheckIfConfIsRunningCommand) command);
+        } else if (command instanceof ForceEjectUserCommand) {
+          manager.forceEjectUser((ForceEjectUserCommand) command);
         }
       }
     };

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/actions/CheckIfConfIsRunningCommand.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/actions/CheckIfConfIsRunningCommand.java
@@ -45,7 +45,7 @@ public class CheckIfConfIsRunningCommand extends FreeswitchCommand {
                                        Integer forceEjectCount) {
             super(room, requesterId);
             this.delayedCommandSenderService = delayedCommandSenderService;
-            this.forceEjectCount = forceEjectCount;
+            this.forceEjectCount = forceEjectCount + 1;
     }
     
     @Override
@@ -90,7 +90,8 @@ public class CheckIfConfIsRunningCommand extends FreeswitchCommand {
             Integer numUsers =  confXML.getConferenceList().size();
             if (numUsers > 0) {
                 log.info("Check conference response: " + responseBody);
-                log.warn("WARNING! Failed to eject all users from conf={},numUsers={}.", room, numUsers);
+                log.warn("WARNING! Failed to eject all users from conf={},numUsers={},attempts={}.",
+                        room, numUsers, forceEjectCount);
                 if (forceEjectCount <= 5) {
                     for (ConferenceMember member : confXML.getConferenceList()) {
                         if ("caller".equals(member.getMemberType())) {


### PR DESCRIPTION
 - when meeting ends, we try to eject all users by force from freeswitch to make sure
   that recording ends. However, we are not actually sending the command to freeswitch.
   This change sends the command so that users can be kicked out.