### PR TITLE
audio: add a configurable throttle to action-bar`s mute toggle

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -315,6 +315,8 @@ public:
     #user activates microphone.
     iceGatheringTimeout: 5000
     sipjsHackViaWs: false
+    # Mute/umute toggle throttle time
+    toggleMuteThrottleTime: 300
     #Websocket keepAlive interval (seconds). You may set this to prevent
     #websocket disconnection in some environments. When set, BBB will send
     #'\r\n\r\n' string through SIP.js's websocket. If not set, default value


### PR DESCRIPTION
### What does this PR do?

The `action-bar` mute toggle currently has no debounce nor throttle, making it spammable.
Pretty easy to overload meteor if remote logging is on and enough people do it at the same time.
So I did the following:
  - Add a throttle to audio-controls' toggleMuteMicrophone
  - Make the throttle's interval configurable
    * New configuration parameter: `Meteor.settings.public.media.toggleMuteThrottleTime`. Throttle interval in ms.
    * Default value is 300 ms. I did not use much science coming up with that default. I just tested it a bit to see what would mitigate damage while not making it too clunky.
    * Original behaviour is restored by setting it to 0 ms (worst case scenario it'll be clamped to 1 ms depending on the JS engine).
    
This is really just a workaround. Throttling should be server-mandated.
  
### Closes Issue(s)

Fixes #11227