### PR TITLE
Fix mobile user removal bug

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -264,7 +264,6 @@ const BaseContainer = withTracker(() => {
     ejected: 1,
     ejectedReason: 1,
     color: 1,
-    mobile: 1,
     effectiveConnectionType: 1,
     extId: 1,
     guest: 1,


### PR DESCRIPTION
### What does this PR do?

Removes a dependency on `BaseContainer` which was leading to a crash when a user tagged as *mobile* is removed from the meeting (the removed line was causing unnecessary re-renders when `user.mobile` property is changed).
 
### Closes Issue(s)

closes #11488