### PR TITLE
Recording bugfixes for presentation format

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -36,11 +36,11 @@ module BigBlueButton
          userId = joinEvent.at_xpath("userId").text
 
          #removing "_N" at the end of userId
-         userId.gsub(/_\d*$/, "")
+         userId.gsub!(/_\d*$/, "")
 
          participants_ids.add(userId)
       end
-      return participants_ids.length
+      participants_ids.length
     end
 
     # Get the meeting metadata

--- a/record-and-playback/presentation/scripts/process/presentation.rb
+++ b/record-and-playback/presentation/scripts/process/presentation.rb
@@ -195,7 +195,7 @@ if not FileTest.directory?(target_dir)
       end
 
       # Copy thumbnails from raw files
-      FileUtils.cp_r("#{pres_dir}/thumbnails", "#{target_pres_dir}/thumbnails")
+      FileUtils.cp_r("#{pres_dir}/thumbnails", "#{target_pres_dir}/thumbnails") if File.exist?("#{pres_dir}/thumbnails")
     end
 
     BigBlueButton.logger.info("Generating closed captions")


### PR DESCRIPTION
This adds workarounds for an issue seen in BigBlueButton where the `presentationName` field in recording events contains invalid data (usually the original filename of the presentation plus several numeric digits). It was failing if the directory matching the `presentationName` did not exist.

Also a fix for the participants count to correctly exclude reconnects