### PR TITLE
Improve handling of recordings

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/generators/audio_processor.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/audio_processor.rb
@@ -33,7 +33,7 @@ module BigBlueButton
     #   archive_dir - directory location of the raw archives. Assumes there is audio file and events.xml present.
     #   file_basename - the file name of the audio output. '.webm' and '.ogg' will be added
     #
-    def self.process(archive_dir, file_basename)
+    def self.process(archive_dir, file_basename, part=0)
       BigBlueButton.logger.info("AudioProcessor.process: Processing audio...")
 
       audio_dir = "#{archive_dir}/audio"
@@ -48,7 +48,7 @@ module BigBlueButton
       start_time = BigBlueButton::Events.first_event_timestamp(events)
       end_time = BigBlueButton::Events.last_event_timestamp(events)
       audio_edl = BigBlueButton::Events.edl_match_recording_marks_audio(
-                      audio_edl, events, start_time, end_time)
+                      audio_edl, events, start_time, end_time, part)
       BigBlueButton::EDL::Audio.dump(audio_edl)
 
       target_dir = File.dirname(file_basename)
@@ -72,12 +72,12 @@ module BigBlueButton
       BigBlueButton::EDL.encode(@audio_file, nil, webm_format, file_basename)
     end
 
-    def self.get_processed_audio_file(archive_dir, file_basename)
+    def self.get_processed_audio_file(archive_dir, file_basename, part=0)
       BigBlueButton.logger.info("AudioProcessor.get_processed_audio_file")
 
       if(@audio_file == nil)
         BigBlueButton.logger.info("AudioProcessor.get_processed_audio_file: audio_file is null. Did you forget to call the process method before this? Processing...")
-        process(archive_dir,file_basename)
+        process(archive_dir,file_basename, part)
       end
 
       return @audio_file

--- a/record-and-playback/core/lib/recordandplayback/generators/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/video.rb
@@ -27,7 +27,7 @@ require File.expand_path('../../edl', __FILE__)
 module BigBlueButton
 
 
-  def BigBlueButton.process_webcam_videos(target_dir, temp_dir, meeting_id, output_width, output_height, audio_offset, processed_audio_file, video_formats=['webm'])
+  def BigBlueButton.process_webcam_videos(target_dir, temp_dir, meeting_id, output_width, output_height, audio_offset, processed_audio_file, video_formats=['webm'], part=0)
     BigBlueButton.logger.info("Processing webcam videos")
 
     events = Nokogiri::XML(File.open("#{temp_dir}/#{meeting_id}/events.xml"))
@@ -38,7 +38,7 @@ module BigBlueButton
     webcam_edl = BigBlueButton::Events.create_webcam_edl(
                     events, "#{temp_dir}/#{meeting_id}")
     user_video_edl = BigBlueButton::Events.edl_match_recording_marks_video(
-                    webcam_edl, events, start_time, end_time)
+                    webcam_edl, events, start_time, end_time, part)
     BigBlueButton::EDL::Video.dump(user_video_edl)
 
     user_video_layout = {
@@ -90,7 +90,7 @@ module BigBlueButton
     end
   end
 
-  def BigBlueButton.process_deskshare_videos(target_dir, temp_dir, meeting_id, output_width, output_height, video_formats=['webm'])
+  def BigBlueButton.process_deskshare_videos(target_dir, temp_dir, meeting_id, output_width, output_height, video_formats=['webm'], part=0)
     BigBlueButton.logger.info("Processing deskshare videos")
 
     events = Nokogiri::XML(File.open("#{temp_dir}/#{meeting_id}/events.xml"))
@@ -100,7 +100,7 @@ module BigBlueButton
     deskshare_edl = BigBlueButton::Events.create_deskshare_edl(
                     events, "#{temp_dir}/#{meeting_id}")
     deskshare_video_edl = BigBlueButton::Events.edl_match_recording_marks_video(
-                    deskshare_edl, events, start_time, end_time)
+                    deskshare_edl, events, start_time, end_time, part)
 
     return if not BigBlueButton.video_recorded?(deskshare_video_edl)
 

--- a/record-and-playback/presentation/scripts/presentation.yml
+++ b/record-and-playback/presentation/scripts/presentation.yml
@@ -8,6 +8,7 @@ deskshare_output_height: 720
 # audio_offset = 1200 means that the audio will be delayed by 1200ms
 audio_offset: 0
 include_deskshare: true
+publish_parts: false
 
 # For PRODUCTION
 publish_dir: /var/bigbluebutton/published/presentation

--- a/record-and-playback/presentation/scripts/process/presentation.rb
+++ b/record-and-playback/presentation/scripts/process/presentation.rb
@@ -42,223 +42,274 @@ props = YAML::load(File.open('../../core/scripts/bigbluebutton.yml'))
 presentation_props = YAML::load(File.open('presentation.yml'))
 presentation_props['audio_offset'] = 0 if presentation_props['audio_offset'].nil?
 presentation_props['include_deskshare'] = false if presentation_props['include_deskshare'].nil?
+presentation_props['publish_parts'] = false if presentation_props['publish_parts'].nil?
 
 recording_dir = props['recording_dir']
 raw_archive_dir = "#{recording_dir}/raw/#{meeting_id}"
 log_dir = props['log_dir']
+logger = Logger.new("#{log_dir}/presentation/process-#{meeting_id}.log", 'daily' )
+BigBlueButton.logger = logger
 
-target_dir = "#{recording_dir}/process/presentation/#{meeting_id}"
-if not FileTest.directory?(target_dir)
-  FileUtils.mkdir_p "#{log_dir}/presentation"
-  logger = Logger.new("#{log_dir}/presentation/process-#{meeting_id}.log", 'daily' )
-  BigBlueButton.logger = logger
-  BigBlueButton.logger.info("Processing script presentation.rb")
-  FileUtils.mkdir_p target_dir
+# work for each recording part of the whole meeting, including part "0" which
+# represents the whole meeting from first to last recording event.
+# if there is only one part or if publish_part!=true, we process *only* this part "0".
+if presentation_props['publish_parts']
+  @eventsdoc = Nokogiri::XML(File.open("#{raw_archive_dir}/events.xml"))
+  $total_rec_events = BigBlueButton::Events.match_start_and_stop_rec_events(
+    BigBlueButton::Events.get_start_and_stop_rec_events(@eventsdoc))
+  parts = $total_rec_events.length()
+  if parts <= 1
+    parts = 0
+    BigBlueButton.logger.info("Processing only one recording part.")
+  else
+    BigBlueButton.logger.info("Processing #{parts} recording parts.")
+  end
+else
+  BigBlueButton.logger.info("Processing of multiple parts in not enabled.")
+  parts = 0
+end
 
-  begin
-    # Create a copy of the raw archives
-    temp_dir = "#{target_dir}/temp"
-    FileUtils.mkdir_p temp_dir
-    FileUtils.cp_r(raw_archive_dir, temp_dir)
+for part in 0..parts
+  if part > 0
+    target_dir = "#{recording_dir}/process/presentation/#{meeting_id}-#{part}"
+    $meeting_part_id = "#{$meeting_id}-#{part}"
+  else
+    target_dir = "#{recording_dir}/process/presentation/#{meeting_id}"
+    $meeting_part_id = $meeting_id
+  end
 
-    # Create initial metadata.xml
-    b = Builder::XmlMarkup.new(:indent => 2)
-    metaxml = b.recording {
-      b.id(meeting_id)
-      b.state("processing")
-      b.published(false)
-      b.start_time
-      b.end_time
-      b.participants
-      b.playback
-      b.meta
-    }
-    metadata_xml = File.new("#{target_dir}/metadata.xml","w")
-    metadata_xml.write(metaxml)
-    metadata_xml.close
-    BigBlueButton.logger.info("Created inital metadata.xml")
+  if not FileTest.directory?(target_dir)
+    FileUtils.mkdir_p "#{log_dir}/presentation"
+    BigBlueButton.logger.info("Processing script presentation.rb")
+    FileUtils.mkdir_p target_dir
 
-    BigBlueButton::AudioProcessor.process("#{temp_dir}/#{meeting_id}", "#{target_dir}/audio")
-    events_xml = "#{temp_dir}/#{meeting_id}/events.xml"
-    FileUtils.cp(events_xml, target_dir)
+    begin
+      # Create a copy of the raw archives
+      temp_dir = "#{target_dir}/temp"
+      FileUtils.mkdir_p temp_dir
+      FileUtils.cp_r(raw_archive_dir, temp_dir)
 
-    presentation_dir = "#{temp_dir}/#{meeting_id}/presentation"
-    presentations = BigBlueButton::Presentation.get_presentations(events_xml)
-
-    processed_pres_dir = "#{target_dir}/presentation"
-    FileUtils.mkdir_p processed_pres_dir
-
-    # Get the real-time start and end timestamp
-    @doc = Nokogiri::XML(File.open("#{target_dir}/events.xml"))
-
-    meeting_start = @doc.xpath("//event")[0][:timestamp]
-    meeting_end = @doc.xpath("//event").last()[:timestamp]
-
-    match = /.*-(\d+)$/.match(meeting_id)
-    real_start_time = match[1]
-    real_end_time = (real_start_time.to_i + (meeting_end.to_i - meeting_start.to_i)).to_s
-
-
-    # Add start_time, end_time and meta to metadata.xml
-    ## Load metadata.xml
-    metadata = Nokogiri::XML(File.open("#{target_dir}/metadata.xml"))
-    ## Add start_time and end_time
-    recording = metadata.root
-    ### Date Format for recordings: Thu Mar 04 14:05:56 UTC 2010
-    start_time = recording.at_xpath("start_time")
-    start_time.content = real_start_time
-    end_time = recording.at_xpath("end_time")
-    end_time.content = real_end_time
-
-    ## Copy the breakout and breakout rooms node from
-    ## events.xml if present.
-    breakout_xpath = @doc.xpath("//breakout")
-    breakout_rooms_xpath = @doc.xpath("//breakoutRooms")
-    meeting_xpath = @doc.xpath("//meeting")
-
-    if (meeting_xpath != nil)
-      recording << meeting_xpath
-    end
-
-    if (breakout_xpath != nil)
-      recording << breakout_xpath
-    end
-
-    if (breakout_rooms_xpath != nil)
-      recording << breakout_rooms_xpath
-    end
-
-    participants = recording.at_xpath("participants")
-    participants.content = BigBlueButton::Events.get_num_participants(@doc)
-
-    ## Remove empty meta
-    metadata.search('//recording/meta').each do |meta|
-      meta.remove
-    end
-    ## Add the actual meta
-    metadata_with_playback = Nokogiri::XML::Builder.with(metadata.at('recording')) do |xml|
-      xml.meta {
-        BigBlueButton::Events.get_meeting_metadata("#{target_dir}/events.xml").each { |k,v| xml.method_missing(k,v) }
+      # Create initial metadata.xml
+      b = Builder::XmlMarkup.new(:indent => 2)
+      metaxml = b.recording {
+        b.id(meeting_id)
+        b.state("processing")
+        b.published(false)
+        b.start_time
+        b.end_time
+        b.participants
+        b.playback
+        b.meta
       }
-    end
-    ## Write the new metadata.xml
-    metadata_file = File.new("#{target_dir}/metadata.xml","w")
-    metadata = Nokogiri::XML(metadata.to_xml) { |x| x.noblanks }
-    metadata_file.write(metadata.root)
-    metadata_file.close
-    BigBlueButton.logger.info("Created an updated metadata.xml with start_time and end_time")
+      metadata_xml = File.new("#{target_dir}/metadata.xml","w")
+      metadata_xml.write(metaxml)
+      metadata_xml.close
+      BigBlueButton.logger.info("Created inital metadata.xml")
 
-    # Start processing raw files
-    presentation_text = {}
-    presentations.each do |pres|
-      pres_dir = "#{presentation_dir}/#{pres}"
-      num_pages = BigBlueButton::Presentation.get_number_of_pages_for(pres_dir)
+      BigBlueButton::AudioProcessor.process("#{temp_dir}/#{meeting_id}", "#{target_dir}/audio", part)
 
-      target_pres_dir = "#{processed_pres_dir}/#{pres}"
-      FileUtils.mkdir_p target_pres_dir
-      FileUtils.mkdir_p "#{target_pres_dir}/textfiles"
+      events_xml = "#{temp_dir}/#{meeting_id}/events.xml"
+      FileUtils.cp(events_xml, target_dir)
 
-      images=Dir.glob("#{pres_dir}/#{pres}.{jpg,jpeg,png,gif,JPG,JPEG,PNG,GIF}")
-      if images.empty?
-        pres_name = "#{pres_dir}/#{pres}"
-        if File.exists?("#{pres_name}.pdf")
-          pres_pdf = "#{pres_name}.pdf"
-          BigBlueButton.logger.info("Found pdf file for presentation #{pres_pdf}")
-        elsif File.exists?("#{pres_name}.PDF")
-          pres_pdf = "#{pres_name}.PDF"
-          BigBlueButton.logger.info("Found PDF file for presentation #{pres_pdf}")
-        elsif File.exists?("#{pres_name}")
-          pres_pdf = pres_name
-          BigBlueButton.logger.info("Falling back to old presentation filename #{pres_pdf}")
-        else
-          pres_pdf = ""
-          BigBlueButton.logger.warn("Could not find pdf file for presentation #{pres}")
-        end
+      presentation_dir = "#{temp_dir}/#{meeting_id}/presentation"
+      presentations = BigBlueButton::Presentation.get_presentations(events_xml)
 
-        if !pres_pdf.empty?
-          text = {}
-          1.upto(num_pages) do |page|
-            BigBlueButton::Presentation.extract_png_page_from_pdf(
-              page, pres_pdf, "#{target_pres_dir}/slide-#{page}.png", '1600x1600')
-            if File.exist?("#{pres_dir}/textfiles/slide-#{page}.txt") then
-              t = File.read("#{pres_dir}/textfiles/slide-#{page}.txt", encoding: 'UTF-8')
-              text["slide-#{page}"] = t.encode('UTF-8', invalid: :replace)
-              FileUtils.cp("#{pres_dir}/textfiles/slide-#{page}.txt", "#{target_pres_dir}/textfiles")
-            end
+      processed_pres_dir = "#{target_dir}/presentation"
+      FileUtils.mkdir_p processed_pres_dir
+
+      # Get the real-time start and end timestamp
+      @doc = Nokogiri::XML(File.open("#{target_dir}/events.xml"))
+
+      meeting_start = @doc.xpath("//event")[0][:timestamp]
+      meeting_end = @doc.xpath("//event").last()[:timestamp]
+
+      match = /.*-(\d+)$/.match(meeting_id)
+      real_start_time = match[1]
+      real_end_time = (real_start_time.to_i + (meeting_end.to_i - meeting_start.to_i)).to_s
+
+
+      # Add start_time, end_time and meta to metadata.xml
+      ## Load metadata.xml
+      metadata = Nokogiri::XML(File.open("#{target_dir}/metadata.xml"))
+      ## Add start_time and end_time
+      recording = metadata.root
+      ### Date Format for recordings: Thu Mar 04 14:05:56 UTC 2010
+      start_time = recording.at_xpath("start_time")
+      start_time.content = real_start_time
+      end_time = recording.at_xpath("end_time")
+      end_time.content = real_end_time
+
+      ## Copy the breakout and breakout rooms node from
+      ## events.xml if present.
+      breakout_xpath = @doc.xpath("//breakout")
+      breakout_rooms_xpath = @doc.xpath("//breakoutRooms")
+      meeting_xpath = @doc.xpath("//meeting")
+
+      if (meeting_xpath != nil)
+        recording << meeting_xpath
+      end
+
+      if (breakout_xpath != nil)
+        recording << breakout_xpath
+      end
+
+      if (breakout_rooms_xpath != nil)
+        recording << breakout_rooms_xpath
+      end
+
+      participants = recording.at_xpath("participants")
+      participants.content = BigBlueButton::Events.get_num_participants(@doc)
+
+      ## Remove empty meta
+      metadata.search('//recording/meta').each do |meta|
+        meta.remove
+      end
+      ## Add the actual meta
+      metadata_with_playback = Nokogiri::XML::Builder.with(metadata.at('recording')) do |xml|
+        xml.meta {
+          BigBlueButton::Events.get_meeting_metadata("#{target_dir}/events.xml").each { |k,v| xml.method_missing(k,v) }
+        }
+      end
+      ## Write the new metadata.xml
+      metadata_file = File.new("#{target_dir}/metadata.xml","w")
+      metadata = Nokogiri::XML(metadata.to_xml) { |x| x.noblanks }
+      metadata_file.write(metadata.root)
+      metadata_file.close
+      BigBlueButton.logger.info("Created an updated metadata.xml with start_time and end_time")
+
+      recorded_slides = BigBlueButton::Events.get_recorded_slides(@doc, part)
+
+      # Start processing raw files
+      presentation_text = {}
+      presentations.each do |pres|
+        pres_dir = "#{presentation_dir}/#{pres}"
+        num_pages = BigBlueButton::Presentation.get_number_of_pages_for(pres_dir)
+
+        target_pres_dir = "#{processed_pres_dir}/#{pres}"
+        FileUtils.mkdir_p target_pres_dir
+        FileUtils.mkdir_p "#{target_pres_dir}/textfiles"
+
+        images=Dir.glob("#{pres_dir}/#{pres}.{jpg,jpeg,png,gif,JPG,JPEG,PNG,GIF}")
+        if images.empty?
+          pres_name = "#{pres_dir}/#{pres}"
+          if File.exists?("#{pres_name}.pdf")
+            pres_pdf = "#{pres_name}.pdf"
+            BigBlueButton.logger.info("Found pdf file for presentation #{pres_pdf}")
+          elsif File.exists?("#{pres_name}.PDF")
+            pres_pdf = "#{pres_name}.PDF"
+            BigBlueButton.logger.info("Found PDF file for presentation #{pres_pdf}")
+          elsif File.exists?("#{pres_name}")
+            pres_pdf = pres_name
+            BigBlueButton.logger.info("Falling back to old presentation filename #{pres_pdf}")
+          else
+            pres_pdf = ""
+            BigBlueButton.logger.warn("Could not find pdf file for presentation #{pres}")
           end
-          presentation_text[pres] = text
+
+          if !pres_pdf.empty?
+            text = {}
+            FileUtils.mkdir_p("#{target_pres_dir}/thumbnails")
+            1.upto(num_pages) do |page|
+              # XXX if this page of this pres is not within recording time ranges: next
+              # take these events into account:
+              #  ResizeAndMoveSlideEvent: id
+              #  SharePresentationEvent (first page? presid/1 ?!)
+              #  GotoSlideEvent: id
+              #
+              pageid = "#{pres}/#{page}"
+              if not recorded_slides.include? pageid
+                BigBlueButton.logger.debug("Slide #{pageid} has not been recorded, ignoring")
+                next
+              else
+                BigBlueButton.logger.debug("Slide #{pageid} has been recorded, processing")
+              end
+              # 
+              BigBlueButton::Presentation.extract_png_page_from_pdf(
+                page, pres_pdf, "#{target_pres_dir}/slide-#{page}.png", '1600x1600')
+              BigBlueButton.logger.debug("Applying presentation #{pres} slide slide-#{page}.png")
+              if File.exist?("#{pres_dir}/textfiles/slide-#{page}.txt") then
+                t = File.read("#{pres_dir}/textfiles/slide-#{page}.txt", encoding: 'UTF-8')
+                text["slide-#{page}"] = t.encode('UTF-8', invalid: :replace)
+                FileUtils.cp("#{pres_dir}/textfiles/slide-#{page}.txt", "#{target_pres_dir}/textfiles")
+                BigBlueButton.logger.debug("Applying presentation #{pres} textfile slide-#{page}.txt")
+              end
+              # Copy thumbnail from raw files
+              FileUtils.cp("#{pres_dir}/thumbnails/thumb-#{page}.png", "#{target_pres_dir}/thumbnails/")
+              BigBlueButton.logger.debug("Applying presentation #{pres} thumbnail thumb-#{page}.png")
+            end
+            presentation_text[pres] = text
+          end
+        else
+          ## WHAT IS THIS???
+          ext = File.extname("#{images[0]}")
+          BigBlueButton::Presentation.convert_image_to_png(
+            images[0], "#{target_pres_dir}/slide-1.png", '1600x1600')
+          BigBlueButton.logger.debug("Applying presentation #{pres} image #{images[0]} as slide-1.png")
         end
-      else
-        ext = File.extname("#{images[0]}")
-        BigBlueButton::Presentation.convert_image_to_png(
-          images[0], "#{target_pres_dir}/slide-1.png", '1600x1600')
       end
 
-      # Copy thumbnails from raw files
-      FileUtils.cp_r("#{pres_dir}/thumbnails", "#{target_pres_dir}/thumbnails")
-    end
+      BigBlueButton.logger.info("Generating closed captions")
+      ret = BigBlueButton.exec_ret('utils/gen_webvtt', '-i', raw_archive_dir, '-o', target_dir)
+      if ret != 0
+        raise "Generating closed caption files failed"
+      end
+      captions = JSON.load(File.new("#{target_dir}/captions.json", 'r'))
 
-    BigBlueButton.logger.info("Generating closed captions")
-    ret = BigBlueButton.exec_ret('utils/gen_webvtt', '-i', raw_archive_dir, '-o', target_dir)
-    if ret != 0
-      raise "Generating closed caption files failed"
-    end
-    captions = JSON.load(File.new("#{target_dir}/captions.json", 'r'))
-
-    if not presentation_text.empty?
-      # Write presentation_text.json to file
-      File.open("#{target_dir}/presentation_text.json","w") { |f| f.puts presentation_text.to_json }
-    end
-
-    # We have to decide whether to actually generate the webcams video file
-    # We do so if any of the following conditions are true:
-    # - There is webcam video present, or
-    # - There's broadcast video present, or
-    # - There are closed captions present (they need a video stream to be rendered on top of)
-    if !Dir["#{raw_archive_dir}/video/*"].empty? or
-        !Dir["#{raw_archive_dir}/video-broadcast/*"].empty? or
-        captions.length > 0
-      webcam_width = presentation_props['video_output_width']
-      webcam_height = presentation_props['video_output_height']
-
-      # Use a higher resolution video canvas if there's broadcast video streams
-      if !Dir["#{raw_archive_dir}/video-broadcast/*"].empty?
-        webcam_width = presentation_props['deskshare_output_width']
-        webcam_height = presentation_props['deskshare_output_height']
+      if not presentation_text.empty?
+        # Write presentation_text.json to file
+        File.open("#{target_dir}/presentation_text.json","w") { |f| f.puts presentation_text.to_json }
       end
 
-      processed_audio_file = BigBlueButton::AudioProcessor.get_processed_audio_file("#{temp_dir}/#{meeting_id}", "#{target_dir}/audio")
-      BigBlueButton.process_webcam_videos(target_dir, temp_dir, meeting_id, webcam_width, webcam_height, presentation_props['audio_offset'], processed_audio_file, presentation_props['video_formats'])
+      # We have to decide whether to actually generate the webcams video file
+      # We do so if any of the following conditions are true:
+      # - There is webcam video present, or
+      # - There's broadcast video present, or
+      # - There are closed captions present (they need a video stream to be rendered on top of)
+      if !Dir["#{raw_archive_dir}/video/*"].empty? or
+          !Dir["#{raw_archive_dir}/video-broadcast/*"].empty? or
+          captions.length > 0
+        webcam_width = presentation_props['video_output_width']
+        webcam_height = presentation_props['video_output_height']
+  
+        # Use a higher resolution video canvas if there's broadcast video streams
+        if !Dir["#{raw_archive_dir}/video-broadcast/*"].empty?
+          webcam_width = presentation_props['deskshare_output_width']
+          webcam_height = presentation_props['deskshare_output_height']
+        end
+        processed_audio_file = BigBlueButton::AudioProcessor.get_processed_audio_file("#{temp_dir}/#{meeting_id}", "#{target_dir}/audio", part)
+        BigBlueButton.process_webcam_videos(target_dir, temp_dir, meeting_id, webcam_width, webcam_height, presentation_props['audio_offset'], processed_audio_file, presentation_props['video_formats'], part)
+      end
+
+      if !Dir["#{raw_archive_dir}/deskshare/*"].empty? and presentation_props['include_deskshare']
+        deskshare_width = presentation_props['deskshare_output_width']
+        deskshare_height = presentation_props['deskshare_output_height']
+        BigBlueButton.process_deskshare_videos(target_dir, temp_dir, meeting_id, deskshare_width, deskshare_height, presentation_props['video_formats'], part)
+      end
+
+      # Update state in metadata.xml
+      ## Load metadata.xml
+      metadata = Nokogiri::XML(File.open("#{target_dir}/metadata.xml"))
+      ## Update status
+      recording = metadata.root
+      state = recording.at_xpath("state")
+      state.content = "processed"
+      ## Write the new metadata.xml
+      metadata_file = File.new("#{target_dir}/metadata.xml","w")
+      metadata_file.write(metadata.root)
+      metadata_file.close
+      BigBlueButton.logger.info("Created an updated metadata.xml with state=processed")
+
+    rescue Exception => e
+      BigBlueButton.logger.error(e.message)
+      e.backtrace.each do |traceline|
+        BigBlueButton.logger.error(traceline)
+      end
+      exit 1
     end
-
-    if !Dir["#{raw_archive_dir}/deskshare/*"].empty? and presentation_props['include_deskshare']
-      deskshare_width = presentation_props['deskshare_output_width']
-      deskshare_height = presentation_props['deskshare_output_height']
-      BigBlueButton.process_deskshare_videos(target_dir, temp_dir, meeting_id, deskshare_width, deskshare_height, presentation_props['video_formats'])
-    end
-
-    process_done = File.new("#{recording_dir}/status/processed/#{meeting_id}-presentation.done", "w")
-    process_done.write("Processed #{meeting_id}")
-    process_done.close
-
-    # Update state in metadata.xml
-    ## Load metadata.xml
-    metadata = Nokogiri::XML(File.open("#{target_dir}/metadata.xml"))
-    ## Update status
-    recording = metadata.root
-    state = recording.at_xpath("state")
-    state.content = "processed"
-    ## Write the new metadata.xml
-    metadata_file = File.new("#{target_dir}/metadata.xml","w")
-    metadata_file.write(metadata.root)
-    metadata_file.close
-    BigBlueButton.logger.info("Created an updated metadata.xml with state=processed")
-
-  rescue Exception => e
-    BigBlueButton.logger.error(e.message)
-    e.backtrace.each do |traceline|
-      BigBlueButton.logger.error(traceline)
-    end
-    exit 1
   end
 end
+
+process_done = File.new("#{recording_dir}/status/processed/#{meeting_id}-presentation.done", "w")
+process_done.write("Processed #{meeting_id}")
+process_done.close
+


### PR DESCRIPTION
Added support for publishing presentation parts.
Controlled by new presentation.yml variable.
part==0 addresses the complete recording as before.

Removed those slides from published presentations which are not within
a given recording part (or the whole "intented" recording time range).
The former behavior, where all slides of all presentations during the
meeting became parts of the published presentation, could be regarded
as a security concern in situations where people present confidential
slides while recording is paused.