### PR TITLE
bbb-conf: respect underscore in nginx server_name

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -733,7 +733,7 @@ check_configuration() {
         fi
     fi
 
-    if [ "$IP" != "$NGINX_IP" ]; then
+    if [ "$IP" != "$NGINX_IP" ] && [ "_" != "$NGINX_IP" ]; then
         if [ "$IP" != "$HOSTS" ]; then
             echo "# IP does not match:"
             echo "#                           IP from ifconfig: $IP"
@@ -1262,9 +1262,9 @@ check_state() {
     # Check that BigBlueButton can connect to port 1935
     #
     if [ -f /usr/share/red5/red5-server.jar ]; then
-      if [[ ! -z $NGINX_IP && $DISTRIB_ID != "centos" ]]; then
-        if ! nc -w 3 $NGINX_IP 1935 > /dev/null; then
-            echo "# Error: Unable to connect to port 1935 (RTMP) on $NGINX_IP"
+      if [[ ! -z $RED5_IP && $DISTRIB_ID != "centos" ]]; then
+        if ! nc -w 3 $RED5_IP 1935 > /dev/null; then
+            echo "# Error: Unable to connect to port 1935 (RTMP) on $RED5_IP"
             echo
         fi
       fi


### PR DESCRIPTION
As pointed out on [bigbluebutton-dev](https://groups.google.com/forum/#!msg/bigbluebutton-dev/iwTMelhdktw/y6RsBhXLAgAJ) it is common practice in nginx config to [specify an underscore](https://nginx.org/en/docs/http/server_names.html#miscellaneous_names) for `server_name` as a catch-all.

The `bbb-conf` script should respect that common practice and suppress warning if `server_name` is `_`.

In order to avoid `postinst` scripts to overwrite the `_`, they should be changed as well:

from:

    sed -i "s/server_name  .*/server_name  $IP;/g" /etc/nginx/sites-available/bigbluebutton

to:

    sed -i "s/server_name  [^_].*/server_name  $IP;/g" /etc/nginx/sites-available/bigbluebutton

Using `server_name  _;` and not touching it anymore also helps preventing problems like #9544.