### PR TITLE
Remove gradient from content styling

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.scss
@@ -75,12 +75,10 @@
 
   &:before {
     top: 0;
-    background: linear-gradient(to bottom, rgba(0, 0, 0, .45) -20%, transparent 20%);
   }
 
   &:after {
     bottom: 0;
-    background: linear-gradient(to top, rgba(0, 0, 0, .45) -20%, transparent 20%);
   }
 
   @include mq($medium-up) {


### PR DESCRIPTION
### What does this PR do?
Removes the gradients being applied to the contents background.

### Motivation
Fixes accessibility contrast issues.
before:
![cc-before-fix](https://user-images.githubusercontent.com/22058534/112380401-ba77fd00-8cbf-11eb-8b7a-982a6f6de7ac.png)

after:
![cc-after-fix](https://user-images.githubusercontent.com/22058534/112380412-bcda5700-8cbf-11eb-93f3-e7a65e1f8d24.png)

The remaining item is related to the user avatar and all the pseudo elements surrounding it. I've verified the avatars all fall within the accepted AA requirement for their randomly selected background colors. https://github.com/bigbluebutton/bigbluebutton/blob/develop/bigbluebutton-html5/imports/api/users/server/modifiers/addUser.js#L14.
