### PR TITLE
video-provider: UI improvements

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/fullscreen-button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/fullscreen-button/styles.scss
@@ -7,7 +7,6 @@
   background-color: var(--color-transparent);
   cursor: pointer;
   border: 0;
-  border-radius: 5px;
   z-index: 2;
 
   [dir="rtl"] & {

--- a/bigbluebutton-html5/imports/ui/components/media/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/media/styles.scss
@@ -159,6 +159,51 @@ $after-content-order: 3;
   width: 100% !important;
 }
 
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(-360deg);
+  }
+}
+
+.connectingSpinner {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  object-fit: contain;
+  color: var(--color-white-with-transparency);
+  font-size: 2.5rem;
+  text-align: center;
+  white-space: nowrap;
+  z-index: 1;
+
+
+  &::after {
+    content: '';
+    display: inline-block;
+    height: 100%;
+    vertical-align: middle;
+    margin: 0 -0.25em 0 0;
+
+    [dir="rtl"] & {
+      margin: 0 0 0 -0.25em
+    }
+  }
+
+  &::before {
+    content: "\e949";
+    /* ascii code for the ellipsis character */
+    font-family: 'bbb-icons' !important;
+    display: inline-block;
+
+    :global(.animationsEnabled) & {
+      animation: spin 4s infinite linear;
+    }
+  }
+}
 
 span[class^=resizeWrapper] {
   div {

--- a/bigbluebutton-html5/imports/ui/components/screenshare/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/styles.scss
@@ -1,8 +1,8 @@
 @import "/imports/ui/stylesheets/variables/_all";
-@import "/imports/ui/components/video-provider/video-list/styles";
+@import "/imports/ui/components/media/styles";
 
 .connecting {
-  @extend .connecting;
+  @extend .connectingSpinner;
   z-index: -1;
   background-color: transparent;
   color: var(--color-white);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -132,7 +132,7 @@
   bottom: 5px;
   left: 5px;
   right: 5px;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
   height: 1.25rem;
   z-index: 2;
@@ -140,9 +140,6 @@
 
 .dropdown,
 .dropdownFireFox {
-  position: absolute;
-  left: 0;
-  flex: 1;
   display: flex;
   outline: none !important;
   width: var(--cam-dropdown-width);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -24,24 +24,24 @@
 
 .videoList {
   display: grid;
-  border-radius: 5px;
 
   grid-auto-flow: dense;
-  grid-gap: 5px;
+  grid-gap: 1px;
 
   align-items: center;
   justify-content: center;
 
   @include mq($medium-up) {
-    grid-gap: 10px;
+    grid-gap: 2px;
   }
 }
+
 
 .videoListItem {
   display: flex;
   overflow: hidden;
   width: 100%;
-  max-height: 100%;
+  height: 100%;
 
   &.focused {
     grid-column: 1 / span 2;
@@ -57,7 +57,6 @@
   position: relative;
   display: flex;
   min-width: 100%;
-  border-radius: 5px;
 
   &::after {
     content: "";
@@ -66,8 +65,7 @@
     right: 0;
     bottom: 0;
     left: 0;
-    border: 5px solid var(--color-white-with-transparency);
-    border-radius: 5px;
+    border: 5px solid var(--color-primary);
     opacity: 0;
     pointer-events: none;
 
@@ -77,7 +75,7 @@
   }
 
   &.talking::after {
-    opacity: 1;
+    opacity: 0.7;
   }
 }
 
@@ -86,7 +84,6 @@
   height: 100%;
   width: 100%;
   object-fit: contain;
-  border-radius: 5px;
 }
 
 .cursorGrab{
@@ -114,41 +111,30 @@
 
 .connecting {
   @extend %media-area;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   position: absolute;
-  color: var(--color-white-with-transparency);
   font-size: 2.5rem;
-  text-align: center;
   white-space: nowrap;
   z-index: 1;
+  height: 100%;
+  vertical-align: middle;
+  margin: 0 -0.25em 0 0;
 
-
-  &::after {
-    content: '';
-    display: inline-block;
-    height: 100%;
-    vertical-align: middle;
-    margin: 0 -0.25em 0 0;
-
-    [dir="rtl"] & {
-      margin: 0 0 0 -0.25em
-    }
+  [dir="rtl"] & {
+    margin: 0 0 0 -0.25em
   }
 
-  &::before {
-    content: "\e949";
-    /* ascii code for the ellipsis character */
-    font-family: 'bbb-icons' !important;
-    display: inline-block;
-
-    :global(.animationsEnabled) & {
-      animation: spin 4s infinite linear;
-    }
-  }
+  background-color: var(--color-black);
+  border-radius: 1px;
+  opacity: 1;
+  color: var(--color-white);
+  font-size: 100%;
 }
 
 .media {
-  @extend %media-area;
-  background-color: var(--color-gray);
+  @extend %media-area; background-color: var(--color-black);
 }
 
 .info {
@@ -185,12 +171,12 @@
 .userName {
   @extend %text-elipsis;
   position: relative;
-  background-color: var(--color-black);
-  opacity: .5;
-  color: var(--color-white);
-  font-size: 80%;
-  border-radius: 15px;
+  // Keep the background with 0.5 opacity, but leave the text with 1
+  background-color: rgba(0, 0, 0, 0.5);
+  border-radius: 1px;
+  color: var(--color-off-white);
   padding: 0 1rem 0 .5rem !important;
+  font-size: 80%;
 }
 
 .noMenu {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -36,7 +36,6 @@
   }
 }
 
-
 .videoListItem {
   display: flex;
   overflow: hidden;
@@ -134,7 +133,8 @@
 }
 
 .media {
-  @extend %media-area; background-color: var(--color-black);
+  @extend %media-area;
+  background-color: var(--color-black);
 }
 
 .info {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -93,16 +93,6 @@
   cursor: grabbing;
 }
 
-@keyframes spin {
-  from {
-    transform: rotate(0deg);
-  }
-
-  to {
-    transform: rotate(-360deg);
-  }
-}
-
 .videoContainer{
   width: 100%;
   height: 100%;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -40,7 +40,7 @@
   display: flex;
   overflow: hidden;
   width: 100%;
-  height: 100%;
+  max-height: 100%;
 
   &.focused {
     grid-column: 1 / span 2;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -83,6 +83,7 @@
   height: 100%;
   width: 100%;
   object-fit: contain;
+  background-color: var(--color-black);
 }
 
 .cursorGrab{
@@ -104,27 +105,22 @@
   justify-content: center;
   align-items: center;
   position: absolute;
-  font-size: 2.5rem;
   white-space: nowrap;
   z-index: 1;
-  height: 100%;
   vertical-align: middle;
   margin: 0 -0.25em 0 0;
-
-  [dir="rtl"] & {
-    margin: 0 0 0 -0.25em
-  }
-
-  background-color: var(--color-black);
   border-radius: 1px;
   opacity: 1;
   color: var(--color-white);
   font-size: 100%;
+
+  [dir="rtl"] & {
+    margin: 0 0 0 -0.25em
+  }
 }
 
 .media {
   @extend %media-area;
-  background-color: var(--color-black);
 }
 
 .info {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -110,12 +110,16 @@
   margin: 0 -0.25em 0 0;
   border-radius: 1px;
   opacity: 1;
-  color: var(--color-white);
-  font-size: 100%;
 
   [dir="rtl"] & {
     margin: 0 0 0 -0.25em
   }
+}
+
+.loadingText {
+  @extend %text-elipsis;
+  color: var(--color-white);
+  font-size: 100%;
 }
 
 .media {
@@ -136,6 +140,8 @@
 
 .dropdown,
 .dropdownFireFox {
+  position: absolute;
+  left: 0;
   flex: 1;
   display: flex;
   outline: none !important;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -28,7 +28,6 @@
   grid-auto-flow: dense;
   grid-gap: 1px;
 
-  align-items: center;
   justify-content: center;
 
   @include mq($medium-up) {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -160,8 +160,10 @@ class VideoListItem extends Component {
       })}
       >
         {
-          !videoIsReady
-          && <div className={styles.connecting} />
+          !videoIsReady &&
+            <div className={styles.connecting}>
+              <span>{name}</span>
+            </div>
         }
         <div
           className={styles.videoContainer}
@@ -183,7 +185,8 @@ class VideoListItem extends Component {
           />
           {videoIsReady && this.renderFullscreenButton()}
         </div>
-        <div className={styles.info}>
+        { videoIsReady &&
+          <div className={styles.info}>
           {enableVideoMenu && availableActions.length >= 3
             ? (
               <Dropdown className={isFirefox ? styles.dropdownFireFox : styles.dropdown}>
@@ -214,6 +217,7 @@ class VideoListItem extends Component {
           {voiceUser.muted && !voiceUser.listenOnly ? <Icon className={styles.muted} iconName="unmute_filled" /> : null}
           {voiceUser.listenOnly ? <Icon className={styles.voice} iconName="listen" /> : null}
         </div>
+        }
       </div>
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -162,7 +162,7 @@ class VideoListItem extends Component {
         {
           !videoIsReady &&
             <div className={styles.connecting}>
-              <span>{name}</span>
+              <span className={styles.loadingText}>{name}</span>
             </div>
         }
         <div


### PR DESCRIPTION
### What does this PR do?

This is a set of UI improvements targeted at cameras in 2.2.

Mainly:
- No more border radius in video containers, fullscreen buttons or user info span;
- Reduced the spacing between cameras to 1px;
- Replaced the loading spinners with a black background + the user name at the center (R.I.P. spinning arrows, won't be missed);
- Changed the color of the talking indicator to be the primary color with 0.7 opacity;
- Make the user name in the video container have opacity 1;
- Fix: make the webcam containers 4:3 even while loading. They were stretched thin before.

This has been widely tested. Also contains two commits from a coworker of mine (@CristianSilvaGrosseli).

_P.S.: PR #10208 follow-up 1._

### Closes Issue(s)

None

### Motivation
I reckon there will be still some improvements to make to the UI and overall camera UX experience, but this tackles some of the things I believe are meh right now:

1. We need something better than the loading spinners when configurations like [`mediaThresholds`](https://github.com/bigbluebutton/bbb-webrtc-sfu/blob/master/config/default.example.yml#L212-L216) are set. With this we have something more descriptive of an user that is less of an eyesore when stream hard limits are set and the server is out of resources. This is where the black background + user name comes from;
2. Spacing between cameras are way too large;
3. Rounded borders take way too much space;
4. Talking indicator color was bland, hard to notice.

### More

Screenshots:
- Complete view, shared cameras (check: spacing, no more borders radius, refurbished talking indicator color)
![image](https://user-images.githubusercontent.com/4529051/89591818-87acf180-d821-11ea-83b1-0f45ec619afa.png)

- New loading state/no resources UI view (second row, first column)
![image](https://user-images.githubusercontent.com/4529051/89591830-91cef000-d821-11ea-8fcf-d7d6925fe502.png)


