### PR TITLE
Show unmuted microphone in video

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -248,6 +248,7 @@ class VideoListItem extends Component {
           }
           {voiceUser.muted && !voiceUser.listenOnly ? <Icon className={styles.muted} iconName="unmute_filled" /> : null}
           {voiceUser.listenOnly ? <Icon className={styles.voice} iconName="listen" /> : null}
+          {voiceUser.joined && !voiceUser.muted ? <Icon className={styles.voice} iconName="unmute" /> : null}
         </div>
         }
       </div>


### PR DESCRIPTION
### What does this PR do?

Adds green microphone icon in video when user has joined audio and is not muted.

#### Old behavior (no icon):
![Screenshot from 2021-03-17 16-24-37](https://user-images.githubusercontent.com/3728706/111526542-a2433380-873d-11eb-9e19-f893a338083e.png)

#### New behavior:
![Screenshot from 2021-03-17 16-24-57](https://user-images.githubusercontent.com/3728706/111526585-b129e600-873d-11eb-93be-9a459e32fdea.png)


### Closes Issue(s)

closes #11637