### PR TITLE
Add a client-side microphone mute/unmute

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -51,14 +51,12 @@ const toggleMuteMicrophone = () => {
       extraInfo: { logType: 'user_action' },
     }, 'microphone unmuted by user');
     makeCall('toggleVoice');
-    AudioManager.unmute();
   } else {
     logger.info({
       logCode: 'audiomanager_mute_audio',
       extraInfo: { logType: 'user_action' },
     }, 'microphone muted by user');
     makeCall('toggleVoice');
-    AudioManager.mute();
   }
 };
 

--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -51,12 +51,14 @@ const toggleMuteMicrophone = () => {
       extraInfo: { logType: 'user_action' },
     }, 'microphone unmuted by user');
     makeCall('toggleVoice');
+    AudioManager.unmute();
   } else {
     logger.info({
       logCode: 'audiomanager_mute_audio',
       extraInfo: { logType: 'user_action' },
     }, 'microphone muted by user');
     makeCall('toggleVoice');
+    AudioManager.mute();
   }
 };
 

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -11,7 +11,6 @@ import { tryGenerateIceCandidates } from '/imports/utils/safari-webrtc';
 import { monitorAudioConnection } from '/imports/utils/stats';
 import AudioErrors from './error-codes';
 
-
 const ENABLE_NETWORK_MONITORING = Meteor.settings.public.networkMonitoring.enableNetworkMonitoring;
 
 const MEDIA = Meteor.settings.public.media;


### PR DESCRIPTION
### What does this PR do?

- Add a client-side microphone mute-unmute via the `MediaStreamTrack.enabled` property.
  * The track enabled property makes the encoder generate silent frames instead of capturing from the input source.
  * It's supported by all major browser for a long time now
  * There will still be OPUS stream being transmitted to the server, but those will be silent frames. That can range up to 48kbps (our current audio limit), but will usually be way lower than 10kbps (depending on the browser).


### Closes Issue(s)

Partially addresses https://github.com/bigbluebutton/bigbluebutton/issues/8951

### Motivation

https://github.com/bigbluebutton/bigbluebutton/issues/8951

### More

Caveats:
  - A server-side unmute (via FreeSWITCH) or a remote unmute (when allowModsToUnmuteUsers=true) will still work. But the local end mute state will be correctly reflected;
    * ie if you call `conference X mute Y` in FS, remote end `Y` will be unmuted, but its client mute state will be updated accordingly
    * To prevent remote unmutes would require a more delicate approach that has to be done with care, probably by cleaning up the mute/unmute state tracking and reversing the priority order for mute state tie breaking from FS to the client's state. So it's a subsequent work (no ETA)