### PR TITLE
fix(recording): Generate thumbnails from uploaded file

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/generators/presentation.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/presentation.rb
@@ -104,10 +104,14 @@ module BigBlueButton
       BigBlueButton.logger.info("Task: Getting from events the presentation to be used for preview")
       presentation = {}
       doc = Nokogiri::XML(File.open(events_xml))
+      presentation_filenames = {}
+      doc.xpath("//event[@eventname='ConversionCompletedEvent']").each do |conversion_event|
+        presentation_filenames[conversion_event.xpath("presentationName").text] = conversion_event.xpath("originalFilename").text
+      end
       doc.xpath("//event[@eventname='SharePresentationEvent']").each do |presentation_event|
         # Extract presentation data from events
         presentation_id = presentation_event.xpath("presentationName").text
-        presentation_filename = presentation_event.xpath("originalFilename").text
+        presentation_filename = presentation_filenames[presentation_id]
         # Set textfile directory
         textfiles_dir = "#{process_dir}/presentation/#{presentation_id}/textfiles"
         # Set presentation hashmap to be returned


### PR DESCRIPTION
### What does this PR do?
Make BBB to generate thumbnails from the presentation file uploaded by users, not from default.pdf, which happens always in my server. 
I found it weird that nobody reports it. I am scared that this is only happening to me...
If not, the bug seems to be that "originalFilename" tag is not present in "SharePresentationEvent" in metadata.xml. 

### More
Same PR in #9570 , but this PR is for the release 2.2. Apologizes if this violates the PR rule here.
I post this here in part because of the PR in Greenlight.
https://github.com/bigbluebutton/greenlight/pull/1796
In this PR I tried to implement a selectable thumbnail dropdown for the room owner. 
Discussions opened in https://github.com/bigbluebutton/greenlight/issues/1767 and #9811.

