### PR TITLE
Stop screenshare on joining breakout room

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/component.jsx
@@ -98,8 +98,8 @@ class BreakoutJoinConfirmation extends Component {
     const urlFromSelectedRoom = getURL(selectValue);
     const url = isFreeJoin ? urlFromSelectedRoom : breakoutURL;
 
+    // leave main room's audio, and stops video and screenshare when joining a breakout room
     if (voiceUserJoined) {
-      // leave main room's audio when joining a breakout room
       AudioService.exitAudio();
       logger.info({
         logCode: 'breakoutjoinconfirmation_ended_audio',
@@ -108,6 +108,7 @@ class BreakoutJoinConfirmation extends Component {
     }
 
     VideoService.exitVideo();
+    window.kurentoExitScreenShare();
     if (url === '') {
       logger.error({
         logCode: 'breakoutjoinconfirmation_redirecting_to_url',

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
@@ -204,12 +204,14 @@ class BreakoutRoom extends PureComponent {
               aria-label={`${intl.formatMessage(intlMessages.breakoutJoin)} ${number}`}
               onClick={() => {
                 this.getBreakoutURL(breakoutId);
+                // leave main room's audio, and stops video and screenshare when joining a breakout room
                 exitAudio();
                 logger.debug({
                   logCode: 'breakoutroom_join',
                   extraInfo: { logType: 'user_action' },
                 }, 'joining breakout room closed audio in the main room');
                 VideoService.exitVideo();
+                window.kurentoExitScreenShare();
               }
               }
               disabled={disable}


### PR DESCRIPTION
### What does this PR do?

Changes screenshare behavior on join breakout room to match audio and video (screenshare will now stop when user joins a breakout room).

### Closes Issue(s)

closes #10035
