### PR TITLE
Unfocus button after clicked

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/button/base/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/button/base/component.jsx
@@ -101,7 +101,7 @@ export default class ButtonBase extends React.Component {
   // Define Mouse Event Handlers
   internalClickHandler(...args) {
     args[0].currentTarget.blur();
-    //if (args[0] && args[0].currentTarget) args[0].currentTarget.blur(); // To be safe, probably not necessary.
+    //if (args[0] && args[0].currentTarget) args[0].currentTarget.blur(); // A more secure version - probably not necessary.
     return this.validateDisabled(this.props.onClick, ...args);
   }
 

--- a/bigbluebutton-html5/imports/ui/components/button/base/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/button/base/component.jsx
@@ -100,6 +100,8 @@ export default class ButtonBase extends React.Component {
 
   // Define Mouse Event Handlers
   internalClickHandler(...args) {
+    args[0].currentTarget.blur();
+    //if (args[0] && args[0].currentTarget) args[0].currentTarget.blur(); // To be safe, probably not necessary.
     return this.validateDisabled(this.props.onClick, ...args);
   }
 


### PR DESCRIPTION
### What does this PR do?

Fixes (appears-to-be) a bug which keeps the mouse and keyboard focuses on the button after clicking.

### Closes Issue(s)

Related to #11773 

### Motivation

Inspired from the discussion with @PhMemmel, we found out that all buttons have been containing this small bug (at least to me it seems) which has been nicely hidden until recently. However, after the PR #11773, which implements a simple toggle button on the action bar, this becomes quite visible.

### More

As pointed out by @PhMemmel, this might lead to a minor UI change (and complaints), that is, the "button hopping" by TAB button will not work anymore. 

Before the change:
![button1](https://user-images.githubusercontent.com/45039819/112842472-8b58f580-90dc-11eb-9779-ff3b9597f644.gif)

After the change:
![button2](https://user-images.githubusercontent.com/45039819/112842540-9e6bc580-90dc-11eb-8bad-a01f66d0e888.gif)

