### PR TITLE
Added clientURL to client logs

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/logger.js
+++ b/bigbluebutton-html5/imports/startup/client/logger.js
@@ -48,22 +48,35 @@ class ServerLoggerStream extends ServerStream {
 class MeteorStream {
   write(rec) {
     const { fullInfo } = Auth;
+    const clientURL = window.location.href;
 
     this.rec = rec;
     if (fullInfo.meetingId != null) {
+      if (!this.rec.extraInfo) {
+        this.rec.extraInfo = {};
+      }
+
+      this.rec.extraInfo.clientURL = clientURL;
+
       Meteor.call(
         'logClient',
         nameFromLevel[this.rec.level],
         this.rec.msg,
         this.rec.logCode,
-        this.rec.extraInfo || {},
+        this.rec.extraInfo,
         fullInfo,
       );
     } else {
-      Meteor.call('logClient', nameFromLevel[this.rec.level], this.rec.msg);
+      Meteor.call(
+        'logClient',
+        nameFromLevel[this.rec.level],
+        this.rec.msg,
+        { clientURL },
+      );
     }
   }
 }
+
 
 function createStreamForTarget(target, options) {
   const TARGET_EXTERNAL = 'external';


### PR DESCRIPTION
This info should help debugging, mostly cases of
- shared publicly/bookmarked link to a BBB session
- hitting Refresh after stumbling upon 401 or network issues


When unable to authenticate:

I20200630-14:11:26.907(-4)? error: {"logCode":{"clientURL":"https://anton-local.blindside-dev.com/html5client/join?sessionToken=w6h6lnxb4l7un0kz_"},"logDescription":"User could not log in HTML5, hit 401","connectionId":"s8B2TjvjY9MPG5Hqg","extraInfo":{"validUser":"notFound"},"userInfo":{}}


When able to authenticate:
I20200630-14:35:25.191(-4)? info: {"logCode":"app_component_componentdidmount","logDescription":"Client loaded successfully","connectionId":"mtjwfQkXCAWhE7j9H","extraInfo":{"clientURL":"https://anton-local.blindside-dev.com/html5client/join?sessionToken=w6h6lnxb4l7un0kz","validUser":"valid"},"userInfo":{"sessionToken":"w6h6lnxb4l7un0kz","meetingId":"183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1593529696319","requesterUserId":"w_sel0aaf8ztat","fullname":"A","confname":"Demo Meeting","externUserID":"w_sel0aaf8ztat","uniqueClientSession":"w6h6lnxb4l7un0kz-4vn1sl"}}
