### PR TITLE
Disable customHeartbeat 10826

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -37,7 +37,7 @@ public:
     # this value to be kept under 12.
     breakoutRoomLimit: 8
     # https://github.com/bigbluebutton/bigbluebutton/pull/10826
-    customHeartbeat: true
+    customHeartbeat: false
     defaultSettings:
       application:
         animations: true


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Changes the default value for customHeartbeat

<!-- A brief description of each change being made with this pull request. -->

<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number -->

### Motivation
We encountered a scenario where the customHeartbeat #10826 keeps the sockJS websocket open despite the fact that the ping-pong procedure #7753 identified users as unresponsive and requested their removal from the meeting

Given that customHeartbeat was introduced to alleviate high nodejs CPU leading to reconnections, and that we see significantly reduced CPU loads since 2.2.30 and 2.2.31, I am disabling customHeartbeat by default to avoid conflicts with ping-pong routine.

<!-- What inspired you to submit this pull request? -->

