### PR TITLE
Fix user-list item text-overflow

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/styles.scss
@@ -82,6 +82,8 @@
     text-align: left;
     padding-left: var(--lg-padding-y);
     text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
 
     [dir="rtl"] & {
       text-align: right;


### PR DESCRIPTION
From this:

![before](https://user-images.githubusercontent.com/1778398/74779919-3dd54c80-527d-11ea-9220-edbfb02544fd.png)

To this:

![after](https://user-images.githubusercontent.com/1778398/74779938-488fe180-527d-11ea-9dbd-551cb8bcc7e0.png)

