### PR TITLE
Increasing userlist menu width

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/styles.scss
@@ -163,10 +163,10 @@
   cursor: default;
   min-width: 10vw;
   @include mq($medium-only) {
-    min-width: 13vw;
+    min-width: 23vw;
   }
   @include mq($large-up) {
-    min-width: 8vw;
+    min-width: 14vw;
   }
   max-width: 100%;
   overflow: visible;


### PR DESCRIPTION
### What does this PR do?

Increases userlist context menu width

#### before - display size: 1366px (large breakpoint)
![1366px-old](https://user-images.githubusercontent.com/3728706/112001402-b3a18c80-8afd-11eb-8606-ab11067bed08.png)

#### after
![1366px-new](https://user-images.githubusercontent.com/3728706/112001516-cd42d400-8afd-11eb-9074-084518b1e352.png)

#### before - display size: 800px (medium breakpoint)
![800px-old](https://user-images.githubusercontent.com/3728706/112001733-fcf1dc00-8afd-11eb-88b8-9233f2dfe32b.png)

#### after
![800px-new](https://user-images.githubusercontent.com/3728706/112001830-1430c980-8afe-11eb-9bfd-a143ca30378d.png)

### Closes Issue(s)

closes #11702
