### PR TITLE
Also delete opus files in freeswitch cache dir

### DIFF
--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -388,6 +388,7 @@ if [ $DELETE ]; then
   rm -rf /usr/share/red5/webapps/video-broadcast/streams/$MEETING_ID
   rm -f /var/bigbluebutton/screenshare/$MEETING_ID*.flv
   rm -f /var/freeswitch/meetings/$MEETING_ID*.wav
+  rm -f /var/freeswitch/meetings/$MEETING_ID*.opus
   rm -rf /var/bigbluebutton/$MEETING_ID
 fi
 
@@ -419,6 +420,7 @@ if [ $DELETEALL ]; then
   find /usr/share/red5/webapps/video-broadcast/streams -name "*.flv" -exec rm '{}' \;
   rm -f /var/bigbluebutton/screenshare/*.flv
   rm -f /var/freeswitch/meetings/*.wav
+  rm -f /var/freeswitch/meetings/*.opus
 
   for meeting in $(ls /var/bigbluebutton | grep "^[0-9a-f]\{40\}-[[:digit:]]\{13\}$"); do
     echo "deleting: $meeting"


### PR DESCRIPTION
Only wav files in freeswitch cache directory were deleted. With this PR also opus files are deleted.



### What does this PR do?

Extends `bbb-record --delete`  and `--deleteall` to remove `opus` files


### Closes Issue(s)

closes #10345

### Motivation

privacy

### More

