### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!--
+PLEASE READ THIS MESSAGE.
+
+HOW TO WRITE A GOOD PULL REQUEST?
+
+- Make it small.
+- Do only one thing.
+- Avoid re-formatting.
+- Make sure the code builds and works.
+- Write useful descriptions and titles.
+- Address review comments in terms of additional commits.
+- Do not amend/squash existing ones unless the PR is trivial.
+- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
+- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code
+
+-->
+
+### What does this PR do?
+
+<!-- A brief description of each change being made with this pull request. -->
+
+### Closes Issue(s)
+
+<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number -->
+
+### Motivation
+
+<!-- What inspired you to submit this pull request? -->
+
+### More
+
+<!-- Anything else we should know when reviewing? -->
+- [ ] Added/updated documentation


### PR DESCRIPTION
### What does this PR do?

- added PULL_REQUEST_TEMPLATE.md

### Motivation

For most external pull requests, a project maintainer or core developer reads the PR, then asks the author to sign the CLA, waits some time for the CLA to be signed and then has to read/review the PR again. This wastes valuable time and increases the PR-to-merge time.
Additionally, there are a bunch of good pull requests which are just waiting weeks/months for a response regarding signing of the CLA. There even exists a [tag](https://github.com/bigbluebutton/bigbluebutton/pulls?q=label%3Arequires-cla+) for it.

The goal of this PR is to show creators of pull requests what basic rules they should follow, including reading the development FAQ and signing the CLA before creating the PR.

### More

Additionally, this PR introduces some suggested topics for pull requests to improve PR documentation and readability. This PR uses the submitted `pull_request_template.md`.