### PR TITLE
audio: fix talking-indicator mute debounce

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/container.jsx
@@ -10,6 +10,7 @@ import Service from './service';
 
 const APP_CONFIG = Meteor.settings.public.app;
 const { enableTalkingIndicator } = APP_CONFIG;
+const TALKING_INDICATOR_MUTE_INTERVAL = 500;
 
 const TalkingIndicatorContainer = (props) => {
   if (!enableTalkingIndicator) return null;
@@ -47,7 +48,7 @@ export default withTracker(() => {
     }
   }
 
-  const muteUser = (id) => {
+  const muteUser = debounce((id) => {
     const user = VoiceUsers.findOne({ meetingId, voiceUserId: id }, {
       fields: {
         muted: 1,
@@ -55,11 +56,11 @@ export default withTracker(() => {
     });
     if (user.muted) return;
     makeCall('toggleVoice', id);
-  };
+  }, TALKING_INDICATOR_MUTE_INTERVAL, { leading: true, trailing: false });
 
   return {
     talkers,
-    muteUser: id => debounce(muteUser(id), 500, { leading: true, trailing: false }),
+    muteUser,
     openPanel: Session.get('openPanel'),
     isBreakoutRoom: meetingIsBreakout(),
   };


### PR DESCRIPTION
### What does this PR do?

The debounce introduced in https://github.com/bigbluebutton/bigbluebutton/pull/9756 was broken because the first argument passed to it was wrong. 

That opened a tiny little breach where a spammer could effectively unmute an user right after muting them (which the talking indicator was designed not to allow even if bbb-web allows mods to unmute users (?)).

Moreover, if akka-apps' rights management ejections are activated and mods aren't allowed to unmute users, the mod would get kicked out. So:

  - Fix `muteUser`'s debouncing
  - Make it's interval a constant (not configurable for the time being, kept the original 500ms)
  
### Closes Issue(s)

Fixes #11226
Might fix https://github.com/bigbluebutton/bigbluebutton/issues/9731 ? I don't really know what's up with that issue. If #9756 was supposed to fix it it should've been closed.
### More

 https://github.com/bigbluebutton/bigbluebutton/pull/9756 
