### PR TITLE
Fix custom parameters for guest users

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
@@ -180,7 +180,7 @@ class JoinHandler extends Component {
       logUserInfo();
 
       Tracker.autorun(async (cd) => {
-        const user = Users.findOne({ userId: Auth.userID, authed: true }, { fields: { _id: 1 } });
+        const user = Users.findOne({ userId: Auth.userID, approved: true }, { fields: { _id: 1 } });
 
         if (user) {
           await setCustomData(response);


### PR DESCRIPTION
### What does this PR do?

Restore capacity of user settings for guest users. The problem was that guest users are not `authed` then the process of saving the user settings never happened.

### Closes Issue(s)
closes #9737 
