### PR TITLE
Map stun/turn servers into WebRTC's iceServers, when using fallback stun

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -3,7 +3,7 @@ import BaseAudioBridge from './base';
 import logger from '/imports/startup/client/logger';
 import {
   fetchWebRTCMappedStunTurnServers,
-  getFallbackStun,
+  getMappedFallbackStun,
 } from '/imports/utils/fetchStunTurnServers';
 import {
   isUnifiedPlan,
@@ -106,7 +106,7 @@ class SIPSession {
           callerIdName: this.user.callerIdName,
         },
       }, 'Full audio bridge failed to fetch STUN/TURN info');
-      return getFallbackStun();
+      return getMappedFallbackStun();
     }
   }
 


### PR DESCRIPTION
Thanks to @prlanzarin , who pointed out we need to also map stun/turn servers when using fallback servers.
Related to #10580  and #10569 