### PR TITLE
Add option to reconnect audio with relay only

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -172,6 +172,7 @@ public:
     callHangupTimeout: 2000
     callHangupMaximumRetries: 10
     echoTestNumber: '9196'
+    relayOnlyOnReconnect: true
   presentation:
     defaultPresentationFile: default.pdf
     panZoomThrottle: 32

--- a/bigbluebutton-html5/public/compatibility/sip.js
+++ b/bigbluebutton-html5/public/compatibility/sip.js
@@ -9569,6 +9569,7 @@ UA.prototype.loadConfig = function(configuration) {
       hackStripTcp: false,
       hackPlanBUnifiedPlanTranslation: false,
       hackAddAudioTransceiver: false,
+      relayOnlyOnReconnect: false,
 
       contactTransport: 'ws',
       forceRport: false,
@@ -9962,6 +9963,12 @@ UA.prototype.getConfigurationCheck = function () {
       contactTransport: function(contactTransport) {
         if (typeof contactTransport === 'string') {
           return contactTransport;
+        }
+      },
+
+      relayOnlyOnReconnect: function(relayOnlyOnReconnect) {
+        if (typeof relayOnlyOnReconnect === 'boolean') {
+          return relayOnlyOnReconnect;
         }
       },
 
@@ -11475,6 +11482,10 @@ MediaHandler.prototype = Object.create(SIP.MediaHandler.prototype, {
       iceServers: servers,
       sdpSemantics:'plan-b'
     };
+
+    if (config.relayOnlyOnReconnect) {
+      connConfig.iceTransportPolicy = 'relay';
+    }
 
     if (config.rtcpMuxPolicy) {
       connConfig.rtcpMuxPolicy = config.rtcpMuxPolicy;


### PR DESCRIPTION
Adds an option to attempt the reconnecting WebRTC audio call using relay candidates only. Most of our failed audio calls are ICE negotiation failures after the call has initially been connected. Hopefully this will force the use of the TURN server on the reconnect and in turn force TCP.