### PR TITLE
Change the color of color-picker icon even when the text tool is selected

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
@@ -283,23 +283,21 @@ class WhiteboardToolbar extends Component {
      * 4. Trigger initial animation for the icons
     */
     // 1st case
-    if (this.thicknessListIconRadius && this.thicknessListIconColor) {
-      if (colorSelected.value !== prevState.colorSelected.value) {
-        // 1st case b)
-        if (annotationSelected.value !== 'text') {
-          this.thicknessListIconColor.beginElement();
-        }
-        // 1st case a)
-        this.colorListIconColor.beginElement();
-        // 2nd case
-      } else if (thicknessSelected.value !== prevState.thicknessSelected.value) {
-        this.thicknessListIconRadius.beginElement();
-        // 3rd case
-      } else if (annotationSelected.value !== 'text'
-        && prevState.annotationSelected.value === 'text') {
-        this.thicknessListIconRadius.beginElement();
+    if (colorSelected.value !== prevState.colorSelected.value) {
+      // 1st case b)
+      if (annotationSelected.value !== 'text') {
         this.thicknessListIconColor.beginElement();
       }
+      // 1st case a)
+      this.colorListIconColor.beginElement();
+      // 2nd case
+    } else if (thicknessSelected.value !== prevState.thicknessSelected.value) {
+      this.thicknessListIconRadius.beginElement();
+      // 3rd case
+    } else if (annotationSelected.value !== 'text'
+      && prevState.annotationSelected.value === 'text') {
+      this.thicknessListIconRadius.beginElement();
+      this.thicknessListIconColor.beginElement();
     }
     // 4th case, initial animation is triggered in componentDidMount
   }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
@@ -283,7 +283,7 @@ class WhiteboardToolbar extends Component {
      * 4. Trigger initial animation for the icons
     */
     // 1st case
-    if (　(this.thicknessListIconRadius && this.thicknessListIconColor) || annotationSelected.value === 'text') {
+    if ( (this.thicknessListIconRadius && this.thicknessListIconColor) || annotationSelected.value === 'text') {
       if (colorSelected.value !== prevState.colorSelected.value) {
         // 1st case b)
         if (annotationSelected.value !== 'text') {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
@@ -291,7 +291,7 @@ class WhiteboardToolbar extends Component {
         }
         // 1st case a)
         this.colorListIconColor.beginElement();
-        // 2nd case  - never happens when the text tool is selected
+        // 2nd case - never happens when the text tool is selected
       } else if (thicknessSelected.value !== prevState.thicknessSelected.value) {
         this.thicknessListIconRadius.beginElement();
         // 3rd case

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
@@ -283,21 +283,23 @@ class WhiteboardToolbar extends Component {
      * 4. Trigger initial animation for the icons
     */
     // 1st case
-    if (colorSelected.value !== prevState.colorSelected.value) {
-      // 1st case b)
-      if (annotationSelected.value !== 'text') {
+    if (　(this.thicknessListIconRadius && this.thicknessListIconColor) || annotationSelected.value === 'text') {
+      if (colorSelected.value !== prevState.colorSelected.value) {
+        // 1st case b)
+        if (annotationSelected.value !== 'text') {
+          this.thicknessListIconColor.beginElement();
+        }
+        // 1st case a)
+        this.colorListIconColor.beginElement();
+        // 2nd case  - never happens when the text tool is selected
+      } else if (thicknessSelected.value !== prevState.thicknessSelected.value) {
+        this.thicknessListIconRadius.beginElement();
+        // 3rd case
+      } else if (annotationSelected.value !== 'text'
+        && prevState.annotationSelected.value === 'text') {
+        this.thicknessListIconRadius.beginElement();
         this.thicknessListIconColor.beginElement();
       }
-      // 1st case a)
-      this.colorListIconColor.beginElement();
-      // 2nd case
-    } else if (thicknessSelected.value !== prevState.thicknessSelected.value) {
-      this.thicknessListIconRadius.beginElement();
-      // 3rd case
-    } else if (annotationSelected.value !== 'text'
-      && prevState.annotationSelected.value === 'text') {
-      this.thicknessListIconRadius.beginElement();
-      this.thicknessListIconColor.beginElement();
     }
     // 4th case, initial animation is triggered in componentDidMount
   }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Let the color of the color-picker icon be changed even when the text tool is selected

### Closes Issue(s)

closes #11641 

### Motivation

I think the color of the color-picker and that of the annotation icon should always be the same to avoid confusion.

### More
In the current implementation, both this.thicknessListIconRadius and this.thicknessListIconColor are null when the text tool is selected. So "if (this.thicknessListIconRadius && this.thicknessListIconColor)" never happens as long as the text tool is selected. I don't think it's the intended behaviour.

Anyway, this is what happens when this modification is applied:
![toolbar2](https://user-images.githubusercontent.com/45039819/111026841-0610e800-8430-11eb-8f07-f68b59576ecf.gif)
