### PR TITLE
fix broken thumbnail display in LTI-plugin

### DIFF
--- a/bbb-lti/grails-app/views/tool/index.gsp
+++ b/bbb-lti/grails-app/views/tool/index.gsp
@@ -51,9 +51,7 @@
                     <g:if test="${r.published}">
                         <div>
                         <g:each in="${r.thumbnails}" var="thumbnail">
-                            <g:each in="${thumbnail.content}" var="thumbnail_url">
-                                <img src="${thumbnail_url}" class="thumbnail"/>
-                            </g:each>
+                            <img src="${thumbnail.content}" class="thumbnail"/>
                         </g:each>
                         </div>
                   </g:if>


### PR DESCRIPTION
The former code showed each character of the preview thumbnail urls in an image tag, which filled up the page without sense.

Please also consider this for backporting to 2.2.x. Because of the corona situation, many universities use the LTI-Plugin and this obvious error makes it hard to use, because the recording list becomes huge without need. But without deb-packages, many deployments will not adapt.

This error was already mentioned in the google-groups, but there were no answer to it.