### PR TITLE
Include Meteor connection ID in logs from client

### DIFF
--- a/bigbluebutton-html5/imports/api/log-client/server/methods/logClient.js
+++ b/bigbluebutton-html5/imports/api/log-client/server/methods/logClient.js
@@ -2,11 +2,12 @@ import Logger from '/imports/startup/server/logger';
 import Users from '/imports/api/users';
 
 const logClient = function (type, logDescription, logCode = 'was_not_provided', extraInfo = {}, userInfo = {}) {
-  const SERVER_CONN_ID = this.connection.id;
-  const User = Users.findOne({ connectionId: SERVER_CONN_ID });
+  const connectionId = this.connection.id;
+  const User = Users.findOne({ connectionId });
   const logContents = {
     logCode,
     logDescription,
+    connectionId,
     extraInfo,
     userInfo,
   };

--- a/bigbluebutton-html5/imports/startup/client/logger.js
+++ b/bigbluebutton-html5/imports/startup/client/logger.js
@@ -36,6 +36,7 @@ class ServerLoggerStream extends ServerStream {
       this.rec.userInfo = fullInfo;
     }
     this.rec.clientBuild = Meteor.settings.public.app.html5ClientBuild;
+    this.rec.connectionId = Meteor.connection._lastSessionId;
     if (this.logTagString) {
       this.rec.logTag = this.logTagString;
     }


### PR DESCRIPTION
Included a new field `connectionId` in logs coming from either client side to Meteor or to nginx endpoint

```
{
"name":"clientLogger",
"level":50,
"logCode":"startup_client_usercouldnotlogin_error",
"levelName":"error",
"msg":"User could not log in HTML5, hit 401",
"time":"2020-04-30T20:41:24.214Z",
"src":"Base.renderByState (https://anton.blindside-dev.com/html5client/app/app.js?hash=9d542d25f0f76711c78d446055acfe1b5f509dff:59121:16)",
"v":1,
"clientBuild":"HTML5_CLIENT_VERSION",
"connectionId":"9E3GpGGLtp6ZFQzPb",
"url":"https://anton-local.blindside-dev.com/html5client/join?sessionToken=xcpeu65pdcemyxpu11",
"userAgent":"...",
"count":2
},
```

