### PR TITLE
Split querySelector with fallback value

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/media/webcam-draggable-overlay/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/webcam-draggable-overlay/component.jsx
@@ -159,11 +159,13 @@ class WebcamDraggable extends PureComponent {
     const { webcamDraggableState } = this.props;
     const { optimalGrid, placement } = webcamDraggableState;
     if (placement === 'top' || placement === 'bottom') {
-      const mediaHeight = document.querySelector('section[class^=media]').offsetHeight;
+      const mediaSelection = document.querySelector('section[class^=media]');
+      const mediaHeight = mediaSelection ? mediaSelection.offsetHeight : 0;
       this.setState({ placementPercent: (optimalGrid.height * 100) / mediaHeight });
     }
     if (placement === 'left' || placement === 'right') {
-      const mediaWidth = document.querySelector('section[class^=media]').offsetWidth;
+      const mediaSelection = document.querySelector('section[class^=media]');
+      const mediaWidth = mediaSelection ? mediaSelection.offsetWidth : 0;
       this.setState({ placementPercent: (optimalGrid.width * 100) / mediaWidth });
     }
   }
@@ -441,8 +443,9 @@ class WebcamDraggable extends PureComponent {
       [styles.dropZoneBgRight]: true,
     });
 
-    const mHeight = document.querySelector('section[class^=media]').offsetHeight;
-    const mWidth = document.querySelector('section[class^=media]').offsetWidth;
+    const mediaSelection = document.querySelector('section[class^=media]');
+    const mHeight = mediaSelection ? mediaSelection.offsetHeight : 0;
+    const mWidth = mediaSelection ? mediaSelection.offsetWidth : 0;
 
     let resizeWidth;
     let resizeHeight;


### PR DESCRIPTION
We had an issue where `document.querySelector('section[class^=media]')` was undefined so referring to its properties would crash the client.