### PR TITLE
Set correct state in user list for selected user onClick

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
@@ -57,6 +57,7 @@ class UserParticipants extends Component {
     this.rove = this.rove.bind(this);
     this.changeState = this.changeState.bind(this);
     this.getUsers = this.getUsers.bind(this);
+    this.handleClickSelectedUser = this.handleClickSelectedUser.bind(this);
   }
 
   componentDidMount() {
@@ -65,6 +66,11 @@ class UserParticipants extends Component {
       this.refScrollContainer.addEventListener(
         'keydown',
         this.rove,
+      );
+
+      this.refScrollContainer.addEventListener(
+        'click',
+        this.handleClickSelectedUser,
       );
     }
   }
@@ -88,6 +94,7 @@ class UserParticipants extends Component {
 
   componentWillUnmount() {
     this.refScrollContainer.removeEventListener('keydown', this.rove);
+    this.refScrollContainer.removeEventListener('click', this.handleClickSelectedUser);
   }
 
   getScrollContainerRef() {
@@ -132,6 +139,11 @@ class UserParticipants extends Component {
         </div>
       </CSSTransition>
     ));
+  }
+
+  handleClickSelectedUser(event) {
+    const selectedUser = event.path.find(p => p.className && p.className.includes('participantsList'));
+    this.setState({ selectedUser });
   }
 
   rove(event) {

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/styles.scss
@@ -88,6 +88,8 @@
   outline-style: solid;
   background-color: var(--list-item-bg-hover);
   box-shadow: inset 0 0 0 var(--border-size) var(--item-focus-border), inset 1px 0 0 1px var(--item-focus-border);
+  border-top-left-radius: var(--sm-padding-y);
+  border-bottom-left-radius: var(--sm-padding-y);
 
   &:focus {
     outline-style: solid;
@@ -96,7 +98,7 @@
 }
 
 .userListItem {
-  //@extend %list-item;
+  @extend %list-item;
   flex-flow: column;
   flex-shrink: 0;
 }


### PR DESCRIPTION
This PR is an improvement on #9365 and fixes the mentioned styling issue. It adds a click handler which correctly sets the currently selected user. The absence of this handler was the underlining cause for the user-list displaying two users as selected when using a mouse.