### PR TITLE
add support for upload of '.jpeg' files (not just '.jpg')

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -215,6 +215,8 @@ public:
       mime: application/vnd.oasis.opendocument.image
     - extension: .jpg
       mime: image/jpeg
+    - extension: .jpeg
+      mime: image/jpeg
     - extension: .png
       mime: image/png
   user:


### PR DESCRIPTION
apply previously merged PR #9025 into v2.2.x-release

------------
### What does this PR do?
This pull request adds `.jpeg` to the supported file extensions list, thus allowing users to upload and use such files as presentation in BigBlueButton.

### Additional Notes
The presentation file upload feature allows users to select files with various file extensions like `.pdf`, `.ppt`, `.jpg` and others. So far, the `/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml` did not include `.jpeg` and thus files with that file ending were not supported.
`.jpg` and `.jpeg` are the same file format. The three letter version is often used because early versions of windows did only allow three letter file endings.