### PR TITLE
bbb-record: Skip ".norecord" meetings when running --rebuildall

### DIFF
--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -319,7 +319,7 @@ fi
 if [ $REBUILDALL ]; then
 	echo "Rebuilding all recordings"
 	for recording in $(dir $BASE/raw); do
-		mark_for_rebuild $recording
+		[[ ! -e $STATUS/archived/$recording.norecord ]] && mark_for_rebuild $recording
 	done
 fi 
 


### PR DESCRIPTION
Users don't expect not-recorded meetings to appear when rebuilding
all of their existing recordings.

You can still use bbb-record --rebuild on a single not-recorded
meeting to force it to process.

Fixes #6394