### PR TITLE
correctly catch bigbluebutton.web.serverURL

### DIFF
--- a/bigbluebutton-config/bin/apply-lib.sh
+++ b/bigbluebutton-config/bin/apply-lib.sh
@@ -28,7 +28,7 @@ BBB_WEB_ETC_CONFIG=/etc/bigbluebutton/bbb-web.properties
 PROTOCOL=http
 if [ -f $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties ]; then
   SERVER_URL=$(cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties $BBB_WEB_ETC_CONFIG | grep -v '#' | sed -n '/^bigbluebutton.web.serverURL/{s/.*\///;p}' | tail -n 1)
-  if cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties $BBB_WEB_ETC_CONFIG | grep -v '#' | grep bigbluebutton.web.serverURL | tail -n 1 | grep -q https; then
+  if cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties $BBB_WEB_ETC_CONFIG | grep -v '#' | grep ^bigbluebutton.web.serverURL | tail -n 1 | grep -q https; then
     PROTOCOL=https
   fi
 fi


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Catch the correct value for the parameter bigbluebutton.web.serverURL in /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties.

### Closes Issue(s)

closes #...
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number -->

### Motivation

In 2.3alpha8, the parameter bigbluebutton.web.serverURL in /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties can be overwritten by the same parameter in  /etc/bigbluebutton/bbb-web.properties, as far as I understand. However, the current implementation almost always change this parameter as "http://server", even though it's set "https://server", because grep bigbluebutton.web.serverURL /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties returns a lot of lines such as "defaultHTML5ClientUrl=${bigbluebutton.web.serverURL}/html5client/join". As a result, the sever makes a 401 error in my server. I guess this is happening in other places.

### More

<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
