### PR TITLE
Record rebuild not working: Bug in events_archiver.rb ?

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/events_archiver.rb
+++ b/record-and-playback/core/lib/recordandplayback/events_archiver.rb
@@ -256,7 +256,7 @@ module BigBlueButton
       end
 
       meeting_metadata = @redis.metadata_for(meeting_id)
-      return if meeting_metadata.nil?
+      return if meeting_metadata.nil? || meeting_metadata.empty?
 
       # Fill in/update the top-level meeting element
       if meeting.nil?


### PR DESCRIPTION
On my server 2.3 alpha, the method metadata_for(meeting_id) gives back {} (empty Hash). Thus "return if meeting_metadata.nil?" does not occur.
Does @redis.hgetall give {} instead of nil, even though there is a comment in node_modules/redis/lib/utils.js "hgetall converts its replies to an Object. If the reply is empty, null is returned"???

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Fixes error when @redis.metadata_for method gives an empty hash.

### Closes Issue(s)

closes #10244
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number -->

### Motivation

My 2.3 alpha server does not process rebuilding the record. 

### More

The server stopped at archiving, and it came from the line "meeting['externalId'] = strip_control_chars(meeting_metadata[MEETINGID])", where meeting_metadata was just an empty hash. Then strip_control_chars complained. 
