### PR TITLE
Fix the UI state on breakout room audio join

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
@@ -221,13 +221,12 @@ class BreakoutRoom extends PureComponent {
               (
                 <Button
                   label={
-                    moderatorJoinedAudio
-                      && stateBreakoutId === breakoutId
-                      && joinedAudioOnly
+                      stateBreakoutId === breakoutId && joinedAudioOnly
                       ? intl.formatMessage(intlMessages.breakoutReturnAudio)
                       : intl.formatMessage(intlMessages.breakoutJoinAudio)
                   }
                   className={styles.button}
+                  disabled={stateBreakoutId !== breakoutId && joinedAudioOnly}
                   key={`join-audio-${breakoutId}`}
                   onClick={audioAction}
                 />


### PR DESCRIPTION
Users must return their audio to the main room before joining a different one.
Since the audio transfer and the UI state manager doesn't provide a shortcut for
jumping from a breakout room to another, avoid making this option available.

@fcecagno recently found out about this problem. If a moderator joins a breakout room by audio and then tries to do the same for another breakout room while his audio is in the other room the client gets in an inconsistent state. Since I'm not sure about the use case scenarios on this feature I just did this small fix just to assure the UI state won't break for the regular users so this issue can be taken care a better way in the future.