### PR TITLE
Prevent logged out user to spam validateAuthToken

### DIFF
--- a/bigbluebutton-html5/imports/api/auth-token-validation/server/modifiers/upsertValidationState.js
+++ b/bigbluebutton-html5/imports/api/auth-token-validation/server/modifiers/upsertValidationState.js
@@ -1,7 +1,7 @@
 import Logger from '/imports/startup/server/logger';
 import AuthTokenValidation from '/imports/api/auth-token-validation';
 
-export default function upsertValidationState(meetingId, userId, validationStatus, connectionId) {
+export default function upsertValidationState(meetingId, userId, validationStatus, connectionId, reason = null) {
   const selector = {
     meetingId, userId, connectionId,
   };
@@ -12,18 +12,17 @@ export default function upsertValidationState(meetingId, userId, validationStatu
       connectionId,
       validationStatus,
       updatedAt: new Date().getTime(),
+      reason,
     },
   };
 
-  const cb = (err, numChanged) => {
-    if (err) {
-      Logger.error(`Could not upsert to collection AuthTokenValidation: ${err}`);
-      return;
-    }
-    if (numChanged) {
+  try {
+    const { numberAffected } = AuthTokenValidation.upsert(selector, modifier);
+
+    if (numberAffected) {
       Logger.info(`Upserted ${JSON.stringify(selector)} ${validationStatus} in AuthTokenValidation`);
     }
-  };
-
-  return AuthTokenValidation.upsert(selector, modifier, cb);
+  } catch (err) {
+    Logger.error(`Could not upsert to collection AuthTokenValidation: ${err}`);
+  }
 }

--- a/bigbluebutton-html5/imports/api/users/server/handlers/validateAuthToken.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/validateAuthToken.js
@@ -25,6 +25,7 @@ export default function handleValidateAuthToken({ body }, meetingId) {
     waitForApproval,
     registeredOn,
     authTokenValidatedOn,
+    reason,
   } = body;
 
   check(userId, String);
@@ -46,7 +47,7 @@ export default function handleValidateAuthToken({ body }, meetingId) {
           const { methodInvocationObject } = pendingAuth;
           const connectionId = methodInvocationObject.connection.id;
 
-          upsertValidationState(meetingId, userId, ValidationStates.INVALID, connectionId);
+          upsertValidationState(meetingId, userId, ValidationStates.INVALID, connectionId, reason);
 
           // Schedule socket disconnection for this user, giving some time for client receiving the reason of disconnection
           Meteor.setTimeout(() => {

--- a/bigbluebutton-html5/imports/ui/services/auth/index.js
+++ b/bigbluebutton-html5/imports/ui/services/auth/index.js
@@ -225,8 +225,6 @@ class Auth {
         });
       }, CONNECTION_TIMEOUT);
 
-      Meteor.subscribe('auth-token-validation', { meetingId: this.meetingID, userId: this.userID });
-
       const result = await makeCall('validateAuthToken', this.meetingID, this.userID, this.token, this.externUserID);
 
       if (result && result.invalid) {
@@ -239,41 +237,20 @@ class Auth {
         return;
       }
 
+      Meteor.subscribe('auth-token-validation', { meetingId: this.meetingID, userId: this.userID });
       Meteor.subscribe('current-user');
 
       Tracker.autorun((c) => {
         computation = c;
 
-        const selector = { meetingId: this.meetingID, userId: this.userID };
-        const fields = {
-          ejected: 1, intId: 1, validated: 1, userId: 1,
-        };
-        const User = Users.findOne(selector, { fields });
-        // Skip in case the user is not in the collection yet or is a dummy user
-        if (!User || !('intId' in User)) {
-          logger.info({ logCode: 'auth_service_resend_validateauthtoken' }, 're-send validateAuthToken for delayed authentication');
-          makeCall('validateAuthToken', this.meetingID, this.userID, this.token);
-
-          return;
-        }
-
-        if (User.ejected) {
-          computation.stop();
-          reject({
-            error: 403,
-            description: 'User has been ejected.',
-          });
-          return;
-        }
-
-        const authenticationTokenValidation = AuthTokenValidation.findOne();
+        const authenticationTokenValidation = AuthTokenValidation.findOne({}, { sort: { updatedAt: -1 } });
 
         if (!authenticationTokenValidation) return;
 
         switch (authenticationTokenValidation.validationStatus) {
           case ValidationStates.INVALID:
             c.stop();
-            reject({ error: 401, description: 'User has been ejected.' });
+            reject({ error: 401, description: authenticationTokenValidation.reason });
             break;
           case ValidationStates.VALIDATED:
             initCursorStreamListener();


### PR DESCRIPTION
### What does this PR do?

Prevent user that logged out to spam validateAuthToken when trying to join using the previous session token.

### Motivation

In 2.2 we had a verification that didn't allowed logged out users to join again using their last session token, since 2.3 we started to remove offline users from collection, because of that we couldn't check if the user has logged out. Changes made in #11607 made it possible to identify those users.