### PR TITLE
Do not return empty array when groupChats is empty

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -217,7 +217,7 @@ const isMe = userId => userId === Auth.userID;
 
 const getActiveChats = ({ groupChatsMessages, groupChats, users }) => {
 
-  if (_.isEmpty(groupChats) || _.isEmpty(users)) return [];
+  if (_.isEmpty(groupChats) && _.isEmpty(users)) return [];
   
   const chatIds = Object.keys(groupChats);
   const lastTimeWindows = chatIds.reduce((acc, chatId) => {


### PR DESCRIPTION
Instead, return empty array when **both** users and groupChats arrays are empty.
The public chat and user chats may be active when groupChats array is empty.
Fixes #11476