### PR TITLE
Change the order of End-meeting and Logout in navigation bar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -260,6 +260,7 @@ class SettingsDropdown extends PureComponent {
         onClick={() => mountModal(<ShortcutHelpComponent />)}
       />),
       (isMeteorConnected ? <DropdownListSeparator key={_.uniqueId('list-separator-')} /> : null),
+      shouldRenderLogoutOption,
       allowedToEndMeeting && isMeteorConnected
         ? (<DropdownListItem
           key="list-item-end-meeting"
@@ -270,7 +271,6 @@ class SettingsDropdown extends PureComponent {
         />
         )
         : null,
-      shouldRenderLogoutOption,
     ]);
   }
 


### PR DESCRIPTION
### What does this PR do?

Changes the order of the item End-meeting and the item Logout in the navigation bar.

### Closes Issue(s)

closes #11324 

### Motivation

I have many times clicked "Logout" when I want to end the meeting, or clicked "End meeting" when I just want to get out the room for a while, leaving the students in the meeting (the latter is more critical). I feel the order "Logout" - "End meeting" is more natural for many users. Or it's a japanese specific feeling ;-)?
