### PR TITLE
Option to eject voice users with no matching user

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
@@ -46,6 +46,7 @@ trait SystemConfiguration {
   lazy val voiceConfRecordCodec = Try(config.getString("voiceConf.recordCodec")).getOrElse("wav")
   lazy val checkVoiceRecordingInterval = Try(config.getInt("voiceConf.checkRecordingInterval")).getOrElse(19)
   lazy val syncVoiceUsersStatusInterval = Try(config.getInt("voiceConf.syncUserStatusInterval")).getOrElse(43)
+  lazy val ejectRogueVoiceUsers = Try(config.getBoolean("voiceConf.ejectRogueVoiceUsers")).getOrElse(false)
 
   lazy val recordingChapterBreakLengthInMinutes = Try(config.getInt("recording.chapterBreakLengthInMinutes")).getOrElse(0)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
@@ -4,7 +4,7 @@ import org.bigbluebutton.LockSettingsUtil
 import org.bigbluebutton.common2.msgs.{ BbbClientMsgHeader, BbbCommonEnvCoreMsg, BbbCoreEnvelope, ConfVoiceUser, MessageTypes, Routing, UserJoinedVoiceConfToClientEvtMsg, UserJoinedVoiceConfToClientEvtMsgBody, UserLeftVoiceConfToClientEvtMsg, UserLeftVoiceConfToClientEvtMsgBody, UserMutedVoiceEvtMsg, UserMutedVoiceEvtMsgBody }
 import org.bigbluebutton.core.apps.breakout.BreakoutHdlrHelpers
 import org.bigbluebutton.core.bus.InternalEventBus
-import org.bigbluebutton.core.models.{ VoiceUserState, VoiceUsers }
+import org.bigbluebutton.core.models.{ Users2x, VoiceUserState, VoiceUsers }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core2.message.senders.MsgBuilder
@@ -135,6 +135,19 @@ object VoiceApp {
             } else {
               // Update the user status to indicate they are still in the voice conference.
               VoiceUsers.setLastStatusUpdate(liveMeeting.voiceUsers, vu)
+            }
+
+            // Purge voice users that don't have a matching user record
+            // Avoid this if the meeting is a breakout room since might be real
+            // voice users participating
+            if (ejectRogueVoiceUsers && !liveMeeting.props.meetingProp.isBreakout) {
+              Users2x.findWithIntId(liveMeeting.users2x, cvu.intId) match {
+                case Some(_) =>
+                case None =>
+                  println(s"Ejecting rogue voice user. meetingId=${liveMeeting.props.meetingProp.intId} userId=${cvu.intId}")
+                  val event = MsgBuilder.buildEjectUserFromVoiceConfSysMsg(liveMeeting.props.meetingProp.intId, liveMeeting.props.voiceProp.voiceConf, cvu.voiceUserId)
+                  outGW.send(event)
+              }
             }
           case None =>
             handleUserJoinedVoiceConfEvtMsg(

--- a/akka-bbb-apps/src/universal/conf/application.conf
+++ b/akka-bbb-apps/src/universal/conf/application.conf
@@ -90,6 +90,8 @@ voiceConf {
   checkRecordingInterval = 23
   # Internval seconds to sync voice users status.
   syncUserStatusInterval = 41
+  # Voice users with no matching user record
+  ejectRogueVoiceUsers = false
 }
 
 recording {


### PR DESCRIPTION
Reconnects may introduce ghost voice users in a meeting when the client fails to
rejoin but the audio connection remains active.

While fetching for the voice conference user's status, apps can now check if a
voice user has a matching user record. If it doesn't, eject the voice user.

**TODO**:
 - Avoid dial-in users to be ejected
 - Once dial-in is covered, the breakout room check can be removed