### PR TITLE
Fix wrong skipCheck handling

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -96,8 +96,7 @@ class AudioManager {
     this.isListenOnly = false;
     this.isEchoTest = false;
 
-    return this.askDevicesPermissions()
-      .then(this.onAudioJoining.bind(this))
+    return this.onAudioJoining.bind(this)()
       .then(() => {
         const callOptions = {
           isListenOnly: false,


### PR DESCRIPTION
We now let sip.js handle getUserMedia calls, same should happen when skipCheck is active.
Solves #10652.
