### PR TITLE
Increasing presenter menu width

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
@@ -118,17 +118,23 @@
   }
 }
 
-.dropdown,
 .btn {
   z-index: 3;
 }
-
+.dropdown{
+  z-index: 4;
+}
 .presentationItem {
   span {
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
-    max-width: 10rem;
+    max-width: 15rem;
+
+    @include mq($small-only) {
+      max-width: 100%;
+    }
+
   }
 }
 

--- a/bigbluebutton-html5/imports/ui/components/dropdown/list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/list/styles.scss
@@ -60,10 +60,6 @@
   display: flex;
   flex: 1 1 100%;
 
-  @include mq($small-only) {
-    justify-content: center;
-  }
-
   .verticalList & {
     padding: calc(var(--line-height-computed) / 3) 0;
 

--- a/bigbluebutton-html5/imports/ui/components/dropdown/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/styles.scss
@@ -312,7 +312,7 @@
 .top-left, [dir="rtl"] .top-right {
   @extend %down-caret;
   @extend %horz-right-caret;
-  min-width: 11.5rem;
+  min-width: 18rem;
 
   @include mq($small-only) {
     width: auto;


### PR DESCRIPTION
### What does this PR do?

- Increases presenter context menu width - desktop
- fixes presentation list width and alignment - mobile
- fixes "close" button z-index - mobile

#### presenter menu (desktop) before
![presentation-old](https://user-images.githubusercontent.com/3728706/112007987-df277580-8b03-11eb-9c28-1722f325f4a2.png)

#### presenter menu (desktop) - after
![presentation-new](https://user-images.githubusercontent.com/3728706/112008048-ebabce00-8b03-11eb-8e75-4776e80392db.png)

#### presentation list (mobile) - before
![mobile-presentation-old](https://user-images.githubusercontent.com/3728706/112008331-244ba780-8b04-11eb-8590-4c26f7010c2d.png)

#### presentation list (mobile) - after
![mobile-presentation-new](https://user-images.githubusercontent.com/3728706/112008349-27469800-8b04-11eb-9019-ee59ff36f3bf.png)

#### close button - before
![close-button-old](https://user-images.githubusercontent.com/3728706/112008490-480eed80-8b04-11eb-84f4-c91af7366fa9.png)

#### close button - after
![close-button-new](https://user-images.githubusercontent.com/3728706/112008507-4c3b0b00-8b04-11eb-8aee-18d1a505b0be.png)

### Closes Issue(s)

closes #11701