### PR TITLE
bbb-config, packaging: prevent cron job from restarting KMS unnecessarily

### DIFF
--- a/bigbluebutton-config/cron.hourly/bbb-restart-kms
+++ b/bigbluebutton-config/cron.hourly/bbb-restart-kms
@@ -9,7 +9,7 @@ if [ ! -f /var/tmp/bbb-kms-last-restart.txt ]; then
   exit
 fi
 
-users=$(mongo --quiet mongodb://127.0.1.1:27017/meteor --eval "db.users.count({connectionStatus: 'online'})")
+users=$(mongo --quiet mongodb://127.0.1.1:27017/meteor --eval "db.users.count()")
 
 if [ "$users" -eq 0 ]; then
 


### PR DESCRIPTION
### What does this PR do?

The `connectionStatus` property was removed from the Users collection in 2.3, so the check was always returning 0 which means the cron job could potentially restart KMS and SFU while there were still active users.

This PR removes the deprecated filter. Since the collection in 2.3 doesn't store offline users anymore, this should be good enough.

### Closes Issue(s)

Closes  #11418

