### PR TITLE
Automate Conflict Check for Pull Requests

### DIFF
--- a/.github/workflows/check-merge-conflict.yml
+++ b/.github/workflows/check-merge-conflict.yml
@@ -1,0 +1,21 @@
+name: Merge conflict check
+on:
+  push:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for dirty pull requests
+        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        with:
+          dirtyLabel: has-conflicts
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: |
+              This pull request has conflicts ☹
+              Please resolve those so we can review the pull request.
+              Thanks.


### PR DESCRIPTION
This patch adds a simple GitHub Actions workflow which will
automatically check open pull requests on code changes, adding a comment
and a label if the pull request has conflicts. The label will
automatically be removed again once the conflict has been resolved.

We use this for a while now with opencast and it really helps since
people do not have to manually check if their pull requests need an
update any longer.

An example, of hoe this looks in action can be found at
https://github.com/opencast/opencast/pull/2053#issuecomment-734987582
