### PR TITLE
Remove muteAll and muteAllExceptPresenter from breakouts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -213,7 +213,7 @@ class UserOptions extends PureComponent {
           onClick={toggleStatus}
         />) : null
       ),
-      (isMeteorConnected ? (
+      (!meetingIsBreakout && isMeteorConnected ? (
         <DropdownListItem
           key={this.muteAllId}
           icon={isMeetingMuted ? 'unmute' : 'mute'}
@@ -222,7 +222,7 @@ class UserOptions extends PureComponent {
           onClick={toggleMuteAllUsers}
         />) : null
       ),
-      (!isMeetingMuted && isMeteorConnected ? (
+      (!meetingIsBreakout && !isMeetingMuted && isMeteorConnected ? (
         <DropdownListItem
           key={this.muteId}
           icon="mute"


### PR DESCRIPTION
Remove the options for MuteAll and MuteAllExceptPresenter from the Gear-menu in active breakout rooms.

Before
![Screenshot from 2020-08-10 13-58-09](https://user-images.githubusercontent.com/290351/89573488-ae0a6700-d7f8-11ea-8481-d0a34bbcea72.png
)


After
![Screenshot from 2020-08-10 13-58-09](https://user-images.githubusercontent.com/6312397/89814959-fb951580-db11-11ea-862b-421344c2ba05.png)


Closes #10210 