### PR TITLE
Fix message list not updating when switching between private chats

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-list/component.jsx
@@ -289,7 +289,7 @@ class MessageList extends Component {
           }
         }}
         className={styles.messageListWrapper}
-        key="chat-list"
+        key={_.uniqueId('chat-list-')}
         data-test="chatMessages"
         ref={node => this.messageListWrapper = node}
       >


### PR DESCRIPTION
### What does this PR do?
Ensures the chat list element `key` is unique so the component knows to update.

### Closes Issue(s)
Closes #10002