### PR TITLE
Make bbb-web listen to 127.0.0.1 only

### DIFF
--- a/bigbluebutton-web/run-prod.sh
+++ b/bigbluebutton-web/run-prod.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-java -Dgrails.env=prod -Dserver.port=8090 -Xms384m -Xmx384m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/bigbluebutton/diagnostics -cp WEB-INF/lib/*:/:WEB-INF/classes/:. org.springframework.boot.loader.WarLauncher
-
+java -Dgrails.env=prod -Dserver.port=8090 -Dserver.address=127.0.0.1 -Xms384m -Xmx384m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/bigbluebutton/diagnostics -cp WEB-INF/lib/*:/:WEB-INF/classes/:. org.springframework.boot.loader.WarLauncher


### PR DESCRIPTION
This patch makes bbb-web listen to localhost only in production. It
should be behind Nginx anyway and there is no need to listen to anything
else.