### PR TITLE
Remove `sender.name` and `color` from message payload

### DIFF
--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addBulkGroupChatMsgs.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addBulkGroupChatMsgs.js
@@ -7,14 +7,22 @@ export default async function addBulkGroupChatMsgs(msgs) {
   if (!msgs.length) return;
 
   const mappedMsgs = msgs
-    .map(({ chatId, meetingId, msg }) => ({
-      _id: new Mongo.ObjectID()._str,
-      ...msg,
-      meetingId,
-      chatId,
-      message: parseMessage(msg.message),
-      sender: msg.sender.id,
-    }))
+    .map(({ chatId, meetingId, msg }) => {
+      const {
+        sender,
+        color,
+        ...restMsg
+      } = msg;
+
+      return {
+        _id: new Mongo.ObjectID()._str,
+        ...restMsg,
+        meetingId,
+        chatId,
+        message: parseMessage(msg.message),
+        sender: sender.id,
+      };
+    })
     .map(el => flat(el, { safe: true }));
 
   try {

--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addGroupChatMsg.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addGroupChatMsg.js
@@ -28,8 +28,16 @@ export default function addGroupChatMsg(meetingId, chatId, msg) {
     message: String,
     correlationId: Match.Maybe(String),
   });
+
+  const {
+    color,
+    sender,
+    ...restMsg
+  } = msg;
+
   const msgDocument = {
-    ...msg,
+    ...restMsg,
+    sender: sender.id,
     meetingId,
     chatId,
     message: parseMessage(msg.message),

--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/syncMeetingChatMsgs.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/syncMeetingChatMsgs.js
@@ -16,12 +16,18 @@ export default function syncMeetingChatMsgs(meetingId, chatId, msgs) {
 
     msgs
       .forEach((msg) => {
+        const {
+          sender,
+          color,
+          ...restMsg
+        } = msg;
+
         const msgToSync = {
-          ...msg,
+          ...restMsg,
           meetingId,
           chatId,
           message: parseMessage(msg.message),
-          sender: msg.sender.id,
+          sender: sender.id,
         };
 
         const modifier = flat(msgToSync, { safe: true });

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-dropdown/component.jsx
@@ -55,11 +55,11 @@ class ChatDropdown extends PureComponent {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { timeWindowsValues } = this.props;
+    const { timeWindowsValues, users } = this.props;
     const { isSettingOpen } = this.state;
     if (prevState.isSettingOpen !== isSettingOpen) {
       this.clipboard = new Clipboard('#clipboardButton', {
-        text: () => ChatService.exportChat(timeWindowsValues),
+        text: () => ChatService.exportChat(timeWindowsValues, users),
       });
     }
   }
@@ -82,7 +82,7 @@ class ChatDropdown extends PureComponent {
 
   getAvailableActions() {
     const {
-      intl, isMeteorConnected, amIModerator, meetingIsBreakout, meetingName, timeWindowsValues,
+      intl, isMeteorConnected, amIModerator, meetingIsBreakout, meetingName, timeWindowsValues, users,
     } = this.props;
 
     const clearIcon = 'delete';
@@ -104,7 +104,7 @@ class ChatDropdown extends PureComponent {
           link.setAttribute(
             'href',
             `data: ${mimeType} ;charset=utf-8,
-            ${encodeURIComponent(ChatService.exportChat(timeWindowsValues))}`,
+            ${encodeURIComponent(ChatService.exportChat(timeWindowsValues, users))}`,
           );
           link.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
         }}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-dropdown/container.jsx
@@ -1,10 +1,16 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import Auth from '/imports/ui/services/auth';
 import Meetings from '/imports/api/meetings';
+import { UsersContext } from '/imports/ui/components/components-data/users-context/context';
 import ChatDropdown from './component';
 
-const ChatDropdownContainer = ({ ...props }) => <ChatDropdown {...props} />;
+const ChatDropdownContainer = ({ ...props }) => {
+  const usingUsersContext = useContext(UsersContext);
+  const { users } = usingUsersContext;
+
+  return <ChatDropdown {...props} users={users} />;
+};
 
 export default withTracker(() => {
   const getMeetingName = () => {

--- a/bigbluebutton-html5/imports/ui/components/chat/service.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/service.js
@@ -312,21 +312,28 @@ const htmlDecode = (input) => {
 };
 
 // Export the chat as [Hour:Min] user: message
-const exportChat = (timeWindowList) => {
-  const messageList = timeWindowList.reduce( (acc, timeWindow) => [...acc, ...timeWindow.content], []);
-  messageList.sort((a, b) => a.time - b.time);
+const exportChat = (timeWindowList, users) => {
+  // const messageList = timeWindowList.reduce( (acc, timeWindow) => [...acc, ...timeWindow.content], []);
+  // messageList.sort((a, b) => a.time - b.time);
 
-  return messageList.map(message => {
-    const date = new Date(message.time);
-    const hour = date.getHours().toString().padStart(2, 0);
-    const min = date.getMinutes().toString().padStart(2, 0);
-    const hourMin = `[${hour}:${min}]`;
+ const messageList = timeWindowList.reduce((acc, timeWindow) => {
 
-    const userName = message.id.endsWith('welcome-msg')
-      ? ''
-      : `${message.name} :`;
-    return `${hourMin} ${userName} ${htmlDecode(message.text)}`;
-  }).join('\n');
+    const msgs = timeWindow.content.map(message => {
+      const date = new Date(message.time);
+      const hour = date.getHours().toString().padStart(2, 0);
+      const min = date.getMinutes().toString().padStart(2, 0);
+      const hourMin = `[${hour}:${min}]`;
+      console.log('message', message);
+      const userName = message.id.endsWith('welcome-msg')
+        ? ''
+        : `${users[timeWindow.sender].name} :`;
+      return `${hourMin} ${userName} ${htmlDecode(message.text)}`;
+    });
+
+    return [...acc, ...msgs];
+  }, [])
+
+  return messageList.join('\n');
 }
 
 

--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/container.jsx
@@ -29,21 +29,19 @@ export default function TimeWindowChatItemContainer(props) {
     key,
     timestamp,
     content,
-    color,
   } = message;
-
   const messages = content;
-  const user = users[sender?.id];
+  const user = users[sender];
   const messageKey = key;
   return (
     <TimeWindowChatItem
       {
       ...{
-        color: user?.color || color,
+        color: user?.color,
         isModerator: user?.role === ROLE_MODERATOR,
         isOnline: !!user,
         avatar: user?.avatar,
-        name: user?.name || sender?.name,
+        name: user?.name,
         read: message.read,
         messages,
         isDefaultPoll,

--- a/bigbluebutton-html5/imports/ui/components/components-data/chat-context/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/chat-context/context.jsx
@@ -46,11 +46,11 @@ export const ChatContext = createContext();
 const generateStateWithNewMessage = (msg, state) => {
   
   const timeWindow = generateTimeWindow(msg.timestamp);
-  const userId = msg.sender.id;
+  const userId = msg.sender;
   const keyName = userId + '-' + timeWindow;
   const msgBuilder = (msg, chat) => {
     const msgTimewindow = generateTimeWindow(msg.timestamp);
-    const key = msg.sender.id + '-' + msgTimewindow;
+    const key = msg.sender + '-' + msgTimewindow;
     const chatIndex = chat?.chatIndexes[key];
     const {
       _id,
@@ -66,7 +66,7 @@ const generateStateWithNewMessage = (msg, state) => {
         lastTimestamp: msg.timestamp,
         read: msg.chatId === PUBLIC_CHAT_KEY && msg.timestamp <= getLoginTime() ? true : false,
         content: [
-          { id: msg.id, name: msg.sender.name, text: msg.message, time: msg.timestamp },
+          { id: msg.id, text: msg.message, time: msg.timestamp },
         ],
       }
     };
@@ -109,7 +109,7 @@ const generateStateWithNewMessage = (msg, state) => {
   const timewindowIndex = stateMessages.chatIndexes[keyName];
   const groupMessage = messageGroups[keyName + '-' + timewindowIndex];
   
-  if (!groupMessage || (groupMessage && groupMessage.sender.id !== stateMessages.lastSender.id)) {
+  if (!groupMessage || (groupMessage && groupMessage.sender !== stateMessages.lastSender)) {
 
     const [tempGroupMessage, sender, newIndex] = msgBuilder(msg, stateMessages);
     stateMessages.lastSender = sender;
@@ -122,13 +122,13 @@ const generateStateWithNewMessage = (msg, state) => {
       messageGroups[key] = tempGroupMessage[key];
       const message = tempGroupMessage[key];
       const previousMessage = message.timestamp <= getLoginTime();
-      if (!previousMessage && message.sender.id !== Auth.userID && !message.id.startsWith(SYSTEM_CHAT_TYPE)) {
+      if (!previousMessage && message.sender !== Auth.userID && !message.id.startsWith(SYSTEM_CHAT_TYPE)) {
         stateMessages.unreadTimeWindows.add(key);
       }
     });
   } else {
     if (groupMessage) {
-      if (groupMessage.sender.id === stateMessages.lastSender.id) {
+      if (groupMessage.sender === stateMessages.lastSender) {
         const previousMessage = msg.timestamp <= getLoginTime();
         const timeWindowKey = keyName + '-' + stateMessages.chatIndexes[keyName];
         messageGroups[timeWindowKey] = {
@@ -137,10 +137,10 @@ const generateStateWithNewMessage = (msg, state) => {
           read: previousMessage ? true : false,
           content: [
             ...groupMessage.content,
-            { id: msg.id, name: groupMessage.sender.name, text: msg.message, time: msg.timestamp }
+            { id: msg.id, text: msg.message, time: msg.timestamp }
           ],
         };
-        if (!previousMessage && groupMessage.sender.id !== Auth.userID) {
+        if (!previousMessage && groupMessage.sender !== Auth.userID) {
           stateMessages.unreadTimeWindows.add(timeWindowKey);
         }
       }


### PR DESCRIPTION
### What does this PR do?

This PR is a follow up for PR #11722, this PR removes the properties `sender.name` and `color` from the message payload because with the new collection we don't need this information in the message anymore.


Clearing the chat and sending private message:

https://user-images.githubusercontent.com/15806883/112378152-5821fb00-8cc5-11eb-83fb-6822fa69569a.mp4




Moderator message:
![image](https://user-images.githubusercontent.com/15806883/112376099-cf09c480-8cc2-11eb-8db9-1138a8921d2b.png)



