### PR TITLE
Fix streamer not working on meteor restart

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/cursor/service.js
+++ b/bigbluebutton-html5/imports/ui/components/cursor/service.js
@@ -35,8 +35,9 @@ export function publishCursorUpdate(payload) {
 }
 
 export function initCursorStreamListener() {
-  logger.debug({
+  logger.info({
     logCode: 'init_cursor_stream_listener',
+    extraInfo: { meetingId: Auth.meetingID, userId: Auth.userID },
   }, 'initCursorStreamListener called');
 
   if (!cursorStreamListener) {

--- a/bigbluebutton-html5/imports/ui/components/cursor/service.js
+++ b/bigbluebutton-html5/imports/ui/components/cursor/service.js
@@ -49,9 +49,11 @@ export function initCursorStreamListener() {
 
   const startStreamHandlersPromise = new Promise((resolve) => {
     const checkStreamHandlersInterval = setInterval(() => {
-      const streamHandlersSize = JSON.parse(JSON.stringify((Meteor.StreamerCentral.instances[`cursor-${Auth.meetingID}`].handlers)));
+      const streamHandlersSize = Object.values(Meteor.StreamerCentral.instances[`cursor-${Auth.meetingID}`].handlers)
+        .filter(el => el != undefined)
+        .length;
 
-      if (!Object.keys(streamHandlersSize).length) {
+      if (!streamHandlersSize) {
         resolve(clearInterval(checkStreamHandlersInterval));
       }
     }, 250);

--- a/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
@@ -6,8 +6,7 @@ import GroupChat from '/imports/api/group-chat';
 import Users from '/imports/api/users';
 import Annotations from '/imports/api/annotations';
 import AnnotationsTextService from '/imports/ui/components/whiteboard/annotations/text/service';
-import AnnotationsLocal, { initAnnotationsStreamListener } from '/imports/ui/components/whiteboard/service';
-import { initCursorStreamListener } from '/imports/ui/components/cursor/service';
+import AnnotationsLocal from '/imports/ui/components/whiteboard/service';
 
 
 const CHAT_CONFIG = Meteor.settings.public.chat;
@@ -95,9 +94,6 @@ export default withTracker(() => {
     Meteor.subscribe('users', credentials, userIsModerator, subscriptionErrorHandler);
     Meteor.subscribe('breakouts', credentials, userIsModerator, subscriptionErrorHandler);
     Meteor.subscribe('meetings', credentials, userIsModerator, subscriptionErrorHandler);
-    logger.debug({ logCode: 'startup_client_subscription_init_streamers', extraInfo: { role: User.role } }, 'Calling init streamers functions');
-    initAnnotationsStreamListener();
-    initCursorStreamListener();
   }
 
   const annotationsHandler = Meteor.subscribe('annotations', credentials, {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -108,9 +108,11 @@ export function initAnnotationsStreamListener() {
 
   const startStreamHandlersPromise = new Promise((resolve) => {
     const checkStreamHandlersInterval = setInterval(() => {
-      const streamHandlersSize = JSON.parse(JSON.stringify((Meteor.StreamerCentral.instances[`annotations-${Auth.meetingID}`].handlers)));
+      const streamHandlersSize = Object.values(Meteor.StreamerCentral.instances[`annotations-${Auth.meetingID}`].handlers)
+        .filter(el => el != undefined)
+        .length;
 
-      if (!Object.keys(streamHandlersSize).length) {
+      if (!streamHandlersSize) {
         resolve(clearInterval(checkStreamHandlersInterval));
       }
     }, 250);

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -99,9 +99,24 @@ function handleRemovedAnnotation({
 }
 
 export function initAnnotationsStreamListener() {
-  if (!annotationsStreamListener) {
-    annotationsStreamListener = new Meteor.Streamer(`annotations-${Auth.meetingID}`, { retransmit: false });
+  /**
+   * We create a promise to add the handlers after a ddp subscription stop.
+   * The problem was caused because we add handlers to stream before the onStop event happens,
+   * which set the handlers to undefined.
+   */
+  annotationsStreamListener = new Meteor.Streamer(`annotations-${Auth.meetingID}`, { retransmit: false });
 
+  const startStreamHandlersPromise = new Promise((resolve) => {
+    const checkStreamHandlersInterval = setInterval(() => {
+      const streamHandlersSize = JSON.parse(JSON.stringify((Meteor.StreamerCentral.instances[`annotations-${Auth.meetingID}`].handlers)));
+
+      if (!Object.keys(streamHandlersSize).length) {
+        resolve(clearInterval(checkStreamHandlersInterval));
+      }
+    }, 250);
+  });
+
+  startStreamHandlersPromise.then(() => {
     annotationsStreamListener.on('removed', handleRemovedAnnotation);
 
     annotationsStreamListener.on('added', ({ annotations }) => {
@@ -110,7 +125,7 @@ export function initAnnotationsStreamListener() {
         .filter(({ annotation }) => !discardedList.includes(annotation.id))
         .forEach(annotation => handleAddedAnnotation(annotation));
     });
-  }
+  });
 }
 
 function increaseBrightness(realHex, percent) {

--- a/bigbluebutton-html5/imports/ui/services/auth/index.js
+++ b/bigbluebutton-html5/imports/ui/services/auth/index.js
@@ -6,6 +6,8 @@ import Storage from '/imports/ui/services/storage/session';
 import Users from '/imports/api/users';
 import logger from '/imports/startup/client/logger';
 import { makeCall } from '/imports/ui/services/api';
+import { initAnnotationsStreamListener } from '/imports/ui/components/whiteboard/service';
+import { initCursorStreamListener } from '/imports/ui/components/cursor/service';
 
 const CONNECTION_TIMEOUT = Meteor.settings.public.app.connectionTimeout;
 
@@ -220,7 +222,7 @@ class Auth {
 
         const selector = { meetingId: this.meetingID, userId: this.userID };
         const fields = {
-          intId: 1, ejected: 1, validated: 1, connectionStatus: 1,
+          intId: 1, ejected: 1, validated: 1, connectionStatus: 1, userId: 1,
         };
         const User = Users.findOne(selector, { fields });
         // Skip in case the user is not in the collection yet or is a dummy user
@@ -239,6 +241,9 @@ class Auth {
         }
 
         if (User.validated === true && User.connectionStatus === 'online') {
+          logger.info({ logCode: 'auth_service_init_streamers', extraInfo: { userId: User.userId } }, 'Calling init streamers functions');
+          initCursorStreamListener();
+          initAnnotationsStreamListener();
           computation.stop();
           clearTimeout(validationTimeout);
           // setTimeout to prevent race-conditions with subscription

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -302,7 +302,7 @@ public:
       - pencil
       - hand
   clientLog:
-    server: { enabled: true, level: debug }
+    server: { enabled: true, level: info }
     console: { enabled: true, level: debug }
     external: { enabled: false, level: info, url: https://LOG_HOST/html5Log, method: POST, throttleInterval: 400, flushOnClose: true, logTag: "" }
 private:

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -302,7 +302,7 @@ public:
       - pencil
       - hand
   clientLog:
-    server: { enabled: true, level: info }
+    server: { enabled: true, level: debug }
     console: { enabled: true, level: debug }
     external: { enabled: false, level: info, url: https://LOG_HOST/html5Log, method: POST, throttleInterval: 400, flushOnClose: true, logTag: "" }
 private:


### PR DESCRIPTION
The problem was caused when meteor restarted without reloading the page, the ddp subscription called a `onStop` event that set all handlers to `undefined` after we set the handlers on the streamer init function.