### PR TITLE
Fix external video extractCredentials usage

### DIFF
--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/emitExternalVideoEvent.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/emitExternalVideoEvent.js
@@ -3,19 +3,18 @@ import Logger from '/imports/startup/server/logger';
 import { extractCredentials } from '/imports/api/common/server/helpers';
 
 export default function emitExternalVideoEvent(messageName, ...rest) {
-  const { meetingId, userId } = extractCredentials(this.userId);
+  const { meetingId, requesterUserId: userId } = extractCredentials(this.userId);
 
-  const user = Users.findOne({ userId });
+  const user = Users.findOne({ userId, meetingId });
 
   if (user && user.presenter) {
     const streamerName = `external-videos-${meetingId}`;
     const streamer = Meteor.StreamerCentral.instances[streamerName];
 
     if (streamer) {
-      streamer.emit(messageName, ...rest)
+      streamer.emit(messageName, ...rest);
     } else {
       Logger.error(`External Video Streamer not found for meetingId: ${meetingId} userId: ${userId}`);
     }
   }
 }
-


### PR DESCRIPTION
The function was trying to get the `userId` property from extractCredentials when it's actually named `requesterUserId`