### PR TITLE
Remove recursively the directory and files

### DIFF
--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1322,7 +1322,7 @@ begin
         FileUtils.rm_r(Dir.glob("#{$process_dir}/*"))
 
         BigBlueButton.logger.info("Removing published files.")
-        FileUtils.rm_r(Dir.glob("#{target_dir}/*"))
+        FileUtils.rm_rf(Dir.glob("#{target_dir}/*"))
         rescue  Exception => e
           BigBlueButton.logger.error(e.message)
           e.backtrace.each do |traceline|


### PR DESCRIPTION
Remove recursively the directory and files.

The actual command: FileUtils.rm_r(Dir.glob("#{target_dir}/*")). Example:
/var/bigbluebutton/recording/publish/presentation/30dc7ccdacd5632ec16bf33cd19fa9e90669f9b1-1585755770320/

But exists other directory in this path.Example:
/var/bigbluebutton/recording/publish/presentation/30dc7ccdacd5632ec16bf33cd19fa9e90669f9b1-1585755770320/30dc7ccdacd5632ec16bf33cd19fa9e90669f9b1-1585755770320

This change remove recursively the folder and files:
FileUtils.rm_rf(Dir.glob("#{target_dir}/*"))

This is log Error.
I, [2020-04-01T12:49:41.005933 #15032]  INFO -- : Removing published files.
E, [2020-04-01T12:49:42.318432 #15032] ERROR -- : Directory not empty @ dir_s_rmdir - /var/bigbluebutton/recording/publish/presentation/30dc7ccdacd5632ec16bf33cd19fa9e90669f9b1-1585755770320/30dc7ccdacd5632ec16bf33cd19fa9e90669f9b1-1585755770320
E, [2020-04-01T12:49:42.318499 #15032] ERROR -- : /usr/lib/ruby/2.3.0/fileutils.rb:1445:in `rmdir'
E, [2020-04-01T12:49:42.318511 #15032] ERROR -- : /usr/lib/ruby/2.3.0/fileutils.rb:1445:in `block in remove_dir1'
E, [2020-04-01T12:49:42.318532 #15032] ERROR -- : /usr/lib/ruby/2.3.0/fileutils.rb:1456:in `platform_support'
E, [2020-04-01T12:49:42.318541 #15032] ERROR -- : /usr/lib/ruby/2.3.0/fileutils.rb:1444:in `remove_dir1'
E, [2020-04-01T12:49:42.318549 #15032] ERROR -- : /usr/lib/ruby/2.3.0/fileutils.rb:1437:in `remove'
E, [2020-04-01T12:49:42.318556 #15032] ERROR -- : /usr/lib/ruby/2.3.0/fileutils.rb:779:in `block in remove_entry'
E, [2020-04-01T12:49:42.318563 #15032] ERROR -- : /usr/lib/ruby/2.3.0/fileutils.rb:1494:in `postorder_traverse'
E, [2020-04-01T12:49:42.318571 #15032] ERROR -- : /usr/lib/ruby/2.3.0/fileutils.rb:777:in `remove_entry'
E, [2020-04-01T12:49:42.318578 #15032] ERROR -- : /usr/lib/ruby/2.3.0/fileutils.rb:635:in `block in rm_r'
E, [2020-04-01T12:49:42.318585 #15032] ERROR -- : /usr/lib/ruby/2.3.0/fileutils.rb:631:in `each'
E, [2020-04-01T12:49:42.318593 #15032] ERROR -- : /usr/lib/ruby/2.3.0/fileutils.rb:631:in `rm_r'
E, [2020-04-01T12:49:42.318600 #15032] ERROR -- : publish/presentation.rb:1377:in `<main>'
E, [2020-04-01T12:49:42.318617 #15032] ERROR -- : exit
E, [2020-04-01T12:49:42.318635 #15032] ERROR -- : publish/presentation.rb:1383:in `exit'
E, [2020-04-01T12:49:42.318643 #15032] ERROR -- : publish/presentation.rb:1383:in `rescue in <main>'
E, [2020-04-01T12:49:42.318651 #15032] ERROR -- : publish/presentation.rb:1203:in `<main>'