### PR TITLE
Don't validate insecure http urls for external video to prevent browser errors

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/service.js
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/service.js
@@ -11,7 +11,7 @@ import ReactPlayer from 'react-player';
 import Panopto from './custom-players/panopto';
 
 const isUrlValid = (url) => {
-  return ReactPlayer.canPlay(url) || Panopto.canPlay(url);
+  return /^https.*$/.test(url) && (ReactPlayer.canPlay(url) || Panopto.canPlay(url));
 }
 
 const startWatching = (url) => {


### PR DESCRIPTION
### What does this PR do?

This prevents problems if the presenter tries to use insecure http urls on the external video modal. If we share them the browser might block the iframe or some users.