### PR TITLE
video-provider: fix mesh stream sorting with multiple cameras

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -53,8 +53,10 @@ class VideoService {
 
   // Full mesh: sort with the following priority: local -> alphabetic
   static sortMeshStreams(s1, s2) {
-    if (s1.userId === Auth.userID) {
+    if (s1.userId === Auth.userID && s2.userId !== Auth.userID) {
       return -1;
+    } else if (s2.userId === Auth.userID && s1.userId !== Auth.userID) {
+      return 1;
     } else {
       return UserListService.sortUsersByName(s1, s2);
     }


### PR DESCRIPTION
### What does this PR do?

Fix a small edge case on full mesh video stream sorting when multiple cameras from the same source are being used.

### Closes Issue(s)
None.

