### PR TITLE
Change message when uploaded file is too large

### DIFF
--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -171,7 +171,7 @@
     "app.presentationUploder.genericError": "Ops, something went wrong",
     "app.presentationUploder.rejectedError": "The selected file(s) have been rejected. Please check the file type(s).",
     "app.presentationUploder.upload.progress": "Uploading ({0}%)",
-    "app.presentationUploder.upload.413": "File is too large, maximum of 200 pages reached",
+    "app.presentationUploder.upload.413": "File is too large. Please split into multiple files.",
     "app.presentationUploder.conversion.conversionProcessingSlides": "Processing page {0} of {1}",
     "app.presentationUploder.conversion.genericConversionStatus": "Converting file ...",
     "app.presentationUploder.conversion.generatingThumbnail": "Generating thumbnails ...",


### PR DESCRIPTION
Tell user to split file when uploaded file is too big (size) or too many pages.

Fixes issue https://github.com/bigbluebutton/bigbluebutton/issues/8272