### PR TITLE
Replaced "Audio Error" with a template literal of the error

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -364,7 +364,7 @@ class AudioManager {
             errorCode: error,
             cause: bridgeError,
           },
-        }, 'Audio Error');
+        }, `errorCode=${error}, cause=${bridgeError}`);
         if (silenceNotifications !== true) {
           this.notify(errorMsg, true);
           this.exitAudio();


### PR DESCRIPTION
Before:
![Screenshot from 2019-11-27 08-45-05](https://user-images.githubusercontent.com/6312397/69728639-c87d3400-10f2-11ea-995f-1c5d8ec2c6fa.png)

After:
![Screenshot from 2019-11-27 08-44-50](https://user-images.githubusercontent.com/6312397/69728640-c87d3400-10f2-11ea-9de8-7765f175a74a.png)

Requested by @ritzalam 