### PR TITLE
Skip publishing poll annotation to whiteboard if presentation swapped

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
@@ -4,6 +4,10 @@ import PollService from '/imports/ui/components/poll/service';
 import { injectIntl, defineMessages } from 'react-intl';
 import styles from './styles';
 import { prototype } from 'clipboard';
+import MediaService, {
+  getSwapLayout,
+  shouldEnableSwapLayout,
+} from '/imports/ui/components/media/service';
 
 const intlMessages = defineMessages({
   pollResultAria: {
@@ -65,6 +69,9 @@ class PollDrawComponent extends Component {
   }
 
   componentDidMount() {
+    const isLayoutSwapped = getSwapLayout() && shouldEnableSwapLayout();
+    if (isLayoutSwapped) return;
+
     this.pollInitialCalculation();
     this.checkSizes();
   }


### PR DESCRIPTION
### What does this PR do?
This PR skips calculating / rendering the poll results to the whiteboard for the specific user who may have a swapped presentation. I suspect this will be a temporary solution until the poll annotation calculations are moved from the client side.

### Closes Issue(s)
Closes #11097 