### PR TITLE
Allow settings for crontab to be set in /etc/default/bigbluebutton

### DIFF
--- a/bigbluebutton-config/cron.daily/bigbluebutton
+++ b/bigbluebutton-config/cron.daily/bigbluebutton
@@ -21,12 +21,18 @@
 test -x /var/bigbluebutton || exit 0
 
 #
-# How N days back to keep files
+# Defaults to decide how many days back to keep files
+# If you need to change them, do so in /etc/default/bigbluebutton
 #
 history=5
 unrecorded_days=14
 published_days=14
 log_history=28
+
+# Load variables from /etc/default/bigbluebutton if it exists
+if [ -r /etc/default/bigbluebutton ]; then
+  . /etc/default/bigbluebutton
+fi
 
 #
 # Delete presentations older than N days


### PR DESCRIPTION
This is a proposal for #9558 

Sorry for not talking about it before, but I don't see how I can join / subscribe without a google account to the -dev group, and do not wish to create one for that purpose.