### PR TITLE
Improve current presentation toast

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/presentation/styles.scss
@@ -1,6 +1,11 @@
 @import "/imports/ui/stylesheets/variables/_all";
 @import "/imports/ui/components/whiteboard/whiteboard-toolbar/styles";
 
+:root {
+  --innerToastWidth: 17rem;
+  --iconWrapperSize: 2rem;
+}
+
 .enter {
   opacity: 0.01;
 }
@@ -85,6 +90,50 @@
   left: 0;
   right: 0;
   bottom: 0;
+}
+
+.innerToastWrapper {
+  display: flex;
+  flex-direction: row;
+  width: var(--innerToastWidth);
+}
+
+.toastTextContent {
+  position: relative;
+  overflow: hidden;
+}
+
+.presentationName {
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.toastIcon {
+  margin-right: var(--sm-padding-x);
+  [dir="rtl"] & {
+    margin-right: 0;
+    margin-left: var(--sm-padding-x);
+  }
+}
+
+.iconWrapper {
+  background-color: var(--color-primary);
+  width: var(--iconWrapperSize);
+  height: var(--iconWrapperSize);
+  border-radius: 50%;
+
+  > i {
+    position: relative;
+    left: var(--md-padding-y);
+    top: var(--sm-padding-y);
+    font-size: var(--font-size-base);
+    color: var(--color-white);
+
+    [dir="rtl"] & {
+      left: 0;
+      right: var(--md-padding-y);
+   }
+  }
 }
 
 .visuallyHidden {


### PR DESCRIPTION
This PR makes the current presentation change notification handle files with long names (removes the scroll bar). Also, improves the notification so it doesn't create extra toast's; if the presentation is changed quickly it updates the existing one.

Before:
![image](https://user-images.githubusercontent.com/22058534/77443169-44e20400-6dc1-11ea-92ed-d58db30ef2a7.png)

After:
![current-pres-toast-update](https://user-images.githubusercontent.com/22058534/77444759-a0f95800-6dc2-11ea-8132-2b0a365a45c3.gif)



Closes #8800 