### PR TITLE
add missing bbb-restart-kms script which was added to 2.2.3 but is missing in the repo

### DIFF
--- a/bigbluebutton-config/cron.hourly/bbb-restart-kms
+++ b/bigbluebutton-config/cron.hourly/bbb-restart-kms
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#
+# Restart Kurento every 24+ hours
+#
+
+if [ ! -f /var/tmp/bbb-kms-last-restart.txt ]; then
+  date +%Y-%m-%d\ %H:%M:%S > /var/tmp/bbb-kms-last-restart.txt
+  exit
+fi
+
+users=$(mongo --quiet mongodb://127.0.1.1:27017/meteor --eval "db.users.count({connectionStatus: 'online'})")
+
+if [ "$users" -eq 0 ]; then
+
+  # Make sure 24 hours have passed since last restart
+
+  # Seconds since epoch for last restart
+  dt1=$(cat /var/tmp/bbb-kms-last-restart.txt)
+  t1=`date --date="$dt1" +%s`
+
+  # Current seconds since epoch
+  dt2=`date +%Y-%m-%d\ %H:%M:%S`
+  t2=`date --date="$dt2" +%s`
+
+  # Hours since last restart
+  let "tDiff=$t2-$t1"
+  let "hDiff=$tDiff/3600"
+
+  if [ "$hDiff" -ge 24 ]; then
+    systemctl restart kurento-media-server bbb-webrtc-sfu
+    date +%Y-%m-%d\ %H:%M:%S > /var/tmp/bbb-kms-last-restart.txt
+  fi
+fi
+


### PR DESCRIPTION
### What does this PR do?
This pull request adds the `bbb-restart-kms` script, which was added to the bbb 2.2.3 release, but never got added to the code repository.
resolves #9048

### Additional Notes
The `/etc/cron.hourly/bbb-restart-kms` script restarts kurento-media-server and bbb-webrtc-sfu every 24 hours if there are currently no bbb users online / actively using the system. This was added to the ubuntu install package with version 2.2.3 and probably is a workaround for memory leaks or similar issues.
This file might be missing the +x file flag so it can be executed on linux based systems.