### PR TITLE
Don't skip video preview if called via interface

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/container.jsx
@@ -13,7 +13,7 @@ const SKIP_VIDEO_PREVIEW = KURENTO_CONFIG.skipVideoPreview;
 
 const VideoPreviewContainer = props => <VideoPreview {...props} />;
 
-export default withModalMounter(withTracker(({ mountModal }) => ({
+export default withModalMounter(withTracker(({ mountModal, fromInterface }) => ({
   startSharing: () => {
     mountModal(null);
     VideoService.joinVideo();
@@ -24,5 +24,5 @@ export default withModalMounter(withTracker(({ mountModal }) => ({
   changeProfile: profileId => Service.changeProfile(profileId),
   hasMediaDevices: deviceInfo.hasMediaDevices,
   userParameterProfile: getFromUserSettings('bbb_preferred_camera_profile', (CAMERA_PROFILES.filter(i => i.default) || {}).id),
-  skipVideoPreview: getFromUserSettings('bbb_skip_video_preview', false) || SKIP_VIDEO_PREVIEW,
+  skipVideoPreview: (getFromUserSettings('bbb_skip_video_preview', false) || SKIP_VIDEO_PREVIEW) && !fromInterface,
 }))(VideoPreviewContainer));

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/container.jsx
@@ -24,7 +24,7 @@ const JoinVideoOptionsContainer = (props) => {
     ...restProps
   } = props;
 
-  const mountPreview = () => { mountModal(<VideoPreviewContainer />); };
+  const mountPreview = () => { mountModal(<VideoPreviewContainer fromInterface />); };
 
   return !isMobileNative && (
   <JoinVideoButton {...{


### PR DESCRIPTION
This PR Removes the skip video preview from video button and just enble if auto share flag is true.