### PR TITLE
video-provider: add missing PropType, remove render socketOpen check

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -83,6 +83,7 @@ const propTypes = {
   isUserLocked: PropTypes.bool.isRequired,
   swapLayout: PropTypes.bool.isRequired,
   currentVideoPageIndex: PropTypes.number.isRequired,
+  totalNumberOfStreams: PropTypes.number.isRequired,
 };
 
 class VideoProvider extends Component {
@@ -879,10 +880,7 @@ class VideoProvider extends Component {
   }
 
   render() {
-    const { swapLayout, currentVideoPageIndex } = this.props;
-    const {
-      streams,
-    } = this.props;
+    const { swapLayout, currentVideoPageIndex, streams } = this.props;
 
     return (
       <VideoListContainer

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -880,12 +880,10 @@ class VideoProvider extends Component {
 
   render() {
     const { swapLayout, currentVideoPageIndex } = this.props;
-    const { socketOpen } = this.state;
-    if (!socketOpen) return null;
-
     const {
       streams,
     } = this.props;
+
     return (
       <VideoListContainer
         streams={streams}


### PR DESCRIPTION
### What does this PR do?

- Add a new `PropType` entry for `totalNumberOfStreams`
- Remove `socketOpen` state check as a trigger for rendering `VideoList`

### Closes Issue(s)

None

### Motivation

Removal of `socketOpen` check:
  - The check is old as hell and makes no sense. Removing it makes the video list load faster and webcam sharing feel more responsive due to pre-rendering named containers even before the websocket connection is established.
  - Still left the state for it because it's "useful" in forcing a re-render when the websocket connection is established.