### PR TITLE
Perform audio processing encoding with 1 channel (mono-mode)

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -20,8 +20,8 @@
 module BigBlueButton
   module EDL
     module Audio
-      FFMPEG_AEVALSRC = "aevalsrc=s=48000:c=stereo:exprs=0|0"
-      FFMPEG_AFORMAT = "aformat=sample_fmts=s16:sample_rates=48000:channel_layouts=stereo"
+      FFMPEG_AEVALSRC = "aevalsrc=s=48000:channel_layout=mono:exprs=0"
+      FFMPEG_AFORMAT = "aformat=sample_fmts=s16:sample_rates=48000:channel_layouts=mono"
       FFMPEG_WF_CODEC = 'libvorbis'
       FFMPEG_WF_ARGS = ['-c:a', FFMPEG_WF_CODEC, '-q:a', '2', '-f', 'ogg']
       WF_EXT = 'ogg'

--- a/record-and-playback/core/lib/recordandplayback/generators/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/video.rb
@@ -73,12 +73,8 @@ module BigBlueButton
       {
         extension: 'mp4',
         parameters: [
-          # These settings are appropriate for medium quality at any resolution
-          # Increase -threads (or remove it, to use all cpu cores) to speed up processing
-          # You can also change the preset: try 'fast' or 'faster'
-          # To change quality, adjust the -crf value. Lower numbers are higher quality.
           %w[-c:v copy
-             -c:a aac -b:a 64K
+             -c:a aac -q:a 0.5
              -f mp4 -movflags faststart]
         ],
         postprocess: [ ]
@@ -139,12 +135,8 @@ module BigBlueButton
       {
         extension: 'mp4',
         parameters: [
-          # These settings are appropriate for medium quality at any resolution
-          # Increase -threads (or remove it, to use all cpu cores) to speed up processing
-          # You can also change the preset: try 'fast' or 'faster'
-          # To change quality, adjust the -crf value. Lower numbers are higher quality.
           %w[-c:v copy
-             -c:a aac -b:a 64K
+             -c:a aac -q:a 0.5
              -f mp4 -movflags faststart]
         ],
         postprocess: [ ]


### PR DESCRIPTION
Perform audio processing encoding with 1 channel (mono-mode). For MP4, use quality based encoding instead of fixed bitrate.

### What does this PR do?

Perform audio processing encoding with 1 channel (mono-mode) because Freeswitch records in mono mode. Also for MP4, switch to quality based encoding (-q:a 0.5) instead of fixed bitrate (-b:a 64K).

### Motivation

It is related to #2483 and https://github.com/bigbluebutton/bigbluebutton/pull/11589#issuecomment-795272225, in order to speed up recording processing and avoid processing redundant data.

### More
For MP4 I switched to quality based encoding instead of picking a fixed bitrate in order to be channel agnostic (for the future) and match the settings used for recording.ogg (-q:a 0.5 for AAC is about the same as -q:a 2 for vorbis).