### PR TITLE
fixed joining room with running webcam stream

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/media/webcam-draggable-overlay/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/webcam-draggable-overlay/component.jsx
@@ -441,8 +441,6 @@ class WebcamDraggable extends PureComponent {
       [styles.dropZoneBgRight]: true,
     });
 
-    const mHeight = document.querySelector('section[class^=media]').offsetHeight;
-    const mWidth = document.querySelector('section[class^=media]').offsetWidth;
 
     let resizeWidth;
     let resizeHeight;
@@ -452,6 +450,8 @@ class WebcamDraggable extends PureComponent {
     }
     if (!resizing && (placement === 'top' || placement === 'bottom') && !dragging) {
       resizeWidth = '100%';
+      const el = document.querySelector('section[class^=media]');
+      const mHeight = el != null ? el.offsetHeight: 64;
       resizeHeight = mHeight * (placementPercent / 100);
     }
 
@@ -460,6 +460,8 @@ class WebcamDraggable extends PureComponent {
       resizeHeight = '100%';
     }
     if (!resizing && (placement === 'left' || placement === 'right') && !dragging) {
+      const el = document.querySelector('section[class^=media]');   
+      const mWidth = el != null ? el.offsetWidth : 64;
       resizeWidth = mWidth * (placementPercent / 100);
       resizeHeight = '100%';
     }


### PR DESCRIPTION
Currently joining a room with an active webcam stream fails. Before is steam is setup for the client it tries to query the media area dom "section[class^=media]". As it dose not yet exist, the query returns null and the later access to the property offestHeight fails which yields an error on the javascript console and aborts the room joining.

This patch add default values for offsetHight / offsetWidth if the media area is not yet setup. These will only be used as long as the media area is not yet properly setup.