### PR TITLE
Prevent 'unmute' calls for others caused by incorrect state

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -406,8 +406,8 @@ const toggleVoice = (userId) => {
   } else {
     makeCall('toggleVoice', userId);
     logger.info({
-      logCode: 'usermenu_option_mute_audio',
-      extraInfo: { logType: 'moderator_action' },
+      logCode: 'usermenu_option_mute_toggle_audio',
+      extraInfo: { logType: 'moderator_action', userId },
     }, 'moderator muted user microphone');
   }
 };


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### Background:
In some cases the VoiceUsers collection has incorrect `muted=true` state for a viewer. If a moderator triggers `toggleVoice` on them, attempting to mute them, the resulting redis message will state that the moderator is trying to unmute rather than to mute. Combined with `meeting.usersProp.allowModsToUnmuteUsers=false`, the result is that the moderator gets kicked out from the meeting.

### What does this PR do?
In this PR I have added a condition so that if `meeting.usersProp.allowModsToUnmuteUsers=false`, the bbb-html5 app will not inject any requests to unmute others.


<!-- A brief description of each change being made with this pull request. -->

### Note:
At first I was trying to convert the `toggle` event into a separate `mute | unmute ` event but this has a more visible negative side effect when the VoiceUsers state is out of sync. Namely, you will not be able to trigger a mute call on an unmuted user for whom the app has stored muted=true state.
We have more work to do to address the remaining edge cases where the real audio state is misrepresented in the collection. However, this patch PR should mitigate the cases where a moderator gets kicked out.