### PR TITLE
Add ability to switch presentations via actions menu (Presenter)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -11,8 +11,10 @@ import DropdownListItem from '/imports/ui/components/dropdown/list/item/componen
 import PresentationUploaderContainer from '/imports/ui/components/presentation/presentation-uploader/container';
 import { withModalMounter } from '/imports/ui/components/modal/service';
 import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
-import { styles } from '../styles';
+import DropdownListSeparator from '/imports/ui/components/dropdown/list/separator/component';
 import ExternalVideoModal from '/imports/ui/components/external-video-player/modal/container';
+import cx from 'classnames';
+import { styles } from '../styles';
 
 const propTypes = {
   amIPresenter: PropTypes.bool.isRequired,
@@ -86,6 +88,7 @@ class ActionsDropdown extends PureComponent {
 
     this.handlePresentationClick = this.handlePresentationClick.bind(this);
     this.handleExternalVideoClick = this.handleExternalVideoClick.bind(this);
+    this.makePresentationItems = this.makePresentationItems.bind(this);
   }
 
   componentWillUpdate(nextProps) {
@@ -176,6 +179,42 @@ class ActionsDropdown extends PureComponent {
     ]);
   }
 
+  makePresentationItems() {
+    const {
+      presentations,
+      setPresentation,
+      podIds,
+    } = this.props;
+
+    let podId = null;
+    if (podIds) {
+      const defaultPodId = podIds[0].podId;
+      podId = podIds.length > 0 ? defaultPodId : null;
+    }
+
+    const presentationItemElements = presentations.map((p) => {
+      const itemStyles = {};
+      itemStyles[styles.presentationItem] = true;
+      itemStyles[styles.isCurrent] = p.isCurrent;
+
+      return (<DropdownListItem
+        className={cx(itemStyles)}
+        icon="file"
+        iconRight={p.isCurrent ? 'check' : null}
+        label={p.filename}
+        description="uploaded presentation file"
+        key={`uploaded-presentation-${p.id}`}
+        onClick={() => {
+          setPresentation(p.id, podId);
+        }}
+      />
+      );
+    });
+
+    presentationItemElements.push(<DropdownListSeparator key={_.uniqueId('list-separator-')} />);
+    return presentationItemElements;
+  }
+
   handleExternalVideoClick() {
     const { mountModal } = this.props;
     mountModal(<ExternalVideoModal />);
@@ -196,6 +235,9 @@ class ActionsDropdown extends PureComponent {
     } = this.props;
 
     const availableActions = this.getAvailableActions();
+    const availablePresentations = this.makePresentationItems();
+    const children = availablePresentations.length > 2
+      ? availablePresentations.concat(availableActions) : availableActions;
 
     if ((!amIPresenter && !amIModerator)
       || availableActions.length === 0
@@ -220,7 +262,7 @@ class ActionsDropdown extends PureComponent {
         </DropdownTrigger>
         <DropdownContent placement="top left">
           <DropdownList>
-            {availableActions}
+            {children}
           </DropdownList>
         </DropdownContent>
       </Dropdown>

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -236,7 +236,7 @@ class ActionsDropdown extends PureComponent {
 
     const availableActions = this.getAvailableActions();
     const availablePresentations = this.makePresentationItems();
-    const children = availablePresentations.length > 2
+    const children = availablePresentations.length > 2 && amIPresenter
       ? availablePresentations.concat(availableActions) : availableActions;
 
     if ((!amIPresenter && !amIModerator)

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -34,6 +34,9 @@ class ActionsBar extends PureComponent {
       isPollingEnabled,
       isThereCurrentPresentation,
       allowExternalVideo,
+      presentations,
+      setPresentation,
+      podIds,
     } = this.props;
 
     const actionBarClasses = {};
@@ -55,6 +58,9 @@ class ActionsBar extends PureComponent {
             isSharingVideo,
             stopExternalVideoShare,
             isMeteorConnected,
+            presentations,
+            setPresentation,
+            podIds,
           }}
           />
           {isPollingEnabled

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
@@ -9,6 +9,8 @@ import Presentations from '/imports/api/presentations';
 import ActionsBar from './component';
 import Service from './service';
 import ExternalVideoService from '/imports/ui/components/external-video-player/service';
+import PresentationUploaderService from '/imports/ui/components/presentation/presentation-uploader/service';
+import PresentationPodService from '/imports/ui/components/presentation-pod/service';
 import CaptionsService from '/imports/ui/components/captions/service';
 import {
   shareScreen,
@@ -49,4 +51,7 @@ export default withTracker(() => ({
   isThereCurrentPresentation: Presentations.findOne({ meetingId: Auth.meetingID, current: true },
     { fields: {} }),
   allowExternalVideo: Meteor.settings.public.externalVideoPlayer.enabled,
+  presentations: PresentationUploaderService.getPresentations(),
+  setPresentation: PresentationUploaderService.setPresentation,
+  podIds: PresentationPodService.getPresentationPodIds(),
 }))(injectIntl(ActionsBarContainer));

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
@@ -86,3 +86,19 @@
     border-color: var(--color-white) !important;
   }
 }
+
+.presentationItem {
+  span {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    max-width: 10rem;
+  }
+}
+
+.isCurrent {
+  i,
+  span {
+    color: var(--color-primary);
+  }
+}

--- a/bigbluebutton-html5/imports/ui/components/media/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/media/styles.scss
@@ -95,6 +95,7 @@ $after-content-order: 3;
   order: 2 !important;
 }
 
+// used to fully hide the presentation area when minimized
 .hideOverlay {
   visibility: hidden !important;
   position: absolute !important;

--- a/bigbluebutton-html5/imports/ui/components/media/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/media/styles.scss
@@ -96,7 +96,15 @@ $after-content-order: 3;
 }
 
 .hideOverlay {
+  visibility: hidden !important;
   position: absolute !important;
+  overflow: hidden !important;
+  clip: rect(0 0 0 0) !important;
+  width: 1px !important;
+  height: 1px !important;
+  margin: -1px !important;
+  padding: 0 !important;
+  border: 0 !important;
 }
 
 .floatingOverlay {

--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -35,5 +35,6 @@ export default withTracker(({ podId }) => {
     currentPresentation: PresentationAreaService.getCurrentPresentation(podId),
     notify,
     zoomSlide: PresentationToolbarService.zoomSlide,
+    podId,
   };
 })(PresentationAreaContainer);

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/service.js
@@ -187,7 +187,9 @@ const uploadAndConvertPresentations = (
   p.onUpload, p.onProgress, p.onConversion,
 )));
 
-const setPresentation = (presentationId, podId) => makeCall('setPresentation', presentationId, podId);
+const setPresentation = (presentationId, podId) => {
+  makeCall('setPresentation', presentationId, podId);
+};
 
 const removePresentation = (presentationId, podId) => {
   const hasPoll = Poll.find({}, { fields: {} }).count();
@@ -243,4 +245,5 @@ export default {
   getPresentations,
   persistPresentationChanges,
   dispatchTogglePresentationDownloadable,
+  setPresentation,
 };


### PR DESCRIPTION
This PR allows the presenter to switch the current presentation via the actions drop down menu, instead of having to open the upload modal.

![toggle-presentation-via-actions-btn](https://user-images.githubusercontent.com/22058534/73189688-d3ecdb80-40f2-11ea-9ca3-3e6615840cdc.gif)
