### PR TITLE
Dont include extra dot in instructure media url

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/arc-player.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/arc-player.jsx
@@ -120,7 +120,7 @@ export class ArcPlayer extends Component {
   getHostUrl() {
     const { url } = this.props;
     const m = url.match(MATCH_URL);
-    return m && 'https://' + m[1] + '.' + m[2];
+    return m && 'https://' + m[1] + m[2];
   }
 
   getEmbedUrl() {


### PR DESCRIPTION
In some cases the extra '.' would be included and the url would not load properly.