### PR TITLE
Recording: Ignore video in audio processing scripts

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -23,7 +23,7 @@ module BigBlueButton
       FFMPEG_AEVALSRC = "aevalsrc=s=48000:c=stereo:exprs=0|0"
       FFMPEG_AFORMAT = "aresample=async=1000,aformat=sample_fmts=s16:sample_rates=48000:channel_layouts=stereo"
       FFMPEG_WF_CODEC = 'libvorbis'
-      FFMPEG_WF_ARGS = ['-c:a', FFMPEG_WF_CODEC, '-q:a', '2', '-f', 'ogg']
+      FFMPEG_WF_ARGS = ['-vn', '-c:a', FFMPEG_WF_CODEC, '-q:a', '2', '-f', 'ogg']
       WF_EXT = 'ogg'
 
       def self.dump(edl)


### PR DESCRIPTION
Screenshare input files have video+audio so the scripts were trying to process video and the default codec theora is not in the bbb ffmpeg package, which lead to error 
`Automatic encoder selection failed for output stream #0:1. Default encoder for format ogg (codec theora) is probably disabled. Please choose an encoder manually.`

Fix #11746