### PR TITLE
Have the recording archive delete originals of archived media

### DIFF
--- a/record-and-playback/core/scripts/archive/archive.rb
+++ b/record-and-playback/core/scripts/archive/archive.rb
@@ -100,6 +100,13 @@ def archive_audio(meeting_id, audio_dir, raw_archive_dir)
   end
 end
 
+def delete_audio(meeting_id, audio_dir)
+  BigBlueButton.logger.info("Deleting audio #{audio_dir}/#{meeting_id}-*.*")
+  Dir.glob("#{audio_dir}/#{meeting_id}-*.*").each do |audio_file|
+    FileUtils.rm_f(audio_file)
+  end
+end
+
 def archive_directory(source, dest)
   BigBlueButton.logger.info("Archiving contents of #{source}")
   FileUtils.mkdir_p(dest)
@@ -189,18 +196,33 @@ BigBlueButton.logger = Logger.new("#{log_dir}/archive-#{meeting_id}.log", 'daily
 target_dir = "#{raw_archive_dir}/#{meeting_id}"
 FileUtils.mkdir_p target_dir
 archive_events(meeting_id, redis_host, redis_port, redis_password, raw_archive_dir, break_timestamp)
+# FreeSWITCH Audio files
 archive_audio(meeting_id, audio_dir, raw_archive_dir)
+# Etherpad notes
 archive_notes(meeting_id, notes_endpoint, notes_formats, raw_archive_dir)
-archive_directory("#{presentation_dir}/#{meeting_id}/#{meeting_id}",
-                  "#{target_dir}/presentation")
-archive_directory("#{screenshare_dir}/#{meeting_id}",
-                  "#{target_dir}/deskshare")
-archive_directory("#{video_dir}/#{meeting_id}",
-                  "#{target_dir}/video/#{meeting_id}")
-archive_directory("#{kurento_screenshare_dir}/#{meeting_id}",
-                  "#{target_dir}/deskshare")
-archive_directory("#{kurento_video_dir}/#{meeting_id}",
-                  "#{target_dir}/video/#{meeting_id}")
+# Presentation files
+archive_directory("#{presentation_dir}/#{meeting_id}/#{meeting_id}", "#{target_dir}/presentation")
+# Red5 media
+archive_directory("#{screenshare_dir}/#{meeting_id}", "#{target_dir}/deskshare")
+archive_directory("#{video_dir}/#{meeting_id}", "#{target_dir}/video/#{meeting_id}")
+# Kurento media
+archive_directory("#{kurento_screenshare_dir}/#{meeting_id}", "#{target_dir}/deskshare")
+archive_directory("#{kurento_video_dir}/#{meeting_id}", "#{target_dir}/video/#{meeting_id}")
+
+# If this was the last (or only) segment in a recording, delete the original media files
+if break_timestamp.nil?
+  BigBlueButton.logger.info('Deleting originals of archived media files.')
+  # FreeSWITCH Audio files
+  delete_audio(meeting_id, audio_dir)
+  # Red5 media
+  # TODO: need to figure out how to set permissions used when red5 creates directories
+  # does this even matter? we're removing red5 soon...
+  # FileUtils.rm_rf("#{screenshare_dir}/#{meeting_id}")
+  # FileUtils.rm_rf("#{video_dir}/#{meeting_id}")
+  # Kurento media
+  FileUtils.rm_rf("#{kurento_screenshare_dir}/#{meeting_id}")
+  FileUtils.rm_rf("#{kurento_video_dir}/#{meeting_id}")
+end
 
 if not archive_has_recording_marks?(meeting_id, raw_archive_dir, break_timestamp)
   BigBlueButton.logger.info("There's no recording marks for #{meeting_id}, not processing recording.")


### PR DESCRIPTION
After the last segment of a recording has been archived, it is safe to delete the original files that were recorded by the various media handling components. This patch deletes the freeswitch audio files and kurento webcam/screenshare files after they have been archived.

It needs to be used in combination with some changes to users/groups and directory permissions to allow the `bigbluebutton` user to delete files that it could previously only read.

## freeswitch

Add bigbluebutton user to freeswitch group

```sh
usermod bigbluebutton -a -G freeswitch
```

Allow group write permissions on the freeswitch meetings directory

```sh
chmod 0775 /var/freeswitch/meetings
```

## red5

???

## kurento

Edit systemd unit `kurento-media-server.service`

```
[Service]
UMask=0002
```

(don't forget to `systemctl daemon-reload` afterwards!)

Add bigbluebutton user to kurento group

```sh
usermod bigbluebutton -a -G kurento
```

## finally

Restart BigBlueButton. Or, at a *minimum*, restart kurento-media-server.