### PR TITLE
Hand raise button now reflects hand raised state

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -93,7 +93,9 @@ class ActionsBar extends PureComponent {
                 }`,
               })}
               accessKey={shortcuts.raisehand}
-              color="primary"
+              color={currentUser.emoji === 'raiseHand' ? 'primary' : 'default'}
+              ghost={currentUser.emoji !== 'raiseHand'}
+              className={cx(currentUser.emoji === 'raiseHand' || styles.btn)}
               hideLabel
               circle
               size="lg"


### PR DESCRIPTION
### What does this PR do?

This PR improves the UX of the in #11703 newly introduced hand raised button so it reflects the current hand raised state.

### Closes Issue(s)

Closes #11772

### Motivation

Improving the UX of the newly introduced great feature of the hand raise button

### More

I transferred the styling code of the webcam share button to the hand raise button code. Works flawlessly in my dev environment.

Maybe we should still have a look at the focusing state of the button (because it keeps the focus when clicking on it). I didn't touch that because I'm not sure if this would influence the accessibility in a bad way. The other buttons don't have this "problem" because they all open up a new window which requests focus, so the buttons lose the focus as far as I understand it.
