### PR TITLE
Screenshare: add support on Safari 13+ and make constraints configurable

### DIFF
--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -8,8 +8,8 @@ const SFU_CONFIG = Meteor.settings.public.kurento;
 const SFU_URL = SFU_CONFIG.wsUrl;
 const CHROME_DEFAULT_EXTENSION_KEY = SFU_CONFIG.chromeDefaultExtensionKey;
 const CHROME_CUSTOM_EXTENSION_KEY = SFU_CONFIG.chromeExtensionKey;
-const CHROME_SCREENSHARE_SOURCES = SFU_CONFIG.chromeScreenshareSources;
-const FIREFOX_SCREENSHARE_SOURCE = SFU_CONFIG.firefoxScreenshareSource;
+const CHROME_SCREENSHARE_SOURCES = SFU_CONFIG.screenshare.chromeScreenshareSources;
+const FIREFOX_SCREENSHARE_SOURCE = SFU_CONFIG.screenshare.firefoxScreenshareSource;
 const SCREENSHARE_VIDEO_TAG = 'screenshareVideo';
 
 const CHROME_EXTENSION_KEY = CHROME_CUSTOM_EXTENSION_KEY === 'KEY' ? CHROME_DEFAULT_EXTENSION_KEY : CHROME_CUSTOM_EXTENSION_KEY;
@@ -161,12 +161,13 @@ export default class KurentoScreenshareBridge {
     window.kurentoExitVideo();
   }
 
-  async kurentoShareScreen(onFail) {
+  async kurentoShareScreen(onFail, stream) {
     let iceServers = [];
     try {
       iceServers = await fetchWebRTCMappedStunTurnServers(getSessionToken());
     } catch (error) {
       logger.error({ logCode: 'screenshare_presenter_fetchstunturninfo_error' },
+
         'Screenshare bridge failed to fetch STUN/TURN info, using default');
     } finally {
       const options = {
@@ -192,6 +193,8 @@ export default class KurentoScreenshareBridge {
           logCode: 'screenshare_presenter_start_success',
         }, 'Screenshare presenter started succesfully');
       };
+
+      options.stream = stream || undefined;
 
       window.kurentoShareScreen(
         SCREENSHARE_VIDEO_TAG,

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/service.js
@@ -1,7 +1,83 @@
 import Meetings from '/imports/api/meetings';
+import logger from '/imports/startup/client/logger';
+
+const {
+  constraints: GDM_CONSTRAINTS,
+} = Meteor.settings.public.kurento.screenshare;
+
+const hasDisplayMedia = (typeof navigator.getDisplayMedia === 'function'
+  || (navigator.mediaDevices && typeof navigator.mediaDevices.getDisplayMedia === 'function'));
 
 const getConferenceBridge = () => Meetings.findOne().voiceProp.voiceConf;
 
+const getScreenStream = async () => {
+  const gDMCallback = (stream) => {
+    if (typeof stream.getVideoTracks === 'function'
+        && typeof constraints.video === 'object') {
+      stream.getVideoTracks().forEach(track => {
+        if (typeof track.applyConstraints  === 'function') {
+          track.applyConstraints(constraints.video).catch(error => {
+            logger.warn({
+              logCode: 'screenshare_videoconstraint_failed',
+              extraInfo: { errorName: error.name, errorCode: error.code },
+            },
+            'Error applying screenshare video constraint');
+          });
+        }
+      });
+    }
+
+    if (typeof stream.getAudioTracks === 'function'
+        && typeof constraints.audio === 'object') {
+      stream.getAudioTracks().forEach(track => {
+        if (typeof track.applyConstraints  === 'function') {
+          track.APplyConstraints(constraints.audio).catch(error => {
+            logger.warn({
+              logCode: 'screenshare_audioconstraint_failed',
+              extraInfo: { errorName: error.name, errorCode: error.code },
+            }, 'Error applying screenshare audio constraint');
+          });
+        }
+      });
+    }
+
+    return Promise.resolve(stream);
+  }
+
+  const constraints = hasDisplayMedia ? GDM_CONSTRAINTS : null;
+
+  // getDisplayMedia isn't supported, generate no stream and let the legacy
+  // constraint fetcher work its way on kurento-extension.js
+  if (constraints == null) {
+    return Promise.resolve();
+  } else  {
+    if (typeof navigator.getDisplayMedia === 'function') {
+      return navigator.getDisplayMedia(constraints)
+        .then(gDMCallback)
+        .catch(error => {
+          logger.error({
+            logCode: 'screenshare_getdisplaymedia_failed',
+            extraInfo: { errorName: error.name, errorCode: error.code },
+          }, 'getDisplayMedia call failed');
+          return Promise.resolve();
+        });
+    } else if (navigator.mediaDevices && typeof navigator.mediaDevices.getDisplayMedia === 'function') {
+      return navigator.mediaDevices.getDisplayMedia(constraints)
+        .then(gDMCallback)
+        .catch(error => {
+          logger.error({
+            logCode: 'screenshare_getdisplaymedia_failed',
+            extraInfo: { errorName: error.name, errorCode: error.code },
+          }, 'getDisplayMedia call failed');
+          return Promise.resolve();
+        });
+    }
+  }
+}
+
+
 export default {
+  hasDisplayMedia,
   getConferenceBridge,
+  getScreenStream,
 };

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/service.js
@@ -31,7 +31,7 @@ const getScreenStream = async () => {
         && typeof constraints.audio === 'object') {
       stream.getAudioTracks().forEach(track => {
         if (typeof track.applyConstraints  === 'function') {
-          track.APplyConstraints(constraints.audio).catch(error => {
+          track.applyConstraints(constraints.audio).catch(error => {
             logger.warn({
               logCode: 'screenshare_audioconstraint_failed',
               extraInfo: { errorName: error.name, errorCode: error.code },

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/desktop-share/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/desktop-share/component.jsx
@@ -9,6 +9,7 @@ import cx from 'classnames';
 import Modal from '/imports/ui/components/modal/simple/component';
 import { withModalMounter } from '../../modal/service';
 import { styles } from '../styles';
+import ScreenshareBridgeService from '/imports/api/screenshare/client/bridge/service';
 
 const propTypes = {
   intl: intlShape.isRequired,
@@ -114,7 +115,7 @@ const isMobileBrowser = (BROWSER_RESULTS ? BROWSER_RESULTS.mobile : false)
   || (BROWSER_RESULTS && BROWSER_RESULTS.os
     ? BROWSER_RESULTS.os.includes('Android') // mobile flag doesn't always work
     : false);
-const isSafari = BROWSER_RESULTS.name === 'safari';
+const IS_SAFARI = BROWSER_RESULTS.name === 'safari';
 
 const DesktopShare = ({
   intl,
@@ -182,7 +183,7 @@ const DesktopShare = ({
         circle
         size="lg"
         onClick={isVideoBroadcasting ? handleUnshareScreen : () => {
-          if (isSafari) {
+          if (!IS_SAFARI || (IS_SAFARI && ScreenshareBridgeService.hasDisplayMedia)) {
             return mountModal(<Modal
               overlayClassName={styles.overlay}
               className={styles.modal}

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/desktop-share/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/desktop-share/component.jsx
@@ -183,7 +183,7 @@ const DesktopShare = ({
         circle
         size="lg"
         onClick={isVideoBroadcasting ? handleUnshareScreen : () => {
-          if (!IS_SAFARI || (IS_SAFARI && ScreenshareBridgeService.hasDisplayMedia)) {
+          if (IS_SAFARI && !ScreenshareBridgeService.hasDisplayMedia)) {
             return mountModal(<Modal
               overlayClassName={styles.overlay}
               className={styles.modal}

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -1,5 +1,6 @@
 import Screenshare from '/imports/api/screenshare';
 import KurentoBridge from '/imports/api/screenshare/client/bridge';
+import BridgeService from '/imports/api/screenshare/client/bridge/service';
 import Settings from '/imports/ui/services/settings';
 import logger from '/imports/startup/client/logger';
 import { tryGenerateIceCandidates } from '/imports/utils/safari-webrtc';
@@ -56,7 +57,9 @@ const shareScreen = (onFail) => {
     stopWatching();
   }
 
-  KurentoBridge.kurentoShareScreen(onFail);
+  BridgeService.getScreenStream().then(stream => {
+    KurentoBridge.kurentoShareScreen(onFail, stream);
+  }).catch(onFail);
 };
 
 const screenShareEndAlert = () => new Audio(`${Meteor.settings.public.app.cdn + Meteor.settings.public.app.basename}/resources/sounds/ScreenshareOff.mp3`).play();

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -90,10 +90,21 @@ public:
     chromeDefaultExtensionLink: https://chrome.google.com/webstore/detail/bigbluebutton-screenshare/akgoaoikmbmhcopjgakkcepdgdgkjfbc
     chromeExtensionKey: KEY
     chromeExtensionLink: LINK
-    chromeScreenshareSources:
-    - window
-    - screen
-    firefoxScreenshareSource: window
+    screenshare:
+      constraints:
+        video:
+          frameRate:
+            ideal: 5
+            max: 10
+          width:
+            max: 2560
+          height:
+            max: 1600
+        audio: false
+      chromeScreenshareSources:
+        - window
+        - screen
+      firefoxScreenshareSource: window
     cameraProfiles:
       - id: low
         name: Low quality

--- a/bigbluebutton-html5/public/compatibility/kurento-extension.js
+++ b/bigbluebutton-html5/public/compatibility/kurento-extension.js
@@ -27,7 +27,7 @@ Kurento = function (
   this.internalMeetingId = internalMeetingId;
 
   // Optional parameters are: userName, caleeName, chromeExtension, wsUrl, iceServers,
-  // chromeScreenshareSources, firefoxScreenshareSource, logger
+  // chromeScreenshareSources, firefoxScreenshareSource, logger, stream
 
   Object.assign(this, options);
 
@@ -449,6 +449,7 @@ Kurento.prototype.startScreensharing = function () {
       this.onIceCandidate(candidate, this.SEND_ROLE);
     },
     sendSource: 'desktop',
+    videoStream: this.stream || undefined,
   };
 
   let resolution;
@@ -876,11 +877,6 @@ window.getScreenConstraints = function (sendSource, callback) {
   // Falls back to getDisplayMedia if the browser supports it
   if (hasDisplayMedia) {
     return callback(null, getDisplayMediaConstraints());
-  }
-
-  if (isSafari) {
-    // At this time (version 11.1), Safari doesn't support screenshare.
-    return document.dispatchEvent(new Event('safariScreenshareNotSupported'));
   }
 };
 

--- a/bigbluebutton-html5/public/compatibility/kurento-utils.js
+++ b/bigbluebutton-html5/public/compatibility/kurento-utils.js
@@ -440,10 +440,20 @@ function WebRtcPeer(mode, options, callback) {
             self.showLocalVideo();
         }
         if (videoStream) {
-            videoStream.getTracks().forEach(track => pc.addTrack(track, videoStream));
+            if (typeof videoStream.getTracks === 'function'
+                  && typeof pc.addTrack === 'function') {
+                videoStream.getTracks().forEach(track => pc.addTrack(track, videoStream));
+            } else {
+                pc.addStream(videoStream);
+            }
         }
         if (audioStream) {
-            audioStream.getTracks().forEach(track => pc.addTrack(track, audioStream));
+            if (typeof audioStream.getTracks === 'function'
+                  && typeof pc.addTrack === 'function') {
+                audioStream.getTracks().forEach(track => pc.addTrack(track, audioStream));
+            } else {
+                pc.addStream(audioStream);
+            }
         }
         var browser = parser.getBrowser();
         if (mode === 'sendonly' && (browser.name === 'Chrome' || browser.name === 'Chromium') && browser.major === 39) {


### PR DESCRIPTION
- Adds support for screensharing on Safari 13+ on **desktops** or whichever version has getDisplayMedia enabled
- To be conservative and backwards compatible, I`ve maintained the current gUM-based code available as a fallback for those still using older versions of FF or Chrome
- Made screenshare constraints configurable. The constraints config will be piped directly to gDM, so it`s just a regular gDM constraint dictionary
- Fixed an issue where Firefox wouldn't pick up the specific screenshare constraints (ie frameRate, width, height). Firefox should now be correctly frame rate and resolution constrained.