### PR TITLE
Remove unused 'app.poll.yn' from locales/en.json

### DIFF
--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -245,7 +245,6 @@
     "app.poll.y": "Yes",
     "app.poll.n": "No",
     "app.poll.abstention": "Abstention",
-    "app.poll.yn": "Yes / No",
     "app.poll.yna": "Yes / No / Abstention",
     "app.poll.a2": "A / B",
     "app.poll.a3": "A / B / C",


### PR DESCRIPTION
This PR removes `app.poll.yn` from [locales/en.json](https://github.com/bigbluebutton/bigbluebutton/blob/3f83691c52f778b9c190cd5990ce4c2f0a1019d4/bigbluebutton-html5/private/locales/en.json#L248) while it's not anymore used.