### PR TITLE
add log for moderator forcing end meeting

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/container.jsx
@@ -3,6 +3,7 @@ import { withTracker } from 'meteor/react-meteor-data';
 import { withModalMounter } from '/imports/ui/components/modal/service';
 import { makeCall } from '/imports/ui/services/api';
 import EndMeetingComponent from './component';
+import logger from '/imports/startup/client/logger';
 
 const EndMeetingContainer = props => <EndMeetingComponent {...props} />;
 
@@ -12,6 +13,10 @@ export default withModalMounter(withTracker(({ mountModal }) => ({
   },
 
   endMeeting: () => {
+    logger.warn({
+      logCode: 'moderator_forcing_end_meeting',
+      extraInfo: { logType: 'user_action' },
+    }, 'this user clicked on EndMeeting and confirmed, removing everybody from the meeting');
     makeCall('endMeeting');
     mountModal(null);
   },


### PR DESCRIPTION
Adding nginx log from client to be able to say with certainty that a meeting X was ended by user Y hitting the EndMeeting button