### PR TITLE
[html5/webrtc] Fix tryGenerateIceCandidates rejections and put it behind a flag

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -277,6 +277,7 @@ public:
     stunTurnServersFetchAddress: "/bigbluebutton/api/stuns"
     cacheStunTurnServers: true
     fallbackStunServer:  ''
+    recvonlyIceGatheringCheck: true
     mediaTag: "#remote-media"
     callTransferTimeout: 5000
     callHangupTimeout: 2000


### PR DESCRIPTION
### What does this PR do?

- Fixed two occurrences where the `tryGenerateIceCandidates` workaround rejected without an error, which borked the callers' (as in all recvonly peer instatiators) error handling
- Put it behind a config flag. Enabled by default.
  * `public.media.recvonlyIceGatheringCheck`

### Closes Issue(s)

None

### Motivation

Besides the clear bug that the empty rejections caused (essentially freezing the peer creation process), there's the flag thing.
This workaround used to be important when Kurento didn't infer prflx candidates properly, but that's no longer the case. With the flag, we can disable the workaround to see if there's any visible regression and hopefully remove it down the road if it's safe. I sure want to get rid of it because it's ugly and error prone.

More details on the workaround motivation are in the inline comments:
```
/*
 * Try to generate candidates for a recvonly RTCPeerConnection without
 * a gUM permission and check if there are any candidates generated other than
 * a mDNS host candidate. If there aren't, forcefully request gUM permission
 * for mic (best chance of a gUM working is mic) to try and make the browser
 * generate at least srflx candidates.
 * This is a workaround due to a behaviour some browsers display (mainly Safari)
 * where they won't generate srflx or relay candidates if no gUM permission is
 * given.
 *
 *
 * UPDATE:
 * This used to be valid when Kurento wasn't treating prflx candidates properly.
 * It is now, so this workaround is being revisited. I've put it under a flag
 * so that we can field trial it disabled and gauge the impact of removing it.
 * Hopelly we can get rid of it.
 *
 * prlanzarin 11-11-20

```
