### PR TITLE
Dockerfile fix

### DIFF
--- a/akka-bbb-apps/Dockerfile
+++ b/akka-bbb-apps/Dockerfile
@@ -5,7 +5,7 @@ ARG COMMON_VERSION=0.0.1-SNAPSHOT
 COPY . /source
 
 RUN cd /source \
- && find -name build.sbt -exec sed -i "s|\(.*org.bigbluebutton.*bbb-common-message[^\"]*\"[ ]*%[ ]*\)\"[^\"]*\"\(.*\)|\1\"$COMMON_VERSION\"\2|g" {} \; \
+ && find -name Dependencies.scala -exec sed -i "s|\(.*org.bigbluebutton.*bbb-common-message[^\"]*\"[ ]*%[ ]*\)Versions\.bbbCommons\(.*\)|\1\"$COMMON_VERSION\"\2|g" {} \; \
  && sbt compile
 
 RUN apt-get update \

--- a/akka-bbb-apps/Dockerfile
+++ b/akka-bbb-apps/Dockerfile
@@ -14,11 +14,13 @@ RUN apt-get update \
 RUN cd /source \
  && sbt debian:packageBin
 
-# FROM ubuntu:16.04
-FROM openjdk:8-jre-slim-stretch
+FROM ubuntu:16.04
+RUN apt-get update \
+ && apt-get install -y openjdk-8-jre-headless
 
 COPY --from=builder /source/target/*.deb /root/
 
 RUN dpkg -i /root/*.deb
 
+WORKDIR /usr/share/bbb-apps-akka
 CMD ["/usr/share/bbb-apps-akka/bin/bbb-apps-akka"]

--- a/akka-bbb-fsesl/Dockerfile
+++ b/akka-bbb-fsesl/Dockerfile
@@ -5,8 +5,8 @@ ARG COMMON_VERSION=0.0.1-SNAPSHOT
 COPY . /source
 
 RUN cd /source \
- && find -name build.sbt -exec sed -i "s|\(.*org.bigbluebutton.*bbb-common-message[^\"]*\"[ ]*%[ ]*\)\"[^\"]*\"\(.*\)|\1\"$COMMON_VERSION\"\2|g" {} \; \
- && find -name build.sbt -exec sed -i "s|\(.*org.bigbluebutton.*bbb-fsesl-client[^\"]*\"[ ]*%[ ]*\)\"[^\"]*\"\(.*\)|\1\"$COMMON_VERSION\"\2|g" {} \; \
+ && find -name Dependencies.scala -exec sed -i "s|\(.*org.bigbluebutton.*bbb-common-message[^\"]*\"[ ]*%[ ]*\)Versions\.bbbCommons\(.*\)|\1\"$COMMON_VERSION\"\2|g" {} \; \
+ && find -name Dependencies.scala -exec sed -i "s|\(.*org.bigbluebutton.*bbb-fsesl-client[^\"]*\"[ ]*%[ ]*\)Versions\.bbbFsesl\(.*\)|\1\"$COMMON_VERSION\"\2|g" {} \; \
  && sbt compile
 
 RUN apt-get update \

--- a/akka-bbb-fsesl/Dockerfile
+++ b/akka-bbb-fsesl/Dockerfile
@@ -15,7 +15,9 @@ RUN apt-get update \
 RUN cd /source \
  && sbt debian:packageBin
 
-FROM openjdk:8-jre-slim-stretch
+FROM ubuntu:16.04
+RUN apt-get update \
+ && apt-get install -y openjdk-8-jre-headless
 
 COPY --from=builder /source/target/*.deb /root/
 
@@ -23,4 +25,5 @@ RUN dpkg -i /root/*.deb
 
 COPY wait-for-it.sh /usr/local/bin/
 
+WORKDIR /usr/share/bbb-fsesl-akka
 CMD ["/usr/share/bbb-fsesl-akka/bin/bbb-fsesl-akka"]

--- a/bbb-common-message/Dockerfile
+++ b/bbb-common-message/Dockerfile
@@ -1,4 +1,4 @@
-FROM sbt:0.13.8
+FROM sbt:1.3.8
 
 ARG COMMON_VERSION
 

--- a/bbb-common-web/Dockerfile
+++ b/bbb-common-web/Dockerfile
@@ -1,13 +1,12 @@
 FROM bbb-common-message
 
-ARG COMMON_VERSION
+ARG COMMON_VERSION=0.0.1-SNAPSHOT
 
 COPY . /bbb-common-web
 
 RUN cd /bbb-common-web \
  && sed -i "s|\(version := \)\".*|\1\"$COMMON_VERSION\"|g" build.sbt \
- && find -name build.sbt -exec sed -i "s|\(.*org.bigbluebutton.*bbb-common-message[^\"]*\"[ ]*%[ ]*\)\"[^\"]*\"\(.*\)|\1\"$COMMON_VERSION\"\2|g" {} \; \
- && echo 'publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository")))' | tee -a build.sbt \
+ && find -name Dependencies.scala -exec sed -i "s|\(.*org.bigbluebutton.*bbb-common-message[^\"]*\"[ ]*%[ ]*\)Versions\.bbbCommons\(.*\)|\1\"$COMMON_VERSION\"\2|g" {} \; \
  && sbt compile \
  && sbt publish \
  && sbt publishLocal

--- a/bbb-fsesl-client/Dockerfile
+++ b/bbb-fsesl-client/Dockerfile
@@ -6,8 +6,7 @@ COPY . /bbb-fsesl-client
 
 RUN cd /bbb-fsesl-client \
  && sed -i "s|\(version := \)\".*|\1\"$COMMON_VERSION\"|g" build.sbt \
- && find -name build.sbt -exec sed -i "s|\(.*org.bigbluebutton.*bbb-common-message[^\"]*\"[ ]*%[ ]*\)\"[^\"]*\"\(.*\)|\1\"$COMMON_VERSION\"\2|g" {} \; \
- && echo 'publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository")))' | tee -a build.sbt \
+ && find -name Dependencies.sbt -exec sed -i "s|\(.*org.bigbluebutton.*bbb-common-message[^\"]*\"[ ]*%[ ]*\)\"[^\"]*\"\(.*\)|\1\"$COMMON_VERSION\"\2|g" {} \; \
  && sbt compile \
- && sbt publish \
+ # && sbt publish \
  && sbt publishLocal

--- a/bbb-lti/Dockerfile
+++ b/bbb-lti/Dockerfile
@@ -8,9 +8,10 @@ RUN mkdir -p /root/tools \
 
 RUN mkdir -p /root/tools \
  && cd /root/tools \
- && wget https://github.com/grails/grails-core/releases/download/v2.5.2/grails-2.5.2.zip \
- && unzip grails-2.5.2.zip \
- && ln -s grails-2.5.2 grails
+ # && wget https://github.com/grails/grails-core/releases/download/v2.5.2/grails-2.5.2.zip \
+ && wget https://github.com/grails/grails-core/releases/download/v3.3.10/grails-3.3.10.zip \
+ && unzip grails-3.3.10.zip \
+ && ln -s grails-3.3.10 grails
 
 ENV PATH="/root/tools/gradle/bin:/root/tools/grails/bin:${PATH}"
 

--- a/bbb-lti/Dockerfile
+++ b/bbb-lti/Dockerfile
@@ -28,12 +28,12 @@ ARG vendor_description='Open source web conferencing system for distance learnin
 ARG vendor_url=http://www.bigbluebutton.org/
 
 RUN cd /source \
- && sed -i "s|\(<blti:title>\)[^<]*|\1$title|g" grails-app/controllers/org/bigbluebutton/ToolController.groovy \
- && sed -i "s|\(<blti:description>\)[^<]*|\1$description|g" grails-app/controllers/org/bigbluebutton/ToolController.groovy \
- && sed -i "s|\(<lticp:code>\)[^<]*|\1$vendor_code|g" grails-app/controllers/org/bigbluebutton/ToolController.groovy \
- && sed -i "s|\(<lticp:name>\)[^<]*|\1$vendor_name|g" grails-app/controllers/org/bigbluebutton/ToolController.groovy \
- && sed -i "s|\(<lticp:description>\)[^<]*|\1$vendor_description|g" grails-app/controllers/org/bigbluebutton/ToolController.groovy \
- && sed -i "s|\(<lticp:url>\)[^<]*|\1$vendor_url|g" grails-app/controllers/org/bigbluebutton/ToolController.groovy \
+ && sed -i "s|\(<blti:title>\)[^<]*|\1$title|g" grails-app/controllers/org/bigbluebutton/lti/controllers/ToolController.groovy \
+ && sed -i "s|\(<blti:description>\)[^<]*|\1$description|g" grails-app/controllers/org/bigbluebutton/lti/controllers/ToolController.groovy \
+ && sed -i "s|\(<lticp:code>\)[^<]*|\1$vendor_code|g" grails-app/controllers/org/bigbluebutton/lti/controllers/ToolController.groovy \
+ && sed -i "s|\(<lticp:name>\)[^<]*|\1$vendor_name|g" grails-app/controllers/org/bigbluebutton/lti/controllers/ToolController.groovy \
+ && sed -i "s|\(<lticp:description>\)[^<]*|\1$vendor_description|g" grails-app/controllers/org/bigbluebutton/lti/controllers/ToolController.groovy \
+ && sed -i "s|\(<lticp:url>\)[^<]*|\1$vendor_url|g" grails-app/controllers/org/bigbluebutton/lti/controllers/ToolController.groovy \
  && sed -i "s|BigBlueButton|$title|g" grails-app/i18n/*.properties \
  && grails war
 
@@ -44,7 +44,7 @@ WORKDIR $CATALINA_HOME
 # clean default webapps
 RUN rm -r webapps/*
 
-COPY --from=builder /source/target/lti-*.war webapps/lti.war
+COPY --from=builder /source/build/libs/bbb-lti-*.war webapps/lti.war
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/bigbluebutton-html5/Dockerfile
+++ b/bigbluebutton-html5/Dockerfile
@@ -1,10 +1,18 @@
-FROM node:8
+FROM node:12
 
 RUN set -x \
  && curl -sL https://install.meteor.com | sed s/--progress-bar/-sL/g | /bin/sh \
  && useradd -m -G users -s /bin/bash meteor
 
-RUN apt-get update && apt-get -y install jq
+# install add-apt-repository
+RUN apt-get update \
+    && apt-get install software-properties-common -y
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CC86BB64 \
+    && add-apt-repository ppa:rmescandon/yq \
+    && apt update \
+    && apt install yq -y
+# RUN apt-get update && apt-get -y install jq
 
 COPY . /source
 
@@ -31,7 +39,12 @@ WORKDIR /app/bundle
 ENV MONGO_URL=mongodb://mongo:27017/html5client \
     PORT=3000 \
     ROOT_URL=http://localhost:3000 \
-    METEOR_SETTINGS_MODIFIER=.
+    KURENTO_WSURL=HOST \
+    KURENTO_VIDEO=true \
+    KURENTO_LISTEN_ONLY=true \
+    KURENTO_SCREENSHARING=true \
+    SCREENSHARE_EXTENSION_KEY=KEY \
+    SCREENSHARE_EXTENSION_LINK=LINK
 
 EXPOSE 3000
 

--- a/bigbluebutton-html5/docker-entrypoint.sh
+++ b/bigbluebutton-html5/docker-entrypoint.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -e
 
-export METEOR_SETTINGS=` jq "${METEOR_SETTINGS_MODIFIER}" ./programs/server/assets/app/config/settings-production.json `
+# Apply settings in environment.
+yq write -i ./programs/server/assets/app/config/settings.yml "public.kurento.wsUrl" "${KURENTO_WSURL}"
+yq write -i ./programs/server/assets/app/config/settings.yml "public.kurento.enableVideo" "${KURENTO_VIDEO}"
+yq write -i ./programs/server/assets/app/config/settings.yml "public.kurento.enableListenOnly" "${KURENTO_LISTEN_ONLY}"
+yq write -i ./programs/server/assets/app/config/settings.yml "public.kurento.enableScreensharing" "${KURENTO_SCREENSHARING}"
+yq write -i ./programs/server/assets/app/config/settings.yml "public.kurento.chromeExtensionKey" "${SCREENSHARING_EXTENSION_KEY}"
+yq write -i ./programs/server/assets/app/config/settings.yml "public.kurento.chromeExtensionLink" "${SCREENSHARING_EXTENSION_LINK}"
 
 node main.js

--- a/bigbluebutton-web/Dockerfile
+++ b/bigbluebutton-web/Dockerfile
@@ -40,7 +40,7 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
  && apt-get -y install imagemagick xpdf-utils netcat libreoffice ttf-liberation fonts-crosextra-carlito fonts-crosextra-caladea unzip procps \
- && wget http://ftp.us.debian.org/debian/pool/main/libj/libjpeg8/libjpeg8_8d-1+deb7u1_amd64.deb \
+ && wget http://archive.debian.org/debian/pool/main/libj/libjpeg8/libjpeg8_8d-1+deb7u1_amd64.deb \
  && dpkg -i libjpeg8*.deb \
  && rm libjpeg8*.deb
 

--- a/bigbluebutton-web/Dockerfile
+++ b/bigbluebutton-web/Dockerfile
@@ -2,15 +2,15 @@ FROM bbb-common-web AS builder
 
 RUN mkdir -p /root/tools \
  && cd /root/tools \
- && wget http://services.gradle.org/distributions/gradle-2.12-bin.zip \
- && unzip gradle-2.12-bin.zip \
- && ln -s gradle-2.12 gradle
+ && wget http://services.gradle.org/distributions/gradle-3.5-bin.zip \
+ && unzip gradle-3.5-bin.zip \
+ && ln -s gradle-3.5 gradle
 
 RUN mkdir -p /root/tools \
  && cd /root/tools \
- && wget https://github.com/grails/grails-core/releases/download/v2.5.2/grails-2.5.2.zip \
- && unzip grails-2.5.2.zip \
- && ln -s grails-2.5.2 grails
+ && wget https://github.com/grails/grails-core/releases/download/v3.3.9/grails-3.3.9.zip \
+ && unzip grails-3.3.9.zip \
+ && ln -s grails-3.3.9 grails
 
 ENV PATH="/root/tools/gradle/bin:/root/tools/grails/bin:${PATH}"
 

--- a/bigbluebutton-web/Dockerfile
+++ b/bigbluebutton-web/Dockerfile
@@ -19,8 +19,10 @@ ARG COMMON_VERSION=0.0.1-SNAPSHOT
 COPY . /source
 
 RUN cd /source \
- && find -name build.gradle -exec sed -i "s|\(.*org.bigbluebutton.*bbb-common-message[^:]*\):.*|\1:$COMMON_VERSION'|g" {} \; \
- && find -name build.gradle -exec sed -i "s|\(.*org.bigbluebutton.*bbb-common-web[^:]*\):.*|\1:$COMMON_VERSION'|g" {} \;
+ && find -name build.gradle -exec sed -i "s|\(.*org.bigbluebutton.*bbb-common-message[^:]*\):.*|\1:$COMMON_VERSION\"|g" {} \; \
+ && find -name build.gradle -exec sed -i "s|\(.*org.bigbluebutton.*bbb-common-web[^:]*\):.*|\1:$COMMON_VERSION\"|g" {} \;
+
+RUN cd /source && gradle -q dependencies --configuration compile
 
 RUN cd /source \
  && gradle resolveDeps \

--- a/bigbluebutton-web/Dockerfile
+++ b/bigbluebutton-web/Dockerfile
@@ -52,15 +52,18 @@ RUN echo "deb http://ubuntu.bigbluebutton.org/xenial-200-dev bigbluebutton-xenia
 # clean default webapps
 RUN rm -r webapps/*
 
-COPY --from=builder /source/target/bigbluebutton-0.9.0.war webapps/bigbluebutton.war
+COPY --from=builder /source/build/libs/bigbluebutton-0.10.0.war webapps/bigbluebutton.war
 
 RUN unzip -q webapps/bigbluebutton.war -d webapps/bigbluebutton \
  && rm webapps/bigbluebutton.war
 
 COPY turn-stun-servers.xml.tmpl turn-stun-servers.xml.tmpl
 
+RUN rm webapps/bigbluebutton/WEB-INF/lib/tomcat-*
+RUN ls -l webapps/bigbluebutton/WEB-INF/lib
+
 COPY docker-entrypoint.sh /usr/local/bin/
 
 CMD [ "dockerize", \
-  "-template", "turn-stun-servers.xml.tmpl:webapps/bigbluebutton/WEB-INF/spring/turn-stun-servers.xml", \
+  "-template", "turn-stun-servers.xml.tmpl:webapps/bigbluebutton/WEB-INF/classes/spring/turn-stun-servers.xml", \
   "docker-entrypoint.sh" ]

--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -52,7 +52,7 @@ dependencies {
   compile "org.springframework.boot:spring-boot-autoconfigure"
   compile "org.grails:grails-core"
   compile "org.springframework.boot:spring-boot-starter-actuator"
-  compile "org.springframework.boot:spring-boot-starter-tomcat"
+  providedRuntime "org.springframework.boot:spring-boot-starter-tomcat"
   compile "org.grails:grails-web-boot"
   compile "org.grails:grails-logging"
   compile "org.grails:grails-plugin-rest"

--- a/labs/docker/Makefile
+++ b/labs/docker/Makefile
@@ -42,7 +42,7 @@ image:
 	fi
 
 release:
-	make image DIR=$(BUILD_DIR_BASE)/labs/docker/sbt IMAGE_NAME=sbt IMAGE_TAG=0.13.8 BUILD_IMAGE=1
+	make image DIR=$(BUILD_DIR_BASE)/labs/docker/sbt IMAGE_NAME=sbt IMAGE_TAG=1.3.8 BUILD_IMAGE=1
 	make image DIR=$(BUILD_DIR_BASE)/bbb-common-message IMAGE_NAME=bbb-common-message BUILD_ARGS="--build-arg COMMON_VERSION=0.0.1-SNAPSHOT" BUILD_IMAGE=1
 	make image DIR=$(BUILD_DIR_BASE)/bbb-common-web IMAGE_NAME=bbb-common-web BUILD_ARGS="--build-arg COMMON_VERSION=0.0.1-SNAPSHOT" BUILD_IMAGE=1
 	make image DIR=$(BUILD_DIR_BASE)/bbb-fsesl-client IMAGE_NAME=bbb-fsesl-client BUILD_ARGS="--build-arg COMMON_VERSION=0.0.1-SNAPSHOT" BUILD_IMAGE=1

--- a/labs/docker/Makefile
+++ b/labs/docker/Makefile
@@ -41,7 +41,12 @@ image:
 		fi \
 	fi
 
-release:
+webrtc-sfu:
+	if [ ! -d $(BUILD_DIR_BASE)/labs/bbb-webrtc-sfu ]; then \
+		git clone https://github.com/bigbluebutton/bbb-webrtc-sfu $(BUILD_DIR_BASE)/labs/bbb-webrtc-sfu; \
+	fi
+
+release: webrtc-sfu
 	make image DIR=$(BUILD_DIR_BASE)/labs/docker/sbt IMAGE_NAME=sbt IMAGE_TAG=1.3.8 BUILD_IMAGE=1
 	make image DIR=$(BUILD_DIR_BASE)/bbb-common-message IMAGE_NAME=bbb-common-message BUILD_ARGS="--build-arg COMMON_VERSION=0.0.1-SNAPSHOT" BUILD_IMAGE=1
 	make image DIR=$(BUILD_DIR_BASE)/bbb-common-web IMAGE_NAME=bbb-common-web BUILD_ARGS="--build-arg COMMON_VERSION=0.0.1-SNAPSHOT" BUILD_IMAGE=1

--- a/labs/docker/docker-compose.yml
+++ b/labs/docker/docker-compose.yml
@@ -4,10 +4,18 @@ services:
   mongo:
     image: mongo:3.4
     restart: unless-stopped
+    networks:
+      - default
+    labels:
+      - "traefik.enable=false"
 
   redis:
     image: redis
     restart: unless-stopped
+    networks:
+      - default
+    labels:
+      - "traefik.enable=false"
 
   bbb-html5:
     image: ${TAG_PREFIX}bbb-html5${TAG_SUFFIX}
@@ -17,12 +25,21 @@ services:
       - redis
     environment:
       MONGO_URL: mongodb://mongo/bbbhtml5
-      METEOR_SETTINGS_MODIFIER: ".public.kurento.wsUrl = \"wss://${SERVER_DOMAIN}/bbb-webrtc-sfu\" | .public.kurento.enableVideo = true | .public.kurento.enableScreensharing = true | .public.kurento.chromeDefaultExtensionKey = \"${SCREENSHARE_EXTENSION_KEY}\" | .public.kurento.chromeDefaultExtensionLink = \"${SCREENSHARE_EXTENSION_LINK}\" | .public.kurento.enableVideoStats = true | .public.kurento.enableListenOnly = true"
       REDIS_HOST: redis
       ROOT_URL: http://127.0.0.1/html5client
+      KURENTO_WSURL: wss://${server_domain}/bbb-webrtc-sfu
+      SCREENSHARE_EXTENSION_LINK: ${SCREENSHARE_EXTENSION_LINK}
+      SCREENSHARE_EXTENSION_KEY: ${SCREENSHARE_EXTENSION_KEY}
+    networks:
+      - traefik
+      - default
     labels:
+      - "traefik.enable=true"
       - "traefik.backend=bbb-html5"
       - "traefik.frontend.rule=PathPrefix: /html5client,/_timesync"
+      - "traefik.port=3000"
+      - "traefik.protocol=http"
+      - "traefik.docker.network=traefik"
 
   bbb-webhooks:
     image: ${TAG_PREFIX}bbb-webhooks${TAG_SUFFIX}
@@ -34,9 +51,16 @@ services:
       SHARED_SECRET: ${SHARED_SECRET}
       BEARER_AUTH: 1
       SERVER_DOMAIN: ${SERVER_DOMAIN}
+    networks:
+      - traefik
+      - default
     labels:
+      - "traefik.enable=true"
       - "traefik.backend=bbb-webhooks"
       - "traefik.frontend.rule=PathPrefix: /bigbluebutton/api/hooks"
+      - "traefik.port=3005"
+      - "traefik.protocol=http"
+      - "traefik.docker.network=traefik"
 
   bbb-freeswitch:
     image: ${TAG_PREFIX}bbb-freeswitch${TAG_SUFFIX}
@@ -45,6 +69,10 @@ services:
       - coturn
     volumes:
       - media-audio:/var/freeswitch/meetings
+    networks:
+      - default
+    labels:
+      - "traefik.enable=false"
 
   bbb-webrtc-sfu:
     image: ${TAG_PREFIX}bbb-webrtc-sfu${TAG_SUFFIX}
@@ -54,14 +82,22 @@ services:
       - kurento
       - bbb-freeswitch
     environment:
-      KURENTO_NAME: kurento
-      KURENTO_URL: ws://kurento:8888/kurento
+      KURENTO: "[{\"url\": \"ws://kurento:8888/kurento\"}]"
       REDIS_HOST: redis
-      FREESWITCH_IP: bbb-freeswitch
+      FREESWITCH_CONN_IP: bbb-freeswitch
+      ESL_IP: bbb-freeswitch
+      FREESWITCH_SIP_IP: bbb-freeswitch
       LOG_LEVEL: debug
+    networks:
+      - traefik
+      - default
     labels:
+      - "traefik.enable=true"
       - "traefik.backend=bbb-webrtc-sfu"
       - "traefik.frontend.rule=PathPrefix: /bbb-webrtc-sfu"
+      - "traefik.port=3008"
+      - "traefik.protocol=http"
+      - "traefik.docker.network=traefik"
 
   coturn:
     image: ${TAG_PREFIX}bbb-coturn${TAG_SUFFIX}
@@ -73,8 +109,12 @@ services:
       ENABLE_REST_API: 1
       PORT: 3478
     ports:
-      - 3478:3478/udp
-      - 3478:3478/tcp
+      - ${EXTERNAL_IP}:3478:3478/udp
+      - ${EXTERNAL_IP}:3478:3478/tcp
+    networks:
+      - default
+    labels:
+      - "traefik.enable=false"
 
   kurento:
     image: ${TAG_PREFIX}bbb-kurento${TAG_SUFFIX}
@@ -85,6 +125,11 @@ services:
     environment:
       STUN_IP: ${EXTERNAL_IP}
       STUN_PORT: 3478
+      TURN_URL: "${EXTERNAL_IP}:3478"
+    networks:
+      - default
+    labels:
+      - "traefik.enable=false"
 
   bbb-apps-akka:
     image: ${TAG_PREFIX}bbb-apps-akka${TAG_SUFFIX}
@@ -93,6 +138,10 @@ services:
       - redis
     environment:
       JAVA_OPTS: -Dredis.host=redis
+    networks:
+      - default
+    labels:
+      - "traefik.enable=false"
 
   bbb-fsesl-akka:
     image: ${TAG_PREFIX}bbb-fsesl-akka${TAG_SUFFIX}
@@ -103,6 +152,10 @@ services:
     command: ["wait-for-it.sh", "bbb-freeswitch:8021", "--timeout=60", "--strict", "--", "/usr/share/bbb-fsesl-akka/bin/bbb-fsesl-akka"]
     environment:
       JAVA_OPTS: -Dredis.host=redis -Dfreeswitch.esl.host=bbb-freeswitch
+    networks:
+      - default
+    labels:
+      - "traefik.enable=false"
 
   bbb-web:
     image: ${TAG_PREFIX}bbb-web${TAG_SUFFIX}
@@ -116,9 +169,16 @@ services:
       SHARED_SECRET: ${SHARED_SECRET}
       TURN_DOMAIN: ${SERVER_DOMAIN}
       TURN_SECRET: ${COTURN_REST_SECRET}
+    networks:
+      - traefik
+      - default
     labels:
+      - "traefik.enable=true"
       - "traefik.backend=bbb-web"
       - "traefik.frontend.rule=PathPrefix: /bigbluebutton"
+      - "traefik.port=8080"
+      - "traefik.protocol=http"
+      - "traefik.docker.network=traefik"
 
   bbb-greenlight:
     image: bigbluebutton/greenlight:v2
@@ -131,9 +191,16 @@ services:
       BIGBLUEBUTTON_SECRET: ${SHARED_SECRET}
       SECRET_KEY_BASE: ${SECRET_KEY_BASE}
       ALLOW_GREENLIGHT_ACCOUNTS: "true"
+    networks:
+      - traefik
+      - default
     labels:
+      - "traefik.enable=true"
       - "traefik.backend=bbb-greenlight"
       - "traefik.frontend.rule=PathPrefix: /b"
+      - "traefik.port=80"
+      - "traefik.protocol=http"
+      - "traefik.docker.network=traefik"
 
   # when we're able to setup traefik properly for wss, nginx is no longer needed
   nginx:
@@ -143,9 +210,16 @@ services:
       - bbb-freeswitch
     environment:
       SERVER_DOMAIN: ${SERVER_DOMAIN}
+    networks:
+      - traefik
+      - default
     labels:
+      - "traefik.enable=true"
       - "traefik.backend=bbb-freeswitch"
       - "traefik.frontend.rule=PathPrefix: /ws"
+      - "traefik.port=80"
+      - "traefik.protocol=http"
+      - "traefik.docker.network=traefik"
 
   traefik:
     image: traefik
@@ -156,6 +230,7 @@ services:
       - 443:443
     command: traefik
       - --docker
+      - --docker.network=traefik
       - --logLevel=INFO
       - --acme
       - --acme.httpchallenge
@@ -171,6 +246,12 @@ services:
     volumes:
       - traefik-acme:/etc/traefik/acme/
       - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - traefik
+
+networks:
+  traefik:
+  default:
 
 volumes:
   traefik-acme:

--- a/labs/docker/sbt/Dockerfile
+++ b/labs/docker/sbt/Dockerfile
@@ -1,6 +1,6 @@
-FROM openjdk:8
+FROM openjdk:8-jdk
 
-ARG SBT_VERSION=0.13.8
+ARG SBT_VERSION=1.3.8
 
 RUN curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb \
  && dpkg -i sbt-$SBT_VERSION.deb \
@@ -9,6 +9,6 @@ RUN curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_V
  && apt-get install sbt \
  && sbt sbtVersion
 
-RUN echo 'resolvers += "Artima Maven Repository" at "http://repo.artima.com/releases"' | tee -a ~/.sbt/0.13/global.sbt
+RUN echo 'resolvers += "Artima Maven Repository" at "http://repo.artima.com/releases"' | tee -a ~/.sbt/1.0/global.sbt
 
 WORKDIR /root


### PR DESCRIPTION
This pull request contains various small fixes to get the docker-compose setup working. The individual fixes are as follows.

bbb-common-message, labs/docker/sbt : 
  - SBT version updated from 0.13.8 to 1.3.8

akka-bbb-apps, akka-bbb-fsesl, bbb-common-web, bbb-fsesl-client : 
  -  As the scala dependencies have been moved from build.sbt to Dependencies.scala / Dependencies.sbt in the develop branch, the dockerfiles are adjusted to reflect this change.

akka-bbb-apps, akka-bbb-fsesl, 
 - The base for the docker images is changed from openjdk to ubuntu. The latest versions of openjdk directly copy the jdk runtimes into the image and no longer install a .deb image containing the jdk/jre. Consequently installing the akka-bbb-* deb packages will fail for the openjdk image als the dependency on jre cannot be resolved.
 - The working directory for the started service is set, so that the service will find the configuration files in their default locations.

bbb-lti:
  - grails version downloaded in Dockerfile is synchronized with the one used in by gradle.
  - Location of the configuration file was changed in develop branch from ` grails-app/controllers/org/bigbluebutton/ToolController.groovy` to ` grails-app/controllers/org/bigbluebutton/lti/controllers/ToolController.groovy`. This change is reflected in the dockerfile.
  - Location of build output was changed in gradle build. The Dockerfile is adjusted accordingly.

bbb-html5:
  - Updated node version for build from 8 to 12.
  - As the configuration file was changed in the develop branch from `programs/server/assets/app/config/settings-production.json` to `programs/server/assets/app/config/settings.yml`. The Dockerfile and the entrypoint of the image is adjusted to reflect this change. instead of jq, the docker images uses yq to alter the configuration on startup according to the environment variables.

bigbluebutton-web:
  - Synchronized grails version with the one used by gradle build.
  - Updated gradle version used in Dockerfile from 2.12 to 3.5.
  - Updated location of build output in Dockerfile.
  - Remove tomcat dependencies from build output. Tomcat provides these dependencies and therefore registering handlers containing them causes errors due to duplicate defintions.
 - Location of configuration file was changed in develop branch from  `webapps/bigbluebutton/WEB-INF/spring/turn-stun-servers.xml` to `webapps/bigbluebutton/WEB-INF/classes/spring/turn-stun-servers.xml`. The Dockerfile is adjusted accordingly

labs/docker:
 - As bbb-webrtc-sfu was extracted to its own repository, the Makefile was adjusted to clone the repo before build the corresponding container.
 - docker-compose file was updated:
      - Specify port numbers of container to be accessible using traefik.
      - Specify network to be used by traefik.
      - bbb-html5 environment variables update to reflect changes of the configuration file format used by the image.
      -  coturn: Expose TURN port.
