### PR TITLE
Fix whiteboard undo failure in 2.3a

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
@@ -152,10 +152,7 @@ class WhiteboardModel extends SystemConfiguration {
 
       val updatedAnnotation = annotation.copy(position = newPosition, annotationInfo = updatedAnnotationData)
 
-      var newUsersAnnotations: List[AnnotationVO] = oldAnnotationOption match {
-        case Some(annotation) => usersAnnotations.tail
-        case None             => usersAnnotations
-      }
+      var newUsersAnnotations: List[AnnotationVO] = usersAnnotations
 
       val newAnnotationsMap = wb.annotationsMap + (userId -> (updatedAnnotation :: newUsersAnnotations))
       //println("Annotation has position [" + usersAnnotations.head.position + "]")


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fixes a problem in undo button which can go back no more than one step for the pen tool.

### Closes Issue(s)

closes #10408 
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number -->

### Motivation

To use 2.3a for the real-world online lecture!

![screen](https://user-images.githubusercontent.com/45039819/93560677-afb17800-f9bd-11ea-9a24-c3dc1f1d3ef8.gif)


### More

<!-- Anything else we should know when reviewing? -->
I am not sure if this is the best solution (in fact I am sure it's not the right answer), but at least this PR shows where the problem is.
The "useAnnotations.tail" gives an empty hash, and thus "newAnnotationMap" will always be overwritten by a new pen drawing, instead of accumulating it upon the past drawings.
