### PR TITLE
Avoid setting empty/undefined constraint

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -988,6 +988,8 @@ class SIPSession {
    */
   async updateAudioConstraints(constraints) {
     try {
+      if (typeof constraints !== 'object') return;
+
       logger.info({
         logCode: 'sipjs_update_audio_constraint',
         extraInfo: {


### PR DESCRIPTION
This removes the console warning about invalid constraint
For more info see: #11206