### PR TITLE
Fix dtls path

### DIFF
--- a/bigbluebutton-config/bin/apply-lib.sh
+++ b/bigbluebutton-config/bin/apply-lib.sh
@@ -129,6 +129,8 @@ enableMultipleKurentos() {
 
     cat /tmp/dtls-srtp-key.pem /tmp/dtls-srtp-cert.pem > /etc/kurento/dtls-srtp.pem
     cat /tmp/dtls-srtp-key.pem /tmp/dtls-srtp-cert.pem > /opt/freeswitch/etc/freeswitch/tls/dtls-srtp.pem
+
+    sed -i 's/;pemCertificateRSA=.*/pemCertificateRSA=\/etc\/kurento\/dtls-srtp.pem/g' /etc/kurento/modules/kurento/WebRtcEndpoint.conf.ini
   fi
 
   # Step 2.  Setup systemd unit files to launch three separate instances of Kurento

--- a/bigbluebutton-config/bin/apply-lib.sh
+++ b/bigbluebutton-config/bin/apply-lib.sh
@@ -130,7 +130,7 @@ enableMultipleKurentos() {
     cat /tmp/dtls-srtp-key.pem /tmp/dtls-srtp-cert.pem > /etc/kurento/dtls-srtp.pem
     cat /tmp/dtls-srtp-key.pem /tmp/dtls-srtp-cert.pem > /opt/freeswitch/etc/freeswitch/tls/dtls-srtp.pem
 
-    sed -i 's/;pemCertificateRSA=.*/pemCertificateRSA=\/etc\/kurento\/dtls-srtp.pem/g' /etc/kurento/modules/kurento/WebRtcEndpoint.conf.ini
+    sed -i 's/;pemCertificateRSA=.*/pemCertificateRSA=\/etc\/kurento\/dtls-srtp.pem/g' /etc/kurento/modules/kurento/WebRtcEndpoint.conf.ini 
   fi
 
   # Step 2.  Setup systemd unit files to launch three separate instances of Kurento


### PR DESCRIPTION
This adds a missing step to setting up with three Kurento servers.  

### What does this PR do?

It adds the path `pemCertificateRSA` in `WebRtcEndpoint.conf.ini`.  

### Closes Issue(s)

closes #10467 

This will be in BigBlueButton 2.2.25.
