### PR TITLE
 Track client's webrtc call session

### DIFF
--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/ESLEventListener.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/ESLEventListener.java
@@ -51,6 +51,7 @@ public class ESLEventListener implements IEslEventListener {
 
     private static final Pattern GLOBAL_AUDION_PATTERN = Pattern.compile("(GLOBAL_AUDIO)_(.*)$");
     private static final Pattern CALLERNAME_PATTERN = Pattern.compile("(.*)-bbbID-(.*)$");
+    private static final Pattern CALLERNAME_WITH_SESS_INFO_PATTERN = Pattern.compile("^(.*)_(\\d+)-bbbID-(.*)$");
     
     @Override
     public void conferenceEventJoin(String uniqueId, String confName, int confSize, EslEvent event) {
@@ -77,7 +78,11 @@ public class ESLEventListener implements IEslEventListener {
             conferenceEventListener.handleConferenceEvent(dsStart);
         } else {
             Matcher matcher = CALLERNAME_PATTERN.matcher(callerIdName);
-            if (matcher.matches()) {
+            Matcher callWithSess = CALLERNAME_WITH_SESS_INFO_PATTERN.matcher(callerIdName);
+            if (callWithSess.matches()) {
+                voiceUserId = callWithSess.group(1).trim();
+                callerIdName = callWithSess.group(3).trim();
+            } else if (matcher.matches()) {
                 voiceUserId = matcher.group(1).trim();
                 callerIdName = matcher.group(2).trim();
             } else {

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -16,9 +16,22 @@ const IPV4_FALLBACK_DOMAIN = Meteor.settings.public.app.ipv4FallbackDomain;
 const ICE_NEGOTIATION_FAILED = ['iceConnectionFailed'];
 const CALL_CONNECT_TIMEOUT = 15000;
 const ICE_NEGOTIATION_TIMEOUT = 20000;
+const AUDIO_SESSION_NUM_KEY = 'AudioSessionNumber';
+
+
+const getAudioSessionNumber = () => {
+  let currItem = parseInt(sessionStorage.getItem(AUDIO_SESSION_NUM_KEY), 10);
+  if (!currItem) {
+    currItem = 0;
+  }
+
+  currItem += 1;
+  sessionStorage.setItem(AUDIO_SESSION_NUM_KEY, currItem);
+  return currItem;
+};
 
 class SIPSession {
-  constructor(user, userData, protocol, hostname, 
+  constructor(user, userData, protocol, hostname,
     baseCallStates, baseErrorCodes, reconnectAttempt) {
     this.user = user;
     this.userData = userData;
@@ -83,7 +96,7 @@ class SIPSession {
     } = this.user;
 
     const callerIdName = [
-      userId,
+      `${userId}_${getAudioSessionNumber()}`,
       'bbbID',
       isListenOnly ? `LISTENONLY-${name}` : name,
     ].join('-').replace(/"/g, "'");


### PR DESCRIPTION
 - We want to be able to correlate client webrtc calls with freeswitch logs. We add extra info
   on callerid which we strip out in akka-fsesl.

NOTE:
Client needs to be modified to add the info. This PR handles both callerid (with and without) formats so can be safely merged without waiting for the client changes.