### PR TITLE
audio: change default SDP format to Unified Plan

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -415,7 +415,7 @@ public:
     #Trace sip/audio messages in browser. If not set, default value is false.
     traceSip: false
     # SDP semantics: plan-b|unified-plan
-    sdpSemantics: 'plan-b'
+    sdpSemantics: 'unified-plan'
   stats:
     enabled: true
     interval: 2000


### PR DESCRIPTION
### What does this PR do?

Change full audio's default SDP format to Unified Plan. Making the default transition a bit earlier so that we can field trial it and be sure it's safe enough.

Rationale in https://github.com/bigbluebutton/bigbluebutton/pull/11631.

### Closes Issue(s)

None.

### Motivation

https://github.com/bigbluebutton/bigbluebutton/pull/11631
