### PR TITLE
video-provider: add inbound/recvonly video reconnection (was #11233)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/media/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/component.jsx
@@ -45,6 +45,7 @@ export default class Media extends Component {
       audioModalIsOpen,
       usersVideo,
       layoutContextState,
+      isMeteorConnected,
     } = this.props;
 
     const { webcamsPlacement: placement } = layoutContextState;
@@ -67,7 +68,7 @@ export default class Media extends Component {
       [styles.containerH]: webcamsPlacement === 'left' || webcamsPlacement === 'right',
     });
     const { viewParticipantsWebcams } = Settings.dataSaving;
-    const showVideo = usersVideo.length > 0 && viewParticipantsWebcams;
+    const showVideo = usersVideo.length > 0 && viewParticipantsWebcams && isMeteorConnected;
     const fullHeight = !showVideo || (webcamsPlacement === 'floating');
 
     return (

--- a/bigbluebutton-html5/imports/ui/components/media/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/container.jsx
@@ -115,6 +115,7 @@ export default withLayoutConsumer(withModalMounter(withTracker(() => {
   const data = {
     children: <DefaultContent {...{ autoSwapLayout, hidePresentation }} />,
     audioModalIsOpen: Session.get('audioModalIsOpen'),
+    isMeteorConnected: Meteor.status().connected,
   };
 
   if (MediaService.shouldShowWhiteboard() && !hidePresentation) {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -635,11 +635,10 @@ class VideoProvider extends Component {
       return;
     }
 
-    const errorMessage = intlClientErrors[error.name]
-      || intlSFUErrors[error] || intlClientErrors.permissionError;
+    const errorMessage = intlClientErrors[error.name] || intlSFUErrors[error];
     // Only display WebRTC negotiation error toasts to sharers. The viewer streams
     // will try to autoreconnect silently, but the error will log nonetheless
-    if (isLocal) {
+    if (isLocal && errorMessage) {
       VideoService.notify(intl.formatMessage(errorMessage));
     } else {
       // If it's a viewer, set the reconnection timeout. There's a good chance

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -204,7 +204,7 @@ class VideoProvider extends Component {
   }
 
   onWsClose() {
-    logger.debug({
+    logger.info({
       logCode: 'video_provider_onwsclose',
     }, 'Multiple video provider websocket connection closed.');
 
@@ -216,7 +216,7 @@ class VideoProvider extends Component {
   }
 
   onWsOpen() {
-    logger.debug({
+    logger.info({
       logCode: 'video_provider_onwsopen',
     }, 'Multiple video provider websocket connection opened.');
 
@@ -300,10 +300,10 @@ class VideoProvider extends Component {
           logger.error({
             logCode: 'video_provider_ws_send_error',
             extraInfo: {
-              sfuRequest: message,
-              error,
+              errorMessage: error.message || 'Unknown',
+              errorCode: error.code,
             },
-          }, `WebSocket failed when sending request to SFU due to ${error.message}`);
+          }, 'Camera request failed to be sent to SFU');
         }
       });
     } else if (message.id !== 'stop') {
@@ -328,13 +328,10 @@ class VideoProvider extends Component {
     const { cameraId, role } = message;
     const peer = this.webRtcPeers[cameraId];
 
-    logger.info({
+    logger.debug({
       logCode: 'video_provider_start_response_success',
-      extraInfo: {
-        cameraId,
-        sfuResponse: message,
-      },
-    }, `Camera start request was accepted by SFU, processing response for ${cameraId}`);
+      extraInfo: { cameraId, role },
+    }, `Camera start request accepted by SFU. Role: ${role}`);
 
     if (peer) {
       peer.processAnswer(message.sdpAnswer, (error) => {
@@ -343,9 +340,10 @@ class VideoProvider extends Component {
             logCode: 'video_provider_peerconnection_processanswer_error',
             extraInfo: {
               cameraId,
-              error,
+              errorMessage: error.message,
+              errorCode: error.code,
             },
-          }, `Processing SDP answer from SFU for ${cameraId} failed due to ${error.message}`);
+          }, 'Camera answer processing failed');
 
           return;
         }
@@ -357,20 +355,14 @@ class VideoProvider extends Component {
     } else {
       logger.warn({
         logCode: 'video_provider_startresponse_no_peer',
-      }, `SFU start response for ${cameraId} arrived after the peer was discarded, ignore it.`);
+        extraInfo: { cameraId },
+      }, 'No peer on SFU camera start response handler');
     }
   }
 
   handleIceCandidate(message) {
     const { cameraId, candidate } = message;
     const peer = this.webRtcPeers[cameraId];
-
-    logger.debug({
-      logCode: 'video_provider_ice_candidate_received',
-      extraInfo: {
-        candidate,
-      },
-    }, `video-provider received candidate for ${cameraId}: ${JSON.stringify(candidate)}`);
 
     if (peer) {
       if (peer.didSDPAnswered) {
@@ -389,7 +381,8 @@ class VideoProvider extends Component {
     } else {
       logger.warn({
         logCode: 'video_provider_addicecandidate_no_peer',
-      }, `SFU ICE candidate for ${cameraId} arrived after the peer was discarded, ignore it.`);
+        extraInfo: { cameraId },
+      }, 'Trailing camera ICE candidate, discarded');
     }
   }
 
@@ -423,7 +416,9 @@ class VideoProvider extends Component {
 
     logger.info({
       logCode: 'video_provider_stopping_webcam_sfu',
-    }, `Sending stop request to SFU. Camera: ${cameraId}, role ${role} and flag restarting ${restarting}`);
+      extraInfo: { role, cameraId, restarting },
+    }, `Camera feed stop requested. Role ${role}, restarting ${restarting}`);
+
     this.sendMessage({
       id: 'stop',
       type: 'video',
@@ -443,9 +438,6 @@ class VideoProvider extends Component {
   destroyWebRTCPeer(cameraId) {
     const peer = this.webRtcPeers[cameraId];
     if (peer) {
-      logger.info({
-        logCode: 'video_provider_destroywebrtcpeer',
-      }, `Disposing WebRTC peer ${cameraId}`);
       if (typeof peer.dispose === 'function') {
         peer.dispose();
       }
@@ -454,7 +446,8 @@ class VideoProvider extends Component {
     } else {
       logger.warn({
         logCode: 'video_provider_destroywebrtcpeer_no_peer',
-      }, `Peer ${cameraId} was already disposed (glare), ignore it.`);
+        extraInfo: { cameraId },
+      }, 'Trailing camera destroy request.');
     }
   }
 
@@ -542,11 +535,12 @@ class VideoProvider extends Component {
             return this._onWebRTCError(errorGenOffer, cameraId, isLocal);
           }
 
+          const role = VideoService.getRole(isLocal);
           const message = {
             id: 'start',
             type: 'video',
             cameraId,
-            role: VideoService.getRole(isLocal),
+            role,
             sdpOffer: offerSdp,
             meetingId: this.info.meetingId,
             voiceBridge: this.info.voiceBridge,
@@ -559,10 +553,11 @@ class VideoProvider extends Component {
           logger.info({
             logCode: 'video_provider_sfu_request_start_camera',
             extraInfo: {
-              sfuRequest: message,
+              cameraId,
               cameraProfile: profileId,
+              role,
             },
-          }, `Camera offer generated. Sending start request to SFU for ${cameraId}`);
+          }, `Camera offer generated. Role: ${role}`);
 
           this.sendMessage(message);
 
@@ -611,7 +606,7 @@ class VideoProvider extends Component {
             oldReconnectTimer,
             newReconnectTimer,
           },
-        }, `Camera VIEWER has not succeeded in ${oldReconnectTimer} for ${cameraId}. Reconnecting.`);
+        }, 'Camera VIEWER failed. Reconnecting.');
 
         this.reconnect(cameraId, isLocal);
       } else {
@@ -619,8 +614,7 @@ class VideoProvider extends Component {
         logger.error({
           logCode: 'video_provider_camera_share_timeout',
           extraInfo: { cameraId },
-        }, `Camera SHARER has not succeeded in ${CAMERA_SHARE_FAILED_WAIT_TIME} for ${cameraId}`);
-
+        }, 'Camera SHARER failed.');
         VideoService.notify(intl.formatMessage(intlClientErrors.mediaFlowTimeout));
         this.stopWebRTCPeer(cameraId, false);
       }
@@ -636,10 +630,10 @@ class VideoProvider extends Component {
       extraInfo: {
         cameraId,
         errorName: error.name,
-        errorMessage,
+        errorMessage: error.message,
         isLocal,
       },
-    }, `Camera peer failed`);
+    }, 'Camera peer failed');
 
     // Only display WebRTC negotiation error toasts to sharers. The viewer streams
     // will try to autoreconnect silently, but the error will log nonetheless
@@ -682,14 +676,6 @@ class VideoProvider extends Component {
       const newReconnectTimer = this.restartTimer[cameraId] || CAMERA_SHARE_FAILED_WAIT_TIME;
       this.restartTimer[cameraId] = newReconnectTimer;
 
-      logger.info({
-        logCode: 'video_provider_setup_reconnect',
-        extraInfo: {
-          cameraId,
-          reconnectTimer: newReconnectTimer,
-        },
-      }, `Camera has a new reconnect timer of ${newReconnectTimer} ms for ${cameraId}`);
-
       this.restartTimeout[cameraId] = setTimeout(
         this._getWebRTCStartTimeout(cameraId, isLocal),
         this.restartTimer[cameraId],
@@ -707,10 +693,6 @@ class VideoProvider extends Component {
       this.setReconnectionTimeout(cameraId, isLocal, false);
 
       if (peer && !peer.didSDPAnswered) {
-        logger.debug({
-          logCode: 'video_provider_client_candidate',
-          extraInfo: { candidate },
-        }, `video-provider client-side candidate queued for ${cameraId}`);
         this.outboundIceQueues[cameraId].push(candidate);
         return;
       }
@@ -720,10 +702,6 @@ class VideoProvider extends Component {
   }
 
   sendIceCandidateToSFU(peer, role, candidate, cameraId) {
-    logger.debug({
-      logCode: 'video_provider_client_candidate',
-      extraInfo: { candidate },
-    }, `video-provider client-side candidate generated for ${cameraId}: ${JSON.stringify(candidate)}`);
     const message = {
       type: 'video',
       role,
@@ -747,13 +725,16 @@ class VideoProvider extends Component {
         const error = new Error('iceConnectionStateError');
         // prevent the same error from being detected multiple times
         pc.onconnectionstatechange = null;
+        const role = VideoService.getRole(isLocal);
+
         logger.error({
           logCode: 'video_provider_ice_connection_failed_state',
           extraInfo: {
             cameraId,
             connectionState,
+            role,
           },
-        }, `ICE connection state transitioned to ${connectionState} for ${cameraId}`);
+        }, `Camera ICE connection state changed: ${connectionState}. Role: ${role}.`);
         if (isLocal) VideoService.notify(intl.formatMessage(intlClientErrors.iceConnectionStateError));
 
         this._onWebRTCError(
@@ -765,10 +746,8 @@ class VideoProvider extends Component {
     } else {
       logger.error({
         logCode: 'video_provider_ice_connection_failed_state',
-        extraInfo: {
-          cameraId,
-        },
-      }, `Missing peer at ICE connection state transition for ${cameraId}`);
+        extraInfo: { cameraId },
+      }, `No peer at ICE connection state handler. Camera: ${cameraId}`);
     }
   }
 
@@ -824,20 +803,20 @@ class VideoProvider extends Component {
   }
 
   handlePlayStop(message) {
-    const { cameraId } = message;
+    const { cameraId, role } = message;
 
     logger.info({
       logCode: 'video_provider_handle_play_stop',
       extraInfo: {
         cameraId,
-        sfuRequest: message,
+        role,
       },
-    }, `Received request from SFU to stop camera ${cameraId}`);
+    }, `Received request from SFU to stop camera. Role: ${role}`);
     this.stopWebRTCPeer(cameraId, false);
   }
 
   handlePlayStart(message) {
-    const { cameraId } = message;
+    const { cameraId, role } = message;
     const peer = this.webRtcPeers[cameraId];
 
     if (peer) {
@@ -845,9 +824,9 @@ class VideoProvider extends Component {
         logCode: 'video_provider_handle_play_start_flowing',
         extraInfo: {
           cameraId,
-          sfuResponse: message,
+          role,
         },
-      }, `SFU says that media is flowing for camera ${cameraId}`);
+      }, `Camera media is flowing (server). Role: ${role}`);
 
       peer.started = true;
 
@@ -862,8 +841,10 @@ class VideoProvider extends Component {
 
       VideoService.playStart(cameraId);
     } else {
-      logger.warn({ logCode: 'video_provider_playstart_no_peer' },
-        `SFU playStart response for ${cameraId} arrived after the peer was discarded, ignore it.`);
+      logger.warn({
+        logCode: 'video_provider_playstart_no_peer',
+        extraInfo: { cameraId },
+      }, 'Trailing camera playStart response.');
     }
   }
 
@@ -874,10 +855,11 @@ class VideoProvider extends Component {
     logger.error({
       logCode: 'video_provider_handle_sfu_error',
       extraInfo: {
-        error: message,
+        errorCode: code,
+        errorReason: reason,
         cameraId,
       },
-    }, `SFU returned error for camera ${cameraId}. Code: ${code}, reason: ${reason}`);
+    }, `SFU returned an error. Code: ${code}, reason: ${reason}`);
 
     const isLocal = VideoService.isLocalStream(cameraId);
     if (isLocal) {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -340,6 +340,7 @@ class VideoProvider extends Component {
             logCode: 'video_provider_peerconnection_processanswer_error',
             extraInfo: {
               cameraId,
+              role,
               errorMessage: error.message,
               errorCode: error.code,
             },
@@ -355,7 +356,7 @@ class VideoProvider extends Component {
     } else {
       logger.warn({
         logCode: 'video_provider_startresponse_no_peer',
-        extraInfo: { cameraId },
+        extraInfo: { cameraId, role },
       }, 'No peer on SFU camera start response handler');
     }
   }
@@ -437,6 +438,9 @@ class VideoProvider extends Component {
 
   destroyWebRTCPeer(cameraId) {
     const peer = this.webRtcPeers[cameraId];
+    const isLocal = VideoService.isLocalStream(cameraId);
+    const role = VideoService.getRole(isLocal);
+
     if (peer) {
       if (typeof peer.dispose === 'function') {
         peer.dispose();
@@ -446,13 +450,14 @@ class VideoProvider extends Component {
     } else {
       logger.warn({
         logCode: 'video_provider_destroywebrtcpeer_no_peer',
-        extraInfo: { cameraId },
+        extraInfo: { cameraId, role },
       }, 'Trailing camera destroy request.');
     }
   }
 
   async createWebRTCPeer(cameraId, isLocal) {
     let iceServers = [];
+    const role = VideoService.getRole(isLocal);
 
     // Check if the peer is already being processed
     if (this.webRtcPeers[cameraId]) {
@@ -470,6 +475,8 @@ class VideoProvider extends Component {
         logger.error({
           logCode: 'video_provider_no_valid_candidate_gum_failure',
           extraInfo: {
+            cameraId,
+            role,
             errorName: error.name,
             errorMessage: error.message,
           },
@@ -483,6 +490,8 @@ class VideoProvider extends Component {
       logger.error({
         logCode: 'video_provider_fetchstunturninfo_error',
         extraInfo: {
+          cameraId,
+          role,
           errorCode: error.code,
           errorMessage: error.message,
         },
@@ -535,7 +544,6 @@ class VideoProvider extends Component {
             return this._onWebRTCError(errorGenOffer, cameraId, isLocal);
           }
 
-          const role = VideoService.getRole(isLocal);
           const message = {
             id: 'start',
             type: 'video',
@@ -581,6 +589,7 @@ class VideoProvider extends Component {
     const { intl } = this.props;
 
     return () => {
+      const role = VideoService.getRole(isLocal);
       if (!isLocal) {
         // Peer that timed out is a subscriber/viewer
         // Subscribers try to reconnect according to their timers if media could
@@ -603,6 +612,7 @@ class VideoProvider extends Component {
           logCode: 'video_provider_camera_view_timeout',
           extraInfo: {
             cameraId,
+            role,
             oldReconnectTimer,
             newReconnectTimer,
           },
@@ -613,7 +623,10 @@ class VideoProvider extends Component {
         // Peer that timed out is a sharer/publisher, clean it up, stop.
         logger.error({
           logCode: 'video_provider_camera_share_timeout',
-          extraInfo: { cameraId },
+          extraInfo: {
+            cameraId,
+            role,
+          },
         }, 'Camera SHARER failed.');
         VideoService.notify(intl.formatMessage(intlClientErrors.mediaFlowTimeout));
         this.stopWebRTCPeer(cameraId, false);
@@ -629,9 +642,9 @@ class VideoProvider extends Component {
       logCode: 'video_provider_webrtc_peer_error',
       extraInfo: {
         cameraId,
+        role: VideoService.getRole(isLocal),
         errorName: error.name,
         errorMessage: error.message,
-        isLocal,
       },
     }, 'Camera peer failed');
 
@@ -715,6 +728,7 @@ class VideoProvider extends Component {
   _handleIceConnectionStateChange (cameraId, isLocal) {
     const { intl } = this.props;
     const peer = this.webRtcPeers[cameraId];
+    const role = VideoService.getRole(isLocal);
 
     if (peer && peer.peerConnection) {
       const pc = peer.peerConnection;
@@ -725,7 +739,6 @@ class VideoProvider extends Component {
         const error = new Error('iceConnectionStateError');
         // prevent the same error from being detected multiple times
         pc.onconnectionstatechange = null;
-        const role = VideoService.getRole(isLocal);
 
         logger.error({
           logCode: 'video_provider_ice_connection_failed_state',
@@ -745,9 +758,9 @@ class VideoProvider extends Component {
       }
     } else {
       logger.error({
-        logCode: 'video_provider_ice_connection_failed_state',
-        extraInfo: { cameraId },
-      }, `No peer at ICE connection state handler. Camera: ${cameraId}`);
+        logCode: 'video_provider_ice_connection_nopeer',
+        extraInfo: { cameraId, role },
+      }, `No peer at ICE connection state handler. Camera: ${cameraId}. Role: ${role}`);
     }
   }
 
@@ -831,9 +844,7 @@ class VideoProvider extends Component {
       peer.started = true;
 
       // Clear camera shared timeout when camera succesfully starts
-      clearTimeout(this.restartTimeout[cameraId]);
-      delete this.restartTimeout[cameraId];
-      delete this.restartTimer[cameraId];
+      this.clearRestartTimers(cameraId);
 
       if (!peer.attached) {
         this.attachVideoStream(cameraId);
@@ -843,7 +854,7 @@ class VideoProvider extends Component {
     } else {
       logger.warn({
         logCode: 'video_provider_playstart_no_peer',
-        extraInfo: { cameraId },
+        extraInfo: { cameraId, role },
       }, 'Trailing camera playStart response.');
     }
   }
@@ -852,16 +863,19 @@ class VideoProvider extends Component {
     const { intl } = this.props;
     const { code, reason, streamId } = message;
     const cameraId = streamId;
+    const isLocal = VideoService.isLocalStream(cameraId);
+    const role = VideoService.getRole(isLocal);
+
     logger.error({
       logCode: 'video_provider_handle_sfu_error',
       extraInfo: {
         errorCode: code,
         errorReason: reason,
         cameraId,
+        role,
       },
     }, `SFU returned an error. Code: ${code}, reason: ${reason}`);
 
-    const isLocal = VideoService.isLocalStream(cameraId);
     if (isLocal) {
       // The publisher instance received an error from the server. There's no reconnect,
       // stop it.

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -568,6 +568,7 @@ class VideoProvider extends Component {
           }, `Camera offer generated. Role: ${role}`);
 
           this.sendMessage(message);
+          this.setReconnectionTimeout(cameraId, isLocal, false);
 
           return false;
         });
@@ -700,10 +701,6 @@ class VideoProvider extends Component {
     return (candidate) => {
       const peer = this.webRtcPeers[cameraId];
       const role = VideoService.getRole(isLocal);
-      // Setup a timeout only when the first candidate is generated and if the peer wasn't
-      // marked as started already (which is done on handlePlayStart after
-      // it was verified that media could circle through the server)
-      this.setReconnectionTimeout(cameraId, isLocal, false);
 
       if (peer && !peer.didSDPAnswered) {
         this.outboundIceQueues[cameraId].push(candidate);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
@@ -14,7 +14,8 @@ import Button from '/imports/ui/components/button/component';
 
 const propTypes = {
   streams: PropTypes.arrayOf(PropTypes.object).isRequired,
-  onMount: PropTypes.func.isRequired,
+  onVideoItemMount: PropTypes.func.isRequired,
+  onVideoItemUnmount: PropTypes.func.isRequired,
   webcamDraggableDispatch: PropTypes.func.isRequired,
   intl: PropTypes.objectOf(Object).isRequired,
   swapLayout: PropTypes.bool.isRequired,
@@ -298,7 +299,8 @@ class VideoList extends Component {
     const {
       intl,
       streams,
-      onMount,
+      onVideoItemMount,
+      onVideoItemUnmount,
       swapLayout,
     } = this.props;
     const { focusedId } = this.state;
@@ -340,10 +342,11 @@ class VideoList extends Component {
             name={name}
             mirrored={isMirrored}
             actions={actions}
-            onMount={(videoRef) => {
+            onVideoItemMount={(videoRef) => {
               this.handleCanvasResize();
-              onMount(cameraId, videoRef);
+              onVideoItemMount(cameraId, videoRef);
             }}
+            onVideoItemUnmount={onVideoItemUnmount}
             swapLayout={swapLayout}
           />
         </div>

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.jsx
@@ -10,7 +10,8 @@ const VideoListContainer = ({ children, ...props }) => {
 
 export default withTracker(props => ({
   streams: props.streams,
-  onMount: props.onMount,
+  onVideoItemMount: props.onVideoItemMount,
+  onVideoItemUnmount: props.onVideoItemUnmount,
   swapLayout: props.swapLayout,
   numberOfPages: VideoService.getNumberOfPages(),
   currentVideoPageIndex: props.currentVideoPageIndex,

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -1,5 +1,6 @@
 @import "/imports/ui/stylesheets/variables/breakpoints";
 @import "/imports/ui/stylesheets/variables/placeholders";
+@import "/imports/ui/components/media/styles";
 
 .videoCanvas {
   --cam-dropdown-width: 70%;
@@ -256,4 +257,14 @@
   @include mq($medium-up) {
     margin-right: 2px;
   }
+}
+
+.unhealthyStream {
+  filter: grayscale(50%) opacity(50%);
+}
+
+.reconnecting {
+  @extend .connectingSpinner;
+  background-color: transparent;
+  color: var(--color-white);
 }

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -18,6 +18,11 @@ import FullscreenButtonContainer from '/imports/ui/components/fullscreen-button/
 import { styles } from '../styles';
 import { withDraggableConsumer } from '/imports/ui/components/media/webcam-draggable-overlay/context';
 import VideoService from '../../service';
+import {
+  isStreamStateUnhealthy,
+  subscribeToStreamStateChange,
+  unsubscribeFromStreamStateChange,
+} from '/imports/ui/services/bbb-webrtc-sfu/stream-state-service';
 
 const ALLOW_FULLSCREEN = Meteor.settings.public.app.allowFullscreen;
 
@@ -29,16 +34,30 @@ class VideoListItem extends Component {
     this.state = {
       videoIsReady: false,
       isFullscreen: false,
+      isStreamHealthy: false,
     };
 
     this.mirrorOwnWebcam = VideoService.mirrorOwnWebcam(props.userId);
 
     this.setVideoIsReady = this.setVideoIsReady.bind(this);
     this.onFullscreenChange = this.onFullscreenChange.bind(this);
+    this.onStreamStateChange = this.onStreamStateChange.bind(this);
+  }
+
+  onStreamStateChange (e) {
+    const { streamState } = e.detail;
+    const { isStreamHealthy } = this.state;
+
+    const newHealthState = !isStreamStateUnhealthy(streamState);
+    e.stopPropagation();
+
+    if (newHealthState !== isStreamHealthy) {
+      this.setState({ isStreamHealthy: newHealthState });
+    }
   }
 
   componentDidMount() {
-    const { onMount, webcamDraggableDispatch } = this.props;
+    const { onVideoItemMount, webcamDraggableDispatch, cameraId } = this.props;
 
     webcamDraggableDispatch(
       {
@@ -47,10 +66,10 @@ class VideoListItem extends Component {
       },
     );
 
-    onMount(this.videoTag);
-
+    onVideoItemMount(this.videoTag);
     this.videoTag.addEventListener('loadeddata', this.setVideoIsReady);
     this.videoContainer.addEventListener('fullscreenchange', this.onFullscreenChange);
+    subscribeToStreamStateChange(cameraId, this.onStreamStateChange);
   }
 
   componentDidUpdate() {
@@ -75,8 +94,12 @@ class VideoListItem extends Component {
   }
 
   componentWillUnmount() {
+    const { cameraId, onVideoItemUnmount } = this.props;
+
     this.videoTag.removeEventListener('loadeddata', this.setVideoIsReady);
     this.videoContainer.removeEventListener('fullscreenchange', this.onFullscreenChange);
+    unsubscribeFromStreamStateChange(cameraId, this.onStreamStateChange);
+    onVideoItemUnmount(cameraId);
   }
 
   onFullscreenChange() {
@@ -136,6 +159,7 @@ class VideoListItem extends Component {
     const {
       videoIsReady,
       isFullscreen,
+      isStreamHealthy,
     } = this.state;
     const {
       name,
@@ -147,6 +171,7 @@ class VideoListItem extends Component {
     } = this.props;
     const availableActions = this.getAvailableActions();
     const enableVideoMenu = Meteor.settings.public.kurento.enableVideoMenu || false;
+    const shouldRenderReconnect = !isStreamHealthy && videoIsReady;
 
     const result = browser();
     const isFirefox = (result && result.name) ? result.name.includes('firefox') : false;
@@ -162,7 +187,14 @@ class VideoListItem extends Component {
             <div data-test="webcamConnecting" className={styles.connecting}>
               <span className={styles.loadingText}>{name}</span>
             </div>
+
         }
+
+        {
+          shouldRenderReconnect
+            && <div className={styles.reconnecting} />
+        }
+
         <div
           className={styles.videoContainer}
           ref={(ref) => { this.videoContainer = ref; }}
@@ -177,6 +209,7 @@ class VideoListItem extends Component {
               [styles.cursorGrabbing]: webcamDraggableState.dragging
                 && !isFullscreen && !swapLayout,
               [styles.mirroredVideo]: (this.mirrorOwnWebcam && !mirrored) || (!this.mirrorOwnWebcam && mirrored),
+              [styles.unhealthyStream]: shouldRenderReconnect,
             })}
             ref={(ref) => { this.videoTag = ref; }}
             autoPlay


### PR DESCRIPTION
### What does this PR do?

Lift #11233 to 2.3.

  - Add (fix) inbound/recvonly video stream reconnections
    * Track all peer's connectionState and trigger a timed reconnect on `failed`
    * Add a new unhealthy stream UI for when the stream is deemed to be unhealthy. The UI is applies a grayscale filter over the video-list-item which is deemed to be unhealthy and also shows the old connecting spinner.
    * The baseTimeout - maxTimeout reconnection time cycle continues to exist. When an inbound feed gets into an unhealthy state, it'll try to reconnect indefinitely and each retry increases the reconnection interval up to maxTimeout.
  - Fix Chromium-based browsers (>= M78) re-connection triggers
  - Refactor the video streams <-> video elements attachment code
  - Fix an issue where camera error toasts would be fired unnecessarily on reconnection scenarios c120dc2
    * This leaves the impression that something is broken at the toast container. It isn't.
    * Since those messages don't bring up much information about the problem we can avoid sending
them until we don't have a more informative one to notify the user.
  - Trim down and rearrange video-provider's logs
    * They were way to verbose and cumbersome (and useless to some extent). Make it slimmer and easier to parse.

### Closes Issue(s)

Partially fixes https://github.com/bigbluebutton/bigbluebutton/issues/10756

### More

**Shared camera (outbound) reconnections are not implemented**. Deeper changes are need to make that work cleanly.

This is a very dehydrated version of the stuff I was doing to the video-provider. When I don't know when I'm finishing that. So this is a quick and dirty rewrite of the inbound video re-connection code over the current video-provider so we can use it as soon as seen fit.

The code is pretty much self-explanatory. It uses the same stream state tracking rationale that screen sharing does. It uses the same reconnection UI as well.

It's a down to earth implementation. Any fancy stuff I'm keeping to a future rewrite (negotiation pacing, getStats heuristics, wildcard peers, ...). It's also backwards compatible with any SFU version (which the rewrite isn't).

This has seen some weeks of field trial already.