### PR TITLE
enable post_events by default by setting keepEvents=true

### DIFF
--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -213,7 +213,7 @@ muteOnStart=false
 allowModsToUnmuteUsers=false
 
 # Saves meeting events even if the meeting is not recorded
-keepEvents=false
+keepEvents=true
 
 #----------------------------------------------------
 # This URL is where the BBB client is accessible. When a user sucessfully


### PR DESCRIPTION
Since we are now including post_events_analytics_callback enabled, it is also necessary to set keepEvents enabled by default.