### PR TITLE
Remove duplicated html id video-modal-input

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/modal/component.jsx
@@ -109,7 +109,7 @@ class ExternalVideoModal extends Component {
 
         <div className={styles.content}>
           <div className={styles.videoUrl}>
-            <label htmlFor="video-modal-input" id="video-modal-input">
+            <label htmlFor="video-modal-input">
               {intl.formatMessage(intlMessages.input)}
               <input
                 id="video-modal-input"


### PR DESCRIPTION
Fixes #10965

The id was duplicated a few lines below (the first one seemed unnecessary) 
```
            <label htmlFor="video-modal-input" id="video-modal-input">
              {intl.formatMessage(intlMessages.input)}
              <input
                id="video-modal-input"
```