### PR TITLE
enabling fullscreen slide on playback

### DIFF
--- a/record-and-playback/presentation/playback/presentation/2.0/acornmediaplayer/jquery.acornmediaplayer.js
+++ b/record-and-playback/presentation/playback/presentation/2.0/acornmediaplayer/jquery.acornmediaplayer.js
@@ -605,6 +605,7 @@
 			 */
 			var goFullscreen = function() {
 				if(fullscreenMode) {
+					$("#presentation-area").css({ position: '', width: '', height: '', zIndex: ''});
 					if(acorn.$self[0].webkitSupportsFullscreen) {
 						acorn.$self[0].webkitExitFullScreen();
 					} else {
@@ -625,30 +626,43 @@
 					
 					fullscreenMode = false;
 					
-				} else {						
-					if(acorn.$self[0].webkitSupportsFullscreen) {
-						acorn.$self[0].webkitEnterFullScreen();
-					} else if (acorn.$self[0].mozRequestFullScreen) {
-						acorn.$self[0].mozRequestFullScreen();
-						acorn.$self.attr('controls', 'controls');
-						document.addEventListener('mozfullscreenchange', function() {
-							console.log('screenchange event found');
-							if (!document.mozFullScreenElement) {
-								acorn.$self.removeAttr('controls');
-								//document.removeEventListener('mozfullscreenchange');
-							}
-						});
-					} else {
-						$('body').css('overflow', 'hidden');
+				} else {	
+					var videoelement = document.getElementById("video-area");
+					if (videoelement.parentNode.getAttribute("id") == "main-section") {
+						if(acorn.$self[0].webkitSupportsFullscreen) {
+							acorn.$self[0].webkitEnterFullScreen();
+						} else if (acorn.$self[0].mozRequestFullScreen) {
+							acorn.$self[0].mozRequestFullScreen();
+							acorn.$self.attr('controls', 'controls');
+							document.addEventListener('mozfullscreenchange', function() {
+								console.log('screenchange event found');
+								if (!document.mozFullScreenElement) {
+									acorn.$self.removeAttr('controls');
+									//document.removeEventListener('mozfullscreenchange');
+								}
+							});
+						} else {
+							$('body').css('overflow', 'hidden');
 					
-						acorn.$self.addClass('fullscreen-video').attr({
-							width: $(window).width(),
-							height: $(window).height()
-						});
+							acorn.$self.addClass('fullscreen-video').attr({
+								width: $(window).width(),
+								height: $(window).height()
+							});
 						
-						$(window).resize(resizeFullscreenVideo);
+							$(window).resize(resizeFullscreenVideo);
 						
-						acorn.$controls.addClass('fullscreen-controls');
+							acorn.$controls.addClass('fullscreen-controls');
+						}
+					} else {
+						if($("#presentation-area")[0].webkitRequestFullScreen) {
+							$("#presentation-area")[0].webkitRequestFullScreen();
+						} else if ($("#presentation-area")[0].mozRequestFullScreen) {
+							$("#presentation-area")[0].mozRequestFullScreen();
+						} else if ($("#presentation-area")[0].msRequestFullscreen) {
+							$("#presentation-area")[0].msRequestFullscreen();
+						} else {
+							$("#presentation-area").css({ width: $(window).width(), zIndex: 1});
+						}
 					}
 					
 					fullscreenMode = true;

--- a/record-and-playback/presentation/playback/presentation/2.0/playback.html
+++ b/record-and-playback/presentation/playback/presentation/2.0/playback.html
@@ -37,7 +37,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     <img id="load-img" class="loading-img" src="logo.png">
     <p id="load-msg">Loading</p>
   </div>
-  <div class="circle" id="cursor"></div>
   <div id="playback-content" class="off-canvas-wrap" data-offcanvas>
 
     <div class="inner-wrap">
@@ -64,6 +63,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
           <div id="presentation-area" role="region" aria-label="Presentation" data-swap>
             <div id="slide" role="img" aria-labelledby="slideText"></div>
             <div id="slideText" class="show-for-sr" aria-live="polite"></div>
+            <div class="circle" id="cursor"></div>
           </div>
 
           <div id="copyright"></div>


### PR DESCRIPTION
As discussed in https://groups.google.com/forum/#!topic/bigbluebutton-dev/h4s6QFbGvP4 , the students may want to full-screen the slide, not the video, on the playback. But the current implementation only allows the video full-screen. 
This PR tries to change the window that is to be full-screened, depending on which is in the main-section between the slide window and the video window.
Knowing this feature to be implemented in the next version planned on this summer, I suppose there are already many users who want this change.