### PR TITLE
video-provider: Revert "Improve 16x9 Support"

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
@@ -71,7 +71,7 @@ const findOptimalGrid = (canvasWidth, canvasHeight, gutter, aspectRatio, numItem
     columns,
     rows,
     width: (cellWidth * columns) + gutterTotalWidth,
-    maxHeight: (cellHeight * rows) + gutterTotalHeight,
+    height: (cellHeight * rows) + gutterTotalHeight,
     filledArea: (cellWidth * cellHeight) * numItems,
   };
 };


### PR DESCRIPTION
### What does this PR do?

This reverts commit b8fc94c722035ef32bb0d6395d6c7a72f5c6b1d9, which was introduced by PR #10912.

### Closes Issue(s)

None.

### Motivation

Mea culpa. I did not test #10912 as thoroughly as I should.
There's a regression with aspect ratio containment in the video dock, with Safari, when there are vertical (ie smartphone) cameras shared in the meeting. Likely induced by the maxHeight change which I know behaves a bit clunkier than in Blink or Gecko. Regressions I've seen:
  - Webcam's aren't contained to the presentation
  - All webcam entries are scaled to the entry with the largest height, and that one isn't cropped
 
Example screenshot: 

![regres1-saf](https://user-images.githubusercontent.com/4529051/105870337-ee43e880-5fd6-11eb-953c-4833d767d5b6.png)


I personally don't intend to invest any time in 16x9 UI support in 2.2, so I'm reverting it for the time being.




### More

#10912.
