### PR TITLE
Updating properties file - Issue 1961

### DIFF
--- a/bigbluebutton-web/README.md
+++ b/bigbluebutton-web/README.md
@@ -38,7 +38,7 @@ Build and run `bbb-web`
 cd bigbluebutton/bigbluebutton-web
 
 # Make sure you don't have old libs lying around. Might cause issues.
-# You need to to this only once to cleanup lib dir.
+# You need to do this only once to cleanup lib dir.
 
 rm lib/*
 

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -23,6 +23,10 @@
 appLogLevel=DEBUG
 
 #----------------------------------------------------
+# Recordings publication setting
+autoPublish=true
+
+#----------------------------------------------------
 # Directory where BigBlueButton stores uploaded slides
 presentationDir=/var/bigbluebutton
 


### PR DESCRIPTION
Fixing #1961 
Updates the properties [file](https://github.com/bigbluebutton/bigbluebutton/blob/4f786f7f033d708fdd3f8d21ed44e3f7acfd4739/bigbluebutton-web/grails-app/conf/bigbluebutton.properties) as per the issue.
Also fixes a typo in the [readme ](https://github.com/bigbluebutton/bigbluebutton/blob/4f786f7f033d708fdd3f8d21ed44e3f7acfd4739/bigbluebutton-web/README.md)file replacing 'to to' by 'to do'.