### PR TITLE
Add the meetingId to the external video sync update logs

### DIFF
--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/initializeExternalVideo.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/initializeExternalVideo.js
@@ -14,7 +14,7 @@ const allowFromPresenter = (eventName, message) => {
   const user = Users.findOne({ userId });
   const ret = user && user.presenter;
 
-  Logger.debug(`ExternalVideo Streamer auth userid: ${userId}, event: ${eventName}, suc: ${ret}, time: ${time}, rate: ${rate}, state: ${state}`);
+  Logger.info(`ExternalVideo Streamer auth userid: ${userId}, meetingId: ${user.meetingId}, event: ${eventName}, suc: ${ret}, time: ${time}, rate: ${rate}, state: ${state}`);
 
   return ret;
 };


### PR DESCRIPTION
I added the meetingId to the external video sync log and also increased the level to info because we need to be able to track this at the default log level.