### PR TITLE
Changes on webcam skip preview behavior

### DIFF
--- a/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
+++ b/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
@@ -48,6 +48,7 @@ const currentParameters = [
   'bbb_enable_video',
   'bbb_record_video',
   'bbb_skip_video_preview',
+  'bbb_skip_video_preview_on_first_join',
   'bbb_mirror_own_webcam',
   // PRESENTATION
   'bbb_force_restore_presentation_on_new_events',

--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -7,10 +7,10 @@ import Button from '/imports/ui/components/button/component';
 // import { notify } from '/imports/ui/services/notification';
 import logger from '/imports/startup/client/logger';
 import Modal from '/imports/ui/components/modal/simple/component';
-import Service from './service';
 import browser from 'browser-detect';
-import VideoService from '../video-provider/service';
 import cx from 'classnames';
+import Service from './service';
+import VideoService from '../video-provider/service';
 import { styles } from './styles';
 
 const CAMERA_PROFILES = Meteor.settings.public.kurento.cameraProfiles;
@@ -30,7 +30,6 @@ const propTypes = {
   changeWebcam: PropTypes.func.isRequired,
   changeProfile: PropTypes.func.isRequired,
   resolve: PropTypes.func,
-  skipVideoPreview: PropTypes.bool.isRequired,
   hasMediaDevices: PropTypes.bool.isRequired,
   hasVideoStream: PropTypes.bool.isRequired,
   webcamDeviceId: PropTypes.string,
@@ -206,13 +205,13 @@ class VideoPreview extends Component {
 
     this.userParameterProfile = VideoService.getUserParameterProfile();
     this.mirrorOwnWebcam = VideoService.mirrorOwnWebcam();
+    this.skipVideoPreview = Service.getSkipVideoPreview();
   }
 
   componentDidMount() {
     const {
       webcamDeviceId,
       hasMediaDevices,
-      skipVideoPreview,
     } = this.props;
 
     this._isMounted = true;
@@ -282,15 +281,15 @@ class VideoPreview extends Component {
                 });
                 this.displayInitialPreview(initialDeviceId);
               }
-              if (!skipVideoPreview) {
+              if (!this.skipVideoPreview) {
                 this.setState({
                   viewState: VIEW_STATES.found,
                 });
               }
             }).catch((error) => {
               this.handleDeviceError('enumerate', error, 'enumerating devices');
+            });
           });
-        });
       } catch (error) {
         this.handleDeviceError('grabbing', error, 'grabbing initial video stream');
       }
@@ -451,7 +450,6 @@ class VideoPreview extends Component {
   displayPreview(deviceId, profile) {
     const {
       changeProfile,
-      skipVideoPreview,
     } = this.props;
 
     this.setState({
@@ -460,7 +458,7 @@ class VideoPreview extends Component {
       previewError: undefined,
     });
     changeProfile(profile.id);
-    if (skipVideoPreview) return this.handleStartSharing();
+    if (this.skipVideoPreview) return this.handleStartSharing();
 
     this.doGUM(deviceId, profile).then((stream) => {
       if (!this._isMounted) return;
@@ -493,7 +491,6 @@ class VideoPreview extends Component {
   renderDeviceSelectors() {
     const {
       intl,
-      skipVideoPreview,
       sharedDevices,
     } = this.props;
 
@@ -518,7 +515,7 @@ class VideoPreview extends Component {
               value={webcamDeviceId || ''}
               className={styles.select}
               onChange={this.handleSelectWebcam}
-              disabled={skipVideoPreview}
+              disabled={this.skipVideoPreview}
             >
               {availableWebcams.map(webcam => (
                 <option key={webcam.deviceId} value={webcam.deviceId}>
@@ -536,14 +533,14 @@ class VideoPreview extends Component {
         { shared
           ? (
             <span className={styles.label}>
-               {intl.formatMessage(intlMessages.sharedCameraLabel)}
-             </span>
+              {intl.formatMessage(intlMessages.sharedCameraLabel)}
+            </span>
           )
           : (
             <span>
-               <label className={styles.label} htmlFor="setQuality">
-                 {intl.formatMessage(intlMessages.qualityLabel)}
-               </label>
+              <label className={styles.label} htmlFor="setQuality">
+                {intl.formatMessage(intlMessages.qualityLabel)}
+              </label>
               {availableProfiles && availableProfiles.length > 0
                 ? (
                   <select
@@ -551,9 +548,9 @@ class VideoPreview extends Component {
                     value={selectedProfile || ''}
                     className={styles.select}
                     onChange={this.handleSelectProfile}
-                    disabled={skipVideoPreview}
+                    disabled={this.skipVideoPreview}
                   >
-                    {availableProfiles.map(profile => {
+                    {availableProfiles.map((profile) => {
                       const label = intlMessages[`${profile.id}`]
                         ? intl.formatMessage(intlMessages[`${profile.id}`])
                         : profile.name;
@@ -562,14 +559,14 @@ class VideoPreview extends Component {
                         <option key={profile.id} value={profile.id}>
                           {`${label}`}
                         </option>
-                      )
+                      );
                     })}
                   </select>
                 )
                 : (
                   <span>
-                     {intl.formatMessage(intlMessages.profileNotFoundLabel)}
-                   </span>
+                    {intl.formatMessage(intlMessages.profileNotFoundLabel)}
+                  </span>
                 )
               }
             </span>
@@ -643,7 +640,6 @@ class VideoPreview extends Component {
   renderModalContent() {
     const {
       intl,
-      skipVideoPreview,
       sharedDevices,
       hasVideoStream,
     } = this.props;
@@ -654,7 +650,7 @@ class VideoPreview extends Component {
       deviceError,
       previewError,
     } = this.state;
-    const shouldDisableButtons = skipVideoPreview && !(deviceError || previewError);
+    const shouldDisableButtons = this.skipVideoPreview && !(deviceError || previewError);
 
     const shared = sharedDevices.includes(webcamDeviceId);
 
@@ -679,15 +675,17 @@ class VideoPreview extends Component {
         {this.renderContent()}
 
         <div className={styles.footer}>
-          {hasVideoStream ?
-            (<div className={styles.extraActions}>
-              <Button
-                color="danger"
-                label={intl.formatMessage(intlMessages.stopSharingAllLabel)}
-                onClick={this.handleStopSharingAll}
-                disabled={shouldDisableButtons}
-              />
-            </div>)
+          {hasVideoStream
+            ? (
+              <div className={styles.extraActions}>
+                <Button
+                  color="danger"
+                  label={intl.formatMessage(intlMessages.stopSharingAllLabel)}
+                  onClick={this.handleStopSharingAll}
+                  disabled={shouldDisableButtons}
+                />
+              </div>
+            )
             : null
           }
           <div className={styles.actions}>
@@ -713,7 +711,6 @@ class VideoPreview extends Component {
     const {
       intl,
       hasMediaDevices,
-      skipVideoPreview,
       isCamLocked,
     } = this.props;
 
@@ -727,7 +724,7 @@ class VideoPreview extends Component {
       previewError,
     } = this.state;
 
-    const allowCloseModal = !!(deviceError || previewError) || !skipVideoPreview;
+    const allowCloseModal = !!(deviceError || previewError) || !this.skipVideoPreview;
 
     return (
       <Modal

--- a/bigbluebutton-html5/imports/ui/components/video-preview/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/container.jsx
@@ -27,7 +27,7 @@ const isCamLocked = () => {
   return false;
 };
 
-export default withModalMounter(withTracker(({ mountModal, fromInterface }) => ({
+export default withModalMounter(withTracker(({ mountModal }) => ({
   startSharing: (deviceId) => {
     mountModal(null);
     VideoService.joinVideo(deviceId);
@@ -48,6 +48,5 @@ export default withModalMounter(withTracker(({ mountModal, fromInterface }) => (
   webcamDeviceId: Service.webcamDeviceId(),
   changeProfile: profileId => Service.changeProfile(profileId),
   hasMediaDevices: deviceInfo.hasMediaDevices,
-  skipVideoPreview: VideoService.getSkipVideoPreview(fromInterface),
   hasVideoStream: VideoService.hasVideoStream(),
 }))(VideoPreviewContainer));

--- a/bigbluebutton-html5/imports/ui/components/video-preview/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/service.js
@@ -1,3 +1,6 @@
+import Storage from '/imports/ui/services/storage/session';
+import getFromUserSettings from '/imports/ui/services/users-settings';
+
 const promiseTimeout = (ms, promise) => {
   const timeout = new Promise((resolve, reject) => {
     const id = setTimeout(() => {
@@ -18,6 +21,24 @@ const promiseTimeout = (ms, promise) => {
   ]);
 };
 
+const getSkipVideoPreview = () => {
+  const KURENTO_CONFIG = Meteor.settings.public.kurento;
+
+  const skipVideoPreviewOnFirstJoin = getFromUserSettings(
+    'bbb_skip_video_preview_on_first_join',
+    KURENTO_CONFIG.skipVideoPreviewOnFirstJoin,
+  );
+  const skipVideoPreview = getFromUserSettings(
+    'bbb_skip_video_preview',
+    KURENTO_CONFIG.skipVideoPreview,
+  );
+
+  return (
+    (Storage.getItem('isFirstJoin') !== false && skipVideoPreviewOnFirstJoin)
+    || skipVideoPreview
+  );
+};
+
 export default {
   promiseTimeout,
   changeWebcam: (deviceId) => {
@@ -27,4 +48,5 @@ export default {
   changeProfile: (profileId) => {
     Session.set('WebcamProfileId', profileId);
   },
+  getSkipVideoPreview,
 };

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/container.jsx
@@ -15,7 +15,7 @@ const JoinVideoOptionsContainer = (props) => {
     ...restProps
   } = props;
 
-  const mountVideoPreview = () => { mountModal(<VideoPreviewContainer fromInterface />); };
+  const mountVideoPreview = () => { mountModal(<VideoPreviewContainer />); };
 
   return (
     <JoinVideoButton {...{

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -240,6 +240,7 @@ public:
     enableListenOnly: true
     autoShareWebcam: false
     skipVideoPreview: false
+    skipVideoPreviewOnFirstJoin: false
     # Entry `thresholds` is an array of:
     # - threshold: minimum number of cameras being shared for profile to applied
     #   profile: a camera profile id from the cameraProfiles configuration array


### PR DESCRIPTION
### What does this PR do?

Reverts the changes in PR #8353, so if the `userdata-bbb_skip_video_preview` parameter is set to `true` the video preview always skips
Introduces `userdata-bbb_skip_video_preview_on_first_join` parameter to skip only on first joining of webcam

### Closes Issue(s)

closes #10454
