### PR TITLE
In Breakouts close the tab if the user intentionally selects Leave -> OK

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
@@ -11,6 +11,7 @@ import { styles } from './styles';
 import logger from '/imports/startup/client/logger';
 import Users from '/imports/api/users';
 import AudioManager from '/imports/ui/services/audio-manager';
+import { meetingIsBreakout } from '/imports/ui/components/app/service';
 
 const intlMessage = defineMessages({
   410: {
@@ -128,6 +129,7 @@ class MeetingEnded extends PureComponent {
     } = this.state;
 
     if (selected <= 0) {
+      if (meetingIsBreakout()) window.close();
       logoutRouteHandler();
       return;
     }


### PR DESCRIPTION
Close the window (tab) when the user selects Menu -> Leave-> OK while in Breakout. In the main meeting we keep the old default, which is to redirect to logoutURL if any.