### PR TITLE
Remove maxInactivity added in merge from 2.2.24

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -502,8 +502,6 @@ public class ParamsProcessorUtil {
         	meeting.setMeetingEndedCallbackURL(meetingEndedCallbackURL);
         }
 
-        meeting.setMaxInactivityTimeoutMinutes(maxInactivityTimeoutMinutes);
-        meeting.setWarnMinutesBeforeMax(warnMinutesBeforeMax);
         meeting.setMeetingExpireIfNoUserJoinedInMinutes(meetingExpireIfNoUserJoinedInMinutes);
 		meeting.setMeetingExpireWhenLastUserLeftInMinutes(meetingExpireWhenLastUserLeftInMinutes);
 		meeting.setUserInactivityInspectTimerInMinutes(userInactivityInspectTimerInMinutes);


### PR DESCRIPTION
Initially removed in #8417 on BBB 2.3. However when propagating #10401 from BBB 2.2 into BBB 2.3 ( #10482 ) these 2 lines incorrectly made their way back to BBB 2.3