### PR TITLE
add samsung internet as compatible browser

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -530,6 +530,8 @@ private:
       version: 50
     - browser: electron
       version: [0, 36]
+    - browser: SamsungInternet
+      version: 10
     - browser: YandexBrowser
       version: 19
 


### PR DESCRIPTION
adds identifier for samsungs mobile browser (based on chromium) as supported browser for check

closes #9952 