### PR TITLE
Case insensitive typed poll responses grouping

### DIFF
--- a/bigbluebutton-html5/imports/api/polls/server/handlers/sendPollChatMsg.js
+++ b/bigbluebutton-html5/imports/api/polls/server/handlers/sendPollChatMsg.js
@@ -11,12 +11,27 @@ export default function sendPollChatMsg({ body }, meetingId) {
 
   const { answers, numRespondents } = poll;
 
+  const caseInsensitiveReducer = (acc, item) => {
+    const index = acc.findIndex(ans => ans.key.toLowerCase() === item.key.toLowerCase());
+    if(index !== -1) {
+      if(acc[index].numVotes >= item.numVotes) acc[index].numVotes += item.numVotes;
+      else {
+        const tempVotes = acc[index].numVotes;
+        acc[index] = item;
+        acc[index].numVotes += tempVotes;
+      }
+    } else {
+      acc.push(item);
+    }
+    return acc;
+  };
+
   let responded = 0;
   let resultString = 'bbb-published-poll-\n';
   answers.map((item) => {
     responded += item.numVotes;
     return item;
-  }).map((item) => {
+  }).reduce(caseInsensitiveReducer, []).map((item) => {
     item.key = item.key.split('<br/>').join('<br#>');
     const numResponded = responded === numRespondents ? numRespondents : responded;
     const pct = Math.round(item.numVotes / numResponded * 100);

--- a/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { defineMessages, injectIntl } from 'react-intl';
 import Button from '/imports/ui/components/button/component';
+import caseInsensitiveReducer from '/imports/utils/caseInsensitiveReducer';
 import { styles } from './styles';
 import Service from './service';
 
@@ -94,7 +95,7 @@ class LiveResult extends PureComponent {
 
     const pollStats = [];
 
-    answers.map((obj) => {
+    answers.reduce(caseInsensitiveReducer, []).map((obj) => {
       const formattedMessageIndex = obj.key.toLowerCase();
       const pct = Math.round(obj.numVotes / numRespondents * 100);
       const pctFotmatted = `${Number.isNaN(pct) ? 0 : pct}%`;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import PollService from '/imports/ui/components/poll/service';
+import caseInsensitiveReducer from '/imports/utils/caseInsensitiveReducer';
 import { injectIntl, defineMessages } from 'react-intl';
 import styles from './styles';
 import { prototype } from 'clipboard';
@@ -230,9 +231,10 @@ class PollDrawComponent extends Component {
     let votesTotal = 0;
     let maxNumVotes = 0;
     const textArray = [];
+    const reducedResult = result.reduce(caseInsensitiveReducer, []);
 
     // counting the total number of votes, finding the biggest number of votes
-    result.reduce((previousValue, currentValue) => {
+    reducedResult.reduce((previousValue, currentValue) => {
       votesTotal = previousValue + currentValue.numVotes;
       if (maxNumVotes < currentValue.numVotes) {
         maxNumVotes = currentValue.numVotes;
@@ -244,10 +246,10 @@ class PollDrawComponent extends Component {
     // filling the textArray with data to display
     // adding value of the iterator to each line needed to create unique
     // keys while rendering at the end
-    const arrayLength = result.length;
+    const arrayLength = reducedResult.length;
     for (let i = 0; i < arrayLength; i += 1) {
       const _tempArray = [];
-      const _result = result[i];
+      const _result = reducedResult[i];
       let isDefaultPoll;
       switch (_result.key.toLowerCase()) {
         case 'true':

--- a/bigbluebutton-html5/imports/utils/caseInsensitiveReducer.js
+++ b/bigbluebutton-html5/imports/utils/caseInsensitiveReducer.js
@@ -1,0 +1,17 @@
+const caseInsensitiveReducer = (acc, item) => {
+  const index = acc.findIndex(ans => ans.key.toLowerCase() === item.key.toLowerCase());
+  if(index !== -1) {
+    if(acc[index].numVotes >= item.numVotes) acc[index].numVotes += item.numVotes;
+    else {
+      const tempVotes = acc[index].numVotes;
+      acc[index] = item;
+      acc[index].numVotes += tempVotes;
+    }
+  } else {
+    acc.push(item);
+  }
+  return acc;
+};
+
+export default caseInsensitiveReducer;
+  


### PR DESCRIPTION
### What does this PR do?

This PR makes sure that the grouping of the typed poll results is case insensitive for presenter live view, chat and whiteboard annotation.
Users->Response table displayed for presenter stays the same (case sensitive).

### Closes Issue(s)

closes #11506