### PR TITLE
Add script to start meteor using external mongo (from packaging) 

### DIFF
--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -9,6 +9,7 @@
     "generate-refs-visual-regression-desktop": "rm -rf tests/webdriverio/screenshots; npm run test-visual-regression-desktop",
     "start:prod": "meteor reset && ROOT_URL=http://127.0.0.1/html5client NODE_ENV=production meteor --production",
     "start:dev": "ROOT_URL=http://127.0.0.1/html5client NODE_ENV=development meteor",
+    "start:dev-fast-mongo": "env ROOT_URL=http://127.0.0.1/html5client MONGO_OPLOG_URL=mongodb://127.0.1.1/local MONGO_URL=mongodb://127.0.1.1/meteor PORT=3000 ROOT_URL=http://127.0.0.1/html5client NODE_ENV=development meteor",
     "test": "wdio ./tests/webdriverio/wdio.conf.js",
     "lint": "eslint . --ext .jsx,.js"
   },


### PR DESCRIPTION
This allows to run meteor in dev mode using the optimized mongo db from packaging instead of embeded meteor mongodb.

Usage: ``` npm run-script start:dev-fast-mongo```