### PR TITLE
Change default value of iceGatheringTimeout to current's SIP.js default

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -30,7 +30,7 @@ const AUDIO_SESSION_NUM_KEY = 'AudioSessionNumber';
 const USER_AGENT_RECONNECTION_ATTEMPTS = 3;
 const USER_AGENT_RECONNECTION_DELAY_MS = 5000;
 const USER_AGENT_CONNECTION_TIMEOUT_MS = 5000;
-const ICE_GATHERING_TIMEOUT = MEDIA.iceGatheringTimeout || 15000;
+const ICE_GATHERING_TIMEOUT = MEDIA.iceGatheringTimeout || 5000;
 
 const getAudioSessionNumber = () => {
   let currItem = parseInt(sessionStorage.getItem(AUDIO_SESSION_NUM_KEY), 10);

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -288,7 +288,7 @@ public:
     #the SDP is sent to the server with the candidates the browser gathered
     #so far. Increasing this value might help avoiding 1004 error when
     #user activates microphone.
-    iceGatheringTimeout: 15000
+    iceGatheringTimeout: 5000
   presentation:
     defaultPresentationFile: default.pdf
     panZoomThrottle: 32


### PR DESCRIPTION
For some reason (still investigating), using turn/coturn on 443/tcp makes firefox's iceGathering process (during echo test) takes 12+ seconds (tested on webrtc's trickle page with multiple instances).
This was found when testing the current default (15s) on production with a private turn/coturn server on port 443/tcp. For default bbb setup (stun only), echo test still runs fast.
To avoid adding extra delay to iceGathering on this scenario (Firefox + turn on 443/tcp), i am just setting the default value back to the 5s (old default).
So , for those who wants to reduce the 1004 occurrences, increasing the iceGatheringTimeout could help (just be aware this adds delay on the mentioned scenario).