### PR TITLE
Remove some atmosphere packages

### DIFF
--- a/bigbluebutton-html5/.meteor/packages
+++ b/bigbluebutton-html5/.meteor/packages
@@ -20,11 +20,9 @@ http@1.4.2
 session@1.2.0
 tracker@1.2.0
 check@1.3.1
-jquery
 
 nathantreid:css-modules@=3.1.4
 rocketchat:streamer
 cfs:power-queue
 cfs:micro-queue
 cfs:reactive-list
-stevezhu:lodash

--- a/bigbluebutton-html5/.meteor/versions
+++ b/bigbluebutton-html5/.meteor/versions
@@ -35,7 +35,6 @@ htmljs@1.0.11
 http@1.4.2
 id-map@1.1.0
 inter-process-messaging@0.1.0
-jquery@1.11.11
 launch-screen@1.1.1
 livedata@1.0.18
 logging@1.1.20
@@ -72,7 +71,6 @@ spacebars-compiler@1.1.3
 standard-minifier-css@1.5.3
 standard-minifier-js@2.4.1
 static-html@1.2.2
-stevezhu:lodash@4.17.2
 templating-tools@1.1.2
 tmeasday:check-npm-versions@0.3.2
 tracker@1.2.0

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import browser from 'browser-detect';
 import { Meteor } from 'meteor/meteor';
 import PropTypes from 'prop-types';
+import _ from 'lodash';
 import cx from 'classnames';
 import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import Dropdown from '/imports/ui/components/dropdown/component';

--- a/bigbluebutton-html5/server/main.js
+++ b/bigbluebutton-html5/server/main.js
@@ -32,3 +32,14 @@ import '/imports/api/local-settings/server';
 import '/imports/api/log-client/server';
 import '/imports/api/common/server/helpers';
 import '/imports/startup/server/logger';
+
+// Needed for Atmosphere package RocketChat/meteor-streamer
+// It is out of date and was written when Meteor contained lodash
+// package. However, we now import lodash as an npm package
+// in order to control versions, update flexibly, etc..
+// Setting the global._ to utilize the npm lodash package is an interim fix
+// and its introduction was inspired by
+// https://github.com/RocketChat/meteor-streamer/issues/40#issuecomment-497627893
+import _ from 'lodash';
+
+global._ = _;


### PR DESCRIPTION
We use RocketChat/meteor-stream (for the cursor, etc) and it had a dependency of an old lodash version (with a vulnerability). This pull request removes the lodash Atmosphere package and uses a trick to replace its use with the npm package lodash.

I also removed the Atmosphere jquery package because it seems to be outdated (with vulnerability) and I am not seeing how/where it is used. jQuery is mentioned in kurento-utils.js but all functionality seems intact after removing it.

In addition it turned out that webcams display was implicitly relying on lodash without importing _ so the client broke when I removed the Atmosphere package. I added an explicit import to point to lodash._