### PR TITLE
 Do not send disconnect message

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ValidateAuthTokenReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ValidateAuthTokenReqMsgHdlr.scala
@@ -79,7 +79,8 @@ trait ValidateAuthTokenReqMsgHdlr extends HandlerHelpers {
     outGW.send(event)
 
     // send a system message to force disconnection
-    Sender.sendDisconnectClientSysMsg(meetingId, userId, SystemUser.ID, reasonCode, outGW)
+    // Comment out as meteor will disconnect the client. Requested by Tiago (ralam apr 28, 2020)
+    //Sender.sendDisconnectClientSysMsg(meetingId, userId, SystemUser.ID, reasonCode, outGW)
 
     state
   }


### PR DESCRIPTION
 Do not send disconnect message when validate token fails as meteor will disconnect the client itself.