### PR TITLE
Set content-type for presentation download

### DIFF
--- a/bigbluebutton-web/grails-app/conf/application.groovy
+++ b/bigbluebutton-web/grails-app/conf/application.groovy
@@ -29,7 +29,11 @@ grails.mime.types = [
     rss:           'application/rss+xml',
     text:          'text/plain',
     hal:           ['application/hal+json','application/hal+xml'],
-    xml:           ['text/xml', 'application/xml']
+    xml:           ['text/xml', 'application/xml'],
+    png:           'image/png',
+    jpg:           'image/jpg',
+    jpeg:          'image/jpg',
+    gif:           'image/gif'
 ]
 
 // URL Mapping Cache Max Size, defaults to 5000

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/PresentationController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/PresentationController.groovy
@@ -19,6 +19,7 @@
 package org.bigbluebutton.web.controllers
 
 import grails.converters.*
+import org.grails.web.mime.DefaultMimeUtility
 import org.bigbluebutton.api.ParamsProcessorUtil;
 
 import java.nio.charset.StandardCharsets
@@ -33,6 +34,7 @@ class PresentationController {
   MeetingService meetingService
   PresentationService presentationService
   ParamsProcessorUtil paramsProcessorUtil
+  DefaultMimeUtility grailsMimeUtility
 
   def index = {
     render(view: 'upload-file')
@@ -300,6 +302,10 @@ class PresentationController {
 
         def bytes = pres.readBytes()
         def responseName = pres.getName();
+        def mimeType = grailsMimeUtility.getMimeTypeForURI(responseName)
+        def mimeName = mimeType != null ? mimeType.name : 'application/octet-stream'
+
+        response.contentType = mimeName
         response.addHeader("content-disposition", "filename=" + URLEncoder.encode(responseName, StandardCharsets.UTF_8.name()))
         response.addHeader("Cache-Control", "no-cache")
         response.outputStream << bytes;


### PR DESCRIPTION
This is a fix for presentation download vulnerabilities.
If js file is uploaded with image file extension, it is executed when downloaded.

How to reproduce:
1. upload js file with filename like 'xxx.png'
2. turn it downloadable
3. download it

-> browser executes javascript.

Please feel free to edit this.

Cheers,
Mitsu