### PR TITLE
Fix multiple external videos synced to different meetings

### DIFF
--- a/bigbluebutton-html5/imports/api/external-videos/index.js
+++ b/bigbluebutton-html5/imports/api/external-videos/index.js
@@ -1,5 +1,13 @@
 import { Meteor } from 'meteor/meteor';
+import { makeCall } from '/imports/ui/services/api';
 
-const Streamer = new Meteor.Streamer('videos');
+let streamer = null;
+const getStreamer = (meetingID) => {
+  if (!streamer) {
+    streamer = new Meteor.Streamer(`external-videos-${meetingID}`);
+    makeCall('initializeExternalVideo');
+  }
+  return streamer;
+};
 
-export default Streamer;
+export { getStreamer };

--- a/bigbluebutton-html5/imports/api/external-videos/server/index.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/index.js
@@ -1,18 +1,2 @@
-import ExternalVideoStreamer from '/imports/api/external-videos';
-import Users from '/imports/api/users';
-import Logger from '/imports/startup/server/logger';
 import './methods';
 
-ExternalVideoStreamer.allowRead('all');
-ExternalVideoStreamer.allowWrite('all');
-
-const allowFromPresenter = (eventName, { userId }) => {
-  const user = Users.findOne({ userId });
-  const ret = user && user.presenter;
-
-  Logger.debug('ExternalVideo Streamer auth userid:', userId, ' event: ', eventName, ' suc: ', ret);
-
-  return ret || eventName === 'viewerJoined';
-};
-
-ExternalVideoStreamer.allowEmit(allowFromPresenter);

--- a/bigbluebutton-html5/imports/api/external-videos/server/methods.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods.js
@@ -1,8 +1,10 @@
 import { Meteor } from 'meteor/meteor';
 import startWatchingExternalVideo from './methods/startWatchingExternalVideo';
 import stopWatchingExternalVideo from './methods/stopWatchingExternalVideo';
+import initializeExternalVideo from './methods/initializeExternalVideo';
 
 Meteor.methods({
+  initializeExternalVideo,
   startWatchingExternalVideo,
   stopWatchingExternalVideo,
 });

--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/destroyExternalVideo.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/destroyExternalVideo.js
@@ -1,0 +1,11 @@
+import { Meteor } from 'meteor/meteor';
+import Logger from '/imports/startup/server/logger';
+
+export default function destroyExternalVideo(meetingId) {
+  const streamName = `external-videos-${meetingId}`;
+
+  if (Meteor.StreamerCentral.instances[streamName]) {
+    Logger.info(`Destroying External Video streamer object for ${streamName}`);
+    delete Meteor.StreamerCentral.instances[streamName];
+  }
+};

--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/initializeExternalVideo.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/initializeExternalVideo.js
@@ -1,0 +1,24 @@
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+import Users from '/imports/api/users';
+import Logger from '/imports/startup/server/logger';
+
+const allowFromPresenter = (eventName, { userId }) => {
+  const user = Users.findOne({ userId });
+  const ret = user && user.presenter;
+
+  Logger.debug('ExternalVideo Streamer auth userid:', userId, ' event: ', eventName, ' suc: ', ret);
+
+  return ret || eventName === 'viewerJoined';
+};
+
+export default function initializeExternalVideo(credentials, options) {
+  const { meetingId } = credentials;
+
+  check(meetingId, String);
+
+  let streamer = new Meteor.Streamer(`external-videos-${meetingId}`);
+  streamer.allowRead('all');
+  streamer.allowWrite('all');
+  streamer.allowEmit(allowFromPresenter);
+}

--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/initializeExternalVideo.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/initializeExternalVideo.js
@@ -19,11 +19,11 @@ export default function initializeExternalVideo(credentials, options) {
 
   const streamName = `external-videos-${meetingId}`;
   if (!Meteor.StreamerCentral.instances[streamName]) {
-    streamer = new Meteor.Streamer(streamName);
+    const streamer = new Meteor.Streamer(streamName);
     streamer.allowRead('all');
     streamer.allowWrite('all');
     streamer.allowEmit(allowFromPresenter);
   } else {
     Logger.debug('External Video streamer is already created for ', streamName);
   }
-};
+}

--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/initializeExternalVideo.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/initializeExternalVideo.js
@@ -17,8 +17,13 @@ export default function initializeExternalVideo(credentials, options) {
 
   check(meetingId, String);
 
-  let streamer = new Meteor.Streamer(`external-videos-${meetingId}`);
-  streamer.allowRead('all');
-  streamer.allowWrite('all');
-  streamer.allowEmit(allowFromPresenter);
-}
+  const streamName = `external-videos-${meetingId}`;
+  if (!Meteor.StreamerCentral.instances[streamName]) {
+    streamer = new Meteor.Streamer(streamName);
+    streamer.allowRead('all');
+    streamer.allowWrite('all');
+    streamer.allowEmit(allowFromPresenter);
+  } else {
+    Logger.debug('External Video streamer is already created for ', streamName);
+  }
+};

--- a/bigbluebutton-html5/imports/api/meetings/server/handlers/meetingDestruction.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/handlers/meetingDestruction.js
@@ -1,10 +1,14 @@
 import RedisPubSub from '/imports/startup/server/redis';
 import { check } from 'meteor/check';
 
+import destroyExternalVideo from '/imports/api/external-videos/server/methods/destroyExternalVideo';
+
 export default function handleMeetingDestruction({ body }) {
   check(body, Object);
   const { meetingId } = body;
   check(meetingId, String);
+
+  destroyExternalVideo(meetingId);
 
   return RedisPubSub.destroyMeetingQueue(meetingId);
 }

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/service.js
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/service.js
@@ -1,7 +1,6 @@
 import Meetings from '/imports/api/meetings';
 import Auth from '/imports/ui/services/auth';
-import ExternalVideoStreamer from '/imports/api/external-videos';
-
+import { getStreamer } from '/imports/api/external-videos';
 import { makeCall } from '/imports/ui/services/api';
 
 import ReactPlayer from 'react-player';
@@ -18,7 +17,9 @@ const stopWatching = () => {
 };
 
 const sendMessage = (event, data) => {
-  ExternalVideoStreamer.emit(event, {
+  const streamer = getStreamer(Auth.meetingID);
+
+  streamer.emit(event, {
     ...data,
     meetingId: Auth.meetingID,
     userId: Auth.userID,
@@ -26,11 +27,13 @@ const sendMessage = (event, data) => {
 };
 
 const onMessage = (message, func) => {
-  ExternalVideoStreamer.on(message, func);
+  const streamer = getStreamer(Auth.meetingID);
+  streamer.on(message, func);
 };
 
 const removeAllListeners = (eventType) => {
-  ExternalVideoStreamer.removeAllListeners(eventType);
+  const streamer = getStreamer(Auth.meetingID);
+  streamer.removeAllListeners(eventType);
 };
 
 const getVideoUrl = () => {


### PR DESCRIPTION
By creating a different server instance of the streamer once for every meeting. Still trying to determine if the streamers are collected automatically when the objetcts are collected or if I should do something to clear them when the meeting ends.