### PR TITLE
Check video data savings to set presentation max-height

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/media/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/component.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import Settings from '/imports/ui/services/settings';
 import WebcamDraggable from './webcam-draggable-overlay/component';
 
 import { styles } from './styles';
@@ -58,6 +59,9 @@ export default class Media extends Component {
       [styles.floatingOverlay]: (webcamPlacement === 'floating'),
     });
 
+    const { viewParticipantsWebcams } = Settings.dataSaving;
+    const fullHeight = usersVideo.length < 1 || (webcamPlacement === 'floating') || !viewParticipantsWebcams;
+
     return (
       <div
         id="container"
@@ -67,7 +71,7 @@ export default class Media extends Component {
         <div
           className={!swapLayout ? contentClassName : overlayClassName}
           style={{
-            maxHeight: usersVideo.length < 1 || (webcamPlacement === 'floating') ? '100%' : '80%',
+            maxHeight: fullHeight ? '100%' : '80%',
             minHeight: '20%',
           }}
         >


### PR DESCRIPTION
Adjust presentation area height to 100% when webcam's data savings is enabled.

from:
![Screenshot_2020-08-18 BigBlueButton - Demo Meeting11](https://user-images.githubusercontent.com/1778398/90559439-fc622300-e173-11ea-86b8-b2af8b13a70c.png)
to:
![Screenshot_2020-08-18 BigBlueButton - random-2893195](https://user-images.githubusercontent.com/1778398/90559445-ff5d1380-e173-11ea-81a8-c8149f5426ce.png)