### PR TITLE
Fix for OSX and iOS Safari errors in console

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/fullscreen-button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/fullscreen-button/container.jsx
@@ -6,7 +6,7 @@ const FullscreenButtonContainer = props => <FullscreenButtonComponent {...props}
 
 export default (props) => {
   const handleToggleFullScreen = ref => FullscreenService.toggleFullScreen(ref);
-  const isIphone = navigator.userAgent.match(/iPhone/i);
+  const isIphone = (navigator.userAgent.match(/iPhone/i)) ? true : false;
   return (
     <FullscreenButtonContainer {...props} {...{ handleToggleFullScreen, isIphone }} />
   );

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/container.jsx
@@ -7,8 +7,8 @@ import { meetingIsBreakout } from '/imports/ui/components/app/service';
 
 const BROWSER_RESULTS = browser();
 const isSafari = BROWSER_RESULTS.name === 'safari';
-const isIphone = navigator.userAgent.match(/iPhone/i);
-const noIOSFullscreen = (isSafari && BROWSER_RESULTS.versionNumber < 12) || isIphone;
+const isIphone = (navigator.userAgent.match(/iPhone/i)) ? true : false;
+const noIOSFullscreen = ((isSafari && BROWSER_RESULTS.versionNumber < 12) || isIphone) ? true : false;
 
 const SettingsDropdownContainer = props => (
   <SettingsDropdown {...props} />


### PR DESCRIPTION
### What does this PR do?

This PR corrects the errors that are thrown in either OSX or iOS Safari. The issue was that both components expected a boolean but navigator.userAgent.match(/iPhone/i) return an array -> ["Iphone"] instead of a boolean. This line of code was used in two different components in the same way.

### Closes Issue(s)

closes #7953

### Motivation

I was experimenting with BBB and this error caught my eye.

### More

- [ ] Added/updated documentation
