### PR TITLE
Prevent calling stopUserTyping when parameters are undefined

### DIFF
--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/methods/stopUserTyping.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/methods/stopUserTyping.js
@@ -10,7 +10,7 @@ export default function stopUserTyping() {
     userId: requesterUserId,
   });
 
-  if (userTyping) {
+  if (userTyping && meetingId && requesterUserId) {
     stopTyping(meetingId, requesterUserId, true);
   }
 }


### PR DESCRIPTION
### What does this PR do?

Prevent calling `stopUserTyping` when parameteres are `undefined`.

closes #10977 