### PR TITLE
Fix padId getter

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ParamsUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ParamsUtil.java
@@ -60,7 +60,8 @@ public class ParamsUtil {
       // If there is no query params, it's an invalid URL already
       if (splitURL.length == 2) {
         String[] params = splitURL[0].split("\\/");
-        padId = params[params.length - 1];
+        // /p/pad/<padId>
+        if (params.length >= 4) padId = params[3];
       }
     } catch (UnsupportedEncodingException e) {
       log.error(e.toString());


### PR DESCRIPTION
Pad exporter uses this same location to serve pad's downloaded content
but the the match was failing because padId is not the last element
of the URL on that scenario.

Pattern follows `/pad/p/<padID>[/export/(format)]?<query>`.

Closes #11545