### PR TITLE
Modern Camera Profiles

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -189,10 +189,16 @@ public:
         name: High quality
         default: false
         bitrate: 500
+        constraints:
+          width: 1280
+          frameRate: 15
       - id: hd
         name: High definition
         default: false
         bitrate: 800
+        constraints:
+          width: 1280
+          frameRate: 30
     enableScreensharing: true
     enableVideo: true
     enableVideoMenu: true


### PR DESCRIPTION
This patch switchessing a somewhat more modern default for the camera
profiles by requesting 720p for the `high` and `hd` profiles like this.

This was discussed on the developer's list at:

- https://groups.google.com/g/bigbluebutton-dev/c/PL3kXV9pZmo
