### PR TITLE
Fix actions bar buttons not being clickable on iPad 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -242,7 +242,7 @@ class ActionsDropdown extends PureComponent {
     }
 
     return (
-      <Dropdown ref={(ref) => { this._dropdown = ref; }}>
+      <Dropdown className={styles.dropdown} ref={(ref) => { this._dropdown = ref; }}>
         <DropdownTrigger tabIndex={0} accessKey={OPEN_ACTIONS_AK}>
           <Button
             hideLabel

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
@@ -118,6 +118,11 @@
   }
 }
 
+.dropdown,
+.btn {
+  z-index: 3;
+}
+
 .presentationItem {
   span {
     text-overflow: ellipsis;


### PR DESCRIPTION
### What does this PR do?
Increases the `z-index` on the buttons in the actions bar

### Closes Issue(s)
#10779 