### PR TITLE
 Keep track of banned dial-in callers

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
@@ -2,7 +2,9 @@ package org.bigbluebutton.core.apps.voice
 
 import org.bigbluebutton.SystemConfiguration
 import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.models.VoiceUsers
 import org.bigbluebutton.core.running.{ LiveMeeting, MeetingActor, OutMsgRouter }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration {
   this: MeetingActor =>
@@ -13,19 +15,29 @@ trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration {
   def handleUserJoinedVoiceConfEvtMsg(msg: UserJoinedVoiceConfEvtMsg): Unit = {
     log.info("Received user joined voice conference " + msg)
 
-    VoiceApp.handleUserJoinedVoiceConfEvtMsg(
-      liveMeeting,
-      outGW,
-      eventBus,
-      msg.body.voiceConf,
-      msg.body.intId,
-      msg.body.voiceUserId,
-      msg.body.callingWith,
-      msg.body.callerIdName,
-      msg.body.callerIdNum,
-      msg.body.muted,
-      msg.body.talking,
-      "freeswitch"
-    )
+    if (VoiceUsers.isCallerBanned(msg.body.callerIdNum, liveMeeting.voiceUsers)) {
+      log.info("Ejecting banned voice user " + msg)
+      val event = MsgBuilder.buildEjectUserFromVoiceConfSysMsg(
+        props.meetingProp.intId,
+        props.voiceProp.voiceConf,
+        msg.body.voiceUserId
+      )
+      outGW.send(event)
+    } else {
+      VoiceApp.handleUserJoinedVoiceConfEvtMsg(
+        liveMeeting,
+        outGW,
+        eventBus,
+        msg.body.voiceConf,
+        msg.body.intId,
+        msg.body.voiceUserId,
+        msg.body.callingWith,
+        msg.body.callerIdName,
+        msg.body.callerIdNum,
+        msg.body.muted,
+        msg.body.talking,
+        "freeswitch"
+      )
+    }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/EjectUserFromVoiceCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/EjectUserFromVoiceCmdMsgHdlr.scala
@@ -23,6 +23,7 @@ trait EjectUserFromVoiceCmdMsgHdlr extends RightsManagementTrait {
         u <- VoiceUsers.findWithIntId(liveMeeting.voiceUsers, msg.body.userId)
       } yield {
         log.info("Ejecting user from voice.  meetingId=" + props.meetingProp.intId + " userId=" + u.intId)
+        VoiceUsers.ban(liveMeeting.voiceUsers, u)
         val event = MsgBuilder.buildEjectUserFromVoiceConfSysMsg(props.meetingProp.intId, props.voiceProp.voiceConf, u.voiceUserId)
         outGW.send(event)
       }


### PR DESCRIPTION
 When a dial-in caller is ejected from the meeting, keep track of the callerid number.
 When the same callerid number rejoins the conference, eject the caller.