### PR TITLE
numUsersVideo being undefined breaks layout

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -394,7 +394,7 @@ const BaseContainer = withTracker(() => {
   }
 
   const codeError = Session.get('codeError');
-  const usersVideo = VideoService.getVideoStreams();
+  const { streams: usersVideo } = VideoService.getVideoStreams();
 
   return {
     approved,


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fixes a layout failure when nobody is using webcam.

### Motivation

On a 2.3 server, sometimes a slide is shown to fit to the width of presentation area (Figure 1), sometimes not (Figure 2; there is space on the sides, seeming to reserve a webcam space) when nobody is joining with a webcam. I believe that the intended design is to show the slide as largely as possible (i.e., Figure 1 style) when nobody is using the webcam. 

After an investigation, I've found that "numUsersVideo" can be "undefined" even though the initial value is "null" in bigbluebutton-html5/imports/ui/components/layout/layout-manager.jsx.
if it's null, numUsersVideo < 1 is true, but if it's undefined, numUsersVideo < 1 is false. Thus depending on this variable being null or undefined, the layout can be changed. I suppose this is not the intended behaviour.
A further investigation brought me to a possible bug in startup/client/base.jsx, in which the variable usersVideo is an object but is expected to be an array.

![109594214-bdb31980-7b55-11eb-993e-fa259c783f9d](https://user-images.githubusercontent.com/45039819/109668047-1a452180-7bb4-11eb-8976-5bbe0d5fdebc.jpg)
Figure 1

![109594232-c3a8fa80-7b55-11eb-9eb4-eff35c78090c](https://user-images.githubusercontent.com/45039819/109668076-2204c600-7bb4-11eb-8344-d4b46c141c25.jpg)
Figure 2
