### PR TITLE
Fix userData-shortcuts causing client crash 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
@@ -92,7 +92,7 @@ class AudioControls extends PureComponent {
               icon={muted ? 'mute' : 'unmute'}
               size="lg"
               circle
-              accessKey={shortcuts.toggleMute}
+              accessKey={shortcuts.togglemute}
             />
           ) : null}
         <Button
@@ -109,7 +109,7 @@ class AudioControls extends PureComponent {
           icon={joinIcon}
           size="lg"
           circle
-          accessKey={inAudio ? shortcuts.leaveAudio : shortcuts.joinAudio}
+          accessKey={inAudio ? shortcuts.leaveaudio : shortcuts.joinaudio}
         />
       </span>);
   }

--- a/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
@@ -32,43 +32,43 @@ const intlMessages = defineMessages({
     id: 'app.shortcut-help.functionLabel',
     description: 'heading for shortcut function column',
   },
-  openOptions: {
+  openoptions: {
     id: 'app.shortcut-help.openOptions',
     description: 'describes the open options shortcut',
   },
-  toggleUserList: {
+  toggleuserlist: {
     id: 'app.shortcut-help.toggleUserList',
     description: 'describes the toggle userlist shortcut',
   },
-  toggleMute: {
+  togglemute: {
     id: 'app.shortcut-help.toggleMute',
     description: 'describes the toggle mute shortcut',
   },
-  togglePublicChat: {
+  togglepublicchat: {
     id: 'app.shortcut-help.togglePublicChat',
     description: 'describes the toggle public chat shortcut',
   },
-  hidePrivateChat: {
+  hideprivatechat: {
     id: 'app.shortcut-help.hidePrivateChat',
     description: 'describes the hide public chat shortcut',
   },
-  closePrivateChat: {
+  closeprivatechat: {
     id: 'app.shortcut-help.closePrivateChat',
     description: 'describes the close private chat shortcut',
   },
-  openActions: {
+  openactions: {
     id: 'app.shortcut-help.openActions',
     description: 'describes the open actions shortcut',
   },
-  openStatus: {
+  openstatus: {
     id: 'app.shortcut-help.openStatus',
     description: 'describes the open status shortcut',
   },
-  joinAudio: {
+  joinaudio: {
     id: 'app.audio.joinAudio',
     description: 'describes the join audio shortcut',
   },
-  leaveAudio: {
+  leaveaudio: {
     id: 'app.audio.leaveAudio',
     description: 'describes the leave audio shortcut',
   },
@@ -122,11 +122,10 @@ const ShortcutHelpComponent = (props) => {
 
   const shortcutItems = shortcuts.map((shortcut) => {
     if (!CHAT_ENABLED && shortcut.descId.indexOf('Chat') !== -1) return null;
-
     return (
       <tr key={_.uniqueId('hotkey-item-')}>
         <td className={styles.keyCell}>{`${accessMod} + ${shortcut.accesskey}`}</td>
-        <td className={styles.descCell}>{intl.formatMessage(intlMessages[`${shortcut.descId}`])}</td>
+        <td className={styles.descCell}>{`${intl.formatMessage(intlMessages[`${shortcut.descId.toLowerCase()}`])}`}</td>
       </tr>
     );
   });

--- a/bigbluebutton-html5/imports/ui/components/shortcut-help/service.jsx
+++ b/bigbluebutton-html5/imports/ui/components/shortcut-help/service.jsx
@@ -23,7 +23,7 @@ const withShortcutHelper = (WrappedComponent, param) => (props) => {
         .pop();
     } else {
       shortcuts = shortcuts
-        .filter(el => param.includes(el.descId))
+        .filter(el => param.map(p => p.toLowerCase()).includes(el.descId.toLowerCase()))
         .reduce((acc, current) => {
           acc[current.descId] = current.accesskey;
           return acc;

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -68,9 +68,6 @@ public:
       openActions:
         accesskey: A
         descId: openActions
-      openStatus:
-        accesskey: S
-        descId: openStatus
     branding:
       displayBrandingArea: false
     connectionTimeout: 60000


### PR DESCRIPTION
Closes #9592,

This PR also fixes shortcuts not working for components with multiple keys and removes the `openStatus` shortcut (this will no longer function as intended since the status items were moved out of the action bar). 