### PR TITLE
Fix presentation downloadable tooltip label

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -556,7 +556,7 @@ class PresentationUploader extends Component {
     };
 
     const hideRemove = this.isDefault(item);
-    const formattedDownloadableLabel = item.isDownloadable
+    const formattedDownloadableLabel = !item.isDownloadable
       ? intl.formatMessage(intlMessages.isDownloadable)
       : intl.formatMessage(intlMessages.isNotDownloadable);
 


### PR DESCRIPTION
### What does this PR do?
Makes the toggle presentation download button tooltip display the correct message.

### Closes Issue(s)
#10748 