### PR TITLE
Breakout room audio fixes

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -597,7 +597,7 @@ class SIPSession {
       );
 
       if (this.inputDeviceId) {
-        matchConstraints.deviceId = { exact: this.inputDeviceId };
+        matchConstraints.deviceId = this.inputDeviceId;
       }
 
       const inviterOptions = {

--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -82,8 +82,9 @@ class AudioContainer extends PureComponent {
 
   componentDidUpdate(prevProps) {
     const { hasBreakoutRooms, joinedAudio } = this.props;
-    const { hasBreakoutRooms: hadBreakoutRooms } = prevProps;    
-    if (hadBreakoutRooms && !hasBreakoutRooms && joinedAudio) {
+    const { hasBreakoutRooms: hadBreakoutRooms } = prevProps;
+    if (hadBreakoutRooms && !hasBreakoutRooms && joinedAudio
+      && !Service.isConnected()) {
       joinMicrophone(true, true);
     }
   }


### PR DESCRIPTION
#### 1st commit:
Do not join microphone when user is already in breakout

Fixes #11511
Related to the feature implemented in c451666

#### 2nd commit (needed due to recent SIP.js changes):
Avoid setting an unknown input deviceId 

Without 'exact' match, the browser fallbacks to the default inputDeviceId
This prevents the error (input device error)  when breakout is ended and we try to skipCheck the microphone when user returns o main room (assuming the user had the microphone active before joining breakout room). 
Related to the feature c451666