### PR TITLE
Fix the spacing in the typing indicator

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/styles.scss
@@ -110,15 +110,11 @@
   [dir="rtl"] & {
     text-align: right;
   }
-
-  &:before {
-    content: "\00a0"; // non-breaking space
-  }
 }
 
 .spacer {
   &:before {
-    content: none;
+    content: "\00a0"; // non-breaking space
   }
 }
 

--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/typing-indicator/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/typing-indicator/component.jsx
@@ -94,16 +94,19 @@ class TypingIndicator extends PureComponent {
   render() {
     const {
       error,
+      indicatorEnabled,
     } = this.props;
 
-    const style = {};
-    style[styles.error] = !!error;
-    style[styles.info] = !error;
-    style[styles.spacer] = !!this.renderTypingElement();
+    const typingElement = this.renderTypingElement();
+
+    const showSpacer = (indicatorEnabled ? !typingElement : !error);
 
     return (
-      <div className={cx(style)}>
-        <span className={styles.typingIndicator}>{error || this.renderTypingElement()}</span>
+      <div className={cx(styles.info, (showSpacer && styles.spacer))}>
+        <div className={styles.typingIndicator}>{typingElement}</div>
+        {error
+          && <div className={cx(styles.typingIndicator, styles.error)}>{error}</div>
+        }
       </div>
     );
   }


### PR DESCRIPTION
The typing indicator wouldn't show the typing users if there was an error. It will now show both and better decide whether or not to leave a space.