### PR TITLE
Mobile video dropdown size

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -146,6 +146,19 @@
       padding: .25rem;
     }
   }
+
+  @include mq($small-only) {
+    button {
+      top: calc(90vh - 85px - 5rem);
+      height: 10vh;
+    }
+  }
+  @include mq($landscape) {
+    button {
+      width: calc(100vw - 4rem);
+      margin-left: 1rem;
+    }
+  }
 }
 
 .dropdownFireFox {
@@ -187,6 +200,11 @@
 
   [dir="rtl"] & {
     right: 2rem;
+  }
+
+  @include mq($small-only) {
+    height: calc(90vh - 85px - 5rem);
+    width: 100vw;
   }
 }
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -149,6 +149,8 @@
 
   @include mq($small-only) {
     button {
+      /* should be placed after .dropdownContent
+      90vh: .dropdownContent height, 85px: navbar, 5rem: actions bar) */
       top: calc(90vh - 85px - 5rem);
       height: 10vh;
     }
@@ -203,6 +205,7 @@
   }
 
   @include mq($small-only) {
+    // use 90% of available height (85px: navbar, 5rem: actions bar)
     height: calc(90vh - 85px - 5rem);
     width: 100vw;
   }


### PR DESCRIPTION
### What does this PR do?

Makes the video dropdown use all available space in mobile (ignoring video size).

#### before changes:
![Screenshot from 2021-03-29 13-47-46](https://user-images.githubusercontent.com/3728706/112871553-bec46180-9095-11eb-8c48-e0c5996443b8.png)

#### before changes (after decreasing video size):
![Screenshot from 2021-03-29 13-47-57](https://user-images.githubusercontent.com/3728706/112871700-e61b2e80-9095-11eb-9881-43a77a8f9f2a.png)

#### after changes:
![Screenshot from 2021-03-29 13-45-05](https://user-images.githubusercontent.com/3728706/112871720-ee736980-9095-11eb-816a-d774bc53995a.png)

### Closes Issue(s)
Closes #7597
