### PR TITLE
Fix client crash race condition with presentation pods

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -186,11 +186,11 @@ class ActionsDropdown extends PureComponent {
       podIds,
     } = this.props;
 
-    let podId = null;
-    if (podIds) {
-      const defaultPodId = podIds[0].podId;
-      podId = podIds.length > 0 ? defaultPodId : null;
-    }
+    if (!podIds || podIds.length < 1) return [];
+
+    // We still have code for other pods from the Flash client. This intentionally only cares
+    // about the first one because it's the default.
+    const { podId } = podIds[0];
 
     const presentationItemElements = presentations.map((p) => {
       const itemStyles = {};


### PR DESCRIPTION
The action button render can run before the presentation information has fully loaded. This PR adds a check to exit the makePresentationItems function if the presentation pods aren't there.