### PR TITLE
Support for parallel bbb-html5 nodejs processes. Part 1

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/intl.jsx
+++ b/bigbluebutton-html5/imports/startup/client/intl.jsx
@@ -92,7 +92,7 @@ class IntlStartup extends Component {
   }
 
   fetchLocalizedMessages(locale, init = false) {
-    const url = `/html5client/locale?locale=${locale}&init=${init}`;
+    const url = `./locale?locale=${locale}&init=${init}`;
 
     this.setState({ fetching: true }, () => {
       fetch(url)

--- a/bigbluebutton-html5/imports/ui/components/legacy/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/legacy/component.jsx
@@ -78,7 +78,7 @@ export default class Legacy extends Component {
       || navigator.language
       || Meteor.settings.public.app.defaultSettings.application.fallbackLocale;
 
-    const url = `/html5client/locale?locale=${locale}`;
+    const url = `./locale?locale=${locale}`;
 
     const that = this;
     this.state = { viewState: FETCHING };

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
@@ -159,7 +159,7 @@ class MeetingEnded extends PureComponent {
       comment: MeetingEnded.getComment(),
       userRole: this.localUserRole,
     };
-    const url = '/html5client/feedback';
+    const url = './feedback';
     const options = {
       method: 'POST',
       body: JSON.stringify(message),

--- a/bigbluebutton-html5/imports/ui/components/settings/service.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/service.js
@@ -27,7 +27,7 @@ const updateSettings = (obj, msg) => {
   }
 };
 
-const getAvailableLocales = () => fetch('/html5client/locales').then(locales => locales.json());
+const getAvailableLocales = () => fetch('./locales').then(locales => locales.json());
 
 export {
   getUserRoles,

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -258,7 +258,7 @@ moderatorsJoinViaHTML5Client=true
 
 # The url of the BigBlueButton HTML5 client. Users will be redirected here when
 # successfully joining the meeting.
-html5ClientUrl=${bigbluebutton.web.serverURL}/html5client/join
+html5ClientUrl=${bigbluebutton.web.serverURL}/html5client/%%INSTANCEID%%/join
 
 
 # The url for where the guest will poll if approved to join or not.

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -510,6 +510,11 @@ class ApiController {
       }
     }
 
+
+    String meetingInstance = meeting.getMetadata()["bbb-meetinginstance"];
+    meetingInstance = (meetingInstance == null) ? "1" : meetingInstance;
+    clientURL = clientURL.replaceAll("%%INSTANCEID%%", meetingInstance);
+
     if (!StringUtils.isEmpty(params.redirect)) {
       try {
         redirectClient = Boolean.parseBoolean(params.redirect);


### PR DESCRIPTION
Code changes to allow for meetings' redis events to be processed on different html5 nodejs pid's


Packaging changes are to be made before this can be used but for this code bypasses the need of loadbalancing of potentially multiple parallel processes. `bbb-meetinginstance=X` (where X is 1...N (the number of running processes)) property will need to be passed as part of the **create** meeting command in the `meta` section.

When this is merged it will be backward compatible (that is you do not need to pass the meta parameter, no need to run multiple nodejs processes either)