### PR TITLE
Add individual video record control

### DIFF
--- a/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
+++ b/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
@@ -45,6 +45,7 @@ const currentParameters = [
   'bbb_preferred_camera_profile',
   'bbb_enable_screen_sharing',
   'bbb_enable_video',
+  'bbb_record_video',
   'bbb_skip_video_preview',
   'bbb_mirror_own_webcam',
   // PRESENTATION

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -550,6 +550,7 @@ class VideoProvider extends Component {
             userId: this.info.userId,
             userName: this.info.userName,
             bitrate,
+            record: VideoService.getRecord(),
           };
 
           logger.info({

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -50,6 +50,8 @@ class VideoService {
 
     this.numberOfDevices = 0;
 
+    this.record = null;
+
     this.updateNumberOfDevices = this.updateNumberOfDevices.bind(this);
     // Safari doesn't support ondevicechange
     if (!this.isSafari) {
@@ -332,6 +334,14 @@ class VideoService {
   getMyRole () {
     return Users.findOne({ userId: Auth.userID },
       { fields: { role: 1 } }).role;
+  }
+
+  getRecord() {
+    if (this.record === null) {
+      this.record = getFromUserSettings('bbb_record_video', true);
+    }
+
+    return this.record;
   }
 
   filterModeratorOnly(streams) {
@@ -669,6 +679,7 @@ export default {
   addCandidateToPeer: (peer, candidate, cameraId) => videoService.addCandidateToPeer(peer, candidate, cameraId),
   processInboundIceQueue: (peer, cameraId) => videoService.processInboundIceQueue(peer, cameraId),
   getRole: isLocal => videoService.getRole(isLocal),
+  getRecord: () => videoService.getRecord(),
   getSharedDevices: () => videoService.getSharedDevices(),
   getSkipVideoPreview: fromInterface => videoService.getSkipVideoPreview(fromInterface),
   getUserParameterProfile: () => videoService.getUserParameterProfile(),


### PR DESCRIPTION
This adds `bbb_record_video` userdata that, when is set to false, signals
bbb-webrtc-sfu to avoid generating the stream recording assets for a
particular user.

By default, `bbb_record_video` is true.

Associated with https://github.com/bigbluebutton/bigbluebutton/issues/10249 and https://github.com/bigbluebutton/bbb-webrtc-sfu/pull/56.