### PR TITLE
2.3 equivalent of #8580

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -618,10 +618,9 @@ class VideoProvider extends Component {
   }
 
   _getOnIceCandidateCallback(cameraId, isLocal) {
-    const peer = this.webRtcPeers[cameraId];
-    const role = VideoService.getRole(isLocal);
-
     return (candidate) => {
+      const peer = this.webRtcPeers[cameraId];
+      const role = VideoService.getRole(isLocal);
       // Setup a timeout only when the first candidate is generated and if the peer wasn't
       // marked as started already (which is done on handlePlayStart after
       // it was verified that media could circle through the server)


### PR DESCRIPTION
From #8580:

> The peer object was being fetched only once in the ICE candidate callback and it would, sometimes, fetch a placeholder empty object which would be kept in the callback closure till the end of the peer lifecycle. 
> With that, the didSDPAnswered state variable which controls the outbound ICE queue wouldn't be correctly read and the queue would never be flushed.