### PR TITLE
Add getter for defaultKeepEvents

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -1036,6 +1036,10 @@ public class ParamsProcessorUtil {
 	public void setDefaultKeepEvents(Boolean mke) {
 		defaultKeepEvents = mke;
 	}
+	
+	public Boolean getDefaultKeepEvents() {
+		return defaultKeepEvents;
+	}
 
 	public void setAllowModsToUnmuteUsers(Boolean value) {
 		defaultAllowModsToUnmuteUsers = value;


### PR DESCRIPTION
Follow up to #11681

I am adding a getter for `defaultKeepEvents`

In some environments I see

```
2021-03-21T19:54:50.686-04:00 ERROR o.s.boot.SpringApplication - Application startup failed
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'meetingService' defined in class path resource [spring/resources.xml]: Cannot resolve reference to bean 'paramsProcessorUtil' while setting bean property 'paramsProcessorUtil'; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'paramsProcessorUtil' defined in class path resource [spring/resources.xml]: Error setting property values; nested exception is org.springframework.beans.NotWritablePropertyException: Invalid property 'defaultKeepEvents' of bean class [org.bigbluebutton.api.ParamsProcessorUtil]: Bean property 'defaultKeepEvents' is not writable or has an invalid setter method. Does the parameter type of the setter match the return type of the getter?
```