### PR TITLE
Set raise hand notification / sound on by default

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -41,8 +41,8 @@ public:
         chatPushAlerts: false
         userJoinAudioAlerts: false
         userJoinPushAlerts: false
-        raiseHandAudioAlerts: false
-        raiseHandPushAlerts: false
+        raiseHandAudioAlerts: true
+        raiseHandPushAlerts: true
         fallbackLocale: en
         overrideLocale: null
       audio:


### PR DESCRIPTION

### What does this PR do?

Sets  `raiseHandAudioAlerts: true` and `raiseHandPushAlerts: true` by default in setting.yml
