### PR TITLE
 Prevent ejected users from rejoining

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ValidateAuthTokenReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ValidateAuthTokenReqMsgHdlr.scala
@@ -5,7 +5,7 @@ import org.bigbluebutton.core.bus.InternalEventBus
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core.running.{ HandlerHelpers, LiveMeeting, OutMsgRouter }
-import org.bigbluebutton.core2.message.senders.{ MsgBuilder }
+import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
 
 trait ValidateAuthTokenReqMsgHdlr extends HandlerHelpers {
   this: UsersApp =>
@@ -17,33 +17,69 @@ trait ValidateAuthTokenReqMsgHdlr extends HandlerHelpers {
   def handleValidateAuthTokenReqMsg(msg: ValidateAuthTokenReqMsg, state: MeetingState2x): MeetingState2x = {
     log.debug("RECEIVED ValidateAuthTokenReqMsg msg {}", msg)
 
+    var failReason = "Invalid auth token."
+    var failReasonCode = EjectReasonCode.VALIDATE_TOKEN
+
     val regUser = RegisteredUsers.getRegisteredUserWithToken(msg.body.authToken, msg.body.userId,
       liveMeeting.registeredUsers)
 
     regUser match {
       case Some(u) =>
-        if (u.guestStatus == GuestStatus.ALLOW) {
+        // Check if ejected user is rejoining.
+        // Fail validation if ejected user is rejoining.
+        // ralam april 21, 2020
+        if (u.guestStatus == GuestStatus.ALLOW && !u.ejected) {
           userValidated(u, state)
         } else {
-          validateTokenFailed(outGW, meetingId = liveMeeting.props.meetingProp.intId,
-            userId = msg.header.userId, authToken = msg.body.authToken,
-            valid = false, waitForApproval = false, state)
+          if (u.ejected) {
+            failReason = "Ejected user rejoining"
+            failReasonCode = EjectReasonCode.EJECTED_USER_REJOINING
+          }
+          validateTokenFailed(
+            outGW,
+            meetingId = liveMeeting.props.meetingProp.intId,
+            userId = msg.header.userId,
+            authToken = msg.body.authToken,
+            valid = false,
+            waitForApproval = false,
+            failReason,
+            failReasonCode,
+            state
+          )
         }
 
       case None =>
-        validateTokenFailed(outGW, meetingId = liveMeeting.props.meetingProp.intId,
-          userId = msg.header.userId, authToken = msg.body.authToken,
-          valid = false, waitForApproval = false, state)
+        validateTokenFailed(
+          outGW,
+          meetingId = liveMeeting.props.meetingProp.intId,
+          userId = msg.header.userId,
+          authToken = msg.body.authToken,
+          valid = false,
+          waitForApproval = false,
+          failReason,
+          failReasonCode,
+          state
+        )
 
     }
   }
 
-  def validateTokenFailed(outGW: OutMsgRouter, meetingId: String, userId: String, authToken: String,
-                          valid: Boolean, waitForApproval: Boolean, state: MeetingState2x): MeetingState2x = {
+  def validateTokenFailed(
+      outGW:           OutMsgRouter,
+      meetingId:       String,
+      userId:          String,
+      authToken:       String,
+      valid:           Boolean,
+      waitForApproval: Boolean,
+      reason:          String,
+      reasonCode:      String,
+      state:           MeetingState2x
+  ): MeetingState2x = {
     val event = MsgBuilder.buildValidateAuthTokenRespMsg(meetingId, userId, authToken, valid, waitForApproval)
     outGW.send(event)
 
-    UsersApp.ejectUserFromMeeting(outGW, liveMeeting, userId, SystemUser.ID, "Invalid auth token.", EjectReasonCode.VALIDATE_TOKEN)
+    // send a system message to force disconnection
+    Sender.sendDisconnectClientSysMsg(meetingId, userId, SystemUser.ID, reasonCode, outGW)
 
     state
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
@@ -18,6 +18,7 @@ object RegisteredUsers {
       guestStatus,
       System.currentTimeMillis(),
       false,
+      false,
       false
     )
   }
@@ -28,6 +29,14 @@ object RegisteredUsers {
 
   def findWithUserId(id: String, users: RegisteredUsers): Option[RegisteredUser] = {
     users.toVector.find(ru => id == ru.id)
+  }
+
+  def findWithExternUserId(id: String, users: RegisteredUsers): Option[RegisteredUser] = {
+    users.toVector.find(ru => id == ru.externId)
+  }
+
+  def findAllWithExternUserId(id: String, users: RegisteredUsers): Vector[RegisteredUser] = {
+    users.toVector.filter(ru => id == ru.externId)
   }
 
   def findUsersNotJoined(users: RegisteredUsers): Vector[RegisteredUser] = {
@@ -50,11 +59,40 @@ object RegisteredUsers {
   }
 
   def add(users: RegisteredUsers, user: RegisteredUser): Vector[RegisteredUser] = {
-    users.save(user)
+
+    findWithExternUserId(user.externId, users) match {
+      case Some(u) =>
+        if (u.ejected) {
+          // Ejected user is rejoining. Don't add so that validate token
+          // will fail and can't join.
+          // ralam april 21, 2020
+          val ejectedUser = user.copy(ejected = true)
+          users.save(ejectedUser)
+        } else {
+          // If user hasn't been ejected, we allow user to join
+          // as the user might be joining using 2 browsers for
+          // better management of meeting.
+          // ralam april 21, 2020
+          users.save(user)
+        }
+      case None =>
+        users.save(user)
+    }
+
   }
 
   def remove(id: String, users: RegisteredUsers): Option[RegisteredUser] = {
-    users.delete(id)
+    for {
+      ru <- findWithUserId(id, users)
+    } yield {
+      // Set a flag that user has been ejected. We flag the user instead of
+      // removing so we can eject when user tries to rejoin with the same
+      // external userid.
+      // ralam april 21, 2020
+      val u = ru.modify(_.ejected).setTo(true)
+      users.save(u)
+      u
+    }
   }
 
   def setWaitingForApproval(users: RegisteredUsers, user: RegisteredUser,
@@ -115,6 +153,7 @@ case class RegisteredUser(
     guestStatus:        String,
     registeredOn:       Long,
     joined:             Boolean,
-    markAsJoinTimedOut: Boolean
+    markAsJoinTimedOut: Boolean,
+    ejected:            Boolean
 )
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -297,4 +297,5 @@ object EjectReasonCode {
   val SYSTEM_EJECT_USER = "system_requested_eject_reason"
   val VALIDATE_TOKEN = "validate_token_failed_eject_reason"
   val USER_INACTIVITY = "user_inactivity_eject_reason"
+  val EJECTED_USER_REJOINING = "ejected_user_rejoining_reason"
 }


### PR DESCRIPTION
 - track ejected user based on external userid. If user rejoins with the same external
   userid, fail the validate token.