### PR TITLE
Harden some server-side collection selectors

### DIFF
--- a/bigbluebutton-html5/imports/api/breakouts/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/publishers.js
@@ -15,7 +15,7 @@ function breakouts(moderator = false) {
   Logger.debug(`Publishing Breakouts for ${meetingId} ${requesterUserId}`);
 
   if (moderator) {
-    const User = Users.findOne({ userId: requesterUserId });
+    const User = Users.findOne({ userId: requesterUserId, meetingId });
     if (!!User && User.role === ROLE_MODERATOR) {
       const presenterSelector = {
         $or: [

--- a/bigbluebutton-html5/imports/api/meetings/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/publishers.js
@@ -21,7 +21,7 @@ function meetings(isModerator = false) {
   };
 
   if (isModerator) {
-    const User = Users.findOne({ userId: requesterUserId });
+    const User = Users.findOne({ userId: requesterUserId, meetingId });
     if (!!User && User.role === ROLE_MODERATOR) {
       selector.$or.push({
         'meetingProp.isBreakout': true,

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
@@ -16,7 +16,7 @@ export default function removeUser(meetingId, userId) {
   check(meetingId, String);
   check(userId, String);
 
-  const userToRemove = Users.findOne({ userId });
+  const userToRemove = Users.findOne({ userId, meetingId });
 
   if (userToRemove) {
     const { presenter } = userToRemove;

--- a/bigbluebutton-html5/imports/api/users/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/users/server/publishers.js
@@ -64,7 +64,7 @@ function users(isModerator = false) {
   };
 
   if (isModerator) {
-    const User = Users.findOne({ userId: requesterUserId });
+    const User = Users.findOne({ userId: requesterUserId, meetingId });
     if (!!User && User.role === ROLE_MODERATOR) {
       selector.$or.push({
         'breakoutProps.isBreakoutUser': true,

--- a/bigbluebutton-html5/imports/api/voice-users/server/methods/listenOnlyToggle.js
+++ b/bigbluebutton-html5/imports/api/voice-users/server/methods/listenOnlyToggle.js
@@ -24,6 +24,7 @@ export default function listenOnlyToggle(isJoining = true) {
 
   const VoiceUser = VoiceUsers.findOne({
     intId: requesterUserId,
+    meetingId,
   });
 
   const Meeting = Meetings.findOne({ meetingId });

--- a/bigbluebutton-html5/imports/api/voice-users/server/methods/muteToggle.js
+++ b/bigbluebutton-html5/imports/api/voice-users/server/methods/muteToggle.js
@@ -19,6 +19,7 @@ export default function muteToggle(uId) {
 
   const voiceUser = VoiceUsers.findOne({
     intId: userToMute,
+    meetingId,
   });
 
   if (!requester || !voiceUser) return;


### PR DESCRIPTION
There were some collection finds that weren't including the meetingId in the selector which could rarely result in a collision because userId is only unique to a meeting.