### PR TITLE
Replace use of $ jquery with javascript in webcam-draggable-overlay

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/media/webcam-draggable-overlay/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/webcam-draggable-overlay/component.jsx
@@ -159,11 +159,11 @@ class WebcamDraggable extends PureComponent {
     const { webcamDraggableState } = this.props;
     const { optimalGrid, placement } = webcamDraggableState;
     if (placement === 'top' || placement === 'bottom') {
-      const mediaHeight = $('section[class^=media]').height();
+      const mediaHeight = document.querySelector('section[class^=media]').offsetHeight;
       this.setState({ placementPercent: (optimalGrid.height * 100) / mediaHeight });
     }
     if (placement === 'left' || placement === 'right') {
-      const mediaWidth = $('section[class^=media]').width();
+      const mediaWidth = document.querySelector('section[class^=media]').offsetWidth;
       this.setState({ placementPercent: (optimalGrid.width * 100) / mediaWidth });
     }
   }
@@ -441,8 +441,8 @@ class WebcamDraggable extends PureComponent {
       [styles.dropZoneBgRight]: true,
     });
 
-    const mHeight = $('section[class^=media]').height();
-    const mWidth = $('section[class^=media]').width();
+    const mHeight = document.querySelector('section[class^=media]').offsetHeight;
+    const mWidth = document.querySelector('section[class^=media]').offsetWidth;
 
     let resizeWidth;
     let resizeHeight;


### PR DESCRIPTION
We removed jquery in BBB 2.2.x as it was not used. Here we have an easy
replacement for jquery in the face of pure javascript. This way we do
not need to re-import jquery package as dependency.
Prior to this commit webcams could not be shared (ever since we merged BBB 2.2.x into 2.3)

credit to @vitormateusalmeida 