### PR TITLE
fix: create meeting message order precedes group chat message in akka…

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -135,10 +135,6 @@ class BigBlueButtonActor(
 
         RunningMeetings.add(meetings, m)
 
-        // Send new 2x message
-        val msgEvent = MsgBuilder.buildMeetingCreatedEvtMsg(m.props.meetingProp.intId, msg.body.props)
-        m.outMsgRouter.send(msgEvent)
-
       case Some(m) =>
         log.info("Meeting already created. meetingID={}", msg.body.props.meetingProp.intId)
       // do nothing

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -156,6 +156,10 @@ class MeetingActor(
 
   var lastRttTestSentOn = System.currentTimeMillis()
 
+  // Send new 2x message
+  val msgEvent = MsgBuilder.buildMeetingCreatedEvtMsg(liveMeeting.props.meetingProp.intId, liveMeeting.props)
+  outGW.send(msgEvent)
+
   // Create a default public group chat
   state = groupChatApp.handleCreateDefaultPublicGroupChat(state, liveMeeting, msgBus)
 


### PR DESCRIPTION
…-apps


### What does this PR do?
This PR moves create meeting message from BBB actor to meeting actor in order to maintain the message sequences. 


### Motivation
Meeting created event message should precede group chat message for compatibility reasons with UI. 
