### PR TITLE
Reduce "Connecting to Echotest" waiting time by 4 seconds

### DIFF
--- a/bigbluebutton-html5/public/compatibility/sip.js
+++ b/bigbluebutton-html5/public/compatibility/sip.js
@@ -9550,7 +9550,7 @@ UA.prototype.loadConfig = function(configuration) {
       userAgentString: SIP.C.USER_AGENT,
 
       // Session parameters
-      iceCheckingTimeout: 5000,
+      iceCheckingTimeout: 1000,
       noAnswerTimeout: 60,
       stunServers: ['stun:stun.l.google.com:19302'],
       turnServers: [],


### PR DESCRIPTION
### What does this PR do?
Change `iceCheckingTimeout` from 5 seconds to 1 second in `/usr/share/meteor/bundle/programs/web.browser/app/compatibility/sip.js`

### Additional Notes
One of the most annoying things about breakout rooms is that the users have to do the echo test again. So they have to wait 7 to 12 seconds again every time (for typical bbb configurations) just for the echo test to connect. This PR reduces the iceCheckingTimeout from 5 seconds to 1 second, which is still way more than enough for finding candidates to connect to the freeswitch server unless there is a configuration or network load issue. Depending on network of the used client, this change saves the user between 4 to 8 seconds for every time they activate audio playback or microphone.
The original 5 seconds timeout is a default of the official sip.js library and was added in #2877 to the bbb-custom sip.js . Documentation for this parameter in sip.js: 
http://sipjs.com/api/0.7.0/ua_configuration_parameters/#icecheckingtimeout
This change was successfully tested with a group of 20 different users on different configurations on different networks in Germany on a couple of private bbb default installs and also on a .rna1_blindsidenetworks_com instance.