### PR TITLE
Add event IDs for webhooks to filter out un-needed messages.

### DIFF
--- a/bbb-webhooks/hook.js
+++ b/bbb-webhooks/hook.js
@@ -84,7 +84,7 @@ module.exports = class Hook {
   // message might be processed instantly.
   enqueue(message) {
     // If the event is not in the hook's event list, skip it.
-    if ((this.eventID != null) && ((message == null) || (message.data == null) || (message.data.id == null) || (!this.eventID.some( ev => message.data.id.toLowerCase() )))) {
+    if ((this.eventID != null) && ((message == null) || (message.data == null) || (message.data.id == null) || (!this.eventID.some( ev => ev == message.data.id.toLowerCase() )))) {
       Logger.info(`[Hook] ${this.callbackURL} skipping message from queue because not in event list for hook:`, JSON.stringify(message));
     }
     else {

--- a/bbb-webhooks/hook.js
+++ b/bbb-webhooks/hook.js
@@ -34,6 +34,7 @@ module.exports = class Hook {
     this.id = null;
     this.callbackURL = null;
     this.externalMeetingID = null;
+    this.eventID = null;
     this.queue = [];
     this.emitter = null;
     this.redisClient = Application.redisClient();
@@ -82,20 +83,26 @@ module.exports = class Hook {
   // Puts a new message in the queue. Will also trigger a processing in the queue so this
   // message might be processed instantly.
   enqueue(message) {
-    this.redisClient.llen(config.get("redis.keys.eventsPrefix") + ":" + this.id, (error, reply) => {
-      const length = reply;
-      if (length < config.get("hooks.queueSize") && this.queue.length < config.get("hooks.queueSize")) {
-        Logger.info(`[Hook] ${this.callbackURL} enqueueing message:`, JSON.stringify(message));
-        // Add message to redis queue
-        this.redisClient.rpush(config.get("redis.keys.eventsPrefix") + ":" + this.id, JSON.stringify(message), (error,reply) => {
-          if (error != null) { Logger.error("[Hook] error pushing event to redis queue:", JSON.stringify(message), error); }
-        });
-        this.queue.push(JSON.stringify(message));
-        this._processQueue();
-      } else {
-        Logger.warn(`[Hook] ${this.callbackURL} queue size exceed, event:`, JSON.stringify(message));
-      }
-    });
+    // If the event is not in the hook's event list, skip it.
+    if ((this.eventID != null) && ((message == null) || (message.data == null) || (message.data.id == null) || (!this.eventID.some( ev => message.data.id.toLowerCase() )))) {
+      Logger.info(`[Hook] ${this.callbackURL} skipping message from queue because not in event list for hook:`, JSON.stringify(message));
+    }
+    else {
+      this.redisClient.llen(config.get("redis.keys.eventsPrefix") + ":" + this.id, (error, reply) => {
+        const length = reply;
+        if (length < config.get("hooks.queueSize") && this.queue.length < config.get("hooks.queueSize")) {
+          Logger.info(`[Hook] ${this.callbackURL} enqueueing message:`, JSON.stringify(message));
+          // Add message to redis queue
+          this.redisClient.rpush(config.get("redis.keys.eventsPrefix") + ":" + this.id, JSON.stringify(message), (error,reply) => {
+            if (error != null) { Logger.error("[Hook] error pushing event to redis queue:", JSON.stringify(message), error); }
+          });
+          this.queue.push(JSON.stringify(message));
+          this._processQueue();
+        } else {
+          Logger.warn(`[Hook] ${this.callbackURL} queue size exceed, event:`, JSON.stringify(message));
+        }
+      });
+    }
   }
 
   toRedis() {
@@ -106,6 +113,7 @@ module.exports = class Hook {
       "getRaw": this.getRaw
     };
     if (this.externalMeetingID != null) { r.externalMeetingID = this.externalMeetingID; }
+    if (this.eventID != null) { r.eventID = this.eventID.join(); }
     return r;
   }
 
@@ -118,6 +126,11 @@ module.exports = class Hook {
       this.externalMeetingID = redisData.externalMeetingID;
     } else {
       this.externalMeetingID = null;
+    }
+    if (redisData.eventID != null) {
+      this.eventID = redisData.eventID.toLowerCase().split(',');
+    } else {
+      this.eventID = null;
     }
   }
 
@@ -155,7 +168,7 @@ module.exports = class Hook {
     });
   }
 
-  static addSubscription(callbackURL, meetingID, getRaw, callback) {
+  static addSubscription(callbackURL, meetingID, eventID, getRaw, callback) {
     let hook = Hook.findByCallbackURLSync(callbackURL);
     if (hook != null) {
       return (typeof callback === 'function' ? callback(new Error("There is already a subscription for this callback URL"), hook) : undefined);
@@ -167,6 +180,9 @@ module.exports = class Hook {
       hook = new Hook();
       hook.callbackURL = callbackURL;
       hook.externalMeetingID = meetingID;
+      if (eventID != null) {
+        hook.eventID = eventID.toLowerCase().split(',');
+      }
       hook.getRaw = getRaw;
       hook.permanent = config.get("hooks.permanentURLs").some( obj => {
         return obj.url === callbackURL

--- a/bbb-webhooks/test/test.js
+++ b/bbb-webhooks/test/test.js
@@ -87,7 +87,7 @@ describe('bbb-webhooks tests', () => {
 
   describe('GET /hooks/destroy', () => {
     before( (done) => {
-      Hook.addSubscription(Helpers.callback,null,false,() => { done(); });
+      Hook.addSubscription(Helpers.callback,null,null,false,() => { done(); });
     });
     it('should destroy a hook', (done) => {
       const hooks = Hook.allGlobalSync();
@@ -152,7 +152,7 @@ describe('bbb-webhooks tests', () => {
   describe('Hook queues', () => {
     before( () => {
       Application.redisPubSubClient().psubscribe("test-channel");
-      Hook.addSubscription(Helpers.callback,null,false, (err,reply) => {
+      Hook.addSubscription(Helpers.callback,null,null,false, (err,reply) => {
         const hooks = Hook.allGlobalSync();
         const hook = hooks[0];
         const hook2 = hooks[hooks.length -1];
@@ -243,7 +243,7 @@ describe('bbb-webhooks tests', () => {
   describe('/POST raw message', () => {
     before( () => {
       Application.redisPubSubClient().psubscribe("test-channel");
-      Hook.addSubscription(Helpers.callback,null,true, (err,hook) => {
+      Hook.addSubscription(Helpers.callback,null,null,true, (err,hook) => {
         Helpers.flushredis(hook);
       })
     });

--- a/bbb-webhooks/web_server.js
+++ b/bbb-webhooks/web_server.js
@@ -49,6 +49,7 @@ module.exports = class WebServer {
     const urlObj = url.parse(req.url, true);
     const callbackURL = urlObj.query["callbackURL"];
     const meetingID = urlObj.query["meetingID"];
+    const eventID = urlObj.query["eventID"];
     let getRaw = urlObj.query["getRaw"];
     if (getRaw){
       getRaw = JSON.parse(getRaw.toLowerCase());
@@ -59,7 +60,7 @@ module.exports = class WebServer {
     if (callbackURL == null) {
       respondWithXML(res, responses.missingParamCallbackURL);
     } else {
-      Hook.addSubscription(callbackURL, meetingID, getRaw, function(error, hook) {
+      Hook.addSubscription(callbackURL, meetingID, eventID, getRaw, function(error, hook) {
         let msg;
         if (error != null) { // the only error for now is for duplicated callbackURL
           msg = responses.createDuplicated(hook.id);
@@ -75,7 +76,7 @@ module.exports = class WebServer {
   // Create a permanent hook. Permanent hooks can't be deleted via API and will try to emit a message until it succeed
   createPermanents(callback) {
     for (let i = 0; i < config.get("hooks.permanentURLs").length; i++) {
-      Hook.addSubscription(config.get("hooks.permanentURLs")[i].url, null, config.get("hooks.permanentURLs")[i].getRaw, function(error, hook) {
+      Hook.addSubscription(config.get("hooks.permanentURLs")[i].url, null, null, config.get("hooks.permanentURLs")[i].getRaw, function(error, hook) {
         if (error != null) { // there probably won't be any errors here
           Logger.info("[WebServer] duplicated permanent hook", error);
         } else if (hook != null) {
@@ -130,6 +131,7 @@ module.exports = class WebServer {
       msg +=   `<hookID>${hook.id}</hookID>`;
       msg +=   `<callbackURL><![CDATA[${hook.callbackURL}]]></callbackURL>`;
       if (!hook.isGlobal()) { msg +=   `<meetingID><![CDATA[${hook.externalMeetingID}]]></meetingID>`; }
+      if (hook.eventID) { msg +=   `<eventID>${hook.eventID.join()}</eventID>`; }
       msg +=   `<permanentHook>${hook.permanent}</permanentHook>`;
       msg +=   `<rawData>${hook.getRaw}</rawData>`;
       msg += "</hook>";

--- a/bbb-webhooks/web_server.js
+++ b/bbb-webhooks/web_server.js
@@ -131,7 +131,7 @@ module.exports = class WebServer {
       msg +=   `<hookID>${hook.id}</hookID>`;
       msg +=   `<callbackURL><![CDATA[${hook.callbackURL}]]></callbackURL>`;
       if (!hook.isGlobal()) { msg +=   `<meetingID><![CDATA[${hook.externalMeetingID}]]></meetingID>`; }
-      if (hook.eventID) { msg +=   `<eventID>${hook.eventID.join()}</eventID>`; }
+      if (hook.eventID != null) { msg +=   `<eventID>${hook.eventID.join()}</eventID>`; }
       msg +=   `<permanentHook>${hook.permanent}</permanentHook>`;
       msg +=   `<rawData>${hook.getRaw}</rawData>`;
       msg += "</hook>";


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Adds the ability to filter out un-needed messages in web hooks.
<!-- A brief description of each change being made with this pull request. -->

### Motivation

Web hooks send a lot of data and messages, while not all messages are needed. After this change, when registering a hook, it is optional to add an eventID parameter with comma-separated event IDs, so only those will be sent.
<!-- What inspired you to submit this pull request? -->

### More

- [ ] Needs to update bbb-webhooks doc (currently they are not updated to the current situation).
