### PR TITLE
Prevent parallel screenshare and external-video

### DIFF
--- a/bigbluebutton-html5/imports/api/screenshare/server/handlers/screenshareStarted.js
+++ b/bigbluebutton-html5/imports/api/screenshare/server/handlers/screenshareStarted.js
@@ -1,16 +1,20 @@
 import { check } from 'meteor/check';
 import Meetings from '/imports/api/meetings';
+import Users from '/imports/api/users';
 import addScreenshare from '../modifiers/addScreenshare';
 import Logger from '/imports/startup/server/logger';
+import stopWatchingExternalVideo from '/imports/api/external-videos/server/methods/stopWatchingExternalVideo';
 
 export default function handleScreenshareStarted({ body }, meetingId) {
   check(meetingId, String);
   check(body, Object);
 
   const meeting = Meetings.findOne({ meetingId });
+  const presenter = Users.findOne({ meetingId, presenter: true });
+  const presenterId = presenter && presenter.userId ? presenter.userId : 'system-screenshare-starting';
   if (meeting && meeting.externalVideoUrl) {
     Logger.info(`ScreenshareStarted: There is external video being shared. Stopping it due to presenter change, ${meeting.externalVideoUrl}`);
-    Meetings.update({ meetingId }, { $set: { externalVideoUrl: null } });
+    stopWatchingExternalVideo({ meetingId, requesterUserId: presenterId });
   }
   return addScreenshare(meetingId, body);
 }

--- a/bigbluebutton-html5/imports/api/screenshare/server/handlers/screenshareStarted.js
+++ b/bigbluebutton-html5/imports/api/screenshare/server/handlers/screenshareStarted.js
@@ -1,9 +1,16 @@
 import { check } from 'meteor/check';
+import Meetings from '/imports/api/meetings';
 import addScreenshare from '../modifiers/addScreenshare';
+import Logger from '/imports/startup/server/logger';
 
 export default function handleScreenshareStarted({ body }, meetingId) {
   check(meetingId, String);
   check(body, Object);
 
+  const meeting = Meetings.findOne({ meetingId });
+  if (meeting && meeting.externalVideoUrl) {
+    Logger.info(`ScreenshareStarted: There is external video being shared. Stopping it due to presenter change, ${meeting.externalVideoUrl}`);
+    Meetings.update({ meetingId }, { $set: { externalVideoUrl: null } });
+  }
   return addScreenshare(meetingId, body);
 }

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/changePresenter.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/changePresenter.js
@@ -1,5 +1,7 @@
 import Logger from '/imports/startup/server/logger';
 import Users from '/imports/api/users';
+import Meetings from '/imports/api/meetings';
+import stopWatchingExternalVideo from '/imports/api/external-videos/server/methods/stopWatchingExternalVideo';
 
 export default function changePresenter(presenter, userId, meetingId, changedBy) {
   const selector = {
@@ -26,5 +28,10 @@ export default function changePresenter(presenter, userId, meetingId, changedBy)
     return null;
   };
 
+  const meeting = Meetings.findOne({ meetingId });
+  if (meeting && meeting.externalVideoUrl) {
+    Logger.info(`ChangePresenter:There is external video being shared. Stopping it due to presenter change, ${meeting.externalVideoUrl}`);
+    stopWatchingExternalVideo({ meetingId, requesterUserId: userId });
+  }
   return Users.update(selector, modifier, cb);
 }

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -3,6 +3,9 @@ import KurentoBridge from '/imports/api/screenshare/client/bridge';
 import Settings from '/imports/ui/services/settings';
 import logger from '/imports/startup/client/logger';
 import { tryGenerateIceCandidates } from '/imports/utils/safari-webrtc';
+import { stopWatching } from '/imports/ui/components/external-video-player/service';
+import Meetings from '/imports/api/meetings';
+import Auth from '/imports/ui/services/auth';
 
 // when the meeting information has been updated check to see if it was
 // screensharing. If it has changed either trigger a call to receive video
@@ -47,6 +50,12 @@ const presenterScreenshareHasStarted = () => {
 };
 
 const shareScreen = (onFail) => {
+  // stop external video share if running
+  const meeting = Meetings.findOne({ meetingId: Auth.meetingID });
+  if (meeting && meeting.externalVideoUrl) {
+    stopWatching();
+  }
+
   KurentoBridge.kurentoShareScreen(onFail);
 };
 


### PR DESCRIPTION

* If presenter changes during external video sharing (YouTube, etc), stop the video
* If screenshare starts while external video is being shared, stop the video.
* If external video is shared while screensharing, stop screensharing
Closes #7334 