### PR TITLE
Enabled scrolling for 'waiting guests' window

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
@@ -13,7 +13,7 @@
   flex-grow: 1;
   flex-direction: column;
   justify-content: space-around;
-  overflow: hidden;
+  overflow: auto;
   height: 100vh;
 
   :global(.browser-chrome) & {


### PR DESCRIPTION
### What does this PR do?

At the moment, the element doesn't support scrolling (which it did previously), this should be enough to get this working again.

### Closes Issue(s)

closes #10791 


### More

Just reverted a part of the earlier commit, don't have accurate test system here at the moment to confirm this is now entirely fixed.
(signed-cla is present).
