### PR TITLE
Prevent chat input shifting with error & typing messages

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/styles.scss
@@ -2,6 +2,10 @@
 @import "/imports/ui/stylesheets/mixins/_indicators";
 @import "/imports/ui/stylesheets/variables/_all";
 
+:root {
+  --max-chat-input-msg-height: .93rem;
+}
+
 .form {
   flex-grow: 0;
   flex-shrink: 0;
@@ -100,28 +104,20 @@
   }
 }
 
-.info {
-  &:before {
-    content: "\00a0"; // non-breaking space
-  }
-}
-
 .error,
 .info {
   font-size: calc(var(--font-size-base) * .75);
   color: var(--color-gray-dark);
   text-align: left;
   padding: var(--border-size) 0;
-
-  [dir="rtl"] & {
-    text-align: right;
-  }
+  position: relative;
 }
 
-.spacer {
-  &:before {
-    content: "\00a0"; // non-breaking space
-  }
+.error,
+.info,
+.space {
+  height: var(--max-chat-input-msg-height);
+  max-height: var(--max-chat-input-msg-height);
 }
 
 .coupleTyper,
@@ -146,10 +142,14 @@
   flex-direction: row;
 
   > span {
-    display: flex;
-    flex-direction: row;
+    display: block;
     width: 100%;
     line-height: var(--font-size-md);
+  }
+
+  text-align: left;
+  [dir="rtl"] & {
+    text-align: right;
   }
 }
 

--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/typing-indicator/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/typing-indicator/component.jsx
@@ -97,16 +97,16 @@ class TypingIndicator extends PureComponent {
       indicatorEnabled,
     } = this.props;
 
-    const typingElement = this.renderTypingElement();
+    const typingElement = indicatorEnabled ? this.renderTypingElement() : null;
 
-    const showSpacer = (indicatorEnabled ? !typingElement : !error);
+    const style = {};
+    style[styles.error] = !!error;
+    style[styles.info] = !error;
+    style[styles.spacer] = !!typingElement;
 
     return (
-      <div className={cx(styles.info, (showSpacer && styles.spacer))}>
-        <div className={styles.typingIndicator}>{typingElement}</div>
-        {error
-          && <div className={cx(styles.typingIndicator, styles.error)}>{error}</div>
-        }
+      <div className={cx(style)}>
+        <span className={styles.typingIndicator}>{error || typingElement}</span>
       </div>
     );
   }


### PR DESCRIPTION
This PR stops the chat input field jumping when the typing or error indicator is displayed.

before:
![shifting-chat-input](https://user-images.githubusercontent.com/22058534/82902766-f6222900-9f2d-11ea-959d-e40ac3a7bf5f.gif)

after:
![fix-shifting-chat-input](https://user-images.githubusercontent.com/22058534/82902779-fae6dd00-9f2d-11ea-8cd7-8e61e2f1eb4c.gif)
