### PR TITLE
Do not uncessarily fetch locales at first time you open/save settings menu

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/intl.jsx
+++ b/bigbluebutton-html5/imports/startup/client/intl.jsx
@@ -55,9 +55,9 @@ class IntlStartup extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { fetching, messages } = this.state;
+    const { fetching, messages, normalizedLocale } = this.state;
     const { locale } = this.props;
-    const shouldFetch = (!fetching && _.isEmpty(messages)) || (locale !== prevProps.locale);
+    const shouldFetch = (!fetching && _.isEmpty(messages)) || ((locale !== prevProps.locale) && (normalizedLocale && (locale !== normalizedLocale)));
     if (shouldFetch) this.fetchLocalizedMessages(locale);
   }
 


### PR DESCRIPTION
Locales were being fetched even if you simply open and save settings window (without changing any setting)
We now test it similarly we do on 2.2
Closes #11318

### Additional info:
When first testing #11318 (bbb2.3-alpha5) , saving/chaing settings also dropped microphone's connection, but this doesn't happen anymore in bbb2.3-alpha7. So i am closing #11318, once  there's no more evidences that microphone would drop after saving/changing settings.


This is the problem this PR fixes (notice the loading page after saving settings):

![screen2](https://user-images.githubusercontent.com/1780868/108599909-a4021d00-7372-11eb-9f80-aeeb00dd8683.gif)
