### PR TITLE
add request for audio track (Chrome and Edge only)

### DIFF
--- a/bigbluebutton-client/resources/prod/lib/kurento-extension.js
+++ b/bigbluebutton-client/resources/prod/lib/kurento-extension.js
@@ -629,9 +629,11 @@ window.getScreenConstraints = function (sendSource, callback) {
     optionalConstraints.width = { max: kurentoManager.kurentoScreenshare.vid_max_width };
     optionalConstraints.height = { max: kurentoManager.kurentoScreenshare.vid_max_height };
     optionalConstraints.frameRate = { ideal: 5, max: 10 };
+    audioConstraint = isChrome;
 
     let gDPConstraints = {
       video: true,
+      audio: audioConstraint,
       optional: optionalConstraints
     }
 


### PR DESCRIPTION
This will ask for an audio track in screensharing when the user checks the `share audio` option when providing screen permission.

The entire system audio can be captured in Windows when using Chrome or Edge, but on Linux and Mac only the audio of a tab can be captured.

Due to the latest build of Edge being chromium based and the way that browser detection has been added to this project `isChrome` will report true for Chrome and Edge.