### PR TITLE
Fix idChatOpen Session usage

### DIFF
--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/handlers/userTyping.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/handlers/userTyping.js
@@ -1,5 +1,4 @@
 import { check } from 'meteor/check';
-import { UsersTyping } from '/imports/api/group-chat-msg';
 import startTyping from '../modifiers/startTyping';
 
 export default function handleUserTyping({ body }, meetingId) {

--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/publishers.js
@@ -35,7 +35,9 @@ function usersTyping() {
     return UsersTyping.find({ meetingId: '' });
   }
 
-  const { meetingId } = extractCredentials(this.userId);
+  const { meetingId, requesterUserId } = extractCredentials(this.userId);
+
+  Logger.debug(`Publishing users-typing for ${meetingId} ${requesterUserId}`);
 
   return UsersTyping.find({ meetingId });
 }

--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -21,7 +21,9 @@ import { notify } from '/imports/ui/services/notification';
 import deviceInfo from '/imports/utils/deviceInfo';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 
-const CHAT_ENABLED = Meteor.settings.public.chat.enabled;
+const CHAT_CONFIG = Meteor.settings.public.chat;
+const CHAT_ENABLED = CHAT_CONFIG.enabled;
+const PUBLIC_CHAT_ID = CHAT_CONFIG.public_id;
 
 const BREAKOUT_END_NOTIFY_DELAY = 50;
 
@@ -356,7 +358,7 @@ const BaseContainer = withTracker(() => {
     Session.set('openPanel', 'userlist');
     if (CHAT_ENABLED) {
       Session.set('openPanel', 'chat');
-      Session.set('idChatOpen', '');
+      Session.set('idChatOpen', PUBLIC_CHAT_ID);
     }
   } else {
     Session.set('openPanel', '');

--- a/bigbluebutton-html5/imports/ui/components/authenticated-handler/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/authenticated-handler/component.jsx
@@ -5,8 +5,6 @@ import Auth from '/imports/ui/services/auth';
 import LoadingScreen from '/imports/ui/components/loading-screen/component';
 
 const STATUS_CONNECTING = 'connecting';
-const CHAT_CONFIG = Meteor.settings.public.chat;
-const PUBLIC_CHAT_ID = CHAT_CONFIG.public_id;
 
 class AuthenticatedHandler extends Component {
   static setError(codeError) {
@@ -85,10 +83,9 @@ class AuthenticatedHandler extends Component {
       authenticated,
     } = this.state;
 
-    Session.set('isChatOpen', false);
-    Session.set('idChatOpen', PUBLIC_CHAT_ID);
     Session.set('isMeetingEnded', false);
     Session.set('isPollOpen', false);
+    // TODO: breakoutRoomIsOpen doesn't seem used
     Session.set('breakoutRoomIsOpen', false);
 
     return authenticated

--- a/bigbluebutton-html5/imports/ui/components/chat/alert/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/alert/container.jsx
@@ -14,12 +14,23 @@ export default withTracker(() => {
   const AppSettings = Settings.application;
   const activeChats = UserListService.getActiveChats();
   const { loginTime } = Users.findOne({ userId: Auth.userID }, { fields: { loginTime: 1 } });
+
+  const openPanel = Session.get('openPanel');
+  let idChatOpen = Session.get('idChatOpen');
+
+  // Currently the panel can switch from the chat panel to something else and the idChatOpen won't
+  // always reset. A better solution would be to make the openPanel Session variable an
+  // Object { panelType: <String>, panelOptions: <Object> } and then get rid of idChatOpen
+  if (openPanel !== 'chat') {
+    idChatOpen = '';
+  }
+
   return {
     audioAlertDisabled: !AppSettings.chatAudioAlerts,
     pushAlertDisabled: !AppSettings.chatPushAlerts,
     activeChats,
     publicUserId: Meteor.settings.public.chat.public_group_id,
     joinTimestamp: loginTime,
-    idChatOpen: Session.get('idChatOpen'),
+    idChatOpen,
   };
 })(memo(ChatAlertContainer));

--- a/bigbluebutton-html5/imports/ui/components/chat/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/container.jsx
@@ -38,7 +38,15 @@ class ChatContainer extends PureComponent {
   }
 
   render() {
-    const { children } = this.props;
+    const {
+      children,
+      unmounting,
+    } = this.props;
+
+    if (unmounting === true) {
+      return null;
+    }
+
     return (
       <Chat {...this.props}>
         {children}
@@ -48,7 +56,7 @@ class ChatContainer extends PureComponent {
 }
 
 export default injectIntl(withTracker(({ intl }) => {
-  const chatID = Session.get('idChatOpen') || PUBLIC_CHAT_KEY;
+  const chatID = Session.get('idChatOpen');
   let messages = [];
   let isChatLocked = ChatService.isChatLocked(chatID);
   let title = intl.formatMessage(intlMessages.titlePublic);
@@ -105,7 +113,7 @@ export default injectIntl(withTracker(({ intl }) => {
       .concat(messagesAfterWelcomeMsg);
 
     messages = messagesFormated.sort((a, b) => (a.time - b.time));
-  } else {
+  } else if (chatID) {
     messages = ChatService.getPrivateGroupMessages();
 
     const receiverUser = ChatService.getUser(chatID);
@@ -131,6 +139,11 @@ export default injectIntl(withTracker(({ intl }) => {
       messages.push(messagePartnerLoggedOut);
       isChatLocked = true;
     }
+  } else {
+    // No chatID is set so the panel is closed, about to close, or wasn't opened correctly
+    return {
+      unmounting: true,
+    };
   }
 
   messages = messages.map((message) => {

--- a/bigbluebutton-html5/imports/ui/components/chat/service.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/service.js
@@ -169,7 +169,7 @@ const lastReadMessageTime = (receiverID) => {
 };
 
 const sendGroupMessage = (message) => {
-  const chatID = Session.get('idChatOpen') || PUBLIC_CHAT_ID;
+  const chatID = Session.get('idChatOpen');
   const isPublicChat = chatID === PUBLIC_CHAT_ID;
 
   let destinationChatId = PUBLIC_GROUP_CHAT_ID;
@@ -220,7 +220,7 @@ const updateScrollPosition = position => ScrollCollection.upsert(
 );
 
 const updateUnreadMessage = (timestamp) => {
-  const chatID = Session.get('idChatOpen') || PUBLIC_CHAT_ID;
+  const chatID = Session.get('idChatOpen');
   const isPublic = chatID === PUBLIC_CHAT_ID;
   const chatType = isPublic ? PUBLIC_GROUP_CHAT_ID : chatID;
   return UnreadMessages.update(chatType, timestamp);


### PR DESCRIPTION
Started digging into the chat panel management because the "who's typing" indicator isn't showing in RC6 and discovered a lot of inconsistencies with how the open chat was being intialized, used, and then destroyed.

When it is first opened the Session variable idChatOpen is set to '' and there are a bunch of places in the code that look for a truthy value and if it's falsey then the code defaults to that meaning the public chat is open. This leads approach leads to problems because it doesn't fix the core problem of why the idChatOpen isn't set correctly and it means that everywhere that gets idChatOpen needs to have the exactly same fallback.

The second problem I found is when the chat panel closes the ChatContainer is re-rendered multiple times while idChatOpen is set to '' which means that the client needs to go through the whole render cycle when the component is about to be destroyed anyways.

The third problem I found is that if you have the chat panel open and switch to a different panel, the idChatOpen stays set to the previously open chat and you will never get alerts for that conversation. The only way to get alerts is to close the chat panel and then open the other panel. There have been inconsistencies with the chat alerting for a while now, but it was always hard to track down and I think this was the cause.

This PR looks to solve all three problems by fixing the core problem and then removing the half-fixes that have been put on top. It also adds a workaround for when idChatOpen is set to a real chatId, but openPanel isn't set to "chat".

Fixes #8713 