### PR TITLE
Fix race condition in addUserSettings

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
@@ -172,7 +172,7 @@ class JoinHandler extends Component {
       logUserInfo();
 
       Tracker.autorun(async (cd) => {
-        const user = Users.findOne({ userId: Auth.userID });
+        const user = Users.findOne({ userId: Auth.userID, authed: true }, { fields: { _id: 1 } });
 
         if (user) {
           await setCustomData(response);

--- a/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
@@ -6,6 +6,7 @@ import { setCustomLogoUrl } from '/imports/ui/components/user-list/service';
 import { makeCall } from '/imports/ui/services/api';
 import logger from '/imports/startup/client/logger';
 import LoadingScreen from '/imports/ui/components/loading-screen/component';
+import Users from '/imports/api/users';
 
 const propTypes = {
   children: PropTypes.element.isRequired,
@@ -170,7 +171,14 @@ class JoinHandler extends Component {
       setLogoURL(response);
       logUserInfo();
 
-      await setCustomData(response);
+      Tracker.autorun(async (cd) => {
+        const user = Users.findOne({ userId: Auth.userID });
+
+        if (user) {
+          await setCustomData(response);
+          cd.stop();
+        }
+      });
 
       logger.info({
         logCode: 'joinhandler_component_joinroutehandler_success',


### PR DESCRIPTION
Fix a race condition where the `userId` isn't available at the moment we set custom parameters.

close #9375 