### PR TITLE
Prevent drag and drop of files closing session

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -133,6 +133,8 @@ class App extends Component {
 
     this.handleWindowResize();
     window.addEventListener('resize', this.handleWindowResize, false);
+    window.ondragover = function (e) { e.preventDefault(); };
+    window.ondrop = function (e) { e.preventDefault(); };
 
     if (ENABLE_NETWORK_MONITORING) {
       if (navigator.connection) {


### PR DESCRIPTION
### What does this PR do?

This prevents the session being closed if you drag and drop a file onto the window.

### Motivation

A simple way to prevent #9661  until we  allow drag-and-drop of presentation over the main BigBlueButton area in a future version.