### PR TITLE
Add fonts-noto-cjk to build of libreoffice docker container

### DIFF
--- a/bbb-libreoffice/docker/Dockerfile
+++ b/bbb-libreoffice/docker/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt update
 
 RUN apt -y install locales-all fontconfig libxt6 libxrender1 
-RUN apt -y install  --no-install-recommends libreoffice fonts-crosextra-carlito fonts-crosextra-caladea fonts-noto
+RUN apt -y install  --no-install-recommends libreoffice fonts-crosextra-carlito fonts-crosextra-caladea fonts-noto fonts-noto-cjk
 
 
 RUN dpkg-reconfigure fontconfig && fc-cache -f -s -v


### PR DESCRIPTION
Fix #11089