### PR TITLE
Customize systemd unit files

### DIFF
--- a/akka-bbb-apps/src/templates/systemloader/systemd/start-template
+++ b/akka-bbb-apps/src/templates/systemloader/systemd/start-template
@@ -1,0 +1,26 @@
+[Unit]
+Description=BigBlueButton Apps (Akka)
+Requires=network.target
+Wants=redis-server.service
+After=redis-server.service
+
+[Service]
+Type=simple
+WorkingDirectory=/usr/share/bbb-apps-akka
+EnvironmentFile=/etc/default/bbb-apps-akka
+ExecStart=/usr/share/bbb-apps-akka/bin/bbb-apps-akka
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=always
+RestartSec=60
+SuccessExitStatus=
+TimeoutStopSec=5
+User=bigbluebutton
+ExecStartPre=/bin/mkdir -p /run/bbb-apps-akka
+ExecStartPre=/bin/chown bigbluebutton:bigbluebutton /run/bbb-apps-akka
+ExecStartPre=/bin/chmod 755 /run/bbb-apps-akka
+PermissionsStartOnly=true
+LimitNOFILE=1024
+
+[Install]
+WantedBy=multi-user.target
+

--- a/akka-bbb-fsesl/src/templates/systemloader/systemd/start-template
+++ b/akka-bbb-fsesl/src/templates/systemloader/systemd/start-template
@@ -1,0 +1,26 @@
+[Unit]
+Description=BigBlueButton FS-ESL (Akka)
+Requires=network.target
+Wants=redis-server.service
+After=redis-server.service
+
+[Service]
+Type=simple
+WorkingDirectory=/usr/share/bbb-fsesl-akka
+EnvironmentFile=/etc/default/bbb-fsesl-akka
+ExecStart=/usr/share/bbb-fsesl-akka/bin/bbb-fsesl-akka
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=always
+RestartSec=60
+SuccessExitStatus=
+TimeoutStopSec=5
+User=bigbluebutton
+ExecStartPre=/bin/mkdir -p /run/bbb-fsesl-akka
+ExecStartPre=/bin/chown bigbluebutton:bigbluebutton /run/bbb-fsesl-akka
+ExecStartPre=/bin/chmod 755 /run/bbb-fsesl-akka
+PermissionsStartOnly=true
+LimitNOFILE=1024
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
Currently there is a mechanism in bbb-config which adds overlay units.
This is not neccesary because sbt allows you to specify your own unit
files.

### What does this PR do?

It removes the necessity to install systemd override files by bbb-config