### PR TITLE
Restore swapped windows for polling

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/polling/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/polling/component.jsx
@@ -7,6 +7,10 @@ import cx from 'classnames';
 import { styles } from './styles.scss';
 import AudioService from '/imports/ui/components/audio/service';
 import {Meteor} from "meteor/meteor";
+import MediaService, {
+  getSwapLayout,
+  shouldEnableSwapLayout,
+} from '../media/service';
 
 const intlMessages = defineMessages({
   pollingTitleLabel: {
@@ -28,6 +32,8 @@ class Polling extends Component {
   }
 
   componentDidMount() {
+    const isLayoutSwapped = getSwapLayout() && shouldEnableSwapLayout();
+    if (isLayoutSwapped) MediaService.toggleSwapLayout();
     this.play();
   }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Restores window swap in order to correctly display the poll results when students minimize the presentation window.

### Closes Issue(s)

closes #11097 (but not the final solution...)

### Motivation

To show just an idea of fixing #11097 .

### More

With the minimized presentation window, BBB gets zero values for keySizes, voteSizes, and percSizes in the whiteboard-annotations-poll-compoment.jsx, which would otherwise be retrieved from the presentation window. I tried to fix it but in the end found that restoring the presentation window is much easier.

When the students minimize the presentation window after the polling window appears, this fix fails. It also fails when the moderator does the same (I assume the moderator wouldn't do it...).

For the comment from @Jossef-767 "it is possible to give up publishing the results on the presentation And leave only on the chat", I personally prefer it left in the presentation window. Good students usually keep opening the presentation, while the chat window closed ;-)