### PR TITLE
Handle ejected presenter case, add missing videoDock locales

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/service.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/service.js
@@ -25,9 +25,9 @@ const takePresenterRole = () => makeCall('assignPresenter', Auth.userID);
 
 export default {
   amIPresenter: () => Users.findOne({ userId: Auth.userID },
-    { fields: { presenter: 1 } }).presenter,
+    { fields: { presenter: 1 } }).presenter || false,
   amIModerator: () => Users.findOne({ userId: Auth.userID },
-    { fields: { role: 1 } }).role === ROLE_MODERATOR,
+    { fields: { role: 1 } }).role === ROLE_MODERATOR || false,
   meetingName: () => Meetings.findOne({ meetingId: Auth.meetingID },
     { fields: { 'meetingProp.name': 1 } }).meetingProp.name,
   users: () => Users.find({

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -668,6 +668,8 @@
     "app.feedback.textarea": "How can we make BigBlueButton better?",
     "app.feedback.sendFeedback": "Send Feedback",
     "app.feedback.sendFeedbackDesc": "Send a feedback and leave the meeting",
+    "app.videoDock.webcamMirrorLabel": "Mirror",
+    "app.videoDock.webcamMirrorDesc": "Mirror the selected webcam",
     "app.videoDock.webcamFocusLabel": "Focus",
     "app.videoDock.webcamFocusDesc": "Focus the selected webcam",
     "app.videoDock.webcamUnfocusLabel": "Unfocus",


### PR DESCRIPTION
The videoDock locales - this is my mistake - when I pull from 2.2 I reset all locales/ files since I don't want to cause conflicts. I should pay more attention if en.json was modified.

The isPresenter needed a default value because now that we don't keep offline users on client side, the presenter's UI was breaking when being removed from the meeting