### PR TITLE
Fix user-list-item dropdowns breaking on mobile screen sizes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/dropdown/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/styles.scss
@@ -108,6 +108,14 @@
   }
 }
 
+// removes transform on tethered dropdown for small screen sizes.
+// prevents the user-list-item dropdown breaking on mobile.
+:global(.tether-out-of-bounds)  {
+  @include mq($small-only) {
+    transform: none !important;
+  }
+}
+
 /* Placements
  * ==========
  */


### PR DESCRIPTION
### What does this PR do?
Removes the `transform` on the `.tether-out-of-bounds` for small breakpoints

### Closes Issue(s)
Closes #10915 