### PR TITLE
screenshare: bump base/max timeouts to 30s/60s

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -163,10 +163,10 @@ public:
       mediaTimeouts:
         maxConnectionAttempts: 2
         # Base screen media timeout (send|recv)
-        baseTimeout: 15000
+        baseTimeout: 30000
         # Max timeout: used as the max camera subscribe reconnection timeout. Each
         # subscribe reattempt increases the reconnection timer up to this
-        maxTimeout: 35000
+        maxTimeout: 60000
         timeoutIncreaseFactor: 1.5
       constraints:
         video:


### PR DESCRIPTION


### What does this PR do?

Bump base and max screen sharing _negotiation_ timeouts to 30s/60s to follow the values we currently use for cameras.

### Closes Issue(s)

None.

### Motivation

I actually forgot to bump those in #11622. They were supposed to be the same as the camera's timeouts (30/60), but I accidentally left the old values (15/35) in place.