### PR TITLE
Fix bbb_skip_check_audio_on_first_join parameter

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -33,9 +33,7 @@ const propTypes = {
   formattedDialNum: PropTypes.string.isRequired,
   showPermissionsOvelay: PropTypes.bool.isRequired,
   listenOnlyMode: PropTypes.bool.isRequired,
-  skipCheck: PropTypes.bool,
   joinFullAudioImmediately: PropTypes.bool,
-  joinFullAudioEchoTest: PropTypes.bool,
   forceListenOnlyAttendee: PropTypes.bool.isRequired,
   audioLocked: PropTypes.bool.isRequired,
   resolve: PropTypes.func,
@@ -51,9 +49,7 @@ const defaultProps = {
   inputDeviceId: null,
   outputDeviceId: null,
   resolve: null,
-  skipCheck: false,
   joinFullAudioImmediately: false,
-  joinFullAudioEchoTest: false,
 };
 
 const intlMessages = defineMessages({
@@ -166,13 +162,10 @@ class AudioModal extends Component {
     const {
       forceListenOnlyAttendee,
       audioLocked,
-      joinFullAudioImmediately,
-      joinFullAudioEchoTest,
     } = this.props;
 
     if (forceListenOnlyAttendee) return this.handleJoinListenOnly();
-    if (joinFullAudioEchoTest) return this.handleGoToEchoTest();
-    if (joinFullAudioImmediately || audioLocked) return this.handleJoinMicrophone();
+    if (audioLocked) return this.handleJoinMicrophone();
   }
 
   componentDidUpdate(prevProps) {
@@ -336,9 +329,6 @@ class AudioModal extends Component {
   skipAudioOptions() {
     const {
       isConnecting,
-      forceListenOnlyAttendee,
-      joinFullAudioEchoTest,
-      joinFullAudioImmediately,
     } = this.props;
 
     const {
@@ -346,12 +336,7 @@ class AudioModal extends Component {
       hasError,
     } = this.state;
 
-    return (
-      isConnecting
-      || forceListenOnlyAttendee
-      || joinFullAudioImmediately
-      || joinFullAudioEchoTest
-    ) && !content && !hasError;
+    return isConnecting && !content && !hasError;
   }
 
   renderAudioOptions() {
@@ -359,7 +344,7 @@ class AudioModal extends Component {
       intl,
       listenOnlyMode,
       forceListenOnlyAttendee,
-      skipCheck,
+      joinFullAudioImmediately,
       audioLocked,
       isMobileNative,
       formattedDialNum,
@@ -383,7 +368,7 @@ class AudioModal extends Component {
                 circle
                 size="jumbo"
                 disabled={audioLocked}
-                onClick={skipCheck ? this.handleJoinMicrophone : this.handleGoToEchoTest}
+                onClick={joinFullAudioImmediately ? this.handleJoinMicrophone : this.handleGoToEchoTest}
               />
             )
             : null}

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -62,7 +62,7 @@ export default lockContextContainer(withModalMounter(withTracker(({ userLocks })
     joinedAudio,
     meetingIsBreakout,
     closeModal,
-    joinMicrophone: skipEchoTest => joinMicrophone(skipEchoTest || skipCheck),
+    joinMicrophone: skipEchoTest => joinMicrophone(skipEchoTest || skipCheck || skipCheckOnJoin),
     joinListenOnly,
     leaveEchoTest,
     changeInputDevice: inputDeviceId => Service.changeInputDevice(inputDeviceId),

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -51,10 +51,8 @@ export default lockContextContainer(withModalMounter(withTracker(({ userLocks })
   const meetingIsBreakout = AppService.meetingIsBreakout();
   const { joinedAudio } = getcookieData();
 
-  const joinFullAudioImmediately = (autoJoin && (skipCheck || skipCheckOnJoin))
+  const joinFullAudioImmediately = (autoJoin && (skipCheck || skipCheckOnJoin && !getEchoTest))
     || (skipCheck || skipCheckOnJoin && !getEchoTest);
-
-  const joinFullAudioEchoTest = joinFullAudioImmediately && getEchoTest;
 
   const forceListenOnlyAttendee = forceListenOnly && !Service.isUserModerator();
 
@@ -76,14 +74,11 @@ export default lockContextContainer(withModalMounter(withTracker(({ userLocks })
     outputDeviceId: Service.outputDeviceId(),
     showPermissionsOvelay: Service.isWaitingPermissions(),
     listenOnlyMode,
-    skipCheck,
-    skipCheckOnJoin,
     formattedDialNum,
     formattedTelVoice,
     combinedDialInNum,
     audioLocked: userLocks.userMic,
     joinFullAudioImmediately,
-    joinFullAudioEchoTest,
     forceListenOnlyAttendee,
     isIOSChrome: browser().name === 'crios',
     isMobileNative: navigator.userAgent.toLowerCase().includes('bbbnative'),


### PR DESCRIPTION
### What does this PR do?

Fixes a bug that made `bbb_skip_check_audio_on_first_join` parameter stop working as expected.

This bug was caused by changes made on PR #11381 and reported by @maths22 

> This PR accidentally broke `bbb_skip_check_audio_on_first_join`. In particular the changes to `bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx` combined with the version of `joinMicrophone` in `bigbluebutton-html5/imports/ui/components/audio/audio-modal/service.js` dropped the check for `skipCheckOnJoin`

