### PR TITLE
Fix webcam video dropdown collapse after expanding

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
@@ -161,7 +161,7 @@ class Dropdown extends Component {
       if (parentElement) parentElement.focus();
     }
 
-    if (keepOpen !== false) return;
+    if (keepOpen === true) return;
     this.handleHide();
   }
 


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where the video actions dropdown won't close after you open it.

### Closes Issue(s)

closes #11338