### PR TITLE
Synching of meetings between meteor and akka-apps

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -74,6 +74,7 @@ class BigBlueButtonActor(
       case m: RegisterUserReqMsg          => handleRegisterUserReqMsg(m)
       case m: EjectDuplicateUserReqMsg    => handleEjectDuplicateUserReqMsg(m)
       case m: GetAllMeetingsReqMsg        => handleGetAllMeetingsReqMsg(m)
+      case m: GetRunningMeetingsReqMsg    => handleGetRunningMeetingsReqMsg(m)
       case m: CheckAlivePingSysMsg        => handleCheckAlivePingSysMsg(m)
       case m: ValidateConnAuthTokenSysMsg => handleValidateConnAuthTokenSysMsg(m)
       case _                              => log.warning("Cannot handle " + msg.envelope.name)
@@ -141,26 +142,26 @@ class BigBlueButtonActor(
       // do nothing
 
     }
+  }
 
+  private def handleGetRunningMeetingsReqMsg(msg: GetRunningMeetingsReqMsg): Unit = {
+    val liveMeetings = RunningMeetings.meetings(meetings)
+    val meetingIds = liveMeetings.map(m => m.props.meetingProp.intId)
+
+    val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
+    val envelope = BbbCoreEnvelope(GetRunningMeetingsRespMsg.NAME, routing)
+    val header = BbbCoreBaseHeader(GetRunningMeetingsRespMsg.NAME)
+
+    val body = GetRunningMeetingsRespMsgBody(meetingIds)
+    val event = GetRunningMeetingsRespMsg(header, body)
+    val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+    outGW.send(msgEvent)
   }
 
   private def handleGetAllMeetingsReqMsg(msg: GetAllMeetingsReqMsg): Unit = {
-    val liveMeetings = RunningMeetings.meetings(meetings)
-    if (liveMeetings.size == 0) {
-      val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
-      val envelope = BbbCoreEnvelope(GetAllMeetingsRepMsg.NAME, routing)
-      val header = BbbCoreBaseHeader(GetAllMeetingsRepMsg.NAME)
-
-      val body = GetAllMeetingsRepMsgBody(Vector())
-      val event = GetAllMeetingsRepMsg(header, body)
-      val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
-      outGW.send(msgEvent)
-    } else {
-      RunningMeetings.meetings(meetings).foreach(m => {
-        m.actorRef ! msg
-      })
-    }
-
+    RunningMeetings.meetings(meetings).foreach(m => {
+      m.actorRef ! msg
+    })
   }
 
   private def handleCheckAlivePingSysMsg(msg: CheckAlivePingSysMsg): Unit = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -221,6 +221,7 @@ class MeetingActor(
 
     case m: EjectDuplicateUserReqMsg          => usersApp.handleEjectDuplicateUserReqMsg(m)
     case m: GetAllMeetingsReqMsg              => handleGetAllMeetingsReqMsg(m)
+    case m: GetRunningMeetingStateReqMsg      => handleGetRunningMeetingStateReqMsg(m)
     case m: ValidateConnAuthTokenSysMsg       => handleValidateConnAuthTokenSysMsg(m)
 
     // Meeting
@@ -493,7 +494,11 @@ class MeetingActor(
     }
   }
 
-  def handleGetAllMeetingsReqMsg(msg: GetAllMeetingsReqMsg): Unit = {
+  def handleGetRunningMeetingStateReqMsg(msg: GetRunningMeetingStateReqMsg): Unit = {
+    processGetRunningMeetingStateReqMsg()
+  }
+
+  def processGetRunningMeetingStateReqMsg(): Unit = {
     // sync all meetings
     handleSyncGetMeetingInfoRespMsg(liveMeeting.props)
 
@@ -513,7 +518,10 @@ class MeetingActor(
     handleSyncGetLockSettingsMsg(state, liveMeeting, msgBus)
 
     // TODO send all screen sharing info
+  }
 
+  def handleGetAllMeetingsReqMsg(msg: GetAllMeetingsReqMsg): Unit = {
+    processGetRunningMeetingStateReqMsg()
   }
 
   def handlePresenterChange(msg: AssignPresenterReqMsg, state: MeetingState2x): MeetingState2x = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
@@ -31,6 +31,8 @@ class AnalyticsActor extends Actor with ActorLogging {
 
     msg.core match {
       case m: GetAllMeetingsReqMsg                           => logMessage(msg)
+      case m: GetRunningMeetingsRespMsg                      => logMessage(msg)
+      case m: GetRunningMeetingsReqMsg                       => logMessage(msg)
 
       case m: RegisterUserReqMsg                             => logMessage(msg)
       case m: RegisteredUserJoinTimeoutMsg                   => logMessage(msg)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/SystemMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/SystemMsgs.scala
@@ -37,12 +37,26 @@ case class GetAllMeetingsReqMsg(
 ) extends BbbCoreMsg
 case class GetAllMeetingsReqMsgBody(requesterId: String)
 
-object GetAllMeetingsRepMsg { val NAME = "GetAllMeetingsRepMsg" }
-case class GetAllMeetingsRepMsg(
+object GetRunningMeetingsReqMsg { val NAME = "GetRunningMeetingsReqMsg" }
+case class GetRunningMeetingsReqMsg(
     header: BbbCoreBaseHeader,
-    body:   GetAllMeetingsRepMsgBody
+    body:   GetRunningMeetingsReqMsgBody
 ) extends BbbCoreMsg
-case class GetAllMeetingsRepMsgBody(meetings: Vector[String])
+case class GetRunningMeetingsReqMsgBody(requesterId: String)
+
+object GetRunningMeetingsRespMsg { val NAME = "GetRunningMeetingsRespMsg" }
+case class GetRunningMeetingsRespMsg(
+    header: BbbCoreBaseHeader,
+    body:   GetRunningMeetingsRespMsgBody
+) extends BbbCoreMsg
+case class GetRunningMeetingsRespMsgBody(meetings: Vector[String])
+
+object GetRunningMeetingStateReqMsg { val NAME = "GetRunningMeetingStateReqMsg" }
+case class GetRunningMeetingStateReqMsg(
+    header: BbbCoreBaseHeader,
+    body:   GetRunningMeetingStateReqMsgBody
+) extends BbbCoreMsg
+case class GetRunningMeetingStateReqMsgBody(meetingId: String)
 
 object PubSubPingSysReqMsg { val NAME = "PubSubPingSysReqMsg" }
 case class PubSubPingSysReqMsg(

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/SystemMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/SystemMsgs.scala
@@ -37,6 +37,13 @@ case class GetAllMeetingsReqMsg(
 ) extends BbbCoreMsg
 case class GetAllMeetingsReqMsgBody(requesterId: String)
 
+object GetAllMeetingsRepMsg { val NAME = "GetAllMeetingsRepMsg" }
+case class GetAllMeetingsRepMsg(
+    header: BbbCoreBaseHeader,
+    body:   GetAllMeetingsRepMsgBody
+) extends BbbCoreMsg
+case class GetAllMeetingsRepMsgBody(meetings: Vector[String])
+
 object PubSubPingSysReqMsg { val NAME = "PubSubPingSysReqMsg" }
 case class PubSubPingSysReqMsg(
     header: BbbCoreBaseHeader,


### PR DESCRIPTION
 When meteor requests for meeting information from akka-apps, no reply is given when there are no meetings running. Send reply to get meeting request when there are no meeting running.