### PR TITLE
Fix XML(Formula) Injection

### DIFF
--- a/bbb-common-web/project/Dependencies.scala
+++ b/bbb-common-web/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
     val apacheHttpAsync = "4.1.4"
 
     // Office and document conversion
-    val jodConverter = "4.2.1"
+    val jodConverter = "4.3.0"
     val apachePoi = "4.1.2"
     val nuProcess = "1.2.4"
     val libreOffice = "5.4.2"

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/Office2PdfPageConverter.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/Office2PdfPageConverter.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.bigbluebutton.presentation.UploadedPresentation;
-import org.jodconverter.OfficeDocumentConverter;
+import org.jodconverter.local.LocalConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +34,7 @@ public class Office2PdfPageConverter {
   private static Logger log = LoggerFactory.getLogger(Office2PdfPageConverter.class);
 
   public boolean convert(File presentationFile, File output, int page, UploadedPresentation pres,
-                         final OfficeDocumentConverter converter){
+                         final LocalConverter converter){
     try {
       Map<String, Object> logData = new HashMap<>();
       logData.put("meetingId", pres.getMeetingId());
@@ -46,7 +46,7 @@ public class Office2PdfPageConverter {
       String logStr = gson.toJson(logData);
       log.info(" --analytics-- data={}", logStr);
 
-      converter.convert(presentationFile, output);
+      converter.convert(presentationFile).to(output).execute();
       if (output.exists()) {
         return true;
       } else {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/OfficeDocumentConversionFilter.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/OfficeDocumentConversionFilter.java
@@ -1,0 +1,29 @@
+package org.bigbluebutton.presentation.imp;
+
+import org.jodconverter.core.office.OfficeContext;
+import org.jodconverter.local.filter.Filter;
+import org.jodconverter.local.filter.FilterChain;
+import org.jodconverter.local.office.utils.Lo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sun.star.lang.XComponent;
+import com.sun.star.sheet.XCalculatable;
+
+public class OfficeDocumentConversionFilter implements Filter {
+
+  private static Logger log = LoggerFactory.getLogger(OfficeDocumentConversionFilter.class);
+
+  @Override
+  public void doFilter(OfficeContext context, XComponent document, FilterChain chain)
+      throws Exception {
+
+    log.info("Applying the OfficeDocumentConversionFilter");
+    Lo.qiOptional(XCalculatable.class, document).ifPresent((x) -> {
+      log.info("Turn AutoCalculate off");
+      x.enableAutomaticCalculation(false);
+    });
+
+    chain.doFilter(context, document);
+  }
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/OfficeToPdfConversionService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/OfficeToPdfConversionService.java
@@ -26,10 +26,10 @@ import java.util.Map;
 import org.bigbluebutton.presentation.ConversionMessageConstants;
 import org.bigbluebutton.presentation.SupportedFileTypes;
 import org.bigbluebutton.presentation.UploadedPresentation;
-import org.jodconverter.OfficeDocumentConverter;
-import org.jodconverter.office.DefaultOfficeManagerBuilder;
-import org.jodconverter.office.OfficeException;
-import org.jodconverter.office.OfficeManager;
+import org.jodconverter.core.office.OfficeException;
+import org.jodconverter.core.office.OfficeManager;
+import org.jodconverter.local.LocalConverter;
+import org.jodconverter.local.office.LocalOfficeManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,14 +40,19 @@ public class OfficeToPdfConversionService {
 
   private OfficeDocumentValidator2 officeDocumentValidator;
   private final OfficeManager officeManager;
-  private final OfficeDocumentConverter documentConverter;
+  private final LocalConverter documentConverter;
   private boolean skipOfficePrecheck = false;
 
-  public OfficeToPdfConversionService() {
-    final DefaultOfficeManagerBuilder configuration = new DefaultOfficeManagerBuilder();
-    configuration.setPortNumbers(8100, 8101, 8102, 8103, 8104);
-    officeManager = configuration.build();
-    documentConverter = new OfficeDocumentConverter(officeManager);
+  public OfficeToPdfConversionService() throws OfficeException {
+    officeManager = LocalOfficeManager
+      .builder()
+      .portNumbers(8100, 8101, 8102, 8103, 8104)
+      .build();
+    documentConverter = LocalConverter
+      .builder()
+      .officeManager(officeManager)
+      .filterChain(new OfficeDocumentConversionFilter())
+      .build();
   }
 
   /*
@@ -139,7 +144,6 @@ public class OfficeToPdfConversionService {
     } catch (OfficeException e) {
       log.error("Could not start Office Manager", e);
     }
-
   }
 
   public void stop() {

--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -76,13 +76,9 @@ dependencies {
   compile "org.freemarker:freemarker:2.3.28"
   compile "com.google.code.gson:gson:2.8.5"
   compile "org.json:json:20180813"
-  compile "org.jodconverter:jodconverter-local:4.2.1"
+  compile "org.jodconverter:jodconverter-local:4.3.0"
   compile "com.zaxxer:nuprocess:1.2.4"
   compile "net.java.dev.jna:jna:4.5.1"
-  compile "org.libreoffice:unoil:5.4.2"
-  compile "org.libreoffice:ridl:5.4.2"
-  compile "org.libreoffice:juh:5.4.2"
-  compile "org.libreoffice:jurt:5.4.2"
   // https://mvnrepository.com/artifact/commons-fileupload/commons-fileupload
   compile group: 'commons-fileupload', name: 'commons-fileupload', version: '1.4'
 


### PR DESCRIPTION
## Problem

When attacker uploads vulnerable excel or libreoffice calc file, the formulas are executed in a server when JODConverter converts documents to pdf.
This produces a potential risk to expose server's data to attackers or
possible DoS attack.

(see as FYI https://www.notsosecure.com/data-exfiltration-formula-injection/)

## Solution

By setting `AutoCalculate` off, you can prevent server from running formula.
