### PR TITLE
Akka config

### DIFF
--- a/akka-bbb-apps/build.sbt
+++ b/akka-bbb-apps/build.sbt
@@ -70,6 +70,6 @@ daemonUser in Linux := user
 // group which will execute the application
 daemonGroup in Linux := group
 
-javaOptions in Universal ++= Seq("-J-Xms130m", "-J-Xmx256m", "-Dconfig.file=conf/application.conf", "-Dlogback.configurationFile=conf/logback.xml")
+javaOptions in Universal ++= Seq("-J-Xms130m", "-J-Xmx256m", "-Dconfig.file=/etc/bigbluebutton/bbb-apps-akka.conf", "-Dlogback.configurationFile=conf/logback.xml")
 
 debianPackageDependencies in Debian ++= Seq("java8-runtime-headless", "bash")

--- a/akka-bbb-apps/src/debian/DEBIAN/postinst
+++ b/akka-bbb-apps/src/debian/DEBIAN/postinst
@@ -1,8 +1,0 @@
-if [ -f /tmp/application.conf ]; then
-  for KEY in bbbWebAPI sharedSecret; do
-    VALUE=$(grep $KEY /tmp/application.conf | sed 's/[^=]*=//')
-    if [ ! -z "$VALUE" ]; then
-      sed -i "/$KEY/s|=.*|=$VALUE|" /usr/share/bbb-apps-akka/conf/application.conf
-    fi
-  done
-fi

--- a/akka-bbb-apps/src/debian/DEBIAN/postrm
+++ b/akka-bbb-apps/src/debian/DEBIAN/postrm
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+  purge)
+    # remove config file added/changed by preinst script
+    OP_CONFIG=/etc/bigbluebutton/bbb-apps-akka.conf
+    if [ -f "${OP_CONFIG}" ]; then
+      rm "${OP_CONFIG}"
+    fi
+esac

--- a/akka-bbb-apps/src/debian/DEBIAN/preinst
+++ b/akka-bbb-apps/src/debian/DEBIAN/preinst
@@ -1,10 +1,38 @@
+#!/bin/sh
+
+write_config_file() {
+  mkdir -p /etc/bigbluebutton
+
+        cat <<END > "${OP_CONFIG}"
+// include default config from upstream
+include "/usr/share/bbb-apps-akka/conf/application.conf"
+
+// you can customize everything here. API endpoint and secret have to be changed
+// This file will not be overridden by packages
+
+services {
+  bbbWebAPI=${API}
+  sharedSecret=${SECRET}
+}
+END
+}
+
 case "$1" in
   install|upgrade|1|2)
 
-    rm -f /tmp/application.conf
-    if [ -f /usr/share/bbb-apps-akka/conf/application.conf ]; then
-      cp /usr/share/bbb-apps-akka/conf/application.conf /tmp/application.conf
+    PACKAGE_CONFIG=/usr/share/bbb-apps-akka/conf/application.conf
+    OP_CONFIG=/etc/bigbluebutton/bbb-apps-akka.conf
+    # this is for upgrading packages from old packaging system where operators had
+    # to change the package config file
+    if [ ! -f "${OP_CONFIG}" -a -f "${PACKAGE_CONFIG}" ]; then
+      API=$(grep bbbWebAPI "${PACKAGE_CONFIG}"  | sed 's/[^=]*=\s*//')
+      SECRET=$(grep sharedSecret "${PACKAGE_CONFIG}"  | sed 's/[^=]*=\s*//')
+      write_config_file
     fi
-
-  ;;
+    # this is for fresh installs, where no config file exists
+    if [ ! -f "${OP_CONFIG}" ]; then
+      SECRET='"changeme"'
+      API='"https://192.168.23.33/bigbluebutton/api"'
+      write_config_file
+    fi
 esac

--- a/akka-bbb-fsesl/build.sbt
+++ b/akka-bbb-fsesl/build.sbt
@@ -77,6 +77,6 @@ daemonUser in Linux := user
 // group which will execute the application
 daemonGroup in Linux := group
 
-javaOptions in Universal ++= Seq("-J-Xms130m", "-J-Xmx256m", "-Dconfig.file=conf/application.conf", "-Dlogback.configurationFile=conf/logback.xml")
+javaOptions in Universal ++= Seq("-J-Xms130m", "-J-Xmx256m", "-Dconfig.file=/etc/bigbluebutton/bbb-fsesl-akka.conf", "-Dlogback.configurationFile=conf/logback.xml")
 
 debianPackageDependencies in Debian ++= Seq("java8-runtime-headless", "bash")

--- a/akka-bbb-fsesl/src/debian/DEBIAN/postrm
+++ b/akka-bbb-fsesl/src/debian/DEBIAN/postrm
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+  purge)
+    # remove config file added/changed by preinst script
+    OP_CONFIG=/etc/bigbluebutton/bbb-fsesl-akka.conf
+    if [ -f "${OP_CONFIG}" ]; then
+      rm "${OP_CONFIG}"
+    fi
+esac
+

--- a/akka-bbb-fsesl/src/debian/DEBIAN/preinst
+++ b/akka-bbb-fsesl/src/debian/DEBIAN/preinst
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -e
+
+write_config_file() {
+  mkdir -p /etc/bigbluebutton
+
+        cat <<END > "${OP_CONFIG}"
+// include default config from upstream
+include "${PACKAGE_CONFIG}"
+
+// you can customize everything starting from here.
+freeswitch {
+    esl {
+        password="ClueCon"
+    }
+}
+END
+}
+
+case "$1" in
+  install|upgrade|1|2)
+
+    PACKAGE_CONFIG=/usr/share/bbb-fsesl-akka/conf/application.conf
+    OP_CONFIG=/etc/bigbluebutton/bbb-fsesl-akka.conf
+    # create config file if it does not exist
+    if [ ! -f "${OP_CONFIG}" ]; then
+      write_config_file
+    fi
+esac

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -592,8 +592,8 @@ if [[ $SECRET ]]; then
         sed -i "s|\(^[ \t]*var shared_secret[ =]*\)[^;]*|\1\"$SECRET\"|g" /usr/local/bigbluebutton/bbb-webhooks/extra/post_catcher.js
     fi
 
-    if [ -f /usr/share/bbb-apps-akka/conf/application.conf ]; then
-        sed -i "s/sharedSecret[ ]*=[ ]*\"[^\"]*\"/sharedSecret=\"$SECRET\"/g" /usr/share/bbb-apps-akka/conf/application.conf
+    if [ -f /etc/bigbluebutton/bbb-apps-akka.conf ]; then
+        sed -i "s/sharedSecret[ ]*=[ ]*\"[^\"]*\"/sharedSecret=\"$SECRET\"/g" /etc/bigbluebutton/bbb-apps-akka.conf
     fi
 
     if [ -f ${LTI_DIR}/WEB-INF/classes/lti-config.properties ]; then

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -1631,10 +1631,10 @@ if [ -n "$HOST" ]; then
     #
     # Update ESL passwords in three configuration files
     #
-    ESL_PASSWORD=$(cat /usr/share/bbb-fsesl-akka/conf/application.conf | grep password | head -n 1 | sed 's/.*="//g' | sed 's/"//g')
+    ESL_PASSWORD=$(cat /etc/bigbluebutton/bbb-fsesl-akka.conf | grep password | head -n 1 | sed 's/.*="//g' | sed 's/"//g')
     if [ "$ESL_PASSWORD" == "ClueCon" ]; then
         ESL_PASSWORD=$(openssl rand -hex 8)
-        sudo sed -i "s/ClueCon/$ESL_PASSWORD/g" /usr/share/bbb-fsesl-akka/conf/application.conf
+        sudo sed -i "s/ClueCon/$ESL_PASSWORD/g" /etc/bigbluebutton/bbb-fsesl-akka.conf
     fi
 
     sudo yq w -i /usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml freeswitch.esl_password "$ESL_PASSWORD"

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -1092,9 +1092,9 @@ check_state() {
         fi
     fi
 
-    if [ "$(cat /usr/share/bbb-apps-akka/conf/application.conf | sed -n '/sharedSecret.*/{s/[^"]*"//;s/".*//;p}')" == "changeme" ]; then
+    if [ "$(cat /etc/bigbluebutton/bbb-apps-akka.conf | sed -n '/sharedSecret.*/{s/[^"]*"//;s/".*//;p}')" == "changeme" ]; then
         BBB_WEB_IP=$(cat ${SERVLET_DIR}/WEB-INF/classes/bigbluebutton.properties | grep -v '#' | sed -n '/^bigbluebutton.web.serverURL/{s/.*\///;p}')
-        echo "# Error: Detected that /usr/share/bbb-apps-akka/conf/application.conf has the default"
+        echo "# Error: Detected that /etc/bigbluebutton/bbb-apps-akka.conf has the default"
         echo "# configuration values.  To update, run"
         echo "#"
         echo "#   $SUDO bbb-conf --setip $BBB_WEB_IP"
@@ -1540,17 +1540,15 @@ if [ -n "$HOST" ]; then
     #
     # Update bbb-apps-akka
     #
-    echo "Assigning $HOST for web application URL in /usr/share/bbb-apps-akka/conf/application.conf"
+    echo "Assigning $HOST for web application URL in /etc/bigbluebutton/bbb-apps-akka.conf"
 
-    if [ -f /usr/share/bbb-apps-akka/conf/application.conf ]; then
+    if [ -f /etc/bigbluebutton/bbb-apps-akka.conf ]; then
         sed -i  "s/bbbWebAPI[ ]*=[ ]*\"[^\"]*\"/bbbWebAPI=\"${PROTOCOL}:\/\/$HOST\/bigbluebutton\/api\"/g" \
-                /usr/share/bbb-apps-akka/conf/application.conf
-        sed -i "s/deskshareip[ ]*=[ ]*\"[^\"]*\"/deskshareip=\"$HOST\"/g" \
-                /usr/share/bbb-apps-akka/conf/application.conf
-        # Fix to ensure application.conf has the latest shared secret
+                /etc/bigbluebutton/bbb-apps-akka.conf
+        # Fix to ensure bbb-apps-akka.conf has the latest shared secret
         SECRET=$(cat ${SERVLET_DIR}/WEB-INF/classes/bigbluebutton.properties | grep -v '#' | grep securitySalt | cut -d= -f2);
         sed -i "s/sharedSecret[ ]*=[ ]*\"[^\"]*\"/sharedSecret=\"$SECRET\"/g" \
-                /usr/share/bbb-apps-akka/conf/application.conf
+                /etc/bigbluebutton/bbb-apps-akka.conf
     fi
 
     #


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

This PR lets `bbb-apps-akka` and `bbb-fsesl-akka` read their configuration from `/etc/bigbluebutton/`. The files in `/etc/bigbluebutton` include the config files shipped with the packages and let the operator customize settings without changing files from the packages.


### Motivation

Operators who use configuration management tools like ansible, chef or puppet have to adjust their templates each time the BigBlueButton developers introduce new configuration settings. With this patch both can be kept seperate. On the other hand it reduces complexity from the postinst/preinst scripts of the packages as well.

