### PR TITLE
akka-bbb-apps only listen on localhost

### DIFF
--- a/akka-bbb-apps/src/universal/conf/application.conf
+++ b/akka-bbb-apps/src/universal/conf/application.conf
@@ -65,7 +65,7 @@ sharedNotes {
 }
 
 http {
-  interface = "0.0.0.0"
+  interface = "127.0.0.1"
   port = 9999
 }
 


### PR DESCRIPTION
### What does this PR do?
- attack surface reduction by having akka-bbb-apps only listen on localhost/127.0.0.1

### Motivation
akka-bbb-apps is the server side application which handles the state of meetings on the server. There is no need to expose it to the internet, as all requests should go through nginx or are directly made from other BBB apps running on localhost