### PR TITLE
Fix for poll result in RTL languages

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
@@ -450,26 +450,21 @@ class PollDrawComponent extends Component {
           fill={backgroundColor}
           strokeWidth={thickness}
         />
-        <text
-          x={innerRect.x}
-          y={innerRect.y}
-          fill="#333333"
-          fontFamily="Arial"
-          fontSize={calcFontSize}
-          textAnchor={isRTL ? 'end' : 'start'}
-        >
-          {extendedTextArray.map(line => (
-            <tspan
-              x={line.keyColumn.xLeft}
-              y={line.keyColumn.yLeft}
-              dy={maxLineHeight / 2}
-              key={`${line.key}_key`}
-              className={styles.outline}
-            >
-              {line.keyColumn.keyString}
-            </tspan>
-          ))}
-        </text>
+        {extendedTextArray.map(line => (
+          <text
+            x={line.keyColumn.xLeft}
+            y={line.keyColumn.yLeft}
+            dy={maxLineHeight / 2}
+            key={`${line.key}_key`}
+            fill="#333333"
+            fontFamily="Arial"
+            fontSize={calcFontSize}
+            textAnchor={isRTL ? 'end' : 'start'}
+            className={styles.outline}
+          >
+            {line.keyColumn.keyString}
+          </text>
+        ))}
         {extendedTextArray.map(line => (
           <rect
             key={`${line.key}_bar`}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
In the poll published results in the presentation canvas, there is an issue for RTL languages that caused to show reverse results label for True/False or Yes/No or even custom polls.
There is a reported issue for `tspan` tag in[chromium]( https://bugs.chromium.org/p/chromium/issues/detail?id=360176) and it can fix with 
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
closes #9273 
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number -->
