### PR TITLE
Enable arrow keys immediately after fullscreen

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/fullscreen-button/service.js
+++ b/bigbluebutton-html5/imports/ui/components/fullscreen-button/service.js
@@ -33,7 +33,11 @@ function fullscreenRequest(element) {
     element.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
   } else if (element.msRequestFullscreen) {
     element.msRequestFullscreen();
+  } else {
+    return;
   }
+  document.activeElement.blur();
+  element.focus();
 }
 
 const toggleFullScreen = (ref = null) => {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Enabling moving slides by arrow keys immediately after toggling the fullscreen mode, by changing the focus.

### Closes Issue(s)

closes #11397 

### Motivation

Increasing demand on "hybrid lecture", which is to broadcast the lecture that is performed face to face, requires me to do the BBB presentation by fullscreen mode all the time (showing it in the classroom by a projector). For doing so, the current implementation of toggling fullscreen is annoying.

### More

I tested on Chrome and Edge. Other browsers have not been tested yet, but I believe it will work.
