### PR TITLE
Hide draggable overlay when data saving is enabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/media/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/component.jsx
@@ -60,7 +60,8 @@ export default class Media extends Component {
     });
 
     const { viewParticipantsWebcams } = Settings.dataSaving;
-    const fullHeight = usersVideo.length < 1 || (webcamPlacement === 'floating') || !viewParticipantsWebcams;
+    const showVideo = usersVideo.length > 0 && viewParticipantsWebcams;
+    const fullHeight = !showVideo || (webcamPlacement === 'floating');
 
     return (
       <div
@@ -77,7 +78,7 @@ export default class Media extends Component {
         >
           {children}
         </div>
-        {usersVideo.length > 0 ? (
+        {showVideo ? (
           <WebcamDraggable
             refMediaContainer={this.refContainer}
             swapLayout={swapLayout}


### PR DESCRIPTION
If someone is sharing her/his webcam and the presenter enables webcam's data savings the
draggable overlay covers a portion of the presentation slide.