### PR TITLE
Adds lastAuthTokenValidatedOn to users

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
@@ -17,6 +17,7 @@ object RegisteredUsers {
       authenticated,
       guestStatus,
       System.currentTimeMillis(),
+      0,
       false,
       false,
       false
@@ -126,6 +127,12 @@ object RegisteredUsers {
     u
   }
 
+  def updateUserLastAuthTokenValidated(users: RegisteredUsers, user: RegisteredUser): RegisteredUser = {
+    val u = user.copy(lastAuthTokenValidatedOn = System.currentTimeMillis())
+    users.save(u)
+    u
+  }
+
   def markAsUserFailedToJoin(users: RegisteredUsers, user: RegisteredUser): RegisteredUser = {
     val u = user.copy(markAsJoinTimedOut = true)
     users.save(u)
@@ -153,18 +160,19 @@ class RegisteredUsers {
 }
 
 case class RegisteredUser(
-    id:                 String,
-    externId:           String,
-    name:               String,
-    role:               String,
-    authToken:          String,
-    avatarURL:          String,
-    guest:              Boolean,
-    authed:             Boolean,
-    guestStatus:        String,
-    registeredOn:       Long,
-    joined:             Boolean,
-    markAsJoinTimedOut: Boolean,
-    banned:             Boolean
+    id:                       String,
+    externId:                 String,
+    name:                     String,
+    role:                     String,
+    authToken:                String,
+    avatarURL:                String,
+    guest:                    Boolean,
+    authed:                   Boolean,
+    guestStatus:              String,
+    registeredOn:             Long,
+    lastAuthTokenValidatedOn: Long,
+    joined:                   Boolean,
+    markAsJoinTimedOut:       Boolean,
+    banned:                   Boolean
 )
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -74,11 +74,11 @@ object MsgBuilder {
   }
 
   def buildValidateAuthTokenRespMsg(meetingId: String, userId: String, authToken: String,
-                                    valid: Boolean, waitForApproval: Boolean, registeredOn: Long): BbbCommonEnvCoreMsg = {
+                                    valid: Boolean, waitForApproval: Boolean, registeredOn: Long, authTokenValidatedOn: Long): BbbCommonEnvCoreMsg = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, meetingId, userId)
     val envelope = BbbCoreEnvelope(ValidateAuthTokenRespMsg.NAME, routing)
     val header = BbbClientMsgHeader(ValidateAuthTokenRespMsg.NAME, meetingId, userId)
-    val body = ValidateAuthTokenRespMsgBody(userId, authToken, valid, waitForApproval, registeredOn)
+    val body = ValidateAuthTokenRespMsgBody(userId, authToken, valid, waitForApproval, registeredOn, authTokenValidatedOn)
     val event = ValidateAuthTokenRespMsg(header, body)
     BbbCommonEnvCoreMsg(envelope, event)
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/ValidateAuthTokenRespMsgSender.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/ValidateAuthTokenRespMsgSender.scala
@@ -6,11 +6,11 @@ import org.bigbluebutton.core.running.OutMsgRouter
 object ValidateAuthTokenRespMsgSender {
 
   def send(outGW: OutMsgRouter, meetingId: String, userId: String, authToken: String,
-           valid: Boolean, waitForApproval: Boolean, registeredOn: Long): Unit = {
+           valid: Boolean, waitForApproval: Boolean, registeredOn: Long, authTokenValidatedOn: Long): Unit = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, meetingId, userId)
     val envelope = BbbCoreEnvelope(ValidateAuthTokenRespMsg.NAME, routing)
     val header = BbbClientMsgHeader(ValidateAuthTokenRespMsg.NAME, meetingId, userId)
-    val body = ValidateAuthTokenRespMsgBody(userId, authToken, valid, waitForApproval, registeredOn)
+    val body = ValidateAuthTokenRespMsgBody(userId, authToken, valid, waitForApproval, registeredOn, authTokenValidatedOn)
     val event = ValidateAuthTokenRespMsg(header, body)
     val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
     outGW.send(msgEvent)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMgs.scala
@@ -59,7 +59,7 @@ case class ValidateAuthTokenRespMsg(
     header: BbbClientMsgHeader,
     body:   ValidateAuthTokenRespMsgBody
 ) extends BbbCoreMsg
-case class ValidateAuthTokenRespMsgBody(userId: String, authToken: String, valid: Boolean, waitForApproval: Boolean, registeredOn: Long)
+case class ValidateAuthTokenRespMsgBody(userId: String, authToken: String, valid: Boolean, waitForApproval: Boolean, registeredOn: Long, authTokenValidatedOn: Long)
 
 object UserLeftMeetingEvtMsg {
   val NAME = "UserLeftMeetingEvtMsg"

--- a/bigbluebutton-html5/imports/api/users/server/handlers/validateAuthToken.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/validateAuthToken.js
@@ -24,6 +24,7 @@ export default function handleValidateAuthToken({ body }, meetingId) {
     authToken,
     waitForApproval,
     registeredOn,
+    authTokenValidatedOn,
   } = body;
 
   check(userId, String);
@@ -31,6 +32,7 @@ export default function handleValidateAuthToken({ body }, meetingId) {
   check(valid, Boolean);
   check(waitForApproval, Boolean);
   check(registeredOn, Number);
+  check(authTokenValidatedOn, Number);
 
   const pendingAuths = pendingAuthenticationsStore.take(meetingId, userId, authToken);
 
@@ -111,6 +113,7 @@ export default function handleValidateAuthToken({ body }, meetingId) {
       validated: valid,
       approved: !waitForApproval,
       loginTime: registeredOn,
+      authTokenValidatedTime: authTokenValidatedOn,
       inactivityCheck: false,
     },
   };


### PR DESCRIPTION
This PR helps @Tainan404 to work on #11438 
When user reconnects the client will load chat messages incrementally to make it faster. It will be made based on the token validation time.

This PR:

1.  Create in Akka `lastAuthTokenValidatedOn`
_Time will be refreshed every time user validates token_
2. Include this info in pubSub `ValidateAuthTokenRespMsg`
_Send the `authTokenValidatedOn` via Redis pubsub in return of token validation_
3. Store in Meteor/Mongo (User)
_Store `authTokenValidatedOn` in mongo user model as `authTokenValidatedTime`_
