### PR TITLE
Add break-word to system messages

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/styles.scss
@@ -34,10 +34,10 @@
   border-radius: var(--border-radius);
   font-weight: var(--btn-font-weight);
   padding: var(--font-size-base);
-  //margin-bottom: var(--line-height-computed);
   color: var(--systemMessage-font-color);
   margin-top: 0px;
   margin-bottom: 0px;
+  overflow-wrap: break-word;
 }
 
 .systemMessageNoBorder {


### PR DESCRIPTION
### What does this PR do?

Adds CSS property to force line breaks on long links (or any other long text) present in system messages.

### Closes Issue(s)

closes #11445