### PR TITLE
Add collection user persistent data

### DIFF
--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/meetingHasEnded.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/meetingHasEnded.js
@@ -28,6 +28,8 @@ import clearRecordMeeting from './clearRecordMeeting';
 import clearVoiceCallStates from '/imports/api/voice-call-states/server/modifiers/clearVoiceCallStates';
 import clearVideoStreams from '/imports/api/video-streams/server/modifiers/clearVideoStreams';
 import clearAuthTokenValidation from '/imports/api/auth-token-validation/server/modifiers/clearAuthTokenValidation';
+import clearUsersPersistentData from '/imports/api/users-persistent-data/server/modifiers/clearUsersPersistentData';
+
 import clearWhiteboardMultiUser from '/imports/api/whiteboard-multi-user/server/modifiers/clearWhiteboardMultiUser';
 import Metrics from '/imports/startup/server/metrics';
 
@@ -62,6 +64,7 @@ export default function meetingHasEnded(meetingId) {
     clearAuthTokenValidation(meetingId);
     clearWhiteboardMultiUser(meetingId);
     clearScreenshare(meetingId);
+    clearUsersPersistentData(meetingId);
     BannedUsers.delete(meetingId);
     Metrics.removeMeeting(meetingId);
 

--- a/bigbluebutton-html5/imports/api/users-persistent-data/index.js
+++ b/bigbluebutton-html5/imports/api/users-persistent-data/index.js
@@ -1,0 +1,9 @@
+import { Meteor } from 'meteor/meteor';
+
+const UsersPersistentData = new Mongo.Collection('users-persistent-data');
+
+if (Meteor.isServer) {
+  UsersPersistentData._ensureIndex({ meetingId: 1, userId: 1 });
+}
+
+export default UsersPersistentData;

--- a/bigbluebutton-html5/imports/api/users-persistent-data/server/index.js
+++ b/bigbluebutton-html5/imports/api/users-persistent-data/server/index.js
@@ -1,0 +1,1 @@
+import './publishers';

--- a/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/addUserPersistentData.js
+++ b/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/addUserPersistentData.js
@@ -50,7 +50,7 @@ export default function addUserPersistentData(user) {
     avatar,
     guest,
     color,
-    online: true,
+    loggedOut: false,
   };
 
   const selector = {

--- a/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/addUserPersistentData.js
+++ b/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/addUserPersistentData.js
@@ -1,0 +1,76 @@
+import { check } from 'meteor/check';
+import UsersPersistentData from '/imports/api/users-persistent-data';
+import Logger from '/imports/startup/server/logger';
+
+export default function addUserPersistentData(user) {
+  check(user, {
+    meetingId: String,
+    sortName: String,
+    color: String,
+    mobile: Boolean,
+    breakoutProps: Object,
+    inactivityCheck: Boolean,
+    responseDelay: Number,
+    loggedOut: Boolean,
+    intId: String,
+    extId: String,
+    name: String,
+    role: String,
+    guest: Boolean,
+    authed: Boolean,
+    guestStatus: String,
+    emoji: String,
+    presenter: Boolean,
+    locked: Boolean,
+    avatar: String,
+    clientType: String,
+    effectiveConnectionType: null,
+  });
+
+
+  const {
+    intId,
+    extId,
+    meetingId,
+    name,
+    role,
+    token,
+    avatar,
+    guest,
+    color,
+  } = user;
+
+  const userData = {
+    userId: intId,
+    extId,
+    meetingId,
+    name,
+    role,
+    token,
+    avatar,
+    guest,
+    color,
+    online: true,
+  };
+
+  const selector = {
+    userId: intId,
+    meetingId,
+  };
+
+  const modifier = {
+    $set: userData,
+  };
+
+  try {
+    const { insertedId } = UsersPersistentData.upsert(selector, modifier);
+
+    if (insertedId) {
+      Logger.info(`Added user id=${intId} to user persistent Data: meeting=${meetingId}`);
+    } else {
+      Logger.info(`Upserted user id=${intId} to user persistent Data: meeting=${meetingId}`);
+    }
+  } catch (err) {
+    Logger.error(`Adding note to the collection: ${err}`);
+  }
+}

--- a/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/clearUsersPersistentData.js
+++ b/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/clearUsersPersistentData.js
@@ -1,0 +1,26 @@
+import Logger from '/imports/startup/server/logger';
+import UsersPersistentData from '/imports/api/users-persistent-data/index';
+
+export default function clearUsersPersistentData(meetingId) {
+  if (meetingId) {
+    try {
+      const numberAffected = UsersPersistentData.remove({ meetingId });
+
+      if (numberAffected) {
+        Logger.info(`Cleared users persistent data (${meetingId})`);
+      }
+    } catch (err) {
+      Logger.error(`Error clearing users persistent data (${meetingId}). ${err}`);
+    }
+  } else {
+    try {
+      const numberAffected = UsersPersistentData.remove({});
+
+      if (numberAffected) {
+        Logger.info('Cleared users persistent data (all)');
+      }
+    } catch (err) {
+      Logger.error(`Error clearing users persistent data (all). ${err}`);
+    }
+  }
+}

--- a/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/setOnlineStatus.js
+++ b/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/setOnlineStatus.js
@@ -1,0 +1,26 @@
+import { check } from 'meteor/check';
+import UsersPersistentData from '/imports/api/users-persistent-data';
+import Logger from '/imports/startup/server/logger';
+
+export default function setOnlineStatus(userId, meetingId, status = false) {
+  check(userId, String);
+  check(meetingId, String);
+  check(status, Boolean);
+
+  const selector = {
+    userId,
+    meetingId,
+  };
+
+  const modifier = {
+    $set: {
+      online: status,
+    },
+  };
+
+  try {
+    UsersPersistentData.update(selector, modifier);
+  } catch (err) {
+    Logger.error(`Adding note to the collection: ${err}`);
+  }
+}

--- a/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/setloggedOutStatus.js
+++ b/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/setloggedOutStatus.js
@@ -2,7 +2,7 @@ import { check } from 'meteor/check';
 import UsersPersistentData from '/imports/api/users-persistent-data';
 import Logger from '/imports/startup/server/logger';
 
-export default function setOnlineStatus(userId, meetingId, status = false) {
+export default function setloggedOutStatus(userId, meetingId, status = true) {
   check(userId, String);
   check(meetingId, String);
   check(status, Boolean);
@@ -14,7 +14,7 @@ export default function setOnlineStatus(userId, meetingId, status = false) {
 
   const modifier = {
     $set: {
-      online: status,
+      loggedOut: status,
     },
   };
 

--- a/bigbluebutton-html5/imports/api/users-persistent-data/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/users-persistent-data/server/publishers.js
@@ -1,0 +1,33 @@
+import UsersPersistentData from '/imports/api/users-persistent-data';
+import { Meteor } from 'meteor/meteor';
+import { extractCredentials } from '/imports/api/common/server/helpers';
+import { check } from 'meteor/check';
+
+function usersPersistentData() {
+  if (!this.userId) {
+    return UsersPersistentData.find({ meetingId: '' });
+  }
+  const { meetingId, requesterUserId } = extractCredentials(this.userId);
+
+  check(meetingId, String);
+  check(requesterUserId, String);
+
+  const selector = {
+    meetingId,
+  };
+
+  const options = {
+    fields: {
+      meetingId: false,
+    },
+  };
+
+  return UsersPersistentData.find(selector, options);
+}
+
+function publishUsersPersistentData(...args) {
+  const boundUsers = usersPersistentData.bind(this);
+  return boundUsers(...args);
+}
+
+Meteor.publish('users-persistent-data', publishUsersPersistentData);

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
@@ -2,7 +2,7 @@ import { check } from 'meteor/check';
 import Users from '/imports/api/users';
 import VideoStreams from '/imports/api/video-streams';
 import Logger from '/imports/startup/server/logger';
-import setOnlineStatus from '/imports/api/users-persistent-data/server/modifiers/setOnlineStatus';
+import setloggedOutStatus from '/imports/api/users-persistent-data/server/modifiers/setloggedOutStatus';
 import stopWatchingExternalVideoSystemCall from '/imports/api/external-videos/server/methods/stopWatchingExternalVideoSystemCall';
 import clearUserInfoForRequester from '/imports/api/users-infos/server/modifiers/clearUserInfoForRequester';
 import ClientConnections from '/imports/startup/server/ClientConnections';
@@ -33,7 +33,7 @@ export default function removeUser(meetingId, userId) {
   };
 
   try {
-    setOnlineStatus(userId, meetingId, false);
+    setloggedOutStatus(userId, meetingId, true);
     VideoStreams.remove({ meetingId, userId });
     const sessionUserId = `${meetingId}-${userId}`;
 

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
@@ -2,6 +2,7 @@ import { check } from 'meteor/check';
 import Users from '/imports/api/users';
 import VideoStreams from '/imports/api/video-streams';
 import Logger from '/imports/startup/server/logger';
+import setOnlineStatus from '/imports/api/users-persistent-data/server/modifiers/setOnlineStatus';
 import stopWatchingExternalVideoSystemCall from '/imports/api/external-videos/server/methods/stopWatchingExternalVideoSystemCall';
 import clearUserInfoForRequester from '/imports/api/users-infos/server/modifiers/clearUserInfoForRequester';
 import ClientConnections from '/imports/startup/server/ClientConnections';
@@ -32,6 +33,7 @@ export default function removeUser(meetingId, userId) {
   };
 
   try {
+    setOnlineStatus(userId, meetingId, false);
     VideoStreams.remove({ meetingId, userId });
     const sessionUserId = `${meetingId}-${userId}`;
 

--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/container.jsx
@@ -40,8 +40,8 @@ export default function TimeWindowChatItemContainer(props) {
       {
       ...{
         color: user?.color || color,
-        isModerator: user?.role === ROLE_MODERATOR,
-        isOnline: !!user,
+        isModerator: !user?.loggedOut && user?.role === ROLE_MODERATOR,
+        isOnline: !user?.loggedOut,
         avatar: user?.avatar,
         name: user?.name || sender?.name,
         read: message.read,

--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/container.jsx
@@ -40,7 +40,7 @@ export default function TimeWindowChatItemContainer(props) {
       {
       ...{
         color: user?.color || color,
-        isModerator: !user?.loggedOut && user?.role === ROLE_MODERATOR,
+        isModerator: user?.role === ROLE_MODERATOR,
         isOnline: !user?.loggedOut,
         avatar: user?.avatar,
         name: user?.name || sender?.name,

--- a/bigbluebutton-html5/imports/ui/components/components-data/users-context/adapter.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/users-context/adapter.jsx
@@ -1,5 +1,6 @@
 import { useContext, useEffect } from 'react';
 import Users from '/imports/api/users';
+import UsersPersistentData from '/imports/api/users-persistent-data';
 import { UsersContext, ACTIONS } from './context';
 import { ChatContext, ACTIONS as CHAT_ACTIONS } from '../chat-context/context';
 import ChatLogger from '/imports/ui/components/chat/chat-logger/ChatLogger';
@@ -8,8 +9,29 @@ const Adapter = () => {
   const usingUsersContext = useContext(UsersContext);
   const { dispatch } = usingUsersContext;
 
-  const usingChatContext = useContext(ChatContext);
-  const { dispatch: chatDispatch } = usingChatContext;
+  useEffect(()=> {
+    const usersPersistentDataCursor = UsersPersistentData.find({}, { sort: { timestamp: 1 } });
+    usersPersistentDataCursor.observe({
+      added: (obj) => {
+        console.log('kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk');
+        dispatch({
+          type: ACTIONS.ADDED_USER_PERSISTENT_DATA,
+          value: {
+            user: obj,
+          },
+        });
+      },
+      changed: (obj) => {
+        dispatch({
+          type: ACTIONS.CHANGED_USER_PERSISTENT_DATA,
+          value: {
+            user: obj,
+          },
+        });
+      },
+      removed: (obj) => {},
+    });
+  }, []);
 
   useEffect(() => {
     const usersCursor = Users.find({}, { sort: { timestamp: 1 } });
@@ -26,14 +48,6 @@ const Adapter = () => {
       changed: (obj) => {
         dispatch({
           type: ACTIONS.CHANGED,
-          value: {
-            user: obj,
-          },
-        });
-      },
-      removed: (obj) => {
-        dispatch({
-          type: ACTIONS.REMOVED,
           value: {
             user: obj,
           },

--- a/bigbluebutton-html5/imports/ui/components/components-data/users-context/adapter.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/users-context/adapter.jsx
@@ -13,7 +13,7 @@ const Adapter = () => {
     const usersPersistentDataCursor = UsersPersistentData.find({}, { sort: { timestamp: 1 } });
     usersPersistentDataCursor.observe({
       added: (obj) => {
-        console.log('kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk');
+        ChatLogger.debug("usersAdapter::observe::added_persistent_user", obj);
         dispatch({
           type: ACTIONS.ADDED_USER_PERSISTENT_DATA,
           value: {
@@ -22,6 +22,7 @@ const Adapter = () => {
         });
       },
       changed: (obj) => {
+        ChatLogger.debug("usersAdapter::observe::changed_persistent_user", obj);
         dispatch({
           type: ACTIONS.CHANGED_USER_PERSISTENT_DATA,
           value: {

--- a/bigbluebutton-html5/imports/ui/components/components-data/users-context/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/users-context/context.jsx
@@ -9,6 +9,8 @@ export const ACTIONS = {
   ADDED: 'added',
   CHANGED: 'changed',
   REMOVED: 'removed',
+  ADDED_USER_PERSISTENT_DATA: 'added_user_persistent_data',
+  CHANGED_USER_PERSISTENT_DATA: 'changed_user_persistent_data',
 };
 
 export const UsersContext = createContext();
@@ -45,6 +47,37 @@ const reducer = (state, action) => {
         return newState;
       }
 
+      return state;
+    }
+
+    //USER PERSISTENT DATA
+    case ACTIONS.ADDED_USER_PERSISTENT_DATA: {
+      const { user } = action.value;
+      if (state[user.userId]) {
+        return state;
+      }
+
+      const newState = {
+        ...state,
+        [user.userId]: {
+          ...user,
+        },
+      };
+      return newState;
+    }
+    case ACTIONS.CHANGED_USER_PERSISTENT_DATA: {
+      const { user } = action.value;
+      const stateUser = state[user.userId];
+      if (stateUser) {
+        const newState = {
+          ...state,
+          [user.userId]: {
+            ...stateUser,
+            ...user,
+          },
+        };
+        return newState;
+      }
       return state;
     }
     default: {

--- a/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
@@ -36,6 +36,8 @@ class Subscriptions extends Component {
   }
 }
 
+let usersPersistentDataHandler = null;
+
 export default withTracker(() => {
   const { credentials } = Auth;
   const { meetingId, requesterUserId } = credentials;
@@ -104,6 +106,9 @@ export default withTracker(() => {
 
     const chatIds = chats.map(chat => chat.chatId);
     groupChatMessageHandler = Meteor.subscribe('group-chat-msg', chatIds, subscriptionErrorHandler);
+  }
+  if (ready && !usersPersistentDataHandler) {
+    usersPersistentDataHandler = Meteor.subscribe('users-persistent-data');
   }
 
   return {

--- a/bigbluebutton-html5/server/main.js
+++ b/bigbluebutton-html5/server/main.js
@@ -21,6 +21,7 @@ import '/imports/api/whiteboard-multi-user/server';
 import '/imports/api/video-streams/server';
 import '/imports/api/network-information/server';
 import '/imports/api/users-infos/server';
+import '/imports/api/users-persistent-data/server';
 import '/imports/api/connection-status/server';
 import '/imports/api/note/server';
 import '/imports/api/external-videos/server';


### PR DESCRIPTION
### What does this PR do?

This PR implements a new collection named `users-persistent-data` with information that we want to keep available to client even for disconnected users: `userId, extId, meetingId, name, role, token, avatar, guest, color, loggedOut`.
This collection is loaded after the initial data synchronization ( after client is usable ), and before the chat history synchronization.
### Closes Issue(s)
Closes #11081
