### PR TITLE
fix TypeError: event.path is undefined

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
@@ -142,7 +142,10 @@ class UserParticipants extends Component {
   }
 
   handleClickSelectedUser(event) {
-    const selectedUser = event.path.find(p => p.className && p.className.includes('participantsList'));
+    let selectedUser = null;
+    if (event.path) {
+      selectedUser = event.path.find(p => p.className && p.className.includes('participantsList'));
+    }
     this.setState({ selectedUser });
   }
 


### PR DESCRIPTION
### What does this PR do?
Fixes type error 
`TypeError: e.path is undefinedf71beea2f99f7310c59d70a61c9275616f36da02.js:336:61653
    handleClickSelectedUser https://develop.bigbluebutton.org/html5client/f71beea2f99f7310c59d70a61c9275616f36da02.js?meteor_js_resource=true:336
    handleClickSelectedUser`