### PR TITLE
User role is incorrect after client reconnect.

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
@@ -21,7 +21,7 @@ trait ChangeUserRoleCmdMsgHdlr extends RightsManagementTrait {
         uvo <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
       } yield {
 
-        val userRole = if (uvo.role == Roles.MODERATOR_ROLE) "MODERATOR" else "VIEWER"
+        val userRole = if (msg.body.role == Roles.MODERATOR_ROLE) Roles.MODERATOR_ROLE else Roles.VIEWER_ROLE
         for {
           // Update guest from waiting list
           u <- RegisteredUsers.findWithUserId(uvo.intId, liveMeeting.registeredUsers)
@@ -33,12 +33,12 @@ trait ChangeUserRoleCmdMsgHdlr extends RightsManagementTrait {
           // Promote non-guest users.
           Users2x.changeRole(liveMeeting.users2x, uvo, msg.body.role)
           val event = buildUserRoleChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.userId,
-            msg.body.changedBy, "MODERATOR")
+            msg.body.changedBy, Roles.MODERATOR_ROLE)
           outGW.send(event)
         } else if (msg.body.role == Roles.VIEWER_ROLE) {
           Users2x.changeRole(liveMeeting.users2x, uvo, msg.body.role)
           val event = buildUserRoleChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.userId,
-            msg.body.changedBy, "VIEWER")
+            msg.body.changedBy, Roles.VIEWER_ROLE)
           outGW.send(event)
         }
       }


### PR DESCRIPTION
### What does this PR do?
Check the resulting role passed through the message body instead of the user's current role.

### Closes Issue(s)
https://github.com/bigbluebutton/bigbluebutton/issues/11182

