### PR TITLE
Only join a user if the connection is still active

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/handlers/validateAuthToken.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/validateAuthToken.js
@@ -30,7 +30,7 @@ export default function handleValidateAuthToken({ body }, meetingId) {
   if (!User) return;
 
   // Publish user join message
-  if (valid && !waitForApproval) {
+  if (valid && !waitForApproval && !!User.connectionId) {
     Logger.info('User=', User);
     userJoin(meetingId, userId, User.authToken);
   }

--- a/bigbluebutton-html5/imports/api/users/server/methods/userLeaving.js
+++ b/bigbluebutton-html5/imports/api/users/server/methods/userLeaving.js
@@ -27,6 +27,13 @@ export default function userLeaving(meetingId, userId, connectionId) {
     return false;
   }
 
+  const modifier = {
+    $set: {
+      connectionId: false,
+    },
+  };
+  Users.upsert(selector, modifier);
+
   const payload = {
     userId,
     sessionId: meetingId,

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
@@ -45,7 +45,7 @@ export default function removeUser(meetingId, userId) {
       return Logger.error(`Removing user from collection: ${err}`);
     }
 
-    const sessionUserId = `${meetingId}-${userId}`;
+    const sessionUserId = `${meetingId}--${userId}`;
     clearAllSessions(sessionUserId);
 
     clearUserInfoForRequester(meetingId, userId);


### PR DESCRIPTION
There was an edge case where a client would send the ValidateAuthToken request message and then disconnect. The ValidateAuthToken response would come back and the HTML5 server would then automatically send a message saying that the user is joining. This resulted in ghost users that the HTML5 server didn't have an active connection for and akka-apps was relying on being told about.

The added protections in this PR are to check that there is an active connection before joining. Even with this PR there's a small window where it can still fail, but a full rework of the login logic is going to have to wait for the next release.