### PR TITLE
Correct path to silence.mp3

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -429,7 +429,7 @@ class AudioManager {
     // Play bogus silent audio to try to circumvent autoplay policy on Safari
     if (!audio.src) {
       audio.src = `${Meteor.settings.public.app.cdn
-      + Meteor.settings.public.app.basename + Meteor.settings.public.app.instanceId}` + 'resources/sounds/silence.mp3';
+      + Meteor.settings.public.app.basename + Meteor.settings.public.app.instanceId}` + '/resources/sounds/silence.mp3';
     }
 
     audio.play().catch((e) => {


### PR DESCRIPTION
Fixes #11057

before: `https://bbb.example.com/html5client/2resources/sounds/silence.mp3`
after:    `https://bbb.example.com/html5client/2/resources/sounds/silence.mp3`
Thanks @Rahimimojtaba for reporting!