### PR TITLE
Shortcut key to toggle fullscreen

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -11,6 +11,7 @@ import ZoomTool from './zoom-tool/component';
 import FullscreenButtonContainer from '../../fullscreen-button/container';
 import TooltipContainer from '/imports/ui/components/tooltip/container';
 import QuickPollDropdownContainer from '/imports/ui/components/actions-bar/quick-poll-dropdown/container';
+import FullscreenService from '/imports/ui/components/fullscreen-button/service';
 import KEY_CODES from '/imports/utils/keyCodes';
 
 const intlMessages = defineMessages({
@@ -101,6 +102,7 @@ class PresentationToolbar extends PureComponent {
   switchSlide(event) {
     const { target, which } = event;
     const isBody = target.nodeName === 'BODY';
+    const { fullscreenRef } = this.props;
 
     if (isBody) {
       switch (which) {
@@ -111,6 +113,9 @@ class PresentationToolbar extends PureComponent {
         case KEY_CODES.ARROW_RIGHT:
         case KEY_CODES.PAGE_DOWN:
           this.nextSlideHandler();
+          break;
+        case KEY_CODES.ENTER:
+          FullscreenService.toggleFullScreen(fullscreenRef);
           break;
         default:
       }


### PR DESCRIPTION
### What does this PR do?

Add a keyboard shortcut (enter key) to toggle fullscreen mode in the presentation toolbar.

### Closes Issue(s)

related to #10589 

### Motivation

I would like to do a parallel presentation, that is, to broadcast by BBB a face-to-face seminar (with a projector and white screen). I need to stay in the fullscreen mode as much as possible. Doing so, however, I encountered a problem indicated in the issue above.

### More

In the perfect world, one should be able to do everything (or many things) staying in the fullscreen mode as well. 
