### PR TITLE
Option to eject voice users with no matching user (re-submit #10959)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
@@ -46,6 +46,7 @@ trait SystemConfiguration {
   lazy val voiceConfRecordCodec = Try(config.getString("voiceConf.recordCodec")).getOrElse("wav")
   lazy val checkVoiceRecordingInterval = Try(config.getInt("voiceConf.checkRecordingInterval")).getOrElse(19)
   lazy val syncVoiceUsersStatusInterval = Try(config.getInt("voiceConf.syncUserStatusInterval")).getOrElse(43)
+  lazy val ejectRogueVoiceUsers = Try(config.getBoolean("voiceConf.ejectRogueVoiceUsers")).getOrElse(false)
 
   lazy val recordingChapterBreakLengthInMinutes = Try(config.getInt("recording.chapterBreakLengthInMinutes")).getOrElse(0)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
@@ -141,7 +141,8 @@ object VoiceApp extends SystemConfiguration {
             // Purge voice users that don't have a matching user record
             // Avoid this if the meeting is a breakout room since might be real
             // voice users participating
-            if (ejectRogueVoiceUsers && !liveMeeting.props.meetingProp.isBreakout) {
+            // Also avoid ejecting if the user is dial-in (v_*)
+            if (ejectRogueVoiceUsers && !liveMeeting.props.meetingProp.isBreakout && !cvu.intId.startsWith("v_")) {
               Users2x.findWithIntId(liveMeeting.users2x, cvu.intId) match {
                 case Some(_) =>
                 case None =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
@@ -1,5 +1,6 @@
 package org.bigbluebutton.core.apps.voice
 
+import org.bigbluebutton.SystemConfiguration
 import org.bigbluebutton.LockSettingsUtil
 import org.bigbluebutton.common2.msgs.{ BbbClientMsgHeader, BbbCommonEnvCoreMsg, BbbCoreEnvelope, ConfVoiceUser, MessageTypes, Routing, UserJoinedVoiceConfToClientEvtMsg, UserJoinedVoiceConfToClientEvtMsgBody, UserLeftVoiceConfToClientEvtMsg, UserLeftVoiceConfToClientEvtMsgBody, UserMutedVoiceEvtMsg, UserMutedVoiceEvtMsgBody }
 import org.bigbluebutton.core.apps.breakout.BreakoutHdlrHelpers
@@ -9,7 +10,7 @@ import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
-object VoiceApp {
+object VoiceApp extends SystemConfiguration {
 
   def genRecordPath(
       recordDir:       String,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
@@ -4,7 +4,7 @@ import org.bigbluebutton.LockSettingsUtil
 import org.bigbluebutton.common2.msgs.{ BbbClientMsgHeader, BbbCommonEnvCoreMsg, BbbCoreEnvelope, ConfVoiceUser, MessageTypes, Routing, UserJoinedVoiceConfToClientEvtMsg, UserJoinedVoiceConfToClientEvtMsgBody, UserLeftVoiceConfToClientEvtMsg, UserLeftVoiceConfToClientEvtMsgBody, UserMutedVoiceEvtMsg, UserMutedVoiceEvtMsgBody }
 import org.bigbluebutton.core.apps.breakout.BreakoutHdlrHelpers
 import org.bigbluebutton.core.bus.InternalEventBus
-import org.bigbluebutton.core.models.{ VoiceUserState, VoiceUsers }
+import org.bigbluebutton.core.models.{ Users2x, VoiceUserState, VoiceUsers }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core2.message.senders.MsgBuilder
@@ -135,6 +135,19 @@ object VoiceApp {
             } else {
               // Update the user status to indicate they are still in the voice conference.
               VoiceUsers.setLastStatusUpdate(liveMeeting.voiceUsers, vu)
+            }
+
+            // Purge voice users that don't have a matching user record
+            // Avoid this if the meeting is a breakout room since might be real
+            // voice users participating
+            if (ejectRogueVoiceUsers && !liveMeeting.props.meetingProp.isBreakout) {
+              Users2x.findWithIntId(liveMeeting.users2x, cvu.intId) match {
+                case Some(_) =>
+                case None =>
+                  println(s"Ejecting rogue voice user. meetingId=${liveMeeting.props.meetingProp.intId} userId=${cvu.intId}")
+                  val event = MsgBuilder.buildEjectUserFromVoiceConfSysMsg(liveMeeting.props.meetingProp.intId, liveMeeting.props.voiceProp.voiceConf, cvu.voiceUserId)
+                  outGW.send(event)
+              }
             }
           case None =>
             handleUserJoinedVoiceConfEvtMsg(

--- a/akka-bbb-apps/src/universal/conf/application.conf
+++ b/akka-bbb-apps/src/universal/conf/application.conf
@@ -90,6 +90,8 @@ voiceConf {
   checkRecordingInterval = 23
   # Internval seconds to sync voice users status.
   syncUserStatusInterval = 41
+  # Voice users with no matching user record
+  ejectRogueVoiceUsers = false
 }
 
 recording {

--- a/akka-bbb-apps/src/universal/conf/application.conf
+++ b/akka-bbb-apps/src/universal/conf/application.conf
@@ -91,7 +91,7 @@ voiceConf {
   # Internval seconds to sync voice users status.
   syncUserStatusInterval = 41
   # Voice users with no matching user record
-  ejectRogueVoiceUsers = false
+  ejectRogueVoiceUsers = true
 }
 
 recording {

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/actions/GetUsersStatusCommand.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/actions/GetUsersStatusCommand.java
@@ -85,10 +85,12 @@ public class GetUsersStatusCommand extends FreeswitchCommand {
                 voiceUserId = callWithSess.group(1).trim();
                 clientSession = callWithSess.group(2).trim();
                 callerIdName = callWithSess.group(3).trim();
-              } else
-              if (matcher.matches()) {
+              } else if (matcher.matches()) {
                 voiceUserId = matcher.group(1).trim();
                 callerIdName = matcher.group(2).trim();
+              } else {
+                // This is a caller using dial in or out
+                voiceUserId = "v_" + member.getId().toString();
               }
 
               log.info("Conf user. uuid=" + uuid


### PR DESCRIPTION
This is a refurbish of PR #10959. Dial-in's are now theoretically handled (need someone to test it).

Reconnects may introduce ghost voice users in a meeting when the client fails to
rejoin but the audio connection remains active.

While fetching for the voice conference user's status, apps can now check if a
voice user has a matching user record. If it doesn't, eject the voice user.

**TODO**:
 - ~~Avoid dial-in users to be ejected~~ Tackled in 8f233b7, 3c0493a
 - ~~Once dial-in is covered, the breakout room check can be removed~~G