### PR TITLE
Fixes interruption of webcam, external video and screenshare when user changes language settings

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/intl.jsx
+++ b/bigbluebutton-html5/imports/startup/client/intl.jsx
@@ -91,10 +91,18 @@ class IntlStartup extends Component {
     const { fetching, normalizedLocale, messages } = this.state;
     const { children } = this.props;
 
-    return (fetching || !normalizedLocale) ? <LoadingScreen /> : (
-      <IntlProvider locale={normalizedLocale} messages={messages}>
-        {children}
-      </IntlProvider>
+    return (
+      <>
+        {(fetching || !normalizedLocale) && <LoadingScreen />}
+
+        {normalizedLocale
+          && (
+          <IntlProvider locale={normalizedLocale} messages={messages}>
+            {children}
+          </IntlProvider>
+          )
+        }
+      </>
     );
   }
 }

--- a/bigbluebutton-html5/imports/ui/components/loading-screen/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/loading-screen/styles.scss
@@ -9,6 +9,7 @@
   width: 100%;
   height: 100%;
   background-color: var(--loader-bg);
+  z-index: 4;
 }
 
 .message {


### PR DESCRIPTION
### What does this PR do?

Changes the way `loadingScreen` component is displayed when changing language settings.

**Before:** when `loadingScreen` appears all content is unmounted, then remounted
**Now:** `loadingScreen` appears on top of content

This change prevents webcam, screenshare and external video interruption when user changes language settings.

### Closes Issue(s)

closes #11351 + #7736
