### PR TITLE
bbb-web to loadbalance bbb-html5 instances

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -159,16 +159,6 @@ class BigBlueButtonActor(
   }
 
   private def handleGetAllMeetingsReqMsg(msg: GetAllMeetingsReqMsg): Unit = {
-    log.info("________________________________________")
-    log.info("________________________________________")
-    log.info("________________________________________" + msg.body.html5InstanceId)
-    log.info("________________________________________")
-    log.info("________________________________________")
-    log.info("________________________________________")
-    RunningMeetings.meetings(meetings).foreach(m => {
-      log.info("______________________________________aa__" + m.props.systemProps.html5InstanceId)
-    })
-    log.info("________________________________________")
     RunningMeetings.meetings(meetings).filter(_.props.systemProps.html5InstanceId == msg.body.html5InstanceId).foreach(m => {
       m.actorRef ! msg
     })

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -159,7 +159,17 @@ class BigBlueButtonActor(
   }
 
   private def handleGetAllMeetingsReqMsg(msg: GetAllMeetingsReqMsg): Unit = {
+    log.info("________________________________________")
+    log.info("________________________________________")
+    log.info("________________________________________" + msg.body.html5InstanceId)
+    log.info("________________________________________")
+    log.info("________________________________________")
+    log.info("________________________________________")
     RunningMeetings.meetings(meetings).foreach(m => {
+      log.info("______________________________________aa__" + m.props.systemProps.html5InstanceId)
+    })
+    log.info("________________________________________")
+    RunningMeetings.meetings(meetings).filter(_.props.systemProps.html5InstanceId == msg.body.html5InstanceId).foreach(m => {
       m.actorRef ! msg
     })
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
@@ -154,7 +154,7 @@ class WhiteboardModel extends SystemConfiguration {
 
       var newUsersAnnotations: List[AnnotationVO] = oldAnnotationOption match {
         //As part of the whiteboard improvments for the HTML5 client it no longer sends
-        //DRAW_START and DRAW_UPDATE events (#9019). Client now sends drawEndOnly in the 
+        //DRAW_START and DRAW_UPDATE events (#9019). Client now sends drawEndOnly in the
         //SendWhiteboardAnnotationPubMsg so akka knows not to expect usersAnnotations to be accumulating.
         case Some(annotation) if (drawEndOnly == true) => usersAnnotations
         case Some(annotation)                          => usersAnnotations.tail

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SyncGetGroupChatsInfoMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SyncGetGroupChatsInfoMsgHdlr.scala
@@ -11,7 +11,7 @@ trait SyncGetGroupChatsInfoMsgHdlr {
   def handleSyncGetGroupChatsInfo(state: MeetingState2x, liveMeeting: LiveMeeting, bus: MessageBus): MeetingState2x = {
 
     def buildSyncGetGroupChatsRespMsg(allChats: Vector[GroupChatInfo]): BbbCommonEnvCoreMsg = {
-      val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, liveMeeting.props.meetingProp.intId, "nodeJSapp")
+      val routing = Routing.addMsgToHtml5InstanceIdRouting(liveMeeting.props.meetingProp.intId, liveMeeting.props.systemProps.html5InstanceId.toString)
       val envelope = BbbCoreEnvelope(SyncGetGroupChatsRespMsg.NAME, routing)
       val header = BbbClientMsgHeader(SyncGetGroupChatsRespMsg.NAME, liveMeeting.props.meetingProp.intId, "nodeJSapp")
       val body = SyncGetGroupChatsRespMsgBody(allChats)
@@ -21,7 +21,7 @@ trait SyncGetGroupChatsInfoMsgHdlr {
     }
 
     def buildSyncGetGroupChatMsgsRespMsg(msgs: Vector[GroupChatMsgToUser], chatId: String): BbbCommonEnvCoreMsg = {
-      val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, liveMeeting.props.meetingProp.intId, "nodeJSapp")
+      val routing = Routing.addMsgToHtml5InstanceIdRouting(liveMeeting.props.meetingProp.intId, liveMeeting.props.systemProps.html5InstanceId.toString)
       val envelope = BbbCoreEnvelope(SyncGetGroupChatMsgsRespMsg.NAME, routing)
       val header = BbbClientMsgHeader(SyncGetGroupChatMsgsRespMsg.NAME, liveMeeting.props.meetingProp.intId, "nodeJSapp")
       val body = SyncGetGroupChatMsgsRespMsgBody(chatId, msgs)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/meeting/SyncGetMeetingInfoRespMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/meeting/SyncGetMeetingInfoRespMsgHdlr.scala
@@ -9,7 +9,7 @@ trait SyncGetMeetingInfoRespMsgHdlr {
   val outGW: OutMsgRouter
 
   def handleSyncGetMeetingInfoRespMsg(props: DefaultProps): Unit = {
-    val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, props.meetingProp.intId, "nodeJSapp")
+    val routing = Routing.addMsgToHtml5InstanceIdRouting(props.meetingProp.intId, props.systemProps.html5InstanceId.toString)
     val envelope = BbbCoreEnvelope(SyncGetMeetingInfoRespMsg.NAME, routing)
     val header = BbbCoreBaseHeader(SyncGetMeetingInfoRespMsg.NAME)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SyncGetPresentationPodsMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SyncGetPresentationPodsMsgHdlr.scala
@@ -12,7 +12,7 @@ trait SyncGetPresentationPodsMsgHdlr {
   def handleSyncGetPresentationPods(state: MeetingState2x, liveMeeting: LiveMeeting, bus: MessageBus): MeetingState2x = {
 
     def buildSyncGetPresentationPodsRespMsg(pods: Vector[PresentationPodVO]): BbbCommonEnvCoreMsg = {
-      val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, liveMeeting.props.meetingProp.intId, "nodeJSapp")
+      val routing = Routing.addMsgToHtml5InstanceIdRouting(liveMeeting.props.meetingProp.intId, liveMeeting.props.systemProps.html5InstanceId.toString)
       val envelope = BbbCoreEnvelope(SyncGetPresentationPodsRespMsg.NAME, routing)
       val header = BbbClientMsgHeader(SyncGetPresentationPodsRespMsg.NAME, liveMeeting.props.meetingProp.intId, "nodeJSapp")
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/SyncGetUsersMeetingRespMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/SyncGetUsersMeetingRespMsgHdlr.scala
@@ -11,9 +11,7 @@ trait SyncGetUsersMeetingRespMsgHdlr {
   val outGW: OutMsgRouter
 
   def handleSyncGetUsersMeetingRespMsg(): Unit = {
-    log.debug("Handling SyncGetUsersMeetingRespMsg")
-
-    val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, liveMeeting.props.meetingProp.intId, "nodeJSapp")
+    val routing = Routing.addMsgToHtml5InstanceIdRouting(liveMeeting.props.meetingProp.intId, liveMeeting.props.systemProps.html5InstanceId.toString)
     val envelope = BbbCoreEnvelope(SyncGetUsersMeetingRespMsg.NAME, routing)
     val header = BbbClientMsgHeader(SyncGetUsersMeetingRespMsg.NAME, liveMeeting.props.meetingProp.intId, "nodeJSapp")
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/SyncGetVoiceUsersMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/SyncGetVoiceUsersMsgHdlr.scala
@@ -17,7 +17,7 @@ trait SyncGetVoiceUsersMsgHdlr {
           callerNum = u.callerNum, muted = u.muted, talking = u.talking, listenOnly = u.listenOnly)
       }
 
-      val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, liveMeeting.props.meetingProp.intId, "nodeJSapp")
+      val routing = Routing.addMsgToHtml5InstanceIdRouting(liveMeeting.props.meetingProp.intId, liveMeeting.props.systemProps.html5InstanceId.toString)
       val envelope = BbbCoreEnvelope(SyncGetVoiceUsersRespMsg.NAME, routing)
       val header = BbbClientMsgHeader(SyncGetVoiceUsersRespMsg.NAME, liveMeeting.props.meetingProp.intId, "nodeJSapp")
       val body = SyncGetVoiceUsersRespMsgBody(voiceUsers)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ClearWhiteboardPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ClearWhiteboardPubMsgHdlr.scala
@@ -11,7 +11,7 @@ trait ClearWhiteboardPubMsgHdlr extends RightsManagementTrait {
   def handle(msg: ClearWhiteboardPubMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
 
     def broadcastEvent(msg: ClearWhiteboardPubMsg, fullClear: Boolean): Unit = {
-      val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, msg.header.userId)
+      val routing = Routing.addMsgToHtml5InstanceIdRouting(liveMeeting.props.meetingProp.intId, liveMeeting.props.systemProps.html5InstanceId.toString)
       val envelope = BbbCoreEnvelope(ClearWhiteboardEvtMsg.NAME, routing)
       val header = BbbClientMsgHeader(ClearWhiteboardEvtMsg.NAME, liveMeeting.props.meetingProp.intId, msg.header.userId)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/GetWhiteboardAnnotationsReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/GetWhiteboardAnnotationsReqMsgHdlr.scala
@@ -10,7 +10,8 @@ trait GetWhiteboardAnnotationsReqMsgHdlr {
   def handle(msg: GetWhiteboardAnnotationsReqMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
 
     def broadcastEvent(msg: GetWhiteboardAnnotationsReqMsg, history: Array[AnnotationVO], multiUser: Boolean): Unit = {
-      val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, liveMeeting.props.meetingProp.intId, msg.header.userId)
+      val routing = Routing.addMsgToHtml5InstanceIdRouting(liveMeeting.props.meetingProp.intId, liveMeeting.props.systemProps.html5InstanceId.toString)
+
       val envelope = BbbCoreEnvelope(GetWhiteboardAnnotationsRespMsg.NAME, routing)
       val header = BbbClientMsgHeader(GetWhiteboardAnnotationsRespMsg.NAME, liveMeeting.props.meetingProp.intId, msg.header.userId)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ModifyWhiteboardAccessPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ModifyWhiteboardAccessPubMsgHdlr.scala
@@ -11,7 +11,7 @@ trait ModifyWhiteboardAccessPubMsgHdlr extends RightsManagementTrait {
   def handle(msg: ModifyWhiteboardAccessPubMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
 
     def broadcastEvent(msg: ModifyWhiteboardAccessPubMsg): Unit = {
-      val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, msg.header.userId)
+      val routing = Routing.addMsgToHtml5InstanceIdRouting(liveMeeting.props.meetingProp.intId, liveMeeting.props.systemProps.html5InstanceId.toString)
       val envelope = BbbCoreEnvelope(ModifyWhiteboardAccessEvtMsg.NAME, routing)
       val header = BbbClientMsgHeader(ModifyWhiteboardAccessEvtMsg.NAME, liveMeeting.props.meetingProp.intId, msg.header.userId)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendCursorPositionPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendCursorPositionPubMsgHdlr.scala
@@ -11,7 +11,7 @@ trait SendCursorPositionPubMsgHdlr extends RightsManagementTrait {
   def handle(msg: SendCursorPositionPubMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
 
     def broadcastEvent(msg: SendCursorPositionPubMsg): Unit = {
-      val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, msg.header.userId)
+      val routing = Routing.addMsgToHtml5InstanceIdRouting(liveMeeting.props.meetingProp.intId, liveMeeting.props.systemProps.html5InstanceId.toString)
       val envelope = BbbCoreEnvelope(SendCursorPositionEvtMsg.NAME, routing)
       val header = BbbClientMsgHeader(SendCursorPositionEvtMsg.NAME, liveMeeting.props.meetingProp.intId, msg.header.userId)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendWhiteboardAnnotationPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendWhiteboardAnnotationPubMsgHdlr.scala
@@ -11,7 +11,7 @@ trait SendWhiteboardAnnotationPubMsgHdlr extends RightsManagementTrait {
   def handle(msg: SendWhiteboardAnnotationPubMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
 
     def broadcastEvent(msg: SendWhiteboardAnnotationPubMsg, annotation: AnnotationVO): Unit = {
-      val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, msg.header.userId)
+      val routing = Routing.addMsgToHtml5InstanceIdRouting(liveMeeting.props.meetingProp.intId, liveMeeting.props.systemProps.html5InstanceId.toString)
       val envelope = BbbCoreEnvelope(SendWhiteboardAnnotationEvtMsg.NAME, routing)
       val header = BbbClientMsgHeader(SendWhiteboardAnnotationEvtMsg.NAME, liveMeeting.props.meetingProp.intId, msg.header.userId)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/UndoWhiteboardPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/UndoWhiteboardPubMsgHdlr.scala
@@ -11,7 +11,7 @@ trait UndoWhiteboardPubMsgHdlr extends RightsManagementTrait {
   def handle(msg: UndoWhiteboardPubMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
 
     def broadcastEvent(msg: UndoWhiteboardPubMsg, removedAnnotationId: String): Unit = {
-      val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, msg.header.userId)
+      val routing = Routing.addMsgToHtml5InstanceIdRouting(liveMeeting.props.meetingProp.intId, liveMeeting.props.systemProps.html5InstanceId.toString)
       val envelope = BbbCoreEnvelope(UndoWhiteboardEvtMsg.NAME, routing)
       val header = BbbClientMsgHeader(UndoWhiteboardEvtMsg.NAME, liveMeeting.props.meetingProp.intId, msg.header.userId)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -278,9 +278,9 @@ class MeetingActor(
 
   private def handleBbbCommonEnvCoreMsg(msg: BbbCommonEnvCoreMsg): Unit = {
     msg.core match {
-      case m: ClientToServerLatencyTracerMsg          => handleClientToServerLatencyTracerMsg(m)
+      case m: ClientToServerLatencyTracerMsg => handleClientToServerLatencyTracerMsg(m)
       case m: CheckRunningAndRecordingVoiceConfEvtMsg => handleCheckRunningAndRecordingVoiceConfEvtMsg(m)
-      case _                                          => handleMessageThatAffectsInactivity(msg)
+      case _ => handleMessageThatAffectsInactivity(msg)
     }
   }
 
@@ -297,7 +297,7 @@ class MeetingActor(
       case m: UserBroadcastCamStartMsg            => handleUserBroadcastCamStartMsg(m)
       case m: UserBroadcastCamStopMsg             => handleUserBroadcastCamStopMsg(m)
       case m: UserJoinedVoiceConfEvtMsg           => handleUserJoinedVoiceConfEvtMsg(m)
-      case m: LogoutAndEndMeetingCmdMsg => usersApp.handleLogoutAndEndMeetingCmdMsg(m, state)
+      case m: LogoutAndEndMeetingCmdMsg           => usersApp.handleLogoutAndEndMeetingCmdMsg(m, state)
       case m: SetRecordingStatusCmdMsg =>
         state = usersApp.handleSetRecordingStatusCmdMsg(m, state)
         updateUserLastActivity(m.body.setBy)
@@ -469,6 +469,7 @@ class MeetingActor(
   }
 
   def processGetRunningMeetingStateReqMsg(): Unit = {
+
     // sync all meetings
     handleSyncGetMeetingInfoRespMsg(liveMeeting.props)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/FromAkkaAppsMsgSenderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/FromAkkaAppsMsgSenderActor.scala
@@ -21,13 +21,22 @@ class FromAkkaAppsMsgSenderActor(msgSender: MessageSender)
   def handleBbbCommonEnvCoreMsg(msg: BbbCommonEnvCoreMsg): Unit = {
     val json = JsonUtil.toJson(msg)
 
+    if (msg.envelope.routing.contains("html5InstanceId")) {
+      val html5InstanceId = msg.envelope.routing.get("html5InstanceId")
+      html5InstanceId match {
+        case Some(id) => {
+//          log.info("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~AAAAAA " + id)
+          msgSender.send(toHTML5RedisChannel.concat(id), json)
+        }
+        case _ => log.info("1 no html5InstanceId for " + msg.envelope.name)
+      }
+      //      log.info("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~AAAAAA " + html5InstanceId)
+      //      msgSender.send(toHTML5RedisChannel.concat(html5InstanceId), json)
+    } else {
+//      log.info("2 no html5InstanceId for " + msg.envelope.name + "   " + msg.envelope.routing)
+    }
+
     msg.envelope.name match {
-      case SyncGetPresentationPodsRespMsg.NAME => msgSender.send(toHTML5RedisChannel, json)
-      case SyncGetMeetingInfoRespMsg.NAME      => msgSender.send(toHTML5RedisChannel, json)
-      case SyncGetUsersMeetingRespMsg.NAME     => msgSender.send(toHTML5RedisChannel, json)
-      case SyncGetGroupChatsRespMsg.NAME       => msgSender.send(toHTML5RedisChannel, json)
-      case SyncGetGroupChatMsgsRespMsg.NAME    => msgSender.send(toHTML5RedisChannel, json)
-      case SyncGetVoiceUsersRespMsg.NAME       => msgSender.send(toHTML5RedisChannel, json)
 
       // Sent to FreeSWITCH
       case ScreenshareStartRtmpBroadcastVoiceConfMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/FromAkkaAppsMsgSenderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/FromAkkaAppsMsgSenderActor.scala
@@ -18,25 +18,27 @@ class FromAkkaAppsMsgSenderActor(msgSender: MessageSender)
     case _                        => log.warning("Cannot handle message ")
   }
 
+  def sendToHTML5InstanceIdChannel(msg: BbbCommonEnvCoreMsg, json: String): Unit = {
+    msg.envelope.routing.get("html5InstanceId") match {
+      case Some(id) => {
+        msgSender.send(toHTML5RedisChannel.concat(id), json)
+      }
+      case _ => log.error("No html5InstanceId for " + msg.envelope.name)
+    }
+  }
+
   def handleBbbCommonEnvCoreMsg(msg: BbbCommonEnvCoreMsg): Unit = {
     val json = JsonUtil.toJson(msg)
 
-    if (msg.envelope.routing.contains("html5InstanceId")) {
-      val html5InstanceId = msg.envelope.routing.get("html5InstanceId")
-      html5InstanceId match {
-        case Some(id) => {
-//          log.info("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~AAAAAA " + id)
-          msgSender.send(toHTML5RedisChannel.concat(id), json)
-        }
-        case _ => log.info("1 no html5InstanceId for " + msg.envelope.name)
-      }
-      //      log.info("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~AAAAAA " + html5InstanceId)
-      //      msgSender.send(toHTML5RedisChannel.concat(html5InstanceId), json)
-    } else {
-//      log.info("2 no html5InstanceId for " + msg.envelope.name + "   " + msg.envelope.routing)
-    }
-
     msg.envelope.name match {
+
+      // HTML5 sync messages
+      case SyncGetPresentationPodsRespMsg.NAME => sendToHTML5InstanceIdChannel(msg, json)
+      case SyncGetMeetingInfoRespMsg.NAME      => sendToHTML5InstanceIdChannel(msg, json)
+      case SyncGetUsersMeetingRespMsg.NAME     => sendToHTML5InstanceIdChannel(msg, json)
+      case SyncGetGroupChatsRespMsg.NAME       => sendToHTML5InstanceIdChannel(msg, json)
+      case SyncGetGroupChatMsgsRespMsg.NAME    => sendToHTML5InstanceIdChannel(msg, json)
+      case SyncGetVoiceUsersRespMsg.NAME       => sendToHTML5InstanceIdChannel(msg, json)
 
       // Sent to FreeSWITCH
       case ScreenshareStartRtmpBroadcastVoiceConfMsg.NAME =>

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
@@ -44,6 +44,10 @@ case class LockSettingsProps(
     lockOnJoinConfigurable: Boolean
 )
 
+case class SystemProps(
+    html5InstanceId: Int
+)
+
 case class DefaultProps(
     meetingProp:       MeetingProp,
     breakoutProps:     BreakoutProps,
@@ -55,7 +59,8 @@ case class DefaultProps(
     usersProp:         UsersProp,
     metadataProp:      MetadataProp,
     screenshareProps:  ScreenshareProps,
-    lockSettingsProps: LockSettingsProps
+    lockSettingsProps: LockSettingsProps,
+    systemProps:       SystemProps
 )
 
 case class StartEndTimeStatus(startTime: Long, endTime: Long)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/Routing.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/Routing.scala
@@ -4,6 +4,7 @@ object Routing {
   val MSG_TYPE = "msgType"
   val MEETING_ID = "meetingId"
   val USER_ID = "userId"
+  val HTML5_INSTANCE_ID = "html5InstanceId"
 
   def addMsgToClientRouting(msgType: String, meetingId: String, userId: String): collection.immutable.Map[String, String] = {
     Map(MSG_TYPE -> msgType, MEETING_ID -> meetingId, USER_ID -> userId)
@@ -11,6 +12,10 @@ object Routing {
 
   def addMsgFromClientRouting(meetingId: String, userId: String): collection.immutable.Map[String, String] = {
     Map(MEETING_ID -> meetingId, USER_ID -> userId)
+  }
+
+  def addMsgToHtml5InstanceIdRouting(meetingId: String, html5InstanceId: String): collection.immutable.Map[String, String] = {
+    Map(MEETING_ID -> meetingId, HTML5_INSTANCE_ID -> html5InstanceId)
   }
 }
 

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/SystemMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/SystemMsgs.scala
@@ -35,7 +35,7 @@ case class GetAllMeetingsReqMsg(
     header: BbbCoreBaseHeader,
     body:   GetAllMeetingsReqMsgBody
 ) extends BbbCoreMsg
-case class GetAllMeetingsReqMsgBody(requesterId: String)
+case class GetAllMeetingsReqMsgBody(requesterId: String, html5InstanceId: Int)
 
 object GetRunningMeetingsReqMsg { val NAME = "GetRunningMeetingsReqMsg" }
 case class GetRunningMeetingsReqMsg(

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -55,6 +55,7 @@ public class ApiParams {
     public static final String WEB_VOICE = "webVoice";
     public static final String WEBCAMS_ONLY_FOR_MODERATOR = "webcamsOnlyForModerator";
     public static final String WELCOME = "welcome";
+    public static final String HTML5_INSTANCE_ID = "html5InstanceId";
 
     public static final String BREAKOUT_ROOMS_ENABLED = "breakoutRoomsEnabled";
     public static final String BREAKOUT_ROOMS_RECORD = "breakoutRoomsRecord";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/HTML5LoadBalancingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/HTML5LoadBalancingService.java
@@ -1,0 +1,83 @@
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ * <p>
+ * Copyright (c) 2020 BigBlueButton Inc. and by respective authors (see below).
+ * <p>
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ * <p>
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.bigbluebutton.api;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.commons.io.IOUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bigbluebutton.api.util.HTML5ProcessLine;
+
+
+public class HTML5LoadBalancingService {
+    private static Logger log = LoggerFactory.getLogger(HTML5LoadBalancingService.class);
+    private ArrayList<HTML5ProcessLine> list = new ArrayList<HTML5ProcessLine>();
+
+    public void init() {
+        log.info("HTML5LoadBalancingService initialised");
+    }
+
+    public void scanHTML5processes() {
+        try {
+            this.list = new ArrayList<HTML5ProcessLine>();
+            Process p1 = Runtime.getRuntime().exec(new String[]{"ps", "-u", "meteor", "-o", "pcpu,cmd="});
+            InputStream input1 = p1.getInputStream();
+            Process p2 = Runtime.getRuntime().exec(new String[]{"grep", "node-"});
+            OutputStream output = p2.getOutputStream();
+            IOUtils.copy(input1, output);
+            output.close(); // signals grep to finish
+            List<String> result = IOUtils.readLines(p2.getInputStream());
+            for (String entry : result) {
+                HTML5ProcessLine line = new HTML5ProcessLine(entry);
+                list.add(line);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public int findSuitableHTML5Process() {
+        this.scanHTML5processes();
+        if (list.isEmpty()) {
+            log.warn("Did not find any instances of html5 process running");
+            return 1;
+        }
+        double smallestCPUvalue = this.list.get(0).percentageCPU;
+        int instanceIDofSmallestCPUValue = this.list.get(0).instanceId;
+        for (HTML5ProcessLine line : this.list) {
+            System.out.println(line.toString());
+            if (smallestCPUvalue > line.percentageCPU) {
+                smallestCPUvalue = line.percentageCPU;
+                instanceIDofSmallestCPUValue = line.instanceId;
+            }
+        }
+        return instanceIDofSmallestCPUValue;
+    }
+
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/HTML5LoadBalancingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/HTML5LoadBalancingService.java
@@ -38,6 +38,8 @@ import org.bigbluebutton.api.util.HTML5ProcessLine;
 public class HTML5LoadBalancingService {
     private static Logger log = LoggerFactory.getLogger(HTML5LoadBalancingService.class);
     private ArrayList<HTML5ProcessLine> list = new ArrayList<HTML5ProcessLine>();
+    private final int MAX_NUMBER_OF_HTML5_INSTANCES = 20;
+    private int lastSelectedInstanceId = 0;
 
     public void init() {
         log.info("HTML5LoadBalancingService initialised");
@@ -62,7 +64,16 @@ public class HTML5LoadBalancingService {
         }
     }
 
-    public int findSuitableHTML5Process() {
+    private boolean listItemWithIdExists(int id) {
+        for (HTML5ProcessLine line : this.list) {
+            if (line.instanceId == id) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public int findSuitableHTML5ProcessByLookingAtCPU() {
         this.scanHTML5processes();
         if (list.isEmpty()) {
             log.warn("Did not find any instances of html5 process running");
@@ -78,6 +89,23 @@ public class HTML5LoadBalancingService {
             }
         }
         return instanceIDofSmallestCPUValue;
+    }
+
+    public int findSuitableHTML5ProcessByRoundRobin() {
+        this.scanHTML5processes();
+        if (list.isEmpty()) {
+            log.warn("Did not find any instances of html5 process running");
+            return 1;
+        }
+
+        for (int i = lastSelectedInstanceId + 1; i <= MAX_NUMBER_OF_HTML5_INSTANCES + lastSelectedInstanceId; i++) {
+            int k = i % (MAX_NUMBER_OF_HTML5_INSTANCES + 1);
+            if (this.listItemWithIdExists(k)) {
+                this.lastSelectedInstanceId = k;
+                return k;
+            }
+        }
+        return 1;
     }
 
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -42,6 +42,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
+import org.bigbluebutton.api.HTML5LoadBalancingService;
 import org.bigbluebutton.api.domain.GuestPolicy;
 import org.bigbluebutton.api.domain.Meeting;
 import org.bigbluebutton.api.domain.Recording;
@@ -115,6 +116,7 @@ public class MeetingService implements MessageListener {
   private StunTurnService stunTurnService;
   private RedisStorageService storeService;
   private CallbackUrlService callbackUrlService;
+  private HTML5LoadBalancingService html5LoadBalancingService;
   private boolean keepEvents;
 
   private long usersTimeout;
@@ -400,7 +402,7 @@ public class MeetingService implements MessageListener {
             m.getUserInactivityInspectTimerInMinutes(), m.getUserInactivityThresholdInMinutes(),
             m.getUserActivitySignResponseDelayInMinutes(), m.getMuteOnStart(), m.getAllowModsToUnmuteUsers(), keepEvents,
             m.breakoutRoomsParams,
-            m.lockSettingsParams);
+            m.lockSettingsParams, m.getHtml5InstanceId());
   }
 
   private String formatPrettyDate(Long timestamp) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -74,9 +74,6 @@ public class ParamsProcessorUtil {
     private int defaultNumDigitsForTelVoice;
     private String defaultClientUrl;
     private String defaultGuestWaitURL;
-    private String html5ClientUrl;
-    private Boolean moderatorsJoinViaHTML5Client;
-    private Boolean attendeesJoinViaHTML5Client;
     private Boolean allowRequestsWithoutSession;
     private Boolean useDefaultAvatar = false;
     private String defaultAvatarURL;
@@ -557,18 +554,6 @@ public class ParamsProcessorUtil {
 		return defaultGuestWaitURL;
         }
 
-	public String getHTML5ClientUrl() {
-		return html5ClientUrl;
-	}
-
-	public Boolean getAttendeesJoinViaHTML5Client() {
-		return attendeesJoinViaHTML5Client;
-	}
-
-	public Boolean getModeratorsJoinViaHTML5Client() {
-		return moderatorsJoinViaHTML5Client;
-	}
-
 	public Boolean getAllowRequestsWithoutSession() {
 		return allowRequestsWithoutSession;
 	}
@@ -919,20 +904,8 @@ public class ParamsProcessorUtil {
 		this.defaultGuestWaitURL = url;
         }
 
-	public void setHtml5ClientUrl(String html5ClientUrl) {
-		this.html5ClientUrl = html5ClientUrl;
-	}
-
-	public void setModeratorsJoinViaHTML5Client(Boolean moderatorsJoinViaHTML5Client) {
-		this.moderatorsJoinViaHTML5Client = moderatorsJoinViaHTML5Client;
-	}
-
 	public void setAllowRequestsWithoutSession(Boolean allowRequestsWithoutSession) {
 		this.allowRequestsWithoutSession = allowRequestsWithoutSession;
-	}
-
-	public void setAttendeesJoinViaHTML5Client(Boolean attendeesJoinViaHTML5Client) {
-		this.attendeesJoinViaHTML5Client = attendeesJoinViaHTML5Client;
 	}
 
 	public void setDefaultMeetingDuration(int defaultMeetingDuration) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -113,6 +113,7 @@ public class ParamsProcessorUtil {
     private Integer userActivitySignResponseDelayInMinutes = 5;
     private Boolean defaultAllowDuplicateExtUserid = true;
 	private Boolean defaultEndWhenNoModerator = false;
+	private Integer defaultHtml5InstanceId = 1;
 
 	private String formatConfNum(String s) {
 		if (s.length() > 5) {
@@ -464,6 +465,8 @@ public class ParamsProcessorUtil {
 
         String avatarURL = useDefaultAvatar ? defaultAvatarURL : "";
 
+        int html5InstanceId = processHtml5InstanceId(params.get(ApiParams.HTML5_INSTANCE_ID));
+
         // Create the meeting with all passed in parameters.
         Meeting meeting = new Meeting.Builder(externalMeetingId,
                 internalMeetingId, createTime).withName(meetingName)
@@ -485,6 +488,7 @@ public class ParamsProcessorUtil {
 				.withBreakoutRoomsParams(breakoutParams)
 				.withLockSettingsParams(lockSettingsParams)
 				.withAllowDuplicateExtUserid(defaultAllowDuplicateExtUserid)
+                .withHTML5InstanceId(html5InstanceId)
                 .build();
 
         String configXML = getDefaultConfigXML();
@@ -507,6 +511,7 @@ public class ParamsProcessorUtil {
 		meeting.setUserInactivityInspectTimerInMinutes(userInactivityInspectTimerInMinutes);
 		meeting.setUserActivitySignResponseDelayInMinutes(userActivitySignResponseDelayInMinutes);
 		meeting.setUserInactivityThresholdInMinutes(userInactivityThresholdInMinutes);
+//		meeting.setHtml5InstanceId(html5InstanceId);
 
         // Add extra parameters for breakout room
         if (isBreakout) {
@@ -673,6 +678,17 @@ public class ParamsProcessorUtil {
 		}
 		
 		return rec;
+	}
+
+	public int processHtml5InstanceId(String instanceId) {
+		int html5InstanceId = 1;
+		try {
+            html5InstanceId = Integer.parseInt(instanceId);
+		} catch(Exception ex) {
+            html5InstanceId = defaultHtml5InstanceId;
+		}
+
+		return html5InstanceId;
 	}
 		
 	public int processMaxUser(String maxUsers) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -97,6 +97,7 @@ public class Meeting {
 
 	public final Boolean endWhenNoModerator;
 
+	private Integer html5InstanceId;
 
     public Meeting(Meeting.Builder builder) {
         name = builder.name;
@@ -128,6 +129,7 @@ public class Meeting {
         lockSettingsParams = builder.lockSettingsParams;
         allowDuplicateExtUserid = builder.allowDuplicateExtUserid;
         endWhenNoModerator = builder.endWhenNoModerator;
+        html5InstanceId = builder.html5InstanceId;
 
         userCustomData = new HashMap<>();
 
@@ -228,7 +230,11 @@ public class Meeting {
 		return GuestPolicy.DENY;
 	}
 
-	public long getStartTime() {
+	public int getHtml5InstanceId() { return html5InstanceId; }
+
+    public void setHtml5InstanceId(int instanceId) { html5InstanceId = instanceId; }
+
+    public long getStartTime() {
 		return startTime;
 	}
 	
@@ -668,6 +674,7 @@ public class Meeting {
     	private LockSettingsParams lockSettingsParams;
 		private Boolean allowDuplicateExtUserid;
 		private Boolean endWhenNoModerator;
+		private int html5InstanceId;
 
     	public Builder(String externalId, String internalId, long createTime) {
     		this.externalId = externalId;
@@ -802,6 +809,11 @@ public class Meeting {
 
 		public Builder withEndWhenNoModerator(Boolean endWhenNoModerator) {
     		this.endWhenNoModerator = endWhenNoModerator;
+    		return this;
+		}
+
+		public Builder withHTML5InstanceId(int instanceId) {
+    		html5InstanceId = instanceId;
     		return this;
 		}
     

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/HTML5ProcessLine.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/HTML5ProcessLine.java
@@ -1,0 +1,41 @@
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ * <p>
+ * Copyright (c) 2020 BigBlueButton Inc. and by respective authors (see below).
+ * <p>
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ * <p>
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.bigbluebutton.api.util;
+
+public class HTML5ProcessLine {
+
+    public int instanceId;
+    public double percentageCPU;
+
+    public HTML5ProcessLine(String input) {
+        // System.out.println("input:" + input);
+        //  0.1 /usr/share/node-v12.16.1-linux-x64/bin/node main.js INFO_INSTANCE_ID=3
+
+        String[] a = input.trim().split(" ");
+        this.percentageCPU = Double.parseDouble(a[0]);
+        String instanceIdInfo = a[3];
+        this.instanceId = Integer.parseInt(instanceIdInfo.replace("INFO_INSTANCE_ID=", ""));
+    }
+
+    public String toString() {
+        return "instanceId:" + this.instanceId + " CPU:" + this.percentageCPU;
+    }
+
+
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
@@ -30,7 +30,8 @@ public interface IBbbWebApiGWApp {
                      Boolean allowModsToUnmuteUsers,
                      Boolean keepEvents,
                      BreakoutRoomsParams breakoutParams,
-                     LockSettingsParams lockSettingsParams);
+                     LockSettingsParams lockSettingsParams,
+                     Integer html5InstanceId);
 
   void registerUser(String meetingID, String internalUserId, String fullname, String role,
                     String externUserID, String authToken, String avatarURL,

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -139,7 +139,8 @@ class BbbWebApiGWApp(
                     allowModsToUnmuteUsers:                 java.lang.Boolean,
                     keepEvents:                             java.lang.Boolean,
                     breakoutParams:                         BreakoutRoomsParams,
-                    lockSettingsParams:                     LockSettingsParams): Unit = {
+                    lockSettingsParams:                     LockSettingsParams,
+                    html5InstanceId:                        java.lang.Integer): Unit = {
 
     val meetingProp = MeetingProp(name = meetingName, extId = extMeetingId, intId = meetingId,
       isBreakout = isBreakout.booleanValue())
@@ -191,6 +192,10 @@ class BbbWebApiGWApp(
       lockOnJoinConfigurable = lockSettingsParams.lockOnJoinConfigurable.booleanValue()
     )
 
+    val systemProps = SystemProps(
+      html5InstanceId
+    )
+
     val defaultProps = DefaultProps(
       meetingProp,
       breakoutProps,
@@ -202,7 +207,8 @@ class BbbWebApiGWApp(
       usersProp,
       metadataProp,
       screenshareProps,
-      lockSettingsProps
+      lockSettingsProps,
+      systemProps
     )
 
     //meetingManagerActorRef ! new CreateMeetingMsg(defaultProps)

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -86,6 +86,9 @@ export default function addMeeting(meeting) {
       lockOnJoinConfigurable: Boolean,
       lockedLayout: Boolean,
     },
+    systemProps: {
+      html5InstanceId: Number,
+    },
   });
 
   const {

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
@@ -41,7 +41,7 @@ export default function removeUser(meetingId, userId) {
 
     clearUserInfoForRequester(meetingId, userId);
 
-    Users.remove(selector, cb);
+    Users.remove(selector);
 
     Logger.info(`Removed user id=${userId} meeting=${meetingId}`);
   } catch (err) {

--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -15,31 +15,6 @@ let guestWaitHtml = '';
 const AVAILABLE_LOCALES = fs.readdirSync('assets/app/locales');
 const FALLBACK_LOCALES = JSON.parse(Assets.getText('config/fallbackLocales.json'));
 
-const generateLocaleOptions = () => {
-  try {
-    Logger.warn('Calculating aggregateLocales (heavy)');
-    const tempAggregateLocales = AVAILABLE_LOCALES
-      .map(file => file.replace('.json', ''))
-      .map(file => file.replace('_', '-'))
-      .map((locale) => {
-        const localeName = (Langmap[locale] || {}).nativeName
-          || (FALLBACK_LOCALES[locale] || {}).nativeName
-          || locale;
-        return {
-          locale,
-          name: localeName,
-        };
-      });
-    Logger.warn(`Total locales: ${tempAggregateLocales.length}`, tempAggregateLocales);
-    return tempAggregateLocales;
-  } catch (e) {
-    Logger.error(`'Could not process locales error: ${e}`);
-    return [];
-  }
-};
-
-let avaibleLocalesNamesJSON = JSON.stringify(generateLocaleOptions());
-
 process.on('uncaughtException', (err) => {
   Logger.error(`uncaughtException: ${err}`);
   process.exit(1);
@@ -49,6 +24,9 @@ Meteor.startup(() => {
   const APP_CONFIG = Meteor.settings.public.app;
   const env = Meteor.isDevelopment ? 'development' : 'production';
   const CDN_URL = APP_CONFIG.cdn;
+  const instanceId = APP_CONFIG.instanceId.slice(1); // remove the leading '/' character
+
+  Logger.warn('Started bbb-html5 process with instanceId=' + instanceId);
 
   const { customHeartbeat } = APP_CONFIG;
 
@@ -152,6 +130,32 @@ Meteor.startup(() => {
     Logger.warn(`SERVER STARTED.\nENV=${env},\nnodejs version=${process.version}\nCDN=${CDN_URL}\n`, APP_CONFIG);
   }
 });
+
+
+const generateLocaleOptions = () => {
+  try {
+    Logger.warn('Calculating aggregateLocales (heavy)');
+    const tempAggregateLocales = AVAILABLE_LOCALES
+      .map(file => file.replace('.json', ''))
+      .map(file => file.replace('_', '-'))
+      .map((locale) => {
+        const localeName = (Langmap[locale] || {}).nativeName
+          || (FALLBACK_LOCALES[locale] || {}).nativeName
+          || locale;
+        return {
+          locale,
+          name: localeName,
+        };
+      });
+    Logger.warn(`Total locales: ${tempAggregateLocales.length}`, tempAggregateLocales);
+    return tempAggregateLocales;
+  } catch (e) {
+    Logger.error(`'Could not process locales error: ${e}`);
+    return [];
+  }
+};
+
+let avaibleLocalesNamesJSON = JSON.stringify(generateLocaleOptions());
 
 WebApp.connectHandlers.use('/check', (req, res) => {
   const payload = { html5clientStatus: 'running' };

--- a/bigbluebutton-html5/imports/startup/server/redis.js
+++ b/bigbluebutton-html5/imports/startup/server/redis.js
@@ -108,6 +108,7 @@ class RedisPubSub {
     const redisConf = Meteor.settings.private.redis;
     this.instanceMax = parseInt(process.env.INSTANCE_MAX, 10) || 1;
     this.instanceId = parseInt(process.env.INSTANCE_ID, 10) || 1; // 1 also handles running in dev mode
+    this.customRedisChannel = `to-html5-redis-channel${this.instanceId}`;
 
     const { password, port } = redisConf;
 
@@ -134,7 +135,8 @@ class RedisPubSub {
     this.sub.on('pmessage', Meteor.bindEnvironment(this.handleMessage));
 
     const channelsToSubscribe = this.config.subscribeTo;
-    channelsToSubscribe.push("to-html5-redis-channel1")
+
+    channelsToSubscribe.push(this.customRedisChannel)
 
     channelsToSubscribe.forEach((channel) => {
       this.sub.psubscribe(channel);
@@ -187,11 +189,11 @@ class RedisPubSub {
 
     const queueId = meetingId || NO_MEETING_ID;
 
-    if (eventName === 'MeetingCreatedEvtMsg') {
+    if (eventName === 'MeetingCreatedEvtMsg' || eventName === 'SyncGetMeetingInfoRespMsg') {
       const newIntId = parsedMessage.core.body.props.meetingProp.intId;
-      const instanceId = parsedMessage.core.body.props.systemProps.html5InstanceId; //  || 1;
+      const instanceId = parsedMessage.core.body.props.systemProps.html5InstanceId;
 
-      Logger.warn(`MeetingCreatedEvtMsg {${parsedMessage.core.body.props.meetingProp.name}}received with meetingInstance: ${instanceId} -- this is instance: ${this.instanceId}`);
+      Logger.warn(`MeetingCreatedEvtMsg (name=${parsedMessage.core.body.props.meetingProp.name})received with meetingInstance: ${instanceId} -- this is instance: ${this.instanceId}`);
 
       if (instanceId === this.instanceId) {
         this.mettingsQueues[newIntId] = new MeetingMessageQueue(this.emitter, async, this.redisDebugEnabled);
@@ -200,7 +202,11 @@ class RedisPubSub {
       }
     }
 
-    if (queueId in this.mettingsQueues) {
+    if (channel !== this.customRedisChannel && queueId in this.mettingsQueues) {
+      Logger.error("Consider routing " + eventName + " to " + this.customRedisChannel);
+    }
+
+    if (channel === this.customRedisChannel || queueId in this.mettingsQueues) {
       this.mettingsQueues[queueId].add({
         pattern,
         channel,
@@ -208,9 +214,6 @@ class RedisPubSub {
         parsedMessage,
       });
     }
-    // else {
-    // Logger.info("Skipping redis message for " + queueId);
-    // }
   }
 
   destroyMeetingQueue(id) {

--- a/bigbluebutton-html5/imports/startup/server/redis.js
+++ b/bigbluebutton-html5/imports/startup/server/redis.js
@@ -136,7 +136,7 @@ class RedisPubSub {
 
     const channelsToSubscribe = this.config.subscribeTo;
 
-    channelsToSubscribe.push(this.customRedisChannel)
+    channelsToSubscribe.push(this.customRedisChannel);
 
     channelsToSubscribe.forEach((channel) => {
       this.sub.psubscribe(channel);
@@ -193,7 +193,7 @@ class RedisPubSub {
       const newIntId = parsedMessage.core.body.props.meetingProp.intId;
       const instanceId = parsedMessage.core.body.props.systemProps.html5InstanceId;
 
-      Logger.warn(`MeetingCreatedEvtMsg (name=${parsedMessage.core.body.props.meetingProp.name})received with meetingInstance: ${instanceId} -- this is instance: ${this.instanceId}`);
+      Logger.warn(`${eventName} (name=${parsedMessage.core.body.props.meetingProp.name}) received with meetingInstance: ${instanceId} -- this is instance: ${this.instanceId}`);
 
       if (instanceId === this.instanceId) {
         this.mettingsQueues[newIntId] = new MeetingMessageQueue(this.emitter, async, this.redisDebugEnabled);
@@ -203,7 +203,8 @@ class RedisPubSub {
     }
 
     if (channel !== this.customRedisChannel && queueId in this.mettingsQueues) {
-      Logger.error("Consider routing " + eventName + " to " + this.customRedisChannel);
+      Logger.error(`Consider routing ${eventName} to ${this.customRedisChannel}` );
+      // Logger.error(`Consider routing ${eventName} to ${this.customRedisChannel}` + message);
     }
 
     if (channel === this.customRedisChannel || queueId in this.mettingsQueues) {

--- a/bigbluebutton-web/docker-entrypoint.sh
+++ b/bigbluebutton-web/docker-entrypoint.sh
@@ -11,7 +11,7 @@ mkdir -p /var/bigbluebutton/published
 mkdir -p /var/bigbluebutton/deleted
 mkdir -p /var/bigbluebutton/unpublished
 
-export JAVA_OPTS="${JAVA_OPTS} -Djava.security.egd=file:/dev/./urandom -DsecuritySalt=${SHARED_SECRET} -Dredis.host=redis -DredisHost=redis -Dbigbluebutton.web.serverURL=https://${SERVER_DOMAIN} -DattendeesJoinViaHTML5Client=true -DmoderatorsJoinViaHTML5Client=true -DsvgImagesRequired=true"
+export JAVA_OPTS="${JAVA_OPTS} -Djava.security.egd=file:/dev/./urandom -DsecuritySalt=${SHARED_SECRET} -Dredis.host=redis -DredisHost=redis -Dbigbluebutton.web.serverURL=https://${SERVER_DOMAIN} -DsvgImagesRequired=true"
 sed -i "s|^securerandom\.source=.*|securerandom.source=file:/dev/urandom|g" ${JAVA_HOME}/lib/security/java.security
 
 catalina.sh run

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -245,21 +245,10 @@ bigbluebutton.web.logoutURL=default
 
 # The url of the BigBlueButton client. Users will be redirected here when
 # successfully joining the meeting.
-defaultClientUrl=${bigbluebutton.web.serverURL}/client/BigBlueButton.html
+defaultClientUrl=${bigbluebutton.web.serverURL}/html5client/%%INSTANCEID%%/join
 
 # Allow requests without JSESSIONID to be handled (default = false)
 allowRequestsWithoutSession=false
-
-# Force all attendees to join the meeting using the HTML5 client
-attendeesJoinViaHTML5Client=true
-
-# Force all moderators to join the meeting using the HTML5 client
-moderatorsJoinViaHTML5Client=true
-
-# The url of the BigBlueButton HTML5 client. Users will be redirected here when
-# successfully joining the meeting.
-html5ClientUrl=${bigbluebutton.web.serverURL}/html5client/%%INSTANCEID%%/join
-
 
 # The url for where the guest will poll if approved to join or not.
 defaultGuestWaitURL=${bigbluebutton.web.serverURL}/html5client/guestWait

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -128,10 +128,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="defaultNumDigitsForTelVoice" value="${defaultNumDigitsForTelVoice}"/>
         <property name="defaultClientUrl" value="${defaultClientUrl}"/>
         <property name="defaultGuestWaitURL" value="${defaultGuestWaitURL}"/>
-        <property name="html5ClientUrl" value="${html5ClientUrl}"/>
-        <property name="allowRequestsWithoutSession" value="${allowRequestsWithoutSession}"/>
-        <property name="moderatorsJoinViaHTML5Client" value="${moderatorsJoinViaHTML5Client}"/>
-        <property name="attendeesJoinViaHTML5Client" value="${attendeesJoinViaHTML5Client}"/>
         <property name="defaultMeetingDuration" value="${defaultMeetingDuration}"/>
         <property name="disableRecordingDefault" value="${disableRecordingDefault}"/>
         <property name="autoStartRecording" value="${autoStartRecording}"/>

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -106,6 +106,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="defaultTextTrackUrl" value="${defaultTextTrackUrl}"/>
     </bean>
 
+    <bean id="html5LoadBalancingService" class="org.bigbluebutton.api.HTML5LoadBalancingService" init-method="init" />
+    
     <bean id="configServiceHelper" class="org.bigbluebutton.api.ClientConfigServiceHelperImp"/>
 
     <bean id="configService" class="org.bigbluebutton.api.ClientConfigService" init-method="init">

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -151,7 +151,7 @@ class ApiController {
       // Still no unique voiceBridge found? Let createMeeting handle it.
     }
 
-    params.html5InstanceId = html5LoadBalancingService.findSuitableHTML5Process().toString()
+    params.html5InstanceId = html5LoadBalancingService.findSuitableHTML5ProcessByRoundRobin().toString()
 
     Meeting newMeeting = paramsProcessorUtil.processCreateParams(params)
 

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -58,6 +58,7 @@ class ApiController {
   ClientConfigService configService
   PresentationUrlDownloadService presDownloadService
   StunTurnService stunTurnService
+  HTML5LoadBalancingService html5LoadBalancingService
   ResponseBuilder responseBuilder = initResponseBuilder()
 
   def initResponseBuilder = {
@@ -149,6 +150,8 @@ class ApiController {
       }
       // Still no unique voiceBridge found? Let createMeeting handle it.
     }
+
+    params.html5InstanceId = html5LoadBalancingService.findSuitableHTML5Process().toString()
 
     Meeting newMeeting = paramsProcessorUtil.processCreateParams(params)
 
@@ -493,7 +496,7 @@ class ApiController {
     boolean redirectClient = true;
     String clientURL = paramsProcessorUtil.getDefaultClientUrl();
 
-    String meetingInstance = meeting.getMetadata()["bbb-meetinginstance"];
+    String meetingInstance = meeting.getHtml5InstanceId();
     meetingInstance = (meetingInstance == null) ? "1" : meetingInstance;
     clientURL = clientURL.replaceAll("%%INSTANCEID%%", meetingInstance);
 

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -269,11 +269,6 @@ class ApiController {
       authenticated = Boolean.parseBoolean(params.auth)
     }
 
-    Boolean joinViaHtml5 = false;
-    if (!StringUtils.isEmpty(params.joinViaHtml5)) {
-      joinViaHtml5 = Boolean.parseBoolean(params.joinViaHtml5)
-    }
-
     // Do we have a name for the user joining? If none, complain.
     if (!StringUtils.isEmpty(params.fullName)) {
       if (StringUtils.isEmpty(params.fullName)) {
@@ -497,28 +492,6 @@ class ApiController {
     //check if exists the param redirect
     boolean redirectClient = true;
     String clientURL = paramsProcessorUtil.getDefaultClientUrl();
-
-    // server-wide configuration:
-    // Depending on configuration, prefer the HTML5 client over Flash for moderators
-    if (paramsProcessorUtil.getModeratorsJoinViaHTML5Client() && role == ROLE_MODERATOR) {
-      joinViaHtml5 = true
-    }
-
-    // Depending on configuration, prefer the HTML5 client over Flash for attendees
-    if (paramsProcessorUtil.getAttendeesJoinViaHTML5Client() && role == ROLE_ATTENDEE) {
-      joinViaHtml5 = true
-    }
-
-    // single client join configuration:
-    // Depending on configuration, prefer the HTML5 client over Flash client
-    if (joinViaHtml5) {
-      clientURL = paramsProcessorUtil.getHTML5ClientUrl();
-    } else {
-      if (!StringUtils.isEmpty(params.clientURL)) {
-        clientURL = params.clientURL;
-      }
-    }
-
 
     String meetingInstance = meeting.getMetadata()["bbb-meetinginstance"];
     meetingInstance = (meetingInstance == null) ? "1" : meetingInstance;


### PR DESCRIPTION
1. bbb-web loadbalances all bbb-html5 instances (based on cpu load it picks the lowest cpu and assigns it to handle new meeting)

```
$ ps -u meteor -o pcpu,cmd= | grep node-
 7.7 /usr/share/node-v12.16.1-linux-x64/bin/node main.js INFO_INSTANCE_ID=3
 7.7 /usr/share/node-v12.16.1-linux-x64/bin/node main.js INFO_INSTANCE_ID=1
 7.6 /usr/share/node-v12.16.1-linux-x64/bin/node main.js INFO_INSTANCE_ID=4
 7.8 /usr/share/node-v12.16.1-linux-x64/bin/node main.js INFO_INSTANCE_ID=2

```
Ensure the new meeting is handled by the process with the most capacity to do so. No need of calculating number of meetings or users, just use CPU load.
No longer need to pass a meta parameter on meeting create to utilize parallel nodejs process.


2. akka-apps sends redis events to a new special channel to each of the bbb-html5 instances (so the redis events are filtered by meeting - only hear what you need to handle, prevent parallel processes handling the same events)
`to-html5-redis-channel1`  - where `1` is the instanceId

No need to "open" each redis message in every process to see whether it is to be handled by that process.

3. Removed the bigbluebutton.properties for picking HTML5 over Flash (reverting #4754 ), now HTML5 client is considered the default

TODO:
 - [ ] Add the `INFO_INSTANCE_ID=` to systemd_start.sh 

```
- PORT=$PORT /usr/share/$NODE_VERSION/bin/node main.js
+ PORT=$PORT /usr/share/$NODE_VERSION/bin/node main.js INFO_INSTANCE_ID=$INSTANCE_ID
```

 - [ ] Go through the akka-apps messages and ensure the 21 messages needed by bbb-web are routed to it and the 82 needed by html5 client are routed to it (and thus reducing the noice to `from-akka-apps*` channels


Related to #10933 #10868 #10860 #10969