### PR TITLE
Cover clear screen share collection case

### DIFF
--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/meetingHasEnded.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/meetingHasEnded.js
@@ -16,6 +16,7 @@ import clearCaptions from '/imports/api/captions/server/modifiers/clearCaptions'
 import clearPresentationPods from '/imports/api/presentation-pods/server/modifiers/clearPresentationPods';
 import clearVoiceUsers from '/imports/api/voice-users/server/modifiers/clearVoiceUsers';
 import clearUserInfo from '/imports/api/users-infos/server/modifiers/clearUserInfo';
+import clearScreenshare from '/imports/api/screenshare/server/modifiers/clearScreenshare';
 import clearNote from '/imports/api/note/server/modifiers/clearNote';
 import clearNetworkInformation from '/imports/api/network-information/server/modifiers/clearNetworkInformation';
 import clearMeetingTimeRemaining from '/imports/api/meetings/server/modifiers/clearMeetingTimeRemaining';
@@ -52,6 +53,7 @@ export default function meetingHasEnded(meetingId) {
     clearVoiceCallStates(meetingId);
     clearVideoStreams(meetingId);
     clearWhiteboardMultiUser(meetingId);
+    clearScreenshare(meetingId);
     BannedUsers.delete(meetingId);
     Metrics.removeMeeting(meetingId);
 

--- a/bigbluebutton-html5/imports/api/screenshare/server/modifiers/clearScreenshare.js
+++ b/bigbluebutton-html5/imports/api/screenshare/server/modifiers/clearScreenshare.js
@@ -7,6 +7,8 @@ export default function clearScreenshare(meetingId, screenshareConf) {
 
     if (meetingId && screenshareConf) {
       numberAffected = Screenshare.remove({ meetingId, 'screenshare.screenshareConf': screenshareConf });
+    } else if (meetingId) {
+      numberAffected = Screenshare.remove({ meetingId });
     } else {
       numberAffected = Screenshare.remove({});
     }


### PR DESCRIPTION
### What does this PR do?

Properly clear screen share collection when a meeting ends. This PR cover the case where the moderator end the meeting before the presenter stop the screen share.