### PR TITLE
Force a stacking context to be created for the media container

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.scss
@@ -198,6 +198,7 @@
   position: relative;
   margin: 0 0 0 var(--panel-margin-right);
   overflow: hidden;
+  z-index: 0;
 
   [dir="rtl"] & {
     margin: 0 var(--panel-margin-right) 0 0;


### PR DESCRIPTION
The styling of the webcam containers sets z-index for them, but nothing higher up in the DOM uses properties that create a new stacking context so the webcams are being placed on top of everything in the client in certain scenarios.

The easiest way to reproduce is to load the client in Firefox, close the chat, share your webcam, and then click the gear icon above the users list. You will be able to interact with the rows that are in line with the presentation area, but any that are in line with the webcams you won't be able to interact with.

This PR sets the z-index on the media container to `0` which tells the browser to create a new stacking context. This means that nothing inside of the media container can escape the stacking order of the container.