### PR TITLE
2.2.x: Fix voiceBridge collision

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiErrors.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiErrors.java
@@ -36,6 +36,10 @@ public class ApiErrors {
 		errors.add(new String[] {"NotUniqueMeetingID", "A meeting already exists with that meeting ID.  Please use a different meeting ID."});
 	}
 
+	public void nonUniqueVoiceBridgeError() {
+		errors.add(new String[] {"nonUniqueVoiceBridge", "The selected voice bridge is already in use."});
+	}
+
 	public void invalidMeetingIdError() {
 		errors.add(new String[] {"invalidMeetingId", "The meeting ID that you supplied did not match any existing meetings"});
 	}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -457,7 +457,7 @@ public class MeetingService implements MessageListener {
           return null;
       for (Map.Entry<String, Meeting> entry : meetings.entrySet()) {
           Meeting m = entry.getValue();
-          if (m.getTelVoice() == telVoice) {
+          if (telVoice.equals(m.getTelVoice())) {
               if (!m.isForciblyEnded())
                   return m;
           }
@@ -470,7 +470,7 @@ public class MeetingService implements MessageListener {
           return null;
       for (Map.Entry<String, Meeting> entry : meetings.entrySet()) {
           Meeting m = entry.getValue();
-          if (m.getWebVoice() == webVoice) {
+          if (webVoice.equals(m.getWebVoice())) {
               if (!m.isForciblyEnded())
                   return m;
           }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -290,8 +290,10 @@ public class MeetingService implements MessageListener {
 
   public synchronized boolean createMeeting(Meeting m) {
     String internalMeetingId = paramsProcessorUtil.convertToInternalMeetingId(m.getExternalId());
-    Meeting existing = getNotEndedMeetingWithId(internalMeetingId);
-    if (existing == null) {
+    Meeting existingId = getNotEndedMeetingWithId(internalMeetingId);
+    Meeting existingTelVoice = getNotEndedMeetingWithTelVoice(m.getTelVoice());
+    Meeting existingWebVoice = getNotEndedMeetingWithWebVoice(m.getWebVoice());
+    if (existingId == null && existingTelVoice == null && existingWebVoice == null) {
       meetings.put(m.getInternalId(), m);
       handle(new CreateMeeting(m));
       return true;
@@ -443,6 +445,32 @@ public class MeetingService implements MessageListener {
           String key = entry.getKey();
           if (key.startsWith(meetingId)) {
               Meeting m = entry.getValue();
+              if (!m.isForciblyEnded())
+                  return m;
+          }
+      }
+      return null;
+  }
+
+  public Meeting getNotEndedMeetingWithTelVoice(String telVoice) {
+      if (telVoice == null)
+          return null;
+      for (Map.Entry<String, Meeting> entry : meetings.entrySet()) {
+          Meeting m = entry.getValue();
+          if (m.getTelVoice() == telVoice) {
+              if (!m.isForciblyEnded())
+                  return m;
+          }
+      }
+      return null;
+  }
+
+  public Meeting getNotEndedMeetingWithWebVoice(String webVoice) {
+      if (webVoice == null)
+          return null;
+      for (Map.Entry<String, Meeting> entry : meetings.entrySet()) {
+          Meeting m = entry.getValue();
+          if (m.getWebVoice() == webVoice) {
               if (!m.isForciblyEnded())
                   return m;
           }

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -136,6 +136,20 @@ class ApiController {
       return
     }
 
+    // Ensure unique TelVoice. Uniqueness is not guaranteed by paramsProcessorUtil.
+    if (!params.voiceBridge) {
+      // Try up to 10 times. We should find a valid telVoice quickly unless
+      // the server hosts ~100k meetings (default 5-digit telVoice)
+      for (int i in 1..10) {
+        String telVoice = paramsProcessorUtil.processTelVoice("");
+        if (!meetingService.getNotEndedMeetingWithTelVoice(telVoice)) {
+          params.voiceBridge = telVoice;
+          break;
+        }
+      }
+      // Still no unique voiceBridge found? Let createMeeting handle it.
+    }
+
     Meeting newMeeting = paramsProcessorUtil.processCreateParams(params)
 
     if (meetingService.createMeeting(newMeeting)) {
@@ -167,6 +181,14 @@ class ApiController {
         }
 
         return
+      } else {
+        Meeting existingTelVoice = meetingService.getNotEndedMeetingWithTelVoice(newMeeting.getTelVoice());
+        Meeting existingWebVoice = meetingService.getNotEndedMeetingWithWebVoice(newMeeting.getWebVoice());
+        if (existingTelVoice != null || existingWebVoice != null) {
+          log.error "VoiceBridge already in use by another meeting (different meetingId)"
+          errors.nonUniqueMeetingIdError()
+          respondWithErrors(errors)
+        }
       }
     }
   }

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -186,7 +186,7 @@ class ApiController {
         Meeting existingWebVoice = meetingService.getNotEndedMeetingWithWebVoice(newMeeting.getWebVoice());
         if (existingTelVoice != null || existingWebVoice != null) {
           log.error "VoiceBridge already in use by another meeting (different meetingId)"
-          errors.nonUniqueMeetingIdError()
+          errors.nonUniqueVoiceBridgeError()
           respondWithErrors(errors)
         }
       }


### PR DESCRIPTION
Cherry-picked the commits from https://github.com/bigbluebutton/bigbluebutton/pull/9251 and https://github.com/bigbluebutton/bigbluebutton/pull/9855 which were already merged into 2.3.x, but not yet into 2.2.x.
Also see Issue #9024

Description from the cherry-picked PR 9251 from @elor:
```
Fixes #9024 (voiceBridge collision for two independent meetings) by performing two changes:

1. Abort meeting creation if either telVoice or webVoice collide with an existing meeting

2. If telVoice is generated by BBB (i.e. not passed to the API), try up to 10 times for a unique telVoice

Since the issue is extremely rare, step 2 should find a valid telVoice within 1 try.

The fix was tested by forcing telVoice collisions through the API as well as by setting colliding values in ApiController.groovy and adjusting the random number generation in ParamsProcessorUtil.java.
Those changes were cleaned before submission.

Normal behavior of BBB is unchanged, this should only handle the corner cases.

```

Co-Authored-By: @elor
Co-Authored-By: @pedrobmarin 