### PR TITLE
Add timestamp on msg envelope

### DIFF
--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/CoreMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/CoreMsgs.scala
@@ -23,11 +23,12 @@ trait StandardSysMsg extends BbbCoreMsg {
   def header: BbbClientMsgHeader
 }
 
-case class RoutingEnvelope(msgType: String, meetingId: String, userId: String)
-
-case class BbbMsgToClientEnvelope(name: String, routing: RoutingEnvelope)
-
-case class BbbCoreEnvelope(name: String, routing: collection.immutable.Map[String, String])
+case class BbbCoreEnvelope(name: String, routing: collection.immutable.Map[String, String], timestamp: Long)
+object BbbCoreEnvelope {
+  def apply(name: String, routing: collection.immutable.Map[String, String]): BbbCoreEnvelope = {
+    BbbCoreEnvelope(name, routing, System.currentTimeMillis())
+  }
+}
 
 case class BbbCommonEnvCoreMsg(envelope: BbbCoreEnvelope, core: BbbCoreMsg) extends BbbCommonMsg
 

--- a/bigbluebutton-html5/imports/startup/server/redis.js
+++ b/bigbluebutton-html5/imports/startup/server/redis.js
@@ -16,6 +16,7 @@ const makeEnvelope = (channel, eventName, header, body, routing) => {
         sender: 'bbb-apps-akka',
         // sender: 'html5-server', // TODO
       },
+      timestamp: Date.now(),
     },
     core: {
       header,


### PR DESCRIPTION
Adding a new timestamp field on message so we can collect stats on message processing times.

Should be merged together with https://github.com/bigbluebutton/bbb-webrtc-sfu/pull/38