### PR TITLE
Replaced keepEvents with defaultKeepEvents and meetingKeepEvents

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -43,6 +43,7 @@ public class ApiParams {
     public static final String MODERATOR_ONLY_MESSAGE = "moderatorOnlyMessage";
     public static final String MODERATOR_PW = "moderatorPW";
     public static final String MUTE_ON_START = "muteOnStart";
+    public static final String MEETING_KEEP_EVENTS = "meetingKeepEvents";
     public static final String ALLOW_MODS_TO_UNMUTE_USERS = "allowModsToUnmuteUsers";
     public static final String NAME = "name";
     public static final String PARENT_MEETING_ID = "parentMeetingID";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -120,7 +120,6 @@ public class MeetingService implements MessageListener {
   private RedisStorageService storeService;
   private CallbackUrlService callbackUrlService;
   private HTML5LoadBalancingService html5LoadBalancingService;
-  private boolean keepEvents;
 
   private long usersTimeout;
   private long enteredUsersTimeout;
@@ -356,7 +355,7 @@ public class MeetingService implements MessageListener {
   }
 
   private boolean storeEvents(Meeting m) {
-    return m.isRecord() || keepEvents;
+    return m.isRecord() || m.getMeetingKeepEvents();
   }
 
   private void handleCreateMeeting(Meeting m) {
@@ -404,6 +403,8 @@ public class MeetingService implements MessageListener {
     logData.put("logCode", "create_meeting");
     logData.put("description", "Create meeting.");
 
+    logData.put("meetingKeepEvents", m.getMeetingKeepEvents());
+
     Gson gson = new Gson();
     String logStr = gson.toJson(logData);
 
@@ -417,7 +418,7 @@ public class MeetingService implements MessageListener {
             m.getDialNumber(), m.getMaxUsers(),
             m.getMeetingExpireIfNoUserJoinedInMinutes(), m.getmeetingExpireWhenLastUserLeftInMinutes(),
             m.getUserInactivityInspectTimerInMinutes(), m.getUserInactivityThresholdInMinutes(),
-            m.getUserActivitySignResponseDelayInMinutes(), m.getMuteOnStart(), m.getAllowModsToUnmuteUsers(), keepEvents,
+            m.getUserActivitySignResponseDelayInMinutes(), m.getMuteOnStart(), m.getAllowModsToUnmuteUsers(), m.getMeetingKeepEvents(),
             m.breakoutRoomsParams,
             m.lockSettingsParams, m.getHtml5InstanceId());
   }
@@ -697,7 +698,7 @@ public class MeetingService implements MessageListener {
     if (m != null) {
       m.setForciblyEnded(true);
       processRecording(m);
-      if (keepEvents) {
+      if (m.getMeetingKeepEvents()) {
         // The creation of the ended tag must occur after the creation of the
         // recorded tag to avoid concurrency issues at the recording scripts
         recordingService.markAsEnded(m.getInternalId());
@@ -1231,10 +1232,6 @@ public class MeetingService implements MessageListener {
 
   public void setStunTurnService(StunTurnService s) {
     stunTurnService = s;
-  }
-
-  public void setKeepEvents(boolean value) {
-    keepEvents = value;
   }
 
   public void setUsersTimeout(long value) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -87,6 +87,7 @@ public class ParamsProcessorUtil {
     private boolean webcamsOnlyForModerator;
     private boolean defaultMuteOnStart = false;
     private boolean defaultAllowModsToUnmuteUsers = false;
+    private boolean defaultKeepEvents = false;
 
 		private boolean defaultBreakoutRoomsEnabled;
 		private boolean defaultBreakoutRoomsRecord;
@@ -543,6 +544,12 @@ public class ParamsProcessorUtil {
         }
 
 		meeting.setMuteOnStart(muteOnStart);
+
+    Boolean meetingKeepEvents = defaultKeepEvents;
+    if (!StringUtils.isEmpty(params.get(ApiParams.MEETING_KEEP_EVENTS))) {
+      meetingKeepEvents = Boolean.parseBoolean(params.get(ApiParams.MEETING_KEEP_EVENTS));
+    }
+    meeting.setMeetingKeepEvents(meetingKeepEvents);
 
         Boolean allowModsToUnmuteUsers = defaultAllowModsToUnmuteUsers;
         if (!StringUtils.isEmpty(params.get(ApiParams.ALLOW_MODS_TO_UNMUTE_USERS))) {
@@ -1024,6 +1031,10 @@ public class ParamsProcessorUtil {
 
 	public Boolean getMuteOnStart() {
 		return defaultMuteOnStart;
+	}
+
+	public void setDefaultKeepEvents(Boolean mke) {
+		defaultKeepEvents = mke;
 	}
 
 	public void setAllowModsToUnmuteUsers(Boolean value) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -84,6 +84,7 @@ public class Meeting {
 	private String customCopyright = "";
 	private Boolean muteOnStart = false;
 	private Boolean allowModsToUnmuteUsers = false;
+	private Boolean meetingKeepEvents;
 
 	private Integer meetingExpireIfNoUserJoinedInMinutes = 5;
 	private Integer meetingExpireWhenLastUserLeftInMinutes = 1;
@@ -502,6 +503,14 @@ public class Meeting {
 	public Boolean getMuteOnStart() {
     	return muteOnStart;
 	}
+
+  public void setMeetingKeepEvents(Boolean mke) {
+    meetingKeepEvents = mke;
+  }
+
+  public Boolean getMeetingKeepEvents() {
+    return meetingKeepEvents;
+  }
 
 	public void setAllowModsToUnmuteUsers(Boolean value) {
 		allowModsToUnmuteUsers = value;

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -222,7 +222,7 @@ muteOnStart=false
 allowModsToUnmuteUsers=false
 
 # Saves meeting events even if the meeting is not recorded
-keepEvents=true
+defaultKeepEvents=false
 
 # Timeout (millis) to remove a joined user after her/his left event without a rejoin
 # e.g. regular user left event

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -54,7 +54,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="enteredUserCleanupTimerTask" ref="enteredUserCleanupTimerTask"/>
         <property name="gw" ref="bbbWebApiGWApp"/>
         <property name="callbackUrlService" ref="callbackUrlService"/>
-        <property name="keepEvents" value="${keepEvents}"/>
         <property name="usersTimeout" value="${usersTimeout}"/>
         <property name="enteredUsersTimeout" value="${enteredUsersTimeout}"/>
     </bean>
@@ -164,6 +163,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="lockSettingsLockOnJoinConfigurable" value="${lockSettingsLockOnJoinConfigurable}"/>
         <property name="allowDuplicateExtUserid" value="${allowDuplicateExtUserid}"/>
         <property name="endWhenNoModerator" value="${endWhenNoModerator}"/>
+        <property name="defaultKeepEvents" value="${defaultKeepEvents}"/>
     </bean>
 
     <import resource="doc-conversion.xml"/>


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
1) Allows for meetings to override the `defaultKeepEvents` property (formerly `keepEvents` https://github.com/bigbluebutton/bigbluebutton/pull/6385 ) by passing `meetingKeepEvents=` `true` or `false`

2) I set `defaultKeepEvents` to false, which is reverting https://github.com/bigbluebutton/bigbluebutton/pull/10097 , cc @jfederico 

Note that `defaultKeepEvents` is only used in case `meetingKeepEvents` is not passed.

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
none
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number -->



### Motivation
We would like to have finer control over which meetings' events are recorded. Until now you would either keep events from all or none of the meetings
<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->
- [x] Added documentation in https://github.com/bigbluebutton/bigbluebutton.github.io/pull/239 (pull request to be merged)
