### PR TITLE
fixes non localized notifications label in settings

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/component.jsx
@@ -51,6 +51,10 @@ const intlMessages = defineMessages({
     id: 'app.settings.main.save.label.description',
     description: 'Settings modal save button label',
   },
+  notificationLabel: {
+    id: 'app.submenu.notification.SectionTitle', // set menu label identical to section title
+    description: 'label for notification tab',
+  },
   dataSavingLabel: {
     id: 'app.settings.dataSavingTab.label',
     description: 'label for data savings tab',
@@ -168,7 +172,7 @@ class Settings extends Component {
             selectedClassName={styles.selected}
           >
             <Icon iconName="alert" className={styles.icon} />
-            <span id="notificationTab">Notification</span>
+            <span id="notificationTab">{intl.formatMessage(intlMessages.notificationLabel)}</span>
           </Tab>
           <Tab
             className={styles.tabSelector}


### PR DESCRIPTION
### What does this PR do?

fixes the missing translation of "Notification" in the "three dot menu" -> settings, the word "Notification" was hardcoded.

### Closes Issue(s)

closes #11271 

### Motivation

Saw the missing translation, realized it's just a quick and small fix

### More

I just reused the language key `app.submenu.notification.SectionTitle` for the menu label. However, one might consider to introduce a separate language key for the menu label in case the menu label should show something different than the title of the corresponding submenu.