### PR TITLE
Add resync data to meteor

### DIFF
--- a/bigbluebutton-html5/imports/api/common/server/helpers.js
+++ b/bigbluebutton-html5/imports/api/common/server/helpers.js
@@ -1,8 +1,24 @@
 import WhiteboardMultiUser from '/imports/api/whiteboard-multi-user/';
 import Users from '/imports/api/users';
+import MeteorSyncConfirmation from '/imports/startup/server/meteorSyncComfirmation';
+import Logger from '/imports/startup/server/logger';
 
 const MSG_DIRECT_TYPE = 'DIRECT';
 const NODE_USER = 'nodeJSapp';
+
+
+export const resyncResolver = (meetingId, dependence) => {
+  if (MeteorSyncConfirmation.isSynced()) return null;
+  const solved = MeteorSyncConfirmation.meetingResolve(meetingId, dependence);
+  if (solved) {
+    Logger.info(`${dependence} synced id=${meetingId}`);
+  } else {
+    Logger.info(`${dependence} not synced id=${meetingId}`);
+  }
+
+  return solved;
+};
+
 
 export const spokeTimeoutHandles = {};
 export const clearSpokeTimeout = (meetingId, userId) => {

--- a/bigbluebutton-html5/imports/api/group-chat/server/handlers/groupChats.js
+++ b/bigbluebutton-html5/imports/api/group-chat/server/handlers/groupChats.js
@@ -1,5 +1,7 @@
 import { check } from 'meteor/check';
 import addGroupChat from '../modifiers/addGroupChat';
+import { resyncResolver } from '/imports/api/common/server/helpers';
+import { dependencies } from '/imports/startup/server/meteorSyncComfirmation';
 
 export default function handleGroupChats({ body }, meetingId) {
   const { chats } = body;
@@ -12,6 +14,6 @@ export default function handleGroupChats({ body }, meetingId) {
   chats.forEach((chat) => {
     chatsAdded.push(addGroupChat(meetingId, chat));
   });
-
+  resyncResolver(meetingId, dependencies.GROUP_CHATS);
   return chatsAdded;
 }

--- a/bigbluebutton-html5/imports/api/meetings/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/eventHandlers.js
@@ -9,6 +9,7 @@ import handleRecordingStatusChange from './handlers/recordingStatusChange';
 import handleRecordingTimerChange from './handlers/recordingTimerChange';
 import handleTimeRemainingUpdate from './handlers/timeRemainingUpdate';
 import handleChangeWebcamOnlyModerator from './handlers/webcamOnlyModerator';
+import handleRunningMettingsSync from './handlers/runningMettingsSync';
 
 RedisPubSub.on('MeetingCreatedEvtMsg', handleMeetingCreation);
 RedisPubSub.on('SyncGetMeetingInfoRespMsg', handleGetAllMeetings);
@@ -21,3 +22,4 @@ RedisPubSub.on('UpdateRecordingTimerEvtMsg', handleRecordingTimerChange);
 RedisPubSub.on('WebcamsOnlyForModeratorChangedEvtMsg', handleChangeWebcamOnlyModerator);
 RedisPubSub.on('GetLockSettingsRespMsg', handleMeetingLocksChange);
 RedisPubSub.on('MeetingTimeRemainingUpdateEvtMsg', handleTimeRemainingUpdate);
+RedisPubSub.on('GetRunningMeetingsRespMsg', handleRunningMettingsSync);

--- a/bigbluebutton-html5/imports/api/meetings/server/handlers/meetingCreation.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/handlers/meetingCreation.js
@@ -6,6 +6,5 @@ export default function handleMeetingCreation({ body }) {
   const durationInSecods = (meeting.durationProps.duration * 60);
   meeting.durationProps.timeRemaining = durationInSecods;
   check(meeting, Object);
-
   return addMeeting(meeting);
 }

--- a/bigbluebutton-html5/imports/api/meetings/server/handlers/runningMettingsSync.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/handlers/runningMettingsSync.js
@@ -1,0 +1,9 @@
+import { check } from 'meteor/check';
+import MeteorSyncConfirmation from '/imports/startup/server/meteorSyncComfirmation';
+
+export default function handleRecordingStatusChange({ body }) {
+  check(body, {
+    meetings: Array,
+  });
+  MeteorSyncConfirmation.setPromises(body.meetings);
+}

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -9,6 +9,8 @@ import createNote from '/imports/api/note/server/methods/createNote';
 import createCaptions from '/imports/api/captions/server/methods/createCaptions';
 import { addAnnotationsStreamer } from '/imports/api/annotations/server/streamer';
 import { addCursorStreamer } from '/imports/api/cursor/server/streamer';
+import { resyncResolver } from '/imports/api/common/server/helpers';
+import { dependencies } from '/imports/startup/server/meteorSyncComfirmation';
 
 export default function addMeeting(meeting) {
   const meetingId = meeting.meetingProp.intId;
@@ -164,10 +166,12 @@ export default function addMeeting(meeting) {
 
     if (insertedId) {
       Logger.info(`Added record prop id=${meetingId}`);
+      resyncResolver(meetingId, dependencies.MEETING);
     }
 
     if (numChanged) {
       Logger.info(`Upserted record prop id=${meetingId}`);
+      resyncResolver(meetingId, dependencies.MEETING);
     }
   };
 

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/changeLockSettings.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/changeLockSettings.js
@@ -1,6 +1,8 @@
 import Logger from '/imports/startup/server/logger';
 import Meetings from '/imports/api/meetings';
 import { check } from 'meteor/check';
+import { resyncResolver } from '/imports/api/common/server/helpers';
+import { dependencies } from '/imports/startup/server/meteorSyncComfirmation';
 
 export default function changeLockSettings(meetingId, payload) {
   check(meetingId, String);
@@ -59,7 +61,7 @@ export default function changeLockSettings(meetingId, payload) {
     if (!numChanged) {
       return Logger.info(`meeting={${meetingId}} lock settings were not updated`);
     }
-
+    resyncResolver(meetingId, dependencies.LOCK_SETTINGS);
     return Logger.info(`Changed meeting={${meetingId}} updated lock settings`);
   };
 

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/meetingHasEnded.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/meetingHasEnded.js
@@ -18,29 +18,36 @@ import clearUserInfo from '/imports/api/users-infos/server/modifiers/clearUserIn
 import clearNote from '/imports/api/note/server/modifiers/clearNote';
 import clearNetworkInformation from '/imports/api/network-information/server/modifiers/clearNetworkInformation';
 import clearLocalSettings from '/imports/api/local-settings/server/modifiers/clearLocalSettings';
+import clearScreenshare from '/imports/api/screenshare/server/modifiers/clearScreenshare';
+import clearWhiteboardMultiUser from '/imports/api/whiteboard-multi-user/server/modifiers/clearWhiteboardMultiUser';
 import clearRecordMeeting from './clearRecordMeeting';
+
+export const clearAllMeetingData = (meetingId) => {
+  clearCaptions(meetingId);
+  clearGroupChat(meetingId);
+  clearPresentationPods(meetingId);
+  clearBreakouts(meetingId);
+  clearPolls(meetingId);
+  clearAnnotations(meetingId);
+  clearSlides(meetingId);
+  clearUsers(meetingId);
+  clearUsersSettings(meetingId);
+  clearVoiceUsers(meetingId);
+  clearUserInfo(meetingId);
+  clearNote(meetingId);
+  clearNetworkInformation(meetingId);
+  clearLocalSettings(meetingId);
+  clearRecordMeeting(meetingId);
+  clearScreenshare(meetingId);
+  clearWhiteboardMultiUser(meetingId);
+
+  return Logger.info(`Cleared Meetings with id ${meetingId}`);
+};
+
 
 export default function meetingHasEnded(meetingId) {
   removeAnnotationsStreamer(meetingId);
   removeCursorStreamer(meetingId);
 
-  return Meetings.remove({ meetingId }, () => {
-    clearCaptions(meetingId);
-    clearGroupChat(meetingId);
-    clearPresentationPods(meetingId);
-    clearBreakouts(meetingId);
-    clearPolls(meetingId);
-    clearAnnotations(meetingId);
-    clearSlides(meetingId);
-    clearUsers(meetingId);
-    clearUsersSettings(meetingId);
-    clearVoiceUsers(meetingId);
-    clearUserInfo(meetingId);
-    clearNote(meetingId);
-    clearNetworkInformation(meetingId);
-    clearLocalSettings(meetingId);
-    clearRecordMeeting(meetingId);
-
-    return Logger.info(`Cleared Meetings with id ${meetingId}`);
-  });
+  return Meetings.remove({ meetingId }, () => clearAllMeetingData(meetingId));
 }

--- a/bigbluebutton-html5/imports/api/presentation-pods/server/handlers/syncGetPresentationPods.js
+++ b/bigbluebutton-html5/imports/api/presentation-pods/server/handlers/syncGetPresentationPods.js
@@ -2,11 +2,12 @@ import { check } from 'meteor/check';
 import PresentationPods from '/imports/api/presentation-pods';
 import removePresentationPod from '../modifiers/removePresentationPod';
 import addPresentationPod from '../modifiers/addPresentationPod';
+import { resyncResolver } from '/imports/api/common/server/helpers';
+import { dependencies } from '/imports/startup/server/meteorSyncComfirmation';
 
 export default function handleSyncGetPresentationPods({ body }, meetingId) {
   check(body, Object);
   check(meetingId, String);
-
   const { pods } = body;
   check(pods, Array);
 
@@ -29,4 +30,5 @@ export default function handleSyncGetPresentationPods({ body }, meetingId) {
     } = pod;
     addPresentationPod(meetingId, { podId, currentPresenterId }, presentations);
   });
+  resyncResolver(meetingId, dependencies.PRESENTATION_PODS);
 }

--- a/bigbluebutton-html5/imports/api/screenshare/server/modifiers/clearScreenshare.js
+++ b/bigbluebutton-html5/imports/api/screenshare/server/modifiers/clearScreenshare.js
@@ -1,17 +1,17 @@
 import Logger from '/imports/startup/server/logger';
 import Screenshare from '/imports/api/screenshare';
 
-export default function clearScreenshare(meetingId, screenshareConf) {
+export default function clearScreenshare(meetingId) {
   const cb = (err) => {
     if (err) {
-      return Logger.error(`removing screenshare to collection: ${err}`);
+      return Logger.error(`Clearing screenshare to collection: ${err}`);
     }
 
-    return Logger.info(`removed screenshare meetingId=${meetingId} id=${screenshareConf}`);
+    return Logger.info(`Cleared screenshare meetingId=${meetingId}`);
   };
 
-  if (meetingId && screenshareConf) {
-    return Screenshare.remove({ meetingId, 'screenshare.screenshareConf': screenshareConf }, cb);
+  if (meetingId) {
+    return Screenshare.remove({ meetingId }, cb);
   }
   return Screenshare.remove({}, cb);
 }

--- a/bigbluebutton-html5/imports/api/screenshare/server/modifiers/removeScreenshare.js
+++ b/bigbluebutton-html5/imports/api/screenshare/server/modifiers/removeScreenshare.js
@@ -1,0 +1,17 @@
+import Logger from '/imports/startup/server/logger';
+import Screenshare from '/imports/api/screenshare';
+
+export default function removeScreenshare(meetingId, screenshareConf) {
+  const cb = (err) => {
+    if (err) {
+      return Logger.error(`removing screenshare to collection: ${err}`);
+    }
+
+    return Logger.info(`removed screenshare meetingId=${meetingId} id=${screenshareConf}`);
+  };
+
+  if (meetingId && screenshareConf) {
+    return Screenshare.remove({ meetingId, 'screenshare.screenshareConf': screenshareConf }, cb);
+  }
+  return Screenshare.remove({}, cb);
+}

--- a/bigbluebutton-html5/imports/api/users/server/handlers/getUsers.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/getUsers.js
@@ -2,13 +2,14 @@ import { check } from 'meteor/check';
 import Users from '/imports/api/users/';
 import addUser from '../modifiers/addUser';
 import removeUser from '../modifiers/removeUser';
+import { resyncResolver } from '/imports/api/common/server/helpers';
+import { dependencies } from '/imports/startup/server/meteorSyncComfirmation';
 
 export default function handleGetUsers({ body }, meetingId) {
   const { users } = body;
 
   check(meetingId, String);
   check(users, Array);
-
   const usersIds = users.map(m => m.intId);
 
   const usersToRemove = Users.find({
@@ -22,6 +23,6 @@ export default function handleGetUsers({ body }, meetingId) {
   users.forEach((user) => {
     usersAdded.push(addUser(meetingId, user));
   });
-
+  resyncResolver(meetingId, dependencies.USERS);
   return usersAdded;
 }

--- a/bigbluebutton-html5/imports/api/users/server/handlers/validateAuthToken.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/validateAuthToken.js
@@ -2,6 +2,7 @@ import { check } from 'meteor/check';
 import Logger from '/imports/startup/server/logger';
 import Users from '/imports/api/users';
 import userJoin from '../methods/userJoin';
+import MeteorSyncConfirmation from '/imports/startup/server/meteorSyncComfirmation';
 
 const clearOtherSessions = (sessionUserId, current = false) => {
   const serverSessions = Meteor.server.sessions;
@@ -30,7 +31,7 @@ export default function handleValidateAuthToken({ body }, meetingId) {
   if (!User) return;
 
   // Publish user join message
-  if (valid && !waitForApproval) {
+  if (valid && !waitForApproval && MeteorSyncConfirmation.isSynced()) {
     Logger.info('User=', User);
     userJoin(meetingId, userId, User.authToken);
   }

--- a/bigbluebutton-html5/imports/api/users/server/methods/validateAuthToken.js
+++ b/bigbluebutton-html5/imports/api/users/server/methods/validateAuthToken.js
@@ -5,12 +5,13 @@ import Logger from '/imports/startup/server/logger';
 import Users from '/imports/api/users';
 import createDummyUser from '../modifiers/createDummyUser';
 import setConnectionIdAndAuthToken from '../modifiers/setConnectionIdAndAuthToken';
+import MeteorSyncConfirmation, { serverSynced } from '/imports/startup/server/meteorSyncComfirmation';
 
-export default function validateAuthToken(credentials) {
+export default async function validateAuthToken(credentials) {
   const REDIS_CONFIG = Meteor.settings.private.redis;
   const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
   const EVENT_NAME = 'ValidateAuthTokenReqMsg';
-
+  await serverSynced;
   const { meetingId, requesterUserId, requesterToken } = credentials;
 
   check(meetingId, String);
@@ -25,7 +26,7 @@ export default function validateAuthToken(credentials) {
     userId: requesterUserId,
   });
 
-  if (!User) {
+  if (!User && MeteorSyncConfirmation.isSynced()) {
     createDummyUser(meetingId, requesterUserId, requesterToken);
   }
 

--- a/bigbluebutton-html5/imports/api/voice-users/server/handlers/getVoiceUsers.js
+++ b/bigbluebutton-html5/imports/api/voice-users/server/handlers/getVoiceUsers.js
@@ -4,10 +4,11 @@ import Meetings from '/imports/api/meetings';
 import addVoiceUser from '../modifiers/addVoiceUser';
 import removeVoiceUser from '../modifiers/removeVoiceUser';
 import updateVoiceUser from '../modifiers/updateVoiceUser';
+import { resyncResolver } from '/imports/api/common/server/helpers';
+import { dependencies } from '/imports/startup/server/meteorSyncComfirmation';
 
 export default function handleGetVoiceUsers({ body }, meetingId) {
   const { users } = body;
-
   check(meetingId, String);
   check(users, Array);
 
@@ -25,6 +26,7 @@ export default function handleGetVoiceUsers({ body }, meetingId) {
       // user already exist, then update
       voiceUsersUpdated.push(updateVoiceUser(meetingId, {
         intId: user.intId,
+
         voiceUserId: user.voiceUserId,
         talking: user.talking,
         muted: user.muted,
@@ -58,6 +60,6 @@ export default function handleGetVoiceUsers({ body }, meetingId) {
     voiceUserId: user.voiceUserId,
     intId: user.intId,
   }));
-
+  resyncResolver(meetingId, dependencies.VOICE_USERS);
   return voiceUsersUpdated;
 }

--- a/bigbluebutton-html5/imports/api/voice-users/server/handlers/voiceUsers.js
+++ b/bigbluebutton-html5/imports/api/voice-users/server/handlers/voiceUsers.js
@@ -4,12 +4,12 @@ import addDialInUser from '/imports/api/users/server/modifiers/addDialInUser';
 import removeVoiceUser from '../modifiers/removeVoiceUser';
 import updateVoiceUser from '../modifiers/updateVoiceUser';
 import addVoiceUser from '../modifiers/addVoiceUser';
-
+import { resyncResolver } from '/imports/api/common/server/helpers';
+import { dependencies } from '/imports/startup/server/meteorSyncComfirmation';
 
 export default function handleVoiceUsers({ header, body }) {
   const { voiceUsers } = body;
   const { meetingId } = header;
-
   const meeting = Meetings.findOne({ meetingId }, { fields: { 'voiceProp.voiceConf': 1 } });
   const usersIds = voiceUsers.map(m => m.intId);
 
@@ -59,6 +59,6 @@ export default function handleVoiceUsers({ header, body }) {
     voiceUserId: user.voiceUserId,
     intId: user.intId,
   }));
-
+  resyncResolver(meetingId, dependencies.VOICE_USERS);
   return voiceUsersUpdated;
 }

--- a/bigbluebutton-html5/imports/api/whiteboard-multi-user/server/modifiers/clearWhiteboardMultiUser.js
+++ b/bigbluebutton-html5/imports/api/whiteboard-multi-user/server/modifiers/clearWhiteboardMultiUser.js
@@ -1,0 +1,17 @@
+import Logger from '/imports/startup/server/logger';
+import WhiteboardMultiUser from '/imports/api/whiteboard-multi-user/';
+
+export default function clearWhiteboardMultiUser(meetingId) {
+  const cb = (err) => {
+    if (err) {
+      return Logger.error(`clearing whiteboard multi user to collection: ${err}`);
+    }
+
+    return Logger.info(`cleared meeting whiteboard multi user meetingId=${meetingId}`);
+  };
+
+  if (meetingId) {
+    return WhiteboardMultiUser.remove({ meetingId }, cb);
+  }
+  return WhiteboardMultiUser.remove({}, cb);
+}

--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -10,6 +10,7 @@ import Logger from './logger';
 import Redis from './redis';
 import setMinBrowserVersions from './minBrowserVersion';
 import userLeaving from '/imports/api/users/server/methods/userLeaving';
+import { clearAllMeetingData } from '/imports/api/meetings/server/modifiers/meetingHasEnded';
 
 const AVAILABLE_LOCALES = fs.readdirSync('assets/app/locales');
 
@@ -19,7 +20,7 @@ Meteor.startup(() => {
   const INTERVAL_TIME = INTERVAL_IN_SETTINGS < 10000 ? 10000 : INTERVAL_IN_SETTINGS;
   const env = Meteor.isDevelopment ? 'development' : 'production';
   const CDN_URL = APP_CONFIG.cdn;
-
+  clearAllMeetingData();
   // Commenting out in BBB 2.3 as node12 does not allow for `memwatch`.
   // We are looking for alternatives
 

--- a/bigbluebutton-html5/imports/startup/server/meteorSyncComfirmation.js
+++ b/bigbluebutton-html5/imports/startup/server/meteorSyncComfirmation.js
@@ -44,13 +44,16 @@ class MeteorSyncComfirmation {
   }
 
   setPromises(meetingsRunning) {
-    if (!meetingsRunning.length) return this.synced = true;
+    if (!meetingsRunning.length) {
+      syncResolver();
+      return this.synced = true;
+    }
 
     this.promises = meetingsRunning.map(this.setMeetingResolver);
     Promise.all(this.promises)
       .then(() => {
         this.synced = true;
-        setTimeout(() => syncResolver(), 5000);
+        syncResolver();
       });
   }
 

--- a/bigbluebutton-html5/imports/startup/server/meteorSyncComfirmation.js
+++ b/bigbluebutton-html5/imports/startup/server/meteorSyncComfirmation.js
@@ -1,0 +1,72 @@
+
+
+export const dependencies = {
+  MEETING: 'meeting',
+  USERS: 'users',
+  PRESENTATION_PODS: 'presentationPods',
+  GROUP_CHATS: 'groupChats',
+  VOICE_USERS: 'voiceUsers',
+  LOCK_SETTINGS: 'lockSettings',
+};
+export let syncResolver = null;
+
+export const serverSynced = new Promise(resolve => syncResolver = resolve);
+
+class MeteorSyncComfirmation {
+  constructor() {
+    this.synced = false;
+    this.promises = null;
+    this.resolvers = {};
+    this.setPromises = this.setPromises.bind(this);
+    this.setMeetingResolver = this.setMeetingResolver.bind(this);
+    this.meetingResolve = this.meetingResolve.bind(this);
+    this.isSynced = this.isSynced.bind(this);
+  }
+
+  setMeetingDependenciesResolvers(meetingId, dependence) {
+    const executor = (resolve) => {
+      this.resolvers[meetingId] = {
+        ...this.resolvers[meetingId],
+        [dependence]: resolve,
+      };
+    };
+    return new Promise(executor);
+  }
+
+  setMeetingResolver(meetingId) {
+    const executor = (resolver) => {
+      Promise.all(
+        Object.values(dependencies).map(i => this.setMeetingDependenciesResolvers(meetingId, i)),
+      )
+        .then(() => resolver());
+    };
+    return new Promise(executor);
+  }
+
+  setPromises(meetingsRunning) {
+    if (!meetingsRunning.length) return this.synced = true;
+
+    this.promises = meetingsRunning.map(this.setMeetingResolver);
+    Promise.all(this.promises)
+      .then(() => {
+        this.synced = true;
+        setTimeout(() => syncResolver(), 5000);
+      });
+  }
+
+  meetingResolve(meetingId, dependence) {
+    const meetingDependencies = this.resolvers[meetingId];
+    if (meetingDependencies) {
+      meetingDependencies[dependence]();
+      return true;
+    }
+
+    return false;
+  }
+
+  isSynced() {
+    return this.synced;
+  }
+}
+
+export default new MeteorSyncComfirmation();

--- a/bigbluebutton-html5/imports/startup/server/redis.js
+++ b/bigbluebutton-html5/imports/startup/server/redis.js
@@ -125,6 +125,7 @@ class RedisPubSub {
 
     this.handleSubscribe = this.handleSubscribe.bind(this);
     this.handleMessage = this.handleMessage.bind(this);
+    this.requestRunningMeetings = this.requestRunningMeetings.bind(this);
     this.debug = makeDebugger(this.config.debug);
   }
 
@@ -159,9 +160,20 @@ class RedisPubSub {
     const body = {
       requesterId: 'nodeJSapp',
     };
-
+    this.requestRunningMeetings();
     this.publishSystemMessage(CHANNEL, EVENT_NAME, body);
     this.didSendRequestEvent = true;
+  }
+
+  requestRunningMeetings() {
+    const REDIS_CONFIG = Meteor.settings.private.redis;
+    const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
+    const EVENT_NAME = 'GetRunningMeetingsReqMsg';
+    const body = {
+      requesterId: 'nodeJSapp',
+    };
+
+    this.publishSystemMessage(CHANNEL, EVENT_NAME, body);
   }
 
   handleMessage(pattern, channel, message) {


### PR DESCRIPTION
This PR adds functions to clear the data from `whiteboard-multi-user`, `screenshare` and `group-chat-msg`. And I made a class to manage the data received from the resync message and hold the validate auth tolkien until receive all data.
Closes #8141