### PR TITLE
Fix console errors in safari on iPad

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-dropdown/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-dropdown/styles.scss
@@ -2,6 +2,8 @@
   --icon-offset: -.4em;
   --square-side-length: 1.56rem;
 
+  z-index: 3;
+
   flex: 0 0;
   margin-top: auto;
 

--- a/bigbluebutton-html5/imports/ui/components/chat/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/chat/styles.scss
@@ -68,6 +68,7 @@
   margin-bottom: var(--border-size);
   padding-left: 0;
   padding-right: inherit;
+  z-index: 3;
 
   [dir="rtl"] & {
     padding-left: inherit;

--- a/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
@@ -183,7 +183,7 @@ class Dropdown extends Component {
     } = this.props;
 
     const { isOpen } = this.state;
-    
+
     const placements = placement && placement.replace(' ', '-');
     const test = isMobile ? {
       width: '100%',
@@ -233,19 +233,19 @@ class Dropdown extends Component {
         tabIndex={-1}
       >
         {
-          tethered ?
-            (
+          tethered
+            ? (
               <TetherComponent
                 style={{
-                  zIndex: isOpen ? 15 : '',
+                  zIndex: isOpen ? 15 : 1,
                   ...test,
                 }}
                 attachment={
-                  isMobile ? 'middle bottom'
+                  isMobile ? 'middle center'
                     : attachments[placements]
                 }
                 targetAttachment={
-                  isMobile ? ''
+                  isMobile ? 'auto auto'
                     : targetAttachments[placements]
                 }
                 constraints={[

--- a/bigbluebutton-html5/imports/ui/components/dropdown/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/styles.scss
@@ -17,6 +17,7 @@
 
 .dropdown {
   position: relative;
+  z-index: 3;
 
   &:focus {
     outline: none;

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/styles.scss
@@ -108,6 +108,8 @@
     box-shadow: none;
   }
 
+  z-index: 3;
+
   &:hover,
   &:focus {
     span {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-submenu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-submenu/component.jsx
@@ -198,6 +198,7 @@ class ToolbarSubmenu extends Component {
 
   handleMouseDown(e) {
     const { handleClose } = this.props;
+    if (e.path === undefined) return false;
     for (let i = 0; i < e.path.length; i += 1) {
       const p = e.path[i];
       if (p && p.className && typeof p.className === 'string') {


### PR DESCRIPTION
### What does this PR do?
Fixes safari console log errors on iPad / add z-index's 

### Motivation
These errors were being shown in the safari console on iPad.

![safari-error-1](https://user-images.githubusercontent.com/22058534/99121038-e70d6100-25c9-11eb-919d-5d81223c5ef4.png)
![safari-error-2](https://user-images.githubusercontent.com/22058534/99121039-e7a5f780-25c9-11eb-81d4-32509b571e51.png)
![safari-error-3](https://user-images.githubusercontent.com/22058534/99121040-e7a5f780-25c9-11eb-8baf-7bf00f3c80cd.png)


