### PR TITLE
Make screen reader announce captions as they are appear

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/captions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/component.jsx
@@ -28,7 +28,6 @@ class Captions extends React.Component {
     } = this.props;
 
     if (padId === nextProps.padId) {
-      if (this.text !== '') this.ariaText = this.text;
       if (revs === nextProps.revs && !nextState.clear) return false;
     }
     return true;
@@ -56,7 +55,9 @@ class Captions extends React.Component {
     const { clear } = this.state;
     if (clear) {
       this.text = '';
+      this.ariaText = '';
     } else {
+      this.ariaText = CaptionsService.formatCaptionsText(data);
       const text = this.text + data;
       this.text = CaptionsService.formatCaptionsText(text);
     }
@@ -105,15 +106,13 @@ class Captions extends React.Component {
 
     return (
       <div>
-        <div
-          aria-hidden
-          style={captionStyles}
-        >
+        <div style={captionStyles}>
           {this.text}
         </div>
         <div
           style={visuallyHidden}
-          aria-live={this.text === '' && this.ariaText !== '' ? 'polite' : 'off'}
+          aria-atomic
+          aria-live="polite"
         >
           {this.ariaText}
         </div>


### PR DESCRIPTION
Improves how screen readers interact with the live close captions. This change makes screen readers announce each word as it is entered in the captions. 

Previously, users would have to navigate to the captions for the screen reader to announce them. (users may not realize captions are displayed before they disappear)