### PR TITLE
Default config relayOnlyOnReconnect set to false (follow-up to #8258)

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -172,7 +172,7 @@ public:
     callHangupTimeout: 2000
     callHangupMaximumRetries: 10
     echoTestNumber: '9196'
-    relayOnlyOnReconnect: true
+    relayOnlyOnReconnect: false
   presentation:
     defaultPresentationFile: default.pdf
     panZoomThrottle: 32


### PR DESCRIPTION
#8258 was supposed to have that config option as `false` by default (TURN is an optional setup step so we can't force it).