### PR TITLE
Only allow for https uri in welcome and modOnly messages

### DIFF
--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -112,6 +112,7 @@ export default function addMeeting(meeting) {
       a: ['href', 'name', 'target'],
       img: ['src'],
     },
+    allowedSchemes: ['https'],
   });
   welcomeMsg = sanitizedWelcomeText.replace(
     'href="event:',
@@ -139,6 +140,7 @@ export default function addMeeting(meeting) {
       a: ['href', 'name', 'target'],
       img: ['src'],
     },
+    allowedSchemes: ['https'],
   });
 
   // note: as of July 2020 `modOnlyMessage` is not published to the client side.

--- a/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
@@ -148,6 +148,7 @@ class JoinHandler extends Component {
             a: ['href', 'name', 'target'],
             img: ['src'],
           },
+          allowedSchemes: ['https'],
         });
         setModeratorOnlyMessage(sanitizedModOnlyText);
       }

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -146,8 +146,8 @@ defaultGuestPolicy=ALWAYS_ACCEPT
 #
 # native2ascii -encoding UTF8 bigbluebutton.properties bigbluebutton.properties
 #
-defaultWelcomeMessage=Welcome to <b>%%CONFNAME%%</b>!<br><br>For help on using BigBlueButton see these (short) <a href="event:http://www.bigbluebutton.org/html5"><u>tutorial videos</u></a>.<br><br>To join the audio bridge click the phone button.  Use a headset to avoid causing background noise for others.
-defaultWelcomeMessageFooter=This server is running <a href="http://docs.bigbluebutton.org/" target="_blank"><u>BigBlueButton</u></a>.
+defaultWelcomeMessage=Welcome to <b>%%CONFNAME%%</b>!<br><br>For help on using BigBlueButton see these (short) <a href="event:https://www.bigbluebutton.org/html5"><u>tutorial videos</u></a>.<br><br>To join the audio bridge click the phone button.  Use a headset to avoid causing background noise for others.
+defaultWelcomeMessageFooter=This server is running <a href="https://docs.bigbluebutton.org/" target="_blank"><u>BigBlueButton</u></a>.
 
 # Default maximum number of users a meeting can have.
 # Current default is 0 (meeting doesn't have a user limit).


### PR DESCRIPTION
Sanitize uri's within welcome message and modOnlyMessage if they contain links different than https.

Also adjusted the default values for `defaultWelcomeMessage` and `defaultWelcomeMessageFooter` so the uri they contain is https, not http.
