### PR TITLE
Restore allowRequestsWithoutSession to resources.xml

### DIFF
--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -130,6 +130,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="defaultNumDigitsForTelVoice" value="${defaultNumDigitsForTelVoice}"/>
         <property name="defaultHTML5ClientUrl" value="${defaultHTML5ClientUrl}"/>
         <property name="defaultGuestWaitURL" value="${defaultGuestWaitURL}"/>
+        <property name="allowRequestsWithoutSession" value="${allowRequestsWithoutSession}"/>
         <property name="defaultMeetingDuration" value="${defaultMeetingDuration}"/>
         <property name="disableRecordingDefault" value="${disableRecordingDefault}"/>
         <property name="autoStartRecording" value="${autoStartRecording}"/>


### PR DESCRIPTION
### What does this PR do?

Restores allowRequestsWithoutSession to actually be populated from the properties file.

### Motivation

I wanted to use bigbluebutton in an iframe in chrome, safari, etc, and allowRequestsWithoutSession
wasn't working.

### More

It was removed in an overzealous deletion in
https://github.com/bigbluebutton/bigbluebutton/pull/11008/commits/418fdb1a318a9d6524d0250485750109883acd82
