### PR TITLE
Fix actions bar buttons overlapped by right side

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -35,11 +35,6 @@ class ActionsBar extends PureComponent {
       shortcuts,
     } = this.props;
 
-    const actionBarClasses = {};
-
-    actionBarClasses[styles.center] = true;
-    actionBarClasses[styles.mobileLayoutSwapped] = isLayoutSwapped && amIPresenter;
-
     return (
       <div
         className={styles.actionsbar}
@@ -68,7 +63,7 @@ class ActionsBar extends PureComponent {
             : null
           }
         </div>
-        <div className={cx(actionBarClasses)}>
+        <div className={styles.center}>
           <AudioControlsContainer />
           {enableVideo
             ? (

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
@@ -28,7 +28,6 @@
 }
 
 .right {
-  flex: 1;
   justify-content: center;
   @include mq($small-only) {
     position: relative;
@@ -71,24 +70,11 @@
 }
 
 .right {
-  position: absolute;
-  right: var(--sm-padding-x);
-  left: auto;
+  position: relative;
 
   [dir="rtl"] & {
     right: auto;
     left: var(--sm-padding-x);
-  }
-}
-
-.mobileLayoutSwapped {
-  @include mq($xsmall-only) {
-    padding-right: var(--mobile-swap-offset);
-
-    [dir="rtl"] & {
-      padding-right: 0;
-      padding-left: var(--mobile-swap-offset);
-    }
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
prevents the left and center actions bar buttons from being overlapped by the right side (raise hand / restore presentation)

### Closes Issue(s)
Closes #11733 