### PR TITLE
Fix poll annotation error with large presentations

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
@@ -217,9 +217,10 @@ class PollDrawComponent extends Component {
 
       // first check if we can still increase the font-size
       if (fontSizeDirection === 1) {
-        if (keySizes.width < maxLineWidth && keySizes.height < maxLineHeight
+        if ((keySizes.width < maxLineWidth && keySizes.height < maxLineHeight
           && voteSizes.width < maxLineWidth && voteSizes.height < maxLineHeight
-          && percSizes.width < maxLineWidth && percSizes.height < maxLineHeight) {
+          && percSizes.width < maxLineWidth && percSizes.height < maxLineHeight)
+          && calcFontSize < 100) {
           return this.setState({
             calcFontSize: calcFontSize + fontSizeIncrement,
           });
@@ -232,9 +233,10 @@ class PollDrawComponent extends Component {
         });
       } if (fontSizeDirection === -1) {
         // check if the font-size is still bigger than allowed
-        if (keySizes.width > maxLineWidth || keySizes.height > maxLineHeight
+        if ((keySizes.width > maxLineWidth || keySizes.height > maxLineHeight
           || voteSizes.width > maxLineWidth || voteSizes.height > maxLineHeight
-          || percSizes.width > maxLineWidth || percSizes.height > maxLineHeight) {
+          || percSizes.width > maxLineWidth || percSizes.height > maxLineHeight)
+          && calcFontSize > 0) {
           return this.setState({
             calcFontSize: calcFontSize - fontSizeIncrement,
           });


### PR DESCRIPTION
### What does this PR do?
This PR prevents the whiteboard crashing when publishing a poll with a large `.pdf` by adding a max font-size to the font calculation.

### Closes Issue(s)
#9451 