### PR TITLE
Add aria-label to whiteboard poll result

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
@@ -1,8 +1,15 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import PollService from '/imports/ui/components/poll/service';
-import { injectIntl, intlShape } from 'react-intl';
+import { defineMessages, injectIntl, intlShape } from 'react-intl';
 import styles from './styles';
+
+const intlMessages = defineMessages({
+  pollResultAria: {
+    id: 'app.whiteboard.annotations.pollResult',
+    description: 'aria label used in poll result string',
+  },
+});
 
 class PollDrawComponent extends Component {
   constructor(props) {
@@ -424,7 +431,7 @@ class PollDrawComponent extends Component {
     }
 
     return (
-      <g>
+      <g aria-hidden>
         <rect
           x={outerRect.x}
           y={outerRect.y}
@@ -575,7 +582,7 @@ class PollDrawComponent extends Component {
       return this.renderLine(lineToMeasure);
     }
     return (
-      <g>
+      <g aria-hidden>
         {textArray.map(line => this.renderLine(line))}
         <text
           fontFamily="Arial"
@@ -591,9 +598,17 @@ class PollDrawComponent extends Component {
   }
 
   render() {
-    const { prepareToDisplay } = this.state;
+    const { intl } = this.props;
+    const { prepareToDisplay, textArray } = this.state;
+
+    let ariaResultLabel = `${intl.formatMessage(intlMessages.pollResultAria)}: `;
+    textArray.map((t, idx) => {
+      const pollLine = t.slice(0, -1);
+      ariaResultLabel += `${idx > 0 ? ' |' : ''} ${pollLine.join(' | ')}`;
+    });
+
     return (
-      <g>
+      <g aria-label={ariaResultLabel}>
         {prepareToDisplay
           ? this.renderTestStrings()
           : this.renderPoll()

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -601,6 +601,7 @@
     "app.sfu.noAvailableCodec2203": "Server could not find an appropriate codec (error 2203)",
     "app.meeting.endNotification.ok.label": "OK",
     "app.whiteboard.annotations.poll": "Poll results were published",
+    "app.whiteboard.annotations.pollResult": "Poll Result",
     "app.whiteboard.toolbar.tools": "Tools",
     "app.whiteboard.toolbar.tools.hand": "Pan",
     "app.whiteboard.toolbar.tools.pencil": "Pencil",


### PR DESCRIPTION
### What does this PR do?

Add's `aria-label` to the poll results in the whiteboard.

### Motivation

Provides clearer poll results for the screen reader in the whiteboard. 

_Before:_
graphic    Unlabeled graphic    To get missing image descriptions, open the context menu.
graphic    00
graphic    0%0%
graphic    TrueFalse

_After:_
graphic Poll Results: True | 0 | 0% | False | 0 | 0%

