### PR TITLE
 Track call session state

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp2x.scala
@@ -3,6 +3,13 @@ package org.bigbluebutton.core.apps.voice
 import org.bigbluebutton.core.running.MeetingActor
 import org.bigbluebutton.core2.message.handlers.RecordingStartedVoiceConfEvtMsgHdlr
 
+object VoiceCallState {
+  val NOT_IN_CALL = "NOT_IN_CALL"
+  val IN_ECHO_TEST = "IN_ECHO_TEST"
+  val IN_CONFERENCE = "IN_CONFERENCE"
+  val CALL_STARTED = "CALL_STARTED"
+  val CALL_ENDED = "CALL_ENDED"
+}
 trait VoiceApp2x extends UserJoinedVoiceConfEvtMsgHdlr
   with UserJoinedVoiceConfMessageHdlr
   with UserLeftVoiceConfEvtMsgHdlr
@@ -11,6 +18,7 @@ trait VoiceApp2x extends UserJoinedVoiceConfEvtMsgHdlr
   with RecordingStartedVoiceConfEvtMsgHdlr
   with VoiceConfRunningEvtMsgHdlr
   with SyncGetVoiceUsersMsgHdlr
+  with VoiceConfCallStateEvtMsgHdlr
   with UserStatusVoiceConfEvtMsgHdlr {
 
   this: MeetingActor =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceConfCallStateEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceConfCallStateEvtMsgHdlr.scala
@@ -1,0 +1,42 @@
+package org.bigbluebutton.core.apps.voice
+
+import org.bigbluebutton.common2.msgs.{ BbbClientMsgHeader, BbbCommonEnvCoreMsg, BbbCoreEnvelope, MessageTypes, Routing, VoiceCallStateEvtMsg, VoiceCallStateEvtMsgBody, VoiceConfCallStateEvtMsg }
+import org.bigbluebutton.core.models.{ VoiceUserState, VoiceUsers }
+import org.bigbluebutton.core.running.{ LiveMeeting, MeetingActor, OutMsgRouter }
+
+trait VoiceConfCallStateEvtMsgHdlr {
+  this: MeetingActor =>
+
+  val liveMeeting: LiveMeeting
+  val outGW: OutMsgRouter
+
+  def handleVoiceConfCallStateEvtMsg(msg: VoiceConfCallStateEvtMsg): Unit = {
+    val routing = Routing.addMsgToClientRouting(
+      MessageTypes.BROADCAST_TO_MEETING,
+      liveMeeting.props.meetingProp.intId,
+      msg.body.voiceConf
+    )
+    val envelope = BbbCoreEnvelope(
+      VoiceCallStateEvtMsg.NAME,
+      routing
+    )
+    val header = BbbClientMsgHeader(
+      VoiceCallStateEvtMsg.NAME,
+      liveMeeting.props.meetingProp.intId,
+      msg.body.voiceConf
+    )
+
+    val body = VoiceCallStateEvtMsgBody(
+      meetingId = liveMeeting.props.meetingProp.intId,
+      voiceConf = msg.body.voiceConf,
+      clientSession = msg.body.callSession,
+      userId = msg.body.userId,
+      callerName = msg.body.callerName,
+      callState = msg.body.callState
+    )
+
+    val event = VoiceCallStateEvtMsg(header, body)
+    val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+    outGW.send(msgEvent)
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceConfCallStateEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceConfCallStateEvtMsgHdlr.scala
@@ -29,7 +29,7 @@ trait VoiceConfCallStateEvtMsgHdlr {
     val body = VoiceCallStateEvtMsgBody(
       meetingId = liveMeeting.props.meetingProp.intId,
       voiceConf = msg.body.voiceConf,
-      clientSession = msg.body.callSession,
+      clientSession = msg.body.clientSession,
       userId = msg.body.userId,
       callerName = msg.body.callerName,
       callState = msg.body.callState

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -152,6 +152,8 @@ class ReceivedJsonMsgHandlerActor(
         routeVoiceMsg[CheckRunningAndRecordingVoiceConfEvtMsg](envelope, jsonNode)
       case UserStatusVoiceConfEvtMsg.NAME =>
         routeVoiceMsg[UserStatusVoiceConfEvtMsg](envelope, jsonNode)
+      case VoiceConfCallStateEvtMsg.NAME =>
+        routeVoiceMsg[VoiceConfCallStateEvtMsg](envelope, jsonNode)
 
       // Breakout rooms
       case BreakoutRoomsListMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -384,6 +384,7 @@ class MeetingActor(
         state = updateInactivityTracker(state)
         updateVoiceUserLastActivity(m.body.voiceUserId)
         handleUserTalkingInVoiceConfEvtMsg(m)
+      case m: VoiceConfCallStateEvtMsg        => handleVoiceConfCallStateEvtMsg(m)
 
       case m: RecordingStartedVoiceConfEvtMsg => handleRecordingStartedVoiceConfEvtMsg(m)
       case m: MuteUserCmdMsg =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
@@ -93,6 +93,8 @@ class AnalyticsActor extends Actor with ActorLogging {
       // Voice
       case m: UserMutedVoiceEvtMsg =>
         logMessage(msg)
+      case m: VoiceConfCallStateEvtMsg => logMessage(msg)
+      case m: VoiceCallStateEvtMsg => logMessage(msg)
 
       // Breakout
       case m: BreakoutRoomEndedEvtMsg => logMessage(msg)

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/FreeswitchConferenceEventListener.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/FreeswitchConferenceEventListener.java
@@ -100,6 +100,19 @@ public class FreeswitchConferenceEventListener implements ConferenceEventListene
         } else if (event instanceof VoiceUsersStatusEvent) {
           VoiceUsersStatusEvent evt = (VoiceUsersStatusEvent) event;
           vcs.voiceUsersStatus(evt.getRoom(), evt.confMembers, evt.confRecordings);
+        } else if (event instanceof VoiceCallStateEvent) {
+          VoiceCallStateEvent evt = (VoiceCallStateEvent) event;
+          vcs.voiceCallStateEvent(evt.getRoom(),
+                  evt.callSession,
+                  evt.clientSession,
+                  evt.userId,
+                  evt.callerName,
+                  evt.callState,
+                  evt.origCallerIdName,
+                  evt.origCalledDest);
+        } else if (event instanceof FreeswitchStatusReplyEvent) {
+          FreeswitchStatusReplyEvent evt = (FreeswitchStatusReplyEvent) event;
+          vcs.freeswitchStatusReplyEvent(evt.jsonResponse);
         }
 
       }

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/IVoiceConferenceService.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/IVoiceConferenceService.java
@@ -65,4 +65,14 @@ public interface IVoiceConferenceService {
                                     Boolean isRecording,
                                     java.util.List<ConfRecording> confRecording);
 
+  void voiceCallStateEvent(String conf,
+                           String callSession,
+                           String clientSession,
+                           String userId,
+                           String callerName,
+                           String callState,
+                           String origCallerIdName,
+                           String origCalledDest);
+
+  void freeswitchStatusReplyEvent(String json);
 }

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/events/FreeswitchStatusReplyEvent.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/events/FreeswitchStatusReplyEvent.java
@@ -1,0 +1,11 @@
+package org.bigbluebutton.freeswitch.voice.events;
+
+public class FreeswitchStatusReplyEvent extends VoiceConferenceEvent {
+
+    public final String jsonResponse;
+
+    public FreeswitchStatusReplyEvent(String json) {
+        super("unused");
+        this.jsonResponse = json;
+    }
+}

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/events/VoiceCallStateEvent.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/events/VoiceCallStateEvent.java
@@ -1,0 +1,30 @@
+package org.bigbluebutton.freeswitch.voice.events;
+
+public class VoiceCallStateEvent extends VoiceConferenceEvent {
+    public final String callSession;
+    public final String clientSession;
+    public final String userId;
+    public final String callerName;
+    public final String callState;
+    public final String origCallerIdName;
+    public final String origCalledDest;
+
+    public VoiceCallStateEvent(
+            String conf,
+            String callSession,
+            String clientSession,
+            String userId,
+            String callerName,
+            String callState,
+            String origCallerIdName,
+            String origCalledDest) {
+        super(conf);
+        this.callSession = callSession;
+        this.clientSession = clientSession;
+        this.userId = userId;
+        this.callerName = callerName;
+        this.callState = callState;
+        this.origCallerIdName = origCallerIdName;
+        this.origCalledDest = origCalledDest;
+    }
+}

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/ConnectionManager.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/ConnectionManager.java
@@ -34,6 +34,7 @@ import org.bigbluebutton.freeswitch.voice.freeswitch.actions.*;
 import org.freeswitch.esl.client.inbound.Client;
 import org.freeswitch.esl.client.inbound.InboundConnectionFailure;
 import org.freeswitch.esl.client.manager.ManagerConnection;
+import org.freeswitch.esl.client.transport.CommandResponse;
 import org.freeswitch.esl.client.transport.message.EslMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,10 +82,18 @@ public class ConnectionManager {
 				if (!subscribed) {
 					log.info("Subscribing for ESL events.");
 					c.cancelEventSubscriptions();
-					c.setEventSubscriptions("plain", "all");
-					//c.addEventFilter(EVENT_NAME, "heartbeat");
-					c.addEventFilter(EVENT_NAME, "custom");
-					c.addEventFilter(EVENT_NAME, "background_job");
+					CommandResponse response = c.setEventSubscriptions("plain", "all");
+					if (response.isOk()) {
+						log.info("Subscribed to ESL events." +
+								" Command: [" + response.getCommand() + "] " +
+								" Response: [" + response.getReplyText() + "]");
+					}
+
+					//c.addEventFilter(EVENT_NAME, "HEARTBEAT");
+					//c.addEventFilter(EVENT_NAME, "custom");
+					//c.addEventFilter(EVENT_NAME, "background_job");
+					c.addEventFilter(EVENT_NAME, "CHANNEL_EXECUTE");
+					c.addEventFilter(EVENT_NAME, "CHANNEL_STATE");
 					subscribed = true;
 				} else {
 					// Let's check for status every minute.

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/ESLEventListener.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/ESLEventListener.java
@@ -80,10 +80,17 @@ public class ESLEventListener implements IEslEventListener {
             ScreenshareStartedEvent dsStart = new ScreenshareStartedEvent(confName, callerId, callerIdName);
             conferenceEventListener.handleConferenceEvent(dsStart);
         } else {
+            String coreuuid = headers.get("Core-UUID");
+            String callState = "IN_CONFERENCE";
+            String origCallerIdName = headers.get("Caller-Caller-ID-Name");
+            String origCallerDestNumber = headers.get("Caller-Destination-Number");
+            String clientSession = "0";
+
             Matcher matcher = CALLERNAME_PATTERN.matcher(callerIdName);
             Matcher callWithSess = CALLERNAME_WITH_SESS_INFO_PATTERN.matcher(callerIdName);
             if (callWithSess.matches()) {
                 voiceUserId = callWithSess.group(1).trim();
+                clientSession = callWithSess.group(2).trim();
                 callerIdName = callWithSess.group(3).trim();
             } else if (matcher.matches()) {
                 voiceUserId = matcher.group(1).trim();
@@ -95,11 +102,6 @@ public class ESLEventListener implements IEslEventListener {
                 voiceUserId = "v_" + memberId.toString();
             }
 
-            String coreuuid = headers.get("Core-UUID");
-            String clientSession = "0";
-            String callState = "IN_CONFERENCE";
-            String origCallerIdName = headers.get("Caller-Caller-ID-Name");
-            String origCallerDestNumber = headers.get("Caller-Destination-Number");
             VoiceCallStateEvent csEvent = new VoiceCallStateEvent(
                     confName,
                     coreuuid,

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/actions/CheckFreeswitchStatusCommand.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/actions/CheckFreeswitchStatusCommand.java
@@ -3,6 +3,7 @@ package org.bigbluebutton.freeswitch.voice.freeswitch.actions;
 import com.google.gson.Gson;
 import org.apache.commons.lang3.StringUtils;
 import org.bigbluebutton.freeswitch.voice.events.ConferenceEventListener;
+import org.bigbluebutton.freeswitch.voice.events.FreeswitchStatusReplyEvent;
 import org.freeswitch.esl.client.transport.message.EslMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,10 +27,11 @@ public class CheckFreeswitchStatusCommand extends FreeswitchCommand {
     }
 
     public void handleResponse(EslMessage response, ConferenceEventListener eventListener) {
-
         Gson gson = new Gson();
         log.info(gson.toJson(response.getBodyLines()));
-
+        FreeswitchStatusReplyEvent statusEvent = new FreeswitchStatusReplyEvent(
+                gson.toJson(response.getBodyLines()));
+        eventListener.handleConferenceEvent(statusEvent);
     }
 
 }

--- a/akka-bbb-fsesl/src/main/scala/org/bigbluebutton/freeswitch/VoiceConferenceService.scala
+++ b/akka-bbb-fsesl/src/main/scala/org/bigbluebutton/freeswitch/VoiceConferenceService.scala
@@ -273,4 +273,41 @@ class VoiceConferenceService(sender: RedisPublisher) extends IVoiceConferenceSer
     sender.publish(fromVoiceConfRedisChannel, json)
   }
 
+  def voiceCallStateEvent(
+      conf:             String,
+      callSession:      String,
+      clientSession:    String,
+      userId:           String,
+      callerName:       String,
+      callState:        String,
+      origCallerIdName: String,
+      origCalledDest:   String
+  ): Unit = {
+    val header = BbbCoreVoiceConfHeader(VoiceConfCallStateEvtMsg.NAME, conf)
+    val body = VoiceConfCallStateEvtMsgBody(
+      voiceConf = conf,
+      callSession = callSession,
+      clientSession = clientSession,
+      userId = userId,
+      callerName = callerName,
+      callState = callState,
+      origCallerIdName = origCallerIdName,
+      origCalledDest = origCalledDest
+    )
+    val envelope = BbbCoreEnvelope(VoiceConfCallStateEvtMsg.NAME, Map("voiceConf" -> conf))
+
+    val msg = new VoiceConfCallStateEvtMsg(header, body)
+    val msgEvent = BbbCommonEnvCoreMsg(envelope, msg)
+
+    val json = JsonUtil.toJson(msgEvent)
+    sender.publish(fromVoiceConfRedisChannel, json)
+  }
+
+  def freeswitchStatusReplyEvent(json: String): Unit = {
+    // Placeholder so we can add a /healthz check endpoint to
+    // monitor akka-fsesl (ralam feb 5, 2020)
+    //println("***** >>>>")
+    //println(json)
+    //println("<<<< *****")
+  }
 }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
@@ -434,3 +434,39 @@ case class UserDisconnectedFromGlobalAudioMsgBody(userId: String, name: String)
 object SyncGetVoiceUsersRespMsg { val NAME = "SyncGetVoiceUsersRespMsg" }
 case class SyncGetVoiceUsersRespMsg(header: BbbClientMsgHeader, body: SyncGetVoiceUsersRespMsgBody) extends BbbCoreMsg
 case class SyncGetVoiceUsersRespMsgBody(voiceUsers: Vector[VoiceConfUser])
+
+/**
+ * Received from FS call state events.
+ */
+object VoiceConfCallStateEvtMsg { val NAME = "VoiceConfCallStateEvtMsg" }
+case class VoiceConfCallStateEvtMsg(
+    header: BbbCoreVoiceConfHeader,
+    body:   VoiceConfCallStateEvtMsgBody
+) extends VoiceStandardMsg
+case class VoiceConfCallStateEvtMsgBody(
+    voiceConf:        String,
+    callSession:      String,
+    clientSession:    String,
+    userId:           String,
+    callerName:       String,
+    callState:        String,
+    origCallerIdName: String,
+    origCalledDest:   String
+)
+
+/**
+ * Sent to interested parties call state events.
+ */
+object VoiceCallStateEvtMsg { val NAME = "VoiceCallStateEvtMsg" }
+case class VoiceCallStateEvtMsg(
+    header: BbbClientMsgHeader,
+    body:   VoiceCallStateEvtMsgBody
+) extends BbbCoreMsg
+case class VoiceCallStateEvtMsgBody(
+    meetingId:     String,
+    voiceConf:     String,
+    clientSession: String,
+    userId:        String,
+    callerName:    String,
+    callState:     String
+)

--- a/bbb-fsesl-client/src/main/java/org/freeswitch/esl/client/inbound/Client.java
+++ b/bbb-fsesl-client/src/main/java/org/freeswitch/esl/client/inbound/Client.java
@@ -428,6 +428,7 @@ public class Client
         public void eventReceived( final EslEvent event )
         {
             log.debug( "Event received [{}]", event );
+
             /*
              *  Notify listeners in a different thread in order to:
              *    - not to block the IO threads with potentially long-running listeners
@@ -537,8 +538,10 @@ public class Client
                                         System.out.println("##### " + sb.toString());
                                          **/
                                     }
+                                } else {
+                                    listener.eventReceived( event );
                                 }
-                                listener.eventReceived( event );
+
                             } catch ( Throwable t ) {
                                 log.error( "Error caught notifying listener of event [" + event + ']', t );
                             }


### PR DESCRIPTION
 Currently, we user DTMF to inform the client when the call session is in echo test and when entering the voice conference.
 Unfortunately, sometimes when FS sends the DTMF, FS crashes.

 Monitor the progress of the call session using ESL events and propagate to the client.

 The client would be informed of these call states: CALL_STARTED, IN_ECHO_TEST, IN_CONFERENCE, CALL_ENDED.

These are the new messages sent by akka-apps. The client should handle these events.

```
{"envelope":{"name":"VoiceCallStateEvtMsg","routing":{"msgType":"BROADCAST_TO_MEETING","meetingId":"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1580941054957","userId":"75998"},"timestamp":1580941069614},"core":{"header":{"name":"VoiceCallStateEvtMsg","meetingId":"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1580941054957","userId":"75998"},"body":{"meetingId":"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1580941054957","voiceConf":"75998","clientSession":"682f36ea-4773-11ea-9415-b7ddbeb9992a","userId":"w_p7fxjlxck7dq","callerName":"red","callState":"CALL_STARTED"}}}


{"envelope":{"name":"VoiceCallStateEvtMsg","routing":{"msgType":"BROADCAST_TO_MEETING","meetingId":"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1580941054957","userId":"75998"},"timestamp":1580941070047},"core":{"header":{"name":"VoiceCallStateEvtMsg","meetingId":"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1580941054957","userId":"75998"},"body":{"meetingId":"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1580941054957","voiceConf":"75998","clientSession":"682f36ea-4773-11ea-9415-b7ddbeb9992a","userId":"w_p7fxjlxck7dq","callerName":"red","callState":"IN_ECHO_TEST"}}}

{"envelope":{"name":"VoiceCallStateEvtMsg","routing":{"msgType":"BROADCAST_TO_MEETING","meetingId":"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1580941054957","userId":"75998"},"timestamp":1580941093242},"core":{"header":{"name":"VoiceCallStateEvtMsg","meetingId":"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1580941054957","userId":"75998"},"body":{"meetingId":"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1580941054957","voiceConf":"75998","clientSession":"682f36ea-4773-11ea-9415-b7ddbeb9992a","userId":"w_p7fxjlxck7dq","callerName":"red","callState":"IN_CONFERENCE"}}}

{"envelope":{"name":"VoiceCallStateEvtMsg","routing":{"msgType":"BROADCAST_TO_MEETING","meetingId":"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1580941054957","userId":"75998"},"timestamp":1580941124859},"core":{"header":{"name":"VoiceCallStateEvtMsg","meetingId":"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1580941054957","userId":"75998"},"body":{"meetingId":"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1580941054957","voiceConf":"75998","clientSession":"682f36ea-4773-11ea-9415-b7ddbeb9992a","userId":"w_p7fxjlxck7dq","callerName":"red","callState":"CALL_ENDED"}}}
```