### PR TITLE
Enforce lock settings on server

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
@@ -58,10 +58,12 @@ object LockSettingsUtil {
           }
         }
       }
+    } else {
+      enforceListenOnlyUserIsMuted(intUserId, liveMeeting, outGW)
     }
   }
 
-  def enforceListenOnlyUserIsMuted(intUserId: String, liveMeeting: LiveMeeting, outGW: OutMsgRouter): Unit = {
+  private def enforceListenOnlyUserIsMuted(intUserId: String, liveMeeting: LiveMeeting, outGW: OutMsgRouter): Unit = {
     val voiceUser = VoiceUsers.findWithIntId(liveMeeting.voiceUsers, intUserId)
     voiceUser.foreach { vu =>
       // Make sure that listen only user is muted. (ralam dec 6, 2019

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
@@ -22,7 +22,7 @@ object LockSettingsUtil {
   private def applyMutingOfUsers(disableMic: Boolean, liveMeeting: LiveMeeting, outGW: OutMsgRouter): Unit = {
     VoiceUsers.findAll(liveMeeting.voiceUsers) foreach { vu =>
       Users2x.findWithIntId(liveMeeting.users2x, vu.intId).foreach { user =>
-        if (user.role == Roles.VIEWER_ROLE && !vu.listenOnly) {
+        if (user.role == Roles.VIEWER_ROLE && !vu.listenOnly && !user.locked) {
           // Apply lock setting to users who are not listen only. (ralam dec 6, 2019)
           muteUserInVoiceConf(liveMeeting, outGW, vu, disableMic)
         }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
@@ -7,7 +7,7 @@ import org.bigbluebutton.core2.{ MeetingStatus2x }
 
 object LockSettingsUtil {
 
-  def muteUserInVoiceConf(liveMeeting: LiveMeeting, outGW: OutMsgRouter, vu: VoiceUserState, mute: Boolean): Unit = {
+  private def muteUserInVoiceConf(liveMeeting: LiveMeeting, outGW: OutMsgRouter, vu: VoiceUserState, mute: Boolean): Unit = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, vu.intId)
     val envelope = BbbCoreEnvelope(MuteUserInVoiceConfSysMsg.NAME, routing)
     val header = BbbCoreHeaderWithMeetingId(MuteUserInVoiceConfSysMsg.NAME, liveMeeting.props.meetingProp.intId)
@@ -19,20 +19,17 @@ object LockSettingsUtil {
     outGW.send(msgEvent)
   }
 
-  def applyMutingOfUsers(mute: Boolean, liveMeeting: LiveMeeting, outGW: OutMsgRouter): Unit = {
+  private def applyMutingOfUsers(disableMic: Boolean, liveMeeting: LiveMeeting, outGW: OutMsgRouter): Unit = {
     VoiceUsers.findAll(liveMeeting.voiceUsers) foreach { vu =>
       Users2x.findWithIntId(liveMeeting.users2x, vu.intId).foreach { user =>
-        if (user.role == Roles.VIEWER_ROLE) {
-          if (mute) {
-            // Mute everyone. We also mute listenOnly users as sledgehammer to make sure
-            // audio can't be transmitted. (ralam dec 6, 2019)
-            muteUserInVoiceConf(liveMeeting, outGW, vu, mute)
-          } else {
-            // Only unmute viewers and non-listenOnly users.
-            if (!vu.listenOnly) {
-              muteUserInVoiceConf(liveMeeting, outGW, vu, mute)
-            }
-          }
+        if (user.role == Roles.VIEWER_ROLE && !vu.listenOnly) {
+          // Apply lock setting to users who are not listen only. (ralam dec 6, 2019)
+          muteUserInVoiceConf(liveMeeting, outGW, vu, disableMic)
+        }
+
+        // Make sure listen only users are muted. (ralam dec 6, 2019)
+        if (vu.listenOnly && !vu.muted) {
+          muteUserInVoiceConf(liveMeeting, outGW, vu, true)
         }
       }
     }
@@ -41,25 +38,21 @@ object LockSettingsUtil {
   def enforceLockSettingsForAllVoiceUsers(liveMeeting: LiveMeeting, outGW: OutMsgRouter): Unit = {
     val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
     applyMutingOfUsers(permissions.disableMic, liveMeeting, outGW)
-
   }
 
-  def enforceLockSettingsForVoiceUser(intUserId: String, liveMeeting: LiveMeeting, outGW: OutMsgRouter): Unit = {
+  def enforceLockSettingsForVoiceUser(voiceUser: VoiceUserState, liveMeeting: LiveMeeting, outGW: OutMsgRouter): Unit = {
     val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
     if (permissions.disableMic) {
-      Users2x.findWithIntId(liveMeeting.users2x, intUserId).foreach { user =>
+      Users2x.findWithIntId(liveMeeting.users2x, voiceUser.intId).foreach { user =>
         if (user.role == Roles.VIEWER_ROLE) {
-          val voiceUser = VoiceUsers.findWithIntId(liveMeeting.voiceUsers, intUserId)
-          voiceUser.foreach { vu =>
-            // Make sure that user is muted when lock settings has mic disabled. (ralam dec 6, 2019
-            if (!vu.muted) {
-              muteUserInVoiceConf(liveMeeting, outGW, vu, true)
-            }
+          // Make sure that user is muted when lock settings has mic disabled. (ralam dec 6, 2019
+          if (!voiceUser.muted) {
+            muteUserInVoiceConf(liveMeeting, outGW, voiceUser, true)
           }
         }
       }
     } else {
-      enforceListenOnlyUserIsMuted(intUserId, liveMeeting, outGW)
+      enforceListenOnlyUserIsMuted(voiceUser.intId, liveMeeting, outGW)
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
@@ -7,31 +7,30 @@ import org.bigbluebutton.core2.{ MeetingStatus2x }
 
 object LockSettingsUtil {
 
+  def muteUserInVoiceConf(liveMeeting: LiveMeeting, outGW: OutMsgRouter, vu: VoiceUserState, mute: Boolean): Unit = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, vu.intId)
+    val envelope = BbbCoreEnvelope(MuteUserInVoiceConfSysMsg.NAME, routing)
+    val header = BbbCoreHeaderWithMeetingId(MuteUserInVoiceConfSysMsg.NAME, liveMeeting.props.meetingProp.intId)
+
+    val body = MuteUserInVoiceConfSysMsgBody(liveMeeting.props.voiceProp.voiceConf, vu.voiceUserId, mute)
+    val event = MuteUserInVoiceConfSysMsg(header, body)
+    val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+
+    outGW.send(msgEvent)
+  }
+
   def applyMutingOfUsers(mute: Boolean, liveMeeting: LiveMeeting, outGW: OutMsgRouter): Unit = {
-
-    def muteUserInVoiceConf(vu: VoiceUserState, mute: Boolean): Unit = {
-      val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, vu.intId)
-      val envelope = BbbCoreEnvelope(MuteUserInVoiceConfSysMsg.NAME, routing)
-      val header = BbbCoreHeaderWithMeetingId(MuteUserInVoiceConfSysMsg.NAME, liveMeeting.props.meetingProp.intId)
-
-      val body = MuteUserInVoiceConfSysMsgBody(liveMeeting.props.voiceProp.voiceConf, vu.voiceUserId, mute)
-      val event = MuteUserInVoiceConfSysMsg(header, body)
-      val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
-
-      outGW.send(msgEvent)
-    }
-
     VoiceUsers.findAll(liveMeeting.voiceUsers) foreach { vu =>
       Users2x.findWithIntId(liveMeeting.users2x, vu.intId).foreach { user =>
         if (user.role == Roles.VIEWER_ROLE) {
           if (mute) {
             // Mute everyone. We also mute listenOnly users as sledgehammer to make sure
             // audio can't be transmitted. (ralam dec 6, 2019)
-            muteUserInVoiceConf(vu, mute)
+            muteUserInVoiceConf(liveMeeting, outGW, vu, mute)
           } else {
             // Only unmute viewers and non-listenOnly users.
             if (!vu.listenOnly) {
-              muteUserInVoiceConf(vu, mute)
+              muteUserInVoiceConf(liveMeeting, outGW, vu, mute)
             }
           }
         }
@@ -39,9 +38,36 @@ object LockSettingsUtil {
     }
   }
 
-  def enforceLockSettingsForVoice(liveMeeting: LiveMeeting, outGW: OutMsgRouter): Unit = {
+  def enforceLockSettingsForAllVoiceUsers(liveMeeting: LiveMeeting, outGW: OutMsgRouter): Unit = {
     val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
     applyMutingOfUsers(permissions.disableMic, liveMeeting, outGW)
 
+  }
+
+  def enforceLockSettingsForVoiceUser(intUserId: String, liveMeeting: LiveMeeting, outGW: OutMsgRouter): Unit = {
+    val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
+    if (permissions.disableMic) {
+      Users2x.findWithIntId(liveMeeting.users2x, intUserId).foreach { user =>
+        if (user.role == Roles.VIEWER_ROLE) {
+          val voiceUser = VoiceUsers.findWithIntId(liveMeeting.voiceUsers, intUserId)
+          voiceUser.foreach { vu =>
+            // Make sure that user is muted when lock settings has mic disabled. (ralam dec 6, 2019
+            if (!vu.muted) {
+              muteUserInVoiceConf(liveMeeting, outGW, vu, true)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  def enforceListenOnlyUserIsMuted(intUserId: String, liveMeeting: LiveMeeting, outGW: OutMsgRouter): Unit = {
+    val voiceUser = VoiceUsers.findWithIntId(liveMeeting.voiceUsers, intUserId)
+    voiceUser.foreach { vu =>
+      // Make sure that listen only user is muted. (ralam dec 6, 2019
+      if (vu.listenOnly && !vu.muted) {
+        muteUserInVoiceConf(liveMeeting, outGW, vu, true)
+      }
+    }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
@@ -22,7 +22,7 @@ object LockSettingsUtil {
   private def applyMutingOfUsers(disableMic: Boolean, liveMeeting: LiveMeeting, outGW: OutMsgRouter): Unit = {
     VoiceUsers.findAll(liveMeeting.voiceUsers) foreach { vu =>
       Users2x.findWithIntId(liveMeeting.users2x, vu.intId).foreach { user =>
-        if (user.role == Roles.VIEWER_ROLE && !vu.listenOnly && !user.locked) {
+        if (user.role == Roles.VIEWER_ROLE && !vu.listenOnly && user.locked) {
           // Apply lock setting to users who are not listen only. (ralam dec 6, 2019)
           muteUserInVoiceConf(liveMeeting, outGW, vu, disableMic)
         }
@@ -44,7 +44,7 @@ object LockSettingsUtil {
     val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
     if (permissions.disableMic) {
       Users2x.findWithIntId(liveMeeting.users2x, voiceUser.intId).foreach { user =>
-        if (user.role == Roles.VIEWER_ROLE) {
+        if (user.role == Roles.VIEWER_ROLE && user.locked) {
           // Make sure that user is muted when lock settings has mic disabled. (ralam dec 6, 2019
           if (!voiceUser.muted) {
             muteUserInVoiceConf(liveMeeting, outGW, voiceUser, true)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
@@ -1,0 +1,47 @@
+package org.bigbluebutton
+
+import org.bigbluebutton.common2.msgs.{ BbbCommonEnvCoreMsg, BbbCoreEnvelope, BbbCoreHeaderWithMeetingId, MessageTypes, MuteUserInVoiceConfSysMsg, MuteUserInVoiceConfSysMsgBody, Routing }
+import org.bigbluebutton.core.models.{ Roles, Users2x, VoiceUserState, VoiceUsers }
+import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
+import org.bigbluebutton.core2.{ MeetingStatus2x }
+
+object LockSettingsUtil {
+
+  def applyMutingOfUsers(mute: Boolean, liveMeeting: LiveMeeting, outGW: OutMsgRouter): Unit = {
+
+    def muteUserInVoiceConf(vu: VoiceUserState, mute: Boolean): Unit = {
+      val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, vu.intId)
+      val envelope = BbbCoreEnvelope(MuteUserInVoiceConfSysMsg.NAME, routing)
+      val header = BbbCoreHeaderWithMeetingId(MuteUserInVoiceConfSysMsg.NAME, liveMeeting.props.meetingProp.intId)
+
+      val body = MuteUserInVoiceConfSysMsgBody(liveMeeting.props.voiceProp.voiceConf, vu.voiceUserId, mute)
+      val event = MuteUserInVoiceConfSysMsg(header, body)
+      val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+
+      outGW.send(msgEvent)
+    }
+
+    VoiceUsers.findAll(liveMeeting.voiceUsers) foreach { vu =>
+      Users2x.findWithIntId(liveMeeting.users2x, vu.intId).foreach { user =>
+        if (user.role == Roles.VIEWER_ROLE) {
+          if (mute) {
+            // Mute everyone. We also mute listenOnly users as sledgehammer to make sure
+            // audio can't be transmitted. (ralam dec 6, 2019)
+            muteUserInVoiceConf(vu, mute)
+          } else {
+            // Only unmute viewers and non-listenOnly users.
+            if (!vu.listenOnly) {
+              muteUserInVoiceConf(vu, mute)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  def enforceLockSettingsForVoice(liveMeeting: LiveMeeting, outGW: OutMsgRouter): Unit = {
+    val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
+    applyMutingOfUsers(permissions.disableMic, liveMeeting, outGW)
+
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
@@ -37,7 +37,7 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
 
         MeetingStatus2x.setPermissions(liveMeeting.status, settings)
 
-        LockSettingsUtil.enforceLockSettingsForVoice(liveMeeting, outGW)
+        LockSettingsUtil.enforceLockSettingsForAllVoiceUsers(liveMeeting, outGW)
 
         val routing = Routing.addMsgToClientRouting(
           MessageTypes.BROADCAST_TO_MEETING,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
@@ -35,9 +35,14 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
       if (!MeetingStatus2x.permissionsEqual(liveMeeting.status, settings) || !MeetingStatus2x.permisionsInitialized(liveMeeting.status)) {
         MeetingStatus2x.initializePermissions(liveMeeting.status)
 
+        val oldPermissions = MeetingStatus2x.getPermissions(liveMeeting.status)
+
         MeetingStatus2x.setPermissions(liveMeeting.status, settings)
 
-        LockSettingsUtil.enforceLockSettingsForAllVoiceUsers(liveMeeting, outGW)
+        if (!oldPermissions.disableMic && settings.disableMic) {
+          // Apply lock settings when disableMic from false to true.
+          LockSettingsUtil.enforceLockSettingsForAllVoiceUsers(liveMeeting, outGW)
+        }
 
         val routing = Routing.addMsgToClientRouting(
           MessageTypes.BROADCAST_TO_MEETING,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
@@ -1,5 +1,6 @@
 package org.bigbluebutton.core.apps.users
 
+import org.bigbluebutton.LockSettingsUtil
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.running.OutMsgRouter
@@ -35,6 +36,8 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
         MeetingStatus2x.initializePermissions(liveMeeting.status)
 
         MeetingStatus2x.setPermissions(liveMeeting.status, settings)
+
+        LockSettingsUtil.enforceLockSettingsForVoice(liveMeeting, outGW)
 
         val routing = Routing.addMsgToClientRouting(
           MessageTypes.BROADCAST_TO_MEETING,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserTalkingInVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserTalkingInVoiceConfEvtMsgHdlr.scala
@@ -1,5 +1,6 @@
 package org.bigbluebutton.core.apps.voice
 
+import org.bigbluebutton.LockSettingsUtil
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.{ VoiceUserState, VoiceUsers }
 import org.bigbluebutton.core.running.{ BaseMeetingActor, LiveMeeting, OutMsgRouter }
@@ -34,6 +35,12 @@ trait UserTalkingInVoiceConfEvtMsgHdlr {
     for {
       talkingUser <- VoiceUsers.userTalking(liveMeeting.voiceUsers, msg.body.voiceUserId, msg.body.talking)
     } yield {
+      // Make sure listen only users cannot talk (ralam dec 6, 2019)
+      LockSettingsUtil.enforceListenOnlyUserIsMuted(
+        talkingUser.intId,
+        liveMeeting,
+        outGW
+      )
       broadcastEvent(talkingUser)
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserTalkingInVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserTalkingInVoiceConfEvtMsgHdlr.scala
@@ -37,7 +37,7 @@ trait UserTalkingInVoiceConfEvtMsgHdlr {
     } yield {
       // Make sure lock settings are in effect (ralam dec 6, 2019)
       LockSettingsUtil.enforceLockSettingsForVoiceUser(
-        talkingUser.intId,
+        talkingUser,
         liveMeeting,
         outGW
       )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserTalkingInVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserTalkingInVoiceConfEvtMsgHdlr.scala
@@ -35,8 +35,8 @@ trait UserTalkingInVoiceConfEvtMsgHdlr {
     for {
       talkingUser <- VoiceUsers.userTalking(liveMeeting.voiceUsers, msg.body.voiceUserId, msg.body.talking)
     } yield {
-      // Make sure listen only users cannot talk (ralam dec 6, 2019)
-      LockSettingsUtil.enforceListenOnlyUserIsMuted(
+      // Make sure lock settings are in effect (ralam dec 6, 2019)
+      LockSettingsUtil.enforceLockSettingsForVoiceUser(
         talkingUser.intId,
         liveMeeting,
         outGW

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
@@ -1,11 +1,11 @@
 package org.bigbluebutton.core.apps.voice
 
 import org.bigbluebutton.LockSettingsUtil
-import org.bigbluebutton.common2.msgs.{BbbClientMsgHeader, BbbCommonEnvCoreMsg, BbbCoreEnvelope, ConfVoiceUser, MessageTypes, Routing, UserJoinedVoiceConfToClientEvtMsg, UserJoinedVoiceConfToClientEvtMsgBody, UserLeftVoiceConfToClientEvtMsg, UserLeftVoiceConfToClientEvtMsgBody, UserMutedVoiceEvtMsg, UserMutedVoiceEvtMsgBody}
+import org.bigbluebutton.common2.msgs.{ BbbClientMsgHeader, BbbCommonEnvCoreMsg, BbbCoreEnvelope, ConfVoiceUser, MessageTypes, Routing, UserJoinedVoiceConfToClientEvtMsg, UserJoinedVoiceConfToClientEvtMsgBody, UserLeftVoiceConfToClientEvtMsg, UserLeftVoiceConfToClientEvtMsgBody, UserMutedVoiceEvtMsg, UserMutedVoiceEvtMsgBody }
 import org.bigbluebutton.core.apps.breakout.BreakoutHdlrHelpers
 import org.bigbluebutton.core.bus.InternalEventBus
-import org.bigbluebutton.core.models.{VoiceUserState, VoiceUsers}
-import org.bigbluebutton.core.running.{LiveMeeting, OutMsgRouter}
+import org.bigbluebutton.core.models.{ VoiceUserState, VoiceUsers }
+import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
@@ -252,9 +252,11 @@ object VoiceApp {
       outGW.send(event)
     }
 
-    LockSettingsUtil.enforceListenOnlyUserIsMuted(intId,
+    LockSettingsUtil.enforceListenOnlyUserIsMuted(
+      intId,
       liveMeeting,
-      outGW)
+      outGW
+    )
 
     LockSettingsUtil.enforceLockSettingsForVoiceUser(intId, liveMeeting, outGW)
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
@@ -1,10 +1,11 @@
 package org.bigbluebutton.core.apps.voice
 
-import org.bigbluebutton.common2.msgs.{ BbbClientMsgHeader, BbbCommonEnvCoreMsg, BbbCoreEnvelope, ConfVoiceUser, MessageTypes, Routing, UserJoinedVoiceConfToClientEvtMsg, UserJoinedVoiceConfToClientEvtMsgBody, UserLeftVoiceConfToClientEvtMsg, UserLeftVoiceConfToClientEvtMsgBody, UserMutedVoiceEvtMsg, UserMutedVoiceEvtMsgBody }
+import org.bigbluebutton.LockSettingsUtil
+import org.bigbluebutton.common2.msgs.{BbbClientMsgHeader, BbbCommonEnvCoreMsg, BbbCoreEnvelope, ConfVoiceUser, MessageTypes, Routing, UserJoinedVoiceConfToClientEvtMsg, UserJoinedVoiceConfToClientEvtMsgBody, UserLeftVoiceConfToClientEvtMsg, UserLeftVoiceConfToClientEvtMsgBody, UserMutedVoiceEvtMsg, UserMutedVoiceEvtMsgBody}
 import org.bigbluebutton.core.apps.breakout.BreakoutHdlrHelpers
 import org.bigbluebutton.core.bus.InternalEventBus
-import org.bigbluebutton.core.models.{ VoiceUserState, VoiceUsers }
-import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
+import org.bigbluebutton.core.models.{VoiceUserState, VoiceUsers}
+import org.bigbluebutton.core.running.{LiveMeeting, OutMsgRouter}
 import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
@@ -250,6 +251,12 @@ object VoiceApp {
       )
       outGW.send(event)
     }
+
+    LockSettingsUtil.enforceListenOnlyUserIsMuted(intId,
+      liveMeeting,
+      outGW)
+
+    LockSettingsUtil.enforceLockSettingsForVoiceUser(intId, liveMeeting, outGW)
   }
 
   def handleUserLeftVoiceConfEvtMsg(

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
@@ -94,12 +94,21 @@ object VoiceApp {
     for {
       mutedUser <- VoiceUsers.userMuted(liveMeeting.voiceUsers, voiceUserId, muted)
     } yield {
-      broadcastUserMutedVoiceEvtMsg(
-        liveMeeting.props.meetingProp.intId,
-        mutedUser,
-        liveMeeting.props.voiceProp.voiceConf,
-        outGW
-      )
+      if (!muted && mutedUser.listenOnly) {
+        // Make sure listen only users cannot talk (ralam dec 6, 2019)
+        LockSettingsUtil.enforceListenOnlyUserIsMuted(
+          mutedUser.intId,
+          liveMeeting,
+          outGW
+        )
+      } else {
+        broadcastUserMutedVoiceEvtMsg(
+          liveMeeting.props.meetingProp.intId,
+          mutedUser,
+          liveMeeting.props.voiceProp.voiceConf,
+          outGW
+        )
+      }
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
@@ -94,9 +94,9 @@ object VoiceApp {
     for {
       mutedUser <- VoiceUsers.userMuted(liveMeeting.voiceUsers, voiceUserId, muted)
     } yield {
-      if (!muted && mutedUser.listenOnly) {
-        // Make sure listen only users cannot talk (ralam dec 6, 2019)
-        LockSettingsUtil.enforceListenOnlyUserIsMuted(
+      if (!muted) {
+        // Make sure lock settings are in effect (ralam dec 6, 2019)
+        LockSettingsUtil.enforceLockSettingsForVoiceUser(
           mutedUser.intId,
           liveMeeting,
           outGW
@@ -261,7 +261,8 @@ object VoiceApp {
       outGW.send(event)
     }
 
-    LockSettingsUtil.enforceListenOnlyUserIsMuted(
+    // Make sure lock settings are in effect. (ralam dec 6, 2019)
+    LockSettingsUtil.enforceLockSettingsForVoiceUser(
       intId,
       liveMeeting,
       outGW


### PR DESCRIPTION
All of the paths to check for users joining, unmuting, and talking
 
If microphones are locked:
[x] 1. Mute users on join if they aren't Moderator
[x] 2. When an unmute comes back from FS check to see if it’s allowed or not and mute them again as necessary
[x] 3. Check that unmutes originating from locked users are disallowed
Already handled
[x] 4. When mic lock settings changes enforce the lock on non-moderators on the server-side (send the events to FS to lock the users)
 
In all cases:
[x] 5. Check if the user is identified as listen-only and mute them if they are
[x] 6. Check the talking events from FS to see if a talking is coming in from a listen-only user and re-mute as necessary
