### PR TITLE
Fix whiteboard text-area not allowing input on Firefox

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/text-draw-listener/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/text-draw-listener/component.jsx
@@ -114,9 +114,8 @@ export default class TextDrawListener extends Component {
     this.sendLastMessage();
   }
 
-  handleClick() {
-    const { isWritingText } = this.state;
-    if (isWritingText) this.sendLastMessage();
+  handleClick(e) {
+    if (e.srcElement.getAttribute('role') !== 'presentation') this.sendLastMessage();
   }
 
   // checks if the input textarea is focused or not, and if not - moves focus there


### PR DESCRIPTION
### What does this PR do?
![text-area-firefox](https://user-images.githubusercontent.com/22058534/108940040-b0130680-7620-11eb-9cb5-69a046afae22.gif)

### Closes Issue(s)
closes #10774 