### PR TITLE
Improve 16x9 Support

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
@@ -65,7 +65,7 @@ const findOptimalGrid = (canvasWidth, canvasHeight, gutter, aspectRatio, numItem
     columns,
     rows,
     width: (cellWidth * columns) + gutterTotalWidth,
-    height: (cellHeight * rows) + gutterTotalHeight,
+    maxHeight: (cellHeight * rows) + gutterTotalHeight,
     filledArea: (cellWidth * cellHeight) * numItems,
   };
 };


### PR DESCRIPTION
This is a very simple patch improving the support for 16x9 cameras.

In mixed mode – if 4x3 and 16x9 cameras are present – everything looks
like it did before but if only 16x9 (or wider) cameras are present,
BigBlueButton will drop the letter boxes and show a 16x9 video
container.

### 16x9 only with presentation

![camera-16x9-only](https://user-images.githubusercontent.com/1008395/100398781-7138d900-3050-11eb-972d-b5134780d0eb.png)

### Mixed mode will be displayed as before

![multi-mixed](https://user-images.githubusercontent.com/1008395/100398793-7b5ad780-3050-11eb-90d2-1031eb9f4d80.png)

### Lots of widescreen cams will use space more efficient

![multi-16x9-only](https://user-images.githubusercontent.com/1008395/100398800-8150b880-3050-11eb-8aa7-4877aa45153d.png)

---

This relates to #6974
This relates to #9463