### PR TITLE
Fix render loop after changing locale with override setting

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/intl.jsx
+++ b/bigbluebutton-html5/imports/startup/client/intl.jsx
@@ -106,7 +106,7 @@ class IntlStartup extends Component {
 
   componentWillMount() {
     const { locale } = this.props;
-    this.fetchLocalizedMessages(locale);
+    this.fetchLocalizedMessages(locale, true);
   }
 
   componentWillUpdate(nextProps) {
@@ -120,8 +120,8 @@ class IntlStartup extends Component {
     }
   }
 
-  fetchLocalizedMessages(locale) {
-    const url = `/html5client/locale?locale=${locale}`;
+  fetchLocalizedMessages(locale, init = false) {
+    const url = `/html5client/locale?locale=${locale}&init=${init}`;
 
     this.setState({ fetching: true }, () => {
       fetch(url)

--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -108,7 +108,9 @@ WebApp.connectHandlers.use('/locale', (req, res) => {
   const APP_CONFIG = Meteor.settings.public.app;
   const fallback = APP_CONFIG.defaultSettings.application.fallbackLocale;
   const override = APP_CONFIG.defaultSettings.application.overrideLocale;
-  const browserLocale = override ? override.split(/[-_]/g) : req.query.locale.split(/[-_]/g);
+  const browserLocale = override && req.query.init === 'true'
+    ? override.split(/[-_]/g) : req.query.locale.split(/[-_]/g);
+
   const localeList = [fallback];
 
   const usableLocales = AVAILABLE_LOCALES


### PR DESCRIPTION
This PR fixes the issue where the client gets stuck in a render loop after trying to change the locale via the UI settings, if the `overrideLocale` config is set.

To test in `settings.yml` set the `overrideLocale` to any supported locale. Once the client loads, change the client locale via the UI settings.  Should no longer cause the client to keep reloading  infinitely.

Was mentioned in #8336 