### PR TITLE
Set default cursorInterval to 150ms (was 40ms)

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -376,7 +376,7 @@ public:
     role_viewer: VIEWER
   whiteboard:
     annotationsQueueProcessInterval: 60
-    cursorInterval: 40
+    cursorInterval: 150
     annotations:
       status:
         start: DRAW_START


### PR DESCRIPTION
Backport of https://github.com/bigbluebutton/bigbluebutton/pull/11322 to 2.2.x-release targeting 2.2.32

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Changes the default value for cursorInterval rom 40ms to 150ms

<!-- A brief description of each change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

Recommended in https://github.com/bigbluebutton/bigbluebutton/issues/11183 and further justified in https://github.com/bigbluebutton/bigbluebutton/pull/11187#issuecomment-764946902 with significant community support
### More

We need to backport this to 2.2.x-release
