### PR TITLE
Add property to settings.yml to enable/disable breakout invitations to moderators

### DIFF
--- a/bigbluebutton-html5/imports/api/breakouts/server/methods/createBreakout.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/methods/createBreakout.js
@@ -6,7 +6,7 @@ import { extractCredentials } from '/imports/api/common/server/helpers';
 export default function createBreakoutRoom(rooms, durationInMinutes, record = false) {
   const REDIS_CONFIG = Meteor.settings.private.redis;
   const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
-  const BREAKOUT_LIM = Meteor.settings.public.app.breakoutRoomLimit;
+  const BREAKOUT_LIM = Meteor.settings.public.app.breakouts.breakoutRoomLimit;
   const MIN_BREAKOUT_ROOMS = 2;
   const MAX_BREAKOUT_ROOMS = BREAKOUT_LIM > MIN_BREAKOUT_ROOMS ? BREAKOUT_LIM : MIN_BREAKOUT_ROOMS;
 

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -113,7 +113,7 @@ const intlMessages = defineMessages({
   },
 });
 
-const BREAKOUT_LIM = Meteor.settings.public.app.breakoutRoomLimit;
+const BREAKOUT_LIM = Meteor.settings.public.app.breakouts.breakoutRoomLimit;
 const MIN_BREAKOUT_ROOMS = 2;
 const MAX_BREAKOUT_ROOMS = BREAKOUT_LIM > MIN_BREAKOUT_ROOMS ? BREAKOUT_LIM : MIN_BREAKOUT_ROOMS;
 
@@ -122,7 +122,7 @@ const propTypes = {
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
   isInvitation: PropTypes.bool.isRequired,
-  isMe: PropTypes.bool.isRequired,
+  isMe: PropTypes.func.isRequired,
   meetingName: PropTypes.string.isRequired,
   users: PropTypes.arrayOf(PropTypes.object).isRequired,
   createBreakoutRoom: PropTypes.func.isRequired,

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/invitation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/invitation/component.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Session } from 'meteor/session';
 import { withModalMounter } from '/imports/ui/components/modal/service';
 import BreakoutJoinConfirmation from '/imports/ui/components/breakout-join-confirmation/container';
+import BreakoutService from '../service';
 
 const BREAKOUT_MODAL_DELAY = 200;
 
@@ -60,7 +61,6 @@ class BreakoutRoomInvitation extends Component {
       currentBreakoutUser,
       getBreakoutByUser,
       breakoutUserIsIn,
-      amIModerator,
     } = this.props;
 
     const {
@@ -73,7 +73,7 @@ class BreakoutRoomInvitation extends Component {
       closeBreakoutJoinConfirmation(mountModal);
     }
 
-    if (hasBreakouts && !breakoutUserIsIn && !amIModerator) {
+    if (hasBreakouts && !breakoutUserIsIn && BreakoutService.checkInviteModerators()) {
       // Have to check for freeJoin breakouts first because currentBreakoutUser will
       // populate after a room has been joined
       const breakoutRoom = getBreakoutByUser(currentBreakoutUser);

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/invitation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/invitation/container.jsx
@@ -18,5 +18,4 @@ export default withTracker(() => ({
   getBreakoutByUser: BreakoutService.getBreakoutByUser,
   currentBreakoutUser: BreakoutService.getBreakoutUserByUserId(Auth.userID),
   breakoutUserIsIn: BreakoutService.getBreakoutUserIsIn(Auth.userID),
-  amIModerator: BreakoutService.amIModerator(),
 }))(BreakoutRoomInvitationContainer);

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/service.js
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/service.js
@@ -63,6 +63,12 @@ const amIModerator = () => {
   return User.role === ROLE_MODERATOR;
 };
 
+const checkInviteModerators = () => {
+  const BREAKOUTS_CONFIG = Meteor.settings.public.app.breakouts;
+
+  return !((amIModerator() && !BREAKOUTS_CONFIG.sendInvitationToIncludedModerators));
+};
+
 const getBreakoutByUserId = userId => Breakouts.find(
   { 'users.userId': userId },
   { fields: { timeRemaining: 0 } },
@@ -121,4 +127,5 @@ export default {
   getBreakoutByUserId,
   getBreakoutUserIsIn,
   isUserInBreakoutRoom,
+  checkInviteModerators,
 };

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -43,7 +43,9 @@ public:
     # Warning: increasing the limit of breakout rooms per meeting
     # can generate excessive overhead to the server. We recommend
     # this value to be kept under 12.
-    breakoutRoomLimit: 8
+    breakouts:
+      breakoutRoomLimit: 8
+      sendInvitationToIncludedModerators: false
     # https://github.com/bigbluebutton/bigbluebutton/pull/10826
     customHeartbeat: true
     defaultSettings:


### PR DESCRIPTION
### What does this PR do?

Added new settings `breakouts.sendInvitationToIncludedModerators` to enable/disable breakout invitations to moderators.

Changes `settings.public.app.breakoutRoomLimit` to `settings.public.app.breakouts.breakoutRoomLimit`

### Closes Issue(s)

closes #11276
