### PR TITLE
Fix whiteboard use for iPad and other landscape mobile devices

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
-import { isMobile } from 'react-device-detect';
+import { isMobile, withOrientationChange } from 'react-device-detect';
 import TetherComponent from 'react-tether';
 import cx from 'classnames';
 import { defineMessages, injectIntl } from 'react-intl';
@@ -179,13 +179,14 @@ class Dropdown extends Component {
       tethered,
       placement,
       getContent,
+      isPortrait,
       ...otherProps
     } = this.props;
 
     const { isOpen } = this.state;
 
     const placements = placement && placement.replace(' ', '-');
-    const test = isMobile ? {
+    const test = isMobile && isPortrait ? {
       width: '100%',
       height: '100%',
       transform: 'translateY(0)',
@@ -237,15 +238,15 @@ class Dropdown extends Component {
             ? (
               <TetherComponent
                 style={{
-                  zIndex: isOpen ? 15 : 1,
+                  zIndex: isOpen ? 15 : -1,
                   ...test,
                 }}
                 attachment={
-                  isMobile ? 'middle center'
+                  isMobile && isPortrait ? 'middle center'
                     : attachments[placements]
                 }
                 targetAttachment={
-                  isMobile ? 'auto auto'
+                  isMobile && isPortrait ? 'auto auto'
                     : targetAttachments[placements]
                 }
                 constraints={[
@@ -300,4 +301,4 @@ class Dropdown extends Component {
 
 Dropdown.propTypes = propTypes;
 Dropdown.defaultProps = defaultProps;
-export default injectIntl(Dropdown, { forwardRef: true });
+export default injectIntl(withOrientationChange(Dropdown), { forwardRef: true });


### PR DESCRIPTION
### What does this PR do?

Prevents "invisible box" of dropdown component from appearing on iPad and other mobile devices when on landscape orientation, by also checking if mobile device is in portrait orientation.

#### Current behavior:
![Screenshot from 2021-02-25 08-44-07](https://user-images.githubusercontent.com/3728706/109149010-c49cef00-7745-11eb-85fe-701fbd84bee6.png)

#### After changes:
![Screenshot from 2021-02-25 08-44-36](https://user-images.githubusercontent.com/3728706/109149000-c1096800-7745-11eb-89e2-191fb59ef68f.png)

#### Further information:
`tether-element` is used on the userlist menu, and should have 100% width/height on mobile devices (only on portrait orientation, but the orientation was not being verified).

![Screenshot from 2021-02-25 08-47-56](https://user-images.githubusercontent.com/3728706/109149715-b56a7100-7746-11eb-9e76-8d419095f3c4.png)


### Closes Issue(s)

closes #11212