### PR TITLE
video-provider: add video pagination UI toggle

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/component.jsx
@@ -70,6 +70,7 @@ const propTypes = {
     chatAudioAlerts: PropTypes.bool,
     chatPushAlerts: PropTypes.bool,
     userJoinAudioAlerts: PropTypes.bool,
+    paginationEnabled: PropTypes.bool,
     fallbackLocale: PropTypes.string,
     fontSize: PropTypes.string,
     locale: PropTypes.string,

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -5,6 +5,7 @@ import Toggle from '/imports/ui/components/switch/component';
 import { defineMessages, injectIntl } from 'react-intl';
 import BaseMenu from '../base/component';
 import { styles } from '../styles';
+import VideoService from '/imports/ui/components/video-provider/service';
 
 const MIN_FONTSIZE = 0;
 const CHAT_ENABLED = Meteor.settings.public.chat.enabled;
@@ -69,6 +70,10 @@ const intlMessages = defineMessages({
   noLocaleOptionLabel: {
     id: 'app.submenu.application.noLocaleOptionLabel',
     description: 'default change language option when no locales available',
+  },
+  paginationEnabledLabel: {
+    id: 'app.submenu.application.paginationEnabledLabel',
+    description: 'enable/disable video pagination',
   },
 });
 
@@ -156,6 +161,35 @@ class ApplicationMenu extends BaseMenu {
     const obj = this.state;
     obj.settings[fieldname] = e.target.value.toLowerCase().replace('_', '-');
     this.handleUpdateSettings('application', obj.settings);
+  }
+
+  renderPaginationToggle() {
+    // See VideoService's method for an explanation
+    if (!VideoService.shouldRenderPaginationToggle()) return;
+
+    const { intl } = this.props;
+
+    return (
+      <div className={styles.row}>
+        <div className={styles.col} aria-hidden="true">
+          <div className={styles.formElement}>
+            <label className={styles.label}>
+              {intl.formatMessage(intlMessages.paginationEnabledLabel)}
+            </label>
+          </div>
+        </div>
+        <div className={styles.col}>
+          <div className={cx(styles.formElement, styles.pullContentRight)}>
+            <Toggle
+              icons={false}
+              defaultChecked={this.state.settings.paginationEnabled}
+              onChange={() => this.handleToggle('paginationEnabled')}
+              ariaLabel={intl.formatMessage(intlMessages.paginationEnabledLabel)}
+            />
+          </div>
+        </div>
+      </div>
+    );
   }
 
   render() {
@@ -287,6 +321,8 @@ class ApplicationMenu extends BaseMenu {
               </div>
             </div>
           </div>
+
+          {this.renderPaginationToggle()}
 
           <div className={styles.row}>
             <div className={styles.col} aria-hidden="true">

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -25,13 +25,14 @@ const ENABLE_NETWORK_MONITORING = Meteor.settings.public.networkMonitoring.enabl
 const MIRROR_WEBCAM = Meteor.settings.public.app.mirrorOwnWebcam;
 const CAMERA_QUALITY_THRESHOLDS = Meteor.settings.public.kurento.cameraQualityThresholds.thresholds || [];
 const {
-  enabled: PAGINATION_ENABLED,
+  paginationToggleEnabled: PAGINATION_TOGGLE_ENABLED,
   pageChangeDebounceTime: PAGE_CHANGE_DEBOUNCE_TIME,
   desktopPageSizes: DESKTOP_PAGE_SIZES,
   mobilePageSizes: MOBILE_PAGE_SIZES,
 } = Meteor.settings.public.kurento.pagination;
 
 const TOKEN = '_';
+const ENABLE_PAGINATION_SESSION_VAR = 'enablePagination';
 
 class VideoService {
   // Paginated streams: sort with following priority: local -> presenter -> alphabetic
@@ -195,8 +196,13 @@ class VideoService {
     return Auth.authenticateURL(SFU_URL);
   }
 
+  shouldRenderPaginationToggle() {
+    // Only enable toggle if configured to do so and if we have a page size properly setup
+    return PAGINATION_TOGGLE_ENABLED && (this.getMyPageSize() > 0);
+  }
+
   isPaginationEnabled () {
-    return PAGINATION_ENABLED && (this.getMyPageSize() > 0);
+    return Settings.application.paginationEnabled && (this.getMyPageSize() > 0);
   }
 
   setNumberOfPages (numberOfPublishers, numberOfSubscribers, pageSize) {
@@ -319,7 +325,7 @@ class VideoService {
     // Pagination is either explictly disabled or pagination is set to 0 (which
     // is equivalent to disabling it), so return the mapped streams as they are
     // which produces the original non paginated behaviour
-    if (!PAGINATION_ENABLED || pageSize === 0) {
+    if (!this.isPaginationEnabled() || pageSize === 0) {
       return {
         streams: mappedStreams.sort(VideoService.sortMeshStreams),
         totalNumberOfStreams: mappedStreams.length
@@ -761,4 +767,5 @@ export default {
   getPreviousVideoPage: () => videoService.getPreviousVideoPage(),
   getNextVideoPage: () => videoService.getNextVideoPage(),
   getPageChangeDebounceTime: () => { return PAGE_CHANGE_DEBOUNCE_TIME },
+  shouldRenderPaginationToggle: () => videoService.shouldRenderPaginationToggle(),
 };

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -44,6 +44,7 @@ public:
         chatPushAlerts: false
         userJoinAudioAlerts: false
         userJoinPushAlerts: false
+        paginationEnabled: false
         fallbackLocale: en
         overrideLocale: null
       audio:
@@ -210,7 +211,11 @@ public:
           profile: low-u30
     pagination:
       # whether to globally enable or disable pagination.
-      enabled: false
+      # WARNING: the pagination.enabled setting has moved to
+      # public.app.defaultSettings.application.paginationEnabled
+      #
+      # show a pagination toggle in settings for the user enable/disable it
+      paginationToggleEnabled: true
       # how long (in ms) the negotiation will be debounced after a page change.
       pageChangeDebounceTime: 2500
       # video page sizes for DESKTOP endpoints. It stands for the number of SUBSCRIBER streams.

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -304,6 +304,7 @@
     "app.submenu.application.languageLabel": "Application Language",
     "app.submenu.application.languageOptionLabel": "Choose language",
     "app.submenu.application.noLocaleOptionLabel": "No active locales",
+    "app.submenu.application.paginationEnabledLabel": "Video pagination",
     "app.submenu.audio.micSourceLabel": "Microphone source",
     "app.submenu.audio.speakerSourceLabel": "Speaker source",
     "app.submenu.audio.streamVolumeLabel": "Your audio stream volume",


### PR DESCRIPTION
### What does this PR do?
  - Add a configuration toggle in Settings -> Application to allow an user to enable/disable pagination on the fly/inside the client
  - pagination.enabled has moved to public.app.defaultSettings.application.paginationEnabled
  - pagination.paginationToggleEnabled: boolean, controls the toggle rendering. 
    * Admins can control whether the toggle is enabled apart from the per-user pagination configurations
    * The toggle will only render for an user if that flag is **true** && the user's **configured page size** is > 0


### Closes Issue(s)

closes https://github.com/bigbluebutton/bigbluebutton/issues/10961

### Motivation

See issue #10961.
Giving agency to users with enough horsepower.

### More
Opening this as a draft. I need to test it more thoroughly. I also think I could move the setting to data savings.
And I also think I could make the toggle more flexible, ie:
  - Do not rely on pagination size 0 to not show it, only the flag
  - Add an initial pagination state for each user-environment combo type
    * eg moderator at desktop, no pagination at start: pagination.moderator.enabled: false, pagination.moderator.pageSize: 5. 
      - Toggle  allows the moderator in the environment to toggle it on or off _if the toggle is enabled_ (pagination.moderator.toggleEnabled: true)
