### PR TITLE
Fix elements overlapping whos talking

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.scss
@@ -26,7 +26,7 @@
 
   font-size: 1.5rem;
   padding: var(--bars-padding) var(--bars-padding) 0 var(--bars-padding);
-  height: 6.75rem;
+  height: 7rem;
 }
 
 .wrapper {

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/styles.scss
@@ -2,6 +2,7 @@
 
 :root {
   --mobile-nav-height: 5rem;
+  --mobile-margin-top: .25rem;
 }
 
 .navbar {
@@ -18,7 +19,7 @@
 
 .bottom {
   @include mq($phone-landscape) {
-    margin-top: .25rem;
+    margin-top: var(--mobile-margin-top);
   }
 }
 

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/styles.scss
@@ -1,23 +1,25 @@
 @import "../../stylesheets/variables/_all";
 
 :root {
-  --safari-mobile-nav-height: 5rem;
+  --mobile-nav-height: 5rem;
 }
 
 .navbar {
   display: flex;
   flex-direction: column;
-  height: var(--jumbo-padding-x);
-  
-  :global(.browser-safari) & {
-    height: var(--safari-mobile-nav-height);
-  }
+  height:var(--mobile-nav-height);
 }
 
 .top,
 .bottom {
   display: flex;
   flex-direction: row;
+}
+
+.bottom {
+  @include mq($phone-landscape) {
+    margin-top: .25rem;
+  }
 }
 
 .left,

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/styles.scss
@@ -75,7 +75,7 @@
     max-width: var(--talker-max-width);
 
     @include mq($phone-landscape) {
-      font-size: .575rem !important;
+      font-size: var(--font-size-xs);
     }
 
     [dir="rtl"]  & {
@@ -93,9 +93,9 @@
     right: var(--talker-margin-sm);
 
     @include mq($phone-landscape) {
-      height: .5rem;
-      width: .5rem;
-      font-size: .575rem;
+      height: var(--talker-margin-sm);
+      width: var(--talker-margin-sm);
+      font-size: var(--font-size-xs);
     }
 
     [dir="rtl"]  & {

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/styles.scss
@@ -56,6 +56,10 @@
   margin-right: var(--border-radius);
   height: var(--talker-height);
   box-shadow: none !important;
+
+  @include mq($phone-landscape) {
+    height: 1rem;
+  }
   
   i,
   span {
@@ -70,6 +74,10 @@
     margin: 0 0 0 0 !important;
     max-width: var(--talker-max-width);
 
+    @include mq($phone-landscape) {
+      font-size: .575rem !important;
+    }
+
     [dir="rtl"]  & {
       margin-left: var(--talker-margin-sm);
     }
@@ -83,6 +91,12 @@
     border-radius: 50%;
     position: relative;
     right: var(--talker-margin-sm);
+
+    @include mq($phone-landscape) {
+      height: .5rem;
+      width: .5rem;
+      font-size: .575rem;
+    }
 
     [dir="rtl"]  & {
       right: calc(var(--talker-margin-sm) * -1);

--- a/bigbluebutton-html5/imports/ui/stylesheets/variables/breakpoints.scss
+++ b/bigbluebutton-html5/imports/ui/stylesheets/variables/breakpoints.scss
@@ -42,6 +42,7 @@ $xxlarge-up: "#{$screen} and (min-width:#{lower-bound($xxlarge-range)})";
 $xxlarge-only: "#{$screen} and (min-width:#{lower-bound($xxlarge-range)}) and (max-width:#{upper-bound($xxlarge-range)})";
 
 $hasPhoneDimentions: "#{$screen} and (max-height: 479px), #{$screen} and (max-width: 479px)";
+$phone-landscape: "#{$screen} and (max-width: 480px) and (orientation: landscape)";
 
 //Breakpoints used for permissions-overlay as relative units are not scalling properly on safari
 $safari1280: "#{$screen} and (max-height: 1280px), #{$screen} and (max-width: 800px)";
@@ -59,6 +60,7 @@ $breakpoints: (
   'large': $large-only,
   'xlarge': $xlarge-only,
   'xxlarge': $xxlarge-only,
+  'phoneLandscape': $phone-landscape,
 );
 
 @mixin mq($media) {

--- a/bigbluebutton-html5/imports/ui/stylesheets/variables/typography.scss
+++ b/bigbluebutton-html5/imports/ui/stylesheets/variables/typography.scss
@@ -10,8 +10,9 @@
   --font-size-md: 0.95rem; 
   --font-size-small: 0.875rem;
   --font-size-smaller: .75rem;
+  --font-size-xs: .575rem;
   --font-size-smallest: .35rem;
-
+  
   --line-height-base: 1.25; // 20/16
   --line-height-computed: 1rem;
 


### PR DESCRIPTION
This pr will prevent the whos talking indicator from being in a state where can be overlapped by the whiteboard or webcams.