### PR TITLE
Fix userlist height if banner is enabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.scss
@@ -113,12 +113,12 @@
   @include mq($medium-up) {
     flex: 0 15vw;
     order: 1;
-    height: 100vh;
+    height: 100%;
   }
 
   @include mq($xlarge-up) {
     flex-basis: 10vw;
-    height: 100vh;
+    height: 100%;
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes an issue with the userlist height, by setting the component height to 100% of available height instead of 100% of viewport height.

### Closes Issue(s)

closes #10850