### PR TITLE
video-provider: add inline docs for pagination configuration

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -197,14 +197,20 @@ public:
         - threshold: 30
           profile: low-u30
     pagination:
+      # whether to globally enable or disable pagination.
       enabled: false
+      # how long (in ms) the negotiation will be debounced after a page change.
       pageChangeDebounceTime: 2500
+      # video page sizes for DESKTOP endpoints. It stands for the number of SUBSCRIBER streams.
+      # PUBLISHERS aren't accounted for .
+      # A page size of 0 (zero) means that the page size is unlimited (disabled).
       desktopPageSizes:
         moderator: 0
         viewer: 5
+      # video page sizes for MOBILE endpoints
       mobilePageSizes:
-        moderator: 3
-        viewer: 3
+        moderator: 2
+        viewer: 2
   pingPong:
     clearUsersInSeconds: 180
     pongTimeInSeconds: 15


### PR DESCRIPTION
### What does this PR do?

- Add inline docs for pagination configuration
- Change the default page sizes for mobile to 2

Follow up to #10293.

### Closes Issue(s)

None

### Motivation

Regarding the default page size change for mobiles: 2 (+ max 1 local) fits mobile screens better. 
I think 2 is what we need; 1 is too little and 3 is just absurd.