### PR TITLE
Cleanup joinedAudioOnly state when user disconnects or reconnect microphone

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -135,4 +135,5 @@ export default {
   },
   isReturningFromBreakoutAudioTransfer:
     () => AudioManager.returningFromBreakoutAudioTransfer,
+  isReconnecting: () => AudioManager.isReconnecting,
 };

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
@@ -102,11 +102,14 @@ class BreakoutRoom extends PureComponent {
       breakoutRoomUser,
       breakoutRooms,
       closeBreakoutPanel,
+      isMicrophoneUser,
+      isReconnecting,
     } = this.props;
 
     const {
       waiting,
       requestedBreakoutId,
+      joinedAudioOnly,
     } = this.state;
 
     if (breakoutRooms.length <= 0) closeBreakoutPanel();
@@ -119,6 +122,10 @@ class BreakoutRoom extends PureComponent {
         window.open(breakoutUser.redirectToHtml5JoinURL, '_blank');
         _.delay(() => this.setState({ waiting: false }), 1000);
       }
+    }
+
+    if (joinedAudioOnly && (!isMicrophoneUser || isReconnecting)) {
+      this.clearJoinedAudioOnly();
     }
   }
 
@@ -142,6 +149,10 @@ class BreakoutRoom extends PureComponent {
       this.setState({ waiting: false });
     }
     return null;
+  }
+
+  clearJoinedAudioOnly() {
+    this.setState({ joinedAudioOnly: false });
   }
 
   transferUserToBreakoutRoom(breakoutId) {

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/container.jsx
@@ -25,6 +25,7 @@ export default withTracker((props) => {
   const breakoutRooms = findBreakouts();
   const isMicrophoneUser = AudioService.isConnected() && !AudioService.isListenOnly();
   const isMeteorConnected = Meteor.status().connected;
+  const isReconnecting = AudioService.isReconnecting();
   const { setReturningFromBreakoutAudioTransfer } = AudioService;
 
   return {
@@ -43,5 +44,6 @@ export default withTracker((props) => {
     isUserInBreakoutRoom,
     exitAudio: () => AudioManager.exitAudio(),
     setReturningFromBreakoutAudioTransfer,
+    isReconnecting,
   };
 })(BreakoutContainer);

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -52,6 +52,7 @@ class AudioManager {
       outputDeviceId: null,
       muteHandle: null,
       autoplayBlocked: false,
+      isReconnecting: false,
     });
 
     this.useKurento = Meteor.settings.public.kurento.enableListenOnly;
@@ -392,12 +393,15 @@ class AudioManager {
       } = response;
 
       if (status === STARTED) {
+        this.isReconnecting = false;
         this.onAudioJoin();
         resolve(STARTED);
       } else if (status === ENDED) {
+        this.isReconnecting = false;
         logger.info({ logCode: 'audio_ended' }, 'Audio ended without issue');
         this.onAudioExit();
       } else if (status === FAILED) {
+        this.isReconnecting = false;
         const errorKey = this.messages.error[error] || this.messages.error.GENERIC_ERROR;
         const errorMsg = this.intl.formatMessage(errorKey, { 0: bridgeError });
         this.error = !!error;
@@ -415,10 +419,12 @@ class AudioManager {
           this.onAudioExit();
         }
       } else if (status === RECONNECTING) {
+        this.isReconnecting = true;
         logger.info({ logCode: 'audio_reconnecting' }, 'Attempting to reconnect audio');
         this.notify(this.intl.formatMessage(this.messages.info.RECONNECTING_AUDIO), true);
         this.playHangUpSound();
       } else if (status === AUTOPLAY_BLOCKED) {
+        this.isReconnecting = false;
         this.autoplayBlocked = true;
         this.onAudioJoin();
         resolve(AUTOPLAY_BLOCKED);


### PR DESCRIPTION
Fixes #11490

The confusion mentioned in #11490 is caused because when you leave audio (while in audio transfer) the state of breakout component isn't properly cleared. This means when user join audio again, the breakout menu will show the label "Return audio" (but the user didn't even join breakout audio). 

This is the behavior fixed by this PR:
![fix-11490](https://user-images.githubusercontent.com/1780868/109338846-93a3e380-7845-11eb-974d-036235511bdc.gif)



### Additional context
The default behavior for audio is: when leaving or reconnecting audio, we recover the mute state but not the 'breakout-room-state' (the breakout-room audio that was active before the audio disconnect/reconnect). So we leave the user to return to breakout room by himself.

We could change this behavior by automatically connecting user into breakout audio transfer (after leaving or reconnecting) , but this could be reported in a new issue/enhancement.

