### PR TITLE
Close tab when user logout from a breakout room

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -178,7 +178,10 @@ class Base extends Component {
       return (<MeetingEnded code="403" />);
     }
 
-    if (meetingHasEnded && meetingIsBreakout) window.close();
+    if ((meetingHasEnded || User.loggedOut) && meetingIsBreakout) {
+      window.close();
+      return null;
+    }
 
     if (((meetingHasEnded && !meetingIsBreakout)) || (codeError && (User && User.loggedOut))) {
       AudioManager.exitAudio();


### PR DESCRIPTION
Currently when the user logout from a breakout room he sees the same message as when he logout from normal room, and after it's redirected to the defined link. 

This PR changes the behavior, so when the user logout from a breakout room the breakout room tab is closed, the same behavior of when the breakout room time expires or moderator end all breakout rooms.