### PR TITLE
Improve permission checks for video, screen sharing and listen only

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenBroadcastPermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenBroadcastPermissionReqMsgHdlr.scala
@@ -3,7 +3,7 @@ package org.bigbluebutton.core2.message.handlers
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core.models.Users2x
-import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
+import org.bigbluebutton.core.apps.PermissionCheck
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait GetScreenBroadcastPermissionReqMsgHdlr {
@@ -22,7 +22,6 @@ trait GetScreenBroadcastPermissionReqMsgHdlr {
         val reason = "No permission to share the screen."
         PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)
       } else if (!user.userLeftFlag.left
-        && user.authed
         && liveMeeting.props.meetingProp.intId == msg.body.meetingId
         && liveMeeting.props.voiceProp.voiceConf == msg.body.voiceConf) {
         allowed = true

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenBroadcastPermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenBroadcastPermissionReqMsgHdlr.scala
@@ -1,0 +1,41 @@
+package org.bigbluebutton.core2.message.handlers
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
+import org.bigbluebutton.core.models.Users2x
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
+
+trait GetScreenBroadcastPermissionReqMsgHdlr {
+  this: MeetingActor =>
+
+  val outGW: OutMsgRouter
+
+  def handleGetScreenBroadcastPermissionReqMsg(msg: GetScreenBroadcastPermissionReqMsg) {
+    var allowed = false
+
+    for {
+      user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
+    } yield {
+      if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+        val meetingId = liveMeeting.props.meetingProp.intId
+        val reason = "No permission to share the screen."
+        PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)
+      } else if (!user.userLeftFlag.left
+        && user.authed
+        && liveMeeting.props.meetingProp.intId == msg.body.meetingId
+        && liveMeeting.props.voiceProp.voiceConf == msg.body.voiceConf) {
+        allowed = true
+      }
+    }
+
+    val event = MsgBuilder.buildGetScreenBroadcastPermissionRespMsg(
+      liveMeeting.props.meetingProp.intId,
+      liveMeeting.props.voiceProp.voiceConf,
+      msg.body.userId,
+      msg.body.sfuSessionId,
+      allowed
+    )
+    outGW.send(event)
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenSubscribePermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenSubscribePermissionReqMsgHdlr.scala
@@ -4,7 +4,6 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core.models.Users2x
 import org.bigbluebutton.core.apps.ScreenshareModel
-import org.bigbluebutton.core.apps.{ ScreenshareModel, PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait GetScreenSubscribePermissionReqMsgHdlr {
@@ -19,7 +18,6 @@ trait GetScreenSubscribePermissionReqMsgHdlr {
       user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
     } yield {
       if (!user.userLeftFlag.left
-        && user.authed
         && liveMeeting.props.meetingProp.intId == msg.body.meetingId
         && liveMeeting.props.voiceProp.voiceConf == msg.body.voiceConf
         && ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel) == msg.body.streamId) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenSubscribePermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenSubscribePermissionReqMsgHdlr.scala
@@ -1,0 +1,40 @@
+package org.bigbluebutton.core2.message.handlers
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
+import org.bigbluebutton.core.models.Users2x
+import org.bigbluebutton.core.apps.ScreenshareModel
+import org.bigbluebutton.core.apps.{ ScreenshareModel, PermissionCheck, RightsManagementTrait }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
+
+trait GetScreenSubscribePermissionReqMsgHdlr {
+  this: MeetingActor =>
+
+  val outGW: OutMsgRouter
+
+  def handleGetScreenSubscribePermissionReqMsg(msg: GetScreenSubscribePermissionReqMsg) {
+    var allowed = false
+
+    for {
+      user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
+    } yield {
+      if (!user.userLeftFlag.left
+        && user.authed
+        && liveMeeting.props.meetingProp.intId == msg.body.meetingId
+        && liveMeeting.props.voiceProp.voiceConf == msg.body.voiceConf
+        && ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel) == msg.body.streamId) {
+        allowed = true
+      }
+    }
+
+    val event = MsgBuilder.buildGetScreenSubscribePermissionRespMsg(
+      liveMeeting.props.meetingProp.intId,
+      liveMeeting.props.voiceProp.voiceConf,
+      msg.body.userId,
+      msg.body.streamId,
+      msg.body.sfuSessionId,
+      allowed
+    )
+    outGW.send(event)
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetCamBroadcastPermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetCamBroadcastPermissionReqMsgHdlr.scala
@@ -2,7 +2,7 @@ package org.bigbluebutton.core2.message.handlers
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
-import org.bigbluebutton.core.models.{ Users2x, Webcams }
+import org.bigbluebutton.core.models.Users2x
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait GetCamBroadcastPermissionReqMsgHdlr {
@@ -17,7 +17,6 @@ trait GetCamBroadcastPermissionReqMsgHdlr {
       user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
     } yield {
       if (!user.userLeftFlag.left
-        && user.authed
         && liveMeeting.props.meetingProp.intId == msg.body.meetingId) {
         allowed = true
       }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetCamBroadcastPermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetCamBroadcastPermissionReqMsgHdlr.scala
@@ -1,0 +1,34 @@
+package org.bigbluebutton.core2.message.handlers
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
+import org.bigbluebutton.core.models.{ Users2x, Webcams }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
+
+trait GetCamBroadcastPermissionReqMsgHdlr {
+  this: MeetingActor =>
+
+  val outGW: OutMsgRouter
+
+  def handleGetCamBroadcastPermissionReqMsg(msg: GetCamBroadcastPermissionReqMsg) {
+    var allowed = false
+
+    for {
+      user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
+    } yield {
+      if (!user.userLeftFlag.left
+        && user.authed
+        && liveMeeting.props.meetingProp.intId == msg.body.meetingId) {
+        allowed = true
+      }
+    }
+
+    val event = MsgBuilder.buildGetCamBroadcastPermissionRespMsg(
+      liveMeeting.props.meetingProp.intId,
+      msg.body.userId,
+      msg.body.sfuSessionId,
+      allowed
+    )
+    outGW.send(event)
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetCamSubscribePermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetCamSubscribePermissionReqMsgHdlr.scala
@@ -17,7 +17,6 @@ trait GetCamSubscribePermissionReqMsgHdlr {
       user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
     } yield {
       if (!user.userLeftFlag.left
-        && user.authed
         && liveMeeting.props.meetingProp.intId == msg.body.meetingId) {
         Webcams.findWithStreamId(liveMeeting.webcams, msg.body.streamId) match {
           case Some(stream) => {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetCamSubscribePermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetCamSubscribePermissionReqMsgHdlr.scala
@@ -1,0 +1,42 @@
+package org.bigbluebutton.core2.message.handlers
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
+import org.bigbluebutton.core.models.{ Users2x, Webcams }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
+
+trait GetCamSubscribePermissionReqMsgHdlr {
+  this: MeetingActor =>
+
+  val outGW: OutMsgRouter
+
+  def handleGetCamSubscribePermissionReqMsg(msg: GetCamSubscribePermissionReqMsg) {
+    var allowed = false
+
+    for {
+      user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
+    } yield {
+      if (!user.userLeftFlag.left
+        && user.authed
+        && liveMeeting.props.meetingProp.intId == msg.body.meetingId) {
+        Webcams.findWithStreamId(liveMeeting.webcams, msg.body.streamId) match {
+          case Some(stream) => {
+            allowed = true
+          }
+          case None => {
+            allowed = false
+          }
+        }
+      }
+    }
+
+    val event = MsgBuilder.buildGetCamSubscribePermissionRespMsg(
+      liveMeeting.props.meetingProp.intId,
+      msg.body.userId,
+      msg.body.streamId,
+      msg.body.sfuSessionId,
+      allowed
+    )
+    outGW.send(event)
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/GetGlobalAudioPermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/GetGlobalAudioPermissionReqMsgHdlr.scala
@@ -1,0 +1,52 @@
+package org.bigbluebutton.core2.message.handlers
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
+import org.bigbluebutton.core.models.Users2x
+
+trait GetGlobalAudioPermissionReqMsgHdlr {
+  this: MeetingActor =>
+
+  val outGW: OutMsgRouter
+
+  def build(
+      meetingId:    String,
+      voiceConf:    String,
+      userId:       String,
+      sfuSessionId: String,
+      allowed:      Boolean
+  ): BbbCommonEnvCoreMsg = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, meetingId, userId)
+    val envelope = BbbCoreEnvelope(GetGlobalAudioPermissionRespMsg.NAME, routing)
+    val header = BbbClientMsgHeader(GetGlobalAudioPermissionRespMsg.NAME, meetingId, userId)
+
+    val body = GetGlobalAudioPermissionRespMsgBody(meetingId, voiceConf, userId, sfuSessionId, allowed)
+    val event = GetGlobalAudioPermissionRespMsg(header, body)
+
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
+
+  def handleGetGlobalAudioPermissionReqMsg(msg: GetGlobalAudioPermissionReqMsg) {
+    var allowed = false
+
+    for {
+      user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
+    } yield {
+      if (!user.userLeftFlag.left
+        && user.authed
+        && liveMeeting.props.meetingProp.intId == msg.body.meetingId
+        && liveMeeting.props.voiceProp.voiceConf == msg.body.voiceConf) {
+        allowed = true
+      }
+    }
+
+    val event = build(
+      liveMeeting.props.meetingProp.intId,
+      liveMeeting.props.voiceProp.voiceConf,
+      msg.body.userId,
+      msg.body.sfuSessionId,
+      allowed
+    )
+    outGW.send(event)
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/GetGlobalAudioPermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/GetGlobalAudioPermissionReqMsgHdlr.scala
@@ -3,28 +3,12 @@ package org.bigbluebutton.core2.message.handlers
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core.models.Users2x
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait GetGlobalAudioPermissionReqMsgHdlr {
   this: MeetingActor =>
 
   val outGW: OutMsgRouter
-
-  def build(
-      meetingId:    String,
-      voiceConf:    String,
-      userId:       String,
-      sfuSessionId: String,
-      allowed:      Boolean
-  ): BbbCommonEnvCoreMsg = {
-    val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, meetingId, userId)
-    val envelope = BbbCoreEnvelope(GetGlobalAudioPermissionRespMsg.NAME, routing)
-    val header = BbbClientMsgHeader(GetGlobalAudioPermissionRespMsg.NAME, meetingId, userId)
-
-    val body = GetGlobalAudioPermissionRespMsgBody(meetingId, voiceConf, userId, sfuSessionId, allowed)
-    val event = GetGlobalAudioPermissionRespMsg(header, body)
-
-    BbbCommonEnvCoreMsg(envelope, event)
-  }
 
   def handleGetGlobalAudioPermissionReqMsg(msg: GetGlobalAudioPermissionReqMsg) {
     var allowed = false
@@ -33,14 +17,13 @@ trait GetGlobalAudioPermissionReqMsgHdlr {
       user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
     } yield {
       if (!user.userLeftFlag.left
-        && user.authed
         && liveMeeting.props.meetingProp.intId == msg.body.meetingId
         && liveMeeting.props.voiceProp.voiceConf == msg.body.voiceConf) {
         allowed = true
       }
     }
 
-    val event = build(
+    val event = MsgBuilder.buildGetGlobalAudioPermissionRespMsg(
       liveMeeting.props.meetingProp.intId,
       liveMeeting.props.voiceProp.voiceConf,
       msg.body.userId,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -118,6 +118,10 @@ class ReceivedJsonMsgHandlerActor(
         routeGenericMsg[UserBroadcastCamStartMsg](envelope, jsonNode)
       case UserBroadcastCamStopMsg.NAME =>
         routeGenericMsg[UserBroadcastCamStopMsg](envelope, jsonNode)
+      case GetCamBroadcastPermissionReqMsg.NAME =>
+        routeGenericMsg[GetCamBroadcastPermissionReqMsg](envelope, jsonNode)
+      case GetCamSubscribePermissionReqMsg.NAME =>
+        routeGenericMsg[GetCamSubscribePermissionReqMsg](envelope, jsonNode)
 
       // Voice
       case RecordingStartedVoiceConfEvtMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -154,6 +154,8 @@ class ReceivedJsonMsgHandlerActor(
         routeVoiceMsg[UserStatusVoiceConfEvtMsg](envelope, jsonNode)
       case VoiceConfCallStateEvtMsg.NAME =>
         routeVoiceMsg[VoiceConfCallStateEvtMsg](envelope, jsonNode)
+      case GetGlobalAudioPermissionReqMsg.NAME =>
+        routeGenericMsg[GetGlobalAudioPermissionReqMsg](envelope, jsonNode)
 
       // Breakout rooms
       case BreakoutRoomsListMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -317,6 +317,10 @@ class ReceivedJsonMsgHandlerActor(
         routeVoiceMsg[ScreenshareStartedVoiceConfEvtMsg](envelope, jsonNode)
       case ScreenshareStoppedVoiceConfEvtMsg.NAME =>
         routeVoiceMsg[ScreenshareStoppedVoiceConfEvtMsg](envelope, jsonNode)
+      case GetScreenBroadcastPermissionReqMsg.NAME =>
+        routeGenericMsg[GetScreenBroadcastPermissionReqMsg](envelope, jsonNode)
+      case GetScreenSubscribePermissionReqMsg.NAME =>
+        routeGenericMsg[GetScreenSubscribePermissionReqMsg](envelope, jsonNode)
 
       // GroupChats
       case GetGroupChatsReqMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -74,6 +74,7 @@ class MeetingActor(
   with MuteAllExceptPresentersCmdMsgHdlr
   with MuteMeetingCmdMsgHdlr
   with IsMeetingMutedReqMsgHdlr
+  with GetGlobalAudioPermissionReqMsgHdlr
 
   with EjectUserFromVoiceCmdMsgHdlr
   with EndMeetingSysCmdMsgHdlr
@@ -405,6 +406,8 @@ class MeetingActor(
         handleCheckRunningAndRecordingVoiceConfEvtMsg(m)
       case m: UserStatusVoiceConfEvtMsg =>
         handleUserStatusVoiceConfEvtMsg(m)
+      case m: GetGlobalAudioPermissionReqMsg =>
+        handleGetGlobalAudioPermissionReqMsg(m)
 
       // Layout
       case m: GetCurrentLayoutReqMsg => handleGetCurrentLayoutReqMsg(m)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -77,6 +77,8 @@ class MeetingActor(
   with GetGlobalAudioPermissionReqMsgHdlr
   with GetScreenBroadcastPermissionReqMsgHdlr
   with GetScreenSubscribePermissionReqMsgHdlr
+  with GetCamBroadcastPermissionReqMsgHdlr
+  with GetCamSubscribePermissionReqMsgHdlr
 
   with EjectUserFromVoiceCmdMsgHdlr
   with EndMeetingSysCmdMsgHdlr
@@ -319,6 +321,9 @@ class MeetingActor(
       case m: UserLeaveReqMsg                     => state = handleUserLeaveReqMsg(m, state)
       case m: UserBroadcastCamStartMsg            => handleUserBroadcastCamStartMsg(m)
       case m: UserBroadcastCamStopMsg             => handleUserBroadcastCamStopMsg(m)
+      case m: GetCamBroadcastPermissionReqMsg     => handleGetCamBroadcastPermissionReqMsg(m)
+      case m: GetCamSubscribePermissionReqMsg     => handleGetCamSubscribePermissionReqMsg(m)
+
       case m: UserJoinedVoiceConfEvtMsg           => handleUserJoinedVoiceConfEvtMsg(m)
       case m: MeetingActivityResponseCmdMsg =>
         state = usersApp.handleMeetingActivityResponseCmdMsg(m, state)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -75,6 +75,8 @@ class MeetingActor(
   with MuteMeetingCmdMsgHdlr
   with IsMeetingMutedReqMsgHdlr
   with GetGlobalAudioPermissionReqMsgHdlr
+  with GetScreenBroadcastPermissionReqMsgHdlr
+  with GetScreenSubscribePermissionReqMsgHdlr
 
   with EjectUserFromVoiceCmdMsgHdlr
   with EndMeetingSysCmdMsgHdlr
@@ -481,6 +483,8 @@ class MeetingActor(
       case m: ScreenshareRtmpBroadcastStartedVoiceConfEvtMsg => screenshareApp2x.handle(m, liveMeeting, msgBus)
       case m: ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg => screenshareApp2x.handle(m, liveMeeting, msgBus)
       case m: GetScreenshareStatusReqMsg                     => screenshareApp2x.handle(m, liveMeeting, msgBus)
+      case m: GetScreenBroadcastPermissionReqMsg             => handleGetScreenBroadcastPermissionReqMsg(m)
+      case m: GetScreenSubscribePermissionReqMsg             => handleGetScreenSubscribePermissionReqMsg(m)
 
       // GroupChat
       case m: CreateGroupChatReqMsg =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -344,4 +344,51 @@ object MsgBuilder {
     val event = RegisteredUserJoinTimeoutMsg(header, body)
     BbbCommonEnvCoreMsg(envelope, event)
   }
+
+  def buildGetScreenSubscribePermissionRespMsg(
+      meetingId:    String,
+      voiceConf:    String,
+      userId:       String,
+      streamId:     String,
+      sfuSessionId: String,
+      allowed:      Boolean
+  ): BbbCommonEnvCoreMsg = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, meetingId, userId)
+    val envelope = BbbCoreEnvelope(GetScreenSubscribePermissionRespMsg.NAME, routing)
+    val header = BbbClientMsgHeader(GetScreenSubscribePermissionRespMsg.NAME, meetingId, userId)
+    val body = GetScreenSubscribePermissionRespMsgBody(
+      meetingId,
+      voiceConf,
+      userId,
+      streamId,
+      sfuSessionId,
+      allowed
+    )
+    val event = GetScreenSubscribePermissionRespMsg(header, body)
+
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
+
+  def buildGetScreenBroadcastPermissionRespMsg(
+      meetingId:    String,
+      voiceConf:    String,
+      userId:       String,
+      sfuSessionId: String,
+      allowed:      Boolean
+  ): BbbCommonEnvCoreMsg = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, meetingId, userId)
+    val envelope = BbbCoreEnvelope(GetScreenBroadcastPermissionRespMsg.NAME, routing)
+    val header = BbbClientMsgHeader(GetScreenBroadcastPermissionRespMsg.NAME, meetingId, userId)
+
+    val body = GetScreenBroadcastPermissionRespMsgBody(
+      meetingId,
+      voiceConf,
+      userId,
+      sfuSessionId,
+      allowed
+    )
+    val event = GetScreenBroadcastPermissionRespMsg(header, body)
+
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -434,4 +434,21 @@ object MsgBuilder {
 
     BbbCommonEnvCoreMsg(envelope, event)
   }
+
+  def buildGetGlobalAudioPermissionRespMsg(
+      meetingId:    String,
+      voiceConf:    String,
+      userId:       String,
+      sfuSessionId: String,
+      allowed:      Boolean
+  ): BbbCommonEnvCoreMsg = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, meetingId, userId)
+    val envelope = BbbCoreEnvelope(GetGlobalAudioPermissionRespMsg.NAME, routing)
+    val header = BbbClientMsgHeader(GetGlobalAudioPermissionRespMsg.NAME, meetingId, userId)
+
+    val body = GetGlobalAudioPermissionRespMsgBody(meetingId, voiceConf, userId, sfuSessionId, allowed)
+    val event = GetGlobalAudioPermissionRespMsg(header, body)
+
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -391,4 +391,47 @@ object MsgBuilder {
 
     BbbCommonEnvCoreMsg(envelope, event)
   }
+
+  def buildGetCamSubscribePermissionRespMsg(
+      meetingId:    String,
+      userId:       String,
+      streamId:     String,
+      sfuSessionId: String,
+      allowed:      Boolean
+  ): BbbCommonEnvCoreMsg = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, meetingId, userId)
+    val envelope = BbbCoreEnvelope(GetCamSubscribePermissionRespMsg.NAME, routing)
+    val header = BbbClientMsgHeader(GetCamSubscribePermissionRespMsg.NAME, meetingId, userId)
+    val body = GetCamSubscribePermissionRespMsgBody(
+      meetingId,
+      userId,
+      streamId,
+      sfuSessionId,
+      allowed
+    )
+    val event = GetCamSubscribePermissionRespMsg(header, body)
+
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
+
+  def buildGetCamBroadcastPermissionRespMsg(
+      meetingId:    String,
+      userId:       String,
+      sfuSessionId: String,
+      allowed:      Boolean
+  ): BbbCommonEnvCoreMsg = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, meetingId, userId)
+    val envelope = BbbCoreEnvelope(GetCamBroadcastPermissionRespMsg.NAME, routing)
+    val header = BbbClientMsgHeader(GetCamBroadcastPermissionRespMsg.NAME, meetingId, userId)
+
+    val body = GetCamBroadcastPermissionRespMsgBody(
+      meetingId,
+      userId,
+      sfuSessionId,
+      allowed
+    )
+    val event = GetCamBroadcastPermissionRespMsg(header, body)
+
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
 }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
@@ -106,6 +106,66 @@ case class ScreenshareStopRtmpBroadcastVoiceConfMsg(
 ) extends BbbCoreMsg
 case class ScreenshareStopRtmpBroadcastVoiceConfMsgBody(voiceConf: String, screenshareConf: String, url: String, timestamp: String)
 
+/* Sent by bbb-webrtc-sfu to ask permission for broadcasting a screen stream
+ */
+object GetScreenBroadcastPermissionReqMsg { val NAME = "GetScreenBroadcastPermissionReqMsg" }
+case class GetScreenBroadcastPermissionReqMsg(
+    header: BbbClientMsgHeader,
+    body:   GetScreenBroadcastPermissionReqMsgBody
+) extends StandardMsg
+case class GetScreenBroadcastPermissionReqMsgBody(
+    meetingId:    String,
+    voiceConf:    String,
+    userId:       String,
+    sfuSessionId: String
+)
+
+/* Sent to bbb-webrtc-sfu to grant or deny screen sharing permission
+ */
+object GetScreenBroadcastPermissionRespMsg { val NAME = "GetScreenBroadcastPermissionRespMsg" }
+case class GetScreenBroadcastPermissionRespMsg(
+    header: BbbClientMsgHeader,
+    body:   GetScreenBroadcastPermissionRespMsgBody
+) extends StandardMsg
+case class GetScreenBroadcastPermissionRespMsgBody(
+    meetingId:    String,
+    voiceConf:    String,
+    userId:       String,
+    sfuSessionId: String,
+    allowed:      Boolean
+)
+
+/* Sent by bbb-webrtc-sfu to ask permission for subscring to a broadcasted
+ * screen stream
+ */
+object GetScreenSubscribePermissionReqMsg { val NAME = "GetScreenSubscribePermissionReqMsg" }
+case class GetScreenSubscribePermissionReqMsg(
+    header: BbbClientMsgHeader,
+    body:   GetScreenSubscribePermissionReqMsgBody
+) extends StandardMsg
+case class GetScreenSubscribePermissionReqMsgBody(
+    meetingId:    String,
+    voiceConf:    String,
+    userId:       String,
+    streamId:     String,
+    sfuSessionId: String
+)
+
+/* Sent to bbb-webrtc-sfu to grant or deny a screen sharing subscribe request
+ */
+object GetScreenSubscribePermissionRespMsg { val NAME = "GetScreenSubscribePermissionRespMsg" }
+case class GetScreenSubscribePermissionRespMsg(
+    header: BbbClientMsgHeader,
+    body:   GetScreenSubscribePermissionRespMsgBody
+) extends StandardMsg
+case class GetScreenSubscribePermissionRespMsgBody(
+    meetingId:    String,
+    voiceConf:    String,
+    userId:       String,
+    streamId:     String,
+    sfuSessionId: String,
+    allowed:      Boolean
+)
 /**
  * Sent to FS to eject all users from the voice conference.
  */

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
@@ -470,3 +470,31 @@ case class VoiceCallStateEvtMsgBody(
     callerName:    String,
     callState:     String
 )
+
+/* Sent by bbb-webrtc-sfu to ask permission for adding a listener to the global
+ * audio bridge
+ */
+object GetGlobalAudioPermissionReqMsg { val NAME = "GetGlobalAudioPermissionReqMsg" }
+case class GetGlobalAudioPermissionReqMsg(
+    header: BbbClientMsgHeader,
+    body:   GetGlobalAudioPermissionReqMsgBody
+) extends StandardMsg
+case class GetGlobalAudioPermissionReqMsgBody(
+    meetingId:    String,
+    voiceConf:    String,
+    userId:       String,
+    sfuSessionId: String
+)
+
+object GetGlobalAudioPermissionRespMsg { val NAME = "GetGlobalAudioPermissionRespMsg" }
+case class GetGlobalAudioPermissionRespMsg(
+    header: BbbClientMsgHeader,
+    body:   GetGlobalAudioPermissionRespMsgBody
+) extends StandardMsg
+case class GetGlobalAudioPermissionRespMsgBody(
+    meetingId:    String,
+    voiceConf:    String,
+    userId:       String,
+    sfuSessionId: String,
+    allowed:      Boolean
+)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WebcamsMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WebcamsMsgs.scala
@@ -50,3 +50,59 @@ case class GetWebcamStreamsRespMsg(header: BbbClientMsgHeader, body: GetWebcamSt
 
 case class GetWebcamStreamsRespMsgBody(webcamStreams: Vector[String])
 
+/* Sent by bbb-webrtc-sfu to ask permission for broadcasting a webcam
+ */
+object GetCamBroadcastPermissionReqMsg { val NAME = "GetCamBroadcastPermissionReqMsg" }
+case class GetCamBroadcastPermissionReqMsg(
+    header: BbbClientMsgHeader,
+    body:   GetCamBroadcastPermissionReqMsgBody
+) extends StandardMsg
+case class GetCamBroadcastPermissionReqMsgBody(
+    meetingId:    String,
+    userId:       String,
+    sfuSessionId: String
+)
+
+/* Sent to bbb-webrtc-sfu to grant or deny webcam broadcasting permission
+ */
+object GetCamBroadcastPermissionRespMsg { val NAME = "GetCamBroadcastPermissionRespMsg" }
+case class GetCamBroadcastPermissionRespMsg(
+    header: BbbClientMsgHeader,
+    body:   GetCamBroadcastPermissionRespMsgBody
+) extends StandardMsg
+case class GetCamBroadcastPermissionRespMsgBody(
+    meetingId:    String,
+    userId:       String,
+    sfuSessionId: String,
+    allowed:      Boolean
+)
+
+/* Sent by bbb-webrtc-sfu to ask permission for subscring to a broadcasted
+ * webcam stream
+ */
+object GetCamSubscribePermissionReqMsg { val NAME = "GetCamSubscribePermissionReqMsg" }
+case class GetCamSubscribePermissionReqMsg(
+    header: BbbClientMsgHeader,
+    body:   GetCamSubscribePermissionReqMsgBody
+) extends StandardMsg
+case class GetCamSubscribePermissionReqMsgBody(
+    meetingId:    String,
+    userId:       String,
+    streamId:     String,
+    sfuSessionId: String
+)
+
+/* Sent to bbb-webrtc-sfu to grant or deny a webcam request
+ */
+object GetCamSubscribePermissionRespMsg { val NAME = "GetCamSubscribePermissionRespMsg" }
+case class GetCamSubscribePermissionRespMsg(
+    header: BbbClientMsgHeader,
+    body:   GetCamSubscribePermissionRespMsgBody
+) extends StandardMsg
+case class GetCamSubscribePermissionRespMsgBody(
+    meetingId:    String,
+    userId:       String,
+    streamId:     String,
+    sfuSessionId: String,
+    allowed:      Boolean
+)


### PR DESCRIPTION
### What does this PR do?
  - Add RPCs to be traded **internally** between `akka-apps` and `bbb-webrtc-sfu` to add better permission checks for **video, listen only and screen sharing**
  - All responses give or deny auth through the `allowed` property (bool). When false, SFU rejects requests with error `{ code: 2301, message: SFU_UNAUTHORIZED }`
  - List of implement probes:
    * GetGlobalAudioPermissionReqMsg/RespMsg, 
    * GetCamBroadcastPermissionReqMsg/RespMsg, 
    * GetCamSubscribePermissionReqMsg/RespMsg, 
    * GetScreenBroadcastPermissionReqMsg/RespMsg, 
    * GetScreenSubscribePermissionReqMsg/RespMsg

Needs https://github.com/bigbluebutton/bbb-webrtc-sfu/pull/79 to have any effect.
