### PR TITLE
Add missing package-lock info for "hark"

### DIFF
--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -3777,6 +3777,14 @@
         "har-schema": "^2.0.0"
       }
     },
+    "hark": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/hark/-/hark-1.2.3.tgz",
+      "integrity": "sha512-u68vz9SCa38ESiFJSDjqK8XbXqWzyot7Cj6Y2b6jk2NJ+II3MY2dIrLMg/kjtIAun4Y1DHF/20hfx4rq1G5GMg==",
+      "requires": {
+        "wildemitter": "^1.2.0"
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -10648,6 +10656,11 @@
       "requires": {
         "string-width": "^1.0.2 || 2"
       }
+    },
+    "wildemitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/wildemitter/-/wildemitter-1.2.1.tgz",
+      "integrity": "sha512-UMmSUoIQSir+XbBpTxOTS53uJ8s/lVhADCkEbhfRjUGFDPme/XGOb0sBWLx5sTz7Wx/2+TlAw1eK9O5lw5PiEw=="
     },
     "winston": {
       "version": "3.3.3",


### PR DESCRIPTION
Pull request #9851 added package 'hark' but did not include package-lock.json details needed for production deployments. I am adding this missing info