### PR TITLE
Refactor STUN/TURN fetch, remove 3rd party fallback STUNs, ...

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
@@ -1,6 +1,6 @@
 import BaseAudioBridge from './base';
 import Auth from '/imports/ui/services/auth';
-import { fetchWebRTCMappedStunTurnServers } from '/imports/utils/fetchStunTurnServers';
+import { fetchWebRTCMappedStunTurnServers, getMappedFallbackStun } from '/imports/utils/fetchStunTurnServers';
 import playAndRetry from '/imports/utils/mediaElementPlayRetry';
 import logger from '/imports/startup/client/logger';
 
@@ -64,6 +64,7 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
       } catch (error) {
         logger.error({ logCode: 'sfuaudiobridge_stunturn_fetch_failed' },
           'SFU audio bridge failed to fetch STUN/TURN info, using default servers');
+        iceServers = getMappedFallbackStun();
       } finally {
         logger.debug({ logCode: 'sfuaudiobridge_stunturn_fetch_sucess', extraInfo: { iceServers } },
           'SFU audio bridge got STUN/TURN servers');

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -1,6 +1,6 @@
 import Auth from '/imports/ui/services/auth';
 import BridgeService from './service';
-import { fetchWebRTCMappedStunTurnServers } from '/imports/utils/fetchStunTurnServers';
+import { fetchWebRTCMappedStunTurnServers, getMappedFallbackStun } from '/imports/utils/fetchStunTurnServers';
 import playAndRetry from '/imports/utils/mediaElementPlayRetry';
 import logger from '/imports/startup/client/logger';
 
@@ -72,6 +72,7 @@ export default class KurentoScreenshareBridge {
     } catch (error) {
       logger.error({ logCode: 'screenshare_viwer_fetchstunturninfo_error', extraInfo: { error } },
         'Screenshare bridge failed to fetch STUN/TURN info, using default');
+      iceServers = getMappedFallbackStun();
     } finally {
       const options = {
         wsUrl: Auth.authenticateURL(SFU_URL),
@@ -168,6 +169,7 @@ export default class KurentoScreenshareBridge {
     } catch (error) {
       logger.error({ logCode: 'screenshare_presenter_fetchstunturninfo_error' },
         'Screenshare bridge failed to fetch STUN/TURN info, using default');
+      iceServers = getMappedFallbackStun();
     } finally {
       const options = {
         wsUrl: Auth.authenticateURL(SFU_URL),

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -3,7 +3,10 @@ import { defineMessages, injectIntl } from 'react-intl';
 import { Session } from 'meteor/session';
 import { notify } from '/imports/ui/services/notification';
 import VisibilityEvent from '/imports/utils/visibilityEvent';
-import { fetchWebRTCMappedStunTurnServers } from '/imports/utils/fetchStunTurnServers';
+import {
+  fetchWebRTCMappedStunTurnServers,
+  getMappedFallbackStun,
+} from '/imports/utils/fetchStunTurnServers';
 import PropTypes from 'prop-types';
 import ReconnectingWebSocket from 'reconnecting-websocket';
 import logger from '/imports/startup/client/logger';
@@ -608,9 +611,12 @@ class VideoProvider extends Component {
       logger.error({
         logCode: 'video_provider_fetchstunturninfo_error',
         extraInfo: {
-          error,
+          errorCode: error.code,
+          errorMessage: error.message,
         },
       }, 'video-provider failed to fetch STUN/TURN info, using default');
+      // Use fallback STUN server
+      iceServers = getMappedFallbackStun();
     } finally {
       const { constraints, bitrate, id: profileId } = VideoProvider.getCameraProfile();
       this.outboundIceQueues[id] = [];

--- a/bigbluebutton-html5/imports/utils/fetchStunTurnServers.js
+++ b/bigbluebutton-html5/imports/utils/fetchStunTurnServers.js
@@ -2,11 +2,18 @@ import _ from 'lodash';
 
 const MEDIA = Meteor.settings.public.media;
 const STUN_TURN_FETCH_URL = MEDIA.stunTurnServersFetchAddress;
+const CACHE_STUN_TURN = MEDIA.cacheStunTurnServers;
+const FALLBACK_STUN_SERVER = MEDIA.fallbackStunServer;
+
+let STUN_TURN_DICT;
+let MAPPED_STUN_TURN_DICT;
 
 const fetchStunTurnServers = function (sessionToken) {
+  if (STUN_TURN_DICT && CACHE_STUN_TURN) return Promise.resolve(STUN_TURN_DICT);
+
   const handleStunTurnResponse = ({ stunServers, turnServers }) => {
     if (!stunServers && !turnServers) {
-      return { error: 404, stun: [], turn: [] };
+      return Promise.reject(new Error('Could not fetch STUN/TURN servers'));
     }
 
     const turnReply = [];
@@ -19,35 +26,57 @@ const fetchStunTurnServers = function (sessionToken) {
       });
     });
 
-    return {
+    const stDictionary = {
       stun: stunServers.map(server => server.url),
       turn: turnReply,
     };
+
+    STUN_TURN_DICT = stDictionary;
+
+    return Promise.resolve(stDictionary);
   };
 
   const url = `${STUN_TURN_FETCH_URL}?sessionToken=${sessionToken}`;
   return fetch(url, { credentials: 'same-origin' })
     .then(res => res.json())
     .then(handleStunTurnResponse)
-    .then((response) => {
-      if (response.error) {
-        return Promise.reject('Could not fetch the stuns/turns servers!');
-      }
-      return response;
-    });
 };
+
+const mapStunTurn = ({ stun, turn }) => {
+  const rtcStuns = stun.map(url => ({ urls: url }));
+  const rtcTurns = turn.map(t => ({ urls: t.urls, credential: t.password, username: t.username }));
+  return rtcStuns.concat(rtcTurns);
+};
+
+const getFallbackStun = () => {
+  const stun = FALLBACK_STUN_SERVER ? [FALLBACK_STUN_SERVER] : []
+  return { stun, turn: [] };
+}
+
+const getMappedFallbackStun = () => {
+  return FALLBACK_STUN_SERVER ? [{ urls: FALLBACK_STUN_SERVER }] : [];
+}
 
 const fetchWebRTCMappedStunTurnServers = function (sessionToken) {
   return new Promise(async (resolve, reject) => {
     try {
-      const { stun, turn } = await fetchStunTurnServers(sessionToken);
-      const rtcStuns = stun.map(url => ({ urls: url }));
-      const rtcTurns = turn.map(t => ({ urls: t.urls, credential: t.password, username: t.username }));
-      return resolve(rtcStuns.concat(rtcTurns));
+      if (MAPPED_STUN_TURN_DICT && CACHE_STUN_TURN) {
+        return resolve(MAPPED_STUN_TURN_DICT);
+      }
+
+      const stDictionary =  await fetchStunTurnServers(sessionToken);
+
+      MAPPED_STUN_TURN_DICT = mapStunTurn(stDictionary);
+      return resolve(MAPPED_STUN_TURN_DICT);
     } catch (error) {
       return reject(error);
     }
   });
 };
 
-export { fetchStunTurnServers, fetchWebRTCMappedStunTurnServers };
+export {
+  fetchStunTurnServers,
+  fetchWebRTCMappedStunTurnServers,
+  getFallbackStun,
+  getMappedFallbackStun,
+};

--- a/bigbluebutton-html5/imports/utils/safari-webrtc.js
+++ b/bigbluebutton-html5/imports/utils/safari-webrtc.js
@@ -1,34 +1,19 @@
-import { fetchWebRTCMappedStunTurnServers } from '/imports/utils/fetchStunTurnServers';
+import {
+  fetchWebRTCMappedStunTurnServers,
+  getMappedFallbackStun,
+} from '/imports/utils/fetchStunTurnServers';
 import Auth from '/imports/ui/services/auth';
 import { Session } from 'meteor/session';
 import logger from '/imports/startup/client/logger';
-
-const defaultIceServersList = [
-  { urls: 'stun:stun.l.google.com:19302' },
-  { urls: 'stun:stun1.l.google.com:19302' },
-  { urls: 'stun:stun2.l.google.com:19302' },
-  { urls: 'stun:stun3.l.google.com:19302' },
-  { urls: 'stun:stun4.l.google.com:19302' },
-  { urls: 'stun:stun.ekiga.net' },
-  { urls: 'stun:stun.ideasip.com' },
-  { urls: 'stun:stun.schlund.de' },
-  { urls: 'stun:stun.stunprotocol.org:3478' },
-  { urls: 'stun:stun.voiparound.com' },
-  { urls: 'stun:stun.voipbuster.com' },
-  { urls: 'stun:stun.voipstunt.com' },
-  { urls: 'stun:stun.voxgratia.org' },
-  { urls: 'stun:stun.services.mozilla.com' },
-];
 
 const getSessionToken = () => Auth.sessionToken;
 
 export async function getIceServersList() {
   try {
     const iceServers = await fetchWebRTCMappedStunTurnServers(getSessionToken());
-
-    return iceServers || defaultIceServersList;
+    return iceServers;
   } catch (error) {
-    return defaultIceServersList;
+    return getMappedFallbackStun();
   }
 }
 

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -170,6 +170,8 @@ public:
     hidePresentation: false
   media:
     stunTurnServersFetchAddress: "/bigbluebutton/api/stuns"
+    cacheStunTurnServers: true
+    fallbackStunServer:  ''
     mediaTag: "#remote-media"
     callTransferTimeout: 5000
     callHangupTimeout: 2000

--- a/bigbluebutton-html5/public/compatibility/kurento-utils.js
+++ b/bigbluebutton-html5/public/compatibility/kurento-utils.js
@@ -1073,20 +1073,6 @@ var freeice = module.exports = function(opts) {
 
 },{"./stun.json":6,"./turn.json":7,"normalice":12}],6:[function(require,module,exports){
 module.exports=[
-  "stun.l.google.com:19302",
-  "stun1.l.google.com:19302",
-  "stun2.l.google.com:19302",
-  "stun3.l.google.com:19302",
-  "stun4.l.google.com:19302",
-  "stun.ekiga.net",
-  "stun.ideasip.com",
-  "stun.schlund.de",
-  "stun.stunprotocol.org:3478",
-  "stun.voiparound.com",
-  "stun.voipbuster.com",
-  "stun.voipstunt.com",
-  "stun.voxgratia.org",
-  "stun.services.mozilla.com"
 ]
 
 },{}],7:[function(require,module,exports){

--- a/bigbluebutton-html5/public/compatibility/sip.js
+++ b/bigbluebutton-html5/public/compatibility/sip.js
@@ -9552,7 +9552,7 @@ UA.prototype.loadConfig = function(configuration) {
       // Session parameters
       iceCheckingTimeout: 5000,
       noAnswerTimeout: 60,
-      stunServers: ['stun:stun.l.google.com:19302'],
+      stunServers: [],
       turnServers: [],
 
       // Logging parameters


### PR DESCRIPTION
Log analysis says we are getting way too many failed fetch requests for STUN/TURN servers. One possible reason is that the current way we're doing it in the client is pretty weird ie we always re-fetch it when a new RTCPeerConn is going to be created, which can generate **a lot** of GETs in some scenarios.
 
  - Refactored STUN/TURN fetch to be done only once per session (or times enough so that it can fetch a valid dictionary from bbb-web) and cache it in mem to avoid too many reqs.
    * Caching is configurable (`[...].media.cacheStunTurnServers`) so that  folks who want to use very short lived TURN credentials can disable it.
  - sip.js/kurento-utils/ICE pre-flight check: remove default 3rd party STUN servers.
    * Remove hard-coded, fallback 3rd party STUN servers (ie stun.l.google.com) from everywhere I found for privacy reasons and to prevent unexpected behaviours.
  - Add a fallback STUN config option to be used when the default STUN/TURN fetch fails
    * `[...].media.fallbackStunServer`: string, empty by default.
  - Fixed a case where full audio/microphone would get stuck on `Connecting to echo test...`
    * STUN/TURN fetch failures weren't being treated properly.
