### PR TITLE
Preparation of video-less video of presenter

### DIFF
--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1172,6 +1172,8 @@ begin
             BigBlueButton.logger.info("Made video dir - copying: #{video_file} to -> #{video_dir}")
             FileUtils.cp(video_file, video_dir)
             BigBlueButton.logger.info("Copied #{File.extname(video_file)} file")
+            BigBlueButton.execute("ffmpeg -i #{video_dir}/#{video_file.sub(/.+\//,'')}  -vn -acodec copy #{video_dir}/#{video_file.sub(/.+\//,'').sub(/(\..+)$/,'_a\1')}")
+            BigBlueButton.logger.info("Created a video-less version")
           end
         else
           audio_dir = "#{package_dir}/audio"


### PR DESCRIPTION
### What does this PR do?
Prepare a video-less video of presenter, by extracting the audio from webcam.webm and webcam.mp4 and creating webcam_a.webm and webcam_a.mp4 files (the latter only when .mp4 encoding is enabled). 

### Closes Issue(s)
This PR is related with #10069 .

### Motivation
Students with narrow band may want to playback the lecture record without the teacher's video, but only with the audio. Not only students in developing countries, but also those in Japan suffer such poor connection problem as Japanese internet providers offer it with a notoriously high price.

### More
Also related with the communication in https://github.com/bigbluebutton/bbb-playback/issues/51
