### PR TITLE
Reduce server side logging

### DIFF
--- a/bigbluebutton-html5/imports/api/cursor/server/handlers/cursorUpdate.js
+++ b/bigbluebutton-html5/imports/api/cursor/server/handlers/cursorUpdate.js
@@ -18,7 +18,7 @@ const proccess = _.throttle(() => {
         CursorStreamer(meetingId).emit('message', { meetingId, cursors });
 
         if (streamerLog) {
-          Logger.debug('CursorUpdate process has finished', { meetingId });
+          // Logger.debug('CursorUpdate process has finished', { meetingId });
         }
       } catch (error) {
         Logger.error(`Error while trying to send cursor streamer data for meeting ${meetingId}. ${error}`);

--- a/bigbluebutton-html5/imports/api/cursor/server/handlers/cursorUpdate.js
+++ b/bigbluebutton-html5/imports/api/cursor/server/handlers/cursorUpdate.js
@@ -17,9 +17,9 @@ const proccess = _.throttle(() => {
         delete cursorQueue[meetingId];
         CursorStreamer(meetingId).emit('message', { meetingId, cursors });
 
-        if (streamerLog) {
-          // Logger.debug('CursorUpdate process has finished', { meetingId });
-        }
+        // if (streamerLog) {
+        //   Logger.debug('CursorUpdate process has finished', { meetingId });
+        // }
       } catch (error) {
         Logger.error(`Error while trying to send cursor streamer data for meeting ${meetingId}. ${error}`);
       }

--- a/bigbluebutton-html5/imports/api/external-videos/server/methods/initializeExternalVideo.js
+++ b/bigbluebutton-html5/imports/api/external-videos/server/methods/initializeExternalVideo.js
@@ -10,7 +10,9 @@ const allowRecentMessages = (eventName, message) => {
     state,
   } = message;
 
-  Logger.debug('ExternalVideo Streamer auth allowed', userId, meetingId, eventName, time, rate, state);
+  Logger.debug('ExternalVideo Streamer auth allowed', {
+    userId, meetingId, eventName, time, rate, state,
+  });
   return true;
 };
 
@@ -25,6 +27,6 @@ export default function initializeExternalVideo() {
     streamer.allowEmit(allowRecentMessages);
     Logger.info(`Created External Video streamer for ${streamName}`);
   } else {
-    Logger.debug('`External Video streamer is already created', { streamName });
+    Logger.debug('External Video streamer is already created', { streamName });
   }
 }

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -420,7 +420,7 @@ public:
       - pencil
       - hand
   clientLog:
-    server: { enabled: true, level: info }
+    server: { enabled: false, level: info }
     console: { enabled: true, level: debug }
     external: { enabled: false, level: info, url: https://LOG_HOST/html5Log, method: POST, throttleInterval: 400, flushOnClose: true, logTag: "" }
 private:


### PR DESCRIPTION
* Disabled by default logging from client -> bbb-html5 (Winston). Most servers I know of utilize the path Bunyan (client side) -> nginx -> writing to file. So the logs in systemd were a duplicate.

* Adjusted two logs that appeared broken

* Removed the too-frequent logging for cursor (when debug enabled)