### PR TITLE
Add debounce to talking indicator mute function

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/container.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import VoiceUsers from '/imports/api/voice-users';
 import Auth from '/imports/ui/services/auth';
+import { debounce } from 'lodash';
 import TalkingIndicator from './component';
 import { makeCall } from '/imports/ui/services/api';
 import Service from './service';
@@ -57,7 +58,7 @@ export default withTracker(() => {
 
   return {
     talkers,
-    muteUser,
+    muteUser: id => debounce(muteUser(id), 500, { leading: true, trailing: false }),
     openPanel: Session.get('openPanel'),
   };
 })(TalkingIndicatorContainer);


### PR DESCRIPTION
### What does this PR do?

adds a debounce to prevent the ability to unmute when spam clicking the button. 

### Closes Issue(s)

partially closes #9731 