### PR TITLE
Keep data-test attributes in production

### DIFF
--- a/bigbluebutton-html5/.babelrc
+++ b/bigbluebutton-html5/.babelrc
@@ -1,9 +1,0 @@
-{
-  "env": {
-    "production": {
-      "plugins": [
-        "react-remove-properties"
-      ]
-    }
-  }
-}

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -1735,11 +1735,6 @@
         "@types/babel__traverse": "^7.0.6"
       }
     },
-    "babel-plugin-react-remove-properties": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-remove-properties/-/babel-plugin-react-remove-properties-0.2.5.tgz",
-      "integrity": "sha1-wHbhKRlAxzD0+337ZwaR/EF4fPg="
-    },
     "babel-preset-jest": {
       "version": "25.1.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.1.0.tgz",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -34,7 +34,6 @@
     "@jitsi/sdp-interop": "0.1.14",
     "autoprefixer": "~9.3.1",
     "axios": "^0.19.1",
-    "babel-plugin-react-remove-properties": "~0.2.5",
     "babel-runtime": "~6.26.0",
     "browser-bunyan": "^1.5.3",
     "browser-detect": "^0.2.28",


### PR DESCRIPTION
This PR removes `babel-plugin-react-remove-properties` package. It allows the HTML5 client to have `data-test` attributes in production.