### PR TITLE
Only set panel settings to login defaults on login, not everytime the…

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -383,13 +383,14 @@ const BaseContainer = withTracker(() => {
   }
 
   if (getFromUserSettings('bbb_show_participants_on_login', true) && !deviceInfo.type().isPhone) {
-    Session.set('openPanel', 'userlist');
     if (CHAT_ENABLED && getFromUserSettings('bbb_show_public_chat_on_login', !Meteor.settings.public.chat.startClosed)) {
-      Session.set('openPanel', 'chat');
-      Session.set('idChatOpen', PUBLIC_CHAT_ID);
+      Session.setDefault('openPanel', 'chat');
+      Session.setDefault('idChatOpen', PUBLIC_CHAT_ID);
+    } else {
+      Session.setDefault('openPanel', 'userlist');
     }
   } else {
-    Session.set('openPanel', '');
+    Session.setDefault('openPanel', '');
   }
 
   const codeError = Session.get('codeError');


### PR DESCRIPTION
… base component renders

### What does this PR do?

Only applies the config settings `bbb_show_participants_on_login` and `bbb_show_public_chat_on_login`
on login, instead of every time the base component renders.

### Closes Issue(s)

closes #10374
closes #9994 (maybe; I think it's the same issue)

### Motivation

Once I close the user list window, it would re-open every time a new video stream started.  I think the user list window should remain in the same state that it was in when a new video starts.

### More

I haven't fully tested this on the latest version of the `develop` branch.