### PR TITLE
Fix reactive issue with reconnection

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
@@ -103,7 +103,7 @@ const Adapter = () => {
         });
       }
     });
-  }, [Meteor.status().connected]);
+  }, [Meteor.status().connected, Meteor.connection._lastSessionId]);
 
   return null;
 };


### PR DESCRIPTION


### What does this PR do?

Reconnection was not being detected in Firefox, this PR adds the connectionID on useState hook 

Single user:

https://user-images.githubusercontent.com/15806883/112214470-ffd3f600-8bfd-11eb-98d4-acb02d1a8bba.mp4

multi user:
	

https://user-images.githubusercontent.com/15806883/112214768-593c2500-8bfe-11eb-9622-8243cb60e781.mp4




