### PR TITLE
Bump nokogiri

### DIFF
--- a/record-and-playback/core/Gemfile.lock
+++ b/record-and-playback/core/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mini_portile2 (2.4.0)
-    nokogiri (1.10.4)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     open4 (1.3.4)
     parallel (1.17.0)


### PR DESCRIPTION
Bump nokogiri for CVE-2020-7595
