### PR TITLE
Removes waiting guests that stop polling for their status

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/GuestsApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/GuestsApp.scala
@@ -1,10 +1,11 @@
 package org.bigbluebutton.core.apps
 
 import org.bigbluebutton.core.running.MeetingActor
-import org.bigbluebutton.core2.message.handlers.guests.{ GetGuestPolicyReqMsgHdlr, GetGuestsWaitingApprovalReqMsgHdlr, GuestsWaitingApprovedMsgHdlr, SetGuestPolicyMsgHdlr }
+import org.bigbluebutton.core2.message.handlers.guests._
 
 trait GuestsApp extends GetGuestsWaitingApprovalReqMsgHdlr
   with GuestsWaitingApprovedMsgHdlr
+  with GuestWaitingLeftMsgHdlr
   with SetGuestPolicyMsgHdlr
   with GetGuestPolicyReqMsgHdlr {
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
@@ -21,6 +21,18 @@ object UsersApp {
     outGW.send(msgEvent)
   }
 
+  def guestWaitingLeft(liveMeeting: LiveMeeting, userId: String, outGW: OutMsgRouter): Unit = {
+    for {
+      u <- RegisteredUsers.findWithUserId(userId, liveMeeting.registeredUsers)
+    } yield {
+
+      RegisteredUsers.remove(u.id, liveMeeting.registeredUsers)
+
+      val event = MsgBuilder.buildGuestWaitingLeftEvtMsg(liveMeeting.props.meetingProp.intId, u.id)
+      outGW.send(event)
+    }
+  }
+
   def approveOrRejectGuest(liveMeeting: LiveMeeting, outGW: OutMsgRouter,
                            guest: GuestApprovedVO, approvedBy: String): Unit = {
     for {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -85,6 +85,8 @@ class ReceivedJsonMsgHandlerActor(
         routeGenericMsg[GetGuestsWaitingApprovalReqMsg](envelope, jsonNode)
       case GuestsWaitingApprovedMsg.NAME =>
         routeGenericMsg[GuestsWaitingApprovedMsg](envelope, jsonNode)
+      case GuestWaitingLeftMsg.NAME =>
+        routeGenericMsg[GuestWaitingLeftMsg](envelope, jsonNode)
       case SetGuestPolicyCmdMsg.NAME =>
         routeGenericMsg[SetGuestPolicyCmdMsg](envelope, jsonNode)
       case GetGuestPolicyReqMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -456,6 +456,7 @@ class MeetingActor(
       case m: GetGuestsWaitingApprovalReqMsg           => handleGetGuestsWaitingApprovalReqMsg(m)
       case m: SetGuestPolicyCmdMsg                     => handleSetGuestPolicyMsg(m)
       case m: GuestsWaitingApprovedMsg                 => handleGuestsWaitingApprovedMsg(m)
+      case m: GuestWaitingLeftMsg                      => handleGuestWaitingLeftMsg(m)
       case m: GetGuestPolicyReqMsg                     => handleGetGuestPolicyReqMsg(m)
 
       // Chat

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
@@ -120,6 +120,8 @@ class AnalyticsActor extends Actor with ActorLogging {
       // Guest Management
       case m: GuestsWaitingApprovedMsg => logMessage(msg)
       case m: GuestsWaitingApprovedEvtMsg => logMessage(msg)
+      case m: GuestWaitingLeftMsg => logMessage(msg)
+      case m: GuestWaitingLeftEvtMsg => logMessage(msg)
       case m: GuestsWaitingForApprovalEvtMsg => logMessage(msg)
       case m: SetGuestPolicyCmdMsg => logMessage(msg)
       case m: GuestPolicyChangedEvtMsg => logMessage(msg)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/guests/GuestWaitingLeftMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/guests/GuestWaitingLeftMsgHdlr.scala
@@ -1,0 +1,18 @@
+package org.bigbluebutton.core2.message.handlers.guests
+
+import org.bigbluebutton.common2.msgs.GuestWaitingLeftMsg
+import org.bigbluebutton.core.apps.users.UsersApp
+import org.bigbluebutton.core.models.GuestsWaiting
+import org.bigbluebutton.core.running.{ BaseMeetingActor, LiveMeeting, OutMsgRouter }
+
+trait GuestWaitingLeftMsgHdlr {
+  this: BaseMeetingActor =>
+
+  val liveMeeting: LiveMeeting
+  val outGW: OutMsgRouter
+
+  def handleGuestWaitingLeftMsg(msg: GuestWaitingLeftMsg): Unit = {
+    GuestsWaiting.remove(liveMeeting.guestsWaiting, msg.body.userId)
+    UsersApp.guestWaitingLeft(liveMeeting, msg.body.userId, outGW)
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -208,6 +208,16 @@ object MsgBuilder {
     BbbCommonEnvCoreMsg(envelope, event)
   }
 
+  def buildGuestWaitingLeftEvtMsg(meetingId: String, userId: String): BbbCommonEnvCoreMsg = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
+    val envelope = BbbCoreEnvelope(GuestWaitingLeftEvtMsg.NAME, routing)
+    val header = BbbClientMsgHeader(GuestWaitingLeftEvtMsg.NAME, meetingId, userId)
+    val body = GuestWaitingLeftEvtMsgBody(userId)
+    val event = GuestWaitingLeftEvtMsg(header, body)
+
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
+
   def buildUserLeftMeetingEvtMsg(meetingId: String, userId: String): BbbCommonEnvCoreMsg = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
     val envelope = BbbCoreEnvelope(UserLeftMeetingEvtMsg.NAME, routing)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GuestsMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GuestsMsgs.scala
@@ -64,6 +64,26 @@ case class GuestApprovedEvtMsg(
 case class GuestApprovedEvtMsgBody(status: String, approvedBy: String)
 
 /**
+ * Message from bbb-web when it detects a guest stopped polling for his status.
+ */
+object GuestWaitingLeftMsg { val NAME = "GuestWaitingLeftMsg" }
+case class GuestWaitingLeftMsg(
+    header: BbbClientMsgHeader,
+    body:   GuestWaitingLeftMsgBody
+) extends StandardMsg
+case class GuestWaitingLeftMsgBody(userId: String)
+
+/**
+ * Message sent to all clients that a guest left the waiting page.
+ */
+object GuestWaitingLeftEvtMsg { val NAME = "GuestWaitingLeftEvtMsg" }
+case class GuestWaitingLeftEvtMsg(
+    header: BbbClientMsgHeader,
+    body:   GuestWaitingLeftEvtMsgBody
+) extends BbbCoreMsg
+case class GuestWaitingLeftEvtMsgBody(userId: String)
+
+/**
  * Message from user to set the guest policy.
  */
 object SetGuestPolicyCmdMsg { val NAME = "SetGuestPolicyCmdMsg" }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -82,6 +82,7 @@ import org.bigbluebutton.api2.domain.UploadedTrack;
 import org.bigbluebutton.common2.redis.RedisStorageService;
 import org.bigbluebutton.presentation.PresentationUrlDownloadService;
 import org.bigbluebutton.web.services.RegisteredUserCleanupTimerTask;
+import org.bigbluebutton.web.services.WaitingGuestCleanupTimerTask;
 import org.bigbluebutton.web.services.callback.CallbackUrlService;
 import org.bigbluebutton.web.services.callback.MeetingEndedEvent;
 import org.bigbluebutton.web.services.turn.StunTurnService;
@@ -107,6 +108,7 @@ public class MeetingService implements MessageListener {
 
   private RecordingService recordingService;
   private RegisteredUserCleanupTimerTask registeredUserCleaner;
+  private WaitingGuestCleanupTimerTask waitingGuestCleaner;
   private StunTurnService stunTurnService;
   private RedisStorageService storeService;
   private CallbackUrlService callbackUrlService;
@@ -198,6 +200,38 @@ public class MeetingService implements MessageListener {
       }
     }
   }
+
+  public void guestIsWaiting(String meetingId, String userId) {
+    Meeting m = getMeeting(meetingId);
+    if (m != null) {
+      m.guestIsWaiting(userId);
+    }
+  }
+
+  /**
+   * Remove registered waiting guest users who left the waiting page.
+   */
+  public void purgeWaitingGuestUsers() {
+    for (AbstractMap.Entry<String, Meeting> entry : this.meetings.entrySet()) {
+      Long now = System.currentTimeMillis();
+      Meeting meeting = entry.getValue();
+
+      ConcurrentMap<String, User> users = meeting.getUsersMap();
+
+      for (AbstractMap.Entry<String, RegisteredUser> registeredUser : meeting.getRegisteredUsers().entrySet()) {
+        String registeredUserID = registeredUser.getKey();
+        RegisteredUser ru = registeredUser.getValue();
+
+        long elapsedTime = now - ru.getGuestWaitedOn();
+        if (elapsedTime >= 15000 && ru.getGuestStatus() == GuestPolicy.WAIT) {
+          if (meeting.userUnregistered(registeredUserID) != null) {
+            gw.guestWaitingLeft(meeting.getInternalId(), registeredUserID);
+          };
+        }
+      }
+    }
+  }
+
 
   private void kickOffProcessingOfRecording(Meeting m) {
     if (m.isRecord() && m.getNumUsers() == 0) {
@@ -1025,6 +1059,7 @@ public class MeetingService implements MessageListener {
   public void stop() {
     processMessage = false;
     registeredUserCleaner.stop();
+    waitingGuestCleaner.stop();
   }
 
   public void setRecordingService(RecordingService s) {
@@ -1043,6 +1078,11 @@ public class MeetingService implements MessageListener {
     this.gw = gw;
   }
 
+  public void setWaitingGuestCleanupTimerTask(WaitingGuestCleanupTimerTask c) {
+    waitingGuestCleaner = c;
+    waitingGuestCleaner.setMeetingService(this);
+    waitingGuestCleaner.start();
+  }
 
   public void setRegisteredUserCleanupTimerTask(
     RegisteredUserCleanupTimerTask c) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -183,6 +183,13 @@ public class Meeting {
 	    return users;
 	}
 
+	public void guestIsWaiting(String userId) {
+		RegisteredUser ruser = registeredUsers.get(userId);
+		if (ruser != null) {
+			ruser.updateGuestWaitedOn();
+		}
+	}
+
 	public void setGuestStatusWithId(String userId, String guestStatus) {
     	User user = getUserById(userId);
     	if (user != null) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/RegisteredUser.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/RegisteredUser.java
@@ -6,12 +6,16 @@ public class RegisteredUser {
     public final Long registeredOn;
 
     private String guestStatus;
+    private Long guestWaitedOn;
 
     public RegisteredUser(String authToken, String userId, String guestStatus) {
         this.authToken = authToken;
         this.userId = userId;
         this.guestStatus = guestStatus;
-        registeredOn = System.currentTimeMillis();
+
+        Long currentTimeMillis = System.currentTimeMillis();
+        this.registeredOn = currentTimeMillis;
+        this.guestWaitedOn = currentTimeMillis;
     }
 
     public void setGuestStatus(String status) {
@@ -22,4 +26,11 @@ public class RegisteredUser {
         return guestStatus;
     }
 
+    public void updateGuestWaitedOn() {
+        this.guestWaitedOn = System.currentTimeMillis();
+    }
+
+    public Long getGuestWaitedOn() {
+        return this.guestWaitedOn;
+    }
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
@@ -38,6 +38,7 @@ public interface IBbbWebApiGWApp {
                     Boolean guest, Boolean authed, String guestStatus);
   void ejectDuplicateUser(String meetingID, String internalUserId, String fullname,
                     String externUserID);
+  void guestWaitingLeft(String meetingID, String internalUserId);
 
   void destroyMeeting(DestroyMeetingMessage msg);
   void endMeeting(EndMeetingMessage msg);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/web/services/WaitingGuestCleanupTimerTask.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/web/services/WaitingGuestCleanupTimerTask.java
@@ -1,0 +1,56 @@
+/**
+* BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+*
+* Copyright (c) 2020 BigBlueButton Inc. and by respective authors (see below).
+*
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License as published by the Free Software
+* Foundation; either version 3.0 of the License, or (at your option) any later
+* version.
+*
+* BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License along
+* with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+package org.bigbluebutton.web.services;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.bigbluebutton.api.MeetingService;
+
+public class WaitingGuestCleanupTimerTask {
+
+    private MeetingService service;
+    private ScheduledExecutorService scheduledThreadPool = Executors.newScheduledThreadPool(1);
+    private long runEvery = 15000;
+
+    public void setMeetingService(MeetingService svc) {
+        this.service = svc;
+    }
+
+    public void start() {
+        scheduledThreadPool.scheduleWithFixedDelay(new CleanupTask(), 60000, runEvery, TimeUnit.MILLISECONDS);
+    }
+
+    public void stop() {
+        scheduledThreadPool.shutdownNow();
+    }
+
+    public void setRunEvery(long v) {
+        runEvery = v;
+    }
+
+    private class CleanupTask implements Runnable {
+        @Override
+        public void run() {
+            service.purgeWaitingGuestUsers();
+        }
+    }
+}

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -237,6 +237,11 @@ class BbbWebApiGWApp(
     msgToAkkaAppsEventBus.publish(MsgToAkkaApps(toAkkaAppsChannel, event))
   }
 
+  def guestWaitingLeft(meetingId: String, intUserId: String): Unit = {
+    val event = MsgBuilder.buildGuestWaitingLeftMsg(meetingId, intUserId)
+    msgToAkkaAppsEventBus.publish(MsgToAkkaApps(toAkkaAppsChannel, event))
+  }
+
   def destroyMeeting(msg: DestroyMeetingMessage): Unit = {
     val event = MsgBuilder.buildDestroyMeetingSysCmdMsg(msg)
     msgToAkkaAppsEventBus.publish(MsgToAkkaApps(toAkkaAppsChannel, event))

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -55,6 +55,15 @@ object MsgBuilder {
     BbbCommonEnvCoreMsg(envelope, req)
   }
 
+  def buildGuestWaitingLeftMsg(meetingId: String, userId: String): BbbCommonEnvCoreMsg = {
+    val routing = collection.immutable.HashMap("sender" -> "bbb-web")
+    val envelope = BbbCoreEnvelope(GuestWaitingLeftMsg.NAME, routing)
+    val header = BbbClientMsgHeader(GuestWaitingLeftMsg.NAME, meetingId, "not-used")
+    val body = GuestWaitingLeftMsgBody(userId)
+    val req = GuestWaitingLeftMsg(header, body)
+    BbbCommonEnvCoreMsg(envelope, req)
+  }
+
   def buildCheckAlivePingSysMsg(system: String, timestamp: Long): BbbCommonEnvCoreMsg = {
     val routing = collection.immutable.HashMap("sender" -> "bbb-web")
     val envelope = BbbCoreEnvelope(CheckAlivePingSysMsg.NAME, routing)

--- a/bigbluebutton-html5/imports/api/guest-users/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/guest-users/server/eventHandlers.js
@@ -2,6 +2,8 @@ import RedisPubSub from '/imports/startup/server/redis';
 import { processForHTML5ServerOnly } from '/imports/api/common/server/helpers';
 import handleGuestApproved from './handlers/guestApproved';
 import handleGuestsWaitingForApproval from './handlers/guestsWaitingForApproval';
+import handleGuestWaitingLeft from './handlers/guestWaitingLeft';
 
+RedisPubSub.on('GuestWaitingLeftEvtMsg', handleGuestWaitingLeft);
 RedisPubSub.on('GuestsWaitingForApprovalEvtMsg', processForHTML5ServerOnly(handleGuestsWaitingForApproval));
 RedisPubSub.on('GuestsWaitingApprovedEvtMsg', processForHTML5ServerOnly(handleGuestApproved));

--- a/bigbluebutton-html5/imports/api/guest-users/server/handlers/guestWaitingLeft.js
+++ b/bigbluebutton-html5/imports/api/guest-users/server/handlers/guestWaitingLeft.js
@@ -1,0 +1,10 @@
+import { check } from 'meteor/check';
+import removeGuest from '../modifiers/removeGuest';
+
+export default function handleGuestWaitingLeft({ body }, meetingId) {
+  const { userId } = body;
+  check(meetingId, String);
+  check(userId, String);
+
+  return removeGuest(meetingId, userId);
+}

--- a/bigbluebutton-html5/imports/api/guest-users/server/modifiers/removeGuest.js
+++ b/bigbluebutton-html5/imports/api/guest-users/server/modifiers/removeGuest.js
@@ -1,0 +1,23 @@
+import { check } from 'meteor/check';
+import GuestUsers from '/imports/api/guest-users';
+import Logger from '/imports/startup/server/logger';
+
+export default function removeGuest(meetingId, intId) {
+  check(meetingId, String);
+  check(intId, String);
+
+  const selector = {
+    meetingId,
+    intId,
+  };
+
+  const cb = (err) => {
+    if (err) {
+      return Logger.error(`Removing guest user from collection: ${err}`);
+    }
+
+    return Logger.info(`Removed guest user id=${intId} meetingId=${meetingId}`);
+  };
+
+  return GuestUsers.remove(selector, cb);
+}

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -28,6 +28,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
 
     <bean id="registeredUserCleanupTimerTask" class="org.bigbluebutton.web.services.RegisteredUserCleanupTimerTask"/>
+    <bean id="waitingGuestCleanupTimerTask" class="org.bigbluebutton.web.services.WaitingGuestCleanupTimerTask"/>
 
     <bean id="keepAliveService" class="org.bigbluebutton.web.services.KeepAliveService"
           init-method="start" destroy-method="stop">
@@ -42,6 +43,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="paramsProcessorUtil" ref="paramsProcessorUtil"/>
         <property name="stunTurnService" ref="stunTurnService"/>
         <property name="registeredUserCleanupTimerTask" ref="registeredUserCleanupTimerTask"/>
+        <property name="waitingGuestCleanupTimerTask" ref="waitingGuestCleanupTimerTask"/>
         <property name="gw" ref="bbbWebApiGWApp"/>
         <property name="callbackUrlService" ref="callbackUrlService"/>
         <property name="keepEvents" value="${keepEvents}"/>

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1316,6 +1316,7 @@ class ApiController {
 
 
       if (guestWaitStatus.equals(GuestPolicy.WAIT)) {
+        meetingService.guestIsWaiting(userSession.meetingID, userSession.internalUserId);
         clientURL = paramsProcessorUtil.getDefaultGuestWaitURL();
         destUrl = clientURL + "?sessionToken=" + sessionToken
         log.debug("GuestPolicy.WAIT - destUrl = " + destUrl)


### PR DESCRIPTION
Fixes #8203 .

This includes in `bbb-web` a monitor for the guests that are polling for their status.
 - If the waiting guest doesn't make a poll to the server for 15 seconds (guest page default is 5 seconds), `bbb-web` removes his registered user and sends a `GuestWaitingLeftMsg` to `akka-apps`.
 - `akka-apps` removes the user from the waiting guest list and from the registered users list and sends a `GuestWaitingLeftEvtMsg` for the clients to update.