### PR TITLE
Clear missing collections on meeting end

### DIFF
--- a/bigbluebutton-html5/imports/api/guest-users/server/modifiers/clearGuestUsers.js
+++ b/bigbluebutton-html5/imports/api/guest-users/server/modifiers/clearGuestUsers.js
@@ -1,0 +1,26 @@
+import GuestUsers from '/imports/api/guest-users';
+import Logger from '/imports/startup/server/logger';
+
+export default function clearGuestUsers(meetingId) {
+  if (meetingId) {
+    try {
+      const numberAffected = GuestUsers.remove({ meetingId });
+
+      if (numberAffected) {
+        Logger.info(`Cleared GuestUsers in (${meetingId})`);
+      }
+    } catch (err) {
+      Logger.info(`Error on clearing GuestUsers in (${meetingId}). ${err}`);
+    }
+  } else {
+    try {
+      const numberAffected = GuestUsers.remove({});
+
+      if (numberAffected) {
+        Logger.info('Cleared GuestUsers in all meetings');
+      }
+    } catch (err) {
+      Logger.error(`Error on clearing GuestUsers in all meetings. ${err}`);
+    }
+  }
+}

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/meetingHasEnded.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/meetingHasEnded.js
@@ -7,6 +7,7 @@ import { removeCursorStreamer } from '/imports/api/cursor/server/streamer';
 import clearUsers from '/imports/api/users/server/modifiers/clearUsers';
 import clearUsersSettings from '/imports/api/users-settings/server/modifiers/clearUsersSettings';
 import clearGroupChat from '/imports/api/group-chat/server/modifiers/clearGroupChat';
+import clearGuestUsers from '/imports/api/guest-users/server/modifiers/clearGuestUsers';
 import clearBreakouts from '/imports/api/breakouts/server/modifiers/clearBreakouts';
 import clearAnnotations from '/imports/api/annotations/server/modifiers/clearAnnotations';
 import clearSlides from '/imports/api/slides/server/modifiers/clearSlides';
@@ -21,6 +22,7 @@ import clearLocalSettings from '/imports/api/local-settings/server/modifiers/cle
 import clearRecordMeeting from './clearRecordMeeting';
 import clearVoiceCallStates from '/imports/api/voice-call-states/server/modifiers/clearVoiceCallStates';
 import clearVideoStreams from '/imports/api/video-streams/server/modifiers/clearVideoStreams';
+import clearWhiteboardMultiUser from '/imports/api/whiteboard-multi-user/server/modifiers/clearWhiteboardMultiUser';
 import BannedUsers from '/imports/api/users/server/store/bannedUsers';
 import Metrics from '/imports/startup/server/metrics';
 
@@ -31,6 +33,7 @@ export default function meetingHasEnded(meetingId) {
   return Meetings.remove({ meetingId }, () => {
     clearCaptions(meetingId);
     clearGroupChat(meetingId);
+    clearGuestUsers(meetingId);
     clearPresentationPods(meetingId);
     clearBreakouts(meetingId);
     clearPolls(meetingId);
@@ -46,6 +49,7 @@ export default function meetingHasEnded(meetingId) {
     clearRecordMeeting(meetingId);
     clearVoiceCallStates(meetingId);
     clearVideoStreams(meetingId);
+    clearWhiteboardMultiUser(meetingId);
     BannedUsers.delete(meetingId);
     Metrics.removeMeeting(meetingId);
 

--- a/bigbluebutton-html5/imports/api/voice-call-states/server/modifiers/clearVoiceCallStates.js
+++ b/bigbluebutton-html5/imports/api/voice-call-states/server/modifiers/clearVoiceCallStates.js
@@ -1,5 +1,5 @@
 import Logger from '/imports/startup/server/logger';
-import VoiceCallStates from '/imports/api/voice-users';
+import VoiceCallStates from '/imports/api/voice-call-states';
 
 export default function clearVoiceCallStates(meetingId) {
   if (meetingId) {

--- a/bigbluebutton-html5/imports/api/whiteboard-multi-user/server/modifiers/clearWhiteboardMultiUser.js
+++ b/bigbluebutton-html5/imports/api/whiteboard-multi-user/server/modifiers/clearWhiteboardMultiUser.js
@@ -1,0 +1,26 @@
+import Logger from '/imports/startup/server/logger';
+import WhiteboardMultiUser from '/imports/api/whiteboard-multi-user';
+
+export default function clearWhiteboardMultiUser(meetingId) {
+  if (meetingId) {
+    try {
+      const numberAffected = WhiteboardMultiUser.remove({ meetingId });
+
+      if (numberAffected) {
+        Logger.info(`Cleared WhiteboardMultiUser (${meetingId})`);
+      }
+    } catch (err) {
+      Logger.info(`Error clearing WhiteboardMultiUser (${meetingId}). ${err}`);
+    }
+  } else {
+    try {
+      const numberAffected = WhiteboardMultiUser.remove({});
+
+      if (numberAffected) {
+        Logger.info('Cleared WhiteboardMultiUser (all)');
+      }
+    } catch (err) {
+      Logger.info(`Error clearing WhiteboardMultiUser (all). ${err}`);
+    }
+  }
+}


### PR DESCRIPTION
### What does this PR do?

The collections for `guestUsers`, `voiceCallStates` and `whiteboard-multi-user` aren't been cleared after a meeting end, this PR implements the missing functions and clear those collection after the meeting has ended.