### PR TITLE
Prevent multiple users displaying as selected in user list

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/styles.scss
@@ -87,6 +87,7 @@
   @include highContrastOutline();
   outline-style: solid;
   background-color: var(--list-item-bg-hover);
+  box-shadow: inset 0 0 0 var(--border-size) var(--item-focus-border), inset 1px 0 0 1px var(--item-focus-border);
 
   &:focus {
     outline-style: solid;
@@ -95,7 +96,7 @@
 }
 
 .userListItem {
-  @extend %list-item;
+  //@extend %list-item;
   flex-flow: column;
   flex-shrink: 0;
 }


### PR DESCRIPTION
This PR fixes an issue when selecting multiple users in the user list with a mouse it was causing previously selected users to remain highlighted.

There was a conflict with the styles, the keyboard navigation styling still needs adjusting.