### PR TITLE
Fix overlapping messages

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-list/component.jsx
@@ -46,6 +46,13 @@ class MessageList extends Component {
     this.cache = new CellMeasurerCache({
       fixedWidth: true,
       minHeight: 18,
+      keyMapper: (rowIndex, columnIndex) => {
+        const { messages } = this.props;
+        const message = messages[rowIndex];
+        const key = message.id;
+        const contentCount = message.content.length;
+        return `${key}-${contentCount}`;
+      },
     });
     
     this.userScrolledBack = false;
@@ -190,9 +197,15 @@ class MessageList extends Component {
     const message = messages[index];
 
     // it's to get an accurate size of the welcome message because it changes after initial render
-
-    if (message.sender === null && !this.systemMessagesResized[index]) {
-      setTimeout(() => this.resizeRow(index), 500);
+    if (message.id.startsWith('welcome-msg') && !this.systemMessagesResized[index]) {
+      [500, 1000, 2000, 3000, 4000, 5000].forEach((i)=>{
+        setTimeout(() => {
+          if (this.listRef) {
+            this.cache.clear(index);
+            this.listRef.recomputeRowHeights(index);
+          }
+        }, i);
+      });
       this.systemMessagesResized[index] = true;
     }
 


### PR DESCRIPTION
This PR fix two issues related to messages ovelapping on chat

The cache:
 In virtualized chat a cache is used for each item to avoid unnecessary recalculations, this logic works great for static items, but in our chat the messages increase in size when grouping messages, to fix I invalidated the old cache by forcing the virtualized list to recalculate when a new message arrives

The CSS calculation:
 The messages of welcome have some styles that changes the final height of the element and the time to apply this stylies depends of the CPU/GPU performance, causing sometime it happens after the vritualized list size calculation, the solutions is trigger the recalculation sometimes to get the right dimensions