### PR TITLE
Fix undo-presentation-fullscreen button label

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/fullscreen-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/fullscreen-button/component.jsx
@@ -10,6 +10,10 @@ const intlMessages = defineMessages({
     id: 'app.fullscreenButton.label',
     description: 'Fullscreen label',
   },
+  fullscreenUndoButton: {
+    id: 'app.fullscreenUndoButton.label',
+    description: 'Undo fullscreen label',
+  },
 });
 
 const propTypes = {
@@ -47,10 +51,17 @@ const FullscreenButtonComponent = ({
 }) => {
   if (isIphone) return null;
 
-  const formattedLabel = intl.formatMessage(
-    intlMessages.fullscreenButton,
-    ({ 0: elementName || '' }),
-  );
+  const formattedLabel = (isFullscreen) => {
+    return(isFullscreen ?
+      intl.formatMessage(
+        intlMessages.fullscreenUndoButton,
+        ({ 0: elementName || '' }),
+      ) :
+      intl.formatMessage(
+        intlMessages.fullscreenButton,
+        ({ 0: elementName || '' }),
+      ));
+  };
 
   const wrapperClassName = cx({
     [styles.wrapper]: true,
@@ -67,7 +78,7 @@ const FullscreenButtonComponent = ({
         icon={!isFullscreen ? 'fullscreen' : 'exit_fullscreen'}
         size="sm"
         onClick={() => handleToggleFullScreen(fullscreenRef)}
-        label={formattedLabel}
+        label={formattedLabel(isFullscreen)}
         hideLabel
         className={cx(styles.button, styles.fullScreenButton, className)}
         data-test="presentationFullscreenButton"

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -607,6 +607,7 @@
     "app.video.stats.encodeUsagePercent": "Encode usage",
     "app.video.stats.currentDelay": "Current delay",
     "app.fullscreenButton.label": "Make {0} fullscreen",
+    "app.fullscreenUndoButton.label": "Undo {0} fullscreen",
     "app.deskshare.iceConnectionStateError": "Connection failed when sharing screen (ICE error 1108)",
     "app.sfu.mediaServerConnectionError2000": "Unable to connect to media server (error 2000)",
     "app.sfu.mediaServerOffline2001": "Media server is offline. Please try again later (error 2001)",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fixes the label of "undoing full screen button" for presentation. 

### Closes Issue(s)

closes #...
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number -->

### Motivation

On the full screen presentation mode, the pop up of  "undo full screen button" (with four-arrows going to center) still reads "Make XXX fullscreen". 

### More

This PR should fix the same problem in full-screened screensharing, but lucky or unlucky, we cannot see it.

PS I realized that this happens only when one uses developer tools (as far as I tested, but who knows). 

![1](https://user-images.githubusercontent.com/45039819/95017272-4efb8e00-0693-11eb-9e08-8b129a209a81.jpg)
