### PR TITLE
bbb-webhooks: add group chat, pad, presentation events

### DIFF
--- a/bbb-webhooks/config/default.example.yml
+++ b/bbb-webhooks/config/default.example.yml
@@ -16,6 +16,8 @@ hooks:
     - from-akka-apps-redis-channel
     - from-bbb-web-redis-channel
     - from-akka-apps-chat-redis-channel
+    - from-akka-apps-pres-redis-channel
+    - from-etherpad-redis-channel
     - bigbluebutton:from-bbb-apps:meeting
     - bigbluebutton:from-bbb-apps:users
     - bigbluebutton:from-bbb-apps:chat

--- a/bbb-webhooks/messageMapping.js
+++ b/bbb-webhooks/messageMapping.js
@@ -257,7 +257,8 @@ module.exports = class MessageMapping {
             "timezone-offset": message.fromTimezoneOffset,
             "time": message.fromTime || message.timestamp
           }
-        }
+        },
+        "chat-id": messageObj.core.body.chatId 
       },
       "event":{
         "ts": Date.now()


### PR DESCRIPTION
- The public chat produces `GroupChatMessageBroadcastEvtMsg` events which were not listened for and have a slightly different mapping than the existing chat events. They can be distinguished from private chat messages by the `MAIN-PUBLIC-GROUP-CHAT` chat ID.
- Shared notes produce `PadUpdateSysMsg` events, which were neither listened for nor mapped.
- Presentation uploads produce `SetCurrentPresentationEvtMsg` events, which were not mapped.