### PR TITLE
Backport audio improvements from 2.3

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -591,7 +591,7 @@ class SIPSession {
       );
 
       if (this.inputDeviceId) {
-        matchConstraints.deviceId = { exact: this.inputDeviceId };
+        matchConstraints.deviceId = this.inputDeviceId;
       }
 
       const inviterOptions = {

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/container.jsx
@@ -54,16 +54,23 @@ const {
   joinListenOnly,
 } = Service;
 
-export default lockContextContainer(withModalMounter(withTracker(({ mountModal, userLocks }) => ({
-  processToggleMuteFromOutside: arg => processToggleMuteFromOutside(arg),
-  showMute: isConnected() && !isListenOnly() && !isEchoTest() && !userLocks.userMic,
-  muted: isConnected() && !isListenOnly() && isMuted(),
-  inAudio: isConnected() && !isEchoTest(),
-  listenOnly: isConnected() && isListenOnly(),
-  disable: isConnecting() || isHangingUp() || !Meteor.status().connected,
-  talking: isTalking() && !isMuted(),
-  isVoiceUser: isVoiceUser(),
-  handleToggleMuteMicrophone: () => toggleMuteMicrophone(),
-  handleJoinAudio: () => (isConnected() ? joinListenOnly() : mountModal(<AudioModalContainer />)),
-  handleLeaveAudio,
-}))(AudioControlsContainer)));
+export default lockContextContainer(withModalMounter(withTracker(({ mountModal, userLocks }) => {
+  if (Service.isReturningFromBreakoutAudioTransfer()) {
+    Service.setReturningFromBreakoutAudioTransfer(false);
+    Service.recoverMicState();
+  }
+
+  return ({
+    processToggleMuteFromOutside: arg => processToggleMuteFromOutside(arg),
+    showMute: isConnected() && !isListenOnly() && !isEchoTest() && !userLocks.userMic,
+    muted: isConnected() && !isListenOnly() && isMuted(),
+    inAudio: isConnected() && !isEchoTest(),
+    listenOnly: isConnected() && isListenOnly(),
+    disable: isConnecting() || isHangingUp() || !Meteor.status().connected,
+    talking: isTalking() && !isMuted(),
+    isVoiceUser: isVoiceUser(),
+    handleToggleMuteMicrophone: () => toggleMuteMicrophone(),
+    handleJoinAudio: () => (isConnected() ? joinListenOnly() : mountModal(<AudioModalContainer />)),
+    handleLeaveAudio,
+  })
+})(AudioControlsContainer)));

--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -124,4 +124,10 @@ export default {
   playAlertSound: url => AudioManager.playAlertSound(url),
   updateAudioConstraints:
     constraints => AudioManager.updateAudioConstraints(constraints),
+  recoverMicState,
+  setReturningFromBreakoutAudioTransfer: (value) => {
+    AudioManager.returningFromBreakoutAudioTransfer = value;
+  },
+  isReturningFromBreakoutAudioTransfer:
+    () => AudioManager.returningFromBreakoutAudioTransfer,
 };

--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -33,7 +33,7 @@ const audioEventHandler = (event) => {
 
   switch (event.name) {
     case 'started':
-      recoverMicState();
+      if (!event.isListenOnly) recoverMicState();
       break;
     default:
       break;

--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -130,4 +130,5 @@ export default {
   },
   isReturningFromBreakoutAudioTransfer:
     () => AudioManager.returningFromBreakoutAudioTransfer,
+  isReconnecting: () => AudioManager.isReconnecting,
 };

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
@@ -162,6 +162,7 @@ class BreakoutRoom extends PureComponent {
       intl,
       isUserInBreakoutRoom,
       exitAudio,
+      setReturningFromBreakoutAudioTransfer,
     } = this.props;
 
     const {
@@ -175,6 +176,7 @@ class BreakoutRoom extends PureComponent {
     const disable = waiting && requestedBreakoutId !== breakoutId;
     const audioAction = joinedAudioOnly
       ? () => {
+        setReturningFromBreakoutAudioTransfer(true);
         this.returnBackToMeeeting(breakoutId);
         return logger.debug({
           logCode: 'breakoutroom_return_main_audio',

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
@@ -101,11 +101,14 @@ class BreakoutRoom extends PureComponent {
       breakoutRoomUser,
       breakoutRooms,
       closeBreakoutPanel,
+      isMicrophoneUser,
+      isReconnecting,
     } = this.props;
 
     const {
       waiting,
       requestedBreakoutId,
+      joinedAudioOnly,
     } = this.state;
 
     if (breakoutRooms.length <= 0) closeBreakoutPanel();
@@ -118,6 +121,10 @@ class BreakoutRoom extends PureComponent {
         window.open(breakoutUser.redirectToHtml5JoinURL, '_blank');
         _.delay(() => this.setState({ waiting: false }), 1000);
       }
+    }
+
+    if (joinedAudioOnly && (!isMicrophoneUser || isReconnecting)) {
+      this.clearJoinedAudioOnly();
     }
   }
 
@@ -141,6 +148,10 @@ class BreakoutRoom extends PureComponent {
       this.setState({ waiting: false });
     }
     return null;
+  }
+
+  clearJoinedAudioOnly() {
+    this.setState({ joinedAudioOnly: false });
   }
 
   transferUserToBreakoutRoom(breakoutId) {

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/container.jsx
@@ -25,6 +25,7 @@ export default withTracker((props) => {
   const breakoutRooms = findBreakouts();
   const isMicrophoneUser = AudioService.isConnected() && !AudioService.isListenOnly();
   const isMeteorConnected = Meteor.status().connected;
+  const isReconnecting = AudioService.isReconnecting();
   const { setReturningFromBreakoutAudioTransfer } = AudioService;
 
   return {
@@ -43,5 +44,6 @@ export default withTracker((props) => {
     isUserInBreakoutRoom,
     exitAudio: () => AudioManager.exitAudio(),
     setReturningFromBreakoutAudioTransfer,
+    isReconnecting,
   };
 })(BreakoutContainer);

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/container.jsx
@@ -25,6 +25,7 @@ export default withTracker((props) => {
   const breakoutRooms = findBreakouts();
   const isMicrophoneUser = AudioService.isConnected() && !AudioService.isListenOnly();
   const isMeteorConnected = Meteor.status().connected;
+  const { setReturningFromBreakoutAudioTransfer } = AudioService;
 
   return {
     ...props,
@@ -41,5 +42,6 @@ export default withTracker((props) => {
     isMeteorConnected,
     isUserInBreakoutRoom,
     exitAudio: () => AudioManager.exitAudio(),
+    setReturningFromBreakoutAudioTransfer,
   };
 })(BreakoutContainer);

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -52,6 +52,7 @@ class AudioManager {
       outputDeviceId: null,
       muteHandle: null,
       autoplayBlocked: false,
+      isReconnecting: false,
     });
 
     this.useKurento = Meteor.settings.public.kurento.enableListenOnly;
@@ -393,12 +394,15 @@ class AudioManager {
       } = response;
 
       if (status === STARTED) {
+        this.isReconnecting = false;
         this.onAudioJoin();
         resolve(STARTED);
       } else if (status === ENDED) {
+        this.isReconnecting = false;
         logger.info({ logCode: 'audio_ended' }, 'Audio ended without issue');
         this.onAudioExit();
       } else if (status === FAILED) {
+        this.isReconnecting = false;
         const errorKey = this.messages.error[error] || this.messages.error.GENERIC_ERROR;
         const errorMsg = this.intl.formatMessage(errorKey, { 0: bridgeError });
         this.error = !!error;
@@ -416,10 +420,12 @@ class AudioManager {
           this.onAudioExit();
         }
       } else if (status === RECONNECTING) {
+        this.isReconnecting = true;
         logger.info({ logCode: 'audio_reconnecting' }, 'Attempting to reconnect audio');
         this.notify(this.intl.formatMessage(this.messages.info.RECONNECTING_AUDIO), true);
         this.playHangUpSound();
       } else if (status === AUTOPLAY_BLOCKED) {
+        this.isReconnecting = false;
         this.autoplayBlocked = true;
         this.onAudioJoin();
         resolve(AUTOPLAY_BLOCKED);

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -37,6 +37,8 @@ class AudioManager {
       tracker: new Tracker.Dependency(),
     };
 
+    this._returningFromBreakoutAudioTransfer = false;
+
     this.defineProperties({
       isMuted: false,
       isConnected: false,
@@ -521,6 +523,14 @@ class AudioManager {
   get inputDeviceId() {
     return (this.bridge && this.bridge.inputDeviceId)
       ? this.bridge.inputDeviceId : DEFAULT_INPUT_DEVICE_ID;
+  }
+
+  get returningFromBreakoutAudioTransfer() {
+    return this._returningFromBreakoutAudioTransfer;
+  }
+
+  set returningFromBreakoutAudioTransfer(value) {
+    this._returningFromBreakoutAudioTransfer = value;
   }
 
   set userData(value) {

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -341,7 +341,10 @@ class AudioManager {
       window.parent.postMessage({ response: 'joinedAudio' }, '*');
       this.notify(this.intl.formatMessage(this.messages.info.JOINED_AUDIO));
       logger.info({ logCode: 'audio_joined' }, 'Audio Joined');
-      this.audioEventHandler({ name: 'started' });
+      this.audioEventHandler({
+        name: 'started',
+        isListenOnly: this.isListenOnly,
+      });
       if (ENABLE_NETWORK_MONITORING) this.monitor();
     }
   }


### PR DESCRIPTION
Latest audio improvements already merged in 2.3. Here's the list:

- Mute state when returning from breakout audio: https://github.com/bigbluebutton/bigbluebutton/pull/11505
- "Confusion" on mute/mic state when leaving audio with breakout transfer active: https://github.com/bigbluebutton/bigbluebutton/pull/11515
- Avoid trying to recover mic state when using listen only mode: https://github.com/bigbluebutton/bigbluebutton/pull/11516
- Avoid setting unknown input device id: https://github.com/bigbluebutton/bigbluebutton/pull/11520/commits/de05622d19a574817f0989b42759fa159d33a033