### PR TITLE
First version of a PeerTube player

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
@@ -6,6 +6,7 @@ import { sendMessage, onMessage, removeAllListeners } from './service';
 import logger from '/imports/startup/client/logger';
 
 import ArcPlayer from './custom-players/arc-player';
+import PeerTubePlayer from './custom-players/peertube';
 
 import { styles } from './styles';
 
@@ -20,6 +21,7 @@ const SYNC_INTERVAL_SECONDS = 5;
 const THROTTLE_INTERVAL_SECONDS = 0.5;
 const AUTO_PLAY_BLOCK_DETECTION_TIMEOUT_SECONDS = 5;
 
+ReactPlayer.addCustomPlayer(PeerTubePlayer);
 ReactPlayer.addCustomPlayer(ArcPlayer);
 
 class VideoPlayer extends Component {
@@ -74,6 +76,9 @@ class VideoPlayer extends Component {
           ecver: 2,
           controls: isPresenter ? 1 : 2,
         },
+      },
+      peertube: {
+        isPresenter,
       },
       twitch: {
         options: {

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/peertube.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/peertube.jsx
@@ -1,0 +1,211 @@
+import loadScript from 'load-script';
+import React, { Component } from 'react'
+
+const MATCH_URL = new RegExp("(https?)://(.*)/videos/watch/(.*)");
+
+const SDK_URL = 'https://unpkg.com/@peertube/embed-api/build/player.min.js';
+
+// Util function to load an external SDK or return the SDK if it is already loaded
+// From https://github.com/CookPete/react-player/blob/master/src/utils.js
+const resolves = {};
+export function getSDK (url, sdkGlobal, sdkReady = null, isLoaded = () => true, fetchScript = loadScript) {
+  if (window[sdkGlobal] && isLoaded(window[sdkGlobal])) {
+    return Promise.resolve(window[sdkGlobal])
+  }
+  return new Promise((resolve, reject) => {
+    // If we are already loading the SDK, add the resolve
+    // function to the existing array of resolve functions
+    if (resolves[url]) {
+      resolves[url].push(resolve);
+      return
+    }
+    resolves[url] = [resolve];
+    const onLoaded = sdk => {
+      // When loaded, resolve all pending promises
+      resolves[url].forEach(resolve => resolve(sdk))
+    };
+    if (sdkReady) {
+      const previousOnReady = window[sdkReady];
+      window[sdkReady] = function () {
+        if (previousOnReady) previousOnReady();
+        onLoaded(window[sdkGlobal])
+      }
+    }
+    fetchScript(url, err => {
+      if (err) {
+        reject(err);
+      }
+      window[sdkGlobal] = url;
+      if (!sdkReady) {
+        onLoaded(window[sdkGlobal])
+      }
+    })
+  })
+}
+
+export class PeerTubePlayer extends Component {
+  static displayName = 'PeerTubePlayer';
+
+  static canPlay = url => {
+    return MATCH_URL.test(url)
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.player = this;
+    this._player = null;
+
+    this.currentTime = 0;
+    this.playbackRate = 1;
+    this.getCurrentTime = this.getCurrentTime.bind(this);
+    this.getEmbedUrl = this.getEmbedUrl.bind(this);
+    this.setupEvents = this.setupEvents.bind(this);
+  }
+
+  componentDidMount () {
+    this.props.onMount && this.props.onMount(this)
+  }
+
+  getEmbedUrl = () => {
+    const { config, url } = this.props;
+    const m = MATCH_URL.exec(url);
+
+    const isPresenter = config && config.peertube && config.peertube.isPresenter;
+
+    return `${m[1]}://${m[2]}/videos/embed/${m[3]}?api=1&controls=${true}`;
+  };
+
+  load() {
+    new Promise((resolve, reject) => {
+      this.render();
+      resolve();
+    })
+    .then(() => { return getSDK(SDK_URL, 'PeerTube') })
+    .then(() => {
+      this._player = new window['PeerTubePlayer'](this.container);
+
+      this.setupEvents();
+
+      return this._player.ready.then(() => {
+        return this.props.onReady();
+      });
+    });
+  }
+
+  setupEvents(event) {
+    const player = this._player;
+
+    if (!player) {
+      return;
+    }
+
+    player.addEventListener("playbackStatusUpdate", (data) => {
+      this.currentTime = data.position;
+    });
+    player.addEventListener("playbackStatusChange", (data) => {
+      if (data === 'playing') {
+        this.props.onPlay();
+      } else {
+        this.props.onPause();
+      }
+    });
+
+  }
+
+  play() {
+    if (this._player) {
+      this._player.play();
+    }
+  }
+
+  pause() {
+    if (this._player) {
+      this._player.pause();
+    }
+  }
+
+  stop() {
+  }
+
+  seekTo(seconds) {
+    if (this._player) {
+      this._player.seek(seconds);
+    }
+  }
+
+  setVolume(fraction) {
+    // console.log("SET VOLUME");
+  }
+
+  setLoop(loop) {
+    // console.log("SET LOOP");
+  }
+
+  mute() {
+    // console.log("SET MUTE");
+  }
+
+  unmute() {
+    // console.log("SET UNMUTE");
+  }
+
+  getDuration() {
+    //console.log("GET DURATION");
+  }
+
+  getCurrentTime () {
+    return this.currentTime;
+  }
+
+  getSecondsLoaded () {
+  }
+
+  getPlaybackRate () {
+
+    if (this._player) {
+      this._player.getPlaybackRate().then((rate) => {
+        this.playbackRate = rate;
+      });
+    }
+
+    return this.playbackRate;
+  }
+
+  setPlaybackRate (rate) {
+
+    if (this._player) {
+      this._player.setPlaybackRate(rate);
+    }
+  }
+
+  render () {
+    const style = {
+      width: '100%',
+      height: '100%',
+      margin: 0,
+      padding: 0,
+      border: 0,
+      overflow: 'hidden',
+    };
+    const { url } = this.props;
+
+    return (
+      <iframe
+        key={url}
+        style={style}
+        src={this.getEmbedUrl(url)}
+        id={"peerTubeContainer"}
+        allow="autoplay; fullscreen"
+        sandbox="allow-same-origin allow-scripts allow-popups"
+        ref={(container) => {
+          this.container = container;
+        }}
+      >
+      </iframe>
+    )
+  }
+}
+
+export default PeerTubePlayer;
+


### PR DESCRIPTION
This implements a ReactPlayer wrapper for the PeerTube video API. Not all functionality is ready, but it's just enough so that we can synchronize it using ou External Video Component. Currently the regex used to detect peertube videos is very broad, since the service could be hosted in any domain, but since it will try the regex after all other services failed it should be ok. This PR was tested with the following videos:

https://peertube.fr/videos/watch/161eaaa2-92ad-47f9-b6e0-17c7585bbef1

https://tube.4aem.com/videos/watch/85107722-44c0-446e-8fcd-8ba2d5ccbdbd

https://worldofvids.com/videos/watch/6e4722a4-028d-4f51-910c-345cc95c5ff9

Currently the presenter can play, pause, seek and change the playback rate of the video and this will be synchronized along to the viewers. Viewer controls are currently being shown t ogive them an opportunity to set video volume, but this could be changed in the future.

I invite you all to test this a little more thoroughly with more users and different peertube instances.