### PR TITLE
preserve bbbWebAPI and sharedSecret over upgrades

### DIFF
--- a/akka-bbb-apps/src/debian/DEBIAN/postinst
+++ b/akka-bbb-apps/src/debian/DEBIAN/postinst
@@ -1,0 +1,8 @@
+if [ -f /tmp/application.conf ]; then
+  for KEY in bbbWebAPI sharedSecret; do
+    VALUE=$(grep $KEY /tmp/application.conf | sed 's/[^=]*=//')
+    if [ ! -z "$VALUE" ]; then
+      sed -i "/$KEY/s|=.*|=$VALUE|" /usr/share/bbb-apps-akka/conf/application.conf
+    fi
+  done
+fi

--- a/akka-bbb-apps/src/debian/DEBIAN/preinst
+++ b/akka-bbb-apps/src/debian/DEBIAN/preinst
@@ -1,0 +1,10 @@
+case "$1" in
+  install|upgrade|1|2)
+
+    rm -f /tmp/application.conf
+    if [ -f /usr/share/bbb-apps-akka/conf/application.conf ]; then
+      cp /usr/share/bbb-apps-akka/conf/application.conf /tmp/application.conf
+    fi
+
+  ;;
+esac


### PR DESCRIPTION
**Goal:** get to the point where upgrades can occur without having to re-run bbb-conf (or anything else)

The Scala build tool (sbt) allows packaging scripts to be put in the `src/debian/DEBIAN` directory to augment (not replace) the standard scripts provided by sbt.

I've verified that this patch successfully preserves the two settings in question over an upgrade, and doesn't affect the script's standard operation, which is to add bbb-apps-akka as a system service and start it running.
