### PR TITLE
Prevent negative values being used in presentation height / width

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -443,8 +443,8 @@ class PresentationArea extends PureComponent {
       <div
         style={{
           position: 'absolute',
-          width: svgDimensions.width,
-          height: svgDimensions.height,
+          width: svgDimensions.width < 0 ? 0 : svgDimensions.width,
+          height: svgDimensions.height < 0 ? 0 : svgDimensions.height,
           textAlign: 'center',
         }}
       >
@@ -454,8 +454,8 @@ class PresentationArea extends PureComponent {
         <svg
           key={currentSlide.id}
           data-test="whiteboard"
-          width={svgDimensions.width}
-          height={svgDimensions.height}
+          width={svgDimensions.width < 0 ? 0 : svgDimensions.width}
+          height={svgDimensions.height < 0 ? 0 : svgDimensions.height}
           ref={(ref) => { if (ref != null) { this.svggroup = ref; } }}
           viewBox={svgViewBox}
           version="1.1"


### PR DESCRIPTION
### What does this PR do?

Fix exception caused by negative values being used in presentation <svg>

### Motivation
attempt to fix

7df6acf6cb0f651dba4e71b3adac0efd23889793.js?meteor_js_resource=true:9 Error: <svg> attribute width: A negative value is not valid. ("-53.333333333333336")
Et @ 7df6acf6cb0f651dba4e71b3adac0efd23889793.js?meteor_js_resource=true:9
7df6acf6cb0f651dba4e71b3adac0efd23889793.js?meteor_js_resource=true:9 Error: <svg> attribute height: A negative value is not valid. ("-30")
Et @ 7df6acf6cb0f651dba4e71b3adac0efd23889793.js?meteor_js_resource=true:9



