### PR TITLE
Move Raise Hand Functionality To Actions Bar Button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 import Button from '/imports/ui/components/button/component';
 import { ACTIONSBAR_HEIGHT } from '/imports/ui/components/layout/layout-manager';
 import CaptionsButtonContainer from '/imports/ui/components/actions-bar/captions/container';
+import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
 
 import { styles } from './styles.scss';
 import ActionsDropdown from './actions-dropdown/container';
@@ -32,6 +33,7 @@ class ActionsBar extends PureComponent {
       allowExternalVideo,
       setEmojiStatus,
       currentUser,
+      shortcuts,
     } = this.props;
 
     const actionBarClasses = {};
@@ -85,6 +87,7 @@ class ActionsBar extends PureComponent {
             <Button
               icon="hand"
               label={intl.formatMessage({ id: 'app.actionsBar.emojiMenu.raiseHandLabel' })}
+              accessKey={shortcuts.raisehand}
               color="primary"
               hideLabel
               circle
@@ -112,4 +115,4 @@ class ActionsBar extends PureComponent {
   }
 }
 
-export default ActionsBar;
+export default withShortcutHelper(ActionsBar, ['raiseHand']);

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -1,13 +1,15 @@
 import React, { PureComponent } from 'react';
 import cx from 'classnames';
+import Button from '/imports/ui/components/button/component';
+import { ACTIONSBAR_HEIGHT } from '/imports/ui/components/layout/layout-manager';
+import CaptionsButtonContainer from '/imports/ui/components/actions-bar/captions/container';
+
 import { styles } from './styles.scss';
 import ActionsDropdown from './actions-dropdown/container';
 import ScreenshareButtonContainer from '/imports/ui/components/actions-bar/screenshare/container';
 import AudioControlsContainer from '../audio/audio-controls/container';
 import JoinVideoOptionsContainer from '../video-provider/video-button/container';
-import CaptionsButtonContainer from '/imports/ui/components/actions-bar/captions/container';
 import PresentationOptionsContainer from './presentation-options/component';
-import { ACTIONSBAR_HEIGHT } from '/imports/ui/components/layout/layout-manager';
 
 class ActionsBar extends PureComponent {
   render() {
@@ -28,11 +30,12 @@ class ActionsBar extends PureComponent {
       isPresentationDisabled,
       isThereCurrentPresentation,
       allowExternalVideo,
+      setEmojiStatus,
+      currentUser,
     } = this.props;
 
     const actionBarClasses = {};
 
-    actionBarClasses[styles.centerWithActions] = amIPresenter;
     actionBarClasses[styles.center] = true;
     actionBarClasses[styles.mobileLayoutSwapped] = isLayoutSwapped && amIPresenter;
 
@@ -78,6 +81,22 @@ class ActionsBar extends PureComponent {
           />
         </div>
         <div className={styles.right}>
+          {
+            <Button
+              icon="hand"
+              label={intl.formatMessage({ id: 'app.actionsBar.emojiMenu.raiseHandLabel' })}
+              color="primary"
+              hideLabel
+              circle
+              size="lg"
+              onClick={() => {
+                setEmojiStatus(
+                  currentUser.userId,
+                  currentUser.emoji === 'raiseHand' ? 'none' : 'raiseHand',
+                );
+              }}
+            />
+          }
           {isLayoutSwapped && !isPresentationDisabled
             ? (
               <PresentationOptionsContainer

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -1,10 +1,9 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import cx from 'classnames';
 import Button from '/imports/ui/components/button/component';
 import { ACTIONSBAR_HEIGHT } from '/imports/ui/components/layout/layout-manager';
 import CaptionsButtonContainer from '/imports/ui/components/actions-bar/captions/container';
 import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
-import { debounce } from 'lodash';
 import { styles } from './styles.scss';
 import ActionsDropdown from './actions-dropdown/container';
 import ScreenshareButtonContainer from '/imports/ui/components/actions-bar/screenshare/container';
@@ -12,25 +11,7 @@ import AudioControlsContainer from '../audio/audio-controls/container';
 import JoinVideoOptionsContainer from '../video-provider/video-button/container';
 import PresentationOptionsContainer from './presentation-options/component';
 
-class ActionsBar extends Component {
-  constructor() {
-    super();
-
-    this.handleSetStatus = debounce(this.handleSetStatus.bind(this), 1000, { leading: true, trailing: false });
-  }
-
-  handleSetStatus() {
-    const {
-      setEmojiStatus,
-      currentUser,
-    } = this.props;
-
-    setEmojiStatus(
-      currentUser.userId,
-      currentUser.emoji === 'raiseHand' ? 'none' : 'raiseHand',
-    );
-  }
-
+class ActionsBar extends PureComponent {
   render() {
     const {
       amIPresenter,
@@ -116,7 +97,12 @@ class ActionsBar extends Component {
               hideLabel
               circle
               size="lg"
-              onClick={this.handleSetStatus}
+              onClick={() => {
+                setEmojiStatus(
+                  currentUser.userId,
+                  currentUser.emoji === 'raiseHand' ? 'none' : 'raiseHand',
+                );
+              }}
             />
           }
           {isLayoutSwapped && !isPresentationDisabled

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -1,10 +1,10 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import cx from 'classnames';
 import Button from '/imports/ui/components/button/component';
 import { ACTIONSBAR_HEIGHT } from '/imports/ui/components/layout/layout-manager';
 import CaptionsButtonContainer from '/imports/ui/components/actions-bar/captions/container';
 import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
-
+import { debounce } from 'lodash';
 import { styles } from './styles.scss';
 import ActionsDropdown from './actions-dropdown/container';
 import ScreenshareButtonContainer from '/imports/ui/components/actions-bar/screenshare/container';
@@ -12,7 +12,25 @@ import AudioControlsContainer from '../audio/audio-controls/container';
 import JoinVideoOptionsContainer from '../video-provider/video-button/container';
 import PresentationOptionsContainer from './presentation-options/component';
 
-class ActionsBar extends PureComponent {
+class ActionsBar extends Component {
+  constructor() {
+    super();
+
+    this.handleSetStatus = debounce(this.handleSetStatus.bind(this), 1000, { leading: true, trailing: false });
+  }
+
+  handleSetStatus() {
+    const {
+      setEmojiStatus,
+      currentUser,
+    } = this.props;
+
+    setEmojiStatus(
+      currentUser.userId,
+      currentUser.emoji === 'raiseHand' ? 'none' : 'raiseHand',
+    );
+  }
+
   render() {
     const {
       amIPresenter,
@@ -98,12 +116,7 @@ class ActionsBar extends PureComponent {
               hideLabel
               circle
               size="lg"
-              onClick={() => {
-                setEmojiStatus(
-                  currentUser.userId,
-                  currentUser.emoji === 'raiseHand' ? 'none' : 'raiseHand',
-                );
-              }}
+              onClick={this.handleSetStatus}
             />
           }
           {isLayoutSwapped && !isPresentationDisabled

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -86,7 +86,13 @@ class ActionsBar extends PureComponent {
           {
             <Button
               icon="hand"
-              label={intl.formatMessage({ id: 'app.actionsBar.emojiMenu.raiseHandLabel' })}
+              label={intl.formatMessage({
+                id: `app.actionsBar.emojiMenu.${
+                  currentUser.emoji === 'raiseHand'
+                    ? 'lowerHandLabel'
+                    : 'raiseHandLabel'
+                }`,
+              })}
               accessKey={shortcuts.raisehand}
               color="primary"
               hideLabel

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
@@ -8,11 +8,9 @@ import PresentationService from '/imports/ui/components/presentation/service';
 import Presentations from '/imports/api/presentations';
 import ActionsBar from './component';
 import Service from './service';
+import UserListService from '/imports/ui/components/user-list/service';
 import ExternalVideoService from '/imports/ui/components/external-video-player/service';
 import CaptionsService from '/imports/ui/components/captions/service';
-import {
-  isVideoBroadcasting,
-} from '/imports/ui/components/screenshare/service';
 
 import MediaService, {
   getSwapLayout,
@@ -43,4 +41,6 @@ export default withTracker(() => ({
   isThereCurrentPresentation: Presentations.findOne({ meetingId: Auth.meetingID, current: true },
     { fields: {} }),
   allowExternalVideo: Meteor.settings.public.externalVideoPlayer.enabled,
+  setEmojiStatus: UserListService.setEmojiStatus,
+  currentUser: Service.currentUser(),
 }))(injectIntl(ActionsBarContainer));

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/service.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/service.js
@@ -52,6 +52,8 @@ export default {
   amIPresenter,
   amIModerator,
   isMe,
+  currentUser: () => Users.findOne({ meetingId: Auth.meetingID, userId: Auth.userID },
+    { fields: { userId: 1, emoji: 1 } }),
   meetingName: () => Meetings.findOne({ meetingId: Auth.meetingID },
     { fields: { 'meetingProp.name': 1 } }).meetingProp.name,
   users: () => Users.find({

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
@@ -62,19 +62,12 @@
 
 .right {
   position: absolute;
-  bottom: var(--sm-padding-x);
   right: var(--sm-padding-x);
   left: auto;
 
   [dir="rtl"] & {
     right: auto;
     left: var(--sm-padding-x);
-  }
-}
-
-.centerWithActions {
-  @include mq($xsmall-only) {
-    justify-content: flex-end;
   }
 }
 

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
@@ -27,8 +27,18 @@
   flex-direction: row;
 }
 
-.center,
 .right {
+  flex: 1;
+  justify-content: center;
+  @include mq($small-only) {
+    position: relative;
+    right: 0;
+    left: 0;
+    display: contents;
+  }
+}
+
+.center {
   flex: 1;
   justify-content: center;
 }

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -63,6 +63,14 @@ const intlMessages = defineMessages({
     id: 'app.toast.setEmoji.label',
     description: 'message when a user emoji has been set',
   },
+  raisedHand: {
+    id: 'app.toast.setEmoji.raiseHand',
+    description: 'toast message for raised hand notification',
+  },
+  loweredHand: {
+    id: 'app.toast.setEmoji.lowerHand',
+    description: 'toast message for lowered hand notification',
+  },
   meetingMuteOn: {
     id: 'app.toast.meetingMuteOn.label',
     description: 'message used when meeting has been muted',
@@ -174,10 +182,21 @@ class App extends Component {
       const formattedEmojiStatus = intl.formatMessage({ id: `app.actionsBar.emojiMenu.${currentUserEmoji.status}Label` })
       || currentUserEmoji.status;
 
+      const raisedHand = currentUserEmoji.status === 'raiseHand';
+
+      let statusLabel = '';
+      if (currentUserEmoji.status === 'none') {
+        statusLabel = prevProps.currentUserEmoji.status === 'raiseHand'
+          ? intl.formatMessage(intlMessages.loweredHand)
+          : intl.formatMessage(intlMessages.clearedEmoji);
+      } else {
+        statusLabel = raisedHand
+          ? intl.formatMessage(intlMessages.raisedHand)
+          : intl.formatMessage(intlMessages.setEmoji, ({ 0: formattedEmojiStatus }));
+      }
+
       notify(
-        currentUserEmoji.status === 'none'
-          ? intl.formatMessage(intlMessages.clearedEmoji)
-          : intl.formatMessage(intlMessages.setEmoji, ({ 0: formattedEmojiStatus })),
+        statusLabel,
         'info',
         currentUserEmoji.status === 'none'
           ? 'clear_status'
@@ -343,7 +362,7 @@ class App extends Component {
 
   render() {
     const {
-      customStyle, customStyleUrl, openPanel, layoutContextState
+      customStyle, customStyleUrl, openPanel, layoutContextState,
     } = this.props;
 
     return (

--- a/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
@@ -76,6 +76,10 @@ const intlMessages = defineMessages({
     id: 'app.audio.leaveAudio',
     description: 'describes the leave audio shortcut',
   },
+  raisehand: {
+    id: 'app.shortcut-help.raiseHand',
+    description: 'describes the toggle raise hand shortcut',
+  },
   togglePan: {
     id: 'app.shortcut-help.togglePan',
     description: 'describes the toggle pan shortcut',
@@ -151,7 +155,7 @@ const ShortcutHelpComponent = (props) => {
       <td className={styles.descCell}>{intl.formatMessage(intlMessages.toggleFullscreen)}</td>
     </tr>
   ));
-  
+
   shortcutItems.push((
     <tr key={_.uniqueId('hotkey-item-')}>
       <td className={styles.keyCell}>Right Arrow</td>

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -449,13 +449,12 @@ const normalizeEmojiName = emoji => (
   emoji in EMOJI_STATUSES ? EMOJI_STATUSES[emoji] : emoji
 );
 
-const setEmojiStatus = (userId, emoji) => {
+const setEmojiStatus = _.debounce((userId, emoji) => {
   const statusAvailable = (Object.keys(EMOJI_STATUSES).includes(emoji));
-
   return statusAvailable
     ? makeCall('setEmojiStatus', Auth.userID, emoji)
     : makeCall('setEmojiStatus', userId, 'none');
-};
+}, 1000, { leading: true, trailing: false });
 
 const assignPresenter = (userId) => { makeCall('assignPresenter', userId); };
 

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -114,6 +114,9 @@ public:
       closePrivateChat:
         accesskey: G
         descId: closePrivateChat
+      raiseHand:
+        accesskey: R
+        descId: raiseHand
       openActions:
         accesskey: A
         descId: openActions

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -583,6 +583,7 @@
     "app.shortcut-help.hidePrivateChat": "Hide private chat",
     "app.shortcut-help.closePrivateChat": "Close private chat",
     "app.shortcut-help.openActions": "Open actions menu",
+    "app.shortcut-help.raiseHand": "Toggle Raise Hand",
     "app.shortcut-help.openDebugWindow": "Open debug window",
     "app.shortcut-help.openStatus": "Open status menu",
     "app.shortcut-help.togglePan": "Activate Pan tool (Presenter)",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -562,6 +562,8 @@
     "app.toast.setEmoji.label": "Emoji status set to {0}",
     "app.toast.meetingMuteOn.label": "All users have been muted",
     "app.toast.meetingMuteOff.label": "Meeting mute turned off",
+    "app.toast.setEmoji.raiseHand": "You have raised your hand",
+    "app.toast.setEmoji.lowerHand": "You have lowered your hand",
     "app.notification.recordingStart": "This session is now being recorded",
     "app.notification.recordingStop": "This session is not being recorded",
     "app.notification.recordingPaused": "This session is not being recorded anymore",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -407,6 +407,7 @@
     "app.actionsBar.emojiMenu.awayLabel": "Away",
     "app.actionsBar.emojiMenu.awayDesc": "Change your status to away",
     "app.actionsBar.emojiMenu.raiseHandLabel": "Raise hand",
+    "app.actionsBar.emojiMenu.lowerHandLabel": "Lower hand",
     "app.actionsBar.emojiMenu.raiseHandDesc": "Raise your hand to ask a question",
     "app.actionsBar.emojiMenu.neutralLabel": "Undecided",
     "app.actionsBar.emojiMenu.neutralDesc": "Change your status to undecided",


### PR DESCRIPTION
### What does this PR do?
Moves the raise hand functionality to a button on the actions bar.
![image](https://user-images.githubusercontent.com/22058534/111914179-4cc19c00-8a47-11eb-953e-5ccd0f26d973.png)


### Motivation
Provides a faster way for a user to raise their hand. Adding a button on the actions bar reduces the number of clicks needed to perform the action from 3 to 1. This will also allow for the addition of an `accesskey` shortcut.