### PR TITLE
Fix slide size problem at fullscreen <-> window-mode transition

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -254,6 +254,7 @@ class PresentationArea extends PureComponent {
     if (isFullscreen !== newIsFullscreen) {
       this.setState({ isFullscreen: newIsFullscreen });
       layoutContextDispatch({ type: 'setPresentationFullscreen', value: newIsFullscreen });
+      window.dispatchEvent(new Event('slideChanged'));
     }
   }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fixes a problem in 2.3a2, that is, the slide size gets crazy when turning on and off fullscreen mode.

### Closes Issue(s)

closes #10459 , related to #10589 

### Motivation

Ultimately to perform whole presentation in fullscreen mode.

### More

The problem is that "PresentationIsFullscreen" variable in layout/layout-manager is one step delayed to be updated. This is caused because the effect of "layoutContextDispatch" method in presentation/component does not reach immediately to that variable.
I mean,
(1) Toggle fullscreen -> (2) slide size decided before the "PresentationIsFullscreen" variable being updated in layout/layout-manager -> (3) "layoutContextDispatch" method in presentation/component fired and "PresentationIsFullscreen" variable is finally updated, but it's too late.

Obviously this PR does not indicate the best solution. Just a workaround. The main purpose is to suggest where the problem is.
