### PR TITLE
Added "-p" to pass additional browser parameters

### DIFF
--- a/bigbluebutton-client/resources/prod/profiles.xml
+++ b/bigbluebutton-client/resources/prod/profiles.xml
@@ -4,6 +4,7 @@
         <locale>
             <en_US>Low quality</en_US>
             <pt_BR>Baixa qualidade</pt_BR>
+            <ru_RU>Низкое качество</ru_RU>
         </locale>
         <width>160</width>
         <height>120</height>
@@ -19,6 +20,7 @@
         <locale>
             <en_US>Medium quality</en_US>
             <pt_BR>Média qualidade</pt_BR>
+            <ru_RU>Среднее качество</ru_RU>
         </locale>
         <width>320</width>
         <height>240</height>
@@ -34,6 +36,7 @@
         <locale>
             <en_US>High quality</en_US>
             <pt_BR>Alta qualidade</pt_BR>
+            <ru_RU>Высокое качество</ru_RU>
         </locale>
         <width>640</width>
         <height>480</height>
@@ -49,6 +52,7 @@
         <locale>
             <en_US>Widescreen</en_US>
             <pt_BR>Panorâmico</pt_BR>
+            <ru_RU>Широкоэкранный</ru_RU>
         </locale>
         <width>1280</width>
         <height>720</height>
@@ -64,6 +68,7 @@
         <locale>
             <en_US>Low Latency</en_US>
             <pt_BR>Baixa Latência</pt_BR>
+            <ru_RU>Низкая задержка</ru_RU>
         </locale>
         <width>640</width>
         <height>480</height>

--- a/labs/stress-testing/bbb-test
+++ b/labs/stress-testing/bbb-test
@@ -46,6 +46,7 @@ while [ -n "$1" ]; do
                 --h|-h) shift; HOST="$1" ;;
                 --n|-n) shift; NUMBER="$1" ;;
                 --b|-b) shift; BROWSER="$1" ;;
+		--p|-p) shift; BROWSER_PARAM="$1" ;;
                 --m|-m) shift; NEWOBJ="$1" ;;
                 --s|-s) shift; SLEEP="$1" ;;
                 *)		echo "$0: Unrecognized option: $1" >&2; exit 1 ;;
@@ -63,6 +64,7 @@ if [ -z "$HOST" ] || [ -z "$NUMBER" ]; then
         echo "   -h remote_bigbluebutton_host"
         echo "   -n number_of_clients"
         echo "   -b web_browser_command (optional, Firefox and Chromium/Chrome are supported, Firefox is default)"
+	echo "   -p web_browser parameters (optional, example -P test1-profile)"
         echo "   -m tab|window (Open new tabs or new windows in the browser, default is tabs)"
         echo "   -s Sleep time in seconds between opening new connections, default is 5"
         echo
@@ -89,7 +91,7 @@ SLEEP="${SLEEP:-5}"
 
 case "$BROWSER" in
 	firefox*|newmoon*|palemoon* )
-		BROWSER_ARGS="-new-${NEWOBJ} -url"
+		BROWSER_ARGS="-new-${NEWOBJ} ${BROWSER_PARAM} -url"
 		;;
 	*chrome*|chromium*|opera*|vivaldi*|yandex* )
 		BROWSER_ARGS="--new-${NEWOBJ}"


### PR DESCRIPTION
For example, some times one browser instance can't usable work with more than N tabs, so, with "-p" we can tell bbb_test to open N tabs in other browser instance with custom profile, that configured to use some proxy server, for example.