### PR TITLE
Visual changes on connection status modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
@@ -122,6 +122,8 @@ class ConnectionStatusComponent extends PureComponent {
       intl,
     } = this.props;
 
+    const isValidUrl = new RegExp(/^(http|https):\/\/[^ "]+$/).test(STATS.help);
+
     return (
       <Modal
         overlayClassName={styles.overlay}
@@ -138,9 +140,13 @@ class ConnectionStatusComponent extends PureComponent {
           </div>
           <div className={styles.description}>
             {intl.formatMessage(intlMessages.description)}{' '}
-            <a href={STATS.help} target="_blank" rel="noopener noreferrer">
-              {`(${intl.formatMessage(intlMessages.more)})`}
-            </a>
+            {isValidUrl
+              && (
+                <a href={STATS.help} target="_blank" rel="noopener noreferrer">
+                  {`(${intl.formatMessage(intlMessages.more)})`}
+                </a>
+              )
+            }
           </div>
           <div className={styles.content}>
             <div className={styles.wrapper}>

--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/styles.scss
@@ -93,6 +93,7 @@
     width: 100%;
     height: 100%;
     align-items: center;
+    justify-content: center;
 
     .text {
       padding-left: .5rem;


### PR DESCRIPTION
### What does this PR do?

Changes connection status modal to only display help link if `stats.help` url is set to a valid link on settings file.
Changes alignment of "no connectivity issues" message to center.

