### PR TITLE
screenshare: improve screenshare service findOne calls

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -12,13 +12,14 @@ import Auth from '/imports/ui/services/auth';
 // screensharing. If it has changed either trigger a call to receive video
 // and display it, or end the call and hide the video
 const isVideoBroadcasting = () => {
-  const ds = Screenshare.findOne({});
+  const screenshareEntry = Screenshare.findOne({ meetingId: Auth.meetingID },
+    { fields: { 'screenshare.stream': 1 } });
 
-  if (!ds) {
+  if (!screenshareEntry) {
     return false;
   }
 
-  return !!ds.screenshare.stream;
+  return !!screenshareEntry.screenshare.stream;
 };
 
 // if remote screenshare has been ended disconnect and hide the video stream


### PR DESCRIPTION
### What does this PR do?

The HTML5 code for screensharing is pretty old in some aspects.
I've improved some of the findOne calls to be more in tune with 2.2.
Specially in `isVideoBroadcasting`. I don't even know how screensharing was working properly the way it was.

### Closes Issue(s)

None.
