### PR TITLE
Adjust #8499 for 58fed457541e9282fb7556aa606e52112ce89d98

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
@@ -26,7 +26,7 @@ object UsersApp {
       u <- RegisteredUsers.findWithUserId(userId, liveMeeting.registeredUsers)
     } yield {
 
-      RegisteredUsers.remove(u.id, liveMeeting.registeredUsers)
+      RegisteredUsers.eject(u.id, liveMeeting.registeredUsers, u.id)
 
       val event = MsgBuilder.buildGuestWaitingLeftEvtMsg(liveMeeting.props.meetingProp.intId, u.id)
       outGW.send(event)


### PR DESCRIPTION
Tweaking `RegisteredUsers.remove(u.id, liveMeeting.registeredUsers)`
since we no longer have .remove on RegisteredUsers