### PR TITLE
Fix rendering after public chat cleared

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-list/component.jsx
@@ -197,7 +197,7 @@ class MessageList extends Component {
     const message = messages[index];
 
     // it's to get an accurate size of the welcome message because it changes after initial render
-    if (message.id.startsWith('welcome-msg') && !this.systemMessagesResized[index]) {
+    if (message.id && message.id.startsWith('welcome-msg') && !this.systemMessagesResized[index]) {
       [500, 1000, 2000, 3000, 4000, 5000].forEach((i)=>{
         setTimeout(() => {
           if (this.listRef) {


### PR DESCRIPTION
### What does this PR do?

This bug fixes clearing the public chat history to not break the client.
This bug was introduced in #11305, as the system-generated message notifying
the user that the chat history has been cleared does not have an id.

### Closes Issue(s)

closes #11349

### Motivation

I want to implement a window.postMessage driven chat clearing event, but first need
to be able to not have chat clearing break everything.