### PR TITLE
 Breakout rooms shouldn't call the end meeting callback url

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -716,7 +716,7 @@ public class MeetingService implements MessageListener {
 
       String endCallbackUrl = "endCallbackUrl".toLowerCase();
       Map<String, String> metadata = m.getMetadata();
-      if (metadata.containsKey(endCallbackUrl)) {
+      if (!m.isBreakout() && metadata.containsKey(endCallbackUrl)) {
         String callbackUrl = metadata.get(endCallbackUrl);
         try {
             callbackUrl = new URIBuilder(new URI(callbackUrl))


### PR DESCRIPTION
 - add check if the meeting that ended isn't a breakout room and if there is an end-meeting-callback-url.