### PR TITLE
Close whiteboard toolbar sub menu on mousedown

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
@@ -115,6 +115,7 @@ class WhiteboardToolbar extends Component {
 
     this.displaySubMenu = this.displaySubMenu.bind(this);
     this.closeSubMenu = this.closeSubMenu.bind(this);
+    this.handleClose = this.handleClose.bind(this);
     this.handleUndo = this.handleUndo.bind(this);
     this.handleClearAll = this.handleClearAll.bind(this);
     this.handleSwitchWhiteboardMode = this.handleSwitchWhiteboardMode.bind(this);
@@ -400,6 +401,13 @@ class WhiteboardToolbar extends Component {
     });
   }
 
+  handleClose() {
+    this.setState({
+      onBlurEnabled: true,
+      currentSubmenuOpen: '',
+    });
+  }
+
   handleFontSizeChange(fontSize) {
     const { actions } = this.props;
     actions.setFontSize(fontSize.value);
@@ -475,6 +483,7 @@ class WhiteboardToolbar extends Component {
                 objectSelected={annotationSelected}
                 handleMouseEnter={this.handleMouseEnter}
                 handleMouseLeave={this.handleMouseLeave}
+                handleClose={this.handleClose}
               />
             )
             : null}
@@ -507,6 +516,7 @@ class WhiteboardToolbar extends Component {
               objectSelected={fontSizeSelected}
               handleMouseEnter={this.handleMouseEnter}
               handleMouseLeave={this.handleMouseLeave}
+              handleClose={this.handleClose}
             />
           )
           : null}
@@ -569,6 +579,7 @@ class WhiteboardToolbar extends Component {
               objectSelected={thicknessSelected}
               handleMouseEnter={this.handleMouseEnter}
               handleMouseLeave={this.handleMouseLeave}
+              handleClose={this.handleClose}
             />
           )
           : null}
@@ -671,6 +682,7 @@ class WhiteboardToolbar extends Component {
               objectSelected={colorSelected}
               handleMouseEnter={this.handleMouseEnter}
               handleMouseLeave={this.handleMouseLeave}
+              handleClose={this.handleClose}
             />
           )
           : null}

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-submenu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-submenu/component.jsx
@@ -129,11 +129,13 @@ class ToolbarSubmenu extends Component {
 
     this.handleMouseEnter = this.handleMouseEnter.bind(this);
     this.handleMouseLeave = this.handleMouseLeave.bind(this);
+    this.handleMouseDown = this.handleMouseDown.bind(this);
     this.onItemClick = this.onItemClick.bind(this);
     this.findCurrentElement = this.findCurrentElement.bind(this);
   }
 
   componentDidMount() {
+    document.addEventListener('mousedown', this.handleMouseDown);
     const { handleMouseEnter, objectSelected, type } = this.props;
 
     if (handleMouseEnter) {
@@ -174,6 +176,10 @@ class ToolbarSubmenu extends Component {
     }
   }
 
+  componentWillUnmount() {
+    document.removeEventListener('mousedown', this.handleMouseDown);
+  }
+
   onItemClick(objectToReturn) {
     const { onItemClick } = this.props;
 
@@ -186,6 +192,21 @@ class ToolbarSubmenu extends Component {
     if (node.nodeName === 'BUTTON') return this.findCurrentElement(node.childNodes[0]);
     if (node.nodeName === 'svg') return node.firstChild;
     return node;
+  }
+
+  handleMouseDown(e) {
+    const { handleClose } = this.props;
+    let shouldClose = true;
+    for (let i = 0; i < e.path.length; i += 1) {
+      const p = e.path[i];
+      if (p && p.className && typeof p.className === 'string') {
+        if (p.className.search('tool') !== -1) {
+          shouldClose = false;
+          break;
+        }
+      }
+    }
+    if (shouldClose) handleClose();
   }
 
   handleMouseEnter() {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-submenu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-submenu/component.jsx
@@ -136,6 +136,7 @@ class ToolbarSubmenu extends Component {
 
   componentDidMount() {
     document.addEventListener('mousedown', this.handleMouseDown);
+    document.addEventListener('touchstart', this.handleMouseDown);
     const { handleMouseEnter, objectSelected, type } = this.props;
 
     if (handleMouseEnter) {
@@ -178,6 +179,7 @@ class ToolbarSubmenu extends Component {
 
   componentWillUnmount() {
     document.removeEventListener('mousedown', this.handleMouseDown);
+    document.removeEventListener('touchstart', this.handleMouseDown);
   }
 
   onItemClick(objectToReturn) {
@@ -196,17 +198,15 @@ class ToolbarSubmenu extends Component {
 
   handleMouseDown(e) {
     const { handleClose } = this.props;
-    let shouldClose = true;
     for (let i = 0; i < e.path.length; i += 1) {
       const p = e.path[i];
       if (p && p.className && typeof p.className === 'string') {
         if (p.className.search('tool') !== -1) {
-          shouldClose = false;
-          break;
+          return false;
         }
       }
     }
-    if (shouldClose) handleClose();
+    return handleClose();
   }
 
   handleMouseEnter() {


### PR DESCRIPTION
### What does this PR do?
Closes the whiteboard toolbar sub menu when outside of the tools are clicked

### Closes Issue(s)
#9730 