### PR TITLE
Empty After= may confuses systemd

### DIFF
--- a/bigbluebutton-config/bin/apply-lib.sh
+++ b/bigbluebutton-config/bin/apply-lib.sh
@@ -184,7 +184,6 @@ HERE
   mkdir -p /etc/systemd/system/bbb-webrtc-sfu.service.d
   cat > /etc/systemd/system/bbb-webrtc-sfu.service.d/override.conf << HERE
 [Unit]
-After=
 After=syslog.target network.target freeswitch.service kurento-media-server-8888.service kurento-media-server-8889.service kurento-media-server-8890.service
 HERE
 


### PR DESCRIPTION
### What does this PR do?

Removes empty `After=` in creation statement for `/etc/systemd/system/bbb-webrtc-sfu.service.d/override.conf` in 
`apply-lib.sh`.

### Motivation

systemd send a warning for this line.

Thanks to @davka :-)

Kind regards
Timm


