### PR TITLE
Check if stream already exists before adding in list

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/User.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/User.java
@@ -151,7 +151,9 @@ public class User {
 	}
 	
 	public void addStream(String stream) {
-		streams.add(stream);
+		if (!streams.contains(stream)) {
+			streams.add(stream);
+		}
 	}
 	
 	public void removeStream(String stream) {


### PR DESCRIPTION
There are some case scenarios where the stream is duplicated at the API collection. It likely happens because of some stream start event duplication or webcam reconnection. This is not so easy to replicate at development but it has been seen in production more than once.

These changes validate the stream before including it at the user's stream collection.

cc @prlanzarin . 