### PR TITLE
Track listen only ICE connection state to trigger reconnections

### DIFF
--- a/bigbluebutton-html5/public/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/public/compatibility/kurento-extension.js
@@ -158,6 +158,10 @@ KurentoManager.prototype.exitAudio = function () {
         'Exiting listen only');
     }
 
+    if (this.kurentoAudio.webRtcPeer) {
+      this.kurentoAudio.webRtcPeer.peerConnection.oniceconnectionstatechange = null;
+    }
+
     if (this.kurentoAudio.ws !== null) {
       this.kurentoAudio.ws.onclose = function () {};
       this.kurentoAudio.ws.close();
@@ -607,7 +611,6 @@ Kurento.prototype.setAudio = function (tag) {
 };
 
 Kurento.prototype.listenOnly = function () {
-  const self = this;
   if (!this.webRtcPeer) {
     const options = {
       onicecandidate : this.onListenOnlyIceCandidate.bind(this),
@@ -619,12 +622,31 @@ Kurento.prototype.listenOnly = function () {
 
     this.addIceServers(this.iceServers, options);
 
-    self.webRtcPeer = kurentoUtils.WebRtcPeer.WebRtcPeerRecvonly(options, function (error) {
+    this.webRtcPeer = kurentoUtils.WebRtcPeer.WebRtcPeerRecvonly(options, (error) => {
       if (error) {
-        return self.onFail(error);
+        return this.onFail(error);
       }
-      self.webRtcPeer.iceQueue = [];
-      this.generateOffer(self.onOfferListenOnly.bind(self));
+
+      this.webRtcPeer.iceQueue = [];
+      this.webRtcPeer.peerConnection.oniceconnectionstatechange = () => {
+        if (this.webRtcPeer) {
+          const iceConnectionState = this.webRtcPeer.peerConnection.iceConnectionState;
+
+          if (iceConnectionState === 'failed' || iceConnectionState === 'closed') {
+            this.webRtcPeer.peerConnection.oniceconnectionstatechange = null;
+            this.logger.error({
+              logCode: 'kurentoextension_listenonly_ice_failed',
+              extraInfo: { iceConnectionState }
+            }, `WebRTC peer for listen only failed due to ICE transitioning to ${iceConnectionState}`);
+            this.onFail({
+              errorCode: 1007,
+              errorMessage: `ICE negotiation failed. Current state - ${iceConnectionState}`,
+            });
+          }
+        }
+      }
+
+      this.webRtcPeer.generateOffer(this.onOfferListenOnly.bind(this));
     });
   }
 };


### PR DESCRIPTION
2.2 backport of #8710.

```
Tracks the listen only WebRTC PC ICE connection state. On transition to failure states:
  - Log the error
  - Trigger a reconnect
```