### PR TITLE
The first element of "hostname -I" is not intended to receive the primary IP address in bbb-conf

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -169,7 +169,7 @@ fi
 if LANG=c ifconfig | grep -q 'venet0:0'; then
     IP=$(ifconfig | grep -v '127.0.0.1' | grep -E "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | tail -1 | cut -d: -f2 | awk '{ print $1}')
 else
-    IP=$(hostname -I | cut -f1 -d' ')
+	IP=$(ifconfig $(route | grep ^default | sed "s/.* //") | awk '/inet /{ print $2}' | cut -d: -f2)
 fi
 
 if [ -z "$IP" ]; then

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -169,7 +169,7 @@ fi
 if LANG=c ifconfig | grep -q 'venet0:0'; then
     IP=$(ifconfig | grep -v '127.0.0.1' | grep -E "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | tail -1 | cut -d: -f2 | awk '{ print $1}')
 else
-	IP=$(ifconfig $(route | grep ^default | sed "s/.* //") | awk '/inet /{ print $2}' | cut -d: -f2)
+    IP=$(ifconfig $(route | grep ^default | sed "s/.* //") | awk '/inet /{ print $2}' | cut -d: -f2)
 fi
 
 if [ -z "$IP" ]; then


### PR DESCRIPTION
Same pull request as in bbb-install, as it uses the same method to determine the primary ip address.

https://github.com/bigbluebutton/bbb-install/pull/286

from the hostname man: "Do not make any assumptions about the order of the output."
Other interfaces, like Docker bridges tend to be first in line in "hostname -I", which will result in a malconfigured BBB.
This change determines the primary interface by looking up the primary device of the default route.