### PR TITLE
Add bbb_show_public_chat_on_login as a join (co-) parameter

### DIFF
--- a/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
+++ b/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
@@ -59,6 +59,7 @@ const currentParameters = [
   'bbb_auto_swap_layout',
   'bbb_hide_presentation',
   'bbb_show_participants_on_login',
+  'bbb_show_public_chat_on_login',
   // OUTSIDE COMMANDS
   'bbb_outside_toggle_self_voice',
   'bbb_outside_toggle_recording',

--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -354,7 +354,7 @@ const BaseContainer = withTracker(() => {
     });
   }
 
-  if (getFromUserSettings('bbb_show_participants_on_login', false) && !deviceInfo.type().isPhone) {
+  if (getFromUserSettings('bbb_show_participants_on_login', true) && !deviceInfo.type().isPhone) {
     Session.set('openPanel', 'userlist');
     if (CHAT_ENABLED) {
       //Session.set('openPanel', 'chat');

--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -356,7 +356,7 @@ const BaseContainer = withTracker(() => {
 
   if (getFromUserSettings('bbb_show_participants_on_login', true) && !deviceInfo.type().isPhone) {
     Session.set('openPanel', 'userlist');
-    if (CHAT_ENABLED && getFromUserSettings('bbb_show_public_chat_on_login', true)) {
+    if (CHAT_ENABLED && getFromUserSettings('bbb_show_public_chat_on_login', !Meteor.settings.public.chat.startClosed)) {
       Session.set('openPanel', 'chat');
       Session.set('idChatOpen', PUBLIC_CHAT_ID);
     }

--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -357,8 +357,8 @@ const BaseContainer = withTracker(() => {
   if (getFromUserSettings('bbb_show_participants_on_login', false) && !deviceInfo.type().isPhone) {
     Session.set('openPanel', 'userlist');
     if (CHAT_ENABLED) {
-      Session.set('openPanel', 'chat');
-      Session.set('idChatOpen', PUBLIC_CHAT_ID);
+      //Session.set('openPanel', 'chat');
+      //Session.set('idChatOpen', PUBLIC_CHAT_ID);
     }
   } else {
     Session.set('openPanel', '');

--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -354,7 +354,7 @@ const BaseContainer = withTracker(() => {
     });
   }
 
-  if (getFromUserSettings('bbb_show_participants_on_login', true) && !deviceInfo.type().isPhone) {
+  if (getFromUserSettings('bbb_show_participants_on_login', false) && !deviceInfo.type().isPhone) {
     Session.set('openPanel', 'userlist');
     if (CHAT_ENABLED) {
       Session.set('openPanel', 'chat');

--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -356,9 +356,9 @@ const BaseContainer = withTracker(() => {
 
   if (getFromUserSettings('bbb_show_participants_on_login', true) && !deviceInfo.type().isPhone) {
     Session.set('openPanel', 'userlist');
-    if (CHAT_ENABLED) {
-      //Session.set('openPanel', 'chat');
-      //Session.set('idChatOpen', PUBLIC_CHAT_ID);
+    if (CHAT_ENABLED && getFromUserSettings('bbb_show_public_chat_on_login', true)) {
+      Session.set('openPanel', 'chat');
+      Session.set('idChatOpen', PUBLIC_CHAT_ID);
     }
   } else {
     Session.set('openPanel', '');

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -139,6 +139,7 @@ public:
     time: 5000
   chat:
     enabled: true
+    startClosed: false
     min_message_length: 1
     max_message_length: 5000
     grouping_messages_window: 10000


### PR DESCRIPTION
Very trivial addition:

If bbb_show_participants_on_login is true (or unset) then setting **bbb_show_public_chat_on_login=false** causes the public chat component (div) to be initially hidden on login (until user expands it).

---

Only thing that needs to be changed is in
greenlight/app/controllers/concerns/bbb_server.rb
and add join_opts["userdata-bbb_show_public_chat_on_login"] = false
to the block with
join_opts = {}
join_opts[:userID] = uid if uid
join_opts[:join_via_html5] = true
join_opts[:guest] = true if options[:require_moderator_approval] && !options[:user_is_moderator]
<<add it here>>