### PR TITLE
Enable video-pagination and cameraQualityThresholds by default

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -197,7 +197,7 @@ public:
     #   profile: a camera profile id from the cameraProfiles configuration array
     #            that will be applied to all cameras when threshold is hit
     cameraQualityThresholds:
-      enabled: false
+      enabled: true
       thresholds:
         - threshold: 8
           profile: low-u8
@@ -213,19 +213,19 @@ public:
           profile: low-u30
     pagination:
       # whether to globally enable or disable pagination.
-      enabled: false
+      enabled: true
       # how long (in ms) the negotiation will be debounced after a page change.
       pageChangeDebounceTime: 2500
       # video page sizes for DESKTOP endpoints. It stands for the number of SUBSCRIBER streams.
       # PUBLISHERS aren't accounted for .
       # A page size of 0 (zero) means that the page size is unlimited (disabled).
       desktopPageSizes:
-        moderator: 0
-        viewer: 5
+        moderator: 50
+        viewer: 25
       # video page sizes for MOBILE endpoints
       mobilePageSizes:
-        moderator: 2
-        viewer: 2
+        moderator: 8
+        viewer: 4
   pingPong:
     clearUsersInSeconds: 180
     pongTimeInSeconds: 15

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -220,11 +220,11 @@ public:
       # PUBLISHERS aren't accounted for .
       # A page size of 0 (zero) means that the page size is unlimited (disabled).
       desktopPageSizes:
-        moderator: 50
-        viewer: 25
+        moderator: 0
+        viewer: 0
       # video page sizes for MOBILE endpoints
       mobilePageSizes:
-        moderator: 8
+        moderator: 6
         viewer: 4
   pingPong:
     clearUsersInSeconds: 180


### PR DESCRIPTION
### What does this PR do?
- enable `cameraQualityThresholds` by default
- enable `videoPagination` for mobile devices @ 4(student)/6(mod) streams ~and for desktop devices @ 25(student)/50(mod) streams~

This change contains rather high values so that admins see that these features exist, but typical use cases which might not want video-pagination enabled (typical 28people school class) are still not "annoyed".

### Motivation

One of the main issues in 2.2.x problem reports currently in the wild in social media and in the bbb admin groups seems to be that people turn a couple of webcams on and the clients or the server or the internet connection already can't handle it any more. In most cases, enabling video-pagination for mobile devices and also cameraQualityThresholds already "solves" the problem and makes it possible for much more students to attend online-class as well as raise acceptance of using BBB instead of other commercial services.
Even after promoting these new settings for weeks, many BBB operators still don't know of them and are surprised and happy once they enable it.

Many (most?) server operators will use lower limits, but this PR has such "high" defaults to not break any use cases.

One more motivation for this change is to reduce amount of support requests...

### RFC
If this change is a problem for your setup, please comment below so we can understand the use case and further improve the defaults.