### PR TITLE
Introduce allowViewersToTakePresenter

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetPresenterInPodReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetPresenterInPodReqMsgHdlr.scala
@@ -33,7 +33,11 @@ object SetPresenterInPodActionHandler extends RightsManagementTrait {
       newPresenterId: String
   ): MeetingState2x = {
 
-    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, assignedBy)) {
+    var isForbidden = permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, assignedBy)
+    if (liveMeeting.props.usersProp.allowViewersToTakePresenter && assignedBy == newPresenterId) {
+      isForbidden = false
+    }
+    if (isForbidden) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to set presenter in presentation pod."
       PermissionCheck.ejectUserForFailedPermission(meetingId, assignedBy, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AssignPresenterReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AssignPresenterReqMsgHdlr.scala
@@ -59,7 +59,11 @@ object AssignPresenterActionHandler extends RightsManagementTrait {
       outGW.send(msgEventAssign)
     }
 
-    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, assignedBy)) {
+    var isForbidden = permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, assignedBy)
+    if (liveMeeting.props.usersProp.allowViewersToTakePresenter && assignedBy == newPresenterId) {
+      isForbidden = false
+    }
+    if (isForbidden) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to change presenter in meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, assignedBy, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
+++ b/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
@@ -39,6 +39,7 @@ trait AppsTestFixtures {
   val maxUsers = 25
   val guestPolicy = "ALWAYS_ASK"
   val allowModsToUnmuteUsers = false
+  val allowViewersToTakePresenter = false
   val authenticatedGuest = false
 
   val red5DeskShareIPTestFixture = "127.0.0.1"
@@ -59,7 +60,7 @@ trait AppsTestFixtures {
     modOnlyMessage = modOnlyMessage)
   val voiceProp = VoiceProp(telVoice = voiceConfId, voiceConf = voiceConfId, dialNumber = dialNumber, muteOnStart = muteOnStart)
   val usersProp = UsersProp(maxUsers = maxUsers, webcamsOnlyForModerator = webcamsOnlyForModerator,
-    guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers, authenticatedGuest = authenticatedGuest)
+    guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers, authenticatedGuest = authenticatedGuest, allowViewersToTakePresenter = allowViewersToTakePresenter)
   val metadataProp = new MetadataProp(metadata)
 
   val defaultProps = DefaultProps(meetingProp, breakoutProps, durationProps, password, recordProp, welcomeProp, voiceProp,

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
@@ -26,7 +26,14 @@ case class WelcomeProp(welcomeMsgTemplate: String, welcomeMsg: String, modOnlyMe
 
 case class VoiceProp(telVoice: String, voiceConf: String, dialNumber: String, muteOnStart: Boolean)
 
-case class UsersProp(maxUsers: Int, webcamsOnlyForModerator: Boolean, guestPolicy: String, allowModsToUnmuteUsers: Boolean, authenticatedGuest: Boolean)
+case class UsersProp(
+    maxUsers:                    Int,
+    webcamsOnlyForModerator:     Boolean,
+    guestPolicy:                 String,
+    allowModsToUnmuteUsers:      Boolean,
+    authenticatedGuest:          Boolean,
+    allowViewersToTakePresenter: Boolean
+)
 
 case class MetadataProp(metadata: collection.immutable.Map[String, String])
 

--- a/bbb-common-message/src/test/scala/org/bigbluebutton/common2/TestFixtures.scala
+++ b/bbb-common-message/src/test/scala/org/bigbluebutton/common2/TestFixtures.scala
@@ -33,6 +33,7 @@ trait TestFixtures {
   val maxUsers = 25
   val muteOnStart = false
   val allowModsToUnmuteUsers = false
+  val allowViewersToTakePresenter = false
   val keepEvents = false
   val guestPolicy = "ALWAYS_ASK"
   val authenticatedGuest = false
@@ -52,7 +53,7 @@ trait TestFixtures {
     modOnlyMessage = modOnlyMessage)
   val voiceProp = VoiceProp(telVoice = voiceConfId, voiceConf = voiceConfId, dialNumber = dialNumber, muteOnStart = muteOnStart)
   val usersProp = UsersProp(maxUsers = maxUsers, webcamsOnlyForModerator = webcamsOnlyForModerator,
-    guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers, authenticatedGuest = authenticatedGuest)
+    guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers, authenticatedGuest = authenticatedGuest, allowViewersToTakePresenter = allowViewersToTakePresenter)
   val metadataProp = new MetadataProp(metadata)
   val screenshareProps = ScreenshareProps(screenshareConf = "FixMe!", red5ScreenshareIp = "fixMe!",
     red5ScreenshareApp = "fixMe!")

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -21,6 +21,8 @@ package org.bigbluebutton.api;
 
 public class ApiParams {
 
+    public static final String ALLOW_MODS_TO_UNMUTE_USERS = "allowModsToUnmuteUsers";
+    public static final String ALLOW_VIEWERS_TO_TAKE_PRESENTER = "allowViewersToTakePresenter";
     public static final String ALLOW_START_STOP_RECORDING = "allowStartStopRecording";
     public static final String ATTENDEE_PW = "attendeePW";
     public static final String AUTO_START_RECORDING = "autoStartRecording";
@@ -33,6 +35,7 @@ public class ApiParams {
     public static final String FREE_JOIN = "freeJoin";
     public static final String FULL_NAME = "fullName";
     public static final String GUEST_POLICY = "guestPolicy";
+    public static final String HTML5_INSTANCE_ID = "html5InstanceId";
     public static final String IS_BREAKOUT = "isBreakout";
     public static final String LOGO = "logo";
     public static final String LOGOUT_TIMER = "logoutTimer";
@@ -43,7 +46,6 @@ public class ApiParams {
     public static final String MODERATOR_ONLY_MESSAGE = "moderatorOnlyMessage";
     public static final String MODERATOR_PW = "moderatorPW";
     public static final String MUTE_ON_START = "muteOnStart";
-    public static final String ALLOW_MODS_TO_UNMUTE_USERS = "allowModsToUnmuteUsers";
     public static final String NAME = "name";
     public static final String PARENT_MEETING_ID = "parentMeetingID";
     public static final String PASSWORD = "password";
@@ -55,7 +57,6 @@ public class ApiParams {
     public static final String WEB_VOICE = "webVoice";
     public static final String WEBCAMS_ONLY_FOR_MODERATOR = "webcamsOnlyForModerator";
     public static final String WELCOME = "welcome";
-    public static final String HTML5_INSTANCE_ID = "html5InstanceId";
 
     public static final String BREAKOUT_ROOMS_ENABLED = "breakoutRoomsEnabled";
     public static final String BREAKOUT_ROOMS_RECORD = "breakoutRoomsRecord";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -400,7 +400,8 @@ public class MeetingService implements MessageListener {
             m.getDialNumber(), m.getMaxUsers(),
             m.getMeetingExpireIfNoUserJoinedInMinutes(), m.getmeetingExpireWhenLastUserLeftInMinutes(),
             m.getUserInactivityInspectTimerInMinutes(), m.getUserInactivityThresholdInMinutes(),
-            m.getUserActivitySignResponseDelayInMinutes(), m.getMuteOnStart(), m.getAllowModsToUnmuteUsers(), keepEvents,
+            m.getUserActivitySignResponseDelayInMinutes(), m.getMuteOnStart(), m.getAllowModsToUnmuteUsers(),
+            m.getAllowViewersToTakePresenter(), keepEvents,
             m.breakoutRoomsParams,
             m.lockSettingsParams, m.getHtml5InstanceId());
   }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -85,6 +85,7 @@ public class ParamsProcessorUtil {
     private boolean autoStartRecording;
     private boolean allowStartStopRecording;
     private boolean webcamsOnlyForModerator;
+	private boolean defaultAllowViewersToTakePresenter;
     private boolean defaultMuteOnStart = false;
     private boolean defaultAllowModsToUnmuteUsers = false;
 
@@ -243,84 +244,26 @@ public class ParamsProcessorUtil {
         return metas;
     }
 
-		private BreakoutRoomsParams processBreakoutRoomsParams(Map<String, String> params) {
-			Boolean breakoutRoomsEnabled = defaultBreakoutRoomsEnabled;
-			String breakoutRoomsEnabledParam = params.get(ApiParams.BREAKOUT_ROOMS_ENABLED);
-			if (!StringUtils.isEmpty(breakoutRoomsEnabledParam)) {
-				breakoutRoomsEnabled = Boolean.parseBoolean(breakoutRoomsEnabledParam);
-			}
-
-			Boolean breakoutRoomsRecord = defaultBreakoutRoomsRecord;
-			String breakoutRoomsRecordParam = params.get(ApiParams.BREAKOUT_ROOMS_RECORD);
-			if (!StringUtils.isEmpty(breakoutRoomsRecordParam)) {
-				breakoutRoomsRecord = Boolean.parseBoolean(breakoutRoomsRecordParam);
-			}
-
-			Boolean breakoutRoomsPrivateChatEnabled =  defaultbreakoutRoomsPrivateChatEnabled;
-			String breakoutRoomsPrivateChatEnabledParam = params.get(ApiParams.BREAKOUT_ROOMS_PRIVATE_CHAT_ENABLED);
-			if (!StringUtils.isEmpty(breakoutRoomsPrivateChatEnabledParam)) {
-				breakoutRoomsPrivateChatEnabled = Boolean.parseBoolean(breakoutRoomsPrivateChatEnabledParam);
-			}
+		private BreakoutRoomsParams processBreakoutRoomsParams(Map<String, String> params, String internalMeetingId) {
+			Boolean breakoutRoomsEnabled = parseBoolean(ApiParams.BREAKOUT_ROOMS_ENABLED, defaultBreakoutRoomsEnabled, params, internalMeetingId);
+			Boolean breakoutRoomsRecord = parseBoolean(ApiParams.BREAKOUT_ROOMS_RECORD, defaultBreakoutRoomsRecord, params, internalMeetingId);
+			Boolean breakoutRoomsPrivateChatEnabled = parseBoolean(ApiParams.BREAKOUT_ROOMS_PRIVATE_CHAT_ENABLED, defaultbreakoutRoomsPrivateChatEnabled, params, internalMeetingId);
 
 			return new BreakoutRoomsParams(breakoutRoomsEnabled,
 							breakoutRoomsRecord,
 							breakoutRoomsPrivateChatEnabled);
 		}
 
-		private LockSettingsParams processLockSettingsParams(Map<String, String> params) {
-			Boolean lockSettingsDisableCam = defaultLockSettingsDisableCam;
-			String lockSettingsDisableCamParam = params.get(ApiParams.LOCK_SETTINGS_DISABLE_CAM);
-			if (!StringUtils.isEmpty(lockSettingsDisableCamParam)) {
-				lockSettingsDisableCam = Boolean.parseBoolean(lockSettingsDisableCamParam);
-			}
-
-			Boolean lockSettingsDisableMic = defaultLockSettingsDisableMic;
-			String lockSettingsDisableMicParam = params.get(ApiParams.LOCK_SETTINGS_DISABLE_MIC);
-			if (!StringUtils.isEmpty(lockSettingsDisableMicParam)) {
-				lockSettingsDisableMic = Boolean.parseBoolean(lockSettingsDisableMicParam);
-			}
-
-			Boolean lockSettingsDisablePrivateChat = defaultLockSettingsDisablePrivateChat;
-			String lockSettingsDisablePrivateChatParam = params.get(ApiParams.LOCK_SETTINGS_DISABLE_PRIVATE_CHAT);
-			if (!StringUtils.isEmpty(lockSettingsDisablePrivateChatParam)) {
-				lockSettingsDisablePrivateChat = Boolean.parseBoolean(lockSettingsDisablePrivateChatParam);
-			}
-
-			Boolean lockSettingsDisablePublicChat = defaultLockSettingsDisablePublicChat;
-			String lockSettingsDisablePublicChatParam = params.get(ApiParams.LOCK_SETTINGS_DISABLE_PUBLIC_CHAT);
-			if (!StringUtils.isEmpty(lockSettingsDisablePublicChatParam)) {
-				lockSettingsDisablePublicChat = Boolean.parseBoolean(lockSettingsDisablePublicChatParam);
-			}
-
-			Boolean lockSettingsDisableNote = defaultLockSettingsDisableNote;
-			String lockSettingsDisableNoteParam = params.get(ApiParams.LOCK_SETTINGS_DISABLE_NOTE);
-			if (!StringUtils.isEmpty(lockSettingsDisableNoteParam)) {
-				lockSettingsDisableNote = Boolean.parseBoolean(lockSettingsDisableNoteParam);
-			}
-
-			Boolean lockSettingsHideUserList = defaultLockSettingsHideUserList;
-			String lockSettingsHideUserListParam = params.get(ApiParams.LOCK_SETTINGS_HIDE_USER_LIST);
-			if (!StringUtils.isEmpty(lockSettingsHideUserListParam)) {
-				lockSettingsHideUserList = Boolean.parseBoolean(lockSettingsHideUserListParam);
-			}
-
-			Boolean lockSettingsLockedLayout = defaultLockSettingsLockedLayout;
-			String lockSettingsLockedLayoutParam = params.get(ApiParams.LOCK_SETTINGS_LOCKED_LAYOUT);
-			if (!StringUtils.isEmpty(lockSettingsLockedLayoutParam)) {
-				lockSettingsLockedLayout = Boolean.parseBoolean(lockSettingsLockedLayoutParam);
-			}
-
-			Boolean lockSettingsLockOnJoin = defaultLockSettingsLockOnJoin;
-			String lockSettingsLockOnJoinParam = params.get(ApiParams.LOCK_SETTINGS_LOCK_ON_JOIN);
-			if (!StringUtils.isEmpty(lockSettingsLockOnJoinParam)) {
-				lockSettingsLockOnJoin = Boolean.parseBoolean(lockSettingsLockOnJoinParam);
-			}
-
-			Boolean lockSettingsLockOnJoinConfigurable = defaultLockSettingsLockOnJoinConfigurable;
-			String lockSettingsLockOnJoinConfigurableParam = params.get(ApiParams.LOCK_SETTINGS_LOCK_ON_JOIN_CONFIGURABLE);
-			if (!StringUtils.isEmpty(lockSettingsLockOnJoinConfigurableParam)) {
-				lockSettingsLockOnJoinConfigurable = Boolean.parseBoolean(lockSettingsLockOnJoinConfigurableParam);
-			}
+		private LockSettingsParams processLockSettingsParams(Map<String, String> params, String internalMeetingId) {
+			Boolean lockSettingsDisableCam = parseBoolean(ApiParams.LOCK_SETTINGS_DISABLE_CAM, defaultLockSettingsDisableCam, params, internalMeetingId);
+			Boolean lockSettingsDisableMic = parseBoolean(ApiParams.LOCK_SETTINGS_DISABLE_MIC, defaultLockSettingsDisableMic, params, internalMeetingId);
+			Boolean lockSettingsDisablePrivateChat = parseBoolean(ApiParams.LOCK_SETTINGS_DISABLE_PRIVATE_CHAT, defaultLockSettingsDisablePrivateChat, params, internalMeetingId);
+			Boolean lockSettingsDisablePublicChat = parseBoolean(ApiParams.LOCK_SETTINGS_DISABLE_PUBLIC_CHAT, defaultLockSettingsDisablePublicChat, params, internalMeetingId);
+			Boolean lockSettingsDisableNote = parseBoolean(ApiParams.LOCK_SETTINGS_DISABLE_NOTE, defaultLockSettingsDisableNote, params, internalMeetingId);
+			Boolean lockSettingsHideUserList = parseBoolean(ApiParams.LOCK_SETTINGS_HIDE_USER_LIST, defaultLockSettingsHideUserList, params, internalMeetingId);
+			Boolean lockSettingsLockedLayout = parseBoolean(ApiParams.LOCK_SETTINGS_LOCKED_LAYOUT, defaultLockSettingsLockedLayout, params, internalMeetingId);
+			Boolean lockSettingsLockOnJoin = parseBoolean(ApiParams.LOCK_SETTINGS_LOCK_ON_JOIN, defaultLockSettingsLockOnJoin, params, internalMeetingId);
+			Boolean lockSettingsLockOnJoinConfigurable = parseBoolean(ApiParams.LOCK_SETTINGS_LOCK_ON_JOIN_CONFIGURABLE, defaultLockSettingsLockOnJoinConfigurable, params, internalMeetingId);
 
 			return new LockSettingsParams(lockSettingsDisableCam,
 							lockSettingsDisableMic,
@@ -394,58 +337,18 @@ public class ParamsProcessorUtil {
             internalMeetingId = getIntMeetingIdForTestMeeting(telVoice);
         }
 
-        boolean autoStartRec = autoStartRecording;
-        if (!StringUtils.isEmpty(params.get(ApiParams.AUTO_START_RECORDING))) {
-            try {
-                autoStartRec = Boolean.parseBoolean(params
-                        .get(ApiParams.AUTO_START_RECORDING));
-            } catch (Exception ex) {
-                log.warn("Invalid param [autoStartRecording] for meeting=[{}]",
-                        internalMeetingId);
-            }
-        }
-
-        boolean allowStartStoptRec = allowStartStopRecording;
-        if (!StringUtils.isEmpty(params.get(ApiParams.ALLOW_START_STOP_RECORDING))) {
-            try {
-                allowStartStoptRec = Boolean.parseBoolean(params
-                        .get(ApiParams.ALLOW_START_STOP_RECORDING));
-            } catch (Exception ex) {
-                log.warn(
-                        "Invalid param [allowStartStopRecording] for meeting=[{}]",
-                        internalMeetingId);
-            }
-        }
-
-        boolean webcamsOnlyForMod = webcamsOnlyForModerator;
-        if (!StringUtils.isEmpty(params.get(ApiParams.WEBCAMS_ONLY_FOR_MODERATOR))) {
-            try {
-                webcamsOnlyForMod = Boolean.parseBoolean(params
-                        .get(ApiParams.WEBCAMS_ONLY_FOR_MODERATOR));
-            } catch (Exception ex) {
-                log.warn(
-                        "Invalid param [webcamsOnlyForModerator] for meeting=[{}]",
-                        internalMeetingId);
-            }
-        }
-
-        boolean endWhenNoModerator = defaultEndWhenNoModerator;
-        if (!StringUtils.isEmpty(params.get(ApiParams.END_WHEN_NO_MODERATOR))) {
-          try {
-	          endWhenNoModerator = Boolean.parseBoolean(params.get(ApiParams.END_WHEN_NO_MODERATOR));
-          } catch (Exception ex) {
-            log.warn("Invalid param [endWhenNoModerator] for meeting=[{}]", internalMeetingId);
-          }
-        }
+        boolean autoStartRec = parseBoolean(ApiParams.AUTO_START_RECORDING, autoStartRecording, params, internalMeetingId);
+        boolean allowStartStoptRec = parseBoolean(ApiParams.ALLOW_START_STOP_RECORDING, allowStartStopRecording, params, internalMeetingId);
+        boolean webcamsOnlyForMod = parseBoolean(ApiParams.WEBCAMS_ONLY_FOR_MODERATOR, webcamsOnlyForModerator, params, internalMeetingId);
+        boolean endWhenNoModerator = parseBoolean(ApiParams.END_WHEN_NO_MODERATOR, defaultEndWhenNoModerator, params, internalMeetingId);
+		boolean allowViewersToTakePresenter = parseBoolean(ApiParams.ALLOW_VIEWERS_TO_TAKE_PRESENTER, defaultAllowViewersToTakePresenter, params, internalMeetingId);
 
         String guestPolicy = defaultGuestPolicy;
         if (!StringUtils.isEmpty(params.get(ApiParams.GUEST_POLICY))) {
         	guestPolicy = params.get(ApiParams.GUEST_POLICY);
 		}
-        BreakoutRoomsParams breakoutParams = processBreakoutRoomsParams(params);
-        LockSettingsParams lockSettingsParams = processLockSettingsParams(params);
-
-
+        BreakoutRoomsParams breakoutParams = processBreakoutRoomsParams(params, internalMeetingId);
+        LockSettingsParams lockSettingsParams = processLockSettingsParams(params, internalMeetingId);
 
         // Collect metadata for this meeting that the third-party app wants to
         // store if meeting is recorded.
@@ -499,6 +402,7 @@ public class ParamsProcessorUtil {
 				.withLockSettingsParams(lockSettingsParams)
 				.withAllowDuplicateExtUserid(defaultAllowDuplicateExtUserid)
                 .withHTML5InstanceId(html5InstanceId)
+				.withAllowViewersToTakePresenter(allowViewersToTakePresenter)
                 .build();
 
         String configXML = getDefaultConfigXML();
@@ -537,17 +441,11 @@ public class ParamsProcessorUtil {
 		if (!StringUtils.isEmpty(params.get(ApiParams.COPYRIGHT))) {
 			meeting.setCustomCopyright(params.get(ApiParams.COPYRIGHT));
 		}
-		Boolean muteOnStart = defaultMuteOnStart;
-		if (!StringUtils.isEmpty(params.get(ApiParams.MUTE_ON_START))) {
-        	muteOnStart = Boolean.parseBoolean(params.get(ApiParams.MUTE_ON_START));
-        }
 
+		Boolean muteOnStart = parseBoolean(ApiParams.MUTE_ON_START, defaultMuteOnStart, params, internalMeetingId);
 		meeting.setMuteOnStart(muteOnStart);
 
-        Boolean allowModsToUnmuteUsers = defaultAllowModsToUnmuteUsers;
-        if (!StringUtils.isEmpty(params.get(ApiParams.ALLOW_MODS_TO_UNMUTE_USERS))) {
-            allowModsToUnmuteUsers = Boolean.parseBoolean(params.get(ApiParams.ALLOW_MODS_TO_UNMUTE_USERS));
-        }
+		Boolean allowModsToUnmuteUsers = parseBoolean(ApiParams.ALLOW_MODS_TO_UNMUTE_USERS, defaultAllowModsToUnmuteUsers, params, internalMeetingId);
         meeting.setAllowModsToUnmuteUsers(allowModsToUnmuteUsers);
 
         return meeting;
@@ -577,6 +475,18 @@ public class ParamsProcessorUtil {
 		defaultConfigXML = getConfig(defaultConfigURL);
 		
 		return defaultConfigXML;
+	}
+
+	private Boolean parseBoolean(String paramName, Boolean defaultValue, Map<String, String> params, String internalMeetingId) {
+		Boolean ret = defaultValue;
+		if (!StringUtils.isEmpty(params.get(paramName))) {
+			try {
+            	ret = Boolean.parseBoolean(params.get(paramName));
+			} catch (Exception ex) {
+            	log.warn("Invalid param [" + paramName + "] for meeting=[{}]", internalMeetingId);
+          	}
+        }
+		return ret;
 	}
 	
 	private String getConfig(String url) {
@@ -954,6 +864,10 @@ public class ParamsProcessorUtil {
         this.webcamsOnlyForModerator = webcamsOnlyForModerator;
     }
 	
+	public void setDefaultAllowViewersToTakePresenter(boolean defaultAllowViewersToTakePresenter) {
+		this.defaultAllowViewersToTakePresenter = defaultAllowViewersToTakePresenter;
+	}
+
 	public void setUseDefaultAvatar(Boolean value) {
 		this.useDefaultAvatar = value;
 	}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -64,6 +64,7 @@ public class Meeting {
 	private boolean allowStartStopRecording = false;
 	private boolean haveRecordingMarks = false;
 	private boolean webcamsOnlyForModerator = false;
+	private boolean allowViewersToTakePresenter = false;
 	private String dialNumber;
 	private String defaultAvatarURL;
 	private String defaultConfigToken;
@@ -116,6 +117,7 @@ public class Meeting {
         autoStartRecording = builder.autoStartRecording;
         allowStartStopRecording = builder.allowStartStopRecording;
         webcamsOnlyForModerator = builder.webcamsOnlyForModerator;
+	    allowViewersToTakePresenter = builder.allowViewersToTakePresenter;
         duration = builder.duration;
         webVoice = builder.webVoice;
         telVoice = builder.telVoice;
@@ -454,6 +456,10 @@ public class Meeting {
         return webcamsOnlyForModerator;
     }
 	
+    public boolean getAllowViewersToTakePresenter() {
+        return allowViewersToTakePresenter;
+    }
+	
 	public boolean hasUserJoined() {
 		return userHasJoined;
 	}
@@ -682,6 +688,7 @@ public class Meeting {
     	private boolean autoStartRecording;
         private boolean allowStartStopRecording;
         private boolean webcamsOnlyForModerator;
+		private boolean allowViewersToTakePresenter;
     	private String moderatorPass;
     	private String viewerPass;
     	private int duration;
@@ -744,6 +751,11 @@ public class Meeting {
     
         public Builder withWebcamsOnlyForModerator(boolean only) {
             this.webcamsOnlyForModerator = only;
+            return this;
+        }
+
+		public Builder withAllowViewersToTakePresenter(boolean allowViewersToTakePresenter) {
+            this.allowViewersToTakePresenter = allowViewersToTakePresenter;
             return this;
         }
     	

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
@@ -28,6 +28,7 @@ public interface IBbbWebApiGWApp {
                      Integer userActivitySignResponseDelayInMinutes,
                      Boolean muteOnStart,
                      Boolean allowModsToUnmuteUsers,
+                     Boolean allowViewersToTakePresenter,
                      Boolean keepEvents,
                      BreakoutRoomsParams breakoutParams,
                      LockSettingsParams lockSettingsParams,

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -137,6 +137,7 @@ class BbbWebApiGWApp(
                     userActivitySignResponseDelayInMinutes: java.lang.Integer,
                     muteOnStart:                            java.lang.Boolean,
                     allowModsToUnmuteUsers:                 java.lang.Boolean,
+                    allowViewersToTakePresenter:            java.lang.Boolean,
                     keepEvents:                             java.lang.Boolean,
                     breakoutParams:                         BreakoutRoomsParams,
                     lockSettingsParams:                     LockSettingsParams,
@@ -172,7 +173,8 @@ class BbbWebApiGWApp(
       modOnlyMessage = modOnlyMessage)
     val voiceProp = VoiceProp(telVoice = voiceBridge, voiceConf = voiceBridge, dialNumber = dialNumber, muteOnStart = muteOnStart.booleanValue())
     val usersProp = UsersProp(maxUsers = maxUsers.intValue(), webcamsOnlyForModerator = webcamsOnlyForModerator.booleanValue(),
-      guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers.booleanValue(), authenticatedGuest = authenticatedGuest.booleanValue())
+      guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers.booleanValue(), authenticatedGuest = authenticatedGuest.booleanValue(),
+      allowViewersToTakePresenter = allowViewersToTakePresenter.booleanValue())
     val metadataProp = MetadataProp(mapAsScalaMap(metadata).toMap)
     val screenshareProps = ScreenshareProps(
       screenshareConf = voiceBridge + screenshareConfSuffix,

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -38,6 +38,7 @@ export default function addMeeting(meeting) {
       authenticatedGuest: Boolean,
       maxUsers: Number,
       allowModsToUnmuteUsers: Boolean,
+      allowViewersToTakePresenter: Boolean,
     },
     durationProps: {
       createdTime: Number,

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -24,6 +24,7 @@ const propTypes = {
   shortcuts: PropTypes.string,
   handleTakePresenter: PropTypes.func.isRequired,
   allowExternalVideo: PropTypes.bool.isRequired,
+  allowViewersToTakePresenter: PropTypes.bool.isRequired,
   stopExternalVideoShare: PropTypes.func.isRequired,
 };
 
@@ -248,6 +249,7 @@ class ActionsDropdown extends PureComponent {
       intl,
       amIPresenter,
       amIModerator,
+      allowViewersToTakePresenter,
       shortcuts: OPEN_ACTIONS_AK,
       isMeteorConnected,
     } = this.props;
@@ -257,7 +259,7 @@ class ActionsDropdown extends PureComponent {
     const children = availablePresentations.length > 2 && amIPresenter
       ? availablePresentations.concat(availableActions) : availableActions;
 
-    if ((!amIPresenter && !amIModerator)
+    if ((!amIPresenter && !amIModerator && !allowViewersToTakePresenter)
       || availableActions.length === 0
       || !isMeteorConnected) {
       return null;

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/container.jsx
@@ -3,12 +3,18 @@ import Presentations from '/imports/api/presentations';
 import PresentationUploaderService from '/imports/ui/components/presentation/presentation-uploader/service';
 import PresentationPodService from '/imports/ui/components/presentation-pod/service';
 import ActionsDropdown from './component';
+import Meetings from '/imports/api/meetings';
+import Auth from '/imports/ui/services/auth';
 
 export default withTracker(() => {
+  const Meeting = Meetings.findOne({
+    meetingId: Auth.meetingID,
+  });
   const presentations = Presentations.find({ 'conversion.done': true }).fetch();
   return ({
     presentations,
     setPresentation: PresentationUploaderService.setPresentation,
     podIds: PresentationPodService.getPresentationPodIds(),
+    allowViewersToTakePresenter: Meeting.usersProp.allowViewersToTakePresenter,
   });
 })(ActionsDropdown);

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -214,6 +214,9 @@ allowStartStopRecording=true
 # Allow webcams streaming reception only to and from moderators
 webcamsOnlyForModerator=false
 
+# Allow viewers to take the presenter role without being moderators
+defaultAllowViewersToTakePresenter=false
+
 # Mute the meeting on start
 muteOnStart=false
 

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -136,6 +136,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="autoStartRecording" value="${autoStartRecording}"/>
         <property name="allowStartStopRecording" value="${allowStartStopRecording}"/>
         <property name="webcamsOnlyForModerator" value="${webcamsOnlyForModerator}"/>
+        <property name="defaultAllowViewersToTakePresenter" value="${defaultAllowViewersToTakePresenter}"/>
         <property name="useDefaultAvatar" value="${useDefaultAvatar}"/>
         <property name="defaultAvatarURL" value="${defaultAvatarURL}"/>
         <property name="defaultConfigURL" value="${defaultConfigURL}"/>

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1542,6 +1542,7 @@ class ApiController {
             isBreakout meeting.isBreakout()
             logoutTimer meeting.getLogoutTimer()
             allowStartStopRecording meeting.getAllowStartStopRecording()
+            allowViewersToTakePresenter meeting.getAllowViewersToTakePresenter()
             welcome us.welcome
             if (!StringUtils.isEmpty(meeting.moderatorOnlyMessage) && us.role.equals(ROLE_MODERATOR)) {
               modOnlyMessage meeting.moderatorOnlyMessage


### PR DESCRIPTION
### What does this PR do?

﻿This adds a parameter `allowViewersToTakePresenter` to createMeeting.  This allows
viewers to self-assign themselves as presenters.


### Motivation

This is useful in contexts where viewers may join a meeting before the moderators
and where all viewers would be trusted to be presenters.  Also useful when the
moderators aren't very technically inclined to reduce their burden when the use
case expects most presentations to be run by viewers.
