### PR TITLE
Add a rule to don't show breakout invitation modal to moderators

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/invitation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/invitation/component.jsx
@@ -60,6 +60,7 @@ class BreakoutRoomInvitation extends Component {
       currentBreakoutUser,
       getBreakoutByUser,
       breakoutUserIsIn,
+      amIModerator,
     } = this.props;
 
     const {
@@ -72,7 +73,7 @@ class BreakoutRoomInvitation extends Component {
       closeBreakoutJoinConfirmation(mountModal);
     }
 
-    if (hasBreakouts && !breakoutUserIsIn) {
+    if (hasBreakouts && !breakoutUserIsIn && !amIModerator) {
       // Have to check for freeJoin breakouts first because currentBreakoutUser will
       // populate after a room has been joined
       const freeJoinBreakout = breakouts.find(breakout => breakout.freeJoin);

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/invitation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/invitation/container.jsx
@@ -18,4 +18,5 @@ export default withTracker(() => ({
   getBreakoutByUser: BreakoutService.getBreakoutByUser,
   currentBreakoutUser: BreakoutService.getBreakoutUserByUserId(Auth.userID),
   breakoutUserIsIn: BreakoutService.getBreakoutUserIsIn(Auth.userID),
+  amIModerator: BreakoutService.amIModerator(),
 }))(BreakoutRoomInvitationContainer);


### PR DESCRIPTION
This PR implements a design behavior that is not to show the  breakout invitation modal to moderator, it is expected that the moderator will use the side menu to join the breakout room.