### PR TITLE
Ensure that files are handled safely in recording scripts

### DIFF
--- a/record-and-playback/core/lib/recordandplayback.rb
+++ b/record-and-playback/core/lib/recordandplayback.rb
@@ -201,7 +201,7 @@ module BigBlueButton
 
   def self.add_tag_to_xml(xml_filename, parent_xpath, tag, content)
     if File.exist? xml_filename
-      doc = Nokogiri::XML(File.open(xml_filename)) {|x| x.noblanks}
+      doc = Nokogiri::XML(File.read(xml_filename)) {|x| x.noblanks}
 
       node = doc.at_xpath("#{parent_xpath}/#{tag}")
       node.remove if not node.nil?

--- a/record-and-playback/core/scripts/rap-publish-worker.rb
+++ b/record-and-playback/core/scripts/rap-publish-worker.rb
@@ -97,7 +97,7 @@ def publish_processed_meetings(recording_dir)
       metadata_xml_path = "#{published_dir}/#{publish_type}/#{done_base}/metadata.xml"
       if File.exists? metadata_xml_path
         begin
-          doc = Hash.from_xml(File.open(metadata_xml_path))
+          doc = Hash.from_xml(File.read(metadata_xml_path))
           playback = doc[:recording][:playback] if !doc[:recording][:playback].nil?
           metadata = doc[:recording][:meta] if !doc[:recording][:meta].nil?
           download = doc[:recording][:download] if !doc[:recording][:download].nil?

--- a/record-and-playback/presentation/scripts/process/presentation.rb
+++ b/record-and-playback/presentation/scripts/process/presentation.rb
@@ -89,7 +89,7 @@ if not FileTest.directory?(target_dir)
     FileUtils.mkdir_p processed_pres_dir
 
     # Get the real-time start and end timestamp
-    @doc = Nokogiri::XML(File.open("#{target_dir}/events.xml"))
+    @doc = Nokogiri::XML(File.read("#{target_dir}/events.xml"))
 
     meeting_start = @doc.xpath("//event")[0][:timestamp]
     meeting_end = @doc.xpath("//event").last()[:timestamp]
@@ -101,7 +101,7 @@ if not FileTest.directory?(target_dir)
 
     # Add start_time, end_time and meta to metadata.xml
     ## Load metadata.xml
-    metadata = Nokogiri::XML(File.open("#{target_dir}/metadata.xml"))
+    metadata = Nokogiri::XML(File.read("#{target_dir}/metadata.xml"))
     ## Add start_time and end_time
     recording = metadata.root
     ### Date Format for recordings: Thu Mar 04 14:05:56 UTC 2010
@@ -243,7 +243,7 @@ if not FileTest.directory?(target_dir)
 
     # Update state in metadata.xml
     ## Load metadata.xml
-    metadata = Nokogiri::XML(File.open("#{target_dir}/metadata.xml"))
+    metadata = Nokogiri::XML(File.read("#{target_dir}/metadata.xml"))
     ## Update status
     recording = metadata.root
     state = recording.at_xpath("state")


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

This PR fixes an issue with reading and writing files.
File.open is used which means that a file will remain open
unless explicilty closed or the program exit. This doesn't work
for an NFS mount as the scripts try to "rm -rf" when the file
is still open. This commit fixes that by replacing all .opens
with .reads in 3 locations.

### Closes Issue(s)

<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number -->

Fixes #9062 and #9110 (duplicates)

### Motivation

<!-- What inspired you to submit this pull request? -->

Our BBB hosts only have a maximum disk size of 25GB so we could not store recordings locally. An external NFS mount was used for the Kurento, FreeSWITCH and other directories to ensure that the entire process still worked. However, we ran into this issue and the existing fixes in the issues were quick hacks that did not solve the issue at large. It is also good practice to close files after using them. It may be necessary to apply this to all scripts in record-and-playback but for us, only these were necessary as we archive and perform sanity on the BBB hosts but process and publish on another machine.

## More

Use the following regexp:
    regexp: '^(.*(Nokogiri::XML|Hash\.from_xml))\(File.open\((.*)$'
    replace: '\1(File.read(\3'
