### PR TITLE
Clarify german document upload prompt

### DIFF
--- a/bigbluebutton-html5/private/locales/de.json
+++ b/bigbluebutton-html5/private/locales/de.json
@@ -165,7 +165,7 @@
     "app.presentationUploder.dropzoneImagesLabel": "Bilder hier hinziehen, um sie hochzuladen",
     "app.presentationUploder.browseFilesLabel": "oder nach Dateien suchen",
     "app.presentationUploder.browseImagesLabel": "oder nach Bildern suchen/aufnehmen",
-    "app.presentationUploder.fileToUpload": "Wird hochgeladen...",
+    "app.presentationUploder.fileToUpload": "Bereit zum Hochladen...",
     "app.presentationUploder.currentBadge": "Aktuell",
     "app.presentationUploder.rejectedError": "Die ausgewählten Dateien wurden zurückgewiesen. Bitte prüfen Sie die zulässigen Dateitypen.",
     "app.presentationUploder.upload.progress": "Hochladen ({0}%)",


### PR DESCRIPTION
This clarifies that a file has been _selected_ for upload, but is _not_ currently being uploaded as the former translation would suggest. Fixes #9093, thanks to @Sea444 for pointing out that this was not a quirk to work around (as I had done before) but a serious UX issue that needs fixing.