### PR TITLE
Make some media connection timeouts configurable

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
@@ -8,7 +8,7 @@ const SFU_URL = Meteor.settings.public.kurento.wsUrl;
 const MEDIA = Meteor.settings.public.media;
 const MEDIA_TAG = MEDIA.mediaTag.replace(/#/g, '');
 const GLOBAL_AUDIO_PREFIX = 'GLOBAL_AUDIO_';
-const RECONNECT_TIMEOUT_MS = 15000;
+const RECONNECT_TIMEOUT_MS = MEDIA.listenOnlyCallTimeout || 15000;
 
 export default class KurentoAudioBridge extends BaseAudioBridge {
   constructor(userData) {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -27,8 +27,13 @@ import VideoList from './video-list/component';
 
 const ENABLE_NETWORK_MONITORING = Meteor.settings.public.networkMonitoring.enableNetworkMonitoring;
 const CAMERA_PROFILES = Meteor.settings.public.kurento.cameraProfiles;
-const WS_CONN_TIMEOUT = Meteor.settings.public.kurento.wsConnectionTimeout;
-
+// Default values and default empty object to be backwards compat with 2.2.
+// FIXME Remove hardcoded defaults 2.3.
+const WS_CONN_TIMEOUT = Meteor.settings.public.kurento.wsConnectionTimeout || 4000;
+const {
+  baseTimeout: CAMERA_SHARE_FAILED_WAIT_TIME = 15000,
+  maxTimeout: MAX_CAMERA_SHARE_FAILED_WAIT_TIME = 60000,
+} = Meteor.settings.public.kurento.cameraTimeouts || {};
 
 const intlClientErrors = defineMessages({
   iceCandidateError: {
@@ -112,8 +117,6 @@ const intlSFUErrors = defineMessages({
   },
 });
 
-const CAMERA_SHARE_FAILED_WAIT_TIME = 15000;
-const MAX_CAMERA_SHARE_FAILED_WAIT_TIME = 60000;
 const PING_INTERVAL = 15000;
 
 const propTypes = {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -27,6 +27,8 @@ import VideoList from './video-list/component';
 
 const ENABLE_NETWORK_MONITORING = Meteor.settings.public.networkMonitoring.enableNetworkMonitoring;
 const CAMERA_PROFILES = Meteor.settings.public.kurento.cameraProfiles;
+const WS_CONN_TIMEOUT = Meteor.settings.public.kurento.wsConnectionTimeout;
+
 
 const intlClientErrors = defineMessages({
   iceCandidateError: {
@@ -174,7 +176,11 @@ class VideoProvider extends Component {
     };
 
     // Set a valid bbb-webrtc-sfu application server socket in the settings
-    this.ws = new ReconnectingWebSocket(Auth.authenticateURL(Meteor.settings.public.kurento.wsUrl));
+    this.ws = new ReconnectingWebSocket(
+      Auth.authenticateURL(Meteor.settings.public.kurento.wsUrl),
+      [],
+      { connectionTimeout: WS_CONN_TIMEOUT },
+    );
     this.wsQueue = [];
 
     this.visibility = new VisibilityEvent();

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -14,7 +14,7 @@ const MEDIA = Meteor.settings.public.media;
 const MEDIA_TAG = MEDIA.mediaTag;
 const ECHO_TEST_NUMBER = MEDIA.echoTestNumber;
 const MAX_LISTEN_ONLY_RETRIES = 1;
-const LISTEN_ONLY_CALL_TIMEOUT_MS = 15000;
+const LISTEN_ONLY_CALL_TIMEOUT_MS = MEDIA.listenOnlyCallTimeout || 15000;
 
 const CALL_STATES = {
   STARTED: 'started',

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -86,6 +86,16 @@ public:
     packetLostThreshold: 10
   kurento:
     wsUrl: HOST
+    # Valid for video-provider. Time (ms) before its WS connection times out
+    # and tries to reconnect.
+    wsConnectionTimeout: 4000
+    cameraTimeouts:
+      # Base camera timeout: used as the camera *sharing* timeout and
+      # as the minimum camera subscribe reconnection timeout
+      baseTimeout: 15000
+      # Max timeout: used as the max camera subscribe reconnection timeout. Each
+      # subscribe reattempt increases the reconnection timer up to this
+      maxTimeout: 60000
     chromeDefaultExtensionKey: akgoaoikmbmhcopjgakkcepdgdgkjfbc
     chromeDefaultExtensionLink: https://chrome.google.com/webstore/detail/bigbluebutton-screenshare/akgoaoikmbmhcopjgakkcepdgdgkjfbc
     chromeExtensionKey: KEY

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -200,6 +200,7 @@ public:
     callHangupMaximumRetries: 10
     echoTestNumber: 'echo'
     relayOnlyOnReconnect: false
+    listenOnlyCallTimeout: 15000
   presentation:
     defaultPresentationFile: default.pdf
     panZoomThrottle: 32


### PR DESCRIPTION
### What does this PR do?

-  video-provider: make ReconnectingWebsocket's `connectionTimeout` configurable (default value was preserved)
-  video-provider: make camera timeouts configurable (default values were preserved)
-  audio: make listen only call timeout configurable

### Closes Issue(s)
None.

### Motivation

Those timeout values were hardcoded and they were always meant to be configurable so that users have the freedom
to adjust their setups according to their user base network conditions (and also make things more flexible if they wish).

I kept the default values, but I do think they should be preferably increased in a default setup. I could blabber about how this is a stopgap and how we should change the mechanics of some of our stuff regarding doing all we can upfront instead of on demand to reduce connection times, but that's a topic for another issue (and 2.3)

Items 1 and 2 from above, when increased, might decrease the number of 1020 errors users with stressed CPU/network get.
Item 3 may reduce the number of FreeSWITCH listen only failovers for the same users.

### More

Would appreciate some testing, backported from a fork and didn't test it in 2.2 upstream.
