### PR TITLE
Handle pad's events and Meteor's instances

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/AbstractPadRecordEvent.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/AbstractPadRecordEvent.scala
@@ -1,0 +1,24 @@
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ *
+ * Copyright (c) 2021 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.bigbluebutton.core.record.events
+
+trait AbstractPadRecordEvent extends RecordEvent {
+  setModule("PAD")
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/AddPadRecordEvent.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/AddPadRecordEvent.scala
@@ -1,0 +1,34 @@
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ *
+ * Copyright (c) 2021 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.bigbluebutton.core.record.events
+
+class AddPadRecordEvent extends AbstractPadRecordEvent {
+  import AddPadRecordEvent._
+
+  setEvent("AddPadEvent")
+
+  def setPadId(padId: String) {
+    eventMap.put(PAD_ID, padId)
+  }
+}
+
+object AddPadRecordEvent {
+  protected final val PAD_ID = "padId"
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
@@ -100,6 +100,9 @@ class RedisRecorderActor(
       // Caption
       case m: EditCaptionHistoryEvtMsg              => handleEditCaptionHistoryEvtMsg(m)
 
+      // Pad
+      case m: AddPadEvtMsg                          => handleAddPadEvtMsg(m)
+
       // Screenshare
       case m: ScreenshareRtmpBroadcastStartedEvtMsg => handleScreenshareRtmpBroadcastStartedEvtMsg(m)
       case m: ScreenshareRtmpBroadcastStoppedEvtMsg => handleScreenshareRtmpBroadcastStoppedEvtMsg(m)
@@ -442,6 +445,14 @@ class RedisRecorderActor(
     ev.setLocale(msg.body.locale)
     ev.setLocaleCode(msg.body.localeCode)
     ev.setText(msg.body.text)
+
+    record(msg.header.meetingId, ev.toMap.asJava)
+  }
+
+  private def handleAddPadEvtMsg(msg: AddPadEvtMsg) {
+    val ev = new AddPadRecordEvent()
+    ev.setMeetingId(msg.header.meetingId)
+    ev.setPadId(msg.body.padId)
 
     record(msg.header.meetingId, ev.toMap.asJava)
   }

--- a/bigbluebutton-html5/imports/api/captions/server/methods/createCaptions.js
+++ b/bigbluebutton-html5/imports/api/captions/server/methods/createCaptions.js
@@ -5,11 +5,12 @@ import {
   isEnabled,
   getLocalesURL,
 } from '/imports/api/captions/server/helpers';
+import { withInstaceId } from '/imports/api/note/server/helpers';
 import addCaption from '/imports/api/captions/server/modifiers/addCaption';
 import addCaptionsPads from '/imports/api/captions/server/methods/addCaptionsPads';
 import axios from 'axios';
 
-export default function createCaptions(meetingId) {
+export default function createCaptions(meetingId, instanceId) {
   // Avoid captions creation if this feature is disabled
   if (!isEnabled()) {
     Logger.warn(`Captions are disabled for ${meetingId}`);
@@ -17,6 +18,7 @@ export default function createCaptions(meetingId) {
   }
 
   check(meetingId, String);
+  check(instanceId, Number);
 
   axios({
     method: 'get',
@@ -31,7 +33,7 @@ export default function createCaptions(meetingId) {
     const padIds = [];
     const locales = response.data;
     locales.forEach((locale) => {
-      const padId = generatePadId(meetingId, locale.locale);
+      const padId = withInstaceId(instanceId, generatePadId(meetingId, locale.locale));
       addCaption(meetingId, padId, locale);
       padIds.push(padId);
     });

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -183,10 +183,11 @@ export default function addMeeting(meeting) {
 
     if (insertedId) {
       Logger.info(`Added meeting id=${meetingId}`);
-      // TODO: Here we call Etherpad API to create this meeting notes. Is there a
-      // better place we can run this post-creation routine?
-      createNote(meetingId);
-      createCaptions(meetingId);
+
+      const { html5InstanceId } = meeting.systemProps;
+      createNote(meetingId, html5InstanceId);
+      createCaptions(meetingId, html5InstanceId);
+
       BannedUsers.init(meetingId);
     } else if (numberAffected) {
       Logger.info(`Upserted meeting id=${meetingId}`);

--- a/bigbluebutton-html5/imports/api/note/server/helpers.js
+++ b/bigbluebutton-html5/imports/api/note/server/helpers.js
@@ -14,6 +14,8 @@ const appendTextURL = (padId, text) => `${BASE_URL}/appendText?apikey=${ETHERPAD
 
 const generateNoteId = (meetingId) => hashSHA1(meetingId+ETHERPAD.apikey);
 
+const withInstaceId = (instanceId, id) => `[${instanceId}]${id}`;
+
 const isEnabled = () => NOTE_CONFIG.enabled;
 
 const getDataFromResponse = (data, key) => {
@@ -47,4 +49,5 @@ export {
   getDataFromResponse,
   appendTextURL,
   processForNotePadOnly,
+  withInstaceId,
 };

--- a/bigbluebutton-html5/imports/api/note/server/methods/createNote.js
+++ b/bigbluebutton-html5/imports/api/note/server/methods/createNote.js
@@ -6,11 +6,12 @@ import {
   getReadOnlyIdURL,
   isEnabled,
   getDataFromResponse,
+  withInstaceId,
 } from '/imports/api/note/server/helpers';
 import addNote from '/imports/api/note/server/modifiers/addNote';
 import axios from 'axios';
 
-export default function createNote(meetingId) {
+export default function createNote(meetingId, instanceId) {
   // Avoid note creation if this feature is disabled
   if (!isEnabled()) {
     Logger.warn(`Notes are disabled for ${meetingId}`);
@@ -18,8 +19,9 @@ export default function createNote(meetingId) {
   }
 
   check(meetingId, String);
+  check(instanceId, Number);
 
-  const noteId = generateNoteId(meetingId);
+  const noteId = withInstaceId(instanceId, generateNoteId(meetingId));
 
   const createURL = createPadURL(noteId);
 

--- a/bigbluebutton-html5/imports/startup/server/etherpad.js
+++ b/bigbluebutton-html5/imports/startup/server/etherpad.js
@@ -1,0 +1,26 @@
+const INSTANCE_ID_REGEX = /\d+/;
+
+const isPadMessage = (message) => {
+ const { name } = message.core.header;
+
+  const isPadCreate = name === 'PadCreateSysMsg';
+  const isPadUpdate = name === 'PadUpdateSysMsg';
+
+  return isPadCreate || isPadUpdate;
+};
+
+const getInstanceIdFromPadMessage = (message) => {
+  let instanceId;
+  const { id } = message.core.body.pad;
+
+  // Pad id is composed by the instance id between brackets
+  const match = id.match(INSTANCE_ID_REGEX);
+  if (match) instanceId = parseInt(match[0]);
+
+  return instanceId;
+};
+
+export {
+  isPadMessage,
+  getInstanceIdFromPadMessage,
+};

--- a/record-and-playback/core/lib/recordandplayback.rb
+++ b/record-and-playback/core/lib/recordandplayback.rb
@@ -35,7 +35,6 @@ require 'find'
 require 'rubygems'
 require 'net/http'
 require 'journald/logger'
-require 'digest'
 require 'shellwords'
 require 'English'
 
@@ -224,12 +223,6 @@ module BigBlueButton
 
   def self.record_id_to_timestamp(r)
     r.split("-")[1].to_i / 1000
-  end
-
-  # Notes id will be a SHA1 hash string based on the meeting id and etherpad's apikey
-  def self.get_notes_id(meeting_id, notes_apikey)
-    value = meeting_id + notes_apikey
-    Digest::SHA1.hexdigest value
   end
 
   def self.done_to_timestamp(r)

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -56,6 +56,17 @@ module BigBlueButton
       metadata
     end
 
+    def self.get_notes_id(events)
+      BigBlueButton.logger.info("Task: Getting notes id")
+      notes_id = 'undefined'
+      cc_token = '_cc_'
+      events.xpath("/recording/event[@eventname='AddPadEvent']").each do |pad_event|
+        pad_id = pad_event.at_xpath('padId').text
+        notes_id = pad_id if ! pad_id.include? cc_token
+      end
+      notes_id
+    end
+
     # Get the external meeting id
     def self.get_external_meeting_id(events_xml)
       BigBlueButton.logger.info("Task: Getting external meeting id")

--- a/record-and-playback/core/scripts/bigbluebutton.yml
+++ b/record-and-playback/core/scripts/bigbluebutton.yml
@@ -8,7 +8,6 @@ raw_webrtc_deskshare_src: /usr/share/red5/webapps/video-broadcast/streams
 raw_deskshare_src: /var/bigbluebutton/deskshare
 raw_presentation_src: /var/bigbluebutton
 notes_endpoint: http://127.0.0.1:9001/p
-notes_apikey: ETHERPAD_APIKEY
 # Specify the notes formats we archive
 # txt, doc and odt are also supported
 notes_formats:


### PR DESCRIPTION
Since Meteor was split in multiple process and events started to be
filtered by instances, all Etherpad's Redis events were being discarded.

Etherpad has a Redis' publisher plugin that is unaware of BigBlueButton's
existence. All the communication between them is kept simple with minimal
of internal data exchange. The concept of distincts subscribers at Meteor's
side broke part of this simplicity and, now, Etherpad has to know which
instance must receive it's messages. To provide such information I decided
to include Meteor's instance as part of the pad's id. Should look like:

 - [instanceId]padId for the shared notes
 - [instanceId]padId_cc_(locale) for the closed captions

With those changes the pad id generation made at the recording scripts had to
be re-done because there is no instance id available. Pad id is now recorded at
akka-apps and queried while archiving the shared notes.

**IMPORTANT**: Etherpad's APIKEY juggling can be removed from RaP packaging.

Closes https://github.com/bigbluebutton/bigbluebutton/issues/11518 & https://github.com/bigbluebutton/bigbluebutton/issues/11659