### PR TITLE
Fix share webcam button label for screen readers

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
@@ -16,10 +16,6 @@ const intlMessages = defineMessages({
     id: 'app.video.leaveVideo',
     description: 'Leave video button label',
   },
-  videoButtonDesc: {
-    id: 'app.video.videoButtonDesc',
-    description: 'video button description',
-  },
   videoLocked: {
     id: 'app.video.videoLocked',
     description: 'video disabled label',
@@ -68,17 +64,18 @@ const JoinVideoButton = ({
     }
   };
 
-  const label = exitVideo() ?
-    intl.formatMessage(intlMessages.leaveVideo) :
-    intl.formatMessage(intlMessages.joinVideo);
+  let label = exitVideo()
+    ? intl.formatMessage(intlMessages.leaveVideo)
+    : intl.formatMessage(intlMessages.joinVideo);
+
+  if (disableReason) label = intl.formatMessage(intlMessages[disableReason]);
 
   return (
     <Button
-      label={disableReason ? intl.formatMessage(intlMessages[disableReason]) : label}
+      label={label}
       className={cx(styles.button, hasVideoStream || styles.btn)}
       onClick={handleOnClick}
       hideLabel
-      aria-label={intl.formatMessage(intlMessages.videoButtonDesc)}
       color={hasVideoStream ? 'primary' : 'default'}
       icon={hasVideoStream ? 'video' : 'video_off'}
       ghost={!hasVideoStream}

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -581,7 +581,6 @@
     "app.video.swapCam": "Swap",
     "app.video.swapCamDesc": "swap the direction of webcams",
     "app.video.videoLocked": "Webcam sharing locked",
-    "app.video.videoButtonDesc": "Share webcam",
     "app.video.videoMenu": "Video menu",
     "app.video.videoMenuDisabled": "Video menu Webcam is disabled in settings",
     "app.video.videoMenuDesc": "Open video menu dropdown",


### PR DESCRIPTION
### What does this PR do?
removes `aria-label` from webcam button. The screen readers announces the `label` prop and since both strings should be the same, we can omit the aria tag.

### Motivation
This fixes the screen reader announcing the wrong message based on the state of the button. Previously no matter what state the button was in, it would always announce "Share webcam".
