### PR TITLE
Improve log for parsed passed parameter error

### DIFF
--- a/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
+++ b/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
@@ -71,7 +71,7 @@ function valueParser(val) {
     const parsedValue = JSON.parse(val.toLowerCase());
     return parsedValue;
   } catch (error) {
-    logger.error('Parameter value could not ber parsed');
+    logger.warn(`addUserSettings:Parameter ${val} could not be parsed (was not json)`);
     return val;
   }
 }


### PR DESCRIPTION
Large number of the parameters' values are not JSON, so this should not be an error. We were not outputting the key-value pair properly.