### PR TITLE
Allow for logTag parameter in settings.yml

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/logger.js
+++ b/bigbluebutton-html5/imports/startup/client/logger.js
@@ -20,17 +20,24 @@ const LOG_CONFIG = Meteor.settings.public.clientLog || { console: { enabled: tru
 
 // Custom stream that logs to an end-point
 class ServerLoggerStream extends ServerStream {
+  constructor(params) {
+    super(params);
+
+    if (params.logTag) {
+      this.logTagString = params.logTag;
+    }
+  }
+
   write(rec) {
     const { fullInfo } = Auth;
-    const { logTag } = Meteor.settings.public.app;
 
     this.rec = rec;
     if (fullInfo.meetingId != null) {
       this.rec.userInfo = fullInfo;
     }
     this.rec.clientBuild = Meteor.settings.public.app.html5ClientBuild;
-    if (logTag) {
-      this.rec.logTag = logTag;
+    if (this.logTagString) {
+      this.rec.logTag = this.logTagString;
     }
     return super.write(this.rec);
   }

--- a/bigbluebutton-html5/imports/startup/client/logger.js
+++ b/bigbluebutton-html5/imports/startup/client/logger.js
@@ -22,12 +22,16 @@ const LOG_CONFIG = Meteor.settings.public.clientLog || { console: { enabled: tru
 class ServerLoggerStream extends ServerStream {
   write(rec) {
     const { fullInfo } = Auth;
+    const { logTag } = Meteor.settings.public.app;
 
     this.rec = rec;
     if (fullInfo.meetingId != null) {
       this.rec.userInfo = fullInfo;
     }
     this.rec.clientBuild = Meteor.settings.public.app.html5ClientBuild;
+    if (logTag) {
+      this.rec.logTag = logTag;
+    }
     return super.write(this.rec);
   }
 }

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -303,7 +303,7 @@ public:
   clientLog:
     server: { enabled: true, level: info }
     console: { enabled: true, level: debug }
-    external: { enabled: true, level: debug, url: https://anton.blindside-dev.com/html5Log, method: POST, throttleInterval: 400, flushOnClose: true, logTag: "" }
+    external: { enabled: false, level: info, url: https://LOG_HOST/html5Log, method: POST, throttleInterval: 400, flushOnClose: true, logTag: "" }
 private:
   app:
     host: 127.0.0.1

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -16,6 +16,7 @@ public:
     helpLink: https://bigbluebutton.org/html5/
     lockOnJoin: true
     cdn: ""
+    logTag: ""
     basename: "/html5client"
     askForFeedbackOnLogout: false
     allowUserLookup: false

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -16,7 +16,6 @@ public:
     helpLink: https://bigbluebutton.org/html5/
     lockOnJoin: true
     cdn: ""
-    logTag: ""
     basename: "/html5client"
     askForFeedbackOnLogout: false
     allowUserLookup: false
@@ -304,7 +303,7 @@ public:
   clientLog:
     server: { enabled: true, level: info }
     console: { enabled: true, level: debug }
-    external: { enabled: false, level: info, url: https://LOG_HOST/html5Log, method: POST, throttleInterval: 400, flushOnClose: true }
+    external: { enabled: true, level: debug, url: https://anton.blindside-dev.com/html5Log, method: POST, throttleInterval: 400, flushOnClose: true, logTag: "" }
 private:
   app:
     host: 127.0.0.1


### PR DESCRIPTION
```[
  {
    "name": "clientLogger",
    "level": 30,
    "logCode": "sip_js_ice_connection_success",
    "extraInfo": {
      "currentState": "connected"
    },
    "levelName": "info",
    "msg": "ICE connection success. Current state - connected",
    "time": "2019-11-14T23:05:40.287Z",
    "src": "MediaHandler.handleConnectionCompleted (https://anton.blindside-dev.com/html5client/app/app.js?hash=f6a7273f42c82fb36b7ef223643ecb40491434ed:56882:16)",
    "v": 1,
    "userInfo": {
      "sessionToken": "j021unnpdmyjbrk1",
      "meetingId": "183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1573669656655",
      "requesterUserId": "w_9tmtmlk0bjqt",
      "fullname": "ee",
      "confname": "Demo Meeting",
      "externUserID": "w_9tmtmlk0bjqt",
      "uniqueClientSession": "j021unnpdmyjbrk1-l582as"
    },
    "clientBuild": "HTML5_CLIENT_VERSION",
    "logTag": "log-from-server-group-003",
    "url": "https://anton.blindside-dev.com/html5client/join?sessionToken=j021unnpdmyjbrk1",
    "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.97 Safari/537.36",
    "count": 1
  }
]
```

Notice ` "logTag": "log-from-server-group-003",` -- the purpose is to provide a server-wide identifier in logs so aggregated logs can be filtered by their assigned logTag - rather than by matching domains, etc