### PR TITLE
Workaround to CTM request in svg out of the screen

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/component.jsx
@@ -9,9 +9,7 @@ export default class WhiteboardOverlay extends Component {
   // a function to transform a screen point to svg point
   // accepts and returns a point of type SvgPoint and an svg object
   static coordinateTransform(screenPoint, someSvgObject) {
-    console.log('screenPoint', screenPoint, 'someSvgObject', someSvgObject);
     const CTM = someSvgObject.getScreenCTM();
-    console.log('CTM', CTM);
     if (!CTM) return {};
     return screenPoint.matrixTransform(CTM.inverse());
   }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/component.jsx
@@ -9,7 +9,10 @@ export default class WhiteboardOverlay extends Component {
   // a function to transform a screen point to svg point
   // accepts and returns a point of type SvgPoint and an svg object
   static coordinateTransform(screenPoint, someSvgObject) {
+    console.log('screenPoint', screenPoint, 'someSvgObject', someSvgObject);
     const CTM = someSvgObject.getScreenCTM();
+    console.log('CTM', CTM);
+    if (!CTM) return {};
     return screenPoint.matrixTransform(CTM.inverse());
   }
 


### PR DESCRIPTION
Following the specification for `getScreenCTM` firefox returns null for the svg out of the screen, but it doesn't comply with the other browsers behavior.

https://bugzilla.mozilla.org/show_bug.cgi?id=1446011

Closes #8439.