### PR TITLE
Create text area's by clicking on whiteboard (text tool selected)

### DIFF
--- a/bigbluebutton-html5/imports/api/annotations/addAnnotation.js
+++ b/bigbluebutton-html5/imports/api/annotations/addAnnotation.js
@@ -2,6 +2,8 @@ import { check } from 'meteor/check';
 
 const ANNOTATION_TYPE_TEXT = 'text';
 const ANNOTATION_TYPE_PENCIL = 'pencil';
+const DEFAULT_TEXT_WIDTH = 40;
+const DEFAULT_TEXT_HEIGHT = 10;
 
 // line, triangle, ellipse, rectangle
 function handleCommonAnnotation(meetingId, whiteboardId, userId, annotation) {
@@ -38,6 +40,14 @@ function handleTextUpdate(meetingId, whiteboardId, userId, annotation) {
   const {
     id, status, annotationType, annotationInfo, wbId, position,
   } = annotation;
+
+  const { textBoxWidth, textBoxHeight } = annotationInfo;
+  const useDefaultSize = textBoxWidth === 0 && textBoxHeight === 0;
+
+  if (useDefaultSize) {
+    annotationInfo.textBoxWidth = DEFAULT_TEXT_WIDTH;
+    annotationInfo.textBoxHeight = DEFAULT_TEXT_HEIGHT;
+  }
 
   const selector = {
     meetingId,

--- a/bigbluebutton-html5/imports/api/annotations/addAnnotation.js
+++ b/bigbluebutton-html5/imports/api/annotations/addAnnotation.js
@@ -2,8 +2,8 @@ import { check } from 'meteor/check';
 
 const ANNOTATION_TYPE_TEXT = 'text';
 const ANNOTATION_TYPE_PENCIL = 'pencil';
-const DEFAULT_TEXT_WIDTH = 40;
-const DEFAULT_TEXT_HEIGHT = 10;
+const DEFAULT_TEXT_WIDTH = 30;
+const DEFAULT_TEXT_HEIGHT = 20;
 
 // line, triangle, ellipse, rectangle
 function handleCommonAnnotation(meetingId, whiteboardId, userId, annotation) {
@@ -47,6 +47,13 @@ function handleTextUpdate(meetingId, whiteboardId, userId, annotation) {
   if (useDefaultSize) {
     annotationInfo.textBoxWidth = DEFAULT_TEXT_WIDTH;
     annotationInfo.textBoxHeight = DEFAULT_TEXT_HEIGHT;
+
+    if (100 - annotationInfo.x < DEFAULT_TEXT_WIDTH) {
+      annotationInfo.textBoxWidth = 100 - annotationInfo.x;
+    }
+    if (100 - annotationInfo.y < DEFAULT_TEXT_HEIGHT) {
+      annotationInfo.textBoxHeight = 100 - annotationInfo.y;
+    }
   }
 
   const selector = {


### PR DESCRIPTION
This PR allows a whiteboard user to create text-area's by clicking on the whiteboard while the text tool is selected.

![textArea-onClick](https://user-images.githubusercontent.com/22058534/72272446-a124ec80-35f6-11ea-8f3e-6778212920b0.gif)
