### PR TITLE
Reduce size of mic icon in talking indicator

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/styles.scss
@@ -64,7 +64,6 @@
   i,
   span {
     position: relative;
-    bottom: var(--bottom-offset);
   }
 
   span {
@@ -73,6 +72,7 @@
     white-space: nowrap;
     margin: 0 0 0 0 !important;
     max-width: var(--talker-max-width);
+    bottom: var(--bottom-offset);
 
     @include mq($phone-landscape) {
       font-size: var(--font-size-xs);
@@ -84,9 +84,10 @@
   }
 
   i {
-    font-size: var(--font-size-small);
+    font-size: var(--font-size-smaller);
     width: 1rem;
     height: 1rem;
+    line-height: 1rem;
     background-color: var(--color-success);
     border-radius: 50%;
     position: relative;


### PR DESCRIPTION
before:
![audio-icon-size_old](https://user-images.githubusercontent.com/22058534/70808989-e56e6400-1d8e-11ea-8116-97b7033612f0.png)

after:
![audio-icon-size_new](https://user-images.githubusercontent.com/22058534/70809007-eef7cc00-1d8e-11ea-86a9-ed152ae3c400.png)
