### PR TITLE
Clean up HTMLAudioElement used for notification sounds

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/activity-check/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/activity-check/component.jsx
@@ -76,6 +76,7 @@ class ActivityCheck extends Component {
 
   playAudioAlert() {
     this.alert = new Audio(`${Meteor.settings.public.app.cdn + Meteor.settings.public.app.basename}/resources/sounds/notify.mp3`);
+    alert.addEventListener('ended', () => { alert.src = null; });
     this.alert.play();
   }
 

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-test/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-test/container.jsx
@@ -9,6 +9,7 @@ export default withTracker(() => ({
   outputDeviceId: Service.outputDeviceId(),
   handlePlayAudioSample: (deviceId) => {
     const sound = new Audio((Meteor.settings.public.app.cdn + Meteor.settings.public.app.basename) + '/resources/sounds/audioSample.mp3');
+    sound.addEventListener('ended', () => { sound.src = null; });
     if (deviceId && sound.setSinkId) sound.setSinkId(deviceId);
     sound.play();
   },

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -628,6 +628,8 @@ class AudioManager {
 
     const audioAlert = new Audio(url);
 
+    audioAlert.addEventListener('ended', () => { audioAlert.src = null; });
+
     if (this.outputDeviceId && (typeof audioAlert.setSinkId === 'function')) {
       return audioAlert
         .setSinkId(this.outputDeviceId)


### PR DESCRIPTION
After ending the notification playback, we set the ".src" property to null, which immediately stop the internal player of mobile browser (tested on Chrome for Android -  device list is on #11458).
For the specific list of devices, this prevents the internal buffer error "-61" described in #11458.
Closes #11458 

## Additional Info ##
Here is the ADB logcat output immediately after setting the ".src" property to null. This log was retrieved from a Moto G8 device (chrome version 88) .
```
02-22 21:16:44.291 14160 14258 D AAudio  : AAudioStream_requestStop(s#24) called                                                                                                                                   
02-22 21:16:44.292 14160 14258 D AudioTrack: stop(155): called with 665036 frames delivered                                                                                                                        
02-22 21:16:44.293 14160 14258 D         : PlayerBase::stop() from IPlayer                                                                                                                                         
02-22 21:16:44.507   961  2332 D MotSpeakerHelper: Speaker ON: volume 0.500000 (step 12), usecase SAFE  
...
```