### PR TITLE
[HTML5 Client] Camera Profile Documentation

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -96,6 +96,17 @@ public:
     - screen
     firefoxScreenshareSource: window
     cameraProfiles:
+      # id: unique identifier of the profile
+      # name: name of the profile visible to users
+      # default: if this is the default profile which is pre-selected
+      # bitrate: the average bitrate for used for a webcam stream
+      # constraints:
+      #   # Optional constraints put on the requested video a browser MAY honor
+      #   # For a detailed list on possible values see:
+      #   # https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints
+      #   # Examples:
+      #   width: requested width of the camera stream
+      #   frameRate: requested framerate
       - id: low
         name: Low quality
         default: false


### PR DESCRIPTION
This patch adds a short comment block to the HTML5 client's
configuration file explaining the options available for the camera
profiles. Having this in the configuration file helps as a quick
reference and means that administrators do not need to find external
sources of information.