### PR TITLE
Show modals overlaid on full-screen slide or shared screen

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/modal/base/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/modal/base/component.jsx
@@ -23,7 +23,16 @@ export default class ModalBase extends Component {
     if (!this.props.isOpen) return null;
 
     return (
-      <ReactModal {...this.props}>
+      <ReactModal
+        {...this.props}
+        parentSelector={() => {
+          if (document.fullscreenElement &&
+              document.fullscreenElement.nodeName &&
+              document.fullscreenElement.nodeName.toLowerCase() === 'div')
+            return document.fullscreenElement;
+          else return document.body;
+        }}
+      >
         {this.props.children}
       </ReactModal>
     );


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Basically same as #11406, but more generic modification - with this PR all modals will be shown over the full-screened slide or shared-screen. Inspired by the comment by @KDSBrowne in the PR 11406.

### Closes Issue(s)

closes #11402. 
The PR #11406 is not necessary anymore if this PR is merged, so can be closed as well.
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number -->

### Motivation

To do a "hybrid" lecture, which is to broadcast a face-to-face lecture by BBB, I need to do lectures by full-screen presentation (which would be shown by a projector in the real lecture room) as much as possible.

### More

The modal overlaying by this PR is possible for a full-screen slide and for a full-screen shared-screen, but not for a full-screen shared external video, which uses iframe.
#11406 is only for the random user selection modal. This PR influences all modals.
