### PR TITLE
screenshare: check if the user is still presenter after gDM resolves

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -88,6 +88,16 @@ const attachLocalPreviewStream = (mediaElement) => {
   }
 }
 
+const stopStreamTracks = (stream) => {
+  if (stream && typeof stream.getTracks === 'function') {
+    stream.getTracks().forEach(track => {
+      if (typeof track.stop === 'function') {
+        track.stop();
+      }
+    });
+  }
+}
+
 const screenshareHasStarted = () => {
   // Presenter's screen preview is local, so skip
   if (!UserListService.amIPresenter()) {
@@ -105,6 +115,7 @@ const shareScreen = async (onFail) => {
 
   try {
     const stream = await BridgeService.getScreenStream();
+    if(!UserListService.isUserPresenter(Auth.userID)) return stopStreamTracks(stream);
     await KurentoBridge.share(stream, onFail);
     setSharingScreen(true);
   } catch (error) {


### PR DESCRIPTION
### What does this PR do?

Add a check after gDM resolves (getDisplayMedia, screen sharing)  to see whether the user is still the presenter; if they aren`t, just clean up the gDM stream and do nothing.


### Closes Issue(s)

None.

### Motivation

getDisplayMedia's promise cannot be aborted.

If the presenter gets changed while the user kept the getDisplayMedia browser picker open, accepting the getDisplayMedia prompt might get the previous presenter´s client-side state inconsistent as if they were sharing. Although screen sharing is a no-op in that scenario, the client side state should be preserved.
