### PR TITLE
Retrieve guest user pre-join messages only when userId is available

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
@@ -4,6 +4,7 @@ import { ChatContext, ACTIONS } from './context';
 import { UsersContext } from '../users-context/context';
 import { makeCall } from '/imports/ui/services/api';
 import ChatLogger from '/imports/ui/components/chat/chat-logger/ChatLogger';
+import Auth from '/imports/ui/services/auth';
 
 let usersData = {};
 let messageQueue = [];
@@ -60,12 +61,12 @@ const Adapter = () => {
 
   useEffect(() => {
     const connectionStatus = Meteor.status();
-    if (connectionStatus.connected && !syncStarted) {
+    if (connectionStatus.connected && !syncStarted && Auth.userID) {
       setSync(true);
 
       startSyncMessagesbeforeJoin(dispatch);
     }
-  }, [Meteor.status().connected, syncStarted]);
+  }, [Meteor.status().connected, syncStarted, Auth.userID]);
 
 
   useEffect(() => {


### PR DESCRIPTION
### What does this PR do?

Wait for userId to be available before trying to get pre-join messages of current meeting.

### Closes Issue(s)

closes #11674
