### PR TITLE
audio: make sdpSemantics configurable

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -39,6 +39,7 @@ const WEBSOCKET_KEEP_ALIVE_DEBOUNCE = MEDIA.websocketKeepAliveDebounce || 10;
 const TRACE_SIP = MEDIA.traceSip || false;
 const AUDIO_MICROPHONE_CONSTRAINTS = Meteor.settings.public.app.defaultSettings
   .application.microphoneConstraints;
+const SDP_SEMANTICS = MEDIA.sdpSemantics;
 
 const getAudioSessionNumber = () => {
   let currItem = parseInt(sessionStorage.getItem(AUDIO_SESSION_NUM_KEY), 10);
@@ -388,7 +389,7 @@ class SIPSession {
         sessionDescriptionHandlerFactoryOptions: {
           peerConnectionConfiguration: {
             iceServers,
-            sdpSemantics: 'plan-b',
+            sdpSemantics: SDP_SEMANTICS,
           },
         },
         displayName: callerIdName,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -368,6 +368,8 @@ public:
     websocketKeepAliveDebounce: 10
     #Trace sip/audio messages in browser. If not set, default value is false.
     traceSip: false
+    # SDP semantics: plan-b|unified-plan
+    sdpSemantics: 'plan-b'
   stats:
     enabled: true
     interval: 2000


### PR DESCRIPTION
### What does this PR do?

Makes audio's peer connection `sdpSemantics` configurable via settings.yml.

### Motivation

Plan B phase out plan in Chrome:
```
    M89 (Stable in February, 2021): Deprecation warning is added in the developer console.

    M93 (Stable in August, 2021): Plan B is removed, with the option to extend this deadline by opting-in to a Reverse Origin Trial. More information about this option will be announced at a later date.

    M96 (Stable in January, 2022): The extended deadline ends and Plan B is removed for everybody.
```

Our SDP usage in audio is dead simple. We don't need to care about P2P scenarios. Switching to Unified Plan should be a no brainer (we already use it with Firefox/Safari because that's the only thing they do and we aren't translating them to Plan B anymore).

That being said, we should field trial it a bit to see whether we hit any bug with Chrome nonetheless. We can't afford a ROT to find bugs.

I kept the default (Plan B) in the settings, but if it's ok I'll just flip it to Unified Plan for the next alpha release if possible and see what happens.