### PR TITLE
video-provider: fix dynamic profile accounting when using pagination

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/media/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/container.jsx
@@ -122,7 +122,7 @@ export default withModalMounter(withTracker(() => {
     data.children = <ScreenshareContainer />;
   }
 
-  const usersVideo = VideoService.getVideoStreams();
+  const { streams: usersVideo } = VideoService.getVideoStreams();
   data.usersVideo = usersVideo;
 
   if (MediaService.shouldShowOverlay() && usersVideo.length && viewParticipantsWebcams) {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -282,7 +282,7 @@ class VideoProvider extends Component {
     this.disconnectStreams(streamsToDisconnect);
 
     if (CAMERA_QUALITY_THRESHOLDS_ENABLED) {
-      this.updateThreshold(streams.length);
+      this.updateThreshold(this.props.totalNumberOfStreams);
     }
   }
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/container.jsx
@@ -8,9 +8,22 @@ const VideoProviderContainer = ({ children, ...props }) => {
   return (!streams.length ? null : <VideoProvider {...props}>{children}</VideoProvider>);
 };
 
-export default withTracker(props => ({
-  swapLayout: props.swapLayout,
-  streams: VideoService.getVideoStreams(),
-  isUserLocked: VideoService.isUserLocked(),
-  currentVideoPageIndex: VideoService.getCurrentVideoPageIndex(),
-}))(VideoProviderContainer);
+export default withTracker(props => {
+  // getVideoStreams returns a dictionary consisting of:
+  // {
+  //  streams: array of mapped streams
+  //  totalNumberOfStreams: total number of shared streams in the server
+  // }
+  const {
+    streams,
+    totalNumberOfStreams
+  } = VideoService.getVideoStreams();
+
+  return {
+    swapLayout: props.swapLayout,
+    streams,
+    totalNumberOfStreams,
+    isUserLocked: VideoService.isUserLocked(),
+    currentVideoPageIndex: VideoService.getCurrentVideoPageIndex(),
+  };
+})(VideoProviderContainer);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -291,11 +291,11 @@ class VideoService {
     // is equivalent to disabling it), so return the mapped streams as they are
     // which produces the original non paginated behaviour
     if (!PAGINATION_ENABLED || pageSize === 0) {
-      return mappedStreams;
+      return { streams: mappedStreams, totalNumberOfStreams: mappedStreams.length };
     };
 
     const paginatedStreams = this.getVideoPage(mappedStreams, pageSize);
-    return paginatedStreams;
+    return { streams: paginatedStreams, totalNumberOfStreams: mappedStreams.length };
   }
 
   getConnectingStream(streams) {


### PR DESCRIPTION
### What does this PR do?

Fixes video-provider's dynamic camera quality thresholds accounting when using pagination mode.
With pagination, the streams array gave a partial vision of shared streams so I had to extend the
service method to return the absolute number of streams as well so dynamic profiles would work
as intended when pagination is enabled

Follow up to #10293 
### Closes Issue(s)

None