### PR TITLE
Allow more tags in welcome message/ mod only message

### DIFF
--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -106,14 +106,17 @@ export default function addMeeting(meeting) {
   const meetingEnded = false;
 
   let { welcomeMsg } = newMeeting.welcomeProp;
-  const sanitizedWelcomeText = SanitizeHTML(welcomeMsg, {
-    allowedTags: ['b', 'strong', 'i', 'u', 'a', 'br', 'img'],
+
+  const sanitizeTextInChat = original => SanitizeHTML(original, {
+    allowedTags: ['a', 'b', 'br', 'i', 'img', 'li', 'small', 'span', 'strong', 'u', 'ul'],
     allowedAttributes: {
       a: ['href', 'name', 'target'],
-      img: ['src'],
+      img: ['src', 'width', 'height'],
     },
     allowedSchemes: ['https'],
   });
+
+  const sanitizedWelcomeText = sanitizeTextInChat(welcomeMsg);
   welcomeMsg = sanitizedWelcomeText.replace(
     'href="event:',
     'href="',
@@ -132,21 +135,10 @@ export default function addMeeting(meeting) {
 
   newMeeting.welcomeProp.welcomeMsg = welcomeMsg;
 
-  const { modOnlyMessage } = newMeeting.welcomeProp;
-
-  const sanitizedModOnlyText = SanitizeHTML(modOnlyMessage, {
-    allowedTags: ['b', 'strong', 'i', 'u', 'a', 'br', 'img'],
-    allowedAttributes: {
-      a: ['href', 'name', 'target'],
-      img: ['src'],
-    },
-    allowedSchemes: ['https'],
-  });
-
   // note: as of July 2020 `modOnlyMessage` is not published to the client side.
   // We are sanitizing this data simply to prevent future potential usage
   // At the moment `modOnlyMessage` is obtained from client side as a response to Enter API
-  newMeeting.welcomeProp.modOnlyMessage = sanitizedModOnlyText;
+  newMeeting.welcomeProp.modOnlyMessage = sanitizeTextInChat(newMeeting.welcomeProp.modOnlyMessage);
 
   const modifier = {
     $set: Object.assign({

--- a/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
@@ -143,10 +143,10 @@ class JoinHandler extends Component {
     const setModOnlyMessage = (resp) => {
       if (resp && resp.modOnlyMessage) {
         const sanitizedModOnlyText = SanitizeHTML(resp.modOnlyMessage, {
-          allowedTags: ['b', 'strong', 'i', 'u', 'a', 'br', 'img'],
+          allowedTags: ['a', 'b', 'br', 'i', 'img', 'li', 'small', 'span', 'strong', 'u', 'ul'],
           allowedAttributes: {
             a: ['href', 'name', 'target'],
-            img: ['src'],
+            img: ['src', 'width', 'height'],
           },
           allowedSchemes: ['https'],
         });


### PR DESCRIPTION
Allowed for a wider range of html tags to be preserved during sanitization step of welcome message and moderator only message

Motivation:
https://groups.google.com/g/bigbluebutton-dev/c/46bfAAMblM0/m/OspyiSU0AwAJ