### PR TITLE
Show random viewer selection modal over the full-screen slide or shared screen

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/modal/random-user/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/modal/random-user/component.jsx
@@ -118,6 +118,12 @@ class RandomUserSelect extends Component {
           mountModal(null);
         }}
         contentLabel={intl.formatMessage(messages.ariaModalTitle)}
+        parentSelector={() => {
+          if (document.fullscreenElement &&
+              document.fullscreenElement.nodeName &&
+              document.fullscreenElement.nodeName.toLowerCase() === 'div') return document.fullscreenElement;
+          else return document.body;
+        }}
       >
         {viewElement}
       </Modal>


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Shows modals (typically those for random viewer selection) overlaid on a full-screen slide or on a full-screen shared-screen.

### Closes Issue(s)

closes #11402
related to #10783, which has been fixed (but only for slide not for shared screen) by #11319.

### Motivation

To do a "hybrid" lecture, which is to broadcast a face-to-face lecture by BBB, I need to do lectures by full-screen presentation (which would be shown by a projector in the real lecture room) as much as possible.

### More

The modal overlaying by this PR is possible for a full-screen slide and for a full-screen shared-screen, but not for a full-screen shared external video, which uses iframe.
