### PR TITLE
Temporarily allow undefined user name for offline chat sender

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-list/message-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-list/message-list-item/component.jsx
@@ -119,6 +119,7 @@ class MessageListItem extends Component {
 
     const dateTime = new Date(time);
     const regEx = /<a[^>]+>/i;
+    const defaultAvatarString = user?.name?.toLowerCase().slice(0, 2) || "  ";
 
     return (
       <div className={styles.item} key={_.uniqueId('message-list-item-')}>
@@ -130,7 +131,7 @@ class MessageListItem extends Component {
               moderator={user.isModerator}
               avatar={user.avatar}
             >
-              {user.name.toLowerCase().slice(0, 2)}
+              {defaultAvatarString}
             </UserAvatar>
           </div>
           <div className={styles.content}>

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
@@ -74,7 +74,7 @@ const JoinVideoButton = ({
     <Button
       label={label}
       data-test="joinVideo"
-      className={cx(styles.button, hasVideoStream || styles.btn)}
+      className={cx(styles.btn, hasVideoStream || styles.btn)}
       onClick={handleOnClick}
       hideLabel
       color={hasVideoStream ? 'primary' : 'default'}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->
This PR addresses the following issue:

Users A and B join a meeting
User A sends public chat message and then leaves
User B refreshes the client. We no longer store info about userA, so when we try to re-render the old chat message, we cannot reconstruct the avatar string in the chat list. In this PR I simply provide a fallback value of "  ".

@Tainan404 has been working on significant changes to chat (including storing the username of the sender in the chat object), so once his work is merged, this temporary fix will be overwritten. It is in place just to ensure there is no errors in 2.3-alpha5 meanwhile.

The chat messages sent from now-offline users will have empty avatar string

### More

<!-- Anything else we should know when reviewing? -->
Related to #11111 
