### PR TITLE
Revert "Add getter for defaultKeepEvents"

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -1036,10 +1036,6 @@ public class ParamsProcessorUtil {
 	public void setDefaultKeepEvents(Boolean mke) {
 		defaultKeepEvents = mke;
 	}
-	
-	public Boolean getDefaultKeepEvents() {
-		return defaultKeepEvents;
-	}
 
 	public void setAllowModsToUnmuteUsers(Boolean value) {
 		defaultAllowModsToUnmuteUsers = value;


### PR DESCRIPTION
Reverts bigbluebutton/bigbluebutton#11705

The issue was caused by old jars with incorrect permission. No need of this change, the setter suffices. The error message was referring to the old jar