### PR TITLE
Remove unwanted debug logging of PDF binaries

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1928,7 +1928,6 @@ class ApiController {
     if (requestBody == null) {
       downloadAndProcessDocument(presentationService.defaultUploadedPresentation, conf.getInternalId(), true /* default presentation */, '');
     } else {
-      log.debug "Request body: \n" + requestBody;
       def xml = new XmlSlurper().parseText(requestBody);
       xml.children().each { module ->
         log.debug("module config found: [${module.@name}]");


### PR DESCRIPTION
### What does this PR do?

It removes a line of code, which dumps the whole base64 encoded binary of every api-uploaded pdf to the logs. This may lead to strange errors (oom / crashes) with big files.

### Closes Issue(s)

#9092 

### More

I do not think that it is really necessary to leave the line of code, wrapped in a "isDebugEnabled" condition as suggested in the issue. It does not make sense to flood the debug log with binary strings by default. Even it makes no sense when debugging arbitrary other things in bbb-web. So I decided myself to remove it.