### PR TITLE
 Ejected users due to permission check cannot rejoin meeting

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/PermissionCheck.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/PermissionCheck.scala
@@ -85,7 +85,8 @@ object PermissionCheck {
                                    outGW: OutMsgRouter, liveMeeting: LiveMeeting): Unit = {
     val ejectedBy = SystemUser.ID
 
-    UsersApp.ejectUserFromMeeting(outGW, liveMeeting, userId, ejectedBy, reason, EjectReasonCode.PERMISSION_FAILED)
+    UsersApp.ejectUserFromMeeting(outGW, liveMeeting, userId, ejectedBy, reason, EjectReasonCode.PERMISSION_FAILED, ban = false)
+
     // send a system message to force disconnection
     Sender.sendDisconnectClientSysMsg(meetingId, userId, ejectedBy, reason, outGW)
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectDuplicateUserReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectDuplicateUserReqMsgHdlr.scala
@@ -17,7 +17,8 @@ trait EjectDuplicateUserReqMsgHdlr {
     val ejectedBy = SystemUser.ID
 
     val reason = "user ejected because of duplicate external userid"
-    UsersApp.ejectUserFromMeeting(outGW, liveMeeting, userId, ejectedBy, reason, EjectReasonCode.DUPLICATE_USER)
+    UsersApp.ejectUserFromMeeting(outGW, liveMeeting, userId, ejectedBy, reason, EjectReasonCode.DUPLICATE_USER, ban = false)
+
     // send a system message to force disconnection
     Sender.sendDisconnectClientSysMsg(meetingId, userId, ejectedBy, EjectReasonCode.DUPLICATE_USER, outGW)
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
@@ -87,13 +87,14 @@ object UsersApp {
   }
 
   def ejectUserFromMeeting(outGW: OutMsgRouter, liveMeeting: LiveMeeting,
-                           userId: String, ejectedBy: String, reason: String, reasonCode: String): Unit = {
+                           userId: String, ejectedBy: String, reason: String,
+                           reasonCode: String, ban: Boolean): Unit = {
 
     val meetingId = liveMeeting.props.meetingProp.intId
 
     for {
       user <- Users2x.ejectFromMeeting(liveMeeting.users2x, userId)
-      reguser <- RegisteredUsers.eject(userId, liveMeeting.registeredUsers, ejectedBy)
+      reguser <- RegisteredUsers.eject(userId, liveMeeting.registeredUsers, ban)
     } yield {
       sendUserEjectedMessageToClient(outGW, meetingId, userId, ejectedBy, reason, reasonCode)
       sendUserLeftMeetingToAllClients(outGW, meetingId, userId)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ValidateAuthTokenReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ValidateAuthTokenReqMsgHdlr.scala
@@ -25,13 +25,13 @@ trait ValidateAuthTokenReqMsgHdlr extends HandlerHelpers {
 
     regUser match {
       case Some(u) =>
-        // Check if ejected user is rejoining.
+        // Check if banned user is rejoining.
         // Fail validation if ejected user is rejoining.
         // ralam april 21, 2020
-        if (u.guestStatus == GuestStatus.ALLOW && !u.ejected) {
+        if (u.guestStatus == GuestStatus.ALLOW && !u.banned) {
           userValidated(u, state)
         } else {
-          if (u.ejected) {
+          if (u.banned) {
             failReason = "Ejected user rejoining"
             failReasonCode = EjectReasonCode.EJECTED_USER_REJOINING
           }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -740,7 +740,16 @@ class MeetingActor(
     users foreach { u =>
       val respondedOnTime = (lastUserInactivityInspectSentOn - expiryTracker.userInactivityThresholdInMs) < u.lastActivityTime && (lastUserInactivityInspectSentOn + expiryTracker.userActivitySignResponseDelayInMs) > u.lastActivityTime
       if (!respondedOnTime) {
-        UsersApp.ejectUserFromMeeting(outGW, liveMeeting, u.intId, SystemUser.ID, "User inactive for too long.", EjectReasonCode.USER_INACTIVITY)
+        UsersApp.ejectUserFromMeeting(
+          outGW,
+          liveMeeting,
+          u.intId,
+          SystemUser.ID,
+          "User inactive for too long.",
+          EjectReasonCode.USER_INACTIVITY,
+          ban = false
+        )
+
         Sender.sendDisconnectClientSysMsg(liveMeeting.props.meetingProp.intId, u.intId, SystemUser.ID, EjectReasonCode.USER_INACTIVITY, outGW)
       }
     }


### PR DESCRIPTION
 - users who are ejected from meeting because of permission check cannot
   rejoin meeting as we mark them as banned. Only users ejected by a
   moderator should be banned. Later on, we should make the moderator
   indicate if the ejected user should be bannd or not.

   see https://github.com/bigbluebutton/bigbluebutton/issues/9608