### PR TITLE
add webcam test using regular selectors

### DIFF
--- a/bigbluebutton-html5/tests/puppeteer/webcam/elements.js
+++ b/bigbluebutton-html5/tests/puppeteer/webcam/elements.js
@@ -1,5 +1,5 @@
-exports.joinVideo = 'button[data-test="joinVideo"]';
-exports.videoPreview = 'video[data-test="videoPreview"]';
-exports.startSharingWebcam = 'button[data-test="startSharingWebcam"]';
-exports.videoContainer = 'video[data-test="videoContainer"]';
-exports.webcamConnecting = '[data-test="webcamConnecting"]';
+exports.joinVideo = 'button[aria-label="Share webcam"]';
+exports.videoPreview = 'video[id="preview"]';
+exports.startSharingWebcam = 'button[aria-label="Start sharing"]';
+exports.videoContainer = 'div[class^="videoListItem"]';
+exports.webcamConnecting = '[class^="connecting-"]';

--- a/bigbluebutton-html5/tests/puppeteer/webcam/util.js
+++ b/bigbluebutton-html5/tests/puppeteer/webcam/util.js
@@ -14,7 +14,7 @@ async function getTestElement(element) {
 }
 
 async function evaluateCheck(test) {
-  await test.waitForSelector(we.videoContainer);
+  await test.waitForSelector(we.videoContainer, {timeout: 5000})
   const videoContainer = await test.evaluate(getTestElement, we.presentationFullscreenButton);
   const response = videoContainer !== null;
   return response;


### PR DESCRIPTION
this webcam test requires to add to `.env` file the following line:

- `VIDEO_FILE=$HOME/bbb/src/bigbluebutton/bigbluebutton-html5/tests/puppeteer/media/video_rgb.y4m`

download link of the audio file: [video_rgb.y4m file](https://drive.google.com/file/d/1I1ehFgKUraSCqCbB4VpxG5KkxQ1o7dKZ/view?usp=sharing)

to run the test, simply execute this line:
`env $(cat ./tests/puppeteer/.env | xargs)  jest webcam.test.js --detectOpenHandles --testTimeout=300000`