### PR TITLE
Submit typed polling response by pressing enter

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/polling/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/polling/component.jsx
@@ -50,6 +50,7 @@ class Polling extends Component {
 
     this.play = this.play.bind(this);
     this.handleUpdateResponseInput = this.handleUpdateResponseInput.bind(this);
+    this.handleMessageKeyDown = this.handleMessageKeyDown.bind(this);
   }
 
   componentDidMount() {
@@ -66,6 +67,21 @@ class Polling extends Component {
   handleUpdateResponseInput(e) {
     this.responseInput.value = validateInput(e.target.value);
     this.setState({ typedAns: this.responseInput.value });
+  }
+
+  handleMessageKeyDown(e) {
+    const {
+      poll,
+      handleTypedVote,
+    } = this.props;
+
+    const {
+      typedAns,
+    } = this.state;
+
+    if (e.keyCode === 13) {
+      handleTypedVote(poll.pollId, typedAns);
+    }
   }
 
   render() {
@@ -167,6 +183,9 @@ class Polling extends Component {
                 onChange={(e) => {
                   this.handleUpdateResponseInput(e);
                 }}
+                onKeyDown={(e) => {
+                  this.handleMessageKeyDown(e);
+                }}
                 type="text"
                 className={styles.typedResponseInput}
                 placeholder={intl.formatMessage(intlMessages.responsePlaceholder)}
@@ -199,6 +218,7 @@ Polling.propTypes = {
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
   handleVote: PropTypes.func.isRequired,
+  handleTypedVote: PropTypes.func.isRequired,
   poll: PropTypes.shape({
     pollId: PropTypes.string.isRequired,
     answers: PropTypes.arrayOf(PropTypes.shape({


### PR DESCRIPTION
### What does this PR do?

Allows the user to press enter to submit response to a typed poll instead of clicking submit button.

### Closes Issue(s)

closes #11578
