### PR TITLE
Fix quick poll / cc button rendering vertically

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
@@ -26,7 +26,7 @@
 }
 
 .left {
-  display: block;
+  display: inherit;
   flex: 0;
   @include mq($small-only) {
     bottom: var(--sm-padding-x);


### PR DESCRIPTION
The quick poll and cc button should both render horizontally instead of vertically now

Closes #8257 