### PR TITLE
Add keep alive message to audio's websocket 

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -33,6 +33,8 @@ const USER_AGENT_RECONNECTION_DELAY_MS = 5000;
 const USER_AGENT_CONNECTION_TIMEOUT_MS = 5000;
 const ICE_GATHERING_TIMEOUT = MEDIA.iceGatheringTimeout || 5000;
 const BRIDGE_NAME = 'sip';
+const WEBSOCKET_KEEP_ALIVE_INTERVAL = MEDIA.websocketKeepAliveInterval || 0;
+const WEBSOCKET_KEEP_ALIVE_DEBOUNCE = MEDIA.websocketKeepAliveDebounce || 10;
 
 const getAudioSessionNumber = () => {
   let currItem = parseInt(sessionStorage.getItem(AUDIO_SESSION_NUM_KEY), 10);
@@ -368,6 +370,8 @@ class SIPSession {
         transportOptions: {
           server: `${(protocol === 'https:' ? 'wss://' : 'ws://')}${hostname}/ws?${token}`,
           connectionTimeout: USER_AGENT_CONNECTION_TIMEOUT_MS,
+          keepAliveInterval: WEBSOCKET_KEEP_ALIVE_INTERVAL,
+          keepAliveDebounce: WEBSOCKET_KEEP_ALIVE_DEBOUNCE,
         },
         sessionDescriptionHandlerFactoryOptions: {
           peerConnectionConfiguration: {

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -35,6 +35,7 @@ const ICE_GATHERING_TIMEOUT = MEDIA.iceGatheringTimeout || 5000;
 const BRIDGE_NAME = 'sip';
 const WEBSOCKET_KEEP_ALIVE_INTERVAL = MEDIA.websocketKeepAliveInterval || 0;
 const WEBSOCKET_KEEP_ALIVE_DEBOUNCE = MEDIA.websocketKeepAliveDebounce || 10;
+const TRACE_SIP = MEDIA.traceSip || false;
 
 const getAudioSessionNumber = () => {
   let currItem = parseInt(sessionStorage.getItem(AUDIO_SESSION_NUM_KEY), 10);
@@ -372,6 +373,7 @@ class SIPSession {
           connectionTimeout: USER_AGENT_CONNECTION_TIMEOUT_MS,
           keepAliveInterval: WEBSOCKET_KEEP_ALIVE_INTERVAL,
           keepAliveDebounce: WEBSOCKET_KEEP_ALIVE_DEBOUNCE,
+          traceSip: TRACE_SIP,
         },
         sessionDescriptionHandlerFactoryOptions: {
           peerConnectionConfiguration: {

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -301,6 +301,8 @@ public:
     #Debounce time (seconds) for sending SIP.js's websocket keep alive message.
     #If not set, default value is 10.
     websocketKeepAliveDebounce: 10
+    #Trace sip/audio messages in browser. If not set, default value is false.
+    traceSip: false
   presentation:
     defaultPresentationFile: default.pdf
     panZoomThrottle: 32

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -293,6 +293,14 @@ public:
     #user activates microphone.
     iceGatheringTimeout: 5000
     sipjsHackViaWs: false
+    #Websocket keepAlive interval (seconds). You may set this to prevent
+    #websocket disconnection in some environments. When set, BBB will send
+    #'\r\n\r\n' string through SIP.js's websocket. If not set, default value
+    #is 0.
+    websocketKeepAliveInterval: 30
+    #Debounce time (seconds) for sending SIP.js's websocket keep alive message.
+    #If not set, default value is 10.
+    websocketKeepAliveDebounce: 10
   presentation:
     defaultPresentationFile: default.pdf
     panZoomThrottle: 32


### PR DESCRIPTION
This was added as an option (websocketKeepAliveInterval), which is the interval to send keep alive messages.
Setting websocketKeepAliveInterval to 0 disables the keep alive, producing the same old behavior.
This helps avoid websocket disconnection due to socket inactivity, preventing it to unnecessarily reconnect.
Also, sometimes reconnect fails and error 1005 is triggered.
Fixes problems reported in bigbluebutton#10985.
Reduces occurrences of error 1005.
Also added option "traceSip in settings.yml (SIP tracing is now disabled by default)