### PR TITLE
Fix shared note unread indicator placement

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/styles.scss
@@ -63,7 +63,7 @@
 
   [dir="rtl"]  & {
     padding-right: var(--lg-padding-y);
-    padding-left: none;
+    padding-left: 0;
   }
 
   > i {
@@ -112,6 +112,11 @@
 .unreadMessages {
   @extend %flex-column;
   justify-content: center;
+  margin-left: auto;
+  [dir="rtl"] & {
+    margin-right: auto;
+    margin-left: 0;
+  }
 }
 
 .unreadMessagesText {


### PR DESCRIPTION
### What does this PR do?

Fixes the position of the unread indicator for the shared notes.

### Motivation
before:
![image](https://user-images.githubusercontent.com/22058534/85296968-26e37880-b470-11ea-841a-c60534831ba3.png)


after:
![image](https://user-images.githubusercontent.com/22058534/85296851-fdc2e800-b46f-11ea-8554-a1cc17fb4650.png)

