### PR TITLE
Remove complementary role from user content

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
@@ -50,7 +50,6 @@ class UserContent extends PureComponent {
       <div
         data-test="userListContent"
         className={styles.content}
-        role="complementary"
       >
         {CHAT_ENABLED
           ? (<UserMessages


### PR DESCRIPTION
### What does this PR do?
remove `role="complementary"` from `UserContent`

### Motivation
Fixes:
![wrong-aside-location](https://user-images.githubusercontent.com/22058534/112381737-4fc7c100-8cc1-11eb-9390-0bc5aa34f79a.png)