### PR TITLE
Allow audio constraints to be changed in bbb-html5's settings.yml

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -306,6 +306,20 @@ public:
     websocketKeepAliveDebounce: 10
     #Trace sip/audio messages in browser. If not set, default value is false.
     traceSip: false
+    #Audio constraints for microphone. Use this to control browser's filters,
+    #such as AGC (Auto Gain Control) , Echo Cancellation, Noise Supression, etc.
+    #See https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSettings#Properties_of_audio_tracks
+    #for more details. Currently, google chrome sets {ideal: true}
+    #for autoGainControl, echoCancellation and noiseSuppression, if not set.
+    #The accepted value for each constraint is an object of type
+    #https://developer.mozilla.org/en-US/docs/Web/API/ConstrainBoolean
+    # audioMicrophoneConstraints:
+    #     autoGainControl:
+    #       ideal: true
+    #     echoCancellation:
+    #       ideal: true
+    #     noiseSuppression:
+    #       ideal: true
   presentation:
     defaultPresentationFile: default.pdf
     panZoomThrottle: 32


### PR DESCRIPTION
In some scenarios, there's no need for the browser to apply such audio filters. For example, when user's microphone already does audio filtering (echo cancellation, noise supression ...).
This commit doens't change the current behavior (filters still follow browser's default config): admins need to uncomment/set these values if disabling/enabling specific filters if desired.
This is related to #4873
