### PR TITLE
Handle chat messages in sync way

### DIFF
--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/handlers/groupChatMsgBroadcast.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/handlers/groupChatMsgBroadcast.js
@@ -8,5 +8,5 @@ export default function handleGroupChatMsgBroadcast({ body }, meetingId) {
   check(chatId, String);
   check(msg, Object);
 
-  return addGroupChatMsg(meetingId, chatId, msg);
+  addGroupChatMsg(meetingId, chatId, msg);
 }

--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addGroupChatMsg.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addGroupChatMsg.js
@@ -47,19 +47,15 @@ export default function addGroupChatMsg(meetingId, chatId, msg) {
     $set: flat(msgDocument, { safe: true }),
   };
 
-  const cb = (err, numChanged) => {
-    if (err) {
-      return Logger.error(`Adding group-chat-msg to collection: ${err}`);
-    }
-
-    const { insertedId } = numChanged;
+  try {
+    const { insertedId } = GroupChatMsg.upsert(selector, modifier);
 
     if (insertedId) {
-      return Logger.info(`Added group-chat-msg msgId=${msg.id} chatId=${chatId} meetingId=${meetingId}`);
+      Logger.info(`Added group-chat-msg msgId=${msg.id} chatId=${chatId} meetingId=${meetingId}`);
+    } else {
+      Logger.info(`Upserted group-chat-msg msgId=${msg.id} chatId=${chatId} meetingId=${meetingId}`);
     }
-
-    return Logger.info(`Upserted group-chat-msg msgId=${msg.id} chatId=${chatId} meetingId=${meetingId}`);
-  };
-
-  return GroupChatMsg.upsert(selector, modifier, cb);
+  } catch (err) {
+    Logger.error(`Adding group-chat-msg to collection: ${err}`);
+  }
 }


### PR DESCRIPTION
The function used for changing data in mongo DB is asynchronous when it receives a callback.

The effect of this is that the queue was not waiting the end of the processing of a message to call the next one.
It could cause a high CPU usage ( hundreds of async calls at same time ).

One practical example of this problem is that under high load the chat messages was being handled out of order, this PR removes the callback from all upsert calls, forcing the handle of queue messages to be synchronous ( making the queue work as expected ).

The gifs below compare the receive order from 100 messages:
### Without this PR ( out of order ):
![skipped_ids](https://user-images.githubusercontent.com/2110278/99588634-a5195c00-29c9-11eb-9ddb-373e069904ba.gif)
### With this PR ( In order ):
![sync_ids](https://user-images.githubusercontent.com/2110278/99588647-ac406a00-29c9-11eb-8d1e-37df1247fc70.gif)