### PR TITLE
Add startClosed chat option

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -83,7 +83,7 @@ class Base extends Component {
 
     if (getFromUserSettings('bbb_show_participants_on_login', true) && !deviceInfo.type().isPhone) {
       Session.set('openPanel', 'userlist');
-      if (CHAT_ENABLED) {
+      if (CHAT_ENABLED && !Meteor.settings.public.chat.startClosed) {
         Session.set('openPanel', 'chat');
         Session.set('idChatOpen', PUBLIC_CHAT_ID);
       }

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -141,6 +141,7 @@ public:
     time: 5000
   chat:
     enabled: true
+    startClosed: false
     min_message_length: 1
     max_message_length: 5000
     grouping_messages_window: 10000


### PR DESCRIPTION
This PR adds the option `app.chat.startClosed`.

I have chosen `startClosed` because it is upgrade save.  
The check is `!startClosed`. This means if it is not there it is open as before.

Relates to #8689