### PR TITLE
Use iceConnectionState to monitor ICE connection status

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -760,22 +760,32 @@ class SIPSession {
         }, 'Audio call session progress update');
 
         this.currentSession.sessionDescriptionHandler.peerConnectionDelegate = {
-          oniceconnectionstatechange: (event) => {
-            const peer = event.target;
-
-            logger.info({
-              logCode: 'sip_js_ice_connection_state_change',
-              extraInfo: {
-                iceConnectionStateChange: peer.iceConnectionState,
-                callerIdName: this.user.callerIdName,
-              },
-            }, 'ICE connection state change - Current ICE Connection state - '
-                + `${peer.iceConnectionState}`);
-          },
           onconnectionstatechange: (event) => {
             const peer = event.target;
 
+            logger.info({
+              logCode: 'sip_js_connection_state_change',
+              extraInfo: {
+                connectionStateChange: peer.connectionState,
+                callerIdName: this.user.callerIdName,
+              },
+            }, 'ICE connection state change - Current connection state - '
+                + `${peer.connectionState}`);
+
             switch (peer.connectionState) {
+              case 'failed':
+                // Chrome triggers 'failed' for connectionState event, only
+                handleIceNegotiationFailed(peer);
+                break;
+              default:
+                break;
+            }
+          },
+          oniceconnectionstatechange: (event) => {
+            const peer = event.target;
+
+            switch (peer.iceConnectionState) {
+              case 'completed':
               case 'connected':
                 if (iceCompleted) {
                   logger.info({


### PR DESCRIPTION
We now use both peer's connectionstatechange and iceconnectionstatechange to monitor ICE state for audio sessions.
The same way we did with old sip.js version, we leave iceconnectionstate trigger audio actions , such as connect, disconnect, reconnect.
We still listen for 'failed' state for connectionstatechange event, because chrome triggers this (tested on 86+).
This should reduce the audio error 1010 ocurrences, once some browsers (specially Chrome/Android) don't trigger connectionstatechangeevent.
This might reduce problems reported in #10708, which still needs more investigation though.