### PR TITLE
Prevent 1005 error log when user close/reload bbb's window/tab

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -311,6 +311,7 @@ class SIPSession {
   }
 
   onBeforeUnload() {
+    this.userRequestedHangup = true;
     if (this.userAgent) {
       return this.userAgent.stop();
     }


### PR DESCRIPTION
When closing/reloading tab with active microphone, audio exits successfully but a wrong log-error (1005) is shown.
We now process closing/reloading tab the same way we do when user hangup the call.