### PR TITLE
Remove setNumberOfHTML5Processes

### DIFF
--- a/bigbluebutton-config/bin/apply-lib.sh
+++ b/bigbluebutton-config/bin/apply-lib.sh
@@ -225,20 +225,6 @@ disableMultipleKurentos() {
   yq w -i $KURENTO_CONFIG balancing-strategy ROUND_ROBIN
 }
 
-setNumberOfHTML5Processes() {
-  HTML5_RESTRICTIONS_FILE=/usr/share/meteor/bundle/bbb-html5.conf
-  NUMBER_OF_PROCESSES=`echo $1 | bc`
-
-  source $HTML5_RESTRICTIONS_FILE
-
-  echo "setNumberOfHTML5Processes with number of processes in the range ($INSTANCE_MIN to $INSTANCE_MAX)"
-  echo "setNumberOfHTML5Processes with NUMBER_OF_PROCESSES=$NUMBER_OF_PROCESSES"
-
-  sed -i -e "s|DESIRED_INSTANCE_COUNT=.*$|DESIRED_INSTANCE_COUNT=$NUMBER_OF_PROCESSES|g" $HTML5_RESTRICTIONS_FILE
-
-  systemctl restart bbb-html5
-}
-
 
 notCalled() {
 #
@@ -266,8 +252,6 @@ source /etc/bigbluebutton/bbb-conf/apply-lib.sh
 #enableHTML5WebcamPagination
 
 #enableMultipleKurentos
-
-#setNumberOfHTML5Processes 2
 
 # Shorten the FreeSWITCH "you have been muted" and "you have been unmuted" prompts
 # cp -r /etc/bigbluebutton/bbb-conf/sounds /opt/freeswitch/share/freeswitch


### PR DESCRIPTION
This function was introduced in 2.3-alpha5 to provide a way to set how many nodejs processes you want to run as part of `bbb-html5`'s routine.

#11317 reverted that approach for parallel processes and introduced an alternative which requires instead two values - number of 'frontend' processes and number of 'backend' processes.

This additonal variable, coupled with comments from community members who treated the `apply-config.sh` as a configuration file rather than a script, has led me to believe that it's best for administrators to go straight to the config file `/usr/share/meteor/bundle/bbb-html5-with-roles.conf` and change the defaults if needed. A restart of `bbb-html5` would be required. (`sudo systemctl restart bbb-html5`)

```
# Default = 1; Min = 1; Max = 4
# On powerful systems with high number of meetings you can set values up to 4 to accelerate handling of events
NUMBER_OF_BACKEND_NODEJS_PROCESSES=2
# Default = 1; Min = 0; Max = 8
# If 0 is set, bbb-html5 will handle both backend and frontend roles in one process (default until Feb 2021)
# Set a number between 1 and 4 times the value of NUMBER_OF_BACKEND_NODEJS_PROCESSES where higher number helps with meetings
# stretching the recommended number of users in BigBlueButton
NUMBER_OF_FRONTEND_NODEJS_PROCESSES=2
```