### PR TITLE
Handle guestWait url for multiple nodejs instanceIds

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -195,7 +195,6 @@ const getUsers = () => {
   let users = Users
     .find({
       meetingId: Auth.meetingID,
-      authed: true,
     }, userFindSorting)
     .fetch();
 

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -251,7 +251,7 @@ defaultHTML5ClientUrl=${bigbluebutton.web.serverURL}/html5client/%%INSTANCEID%%/
 allowRequestsWithoutSession=false
 
 # The url for where the guest will poll if approved to join or not.
-defaultGuestWaitURL=${bigbluebutton.web.serverURL}/html5client/guestWait
+defaultGuestWaitURL=${bigbluebutton.web.serverURL}/html5client/%%INSTANCEID%%/guestWait
 
 # The default avatar image to display.
 useDefaultAvatar=false

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -524,6 +524,7 @@ class ApiController {
     String destUrl = clientURL + "?sessionToken=" + sessionToken
     if (guestStatusVal.equals(GuestPolicy.WAIT)) {
       String guestWaitUrl = paramsProcessorUtil.getDefaultGuestWaitURL();
+      guestWaitUrl = guestWaitUrl.replaceAll("%%INSTANCEID%%", meetingInstance);
       destUrl = guestWaitUrl + "?sessionToken=" + sessionToken
       msgKey = "guestWait"
       msgValue = "Guest waiting for approval to join meeting."
@@ -1353,10 +1354,13 @@ class ApiController {
       String destUrl = clientURL
       log.debug("destUrl = " + destUrl)
 
+      String meetingInstance = meeting.getHtml5InstanceId();
+      meetingInstance = (meetingInstance == null) ? "1" : meetingInstance;
 
       if (guestWaitStatus.equals(GuestPolicy.WAIT)) {
-        meetingService.guestIsWaiting(userSession.meetingID, userSession.internalUserId);
+        meetingService.guestIsWaiting(us.meetingID, us.internalUserId);
         clientURL = paramsProcessorUtil.getDefaultGuestWaitURL();
+        clientURL = clientURL.replaceAll("%%INSTANCEID%%", meetingInstance);
         destUrl = clientURL + "?sessionToken=" + sessionToken
         log.debug("GuestPolicy.WAIT - destUrl = " + destUrl)
         msgKey = "guestWait"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
This PR adds bbb-web code for adjusting the guestWaitURL so it contains the meeting instanceId needed for bbb-html5.
It also removes the requirement for `authed: true` in the HTML5 client which was causing [approve] guests to not be shown in the userlist (although they were in the meeting). This requirement was fairly new (2.3), and in the past used to be `connectionStatus: 'online'`. Given that on 2.3 we added a ConnectionManager to filter the offline users, I think it is a more correct transition to just drop the connectionStatus condition, rather than replacing it with a stricter one.

### Motivation
Before this PR waiting guests would be redirected to 404 page, where the URL did not contain meeting instanceId
<!-- What inspired you to submit this pull request? -->

### More

Related to #11008 where the joinURL underwent the same replacement of %%INSTANCEID%%
