### PR TITLE
Added setNumberOfHTML5Processes to apply-lib.sh

### DIFF
--- a/bigbluebutton-config/bin/apply-lib.sh
+++ b/bigbluebutton-config/bin/apply-lib.sh
@@ -225,6 +225,19 @@ disableMultipleKurentos() {
   yq w -i $KURENTO_CONFIG balancing-strategy ROUND_ROBIN
 }
 
+setNumberOfHTML5Processes() {
+  HTML5_RESTRICTIONS_FILE=/usr/share/meteor/bundle/bbb-html5.conf
+  NUMBER_OF_PROCESSES=`echo $1 | bc`
+
+  source $HTML5_RESTRICTIONS_FILE
+
+  echo "setNumberOfHTML5Processes with number of processes in the range ($INSTANCE_MIN to $INSTANCE_MAX)"
+  echo "setNumberOfHTML5Processes with NUMBER_OF_PROCESSES=$NUMBER_OF_PROCESSES"
+
+  sed -i -e "s|DESIRED_INSTANCE_COUNT=.*$|DESIRED_INSTANCE_COUNT=$NUMBER_OF_PROCESSES|g" $HTML5_RESTRICTIONS_FILE
+
+  systemctl restart bbb-html5
+}
 
 
 notCalled() {
@@ -253,6 +266,9 @@ source /etc/bigbluebutton/bbb-conf/apply-lib.sh
 #enableHTML5WebcamPagination
 
 #enableMultipleKurentos
+
+#setNumberOfHTML5Processes 2
+
 
 HERE
 chmod +x /etc/bigbluebutton/bbb-conf/apply-config.sh


### PR DESCRIPTION
Activated by calling `setNumberOfHTML5Processes 2` (or change 2 with different number, representing the desired number of parallel instances of nodejs)

The checks for min / max acceptable values are done in `workers-start.sh` (included in bbb-html5)

Related to #10933  #10868 #10860