### PR TITLE
Fix note id length

### DIFF
--- a/record-and-playback/core/lib/recordandplayback.rb
+++ b/record-and-playback/core/lib/recordandplayback.rb
@@ -36,6 +36,7 @@ require 'logger'
 require 'find'
 require 'rubygems'
 require 'net/http'
+require 'fnv'
 
 module BigBlueButton
   class MissingDirectoryException < RuntimeError
@@ -233,6 +234,11 @@ module BigBlueButton
 
   def self.record_id_to_timestamp(r)
     r.split("-")[1].to_i / 1000
+  end
+
+  # Notes id will be an 8-sized hash string based on the meeting id
+  def self.get_notes_id(meeting_id)
+    FNV.new.fnv1a_32(meeting_id).to_s(16).rjust(8, '0')
   end
 
   def self.done_to_timestamp(r)

--- a/record-and-playback/core/scripts/archive/archive.rb
+++ b/record-and-playback/core/scripts/archive/archive.rb
@@ -21,7 +21,6 @@ require '../lib/recordandplayback'
 require 'logger'
 require 'trollop'
 require 'yaml'
-require 'fnv'
 
 AUDIO_ARCHIVE_FORMAT = {
   extension: 'opus',
@@ -50,7 +49,7 @@ def archive_notes(meeting_id, notes_endpoint, notes_formats, raw_archive_dir)
   BigBlueButton.logger.info("Archiving notes for #{meeting_id}")
   notes_dir = "#{raw_archive_dir}/#{meeting_id}/notes"
   FileUtils.mkdir_p(notes_dir)
-  notes_id = FNV.new.fnv1a_32(meeting_id).to_s(16)
+  notes_id = BigBlueButton.get_notes_id(meeting_id)
 
   tmp_note = "#{notes_dir}/tmp_note.txt"
   BigBlueButton.try_download("#{notes_endpoint}/#{notes_id}/export/txt", tmp_note)


### PR DESCRIPTION
RaP can generate smaller notes id when there should be zeros at start of it. It wasn't possible to retrieve notes in those cases with Etherpad responding 404's.