### PR TITLE
Prevent sending typed poll empty response

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/polling/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/polling/component.jsx
@@ -79,7 +79,7 @@ class Polling extends Component {
       typedAns,
     } = this.state;
 
-    if (e.keyCode === 13) {
+    if (e.keyCode === 13 && typedAns.length > 0) {
       handleTypedVote(poll.pollId, typedAns);
     }
   }


### PR DESCRIPTION
### What does this PR do?

Prevents the sending of a typed poll response by pressing enter if the response is empty.