### PR TITLE
Revert "Webcams area resizable"

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/fullscreen-button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/fullscreen-button/styles.scss
@@ -14,7 +14,6 @@
   cursor: pointer;
   border: 0;
   border-radius: 5px;
-  z-index: 2;
 
   [dir="rtl"] & {
     right: auto;

--- a/bigbluebutton-html5/imports/ui/components/media/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/component.jsx
@@ -65,7 +65,6 @@ export default class Media extends Component {
       children,
       audioModalIsOpen,
       usersVideo,
-      webcamPlacement,
     } = this.props;
 
     const contentClassName = cx({
@@ -78,21 +77,16 @@ export default class Media extends Component {
       [styles.floatingOverlay]: floatingOverlay,
     });
 
-    const containerClassName = cx({
-      [styles.containerV]: webcamPlacement === 'top' || webcamPlacement === 'bottom' || webcamPlacement === 'floating',
-    });
-
     return (
       <div
         id="container"
-        className={containerClassName}
+        className={cx(styles.container)}
         ref={this.refContainer}
       >
         <div
           className={!swapLayout ? contentClassName : overlayClassName}
           style={{
             maxHeight: usersVideo.length < 1 || floatingOverlay ? '100%' : '80%',
-            minHeight: '20%',
           }}
         >
           {children}

--- a/bigbluebutton-html5/imports/ui/components/media/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/container.jsx
@@ -14,7 +14,6 @@ import PresentationPodsContainer from '../presentation-pod/container';
 import ScreenshareContainer from '../screenshare/container';
 import DefaultContent from '../presentation/default-content/component';
 import ExternalVideoContainer from '../external-video-player/container';
-import Storage from '../../services/storage/session';
 
 const LAYOUT_CONFIG = Meteor.settings.public.layout;
 const KURENTO_CONFIG = Meteor.settings.public.kurento;
@@ -147,8 +146,6 @@ export default withModalMounter(withTracker(() => {
       />
     );
   }
-
-  data.webcamPlacement = Storage.getItem('webcamPlacement');
 
   MediaContainer.propTypes = propTypes;
   return data;

--- a/bigbluebutton-html5/imports/ui/components/media/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/media/styles.scss
@@ -1,30 +1,22 @@
 @import "../../stylesheets/variables/_all";
 @import "../../stylesheets/variables/video";
 
-$content-order: 2;
-$before-content-order: 1;
-$after-content-order: 3;
-
-.cursorGrab {
+.cursorGrab{
   cursor: grab;
 }
 
-.cursorGrabbing {
+.cursorGrabbing{
   cursor: grabbing;
 }
 
-%container {
+.container {
   order: 1;
   flex: 2;
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-direction: column-reverse;
   overflow: hidden;
-}
-
-.containerV {
-  @extend %container;
-  flex-direction: column;
 }
 
 .content {
@@ -36,7 +28,7 @@ $after-content-order: 3;
   overflow: hidden;
   width: 100%;
   position: relative;
-  order: $content-order;
+  order: 2;
 }
 
 %overlay {
@@ -44,10 +36,10 @@ $after-content-order: 3;
   border: 0;
   z-index: 2;
   align-items: center;
+  max-height: var(--video-height);
   min-height: var(--video-height);
-  max-height: 100%;
-  height: 100%;
-  position: relative !important;
+  overflow: hidden;
+  position: relative;
   margin-top: 10px;
   margin-bottom: 10px;
 }
@@ -57,23 +49,23 @@ $after-content-order: 3;
 }
 
 .overlayToTop {
-  order: $before-content-order !important;
+  order: 3;
 }
 
 .overlayToBottom {
-  order: $after-content-order !important;
+  order: 1;
 }
 
 .hideOverlay {
-  visibility: hidden !important;
-  position: absolute !important;
-  overflow: hidden !important;
-  clip: rect(0 0 0 0) !important;
-  width: 1px !important;
-  height: 1px !important;
-  margin: -1px !important;
-  padding: 0 !important;
-  border: 0 !important;
+  visibility: hidden;
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
 }
 
 .floatingOverlay {
@@ -82,26 +74,21 @@ $after-content-order: 3;
   left: 0;
 
   z-index: 2;
-  position: absolute !important;
-  min-width: calc(var(--video-height) * var(--video-ratio)) !important;
-  min-height: var(--video-height) !important;
+  position: absolute;
+  min-width: calc(var(--video-height) * var(--video-ratio));
+  min-height: var(--video-height);
 }
 
-.autoWidth {
-  min-width: calc(var(--video-height) * var(--video-ratio)) !important;
+.fit {
+  width: fit-content;
+  height: fit-content;
+  max-width: fit-content;
+}
+
+.full {
+  min-width: 100%;
+  width: 100%;
   max-width: 100%;
-}
-
-.fullWidth {
-  width: 100% !important;
-  min-width: 100% !important;
-  max-width: 100%;
-}
-
-.fullHeight {
-  height: 100% !important;
-  min-height: 100% !important;
-  max-height: 100%;
 }
 
 .hide {
@@ -113,70 +100,35 @@ $after-content-order: 3;
 }
 
 .dragging {
-  opacity: .5 !important;
+  opacity: .5;
 }
 
-%dropZone {
+.dropZoneTop,
+.dropZoneBottom {
   border: 1px dashed var(--color-gray-light);
   position: absolute;
+  width: 100%;
   z-index: 9999;
 }
 
-%dropZoneTopBottom {
-  @extend %dropZone;
-  width: 100%;
-}
-
-%dropZoneBg {
-  z-index: 99;
-  width: 100%;
-  height: 100%;
-
-  &:hover {
-    background-color: rgba(255, 255, 255, .3);
-  }
-}
-
-%dropZoneBgTopBottom {
-  z-index: 99;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(255, 255, 255, .3);
-
-  &:hover {
-    background-color: rgba(255, 255, 255, .3);
-  }
-}
-
-.dropZoneTop {
-  @extend %dropZoneTopBottom;
-  top: 0;
-}
-
-.dropZoneBottom {
-  @extend %dropZoneTopBottom;
-  bottom: 0;
-}
-
-.dropZoneBgTop {
-  @extend %dropZoneBg;
-  top: 0;
-}
-
+.dropZoneBgTop,
 .dropZoneBgBottom {
-  @extend %dropZoneBg;
+  z-index: 99;
+  width: 100%;
+  height: 100%;
+}
+
+.dropZoneTop,
+.dropZoneBgTop {
+  top: 0;
+}
+
+.dropZoneBottom,
+.dropZoneBgBottom {
   bottom: 0;
 }
 
-.resizable {
-  width: 100% !important;
-}
-
-
-span[class^=resizeWrapper] {
-  div {
-    height: 15px !important;
-    z-index: 1;
-    bottom: -10px !important;
-  }
+.dropZoneTop:hover .dropZoneBgTop,
+.dropZoneBottom:hover .dropZoneBgBottom {
+  background-color: rgba(255, 255, 255, .3);
 }

--- a/bigbluebutton-html5/imports/ui/components/media/webcam-draggable-overlay/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/webcam-draggable-overlay/context.jsx
@@ -9,10 +9,6 @@ const initialState = {
     width: 0,
     height: 0,
   },
-  videoListSize: {
-    width: 0,
-    height: 0,
-  },
   initialRef: {
     x: 0,
     y: 0,
@@ -55,15 +51,6 @@ const reducer = (state, action) => {
       return {
         ...state,
         mediaSize: {
-          width: action.value.width,
-          height: action.value.height,
-        },
-      };
-    }
-    case 'setVideoListSize': {
-      return {
-        ...state,
-        videoListSize: {
           width: action.value.width,
           height: action.value.height,
         },

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -41,7 +41,7 @@
   display: flex;
   overflow: hidden;
   width: 100%;
-  max-height: 100%;
+  height: 100%;
 
   &.focused {
     grid-column: 1 / span 2;


### PR DESCRIPTION
Reverts bigbluebutton/bigbluebutton#7859

When testing further in a larger meeting noticed:
 * in some cases we cannot view webcams until we minimize the presentation
 * in some cases switching between tabs causes the webcams to disappear
 * in some cases the view for presenter and viewer differs when 2 webcams running

Got to do some more cleanup. The resizing part seems fine but these regressions are disruptive
![Screenshot from 2019-11-01 14-29-50](https://user-images.githubusercontent.com/6312397/68047207-2c5b3b00-fcb4-11e9-9040-25b6fdbe6bda.png)
