### PR TITLE
Make emoji list item announce active state for screen readers

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/dropdown/list/item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/list/item/component.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { defineMessages, injectIntl } from 'react-intl';
 import _ from 'lodash';
 import cx from 'classnames';
 import Icon from '/imports/ui/components/icon/component';
@@ -18,7 +19,13 @@ const defaultProps = {
   tabIndex: 0,
 };
 
-export default class DropdownListItem extends Component {
+const messages = defineMessages({
+  activeAriaLabel: {
+    id: 'app.dropdown.list.item.activeLabel',
+  },
+});
+
+class DropdownListItem extends Component {
   constructor(props) {
     super(props);
     this.labelID = _.uniqueId('dropdown-item-label-');
@@ -38,8 +45,11 @@ export default class DropdownListItem extends Component {
   render() {
     const {
       id, label, description, children, injectRef, tabIndex, onClick, onKeyDown,
-      className, style,
+      className, style, intl,
     } = this.props;
+
+    const isSelected = className && className.includes('emojiSelected');
+    const _label = isSelected ? `${label} (${intl.formatMessage(messages.activeAriaLabel)})` : label;
 
     return (
       <li
@@ -59,8 +69,8 @@ export default class DropdownListItem extends Component {
           children || this.renderDefault()
         }
         {
-          label ?
-            (<span id={this.labelID} key="labelledby" hidden>{label}</span>)
+          label
+            ? (<span id={this.labelID} key="labelledby" hidden>{_label}</span>)
             : null
         }
         <span id={this.descID} key="describedby" hidden>{description}</span>
@@ -68,6 +78,8 @@ export default class DropdownListItem extends Component {
     );
   }
 }
+
+export default injectIntl(DropdownListItem);
 
 DropdownListItem.propTypes = propTypes;
 DropdownListItem.defaultProps = defaultProps;

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -488,6 +488,7 @@
     "app.modal.newTab": "(opens new tab)",
     "app.modal.confirm.description": "Saves changes and closes the modal",
     "app.dropdown.close": "Close",
+    "app.dropdown.list.item.activeLabel": "Active",
     "app.error.400": "Bad Request",
     "app.error.401": "Unauthorized",
     "app.error.403": "You have been removed from the meeting",

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -373,7 +373,7 @@
     "app.actionsBar.emojiMenu.statusTriggerLabel": "Set status",
     "app.actionsBar.emojiMenu.awayLabel": "Away",
     "app.actionsBar.emojiMenu.awayDesc": "Change your status to away",
-    "app.actionsBar.emojiMenu.raiseHandLabel": "Raise",
+    "app.actionsBar.emojiMenu.raiseHandLabel": "Raise hand",
     "app.actionsBar.emojiMenu.raiseHandDesc": "Raise your hand to ask a question",
     "app.actionsBar.emojiMenu.neutralLabel": "Undecided",
     "app.actionsBar.emojiMenu.neutralDesc": "Change your status to undecided",


### PR DESCRIPTION
### What does this PR do?

Updates the message announced by screen readers for currently active emoji's.

### Motivation
![image](https://user-images.githubusercontent.com/22058534/95336206-664a9f00-087e-11eb-89a6-302bbc847fac.png)

The selected emoji menu item shows a visual blue highlight to indicate that it is active. This info should be relayed to the screen readers as well.

announced before: `Away`
announced after: `Away active`

