### PR TITLE
Fix clear chat for single message

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
@@ -118,6 +118,12 @@ class TimeWindowList extends PureComponent {
         userScrolledBack: false,
       }, ()=> setUserSentMessage(false));
     }
+
+    // this condition exist to the case where the chat has a single message and the chat is cleared
+    // The component List from react-virtualized doesn't have a reference to the list of messages so I need force the update to fix it
+    if ((timeWindowsValues !== prevTimeWindowsValues) && timeWindowsValues.length === prevTimeWindowsValues.length) {
+      this.listRef.forceUpdateGrid();
+    }
   }
 
   componentWillUnmount() {

--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
@@ -121,7 +121,7 @@ class TimeWindowList extends PureComponent {
 
     // this condition exist to the case where the chat has a single message and the chat is cleared
     // The component List from react-virtualized doesn't have a reference to the list of messages so I need force the update to fix it
-    if ((timeWindowsValues !== prevTimeWindowsValues) && timeWindowsValues.length === prevTimeWindowsValues.length) {
+    if (lastTimeWindow.id === 'SYSTEM_MESSAGE-PUBLIC_CHAT_CLEAR') {
       this.listRef.forceUpdateGrid();
     }
   }

--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
@@ -121,7 +121,7 @@ class TimeWindowList extends PureComponent {
 
     // this condition exist to the case where the chat has a single message and the chat is cleared
     // The component List from react-virtualized doesn't have a reference to the list of messages so I need force the update to fix it
-    if (lastTimeWindow.id === 'SYSTEM_MESSAGE-PUBLIC_CHAT_CLEAR') {
+    if (lastTimeWindow?.id === 'SYSTEM_MESSAGE-PUBLIC_CHAT_CLEAR') {
       this.listRef.forceUpdateGrid();
     }
   }


### PR DESCRIPTION
### What does this PR do?

This PR fix the clear for single message, the "issue" is on react-virtualized, the List component doesn't have reference to the list only to the list's size so when a chat with single message is cleared the size keeps the same, in that case I force the list to re-render.  

### Closes Issue(s)
closes #11530 

