### PR TITLE
Prevent ejecting user from them main room when leaving breakout room

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -85,7 +85,7 @@ export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) 
     endMeeting('403');
   }
 
-  Users.find({ userId: Auth.userID }).observe({
+  Users.find({ userId: Auth.userID, meetingId: Auth.meetingID }).observe({
     removed() {
       endMeeting('403');
     },


### PR DESCRIPTION
When observing changes in User colletion, we must guarantee these changes are from main room, and not from breakout one.
Fixes #11029