### PR TITLE
Fix user-sent poll result messages

### DIFF
--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addSystemMsg.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addSystemMsg.js
@@ -1,0 +1,45 @@
+import { Match, check } from 'meteor/check';
+import Logger from '/imports/startup/server/logger';
+import { GroupChatMsg } from '/imports/api/group-chat-msg';
+import { BREAK_LINE } from '/imports/utils/lineEndings';
+
+export function parseMessage(message) {
+  let parsedMessage = message || '';
+
+  // Replace \r and \n to <br/>
+  parsedMessage = parsedMessage.replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, `$1${BREAK_LINE}$2`);
+
+  // Replace flash links to html valid ones
+  parsedMessage = parsedMessage.split('<a href=\'event:').join('<a target="_blank" href=\'');
+  parsedMessage = parsedMessage.split('<a href="event:').join('<a target="_blank" href="');
+
+  return parsedMessage;
+}
+
+export default function addSystemMsg(meetingId, chatId, msg) {
+  check(meetingId, String);
+  check(chatId, String);
+  check(msg, {
+    id: Match.Maybe(String),
+    timestamp: Number,
+    sender: Object,
+    message: String,
+    correlationId: Match.Maybe(String),
+  });
+  const msgDocument = {
+    ...msg,
+    meetingId,
+    chatId,
+    message: parseMessage(msg.message),
+  };
+
+  try {
+    const insertedId = GroupChatMsg.insert(msgDocument);
+
+    if (insertedId) {
+      Logger.info(`Added system-msg msgId=${msg.id} chatId=${chatId} meetingId=${meetingId}`);
+    }
+  } catch (err) {
+    Logger.error(`Error on adding system-msg to collection: ${err}`);
+  }
+}

--- a/bigbluebutton-html5/imports/api/polls/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/polls/server/eventHandlers.js
@@ -2,10 +2,12 @@ import RedisPubSub from '/imports/startup/server/redis';
 import handlePollStarted from './handlers/pollStarted';
 import handlePollStopped from './handlers/pollStopped';
 import handlePollPublished from './handlers/pollPublished';
+import handleSendSystemChatForPublishedPoll from './handlers/sendPollChatMsg';
 import handleUserVoted from './handlers/userVoted';
 import handleUserResponded from './handlers/userResponded';
 
 RedisPubSub.on('PollShowResultEvtMsg', handlePollPublished);
+RedisPubSub.on('PollShowResultEvtMsg', handleSendSystemChatForPublishedPoll);
 RedisPubSub.on('PollStartedEvtMsg', handlePollStarted);
 RedisPubSub.on('PollStoppedEvtMsg', handlePollStopped);
 RedisPubSub.on('PollUpdatedEvtMsg', handleUserVoted);

--- a/bigbluebutton-html5/imports/api/polls/server/handlers/sendPollChatMsg.js
+++ b/bigbluebutton-html5/imports/api/polls/server/handlers/sendPollChatMsg.js
@@ -1,0 +1,38 @@
+import addSystemMsg from '../../../group-chat-msg/server/modifiers/addSystemMsg';
+
+export default function sendPollChatMsg({ body }, meetingId) {
+  const { poll } = body;
+
+  const CHAT_CONFIG = Meteor.settings.public.chat;
+  const PUBLIC_GROUP_CHAT_ID = CHAT_CONFIG.public_group_id;
+  const PUBLIC_CHAT_SYSTEM_ID = CHAT_CONFIG.system_userid;
+  const CHAT_POLL_RESULTS_MESSAGE = CHAT_CONFIG.system_messages_keys.chat_poll_result;
+  const SYSTEM_CHAT_TYPE = CHAT_CONFIG.type_system;
+
+  const { answers, numRespondents } = poll;
+
+  let responded = 0;
+  let resultString = 'bbb-published-poll-\n';
+  answers.map((item) => {
+    responded += item.numVotes;
+    return item;
+  }).map((item) => {
+    const numResponded = responded === numRespondents ? numRespondents : responded;
+    const pct = Math.round(item.numVotes / numResponded * 100);
+    const pctFotmatted = `${Number.isNaN(pct) ? 0 : pct}%`;
+    resultString += `${item.key}: ${item.numVotes || 0} | ${pctFotmatted}\n`;
+  });
+
+  const payload = {
+    id: `${SYSTEM_CHAT_TYPE}-${CHAT_POLL_RESULTS_MESSAGE}`,
+    timestamp: Date.now(),
+    correlationId: `${PUBLIC_CHAT_SYSTEM_ID}-${Date.now()}`,
+    sender: {
+      id: PUBLIC_CHAT_SYSTEM_ID,
+      name: '',
+    },
+    message: resultString,
+  };
+
+  return addSystemMsg(meetingId, PUBLIC_GROUP_CHAT_ID, payload);
+}

--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/component.jsx
@@ -72,6 +72,10 @@ class TimeWindowChatItem extends PureComponent {
       intl,
     } = this.props;
 
+    if (messages && messages[0].text.includes('bbb-published-poll-<br/>')) {
+      return this.renderPollItem();
+    }
+
     return (
       <div className={styles.item} key={`time-window-chat-item-${messageKey}`}>
         <div className={styles.messages}>
@@ -102,15 +106,12 @@ class TimeWindowChatItem extends PureComponent {
       scrollArea,
       intl,
       messages,
+      color,
       messageKey,
       dispatch,
       chatId,
       read,
     } = this.props;
-
-    if (messages && messages[0].text.includes('bbb-published-poll-<br/>')) {
-      return this.renderPollItem();
-    }
 
     const dateTime = new Date(time);
     const regEx = /<a[^>]+>/i;
@@ -178,7 +179,6 @@ class TimeWindowChatItem extends PureComponent {
 
   renderPollItem() {
     const {
-      user,
       time,
       intl,
       isDefaultPoll,
@@ -194,15 +194,6 @@ class TimeWindowChatItem extends PureComponent {
     return messages ? (
       <div className={styles.item} key={_.uniqueId('message-poll-item-')}>
         <div className={styles.wrapper} ref={(ref) => { this.item = ref; }}>
-          <div className={styles.avatarWrapper}>
-            <UserAvatar
-              className={styles.avatar}
-              color={user.color}
-              moderator={user.isModerator}
-            >
-              {<Icon className={styles.isPoll} iconName="polling" />}
-            </UserAvatar>
-          </div>
           <div className={styles.content}>
             <div className={styles.meta}>
               <div className={styles.name}>
@@ -222,7 +213,6 @@ class TimeWindowChatItem extends PureComponent {
               lastReadMessageTime={lastReadMessageTime}
               handleReadMessage={handleReadMessage}
               scrollArea={scrollArea}
-              color={user.color}
               isDefaultPoll={isDefaultPoll(messages[0].text.replace('bbb-published-poll-<br/>', ''))}
             />
           </div>

--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/container.jsx
@@ -21,6 +21,7 @@ export default class TimeWindowChatItemContainer extends PureComponent {
   render() {
     ChatLogger.debug('TimeWindowChatItemContainer::render', { ...this.props });
     const messages = this.props.message.content;
+    const color = this.props.message.color;
 
     const user = this.props.message.sender;
     const messageKey = this.props.message.key;
@@ -32,6 +33,7 @@ export default class TimeWindowChatItemContainer extends PureComponent {
         ...{
           read: this.props.message.read,
           messages,
+          color,
           isDefaultPoll,
           user,
           time,

--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -248,7 +248,6 @@ class Poll extends Component {
       stopPoll,
       currentPoll,
       pollAnswerIds,
-      sendGroupMessage,
     } = this.props;
 
     return (
@@ -262,7 +261,6 @@ class Poll extends Component {
             stopPoll,
             currentPoll,
             pollAnswerIds,
-            sendGroupMessage,
           }}
           handleBackClick={this.handleBackClick}
         />

--- a/bigbluebutton-html5/imports/ui/components/poll/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/container.jsx
@@ -40,6 +40,5 @@ export default withTracker(() => {
     resetPollPanel: Session.get('resetPollPanel') || false,
     pollAnswerIds: Service.pollAnswerIds,
     isMeteorConnected: Meteor.status().connected,
-    sendGroupMessage: Service.sendGroupMessage,
   };
 })(PollContainer);

--- a/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
@@ -145,7 +145,6 @@ class LiveResult extends PureComponent {
       stopPoll,
       handleBackClick,
       currentPoll,
-      sendGroupMessage,
     } = this.props;
 
     const { userAnswers, pollStats } = this.state;
@@ -192,20 +191,6 @@ class LiveResult extends PureComponent {
               onClick={() => {
                 Session.set('pollInitiated', false);
                 Service.publishPoll();
-                const { answers, numRespondents } = currentPoll;
-                let responded = 0;
-                let resultString = 'bbb-published-poll-\n';
-                answers.map((item) => {
-                  responded += item.numVotes;
-                  return item;
-                }).map((item) => {
-                  const numResponded = responded === numRespondents ? numRespondents : responded;
-                  const pct = Math.round(item.numVotes / numResponded * 100);
-                  const pctFotmatted = `${Number.isNaN(pct) ? 0 : pct}%`;
-                  resultString += `${item.key}: ${item.numVotes || 0} | ${pctFotmatted}\n`;
-                });
-
-                sendGroupMessage(resultString);
                 stopPoll();
               }}
               label={intl.formatMessage(intlMessages.publishLabel)}

--- a/bigbluebutton-html5/imports/ui/components/poll/service.js
+++ b/bigbluebutton-html5/imports/ui/components/poll/service.js
@@ -1,4 +1,3 @@
-import { makeCall } from '/imports/ui/services/api';
 import Users from '/imports/api/users';
 import Auth from '/imports/ui/services/auth';
 import Polls from '/imports/api/polls';
@@ -57,24 +56,6 @@ const pollAnswerIds = {
   },
 };
 
-const CHAT_CONFIG = Meteor.settings.public.chat;
-const PUBLIC_GROUP_CHAT_ID = CHAT_CONFIG.public_group_id;
-const PUBLIC_CHAT_SYSTEM_ID = CHAT_CONFIG.system_userid;
-
-const sendGroupMessage = (message) => {
-  const payload = {
-    color: '0',
-    correlationId: `${PUBLIC_CHAT_SYSTEM_ID}-${Date.now()}`,
-    sender: {
-      id: Auth.userID,
-      name: '',
-    },
-    message,
-  };
-
-  return makeCall('sendGroupChatMsg', PUBLIC_GROUP_CHAT_ID, payload);
-};
-
 export default {
   amIPresenter: () => Users.findOne(
     { userId: Auth.userID },
@@ -83,6 +64,5 @@ export default {
   pollTypes,
   currentPoll: () => Polls.findOne({ meetingId: Auth.meetingID }),
   pollAnswerIds,
-  sendGroupMessage,
   POLL_AVATAR_COLOR,
 };

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -316,6 +316,7 @@ public:
     storage_key: UNREAD_CHATS
     system_messages_keys:
       chat_clear: PUBLIC_CHAT_CLEAR
+      chat_poll_result: PUBLIC_CHAT_POLL_RESULT
     typingIndicator:
       enabled: true
   note:


### PR DESCRIPTION
### What does this PR do?

Prevents user messages containing `bbb-published-poll-` from being displayed as poll results, by changing the way poll result messages are parsed before being displayed on chat.

#### New poll result message
![Screenshot from 2021-02-17 17-33-06](https://user-images.githubusercontent.com/3728706/108264522-691ba180-7146-11eb-85f4-94210102c919.png)

#### If a user send a message containing `bbb-published-poll-`  now, it will be displayed as any other user message
![Screenshot from 2021-02-17 17-30-40](https://user-images.githubusercontent.com/3728706/108264645-8e101480-7146-11eb-9331-f269a2ba5578.png)


### Closes Issue(s)

closes #11393
