### PR TITLE
Restore minimized presentation for viewer on (slide or zoom change / pub…

### DIFF
--- a/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
+++ b/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
@@ -48,6 +48,8 @@ const currentParameters = [
   'bbb_enable_video',
   'bbb_enable_video_stats',
   'bbb_skip_video_preview',
+  // PRESENTATION
+  'bbb_force_restore_presentation_on_new_events',
   // WHITEBOARD
   'bbb_multi_user_pen_only',
   'bbb_presenter_tools',

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -94,10 +94,14 @@ class PresentationArea extends PureComponent {
       publishedPoll,
       isViewer,
       toggleSwapLayout,
+      currentPresentationId,
       restoreOnUpdate,
     } = this.props;
 
-    if (prevProps.currentPresentation.name !== currentPresentation.name) {
+    const presentationChanged = currentPresentationId !== currentPresentation._id;
+
+    if (presentationChanged) {
+      Session.set('currentPresentationId', currentPresentation._id);
       notify(
         `${intl.formatMessage(intlMessages.changeNotification)} ${currentPresentation.name}`,
         'info',
@@ -110,7 +114,7 @@ class PresentationArea extends PureComponent {
       const positionChanged = slidePosition.viewBoxHeight !== prevProps.slidePosition.viewBoxHeight
         || slidePosition.viewBoxWidth !== prevProps.slidePosition.viewBoxWidth;
       const pollPublished = publishedPoll && !prevProps.publishedPoll;
-      if (slideChanged || positionChanged || pollPublished) {
+      if (slideChanged || positionChanged || pollPublished || presentationChanged) {
         toggleSwapLayout();
       }
     }

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -84,7 +84,18 @@ class PresentationArea extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    const { currentPresentation, notify, intl } = this.props;
+    const {
+      currentPresentation,
+      notify,
+      intl,
+      layoutSwapped,
+      currentSlide,
+      slidePosition,
+      publishedPoll,
+      isViewer,
+      toggleSwapLayout,
+      restoreOnUpdate,
+    } = this.props;
 
     if (prevProps.currentPresentation.name !== currentPresentation.name) {
       notify(
@@ -92,6 +103,16 @@ class PresentationArea extends PureComponent {
         'info',
         'presentation',
       );
+    }
+
+    if (layoutSwapped && restoreOnUpdate && isViewer && currentSlide) {
+      const slideChanged = currentSlide.id !== prevProps.currentSlide.id;
+      const positionChanged = slidePosition.viewBoxHeight !== prevProps.slidePosition.viewBoxHeight
+        || slidePosition.viewBoxWidth !== prevProps.slidePosition.viewBoxWidth;
+      const pollPublished = publishedPoll && !prevProps.publishedPoll;
+      if (slideChanged || positionChanged || pollPublished) {
+        toggleSwapLayout();
+      }
     }
   }
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
-import { getSwapLayout, shouldEnableSwapLayout } from '/imports/ui/components/media/service';
+import MediaService, { getSwapLayout, shouldEnableSwapLayout } from '/imports/ui/components/media/service';
 import { notify } from '/imports/ui/services/notification';
 import PresentationAreaService from './service';
 import PresentationArea from './component';
 import PresentationToolbarService from './presentation-toolbar/service';
+import Auth from '/imports/ui/services/auth';
+import Meetings from '/imports/api/meetings';
+import Users from '/imports/api/users';
+import getFromUserSettings from '/imports/ui/services/users-settings';
+
+const ROLE_VIEWER = Meteor.settings.public.user.role_viewer;
 
 const PresentationAreaContainer = ({ presentationPodIds, mountPresentationArea, ...props }) => (
   mountPresentationArea && <PresentationArea {...props} />
@@ -14,6 +20,11 @@ export default withTracker(({ podId }) => {
   const currentSlide = PresentationAreaService.getCurrentSlide(podId);
   const presentationIsDownloadable = PresentationAreaService.isPresentationDownloadable(podId);
   const layoutSwapped = getSwapLayout() && shouldEnableSwapLayout();
+  const isViewer = Users.findOne({ meetingId: Auth.meetingID, userId: Auth.userID }, {
+    fields: {
+      role: 1,
+    },
+  }).role === ROLE_VIEWER;
 
   let slidePosition;
   if (currentSlide) {
@@ -35,5 +46,17 @@ export default withTracker(({ podId }) => {
     currentPresentation: PresentationAreaService.getCurrentPresentation(podId),
     notify,
     zoomSlide: PresentationToolbarService.zoomSlide,
+    layoutSwapped,
+    toggleSwapLayout: MediaService.toggleSwapLayout,
+    publishedPoll: Meetings.findOne({ meetingId: Auth.meetingID }, {
+      fields: {
+        publishedPoll: 1,
+      },
+    }).publishedPoll,
+    isViewer,
+    restoreOnUpdate: getFromUserSettings(
+      'bbb_force_restore_presentation_on_new_events',
+      Meteor.settings.public.presentation.restoreOnUpdate,
+    ),
   };
 })(PresentationAreaContainer);

--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -54,6 +54,7 @@ export default withTracker(({ podId }) => {
       },
     }).publishedPoll,
     isViewer,
+    currentPresentationId: Session.get('currentPresentationId') || null,
     restoreOnUpdate: getFromUserSettings(
       'bbb_force_restore_presentation_on_new_events',
       Meteor.settings.public.presentation.restoreOnUpdate,

--- a/bigbluebutton-html5/imports/ui/components/presentation/cursor/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/cursor/component.jsx
@@ -191,7 +191,7 @@ export default class Cursor extends Component {
         <circle
           cx={x}
           cy={y}
-          r={finalRadius}
+          r={finalRadius === Infinity ? 0 : finalRadius}
           fill={fill}
           fillOpacity="0.6"
         />

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotation-factory/reactive-annotation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotation-factory/reactive-annotation/container.jsx
@@ -1,8 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withTracker } from 'meteor/react-meteor-data';
+import MediaService, { getSwapLayout, shouldEnableSwapLayout } from '/imports/ui/components/media/service';
 import ReactiveAnnotationService from './service';
 import ReactiveAnnotation from './component';
+import Auth from '/imports/ui/services/auth';
+import Users from '/imports/api/users';
+import getFromUserSettings from '/imports/ui/services/users-settings';
+
+const ROLE_VIEWER = Meteor.settings.public.user.role_viewer;
 
 const ReactiveAnnotationContainer = (props) => {
   const { annotation, drawObject } = props;
@@ -24,6 +30,21 @@ const ReactiveAnnotationContainer = (props) => {
 export default withTracker((params) => {
   const { shapeId } = params;
   const annotation = ReactiveAnnotationService.getAnnotationById(shapeId);
+  const isViewer = Users.findOne({ meetingId: Auth.meetingID, userId: Auth.userID }, {
+    fields: {
+      role: 1,
+    },
+  }).role === ROLE_VIEWER;
+
+  const restoreOnUpdate = getFromUserSettings(
+    'bbb_force_restore_presentation_on_new_events',
+    Meteor.settings.public.presentation.restoreOnUpdate,
+  );
+
+  if (restoreOnUpdate && isViewer) {
+    const layoutSwapped = getSwapLayout() && shouldEnableSwapLayout();
+    if (layoutSwapped) MediaService.toggleSwapLayout();
+  }
 
   return {
     annotation,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -179,6 +179,7 @@ public:
   presentation:
     defaultPresentationFile: default.pdf
     panZoomThrottle: 32
+    restoreOnUpdate: false
     uploadEndpoint: "/bigbluebutton/presentation/upload"
     uploadSizeMin: 0
     uploadSizeMax: 50000000


### PR DESCRIPTION
This PR adds a new config prop `restoreOnUpdate` when enabled the presentation area will be forcefully restored if it is minimized (Viewers only) for actions:
* presentation / slide / zoom change
* published poll
* added annotation

this can also be enabled via the userData `userdata-bbb_force_restore_presentation_on_new_events=true`
