### PR TITLE
Add license and copyright info for HTML5 client

### DIFF
--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -1,3 +1,21 @@
+<!--
+BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+
+Copyright (c) 2019 BigBlueButton Inc. and by respective authors (see below).
+
+This program is free software; you can redistribute it and/or modify it under the
+terms of the GNU Lesser General Public License as published by the Free Software
+Foundation; either version 3.0 of the License, or (at your option) any later
+version.
+
+BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+-->
+
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <style>

--- a/bigbluebutton-html5/client/main.jsx
+++ b/bigbluebutton-html5/client/main.jsx
@@ -1,3 +1,20 @@
+/*
+    BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+
+    Copyright (c) 2019 BigBlueButton Inc. and by respective authors (see below).
+
+    This program is free software; you can redistribute it and/or modify it under the
+    terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 3.0 of the License, or (at your option) any later
+    version.
+
+    BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+    PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License along
+    with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+*/
 /* eslint no-unused-vars: 0 */
 import React from 'react';
 import { Meteor } from 'meteor/meteor';

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -1,6 +1,7 @@
 {
   "name": "bbb-html5-client",
   "description": "BigBlueButton HTML5 Client",
+  "license": "LGPL-3.0",
   "scripts": {
     "start": "if test \"$NODE_ENV\" = \"production\" ; then npm run start:prod; else npm run start:dev; fi",
     "test-visual-regression": "export BROWSER_NAME=firefox; wdio ./tests/webdriverio/wdio.vreg.conf.js; export BROWSER_NAME=chrome; wdio ./tests/webdriverio/wdio.vreg.conf.js; export BROWSER_NAME=chrome_mobile; DEVICE_NAME='iPhone 6 Plus'; export DEVICE_NAME; wdio ./tests/webdriverio/wdio.vreg.conf.js; DEVICE_NAME='Nexus 5X'; export DEVICE_NAME; wdio ./tests/webdriverio/wdio.vreg.conf.js",


### PR DESCRIPTION
Adds clarification regarding the license of the HTML5 client

Initially I added the text to [almost] all source files in the client in https://github.com/antobinary/bigbluebutton/commit/15f4efe4223b9a6784c70344c8bbcf38b83a51d3 but the issue is that when minimizing the code, these lines are kept, so the resulting client files to be served (js and css) are ~500KB larger.