### PR TITLE
Fix stream stop for multiple webcams

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -164,11 +164,18 @@ class VideoService {
         meetingId: Auth.meetingID,
         userId: Auth.userID,
       }, { fields: { stream: 1 } },
-    ).fetch().length;
-    this.sendUserUnshareWebcam(cameraId);
-    if (streams < 2) {
-      // If the user had less than 2 streams, set as a full disconnection
-      this.exitedVideo();
+    ).fetch();
+
+    const hasStream = streams.some(s => s.stream === cameraId);
+
+    if (hasStream) {
+      this.sendUserUnshareWebcam(cameraId);
+
+      const hasOtherStream = streams.some(s => s.stream !== cameraId);
+      if (!hasOtherStream) {
+        // Was the last stream this user had. Set as a full disconnection
+        this.exitedVideo();
+      }
     }
   }
 


### PR DESCRIPTION
Video provider's service for local stream control was wrongly setting the disconnected
state when a multiple webcam user tried to stop a single cam. The `stopVideo` method
was inconsistent when called multiple times for the same `cameraId`.

Included a better testing scope for event dispatching and disconnected state handling.

Closes #11140