### PR TITLE
video-provider: dynamic video profiles (aka automatic bitrate/frame rate throttling)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -395,7 +395,7 @@ class VideoPreview extends Component {
 
   displayInitialPreview(deviceId) {
     const { changeWebcam } = this.props;
-    const availableProfiles = CAMERA_PROFILES;
+    const availableProfiles = CAMERA_PROFILES.filter(p => !p.hidden);
 
     this.setState({
       webcamDeviceId: deviceId,

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -22,6 +22,7 @@ const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 const ROLE_VIEWER = Meteor.settings.public.user.role_viewer;
 const ENABLE_NETWORK_MONITORING = Meteor.settings.public.networkMonitoring.enableNetworkMonitoring;
 const MIRROR_WEBCAM = Meteor.settings.public.app.mirrorOwnWebcam;
+const CAMERA_QUALITY_THRESHOLDS = Meteor.settings.public.kurento.cameraQualityThresholds.thresholds || [];
 
 const TOKEN = '_';
 
@@ -405,6 +406,113 @@ class VideoService {
   monitor(conn) {
     if (ENABLE_NETWORK_MONITORING) monitorVideoConnection(conn);
   }
+
+  amIModerator() {
+    return Users.findOne({ userId: Auth.userID },
+      { fields: { role: 1 } }).role === ROLE_MODERATOR;
+  }
+
+  getNumberOfPublishers() {
+    return VideoStreams.find({ meetingId: Auth.meetingID }).count();
+  }
+
+  isProfileBetter (newProfileId, originalProfileId) {
+    return CAMERA_PROFILES.findIndex(({ id }) => id === newProfileId)
+      > CAMERA_PROFILES.findIndex(({ id }) => id === originalProfileId);
+  }
+
+  applyBitrate (peer, bitrate) {
+    const peerConnection = peer.peerConnection;
+    if ('RTCRtpSender' in window
+      && 'setParameters' in window.RTCRtpSender.prototype
+      && 'getParameters' in window.RTCRtpSender.prototype) {
+      peerConnection.getSenders().forEach(sender => {
+        const { track } = sender;
+        if (track && track.kind === 'video') {
+          const parameters = sender.getParameters();
+          if (!parameters.encodings) {
+            parameters.encodings = [{}];
+          }
+
+          parameters.encodings[0].maxBitrate = bitrate * 1000;
+          sender.setParameters(parameters)
+            .then(() => {
+              logger.info({
+                logCode: 'video_provider_bitratechange',
+                extraInfo: { bitrate },
+              }, `Bitrate changed: ${bitrate}`);
+            })
+            .catch(error => {
+              logger.warn({
+                logCode: 'video_provider_bitratechange_failed',
+                extraInfo: { bitrate, errorMessage: error.message, errorCode: error.code },
+              }, `Bitrate change failed.`);
+            });
+        }
+      })
+    }
+  }
+
+  applyCameraProfile (peer, profileId) {
+    const profile = CAMERA_PROFILES.find(targetProfile => targetProfile.id === profileId);
+
+    if (!profile) {
+      logger.warn({
+        logCode: 'video_provider_noprofile',
+        extraInfo: { profileId },
+      }, `Apply failed: no camera profile found.`);
+      return;
+    }
+
+    // Profile is currently applied or it's better than the original user's profile,
+    // skip
+    if (peer.currentProfileId === profileId
+      || this.isProfileBetter(profileId, peer.originalProfileId)) {
+      return;
+    }
+
+    const { bitrate, constraints } = profile;
+
+    if (bitrate) {
+      this.applyBitrate(peer, bitrate);
+    }
+
+    if (constraints && typeof constraints.video === 'object') {
+      peer.peerConnection.getSenders().forEach(sender => {
+        const { track } = sender;
+        if (track && track.kind === 'video' && typeof track.applyConstraints  === 'function') {
+          track.applyConstraints(constraints.video)
+            .then(() => {
+              logger.info({
+                logCode: 'video_provider_profile_applied',
+                extraInfo: { profileId },
+              }, `New camera profile applied: ${profileId}`);
+              peer.currentProfileId = profileId;
+            })
+            .catch(error => {
+              logger.warn({
+                logCode: 'video_provider_profile_apply_failed',
+                extraInfo: { errorName: error.name, errorCode: error.code },
+              }, 'Error applying camera profile');
+            });
+        }
+      });
+    }
+  }
+
+  getThreshold (numberOfPublishers) {
+    let targetThreshold = { threshold: 0, profile: 'original' };
+    let finalThreshold = { threshold: 0, profile: 'original' };
+
+    for(let mapIndex = 0; mapIndex < CAMERA_QUALITY_THRESHOLDS.length; mapIndex++) {
+      targetThreshold = CAMERA_QUALITY_THRESHOLDS[mapIndex];
+      if (targetThreshold.threshold <= numberOfPublishers) {
+        finalThreshold = targetThreshold;
+      }
+    }
+
+    return finalThreshold;
+  }
 }
 
 const videoService = new VideoService();
@@ -436,4 +544,6 @@ export default {
   onBeforeUnload: () => videoService.onBeforeUnload(),
   notify: message => notify(message, 'error', 'video'),
   updateNumberOfDevices: devices => videoService.updateNumberOfDevices(devices),
+  applyCameraProfile: (peer, newProfile) => videoService.applyCameraProfile(peer, newProfile),
+  getThreshold: (numberOfPublishers) => videoService.getThreshold(numberOfPublishers),
 };

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -123,48 +123,42 @@ public:
         hidden: true
         constraints:
            video:
-              frameRate:
-                ideal: 1
+              frameRate: 1
       - id: low-u25
         name: low-u25
         bitrate: 40
         hidden: true
         constraints:
            video:
-              frameRate:
-                ideal: 3
+              frameRate: 3
       - id: low-u20
         name: low-u4
         bitrate: 50
         hidden: true
         constraints:
            video:
-              frameRate:
-                ideal: 5
+              frameRate: 5
       - id: low-u15
         name: low-u5
         bitrate: 70
         hidden: true
         constraints:
            video:
-              frameRate:
-                ideal: 8
+              frameRate: 8
       - id: low-u12
         name: low-u5
         bitrate: 90
         hidden: true
         constraints:
            video:
-              frameRate:
-                ideal: 10
+              frameRate: 10
       - id: low-u8
         name: low-u5
         bitrate: 100
         hidden: true
         constraints:
            video:
-              frameRate:
-                ideal: 10
+              frameRate: 10
       - id: low
         name: Low quality
         default: false

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -119,11 +119,11 @@ public:
     cameraProfiles:
       - id: low-u30
         name: low-u30
-        bitrate: 35
+        bitrate: 30
         hidden: true
         constraints:
            video:
-              frameRate: 1
+              frameRate: 3
       - id: low-u25
         name: low-u25
         bitrate: 40

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -132,28 +132,28 @@ public:
            video:
               frameRate: 3
       - id: low-u20
-        name: low-u4
+        name: low-u20
         bitrate: 50
         hidden: true
         constraints:
            video:
               frameRate: 5
       - id: low-u15
-        name: low-u5
+        name: low-u15
         bitrate: 70
         hidden: true
         constraints:
            video:
               frameRate: 8
       - id: low-u12
-        name: low-u5
+        name: low-u12
         bitrate: 90
         hidden: true
         constraints:
            video:
               frameRate: 10
       - id: low-u8
-        name: low-u5
+        name: low-u8
         bitrate: 100
         hidden: true
         constraints:

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -117,6 +117,54 @@ public:
         - screen
       firefoxScreenshareSource: window
     cameraProfiles:
+      - id: low-u30
+        name: low-u30
+        bitrate: 35
+        hidden: true
+        constraints:
+           video:
+              frameRate:
+                ideal: 1
+      - id: low-u25
+        name: low-u25
+        bitrate: 40
+        hidden: true
+        constraints:
+           video:
+              frameRate:
+                ideal: 3
+      - id: low-u20
+        name: low-u4
+        bitrate: 50
+        hidden: true
+        constraints:
+           video:
+              frameRate:
+                ideal: 5
+      - id: low-u15
+        name: low-u5
+        bitrate: 70
+        hidden: true
+        constraints:
+           video:
+              frameRate:
+                ideal: 8
+      - id: low-u12
+        name: low-u5
+        bitrate: 90
+        hidden: true
+        constraints:
+           video:
+              frameRate:
+                ideal: 10
+      - id: low-u8
+        name: low-u5
+        bitrate: 100
+        hidden: true
+        constraints:
+           video:
+              frameRate:
+                ideal: 10
       - id: low
         name: Low quality
         default: false
@@ -139,6 +187,21 @@ public:
     enableListenOnly: true
     autoShareWebcam: false
     skipVideoPreview: false
+    cameraQualityThresholds:
+      enabled: false
+      thresholds:
+        - threshold: 8
+          profile: low-u8
+        - threshold: 12
+          profile: low-u12
+        - threshold: 15
+          profile: low-u15
+        - threshold: 20
+          profile: low-u20
+        - threshold: 25
+          profile: low-u25
+        - threshold: 30
+          profile: low-u30
   pingPong:
     clearUsersInSeconds: 180
     pongTimeInSeconds: 15


### PR DESCRIPTION
### What does this PR do?

Adds the ability to automatically throttle camera streams according to the number of shared cameras **in a meeting**. Mainly:

- Possibility of configuring ["invisible" camera profiles](https://github.com/bigbluebutton/bigbluebutton/blob/629e2dbfd46632ee2bb2d6e89fdedfb39e5483a8/bigbluebutton-html5/private/config/settings.yml#L123) in the `cameraProfiles` property of HTML5's `settings.yml`. Those can be configured with a `hidden: true` property and **won't** appear in the **video preview**.
- New `kurento.cameraQualityThresholds` configuration dictionary in HTML5's `settings.yml`.
```
  cameraQualityThresholds:
      enabled: true
      thresholds: # array
        - threshold: N # number of cameras used as a threshold for `profile` to be activated
          profile: <profileId> # An `id` from one of the `kurento.cameraProfiles` configuration entries
```
  * The idea here is to give the agency for administrators to set multiple threshold values according to their infrastructure, configure hidden cameraProfiles which have specific set of [media constraints](https://developer.mozilla.org/en-US/docs/Web/API/Media_Streams_API/Constraints) and bitrate values, associate those to threshold levels and therefore be able to control throughput in the client itself. [There's a default `cameraQualityThresholds` configuration](https://github.com/bigbluebutton/bigbluebutton/blob/629e2dbfd46632ee2bb2d6e89fdedfb39e5483a8/bigbluebutton-html5/private/config/settings.yml#L184-L198) and a set of hidden cameraProfiles constraints which was designed based on a 8 core/16 Gb VM through load testing. It should depict what I'm trying to say.

This has seen some production usage. Stable.

_P.S.: PR #10208 follow-up 2._

<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number -->

### Motivation

There's demand for some way to control camera framerate and bitrate that scales according to the number of cameras in a meeting. This is a naive but effective way of adding that. Should decrease server AND client CPU/bandwidth usage for meetings with many cameras.

Ideally we'd want these thresholds to be based on usage heuristics (packet loss, client environment, client saturation, server saturation, server CPU usage) rather than on absolute stream numbers (which have to be determined case by case). I think an heuristic based approach will eventually be implemented and live alongside this in the form of better REMB and transport-wide congestion control, but this is what we have for now as an effective "stopgap".

### Pending
  - Add voice activity detection through floor holder heuristics (not the current talking indication) to privilege the current talker/floor holder's camera profile so that it has a better quality than the rest. tl;dr: 30 cameras, 29 with crappy FPS and the current talker with a good FPS/bitrate. This is already WIP and will come in a subsequent PR.

### More

* Server-side CPU comparison 
  - 8 core Digital Ocean VM; 30 cameras, 30 users, full mesh; roughly 900 streams;
  - Current 2.2.21 (without automatic throttling):
![image](https://user-images.githubusercontent.com/4529051/89607887-f7cf6d80-d849-11ea-9832-c3999d0a8583.png)
  - This pull request (**with automatic throttling/dynamic camera profiles**):
![image](https://user-images.githubusercontent.com/4529051/89607891-fd2cb800-d849-11ea-9784-770260f79cad.png)

* Client-side CPU comparison
  - Haven't got the time to capture CPU usage graphs from an isolated browser instance with and without this PR; but from naive observation of top/ntop stats and client experimentation, there's a **very significant** difference in responsiveness, CPU usage and bandwidth usage (for the better) with this PR.
