### PR TITLE
Use INFO message as default for sending dtmf on call transfer

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -180,18 +180,13 @@ class SIPSession {
       }, CALL_TRANSFER_TIMEOUT);
 
       // This is is the call transfer code ask @chadpilkey
-      if (this.sessionSupportRTPPayloadDtmf(this.currentSession)) {
-        this.currentSession.sessionDescriptionHandler.sendDtmf(1);
-      } else {
-        // RFC4733 not supported , sending DTMF through INFO
-        logger.debug({
-          logCode: 'sip_js_rtp_payload_dtmf_not_supported',
-          extraInfo: {
-            callerIdName: this.user.callerIdName,
-          },
-        }, 'Browser do not support payload dtmf, using INFO instead');
-        this.sendDtmf(1);
-      }
+      logger.debug({
+        logCode: 'sip_js_rtp_payload_dtmf_send',
+        extraInfo: {
+          callerIdName: this.user.callerIdName,
+        },
+      }, 'Sending DTMF INFO to transfer user');
+      this.sendDtmf(1);
 
       Tracker.autorun((c) => {
         trackerControl = c;

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -181,7 +181,7 @@ class SIPSession {
 
       // This is is the call transfer code ask @chadpilkey
       logger.debug({
-        logCode: 'sip_js_rtp_payload_dtmf_send',
+        logCode: 'sip_js_rtp_payload_send_dtmf',
         extraInfo: {
           callerIdName: this.user.callerIdName,
         },


### PR DESCRIPTION
Instead of sending using rfc4733 standard, we use INFO message for all transfers
INFO message was used in older SIP.js version. Although this is not a standard for sending DTMF tones, this has more reliability (once it sent over TCP)
This might reduce occurrences of 1008