### PR TITLE
Do not display "Lock viewers" option in breakouts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -241,7 +241,7 @@ class UserOptions extends PureComponent {
           />)
         : null
       ),
-      (isMeteorConnected ? (
+      (!meetingIsBreakout && isMeteorConnected ? (
         <DropdownListItem
           key={this.lockId}
           icon="lock"


### PR DESCRIPTION
In breakout rooms everyone is moderator, so there is no point of lock settings