### PR TITLE
Outside chat clearing

### DIFF
--- a/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
+++ b/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
@@ -66,6 +66,7 @@ const currentParameters = [
   'bbb_show_participants_on_login',
   'bbb_show_public_chat_on_login',
   // OUTSIDE COMMANDS
+  'bbb_outside_clear_public_chat',
   'bbb_outside_toggle_self_voice',
   'bbb_outside_toggle_recording',
 ];

--- a/bigbluebutton-html5/imports/ui/components/chat/message-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-list/component.jsx
@@ -197,7 +197,7 @@ class MessageList extends Component {
     const message = messages[index];
 
     // it's to get an accurate size of the welcome message because it changes after initial render
-    if (message.id.startsWith('welcome-msg') && !this.systemMessagesResized[index]) {
+    if (message.id && message.id.startsWith('welcome-msg') && !this.systemMessagesResized[index]) {
       [500, 1000, 2000, 3000, 4000, 5000].forEach((i)=>{
         setTimeout(() => {
           if (this.listRef) {

--- a/bigbluebutton-html5/imports/ui/components/chat/service.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/service.js
@@ -334,6 +334,18 @@ const getLastMessageTimestampFromChatList = activeChats => activeChats
   .map(chatId => getAllMessages(chatId).reduce(maxTimestampReducer, 0))
   .reduce(maxNumberReducer, 0);
 
+const processClearPublicChatFromOutside = (e) => {
+  switch (e.data) {
+    case 'clear_public_chat': {
+      clearPublicChatHistory();
+      break;
+    }
+    default: {
+      // console.log(e.data);
+    }
+  }
+};
+
 export default {
   mapGroupMessage,
   reduceAndMapGroupMessages,
@@ -356,5 +368,6 @@ export default {
   clearPublicChatHistory,
   maxTimestampReducer,
   getLastMessageTimestampFromChatList,
+  processClearPublicChatFromOutside,
   UnsentMessagesCollection,
 };

--- a/bigbluebutton-html5/imports/ui/components/panel-manager/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/panel-manager/component.jsx
@@ -99,7 +99,7 @@ class PanelManager extends Component {
 
     this.setUserListWidth = this.setUserListWidth.bind(this);
   }
-  
+
   componentDidMount() {
     if (Meteor.settings.public.allowOutsideCommands.clearPublicChat
         || getFromUserSettings('bbb_outside_clear_public_chat', false)) {

--- a/bigbluebutton-html5/imports/ui/components/panel-manager/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/panel-manager/component.jsx
@@ -18,6 +18,8 @@ import {
   CHAT_MIN_WIDTH,
   CHAT_MAX_WIDTH,
 } from '/imports/ui/components/layout/layout-manager';
+import getFromUserSettings from '/imports/ui/services/users-settings';
+import ChatService from '/imports/ui/components/chat/service';
 
 const intlMessages = defineMessages({
   chatLabel: {
@@ -96,6 +98,13 @@ class PanelManager extends Component {
     };
 
     this.setUserListWidth = this.setUserListWidth.bind(this);
+  }
+  
+  componentDidMount() {
+    if (Meteor.settings.public.allowOutsideCommands.clearPublicChat
+        || getFromUserSettings('bbb_outside_clear_public_chat', false)) {
+      window.addEventListener('message', ChatService.processClearPublicChatFromOutside);
+    }
   }
 
   componentDidUpdate(prevProps) {

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -282,7 +282,7 @@ public:
     enabled: false
     syncInterval: 60000
   allowOutsideCommands:
-    clearPublicChat: true
+    clearPublicChat: false
     toggleRecording: false
     toggleSelfVoice: false
   poll:

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -12,7 +12,7 @@ public:
     appName: BigBlueButton HTML5 Client
     bbbServerVersion: 2.3-dev
     copyright: '©2021 BigBlueButton Inc.'
-    html5ClientBuild: 1353
+    html5ClientBuild: HTML5_CLIENT_VERSION
     helpLink: https://bigbluebutton.org/html5/
     lockOnJoin: true
     cdn: ''
@@ -28,7 +28,7 @@ public:
     enableTalkingIndicator: true
     mirrorOwnWebcam: false
     viewersInWebcam: 8
-    ipv4FallbackDomain: "app-helpful-sodium-ipv4.bbb-pdx-dev.ftclive.org"
+    ipv4FallbackDomain: ''
     allowLogout: true
     allowFullscreen: true
     preloadNextSlides: 2
@@ -129,7 +129,7 @@ public:
     enableNetworkMonitoring: false
     packetLostThreshold: 10
   kurento:
-    wsUrl: wss://app-helpful-sodium.bbb-pdx-dev.ftclive.org/bbb-webrtc-sfu
+    wsUrl: HOST
     # Valid for video-provider. Time (ms) before its WS connection times out
     # and tries to reconnect.
     wsConnectionTimeout: 4000
@@ -249,7 +249,7 @@ public:
     #   profile: a camera profile id from the cameraProfiles configuration array
     #            that will be applied to all cameras when threshold is hit
     cameraQualityThresholds:
-      enabled: true
+      enabled: false
       thresholds:
         - threshold: 8
           profile: low-u8
@@ -265,7 +265,7 @@ public:
           profile: low-u30
     pagination:
       # whether to globally enable or disable pagination.
-      enabled: true
+      enabled: false
       # how long (in ms) the negotiation will be debounced after a page change.
       pageChangeDebounceTime: 2500
       # video page sizes for DESKTOP endpoints. It stands for the number of SUBSCRIBER streams.
@@ -320,8 +320,8 @@ public:
     typingIndicator:
       enabled: true
   note:
-    enabled: true
-    url: https://app-helpful-sodium.bbb-pdx-dev.ftclive.org/pad
+    enabled: false
+    url: ETHERPAD_HOST
     config:
       showLineNumbers: false
       showChat: false
@@ -349,7 +349,7 @@ public:
     #so far. Increasing this value might help avoiding 1004 error when
     #user activates microphone.
     iceGatheringTimeout: 5000
-    sipjsHackViaWs: true
+    sipjsHackViaWs: false
     # Mute/umute toggle throttle time
     toggleMuteThrottleTime: 300
     #Websocket keepAlive interval (seconds). You may set this to prevent
@@ -536,7 +536,7 @@ private:
     pencilChunkLength: 100
     loadSlidesFromHttpAlways: false
   etherpad:
-    apikey: yyrLS6M0rG73dzJ2rLmFY3zfYgRshyGwFP9os7rlsjyOUZVOwlBbZgykCZd7b
+    apikey: ETHERPAD_APIKEY
     version: 1.2.13
     host: 127.0.0.1
     port: 9001

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -12,7 +12,7 @@ public:
     appName: BigBlueButton HTML5 Client
     bbbServerVersion: 2.3-dev
     copyright: '©2021 BigBlueButton Inc.'
-    html5ClientBuild: HTML5_CLIENT_VERSION
+    html5ClientBuild: 1353
     helpLink: https://bigbluebutton.org/html5/
     lockOnJoin: true
     cdn: ''
@@ -28,7 +28,7 @@ public:
     enableTalkingIndicator: true
     mirrorOwnWebcam: false
     viewersInWebcam: 8
-    ipv4FallbackDomain: ''
+    ipv4FallbackDomain: "app-helpful-sodium-ipv4.bbb-pdx-dev.ftclive.org"
     allowLogout: true
     allowFullscreen: true
     preloadNextSlides: 2
@@ -129,7 +129,7 @@ public:
     enableNetworkMonitoring: false
     packetLostThreshold: 10
   kurento:
-    wsUrl: HOST
+    wsUrl: wss://app-helpful-sodium.bbb-pdx-dev.ftclive.org/bbb-webrtc-sfu
     # Valid for video-provider. Time (ms) before its WS connection times out
     # and tries to reconnect.
     wsConnectionTimeout: 4000
@@ -249,7 +249,7 @@ public:
     #   profile: a camera profile id from the cameraProfiles configuration array
     #            that will be applied to all cameras when threshold is hit
     cameraQualityThresholds:
-      enabled: false
+      enabled: true
       thresholds:
         - threshold: 8
           profile: low-u8
@@ -265,7 +265,7 @@ public:
           profile: low-u30
     pagination:
       # whether to globally enable or disable pagination.
-      enabled: false
+      enabled: true
       # how long (in ms) the negotiation will be debounced after a page change.
       pageChangeDebounceTime: 2500
       # video page sizes for DESKTOP endpoints. It stands for the number of SUBSCRIBER streams.
@@ -282,6 +282,7 @@ public:
     enabled: false
     syncInterval: 60000
   allowOutsideCommands:
+    clearPublicChat: true
     toggleRecording: false
     toggleSelfVoice: false
   poll:
@@ -319,8 +320,8 @@ public:
     typingIndicator:
       enabled: true
   note:
-    enabled: false
-    url: ETHERPAD_HOST
+    enabled: true
+    url: https://app-helpful-sodium.bbb-pdx-dev.ftclive.org/pad
     config:
       showLineNumbers: false
       showChat: false
@@ -348,7 +349,7 @@ public:
     #so far. Increasing this value might help avoiding 1004 error when
     #user activates microphone.
     iceGatheringTimeout: 5000
-    sipjsHackViaWs: false
+    sipjsHackViaWs: true
     # Mute/umute toggle throttle time
     toggleMuteThrottleTime: 300
     #Websocket keepAlive interval (seconds). You may set this to prevent
@@ -535,7 +536,7 @@ private:
     pencilChunkLength: 100
     loadSlidesFromHttpAlways: false
   etherpad:
-    apikey: ETHERPAD_APIKEY
+    apikey: yyrLS6M0rG73dzJ2rLmFY3zfYgRshyGwFP9os7rlsjyOUZVOwlBbZgykCZd7b
     version: 1.2.13
     host: 127.0.0.1
     port: 9001


### PR DESCRIPTION
### What does this PR do?

This allows the parent frame to send a postMessage to clear the public chat

### Motivation

I am integrating bigbluebutton in an iframe into an application for judging teams in a high school robotics competition where some users (team members) will regularly join/leave an ongoing conference, while other users (judges) will remain in the conference for an extended period.  I would like to be able to programmatically wipe the chat between team members joining from different teams to avoid sharing information that should not be shared.
