### PR TITLE
video-provider: make video-list-item actions dropdown keys unique

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
@@ -77,6 +77,8 @@ const findOptimalGrid = (canvasWidth, canvasHeight, gutter, aspectRatio, numItem
 };
 
 const ASPECT_RATIO = 4 / 3;
+const ACTION_NAME_FOCUS = 'focus';
+const ACTION_NAME_MIRROR = 'mirror';
 
 class VideoList extends Component {
   constructor(props) {
@@ -300,6 +302,7 @@ class VideoList extends Component {
       const isFocusedIntlKey = !isFocused ? 'focus' : 'unfocus';
       const isMirrored = this.cameraIsMirrored(cameraId);
       let actions = [{
+        actionName: ACTION_NAME_MIRROR,
         label: intl.formatMessage(intlMessages['mirrorLabel']),
         description: intl.formatMessage(intlMessages['mirrorDesc']),
         onClick: () => this.mirrorCamera(cameraId),
@@ -307,6 +310,7 @@ class VideoList extends Component {
 
       if (numOfStreams > 2) {
         actions.push({
+          actionName: ACTION_NAME_FOCUS,
           label: intl.formatMessage(intlMessages[`${isFocusedIntlKey}Label`]),
           description: intl.formatMessage(intlMessages[`${isFocusedIntlKey}Desc`]),
           onClick: () => this.handleVideoFocus(cameraId),

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -111,7 +111,7 @@ class VideoListItem extends Component {
     return _.compact([
       <DropdownListTitle className={styles.hiddenDesktop} key="name">{name}</DropdownListTitle>,
       <DropdownListSeparator className={styles.hiddenDesktop} key="sep" />,
-      ...actions.map(action => (<DropdownListItem key={cameraId} {...action} />)),
+      ...actions.map(action => (<DropdownListItem key={`${cameraId}-${action.actionName}`} {...action} />)),
     ]);
   }
 


### PR DESCRIPTION
### What does this PR do?

When multiple actions were bolted in the dropdown (mirror, focus), the video-list-item actions dropdown entry keys were getting duplicated as $cameraId. 

This is a regression from https://github.com/bigbluebutton/bigbluebutton/pull/10925. I'm not sure why React isn't churning out warnings in the console, but nonetheless the keys should be revised.

So:
  - Add a new entry to video-list's `actions` called `actionName`, which is the hardcoded action name (constants)
  - Use the actionName to create a unique ID concatenated with the cameraId `${cameraId}-${action.actionName}`
  
### Closes Issue(s)

None

### More

https://github.com/bigbluebutton/bigbluebutton/pull/10925
