### PR TITLE
Improve the end meeting confirmation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/component.jsx
@@ -4,7 +4,7 @@ import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import Button from '/imports/ui/components/button/component';
 import Modal from '/imports/ui/components/modal/simple/component';
 import { styles } from './styles';
-
+import EndMeetingUserList from './user-list/component';
 
 const intlMessages = defineMessages({
   endMeetingTitle: {
@@ -29,11 +29,14 @@ const propTypes = {
   intl: intlShape.isRequired,
   closeModal: PropTypes.func.isRequired,
   endMeeting: PropTypes.func.isRequired,
+  users: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
 };
 
 class EndMeetingComponent extends React.PureComponent {
   render() {
-    const { intl, closeModal, endMeeting } = this.props;
+    const {
+      users, intl, closeModal, endMeeting,
+    } = this.props;
 
     return (
       <Modal
@@ -45,6 +48,9 @@ class EndMeetingComponent extends React.PureComponent {
       >
         <div className={styles.container}>
           <div className={styles.description}>
+            <EndMeetingUserList
+              users={users}
+            />
             {intl.formatMessage(intlMessages.endMeetingDescription)}
           </div>
           <div className={styles.footer}>

--- a/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/container.jsx
@@ -3,11 +3,12 @@ import { withTracker } from 'meteor/react-meteor-data';
 import { withModalMounter } from '/imports/ui/components/modal/service';
 import { makeCall } from '/imports/ui/services/api';
 import EndMeetingComponent from './component';
+import Service from './service';
 
 const EndMeetingContainer = props => <EndMeetingComponent {...props} />;
 
 export default withModalMounter(withTracker(({ mountModal }) => ({
-  closeModal() {
+  closeModal: () => {
     mountModal(null);
   },
 
@@ -16,4 +17,5 @@ export default withModalMounter(withTracker(({ mountModal }) => ({
     mountModal(null);
   },
 
+  users: Service.getUsers(),
 }))(EndMeetingContainer));

--- a/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/service.js
@@ -1,0 +1,36 @@
+import Users from '/imports/api/users';
+import Auth from '/imports/ui/services/auth';
+
+const USERS_TO_DISPLAY = Meteor.settings.public.app.maxUsersForConfirmation;
+
+const userFindSorting = {
+  emojiTime: 1,
+  role: 1,
+  phoneUser: 1,
+  sortName: 1,
+  userId: 1,
+};
+
+const getUsers = () => {
+  let users = Users
+    .find({
+      meetingId: Auth.meetingID,
+      connectionStatus: 'online',
+    }, userFindSorting)
+    .fetch();
+
+  // user shouldn't see themselves in the list
+  users = users.filter(u => u.userId !== Auth.userID);
+
+  return users;
+};
+
+const getUsersToDisplay = (users) => {
+  const diff = users.length - USERS_TO_DISPLAY;
+  return { displayUsers: users.slice(0, USERS_TO_DISPLAY), remainder: diff <= 0 ? false : diff };
+};
+
+export default {
+  getUsers,
+  getUsersToDisplay,
+};

--- a/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/styles.scss
@@ -60,3 +60,25 @@
   line-height: var(--title-position-left);
   margin-bottom: var(--lg-padding-y);
 }
+
+.warningItem {
+  display: flex;
+  flex-grow: 1;
+  align-items: center;
+  text-decoration: none;
+  font-weight: bold;
+  width: 100%;
+}
+
+.warningIcon{
+  flex: 0 0 2.2rem;
+  padding-right: var(--lg-padding-y);
+}
+
+.userListItemText {
+  text-overflow: ellipsis;
+}
+
+.userListText {
+  text-align: left;
+}

--- a/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/user-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/user-list/component.jsx
@@ -31,13 +31,7 @@ class EndMeetingUserListComponent extends Component {
             ))}
           </ul>
           {remainder && (
-            <p>
-              and
-              {' '}
-              {remainder}
-              {' '}
-other active users in this session.
-            </p>
+            <p>and {remainder} other active users in this session.</p>
           )}
         </div>
       </div>

--- a/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/user-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/user-list/component.jsx
@@ -1,0 +1,51 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { styles } from '../styles.scss';
+import WarningIcon from '../warning-icon/component';
+import Service from '../service';
+
+const propTypes = {
+  users: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+};
+
+class EndMeetingUserListComponent extends Component {
+  render() {
+    const { users } = this.props;
+
+    const { displayUsers, remainder } = Service.getUsersToDisplay(users);
+    const list = users.length > 0 ? (
+      <div>
+        <div className={styles.warningItem}>
+          <div className={styles.warningIcon}>
+            <WarningIcon icon="warning" />
+          </div>
+          <p>Attention</p>
+        </div>
+        <div className={styles.userListText}>
+          <p>This action will end the meeting for:</p>
+          <ul className={styles.userListItemText}>
+            {displayUsers.map(user => (
+              <li key={user.userId}>
+                {user.name}
+              </li>
+            ))}
+          </ul>
+          {remainder && (
+            <p>
+              and
+              {' '}
+              {remainder}
+              {' '}
+other active users in this session.
+            </p>
+          )}
+        </div>
+      </div>
+    ) : null;
+    return list;
+  }
+}
+
+EndMeetingUserListComponent.propTypes = propTypes;
+
+export default EndMeetingUserListComponent;

--- a/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/warning-icon/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/warning-icon/component.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { styles } from './styles.scss';
+import Icon from '/imports/ui/components/icon/component';
+
+const propTypes = {
+  icon: PropTypes.elementType.isRequired,
+};
+
+const WarningIcon = (props) => {
+  const { icon } = props;
+  return (
+    <div className={styles.warningThumbnail}>
+      <Icon iconName={icon} />
+    </div>
+  );
+};
+
+WarningIcon.propTypes = propTypes;
+
+export default WarningIcon;

--- a/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/warning-icon/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/warning-icon/styles.scss
@@ -1,0 +1,6 @@
+.warningThumbnail {
+//  color: var(--color-gray-light);
+  font-size: 175%;
+  padding: 0;
+  margin: 0;
+}

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -22,6 +22,7 @@ public:
     enableLimitOfViewersInWebcam: false
     enableTalkingIndicator: true
     mirrorOwnWebcam: false
+    maxUsersForConfirmation: 8
     viewersInWebcam: 8
     ipv4FallbackDomain: ""
     allowLogout: true


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

This PR improves the end meeting screen by better informing the users of the consequences of their actions. Adds:

* New setting to modify the number of users to display in the end meeting modal
* Two new components, `WarningIcon` and `EndMeetingUserListComponent`

### Closes Issue(s)

Closes #9898 and related issues therein

### Motivation

The community suggested that the "logout" and "end meeting" buttons could have their text altered to prevent accidental meeting closures. This is another way (or even an addition) to go about doing that.

### More
2nd time's the charm!
<!-- Anything else we should know when reviewing? -->
TODO: localization

Looks like:

<img width="569" alt="PR" src="https://user-images.githubusercontent.com/23108156/85859569-47d00480-b7b5-11ea-93da-fb1090fa55e4.png">

