### PR TITLE
Add new join param skip echo test on first join only

### DIFF
--- a/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
+++ b/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
@@ -24,6 +24,7 @@ const oldParameters = {
   presenterTools: 'bbb_presenter_tools',
   shortcuts: 'bbb_shortcuts',
   skipCheck: 'bbb_skip_check_audio',
+  skipCheckOnJoin: 'bbb_skip_check_audio_on_first_join',
 };
 
 const oldParametersKeys = Object.keys(oldParameters);
@@ -37,6 +38,7 @@ const currentParameters = [
   'bbb_force_listen_only',
   'bbb_listen_only_mode',
   'bbb_skip_check_audio',
+  'bbb_skip_check_audio_on_first_join',
   // BRANDING
   'bbb_display_branding_area',
   // SHORTCUTS

--- a/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
+++ b/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
@@ -24,7 +24,6 @@ const oldParameters = {
   presenterTools: 'bbb_presenter_tools',
   shortcuts: 'bbb_shortcuts',
   skipCheck: 'bbb_skip_check_audio',
-  skipCheckOnJoin: 'bbb_skip_check_audio_on_first_join',
 };
 
 const oldParametersKeys = Object.keys(oldParameters);

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/container.jsx
@@ -7,11 +7,14 @@ import lockContextContainer from '/imports/ui/components/lock-viewers/context/co
 import logger from '/imports/startup/client/logger';
 import Auth from '/imports/ui/services/auth';
 import Users from '/imports/api/users';
+import Storage from '/imports/ui/services/storage/session';
+import getFromUserSettings from '/imports/ui/services/users-settings';
 import AudioControls from './component';
 import AudioModalContainer from '../audio-modal/container';
 import Service from '../service';
 
 const ROLE_VIEWER = Meteor.settings.public.user.role_viewer;
+const APP_CONFIG = Meteor.settings.public.app;
 
 const AudioControlsContainer = props => <AudioControls {...props} />;
 
@@ -38,6 +41,10 @@ const processToggleMuteFromOutside = (e) => {
 };
 
 const handleLeaveAudio = () => {
+  if (getFromUserSettings('bbb_skip_check_audio_on_first_join', APP_CONFIG.skipCheckOnJoin)) {
+    Storage.setItem('getEchoTest', true);
+  }
+
   Service.exitAudio();
   logger.info({
     logCode: 'audiocontrols_leave_audio',

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/container.jsx
@@ -41,7 +41,8 @@ const processToggleMuteFromOutside = (e) => {
 };
 
 const handleLeaveAudio = () => {
-  if (getFromUserSettings('bbb_skip_check_audio_on_first_join', APP_CONFIG.skipCheckOnJoin)) {
+  const skipOnFistJoin = getFromUserSettings('bbb_skip_check_audio_on_first_join', APP_CONFIG.skipCheckOnJoin);
+  if (skipOnFistJoin && !Storage.getItem('getEchoTest')) {
     Storage.setItem('getEchoTest', true);
   }
 

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -33,9 +33,8 @@ const propTypes = {
   formattedDialNum: PropTypes.string.isRequired,
   showPermissionsOvelay: PropTypes.bool.isRequired,
   listenOnlyMode: PropTypes.bool.isRequired,
-  skipCheck: PropTypes.bool.isRequired,
-  joinFullAudioImmediately: PropTypes.bool.isRequired,
-  joinFullAudioEchoTest: PropTypes.bool.isRequired,
+  skipCheck: PropTypes.bool,
+  skipCheckOnJoin: PropTypes.bool,
   forceListenOnlyAttendee: PropTypes.bool.isRequired,
   audioLocked: PropTypes.bool.isRequired,
   resolve: PropTypes.func,
@@ -52,6 +51,8 @@ const defaultProps = {
   inputDeviceId: null,
   outputDeviceId: null,
   resolve: null,
+  skipCheck: false,
+  skipCheckOnJoin: false,
 };
 
 const intlMessages = defineMessages({
@@ -162,22 +163,26 @@ class AudioModal extends Component {
 
   componentDidMount() {
     const {
-      joinFullAudioImmediately,
-      joinFullAudioEchoTest,
       forceListenOnlyAttendee,
       audioLocked,
+      autoJoin,
+      skipCheck,
+      skipCheckOnJoin,
+      useEchoTest,
     } = this.props;
 
-    if (joinFullAudioImmediately) {
-      this.handleJoinMicrophone();
-    }
+    if (autoJoin) {
+      if (forceListenOnlyAttendee || audioLocked) {
+        return this.handleJoinListenOnly();
+      }
 
-    if (joinFullAudioEchoTest) {
-      this.handleGoToEchoTest();
-    }
+      if (useEchoTest) {
+        return this.handleGoToEchoTest();
+      }
 
-    if (forceListenOnlyAttendee || audioLocked) {
-      this.handleJoinListenOnly();
+      if (skipCheck || skipCheckOnJoin) {
+        return this.handleJoinMicrophone();
+      }
     }
   }
 
@@ -221,14 +226,10 @@ class AudioModal extends Component {
   }
 
   handleRetryGoToEchoTest() {
-    const { joinFullAudioImmediately } = this.props;
-
     this.setState({
       hasError: false,
       content: null,
     });
-
-    if (joinFullAudioImmediately) return this.joinMicrophone();
 
     return this.handleGoToEchoTest();
   }
@@ -262,7 +263,7 @@ class AudioModal extends Component {
     });
 
     return joinEchoTest().then(() => {
-      //console.log(inputDeviceId, outputDeviceId);
+      // console.log(inputDeviceId, outputDeviceId);
       this.setState({
         content: 'echoTest',
         disableActions: false,
@@ -347,9 +348,9 @@ class AudioModal extends Component {
   skipAudioOptions() {
     const {
       isConnecting,
-      joinFullAudioImmediately,
-      joinFullAudioEchoTest,
       forceListenOnlyAttendee,
+      skipCheck,
+      skipCheckOnJoin,
     } = this.props;
 
     const {
@@ -361,8 +362,8 @@ class AudioModal extends Component {
     return (
       isConnecting
       || forceListenOnlyAttendee
-      || joinFullAudioImmediately
-      || joinFullAudioEchoTest
+      || skipCheck
+      || skipCheckOnJoin
     ) && !content && !hasError;
   }
 

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -184,6 +184,10 @@ class AudioModal extends Component {
         return this.handleJoinMicrophone();
       }
     }
+
+    if (skipCheck || skipCheckOnJoin && !useEchoTest) {
+      return this.handleJoinMicrophone();
+    }
   }
 
   componentDidUpdate(prevProps) {
@@ -349,6 +353,7 @@ class AudioModal extends Component {
     const {
       isConnecting,
       forceListenOnlyAttendee,
+      useEchoTest,
       skipCheck,
       skipCheckOnJoin,
     } = this.props;
@@ -363,7 +368,7 @@ class AudioModal extends Component {
       isConnecting
       || forceListenOnlyAttendee
       || skipCheck
-      || skipCheckOnJoin
+      || skipCheckOnJoin && !useEchoTest
     ) && !content && !hasError;
   }
 

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -34,7 +34,8 @@ const propTypes = {
   showPermissionsOvelay: PropTypes.bool.isRequired,
   listenOnlyMode: PropTypes.bool.isRequired,
   skipCheck: PropTypes.bool,
-  skipCheckOnJoin: PropTypes.bool,
+  joinFullAudioImmediately: PropTypes.bool,
+  joinFullAudioEchoTest: PropTypes.bool,
   forceListenOnlyAttendee: PropTypes.bool.isRequired,
   audioLocked: PropTypes.bool.isRequired,
   resolve: PropTypes.func,
@@ -52,7 +53,8 @@ const defaultProps = {
   outputDeviceId: null,
   resolve: null,
   skipCheck: false,
-  skipCheckOnJoin: false,
+  joinFullAudioImmediately: false,
+  joinFullAudioEchoTest: false,
 };
 
 const intlMessages = defineMessages({
@@ -165,29 +167,13 @@ class AudioModal extends Component {
     const {
       forceListenOnlyAttendee,
       audioLocked,
-      autoJoin,
-      skipCheck,
-      skipCheckOnJoin,
-      useEchoTest,
+      joinFullAudioImmediately,
+      joinFullAudioEchoTest,
     } = this.props;
 
-    if (autoJoin) {
-      if (forceListenOnlyAttendee || audioLocked) {
-        return this.handleJoinListenOnly();
-      }
-
-      if (useEchoTest) {
-        return this.handleGoToEchoTest();
-      }
-
-      if (skipCheck || skipCheckOnJoin) {
-        return this.handleJoinMicrophone();
-      }
-    }
-
-    if (skipCheck || skipCheckOnJoin && !useEchoTest) {
-      return this.handleJoinMicrophone();
-    }
+    if (forceListenOnlyAttendee) return this.handleJoinListenOnly();
+    if (joinFullAudioEchoTest) return this.handleGoToEchoTest();
+    if (joinFullAudioImmediately) return this.handleJoinMicrophone();
   }
 
   componentDidUpdate(prevProps) {
@@ -353,9 +339,8 @@ class AudioModal extends Component {
     const {
       isConnecting,
       forceListenOnlyAttendee,
-      useEchoTest,
-      skipCheck,
-      skipCheckOnJoin,
+      joinFullAudioEchoTest,
+      joinFullAudioImmediately,
     } = this.props;
 
     const {
@@ -363,12 +348,11 @@ class AudioModal extends Component {
       hasError,
     } = this.state;
 
-
     return (
       isConnecting
       || forceListenOnlyAttendee
-      || skipCheck
-      || skipCheckOnJoin && !useEchoTest
+      || joinFullAudioImmediately
+      || joinFullAudioEchoTest
     ) && !content && !hasError;
   }
 

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -173,7 +173,7 @@ class AudioModal extends Component {
 
     if (forceListenOnlyAttendee) return this.handleJoinListenOnly();
     if (joinFullAudioEchoTest) return this.handleGoToEchoTest();
-    if (joinFullAudioImmediately) return this.handleJoinMicrophone();
+    if (joinFullAudioImmediately || audioLocked) return this.handleJoinMicrophone();
   }
 
   componentDidUpdate(prevProps) {

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -26,7 +26,7 @@ export default lockContextContainer(withModalMounter(withTracker(({ mountModal, 
   const skipCheckOnJoin = getFromUserSettings('bbb_skip_check_audio_on_first_join', APP_CONFIG.skipCheckOnJoin);
   const autoJoin = getFromUserSettings('bbb_auto_join_audio', APP_CONFIG.autoJoin);
   const meeting = Meetings.findOne({ meetingId: Auth.meetingID }, { fields: { voiceProp: 1 } });
-  const getEchoTest = Storage.getItem('getEchoTest', false);
+  const getEchoTest = Storage.getItem('getEchoTest');
 
   let formattedDialNum = '';
   let formattedTelVoice = '';

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -26,7 +26,7 @@ export default lockContextContainer(withModalMounter(withTracker(({ mountModal, 
   const skipCheckOnJoin = getFromUserSettings('bbb_skip_check_audio_on_first_join', APP_CONFIG.skipCheckOnJoin);
   const autoJoin = getFromUserSettings('bbb_auto_join_audio', APP_CONFIG.autoJoin);
   const meeting = Meetings.findOne({ meetingId: Auth.meetingID }, { fields: { voiceProp: 1 } });
-  const useEchoTest = Storage.getItem('getEchoTest', false);
+  const getEchoTest = Storage.getItem('getEchoTest', false);
 
   let formattedDialNum = '';
   let formattedTelVoice = '';
@@ -39,6 +39,13 @@ export default lockContextContainer(withModalMounter(withTracker(({ mountModal, 
       combinedDialInNum = `${dialNumber.replace(/\D+/g, '')},,,${telVoice.replace(/\D+/g, '')}`;
     }
   }
+
+  const joinFullAudioImmediately = (autoJoin && (skipCheck || skipCheckOnJoin))
+    || (skipCheck || skipCheckOnJoin && !getEchoTest);
+
+  const joinFullAudioEchoTest = joinFullAudioImmediately && getEchoTest;
+
+  const forceListenOnlyAttendee = forceListenOnly && !Service.isUserModerator();
 
   return ({
     closeModal: () => {
@@ -96,15 +103,15 @@ export default lockContextContainer(withModalMounter(withTracker(({ mountModal, 
     outputDeviceId: Service.outputDeviceId(),
     showPermissionsOvelay: Service.isWaitingPermissions(),
     listenOnlyMode,
-    autoJoin,
-    useEchoTest,
     skipCheck,
     skipCheckOnJoin,
     formattedDialNum,
     formattedTelVoice,
     combinedDialInNum,
     audioLocked: userLocks.userMic,
-    forceListenOnlyAttendee: forceListenOnly && !Service.isUserModerator(),
+    joinFullAudioImmediately,
+    joinFullAudioEchoTest,
+    forceListenOnlyAttendee,
     isIOSChrome: browser().name === 'crios',
     isMobileNative: navigator.userAgent.toLowerCase().includes('bbbnative'),
     isIEOrEdge: browser().name === 'edge' || browser().name === 'ie',

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -9,6 +9,7 @@ import Auth from '/imports/ui/services/auth';
 import deviceInfo from '/imports/utils/deviceInfo';
 import lockContextContainer from '/imports/ui/components/lock-viewers/context/container';
 import AudioError from '/imports/ui/services/audio-manager/error-codes';
+import Storage from '/imports/ui/services/storage/session';
 import Service from '../service';
 
 const AudioModalContainer = props => <AudioModal {...props} />;
@@ -22,7 +23,11 @@ export default lockContextContainer(withModalMounter(withTracker(({ mountModal, 
   const listenOnlyMode = getFromUserSettings('bbb_listen_only_mode', APP_CONFIG.listenOnlyMode);
   const forceListenOnly = getFromUserSettings('bbb_force_listen_only', APP_CONFIG.forceListenOnly);
   const skipCheck = getFromUserSettings('bbb_skip_check_audio', APP_CONFIG.skipCheck);
+  const skipCheckOnJoin = getFromUserSettings('bbb_skip_check_audio_on_first_join', APP_CONFIG.skipCheckOnJoin);
+  const autoJoin = getFromUserSettings('bbb_auto_join_audio', APP_CONFIG.autoJoin);
   const meeting = Meetings.findOne({ meetingId: Auth.meetingID }, { fields: { voiceProp: 1 } });
+  const useEchoTest = Storage.getItem('getEchoTest', false);
+
   let formattedDialNum = '';
   let formattedTelVoice = '';
   let combinedDialInNum = '';
@@ -41,7 +46,7 @@ export default lockContextContainer(withModalMounter(withTracker(({ mountModal, 
     },
     joinMicrophone: () => {
       const call = new Promise((resolve, reject) => {
-        if (skipCheck) {
+        if (skipCheck || skipCheckOnJoin) {
           resolve(Service.joinMicrophone());
         } else {
           resolve(Service.transferCall());
@@ -91,14 +96,15 @@ export default lockContextContainer(withModalMounter(withTracker(({ mountModal, 
     outputDeviceId: Service.outputDeviceId(),
     showPermissionsOvelay: Service.isWaitingPermissions(),
     listenOnlyMode,
+    autoJoin,
+    useEchoTest,
     skipCheck,
+    skipCheckOnJoin,
     formattedDialNum,
     formattedTelVoice,
     combinedDialInNum,
     audioLocked: userLocks.userMic,
-    joinFullAudioImmediately: !listenOnlyMode && skipCheck,
-    joinFullAudioEchoTest: !listenOnlyMode && !skipCheck,
-    forceListenOnlyAttendee: listenOnlyMode && forceListenOnly && !Service.isUserModerator(),
+    forceListenOnlyAttendee: forceListenOnly && !Service.isUserModerator(),
     isIOSChrome: browser().name === 'crios',
     isMobileNative: navigator.userAgent.toLowerCase().includes('bbbnative'),
     isIEOrEdge: browser().name === 'edge' || browser().name === 'ie',

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -7,6 +7,7 @@ public:
     listenOnlyMode: true
     forceListenOnly: false
     skipCheck: false
+    skipCheckOnJoin: false
     clientTitle: BigBlueButton
     appName: BigBlueButton HTML5 Client
     bbbServerVersion: 2.3-dev


### PR DESCRIPTION
### What does this PR do?
Adds a join param `bbb_skip_check_audio_on_first_join` to skip echo test on the first join only.

when `bbb_skip_check_audio_on_first_join`=true on client load you are automatically joined in audio, bypassing echo test. If you hang up and try to join audio again (via UI button) you will be presented with echo test

### Closes Issue(s)
Closes #11283 