### PR TITLE
Default enable banner alert when user speaks with mic muted

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
@@ -103,7 +103,7 @@ class AudioControls extends PureComponent {
 
     return (
       <span className={styles.container}>
-        {inputStream && muteAlertEnabled ? (
+        {isVoiceUser && inputStream && muteAlertEnabled ? (
           <MutedAlert {...{
             muted, inputStream, isViewer, isPresenter,
           }}

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -34,7 +34,7 @@ public:
     allowFullscreen: true
     preloadNextSlides: 2
     mutedAlert:
-      enabled: false
+      enabled: true
       interval: 200
       threshold: -50
       duration: 4000


### PR DESCRIPTION
This sets back the default value after fixes done in #11272 and #11268

This PR also fixes #11433
