### PR TITLE
Move quick poll button to presentation tool bar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -209,7 +209,6 @@ class ActionsDropdown extends PureComponent {
           <Button
             hideLabel
             aria-label={intl.formatMessage(intlMessages.actionsLabel)}
-            className={styles.button}
             label={intl.formatMessage(intlMessages.actionsLabel)}
             icon="plus"
             color="primary"

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/captions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/captions/component.jsx
@@ -24,7 +24,7 @@ const intlMessages = defineMessages({
 
 const CaptionsButton = ({ intl, isActive, handleOnClick }) => (
   <Button
-    className={cx(styles.button, isActive || styles.btn)}
+    className={cx(isActive || styles.btn)}
     icon="closed_caption"
     label={intl.formatMessage(isActive ? intlMessages.stop : intlMessages.start)}
     color={isActive ? 'primary' : 'default'}

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -3,7 +3,6 @@ import cx from 'classnames';
 import { styles } from './styles.scss';
 import DesktopShare from './desktop-share/component';
 import ActionsDropdown from './actions-dropdown/component';
-import QuickPollDropdown from './quick-poll-dropdown/component';
 import AudioControlsContainer from '../audio/audio-controls/container';
 import JoinVideoOptionsContainer from '../video-provider/video-button/container';
 import CaptionsButtonContainer from '/imports/ui/components/actions-bar/captions/container';
@@ -59,18 +58,6 @@ class ActionsBar extends PureComponent {
             isMeteorConnected,
           }}
           />
-          {isPollingEnabled
-            ? (
-              <QuickPollDropdown
-                {...{
-                  currentSlidHasContent,
-                  intl,
-                  amIPresenter,
-                  parseCurrentSlideContent,
-                }}
-              />
-            ) : null
-          }
           {isCaptionsAvailable
             ? (
               <CaptionsButtonContainer {...{ intl }} />

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/desktop-share/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/desktop-share/component.jsx
@@ -161,7 +161,7 @@ const DesktopShare = ({
   return (shouldAllowScreensharing
     ? (
       <Button
-        className={cx(styles.button, isVideoBroadcasting || styles.btn)}
+        className={cx(isVideoBroadcasting || styles.btn)}
         disabled={(!isMeteorConnected && !isVideoBroadcasting) || !screenshareDataSavingSetting}
         icon={isVideoBroadcasting ? 'desktop' : 'desktop_off'}
         label={intl.formatMessage(vLabel)}

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import Button from '/imports/ui/components/button/component';
 import MediaService from '/imports/ui/components/media/service';
-import { styles } from '../styles';
 
 const propTypes = {
   intl: intlShape.isRequired,
@@ -27,7 +26,6 @@ const PresentationOptionsContainer = ({ intl, toggleSwapLayout, isThereCurrentPr
   if (shouldUnswapLayout()) toggleSwapLayout();
   return (
     <Button
-      className={styles.button}
       icon="presentation"
       label={intl.formatMessage(intlMessages.restorePresentationLabel)}
       description={intl.formatMessage(intlMessages.restorePresentationDesc)}

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -88,7 +88,9 @@ const getAvailableQuickPolls = (slideId, parsedSlides) => {
 };
 
 const QuickPollDropdown = (props) => {
-  const { amIPresenter, intl, parseCurrentSlideContent } = props;
+  const {
+    amIPresenter, intl, parseCurrentSlideContent,
+  } = props;
   const parsedSlide = parseCurrentSlideContent(
     intl.formatMessage(intlMessages.yesOptionLabel),
     intl.formatMessage(intlMessages.noOptionLabel),
@@ -97,25 +99,29 @@ const QuickPollDropdown = (props) => {
   );
 
   const { slideId, quickPollOptions } = parsedSlide;
+  const quickPolls = getAvailableQuickPolls(slideId, quickPollOptions);
+
+  let quickPollLabel = '';
+  if (quickPolls.length > 0) {
+    const { props: pollProps } = quickPolls[0];
+    quickPollLabel = pollProps.label;
+  }
 
   return amIPresenter && quickPollOptions && quickPollOptions.length ? (
     <Dropdown>
       <DropdownTrigger tabIndex={0}>
         <Button
           aria-label={intl.formatMessage(intlMessages.quickPollLabel)}
-          circle
-          className={styles.button}
-          color="primary"
-          hideLabel
-          icon="polling"
-          label={intl.formatMessage(intlMessages.quickPollLabel)}
+          className={styles.quickPollBtn}
+          label={quickPollLabel}
+          tooltipLabel={intl.formatMessage(intlMessages.quickPollLabel)}
           onClick={() => null}
           size="lg"
         />
       </DropdownTrigger>
       <DropdownContent placement="top left">
         <DropdownList>
-          {getAvailableQuickPolls(slideId, quickPollOptions)}
+          {quickPolls}
         </DropdownList>
       </DropdownContent>
     </Dropdown>

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -101,6 +101,8 @@ const QuickPollDropdown = (props) => {
   const { slideId, quickPollOptions } = parsedSlide;
   const quickPolls = getAvailableQuickPolls(slideId, quickPollOptions);
 
+  if (quickPollOptions.length === 0) return null;
+
   let quickPollLabel = '';
   if (quickPolls.length > 0) {
     const { props: pollProps } = quickPolls[0];
@@ -113,25 +115,7 @@ const QuickPollDropdown = (props) => {
     singlePollType = type;
   }
 
-  return amIPresenter && quickPollOptions && quickPollOptions.length && quickPolls.length > 1 ? (
-    <Dropdown>
-      <DropdownTrigger tabIndex={0}>
-        <Button
-          aria-label={intl.formatMessage(intlMessages.quickPollLabel)}
-          className={styles.quickPollBtn}
-          label={quickPollLabel}
-          tooltipLabel={intl.formatMessage(intlMessages.quickPollLabel)}
-          onClick={() => null}
-          size="lg"
-        />
-      </DropdownTrigger>
-      <DropdownContent placement="top left">
-        <DropdownList>
-          {quickPolls}
-        </DropdownList>
-      </DropdownContent>
-    </Dropdown>
-  ) : (
+  const btn = (
     <Button
       aria-label={intl.formatMessage(intlMessages.quickPollLabel)}
       className={styles.quickPollBtn}
@@ -140,6 +124,32 @@ const QuickPollDropdown = (props) => {
       onClick={() => startPoll(singlePollType, currentSlide.id)}
       size="lg"
     />
+  );
+
+  const usePollDropdown = quickPollOptions && quickPollOptions.length && quickPolls.length > 1;
+  let dropdown = null;
+
+  if (usePollDropdown) {
+    btn.props.onClick = null;
+
+    dropdown = (
+      <Dropdown>
+        <DropdownTrigger tabIndex={0}>
+          {btn}
+        </DropdownTrigger>
+        <DropdownContent placement="top left">
+          <DropdownList>
+            {quickPolls}
+          </DropdownList>
+        </DropdownContent>
+      </Dropdown>
+    );
+  }
+
+  return amIPresenter && usePollDropdown ? (
+    dropdown
+  ) : (
+    btn
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -89,7 +89,7 @@ const getAvailableQuickPolls = (slideId, parsedSlides) => {
 
 const QuickPollDropdown = (props) => {
   const {
-    amIPresenter, intl, parseCurrentSlideContent,
+    amIPresenter, intl, parseCurrentSlideContent, startPoll, currentSlide,
   } = props;
   const parsedSlide = parseCurrentSlideContent(
     intl.formatMessage(intlMessages.yesOptionLabel),
@@ -107,7 +107,13 @@ const QuickPollDropdown = (props) => {
     quickPollLabel = pollProps.label;
   }
 
-  return amIPresenter && quickPollOptions && quickPollOptions.length ? (
+  let singlePollType = null;
+  if (quickPolls.length === 1 && quickPollOptions.length) {
+    const { type } = quickPollOptions[0];
+    singlePollType = type;
+  }
+
+  return amIPresenter && quickPollOptions && quickPollOptions.length && quickPolls.length > 1 ? (
     <Dropdown>
       <DropdownTrigger tabIndex={0}>
         <Button
@@ -125,7 +131,16 @@ const QuickPollDropdown = (props) => {
         </DropdownList>
       </DropdownContent>
     </Dropdown>
-  ) : null;
+  ) : (
+    <Button
+      aria-label={intl.formatMessage(intlMessages.quickPollLabel)}
+      className={styles.quickPollBtn}
+      label={quickPollLabel}
+      tooltipLabel={intl.formatMessage(intlMessages.quickPollLabel)}
+      onClick={() => startPoll(singlePollType, currentSlide.id)}
+      size="lg"
+    />
+  );
 };
 
 QuickPollDropdown.propTypes = propTypes;

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -97,6 +97,7 @@ class QuickPollDropdown extends Component {
       startPoll,
       currentSlide,
       activePoll,
+      className,
     } = this.props;
 
     const parsedSlide = parseCurrentSlideContent(
@@ -152,7 +153,7 @@ class QuickPollDropdown extends Component {
       );
 
       dropdown = (
-        <Dropdown>
+        <Dropdown className={className}>
           <DropdownTrigger tabIndex={0}>
             {btn}
           </DropdownTrigger>

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/container.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Meteor } from 'meteor/meteor';
+import { withTracker } from 'meteor/react-meteor-data';
+import { injectIntl } from 'react-intl';
+import QuickPollDropdown from './component';
+
+const QuickPollDropdownContainer = props => <QuickPollDropdown {...props} />;
+
+export default withTracker(() => ({
+  activePoll: Session.get('pollInitiated') || false,
+}))(injectIntl(QuickPollDropdownContainer));

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
@@ -74,19 +74,17 @@
 }
 
 .quickPollBtn {
-  padding-left: 0;
-  padding-right: 0;
-  margin-left: .25rem;
+  padding: var(--whiteboard-toolbar-padding);
+
   span:first-child {
-    border: .1rem solid var(--toolbar-button-color);
-    border-radius: 2px;
+    border: 1px solid var(--toolbar-button-color);
+    border-radius: var(--border-size-large);
     color: var(--toolbar-button-color);
     font-size: small;
-    font-weight: 500;
-    padding: 0.25rem;
-    position: relative;
-    top: 1px;
-    //right: 1rem;
+    font-weight: var(--headings-font-weight);
+    opacity: 1;
+    padding-right: var(--border-size-large);
+    padding-left: var(--border-size-large);
   }
 
   span:first-child:hover {

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
@@ -75,6 +75,8 @@
 
 .quickPollBtn {
   padding: var(--whiteboard-toolbar-padding);
+  background-color: var(--color-off-white) !important;
+  box-shadow: none !important;
 
   span:first-child {
     border: 1px solid var(--toolbar-button-color);

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
@@ -73,9 +73,24 @@
   }
 }
 
-.button {
+.quickPollBtn {
+  padding-left: 0;
+  padding-right: 0;
+  margin-left: .25rem;
   span:first-child {
-    box-shadow: 0 2px 5px 0 rgb(0, 0, 0);
+    border: .1rem solid var(--toolbar-button-color);
+    border-radius: 2px;
+    color: var(--toolbar-button-color);
+    font-size: small;
+    font-weight: 500;
+    padding: 0.25rem;
+    position: relative;
+    top: 1px;
+    //right: 1rem;
+  }
+
+  span:first-child:hover {
+    opacity: 1 !important;
   }
 }
 

--- a/bigbluebutton-html5/imports/ui/components/dropdown/list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/list/styles.scss
@@ -25,6 +25,7 @@
 .verticalList {
   @extend %list;
   flex-direction: column;
+  width: 100%;
 }
 
 .horizontalList {

--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -355,6 +355,7 @@ class Poll extends Component {
               }
               Session.set('openPanel', 'userlist');
               Session.set('forcePollOpen', false);
+              Session.set('pollInitiated', false);
             }}
             className={styles.closeBtn}
             icon="close"

--- a/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
@@ -189,6 +189,7 @@ class LiveResult extends PureComponent {
             <Button
               disabled={!isMeteorConnected}
               onClick={() => {
+                Session.set('pollInitiated', false);
                 Service.publishPoll();
                 stopPoll();
               }}

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -494,6 +494,7 @@ class PresentationArea extends PureComponent {
           fitToWidth,
           zoom,
           podId,
+          currentSlide,
         }}
         isFullscreen={isFullscreen}
         fullscreenRef={this.refPresentationContainer}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -10,6 +10,7 @@ import { styles } from './styles.scss';
 import ZoomTool from './zoom-tool/component';
 import FullscreenButtonContainer from '../../fullscreen-button/container';
 import Tooltip from '/imports/ui/components/tooltip/component';
+import QuickPollDropdown from '/imports/ui/components/actions-bar/quick-poll-dropdown/component';
 import KEY_CODES from '/imports/utils/keyCodes';
 
 const intlMessages = defineMessages({
@@ -211,6 +212,10 @@ class PresentationToolbar extends PureComponent {
       isFullscreen,
       fullscreenRef,
       isMeteorConnected,
+      isPollingEnabled,
+      amIPresenter,
+      currentSlidHasContent,
+      parseCurrentSlideContent,
     } = this.props;
 
     const BROWSER_RESULTS = browser();
@@ -231,7 +236,23 @@ class PresentationToolbar extends PureComponent {
     return (
       <div id="presentationToolbarWrapper" className={styles.presentationToolbarWrapper}>
         {this.renderAriaDescs()}
-        {<div />}
+        {
+          <div>
+            {isPollingEnabled
+              ? (
+                <QuickPollDropdown
+                  {...{
+                    currentSlidHasContent,
+                    intl,
+                    amIPresenter,
+                    parseCurrentSlideContent,
+
+                  }}
+                />
+              ) : null
+          }
+          </div>
+        }
         {
           <div className={styles.presentationSlideControls}>
             <Button

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -216,6 +216,8 @@ class PresentationToolbar extends PureComponent {
       amIPresenter,
       currentSlidHasContent,
       parseCurrentSlideContent,
+      startPoll,
+      currentSlide,
     } = this.props;
 
     const BROWSER_RESULTS = browser();
@@ -246,7 +248,8 @@ class PresentationToolbar extends PureComponent {
                     intl,
                     amIPresenter,
                     parseCurrentSlideContent,
-
+                    startPoll,
+                    currentSlide,
                   }}
                 />
               ) : null

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -10,7 +10,7 @@ import { styles } from './styles.scss';
 import ZoomTool from './zoom-tool/component';
 import FullscreenButtonContainer from '../../fullscreen-button/container';
 import Tooltip from '/imports/ui/components/tooltip/component';
-import QuickPollDropdown from '/imports/ui/components/actions-bar/quick-poll-dropdown/component';
+import QuickPollDropdownContainer from '/imports/ui/components/actions-bar/quick-poll-dropdown/container';
 import KEY_CODES from '/imports/utils/keyCodes';
 
 const intlMessages = defineMessages({
@@ -242,7 +242,7 @@ class PresentationToolbar extends PureComponent {
           <div>
             {isPollingEnabled
               ? (
-                <QuickPollDropdown
+                <QuickPollDropdownContainer
                   {...{
                     currentSlidHasContent,
                     intl,

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -251,6 +251,7 @@ class PresentationToolbar extends PureComponent {
                     startPoll,
                     currentSlide,
                   }}
+                  className={styles.presentationBtn}
                 />
               ) : null
           }

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -3,8 +3,11 @@ import PropTypes from 'prop-types';
 import { withTracker } from 'meteor/react-meteor-data';
 import PresentationService from '/imports/ui/components/presentation/service';
 import MediaService from '/imports/ui/components/media/service';
+import Service from '/imports/ui/components/actions-bar/service';
 import PresentationToolbar from './component';
 import PresentationToolbarService from './service';
+
+const POLLING_ENABLED = Meteor.settings.public.poll.enabled;
 
 const PresentationToolbarContainer = (props) => {
   const {
@@ -31,6 +34,7 @@ export default withTracker((params) => {
   } = params;
 
   return {
+    amIPresenter: Service.amIPresenter(),
     layoutSwapped: MediaService.getSwapLayout() && MediaService.shouldEnableSwapLayout(),
     userIsPresenter: PresentationService.isPresenter(podId),
     numberOfSlides: PresentationToolbarService.getNumberOfSlides(podId, presentationId),
@@ -38,6 +42,9 @@ export default withTracker((params) => {
     previousSlide: PresentationToolbarService.previousSlide,
     skipToSlide: PresentationToolbarService.skipToSlide,
     isMeteorConnected: Meteor.status().connected,
+    isPollingEnabled: POLLING_ENABLED,
+    currentSlidHasContent: PresentationService.currentSlidHasContent(),
+    parseCurrentSlideContent: PresentationService.parseCurrentSlideContent,
   };
 })(PresentationToolbarContainer);
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -4,7 +4,6 @@ import { withTracker } from 'meteor/react-meteor-data';
 import PresentationService from '/imports/ui/components/presentation/service';
 import MediaService from '/imports/ui/components/media/service';
 import Service from '/imports/ui/components/actions-bar/service';
-import Presentations from '/imports/api/presentations';
 import { makeCall } from '/imports/ui/services/api';
 import PresentationToolbar from './component';
 import PresentationToolbarService from './service';
@@ -33,7 +32,6 @@ export default withTracker((params) => {
   const {
     podId,
     presentationId,
-    currentSlide,
   } = params;
 
   const startPoll = (type, id) => {

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -4,6 +4,8 @@ import { withTracker } from 'meteor/react-meteor-data';
 import PresentationService from '/imports/ui/components/presentation/service';
 import MediaService from '/imports/ui/components/media/service';
 import Service from '/imports/ui/components/actions-bar/service';
+import Presentations from '/imports/api/presentations';
+import { makeCall } from '/imports/ui/services/api';
 import PresentationToolbar from './component';
 import PresentationToolbarService from './service';
 
@@ -31,7 +33,15 @@ export default withTracker((params) => {
   const {
     podId,
     presentationId,
+    currentSlide,
   } = params;
+
+  const startPoll = (type, id) => {
+    Session.set('openPanel', 'poll');
+    Session.set('forcePollOpen', true);
+
+    makeCall('startPoll', type, id);
+  };
 
   return {
     amIPresenter: Service.amIPresenter(),
@@ -45,6 +55,7 @@ export default withTracker((params) => {
     isPollingEnabled: POLLING_ENABLED,
     currentSlidHasContent: PresentationService.currentSlidHasContent(),
     parseCurrentSlideContent: PresentationService.parseCurrentSlideContent,
+    startPoll,
   };
 })(PresentationToolbarContainer);
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.scss
@@ -26,6 +26,16 @@
 
 .presentationBtn {
   position: relative;
+  color: var(--toolbar-button-color);
+  background-color: var(--color-off-white);
+  border-radius: 0;
+  box-shadow: none !important;
+  border: 0;
+
+  &:focus {
+    background-color: var(--color-off-white);
+    border: 0;
+  }
 }
 
 .presentationZoomControls {
@@ -86,30 +96,10 @@
     }
   }
 
-  button,
-  select,
-  >div {
-    color: var(--toolbar-button-color);
-    background-color: var(--color-off-white);
-    border-radius: 0;
-    box-shadow: none !important;
-    border: 0;
-
-    &:focus {
-      background-color: var(--color-off-white);
-      border: 0;
-    }
-  }
-
   i {
     color: var(--toolbar-button-color);
     display: flex;
     justify-content: center;
-    align-items: center;
-  }
-
-  div {
-    display: flex;
     align-items: center;
   }
 }

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.scss
@@ -107,6 +107,11 @@
     justify-content: center;
     align-items: center;
   }
+
+  div {
+    display: flex;
+    align-items: center;
+  }
 }
 
 .zoomWrapper {

--- a/bigbluebutton-html5/imports/ui/components/presentation/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/presentation/styles.scss
@@ -54,7 +54,7 @@
 
 .presentationToolbar{
   display: flex;
-  overflow-x: auto;
+  overflow-x: visible;
   order: 2;
   position: absolute;
   bottom: 0;


### PR DESCRIPTION
This PR moves the quick poll button which was a part of the actions bar into the presentation toolbar

![quickPoll-presentationToolbar](https://user-images.githubusercontent.com/22058534/72274511-573e0580-35fa-11ea-9f3f-8c2385ce16e3.gif)
