### PR TITLE
customSvgIcon css class bug fixed for rtl layouts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/styles.scss
@@ -232,6 +232,8 @@
   position: absolute;
   width: var(--toolbar-button-width);
   height: var(--toolbar-button-height);
+  left: 0;
+  top: 0;
 }
 
 .textThickness {


### PR DESCRIPTION
in RTL layout, selecting colors and font thickness parts in whiteboard, will not appear correctly when they expand; one item will be thrown out of the container (overflow).
the following images demonstrate the problems.
adding some additional style to customSvgIcon class in css will fix the bug.

http://up.maralhost.com/do.php?img=359
http://up.maralhost.com/do.php?img=364