### PR TITLE
Skip recording process step for norecord meetings

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/workers/sanity_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/sanity_worker.rb
@@ -47,7 +47,10 @@ module BigBlueButton
             FileUtils.touch(@sanity_fail)
           end
 
-          step_succeeded
+          # Avoid the regular process flow if it's a norecord meeting
+          process = !File.exist?(@archived_norecord)
+
+          step_succeeded && process
         end
       end
 
@@ -60,6 +63,7 @@ module BigBlueButton
         super(opts)
         @step_name = 'sanity'
         @post_scripts_path = File.join(BigBlueButton.rap_scripts_path, 'post_archive')
+        @archived_norecord = "#{@recording_dir}/status/archived/#{@full_id}.norecord"
         @sanity_fail = "#{@recording_dir}/status/sanity/#{@full_id}.fail"
         @sanity_done = "#{@recording_dir}/status/sanity/#{@full_id}.done"
       end


### PR DESCRIPTION
Closes #8790.

Included an extra check after post archive routine to interrupt the regular record processing flow if it's a norecord meeting