### PR TITLE
Allow bbb-lti to support multiple LTI clients

### DIFF
--- a/bbb-lti/grails-app/services/org/bigbluebutton/LtiService.groovy
+++ b/bbb-lti/grails-app/services/org/bigbluebutton/LtiService.groovy
@@ -58,8 +58,8 @@ class LtiService {
 
     private void initConsumerMap() {
         this.consumerMap = new HashMap<String, String>()
-        String[] consumers = this.consumers.split(",")
-        consumers.each { consumerPair ->
+        String[] consumersPairs = this.consumers.split(",")
+        consumersPairs.each { consumerPair ->
             String[] consumer = consumerPair.split(":")
             if( consumer.length == 2 ){
                 this.consumerMap.put(consumer[0], consumer[1])

--- a/bbb-lti/grails-app/services/org/bigbluebutton/LtiService.groovy
+++ b/bbb-lti/grails-app/services/org/bigbluebutton/LtiService.groovy
@@ -59,9 +59,8 @@ class LtiService {
     private void initConsumerMap() {
         this.consumerMap = new HashMap<String, String>()
         String[] consumers = this.consumers.split(",")
-        if ( consumers.length > 0 ) {
-            int i = 0;
-            String[] consumer = consumers[i].split(":")
+        consumers.each { consumerPair ->
+            String[] consumer = consumerPair.split(":")
             if( consumer.length == 2 ){
                 this.consumerMap.put(consumer[0], consumer[1])
             }


### PR DESCRIPTION
Currently bbb-lti will only load one consumer id & key pair from the configuration. 

The [documentation](https://github.ibm.com/skills-network/bbb-lti/blob/master/grails-app/conf/lti-config.properties#L37) references multiple credentials separated by commas. This PR allows the `initConsumerMap` function to load all LTI credentials from the configuration.