### PR TITLE
numUsersVideo being undefined breaks layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager.jsx
@@ -378,7 +378,7 @@ class LayoutManager extends Component {
     let webcamsAreaWidth;
     let webcamsAreaHeight;
 
-    if (numUsersVideo < 1) {
+    if (!numUsersVideo || numUsersVideo < 1) {
       return {
         webcamsAreaWidth: 0,
         webcamsAreaHeight: 0,
@@ -442,7 +442,7 @@ class LayoutManager extends Component {
       numUsersVideo,
     } = layoutContextState;
 
-    if (numUsersVideo < 1) {
+    if (!numUsersVideo || numUsersVideo < 1) {
       return {
         presentationAreaWidth: mediaAreaWidth,
         presentationAreaHeight: mediaAreaHeight - 20,


### PR DESCRIPTION
### What does this PR do?

Fixes a layout failure when nobody is using webcam.

### Closes Issue(s)

### Motivation

On a 2.3 server, sometimes a slide is shown to fit to the width of presentation area (Figure 1), sometimes not (Figure 2; there is space on the sides, seeming to reserve a webcam space) when nobody is joining with a webcam. I believe that the intended design is to show the slide as largely as possible (i.e., Figure 1 style) when nobody is using the webcam. 

After an investigation, I've found that "numUsersVideo" can be "undefined" even though the initial value is "null" in bigbluebutton-html5/imports/ui/components/layout/layout-manager.jsx. 
if it's null, numUsersVideo < 1 is true, but if it's undefined, numUsersVideo < 1 is false. Thus depending on this variable being null or undefined, the layout can be changed. I suppose this is not the intended behaviour. 

### More

I personally prefer the design having always some space on the sides of the slide and the whiteboard toolbar does not overlap with the slide (Figure 2). In the test23 server, the slide is always in the Figure 2 style when opened with Chrome.

![名称未設定 1のコピー](https://user-images.githubusercontent.com/45039819/109594214-bdb31980-7b55-11eb-993e-fa259c783f9d.jpg)
Figure 1

![名称未設定 1のコピー2](https://user-images.githubusercontent.com/45039819/109594232-c3a8fa80-7b55-11eb-9eb4-eff35c78090c.jpg)
Figure 2
