### PR TITLE
Guest feature revamp

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
@@ -28,8 +28,9 @@ trait ChangeUserRoleCmdMsgHdlr extends RightsManagementTrait {
         } yield {
           RegisteredUsers.updateUserRole(liveMeeting.registeredUsers, u, userRole)
         }
-
-        if (msg.body.role == Roles.MODERATOR_ROLE && !uvo.guest) {
+        // Mconf's guest should always be fit for promotion
+        val promoteGuest = !liveMeeting.props.usersProp.authenticatedGuest
+        if (msg.body.role == Roles.MODERATOR_ROLE && (!uvo.guest || promoteGuest)) {
           // Promote non-guest users.
           Users2x.changeRole(liveMeeting.users2x, uvo, msg.body.role)
           val event = buildUserRoleChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.userId,

--- a/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
+++ b/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
@@ -41,6 +41,7 @@ trait AppsTestFixtures {
   val maxUsers = 25
   val guestPolicy = "ALWAYS_ASK"
   val allowModsToUnmuteUsers = false
+  val authenticatedGuest = false
 
   val red5DeskShareIPTestFixture = "127.0.0.1"
   val red5DeskShareAppTestFixtures = "red5App"
@@ -60,7 +61,7 @@ trait AppsTestFixtures {
     modOnlyMessage = modOnlyMessage)
   val voiceProp = VoiceProp(telVoice = voiceConfId, voiceConf = voiceConfId, dialNumber = dialNumber, muteOnStart = muteOnStart)
   val usersProp = UsersProp(maxUsers = maxUsers, webcamsOnlyForModerator = webcamsOnlyForModerator,
-    guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers)
+    guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers, authenticatedGuest = authenticatedGuest)
   val metadataProp = new MetadataProp(metadata)
 
   val defaultProps = DefaultProps(meetingProp, breakoutProps, durationProps, password, recordProp, welcomeProp, voiceProp,

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
@@ -27,7 +27,7 @@ case class WelcomeProp(welcomeMsgTemplate: String, welcomeMsg: String, modOnlyMe
 
 case class VoiceProp(telVoice: String, voiceConf: String, dialNumber: String, muteOnStart: Boolean)
 
-case class UsersProp(maxUsers: Int, webcamsOnlyForModerator: Boolean, guestPolicy: String, allowModsToUnmuteUsers: Boolean)
+case class UsersProp(maxUsers: Int, webcamsOnlyForModerator: Boolean, guestPolicy: String, allowModsToUnmuteUsers: Boolean, authenticatedGuest: Boolean)
 
 case class MetadataProp(metadata: collection.immutable.Map[String, String])
 

--- a/bbb-common-message/src/test/scala/org/bigbluebutton/common2/TestFixtures.scala
+++ b/bbb-common-message/src/test/scala/org/bigbluebutton/common2/TestFixtures.scala
@@ -37,6 +37,7 @@ trait TestFixtures {
   val allowModsToUnmuteUsers = false
   val keepEvents = false
   val guestPolicy = "ALWAYS_ASK"
+  val authenticatedGuest = false
   val metadata: collection.immutable.Map[String, String] = Map("foo" -> "bar", "bar" -> "baz", "baz" -> "foo")
 
   val meetingProp = MeetingProp(name = meetingName, extId = externalMeetingId, intId = meetingId,
@@ -53,7 +54,7 @@ trait TestFixtures {
     modOnlyMessage = modOnlyMessage)
   val voiceProp = VoiceProp(telVoice = voiceConfId, voiceConf = voiceConfId, dialNumber = dialNumber, muteOnStart = muteOnStart)
   val usersProp = UsersProp(maxUsers = maxUsers, webcamsOnlyForModerator = webcamsOnlyForModerator,
-    guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers)
+    guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers, authenticatedGuest = authenticatedGuest)
   val metadataProp = new MetadataProp(metadata)
   val screenshareProps = ScreenshareProps(screenshareConf = "FixMe!", red5ScreenshareIp = "fixMe!",
     red5ScreenshareApp = "fixMe!")

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -360,7 +360,7 @@ public class MeetingService implements MessageListener {
             m.getTelVoice(), m.getDuration(), m.getAutoStartRecording(), m.getAllowStartStopRecording(),
             m.getWebcamsOnlyForModerator(), m.getModeratorPassword(), m.getViewerPassword(), m.getCreateTime(),
             formatPrettyDate(m.getCreateTime()), m.isBreakout(), m.getSequence(), m.isFreeJoin(), m.getMetadata(),
-            m.getGuestPolicy(), m.getWelcomeMessageTemplate(), m.getWelcomeMessage(), m.getModeratorOnlyMessage(),
+            m.getGuestPolicy(), m.getAuthenticatedGuest(), m.getWelcomeMessageTemplate(), m.getWelcomeMessage(), m.getModeratorOnlyMessage(),
             m.getDialNumber(), m.getMaxUsers(), m.getMaxInactivityTimeoutMinutes(), m.getWarnMinutesBeforeMax(),
             m.getMeetingExpireIfNoUserJoinedInMinutes(), m.getmeetingExpireWhenLastUserLeftInMinutes(),
             m.getUserInactivityInspectTimerInMinutes(), m.getUserInactivityThresholdInMinutes(),

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -81,6 +81,7 @@ public class ParamsProcessorUtil {
     private String defaultAvatarURL;
     private String defaultConfigURL;
     private String defaultGuestPolicy;
+    private Boolean authenticatedGuest;
     private int defaultMeetingDuration;
     private boolean disableRecordingDefault;
     private boolean autoStartRecording;
@@ -484,6 +485,7 @@ public class ParamsProcessorUtil {
                 .withWelcomeMessageTemplate(welcomeMessageTemplate)
                 .withWelcomeMessage(welcomeMessage).isBreakout(isBreakout)
                 .withGuestPolicy(guestPolicy)
+                .withAuthenticatedGuest(authenticatedGuest)
 				.withBreakoutRoomsParams(breakoutParams)
 				.withLockSettingsParams(lockSettingsParams)
 				.withAllowDuplicateExtUserid(defaultAllowDuplicateExtUserid)
@@ -962,6 +964,10 @@ public class ParamsProcessorUtil {
 
 	public void setDefaultGuestPolicy(String guestPolicy) {
 		this.defaultGuestPolicy =  guestPolicy;
+	}
+
+	public void setAuthenticatedGuest(Boolean value) {
+		this.authenticatedGuest = value;
 	}
 
 	public void setMaxInactivityTimeoutMinutes(Integer value) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -68,6 +68,7 @@ public class Meeting {
 	private String defaultAvatarURL;
 	private String defaultConfigToken;
 	private String guestPolicy = GuestPolicy.ASK_MODERATOR;
+	private Boolean authenticatedGuest = false;
 	private boolean userHasJoined = false;
 	private Map<String, String> metadata;
 	private Map<String, Object> userCustomData;
@@ -126,6 +127,7 @@ public class Meeting {
         createdTime = builder.createdTime;
         isBreakout = builder.isBreakout;
         guestPolicy = builder.guestPolicy;
+        authenticatedGuest = builder.authenticatedGuest;
         breakoutRoomsParams = builder.breakoutRoomsParams;
         lockSettingsParams = builder.lockSettingsParams;
         allowDuplicateExtUserid = builder.allowDuplicateExtUserid;
@@ -351,8 +353,36 @@ public class Meeting {
     	return guestPolicy;
 	}
 
+	public void setAuthenticatedGuest(Boolean authGuest) {
+		authenticatedGuest = authGuest;
+	}
+
+	public Boolean getAuthenticatedGuest() {
+		return authenticatedGuest;
+	}
+
+  private String getUnauthenticatedGuestStatus(Boolean guest) {
+		if (guest) {
+			switch(guestPolicy) {
+				case GuestPolicy.ALWAYS_ACCEPT:
+				case GuestPolicy.ALWAYS_ACCEPT_AUTH:
+					return GuestPolicy.ALLOW;
+				case GuestPolicy.ASK_MODERATOR:
+					return GuestPolicy.WAIT;
+				case GuestPolicy.ALWAYS_DENY:
+					return GuestPolicy.DENY;
+				default:
+					return GuestPolicy.DENY;
+			}
+		} else {
+			return GuestPolicy.ALLOW;
+		}
+	}
 
 	public String calcGuestStatus(String role, Boolean guest, Boolean authned) {
+		// Good ol' Mconf guest status
+		if (!authenticatedGuest) return getUnauthenticatedGuestStatus(guest);
+
 		// Allow moderators all the time.
 		if (ROLE_MODERATOR.equals(role)) {
 			return GuestPolicy.ALLOW;
@@ -675,6 +705,7 @@ public class Meeting {
     	private long createdTime;
     	private boolean isBreakout;
     	private String guestPolicy;
+    	private Boolean authenticatedGuest;
     	private BreakoutRoomsParams breakoutRoomsParams;
     	private LockSettingsParams lockSettingsParams;
 		private Boolean allowDuplicateExtUserid;
@@ -795,6 +826,11 @@ public class Meeting {
     		guestPolicy = policy;
     		return  this;
 		}
+    
+    	public Builder withAuthenticatedGuest(Boolean authGuest) {
+    		authenticatedGuest = authGuest;
+    		return this;
+    	}
 
 		public Builder withBreakoutRoomsParams(BreakoutRoomsParams params) {
     		breakoutRoomsParams = params;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
@@ -19,7 +19,7 @@ public interface IBbbWebApiGWApp {
                      Boolean allowStartStopRecording, Boolean webcamsOnlyForModerator,
                      String moderatorPass, String viewerPass, Long createTime,
                      String createDate, Boolean isBreakout, Integer sequence, Boolean freejoin, Map<String, String> metadata,
-                     String guestPolicy, String welcomeMsgTemplate, String welcomeMsg, String modOnlyMessage,
+                     String guestPolicy, Boolean authenticatedGuest, String welcomeMsgTemplate, String welcomeMsg, String modOnlyMessage,
                      String dialNumber, Integer maxUsers,
                      Integer maxInactivityTimeoutMinutes, Integer warnMinutesBeforeMax,
                      Integer meetingExpireIfNoUserJoinedInMinutes,

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/domain/UsersProp2.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/domain/UsersProp2.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 public class UsersProp2 {
     public final String guestPolicy;
+    public final boolean authenticatedGuest;
     public final boolean userHasJoined;
     public final boolean webcamsOnlyForModerator;
     public final int maxUsers;
@@ -15,6 +16,7 @@ public class UsersProp2 {
     public UsersProp2(int maxUsers,
                       boolean webcamsOnlyForModerator,
                       String guestPolicy,
+                      boolean authenticatedGuest,
                       boolean userHasJoined,
                       Map<String, String> userCustomData,
                       Map<String, User2> users,
@@ -22,6 +24,7 @@ public class UsersProp2 {
         this.maxUsers = maxUsers;
         this.webcamsOnlyForModerator = webcamsOnlyForModerator;
         this.guestPolicy = guestPolicy;
+        this.authenticatedGuest = authenticatedGuest;
         this.userHasJoined = userHasJoined;
         this.userCustomData = userCustomData;
         this.users = users;

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -127,7 +127,7 @@ class BbbWebApiGWApp(
                     viewerPass: String, createTime: java.lang.Long, createDate: String, isBreakout: java.lang.Boolean,
                     sequence: java.lang.Integer,
                     freeJoin: java.lang.Boolean,
-                    metadata: java.util.Map[String, String], guestPolicy: String,
+                    metadata: java.util.Map[String, String], guestPolicy: String, authenticatedGuest: java.lang.Boolean,
                     welcomeMsgTemplate: String, welcomeMsg: String, modOnlyMessage: String,
                     dialNumber: String, maxUsers: java.lang.Integer, maxInactivityTimeoutMinutes: java.lang.Integer,
                     warnMinutesBeforeMax:                   java.lang.Integer,
@@ -174,7 +174,7 @@ class BbbWebApiGWApp(
       modOnlyMessage = modOnlyMessage)
     val voiceProp = VoiceProp(telVoice = voiceBridge, voiceConf = voiceBridge, dialNumber = dialNumber, muteOnStart = muteOnStart.booleanValue())
     val usersProp = UsersProp(maxUsers = maxUsers.intValue(), webcamsOnlyForModerator = webcamsOnlyForModerator.booleanValue(),
-      guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers.booleanValue())
+      guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers.booleanValue(), authenticatedGuest = authenticatedGuest.booleanValue())
     val metadataProp = MetadataProp(mapAsScalaMap(metadata).toMap)
     val screenshareProps = ScreenshareProps(
       screenshareConf = voiceBridge + screenshareConfSuffix,

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -35,6 +35,7 @@ export default function addMeeting(meeting) {
     usersProp: {
       webcamsOnlyForModerator: Boolean,
       guestPolicy: String,
+      authenticatedGuest: Boolean,
       maxUsers: Number,
       allowModsToUnmuteUsers: Boolean,
     },

--- a/bigbluebutton-html5/imports/api/users/server/methods.js
+++ b/bigbluebutton-html5/imports/api/users/server/methods.js
@@ -1,6 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import validateAuthToken from './methods/validateAuthToken';
 import setEmojiStatus from './methods/setEmojiStatus';
+import setMobileUser from './methods/setMobileUser';
 import assignPresenter from './methods/assignPresenter';
 import changeRole from './methods/changeRole';
 import removeUser from './methods/removeUser';
@@ -11,6 +12,7 @@ import userLeftMeeting from './methods/userLeftMeeting';
 
 Meteor.methods({
   setEmojiStatus,
+  setMobileUser,
   assignPresenter,
   changeRole,
   removeUser,

--- a/bigbluebutton-html5/imports/api/users/server/methods/setMobileUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/methods/setMobileUser.js
@@ -1,0 +1,15 @@
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+import Logger from '/imports/startup/server/logger';
+import setMobile from '../modifiers/setMobile';
+
+export default function setMobileUser(credentials) {
+  const { meetingId, requesterUserId } = credentials;
+
+  check(meetingId, String);
+  check(requesterUserId, String);
+
+  Logger.verbose(`Mobile user ${requesterUserId} from meeting ${meetingId}`);
+
+  setMobile(meetingId, requesterUserId);
+}

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/addUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/addUser.js
@@ -65,6 +65,7 @@ export default function addUser(meetingId, userData) {
         connectionStatus: 'online',
         sortName: user.name.trim().toLowerCase(),
         color,
+        mobile: false,
         breakoutProps: {
           isBreakoutUser: Meeting.meetingProp.isBreakout,
           parentId: Meeting.breakoutProps.parentId,

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/setMobile.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/setMobile.js
@@ -1,0 +1,32 @@
+import Logger from '/imports/startup/server/logger';
+import { check } from 'meteor/check';
+import Users from '/imports/api/users';
+
+export default function setMobile(meetingId, userId) {
+  check(meetingId, String);
+  check(userId, String);
+
+  const selector = {
+    meetingId,
+    userId,
+  };
+
+  const modifier = {
+    $set: {
+      mobile: true,
+    },
+  };
+
+  const cb = (err, numChanged) => {
+    if (err) {
+      Logger.error(`Assigning mobile user: ${err}`);
+      return;
+    }
+
+    if (numChanged) {
+      Logger.info(`Assigned mobile user id=${userId} meeting=${meetingId}`);
+    }
+  };
+
+  return Users.update(selector, modifier, cb);
+}

--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -243,6 +243,7 @@ const BaseContainer = withTracker(() => {
     authed: 1,
     ejected: 1,
     color: 1,
+    mobile: 1,
     effectiveConnectionType: 1,
     extId: 1,
     guest: 1,

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -22,6 +22,7 @@ import PingPongContainer from '/imports/ui/components/ping-pong/container';
 import MediaService from '/imports/ui/components/media/service';
 import ManyWebcamsNotifier from '/imports/ui/components/video-provider/many-users-notify/container';
 import { styles } from './styles';
+import { makeCall } from '/imports/ui/services/api';
 
 const MOBILE_MEDIA = 'only screen and (max-width: 40em)';
 const APP_CONFIG = Meteor.settings.public.app;
@@ -144,6 +145,8 @@ class App extends Component {
 
       startBandwidthMonitoring();
     }
+
+    if (isMobileBrowser) makeCall('setMobileUser');
 
     logger.info({ logCode: 'app_component_componentdidmount' }, 'Client loaded successfully');
   }

--- a/bigbluebutton-html5/imports/ui/components/panel-manager/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/panel-manager/component.jsx
@@ -63,8 +63,8 @@ const CAPTIONS_MIN_WIDTH = DEFAULT_PANEL_WIDTH;
 const CAPTIONS_MAX_WIDTH = 400;
 
 // Variables for resizing waiting users.
-const WAITING_MIN_WIDTH = DEFAULT_PANEL_WIDTH;
-const WAITING_MAX_WIDTH = 800;
+const WAITING_MIN_WIDTH = 300;
+const WAITING_MAX_WIDTH = 350;
 
 const dispatchResizeEvent = () => window.dispatchEvent(new Event('resize'));
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -296,13 +296,23 @@ const isMeetingLocked = (id) => {
   return isLocked;
 };
 
-const areUsersUnmutable = () => {
-  const meeting = Meetings.findOne({ meetingId: Auth.meetingID },
-    { fields: { 'usersProp.allowModsToUnmuteUsers': 1 } });
-  if (meeting.usersProp) {
-    return meeting.usersProp.allowModsToUnmuteUsers;
+const getUsersProp = () => {
+  const meeting = Meetings.findOne(
+    { meetingId: Auth.meetingID },
+    {
+      fields: {
+        'usersProp.allowModsToUnmuteUsers': 1,
+        'usersProp.authenticatedGuest': 1,
+      },
+    }
+  );
+
+  if (meeting.usersProp) return meeting.usersProp;
+
+  return {
+    allowModsToUnmuteUsers: false,
+    authenticatedGuest: false,
   }
-  return false;
 };
 
 const curatedVoiceUser = (intId) => {
@@ -315,10 +325,11 @@ const curatedVoiceUser = (intId) => {
   };
 };
 
-const getAvailableActions = (amIModerator, isBreakoutRoom, subjectUser, subjectVoiceUser) => {
+const getAvailableActions = (amIModerator, isBreakoutRoom, subjectUser, subjectVoiceUser, usersProp) => {
   const isDialInUser = isVoiceOnlyUser(subjectUser.userId) || subjectUser.phone_user;
   const amISubjectUser = isMe(subjectUser.userId);
   const isSubjectUserModerator = subjectUser.role === ROLE_MODERATOR;
+  const isSubjectUserGuest = subjectUser.guest;
 
   const hasAuthority = amIModerator || amISubjectUser;
   const allowedToChatPrivately = !amISubjectUser && !isDialInUser;
@@ -331,7 +342,7 @@ const getAvailableActions = (amIModerator, isBreakoutRoom, subjectUser, subjectV
     && subjectVoiceUser.isVoiceUser
     && !subjectVoiceUser.isListenOnly
     && subjectVoiceUser.isMuted
-    && (amISubjectUser || areUsersUnmutable());
+    && (amISubjectUser || usersProp.allowedToUnmuteAudio);
 
   const allowedToResetStatus = hasAuthority
     && subjectUser.emoji !== EMOJI_STATUSES.none
@@ -350,13 +361,15 @@ const getAvailableActions = (amIModerator, isBreakoutRoom, subjectUser, subjectV
     && !amISubjectUser
     && !isSubjectUserModerator
     && !isDialInUser
-    && !isBreakoutRoom;
+    && !isBreakoutRoom
+    && !(isSubjectUserGuest && usersProp.authenticatedGuest);
 
   const allowedToDemote = amIModerator
     && !amISubjectUser
     && isSubjectUserModerator
     && !isDialInUser
-    && !isBreakoutRoom;
+    && !isBreakoutRoom
+    && !(isSubjectUserGuest && usersProp.authenticatedGuest);
 
   const allowedToChangeStatus = amISubjectUser;
 
@@ -575,4 +588,5 @@ export default {
   toggleUserLock,
   requestUserInformation,
   isUserPresenter,
+  getUsersProp,
 };

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
@@ -44,6 +44,7 @@ class UserListItem extends PureComponent {
       meetingIsBreakout,
       isMeteorConnected,
       isMe,
+      usersProp,
       voiceUser,
     } = this.props;
 
@@ -75,6 +76,7 @@ class UserListItem extends PureComponent {
           meetingIsBreakout,
           isMeteorConnected,
           isMe,
+          usersProp,
           voiceUser,
         }}
       />

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/container.jsx
@@ -34,6 +34,7 @@ export default withTracker(({ user }) => {
     getGroupChatPrivate: UserListService.getGroupChatPrivate,
     getEmojiList: UserListService.getEmojiList(),
     getEmoji: UserListService.getEmoji(),
+    usersProp: UserListService.getUsersProp(),
     hasPrivateChatBetweenUsers: UserListService.hasPrivateChatBetweenUsers,
   };
 })(UserListItemContainer);

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
@@ -32,10 +32,6 @@ const messages = defineMessages({
     id: 'app.userList.locked',
     description: 'Text for identifying locked user',
   },
-  guest: {
-    id: 'app.userList.guest',
-    description: 'Text for identifying guest user',
-  },
   menuTitleContext: {
     id: 'app.userList.menuTitleContext',
     description: 'adds context to userListItem menu title',
@@ -238,11 +234,12 @@ class UserDropdown extends PureComponent {
       isMe,
       meetingIsBreakout,
       mountModal,
+      usersProp,
     } = this.props;
     const { showNestedOptions } = this.state;
 
     const amIModerator = currentUser.role === ROLE_MODERATOR;
-    const actionPermissions = getAvailableActions(amIModerator, meetingIsBreakout, user, voiceUser);
+    const actionPermissions = getAvailableActions(amIModerator, meetingIsBreakout, user, voiceUser, usersProp);
     const actions = [];
 
     const {
@@ -369,7 +366,7 @@ class UserDropdown extends PureComponent {
       ));
     }
 
-    if (allowedToPromote && !user.guest && isMeteorConnected) {
+    if (allowedToPromote && isMeteorConnected) {
       actions.push(this.makeDropdownItem(
         'promote',
         intl.formatMessage(messages.PromoteUserLabel),
@@ -378,7 +375,7 @@ class UserDropdown extends PureComponent {
       ));
     }
 
-    if (allowedToDemote && !user.guest && isMeteorConnected) {
+    if (allowedToDemote && isMeteorConnected) {
       actions.push(this.makeDropdownItem(
         'demote',
         intl.formatMessage(messages.DemoteUserLabel),

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-name/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-name/component.jsx
@@ -17,6 +17,10 @@ const messages = defineMessages({
     id: 'app.userList.locked',
     description: 'Text for identifying locked user',
   },
+  mobile: {
+    id: 'app.userList.mobile',
+    description: 'Text for identifying mobile user',
+  },
   guest: {
     id: 'app.userList.guest',
     description: 'Text for identifying guest user',
@@ -75,6 +79,10 @@ const UserName = (props) => {
         {intl.formatMessage(messages.locked)}
       </span>,
     );
+  }
+
+  if (user.mobile) {
+    userNameSub.push(intl.formatMessage(messages.mobile));
   }
 
   if (user.guest) {

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-name/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-name/component.jsx
@@ -17,6 +17,10 @@ const messages = defineMessages({
     id: 'app.userList.locked',
     description: 'Text for identifying locked user',
   },
+  moderator: {
+    id: 'app.userList.moderator',
+    description: 'Text for identifying moderator user',
+  },
   mobile: {
     id: 'app.userList.mobile',
     description: 'Text for identifying mobile user',
@@ -49,6 +53,7 @@ const propTypes = {
   isActionsOpen: PropTypes.bool.isRequired,
 };
 
+const LABEL = Meteor.settings.public.user.label;
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 
 const UserName = (props) => {
@@ -81,12 +86,16 @@ const UserName = (props) => {
     );
   }
 
+  if (user.role === ROLE_MODERATOR) {
+    if (LABEL.moderator) userNameSub.push(intl.formatMessage(messages.moderator));
+  }
+
   if (user.mobile) {
-    userNameSub.push(intl.formatMessage(messages.mobile));
+    if (LABEL.mobile) userNameSub.push(intl.formatMessage(messages.mobile));
   }
 
   if (user.guest) {
-    userNameSub.push(intl.formatMessage(messages.guest));
+    if (LABEL.guest) userNameSub.push(intl.formatMessage(messages.guest));
   }
 
   return (

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
@@ -114,18 +114,22 @@ const renderGuestUserItem = (name, color, handleAccept, handleDeny, role, sequen
 const renderPendingUsers = (message, usersArray, action, intl) => {
   if (!usersArray.length) return null;
   return (
-    <div>
+    <div className={styles.pendingUsers}>
       <p className={styles.mainTitle}>{message}</p>
-      {usersArray.map((user, idx) => renderGuestUserItem(
-        user.name,
-        user.color,
-        () => action([user], ALLOW_STATUS),
-        () => action([user], DENY_STATUS),
-        user.role,
-        idx + 1,
-        user.intId,
-        intl,
-      ))}
+      <div className={styles.usersWrapper}>
+        <div className={styles.users}>
+          {usersArray.map((user, idx) => renderGuestUserItem(
+            user.name,
+            user.color,
+            () => action([user], ALLOW_STATUS),
+            () => action([user], DENY_STATUS),
+            user.role,
+            idx + 1,
+            user.intId,
+            intl,
+          ))}
+        </div>
+      </div>
     </div>
   );
 };
@@ -228,7 +232,7 @@ const WaitingUsers = (props) => {
           />
         </div>
       </header>
-      <main>
+      <div>
         <div>
           <p className={styles.mainTitle}>{intl.formatMessage(intlMessages.optionTitle)}</p>
           {
@@ -244,21 +248,21 @@ const WaitingUsers = (props) => {
             {intl.formatMessage(intlMessages.rememberChoice)}
           </label>
         </div>
-        {renderPendingUsers(
-          intl.formatMessage(intlMessages.pendingUsers,
-            { 0: authenticatedUsers.length }),
-          authenticatedUsers,
-          guestUsersCall,
-          intl,
-        )}
-        {renderPendingUsers(
-          intl.formatMessage(intlMessages.pendingGuestUsers,
-            { 0: guestUsers.length }),
-          guestUsers,
-          guestUsersCall,
-          intl,
-        )}
-      </main>
+      </div>
+      {renderPendingUsers(
+        intl.formatMessage(intlMessages.pendingUsers,
+          { 0: authenticatedUsers.length }),
+        authenticatedUsers,
+        guestUsersCall,
+        intl,
+      )}
+      {renderPendingUsers(
+        intl.formatMessage(intlMessages.pendingGuestUsers,
+          { 0: guestUsers.length }),
+        guestUsers,
+        guestUsersCall,
+        intl,
+      )}
     </div>
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
@@ -48,12 +48,26 @@ const intlMessages = defineMessages({
     id: 'app.userList.guest.rememberChoice',
     description: 'Remember label for checkbox',
   },
+  accept: {
+    id: 'app.userList.guest.acceptLabel',
+    description: 'Accept guest button label'
+  },
+  deny: {
+    id: 'app.userList.guest.denyLabel',
+    description: 'Deny guest button label',
+  },
 });
 
 const ALLOW_STATUS = 'ALLOW';
 const DENY_STATUS = 'DENY';
 
-const renderGuestUserItem = (name, color, handleAccept, handleDeny, role, sequence, userId) => (
+const getNameInitials = (name) => {
+  const nameInitials = name.slice(0, 2);
+
+  return nameInitials.replace(/^\w/, c => c.toUpperCase());
+}
+
+const renderGuestUserItem = (name, color, handleAccept, handleDeny, role, sequence, userId, intl) => (
   <div key={`userlist-item-${userId}`} className={styles.listItem}>
     <div key={`user-content-container-${userId}`} className={styles.userContentContainer}>
       <div key={`user-avatar-container-${userId}`} className={styles.userAvatar}>
@@ -62,7 +76,7 @@ const renderGuestUserItem = (name, color, handleAccept, handleDeny, role, sequen
           moderator={role === 'MODERATOR'}
           color={color}
         >
-          {name.slice(0, 2).toUpperCase()}
+          {getNameInitials(name)}
         </UserAvatar>
       </div>
       <p key={`user-name-${userId}`} className={styles.userName}>
@@ -80,7 +94,7 @@ const renderGuestUserItem = (name, color, handleAccept, handleDeny, role, sequen
         color="primary"
         size="lg"
         ghost
-        label="Accept"
+        label={intl.formatMessage(intlMessages.accept)}
         onClick={handleAccept}
       />
       |
@@ -90,14 +104,14 @@ const renderGuestUserItem = (name, color, handleAccept, handleDeny, role, sequen
         color="primary"
         size="lg"
         ghost
-        label="Deny"
+        label={intl.formatMessage(intlMessages.deny)}
         onClick={handleDeny}
       />
     </div>
   </div>
 );
 
-const renderPendingUsers = (message, usersArray, action) => {
+const renderPendingUsers = (message, usersArray, action, intl) => {
   if (!usersArray.length) return null;
   return (
     <div>
@@ -110,6 +124,7 @@ const renderPendingUsers = (message, usersArray, action) => {
         user.role,
         idx + 1,
         user.intId,
+        intl,
       ))}
     </div>
   );
@@ -234,12 +249,14 @@ const WaitingUsers = (props) => {
             { 0: authenticatedUsers.length }),
           authenticatedUsers,
           guestUsersCall,
+          intl,
         )}
         {renderPendingUsers(
           intl.formatMessage(intlMessages.pendingGuestUsers,
             { 0: guestUsers.length }),
           guestUsers,
           guestUsersCall,
+          intl,
         )}
       </main>
     </div>

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { Session } from 'meteor/session';
 import { defineMessages, injectIntl } from 'react-intl';
@@ -131,6 +132,7 @@ const WaitingUsers = (props) => {
     guestUsers,
     guestUsersCall,
     changeGuestPolicy,
+    authenticatedGuest,
   } = props;
 
   const onCheckBoxChange = (e) => {
@@ -156,7 +158,7 @@ const WaitingUsers = (props) => {
     />
   );
 
-  const buttonsData = [
+  const authGuestButtonsData = [
     {
       messageId: intlMessages.allowAllAuthenticated,
       action: () => guestUsersCall(authenticatedUsers, ALLOW_STATUS),
@@ -172,6 +174,9 @@ const WaitingUsers = (props) => {
       key: 'allow-all-guest',
       policy: 'ALWAYS_ACCEPT',
     },
+  ];
+
+  const guestButtonsData = [
     {
       messageId: intlMessages.allowEveryone,
       action: () => guestUsersCall([...guestUsers, ...authenticatedUsers], ALLOW_STATUS),
@@ -185,6 +190,8 @@ const WaitingUsers = (props) => {
       policy: 'ALWAYS_DENY',
     },
   ];
+
+  const buttonsData = authenticatedGuest ? _.concat(authGuestButtonsData , guestButtonsData) : guestButtonsData;
 
   return (
     <div

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/container.jsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import Auth from '/imports/ui/services/auth';
 import GuestUsers from '/imports/api/guest-users/';
+import Meetings from '/imports/api/meetings';
 import Service from './service';
 import WaitingComponent from './component';
 
@@ -30,10 +31,13 @@ export default withTracker(() => {
     denied: false,
   }).fetch();
 
+  const authenticatedGuest = Meetings.findOne({ meetingId: Auth.meetingID }).usersProp.authenticatedGuest;
+
   return {
     guestUsers,
     authenticatedUsers,
     guestUsersCall: Service.guestUsersCall,
     changeGuestPolicy: Service.changeGuestPolicy,
+    authenticatedGuest,
   };
 })(WaitingContainer);

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
@@ -81,7 +81,7 @@
 }
 
 .userAvatar {
-  width: 2rem;
+  min-width: 2.25rem;
   margin: .5rem;
 }
 
@@ -150,7 +150,6 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  width: 100%;
 }
 
 .rememberContainer {

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
@@ -144,6 +144,33 @@
   }
 }
 
+.pendingUsers {
+  display: flex;
+  height: 100%;
+  width: 100%;
+  flex-direction: column;
+}
+
+.usersWrapper {
+  display: flex;
+  height: 100%;
+  width: 100%;
+  flex-direction: column;
+  position: relative;
+}
+
+.users {
+  display: flex;
+  flex-direction: column;
+  overflow-x: hidden;
+  overflow-y: auto;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  height: 100%;
+  width: 100%;
+}
+
 .userName {
   min-width: 0;
   display: inline-block;

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
@@ -2,36 +2,36 @@
 @import "/imports/ui/stylesheets/variables/_all";
 
 .panel {
-  background-color: #fff;
-  padding: var(--md-padding-x);
+  background-color: var(--color-white);
+  padding:
+    var(--md-padding-x)
+    var(--md-padding-y)
+    var(--md-padding-x)
+    var(--md-padding-x);
+
   display: flex;
   flex-grow: 1;
   flex-direction: column;
+  justify-content: space-around;
   overflow: hidden;
   height: 100vh;
+
+  :global(.browser-chrome) & {
+    transform: translateZ(0);
+  }
+
+  @include mq($small-only) {
+    transform: none !important;
+  }
 }
 
 .header {
+  position: relative;
+  top: var(--poll-header-offset);
   display: flex;
   flex-direction: row;
-  align-items: left;
-  flex-shrink: 0;
-
-  a {
-    @include elementFocus(var(--color-primary));
-    padding: 0 0 var(--sm-padding-y) var(--sm-padding-y);
-    text-decoration: none;
-    display: block;
-
-    [dir="rtl"] & {
-      padding: 0 var(--sm-padding-y) var(--sm-padding-y) 0;
-    }
-  }
-
-  [class^="icon-bbb-"],
-  [class*=" icon-bbb-"] {
-    font-size: 85%;
-  }
+  align-items: center;
+  justify-content: space-between;
 }
 
 .title {
@@ -39,9 +39,7 @@
   flex: 1;
 
   & > button, button:hover {
-    margin-top: 0;
-    padding-top: 0;
-    border-top: 0;
+    max-width: var(--toast-content-width);
   }
 }
 
@@ -49,8 +47,8 @@
   position: relative;
   background-color: var(--color-white);
   display: block;
-  margin: 4px;
-  margin-bottom: 2px;
+  margin: var(--border-size-large);
+  margin-bottom: var(--border-size);
   padding-left: 0;
   padding-right: inherit;
 
@@ -60,7 +58,16 @@
   }
 
   > i {
-    color: black;
+    color: var(--color-gray-dark);
+    font-size: smaller;
+
+    [dir="rtl"] & {
+      -webkit-transform: scale(-1, 1);
+      -moz-transform: scale(-1, 1);
+      -ms-transform: scale(-1, 1);
+      -o-transform: scale(-1, 1);
+      transform: scale(-1, 1);
+    }
   }
 
   &:hover {

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -353,6 +353,10 @@ public:
   user:
     role_moderator: MODERATOR
     role_viewer: VIEWER
+    label:
+      moderator: false
+      mobile: true
+      guest: false
   whiteboard:
     annotations:
       status:

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -356,7 +356,7 @@ public:
     label:
       moderator: false
       mobile: true
-      guest: false
+      guest: true
   whiteboard:
     annotations:
       status:

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -493,6 +493,8 @@
     "app.userList.guest.pendingGuestUsers": "{0} Pending Guest Users",
     "app.userList.guest.pendingGuestAlert": "Has joined the session and is waiting for your approval.",
     "app.userList.guest.rememberChoice": "Remember choice",
+    "app.userList.guest.acceptLabel": "Accept",
+    "app.userList.guest.denyLabel": "Deny",
     "app.user-info.title": "Directory Lookup",
     "app.toast.breakoutRoomEnded": "The breakout room ended.  Please rejoin in the audio.",
     "app.toast.chat.public": "New Public Chat message",

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -66,6 +66,7 @@
     "app.userList.byModerator": "by (Moderator)",
     "app.userList.label": "User list",
     "app.userList.toggleCompactView.label": "Toggle compact view mode",
+    "app.userList.mobile": "Mobile",
     "app.userList.guest": "Guest",
     "app.userList.menuTitleContext": "Available options",
     "app.userList.chatListItem.unreadSingular": "{0} New Message",

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -66,6 +66,7 @@
     "app.userList.byModerator": "by (Moderator)",
     "app.userList.label": "User list",
     "app.userList.toggleCompactView.label": "Toggle compact view mode",
+    "app.userList.moderator": "Moderator",
     "app.userList.mobile": "Mobile",
     "app.userList.guest": "Guest",
     "app.userList.menuTitleContext": "Available options",

--- a/bigbluebutton-html5/private/locales/pt_BR.json
+++ b/bigbluebutton-html5/private/locales/pt_BR.json
@@ -66,6 +66,7 @@
     "app.userList.byModerator": "Por (Moderador)",
     "app.userList.label": "Lista de participantes",
     "app.userList.toggleCompactView.label": "Alternar para o modo de exibição compacta",
+    "app.userList.moderator": "Moderador",
     "app.userList.mobile": "Móvel",
     "app.userList.guest": "Convidado",
     "app.userList.menuTitleContext": "Opções disponíveis",

--- a/bigbluebutton-html5/private/locales/pt_BR.json
+++ b/bigbluebutton-html5/private/locales/pt_BR.json
@@ -66,6 +66,7 @@
     "app.userList.byModerator": "Por (Moderador)",
     "app.userList.label": "Lista de participantes",
     "app.userList.toggleCompactView.label": "Alternar para o modo de exibição compacta",
+    "app.userList.mobile": "Móvel",
     "app.userList.guest": "Convidado",
     "app.userList.menuTitleContext": "Opções disponíveis",
     "app.userList.chatListItem.unreadSingular": "{0} nova mensagem",

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -133,6 +133,9 @@ defaultDialAccessNumber=613-555-1234
 #
 defaultGuestPolicy=ALWAYS_ACCEPT
 
+# Enables or disables authenticated guest
+authenticatedGuest=false
+
 #
 #----------------------------------------------------
 # Default welcome message to display when the participant joins the web

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -134,7 +134,7 @@ defaultDialAccessNumber=613-555-1234
 defaultGuestPolicy=ALWAYS_ACCEPT
 
 # Enables or disables authenticated guest
-authenticatedGuest=false
+authenticatedGuest=true
 
 #
 #----------------------------------------------------

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -138,6 +138,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="defaultAvatarURL" value="${defaultAvatarURL}"/>
         <property name="defaultConfigURL" value="${defaultConfigURL}"/>
         <property name="defaultGuestPolicy" value="${defaultGuestPolicy}"/>
+        <property name="authenticatedGuest" value="${authenticatedGuest}"/>
         <property name="maxInactivityTimeoutMinutes" value="${maxInactivityTimeoutMinutes}"/>
         <property name="warnMinutesBeforeMax" value="${warnMinutesBeforeMax}"/>
         <property name="meetingExpireIfNoUserJoinedInMinutes" value="${meetingExpireIfNoUserJoinedInMinutes}"/>


### PR DESCRIPTION
Brings the original guest feature back when bbb-web sets `authenticatedGuest=false`. Decided to sent this to 2.2 because it can only benefits from this changes. I apply myself to merge this branch with `develop` when needed.

**Authenticated user is something that does not apply for the regular use case of a bigbluebutton's meeting**. This work includes a simple way to disable it and remove a load of complexity from the guest feature:
 - `authenticatedGuest` property at bbb-web: when false, the only users that will need moderator approval to join the room are guests. A guest user is an user that have the `guest=true` parameter on his/her join URL.
 - multiple fixes for the waiting-users panel:
   - avatar style
   - vertical scroll
   - hide authenticated users options when `authenticatedGuest` is false
   - adjusts at header and width
- user's name labels configurable at `settings.yml`. Enables/disables:
  - mobile users identification
  - guest users identification
  - moderator users identification
- guests will be candidates for promotion/demotion when `authenticatedGuest` is false

TL;DR: When `authenticatedGuest` is set to false, guests will be just like regular users. The only difference is that they will need approval to join the room following the meeting's guest policy.