### PR TITLE
bbb-webhooks: add a timeout configuration to be used on POST requests

### DIFF
--- a/bbb-webhooks/callback_emitter.js
+++ b/bbb-webhooks/callback_emitter.js
@@ -61,10 +61,11 @@ module.exports = class CallbackEmitter extends EventEmitter {
   }
 
   _emitMessage(callback) {
-    let data,requestOptions;
+    let data, requestOptions;
     const serverDomain = config.get("bbb.serverDomain");
     const sharedSecret = config.get("bbb.sharedSecret");
     const bearerAuth = config.get("bbb.auth2_0");
+    const timeout = config.get('hooks.requestTimeout');
 
     // data to be sent
     // note: keep keys in alphabetical order
@@ -85,7 +86,8 @@ module.exports = class CallbackEmitter extends EventEmitter {
         form: data,
         auth: {
           bearer: sharedSecret
-        }
+        },
+        timeout
       };
     }
     else {
@@ -103,7 +105,8 @@ module.exports = class CallbackEmitter extends EventEmitter {
         maxRedirects: 10,
         uri: callbackURL,
         method: "POST",
-        form: data
+        form: data,
+        timeout
       };
     }
 

--- a/bbb-webhooks/config/custom-environment-variables.yml
+++ b/bbb-webhooks/config/custom-environment-variables.yml
@@ -6,6 +6,9 @@ hooks:
   permanentURLs:
     __name: PERMANENT_HOOKS
     __format: json
+  requestTimeout:
+    __name: REQUEST_TIMEOUT
+    __format: json
 redis:
   host: REDIS_HOST
   port: REDIS_PORT

--- a/bbb-webhooks/config/default.example.yml
+++ b/bbb-webhooks/config/default.example.yml
@@ -47,6 +47,8 @@ hooks:
     - 60000
   # Reset permanent interval when exceeding maximum attemps
   permanentIntervalReset: 8
+  # Hook's request module timeout for socket conn establishment and/or responses (ms)
+  requestTimeout: 5000
 
 # Mappings of internal to external meeting IDs
 mappings:


### PR DESCRIPTION
### What does this PR do?

- Add a new config `requestTimeout`.
  * Add a new environment variable mapping for it called `REQUEST_TIMEOUT`.
  * The config is piped to the `request` module POST request in `callback_emitter.js`. It makes it properly throw socket establishment timeout errors and prevent queue clogging when there's no response from the webhook recipient.

### Motivation

The lack of the timeout config caused queue clogs when, due to ie network instability or network misconfigs, no response was received for a POST request fired from bbb-webhooks. Worst of all, it'd clog silently. So this will make it properly log the timeout errors and keep trying to resend the POST requests until it works.

