### PR TITLE
enabling copy-pasting in the chat window on 2.3a3

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-list/message-list-item/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-list/message-list-item/styles.scss
@@ -10,6 +10,7 @@
 .item {
   padding: calc(var(--line-height-computed) / 4) 0 calc(var(--line-height-computed) / 2) 0;
   font-size: var(--font-size-base);
+  pointer-events: auto;
 }
 
 .wrapper {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Enables the copy-pasting (pointer events) in the chat window on 2.3a3

### Motivation

Most likely after 2.3a3, copy and pasting in the chat window has been impossible. Thus copying the invitation URL has been quite tedious. 

### More

The problem was confirmed in test23 server. The attribute "pointer-events: none;" is falling down from somewhere.
