### PR TITLE
Avoid cache usage when building docker image

### DIFF
--- a/bbb-libreoffice/install.sh
+++ b/bbb-libreoffice/install.sh
@@ -25,7 +25,7 @@ fi
 IMAGE_CHECK=`docker image inspect bbb-libreoffice &> /dev/null && echo 1 || echo 0`
 if [ "$IMAGE_CHECK"  = "0" ]; then
 	echo "Docker image doesn't exists, building"
-	docker build -t bbb-libreoffice docker/
+	docker build --no-cache -t bbb-libreoffice docker/
 else
 	echo "Docker image already exists";
 fi


### PR DESCRIPTION
This is a simple change that will avoid problems on upgrades of development server ( where `./uninstall.sh` and `./install.sh` are called multiple times ).