### PR TITLE
 Keep recording status files

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/workers/archive_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/archive_worker.rb
@@ -27,7 +27,12 @@ module BigBlueButton
           @logger.info("Running archive worker for #{@full_id}")
           @publisher.put_archive_started(@meeting_id)
 
-          remove_status_files
+          # Keep the status files so we can still track
+          # the recording progress. We need these at the moment
+          # for the monitoring tools to continue to work.
+          # We need to find a better way (storing in redis?)
+          # in the future to be able to monitor progress.
+          #remove_status_files
 
           script = File.join(BigBlueButton.rap_scripts_path, 'archive', 'archive.rb')
           if @break_timestamp.nil?

--- a/record-and-playback/core/lib/recordandplayback/workers/process_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/process_worker.rb
@@ -29,7 +29,12 @@ module BigBlueButton
           script = File.join(BigBlueButton.rap_scripts_path,
                              'process', "#{@format_name}.rb")
           if File.exist?(script)
-            remove_status_files
+            # Keep the status files so we can still track
+            # the recording progress. We need these at the moment
+            # for the monitoring tools to continue to work.
+            # We need to find a better way (storing in redis?)
+            # in the future to be able to monitor progress.
+            #remove_status_files
 
             @publisher.put_process_started(@format_name, @meeting_id)
 

--- a/record-and-playback/core/lib/recordandplayback/workers/publish_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/publish_worker.rb
@@ -35,7 +35,13 @@ module BigBlueButton
 
             # If the publish directory exists, the script does nothing
             FileUtils.rm_rf("#{@recording_dir}/publish/#{@format_name}/#{@full_id}")
-            remove_status_files
+
+            # Keep the status files so we can still track
+            # the recording progress. We need these at the moment
+            # for the monitoring tools to continue to work.
+            # We need to find a better way (storing in redis?)
+            # in the future to be able to monitor progress.
+            #remove_status_files
 
             # For legacy reasons, the meeting ID passed to the publish script contains
             # the playback format name.

--- a/record-and-playback/core/lib/recordandplayback/workers/sanity_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/sanity_worker.rb
@@ -27,7 +27,12 @@ module BigBlueButton
           @logger.info("Running sanity worker for #{@full_id}")
           @publisher.put_sanity_started(@meeting_id)
 
-          remove_status_files
+          # Keep the status files so we can still track
+          # the recording progress. We need these at the moment
+          # for the monitoring tools to continue to work.
+          # We need to find a better way (storing in redis?)
+          # in the future to be able to monitor progress.
+          #remove_status_files
 
           script = File.join(BigBlueButton.rap_scripts_path, 'sanity', 'sanity.rb')
           if @break_timestamp.nil?


### PR DESCRIPTION

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Comment out code that deletes the recording status files. This reverts to the original behaviour of
keeping status files.

### Closes Issue(s)

closes #...
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number -->

### Motivation

<!-- What inspired you to submit this pull request? -->
Previously, the status files provided the recording processing triggers to go through the next steps
in the recording process. With the move to using resque, these files are not needed to move the
process along. However,  the recording status files are also used to externally monitor the
progress of the recordings. Let's keep these files for now until we figure out a different way to track 
the status of the recording.
### More

<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
