### PR TITLE
More enhancements to the external video code

### DIFF
--- a/bigbluebutton-html5/imports/api/external-videos/server/methods.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods.js
@@ -2,9 +2,11 @@ import { Meteor } from 'meteor/meteor';
 import startWatchingExternalVideo from './methods/startWatchingExternalVideo';
 import stopWatchingExternalVideo from './methods/stopWatchingExternalVideo';
 import initializeExternalVideo from './methods/initializeExternalVideo';
+import emitExternalVideoEvent from './methods/emitExternalVideoEvent';
 
 Meteor.methods({
   initializeExternalVideo,
   startWatchingExternalVideo,
   stopWatchingExternalVideo,
+  emitExternalVideoEvent,
 });

--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/emitExternalVideoEvent.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/emitExternalVideoEvent.js
@@ -1,0 +1,20 @@
+import Users from '/imports/api/users';
+import { extractCredentials } from '/imports/api/common/server/helpers';
+
+export default function emitExternalVideoEvent(messageName, ...rest) {
+  const { meetingId, userId } = extractCredentials(this.userId);
+
+  const user = Users.findOne({ userId });
+
+  if (user && user.presenter) {
+    const streamerName = `external-videos-${meetingId}`;
+    const streamer = Meteor.StreamerCentral.instances[streamerName];
+
+    if (streamer) {
+      streamer.emit(messageName, ...rest)
+    } else {
+      console.log("streamer not found")
+    }
+  }
+}
+

--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/emitExternalVideoEvent.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/emitExternalVideoEvent.js
@@ -1,4 +1,5 @@
 import Users from '/imports/api/users';
+import Logger from '/imports/startup/server/logger';
 import { extractCredentials } from '/imports/api/common/server/helpers';
 
 export default function emitExternalVideoEvent(messageName, ...rest) {
@@ -13,7 +14,7 @@ export default function emitExternalVideoEvent(messageName, ...rest) {
     if (streamer) {
       streamer.emit(messageName, ...rest)
     } else {
-      console.log("streamer not found")
+      Logger.info("streamer not found")
     }
   }
 }

--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/initializeExternalVideo.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/initializeExternalVideo.js
@@ -1,5 +1,4 @@
 import { extractCredentials } from '/imports/api/common/server/helpers';
-import { check } from 'meteor/check';
 import Logger from '/imports/startup/server/logger';
 
 const allowRecentMessages = (eventName, message) => {

--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/initializeExternalVideo.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/initializeExternalVideo.js
@@ -12,7 +12,7 @@ const allowFromPresenter = (eventName, message) => {
     state,
   } = message;
 
-  Logger.info(`ExternalVideo Streamer auth userId: ${userId}, meetingId: ${meetingId}, event: ${eventName}, time: ${time}, timestamp: ${timestamp/1000} rate: ${rate}, state: ${state}`);
+  Logger.debug(`ExternalVideo Streamer auth userId: ${userId}, meetingId: ${meetingId}, event: ${eventName}, time: ${time}, timestamp: ${timestamp/1000} rate: ${rate}, state: ${state}`);
 
   return true;
 };

--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/initializeExternalVideo.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/initializeExternalVideo.js
@@ -1,22 +1,20 @@
-import { Meteor } from 'meteor/meteor';
 import { extractCredentials } from '/imports/api/common/server/helpers';
-import Users from '/imports/api/users';
+import { check } from 'meteor/check';
 import Logger from '/imports/startup/server/logger';
 
 const allowFromPresenter = (eventName, message) => {
   const {
     userId,
+    meetingId,
     time,
+    timestamp,
     rate,
     state,
   } = message;
 
-  const user = Users.findOne({ userId });
-  const ret = user && user.presenter;
+  Logger.info(`ExternalVideo Streamer auth userId: ${userId}, meetingId: ${meetingId}, event: ${eventName}, time: ${time}, timestamp: ${timestamp/1000} rate: ${rate}, state: ${state}`);
 
-  Logger.info(`ExternalVideo Streamer auth userid: ${userId}, meetingId: ${user.meetingId}, event: ${eventName}, suc: ${ret}, time: ${time}, rate: ${rate}, state: ${state}`);
-
-  return ret;
+  return true;
 };
 
 export default function initializeExternalVideo() {

--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/stopWatchingExternalVideo.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/stopWatchingExternalVideo.js
@@ -9,7 +9,11 @@ export default function stopWatchingExternalVideo(options) {
   const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
   const EVENT_NAME = 'StopExternalVideoMsg';
 
-  const { meetingId, requesterUserId } = extractCredentials(this.userId);
+  if (this.userId) {
+    options = extractCredentials(this.userId);
+  }
+
+  const { meetingId, requesterUserId } = options;
 
   const meeting = Meetings.findOne({ meetingId });
   if (!meeting || meeting.externalVideoUrl === null) return;

--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/stopWatchingExternalVideo.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/stopWatchingExternalVideo.js
@@ -2,11 +2,14 @@ import { Meteor } from 'meteor/meteor';
 import Logger from '/imports/startup/server/logger';
 import Meetings from '/imports/api/meetings';
 import RedisPubSub from '/imports/startup/server/redis';
+import { extractCredentials } from '/imports/api/common/server/helpers';
 
-export default function stopWatchingExternalVideo(meetingId, requesterUserId) {
+export default function stopWatchingExternalVideo(options) {
   const REDIS_CONFIG = Meteor.settings.private.redis;
   const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
   const EVENT_NAME = 'StopExternalVideoMsg';
+
+  const { meetingId, requesterUserId } = extractCredentials(this.userId);
 
   const meeting = Meetings.findOne({ meetingId });
   if (!meeting || meeting.externalVideoUrl === null) return;

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
@@ -355,7 +355,7 @@ class VideoPlayer extends Component {
       logger.debug({
         logCode: 'external_video_client_update_seek',
         extraInfo: { time, timestamp, },
-      }, 'Seek external video to:');
+      }, `Seek external video to: ${time}`);
     }
   }
 

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/service.js
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/service.js
@@ -20,25 +20,10 @@ const stopWatching = () => {
 };
 
 const sendMessage = (event, data) => {
-  const {
-    time,
-    rate,
-    state,
-    timestamp,
-  } = data;
-
   const meetingId = Auth.meetingID;
   const userId = Auth.userID;
 
-  const user = Users.findOne({ userId });
-  const suc = user && user.presenter;
-
-  if (!suc) {
-    Logger.warn("Message rejected");
-  } else {
-    const streamer = getStreamer(meetingId);
-    streamer.emit(event, { ...data, meetingId, userId});
-  }
+  makeCall('emitExternalVideoEvent', event, { ...data, meetingId, userId });
 };
 
 const onMessage = (message, func) => {


### PR DESCRIPTION
* Using less call to mongodb by moving presenter check code outside of the streamer callback. This meant it was called once per user per message, now it's only called once per message. Code can handle more messages per second now.
* Sending a timestamp together with playerUpdate messages. This allows us to sync the videos better if the message arrives a little late or ignore the messages if they arrive very late (which would cause skipping)
* Fix stopWatchingExternalVideo to use the correct credentials and make it work again (edit: added one more commit as per Anton's comments)
* New throttling logic for pausing/unpausing the video. This make it impossible for the presenter to generate a high number of useless start/stop messages by simply holding the space bar or clicking very fast