### PR TITLE
Fix TypeError: Cannot read property 'map' of undefined

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/container.jsx
@@ -157,11 +157,11 @@ export default injectIntl(withTracker(({ intl }) => {
 
     return {
       ...message,
-      content: message.content.map(content => ({
+      content: message.content ? message.content.map(content => ({
         ...content,
         text: content.text in intlMessages
           ? `<b><i>${intl.formatMessage(intlMessages[content.text], systemMessageIntl)}</i></b>` : content.text,
-      })),
+      })) : [],
     };
   });
 

--- a/bigbluebutton-html5/imports/ui/components/chat/message-list/message-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-list/message-list-item/component.jsx
@@ -16,7 +16,7 @@ const propTypes = {
     name: PropTypes.string,
   }),
   messages: PropTypes.arrayOf(Object).isRequired,
-  time: PropTypes.number.isRequired,
+  time: PropTypes.number,
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
@@ -30,6 +30,7 @@ const defaultProps = {
   user: null,
   scrollArea: null,
   lastReadMessageTime: 0,
+  time: 0,
 };
 
 const intlMessages = defineMessages({


### PR DESCRIPTION
### What does this PR do?

Fixes `Cannot read property 'map' of undefined` error that was causing the client to hang when joining from greenlight.

### Closes Issue(s)

#10058