### PR TITLE
Fix broken undo of consecutive pencil annotations

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
@@ -97,7 +97,7 @@ class WhiteboardModel extends SystemConfiguration {
     }
   }
 
-  def endAnnotationPencil(wbId: String, userId: String, annotation: AnnotationVO): AnnotationVO = {
+  def endAnnotationPencil(wbId: String, userId: String, annotation: AnnotationVO, drawEndOnly: Boolean): AnnotationVO = {
     var rtnAnnotation: AnnotationVO = annotation
 
     val wb = getWhiteboard(wbId)
@@ -153,8 +153,12 @@ class WhiteboardModel extends SystemConfiguration {
       val updatedAnnotation = annotation.copy(position = newPosition, annotationInfo = updatedAnnotationData)
 
       var newUsersAnnotations: List[AnnotationVO] = oldAnnotationOption match {
-        case Some(annotation) => usersAnnotations.tail
-        case None             => usersAnnotations
+        //As part of the whiteboard improvments for the HTML5 client it no longer sends
+        //DRAW_START and DRAW_UPDATE events (#9019). Client now sends drawEndOnly in the 
+        //SendWhiteboardAnnotationPubMsg so akka knows not to expect usersAnnotations to be accumulating.
+        case Some(annotation) if (drawEndOnly == true) => usersAnnotations
+        case Some(annotation)                          => usersAnnotations.tail
+        case None                                      => usersAnnotations
       }
 
       val newAnnotationsMap = wb.annotationsMap + (userId -> (updatedAnnotation :: newUsersAnnotations))

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendWhiteboardAnnotationPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendWhiteboardAnnotationPubMsgHdlr.scala
@@ -95,7 +95,7 @@ trait SendWhiteboardAnnotationPubMsgHdlr extends RightsManagementTrait {
       //println("============= Printing Sanitized annotation ============")
       //printAnnotationInfo(sanitizedShape)
       //println("============= Printed Sanitized annotation  ============")
-      val annotation = sendWhiteboardAnnotation(sanitizedShape, liveMeeting)
+      val annotation = sendWhiteboardAnnotation(sanitizedShape, msg.body.drawEndOnly, liveMeeting)
       broadcastEvent(msg, annotation)
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/WhiteboardApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/WhiteboardApp2x.scala
@@ -18,7 +18,7 @@ class WhiteboardApp2x(implicit val context: ActorContext)
 
   val log = Logging(context.system, getClass)
 
-  def sendWhiteboardAnnotation(annotation: AnnotationVO, liveMeeting: LiveMeeting): AnnotationVO = {
+  def sendWhiteboardAnnotation(annotation: AnnotationVO, drawEndOnly: Boolean, liveMeeting: LiveMeeting): AnnotationVO = {
     //    println("Received whiteboard annotation. status=[" + status + "], annotationType=[" + annotationType + "]")
     var rtnAnnotation: AnnotationVO = annotation
 
@@ -32,7 +32,7 @@ class WhiteboardApp2x(implicit val context: ActorContext)
       }
     } else if (WhiteboardKeyUtil.DRAW_END_STATUS == annotation.status) {
       if (WhiteboardKeyUtil.PENCIL_TYPE == annotation.annotationType) {
-        rtnAnnotation = liveMeeting.wbModel.endAnnotationPencil(annotation.wbId, annotation.userId, annotation)
+        rtnAnnotation = liveMeeting.wbModel.endAnnotationPencil(annotation.wbId, annotation.userId, annotation, drawEndOnly)
       } else {
         rtnAnnotation = liveMeeting.wbModel.updateAnnotation(annotation.wbId, annotation.userId, annotation)
       }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WhiteboardMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WhiteboardMsgs.scala
@@ -26,7 +26,7 @@ case class SendCursorPositionPubMsgBody(whiteboardId: String, xPercent: Double, 
 
 object SendWhiteboardAnnotationPubMsg { val NAME = "SendWhiteboardAnnotationPubMsg" }
 case class SendWhiteboardAnnotationPubMsg(header: BbbClientMsgHeader, body: SendWhiteboardAnnotationPubMsgBody) extends StandardMsg
-case class SendWhiteboardAnnotationPubMsgBody(annotation: AnnotationVO)
+case class SendWhiteboardAnnotationPubMsgBody(annotation: AnnotationVO, drawEndOnly: Boolean)
 
 object UndoWhiteboardPubMsg { val NAME = "UndoWhiteboardPubMsg" }
 case class UndoWhiteboardPubMsg(header: BbbClientMsgHeader, body: UndoWhiteboardPubMsgBody) extends StandardMsg

--- a/bigbluebutton-html5/imports/api/annotations/server/methods/sendAnnotationHelper.js
+++ b/bigbluebutton-html5/imports/api/annotations/server/methods/sendAnnotationHelper.js
@@ -59,6 +59,7 @@ export default function sendAnnotationHelper(annotation, meetingId, requesterUse
 
   const payload = {
     annotation,
+    drawEndOnly: true,
   };
 
   return RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);


### PR DESCRIPTION
### What does this PR do?

Adds `drawEndOnly` to `SendWhiteboardAnnotationPubMsg`. As part of the whiteboard improvements for the HTML5 client it no longer sends `DRAW_START` and `DRAW_UPDATE` events (#9019). 

Thanks @hiroshisuga  for pointing out where the problem was in #10485

### Closes Issue(s)

Closes #10408 
