### PR TITLE
video-provider: first tackle at video pagination

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/container.jsx
@@ -12,4 +12,5 @@ export default withTracker(props => ({
   swapLayout: props.swapLayout,
   streams: VideoService.getVideoStreams(),
   isUserLocked: VideoService.isUserLocked(),
+  currentVideoPageIndex: VideoService.getCurrentVideoPageIndex(),
 }))(VideoProviderContainer);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -26,7 +26,7 @@ const MIRROR_WEBCAM = Meteor.settings.public.app.mirrorOwnWebcam;
 const CAMERA_QUALITY_THRESHOLDS = Meteor.settings.public.kurento.cameraQualityThresholds.thresholds || [];
 const {
   enabled: PAGINATION_ENABLED,
-  pageChangeLockTimeout: PAGE_CHANGE_LOCK_TIMEOUT,
+  pageChangeDebounceTime: PAGE_CHANGE_DEBOUNCE_TIME,
   desktopPageSizes: DESKTOP_PAGE_SIZES,
   mobilePageSizes: MOBILE_PAGE_SIZES,
 } = Meteor.settings.public.kurento.pagination;
@@ -194,19 +194,9 @@ class VideoService {
     return this.numberOfPages;
   }
 
-  enablePageChangeLock () {
-    if (PAGE_CHANGE_LOCK_TIMEOUT > 0) {
-      this.pageChangeLocked = true;
-      this.pageChangeLockClearTimeout = setTimeout(() => {
-        this.pageChangeLocked = false;
-      }, PAGE_CHANGE_LOCK_TIMEOUT);
-    }
-  }
-
   setCurrentVideoPageIndex (newVideoPageIndex) {
     if (this.currentVideoPageIndex !== newVideoPageIndex) {
       this.currentVideoPageIndex = newVideoPageIndex;
-      this.enablePageChangeLock();
     }
   }
 
@@ -223,16 +213,12 @@ class VideoService {
   }
 
   getNextVideoPage() {
-    if (this.pageChangeLocked) return;
-
     this.setCurrentVideoPageIndex(this.calculateNextPage());
 
     return this.currentVideoPageIndex;
   }
 
   getPreviousVideoPage() {
-    if (this.pageChangeLocked) return;
-
     this.setCurrentVideoPageIndex(this.calculatePreviousPage());
 
     return this.currentVideoPageIndex;
@@ -695,4 +681,5 @@ export default {
   getCurrentVideoPageIndex: () => videoService.getCurrentVideoPageIndex(),
   getPreviousVideoPage: () => videoService.getPreviousVideoPage(),
   getNextVideoPage: () => videoService.getNextVideoPage(),
+  getPageChangeDebounceTime: () => { return PAGE_CHANGE_DEBOUNCE_TIME },
 };

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -170,6 +170,10 @@ class VideoService {
     return Auth.authenticateURL(SFU_URL);
   }
 
+  isPaginationEnabled () {
+    return PAGINATION_ENABLED && (this.getMyPageSize() > 0);
+  }
+
   setNumberOfPages (numberOfPublishers, numberOfSubscribers, pageSize) {
     // Page size 0 means no pagination, return itself
     if (pageSize === 0) return pageSize;
@@ -676,7 +680,7 @@ export default {
   updateNumberOfDevices: devices => videoService.updateNumberOfDevices(devices),
   applyCameraProfile: (peer, newProfile) => videoService.applyCameraProfile(peer, newProfile),
   getThreshold: (numberOfPublishers) => videoService.getThreshold(numberOfPublishers),
-  isPaginationEnabled: () => { return PAGINATION_ENABLED },
+  isPaginationEnabled: () => videoService.isPaginationEnabled(),
   getNumberOfPages: () => videoService.getNumberOfPages(),
   getCurrentVideoPageIndex: () => videoService.getCurrentVideoPageIndex(),
   getPreviousVideoPage: () => videoService.getPreviousVideoPage(),

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -214,14 +214,18 @@ class VideoService {
     return this.currentVideoPageIndex;
   }
 
+  calculateNextPage () {
+    return ((this.currentVideoPageIndex + 1) % this.numberOfPages + this.numberOfPages) % this.numberOfPages;
+  }
+
+  calculatePreviousPage () {
+    return ((this.currentVideoPageIndex - 1) % this.numberOfPages + this.numberOfPages) % this.numberOfPages;
+  }
+
   getNextVideoPage() {
     if (this.pageChangeLocked) return;
 
-    const nextVideoPageIndex = this.currentVideoPageIndex + 1;
-
-    if (nextVideoPageIndex < this.numberOfPages)  {
-      this.setCurrentVideoPageIndex(nextVideoPageIndex);
-    }
+    this.setCurrentVideoPageIndex(this.calculateNextPage());
 
     return this.currentVideoPageIndex;
   }
@@ -229,10 +233,7 @@ class VideoService {
   getPreviousVideoPage() {
     if (this.pageChangeLocked) return;
 
-    if (this.currentVideoPageIndex > 0) {
-      const previousVideoPageIndex = this.currentVideoPageIndex - 1;
-      this.setCurrentVideoPageIndex(previousVideoPageIndex);
-    }
+    this.setCurrentVideoPageIndex(this.calculatePreviousPage());
 
     return this.currentVideoPageIndex;
   }

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
@@ -214,7 +214,7 @@ class VideoList extends Component {
   renderNextPageButton() {
     const { intl, numberOfPages, currentVideoPageIndex } = this.props;
 
-    if (!VideoService.isPaginationEnabled() || numberOfPages === 1) return null;
+    if (!VideoService.isPaginationEnabled() || numberOfPages <= 1) return null;
 
     const currentPage = currentVideoPageIndex + 1;
     const nextPageLabel = intl.formatMessage(intlMessages.nextPageLabel);
@@ -238,7 +238,7 @@ class VideoList extends Component {
   renderPreviousPageButton() {
     const { intl, currentVideoPageIndex, numberOfPages } = this.props;
 
-    if (!VideoService.isPaginationEnabled() || numberOfPages === 1) return null;
+    if (!VideoService.isPaginationEnabled() || numberOfPages <= 1) return null;
 
     const currentPage = currentVideoPageIndex + 1;
     const prevPageLabel = intl.formatMessage(intlMessages.prevPageLabel);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
@@ -9,6 +9,8 @@ import { withDraggableConsumer } from '../../media/webcam-draggable-overlay/cont
 import AutoplayOverlay from '../../media/autoplay-overlay/component';
 import logger from '/imports/startup/client/logger';
 import playAndRetry from '/imports/utils/mediaElementPlayRetry';
+import VideoService from '/imports/ui/components/video-provider/service';
+import Button from '/imports/ui/components/button/component';
 
 const propTypes = {
   streams: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -16,6 +18,8 @@ const propTypes = {
   webcamDraggableDispatch: PropTypes.func.isRequired,
   intl: PropTypes.objectOf(Object).isRequired,
   swapLayout: PropTypes.bool.isRequired,
+  numberOfPages: PropTypes.number.isRequired,
+  currentVideoPageIndex: PropTypes.number.isRequired,
 };
 
 const intlMessages = defineMessages({
@@ -36,6 +40,12 @@ const intlMessages = defineMessages({
   },
   autoplayAllowLabel: {
     id: 'app.videoDock.autoplayAllowLabel',
+  },
+  nextPageLabel: {
+    id: 'app.video.pagination.nextPage',
+  },
+  prevPageLabel: {
+    id: 'app.video.pagination.prevPage',
   },
 });
 
@@ -201,6 +211,58 @@ class VideoList extends Component {
     this.ticking = true;
   }
 
+  renderNextPageButton() {
+    const { intl, numberOfPages, currentVideoPageIndex } = this.props;
+
+    if (!VideoService.isPaginationEnabled() || numberOfPages === 1) return null;
+
+    const currentPage = currentVideoPageIndex + 1;
+    const lastPage = (currentVideoPageIndex + 1) >= numberOfPages;
+    const nextPageLabel = intl.formatMessage(intlMessages.nextPageLabel);
+    const nextPageDetailedLabel = `${nextPageLabel} (${lastPage ? currentPage : currentPage + 1}/${numberOfPages})`;
+
+    return (
+      <Button
+        role="button"
+        aria-label={nextPageLabel}
+        disabled={lastPage}
+        color="primary"
+        icon="right_arrow"
+        size="md"
+        onClick={VideoService.getNextVideoPage}
+        label={nextPageDetailedLabel}
+        hideLabel
+        className={cx(styles.nextPage)}
+      />
+    );
+  }
+
+  renderPreviousPageButton() {
+    const { intl, currentVideoPageIndex, numberOfPages } = this.props;
+
+    if (!VideoService.isPaginationEnabled() || numberOfPages === 1) return null;
+
+    const currentPage = currentVideoPageIndex + 1;
+    const firstPage = currentVideoPageIndex === 0;
+    const prevPageLabel = intl.formatMessage(intlMessages.prevPageLabel);
+    const prevPageDetailedLabel = `${prevPageLabel} (${firstPage ? currentPage : currentPage - 1}/${numberOfPages})`;
+
+    return (
+      <Button
+        role="button"
+        aria-label={prevPageLabel}
+        disabled={firstPage}
+        color="primary"
+        icon="left_arrow"
+        size="md"
+        onClick={VideoService.getPreviousVideoPage}
+        label={prevPageDetailedLabel}
+        hideLabel
+        className={cx(styles.previousPage)}
+      />
+    );
+  }
+
   renderVideoList() {
     const {
       intl,
@@ -269,6 +331,9 @@ class VideoList extends Component {
         }}
         className={canvasClassName}
       >
+
+        {this.renderPreviousPageButton()}
+
         {!streams.length ? null : (
           <div
             ref={(ref) => {
@@ -292,6 +357,9 @@ class VideoList extends Component {
             handleAllowAutoplay={this.handleAllowAutoplay}
           />
         )}
+
+        {this.renderNextPageButton()}
+
       </div>
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
@@ -217,15 +217,13 @@ class VideoList extends Component {
     if (!VideoService.isPaginationEnabled() || numberOfPages === 1) return null;
 
     const currentPage = currentVideoPageIndex + 1;
-    const lastPage = (currentVideoPageIndex + 1) >= numberOfPages;
     const nextPageLabel = intl.formatMessage(intlMessages.nextPageLabel);
-    const nextPageDetailedLabel = `${nextPageLabel} (${lastPage ? currentPage : currentPage + 1}/${numberOfPages})`;
+    const nextPageDetailedLabel = `${nextPageLabel} (${currentPage}/${numberOfPages})`;
 
     return (
       <Button
         role="button"
         aria-label={nextPageLabel}
-        disabled={lastPage}
         color="primary"
         icon="right_arrow"
         size="md"
@@ -243,15 +241,13 @@ class VideoList extends Component {
     if (!VideoService.isPaginationEnabled() || numberOfPages === 1) return null;
 
     const currentPage = currentVideoPageIndex + 1;
-    const firstPage = currentVideoPageIndex === 0;
     const prevPageLabel = intl.formatMessage(intlMessages.prevPageLabel);
-    const prevPageDetailedLabel = `${prevPageLabel} (${firstPage ? currentPage : currentPage - 1}/${numberOfPages})`;
+    const prevPageDetailedLabel = `${prevPageLabel} (${currentPage}/${numberOfPages})`;
 
     return (
       <Button
         role="button"
         aria-label={prevPageLabel}
-        disabled={firstPage}
         color="primary"
         icon="left_arrow"
         size="md"

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { withTracker } from 'meteor/react-meteor-data';
+import VideoList from '/imports/ui/components/video-provider/video-list/component';
+import VideoService from '/imports/ui/components/video-provider/service';
+
+const VideoListContainer = ({ children, ...props }) => {
+  const { streams } = props;
+  return (!streams.length ? null : <VideoList{...props}>{children}</VideoList>);
+};
+
+export default withTracker(props => ({
+  streams: props.streams,
+  onMount: props.onMount,
+  swapLayout: props.swapLayout,
+  numberOfPages: VideoService.getNumberOfPages(),
+  currentVideoPageIndex: VideoService.getCurrentVideoPageIndex(),
+}))(VideoListContainer);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.jsx
@@ -13,5 +13,5 @@ export default withTracker(props => ({
   onMount: props.onMount,
   swapLayout: props.swapLayout,
   numberOfPages: VideoService.getNumberOfPages(),
-  currentVideoPageIndex: VideoService.getCurrentVideoPageIndex(),
+  currentVideoPageIndex: props.currentVideoPageIndex,
 }))(VideoListContainer);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -229,3 +229,35 @@
 .voice {
   background-color: var(--color-success);
 }
+
+.nextPage,
+.previousPage{
+  color: var(--color-white);
+  width: var(--md-padding-x);
+
+  i {
+    [dir="rtl"] & {
+      -webkit-transform: scale(-1, 1);
+      -moz-transform: scale(-1, 1);
+      -ms-transform: scale(-1, 1);
+      -o-transform: scale(-1, 1);
+      transform: scale(-1, 1);
+    }
+  }
+}
+
+.nextPage {
+  margin-left: 1px;
+
+  @include mq($medium-up) {
+    margin-left: 2px;
+  }
+}
+
+.previousPage {
+  margin-right: 1px;
+
+  @include mq($medium-up) {
+    margin-right: 2px;
+  }
+}

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -62,10 +62,6 @@ class VideoListItem extends Component {
             const tagFailedEvent = new CustomEvent('videoPlayFailed', { detail: { mediaTag: elem } });
             window.dispatchEvent(tagFailedEvent);
           }
-          logger.warn({
-            logCode: 'videolistitem_component_play_maybe_error',
-            extraInfo: { error },
-          }, `Could not play video tag due to ${error.name}`);
         });
       }
     };

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -196,6 +196,14 @@ public:
           profile: low-u25
         - threshold: 30
           profile: low-u30
+    pagination:
+      enabled: false
+      desktopPageSizes:
+        moderator: 0
+        viewer: 5
+      mobilePageSizes:
+        moderator: 3
+        viewer: 3
   pingPong:
     clearUsersInSeconds: 180
     pongTimeInSeconds: 15

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -198,6 +198,7 @@ public:
           profile: low-u30
     pagination:
       enabled: false
+      pageChangeLockTimeout: 5000
       desktopPageSizes:
         moderator: 0
         viewer: 5

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -198,7 +198,7 @@ public:
           profile: low-u30
     pagination:
       enabled: false
-      pageChangeLockTimeout: 5000
+      pageChangeDebounceTime: 2500
       desktopPageSizes:
         moderator: 0
         viewer: 5

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -578,6 +578,8 @@
     "app.video.videoMenuDesc": "Open video menu dropdown",
     "app.video.chromeExtensionError": "You must install",
     "app.video.chromeExtensionErrorLink": "this Chrome extension",
+    "app.video.pagination.prevPage": "See previous videos",
+    "app.video.pagination.nextPage": "See next videos",
     "app.fullscreenButton.label": "Make {0} fullscreen",
     "app.deskshare.iceConnectionStateError": "Connection failed when sharing screen (ICE error 1108)",
     "app.sfu.mediaServerConnectionError2000": "Unable to connect to media server (error 2000)",


### PR DESCRIPTION
### What does this PR do?

Adds a configurable video pagination mode which gives the possibility to control the number
of simultaneous cameras being showed to an end user, but give them the agency to see all of
them separately (in pages).

Caveat: page changes renegotiate WebRTC peers. See the last item in `Pending` for more info.

More testing is welcome (please).

### Using it
```
    pagination:
      # whether to globally enable or disable pagination altogether
      enabled: false 
      # time in ms to lock the page change action after the page has been changed
      pageChangeLockTimeout: 5000
      # video page sizes for DESKTOP endpoints. The numbers here relate to the number of SUBSCRIBER streams
      # PUBLISHERS aren't accounted for (ie moderator: 2 implies a moderator will see 2 remote streams 
      # and itself if his webcam's being shared)
      # A page size of 0 (zero) means that the page size is unlimited. This is equivalent to disabling pagination
      # to an specific scenario (ie disable pagination for moderators on desktop endpoints)
      desktopPageSizes:
        moderator: 0
        viewer: 5
      #  video page sizes for MOBILE endpoints
      mobilePageSizes:
        moderator: 3
        viewer: 3
```

### Motivation

There's demand for some way to control the number of concurrent streams being shown to end users for both server-side and client-side reasons. We need to rein in Kurento's CPU/bandwidth usage in some way and also prevent end users from getting their computers melted with a full mesh scenario. This is an initial tackle to both of those problems.

### Pending
  - Centralize the arrow icon in the page change buttons. I tried a bit, couldn't because I had to style the button to be square and I can't seem to get the arrow to centralize to the new button width, even with a customIcon. But then again, I'm pretty bad at CSS so I'd rather leave this to someone that knows better.
  - Prevent renegotiation when changing pages and instead rely on server-side routing. This should come in the future when Last-N lands.

### Closes Issue(s)

https://github.com/bigbluebutton/bigbluebutton/issues/9655 (maybe?)

### More

- [ ] Needs a docs entry

### Screenshots
![pag3](https://user-images.githubusercontent.com/4529051/90652461-79dd7000-e214-11ea-98a0-ff665dbd1686.png)
![pag2](https://user-images.githubusercontent.com/4529051/90652464-7b0e9d00-e214-11ea-8fef-e792f8ba47d0.png)
![pag1](https://user-images.githubusercontent.com/4529051/90652469-7ba73380-e214-11ea-97a2-db32b57e52d8.png)
![image (3)](https://user-images.githubusercontent.com/4529051/90652476-7ea22400-e214-11ea-9b63-91a0b05a648e.png)

