### PR TITLE
Preserve mutestatus when disconnecting/reconnecting microphone

### DIFF
--- a/bigbluebutton-html5/imports/api/voice-users/server/methods/muteToggle.js
+++ b/bigbluebutton-html5/imports/api/voice-users/server/methods/muteToggle.js
@@ -6,7 +6,7 @@ import VoiceUsers from '/imports/api/voice-users';
 import Meetings from '/imports/api/meetings';
 import Logger from '/imports/startup/server/logger';
 
-export default function muteToggle(uId) {
+export default function muteToggle(uId, toggle) {
   const REDIS_CONFIG = Meteor.settings.private.redis;
   const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
   const EVENT_NAME = 'MuteUserCmdMsg';
@@ -39,10 +39,18 @@ export default function muteToggle(uId) {
     }
   }
 
+  let _muted;
+
+  if ((toggle === undefined) || (toggle === null)) {
+    _muted = !muted;
+  } else {
+    _muted = !!toggle;
+  }
+
   const payload = {
     userId: userToMute,
     mutedBy: requesterUserId,
-    mute: !muted,
+    mute: _muted,
   };
 
   RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);

--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -6,9 +6,39 @@ import { makeCall } from '/imports/ui/services/api';
 import VoiceUsers from '/imports/api/voice-users';
 import logger from '/imports/startup/client/logger';
 import { throttle } from 'lodash';
+import Storage from '../../services/storage/session';
 
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 const TOGGLE_MUTE_THROTTLE_TIME = Meteor.settings.public.media.toggleMuteThrottleTime;
+
+const MUTED_KEY = 'muted';
+
+const recoverMicState = () => {
+  const muted = Storage.getItem(MUTED_KEY);
+
+  if ((muted === undefined) || (muted === null)) {
+    return;
+  }
+
+  logger.debug({
+    logCode: 'audio_recover_mic_state',
+  }, `Audio recover previous mic state: muted = ${muted}`);
+  makeCall('toggleVoice', null, muted);
+};
+
+const audioEventHandler = (event) => {
+  if (!event) {
+    return;
+  }
+
+  switch (event.name) {
+    case 'started':
+      recoverMicState();
+      break;
+    default:
+      break;
+  }
+};
 
 const init = (messages, intl) => {
   AudioManager.setAudioMessages(messages, intl);
@@ -33,7 +63,7 @@ const init = (messages, intl) => {
     microphoneLockEnforced,
   };
 
-  AudioManager.init(userData);
+  AudioManager.init(userData, audioEventHandler);
 };
 
 const isVoiceUser = () => {
@@ -46,6 +76,9 @@ const toggleMuteMicrophone = throttle(() => {
   const user = VoiceUsers.findOne({
     meetingId: Auth.meetingID, intId: Auth.userID,
   }, { fields: { muted: 1 } });
+
+  Storage.setItem(MUTED_KEY, !user.muted);
+
   if (user.muted) {
     logger.info({
       logCode: 'audiomanager_unmute_audio',

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -58,13 +58,14 @@ class AudioManager {
     this.monitor = this.monitor.bind(this);
   }
 
-  init(userData) {
+  init(userData, audioEventHandler) {
     this.bridge = new SIPBridge(userData); // no alternative as of 2019-03-08
     if (this.useKurento) {
       this.listenOnlyBridge = new KurentoBridge(userData);
     }
     this.userData = userData;
     this.initialized = true;
+    this.audioEventHandler = audioEventHandler;
   }
 
   setAudioMessages(messages, intl) {
@@ -337,6 +338,7 @@ class AudioManager {
       window.parent.postMessage({ response: 'joinedAudio' }, '*');
       this.notify(this.intl.formatMessage(this.messages.info.JOINED_AUDIO));
       logger.info({ logCode: 'audio_joined' }, 'Audio Joined');
+      this.audioEventHandler({ name: 'started' });
       if (ENABLE_NETWORK_MONITORING) this.monitor();
     }
   }


### PR DESCRIPTION
After audio reconnection, a muted user would have it's microphone unmuted by default, unless muteOnStart is set to true. This fix this problem.
Fixes #9016

![reconnect](https://user-images.githubusercontent.com/1780868/107726949-026f3180-6cc9-11eb-90d2-7a0e68257137.gif)
