### PR TITLE
Revive "no selectable viewer" warning in random viewer selection

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/SelectRandomViewerReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/SelectRandomViewerReqMsgHdlr.scala
@@ -33,9 +33,14 @@ trait SelectRandomViewerReqMsgHdlr extends RightsManagementTrait {
     } else {
       val users = Users2x.findViewers(liveMeeting.users2x)
       val randNum = new scala.util.Random
+      val presenter = Users2x.findPresenter(liveMeeting.users2x)
 
       if (users.size > 0) {
         broadcastEvent(msg, users(randNum.nextInt(users.size)))
+      } else if (users.size == 0) {
+        if (presenter.isDefined) {
+          broadcastEvent(msg, presenter.get)
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fixes the bug #11209 by sending a dummy (presenter's) UserState when no viewer joins the meeting, so that the SelectRandomViewerReqMsg message is sent even without a viewer.

### Closes Issue(s)

closes #11209
related to #11175 and  #10359
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number -->

### Motivation

The code at line 76, "intl.formatMessage(messages.noViewers)", in bigbluebutton-html5/imports/ui/components/modal/random-user/component.jsx was never used and "no selectable user" warning was not displayed as the PR originally intended.

