### PR TITLE
video-provider: add dynamic video page sizes based on number of users 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -209,6 +209,10 @@ const getUsers = () => {
   return users.sort(sortUsers);
 };
 
+const getUserCount = () => {
+  return Users.find({ meetingId: Auth.meetingID, connectionStatus: 'online' }).count();
+};
+
 const hasBreakoutRoom = () => Breakouts.find({ parentMeetingId: Auth.meetingID },
   { fields: {} }).count() > 0;
 
@@ -652,4 +656,5 @@ export default {
   isUserPresenter,
   amIPresenter,
   getUsersProp,
+  getUserCount,
 };

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -210,7 +210,7 @@ const getUsers = () => {
 };
 
 const getUserCount = () => {
-  return Users.find({ meetingId: Auth.meetingID, connectionStatus: 'online' }).count();
+  return Users.find({ meetingId: Auth.meetingID }).count();
 };
 
 const hasBreakoutRoom = () => Breakouts.find({ parentMeetingId: Auth.meetingID },

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -286,6 +286,41 @@ public:
       mobilePageSizes:
         moderator: 2
         viewer: 2
+    paginationThresholds:
+      enabled: false
+      thresholds:
+        - users: 30
+          desktopPageSizes:
+            moderator: 25
+            viewer: 25
+        - users: 40
+          desktopPageSizes:
+            moderator: 20
+            viewer: 20
+        - users: 50
+          desktopPageSizes:
+            moderator: 16
+            viewer: 16
+        - users: 60
+          desktopPageSizes:
+            moderator: 14
+            viewer: 12
+        - users: 70
+          desktopPageSizes:
+            moderator: 12
+            viewer: 10
+        - users: 80
+          desktopPageSizes:
+            moderator: 10
+            viewer: 8
+        - users: 90
+          desktopPageSizes:
+            moderator: 8
+            viewer: 6
+        - users: 100
+          desktopPageSizes:
+            moderator: 6
+            viewer: 4
   syncUsersWithConnectionManager:
     enabled: false
     syncInterval: 60000


### PR DESCRIPTION
### What does this PR do?

- New config called `public.kurento.paginationThresholds` defines classes of page sizes to be applied based on the number of participants in a meeting;
- The rationale is pretty much the same as the `cameraQualityThresholds`, but here thresholds are users and the ceilings are page sizes;
- Disabled by default. `public.kurento.paginationThresholds.enabled` is that flag that controls it;
- Don't need to define mobile/desktop entries for every threshold class. If one of those is not set, it'll fall back to the default page sizes from `public.kurento.pagination.desktop/mobilePageSizes`.
- The default page sizes (`public.kurento.pagination.desktop/mobilePageSizes`) will be applied when there's no threshold hit yet.

### Closes Issue(s)

None

### Motivation

Pagination serves two purposes: 1) constraining client-side resource usage and peer complexity 2) constraining server-side resource usage and peer complexity.

Our current approach achieves both to some degree, but is too inflexible in some scenarios. A meeting with 15 users and 15 webcams is not nearly as damaging in ther server as a meeting with 100 users and 10 webcams, for instance.

This PRs aims on increasing flexibility on scenario 2 by allowing us to define dynamic page sizes based on the number of users in a meeting. That way we can prevent servers from blowing up while allowing a better experience for smaller sized meetings.

Regarding flexibility in scenario 1: it's something for another PR.

### More

- Unlike I did with dynamic camera profiles, I decided to not implement a baseline check to detect whether a pagination profile has a bigger page size than the default pagination profile. I'm trusting the operators on this one. If you're enabling the pagination thresholds, please make sure your default page sizes make sense when paired with the dynamic profiles.
- The default values in this PR serve as **EXAMPLES**. This is way more complicated than the cameraQualityThresholds to come up with a sane default configuration array. So take the values with a grain of salt.
