### PR TITLE
Increase the pingpong removal timeout to reduce false positives

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -119,7 +119,7 @@ public:
     autoShareWebcam: false
     skipVideoPreview: false
   pingPong:
-    clearUsersInSeconds: 30
+    clearUsersInSeconds: 180
     pongTimeInSeconds: 15
   allowOutsideCommands:
     toggleRecording: false


### PR DESCRIPTION
The original value of 30s was leading to people getting removed from meetings if they missed one ping. Setting it to three minutes should cut down drastically on the chance of a false positive happening.