### PR TITLE
Show uploaded slides from other users

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/container.jsx
@@ -10,9 +10,12 @@ import PresentationUploader from './component';
 const PRESENTATION_CONFIG = Meteor.settings.public.presentation;
 
 const PresentationUploaderContainer = props => (
+  props.isPresenter
+  && (
   <ErrorBoundary Fallback={() => <FallbackModal />}>
     <PresentationUploader {...props} />
   </ErrorBoundary>
+  )
 );
 
 export default withTracker(() => {


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where a user had to open the slide upload dialog twice to see all uploaded slides after he has become presenter.

### Closes Issue(s)

closes #10377