### PR TITLE
Prevent validateAuthToken spamming for ejected users

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/methods/validateAuthToken.js
+++ b/bigbluebutton-html5/imports/api/users/server/methods/validateAuthToken.js
@@ -3,6 +3,7 @@ import RedisPubSub from '/imports/startup/server/redis';
 import Logger from '/imports/startup/server/logger';
 import pendingAuthenticationsStore from '../store/pendingAuthentications';
 import BannedUsers from '../store/bannedUsers';
+import Users from '/imports/api/users';
 
 export default function validateAuthToken(meetingId, requesterUserId, requesterToken, externalId) {
   const REDIS_CONFIG = Meteor.settings.private.redis;
@@ -13,8 +14,16 @@ export default function validateAuthToken(meetingId, requesterUserId, requesterT
   if (externalId) {
     if (BannedUsers.has(meetingId, externalId)) {
       Logger.warn(`A banned user with extId ${externalId} tried to enter in meeting ${meetingId}`);
-      return;
+      return { invalid: true, reason: 'User has been banned.' };
     }
+  }
+
+  // Check if a removed user is trying to access the meeting using the same sessionToken
+  const isUserEjected = Users.findOne({ meetingId, authToken: requesterToken, ejected: true });
+
+  if (isUserEjected) {
+    Logger.warn(`An invalid sessionToken tried to validateAuthToken meetingId=${meetingId} authToken=${requesterToken}`);
+    return { invalid: true, reason: 'User has been ejected.' };
   }
 
   // Store reference of methodInvocationObject ( to postpone the connection userId definition )

--- a/bigbluebutton-html5/imports/ui/services/auth/index.js
+++ b/bigbluebutton-html5/imports/ui/services/auth/index.js
@@ -220,11 +220,11 @@ class Auth {
 
       const result = await makeCall('validateAuthToken', this.meetingID, this.userID, this.token, this.externUserID);
 
-      if (!result) {
+      if (result && result.invalid) {
         clearTimeout(validationTimeout);
         reject({
           error: 401,
-          description: 'User has been banned.',
+          description: result.reason,
         });
         return;
       }


### PR DESCRIPTION
### What does this PR do?
If an ejected user tries to enter in the meeting using the current url, the client keep trying to validate that user, but without success causing a validateAuthToken message spam until the connection times out. This PR invalidated this behavior on the first time the user tries to rejoin.
