### PR TITLE
Reduce Audio Modal Heading To H2

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -558,11 +558,11 @@ class AudioModal extends Component {
                 {
                   isIOSChrome ? null
                     : (
-                      <h3 className={styles.title}>
+                      <h2 className={styles.title}>
                         {content
                           ? intl.formatMessage(this.contents[content].title)
                           : intl.formatMessage(intlMessages.audioChoiceLabel)}
-                      </h3>
+                      </h2>
                     )
                 }
               </header>


### PR DESCRIPTION
### What does this PR do?
Reduces the audio modal heading from `h3` to `h2` in order to be more semantically correct.
 
### Motivation
fixes:
![h-levels](https://user-images.githubusercontent.com/22058534/112382263-07f56980-8cc2-11eb-9bff-0d04c8847800.png)
