### PR TITLE
Fixes incomplete session data error caused by PR #11529

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager.jsx
@@ -307,11 +307,11 @@ class LayoutManager extends Component {
     let storageBreakoutRoomWidth;
 
     if (storageLData) {
-      storageUserListWidth = storageLData.userListSize.width;
-      storageChatWidth = storageLData.chatSize.width;
-      storagePollWidth = storageLData.pollSize.width;
-      storageNoteWidth = storageLData.noteSize.width;
-      storageBreakoutRoomWidth = storageLData.breakoutRoomSize.width;
+      storageUserListWidth = storageLData.userListSize?.width;
+      storageChatWidth = storageLData.chatSize?.width;
+      storagePollWidth = storageLData.pollSize?.width;
+      storageNoteWidth = storageLData.noteSize?.width;
+      storageBreakoutRoomWidth = storageLData.breakoutRoomSize?.width;
     }
 
     let newUserListSize;


### PR DESCRIPTION
### What does this PR do?

User may have incomplete session layout data if PR #11529 is applied, causing the error `Cannot read property 'width' of undefined`. 

This PR fixes it by checking if all required information is present.

![Screenshot from 2021-03-10 09-18-04](https://user-images.githubusercontent.com/3728706/110628153-8bbb3c00-8181-11eb-9854-5cbfa9ad565d.png)

