### PR TITLE
Fix for random user picking: presenter is notified when there's no viewers to randomly pick from

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/modal/random-user/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/modal/random-user/component.jsx
@@ -64,42 +64,51 @@ class RandomUserSelect extends Component {
       clearRandomlySelectedUser,
     } = this.props;
 
-    const isSelectedUser = selectedUser ? (currentUser.userId === selectedUser.userId) : false;
+    let viewElement;
 
-    const viewElement = (numAvailableViewers < 1 || !selectedUser) ? (
-      <div className={styles.modalViewContainer}>
-        <div className={styles.modalViewTitle}>
-          {intl.formatMessage(messages.randUserTitle)}
+    if (numAvailableViewers < 1) { // there's no viewers to select from
+      // display modal informing presenter that there's no viewers to select from
+      viewElement = (
+        <div className={styles.modalViewContainer}>
+          <div className={styles.modalViewTitle}>
+            {intl.formatMessage(messages.randUserTitle)}
+          </div>
+          <div>{intl.formatMessage(messages.noViewers)}</div>
         </div>
-        <div>{intl.formatMessage(messages.noViewers)}</div>
-      </div>
-    ) : (
-      <div className={styles.modalViewContainer}>
-        <div className={styles.modalViewTitle}>
-          {isSelectedUser
-            ? `${intl.formatMessage(messages.selected)}`
-            : `${intl.formatMessage(messages.randUserTitle)}`
+      );
+    } else { // viewers are available
+      if (!selectedUser) return null; // rendering triggered before selectedUser is available
+
+      // display modal with random user selection
+      const amISelectedUser = currentUser.userId === selectedUser.userId;
+      viewElement = (
+        <div className={styles.modalViewContainer}>
+          <div className={styles.modalViewTitle}>
+            {amISelectedUser
+              ? `${intl.formatMessage(messages.selected)}`
+              : `${intl.formatMessage(messages.randUserTitle)}`
+            }
+          </div>
+          <div aria-hidden className={styles.modalAvatar} style={{ backgroundColor: `${selectedUser.color}` }}>
+            {selectedUser.name.slice(0, 2)}
+          </div>
+          <div className={styles.selectedUserName}>
+            {selectedUser.name}
+          </div>
+          {!amISelectedUser
+            && (
+            <Button
+              label={intl.formatMessage(messages.reselect)}
+              color="primary"
+              size="md"
+              className={styles.selectBtn}
+              onClick={() => randomUserReq()}
+            />
+            )
           }
         </div>
-        <div aria-hidden className={styles.modalAvatar} style={{ backgroundColor: `${selectedUser.color}` }}>
-          {selectedUser.name.slice(0, 2)}
-        </div>
-        <div className={styles.selectedUserName}>
-          {selectedUser.name}
-        </div>
-        {!isSelectedUser
-          && (
-          <Button
-            label={intl.formatMessage(messages.reselect)}
-            color="primary"
-            size="md"
-            className={styles.selectBtn}
-            onClick={() => randomUserReq()}
-          />
-          )
-        }
-      </div>
-    );
+      );
+    }
 
     return (
       <Modal

--- a/bigbluebutton-html5/imports/ui/components/modal/random-user/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/modal/random-user/component.jsx
@@ -64,11 +64,9 @@ class RandomUserSelect extends Component {
       clearRandomlySelectedUser,
     } = this.props;
 
-    if (!selectedUser) return null;
+    const isSelectedUser = selectedUser ? (currentUser.userId === selectedUser.userId) : false;
 
-    const isSelectedUser = currentUser.userId === selectedUser.userId;
-
-    const viewElement = numAvailableViewers < 1 ? (
+    const viewElement = (numAvailableViewers < 1 || !selectedUser) ? (
       <div className={styles.modalViewContainer}>
         <div className={styles.modalViewTitle}>
           {intl.formatMessage(messages.randUserTitle)}


### PR DESCRIPTION
### What does this PR do?

This PR introduces a small fix for random user picking. The modal that says there's no viewers to pick from didn't work properly. This PR makes sure presenter sees such modal when the meeting consists of moderators only.