### PR TITLE
Increase camera baseTimeout to 30 seconds (webcam share timeout workaround)

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -104,7 +104,7 @@ public:
     cameraTimeouts:
       # Base camera timeout: used as the camera *sharing* timeout and
       # as the minimum camera subscribe reconnection timeout
-      baseTimeout: 15000
+      baseTimeout: 30000
       # Max timeout: used as the max camera subscribe reconnection timeout. Each
       # subscribe reattempt increases the reconnection timer up to this
       maxTimeout: 60000


### PR DESCRIPTION
### What does this PR do?

Increased camera `baseTimeout` from 15 to 30 seconds in the HTML5 client. After this timeout, the frontend cancels the webcam sharing dialog and displays a `1020 error`.

### Motivation

When most students of one or more school classes start webcam sharing at the same time, Kurento occasionally takes longer than 15 seconds to return the webrtc connection success state to the client. This problem also happens quite often when students return from breakout rooms. 
This change reduces the amounts of the frontend showing `error 1020` and thus avoid the additional connection establishing requests from clients who try multiple times and who thus made the problem exponentially worse.
See https://github.com/bigbluebutton/bigbluebutton/issues/11099#issuecomment-753985300