### PR TITLE
fixes shortcut help on mac browsers

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
@@ -91,10 +91,13 @@ const CHAT_ENABLED = CHAT_CONFIG.enabled;
 
 const ShortcutHelpComponent = (props) => {
   const { intl, shortcuts } = props;
-  const { name } = browser();
+  const { name, os } = browser();
 
   let accessMod = null;
 
+  // different browsers use different access modifier keys
+  // on different systems when using accessKey property.
+  // Overview how different browsers behave: https://www.w3schools.com/jsref/prop_html_accesskey.asp
   switch (name) {
     case 'chrome':
     case 'edge':
@@ -110,6 +113,11 @@ const ShortcutHelpComponent = (props) => {
       break;
     default:
       break;
+  }
+
+  // all Browsers on MacOS are using Control + Option as access modifier
+  if (os.includes('OS X 10')) {
+    accessMod = 'Control + Option';
   }
 
   const shortcutItems = shortcuts.map((shortcut) => {


### PR DESCRIPTION
Browsers on MacOS are using differen modifier keys for shortcuts. (Table https://www.w3schools.com/jsref/prop_html_accesskey.asp)
This PR is adding the correct keys to the Shortcut help menu in html5 client.