### PR TITLE
Remove the minMessageLength warning from chat

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
@@ -44,9 +44,6 @@ const messages = defineMessages({
     id: 'app.chat.inputPlaceholder',
     description: 'Chat message input placeholder',
   },
-  errorMinMessageLength: {
-    id: 'app.chat.errorMinMessageLength',
-  },
   errorMaxMessageLength: {
     id: 'app.chat.errorMaxMessageLength',
   },
@@ -229,7 +226,6 @@ class MessageForm extends PureComponent {
     e.preventDefault();
 
     const {
-      intl,
       disabled,
       minMessageLength,
       maxMessageLength,
@@ -239,18 +235,9 @@ class MessageForm extends PureComponent {
     const { message } = this.state;
     let msg = message.trim();
 
-    if (message.length < minMessageLength) {
-      this.setState({
-        hasErrors: true,
-        error: intl.formatMessage(
-          messages.errorMinMessageLength,
-          { 0: minMessageLength - message.length },
-        ),
-      });
-    }
+    if (msg.length < minMessageLength) return;
 
     if (disabled
-      || msg.length === 0
       || msg.length > maxMessageLength) {
       this.setState({ hasErrors: true });
       return false;

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -1,7 +1,6 @@
 {
     "app.home.greeting": "Your presentation will begin shortly ...",
     "app.chat.submitLabel": "Send message",
-    "app.chat.errorMinMessageLength": "The message is {0} characters(s) too short",
     "app.chat.errorMaxMessageLength": "The message is {0} characters(s) too long",
     "app.chat.disconnected": "You are disconnected, messages can't be sent",
     "app.chat.locked": "Chat is locked, messages can't be sent",


### PR DESCRIPTION
The minimum length warning for a chat message will flicker and shift every time you press enter with an empty input box. Every other application that I checked that had chat just did nothing when I tried to send an empty message.