### PR TITLE
Added allowDefaultLogoutUrl config to optionally ignore non-custom logoutUrl

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
@@ -4,6 +4,7 @@ import { defineMessages, injectIntl } from 'react-intl';
 import { Meteor } from 'meteor/meteor';
 import Auth from '/imports/ui/services/auth';
 import Button from '/imports/ui/components/button/component';
+import allowRedirectToLogoutURL from './service';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import logoutRouteHandler from '/imports/utils/logoutRouteHandler';
 import Rating from './rating/component';
@@ -102,6 +103,7 @@ class MeetingEnded extends PureComponent {
     super(props);
     this.state = {
       selected: 0,
+      dispatched: false,
     };
 
     const user = Users.findOne({ userId: Auth.userID });
@@ -110,8 +112,9 @@ class MeetingEnded extends PureComponent {
     }
 
     this.setSelectedStar = this.setSelectedStar.bind(this);
+    this.confirmRedirect = this.confirmRedirect.bind(this);
     this.sendFeedback = this.sendFeedback.bind(this);
-    this.shouldShowFeedback = getFromUserSettings('bbb_ask_for_feedback_on_logout', Meteor.settings.public.app.askForFeedbackOnLogout);
+    this.shouldShowFeedback = this.shouldShowFeedback.bind(this);
 
     AudioManager.exitAudio();
     Meteor.disconnect();
@@ -123,16 +126,26 @@ class MeetingEnded extends PureComponent {
     });
   }
 
-  sendFeedback() {
+  shouldShowFeedback() {
+    const { dispatched } = this.state;
+    return getFromUserSettings('bbb_ask_for_feedback_on_logout', Meteor.settings.public.app.askForFeedbackOnLogout) && !dispatched;
+  }
+
+  confirmRedirect() {
     const {
       selected,
     } = this.state;
 
     if (selected <= 0) {
       if (meetingIsBreakout()) window.close();
-      logoutRouteHandler();
-      return;
+      if (allowRedirectToLogoutURL()) logoutRouteHandler();
     }
+  }
+
+  sendFeedback() {
+    const {
+      selected,
+    } = this.state;
 
     const { fullname } = Auth.credentials;
 
@@ -157,27 +170,70 @@ class MeetingEnded extends PureComponent {
     // client logger
     logger.info({ logCode: 'feedback_functionality', extraInfo: { feedback: message } }, 'Feedback component');
 
-    const FEEDBACK_WAIT_TIME = 500;
-    setTimeout(() => {
-      fetch(url, options)
-        .then(() => {
-          logoutRouteHandler();
-        })
-        .catch(() => {
-          logoutRouteHandler();
-        });
-    }, FEEDBACK_WAIT_TIME);
+    this.setState({
+      dispatched: true,
+    });
+
+    if (allowRedirectToLogoutURL()) {
+      const FEEDBACK_WAIT_TIME = 500;
+      setTimeout(() => {
+        fetch(url, options)
+          .then(() => {
+            logoutRouteHandler();
+          })
+          .catch(() => {
+            logoutRouteHandler();
+          });
+      }, FEEDBACK_WAIT_TIME);
+    }
   }
 
-  render() {
+  renderNoFeedback() {
+    const { intl, code } = this.props;
+
+    logger.info({ logCode: 'meeting_ended_code', extraInfo: { endedCode: code } }, 'Meeting ended component, no feedback configured');
+
+    return (
+      <div className={styles.parent}>
+        <div className={styles.modal}>
+          <div className={styles.content}>
+            <h1 className={styles.title} data-test="meetingEndedModalTitle">
+              {
+                intl.formatMessage(intlMessage[code] || intlMessage[430])
+              }
+            </h1>
+            {!allowRedirectToLogoutURL() ? null : (
+              <div>
+                <div className={styles.text}>
+                  {intl.formatMessage(intlMessage.messageEnded)}
+                </div>
+
+                <Button
+                  color="primary"
+                  onClick={this.confirmRedirect}
+                  className={styles.button}
+                  label={intl.formatMessage(intlMessage.buttonOkay)}
+                  description={intl.formatMessage(intlMessage.confirmDesc)}
+                />
+              </div>
+
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  renderFeedback() {
     const { intl, code } = this.props;
     const {
       selected,
+      dispatched,
     } = this.state;
 
     const noRating = selected <= 0;
 
-    logger.info({ logCode: 'meeting_ended_code', extraInfo: { endedCode: code } }, 'Meeting ended component');
+    logger.info({ logCode: 'meeting_ended_code', extraInfo: { endedCode: code } }, 'Meeting ended component, feedback allowed');
 
     return (
       <div className={styles.parent}>
@@ -189,11 +245,12 @@ class MeetingEnded extends PureComponent {
               }
             </h1>
             <div className={styles.text}>
-              {this.shouldShowFeedback
+              {this.shouldShowFeedback()
                 ? intl.formatMessage(intlMessage.subtitle)
                 : intl.formatMessage(intlMessage.messageEnded)}
             </div>
-            {this.shouldShowFeedback ? (
+
+            {this.shouldShowFeedback() ? (
               <div>
                 <Rating
                   total="5"
@@ -210,21 +267,34 @@ class MeetingEnded extends PureComponent {
                 ) : null}
               </div>
             ) : null }
-            <Button
-              color="primary"
-              onClick={this.sendFeedback}
-              className={styles.button}
-              label={noRating
-                ? intl.formatMessage(intlMessage.buttonOkay)
-                : intl.formatMessage(intlMessage.sendLabel)}
-              description={noRating
-                ? intl.formatMessage(intlMessage.confirmDesc)
-                : intl.formatMessage(intlMessage.sendDesc)}
-            />
+            {noRating && allowRedirectToLogoutURL() ? (
+              <Button
+                color="primary"
+                onClick={this.confirmRedirect}
+                className={styles.button}
+                label={intl.formatMessage(intlMessage.buttonOkay)}
+                description={intl.formatMessage(intlMessage.confirmDesc)}
+              />
+            ) : null}
+
+            {!noRating && !dispatched ? (
+              <Button
+                color="primary"
+                onClick={this.sendFeedback}
+                className={styles.button}
+                label={intl.formatMessage(intlMessage.sendLabel)}
+                description={intl.formatMessage(intlMessage.sendDesc)}
+              />
+            ) : null}
           </div>
         </div>
       </div>
     );
+  }
+
+  render() {
+    if (this.shouldShowFeedback()) return this.renderFeedback();
+    return this.renderNoFeedback();
   }
 }
 

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/service.js
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/service.js
@@ -1,26 +1,12 @@
 import { Meteor } from 'meteor/meteor';
 import Auth from '/imports/ui/services/auth';
-import logger from '/imports/startup/client/logger';
+
 
 export default function allowRedirectToLogoutURL() {
   const ALLOW_DEFAULT_LOGOUT_URL = Meteor.settings.public.app.allowDefaultLogoutUrl;
   if (Auth.logoutURL) {
-    // default logoutURL case
-    // compare only the host to ignore protocols, www, trailing '/', etc
-    try {
-      // new URL object with invalid url throws an error and could crash the application
-      const urlWithoutProtocolForAuthLogout = new URL(Auth.logoutURL).host;
-      const urlWithoutProtocolForLocationOrigin = new URL(window.location.origin).host;
-      if (urlWithoutProtocolForAuthLogout === urlWithoutProtocolForLocationOrigin) {
-        return ALLOW_DEFAULT_LOGOUT_URL;
-      }
-    } catch (error) {
-      // there was an issue checking if the passed logoutURL was a valid URL.
-      // Do not use it for a redirect
-      logger.error({ logCode: 'meeting_ended_logouturl_redirect_error', extraInfo: { error, logoutURL: Auth.logoutURL } },
-        'There was an issue checking if the passed logoutURL was a valid URL');
-      return false;
-    }
+    // default logoutURL
+    if (Auth.logoutURL === window.location.origin) return ALLOW_DEFAULT_LOGOUT_URL;
 
     // custom logoutURL
     return true;

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/service.js
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/service.js
@@ -1,0 +1,16 @@
+import { Meteor } from 'meteor/meteor';
+import Auth from '/imports/ui/services/auth';
+
+
+export default function allowRedirectToLogoutURL() {
+  const ALLOW_DEFAULT_LOGOUT_URL = Meteor.settings.public.app.allowDefaultLogoutUrl;
+  if (Auth.logoutURL) {
+    // default logoutURL
+    if (Auth.logoutURL === window.location.origin) return ALLOW_DEFAULT_LOGOUT_URL;
+
+    // custom logoutURL
+    return true;
+  }
+  // no logout url
+  return false;
+}

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/service.js
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/service.js
@@ -1,12 +1,26 @@
 import { Meteor } from 'meteor/meteor';
 import Auth from '/imports/ui/services/auth';
-
+import logger from '/imports/startup/client/logger';
 
 export default function allowRedirectToLogoutURL() {
   const ALLOW_DEFAULT_LOGOUT_URL = Meteor.settings.public.app.allowDefaultLogoutUrl;
   if (Auth.logoutURL) {
-    // default logoutURL
-    if (Auth.logoutURL === window.location.origin) return ALLOW_DEFAULT_LOGOUT_URL;
+    // default logoutURL case
+    // compare only the host to ignore protocols, www, trailing '/', etc
+    try {
+      // new URL object with invalid url throws an error and could crash the application
+      const urlWithoutProtocolForAuthLogout = new URL(Auth.logoutURL).host;
+      const urlWithoutProtocolForLocationOrigin = new URL(window.location.origin).host;
+      if (urlWithoutProtocolForAuthLogout === urlWithoutProtocolForLocationOrigin) {
+        return ALLOW_DEFAULT_LOGOUT_URL;
+      }
+    } catch (error) {
+      // there was an issue checking if the passed logoutURL was a valid URL.
+      // Do not use it for a redirect
+      logger.error({ logCode: 'meeting_ended_logouturl_redirect_error', extraInfo: { error, logoutURL: Auth.logoutURL } },
+        'There was an issue checking if the passed logoutURL was a valid URL');
+      return false;
+    }
 
     // custom logoutURL
     return true;

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/service.js
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/service.js
@@ -4,9 +4,15 @@ import Auth from '/imports/ui/services/auth';
 
 export default function allowRedirectToLogoutURL() {
   const ALLOW_DEFAULT_LOGOUT_URL = Meteor.settings.public.app.allowDefaultLogoutUrl;
+  const protocolPattern = /^((http|https):\/\/)/;
   if (Auth.logoutURL) {
     // default logoutURL
-    if (Auth.logoutURL === window.location.origin) return ALLOW_DEFAULT_LOGOUT_URL;
+    // compare only the host to ignore protocols
+    const urlWithoutProtocolForAuthLogout = Auth.logoutURL.replace(protocolPattern, '');
+    const urlWithoutProtocolForLocationOrigin = window.location.origin.replace(protocolPattern, '');
+    if (urlWithoutProtocolForAuthLogout === urlWithoutProtocolForLocationOrigin) {
+      return ALLOW_DEFAULT_LOGOUT_URL;
+    }
 
     // custom logoutURL
     return true;

--- a/bigbluebutton-html5/imports/ui/services/auth/index.js
+++ b/bigbluebutton-html5/imports/ui/services/auth/index.js
@@ -7,6 +7,7 @@ import Users from '/imports/api/users';
 import logger from '/imports/startup/client/logger';
 import { makeCall } from '/imports/ui/services/api';
 import { initAnnotationsStreamListener } from '/imports/ui/components/whiteboard/service';
+import allowRedirectToLogoutURL from '/imports/ui/components/meeting-ended/service';
 import { initCursorStreamListener } from '/imports/ui/components/cursor/service';
 
 const CONNECTION_TIMEOUT = Meteor.settings.public.app.connectionTimeout;
@@ -182,7 +183,12 @@ class Auth {
 
 
     return new Promise((resolve) => {
-      resolve(this._logoutURL);
+      if (allowRedirectToLogoutURL()) {
+        resolve(this._logoutURL);
+      }
+
+      // do not redirect
+      resolve();
     });
   }
 

--- a/bigbluebutton-html5/imports/utils/logoutRouteHandler.js
+++ b/bigbluebutton-html5/imports/utils/logoutRouteHandler.js
@@ -2,13 +2,11 @@ import Auth from '/imports/ui/services/auth';
 
 const logoutRouteHandler = () => {
   Auth.logout()
-    .then((logoutURL = window.location.origin) => {
-      const protocolPattern = /^((http|https):\/\/)/;
-
-      window.location.href =
-        protocolPattern.test(logoutURL) ?
-          logoutURL :
-          `http://${logoutURL}`;
+    .then((logoutURL) => {
+      if (logoutURL) {
+        const protocolPattern = /^((http|https):\/\/)/;
+        window.location.href = protocolPattern.test(logoutURL) ? logoutURL : `http://${logoutURL}`;
+      }
     });
 };
 

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -17,6 +17,9 @@ public:
     cdn: ""
     basename: "/html5client"
     askForFeedbackOnLogout: false
+    # the default logoutUrl matches window.location.origin i.e. bigbluebutton.org for demo.bigbluebutton.org
+    # in some cases we want only custom logoutUrl to be used when provided on meeting create. Default value: true
+    allowDefaultLogoutUrl: true
     allowUserLookup: false
     enableNetworkInformation: false
     enableLimitOfViewersInWebcam: false


### PR DESCRIPTION
Added allowDefaultLogoutUrl config to optionally ignore non-custom logoutUrl
Split the MeetingEnded component's render into two parts for simplification - based on whether user feedback is enabled

### Motivation:
On large deployments if no custom logout parameter is set on meeting create you get unnecessary requests for your business' homepage every time a user is logged out / provides feedback / meeting is ended. That load to the homepage can prove to be significant, so with this new configuration you can set it up so users are hitting a 'dead end' page - i.e. there is no appropriate page to be redirected to and `window.close()` is not an option due to the window not being opened programatically in first place.(Note: in #10455 we could close the tab due to the fact that we had opened it in first place)

case when redirecting is allowed:
![Screenshot from 2020-10-08 05-31-40](https://user-images.githubusercontent.com/6312397/95441016-a154dd00-0927-11eb-937f-49f35a1fa4cf.png)

case when redirecting is not allowed:
![Screenshot from 2020-10-08 05-30-58](https://user-images.githubusercontent.com/6312397/95441020-a1ed7380-0927-11eb-8b9a-a28ea06ef34b.png)
