### PR TITLE
max number of breakout rooms is increased

### DIFF
--- a/bigbluebutton-html5/imports/api/breakouts/server/methods/createBreakout.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/methods/createBreakout.js
@@ -6,7 +6,11 @@ import { extractCredentials } from '/imports/api/common/server/helpers';
 export default function createBreakoutRoom(rooms, durationInMinutes, record = false) {
   const REDIS_CONFIG = Meteor.settings.private.redis;
   const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
-  const MAX_BREAKOUT_ROOMS = Meteor.settings.public.app.breakoutRoomLimit;
+
+  const BREAKOUT_LIM = Meteor.settings.public.app.breakoutRoomLimit;
+  const MIN_BREAKOUT_ROOMS = 2;
+  const MAX_BREAKOUT_ROOMS = BREAKOUT_LIM > MIN_BREAKOUT_ROOMS ? BREAKOUT_LIM : MIN_BREAKOUT_ROOMS;
+
 
   const { meetingId, requesterUserId } = extractCredentials(this.userId);
 

--- a/bigbluebutton-html5/imports/api/breakouts/server/methods/createBreakout.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/methods/createBreakout.js
@@ -6,11 +6,12 @@ import { extractCredentials } from '/imports/api/common/server/helpers';
 export default function createBreakoutRoom(rooms, durationInMinutes, record = false) {
   const REDIS_CONFIG = Meteor.settings.private.redis;
   const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
+  const MAX_BREAKOUT_ROOMS = Meteor.settings.public.app.breakoutRoomLimit;
 
   const { meetingId, requesterUserId } = extractCredentials(this.userId);
 
   const eventName = 'CreateBreakoutRoomsCmdMsg';
-  if (rooms.length > 8) return Logger.info(`Attempt to create breakout rooms with invalid number of rooms in meeting id=${meetingId}`);
+  if (rooms.length > MAX_BREAKOUT_ROOMS) return Logger.info(`Attempt to create breakout rooms with invalid number of rooms in meeting id=${meetingId}`);
   const payload = {
     record,
     durationInMinutes,

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -110,7 +110,7 @@ const intlMessages = defineMessages({
 });
 
 const MIN_BREAKOUT_ROOMS = 2;
-const MAX_BREAKOUT_ROOMS = 8;
+const MAX_BREAKOUT_ROOMS = Meteor.settings.public.app.breakoutRoomLimit;
 
 const propTypes = {
   intl: intlShape.isRequired,

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -109,8 +109,9 @@ const intlMessages = defineMessages({
   },
 });
 
+const BREAKOUT_LIM = Meteor.settings.public.app.breakoutRoomLimit;
 const MIN_BREAKOUT_ROOMS = 2;
-const MAX_BREAKOUT_ROOMS = Meteor.settings.public.app.breakoutRoomLimit;
+const MAX_BREAKOUT_ROOMS = BREAKOUT_LIM > MIN_BREAKOUT_ROOMS ? BREAKOUT_LIM : MIN_BREAKOUT_ROOMS;
 
 const propTypes = {
   intl: intlShape.isRequired,

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
@@ -261,7 +261,7 @@ class BreakoutRoom extends PureComponent {
       >
         <div className={styles.content} key={`breakoutRoomList-${breakout.breakoutId}`}>
           <span aria-hidden>
-            {intl.formatMessage(intlMessages.breakoutRoom, breakout.sequence.toString())}
+            {intl.formatMessage(intlMessages.breakoutRoom, { 0: breakout.sequence })}
             <span className={styles.usersAssignedNumberLabel}>
               (
               {breakout.joinedUsers.length}

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -34,6 +34,7 @@ public:
       duration: 4000
     remainingTimeThreshold: 30
     remainingTimeAlertThreshold: 1
+    breakoutRoomLimit: 30
     defaultSettings:
       application:
         animations: true

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -34,7 +34,7 @@ public:
       duration: 4000
     remainingTimeThreshold: 30
     remainingTimeAlertThreshold: 1
-    breakoutRoomLimit: 30
+    breakoutRoomLimit: 8
     defaultSettings:
       application:
         animations: true
@@ -424,4 +424,3 @@ private:
       version: [0, 36]
     - browser: YandexBrowser
       version: 19
-


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
~~Max number of breakout rooms is increased to 30.~~
breakoutRoomLimit parameter was introduced to controll max number of breakout rooms in private/config/settings.yml.
Minor UI bug fixed (room number was truncated to single digit). 

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
closes #8657
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number -->

### Motivation
We have a demand for more breakout rooms to work in smaller groups.
<!-- What inspired you to submit this pull request? -->
