### PR TITLE
[Mobile] - Setting or clearing user status locks the whole screen

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
@@ -161,7 +161,7 @@ class Dropdown extends Component {
       if (parentElement) parentElement.focus();
     }
 
-    if (keepOpen !== null) return;
+    if (keepOpen !== false) return;
     this.handleHide();
   }
 


### PR DESCRIPTION
### What does this PR do?

On mobile if you clicked on a user or your own user to set their status, the tethered modal would keep it's z-index (15), which would prevent the user from interacting with anything because the tethered modal would overlap the whole site.

I think strictly comparing **keepOpen** variable to **null** was done mistakenly as the **keepOpen** variable is either true or false and that was the reason the modal didn't close after setting or clearing user status.

### Closes Issue(s)

closes #...
Haven't found any issues about this problem

### Motivation

After work debugging
