### PR TITLE
Show current user identification on breakout room creation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -107,6 +107,10 @@ const intlMessages = defineMessages({
     id: 'app.createBreakoutRoom.numberOfRoomsError',
     description: 'Label an error message',
   },
+  you: {
+    id: 'app.userList.you',
+    description: 'Text for identifying your user',
+  },
 });
 
 const BREAKOUT_LIM = Meteor.settings.public.app.breakoutRoomLimit;
@@ -114,8 +118,11 @@ const MIN_BREAKOUT_ROOMS = 2;
 const MAX_BREAKOUT_ROOMS = BREAKOUT_LIM > MIN_BREAKOUT_ROOMS ? BREAKOUT_LIM : MIN_BREAKOUT_ROOMS;
 
 const propTypes = {
-  intl: PropTypes.object.isRequired,
+  intl: PropTypes.shape({
+    formatMessage: PropTypes.func.isRequired,
+  }).isRequired,
   isInvitation: PropTypes.bool.isRequired,
+  isMe: PropTypes.bool.isRequired,
   meetingName: PropTypes.string.isRequired,
   users: PropTypes.arrayOf(PropTypes.object).isRequired,
   createBreakoutRoom: PropTypes.func.isRequired,
@@ -629,6 +636,9 @@ class BreakoutRoom extends PureComponent {
       valid,
       seletedId,
     } = this.state;
+
+    const { intl, isMe } = this.props;
+
     const dragStart = (ev) => {
       ev.dataTransfer.setData('text', ev.target.id);
       this.setState({ seletedId: ev.target.id });
@@ -658,6 +668,7 @@ class BreakoutRoom extends PureComponent {
           onDragEnd={dragEnd}
         >
           {user.userName}
+          <i>{(isMe(user.userId)) ? ` (${intl.formatMessage(intlMessages.you)})` : ''}</i>
         </p>));
   }
 

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/container.jsx
@@ -10,5 +10,6 @@ export default withTracker(() => ({
   sendInvitation: ActionsBarService.sendInvitation,
   breakoutJoinedUsers: ActionsBarService.breakoutJoinedUsers(),
   users: ActionsBarService.users(),
+  isMe: ActionsBarService.isMe,
   meetingName: ActionsBarService.meetingName(),
 }))(CreateBreakoutRoomModal);

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/service.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/service.js
@@ -45,9 +45,13 @@ const amIModerator = () => {
   return currentUser.role === ROLE_MODERATOR;
 };
 
+const isMe = intId => intId === Auth.userID;
+
+
 export default {
   amIPresenter,
   amIModerator,
+  isMe,
   meetingName: () => Meetings.findOne({ meetingId: Auth.meetingID },
     { fields: { 'meetingProp.name': 1 } }).meetingProp.name,
   users: () => Users.find({


### PR DESCRIPTION
### What does this PR do?

Changes the username listing on breakout room creation by adding an identification to the current user name.

### Closes Issue(s)

closes #8551