### PR TITLE
Fix listing of recordings in LTI integration

### DIFF
--- a/bbb-lti/grails-app/views/tool/index.gsp
+++ b/bbb-lti/grails-app/views/tool/index.gsp
@@ -51,9 +51,7 @@
                     <g:if test="${r.published}">
                         <div>
                         <g:each in="${r.thumbnails}" var="thumbnail">
-                            <g:each in="${thumbnail.content}" var="thumbnail_url">
-                                <img src="${thumbnail_url}" class="thumbnail"/>
-                            </g:each>
+                            <img src="${thumbnail.content}" class="thumbnail"/>
                         </g:each>
                         </div>
                   </g:if>


### PR DESCRIPTION
Without this change the LTI integration returns this as recording thumbnails:

    <img src="h" class="thumbnail"/>
    <img src="t" class="thumbnail"/>
    <img src="t" class="thumbnail"/>
    <img src="p" class="thumbnail"/>
    <img src="s" class="thumbnail"/>
    <img src=":" class="thumbnail"/>
    <img src="/" class="thumbnail"/>
    <img src="/" class="thumbnail"/>

With this change I get this:

    <img src="https://example.com/presentation/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-YYYYYYYYYYYY/presentation/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-YYYYYYYYYYYYY/thumbnails/thumb-1.png" class="thumbnail"/>