### PR TITLE
Quick poll improvements

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages } from 'react-intl';
 import _ from 'lodash';
-import { makeCall } from '/imports/ui/services/api';
 import Button from '/imports/ui/components/button/component';
 import Dropdown from '/imports/ui/components/dropdown/component';
 import DropdownTrigger from '/imports/ui/components/dropdown/trigger/component';
@@ -44,16 +43,7 @@ const propTypes = {
   amIPresenter: PropTypes.bool.isRequired,
 };
 
-const handleClickQuickPoll = (slideId, poll) => {
-  const { type } = poll;
-  Session.set('openPanel', 'poll');
-  Session.set('forcePollOpen', true);
-  Session.set('pollInitiated', true);
-
-  makeCall('startPoll', type, slideId);
-};
-
-const getAvailableQuickPolls = (slideId, parsedSlides) => {
+const getAvailableQuickPolls = (slideId, parsedSlides, startPoll) => {
   const pollItemElements = parsedSlides.map((poll) => {
     const { poll: label, type } = poll;
     let itemLabel = label;
@@ -78,7 +68,7 @@ const getAvailableQuickPolls = (slideId, parsedSlides) => {
       <DropdownListItem
         label={itemLabel}
         key={_.uniqueId('quick-poll-item')}
-        onClick={() => handleClickQuickPoll(slideId, poll)}
+        onClick={() => startPoll(type, slideId)}
       />
     );
   });
@@ -113,7 +103,7 @@ class QuickPollDropdown extends Component {
     );
 
     const { slideId, quickPollOptions } = parsedSlide;
-    const quickPolls = getAvailableQuickPolls(slideId, quickPollOptions);
+    const quickPolls = getAvailableQuickPolls(slideId, quickPollOptions, startPoll);
 
     if (quickPollOptions.length === 0) return null;
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -85,16 +85,15 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
   let optionsPoll = content.match(pollRegex) || [];
   if (optionsPoll) optionsPoll = optionsPoll.map(opt => `\r${opt[0]}.`);
 
-  const excludePatt = '[^.)]';
-  const ynPollString = `(${excludePatt}${yesValue}\\s*\\/\\s*${noValue})|(${excludePatt}${noValue}\\s*\\/\\s*${yesValue})`;
+  const ynPollString = `(${yesValue}\\s*\\/\\s*${noValue})|(${noValue}\\s*\\/\\s*${yesValue})`;
   const ynOptionsRegex = new RegExp(ynPollString, 'gi');
   const ynPoll = content.match(ynOptionsRegex) || [];
 
-  const ynaPollString = `(${excludePatt}${yesValue}\\s*\\/\\s*${noValue}\\s*\\/\\s*${abstentionValue})|(${excludePatt}${yesValue}\\s*\\/\\s*${abstentionValue}\\s*\\/\\s*${noValue})|(${excludePatt}${abstentionValue}\\s*\\/\\s*${yesValue}\\s*\\/\\s*${noValue})|(${excludePatt}${abstentionValue}\\s*\\/\\s*${noValue}\\s*\\/\\s*${yesValue})|(${excludePatt}${noValue}\\s*\\/\\s*${yesValue}\\s*\\/\\s*${abstentionValue})|(${excludePatt}${noValue}\\s*\\/\\s*${abstentionValue}\\s*\\/\\s*${yesValue})`;
+  const ynaPollString = `(${yesValue}\\s*\\/\\s*${noValue}\\s*\\/\\s*${abstentionValue})|(${yesValue}\\s*\\/\\s*${abstentionValue}\\s*\\/\\s*${noValue})|(${abstentionValue}\\s*\\/\\s*${yesValue}\\s*\\/\\s*${noValue})|(${abstentionValue}\\s*\\/\\s*${noValue}\\s*\\/\\s*${yesValue})|(${noValue}\\s*\\/\\s*${yesValue}\\s*\\/\\s*${abstentionValue})|(${noValue}\\s*\\/\\s*${abstentionValue}\\s*\\/\\s*${yesValue})`;
   const ynaOptionsRegex = new RegExp(ynaPollString, 'gi');
   const ynaPoll = content.match(ynaOptionsRegex) || [];
 
-  const tfPollString = `(${excludePatt}${trueValue}\\s*\\/\\s*${falseValue})|(${excludePatt}${falseValue}\\s*\\/\\s*${trueValue})`;
+  const tfPollString = `(${trueValue}\\s*\\/\\s*${falseValue})|(${falseValue}\\s*\\/\\s*${trueValue})`;
   const tgOptionsRegex = new RegExp(tfPollString, 'gi');
   const tfPoll = content.match(tgOptionsRegex) || [];
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -77,25 +77,13 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
   const quickPollOptions = [];
   if (!currentSlide) return quickPollOptions;
 
-  const {
+  let {
     content,
   } = currentSlide;
 
   const pollRegex = /[1-6A-Fa-f][.)].*/g;
   let optionsPoll = content.match(pollRegex) || [];
   if (optionsPoll) optionsPoll = optionsPoll.map(opt => `\r${opt[0]}.`);
-
-  const ynPollString = `(${yesValue}\\s*\\/\\s*${noValue})|(${noValue}\\s*\\/\\s*${yesValue})`;
-  const ynOptionsRegex = new RegExp(ynPollString, 'gi');
-  const ynPoll = content.match(ynOptionsRegex) || [];
-
-  const ynaPollString = `(${yesValue}\\s*\\/\\s*${noValue}\\s*\\/\\s*${abstentionValue})|(${yesValue}\\s*\\/\\s*${abstentionValue}\\s*\\/\\s*${noValue})|(${abstentionValue}\\s*\\/\\s*${yesValue}\\s*\\/\\s*${noValue})|(${abstentionValue}\\s*\\/\\s*${noValue}\\s*\\/\\s*${yesValue})|(${noValue}\\s*\\/\\s*${yesValue}\\s*\\/\\s*${abstentionValue})|(${noValue}\\s*\\/\\s*${abstentionValue}\\s*\\/\\s*${yesValue})`;
-  const ynaOptionsRegex = new RegExp(ynaPollString, 'gi');
-  const ynaPoll = content.match(ynaOptionsRegex) || [];
-
-  const tfPollString = `(${trueValue}\\s*\\/\\s*${falseValue})|(${falseValue}\\s*\\/\\s*${trueValue})`;
-  const tgOptionsRegex = new RegExp(tfPollString, 'gi');
-  const tfPoll = content.match(tgOptionsRegex) || [];
 
   optionsPoll.reduce((acc, currentValue) => {
     const lastElement = acc[acc.length - 1];
@@ -136,6 +124,22 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
     type: `A-${poll.options.length}`,
     poll,
   }));
+
+  if (quickPollOptions.length > 0) {
+    content = content.replace(new RegExp(pollRegex), '');
+  }
+
+  const ynPollString = `(${yesValue}\\s*\\/\\s*${noValue})|(${noValue}\\s*\\/\\s*${yesValue})`;
+  const ynOptionsRegex = new RegExp(ynPollString, 'gi');
+  const ynPoll = content.match(ynOptionsRegex) || [];
+
+  const ynaPollString = `(${yesValue}\\s*\\/\\s*${noValue}\\s*\\/\\s*${abstentionValue})|(${yesValue}\\s*\\/\\s*${abstentionValue}\\s*\\/\\s*${noValue})|(${abstentionValue}\\s*\\/\\s*${yesValue}\\s*\\/\\s*${noValue})|(${abstentionValue}\\s*\\/\\s*${noValue}\\s*\\/\\s*${yesValue})|(${noValue}\\s*\\/\\s*${yesValue}\\s*\\/\\s*${abstentionValue})|(${noValue}\\s*\\/\\s*${abstentionValue}\\s*\\/\\s*${yesValue})`;
+  const ynaOptionsRegex = new RegExp(ynaPollString, 'gi');
+  const ynaPoll = content.match(ynaOptionsRegex) || [];
+
+  const tfPollString = `(${trueValue}\\s*\\/\\s*${falseValue})|(${falseValue}\\s*\\/\\s*${trueValue})`;
+  const tgOptionsRegex = new RegExp(tfPollString, 'gi');
+  const tfPoll = content.match(tgOptionsRegex) || [];
 
   ynPoll.forEach(poll => quickPollOptions.push({
     type: 'YN',


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where a slide with `(True/False)` would auto-generate a quick polling with the wrong label

#### Current behavior
![Screenshot from 2021-03-03 14-37-10](https://user-images.githubusercontent.com/3728706/109997002-83c94b00-7cee-11eb-9d7c-fceacf397db0.png)

Changes quick poll `onClick` event when there's more than one option available to match single option behavior

#### Current behavior: if there's more than one option to click, it won't auto-start a poll
![current-quick-poll](https://user-images.githubusercontent.com/3728706/109997681-34cfe580-7cef-11eb-8511-97a579e12bce.gif)

#### New behavior: auto-start poll when the user clicks on one option of the list
![new-quick-poll](https://user-images.githubusercontent.com/3728706/109997709-3d282080-7cef-11eb-8e3c-b82a081289fc.gif)

Slides used for testing: 
[quick-poll-slides.pdf](https://github.com/bigbluebutton/bigbluebutton/files/6085723/quick-poll-slides.pdf)

