### PR TITLE
Reduces the number of options displayed on locale settings dropdown

### DIFF
--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -31,7 +31,7 @@ Meteor.startup(() => {
   const CDN_URL = APP_CONFIG.cdn;
   const instanceId = APP_CONFIG.instanceId.slice(1); // remove the leading '/' character
 
-  Logger.warn('Started bbb-html5 process with instanceId=' + instanceId);
+  Logger.warn(`Started bbb-html5 process with instanceId=${instanceId}`);
 
   const { customHeartbeat } = APP_CONFIG;
 
@@ -140,6 +140,9 @@ Meteor.startup(() => {
 const generateLocaleOptions = () => {
   try {
     Logger.warn('Calculating aggregateLocales (heavy)');
+
+
+    // remove duplicated locales (always remove more generic if same name)
     const tempAggregateLocales = AVAILABLE_LOCALES
       .map(file => file.replace('.json', ''))
       .map(file => file.replace('_', '-'))
@@ -151,8 +154,14 @@ const generateLocaleOptions = () => {
           locale,
           name: localeName,
         };
-      });
+      }).reverse()
+      .filter((item, index, self) => index === self.findIndex(i => (
+        i.name === item.name
+      )))
+      .reverse();
+
     Logger.warn(`Total locales: ${tempAggregateLocales.length}`, tempAggregateLocales);
+
     return tempAggregateLocales;
   } catch (e) {
     Logger.error(`'Could not process locales error: ${e}`);

--- a/bigbluebutton-html5/imports/ui/components/captions/writer-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/writer-menu/component.jsx
@@ -5,11 +5,8 @@ import { withModalMounter } from '/imports/ui/components/modal/service';
 import PropTypes from 'prop-types';
 import Modal from '/imports/ui/components/modal/simple/component';
 import Button from '/imports/ui/components/button/component';
+import LocalesDropdown from '/imports/ui/components/locales-dropdown/component';
 import { styles } from './styles';
-
-const DEFAULT_VALUE = 'select';
-
-const DEFAULT_KEY = -1;
 
 const intlMessages = defineMessages({
   closeLabel: {
@@ -48,7 +45,7 @@ const intlMessages = defineMessages({
 
 const propTypes = {
   takeOwnership: PropTypes.func.isRequired,
-  availableLocales: PropTypes.arrayOf(PropTypes.object).isRequired,
+  allLocales: PropTypes.arrayOf(PropTypes.object).isRequired,
   closeModal: PropTypes.func.isRequired,
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired,
@@ -58,9 +55,9 @@ const propTypes = {
 class WriterMenu extends PureComponent {
   constructor(props) {
     super(props);
-    const { availableLocales, intl } = this.props;
+    const { allLocales, intl } = this.props;
 
-    const candidate = availableLocales.filter(
+    const candidate = allLocales.filter(
       l => l.locale.substring(0, 2) === intl.locale.substring(0, 2),
     );
 
@@ -90,12 +87,12 @@ class WriterMenu extends PureComponent {
   render() {
     const {
       intl,
-      availableLocales,
+      allLocales,
       closeModal,
     } = this.props;
 
     const { locale } = this.state;
-    const defaultLocale = locale || DEFAULT_VALUE;
+
     return (
       <Modal
         overlayClassName={styles.overlay}
@@ -118,21 +115,16 @@ class WriterMenu extends PureComponent {
             htmlFor="captionsLangSelector"
             aria-label={intl.formatMessage(intlMessages.ariaSelect)}
           />
-          <select
-            id="captionsLangSelector"
-            className={styles.select}
-            onChange={this.handleChange}
-            defaultValue={defaultLocale}
-          >
-            <option disabled key={DEFAULT_KEY} value={DEFAULT_VALUE}>
-              {intl.formatMessage(intlMessages.select)}
-            </option>
-            {availableLocales.map(localeItem => (
-              <option key={localeItem.locale} value={localeItem.locale}>
-                {localeItem.name}
-              </option>
-            ))}
-          </select>
+
+          <LocalesDropdown
+            allLocales={allLocales}
+            handleChange={this.handleChange}
+            value={locale}
+            elementId="captionsLangSelector"
+            elementClass={styles.select}
+            selectMessage={intl.formatMessage(intlMessages.select)}
+          />
+
           <Button
             className={styles.startBtn}
             label={intl.formatMessage(intlMessages.start)}

--- a/bigbluebutton-html5/imports/ui/components/captions/writer-menu/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/writer-menu/container.jsx
@@ -8,6 +8,6 @@ const WriterMenuContainer = props => <WriterMenu {...props} />;
 
 export default withModalMounter(withTracker(({ mountModal }) => ({
   closeModal: () => mountModal(null),
-  availableLocales: CaptionsService.getAvailableLocales(),
+  allLocales: CaptionsService.getAvailableLocales(),
   takeOwnership: locale => CaptionsService.takeOwnership(locale),
 }))(WriterMenuContainer));

--- a/bigbluebutton-html5/imports/ui/components/locales-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/locales-dropdown/component.jsx
@@ -30,8 +30,17 @@ class LocalesDropdown extends PureComponent {
       // splits value if not empty
       const splitValue = (value) ? value.split('-')[0] : '';
 
+      const allLocaleCodes = [];
+      allLocales.map(item => allLocaleCodes.push(item.locale));
+
+      /*
+        locales show if:
+        1. it is a general version of a locale with no specific locales
+        2. it is a specific version of a selected locale with many specific versions
+        3. it is a specific version of a locale with no general locale
+      */
       return allLocales.filter(
-        locale => (!locale.locale.includes('-') || locale.locale.split('-')[0] === splitValue),
+        locale => (!locale.locale.includes('-') || locale.locale.split('-')[0] === splitValue || !allLocaleCodes.includes(locale.locale.split('-')[0])),
       );
     }
     return [];

--- a/bigbluebutton-html5/imports/ui/components/locales-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/locales-dropdown/component.jsx
@@ -1,0 +1,71 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+const DEFAULT_VALUE = 'select';
+const DEFAULT_KEY = -1;
+
+const propTypes = {
+  allLocales: PropTypes.arrayOf(PropTypes.object).isRequired,
+  value: PropTypes.string,
+  handleChange: PropTypes.func.isRequired,
+  elementId: PropTypes.string.isRequired,
+  selectMessage: PropTypes.string.isRequired,
+  elementClass: PropTypes.string.isRequired,
+};
+
+const defaultProps = {
+  value: null,
+};
+
+
+class LocalesDropdown extends PureComponent {
+  // returns an array with the base language list + variations of currently selected language
+  filterLocaleVariations(value) {
+    const { allLocales } = this.props;
+    if (allLocales) {
+      if (Meteor.settings.public.app.showAllAvailableLocales) {
+        return allLocales;
+      }
+
+      // splits value if not empty
+      const splitValue = (value) ? value.split('-')[0] : '';
+
+      return allLocales.filter(
+        locale => (!locale.locale.includes('-') || locale.locale.split('-')[0] === splitValue),
+      );
+    }
+    return [];
+  }
+
+  render() {
+    const {
+      value, handleChange, elementId, selectMessage, elementClass,
+    } = this.props;
+    const defaultLocale = value || DEFAULT_VALUE;
+
+    const availableLocales = this.filterLocaleVariations(value);
+
+    return (
+      <select
+        id={elementId}
+        onChange={handleChange}
+        value={defaultLocale}
+        className={elementClass}
+      >
+        <option disabled key={DEFAULT_KEY} value={DEFAULT_VALUE}>
+          {selectMessage}
+        </option>
+        {availableLocales.map(localeItem => (
+          <option key={localeItem.locale} value={localeItem.locale}>
+            {localeItem.name}
+          </option>
+        ))}
+      </select>
+    );
+  }
+}
+
+LocalesDropdown.propTypes = propTypes;
+LocalesDropdown.defaultProps = defaultProps;
+
+export default LocalesDropdown;

--- a/bigbluebutton-html5/imports/ui/components/settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/component.jsx
@@ -62,7 +62,9 @@ const intlMessages = defineMessages({
 });
 
 const propTypes = {
-  intl: PropTypes.object.isRequired,
+  intl: PropTypes.shape({
+    formatMessage: PropTypes.func.isRequired,
+  }).isRequired,
   dataSaving: PropTypes.shape({
     viewParticipantsWebcams: PropTypes.bool,
     viewScreenshare: PropTypes.bool,
@@ -111,9 +113,26 @@ class Settings extends Component {
 
   componentDidMount() {
     const { availableLocales } = this.props;
+
     availableLocales.then((locales) => {
-      this.setState({ availableLocales: locales });
+      this.setState({ allLocales: locales });
     });
+  }
+
+  // returns an array with the base language list + variations of currently selected language
+  filterLocaleVariations(value) {
+    const { allLocales } = this.state;
+
+    if (allLocales) {
+      if (Meteor.settings.public.app.showAllAvailableLocales) {
+        return allLocales;
+      }
+
+      return allLocales.filter(
+        locale => (!locale.locale.includes('-') || locale.locale.split('-')[0] === value.split('-')[0]),
+      );
+    }
+    return [];
   }
 
   handleUpdateSettings(key, newSettings) {
@@ -136,9 +155,10 @@ class Settings extends Component {
 
     const {
       selectedTab,
-      availableLocales,
       current,
     } = this.state;
+
+    const availableLocales = this.filterLocaleVariations(current.application.locale);
 
     return (
       <Tabs

--- a/bigbluebutton-html5/imports/ui/components/settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/component.jsx
@@ -119,22 +119,6 @@ class Settings extends Component {
     });
   }
 
-  // returns an array with the base language list + variations of currently selected language
-  filterLocaleVariations(value) {
-    const { allLocales } = this.state;
-
-    if (allLocales) {
-      if (Meteor.settings.public.app.showAllAvailableLocales) {
-        return allLocales;
-      }
-
-      return allLocales.filter(
-        locale => (!locale.locale.includes('-') || locale.locale.split('-')[0] === value.split('-')[0]),
-      );
-    }
-    return [];
-  }
-
   handleUpdateSettings(key, newSettings) {
     const settings = this.state;
     settings.current[key] = newSettings;
@@ -156,9 +140,8 @@ class Settings extends Component {
     const {
       selectedTab,
       current,
+      allLocales,
     } = this.state;
-
-    const availableLocales = this.filterLocaleVariations(current.application.locale);
 
     return (
       <Tabs
@@ -206,7 +189,7 @@ class Settings extends Component {
         </TabList>
         <TabPanel className={styles.tabPanel}>
           <Application
-            availableLocales={availableLocales}
+            allLocales={allLocales}
             handleUpdateSettings={this.handleUpdateSettings}
             settings={current.application}
           />

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -83,17 +83,6 @@ class ApplicationMenu extends BaseMenu {
     this.setInitialFontSize();
   }
 
-  componentDidUpdate() {
-    const { availableLocales } = this.props;
-
-    if (availableLocales && availableLocales.length > 0) {
-      // I used setTimout to create a smooth animation transition
-      setTimeout(() => this.setState({
-        showSelect: true,
-      }), 100);
-    }
-  }
-
   componentWillUnmount() {
     // fix Warning: Can't perform a React state update on an unmounted component
     this.setState = (state, callback) => {
@@ -156,14 +145,14 @@ class ApplicationMenu extends BaseMenu {
 
   handleSelectChange(fieldname, options, e) {
     const obj = this.state;
-    obj.settings[fieldname] = e.target.value.toLowerCase().replace('_', '-');
+    obj.settings[fieldname] = e.target.value;
     this.handleUpdateSettings('application', obj.settings);
   }
 
   render() {
     const { availableLocales, intl } = this.props;
     const {
-      isLargestFontSize, isSmallestFontSize, settings, showSelect,
+      isLargestFontSize, isSmallestFontSize, settings,
     } = this.state;
 
     // conversions can be found at http://pxtoem.com
@@ -178,6 +167,8 @@ class ApplicationMenu extends BaseMenu {
     };
 
     const ariaValueLabel = intl.formatMessage(intlMessages.currentValue, { 0: `${pixelPercentage[settings.fontSize]}` });
+
+    const showSelect = availableLocales && availableLocales.length > 0;
 
     return (
       <div>
@@ -225,14 +216,13 @@ class ApplicationMenu extends BaseMenu {
                 {showSelect ? (
                   <select
                     id="langSelector"
-                    defaultValue={this.state.settings.locale}
-                    lang={this.state.settings.locale}
+                    value={this.state.settings.locale}
                     className={styles.select}
-                    onChange={this.handleSelectChange.bind(this, 'locale', availableLocales)}
+                    onChange={e => this.handleSelectChange('locale', availableLocales, e)}
                   >
                     <option disabled>{intl.formatMessage(intlMessages.languageOptionLabel)}</option>
-                    {availableLocales.map((locale, index) => (
-                      <option key={index} value={locale.locale} lang={locale.locale}>
+                    {availableLocales.map((locale) => (
+                      <option key={locale.locale} value={locale.locale}>
                         {locale.name}
                       </option>
                     ))}

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import cx from 'classnames';
 import Button from '/imports/ui/components/button/component';
 import Toggle from '/imports/ui/components/switch/component';
+import LocalesDropdown from '/imports/ui/components/locales-dropdown/component';
 import { defineMessages, injectIntl } from 'react-intl';
 import BaseMenu from '../base/component';
 import { styles } from '../styles';
@@ -150,7 +151,7 @@ class ApplicationMenu extends BaseMenu {
   }
 
   render() {
-    const { availableLocales, intl } = this.props;
+    const { allLocales, intl } = this.props;
     const {
       isLargestFontSize, isSmallestFontSize, settings,
     } = this.state;
@@ -168,7 +169,7 @@ class ApplicationMenu extends BaseMenu {
 
     const ariaValueLabel = intl.formatMessage(intlMessages.currentValue, { 0: `${pixelPercentage[settings.fontSize]}` });
 
-    const showSelect = availableLocales && availableLocales.length > 0;
+    const showSelect = allLocales && allLocales.length > 0;
 
     return (
       <div>
@@ -214,19 +215,14 @@ class ApplicationMenu extends BaseMenu {
             <div className={styles.col}>
               <span className={cx(styles.formElement, styles.pullContentRight)}>
                 {showSelect ? (
-                  <select
-                    id="langSelector"
+                  <LocalesDropdown
+                    allLocales={allLocales}
+                    handleChange={e => this.handleSelectChange('locale', allLocales, e)}
                     value={this.state.settings.locale}
-                    className={styles.select}
-                    onChange={e => this.handleSelectChange('locale', availableLocales, e)}
-                  >
-                    <option disabled>{intl.formatMessage(intlMessages.languageOptionLabel)}</option>
-                    {availableLocales.map((locale) => (
-                      <option key={locale.locale} value={locale.locale}>
-                        {locale.name}
-                      </option>
-                    ))}
-                  </select>
+                    elementId="langSelector"
+                    elementClass={styles.select}
+                    selectMessage={intl.formatMessage(intlMessages.languageOptionLabel)}
+                  />
                 )
                   : (
                     <div className={styles.spinnerOverlay}>

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -45,6 +45,7 @@ public:
     breakoutRoomLimit: 8
     # https://github.com/bigbluebutton/bigbluebutton/pull/10826
     customHeartbeat: true
+    showAllAvailableLocales: false
     defaultSettings:
       application:
         animations: true


### PR DESCRIPTION
### What does this PR do?

- Adds `showAllAvailableLocales` (default: false) flag to the settings file for quick enable/disable.
- Changes locale settings and captions dropdown to only display a locale if:
  - it is a general version of a locale with no specific locales
  - it is a specific version of a selected locale with many specific versions
  - it is a specific version of a locale with no general locale


