### PR TITLE
adds data-tests to chat all different types of messages

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-list/message-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-list/message-list-item/component.jsx
@@ -89,6 +89,7 @@ class MessageListItem extends Component {
                   key={message.id ? message.id : _.uniqueId('id-')}
                   text={message.text}
                   time={message.time}
+                  isSystemMessage={message.id ? true : false}
                   chatAreaId={chatAreaId}
                   handleReadMessage={handleReadMessage}
                 />
@@ -109,6 +110,7 @@ class MessageListItem extends Component {
       scrollArea,
       intl,
       messages,
+      chatUserMessageItem,
     } = this.props;
 
     if (messages && messages[0].text.includes('bbb-published-poll-<br/>')) {
@@ -147,7 +149,7 @@ class MessageListItem extends Component {
                 <FormattedTime value={dateTime} />
               </time>
             </div>
-            <div className={styles.messages} data-test="chatUserMessage">
+            <div className={styles.messages}>
               {messages.map(message => (
                 <Message
                   className={(regEx.test(message.text) ? styles.hyperlink : styles.message)}
@@ -155,6 +157,7 @@ class MessageListItem extends Component {
                   text={message.text}
                   time={message.time}
                   chatAreaId={chatAreaId}
+                  chatUserMessageItem={true}
                   lastReadMessageTime={lastReadMessageTime}
                   handleReadMessage={handleReadMessage}
                   scrollArea={scrollArea}

--- a/bigbluebutton-html5/imports/ui/components/chat/message-list/message-list-item/message/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-list/message-list-item/message/component.jsx
@@ -186,7 +186,7 @@ class MessageListItem extends PureComponent {
         style={{ borderLeft: `3px ${color} solid` }}
         ref={(ref) => { this.text = ref; }}
         dangerouslySetInnerHTML={{ __html: isDefaultPoll ? formatBoldBlack(_text) : _text }}
-        data-test="chatMessageText"
+        data-test="chatPollMessageText"
       />
     );
   }
@@ -196,6 +196,8 @@ class MessageListItem extends PureComponent {
       text,
       type,
       className,
+      isSystemMessage,
+      chatUserMessageItem,
     } = this.props;
 
     if (type === 'poll') return this.renderPollListItem();
@@ -205,7 +207,7 @@ class MessageListItem extends PureComponent {
         className={className}
         ref={(ref) => { this.text = ref; }}
         dangerouslySetInnerHTML={{ __html: text }}
-        data-test="chatMessageText"
+        data-test={isSystemMessage ? 'chatWelcomeMessageText' : chatUserMessageItem ? 'chatUserMessageText' : 'chatClearMessageText'}
       />
     );
   }


### PR DESCRIPTION
This PR adds data-tests to all different types of chat messages **system**/**user**:
- adds **data-test="chatWelcomeMessageText"** to Welcome chat message
- adds **data-test="chatUserMessageText"** to Users chat messages
- adds **data-test="chatPollMessageText"** to Poll results chat messages
- adds **data-test="chatClearMessageText"** to Clear Messages chat message

It's gonna be used to fix and update old automated tests and add Welcome Message test spec to Chat test suite.