### PR TITLE
Revert webkit media control force removal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/fullscreen-button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/fullscreen-button/styles.scss
@@ -1,11 +1,5 @@
 @import '/imports/ui/stylesheets/variables/_all';
 
-:root {
-  ::-webkit-media-controls {
-    display: none !important;
-  }
-}
-
 .wrapper {
   position: absolute;
   right: 0;

--- a/bigbluebutton-html5/imports/ui/components/presentation/download-presentation-button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/presentation/download-presentation-button/styles.scss
@@ -1,11 +1,5 @@
 @import '/imports/ui/stylesheets/variables/_all';
 
-:root {
-  ::-webkit-media-controls {
-    display:none !important;
-  }
-}
-
 .wrapper {
   position: absolute;
   left: 0;


### PR DESCRIPTION
Related with #9973.

@lfzawacki noticed a couple of days ago this webkit style we force apply to avoid webcams controls when on fullscreen. Since this is now harmful to another feature we vote for it's removal.