### PR TITLE
Changes on end meeting message

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/component.jsx
@@ -40,6 +40,8 @@ class EndMeetingComponent extends React.PureComponent {
       users, intl, closeModal, endMeeting, meetingTitle,
     } = this.props;
 
+    const message = intl.formatMessage(intlMessages.endMeetingDescription, { 0: users }).split('.');
+
     return (
       <Modal
         overlayClassName={styles.overlay}
@@ -50,7 +52,7 @@ class EndMeetingComponent extends React.PureComponent {
       >
         <div className={styles.container}>
           <div className={styles.description}>
-            {intl.formatMessage(intlMessages.endMeetingDescription, { 0: users })}
+            {users > 0 ? message.join('.') : message[1]}
           </div>
           <div className={styles.footer}>
             <Button

--- a/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/component.jsx
@@ -12,6 +12,10 @@ const intlMessages = defineMessages({
   },
   endMeetingDescription: {
     id: 'app.endMeeting.description',
+    description: 'end meeting description with affected users information',
+  },
+  endMeetingNoUserDescription: {
+    id: 'app.endMeeting.noUserDescription',
     description: 'end meeting description',
   },
   yesLabel: {
@@ -40,8 +44,6 @@ class EndMeetingComponent extends React.PureComponent {
       users, intl, closeModal, endMeeting, meetingTitle,
     } = this.props;
 
-    const message = intl.formatMessage(intlMessages.endMeetingDescription, { 0: users }).split('.');
-
     return (
       <Modal
         overlayClassName={styles.overlay}
@@ -52,7 +54,10 @@ class EndMeetingComponent extends React.PureComponent {
       >
         <div className={styles.container}>
           <div className={styles.description}>
-            {users > 0 ? message.join('.') : message[1]}
+            {users > 0
+              ? intl.formatMessage(intlMessages.endMeetingDescription, { 0: users })
+              : intl.formatMessage(intlMessages.endMeetingNoUserDescription)
+            }
           </div>
           <div className={styles.footer}>
             <Button

--- a/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/service.js
@@ -13,6 +13,7 @@ const getMeetingTitle = () => {
 const getUsers = () => {
   const numUsers = Users.find({
     meetingId: Auth.meetingID,
+    userId: { $ne: Auth.userID },
   }, { fields: { _id: 1 } }).count();
 
   return numUsers;

--- a/bigbluebutton-html5/private/locales/en.json
+++ b/bigbluebutton-html5/private/locales/en.json
@@ -303,6 +303,7 @@
     "app.leaveConfirmation.confirmDesc": "Logs you out of the meeting",
     "app.endMeeting.title": "End {0}",
     "app.endMeeting.description": "This action will end the session for {0} active user(s). Are you sure you want to end this session?",
+    "app.endMeeting.noUserDescription": "Are you sure you want to end this session?",
     "app.endMeeting.yesLabel": "Yes",
     "app.endMeeting.noLabel": "No",
     "app.about.title": "About",


### PR DESCRIPTION
### What does this PR do?

- Do not display `This action will end the session for X active user(s).` part of the `endMeetingDescription` message if no other participants are active.
- Changes active users counting so it ignores current user


### Closes Issue(s)

closes #11585