### PR TITLE
Implement a simple Panopto external video player

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
@@ -55,7 +55,9 @@ class VideoPlayer extends Component {
       },
       file: {
         attributes: {
-          controls: true,
+          controls: 'controls',
+          autoplay: 'autoplay',
+          playsinline: 'playsinline',
         },
       },
       dailymotion: {

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/panopto.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/panopto.jsx
@@ -1,0 +1,16 @@
+const MATCH_URL = /https?\:\/\/(([a-zA-Z]+\.)?hosted\.panopto\.com\/Panopto)\/Pages\/Viewer\.aspx\?id=([-a-zA-Z0-9]+)/;
+
+export class Panopto {
+
+  static canPlay = url => {
+    return MATCH_URL.test(url)
+  };
+
+  static getSocialUrl(url) {
+    const m = url.match(MATCH_URL);
+    return 'https://' + m[1] + '/Podcast/Social/' + m[3] + '.mp4';
+  }
+}
+
+export default Panopto;
+

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/service.js
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/service.js
@@ -8,10 +8,19 @@ import { makeCall } from '/imports/ui/services/api';
 
 import ReactPlayer from 'react-player';
 
-const isUrlValid = url => ReactPlayer.canPlay(url);
+import Panopto from './custom-players/panopto';
+
+const isUrlValid = (url) => {
+  return ReactPlayer.canPlay(url) || Panopto.canPlay(url);
+}
 
 const startWatching = (url) => {
-  const externalVideoUrl = url;
+  let externalVideoUrl = url;
+
+  if (Panopto.canPlay(url)) {
+    externalVideoUrl = Panopto.getSocialUrl(url);
+  }
+
   makeCall('startWatchingExternalVideo', { externalVideoUrl });
 };
 

--- a/bigbluebutton-html5/imports/ui/components/fullscreen-button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/fullscreen-button/styles.scss
@@ -1,11 +1,5 @@
 @import '/imports/ui/stylesheets/variables/_all';
 
-:root {
-  ::-webkit-media-controls {
-    display: none !important;
-  }
-}
-
 .wrapper {
   position: absolute;
   right: 0;

--- a/bigbluebutton-html5/imports/ui/components/presentation/download-presentation-button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/presentation/download-presentation-button/styles.scss
@@ -1,11 +1,5 @@
 @import '/imports/ui/stylesheets/variables/_all';
 
-:root {
-  ::-webkit-media-controls {
-    display:none !important;
-  }
-}
-
 .wrapper {
   position: absolute;
   left: 0;


### PR DESCRIPTION
This uses the "social URL" avaialble from Panopto to play their video content using ou simple FilePlayer.

Example of a Panopto video URL: https://rwu.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=353d11ad-cd72-461b-9fe9-aa49010d3c8e

Also included is a fix for a situation where Chrome would not display video controls for mp4 videos on the html5 client. There was a style override of the control bar style in Chrome, I think the goal was to hide controls when a camera is made fullscreen. This doesn't seem to be necessary anymore and had the side-effect of hiding the actual video player controls we needed to make video sharing work.