### PR TITLE
Publish recorded shared notes' content

### DIFF
--- a/record-and-playback/presentation/scripts/process/presentation.rb
+++ b/record-and-playback/presentation/scripts/process/presentation.rb
@@ -237,6 +237,11 @@ if not FileTest.directory?(target_dir)
       BigBlueButton.process_deskshare_videos(target_dir, temp_dir, meeting_id, deskshare_width, deskshare_height, presentation_props['video_formats'])
     end
 
+    # Copy shared notes from raw files
+    if !Dir["#{raw_archive_dir}/notes/*"].empty?
+      FileUtils.cp_r("#{raw_archive_dir}/notes", target_dir)
+    end
+
     process_done = File.new("#{recording_dir}/status/processed/#{meeting_id}-presentation.done", "w")
     process_done.write("Processed #{meeting_id}")
     process_done.close

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1267,6 +1267,10 @@ begin
           FileUtils.cp("#{$process_dir}/presentation_text.json", package_dir)
         end
 
+        if File.exist?("#{$process_dir}/notes/notes.html")
+          FileUtils.cp("#{$process_dir}/notes/notes.html", package_dir)
+        end
+
         processing_time = File.read("#{$process_dir}/processing_time")
 
         @doc = Nokogiri::XML(File.open("#{$process_dir}/events.xml"))


### PR DESCRIPTION
Collects the shared notes' HTML raw data and publishes it along with the other
recording files. The playback will fetch for this file and include an option to
display it's content over the chat.

Along with the new playback (https://github.com/bigbluebutton/bbb-playback)
this can be used to check the last state of the shared notes from a meeting that
was recorded.

![100785897-13a9e100-33f0-11eb-97cd-80eb9d52f809](https://user-images.githubusercontent.com/1778398/101162330-f738bf00-3610-11eb-9ccf-5515e1876484.png)
