### PR TITLE
Detect big PDF files and check the page size

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PdfConversionInvalidErrorSysPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PdfConversionInvalidErrorSysPubMsgHdlr.scala
@@ -1,0 +1,36 @@
+package org.bigbluebutton.core.apps.presentationpod
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.bus.MessageBus
+import org.bigbluebutton.core.domain.MeetingState2x
+import org.bigbluebutton.core.running.LiveMeeting
+
+trait PdfConversionInvalidErrorSysPubMsgHdlr {
+    this: PresentationPodHdlrs =>
+
+  def handle(
+      msg: PdfConversionInvalidErrorSysPubMsg, state: MeetingState2x,
+      liveMeeting: LiveMeeting, bus: MessageBus
+  ): MeetingState2x = {
+
+    def broadcastEvent(msg: PdfConversionInvalidErrorSysPubMsg): Unit = {
+      val routing = Routing.addMsgToClientRouting(
+        MessageTypes.BROADCAST_TO_MEETING,
+        liveMeeting.props.meetingProp.intId, msg.header.userId
+      )
+      val envelope = BbbCoreEnvelope(PdfConversionInvalidErrorSysPubMsg.NAME, routing)
+      val header = BbbClientMsgHeader(
+        PdfConversionInvalidErrorSysPubMsg.NAME,
+        liveMeeting.props.meetingProp.intId, msg.header.userId
+      )
+
+      val body = PdfConversionInvalidErrorSysPubMsgBody(msg.body.podId, msg.body.messageKey, msg.body.code, msg.body.presentationId, msg.body.bigPageNumber, msg.body.bigPageSize, msg.body.presName)
+      val event = PdfConversionInvalidErrorSysPubMsg(header, body)
+      val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+      bus.outGW.send(msgEvent)
+    }
+
+    broadcastEvent(msg)
+    state
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PdfConversionInvalidErrorSysPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PdfConversionInvalidErrorSysPubMsgHdlr.scala
@@ -18,14 +18,14 @@ trait PdfConversionInvalidErrorSysPubMsgHdlr {
         MessageTypes.BROADCAST_TO_MEETING,
         liveMeeting.props.meetingProp.intId, msg.header.userId
       )
-      val envelope = BbbCoreEnvelope(PdfConversionInvalidErrorSysPubMsg.NAME, routing)
+      val envelope = BbbCoreEnvelope(PdfConversionInvalidErrorEvtMsg.NAME, routing)
       val header = BbbClientMsgHeader(
-        PdfConversionInvalidErrorSysPubMsg.NAME,
+        PdfConversionInvalidErrorEvtMsg.NAME,
         liveMeeting.props.meetingProp.intId, msg.header.userId
       )
 
-      val body = PdfConversionInvalidErrorSysPubMsgBody(msg.body.podId, msg.body.messageKey, msg.body.code, msg.body.presentationId, msg.body.bigPageNumber, msg.body.bigPageSize, msg.body.presName)
-      val event = PdfConversionInvalidErrorSysPubMsg(header, body)
+      val body = PdfConversionInvalidErrorEvtMsgBody(msg.body.podId, msg.body.messageKey, msg.body.code, msg.body.presentationId, msg.body.bigPageNumber, msg.body.bigPageSize, msg.body.presName)
+      val event = PdfConversionInvalidErrorEvtMsg(header, body)
       val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
       bus.outGW.send(msgEvent)
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationPodHdlrs.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationPodHdlrs.scala
@@ -9,6 +9,7 @@ class PresentationPodHdlrs(implicit val context: ActorContext)
   with GetAllPresentationPodsReqMsgHdlr
   with SetCurrentPresentationPubMsgHdlr
   with PresentationConversionCompletedSysPubMsgHdlr
+  with PdfConversionInvalidErrorSysPubMsgHdlr
   with SetCurrentPagePubMsgHdlr
   with SetPresenterInPodReqMsgHdlr
   with RemovePresentationPubMsgHdlr

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -215,6 +215,8 @@ class ReceivedJsonMsgHandlerActor(
         routeGenericMsg[PresentationPageGeneratedSysPubMsg](envelope, jsonNode)
       case PresentationConversionCompletedSysPubMsg.NAME =>
         routeGenericMsg[PresentationConversionCompletedSysPubMsg](envelope, jsonNode)
+      case PdfConversionInvalidErrorSysPubMsg.NAME =>
+        routeGenericMsg[PdfConversionInvalidErrorSysPubMsg](envelope, jsonNode)
       case AssignPresenterReqMsg.NAME =>
         routeGenericMsg[AssignPresenterReqMsg](envelope, jsonNode)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -399,6 +399,7 @@ class MeetingActor(
       case m: GetAllPresentationPodsReqMsg             => state = presentationPodsApp.handle(m, state, liveMeeting, msgBus)
       case m: SetCurrentPresentationPubMsg             => state = presentationPodsApp.handle(m, state, liveMeeting, msgBus)
       case m: PresentationConversionCompletedSysPubMsg => state = presentationPodsApp.handle(m, state, liveMeeting, msgBus)
+      case m: PdfConversionInvalidErrorSysPubMsg       => state = presentationPodsApp.handle(m, state, liveMeeting, msgBus)
       case m: SetCurrentPagePubMsg                     => state = presentationPodsApp.handle(m, state, liveMeeting, msgBus)
       case m: SetPresenterInPodReqMsg                  => state = presentationPodsApp.handle(m, state, liveMeeting, msgBus)
       case m: RemovePresentationPubMsg                 => state = presentationPodsApp.handle(m, state, liveMeeting, msgBus)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
@@ -93,6 +93,7 @@ class AnalyticsActor extends Actor with ActorLogging {
 
       // Presentation
       case m: PresentationConversionCompletedSysPubMsg => logMessage(msg)
+      case m: PdfConversionInvalidErrorSysPubMsg => logMessage(msg)
       case m: SetCurrentPresentationPubMsg => logMessage(msg)
       case m: SetCurrentPresentationEvtMsg => logMessage(msg)
       case m: SetPresentationDownloadablePubMsg => logMessage(msg)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PresentationPodsMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PresentationPodsMsgs.scala
@@ -101,6 +101,10 @@ object RemovePresentationPodEvtMsg { val NAME = "RemovePresentationPodEvtMsg" }
 case class RemovePresentationPodEvtMsg(header: BbbClientMsgHeader, body: RemovePresentationPodEvtMsgBody) extends StandardMsg
 case class RemovePresentationPodEvtMsgBody(podId: String)
 
+object PdfConversionInvalidErrorEvtMsg { val NAME = "PdfConversionInvalidErrorEvtMsg" }
+case class PdfConversionInvalidErrorEvtMsg(header: BbbClientMsgHeader, body: PdfConversionInvalidErrorEvtMsgBody) extends StandardMsg
+case class PdfConversionInvalidErrorEvtMsgBody(podId: String, messageKey: String, code: String, presentationId: String, bigPageNumber: Int, bigPageSize: Int, presName: String)
+
 object PresentationUploadTokenPassRespMsg { val NAME = "PresentationUploadTokenPassRespMsg" }
 case class PresentationUploadTokenPassRespMsg(header: BbbClientMsgHeader, body: PresentationUploadTokenPassRespMsgBody) extends StandardMsg
 case class PresentationUploadTokenPassRespMsgBody(podId: String, authzToken: String, filename: String)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PresentationPodsMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PresentationPodsMsgs.scala
@@ -67,6 +67,14 @@ case class PresentationPageCountErrorSysPubMsg(
 case class PresentationPageCountErrorSysPubMsgBody(podId: String, messageKey: String, code: String, presentationId: String,
                                                    numberOfPages: Int, maxNumberPages: Int, presName: String)
 
+object PdfConversionInvalidErrorSysPubMsg { val NAME = "PdfConversionInvalidErrorSysPubMsg" }
+case class PdfConversionInvalidErrorSysPubMsg(
+    header: BbbClientMsgHeader,
+    body:   PdfConversionInvalidErrorSysPubMsgBody
+) extends StandardMsg
+case class PdfConversionInvalidErrorSysPubMsgBody(podId: String, messageKey: String, code: String, presentationId: String,
+                                                   bigPageNumber: Int, bigPageSize: Int, presName: String)
+                                                   
 object PresentationPageGeneratedSysPubMsg { val NAME = "PresentationPageGeneratedSysPubMsg" }
 case class PresentationPageGeneratedSysPubMsg(
     header: BbbClientMsgHeader,

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/ConversionMessageConstants.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/ConversionMessageConstants.java
@@ -27,6 +27,7 @@ public class ConversionMessageConstants {
     public static final String UNSUPPORTED_DOCUMENT_KEY = "UNSUPPORTED_DOCUMENT";
     public static final String PAGE_COUNT_FAILED_KEY = "PAGE_COUNT_FAILED";
     public static final String PAGE_COUNT_EXCEEDED_KEY = "PAGE_COUNT_EXCEEDED";
+    public static final String PDF_HAS_BIG_PAGE = "PDF_HAS_BIG_PAGE";
     public static final String GENERATED_SLIDE_KEY = "GENERATED_SLIDE";
     public static final String GENERATING_THUMBNAIL_KEY = "GENERATING_THUMBNAIL";
     public static final String GENERATED_THUMBNAIL_KEY = "GENERATED_THUMBNAIL";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/BigPdfException.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/BigPdfException.java
@@ -1,0 +1,50 @@
+/**
+* BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+* 
+* Copyright (c) 2019 BigBlueButton Inc. and by respective authors (see below).
+*
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License as published by the Free Software
+* Foundation; either version 3.0 of the License, or (at your option) any later
+* version.
+* 
+* BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License along
+* with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+*
+*/
+package org.bigbluebutton.presentation.imp;
+
+@SuppressWarnings("serial")
+public class BigPdfException extends Exception {
+  
+  private final int bigPageNumber;
+  private final long bigPageSize;
+  private final ExceptionType exceptionType;
+
+  public BigPdfException(BigPdfException.ExceptionType type, int bigPageNumber, long bigPageSize) {
+      super("Exception while converting PDF that has at least one big page.");
+      this.bigPageNumber = bigPageNumber;
+      this.bigPageSize = bigPageSize;
+      exceptionType = type;
+  }
+
+  public int getBigPageNumber() {
+      return bigPageNumber;
+  }
+
+  public BigPdfException.ExceptionType getExceptionType() {
+      return exceptionType;
+  }
+
+  public long getBigPageSize() {
+      return bigPageSize;
+  }
+  
+  public enum ExceptionType {
+    PDF_HAS_BIG_PAGE
+  }
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/BigPdfException.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/BigPdfException.java
@@ -16,6 +16,7 @@
 * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 *
 */
+
 package org.bigbluebutton.presentation.imp;
 
 @SuppressWarnings("serial")

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/messages/PdfConversionInvalid.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/messages/PdfConversionInvalid.java
@@ -1,0 +1,31 @@
+package org.bigbluebutton.presentation.messages;
+
+public class PdfConversionInvalid implements IDocConversionMsg {
+  public final String podId;
+  public final String meetingId;
+  public final String presId;
+  public final String presInstance;
+  public final String filename;
+  public final String uploaderId;
+  public final String authzToken;
+  public final Boolean downloadable;
+  public final String key;
+  public final Integer bigPageNumber;
+  public final Integer bigPageSize;
+
+  public PdfConversionInvalid(String podId, String meetingId, String presId, String presInstance,
+                              String filename, String uploaderId, String authzToken,
+                              Boolean downloadable, Integer bigPageNumber, Integer bigPageSize, String key) {
+    this.podId = podId;
+    this.meetingId = meetingId;
+    this.presId = presId;
+    this.presInstance = presInstance;
+    this.filename = filename;
+    this.uploaderId = uploaderId;
+    this.authzToken = authzToken;
+    this.downloadable = downloadable;
+    this.bigPageNumber = bigPageNumber;
+    this.bigPageSize = bigPageSize;
+    this.key = key;
+  }
+}

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -286,6 +286,9 @@ class BbbWebApiGWApp(
     } else if (msg.isInstanceOf[DocPageCountExceeded]) {
       val event = MsgBuilder.buildPresentationPageCountExceededSysPubMsg(msg.asInstanceOf[DocPageCountExceeded])
       msgToAkkaAppsEventBus.publish(MsgToAkkaApps(toAkkaAppsChannel, event))
+    } else if (msg.isInstanceOf[PdfConversionInvalid]) {
+      val event = MsgBuilder.buildPdfConversionInvalidErrorSysPubMsg(msg.asInstanceOf[PdfConversionInvalid])
+      msgToAkkaAppsEventBus.publish(MsgToAkkaApps(toAkkaAppsChannel, event))
     }
   }
 

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -143,6 +143,17 @@ object MsgBuilder {
     BbbCommonEnvCoreMsg(envelope, req)
   }
 
+  def buildPdfConversionInvalidErrorSysPubMsg(msg: PdfConversionInvalid): BbbCommonEnvCoreMsg ={
+    val routing = collection.immutable.HashMap("sender" -> "bbb-web")
+    val envelope = BbbCoreEnvelope(PdfConversionInvalidErrorSysPubMsg.NAME, routing)
+    val header = BbbClientMsgHeader(PdfConversionInvalidErrorSysPubMsg.NAME, msg.meetingId, msg.authzToken)
+
+    val body = PdfConversionInvalidErrorSysPubMsgBody(podId = msg.podId, messageKey = msg.key,
+      code = msg.key, msg.presId, msg.bigPageNumber.intValue(), msg.bigPageSize.intValue(), msg.filename)
+    val req = PdfConversionInvalidErrorSysPubMsg(header, body)
+    BbbCommonEnvCoreMsg(envelope, req)
+  }
+  
   def buildPublishedRecordingSysMsg(msg: PublishedRecordingMessage): BbbCommonEnvCoreMsg = {
     val routing = collection.immutable.HashMap("sender" -> "bbb-web")
     val envelope = BbbCoreEnvelope(PublishedRecordingSysMsg.NAME, routing)

--- a/bigbluebutton-html5/imports/api/presentations/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/presentations/server/eventHandlers.js
@@ -5,6 +5,7 @@ import handlePresentationCurrentSet from './handlers/presentationCurrentSet';
 import handlePresentationConversionUpdate from './handlers/presentationConversionUpdate';
 import handlePresentationDownloadableSet from './handlers/presentationDownloadableSet';
 
+RedisPubSub.on('PdfConversionInvalidErrorEvtMsg', handlePresentationConversionUpdate);
 RedisPubSub.on('PresentationPageGeneratedEvtMsg', handlePresentationConversionUpdate);
 RedisPubSub.on('PresentationPageCountErrorEvtMsg', handlePresentationConversionUpdate);
 RedisPubSub.on('PresentationConversionUpdateEvtMsg', handlePresentationConversionUpdate);

--- a/bigbluebutton-html5/imports/api/presentations/server/handlers/presentationConversionUpdate.js
+++ b/bigbluebutton-html5/imports/api/presentations/server/handlers/presentationConversionUpdate.js
@@ -9,6 +9,7 @@ const SUPPORTED_DOCUMENT_KEY = 'SUPPORTED_DOCUMENT';
 const UNSUPPORTED_DOCUMENT_KEY = 'UNSUPPORTED_DOCUMENT';
 const PAGE_COUNT_FAILED_KEY = 'PAGE_COUNT_FAILED';
 const PAGE_COUNT_EXCEEDED_KEY = 'PAGE_COUNT_EXCEEDED';
+const PDF_HAS_BIG_PAGE_KEY = 'PDF_HAS_BIG_PAGE';
 const GENERATED_SLIDE_KEY = 'GENERATED_SLIDE';
 // const GENERATING_THUMBNAIL_KEY = 'GENERATING_THUMBNAIL';
 // const GENERATED_THUMBNAIL_KEY = 'GENERATED_THUMBNAIL';
@@ -47,6 +48,7 @@ export default function handlePresentationConversionUpdate({ body }, meetingId) 
     case OFFICE_DOC_CONVERSION_INVALID_KEY:
     case PAGE_COUNT_FAILED_KEY:
     case PAGE_COUNT_EXCEEDED_KEY:
+    case PDF_HAS_BIG_PAGE_KEY:
       statusModifier.id = presentationId;
       statusModifier.name = presentationName;
       statusModifier['conversion.error'] = true;

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -132,6 +132,10 @@ const intlMessages = defineMessages({
     id: 'app.presentationUploder.conversion.pageCountExceeded',
     description: 'warns the user that the conversion failed because of the page count',
   },
+  PDF_HAS_BIG_PAGE: {
+    id: 'app.presentationUploder.conversion.pdfHasBigPage',
+    description: 'warns the user that the conversion failed because of the pdf page siz that exceeds the allowed limit',
+  },
   isDownloadable: {
     id: 'app.presentationUploder.isDownloadableLabel',
     description: 'presentation is available for downloading by all viewers',

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -178,6 +178,7 @@
     "app.presentationUploder.conversion.generatedSlides": "Slides generated ...",
     "app.presentationUploder.conversion.generatingSvg": "Generating SVG images ...",
     "app.presentationUploder.conversion.pageCountExceeded": "Ops, the page count exceeded the limit of 200 pages",
+    "app.presentationUploder.conversion.pdfHasBigPage": "We could not convert the PDF file, please try optimizing it",
     "app.presentationUploder.conversion.timeout": "Ops, the conversion took too long",
     "app.presentationUploder.isDownloadableLabel": "Do not allow presentation to be downloaded",
     "app.presentationUploder.isNotDownloadableLabel": "Allow presentation to be downloaded",

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -104,8 +104,15 @@ pngSlideWidth=1200
 defaultNumDigitsForTelVoice=5
 
 #----------------------------------------------------
-# Configuration for large images, 2 MB by default, if bigger it will downscaled
+# Configuration for large images, 2 MB by default, if bigger it will down-scaled
 maxImageSize=2000000
+
+#----------------------------------------------------
+# Configuration for large PDF, 14 MB by default, if bigger it will be analysed during the conversion process
+bigPdfSize=14000000
+
+# The maximum allowed page size for PDF files exceeding the 'pdfCheckSize' value, 12 MB by default
+maxBigPdfPageSize=12000000
 
 #----------------------------------------------------
 # Default dial access number

--- a/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
@@ -96,9 +96,12 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="pngCreator" ref="pngCreator"/>
         <property name="textFileCreator" ref="textFileCreator"/>
         <property name="svgImageCreator" ref="svgImageCreator"/>
+        <property name="pageExtractor" ref="pageExtractor"/>
         <property name="blankSlide" value="${BLANK_SLIDE}"/>
         <property name="maxSwfFileSize" value="${MAX_SWF_FILE_SIZE}"/>
         <property name="maxConversionTime" value="${maxConversionTime}"/>
+        <property name="bigPdfSize" value="${bigPdfSize}"/>
+        <property name="maxBigPdfPageSize" value="${maxBigPdfPageSize}"/>
         <property name="swfSlidesGenerationProgressNotifier" ref="swfSlidesGenerationProgressNotifier"/>
         <property name="swfSlidesRequired" value="${swfSlidesRequired}"/>
         <property name="svgImagesRequired" value="${svgImagesRequired}"/>


### PR DESCRIPTION
**The problem:** In some cases a user uploads a PDF that generated blank pages. The issue we found is that sometimes a PDF page conversion times out.

**The solution:** If a PDF size is 10MB+, we extract the pages one by one and check that it has no page exceeds 8MB+. If a page has 8MB+ size, the PDF is marked as big and would not be converted. The client then asks the user to compress/optimize the uploaded PDF before uploading it again.