### PR TITLE
Do not trigger reconnect when ICE connection terminates before hanging up process is finished

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -743,7 +743,7 @@ class SIPSession {
               callerIdName: this.user.callerIdName,
             },
           }, 'ICE connection closed');
-        }
+        } else return;
 
         this.callback({
           status: this.baseCallStates.failed,

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -145,13 +145,10 @@ class SIPSession {
       sessionToken,
     } = this.user;
 
-    const encodedName =
-      btoa && name ? btoa(name) : name;
-
     const callerIdName = [
       `${userId}_${getAudioSessionNumber()}`,
       'bbbID',
-      isListenOnly ? `LISTENONLY-${encodedName}` : encodedName,
+      isListenOnly ? `LISTENONLY-${name}` : name,
     ].join('-').replace(/"/g, "'");
 
     this.user.callerIdName = callerIdName;

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/container.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import VoiceUsers from '/imports/api/voice-users';
-import Users from '/imports/api/users'
 import Auth from '/imports/ui/services/auth';
 import { debounce } from 'lodash';
 import TalkingIndicator from './component';
@@ -38,16 +37,12 @@ export default withTracker(() => {
         callerName, talking, color, voiceUserId, muted, intId,
       } = usersTalking[i];
 
-      const user = Users.findOne({ userId: voiceUserId }, { fields: { name: 1 } });
-
-      const _name = user ? user.name : 'USER';
-
       talkers[`${intId}`] = {
         color,
         talking,
         voiceUserId,
         muted,
-        callerName: _name,
+        callerName,
       };
     }
   }


### PR DESCRIPTION
This could leave users to have your audio reconnected in the main room, while joining a breakout room, causing confusion between participants.
Some information can be found in #10528

I am also reverting 0a601359bbc8c45eafc784da08f49d1e6162cfa1, because this breaks the username in breakout's participant list every time moderator activate the audio in the breakout room. This happens because, when activating audio from the main's room, the moderator joins the breakout room as a FreeSWITCH's voice user; since callerIdName contains base64-encoded name (instead of the username of the moderator), users in breakout see the encoded name, instead of the real one.
Fixing this will take more changes on akka-apps that i will separate in a new patch, containing the reverted commit + akka-apps changes. 