### PR TITLE
Fix chat textarea resizing bug

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
@@ -297,6 +297,7 @@ class MessageForm extends PureComponent {
             value={message}
             onChange={this.handleMessageChange}
             onKeyDown={this.handleMessageKeyDown}
+            async={true}
           />
           <Button
             hideLabel


### PR DESCRIPTION
### What does this PR do?

Fix textarea resizing to the wrong height, by setting `async = true` as mentioned in the [lib docs](https://github.com/buildo/react-autosize-textarea#props)

#### Current behavior
![textarea-bug-before](https://user-images.githubusercontent.com/3728706/109542885-6c971d00-7aa4-11eb-835c-7d76f7330b02.gif)


#### New behavior
![textarea-bug-after](https://user-images.githubusercontent.com/3728706/109542915-76b91b80-7aa4-11eb-87d6-b698db659f18.gif)


### Closes Issue(s)

closes #11354