### PR TITLE
Show users names on videos at playback

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -42,6 +42,22 @@ module BigBlueButton
       end
       participants_ids.length
     end
+    
+    # Get userID list
+    def self.get_userIDs(events)
+      participants_ids = Hash.new
+
+      events.xpath("/recording/event[@eventname='ParticipantJoinEvent']").each do |joinEvent|
+         name = joinEvent.at_xpath("name").text
+         userId = joinEvent.at_xpath("userId").text
+
+         #removing "_N" at the end of userId
+         userId.gsub!(/_\d*$/, "")
+
+         participants_ids[userId] = name if name.size != 0
+      end
+      participants_ids
+    end
 
     # Get the meeting metadata
     def self.get_meeting_metadata(events_xml)

--- a/record-and-playback/presentation/scripts/process/presentation.rb
+++ b/record-and-playback/presentation/scripts/process/presentation.rb
@@ -130,6 +130,11 @@ if not FileTest.directory?(target_dir)
 
     participants = recording.at_xpath("participants")
     participants.content = BigBlueButton::Events.get_num_participants(@doc)
+    
+    participantsIDs = BigBlueButton::Events.get_userIDs(@doc)
+    userID_file = File.new("#{target_dir}/users.json","w")
+    JSON.dump(participantsIDs, userID_file)
+    userID_file.close
 
     ## Remove empty meta
     metadata.search('//recording/meta').each do |meta|


### PR DESCRIPTION
#9910 # What does this PR do?

Burn-in the users' names on the video during playback.

### Closes Issue(s)

closes #4025 

### Motivation

To identify the users in webcam videos during the playback. I needed this function to find out students that might have done fraud during the exam. I did not know who's who because I had never met them personally due to the Covid-19!

### More

I am pretty sure that this is not the best implementation, but is at least working.
At this moment those who do not like this functionality have to modify the parameters in the first part of video.rb directly. It may be better to move these parameters to the setting files so that the user can change more easily.
