### PR TITLE
Services run as starting PID

### DIFF
--- a/akka-bbb-apps/run-dev.sh
+++ b/akka-bbb-apps/run-dev.sh
@@ -2,5 +2,4 @@
 
 rm -rf src/main/resources
 cp -R src/universal/conf src/main/resources
-sbt run
-
+exec sbt run

--- a/akka-bbb-apps/run.sh
+++ b/akka-bbb-apps/run.sh
@@ -3,4 +3,4 @@
 sbt clean stage
 sudo service bbb-apps-akka stop
 cd target/universal/stage
-./bin/bbb-apps-akka
+exec ./bin/bbb-apps-akka

--- a/akka-bbb-fsesl/run-dev.sh
+++ b/akka-bbb-fsesl/run-dev.sh
@@ -2,5 +2,4 @@
 
 rm -rf src/main/resources
 cp -R src/universal/conf src/main/resources
-sbt run
-
+exec sbt run

--- a/akka-bbb-fsesl/run.sh
+++ b/akka-bbb-fsesl/run.sh
@@ -3,4 +3,4 @@
 sbt clean stage
 sudo service bbb-fsesl-akka stop
 cd target/universal/stage
-./bin/bbb-fsesl-akka
+exec ./bin/bbb-fsesl-akka

--- a/akka-bbb-transcode/run.sh
+++ b/akka-bbb-transcode/run.sh
@@ -3,4 +3,4 @@
 sbt clean stage
 sudo service bbb-transcode-akka stop
 cd target/universal/stage
-./bin/bbb-transcode-akka
+exec ./bin/bbb-transcode-akka

--- a/bbb-lti/docker-entrypoint.sh
+++ b/bbb-lti/docker-entrypoint.sh
@@ -9,5 +9,4 @@ if [ -f webapps/lti.war ]; then
   rm webapps/lti.war
 fi
 
-catalina.sh run
-
+exec catalina.sh run

--- a/bbb-lti/run.sh
+++ b/bbb-lti/run.sh
@@ -2,4 +2,4 @@
 rm -rf libs
 grails clean
 grails compile
-grails prod run-app --port 8181
+exec grails prod run-app --port 8181

--- a/bigbluebutton-html5/docker-entrypoint.sh
+++ b/bigbluebutton-html5/docker-entrypoint.sh
@@ -2,4 +2,4 @@
 
 export METEOR_SETTINGS=` jq "${METEOR_SETTINGS_MODIFIER}" ./programs/server/assets/app/config/settings-production.json `
 
-node main.js
+exec node main.js

--- a/bigbluebutton-web/pres-checker/run.sh
+++ b/bigbluebutton-web/pres-checker/run.sh
@@ -1,1 +1,2 @@
-java -cp "/usr/share/prescheck/lib/*" org.bigbluebutton.prescheck.Main $@
+#!/bin/sh
+exec java -cp "/usr/share/prescheck/lib/*" org.bigbluebutton.prescheck.Main $@

--- a/bigbluebutton-web/run-prod.sh
+++ b/bigbluebutton-web/run-prod.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-java -Dgrails.env=prod -Dserver.port=8090 -Xms384m -Xmx384m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/bigbluebutton/diagnostics -cp WEB-INF/lib/*:/:WEB-INF/classes/:. org.springframework.boot.loader.WarLauncher
-
+exec java -Dgrails.env=prod -Dserver.port=8090 -Xms384m -Xmx384m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/bigbluebutton/diagnostics -cp WEB-INF/lib/*:/:WEB-INF/classes/:. org.springframework.boot.loader.WarLauncher

--- a/bigbluebutton-web/run.sh
+++ b/bigbluebutton-web/run.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-grails prod run-app --port 8090
+exec grails prod run-app --port 8090

--- a/deskshare/applet/scripts/deskshare.sh
+++ b/deskshare/applet/scripts/deskshare.sh
@@ -1,1 +1,2 @@
-java -cp bbb-deskshare-applet-0.9.0.jar org.bigbluebutton.deskshare.client.DeskshareMain $@
+#!/bin/sh
+exec java -cp bbb-deskshare-applet-0.9.0.jar org.bigbluebutton.deskshare.client.DeskshareMain $@

--- a/labs/docker/freeswitch/docker-entrypoint.sh
+++ b/labs/docker/freeswitch/docker-entrypoint.sh
@@ -11,4 +11,4 @@ xmlstarlet edit --inplace --insert '//newsubnode' --type attr --name 'name' --va
 xmlstarlet edit --inplace --insert '//newsubnode' --type attr --name 'value' --value ':7443'  /opt/freeswitch/conf/sip_profiles/external.xml
 xmlstarlet edit --inplace --rename '//newsubnode' --value 'param'  /opt/freeswitch/conf/sip_profiles/external.xml
 
-/opt/freeswitch/bin/freeswitch
+exec /opt/freeswitch/bin/freeswitch


### PR DESCRIPTION
The starting scripts now `exec` the main service instead of starting it as a subprocess, avoiding the need for an (unnecessary) parent shell hanging around. Also in line with docker-entrypoint recommendations.