### PR TITLE
Make presentation playback continue if deskshare.xml was not found

### DIFF
--- a/record-and-playback/presentation/playback/presentation/2.0/lib/writing.js
+++ b/record-and-playback/presentation/playback/presentation/2.0/lib/writing.js
@@ -641,7 +641,12 @@ function loadData() {
   asyncRequest('GET', deskshareXML).then(function (response) {
     processDeskshareXML(response);
   }).catch(function(error) {
-    logger.error("==Couldn't load deskshare.xml", error);
+    if (error.status == 404) {
+      logger.warn("==Couldn't find deskshare.xml, assuming there's no deskshare");
+      document.dispatchEvent(new CustomEvent('data-ready', {'detail': 'deskshare-xml'}));
+    } else {
+      logger.error("==Couldn't load deskshare.xml", error);
+    }
   });
 };
 


### PR DESCRIPTION
Someone on the mailing list had some recordings which were using the 2.0
playback, but were missing the deskshare.xml file (which should always
be present for 2.0… strange). It's safe to continue loading the recording
playback if the deskshare.xml file is not found, the recording will just act
as if there were no deskshare start/stop events.