### PR TITLE
Make screen reader announce status changes in userlist

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
@@ -631,6 +631,7 @@ class UserDropdown extends PureComponent {
         autoFocus={false}
         aria-haspopup="true"
         aria-live="assertive"
+        aria-label={userAriaLabel}
         aria-relevant="additions"
         placement={placement}
         getContent={dropdownContent => this.dropdownContent = dropdownContent}

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-name/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-name/component.jsx
@@ -105,7 +105,7 @@ const UserName = (props) => {
       aria-label={userAriaLabel}
       aria-expanded={isActionsOpen}
     >
-      <span className={styles.userNameMain}>
+      <span aria-hidden className={styles.userNameMain}>
         <span>
           {user.name}
 &nbsp;
@@ -115,7 +115,7 @@ const UserName = (props) => {
       {
         userNameSub.length
           ? (
-            <span className={styles.userNameSub}>
+            <span aria-hidden className={styles.userNameSub}>
               {userNameSub.reduce((prev, curr) => [prev, ' | ', curr])}
             </span>
           )


### PR DESCRIPTION
### What does this PR do?
This makes the screen reader announce the status changes in the user list so user's don't have to navigate to get the info. 

![sr-status-alert](https://user-images.githubusercontent.com/22058534/107589535-3fa5c780-6bd4-11eb-992e-022016d69f95.gif)

The caveat with this solution is the status notifications are not done through the toasts. For the screen reader this means to announce the status changes, the user-list must be open.

### Closes Issue(s)
Closes #11372 
