### PR TITLE
Added the possibility to deny attendees creating new meetings via LTI

### DIFF
--- a/bbb-lti/grails-app/conf/lti-config.properties
+++ b/bbb-lti/grails-app/conf/lti-config.properties
@@ -16,7 +16,7 @@
 # with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 #
 #
-# These are the default properites for the BigBlueButton LTI interface
+# These are the default properties for the BigBlueButton LTI interface
 
 # BigBlueButton integration information
 #----------------------------------------------------
@@ -51,18 +51,23 @@ ltiAllRecordedByDefault=false
 ltiCanvasPlacements=
 ltiCanvasPlacementName=BigBlueButton
 
+# Defines if a student/attendee can create a meeting. Defaults to 'true' which means that a meeting can be started
+# by a student.
+# If set to false joining is only possible when an instructor has created/started the meeting before.
+ltiAttendeeCanStartMeeting=true
+
 # Parameters to generate a unique meeting ID from
 # By default, resource_link_id and oauth_consumer_key are used, but certain LMS don't provide unique resource_link_ids
 # Specify parameters separated by commas. Can leave blank to use default.
 meetingIdParams=resource_link_id,oauth_consumer_key
 
 #----------------------------------------------------
-# Inject configuration values into BigbluebuttonSrvice beans
+# Inject configuration values into BigbluebuttonService beans
 beans.bigbluebuttonService.url=${bigbluebuttonURL}
 beans.bigbluebuttonService.salt=${bigbluebuttonSalt}
 beans.bigbluebuttonService.idParams=${meetingIdParams}
 #----------------------------------------------------
-# Inject configuration values into LtiSrvice beans
+# Inject configuration values into LtiService beans
 beans.ltiService.endPoint=${ltiEndPoint}
 beans.ltiService.consumers=${ltiConsumers}
 beans.ltiService.mode=${ltiMode}
@@ -70,5 +75,6 @@ beans.ltiService.restrictedAccess=${ltiRestrictedAccess}
 beans.ltiService.recordedByDefault=${ltiAllRecordedByDefault}
 beans.ltiService.canvasPlacements=${ltiCanvasPlacements}
 beans.ltiService.canvasPlacementName=${ltiCanvasPlacementName}
+beans.ltiService.attendeeCanStartMeeting=${ltiAttendeeCanStartMeeting}
 
 beans.toolService.appName=${appName}

--- a/bbb-lti/grails-app/services/org/bigbluebutton/BigbluebuttonService.groovy
+++ b/bbb-lti/grails-app/services/org/bigbluebutton/BigbluebuttonService.groovy
@@ -391,4 +391,20 @@ class BigbluebuttonService {
 	}
 	return result;
     }
+
+    public boolean isMeetingRunning(params) {
+        // Set the injected values
+        if (!url.equals(bbbProxy.url) && !url.equals("")) {
+            bbbProxy.setUrl(url)
+        }
+        if (!salt.equals(bbbProxy.salt) && !salt.equals("")) {
+            bbbProxy.setSalt(salt)
+        }
+
+        Map<String, Object> apiCallResult = doAPICall(bbbProxy.getIsMeetingRunningURL(getValidatedMeetingId(getParamsForMeetingId(params))));
+        JSONObject jsonResponseObject = (JSONObject) apiCallResult.get("response");
+
+        return jsonResponseObject.get("returncode") == "SUCCESS" ?
+                Boolean.parseBoolean(jsonResponseObject.get("running").toString()) : false;
+    }
 }

--- a/bbb-lti/grails-app/services/org/bigbluebutton/LtiService.groovy
+++ b/bbb-lti/grails-app/services/org/bigbluebutton/LtiService.groovy
@@ -35,6 +35,7 @@ class LtiService {
     def recordedByDefault = "false"
     def canvasPlacements = ""
     def canvasPlacementName = "BigBlueButton"
+    def attendeeCanStartMeeting = "true"
 
     Map<String, String> consumerMap
 
@@ -149,6 +150,10 @@ class LtiService {
 
     def String[] getCanvasPlacements() {
         return this.canvasPlacements
+    }
+
+    def boolean getAttendeeCanStartMeeting() {
+        return Boolean.parseBoolean(this.attendeeCanStartMeeting);
     }
 }
 


### PR DESCRIPTION
### Background

If you don't want students/attendees to be able to create meetings on their own via LTI you would have to force the waiting room feature to be enabled globally on the BBB server which you maybe don't want to do if running an additional frontend like greenlight where the waiting room feature should not be mandatory.

If waiting room feature is forced globally a room is always created on the BBB server when an attendee is trying to access the room via LTI, because he/she then waits in the waiting room without an instructor being there to let him/her in.

Another problem is that this empty room is actually running (shown in getMeetings via BBB API e. g.) which influences the server load calculation of scalelite in a negative way. This is not as big of a deal as the rooms get automatically closed by BBB after a given timeout which can be configured in `bigbluebutton.properties`, but can be annoying anyway.

In addition to that, seeing rooms which aren't really running in monitoring tools can still be confusing. BTW: Greenlight, e.g., doesn't redirect join requests to BBB as well if the corresponding room hasn't been started yet.

### What does this PR do?

It adds a configuration parameter `ltiAttendeeCanStartMeeting` in `lti-config.properties`. To be backwards compatible it defaults to `true` at the moment.
If set to `false` the LTI join request of a normal student/attendee is not being pushed through to the bbb server api as long as the meeting has not been started by an instructor/moderator yet which fixes the mentioned "problems" for scalelite and monitoring tools.
This also avoids many room creation requests and room creations to the bbb api which might be a slight performance improvement, because an isMeetingRunning call to the bbb api is not as expensive as the creation of a room and the deletion of it after a given timeout afterwards. On the other hand every join call now needs an isMeetingRunning call before, so maybe it's evening out overall :-)

### Closes Issue(s)

closes #11170 

### Motivation

I was annoyed by opened up rooms in the BBB api which aren't supposed to be opened, just because students randomly click on icons in their LMS. Sometimes this also led to uneven distribution of sessions via scalelite

### More

I couldn't think of an easy, yet satisfying way of informing the attendee that the room is not running yet so he can't join. So I decided to redirect the attendee to the return page when the room he tries to access is not running (yet).

These "ghost rooms" are annoying me daily so I fixed it. I created the PR because people might find it useful. However, I'm fine with it if you don't want to merge this, especially due to the bad UX simply getting redirected to the return page without any further notice. If you have a better solution for this, just let me know.

EDIT: I tested this with a moodle 3.9 with a scalelite bbb backend with a bunch of 2.2.31 servers. Everything worked fine so far. Additional testing is very welcome.