### PR TITLE
Make the client end the call when kicked

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -169,10 +169,9 @@ class Base extends Component {
       return (<LoadingScreen>{loading}</LoadingScreen>);
     }
 
-    if (ejected && ejected.ejectedReason) {
-      const { ejectedReason } = ejected;
+    if (ejected) {
       AudioManager.exitAudio();
-      return (<MeetingEnded code={ejectedReason} />);
+      return (<MeetingEnded code="403" />);
     }
 
     if (meetingHasEnded && meetingIsBreakout) window.close();


### PR DESCRIPTION
The server already requests that FreeSWITCH end a user's audio call if they're kicked, but the client was handling that as an unexpected disconnect and trying to reconnect. Most of the work was to ensure that the client stops trying to rejoin. There's one line change in base.jsx that restores the original look of meeting eject experience.

![image](https://user-images.githubusercontent.com/1395090/72114338-367f6280-3311-11ea-9200-c41ad3112cb4.png)