### PR TITLE
Add Yandex Browser to supported browser list

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/legacy/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/legacy/component.jsx
@@ -68,7 +68,7 @@ addLocaleData([
 const FETCHING = 'fetching';
 const FALLBACK = 'fallback';
 const READY = 'ready';
-const supportedBrowsers = ['chrome', 'firefox', 'safari', 'opera', 'edge'];
+const supportedBrowsers = ['chrome', 'firefox', 'safari', 'opera', 'edge', 'yandex'];
 
 export default class Legacy extends Component {
   constructor(props) {


### PR DESCRIPTION
"Yandex Browser" is the 2nd popular browser in Russia after Chrome.  Today due to coronavirus epidemy a lot of people in Russia use BBB to online work  but can't use YB.