### PR TITLE
Do not try to recover mute state when joining listenonly

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -33,7 +33,7 @@ const audioEventHandler = (event) => {
 
   switch (event.name) {
     case 'started':
-      recoverMicState();
+      if (!event.isListenOnly) recoverMicState();
       break;
     default:
       break;

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -342,7 +342,10 @@ class AudioManager {
       this.notify(this.intl.formatMessage(this.messages.info.JOINED_AUDIO));
       logger.info({ logCode: 'audio_joined' }, 'Audio Joined');
       if (STATS.enabled) this.monitor();
-      this.audioEventHandler({ name: 'started' });
+      this.audioEventHandler({
+        name: 'started',
+        isListenOnly: this.isListenOnly,
+      });
     }
   }
 


### PR DESCRIPTION
Prevent toggleMute api call to be called for listenonly
This has no effect to the end user, but avoids unnecessary server calls