### PR TITLE
set new minimum browsers versions to run html5 client

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -358,7 +358,7 @@ private:
     - browser: firefoxMobile
       version: 68
     - browser: edge
-      version: 72
+      version: 79
     - browser: ie
       version: Infinity
     - browser: safari

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -88,7 +88,7 @@ public:
     packetLostThreshold: 10
   kurento:
     wsUrl: HOST
-    chromeDefaultExtensionKey: fhgnhnjcnkmgmbpebmpankimbdfifdkj
+    chromeDefaultExtensionKey: akgoaoikmbmhcopjgakkcepdgdgkjfbc
     chromeDefaultExtensionLink: https://chrome.google.com/webstore/detail/bigbluebutton-screenshare/akgoaoikmbmhcopjgakkcepdgdgkjfbc
     chromeExtensionKey: KEY
     chromeExtensionLink: LINK

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -350,23 +350,23 @@ private:
       enabled: false
   minBrowserVersions:
     - browser: chrome
-      version: 59
+      version: 62
     - browser: chromeMobileIOS
       version: Infinity
     - browser: firefox
-      version: 52
+      version: 63
     - browser: firefoxMobile
-      version: 52
+      version: 68
     - browser: edge
-      version: 17
+      version: 72
     - browser: ie
       version: Infinity
     - browser: safari
-      version: [11, 1]
+      version: [12, 1]
     - browser: mobileSafari
-      version: [11, 1]
+      version: [12, 1]
     - browser: opera
-      version: 46
+      version: 50
     - browser: electron
       version: [0, 36]
     - browser: YandexBrowser

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -88,7 +88,7 @@ public:
     packetLostThreshold: 10
   kurento:
     wsUrl: HOST
-    chromeDefaultExtensionKey: akgoaoikmbmhcopjgakkcepdgdgkjfbc
+    chromeDefaultExtensionKey: fhgnhnjcnkmgmbpebmpankimbdfifdkj
     chromeDefaultExtensionLink: https://chrome.google.com/webstore/detail/bigbluebutton-screenshare/akgoaoikmbmhcopjgakkcepdgdgkjfbc
     chromeExtensionKey: KEY
     chromeExtensionLink: LINK
@@ -350,7 +350,7 @@ private:
       enabled: false
   minBrowserVersions:
     - browser: chrome
-      version: 62
+      version: 72
     - browser: chromeMobileIOS
       version: Infinity
     - browser: firefox


### PR DESCRIPTION
This PR updates the minimum browser version requirements to run the html5 client. I based this update on the following browser features used by the client: `Network Information`, `Page Visibility`, `WebSocket`, `MediaDevices` and `WebRTC`.

Closes #8521.