### PR TITLE
Update active poll panel description message string

### DIFF
--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -193,7 +193,7 @@
     "app.poll.quickPollInstruction": "Select an option below to start your poll.",
     "app.poll.customPollLabel": "Custom poll",
     "app.poll.startCustomLabel": "Start custom poll",
-    "app.poll.activePollInstruction": "Leave this window open to allow others to respond to the poll. Selecting 'Publish polling results' or navigating back will end the poll.",
+    "app.poll.activePollInstruction": "Leave this panel open to see live responses to your poll. When you are ready, select “Publish polling results” to publish the results and end the poll.",
     "app.poll.publishLabel": "Publish polling results",
     "app.poll.backLabel": "Back to polling options",
     "app.poll.closeLabel": "Close",

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -193,7 +193,7 @@
     "app.poll.quickPollInstruction": "Select an option below to start your poll.",
     "app.poll.customPollLabel": "Custom poll",
     "app.poll.startCustomLabel": "Start custom poll",
-    "app.poll.activePollInstruction": "Leave this panel open to see live responses to your poll. When you are ready, select “Publish polling results” to publish the results and end the poll.",
+    "app.poll.activePollInstruction": "Leave this panel open to see live responses to your poll. When you are ready, select 'Publish polling results' to publish the results and end the poll.",
     "app.poll.publishLabel": "Publish polling results",
     "app.poll.backLabel": "Back to polling options",
     "app.poll.closeLabel": "Close",


### PR DESCRIPTION
The message used for this string provided misleading information to the user, giving the impression that a poll would end if the panel is no longer open. However, polls do remain active if the panel is not visible due to the use of the hide panel button.



