### PR TITLE
Config overlay for bbb-web turn server config

### DIFF
--- a/bigbluebutton-web/grails-app/conf/spring/resources.groovy
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.groovy
@@ -1,6 +1,22 @@
 // Place your Spring DSL code here
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+Logger logger = LoggerFactory.getLogger("org.bigbluebutton.web.services.turn.StunTurnService")
+
 beans = {
+  def turnConfigFilePath = "/etc/bigbluebutton/turn-stun-servers.xml"
+  def turnConfigFile = new File(turnConfigFilePath)
+  if (turnConfigFile.canRead()) {
+    logger.info("Reading stun/turn server config from overlay config file " + turnConfigFilePath)
+    importBeans('file:' + turnConfigFilePath)
+  } else {
+    logger.info("Overlay stun/turn server config file " + turnConfigFilePath
+      + " not found/readable, reading from default config file location")
+    importBeans('spring/turn-stun-servers.xml')
+  }
 }
+
 /*
 Add back applicationContext.xml
 

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -168,5 +168,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
     <import resource="doc-conversion.xml"/>
     <import resource="bbb-redis-messaging.xml"/>
-    <import resource="turn-stun-servers.xml"/>
+    <!-- moved the following import statement for turn-stun-servers.xml to resources.groovy to be able to use overlay config for turn/stun servers -->
+    <!--	 <import resource="turn-stun-servers.xml"/>-->
 </beans>


### PR DESCRIPTION
### What does this PR do?

This adds a config overlay for the turn/stun server config of bbb-web:
If `/etc/bigbluebutton/turn-stun-servers.xml` exists/is readable bbb-web now uses this config file.
If `/etc/bigbluebutton/turn-stun-servers.xml` is missing/not readable the default configuration file `/usr/share/bbb-web/WEB-INF/classes/spring/turn-stun-servers.xml` is used. Which configuration file is used is being logged to `bbb-web.log`.

### Motivation

With the new config overlay options in `/etc/bigbluebutton` it is possible to deploy a BBB server without touching any of the packaged config files with one exception: turn/stun server configuration. This PR closes this last gap.

This is in a way a follow up PR of #11470 by @schrd

### Tested

Tested on my dev environment: BBB 2.3-beta1, worked without problems so far

### Todo

Add documentation

### More

Idea for this PR by @schrd, already discussed it with him.