### PR TITLE
Only request a breakout join URL once

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/component.jsx
@@ -65,6 +65,22 @@ class BreakoutJoinConfirmation extends Component {
     this.handleSelectChange = this.handleSelectChange.bind(this);
   }
 
+  componentDidMount() {
+    const {
+      isFreeJoin,
+      requestJoinURL,
+      getURL,
+    } = this.props;
+
+    const {
+      selectValue,
+    } = this.state;
+
+    if (isFreeJoin && !getURL(selectValue)) {
+      requestJoinURL(selectValue);
+    }
+  }
+
   handleJoinBreakoutConfirmation() {
     const {
       getURL,
@@ -93,9 +109,15 @@ class BreakoutJoinConfirmation extends Component {
 
   handleSelectChange(e) {
     const { value } = e.target;
-    const { requestJoinURL } = this.props;
+    const {
+      requestJoinURL,
+      getURL,
+    } = this.props;
+
     this.setState({ selectValue: value });
-    requestJoinURL(value);
+    if (!getURL(value)) {
+      requestJoinURL(value);
+    }
   }
 
   renderSelectMeeting() {

--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/container.jsx
@@ -31,9 +31,6 @@ export default withTracker(({ breakout, mountModal, breakoutName }) => {
   const isFreeJoin = breakout.freeJoin;
   const { breakoutId } = breakout;
   const url = getURL(breakoutId);
-  if (isFreeJoin && !url) {
-    requestJoinURL(breakoutId);
-  }
 
   return {
     isFreeJoin,


### PR DESCRIPTION
The request to get a join URL for the initial breakout room was being done in a Tracker when in freeJoin mode. It lead to a flood of messages and potentially taking down the whole server if there were enough people in the meeting.

Fixes #8234