### PR TITLE
Add handling route for GetRunningMeetingsReqMsg

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -54,6 +54,9 @@ class ReceivedJsonMsgHandlerActor(
       case CheckAlivePingSysMsg.NAME =>
         route[CheckAlivePingSysMsg](meetingManagerChannel, envelope, jsonNode)
 
+      case GetRunningMeetingsReqMsg.NAME =>
+        route[GetRunningMeetingsReqMsg](meetingManagerChannel, envelope, jsonNode)
+
       case CreateMeetingReqMsg.NAME =>
         route[CreateMeetingReqMsg](meetingManagerChannel, envelope, jsonNode)
       case ValidateAuthTokenReqMsg.NAME =>


### PR DESCRIPTION
Cont'd from #8386 

Before:
`2020-01-09T15:50:49.859Z ERROR o.b.c.p.s.ReceivedJsonMsgHandlerActor - Cannot route envelope name GetRunningMeetingsReqMsg`

After:

```
2020-01-09T15:57:44.970Z INFO  o.b.core2.AnalyticsActor - -- analytics -- {"envelope":{"name":"GetRunningMeetingsReqMsg","routing":{"sender":"bbb-apps-akka"},"timestamp":1578585464967},"core":{"header":{"name":"GetRunningMeetingsReqMsg"},"body":{"requesterId":"nodeJSapp"}}}
2020-01-09T15:57:44.971Z INFO  o.b.core2.AnalyticsActor - -- analytics -- {"envelope":{"name":"GetRunningMeetingsRespMsg","routing":{"sender":"bbb-apps-akka"},"timestamp":1578585464970},"core":{"header":{"name":"GetRunningMeetingsRespMsg"},"body":{"meetings":["1ebc36f58d48e60778e021173a69fb6326154fbd-1578585441601"]}}}
```