### PR TITLE
Correctly set audio input/output devices - latest SIP.js version

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -333,8 +333,9 @@ const BaseContainer = withTracker(() => {
       changed: (newDocument) => {
         if (newDocument.validated && newDocument.name && newDocument.userId !== localUserId) {
           if (userJoinAudioAlerts) {
-            const audio = new Audio(`${Meteor.settings.public.app.cdn + Meteor.settings.public.app.basename}/resources/sounds/userJoin.mp3`);
-            audio.play();
+            AudioService.playAlertSound(`${Meteor.settings.public.app.cdn
+              + Meteor.settings.public.app.basename}`
+              + '/resources/sounds/userJoin.mp3');
           }
 
           if (userJoinPushAlerts) {

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -245,8 +245,6 @@ class AudioModal extends Component {
     }
 
     const {
-      inputDeviceId,
-      outputDeviceId,
       joinEchoTest,
     } = this.props;
 
@@ -271,7 +269,7 @@ class AudioModal extends Component {
       if (err.type === 'MEDIA_ERROR') {
         this.setState({
           content: 'help',
-          errCode: err.code,
+          errCode: 0,
           disableActions: false,
         });
       }

--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -87,4 +87,5 @@ export default {
   isVoiceUser,
   autoplayBlocked: () => AudioManager.autoplayBlocked,
   handleAllowAutoplay: () => AudioManager.handleAllowAutoplay(),
+  playAlertSound: url => AudioManager.playAlertSound(url),
 };

--- a/bigbluebutton-html5/imports/ui/components/chat/alert/audio-alert/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/alert/audio-alert/component.jsx
@@ -1,5 +1,6 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
+import AudioService from '/imports/ui/components/audio/service';
 
 const propTypes = {
   play: PropTypes.bool.isRequired,
@@ -8,17 +9,16 @@ const propTypes = {
 class ChatAudioAlert extends Component {
   constructor(props) {
     super(props);
-    this.audio = new Audio(`${Meteor.settings.public.app.cdn + Meteor.settings.public.app.basename}/resources/sounds/notify.mp3`);
     this.handleAudioLoaded = this.handleAudioLoaded.bind(this);
     this.playAudio = this.playAudio.bind(this);
   }
 
   componentDidMount() {
-    this.audio.addEventListener('loadedmetadata', this.handleAudioLoaded);
+    this.handleAudioLoaded();
   }
 
   componentWillUnmount() {
-    this.audio.removeEventListener('loadedmetadata', this.handleAudioLoaded);
+    this.handleAudioLoaded();
   }
 
   handleAudioLoaded() {
@@ -28,7 +28,9 @@ class ChatAudioAlert extends Component {
   playAudio() {
     const { play } = this.props;
     if (!play) return;
-    this.audio.play();
+    AudioService.playAlertSound(`${Meteor.settings.public.app.cdn
+      + Meteor.settings.public.app.basename}`
+      + '/resources/sounds/notify.mp3');
   }
 
   render() {

--- a/bigbluebutton-html5/imports/ui/components/polling/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/polling/component.jsx
@@ -5,6 +5,7 @@ import injectWbResizeEvent from '/imports/ui/components/presentation/resize-wrap
 import { defineMessages, injectIntl } from 'react-intl';
 import cx from 'classnames';
 import { styles } from './styles.scss';
+import AudioService from '/imports/ui/components/audio/service';
 
 const intlMessages = defineMessages({
   pollingTitleLabel: {
@@ -30,8 +31,9 @@ class Polling extends Component {
   }
 
   play() {
-    this.alert = new Audio(`${Meteor.settings.public.app.cdn + Meteor.settings.public.app.basename}/resources/sounds/Poll.mp3`);
-    this.alert.play();
+    AudioService.playAlertSound(`${Meteor.settings.public.app.cdn
+      + Meteor.settings.public.app.basename}`
+      + '/resources/sounds/Poll.mp3');
   }
 
   render() {

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -8,6 +8,7 @@ import { stopWatching } from '/imports/ui/components/external-video-player/servi
 import Meetings from '/imports/api/meetings';
 import Auth from '/imports/ui/services/auth';
 import UserListService from '/imports/ui/components/user-list/service';
+import AudioService from '/imports/ui/components/audio/service';
 
 // when the meeting information has been updated check to see if it was
 // screensharing. If it has changed either trigger a call to receive video
@@ -70,7 +71,10 @@ const shareScreen = (onFail) => {
   }).catch(onFail);
 };
 
-const screenShareEndAlert = () => new Audio(`${Meteor.settings.public.app.cdn + Meteor.settings.public.app.basename}/resources/sounds/ScreenshareOff.mp3`).play();
+const screenShareEndAlert = () => AudioService
+  .playAlertSound(`${Meteor.settings.public.app.cdn
+    + Meteor.settings.public.app.basename}`
+    + '/resources/sounds/ScreenshareOff.mp3');
 
 const unshareScreen = () => {
   KurentoBridge.kurentoExitScreenShare();

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -18,6 +18,8 @@ const MEDIA_TAG = MEDIA.mediaTag;
 const ECHO_TEST_NUMBER = MEDIA.echoTestNumber;
 const MAX_LISTEN_ONLY_RETRIES = 1;
 const LISTEN_ONLY_CALL_TIMEOUT_MS = MEDIA.listenOnlyCallTimeout || 25000;
+const DEFAULT_INPUT_DEVICE_ID = 'default';
+const DEFAULT_OUTPUT_DEVICE_ID = 'default';
 
 const CALL_STATES = {
   STARTED: 'started',
@@ -30,7 +32,7 @@ const CALL_STATES = {
 class AudioManager {
   constructor() {
     this._inputDevice = {
-      value: 'default',
+      value: DEFAULT_INPUT_DEVICE_ID,
       tracker: new Tracker.Dependency(),
     };
 
@@ -90,35 +92,6 @@ class AudioManager {
     });
   }
 
-  askDevicesPermissions() {
-    // Check to see if the stream has already been retrieved becasue then we don't need to
-    // request. This is a fix for an issue with the input device selector.
-    if (this.inputStream) {
-      return Promise.resolve();
-    }
-
-    // Only change the isWaitingPermissions for the case where the user didnt allowed it yet
-    const permTimeout = setTimeout(() => {
-      if (!this.devicesInitialized) { this.isWaitingPermissions = true; }
-    }, 100);
-
-    this.isWaitingPermissions = false;
-    this.devicesInitialized = false;
-
-    return Promise.all([
-      this.setDefaultInputDevice(),
-      this.setDefaultOutputDevice(),
-    ]).then(() => {
-      this.devicesInitialized = true;
-      this.isWaitingPermissions = false;
-    }).catch((err) => {
-      clearTimeout(permTimeout);
-      this.isConnecting = false;
-      this.isWaitingPermissions = false;
-      throw err;
-    });
-  }
-
   joinMicrophone() {
     this.isListenOnly = false;
     this.isEchoTest = false;
@@ -139,8 +112,7 @@ class AudioManager {
     this.isListenOnly = false;
     this.isEchoTest = true;
 
-    return this.askDevicesPermissions()
-      .then(this.onAudioJoining.bind(this))
+    return this.onAudioJoining.bind(this)()
       .then(() => {
         const callOptions = {
           isListenOnly: false,
@@ -155,21 +127,42 @@ class AudioManager {
   joinAudio(callOptions, callStateCallback) {
     return this.bridge.joinAudio(callOptions,
       callStateCallback.bind(this)).catch((error) => {
-      if (error.name === 'NotAllowedError') {
-        logger.error({
-          logCode: 'audiomanager_error_getting_device',
-          extraInfo: {
-            errorName: error.name,
-            errorMessage: error.message,
-          },
-        }, `Error getting microphone - {${error.name}: ${error.message}}`);
+      const { name } = error;
 
-        throw {
-          type: 'MEDIA_ERROR'
-        };
-      } else {
+      if (!name) {
         throw error;
       }
+
+      switch (name) {
+        case 'NotAllowedError':
+          logger.error({
+            logCode: 'audiomanager_error_getting_device',
+            extraInfo: {
+              errorName: error.name,
+              errorMessage: error.message,
+            },
+          }, `Error getting microphone - {${error.name}: ${error.message}}`);
+          break;
+        case 'NotFoundError':
+          logger.error({
+            logCode: 'audiomanager_error_device_not_found',
+            extraInfo: {
+              errorName: error.name,
+              errorMessage: error.message,
+            },
+          }, `Error getting microphone - {${error.name}: ${error.message}}`);
+          break;
+
+        default:
+          break;
+      }
+
+      this.isConnecting = false;
+      this.isWaitingPermissions = false;
+
+      throw {
+        type: 'MEDIA_ERROR',
+      };
     });
   }
 
@@ -464,12 +457,47 @@ class AudioManager {
   }
 
   changeInputDevice(deviceId) {
-    // kept for compatibility
-    return Promise.resolve();
+    if (!deviceId) {
+      return Promise.resolve();
+    }
+
+    const handleChangeInputDeviceSuccess = (inputDeviceId) => {
+      this.inputDevice.id = inputDeviceId;
+      return Promise.resolve(inputDeviceId);
+    };
+
+    const handleChangeInputDeviceError = (error) => {
+      logger.error({
+        logCode: 'audiomanager_error_getting_device',
+        extraInfo: {
+          errorName: error.name,
+          errorMessage: error.message,
+        },
+      }, `Error getting microphone - {${error.name}: ${error.message}}`);
+
+      const { MIC_ERROR } = AudioErrors;
+      const disabledSysSetting = error.message.includes('Permission denied by system');
+      const isMac = navigator.platform.indexOf('Mac') !== -1;
+
+      let code = MIC_ERROR.NO_PERMISSION;
+      if (isMac && disabledSysSetting) code = MIC_ERROR.MAC_OS_BLOCK;
+
+      return Promise.reject({
+        type: 'MEDIA_ERROR',
+        message: this.messages.error.MEDIA_ERROR,
+        code,
+      });
+    };
+
+    return this.bridge.changeInputDeviceId(deviceId)
+      .then(handleChangeInputDeviceSuccess)
+      .catch(handleChangeInputDeviceError);
   }
 
   async changeOutputDevice(deviceId) {
-    this.outputDeviceId = await this.bridge.changeOutputDevice(deviceId);
+    this.outputDeviceId = await this
+      .bridge
+      .changeOutputDevice(deviceId || DEFAULT_OUTPUT_DEVICE_ID);
   }
 
   set inputDevice(value) {
@@ -482,9 +510,13 @@ class AudioManager {
     return this._inputDevice.value.stream;
   }
 
+  get inputDevice() {
+    return this._inputDevice;
+  }
+
   get inputDeviceId() {
-    this._inputDevice.tracker.depend();
-    return this._inputDevice.value.id;
+    return (this.bridge && this.bridge.inputDeviceId)
+      ? this.bridge.inputDeviceId : DEFAULT_INPUT_DEVICE_ID;
   }
 
   set userData(value) {
@@ -496,8 +528,9 @@ class AudioManager {
   }
 
   playHangUpSound() {
-    this.alert = new Audio(`${Meteor.settings.public.app.cdn + Meteor.settings.public.app.basename}/resources/sounds/LeftCall.mp3`);
-    this.alert.play();
+    this.playAlertSound(`${Meteor.settings.public.app.cdn
+      + Meteor.settings.public.app.basename}`
+      + '/resources/sounds/LeftCall.mp3');
   }
 
   notify(message, error = false, icon = 'unmute') {
@@ -582,6 +615,22 @@ class AudioManager {
 
   unmute () {
     this.setSenderTrackEnabled(true);
+  }
+
+  playAlertSound (url) {
+    if (!url) {
+      return Promise.resolve();
+    }
+
+    const audioAlert = new Audio(url);
+
+    if (this.outputDeviceId && (typeof audioAlert.setSinkId === 'function')) {
+      return audioAlert
+        .setSinkId(this.outputDeviceId)
+        .then(() => audioAlert.play());
+    }
+
+    return audioAlert.play();
   }
 }
 


### PR DESCRIPTION
When refusing ("thumbs down" button) echo test, user is able to select a different input device. This should work fine for chrome, firefox and safari (once user grants permission when asked by html5client).
For output devices, we depend on setSinkId function, which is enabled by default on current chrome release (2020) but not in Firefox (user needs to enable "setSinkId in about:config page). This implementation is listed as (?) in MDN.
In other words, output device selection should work out of the box for chrome, only.
When selecting an output device, all alert sounds (hangup, screen-share , polling, etc) also goes to the same output device.
This solves #10592

### What does this PR do?
Fix wrong input/output device selection in latest audio-manager code (which is ported to latest SIP.js version) 

### Closes Issue(s)

closes #10592 

### Motivation

This is basically the second last known issue related to the SIP.js port.
The last one still needs to be confirmed (once confirmed, i will open an issue for that).
