### PR TITLE
don't prompt for "Microphone" if that's the only option presented to the user

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -161,11 +161,13 @@ class AudioModal extends Component {
   componentDidMount() {
     const {
       forceListenOnlyAttendee,
+      joinFullAudioImmediately,
+      listenOnlyMode,
       audioLocked,
     } = this.props;
 
     if (forceListenOnlyAttendee) return this.handleJoinListenOnly();
-    if (audioLocked) return this.handleJoinMicrophone();
+    if ((joinFullAudioImmediately && !listenOnlyMode) || audioLocked) return this.handleJoinMicrophone();
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
The recent work on the echo test, especially b01246, created a visible change in my user experience.

I typically set autoJoin=true, listenOnlyMode=false, and skipCheck=true.  This causes my users to connect in to the conference with no modal dialog, just a "Connecting..." box that appears and then vanishes once the audio connection is established.

After b01246, they now get a modal dialog with a single option: "Microphone".

The current PR ensures that in this case, the dialog box is not presented at all and the user connects as before.

I was thinking about making a table of all the different audio join options and how the system is expected to respond in each case, but I decided to keep the PR short and simple.