### PR TITLE
Fix the paths to the ruby scripts on the rap workers

### DIFF
--- a/record-and-playback/core/lib/recordandplayback.rb
+++ b/record-and-playback/core/lib/recordandplayback.rb
@@ -239,9 +239,18 @@ module BigBlueButton
     BigBlueButton.record_id_to_timestamp(File.basename(r, ".done"))
   end
 
+  def self.rap_core_path
+    File.expand_path('../../', __FILE__)
+  end
+
+  def self.rap_scripts_path
+    File.join(BigBlueButton.rap_core_path, 'scripts')
+  end
+
   def self.read_props
     return @props if @props
-    filepath = File.expand_path('../../scripts/bigbluebutton.yml', __FILE__)
+
+    filepath = File.join(BigBlueButton.rap_scripts_path, 'bigbluebutton.yml')
     @props = YAML::load(File.open(filepath))
   end
 

--- a/record-and-playback/core/lib/recordandplayback/workers/archive_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/archive_worker.rb
@@ -29,7 +29,7 @@ module BigBlueButton
 
           remove_status_files
 
-          script = File.expand_path('../archive/archive.rb', __dir__)
+          script = File.join(BigBlueButton.rap_scripts_path, 'archive', 'archive.rb')
           if @break_timestamp.nil?
             ret, step_time = run_script(script, '-m', @meeting_id)
           else

--- a/record-and-playback/core/lib/recordandplayback/workers/captions_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/captions_worker.rb
@@ -26,7 +26,8 @@ module BigBlueButton
         super do
           @logger.info("Running captions worker for #{@full_id}")
 
-          ret, = run_script('utils/captions.rb', '-m', @meeting_id)
+          script = File.join(BigBlueButton.rap_scripts_path, 'utils', 'captions.rb')
+          ret, = run_script(script, '-m', @meeting_id)
 
           if ret.zero?
             @logger.info("Succeeded generating captions for #{@full_id}")

--- a/record-and-playback/core/lib/recordandplayback/workers/events_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/events_worker.rb
@@ -68,7 +68,7 @@ module BigBlueButton
         super(opts)
         @step_name = 'events'
         @events_dir = @props['events_dir']
-        @post_scripts_path = File.expand_path('../post_events', __dir__)
+        @post_scripts_path = File.join(BigBlueButton.rap_scripts_path, 'post_events')
         @ended_done = "#{@recording_dir}/status/ended/#{@full_id}.done"
       end
     end

--- a/record-and-playback/core/lib/recordandplayback/workers/process_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/process_worker.rb
@@ -26,7 +26,8 @@ module BigBlueButton
         super do
           @logger.info("Running process worker for #{@full_id}:#{@format_name}")
 
-          script = File.expand_path("../../process/#{@format_name}.rb", __FILE__)
+          script = File.join(BigBlueButton.rap_scripts_path,
+                             'process', "#{@format_name}.rb")
           if File.exist?(script)
             remove_status_files
 
@@ -79,7 +80,7 @@ module BigBlueButton
         super(opts)
         @step_name = 'process'
         @format_name = opts['format_name']
-        @post_scripts_path = File.expand_path('../post_process', __dir__)
+        @post_scripts_path = File.join(BigBlueButton.rap_scripts_path, 'post_process')
         @processed_done = "#{@recording_dir}/status/processed/#{@full_id}-#{@format_name}.done"
         @processed_fail = "#{@recording_dir}/status/processed/#{@full_id}-#{@format_name}.fail"
       end

--- a/record-and-playback/core/lib/recordandplayback/workers/publish_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/publish_worker.rb
@@ -28,7 +28,8 @@ module BigBlueButton
         super do
           @logger.info("Running publish worker for #{@full_id}:#{@format_name}")
 
-          script = File.expand_path("../../publish/#{@format_name}.rb", __FILE__)
+          script = File.join(BigBlueButton.rap_scripts_path,
+                             'publish', "#{@format_name}.rb")
           if File.exist?(script)
             @publisher.put_publish_started(@format_name, @meeting_id)
 
@@ -117,7 +118,7 @@ module BigBlueButton
         super(opts)
         @step_name = 'publish'
         @format_name = opts['format_name']
-        @post_scripts_path = File.expand_path('../post_publish', __dir__)
+        @post_scripts_path = File.join(BigBlueButton.rap_scripts_path, 'post_publish')
         @published_done = "#{@recording_dir}/status/published/#{@full_id}-#{@format_name}.done"
         @published_fail = "#{@recording_dir}/status/published/#{@full_id}-#{@format_name}.fail"
       end

--- a/record-and-playback/core/lib/recordandplayback/workers/sanity_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/sanity_worker.rb
@@ -29,7 +29,7 @@ module BigBlueButton
 
           remove_status_files
 
-          script = File.expand_path('../sanity/sanity.rb', __dir__)
+          script = File.join(BigBlueButton.rap_scripts_path, 'sanity', 'sanity.rb')
           if @break_timestamp.nil?
             ret, step_time = run_script(script, '-m', @meeting_id)
           else
@@ -59,7 +59,7 @@ module BigBlueButton
       def initialize(opts)
         super(opts)
         @step_name = 'sanity'
-        @post_scripts_path = File.expand_path('../post_archive', __dir__)
+        @post_scripts_path = File.join(BigBlueButton.rap_scripts_path, 'post_archive')
         @sanity_fail = "#{@recording_dir}/status/sanity/#{@full_id}.fail"
         @sanity_done = "#{@recording_dir}/status/sanity/#{@full_id}.done"
       end

--- a/record-and-playback/core/scripts/rap-starter.rb
+++ b/record-and-playback/core/scripts/rap-starter.rb
@@ -73,7 +73,7 @@ def archive_recorded_meetings(recording_dir, done_file)
 
   BigBlueButton.logger.info("Enqueuing job to archive #{attrs.inspect}")
   Resque.enqueue(BigBlueButton::Resque::ArchiveWorker, attrs)
-  FileUtils.rm_f(recorded_done_file)
+  FileUtils.rm_f(done_file)
 end
 
 begin


### PR DESCRIPTION
Was pointing to the wrong directory when loading the ruby scripts. Also made the directory easier to configure, it's all in a single place now.