### PR TITLE
video-provider: add inbound/recvonly video reconnection

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/media/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/component.jsx
@@ -47,6 +47,7 @@ export default class Media extends Component {
       audioModalIsOpen,
       usersVideo,
       webcamPlacement,
+      isMeteorConnected,
     } = this.props;
 
     const contentClassName = cx({
@@ -60,7 +61,7 @@ export default class Media extends Component {
     });
 
     const { viewParticipantsWebcams } = Settings.dataSaving;
-    const showVideo = usersVideo.length > 0 && viewParticipantsWebcams;
+    const showVideo = usersVideo.length > 0 && viewParticipantsWebcams && isMeteorConnected;
     const fullHeight = !showVideo || (webcamPlacement === 'floating');
 
     return (

--- a/bigbluebutton-html5/imports/ui/components/media/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/container.jsx
@@ -111,6 +111,7 @@ export default withModalMounter(withTracker(() => {
   const data = {
     children: <DefaultContent {...{ autoSwapLayout, hidePresentation }} />,
     audioModalIsOpen: Session.get('audioModalIsOpen'),
+    isMeteorConnected: Meteor.status().connected,
   };
 
   if (MediaService.shouldShowWhiteboard() && !hidePresentation) {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -341,6 +341,7 @@ class VideoProvider extends Component {
             logCode: 'video_provider_peerconnection_processanswer_error',
             extraInfo: {
               cameraId,
+              role,
               errorMessage: error.message,
               errorCode: error.code,
             },
@@ -356,7 +357,7 @@ class VideoProvider extends Component {
     } else {
       logger.warn({
         logCode: 'video_provider_startresponse_no_peer',
-        extraInfo: { cameraId },
+        extraInfo: { cameraId, role },
       }, 'No peer on SFU camera start response handler');
     }
   }
@@ -438,6 +439,9 @@ class VideoProvider extends Component {
 
   destroyWebRTCPeer(cameraId) {
     const peer = this.webRtcPeers[cameraId];
+    const isLocal = VideoService.isLocalStream(cameraId);
+    const role = VideoService.getRole(isLocal);
+
     if (peer) {
       if (typeof peer.dispose === 'function') {
         peer.dispose();
@@ -447,13 +451,14 @@ class VideoProvider extends Component {
     } else {
       logger.warn({
         logCode: 'video_provider_destroywebrtcpeer_no_peer',
-        extraInfo: { cameraId },
+        extraInfo: { cameraId, role },
       }, 'Trailing camera destroy request.');
     }
   }
 
   async createWebRTCPeer(cameraId, isLocal) {
     let iceServers = [];
+    const role = VideoService.getRole(isLocal);
 
     // Check if the peer is already being processed
     if (this.webRtcPeers[cameraId]) {
@@ -471,6 +476,8 @@ class VideoProvider extends Component {
         logger.error({
           logCode: 'video_provider_no_valid_candidate_gum_failure',
           extraInfo: {
+            cameraId,
+            role,
             errorName: error.name,
             errorMessage: error.message,
           },
@@ -484,6 +491,8 @@ class VideoProvider extends Component {
       logger.error({
         logCode: 'video_provider_fetchstunturninfo_error',
         extraInfo: {
+          cameraId,
+          role,
           errorCode: error.code,
           errorMessage: error.message,
         },
@@ -536,7 +545,6 @@ class VideoProvider extends Component {
             return this._onWebRTCError(errorGenOffer, cameraId, isLocal);
           }
 
-          const role = VideoService.getRole(isLocal);
           const message = {
             id: 'start',
             type: 'video',
@@ -582,6 +590,7 @@ class VideoProvider extends Component {
     const { intl } = this.props;
 
     return () => {
+      const role = VideoService.getRole(isLocal);
       if (!isLocal) {
         // Peer that timed out is a subscriber/viewer
         // Subscribers try to reconnect according to their timers if media could
@@ -604,6 +613,7 @@ class VideoProvider extends Component {
           logCode: 'video_provider_camera_view_timeout',
           extraInfo: {
             cameraId,
+            role,
             oldReconnectTimer,
             newReconnectTimer,
           },
@@ -614,7 +624,10 @@ class VideoProvider extends Component {
         // Peer that timed out is a sharer/publisher, clean it up, stop.
         logger.error({
           logCode: 'video_provider_camera_share_timeout',
-          extraInfo: { cameraId },
+          extraInfo: {
+            cameraId,
+            role,
+          },
         }, 'Camera SHARER failed.');
         VideoService.notify(intl.formatMessage(intlClientErrors.mediaFlowTimeout));
         this.stopWebRTCPeer(cameraId, false);
@@ -630,9 +643,9 @@ class VideoProvider extends Component {
       logCode: 'video_provider_webrtc_peer_error',
       extraInfo: {
         cameraId,
+        role: VideoService.getRole(isLocal),
         errorName: error.name,
         errorMessage: error.message,
-        isLocal,
       },
     }, 'Camera peer failed');
 
@@ -716,6 +729,7 @@ class VideoProvider extends Component {
   _handleIceConnectionStateChange (cameraId, isLocal) {
     const { intl } = this.props;
     const peer = this.webRtcPeers[cameraId];
+    const role = VideoService.getRole(isLocal);
 
     if (peer && peer.peerConnection) {
       const pc = peer.peerConnection;
@@ -726,7 +740,6 @@ class VideoProvider extends Component {
         const error = new Error('iceConnectionStateError');
         // prevent the same error from being detected multiple times
         pc.onconnectionstatechange = null;
-        const role = VideoService.getRole(isLocal);
 
         logger.error({
           logCode: 'video_provider_ice_connection_failed_state',
@@ -746,9 +759,9 @@ class VideoProvider extends Component {
       }
     } else {
       logger.error({
-        logCode: 'video_provider_ice_connection_failed_state',
-        extraInfo: { cameraId },
-      }, `No peer at ICE connection state handler. Camera: ${cameraId}`);
+        logCode: 'video_provider_ice_connection_nopeer',
+        extraInfo: { cameraId, role },
+      }, `No peer at ICE connection state handler. Camera: ${cameraId}. Role: ${role}`);
     }
   }
 
@@ -832,9 +845,7 @@ class VideoProvider extends Component {
       peer.started = true;
 
       // Clear camera shared timeout when camera succesfully starts
-      clearTimeout(this.restartTimeout[cameraId]);
-      delete this.restartTimeout[cameraId];
-      delete this.restartTimer[cameraId];
+      this.clearRestartTimers(cameraId);
 
       if (!peer.attached) {
         this.attachVideoStream(cameraId);
@@ -844,7 +855,7 @@ class VideoProvider extends Component {
     } else {
       logger.warn({
         logCode: 'video_provider_playstart_no_peer',
-        extraInfo: { cameraId },
+        extraInfo: { cameraId, role },
       }, 'Trailing camera playStart response.');
     }
   }
@@ -853,16 +864,19 @@ class VideoProvider extends Component {
     const { intl } = this.props;
     const { code, reason, streamId } = message;
     const cameraId = streamId;
+    const isLocal = VideoService.isLocalStream(cameraId);
+    const role = VideoService.getRole(isLocal);
+
     logger.error({
       logCode: 'video_provider_handle_sfu_error',
       extraInfo: {
         errorCode: code,
         errorReason: reason,
         cameraId,
+        role,
       },
     }, `SFU returned an error. Code: ${code}, reason: ${reason}`);
 
-    const isLocal = VideoService.isLocalStream(cameraId);
     if (isLocal) {
       // The publisher instance received an error from the server. There's no reconnect,
       // stop it.

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -636,11 +636,10 @@ class VideoProvider extends Component {
       return;
     }
 
-    const errorMessage = intlClientErrors[error.name]
-      || intlSFUErrors[error] || intlClientErrors.permissionError;
+    const errorMessage = intlClientErrors[error.name] || intlSFUErrors[error];
     // Only display WebRTC negotiation error toasts to sharers. The viewer streams
     // will try to autoreconnect silently, but the error will log nonetheless
-    if (isLocal) {
+    if (isLocal && errorMessage) {
       VideoService.notify(intl.formatMessage(errorMessage));
     } else {
       // If it's a viewer, set the reconnection timeout. There's a good chance

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -569,6 +569,7 @@ class VideoProvider extends Component {
           }, `Camera offer generated. Role: ${role}`);
 
           this.sendMessage(message);
+          this.setReconnectionTimeout(cameraId, isLocal, false);
 
           return false;
         });
@@ -701,10 +702,6 @@ class VideoProvider extends Component {
     return (candidate) => {
       const peer = this.webRtcPeers[cameraId];
       const role = VideoService.getRole(isLocal);
-      // Setup a timeout only when the first candidate is generated and if the peer wasn't
-      // marked as started already (which is done on handlePlayStart after
-      // it was verified that media could circle through the server)
-      this.setReconnectionTimeout(cameraId, isLocal, false);
 
       if (peer && !peer.didSDPAnswered) {
         this.outboundIceQueues[cameraId].push(candidate);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -11,6 +11,7 @@ import {
 import { tryGenerateIceCandidates } from '/imports/utils/safari-webrtc';
 import logger from '/imports/startup/client/logger';
 import _ from 'lodash';
+import { notifyStreamStateChange } from '/imports/ui/services/bbb-webrtc-sfu/stream-state-service';
 
 // Default values and default empty object to be backwards compat with 2.2.
 // FIXME Remove hardcoded defaults 2.3.
@@ -103,7 +104,6 @@ class VideoProvider extends Component {
       { connectionTimeout: WS_CONN_TIMEOUT },
     );
     this.wsQueue = [];
-
     this.restartTimeout = {};
     this.restartTimer = {};
     this.webRtcPeers = {};
@@ -111,12 +111,11 @@ class VideoProvider extends Component {
     this.videoTags = {};
 
     this.createVideoTag = this.createVideoTag.bind(this);
+    this.destroyVideoTag = this.destroyVideoTag.bind(this);
     this.onWsOpen = this.onWsOpen.bind(this);
     this.onWsClose = this.onWsClose.bind(this);
     this.onWsMessage = this.onWsMessage.bind(this);
-
     this.onBeforeUnload = this.onBeforeUnload.bind(this);
-
     this.updateStreams = this.updateStreams.bind(this);
     this.debouncedConnectStreams = _.debounce(
       this.connectStreams,
@@ -162,7 +161,7 @@ class VideoProvider extends Component {
     VideoService.exitVideo();
 
     Object.keys(this.webRtcPeers).forEach((cameraId) => {
-      this.stopWebRTCPeer(cameraId);
+      this.stopWebRTCPeer(cameraId, false);
     });
 
     // Close websocket connection to prevent multiple reconnects from happening
@@ -268,7 +267,7 @@ class VideoProvider extends Component {
   }
 
   disconnectStreams(streamsToDisconnect) {
-    streamsToDisconnect.forEach(cameraId => this.stopWebRTCPeer(cameraId));
+    streamsToDisconnect.forEach(cameraId => this.stopWebRTCPeer(cameraId, false));
   }
 
   updateStreams(streams, shouldDebounce = false) {
@@ -395,6 +394,17 @@ class VideoProvider extends Component {
     }
   }
 
+  clearRestartTimers (cameraId) {
+    if (this.restartTimeout[cameraId]) {
+      clearTimeout(this.restartTimeout[cameraId]);
+      delete this.restartTimeout[cameraId];
+    }
+
+    if (this.restartTimer[cameraId]) {
+      delete this.restartTimer[cameraId];
+    }
+  }
+
   stopWebRTCPeer(cameraId, restarting = false) {
     const isLocal = VideoService.isLocalStream(cameraId);
 
@@ -425,14 +435,7 @@ class VideoProvider extends Component {
     // Clear the shared camera media flow timeout and current reconnect period
     // when destroying it if the peer won't restart
     if (!restarting) {
-      if (this.restartTimeout[cameraId]) {
-        clearTimeout(this.restartTimeout[cameraId]);
-        delete this.restartTimeout[cameraId];
-      }
-
-      if (this.restartTimer[cameraId]) {
-        delete this.restartTimer[cameraId];
-      }
+      this.clearRestartTimers(cameraId);
     }
 
     this.destroyWebRTCPeer(cameraId);
@@ -572,7 +575,9 @@ class VideoProvider extends Component {
       const peer = this.webRtcPeers[cameraId];
       if (peer && peer.peerConnection) {
         const conn = peer.peerConnection;
-        conn.oniceconnectionstatechange = this._getOnIceConnectionStateChangeCallback(cameraId, isLocal);
+        conn.onconnectionstatechange = () => {
+          this._handleIceConnectionStateChange(cameraId, isLocal);
+        };
         VideoService.monitor(conn);
       }
     }
@@ -582,16 +587,11 @@ class VideoProvider extends Component {
     const { intl } = this.props;
 
     return () => {
-      // Peer that timed out is a sharer/publisher
-      if (isLocal) {
-        logger.error({
-          logCode: 'video_provider_camera_share_timeout',
-          extraInfo: { cameraId },
-        }, `Camera SHARER has not succeeded in ${CAMERA_SHARE_FAILED_WAIT_TIME} for ${cameraId}`);
-
-        VideoService.notify(intl.formatMessage(intlClientErrors.mediaFlowTimeout));
-        this.stopWebRTCPeer(cameraId);
-      } else {
+      if (!isLocal) {
+        // Peer that timed out is a subscriber/viewer
+        // Subscribers try to reconnect according to their timers if media could
+        // not reach the server. That's why we pass the restarting flag as true
+        // to the stop procedure as to not destroy the timers
         // Create new reconnect interval time
         const oldReconnectTimer = this.restartTimer[cameraId];
         const newReconnectTimer = Math.min(
@@ -605,10 +605,6 @@ class VideoProvider extends Component {
           delete this.restartTimeout[cameraId];
         }
 
-        // Peer that timed out is a subscriber/viewer
-        // Subscribers try to reconnect according to their timers if media could
-        // not reach the server. That's why we pass the restarting flag as true
-        // to the stop procedure as to not destroy the timers
         logger.error({
           logCode: 'video_provider_camera_view_timeout',
           extraInfo: {
@@ -618,54 +614,71 @@ class VideoProvider extends Component {
           },
         }, `Camera VIEWER has not succeeded in ${oldReconnectTimer} for ${cameraId}. Reconnecting.`);
 
-        this.stopWebRTCPeer(cameraId, true);
-        this.createWebRTCPeer(cameraId, isLocal);
+        this.reconnect(cameraId, isLocal);
+      } else {
+        // Peer that timed out is a sharer/publisher, clean it up, stop.
+        logger.error({
+          logCode: 'video_provider_camera_share_timeout',
+          extraInfo: { cameraId },
+        }, `Camera SHARER has not succeeded in ${CAMERA_SHARE_FAILED_WAIT_TIME} for ${cameraId}`);
+
+        VideoService.notify(intl.formatMessage(intlClientErrors.mediaFlowTimeout));
+        this.stopWebRTCPeer(cameraId, false);
       }
     };
   }
 
   _onWebRTCError(error, cameraId, isLocal) {
     const { intl } = this.props;
-
-    // 2001 means MEDIA_SERVER_OFFLINE. It's a server-wide error.
-    // We only display it to a sharer/publisher instance to avoid popping up
-    // redundant toasts.
-    // If the client only has viewer instances, the WS will close unexpectedly
-    // and an error will be shown there for them.
-    if (error === 2001 && !isLocal) {
-      return;
-    }
-
     const errorMessage = intlClientErrors[error.name] || intlSFUErrors[error];
-    // Only display WebRTC negotiation error toasts to sharers. The viewer streams
-    // will try to autoreconnect silently, but the error will log nonetheless
-    if (isLocal && errorMessage) {
-      VideoService.notify(intl.formatMessage(errorMessage));
-    } else {
-      // If it's a viewer, set the reconnection timeout. There's a good chance
-      // no local candidate was generated and it wasn't set.
-      this.setReconnectionTimeout(cameraId, isLocal);
-    }
-
-    // shareWebcam as the second argument means it will only try to reconnect if
-    // it's a viewer instance (see stopWebRTCPeer restarting argument)
-    this.stopWebRTCPeer(cameraId, !isLocal);
 
     logger.error({
       logCode: 'video_provider_webrtc_peer_error',
       extraInfo: {
         cameraId,
-        normalizedError: errorMessage,
-        error,
+        errorName: error.name,
+        errorMessage,
+        isLocal,
       },
-    }, `Camera peer creation failed for ${cameraId} due to ${error.message}`);
+    }, `Camera peer failed`);
+
+    // Only display WebRTC negotiation error toasts to sharers. The viewer streams
+    // will try to autoreconnect silently, but the error will log nonetheless
+    if (isLocal) {
+      this.stopWebRTCPeer(cameraId, false);
+      if (errorMessage) VideoService.notify(intl.formatMessage(errorMessage));
+    } else {
+      // If it's a viewer, set the reconnection timeout. There's a good chance
+      // no local candidate was generated and it wasn't set.
+      const peer = this.webRtcPeers[cameraId];
+      const isEstablishedConnection = peer && peer.started;
+      this.setReconnectionTimeout(cameraId, isLocal, isEstablishedConnection);
+      // second argument means it will only try to reconnect if
+      // it's a viewer instance (see stopWebRTCPeer restarting argument)
+      this.stopWebRTCPeer(cameraId, true);
+    }
   }
 
-  setReconnectionTimeout(cameraId, isLocal) {
-    const peer = this.webRtcPeers[cameraId];
-    const peerHasStarted = peer && peer.started === true;
-    const shouldSetReconnectionTimeout = !this.restartTimeout[cameraId] && !peerHasStarted;
+  reconnect(cameraId, isLocal) {
+    this.stopWebRTCPeer(cameraId, true);
+    this.createWebRTCPeer(cameraId, isLocal);
+  }
 
+  setReconnectionTimeout(cameraId, isLocal, isEstablishedConnection) {
+    const peer = this.webRtcPeers[cameraId];
+    const shouldSetReconnectionTimeout = !this.restartTimeout[cameraId] && !isEstablishedConnection;
+
+    // This is an ongoing reconnection which succeeded in the first place but
+    // then failed mid call. Try to reconnect it right away. Clear the restart
+    // timers since we don't need them in this case.
+    if (isEstablishedConnection) {
+      this.clearRestartTimers(cameraId);
+      return this.reconnect(cameraId, isLocal);
+    }
+
+    // This is a reconnection timer for a peer that hasn't succeeded in the first
+    // place. Set reconnection timeouts with random intervals between them to try
+    // and reconnect without flooding the server
     if (shouldSetReconnectionTimeout) {
       const newReconnectTimer = this.restartTimer[cameraId] || CAMERA_SHARE_FAILED_WAIT_TIME;
       this.restartTimer[cameraId] = newReconnectTimer;
@@ -692,7 +705,7 @@ class VideoProvider extends Component {
       // Setup a timeout only when the first candidate is generated and if the peer wasn't
       // marked as started already (which is done on handlePlayStart after
       // it was verified that media could circle through the server)
-      this.setReconnectionTimeout(cameraId, isLocal);
+      this.setReconnectionTimeout(cameraId, isLocal, false);
 
       if (peer && !peer.didSDPAnswered) {
         logger.debug({
@@ -722,94 +735,93 @@ class VideoProvider extends Component {
     this.sendMessage(message);
   }
 
-  _getOnIceConnectionStateChangeCallback(cameraId, isLocal) {
+  _handleIceConnectionStateChange (cameraId, isLocal) {
     const { intl } = this.props;
     const peer = this.webRtcPeers[cameraId];
+
     if (peer && peer.peerConnection) {
-      const conn = peer.peerConnection;
-      const { iceConnectionState } = conn;
+      const pc = peer.peerConnection;
+      const connectionState = pc.connectionState;
+      notifyStreamStateChange(cameraId, connectionState);
 
-      return () => {
-        if (iceConnectionState === 'failed' || iceConnectionState === 'closed') {
-          // prevent the same error from being detected multiple times
-          conn.oniceconnectionstatechange = null;
-          logger.error({
-            logCode: 'video_provider_ice_connection_failed_state',
-            extraInfo: {
-              cameraId,
-              iceConnectionState,
-            },
-          }, `ICE connection state transitioned to ${iceConnectionState} for ${cameraId}`);
+      if (connectionState === 'failed' || connectionState === 'closed') {
+        const error = new Error('iceConnectionStateError');
+        // prevent the same error from being detected multiple times
+        pc.onconnectionstatechange = null;
+        logger.error({
+          logCode: 'video_provider_ice_connection_failed_state',
+          extraInfo: {
+            cameraId,
+            connectionState,
+          },
+        }, `ICE connection state transitioned to ${connectionState} for ${cameraId}`);
+        if (isLocal) VideoService.notify(intl.formatMessage(intlClientErrors.iceConnectionStateError));
 
-          this.stopWebRTCPeer(cameraId);
-          VideoService.notify(intl.formatMessage(intlClientErrors.iceConnectionStateError));
-        }
-      };
-    }
-    return () => {
+        this._onWebRTCError(
+          error,
+          cameraId,
+          isLocal
+        );
+      }
+    } else {
       logger.error({
         logCode: 'video_provider_ice_connection_failed_state',
         extraInfo: {
           cameraId,
-          iceConnectionState: undefined,
         },
       }, `Missing peer at ICE connection state transition for ${cameraId}`);
-
-      // isLocal as the second argument means it will only try to reconnect if
-      // it's a viewer instance (see stopWebRTCPeer restarting argument)
-      this.stopWebRTCPeer(cameraId, !isLocal);
-      VideoService.notify(intl.formatMessage(intlClientErrors.iceConnectionStateError));
-    };
+    }
   }
 
   attachVideoStream(cameraId) {
     const video = this.videoTags[cameraId];
+
     if (video == null) {
       logger.warn({
         logCode: 'video_provider_delay_attach_video_stream',
         extraInfo: { cameraId },
-      }, `Will attach stream later because camera has not started yet for ${cameraId}`);
+      }, 'Delaying video stream attachment');
       return;
-    }
-
-    if (video.srcObject) {
-      delete this.videoTags[cameraId];
-      return; // Skip if the stream is already attached
     }
 
     const isLocal = VideoService.isLocalStream(cameraId);
     const peer = this.webRtcPeers[cameraId];
+
+    if (peer && peer.attached && video.srcObject) {
+      return; // Skip if the stream is already attached
+    }
 
     const attachVideoStreamHelper = () => {
       const stream = isLocal ? peer.getLocalStream() : peer.getRemoteStream();
       video.pause();
       video.srcObject = stream;
       video.load();
-
       peer.attached = true;
-      delete this.videoTags[cameraId];
     };
 
-
-    // If peer has started playing attach to tag, otherwise wait a while
-    if (peer) {
-      if (peer.started) {
-        attachVideoStreamHelper();
-      }
-
-      // So we can start it later when we get a playStart
-      // or if we need to do a restart timeout
-      peer.videoTag = video;
-    }
+    // Conditions to safely attach a stream to a video element in all browsers:
+    // 1 - Peer exists
+    // 2 - It hasn't been attached yet
+    // 3a - If the stream is a local one (webcam sharer), we can just attach it
+    // (no need to wait for server confirmation)
+    // 3b - If the stream is a remote one, the safest (*ahem* Safari) moment to
+    // do so is waiting for the server to confirm that media has flown out of it
+    // towards the remote end.
+    const isAbleToAttach = peer && !peer.attached && (peer.started || isLocal);
+    if (isAbleToAttach) attachVideoStreamHelper();
   }
 
   createVideoTag(cameraId, video) {
     const peer = this.webRtcPeers[cameraId];
     this.videoTags[cameraId] = video;
 
-    if (peer) {
+    if (peer && !peer.attached) {
       this.attachVideoStream(cameraId);
     }
+  }
+
+  destroyVideoTag(cameraId) {
+    delete this.videoTags[cameraId]
   }
 
   handlePlayStop(message) {
@@ -885,7 +897,8 @@ class VideoProvider extends Component {
     return (
       <VideoListContainer
         streams={streams}
-        onMount={this.createVideoTag}
+        onVideoItemMount={this.createVideoTag}
+        onVideoItemUnmount={this.destroyVideoTag}
         swapLayout={swapLayout}
         currentVideoPageIndex={currentVideoPageIndex}
       />

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
@@ -14,7 +14,8 @@ import Button from '/imports/ui/components/button/component';
 
 const propTypes = {
   streams: PropTypes.arrayOf(PropTypes.object).isRequired,
-  onMount: PropTypes.func.isRequired,
+  onVideoItemMount: PropTypes.func.isRequired,
+  onVideoItemUnmount: PropTypes.func.isRequired,
   webcamDraggableDispatch: PropTypes.func.isRequired,
   intl: PropTypes.objectOf(Object).isRequired,
   swapLayout: PropTypes.bool.isRequired,
@@ -288,7 +289,8 @@ class VideoList extends Component {
     const {
       intl,
       streams,
-      onMount,
+      onVideoItemMount,
+      onVideoItemUnmount,
       swapLayout,
     } = this.props;
     const { focusedId } = this.state;
@@ -328,10 +330,11 @@ class VideoList extends Component {
             name={name}
             mirrored={isMirrored}
             actions={actions}
-            onMount={(videoRef) => {
+            onVideoItemMount={(videoRef) => {
               this.handleCanvasResize();
-              onMount(cameraId, videoRef);
+              onVideoItemMount(cameraId, videoRef);
             }}
+            onVideoItemUnmount={onVideoItemUnmount}
             swapLayout={swapLayout}
           />
         </div>

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.jsx
@@ -10,7 +10,8 @@ const VideoListContainer = ({ children, ...props }) => {
 
 export default withTracker(props => ({
   streams: props.streams,
-  onMount: props.onMount,
+  onVideoItemMount: props.onVideoItemMount,
+  onVideoItemUnmount: props.onVideoItemUnmount,
   swapLayout: props.swapLayout,
   numberOfPages: VideoService.getNumberOfPages(),
   currentVideoPageIndex: props.currentVideoPageIndex,

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -1,5 +1,6 @@
 @import "/imports/ui/stylesheets/variables/_all";
 @import "/imports/ui/stylesheets/variables/video";
+@import "/imports/ui/components/media/styles";
 
 :root {
   --color-white-with-transparency: #ffffff40;
@@ -260,4 +261,14 @@
   @include mq($medium-up) {
     margin-right: 2px;
   }
+}
+
+.unhealthyStream {
+  filter: grayscale(50%) opacity(50%);
+}
+
+.reconnecting {
+  @extend .connectingSpinner;
+  background-color: transparent;
+  color: var(--color-white);
 }

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -18,6 +18,11 @@ import FullscreenButtonContainer from '/imports/ui/components/fullscreen-button/
 import { styles } from '../styles';
 import { withDraggableConsumer } from '/imports/ui/components/media/webcam-draggable-overlay/context';
 import VideoService from '../../service';
+import {
+  isStreamStateUnhealthy,
+  subscribeToStreamStateChange,
+  unsubscribeFromStreamStateChange,
+} from '/imports/ui/services/bbb-webrtc-sfu/stream-state-service';
 
 const ALLOW_FULLSCREEN = Meteor.settings.public.app.allowFullscreen;
 
@@ -29,16 +34,30 @@ class VideoListItem extends Component {
     this.state = {
       videoIsReady: false,
       isFullscreen: false,
+      isStreamHealthy: false,
     };
 
     this.mirrorOwnWebcam = VideoService.mirrorOwnWebcam(props.userId);
 
     this.setVideoIsReady = this.setVideoIsReady.bind(this);
     this.onFullscreenChange = this.onFullscreenChange.bind(this);
+    this.onStreamStateChange = this.onStreamStateChange.bind(this);
+  }
+
+  onStreamStateChange (e) {
+    const { streamState } = e.detail;
+    const { isStreamHealthy } = this.state;
+
+    const newHealthState = !isStreamStateUnhealthy(streamState);
+    e.stopPropagation();
+
+    if (newHealthState !== isStreamHealthy) {
+      this.setState({ isStreamHealthy: newHealthState });
+    }
   }
 
   componentDidMount() {
-    const { onMount, webcamDraggableDispatch } = this.props;
+    const { onVideoItemMount, webcamDraggableDispatch, cameraId } = this.props;
 
     webcamDraggableDispatch(
       {
@@ -47,10 +66,10 @@ class VideoListItem extends Component {
       },
     );
 
-    onMount(this.videoTag);
-
+    onVideoItemMount(this.videoTag);
     this.videoTag.addEventListener('loadeddata', this.setVideoIsReady);
     this.videoContainer.addEventListener('fullscreenchange', this.onFullscreenChange);
+    subscribeToStreamStateChange(cameraId, this.onStreamStateChange);
   }
 
   componentDidUpdate() {
@@ -75,8 +94,12 @@ class VideoListItem extends Component {
   }
 
   componentWillUnmount() {
+    const { cameraId, onVideoItemUnmount } = this.props;
+
     this.videoTag.removeEventListener('loadeddata', this.setVideoIsReady);
     this.videoContainer.removeEventListener('fullscreenchange', this.onFullscreenChange);
+    unsubscribeFromStreamStateChange(cameraId, this.onStreamStateChange);
+    onVideoItemUnmount(cameraId);
   }
 
   onFullscreenChange() {
@@ -135,6 +158,7 @@ class VideoListItem extends Component {
     const {
       videoIsReady,
       isFullscreen,
+      isStreamHealthy,
     } = this.state;
     const {
       name,
@@ -146,6 +170,7 @@ class VideoListItem extends Component {
     } = this.props;
     const availableActions = this.getAvailableActions();
     const enableVideoMenu = Meteor.settings.public.kurento.enableVideoMenu || false;
+    const shouldRenderReconnect = !isStreamHealthy && videoIsReady;
 
     const result = browser();
     const isFirefox = (result && result.name) ? result.name.includes('firefox') : false;
@@ -161,7 +186,14 @@ class VideoListItem extends Component {
             <div className={styles.connecting}>
               <span className={styles.loadingText}>{name}</span>
             </div>
+
         }
+
+        {
+          shouldRenderReconnect
+            && <div className={styles.reconnecting} />
+        }
+
         <div
           className={styles.videoContainer}
           ref={(ref) => { this.videoContainer = ref; }}
@@ -175,6 +207,7 @@ class VideoListItem extends Component {
               [styles.cursorGrabbing]: webcamDraggableState.dragging
                 && !isFullscreen && !swapLayout,
               [styles.mirroredVideo]: (this.mirrorOwnWebcam && !mirrored) || (!this.mirrorOwnWebcam && mirrored),
+              [styles.unhealthyStream]: shouldRenderReconnect,
             })}
             ref={(ref) => { this.videoTag = ref; }}
             autoPlay


### PR DESCRIPTION
### What does this PR do?
  - Shared camera (outbound) reconnections **were not implemented**. Deeper changes are need to make that work cleanly.
  - Add (fix) inbound/recvonly video stream reconnections
    * Track all peer's connectionState and trigger a timed reconnect on `failed`
    * Add a new unhealthy stream UI for when the stream is deemed to be unhealthy (connectionState == (disconnect|failed|closed) && no packets incoming). The UI is applies a grayscale filter over the video-list-item which is deemed to be unhealthy and also shows the old connecting spinner to indicate that it's going to reconnect
    * The baseTimeout - maxTimeout reconnection time cycle continues to exist. When an inbound feed gets into an unhealthy state, it'll try to reconnect indefinitely and each retry increases the reconnection interval up to maxTimeout.
  - Fix Chromium-based browsers (>= M78) re-connection triggers
  - Refactor the video stream attachment to the video element
    * Make the attachment/deattachment methods props to be passed down to video-list-item to make them safer to call (and to be called only once)
    * Clean up some flaky code around there
  - Fix an issue where camera error toasts would be fired unnecessarily on reconnection scenarios e3a6711
    * There's some scenarios that video errors triggers multiple toast notifications
that don't have any mapped defined message feedback so they all drop to the default
permission error. This leaves the impression that something is broken at the toast
container.
    * Since those messages don't bring up much information about the problem we can avoid sending
them until we don't have a more informative one to notify the user.

### Closes Issue(s)

Partially fixes https://github.com/bigbluebutton/bigbluebutton/issues/10756

### More

This is a very dehydrated version of the stuff I was doing to the video-provider. I need a few more days on it, so I changed my mind. This is a quick and dirty rewrite of the inbound video re-connection code over the current video-provider so we can use it as soon as seen fit.

The code is pretty much self-explanatory. It uses the same stream state tracking rationale that screen sharing does. It uses the same reconnection UI as well.

It's a down to earth implementation. The fancy stuff I'm keeping to the rewrite (negotiation pacing, getStats heuristics, wildcard peers, ...). It's also backwards compatible with any SFU version (which the rewrite isn't).

Also, I'm keeping this as a draft while I put it into a field trial on my side and fix any outlying bugs.

Related to #11025, #10945.