### PR TITLE
Remove the drag and drop input field for typed responses polls

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -541,7 +541,7 @@ class Poll extends Component {
                         }}
                       />
                       {
-                        FILE_DRAG_AND_DROP_ENABLED && this.renderDragDrop()
+                        FILE_DRAG_AND_DROP_ENABLED && type !== 'RP' && this.renderDragDrop()
                       }
                     </div>
                     )


### PR DESCRIPTION
### What does this PR do?

This small PR makes sure that the drag and drop input field is not displayed when typed response poll is chosen.

### Closes Issue(s)

closes #11740

### Motivation

When typed response poll is chosen during the poll creation, it doesn't make sense to display the drag and drop functionality, since presenter doesn't specify the responses.