### PR TITLE
Office to PDF conversion failed message

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/DocumentConversionServiceImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/DocumentConversionServiceImp.java
@@ -63,10 +63,16 @@ public class DocumentConversionServiceImp implements DocumentConversionService {
         pres = officeToPdfConversionService.convertOfficeToPdf(pres);
         OfficeToPdfConversionSuccessFilter ocsf = new OfficeToPdfConversionSuccessFilter(gw);
         if (ocsf.didConversionSucceed(pres)) {
+          ocsf.sendProgress(pres);
           // Successfully converted to pdf. Call the process again, this time it
           // should be handled by
           // the PDF conversion service.
           processDocument(pres);
+        } else {
+          // Send notification that office to pdf conversion failed.
+          // The cause should have been set by the previous step.
+          // (ralam feb 15, 2020)
+          ocsf.sendProgress(pres);
         }
       } else if (SupportedFileTypes.isPdfFile(fileType)) {
         pdfToSwfSlidesGenerationService.generateSlides(pres);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/OfficeToPdfConversionSuccessFilter.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/OfficeToPdfConversionSuccessFilter.java
@@ -48,32 +48,19 @@ public class OfficeToPdfConversionSuccessFilter {
   }
 
   public boolean didConversionSucceed(UploadedPresentation pres) {
-    notifyProgressListener(pres);
     return ConversionMessageConstants.OFFICE_DOC_CONVERSION_SUCCESS_KEY.equals(pres.getConversionStatus());
   }
 
-  private void notifyProgressListener(UploadedPresentation pres) {
-    Map<String, Object> msg = new HashMap<String, Object>();
-    msg.put("conference", pres.getMeetingId());
-    msg.put("room", pres.getMeetingId());
-    msg.put("returnCode", "CONVERT");
-    msg.put("presentationId", pres.getId());
-    msg.put("podId", pres.getPodId());
-    msg.put("presentationName", pres.getId());
-    msg.put("filename", pres.getName());
-    msg.put("message", conversionMessagesMap.get(pres.getConversionStatus()));
-    msg.put("messageKey", pres.getConversionStatus());
-
-    log.info("Notifying of {} for {}", pres.getConversionStatus(), pres.getUploadedFile().getAbsolutePath());
-    sendProgress(pres);
-  }
-
-
   public void sendProgress(UploadedPresentation pres) {
     OfficeDocConversionProgress progress = new OfficeDocConversionProgress(pres.getPodId(),
-      pres.getMeetingId(),pres.getId(), pres.getId(),
-      pres.getName(), "notUsedYet", "notUsedYet",
-      pres.isDownloadable(), pres.getConversionStatus());
+      pres.getMeetingId(),
+      pres.getId(),
+      pres.getId(),
+      pres.getName(),
+      "notUsedYet",
+      "notUsedYet",
+      pres.isDownloadable(),
+      pres.getConversionStatus());
     gw.sendDocConversionMsg(progress);
   }
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/OfficeToPdfConversionService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/OfficeToPdfConversionService.java
@@ -95,6 +95,8 @@ public class OfficeToPdfConversionService {
         Gson gson = new Gson();
         String logStr = gson.toJson(logData);
         log.warn(" --analytics-- data={}", logStr);
+        pres.setConversionStatus(ConversionMessageConstants.OFFICE_DOC_CONVERSION_FAILED_KEY);
+        return pres;
       }
     }
     return pres;


### PR DESCRIPTION
Send message when office to pdf conversion failed.

When converting an office doc to pdf fails, the client displays the message "Ops, something went wrong" which isn't helpful.

![ooops-office-to-pdf-failed](https://user-images.githubusercontent.com/184672/74592203-ede05680-4fec-11ea-8507-34c5728847f0.PNG)

Send message to client why office to pdf conversion failed. And it looks like it is already handled in ```imports/api/presentations/server/handlers/presentationConversionUpdate.js```. Just need to modify the client to display an appropriate message like "Failed to convert office document. Please upload a pdf instead."

This PR sends a message when pre-check of office doc fails and when libreoffice fails to convert the document.