### PR TITLE
Call onmount for custom arc-player

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/arc-player.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/arc-player.jsx
@@ -62,6 +62,10 @@ export class ArcPlayer extends Component {
     this.onStateChange = this.onStateChange.bind(this);
   }
 
+  componentDidMount () {
+    this.props.onMount && this.props.onMount(this)
+  }
+
   load() {
     new Promise((resolve, reject) => {
       this.render();


### PR DESCRIPTION
### What does this PR do?

Add the onMount callback to our custom instructure media player and make sure it loads again.
