### PR TITLE
Fix messages being not cleared

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
@@ -96,6 +96,7 @@ const Adapter = () => {
         }
       }
       if (msg.data.indexOf('{"msg":"removed","collection":"group-chat-msg"') != -1) {
+        messageQueue = [];
         dispatch({
           type: ACTIONS.REMOVED,
         });


### PR DESCRIPTION
### What does this PR do?

The bug happened because the message queue to be processed wasn't cleared when the clear chat is triggered, thus being processed later and added to the context, causing the bug of having message before the clear message.

### Closes Issue(s)
closes #11618 