### PR TITLE
Prevent screen share cropping on chrome 84

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -176,7 +176,7 @@ class ScreenshareComponent extends React.Component {
           <video
             id="screenshareVideo"
             key="screenshareVideo"
-            style={{ maxHeight: '100%', width: '100%' }}
+            style={{ maxHeight: '100%', width: '100%', height: '100%' }}
             playsInline
             onLoadedData={this.onVideoLoad}
             ref={(ref) => { this.videoTag = ref; }}


### PR DESCRIPTION
### What does this PR do?

Adds `height: 100%` to `screenshareVideo ` element

### Closes Issue(s)

#9735 