### PR TITLE
Enabled by default screenshare with audio (#11622)

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -177,7 +177,7 @@ public:
             max: 2560
           height:
             max: 1600
-        audio: false
+        audio: true
     # cameraProfiles is an array of:
     # - id: profile identifier
     #   name: human-readable profile name


### PR DESCRIPTION
Initially enabled was `false`, waiting for the recording portion of the work to be completed. That was finished in #11626

As of time of writing screenshare with audio is only supported when sharing a *tab* via Chromium based browsers