### PR TITLE
Send browser UA string in SIP UA, also add BBB server and client version

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -47,6 +47,8 @@ const DEFAULT_OUTPUT_DEVICE_ID = 'default';
 
 const INPUT_DEVICE_ID_KEY = 'audioInputDeviceId';
 const OUTPUT_DEVICE_ID_KEY = 'audioOutputDeviceId';
+const UA_SERVER_VERSION = Meteor.settings.public.app.bbbServerVersion;
+const UA_CLIENT_VERSION = Meteor.settings.public.app.html5ClientBuild;
 
 const getAudioSessionNumber = () => {
   let currItem = parseInt(sessionStorage.getItem(AUDIO_SESSION_NUM_KEY), 10);
@@ -481,7 +483,7 @@ class SIPSession {
         },
         displayName: callerIdName,
         register: false,
-        userAgentString: 'BigBlueButton',
+        userAgentString: `BigBlueButton/${UA_SERVER_VERSION} (HTML5, rv:${UA_CLIENT_VERSION}) ${window.navigator.userAgent}`,
         hackViaWs: SIPJS_HACK_VIA_WS,
       });
 


### PR DESCRIPTION
When troubleshooting audio issues it is often useful to know which devices and browsers users are actually connecting with. This PR adds the browser user agent as well as BBB server and HTML5 client versions to the SIP user agent string. Refs: #7007