### PR TITLE
Sort sanity files so it processes older recordings first

### DIFF
--- a/record-and-playback/core/scripts/rap-process-worker.rb
+++ b/record-and-playback/core/scripts/rap-process-worker.rb
@@ -27,8 +27,7 @@ def process_archived_meetings(recording_dir)
   sanity_done_files = Dir.glob("#{recording_dir}/status/sanity/*.done")
 
   FileUtils.mkdir_p("#{recording_dir}/status/processed")
-  # TODO sort by timestamp(s)
-  sanity_done_files.each do |sanity_done|
+  sanity_done_files.sort{ |a,b| BigBlueButton.done_to_timestamp(a) <=> BigBlueButton.done_to_timestamp(b) }.each do |sanity_done|
     done_base = File.basename(sanity_done, '.done')
     meeting_id = nil
     break_timestamp = nil


### PR DESCRIPTION
Simpler solution than the ones proposed by #9183 and #9249.

Uses function from the module: https://github.com/bigbluebutton/bigbluebutton/blob/v2.2.x-release/record-and-playback/core/lib/recordandplayback.rb#L244