### PR TITLE
[html5/audio] Add a configurable hackViaWs to SIP.js. Part of a workaround for #9667 

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -23,6 +23,7 @@ const MEDIA_TAG = MEDIA.mediaTag;
 const CALL_TRANSFER_TIMEOUT = MEDIA.callTransferTimeout;
 const CALL_HANGUP_TIMEOUT = MEDIA.callHangupTimeout;
 const CALL_HANGUP_MAX_RETRIES = MEDIA.callHangupMaximumRetries;
+const SIPJS_HACK_VIA_WS = MEDIA.sipjsHackViaWs;
 const IPV4_FALLBACK_DOMAIN = Meteor.settings.public.app.ipv4FallbackDomain;
 const CALL_CONNECT_TIMEOUT = 20000;
 const ICE_NEGOTIATION_TIMEOUT = 20000;
@@ -379,6 +380,7 @@ class SIPSession {
         displayName: callerIdName,
         register: false,
         userAgentString: 'BigBlueButton',
+        hackViaWs: SIPJS_HACK_VIA_WS,
       });
 
       const handleUserAgentConnection = () => {

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -289,6 +289,7 @@ public:
     #so far. Increasing this value might help avoiding 1004 error when
     #user activates microphone.
     iceGatheringTimeout: 5000
+    sipjsHackViaWs: false
   presentation:
     defaultPresentationFile: default.pdf
     panZoomThrottle: 32

--- a/bigbluebutton-html5/public/compatibility/sip.js
+++ b/bigbluebutton-html5/public/compatibility/sip.js
@@ -3831,6 +3831,7 @@ class OutgoingRequestMessage {
             fromTag: "",
             forceRport: false,
             hackViaTcp: false,
+            hackViaWs: false,
             optionTags: ["outbound"],
             routeSet: [],
             userAgentString: "sip.js",
@@ -3937,6 +3938,8 @@ class OutgoingRequestMessage {
         // FIXME: Hack
         if (this.options.hackViaTcp) {
             transport = "TCP";
+        } else if (this.options.hackViaWs) {
+            transport = "WS";
         }
         let via = "SIP/2.0/" + transport;
         via += " " + this.options.viaHost + ";branch=" + branch;
@@ -9812,6 +9815,7 @@ class UserAgentCore {
         const fromDisplayName = this.configuration.displayName;
         const forceRport = this.configuration.viaForceRport;
         const hackViaTcp = this.configuration.hackViaTcp;
+        const hackViaWs = this.configuration.hackViaWs;
         const optionTags = this.configuration.supportedOptionTags.slice();
         if (method === _messages__WEBPACK_IMPORTED_MODULE_0__["C"].REGISTER) {
             optionTags.push("path", "gruu");
@@ -9827,6 +9831,7 @@ class UserAgentCore {
             forceRport,
             fromDisplayName,
             hackViaTcp,
+            hackViaWs,
             optionTags,
             routeSet,
             userAgentString,
@@ -17303,6 +17308,7 @@ class UserAgent {
             hackAllowUnregisteredOptionTags: false,
             hackIpInContact: false,
             hackViaTcp: false,
+            hackViaWs: false,
             hackWssInTransport: false,
             logBuiltinEnabled: true,
             logConfiguration: true,
@@ -17657,6 +17663,7 @@ class UserAgent {
             displayName: this.options.displayName,
             loggerFactory: this.loggerFactory,
             hackViaTcp: this.options.hackViaTcp,
+            hackViaWs: this.options.hackViaWs,
             routeSet: this.options.preloadedRouteSet,
             supportedOptionTags,
             supportedOptionTagsResponse,


### PR DESCRIPTION


### What does this PR do?

Long story short: this adds the possibility to configure the SIP Via header to plain WS to allow reverse proxying from WSS to WS internally. This potentially works around FreeSWITCH's sofia-sip transport stack lockup, issue #9667, as some community members have tested it with positive indications.

### Closes Issue(s)

Partially addresses #9667. Don't think it closes the issue as I'd prefer fixing the bug in FreeSWITCH.

### Motivation

Working around the sofia-sip transport stack deadlock while we can't find a definitive fix.
Less intrusive than other suggested workarounds with no need to setup additional watchdogs.
Trade-off is making the internal nginx <-> freeswitch connection unencrypted.

Detailed discussion: https://github.com/bigbluebutton/bigbluebutton/issues/9667

Special thanks to @jarmediagmbh for testing this and confirming it works on some level.

### More

Necessary changes to enable the workaround:
  - Flip settings.yml `public.media.sipjsHackViaWs` to `true`
  - `/etc/bigbluebutton/nginx/sip.nginx`: change `proxy_pass https://<external_ip>:7443` to `proxy_pass http:<external_ip>:5066`

Original workaround instructions: https://github.com/bigbluebutton/bigbluebutton/issues/9667#issuecomment-718289743

### Pending

Some decisions to be made (cc @ffdixon, @antobinary, @jarmediagmbh and any other interested parties):
  - Do we make this enabled by default?
    * Making it the default implies flipping the flag in a subsequent PR **and** altering whatever builds the sip.nginx entry to reverse proxy to WS as mentioned above.
  - If we don't make it enabled by default, do we add a bbb-conf toggle or just docs for it?
  