### PR TITLE
Tweak sockjs timeout value

### DIFF
--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -51,6 +51,12 @@ Meteor.startup(() => {
   const newSend = function send(data) {
     this.lastSentFrameTimestamp = new Date().getTime();
 
+    // Call https://github.com/meteor/meteor/blob/1e7e56eec8414093cd0c1c70750b894069fc972a/packages/ddp-common/heartbeat.js#L80-L88
+    this.meteorHeartbeat._seenPacket = true;
+    if (this.meteorHeartbeat._heartbeatTimeoutHandle) {
+      this.meteorHeartbeat._clearHeartbeatTimeoutTimer();
+    }
+
     if (this.readyState > 1/* API.OPEN = 1 */) return false;
     if (!(data instanceof Buffer)) data = String(data);
     return this._driver.messages.write(data);
@@ -65,6 +71,7 @@ Meteor.startup(() => {
         continue;
       }
 
+      recv.ws.meteorHeartbeat = session.heartbeat;
       recv.__proto__.heartbeat = newHeartbeat;
       recv.ws.__proto__.send = newSend;
       session.bbbFixApplied = true;

--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -23,6 +23,7 @@ Meteor.startup(() => {
   const CDN_URL = APP_CONFIG.cdn;
   let heapDumpMbThreshold = 100;
 
+  // https://github.com/sockjs/sockjs-node/blob/1ef08901f045aae7b4df0f91ef598d7a11e82897/lib/transport/websocket.js#L74-L82
   const newHeartbeat = function heartbeat() {
     const currentTime = new Date().getTime();
 
@@ -46,6 +47,7 @@ Meteor.startup(() => {
     }
   };
 
+  // https://github.com/davhani/hagty/blob/6a5c78e9ae5a5e4ade03e747fb4cc8ea2df4be0c/faye-websocket/lib/faye/websocket/api.js#L84-L88
   const newSend = function send(data) {
     this.lastSentFrameTimestamp = new Date().getTime();
 


### PR DESCRIPTION
### What does this PR do?
 Sockjs-node has a hardcoded timeout for ping/pong of 10 seconds ( https://github.com/sockjs/sockjs-node/blob/1ef08901f045aae7b4df0f91ef598d7a11e82897/lib/transport/websocket.js#L78 ).

When meteor is busy ( CPU 100% ) it causes all clients to be disconnected and reconnecting, causing new timeouts, this PR inject's a modified version of heartbeat function that:
         

1. Keeps track of last websocket traffic event.
2. Skips sending the heartbeat if the connection is not inactive ( if there is traffic, doesn't generate server->client heartbeats ).
3. Logs user ID when a disconnection happens due to ping ( server-> client ) timeout.

#### Code without changes(Disconnect after 01:57s):
https://www.dropbox.com/s/jgc8cmv6inizndx/Jo%C3%A3o%20Siebel%20-%20sem_pr.mp4?dl=0

#### Code with changes(No disconnection):
https://www.dropbox.com/s/02mlob93gxa0e8u/Jo%C3%A3o%20Siebel%20-%20com_pr.mp4?dl=0



