### PR TITLE
Fix client crash when user is sharing video

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/many-users-notify/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/many-users-notify/container.jsx
@@ -27,7 +27,7 @@ export default withTracker(() => {
       presenter: false,
     }, { fields: {} }).count(),
     currentUserIsModerator: Users.findOne({ userId: Auth.userID },
-      { fields: { role: 1 } }).role === ROLE_MODERATOR,
+      { fields: { role: 1 } })?.role === ROLE_MODERATOR,
     lockSettings: meeting.lockSettingsProps,
     webcamOnlyForModerator: meeting.usersProp.webcamsOnlyForModerator,
     limitOfViewersInWebcam: Meteor.settings.public.app.viewersInWebcam,


### PR DESCRIPTION
### What does this PR do?

Fixes crash that happens on an ejection if the ejected user has a webcam active.

### Closes Issue(s)

closes #11680