### PR TITLE
Update fsesl password on package installation

### DIFF
--- a/akka-bbb-fsesl/build.sbt
+++ b/akka-bbb-fsesl/build.sbt
@@ -79,4 +79,4 @@ daemonGroup in Linux := group
 
 javaOptions in Universal ++= Seq("-J-Xms130m", "-J-Xmx256m", "-Dconfig.file=/etc/bigbluebutton/bbb-fsesl-akka.conf", "-Dlogback.configurationFile=conf/logback.xml")
 
-debianPackageDependencies in Debian ++= Seq("java8-runtime-headless", "bash")
+debianPackageDependencies in Debian ++= Seq("java8-runtime-headless", "bash", "bbb-freeswitch-core")

--- a/akka-bbb-fsesl/src/debian/DEBIAN/postinst
+++ b/akka-bbb-fsesl/src/debian/DEBIAN/postinst
@@ -6,5 +6,5 @@
 ESL_PASSWORD=$(xmlstarlet sel -t -m 'configuration/settings/param[@name="password"]' -v @value /opt/freeswitch/etc/freeswitch/autoload_configs/event_socket.conf.xml)
 
 if [ -n "$ESL_PASSWORD" ]; then
-    sed -i "s/ClueCon/$ESL_PASSWORD/g" /usr/share/bbb-fsesl-akka/conf/application.conf
+    sed -i "s/ClueCon/$ESL_PASSWORD/g" /etc/bigbluebutton/bbb-fsesl-akka.conf
 fi

--- a/akka-bbb-fsesl/src/debian/DEBIAN/postinst
+++ b/akka-bbb-fsesl/src/debian/DEBIAN/postinst
@@ -1,0 +1,10 @@
+#
+# Update ESL password to match the password from bbb-freeswitch-core, which is
+# listed as a package dependency to ensure that it configures first.
+#
+
+ESL_PASSWORD=$(xmlstarlet sel -t -m 'configuration/settings/param[@name="password"]' -v @value /opt/freeswitch/etc/freeswitch/autoload_configs/event_socket.conf.xml)
+
+if [ -n "$ESL_PASSWORD" ]; then
+    sed -i "s/ClueCon/$ESL_PASSWORD/g" /usr/share/bbb-fsesl-akka/conf/application.conf
+fi


### PR DESCRIPTION
This PR adds a post-install script to akka-bbb-fsesl that pulls the esl password from event_socket.conf.xml and installs it in the proper place in /etc/bigbluebutton/bbb-fsesl-akka.conf.

It also adds a dependency, to make akka-bbb-fsesl depend on bbb-freeswitch-core.  Not only does this make sense, but it ensures that bbb-freeswitch-core will get configured first, and its post-install script currently copies the esl password from an older event_socket.conf.xml into the new one (on an update).  So, configuring in this order makes everything upgrade properly.

