### PR TITLE
Prevent repeated setUserId

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/handlers/validateAuthToken.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/validateAuthToken.js
@@ -59,7 +59,8 @@ export default function handleValidateAuthToken({ body }, meetingId) {
 
         /* Logic migrated from validateAuthToken method ( postponed to only run in case of success response ) - Begin */
         const sessionId = `${meetingId}--${userId}`;
-        methodInvocationObject.setUserId(sessionId);
+
+        if (!methodInvocationObject.userId) methodInvocationObject.setUserId(sessionId);
 
         const User = Users.findOne({
           meetingId,

--- a/bigbluebutton-html5/imports/api/users/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/users/server/publishers.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import Users from '/imports/api/users';
 import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
@@ -9,7 +8,7 @@ import { extractCredentials } from '/imports/api/common/server/helpers';
 
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 
-function currentUser(registerCallback) {
+function currentUser() {
   if (!this.userId) {
     return Users.find({ meetingId: '' });
   }
@@ -27,9 +26,7 @@ function currentUser(registerCallback) {
     }
   });
 
-  if (registerCallback) {
-    this._session.socket.on('close', _.debounce(onCloseConnection, 100));
-  }
+  this._session.socket.on('close', onCloseConnection);
 
   const selector = {
     meetingId,

--- a/bigbluebutton-html5/imports/ui/services/auth/index.js
+++ b/bigbluebutton-html5/imports/ui/services/auth/index.js
@@ -229,11 +229,10 @@ class Auth {
         return;
       }
 
-      let registerCallback = true;
+      Meteor.subscribe('current-user');
 
       Tracker.autorun((c) => {
         computation = c;
-        Meteor.subscribe('current-user', registerCallback);
 
         const selector = { meetingId: this.meetingID, userId: this.userID };
         const fields = {
@@ -244,7 +243,7 @@ class Auth {
         if (!User || !('intId' in User)) {
           logger.info({ logCode: 'auth_service_resend_validateauthtoken' }, 're-send validateAuthToken for delayed authentication');
           makeCall('validateAuthToken', this.meetingID, this.userID, this.token);
-          registerCallback = false;
+
           return;
         }
 


### PR DESCRIPTION
### What does this PR do?

Another attempt to prevent multiple calls on onClose event. Prevent to set userId if previous set, because when we set userId in `validateAuthToken` the `current-user` publisher trigger again. [https://docs.meteor.com/api/pubsub.html#Subscription-userId](url)