### PR TITLE
Throttle the pencil updates and increase cursor throttle

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/cursor-listener/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/cursor-listener/component.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 // maximum value of z-index to prevent other things from overlapping
 const MAX_Z_INDEX = (2 ** 31) - 1;
-const CURSOR_INTERVAL = 32;
+const CURSOR_INTERVAL = 40;
 
 export default class CursorListener extends Component {
   static touchCenterPoint(touches) {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/pencil-draw-listener/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/pencil-draw-listener/component.jsx
@@ -8,6 +8,7 @@ const DRAW_END = ANNOTATION_CONFIG.status.end;
 
 // maximum value of z-index to prevent other things from overlapping
 const MAX_Z_INDEX = (2 ** 31) - 1;
+const POINTS_TO_BUFFER = 5;
 
 export default class PencilDrawListener extends Component {
   constructor() {
@@ -92,7 +93,9 @@ export default class PencilDrawListener extends Component {
       this.points.push(transformedSvgPoint.x);
       this.points.push(transformedSvgPoint.y);
 
-      this.sendCoordinates();
+      if (this.points.length > POINTS_TO_BUFFER) {
+        this.sendCoordinates();
+      }
     }
   }
 


### PR DESCRIPTION
Just trying to reduce the frequency of updates of some potentially problematic areas. Both the cursor and the annotations update quite frequently and often the browser and computer can't keep up. This PR slightly increases the throttle of the cursor updates and adds a three point buffer of pencil updates.