### PR TITLE
Fix video preview modal behavior

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -515,7 +515,6 @@ class VideoPreview extends Component {
               value={webcamDeviceId || ''}
               className={styles.select}
               onChange={this.handleSelectWebcam}
-              disabled={this.skipVideoPreview}
             >
               {availableWebcams.map(webcam => (
                 <option key={webcam.deviceId} value={webcam.deviceId}>
@@ -548,7 +547,6 @@ class VideoPreview extends Component {
                     value={selectedProfile || ''}
                     className={styles.select}
                     onChange={this.handleSelectProfile}
-                    disabled={this.skipVideoPreview}
                   >
                     {availableProfiles.map((profile) => {
                       const label = intlMessages[`${profile.id}`]
@@ -716,6 +714,10 @@ class VideoPreview extends Component {
 
     if (isCamLocked === true) {
       this.handleProceed();
+      return null;
+    }
+
+    if (this.skipVideoPreview) {
       return null;
     }
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
@@ -73,7 +73,7 @@ const JoinVideoButton = ({
   return (
     <Button
       label={label}
-      data-test="joinVideo"
+      data-test={hasVideoStream ? 'leaveVideo' : 'joinVideo'}
       className={cx(hasVideoStream || styles.btn)}
       onClick={handleOnClick}
       hideLabel


### PR DESCRIPTION
### What does this PR do?

Changes video preview modal behavior by not rendering it if `userdata-bbb_skip_video_preview_on_first_join=true` or `userdata-bbb_skip_video_preview=true`

Restores `data-test` on join video button