### PR TITLE
Fix ending of screenshare displaying empty container

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -59,8 +59,14 @@ class ScreenshareComponent extends React.Component {
 
   componentWillUnmount() {
     const {
-      presenterScreenshareHasEnded, unshareScreen,
+      presenterScreenshareHasEnded,
+      unshareScreen,
+      getSwapLayout,
+      shouldEnableSwapLayout,
+      toggleSwapLayout,
     } = this.props;
+    const layoutSwapped = getSwapLayout() && shouldEnableSwapLayout();
+    if (layoutSwapped) toggleSwapLayout();
     presenterScreenshareHasEnded();
     unshareScreen();
     this.screenshareContainer.removeEventListener('fullscreenchange', this.onFullscreenChange);

--- a/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import Users from '/imports/api/users/';
 import Auth from '/imports/ui/services/auth';
+import MediaService, { getSwapLayout, shouldEnableSwapLayout } from '/imports/ui/components/media/service';
 import {
   isVideoBroadcasting, presenterScreenshareHasEnded, unshareScreen,
   presenterScreenshareHasStarted,
@@ -24,5 +25,8 @@ export default withTracker(() => {
     isVideoBroadcasting,
     presenterScreenshareHasStarted,
     presenterScreenshareHasEnded,
+    getSwapLayout,
+    shouldEnableSwapLayout,
+    toggleSwapLayout: MediaService.toggleSwapLayout,
   };
 })(ScreenshareContainer);


### PR DESCRIPTION
### What does this PR do?
invokes `toggleSwapLayout` if the layout is swapped when the screen share closes

### Closes Issue(s)
#9768
