### PR TITLE
Add check when start/stop an external video

### DIFF
--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/startWatchingExternalVideo.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/startWatchingExternalVideo.js
@@ -13,13 +13,19 @@ export default function startWatchingExternalVideo(options) {
   const { meetingId, requesterUserId } = extractCredentials(this.userId);
   const { externalVideoUrl } = options;
 
-  check(externalVideoUrl, String);
+  try {
+    check(meetingId, String);
+    check(requesterUserId, String);
+    check(externalVideoUrl, String);
 
-  Meetings.update({ meetingId }, { $set: { externalVideoUrl } });
+    Meetings.update({ meetingId }, { $set: { externalVideoUrl } });
 
-  const payload = { externalVideoUrl };
+    const payload = { externalVideoUrl };
 
-  Logger.info(`User id=${requesterUserId} sharing an external video: ${externalVideoUrl} for meeting ${meetingId}`);
+    Logger.info(`User id=${requesterUserId} sharing an external video: ${externalVideoUrl} for meeting ${meetingId}`);
 
-  return RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);
+    return RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);
+  } catch (error) {
+    Logger.error(`Error on sharing an external video: ${externalVideoUrl} ${error}`);
+  }
 }

--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/stopWatchingExternalVideo.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/stopWatchingExternalVideo.js
@@ -9,19 +9,22 @@ export default function stopWatchingExternalVideo(options) {
   const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
   const EVENT_NAME = 'StopExternalVideoMsg';
 
-  if (this.userId) {
-    options = extractCredentials(this.userId);
+  const { meetingId, requesterUserId } = this.userId ? this.userId : options;
+
+  try {
+    check(meetingId, String);
+    check(requesterUserId, String);
+
+    const meeting = Meetings.findOne({ meetingId });
+    if (!meeting || meeting.externalVideoUrl === null) return;
+
+    Meetings.update({ meetingId }, { $set: { externalVideoUrl: null } });
+    const payload = {};
+
+    Logger.info(`User id=${requesterUserId} stopped sharing an external video for meeting=${meetingId}`);
+
+    RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);
+  } catch (error) {
+    Logger.error(`Error on stop sharing an external video for meeting=${meetingId} ${error}`);
   }
-
-  const { meetingId, requesterUserId } = options;
-
-  const meeting = Meetings.findOne({ meetingId });
-  if (!meeting || meeting.externalVideoUrl === null) return;
-
-  Meetings.update({ meetingId }, { $set: { externalVideoUrl: null } });
-  const payload = {};
-
-  Logger.info(`User id=${requesterUserId} stopped sharing an external video for meeting=${meetingId}`);
-
-  RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);
 }

--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/stopWatchingExternalVideo.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/stopWatchingExternalVideo.js
@@ -9,7 +9,7 @@ export default function stopWatchingExternalVideo(options) {
   const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
   const EVENT_NAME = 'StopExternalVideoMsg';
 
-  const { meetingId, requesterUserId } = this.userId ? this.userId : options;
+  const { meetingId, requesterUserId } = this.userId ? extractCredentials(this.userId) : options;
 
   try {
     check(meetingId, String);


### PR DESCRIPTION
### What does this PR do?

Add an extra verification on extracted data to avoid some edge case where those values are `undefined` and the video started to play in into another meeting.
