### PR TITLE
Set listenOnly to false when user left voice

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -919,6 +919,11 @@ public class MeetingService implements MessageListener {
           User vuser = m.userLeft(message.userId);
         } else {
           user.setVoiceJoined(false);
+          // userLeftVoice is also used when user leaves Global (listenonly)
+          // audio. Also tetting listenOnly to false is not a problem,
+          // once user can't join both voice/mic and global/listenonly
+          // at the same time.
+          user.setListeningOnly(false);
         }
       }
     }


### PR DESCRIPTION
The message/event UserLeftVoiceConfToClientEvtMsg is used when user leaves mic and listenonly, but it only sets to false the 'voiceJoined' (which represents the <hasVoiceVoiceJoined> property in BBB's XML API.
We now also set to false the 'listeningOnly' (which represents the <isListeningOnly> property in BBB's XML API). Setting both to false is not a problem, once 'MIC' and 'ListenOnly' states are mutually exclusives
Fixes #10852