### PR TITLE
enable deletion of 14d old already published raw recordings by default

### DIFF
--- a/bigbluebutton-config/cron.daily/bigbluebutton
+++ b/bigbluebutton-config/cron.daily/bigbluebutton
@@ -120,7 +120,7 @@ remove_raw_of_published_recordings(){
     done
 }
 
-#remove_raw_of_published_recordings
+remove_raw_of_published_recordings
 
 #
 # Remove old *.afm and *.pfb files from /tmp directory (if any exist)


### PR DESCRIPTION
### What does this PR do?
- Enabled deletion of >14d old already published raw recording data by default in the daily cronjob script

### Motivation
- reduce amount of `harddrive full - what do?` issues
- improve data privacy by default: User expectation is that parts of the recording which are not "recorded" by pressing the recording-marker do not actually get recorded. For technical reasons the whole session gets recorded, but there is no need to keep that raw recording data for longer than the configured 14 days.

Partially solves #9202