### PR TITLE
Update Note About Sharing External Video

### DIFF
--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -676,7 +676,7 @@
     "app.externalVideo.autoPlayWarning": "Play the video to enable media synchronization",
     "app.network.connection.effective.slow": "We're noticing connectivity issues.",
     "app.network.connection.effective.slow.help": "More information",
-    "app.externalVideo.noteLabel": "Note: Shared external videos will not appear in the recording. YouTube, Vimeo, Instructure Media, Twitch and Daily Motion URLs are supported.",
+    "app.externalVideo.noteLabel": "Note: Shared external videos will not appear in the recording. YouTube, Vimeo, Instructure Media, Twitch, Dailymotion and media file URLs (e.g. https://example.com/xy.mp4) are supported.",
     "app.actionsBar.actionsDropdown.shareExternalVideo": "Share an external video",
     "app.actionsBar.actionsDropdown.stopShareExternalVideo": "Stop sharing external video",
     "app.iOSWarning.label": "Please upgrade to iOS 12.2 or higher",


### PR DESCRIPTION
This patch updates the note about which external videos can be shared
by looking at what react-player supports. Most notably, SoundCloud and
external video URLs are added.

This also removes the mention of Instructure Media for which I could not
find a way to actually use it. It is also not mentioned in the list of
supported sources by react-player.

Finally, this fixes the misspelled name of Dailymotion.