### PR TITLE
Add secure tag to bbb-web JSESSIONID cookie

### DIFF
--- a/bigbluebutton-web/grails-app/conf/application.yml
+++ b/bigbluebutton-web/grails-app/conf/application.yml
@@ -26,6 +26,11 @@ endpoints:
     jmx:
         enabled: true
 
+server:
+    session:
+        cookie:
+            secure: true
+
 ---
 grails:
     mime:


### PR DESCRIPTION
Revert this to make whatever you want when running bbb-web without https