### PR TITLE
Check if DOMMatrix exists before cursor coordinate transform

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/component.jsx
@@ -8,9 +8,19 @@ import CursorListener from './cursor-listener/component';
 export default class WhiteboardOverlay extends Component {
   // a function to transform a screen point to svg point
   // accepts and returns a point of type SvgPoint and an svg object
+  // if unable to get the screen CTM, returns an out
+  // of bounds (-1, -1) svg point
   static coordinateTransform(screenPoint, someSvgObject) {
     const CTM = someSvgObject.getScreenCTM();
-    return screenPoint.matrixTransform(CTM.inverse());
+    if (CTM !== null) {
+      return screenPoint.matrixTransform(CTM.inverse());
+    }
+
+    const outOfBounds = someSvgObject.createSVGPoint();
+    outOfBounds.x = -1;
+    outOfBounds.y = -1;
+
+    return outOfBounds;
   }
 
   // Removes selection from all selected elements


### PR DESCRIPTION
Cursor coordinates are calculated using the presentation SVG object
DOMMatrix. When getting this matrix, some browsers (Firefox at least)
responds it as null if the svg object does not have a visible area.

This adds a check before trying to transform the cursor coordinates
using the matrix inverse so we avoid calling a method from a null object.
If there isn't a DOMMatrix to be used as reference, returns a simple out of
bounds SVGPoint (-1, -1).

```
[15:05:49:0695] ERROR: clientLogger: TypeError: CTM is null https://lxc.bbb/html5client/app/app.js?hash=c0787811183bca015570b0925f99e84f6ab20362:63105:12 modules.js:56509:1396
Uncaught TypeError: CTM is null
    coordinateTransform component.jsx:13
    getTransformedSvgPoint component.jsx:59
    checkLastCursor component.jsx:86
    render component.jsx:178
    finishClassComponent modules.js:21517
    updateClassComponent modules.js:21467
    beginWork modules.js:22977
    callCallback modules.js:4545
    invokeGuardedCallbackDev modules.js:4594
    invokeGuardedCallback modules.js:4649
    beginWork$1 modules.js:27560
    performUnitOfWork modules.js:26511
    workLoopSync modules.js:26487
    performSyncWorkOnRoot modules.js:26113
    flushSyncCallbackQueueImpl modules.js:15446
    unstable_runWithPriority modules.js:30099
    runWithPriority$1 modules.js:15396
    flushSyncCallbackQueueImpl modules.js:15441
    flushSyncCallbackQueue modules.js:15429
    scheduleUpdateOnFiber modules.js:25556
    enqueueSetState modules.js:16996
    setState modules.js:1558
    handleResize component.jsx:212
component.jsx:13:4
```

from:
![Peek 2020-10-07 15-05](https://user-images.githubusercontent.com/1778398/95370501-3c5da080-08af-11eb-872c-1923b8d8bcc4.gif)
to:
![Peek 2020-10-07 15-08](https://user-images.githubusercontent.com/1778398/95370527-45e70880-08af-11eb-9776-6798078a3f67.gif)

Closes #10606