### PR TITLE
Fix: Presentation publishing fails when run on NFS storage

### DIFF
--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -31,7 +31,7 @@ require 'fastimage' # require fastimage to get the image size of the slides (gem
 
 # This script lives in scripts/archive/steps while properties.yaml lives in scripts/
 bbb_props = YAML::load(File.open('../../core/scripts/bigbluebutton.yml'))
-$presentation_props = YAML::load(File.open('presentation.yml'))
+$presentation_props = YAML::load(File.read('presentation.yml'))
 
 # There's a couple of places where stuff is mysteriously divided or multiplied
 # by 2. This is just here to call out how spooky that is.
@@ -926,7 +926,7 @@ def processPresentation(package_dir)
   # Iterate through the events.xml and store the events, building the
   # xml files as we go
   last_timestamp = 0.0
-  events_xml = Nokogiri::XML(File.open("#{$process_dir}/events.xml"))
+  events_xml = Nokogiri::XML(File.read("#{$process_dir}/events.xml"))
   events_xml.xpath('/recording/event').each do |event|
     eventname = event['eventname']
     last_timestamp = timestamp =
@@ -1269,7 +1269,7 @@ begin
 
         processing_time = File.read("#{$process_dir}/processing_time")
 
-        @doc = Nokogiri::XML(File.open("#{$process_dir}/events.xml"))
+        @doc = Nokogiri::XML(File.read("#{$process_dir}/events.xml"))
 
         # Retrieve record events and calculate total recording duration.
         $rec_events = BigBlueButton::Events.match_start_and_stop_rec_events(
@@ -1300,7 +1300,7 @@ begin
 
         # Update state and add playback to metadata.xml
         ## Load metadata.xml
-        metadata = Nokogiri::XML(File.open("#{package_dir}/metadata.xml"))
+        metadata = Nokogiri::XML(File.read("#{package_dir}/metadata.xml"))
         ## Update state
         recording = metadata.root
         state = recording.at_xpath("state")


### PR DESCRIPTION
# What does this PR do?

This is the same as #10252 but with a new target branch.

During presentation publishing, files are opened but not closed. On NFS storage, this prevents cleanup of the parent directory after the actual work is done. The scripts fail with an `Directory not empty @ dir_s_rmdir` error. PR #9857 tried to fix this, but missed some spots. This PR fixes the "publish" phase, which was missed by the previous PR.

### Closes Issue(s)

closes #9062
closes #9110

Both are already closed, though.

### Motivation

We run a large BBB Instance on NFS storage and hat custom fixes for this issue in place. We removed the custom fixes thinking this issue is resolved. It broke again. Thus, this PR.

### More

That's all.