### PR TITLE
Avoid wrongly naming a thumbnail as thumb-1

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ThumbnailCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ThumbnailCreatorImp.java
@@ -64,7 +64,9 @@ public class ThumbnailCreatorImp implements ThumbnailCreator {
     renameThumbnails(thumbsDir, page);
 
     // Create blank thumbnails for pages that failed to generate a thumbnail.
-    createBlankThumbnail(thumbsDir, page);
+    if (!success) {
+      createBlankThumbnail(thumbsDir, page);
+    }
 
 
     return success;
@@ -117,9 +119,9 @@ public class ThumbnailCreatorImp implements ThumbnailCreator {
      * If more than 1 file, filename like 'temp-thumb-X.png' else filename is
      * 'temp-thumb.png'
      */
+    Matcher matcher;
     if (dir.list().length > 1) {
       File[] files = dir.listFiles();
-      Matcher matcher;
       for (File file : files) {
         matcher = PAGE_NUMBER_PATTERN.matcher(file.getAbsolutePath());
         if (matcher.matches()) {
@@ -144,6 +146,15 @@ public class ThumbnailCreatorImp implements ThumbnailCreator {
       File oldFilename = new File(
           dir.getAbsolutePath() + File.separatorChar + dir.list()[0]);
       String newFilename = "thumb-1.png";
+
+      // Might be the first thumbnail of a set and it might be out of order
+      // Avoid setting the second/third/... slide as thumb-1.png
+      matcher = PAGE_NUMBER_PATTERN.matcher(oldFilename.getAbsolutePath());
+      if (matcher.matches()) {
+        int pageNum = Integer.valueOf(matcher.group(2).trim()).intValue();
+        newFilename = "thumb-" + (pageNum) + ".png";
+      }
+
       File renamedFile = new File(
           oldFilename.getParent() + File.separatorChar + newFilename);
       oldFilename.renameTo(renamedFile);


### PR DESCRIPTION
There are some cases where the thumbnails are mistakenly going to the blank fallback.

The problem normally happens to me when the second page enters the rename method https://github.com/bigbluebutton/bigbluebutton/blob/de14c705f469aa864573367c76f70c7d25c0a839/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ThumbnailCreatorImp.java#L115-L151 before the first page to finishes. This happens every time for the default presentation because the first slide is an image much more complex than the followers. So what's going on is that the second thumbnail is receiving a hardcoded `thumbs-1.png` name and then the first page enters it and overrides it. So when the blank slide generator starts it can't find `thumbs-2.png` because it actually doesn't exists.

I believe there are better solutions to this and I'm not sure why we iterate things inside the rename function. But, at the same time, I don't want to introduce a regression over here by changing things up drastically.