### PR TITLE
rap: Fix require paths in Rakefile

### DIFF
--- a/record-and-playback/core/Rakefile
+++ b/record-and-playback/core/Rakefile
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require 'resque/tasks'
 
-task "resque:setup" => :environment do
+task 'resque:setup' => :environment do
   props = BigBlueButton.read_props
   redis_host = props['redis_workers_host'] || props['redis_host']
   redis_port = props['redis_workers_port'] || props['redis_port']
@@ -8,10 +10,10 @@ task "resque:setup" => :environment do
 
   # Make sure we're in the right directory because several rap scripts assume
   # they are being executed from there and will fail otherwise
-  Dir.chdir(File.expand_path('../scripts', __FILE__))
+  Dir.chdir(File.expand_path('scripts', __dir__))
 end
 
 task :environment do
-  require File.expand_path('../lib/recordandplayback', __FILE__)
-  require File.expand_path('../scripts/workers/workers', __FILE__)
+  require_relative 'lib/boot'
+  require 'recordandplayback/workers'
 end


### PR DESCRIPTION
I moved the location of the worker classes around, but forgot to update
the Rakefile to include them from the new location.