### PR TITLE
Support for bbb-playback

### DIFF
--- a/record-and-playback/presentation/scripts/presentation.nginx
+++ b/record-and-playback/presentation/scripts/presentation.nginx
@@ -16,14 +16,18 @@
 # with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 #
 
-	location /playback/presentation/playback.html {
-		return 301 /playback/presentation/0.81/playback.html?$query_string;
-		# If you have recordings from 0.9.0 beta versions and are sure
-		# that you will never want to play recordings made with
-		# BigBlueButton 0.81, comment the line above and uncomment the
-		# following line:
-		#return 301 /playback/presentation/0.9.0/playback.html?$query_string;
-	}
+        location /playback/presentation/playback.html {
+                return 301 /playback/presentation/0.81/playback.html?$query_string;
+                # If you have recordings from 0.9.0 beta versions and are sure
+                # that you will never want to play recordings made with
+                # BigBlueButton 0.81, comment the line above and uncomment the
+                # following line:
+                #return 301 /playback/presentation/0.9.0/playback.html?$query_string;
+        }
+
+        location /playback/presentation/2.0/playback.html {
+                return 301 /playback/presentation/2.3/$arg_meetingId?$query_string;
+        }
 
         location /playback/presentation {
                 root    /var/bigbluebutton;

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1268,7 +1268,7 @@ begin
         metadata_with_playback = Nokogiri::XML::Builder.with(metadata.at('recording')) do |xml|
             xml.playback {
               xml.format("presentation")
-              xml.link("#{playback_protocol}://#{playback_host}/playback/presentation/2.0/playback.html?meetingId=#{$meeting_id}")
+              xml.link("#{playback_protocol}://#{playback_host}/playback/presentation/2.3/#{$meeting_id}")
               xml.processing_time("#{processing_time}")
               xml.duration("#{recording_time}")
               unless presentation.empty?
@@ -1370,4 +1370,3 @@ rescue Exception => e
 
   exit 1
 end
-


### PR DESCRIPTION
This PR modifies the presentation playback link to https://github.com/bigbluebutton/bbb-playback. Also, it makes bbb-playback the default playback for presentation even for old recordings.