### PR TITLE
Allow user bigbluebutton to delete recordings

### DIFF
--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -116,6 +116,13 @@ need_root() {
    fi
 }
 
+need_root_or_bigbluebutton() {
+   if [ $EUID != 0 -a "$USER" != 'bigbluebutton']; then
+      echo "Need to be user root or bigbluebutton to run this option"
+      exit 1
+   fi
+}
+
 print_header() {
    if [ ! $HEADER ]; then
       echo
@@ -216,7 +223,7 @@ while [ $# -gt 0 ]; do
    fi
 
    if [ "$1" = "-delete" -o "$1" = "--delete" ]; then
-      need_root
+      need_root_or_bigbluebutton
       if [ ! -z "${2}" ]; then
          MEETING_ID="${2}"
          shift


### PR DESCRIPTION
This patch modifies `bbb-record` allowing the user `bigbluebutton` to
delete recordings. The user has all necessary access rights, meaning
that the deletion works without a problem and the check for root does
not protect anything. The user owns the data after all. The current
check just makes things less convenient.

This is the `develop` variant of pull request #10841 which went into 2.2.x