### PR TITLE
Change bigbluebutton.properties client url param to defaultHTML5ClientUrl

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -72,7 +72,7 @@ public class ParamsProcessorUtil {
     private String defaultLogoutUrl;
     private String defaultServerUrl;
     private int defaultNumDigitsForTelVoice;
-    private String defaultClientUrl;
+    private String defaultHTML5ClientUrl;
     private String defaultGuestWaitURL;
     private Boolean allowRequestsWithoutSession;
     private Boolean useDefaultAvatar = false;
@@ -551,8 +551,8 @@ public class ParamsProcessorUtil {
 		return serviceEnabled;
 	}
 	
-	public String getDefaultClientUrl() {
-		return defaultClientUrl;
+	public String getDefaultHTML5ClientUrl() {
+		return defaultHTML5ClientUrl;
 	}
 
 	public String getDefaultGuestWaitURL() {
@@ -912,8 +912,8 @@ public class ParamsProcessorUtil {
 		this.defaultNumDigitsForTelVoice = defaultNumDigitsForTelVoice;
 	}
 
-	public void setDefaultClientUrl(String defaultClientUrl) {
-		this.defaultClientUrl = defaultClientUrl;
+	public void setDefaultHTML5ClientUrl(String defaultHTML5ClientUrl) {
+		this.defaultHTML5ClientUrl = defaultHTML5ClientUrl;
 	}
 
 	public void setDefaultGuestWaitURL(String url) {

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -243,9 +243,9 @@ bigbluebutton.web.serverURL=http://bigbluebutton.example.com
 # If "default", it returns to bigbluebutton.web.serverURL
 bigbluebutton.web.logoutURL=default
 
-# The url of the BigBlueButton client. Users will be redirected here when
+# The url of the BigBlueButton HTML5 client. Users will be redirected here when
 # successfully joining the meeting.
-defaultClientUrl=${bigbluebutton.web.serverURL}/html5client/%%INSTANCEID%%/join
+defaultHTML5ClientUrl=${bigbluebutton.web.serverURL}/html5client/%%INSTANCEID%%/join
 
 # Allow requests without JSESSIONID to be handled (default = false)
 allowRequestsWithoutSession=false

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -128,7 +128,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="defaultLogoutUrl" value="${bigbluebutton.web.logoutURL}"/>
         <property name="defaultServerUrl" value="${bigbluebutton.web.serverURL}"/>
         <property name="defaultNumDigitsForTelVoice" value="${defaultNumDigitsForTelVoice}"/>
-        <property name="defaultClientUrl" value="${defaultClientUrl}"/>
+        <property name="defaultHTML5ClientUrl" value="${defaultHTML5ClientUrl}"/>
         <property name="defaultGuestWaitURL" value="${defaultGuestWaitURL}"/>
         <property name="defaultMeetingDuration" value="${defaultMeetingDuration}"/>
         <property name="disableRecordingDefault" value="${disableRecordingDefault}"/>

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -494,7 +494,7 @@ class ApiController {
 
     //check if exists the param redirect
     boolean redirectClient = true;
-    String clientURL = paramsProcessorUtil.getDefaultClientUrl();
+    String clientURL = paramsProcessorUtil.getDefaultHTML5ClientUrl();
 
     String meetingInstance = meeting.getHtml5InstanceId();
     meetingInstance = (meetingInstance == null) ? "1" : meetingInstance;


### PR DESCRIPTION
In #11008 I removed the obsolete url for Flash client and had consolidated the join url for the HTML5 client under the same name (i.e. `defaultClientUrl`) since we only support one client type now. However, this change caused issues when upgrading servers due to the fact that we do not overwrite bigbluebutton.properties ..

In this PR I rename the `defaultClientUrl` parameter to be the new, unused `defaultHTML5ClientUrl` to avoid any collisions and to ensure the correct values are used on any type of BBB 2.3 installation