### PR TITLE
Make List of waiting users scrollable

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
@@ -7,7 +7,7 @@
   display: flex;
   flex-grow: 1;
   flex-direction: column;
-  overflow: hidden;
+  overflow: scroll;
   height: 100vh;
 }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

This change allows the List of waiting users to scroll if it is longer than the screen. 

### Closes Issue(s)

fixes #9533

### Motivation
When there are more users than a single screen height can accomodate, it is impossible to get to the last few users in the list. 
![Screenshot_20200710_090602](https://user-images.githubusercontent.com/24311754/87132219-d785b080-c295-11ea-89c3-b2f6f930f67a.png)


### More

Tested with Firefox


