### PR TITLE
Translucent textbox 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/text/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/text/component.jsx
@@ -41,6 +41,7 @@ export default class TextDrawComponent extends Component {
       resize: 'none',
       overflow: 'hidden',
       outline: 'none',
+      backgroundColor: 'rgba(128, 128, 128, 0.2)',
       color: results.fontColor,
       fontSize: results.calcedFontSize,
       padding: '0',


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Makes the textbox translucent so that the presenter can see the background slide during writing an annotation text.

### Closes Issue(s)

closes #...
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number -->

### Motivation

Currently the textbox is white opaque and text annotation is not very comfortable when you want to write texts precisely overlaid on the slide. It offers a better user experience when combined with the PR #11604 .
![名称未設定 1のコピー](https://user-images.githubusercontent.com/45039819/110883917-8a2b7880-8327-11eb-8d32-f4cb834882a4.jpg)

