### PR TITLE
Ensure getURL value for breakout before redirecting

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/component.jsx
@@ -15,11 +15,11 @@ const intlMessages = defineMessages({
   },
   message: {
     id: 'app.breakoutJoinConfirmation.message',
-    description: 'Join breakout confim message',
+    description: 'Join breakout confirm message',
   },
   freeJoinMessage: {
     id: 'app.breakoutJoinConfirmation.freeJoinMessage',
-    description: 'Join breakout confim message',
+    description: 'Join breakout confirm message',
   },
   confirmLabel: {
     id: 'app.createBreakoutRoom.join',
@@ -88,10 +88,15 @@ class BreakoutJoinConfirmation extends Component {
       breakoutURL,
       isFreeJoin,
       voiceUserJoined,
+      requestJoinURL,
     } = this.props;
 
     const { selectValue } = this.state;
-    const url = isFreeJoin ? getURL(selectValue) : breakoutURL;
+    if (!getURL(selectValue)) {
+      requestJoinURL(selectValue);
+    }
+    const urlFromSelectedRoom = getURL(selectValue);
+    const url = isFreeJoin ? urlFromSelectedRoom : breakoutURL;
 
     if (voiceUserJoined) {
       // leave main room's audio when joining a breakout room
@@ -103,6 +108,12 @@ class BreakoutJoinConfirmation extends Component {
     }
 
     VideoService.exitVideo();
+    if (url === '') {
+      logger.error({
+        logCode: 'breakoutjoinconfirmation_redirecting_to_url',
+        extraInfo: { breakoutURL, isFreeJoin },
+      }, 'joining breakout room but redirected to about://blank');
+    }
     window.open(url);
     mountModal(null);
   }


### PR DESCRIPTION
Issue: participants redirected to about://blank when attempting to join a breakout (`isFreeJoin=true`)

Steps to reproduce:
Join a new meeting as moderator. Create Breakouts, with the option to choose which room to enter. Bring your user to a room 1and hit Create.
![Screenshot from 2020-07-09 16-29-51](https://user-images.githubusercontent.com/6312397/87087635-73191180-c201-11ea-9ae1-dc95ef358e33.png)


In the new modal
![Screenshot from 2020-07-09 16-31-38](https://user-images.githubusercontent.com/6312397/87087771-b2476280-c201-11ea-8d9c-5aa003bc148b.png)
in _some_ cases clicking on "Join room" - we are redirected in a new tab to a blank tab. In Chrome this is about://blank

I have seen this a few times in large meetings on a busy server but was able to replicate once on a local server with 1 meeting, 1 user.
I have seen it only in the cases when I do not touch the dropdown in the modal, but it might be a timing (race condition) issue.
When debugging I would occasionally see only user with different userId in https://github.com/bigbluebutton/bigbluebutton/blob/v2.2.x-release/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/container.jsx#L19 leading to returning `''` in `getURL`  in https://github.com/bigbluebutton/bigbluebutton/blob/v2.2.x-release/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/component.jsx#L94


In this PR I trigger `requestJoinURL(selectValue)` prior to using the result to ensure a url is returned.
I also add a log so we can check if this issue occurs in the future (it's been tricky to reproduce)