### PR TITLE
Fix voice bridge compare

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiErrors.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiErrors.java
@@ -36,6 +36,10 @@ public class ApiErrors {
 		errors.add(new String[] {"NotUniqueMeetingID", "A meeting already exists with that meeting ID.  Please use a different meeting ID."});
 	}
 
+	public void nonUniqueVoiceBridgeError() {
+		errors.add(new String[] {"nonUniqueVoiceBridge", "The selected voice bridge is already in use."});
+	}
+
 	public void invalidMeetingIdError() {
 		errors.add(new String[] {"invalidMeetingId", "The meeting ID that you supplied did not match any existing meetings"});
 	}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -444,7 +444,7 @@ public class MeetingService implements MessageListener {
           return null;
       for (Map.Entry<String, Meeting> entry : meetings.entrySet()) {
           Meeting m = entry.getValue();
-          if (m.getTelVoice() == telVoice) {
+          if (telVoice.equals(m.getTelVoice())) {
               if (!m.isForciblyEnded())
                   return m;
           }
@@ -457,7 +457,7 @@ public class MeetingService implements MessageListener {
           return null;
       for (Map.Entry<String, Meeting> entry : meetings.entrySet()) {
           Meeting m = entry.getValue();
-          if (m.getWebVoice() == webVoice) {
+          if (webVoice.equals(m.getWebVoice())) {
               if (!m.isForciblyEnded())
                   return m;
           }

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -181,7 +181,7 @@ class ApiController {
         Meeting existingWebVoice = meetingService.getNotEndedMeetingWithWebVoice(newMeeting.getWebVoice());
         if (existingTelVoice != null || existingWebVoice != null) {
           log.error "VoiceBridge already in use by another meeting (different meetingId)"
-          errors.nonUniqueMeetingIdError()
+          errors.nonUniqueVoiceBridgeError()
           respondWithErrors(errors)
         }
       }


### PR DESCRIPTION
@elor I was having some trouble trying to understand #9251. Somehow I was still able to create meetings with the same `voiceBridge`. Does this makes any sense?

Replaced `==` string compare to a `String.equals` (since the string is a validated non-null object) and included a new API error to make it more clear at the response.