### PR TITLE
Reduce delay for the first reconnection attempt of audio's websocket

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -541,19 +541,19 @@ class SIPSession {
         },
       }, `User agent reconnection attempt ${attempts}`);
 
-      setTimeout(() => {
-        this.userAgent.reconnect().then(() => {
-          this._reconnecting = false;
-          resolve();
-        }).catch(() => {
+      this.userAgent.reconnect().then(() => {
+        this._reconnecting = false;
+        resolve();
+      }).catch(() => {
+        setTimeout(() => {
           this._reconnecting = false;
           this.reconnect(++attempts).then(() => {
             resolve();
           }).catch((error) => {
             reject(error);
           });
-        });
-      }, USER_AGENT_RECONNECTION_DELAY_MS);
+        }, USER_AGENT_RECONNECTION_DELAY_MS);
+      });
     });
   }
 


### PR DESCRIPTION
This is the same behavior we used to have on older sip.js version code
By doing this we reduce errors when user try to perform join/hangup during an websocket reconnection