### PR TITLE
Fix presentation width of undefined or null

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -31,8 +31,8 @@ const intlMessages = defineMessages({
     description: 'label displayed in toast when presentation switches',
   },
   downloadLabel: {
-  id: 'app.presentation.downloadLabel',
-  description: 'label for downloadable presentations',
+    id: 'app.presentation.downloadLabel',
+    description: 'label for downloadable presentations',
   },
   slideContentStart: {
     id: 'app.presentation.startSlideContent',
@@ -112,7 +112,14 @@ class PresentationArea extends PureComponent {
     window.addEventListener('webcamAreaResize', this.handleResize, false);
 
     const { slidePosition, layoutContextDispatch } = this.props;
-    const { width: currWidth, height: currHeight } = slidePosition;
+
+    let currWidth = 0;
+    let currHeight = 0;
+
+    if (slidePosition) {
+      currWidth = slidePosition.width;
+      currHeight = slidePosition.height;
+    }
 
     layoutContextDispatch({
       type: 'setPresentationSlideSize',


### PR DESCRIPTION
### What does this PR do?

Default the presentations current width / height to 0 if the `slidePosition` doesn't exist.

### Closes Issue(s)

#10372 