### PR TITLE
video,screeshare,listenonly: remove Safari gathering barrier for SDP offer generation

### DIFF
--- a/bigbluebutton-html5/public/compatibility/kurento-utils.js
+++ b/bigbluebutton-html5/public/compatibility/kurento-utils.js
@@ -277,17 +277,6 @@ function WebRtcPeer(mode, options, callback) {
             callback(null, localDescription.sdp, self.processAnswer.bind(self));
         }
 
-        const isSafari = ((userAgent.indexOf('iphone') > -1 || userAgent.indexOf('ipad') > -1) || browser.name.toLowerCase() == 'safari');
-
-        // Bind the SDP release to the gathering state on Safari-based envs
-        if (isSafari) {
-            pc.onicegatheringstatechange = function (event) {
-                if(event.target.iceGatheringState == "complete") {
-                  descriptionCallback();
-                }
-            }
-        }
-
         var offerAudio = true;
         var offerVideo = true;
         if (mediaConstraints) {
@@ -305,10 +294,6 @@ function WebRtcPeer(mode, options, callback) {
             offer = mangleSdpToAddSimulcast(offer);
             return pc.setLocalDescription(offer);
         }).then(() => {
-            // The Safari offer release was already binded to the gathering state
-            if (isSafari) {
-                return;
-            }
             descriptionCallback();
         }).catch(callback);
     };


### PR DESCRIPTION
### What does this PR do?

Removes a barrier in kurento-utils (which I added a few years ago) that only released SDP offers from Safari endpoints when the ICE gathering state transitioned to `complete`.
Affected components: video, screen sharing, listen only.

### Closes Issue(s)

None

### Motivation

This basically stemmed from a discussion I had with @rasos in https://github.com/bigbluebutton/bigbluebutton/issues/10746.
After analyzing some info, I tripped upon this beautiful chunk of code when I was investigating that issue.

Back when Safari 11 was still a thing, there was this _annoying_ bug where peer connections COULD get stuck during it's startup phase if, due to some unknown trigger, the SDP was generated BEFORE the ICE candidate gathering had run its course.

To work around that, the SDP generation was put behind a barrier that was opened when the ICE gathering was marked as complete. A few things about that:

1) I don't believe this bug is a thing anymore (Safari >= 12)
2) this workaround can be _very_ harmful to Safari endpoints, mainly when gathering might take a long time due to additional network interfaces or restricted network environments
3) we don't support Safari 11 anymore

I've tested this with the widest array of Safari endpoints I could get my hands on: iPhones [8-12, XS, SE, ...], iPads 6-8 and Pro, macOS Safari 12-14.

Baseline tests were: 8 inbound cameras, 1 inbound screen. Join the meeting, try listen only, see if everything works. Share the device's camera. Refresh and do this 2 more times.

