### PR TITLE
Don't print audio info for corrupt audio files

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -82,6 +82,7 @@ module BigBlueButton
           if !info[:audio] || !info[:duration]
             BigBlueButton.logger.warn "    This audio file is corrupt! It will be removed from the output."
             corrupt_audios << audiofile
+            next
           end
 
           BigBlueButton.logger.debug "    format: #{info[:format][:format_name]}, codec: #{info[:audio][:codec_name]}"


### PR DESCRIPTION
Fixes a crash: ``undefined method `[]' for nil:NilClass``
that happens in the log output statements when a corrupt audio file is hit.