### PR TITLE
New option for bbb-record to delete recordings marked as norecord

### DIFF
--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -235,7 +235,7 @@ while [ $# -gt 0 ]; do
 
         if [ "$1" = "-deletenorecord" -o "$1" = "--deletenorecord" ]; then
 		need_root
-                DELETEALL=1
+                DELETENORECORD=1
 		shift
                 continue
         fi
@@ -435,7 +435,7 @@ if [ $DELETEALL ]; then
   done
 fi
 
-if [ $DELETEALL ]; then
+if [ $DELETENORECORD ]; then
   # check for *.norecord files
   # if found call a new instance of bbb-record for deleting identified recordings.
 

--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -140,6 +140,7 @@ usage() {
         echo "   --rebuildall			        rebuild every recording"
 	echo "   --delete <internal meetingID>	delete one meeting and recording"
         echo "   --deleteall                      	delete all meetings and recordings"
+        echo "   --deletenorecord			delete all meetings and recordings which have no recording marks"
         echo "   --debug                          	check for recording errors"
         echo "   --check                          	check for configuration errors"
         echo "   --enable <workflow>              	enable a recording workflow"
@@ -226,6 +227,13 @@ while [ $# -gt 0 ]; do
         fi
 
         if [ "$1" = "-deleteall" -o "$1" = "--deleteall" ]; then
+		need_root
+                DELETEALL=1
+		shift
+                continue
+        fi
+
+        if [ "$1" = "-deletenorecord" -o "$1" = "--deletenorecord" ]; then
 		need_root
                 DELETEALL=1
 		shift
@@ -426,6 +434,18 @@ if [ $DELETEALL ]; then
     rm -rf /var/bigbluebutton/captions/$meeting
   done
 fi
+
+if [ $DELETEALL ]; then
+  # check for *.norecord files
+  # if found call a new instance of bbb-record for deleting identified recordings.
+
+  for meetings in $STATUS/archived/*.norecord
+  do 
+    meeting=$(basename ${meetings%.norecord})
+    /usr/bin/bbb-record --delete $meeting
+  done
+fi
+
 
 if [ $LIST ]; then
 

--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -439,8 +439,7 @@ if [ $DELETENORECORD ]; then
   # check for *.norecord files
   # if found call a new instance of bbb-record for deleting identified recordings.
 
-  for meetings in $STATUS/archived/*.norecord
-  do 
+  for meetings in $(ls $STATUS/archived/ | grep "^[0-9a-f]\{40\}-[[:digit:]]\{13\}.norecord$"); do
     meeting=$(basename ${meetings%.norecord})
     /usr/bin/bbb-record --delete $meeting
   done


### PR DESCRIPTION
### What does this PR do?

This PR adds a new option to `bbb-record` that deletes recordings marked as `norecord`

`bbb-record --deletenorecord`

### Closes Issue(s)

closes #10347 


### Motivation

Privacy

### More

- [ ] Added/updated documentation
- [ ] May add a systemd path and oneshot service to run this if a new `.norecord` file appears. I'll add an example to #10347 for documentation.