### PR TITLE
Add delay to join video button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
@@ -6,6 +6,7 @@ import VideoService from '../service';
 import { defineMessages, injectIntl } from 'react-intl';
 import { styles } from './styles';
 import { validIOSVersion } from '/imports/ui/components/app/service';
+import { debounce } from 'lodash';
 
 const intlMessages = defineMessages({
   joinVideo: {
@@ -38,6 +39,8 @@ const intlMessages = defineMessages({
   },
 });
 
+const JOIN_VIDEO_DELAY_MILLISECONDS = 500;
+
 const propTypes = {
   intl: PropTypes.object.isRequired,
   hasVideoStream: PropTypes.bool.isRequired,
@@ -52,7 +55,7 @@ const JoinVideoButton = ({
 }) => {
   const exitVideo = () => hasVideoStream && !VideoService.isMultipleCamerasEnabled();
 
-  const handleOnClick = () => {
+  const handleOnClick = debounce(() => {
     if (!validIOSVersion()) {
       return VideoService.notify(intl.formatMessage(intlMessages.iOSWarning));
     }
@@ -62,7 +65,7 @@ const JoinVideoButton = ({
     } else {
       mountVideoPreview();
     }
-  };
+  }, JOIN_VIDEO_DELAY_MILLISECONDS);
 
   let label = exitVideo()
     ? intl.formatMessage(intlMessages.leaveVideo)


### PR DESCRIPTION
### What does this PR do?

Adds a delay to join video button click event, to prevent double clicks on leave/join video

### Closes Issue(s)

closes #8367 
