### PR TITLE
Do not ban user who left while in waiting list. Adjusting after mergi…

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
@@ -26,7 +26,7 @@ object UsersApp {
       u <- RegisteredUsers.findWithUserId(userId, liveMeeting.registeredUsers)
     } yield {
 
-      RegisteredUsers.eject(u.id, liveMeeting.registeredUsers, u.id)
+      RegisteredUsers.eject(u.id, liveMeeting.registeredUsers, false)
 
       val event = MsgBuilder.buildGuestWaitingLeftEvtMsg(liveMeeting.props.meetingProp.intId, u.id)
       outGW.send(event)


### PR DESCRIPTION
…ng 2.2. into 2.3 in #9672

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

In 2.2.6 we introduced banning of ejected users.
Upstream in 2.3 development we had merged PR https://github.com/bigbluebutton/bigbluebutton/pull/8499 from @pedrobmarin to eject users who leave (disconnect) while in waiting list.
In this pull request I am tweaking the call for ejecting since it now requires boolean `ban` instead of string `userId`.
Without this change bbb-apps-akka does not compile...
