### PR TITLE
CPUSchedulingPolicy=fifo for bbb-html5.service

### DIFF
--- a/bigbluebutton-config/bin/apply-lib.sh
+++ b/bigbluebutton-config/bin/apply-lib.sh
@@ -61,7 +61,7 @@ disableNodeFifo() {
 }
 #
 # do not enable by default in containerized or chroot env
-systemd-detect-virt -c || systemd-detect-virt -r || enableNodeFifo
+systemd-detect-virt -qc || systemd-detect-virt -qr || enableNodeFifo
 
 
 #

--- a/bigbluebutton-config/bin/apply-lib.sh
+++ b/bigbluebutton-config/bin/apply-lib.sh
@@ -40,7 +40,8 @@ HTML5_CONFIG=/usr/share/meteor/bundle/programs/server/assets/app/config/settings
 # Set CPUSchedulingPolicy=fifo and Nice=19 for HTML5 Client's node.js process.
 #  This should avoid user disconnects or interrupts in situations of high load on server
 #
-# Enabled by default. Call "disableNodeFifo" in /etc/bigbluebutton/bbb-conf/apply-config.sh to disable.
+# Enabled by default if instance is not in containerized or chroot env. 
+# Call "disableNodeFifo" in /etc/bigbluebutton/bbb-conf/apply-config.sh to disable.
 #
 enableNodeFifo() {
   if [ ! "$noNodeFifo" ]; then
@@ -58,7 +59,9 @@ disableNodeFifo() {
   [ -f /etc/systemd/system/bbb-html5.service.d/override.conf ] && rm -f /etc/systemd/system/bbb-html5.service.d/override.conf
   [ -d /etc/systemd/system/bbb-html5.service.d/ ] && rmdir /etc/systemd/system/bbb-html5.service.d/ && systemctl daemon-reload
 }
-enableNodeFifo
+#
+# do not enable by default in containerized or chroot env
+systemd-detect-virt -c || systemd-detect-virt -r || enableNodeFifo
 
 
 #

--- a/bigbluebutton-config/bin/apply-lib.sh
+++ b/bigbluebutton-config/bin/apply-lib.sh
@@ -54,7 +54,7 @@ enableNodeFifo() {
 # Disable CPUSchedulingPolicy and Nice for HTML5 Client's node.js process
 #
 disableNodeFifo() {
-  noNodeFilo=true
+  noNodeFifo=true
   [ -f /etc/systemd/system/bbb-html5.service.d/override.conf ] && rm -f /etc/systemd/system/bbb-html5.service.d/override.conf
   [ -d /etc/systemd/system/bbb-html5.service.d/ ] && rmdir /etc/systemd/system/bbb-html5.service.d/ && systemctl daemon-reload
 }

--- a/bigbluebutton-config/bin/apply-lib.sh
+++ b/bigbluebutton-config/bin/apply-lib.sh
@@ -304,4 +304,3 @@ chmod +x /etc/bigbluebutton/bbb-conf/apply-config.sh
 ## Stop Copying HERE
 }
 
-

--- a/bigbluebutton-config/bin/apply-lib.sh
+++ b/bigbluebutton-config/bin/apply-lib.sh
@@ -37,6 +37,31 @@ HTML5_CONFIG=/usr/share/meteor/bundle/programs/server/assets/app/config/settings
 
 
 #
+# Set CPUSchedulingPolicy=fifo and Nice=19 for HTML5 Client's node.js process.
+#  This should avoid user disconnects or interrupts in situations of high load on server
+#
+# Enabled by default. Call "disableNodeFifo" in /etc/bigbluebutton/bbb-conf/apply-config.sh to disable.
+#
+enableNodeFifo() {
+  if [ ! "$noNodeFifo" ]; then
+    [ -d /etc/systemd/system/bbb-html5.service.d/ ] || mkdir -p /etc/systemd/system/bbb-html5.service.d/
+    echo -e '[Service]\nCPUSchedulingPolicy=fifo\nNice=19' > /etc/systemd/system/bbb-html5.service.d/override.conf
+    systemctl daemon-reload
+  fi
+}
+
+#
+# Disable CPUSchedulingPolicy and Nice for HTML5 Client's node.js process
+#
+disableNodeFifo() {
+  noNodeFilo=true
+  [ -f /etc/systemd/system/bbb-html5.service.d/override.conf ] && rm -f /etc/systemd/system/bbb-html5.service.d/override.conf
+  [ -d /etc/systemd/system/bbb-html5.service.d/ ] && rmdir /etc/systemd/system/bbb-html5.service.d/ && systemctl daemon-reload
+}
+enableNodeFifo
+
+
+#
 # Enable Looging of the HTML5 client for debugging
 #
 enableHTML5ClientLog() {
@@ -278,4 +303,5 @@ HERE
 chmod +x /etc/bigbluebutton/bbb-conf/apply-config.sh
 ## Stop Copying HERE
 }
+
 


### PR DESCRIPTION
### What does this PR do?

Set `CPUSchedulingPolicy=fifo` and `Nice=19` via override.conf to bbb-html5.service

related to #10739

### Motivation

This should avoid user disconnects or interrupts in situations of high load on server.
Credits to @basisbit 

### More

Enabled by default. Call `disableNodeFifo` in `/etc/bigbluebutton/bbb-conf/apply-config.sh` to disable.
