### PR TITLE
Show polling button over the full-screened shared-screen

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -8,6 +8,7 @@ import { styles } from './styles';
 import AutoplayOverlay from '../media/autoplay-overlay/component';
 import logger from '/imports/startup/client/logger';
 import playAndRetry from '/imports/utils/mediaElementPlayRetry';
+import PollingContainer from '/imports/ui/components/polling/container';
 
 const intlMessages = defineMessages({
   screenShareLabel: {
@@ -144,7 +145,7 @@ class ScreenshareComponent extends React.Component {
   }
 
   render() {
-    const { loaded, autoplayBlocked } = this.state;
+    const { loaded, autoplayBlocked, isFullscreen } = this.state;
     const { intl } = this.props;
 
     return (
@@ -173,6 +174,7 @@ class ScreenshareComponent extends React.Component {
           key="screenshareContainer"
           ref={(ref) => { this.screenshareContainer = ref; }}
         >
+          {isFullscreen && <PollingContainer />}
           {loaded && this.renderFullscreenButton()}
           <video
             id="screenshareVideo"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Shows the polling button over the shared screen shown full-screen.

### Closes Issue(s)

related to #10783, which has been partially fixed by #11319. This PR complements #11319.

### Motivation

Currently the polling button is not shown when the shared screen is displayed in full-screen mode (even the polling sound does not ring). The lecturer wants to do polling during a screen is shared, but he cannot control if the students watch it by full-screen or not. 

### More

The problem is that the poll result is not visible anyway when the students stay full-screen. The presenter has to stop the screen share to show the result, or ask the students to stop full screen to see it. But I believe it's better than the current implementation. Currently, the poll button would not be shown in the display of full-screen students, which the presenter cannot be aware of. So the full-screened students would get confused if the presenter asks them to select the option. By showing the poll button to the full-screen students, the presenter can at least engage them for the polling.
