### PR TITLE
bbb-webrtc-sfu wait for multiple Kurentos

### DIFF
--- a/bigbluebutton-config/bin/apply-lib.sh
+++ b/bigbluebutton-config/bin/apply-lib.sh
@@ -148,7 +148,7 @@ HERE
     cp /etc/kurento/kurento.conf.json /etc/kurento/kurento-${i}.conf.json
     sed -i "s/8888/${i}/g" /etc/kurento/kurento-${i}.conf.json
     
-    # let Kurento start before bbb-webrtc-sfu is started
+    # let Kurentos start before bbb-webrtc-sfu is started
     sed -i -e "/^After/s/kurento-media-server.service/kurento-media-server-8888.service\ kurento-media-server-8889.service\ kurento-media-server-8890.service/" /usr/lib/systemd/system/bbb-webrtc-sfu.service
 
 
@@ -208,6 +208,8 @@ disableMultipleKurentos() {
 
   # Remove the overrride (restoring the original kurento-media-server.service unit file)
   rm -f /etc/systemd/system/kurento-media-server.service
+  
+  # Change bbb-webrtc-sfu.service back to wait for single Kurento service.
   sed -i -e "/^After/s/kurento-media-server-8888.service\ kurento-media-server-8889.service\ kurento-media-server-8890.service/kurento-media-server.service/" /usr/lib/systemd/system/bbb-webrtc-sfu.service
 
   systemctl daemon-reload

--- a/bigbluebutton-config/bin/apply-lib.sh
+++ b/bigbluebutton-config/bin/apply-lib.sh
@@ -147,6 +147,10 @@ HERE
     # Make a new configuration file each instance of Kurento that binds to a different port
     cp /etc/kurento/kurento.conf.json /etc/kurento/kurento-${i}.conf.json
     sed -i "s/8888/${i}/g" /etc/kurento/kurento-${i}.conf.json
+    
+    # let Kurento start before bbb-webrtc-sfu is started
+    sed -i -e "/^After/s/kurento-media-server.service/kurento-media-server-8888.service\ kurento-media-server-8889.service\ kurento-media-server-8890.service/" /usr/lib/systemd/system/bbb-webrtc-sfu.service
+
 
   done
 
@@ -204,6 +208,8 @@ disableMultipleKurentos() {
 
   # Remove the overrride (restoring the original kurento-media-server.service unit file)
   rm -f /etc/systemd/system/kurento-media-server.service
+  sed -i -e "/^After/s/kurento-media-server-8888.service\ kurento-media-server-8889.service\ kurento-media-server-8890.service/kurento-media-server.service/" /usr/lib/systemd/system/bbb-webrtc-sfu.service
+
   systemctl daemon-reload
 
   # Restore bbb-webrtc-sfu configuration to use a single instance of Kurento

--- a/bigbluebutton-config/bin/apply-lib.sh
+++ b/bigbluebutton-config/bin/apply-lib.sh
@@ -147,10 +147,6 @@ HERE
     # Make a new configuration file each instance of Kurento that binds to a different port
     cp /etc/kurento/kurento.conf.json /etc/kurento/kurento-${i}.conf.json
     sed -i "s/8888/${i}/g" /etc/kurento/kurento-${i}.conf.json
-    
-    # let Kurentos start before bbb-webrtc-sfu is started
-    sed -i -e "/^After/s/kurento-media-server.service/kurento-media-server-8888.service\ kurento-media-server-8889.service\ kurento-media-server-8890.service/" /usr/lib/systemd/system/bbb-webrtc-sfu.service
-
 
   done
 
@@ -168,6 +164,9 @@ HERE
   [Install]
   WantedBy=multi-user.target
 HERE
+    
+  # let Kurentos start before bbb-webrtc-sfu is started
+  sed -i -e "/^After/s/kurento-media-server.service/kurento-media-server-8888.service\ kurento-media-server-8889.service\ kurento-media-server-8890.service/" /usr/lib/systemd/system/bbb-webrtc-sfu.service
 
   systemctl daemon-reload
 


### PR DESCRIPTION
### What does this PR do?

Make systemd service unit of bbb-webrtc-sfu wait for multiple Kurentos if enableMultipleKurentos is used.

### Motivation

If `enableMultipleKurentos` is used sometimes (especially after reboots) bbb-webrtc-sfu is started before Kurentos were ready to accept connections.
In these Cases Webcams and Screenshares are not usable.

