### PR TITLE
 Add timeout waiting for response from FreeSWITCH when sending ESL command

### DIFF
--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/FreeswitchApplication.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/FreeswitchApplication.java
@@ -162,43 +162,47 @@ public class FreeswitchApplication implements  IDelayedCommandListener{
     Runnable task = new Runnable() {
       public void run() {
         log.info("Sending message: " + command.getCommand() + " " + command.getCommandArgs());
-        if (command instanceof GetAllUsersCommand) {
-          GetAllUsersCommand cmd = (GetAllUsersCommand) command;
-          manager.getUsers(cmd);
-        } else if (command instanceof MuteUserCommand) {
-          MuteUserCommand cmd = (MuteUserCommand) command;
-          manager.mute(cmd);
-        } else if (command instanceof EjectUserCommand) {
-          EjectUserCommand cmd = (EjectUserCommand) command;
-          manager.eject(cmd);
-        } else if (command instanceof EjectAllUsersCommand) {
-          EjectAllUsersCommand cmd = (EjectAllUsersCommand) command;
-          manager.ejectAll(cmd);
+        try {
+          if (command instanceof GetAllUsersCommand) {
+            GetAllUsersCommand cmd = (GetAllUsersCommand) command;
+            manager.getUsers(cmd);
+          } else if (command instanceof MuteUserCommand) {
+            MuteUserCommand cmd = (MuteUserCommand) command;
+            manager.mute(cmd);
+          } else if (command instanceof EjectUserCommand) {
+            EjectUserCommand cmd = (EjectUserCommand) command;
+            manager.eject(cmd);
+          } else if (command instanceof EjectAllUsersCommand) {
+            EjectAllUsersCommand cmd = (EjectAllUsersCommand) command;
+            manager.ejectAll(cmd);
 
-          CheckIfConfIsRunningCommand command = new CheckIfConfIsRunningCommand(cmd.getRoom(),
-                  cmd.getRequesterId(),
-                  delayedCommandSenderService, 0);
-          delayedCommandSenderService.handleMessage(command, 5000);
-        } else if (command instanceof TransferUserToMeetingCommand) {
-          TransferUserToMeetingCommand cmd = (TransferUserToMeetingCommand) command;
-          manager.tranfer(cmd);
-        } else if (command instanceof RecordConferenceCommand) {
-          manager.record((RecordConferenceCommand) command);
-        } else if (command instanceof ScreenshareBroadcastRTMPCommand) {
-          manager.broadcastRTMP((ScreenshareBroadcastRTMPCommand) command);
-        } else if (command instanceof ScreenshareHangUpCommand) {
-          ScreenshareHangUpCommand cmd = (ScreenshareHangUpCommand) command;
-          manager.hangUp(cmd);
-        } else if (command instanceof BroadcastConferenceCommand) {
-          manager.broadcast((BroadcastConferenceCommand) command);
-        } else if (command instanceof ConferenceCheckRecordCommand) {
-          manager.checkIfConferenceIsRecording((ConferenceCheckRecordCommand) command);
-        } else if (command instanceof CheckIfConfIsRunningCommand) {
-          manager.checkIfConfIsRunningCommand((CheckIfConfIsRunningCommand) command);
-        } else if (command instanceof ForceEjectUserCommand) {
-          manager.forceEjectUser((ForceEjectUserCommand) command);
-        } else if (command instanceof GetUsersStatusCommand) {
-          manager.getUsersStatus((GetUsersStatusCommand) command);
+            CheckIfConfIsRunningCommand command = new CheckIfConfIsRunningCommand(cmd.getRoom(),
+                    cmd.getRequesterId(),
+                    delayedCommandSenderService, 0);
+            delayedCommandSenderService.handleMessage(command, 5000);
+          } else if (command instanceof TransferUserToMeetingCommand) {
+            TransferUserToMeetingCommand cmd = (TransferUserToMeetingCommand) command;
+            manager.tranfer(cmd);
+          } else if (command instanceof RecordConferenceCommand) {
+            manager.record((RecordConferenceCommand) command);
+          } else if (command instanceof ScreenshareBroadcastRTMPCommand) {
+            manager.broadcastRTMP((ScreenshareBroadcastRTMPCommand) command);
+          } else if (command instanceof ScreenshareHangUpCommand) {
+            ScreenshareHangUpCommand cmd = (ScreenshareHangUpCommand) command;
+            manager.hangUp(cmd);
+          } else if (command instanceof BroadcastConferenceCommand) {
+            manager.broadcast((BroadcastConferenceCommand) command);
+          } else if (command instanceof ConferenceCheckRecordCommand) {
+            manager.checkIfConferenceIsRecording((ConferenceCheckRecordCommand) command);
+          } else if (command instanceof CheckIfConfIsRunningCommand) {
+            manager.checkIfConfIsRunningCommand((CheckIfConfIsRunningCommand) command);
+          } else if (command instanceof ForceEjectUserCommand) {
+            manager.forceEjectUser((ForceEjectUserCommand) command);
+          } else if (command instanceof GetUsersStatusCommand) {
+            manager.getUsersStatus((GetUsersStatusCommand) command);
+          }
+        } catch (RuntimeException e) {
+          log.warn(e.getMessage());
         }
       }
     };

--- a/bbb-fsesl-client/src/main/java/org/freeswitch/esl/client/inbound/InboundClientHandler.java
+++ b/bbb-fsesl-client/src/main/java/org/freeswitch/esl/client/inbound/InboundClientHandler.java
@@ -23,6 +23,7 @@ import org.freeswitch.esl.client.transport.message.EslHeaders.Value;
 import org.freeswitch.esl.client.transport.message.EslMessage;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.handler.execution.ExecutionHandler;
+import org.jboss.netty.channel.ExceptionEvent;
 
 /**
  * End users of the inbound {@link Client} should not need to use this class. 
@@ -82,5 +83,15 @@ public class InboundClientHandler extends AbstractEslClientHandler
         log.debug( "Received disconnection notice" );
         listener.disconnected();
     }
-    
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e) throws Exception
+    {
+        if ("WAIT_FOR_ESL_RESPONSE_TIMEOUT".equals(e.getCause().getMessage())) {
+            throw new RuntimeException("WAIT_FOR_ESL_RESPONSE_TIMEOUT");
+        } else {
+            log.warn(e.getCause().getMessage());
+        }
+
+    }
 }

--- a/bbb-fsesl-client/src/main/java/org/freeswitch/esl/client/internal/AbstractEslClientHandler.java
+++ b/bbb-fsesl-client/src/main/java/org/freeswitch/esl/client/internal/AbstractEslClientHandler.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -231,15 +232,18 @@ public abstract class AbstractEslClientHandler extends SimpleChannelUpstreamHand
             try
             {
                 log.trace( "awaiting latch ... " );
-                latch.await();
+                if (latch.await(10, TimeUnit.SECONDS)) {
+                    log.trace( "returning response [{}]", response );
+                    return response;
+                } else {
+                    log.warn("Timeout waiting for response from ESL command.");
+                    throw new RuntimeException("WAIT_FOR_ESL_RESPONSE_TIMEOUT");
+                }
             }
             catch ( InterruptedException e )
             {
                 throw new RuntimeException( e );
             }
-            
-            log.trace( "returning response [{}]", response );
-            return response;
         }
 
         /**


### PR DESCRIPTION
 When waiting for a response from FS after sending an ESL command and the ESL connection disconnects, the sending thread will be blocked as the trigger for it to unblock is the response from FS which never comes.

   Add a 30 second timeout waiting for response and give up to go send a new FS ESL command.