### PR TITLE
Fixes presentation invisible box appearing if presentation is hidden

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/media/webcam-draggable-overlay/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/webcam-draggable-overlay/component.jsx
@@ -489,6 +489,7 @@ class WebcamDraggable extends PureComponent {
             style={{
               marginLeft: 0,
               marginRight: 0,
+              zIndex: 2,
               display: hideWebcams ? 'none' : undefined,
             }}
           >


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where an invisible box would appear in front of the cameras if presentation is hidden, preventing the user from clicking on the video dropdown.

![Screenshot from 2021-03-09 16-46-00](https://user-images.githubusercontent.com/3728706/110528496-fa06ec80-80f6-11eb-8c26-80fcb85e5d00.png)
