### PR TITLE
Use meta meetingId as "meetingID" when the "meeting" tag is not available in metadata.xml

### DIFF
--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/domain/Recording.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/domain/Recording.scala
@@ -8,7 +8,11 @@ object RecMeta {
   def getMeetingId(r: RecMeta): String = {
     r.meeting match {
       case Some(m) => m.externalId
-      case None    => r.id
+      case None =>
+        r.meta match {
+          case Some(m) => m.getOrElse("meetingId", "unknown")
+          case None    => "unknown"
+        }
     }
   }
 


### PR DESCRIPTION
Fix for #8290 

@ritzalam Can you please test it?