### PR TITLE
Quick fix to avoid empty slides ( 2.2 backport )

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -29,8 +29,8 @@ public class SvgImageCreatorImp implements SvgImageCreator {
     private SwfSlidesGenerationProgressNotifier notifier;
     private long imageTagThreshold;
     private long pathsThreshold;
-    private String convTimeout = "7s";
-    private int WAIT_FOR_SEC = 7;
+    private String convTimeout = "60s";
+    private int WAIT_FOR_SEC = 60;
 	private String BLANK_SVG;
 
     @Override


### PR DESCRIPTION
This is a backport of #11750

This PR reduces the impact of #8618 by increasing hardcoded timeout from 7s to 60s