### PR TITLE
 Do not ban users ejecting self from meeting

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectUserFromMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectUserFromMeetingCmdMsgHdlr.scala
@@ -34,12 +34,12 @@ trait EjectUserFromMeetingCmdMsgHdlr extends RightsManagementTrait {
       } yield {
         if (registeredUser.externId != ejectedByUser.externId) {
           // Eject users
-          println("****************** User " + ejectedBy + " ejecting user " + userId)
+          //println("****************** User " + ejectedBy + " ejecting user " + userId)
           // User might have joined using multiple browsers.
           // Hunt down all registered users based on extern userid and eject them all.
           // ralam april 21, 2020
           RegisteredUsers.findAllWithExternUserId(registeredUser.externId, liveMeeting.registeredUsers) foreach { ru =>
-            println("****************** User " + ejectedBy + " ejecting other user " + ru.id)
+            //println("****************** User " + ejectedBy + " ejecting other user " + ru.id)
             UsersApp.ejectUserFromMeeting(outGW, liveMeeting, ru.id, ejectedBy, reason, EjectReasonCode.EJECT_USER)
             // send a system message to force disconnection
             Sender.sendDisconnectClientSysMsg(meetingId, ru.id, ejectedBy, EjectReasonCode.EJECT_USER, outGW)
@@ -47,7 +47,7 @@ trait EjectUserFromMeetingCmdMsgHdlr extends RightsManagementTrait {
         } else {
           // User is ejecting self, so just eject this userid not all sessions if joined using multiple
           // browsers. ralam april 23, 2020
-          println("****************** User " + ejectedBy + " ejecting self " + userId)
+          //println("****************** User " + ejectedBy + " ejecting self " + userId)
           UsersApp.ejectUserFromMeeting(outGW, liveMeeting, userId, ejectedBy, reason, EjectReasonCode.EJECT_USER)
           // send a system message to force disconnection
           Sender.sendDisconnectClientSysMsg(meetingId, userId, ejectedBy, EjectReasonCode.EJECT_USER, outGW)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectUserFromMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectUserFromMeetingCmdMsgHdlr.scala
@@ -30,15 +30,29 @@ trait EjectUserFromMeetingCmdMsgHdlr extends RightsManagementTrait {
       val reason = "user ejected by another user"
       for {
         registeredUser <- RegisteredUsers.findWithUserId(userId, liveMeeting.registeredUsers)
+        ejectedByUser <- RegisteredUsers.findWithUserId(ejectedBy, liveMeeting.registeredUsers)
       } yield {
-        // User might have joined using multiple browsers.
-        // Hunt down all registered users based on extern userid and eject them all.
-        // ralam april 21, 2020
-        RegisteredUsers.findAllWithExternUserId(registeredUser.externId, liveMeeting.registeredUsers) foreach { ru =>
-          UsersApp.ejectUserFromMeeting(outGW, liveMeeting, ru.id, ejectedBy, reason, EjectReasonCode.EJECT_USER)
+        if (registeredUser.externId != ejectedByUser.externId) {
+          // Eject users
+          println("****************** User " + ejectedBy + " ejecting user " + userId)
+          // User might have joined using multiple browsers.
+          // Hunt down all registered users based on extern userid and eject them all.
+          // ralam april 21, 2020
+          RegisteredUsers.findAllWithExternUserId(registeredUser.externId, liveMeeting.registeredUsers) foreach { ru =>
+            println("****************** User " + ejectedBy + " ejecting other user " + ru.id)
+            UsersApp.ejectUserFromMeeting(outGW, liveMeeting, ru.id, ejectedBy, reason, EjectReasonCode.EJECT_USER)
+            // send a system message to force disconnection
+            Sender.sendDisconnectClientSysMsg(meetingId, ru.id, ejectedBy, EjectReasonCode.EJECT_USER, outGW)
+          }
+        } else {
+          // User is ejecting self, so just eject this userid not all sessions if joined using multiple
+          // browsers. ralam april 23, 2020
+          println("****************** User " + ejectedBy + " ejecting self " + userId)
+          UsersApp.ejectUserFromMeeting(outGW, liveMeeting, userId, ejectedBy, reason, EjectReasonCode.EJECT_USER)
           // send a system message to force disconnection
-          Sender.sendDisconnectClientSysMsg(meetingId, ru.id, ejectedBy, EjectReasonCode.EJECT_USER, outGW)
+          Sender.sendDisconnectClientSysMsg(meetingId, userId, ejectedBy, EjectReasonCode.EJECT_USER, outGW)
         }
+
       }
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
@@ -93,7 +93,7 @@ object UsersApp {
 
     for {
       user <- Users2x.ejectFromMeeting(liveMeeting.users2x, userId)
-      reguser <- RegisteredUsers.remove(userId, liveMeeting.registeredUsers)
+      reguser <- RegisteredUsers.eject(userId, liveMeeting.registeredUsers, ejectedBy)
     } yield {
       sendUserEjectedMessageToClient(outGW, meetingId, userId, ejectedBy, reason, reasonCode)
       sendUserLeftMeetingToAllClients(outGW, meetingId, userId)


### PR DESCRIPTION
 Some users join with multiple browsers. When user is ejecting self from one browser,
 do not eject all sessions for that user and do not prevent them from rejoining.