### PR TITLE
audio-manager: shortcut on setSenderTrackEnabled when in listen only

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -577,6 +577,10 @@ class AudioManager {
   }
 
   setSenderTrackEnabled (shouldEnable) {
+    // If the bridge is set to listen only mode, nothing to do here. This method
+    // is solely for muting outbound tracks.
+    if (this.isListenOnly) return;
+
     // Bridge -> SIP.js bridge, the only full audio capable one right now
     const peer = this.bridge.getPeerConnection();
     peer.getSenders().forEach(sender => {


### PR DESCRIPTION
### What does this PR do?

Abort the `setSenderTrackEnabled` call if the bridge is in listen only mode as it's pointless.
Also fixes some occasional exceptions when on listen only that I introduced with the mute stuff.

