### PR TITLE
Move the check to disable mutedAlert feature; temp disable it

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
@@ -98,9 +98,11 @@ class AudioControls extends PureComponent {
       />
     );
 
+    const MUTE_ALERT_CONFIG = Meteor.settings.public.app.mutedAlert;
+    const { enabled: muteAlertEnabled } = MUTE_ALERT_CONFIG;
     return (
       <span className={styles.container}>
-        {muted ? <MutedAlert {...{ inputStream, isViewer, isPresenter }} /> : null}
+        {muted && muteAlertEnabled ? <MutedAlert {...{ inputStream, isViewer, isPresenter }} /> : null}
         {showMute && isVoiceUser ? toggleMuteBtn : null}
         <Button
           className={cx(inAudio || styles.btn)}

--- a/bigbluebutton-html5/imports/ui/components/muted-alert/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/muted-alert/component.jsx
@@ -56,8 +56,6 @@ class MutedAlert extends Component {
   }
 
   render() {
-    const { enabled } = MUTE_ALERT_CONFIG;
-    if (!enabled) return null;
     const { isViewer, isPresenter } = this.props;
     const { visible } = this.state;
     const style = {};

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -32,7 +32,7 @@ public:
     allowFullscreen: true
     preloadNextSlides: 2
     mutedAlert:
-      enabled: true
+      enabled: false
       interval: 200
       threshold: -50
       duration: 4000


### PR DESCRIPTION
We now check if `muteAlert` #9851 when we include the component, not when we render it.
This allows now to properly disable the feature (temporarily until we figure out a breaking issue)