### PR TITLE
Mobile video dropdown

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
@@ -54,6 +54,7 @@ const propTypes = {
   autoFocus: PropTypes.bool,
   intl: PropTypes.object.isRequired,
   tethered: PropTypes.bool,
+  ignoreMobile: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -64,6 +65,7 @@ const defaultProps = {
   isOpen: false,
   keepOpen: null,
   getContent: () => {},
+  ignoreMobile: false,
 };
 
 const attachments = {
@@ -180,6 +182,7 @@ class Dropdown extends Component {
       placement,
       getContent,
       isPortrait,
+      ignoreMobile,
       ...otherProps
     } = this.props;
 
@@ -189,7 +192,7 @@ class Dropdown extends Component {
     const isSmall = window.matchMedia(MOBILE_MEDIA).matches;
 
     const placements = placement && placement.replace(' ', '-');
-    const test = isMobile && isPortrait && isSmall ? {
+    const test = isMobile && isPortrait && isSmall && !ignoreMobile ? {
       width: '100%',
       height: '100%',
       transform: 'translateY(0)',
@@ -224,7 +227,7 @@ class Dropdown extends Component {
       keepopen: `${keepOpen}`,
     });
 
-    const showCloseBtn = (isOpen && keepOpen) || (isOpen && keepOpen === null);
+    const showCloseBtn = ((isOpen && keepOpen) || (isOpen && keepOpen === null) && !ignoreMobile);
 
     return (
       <div
@@ -245,11 +248,11 @@ class Dropdown extends Component {
                   ...test,
                 }}
                 attachment={
-                  isMobile && isPortrait && isSmall ? 'middle center'
+                  isMobile && isPortrait && isSmall && !ignoreMobile ? 'middle center'
                     : attachments[placements]
                 }
                 targetAttachment={
-                  isMobile && isPortrait && isSmall ? 'auto auto'
+                  isMobile && isPortrait && isSmall && !ignoreMobile ? 'auto auto'
                     : targetAttachments[placements]
                 }
                 constraints={[

--- a/bigbluebutton-html5/imports/ui/components/dropdown/content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/content/component.jsx
@@ -16,11 +16,13 @@ const propTypes = {
    * @defaultValue 'top'
    */
   placement: PropTypes.oneOf(PLACEMENTS),
+  ignoreMobile: PropTypes.bool,
 };
 
 const defaultProps = {
   placement: 'top',
   'aria-expanded': false,
+  ignoreMobile: false,
 };
 
 export default class DropdownContent extends Component {
@@ -34,6 +36,7 @@ export default class DropdownContent extends Component {
       dropdownHide,
       dropdownIsOpen,
       keepOpen,
+      ignoreMobile,
       ...restProps
     } = this.props;
 
@@ -50,10 +53,10 @@ export default class DropdownContent extends Component {
     return (
       <div
         data-test="dropdownContent"
-        className={cx(styles.content, styles[placementName], className)}
+        className={cx(ignoreMobile ? styles.ignoreMobileContent : styles.content, styles[placementName], className)}
         {...restProps}
       >
-        <div className={styles.scrollable}>
+        <div className={ignoreMobile ? styles.ignoreMobileScrollable : styles.scrollable}>
           {boundChildren}
         </div>
       </div>

--- a/bigbluebutton-html5/imports/ui/components/dropdown/list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/list/component.jsx
@@ -21,10 +21,12 @@ const propTypes = {
   }).isRequired,
 
   horizontal: PropTypes.bool,
+  ignoreMobile: PropTypes.bool,
 };
 
 const defaultProps = {
   horizontal: false,
+  ignoreMobile: false,
 };
 
 export default class DropdownList extends Component {
@@ -142,7 +144,7 @@ export default class DropdownList extends Component {
   }
 
   render() {
-    const { children, style, className } = this.props;
+    const { children, style, className, ignoreMobile } = this.props;
 
     const boundChildren = Children.map(
       children,
@@ -177,7 +179,7 @@ export default class DropdownList extends Component {
     return (
       <ul
         style={style}
-        className={cx(listDirection, className)}
+        className={cx(ignoreMobile ? styles.ignoreMobileVerticalList : listDirection, className)}
         role="menu"
         ref={(menu) => {
           this._menu = menu;

--- a/bigbluebutton-html5/imports/ui/components/dropdown/list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/list/styles.scss
@@ -29,6 +29,28 @@
   width: 100%;
 }
 
+%ignoreMobileList {
+  list-style: none;
+  font-size: var(--font-size-base);
+  margin: 0;
+  padding: 0;
+  text-align: left;
+  color: var(--color-gray-dark);
+  display: flex;
+  overflow-wrap: break-word;
+  white-space: pre-line;
+
+  [dir="rtl"] & {
+    text-align: right;
+  }
+}
+
+.ignoreMobileVerticalList {
+  @extend %ignoreMobileList;
+  flex-direction: column;
+  width: 100%;
+}
+
 .horizontalList {
   @extend %list;
   padding: 0;

--- a/bigbluebutton-html5/imports/ui/components/dropdown/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/styles.scss
@@ -77,6 +77,37 @@
   }
 }
 
+.ignoreMobileContent {
+  @extend %highContrastOutline;
+  outline-style: solid;
+  z-index: 9999;
+  position: absolute;
+  background: var(--dropdown-bg);
+  border-radius: var(--border-radius);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+  border: 0;
+  padding: calc(var(--line-height-computed) / 2);
+
+  [dir="rtl"] & {
+    right: var(--rtl-content-offset);
+  }
+
+  &:after,
+  &:before {
+    content: '';
+    position: absolute;
+    width: 0;
+    height: 0;
+  }
+
+  &[aria-expanded="false"] {
+    display: none;
+  }
+
+  &[aria-expanded="true"] {
+    display: block;
+  }
+}
 .scrollable {
   @include mq($small-only) {
     @include scrollbox-vertical();
@@ -86,9 +117,6 @@
     right: 0;
     bottom: 0;
   }
-}
-
-.trigger {
 }
 
 .close {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -141,25 +141,8 @@
   outline: none !important;
   width: var(--cam-dropdown-width);
 
-  @include mq($medium-up) {
-    >[aria-expanded] {
-      padding: .25rem;
-    }
-  }
-
-  @include mq($small-only) {
-    button {
-      /* should be placed after .dropdownContent
-      90vh: .dropdownContent height, 85px: navbar, 5rem: actions bar) */
-      top: calc(90vh - 85px - 5rem);
-      height: 10vh;
-    }
-  }
-  @include mq($landscape) {
-    button {
-      width: calc(100vw - 4rem);
-      margin-left: 1rem;
-    }
+  >[aria-expanded] {
+    padding: .25rem;
   }
 }
 
@@ -203,26 +186,14 @@
   [dir="rtl"] & {
     right: 2rem;
   }
-
-  @include mq($small-only) {
-    // use 90% of available height (85px: navbar, 5rem: actions bar)
-    height: calc(90vh - 85px - 5rem);
-    width: 100vw;
-  }
 }
 
 .dropdownList {
-  @include mq($medium-up) {
-    font-size: .86rem;
-  }
+  font-size: .86rem;
 }
 
 .hiddenDesktop {
   display: none;
-
-  @include mq($small-only) {
-    display: block;
-  }
 }
 
 .muted,

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -223,39 +223,41 @@ class VideoListItem extends Component {
           />
           {videoIsReady && this.renderFullscreenButton()}
         </div>
-        { videoIsReady &&
+        { videoIsReady
+          && (
           <div className={styles.info}>
-          {enableVideoMenu && availableActions.length >= 3
-            ? (
-              <Dropdown className={isFirefox ? styles.dropdownFireFox : styles.dropdown}>
-                <DropdownTrigger className={styles.dropdownTrigger}>
-                  <span>{name}</span>
-                </DropdownTrigger>
-                <DropdownContent placement="top left" className={styles.dropdownContent}>
-                  <DropdownList className={styles.dropdownList}>
-                    {availableActions}
-                  </DropdownList>
-                </DropdownContent>
-              </Dropdown>
-            )
-            : (
-              <div className={isFirefox ? styles.dropdownFireFox
-                : styles.dropdown}
-              >
-                <span className={cx({
-                  [styles.userName]: true,
-                  [styles.noMenu]: numOfStreams < 3,
-                })}
+            {enableVideoMenu && availableActions.length >= 3
+              ? (
+                <Dropdown ignoreMobile className={isFirefox ? styles.dropdownFireFox : styles.dropdown}>
+                  <DropdownTrigger className={styles.dropdownTrigger}>
+                    <span>{name}</span>
+                  </DropdownTrigger>
+                  <DropdownContent ignoreMobile placement="top left" className={styles.dropdownContent}>
+                    <DropdownList ignoreMobile className={styles.dropdownList}>
+                      {availableActions}
+                    </DropdownList>
+                  </DropdownContent>
+                </Dropdown>
+              )
+              : (
+                <div className={isFirefox ? styles.dropdownFireFox
+                  : styles.dropdown}
                 >
-                  {name}
-                </span>
-              </div>
-            )
+                  <span className={cx({
+                    [styles.userName]: true,
+                    [styles.noMenu]: numOfStreams < 3,
+                  })}
+                  >
+                    {name}
+                  </span>
+                </div>
+              )
           }
-          {voiceUser.muted && !voiceUser.listenOnly ? <Icon className={styles.muted} iconName="unmute_filled" /> : null}
-          {voiceUser.listenOnly ? <Icon className={styles.voice} iconName="listen" /> : null}
-          {voiceUser.joined && !voiceUser.muted ? <Icon className={styles.voice} iconName="unmute" /> : null}
-        </div>
+            {voiceUser.muted && !voiceUser.listenOnly ? <Icon className={styles.muted} iconName="unmute_filled" /> : null}
+            {voiceUser.listenOnly ? <Icon className={styles.voice} iconName="listen" /> : null}
+            {voiceUser.joined && !voiceUser.muted ? <Icon className={styles.voice} iconName="unmute" /> : null}
+          </div>
+          )
         }
       </div>
     );


### PR DESCRIPTION
### What does this PR do?

Makes the video dropdown have the same behavior in desktop and mobile

#### before changes:
![Screenshot from 2021-03-29 13-47-46](https://user-images.githubusercontent.com/3728706/112871553-bec46180-9095-11eb-8c48-e0c5996443b8.png)

#### after changes:
![Screenshot from 2021-03-30 17-20-21](https://user-images.githubusercontent.com/3728706/113051376-44bad800-917c-11eb-9a6d-9134ed0d9482.png)

#### further information:

The initial ideia was to make the dropdown use all available space (like the other dropdowns in mobile), but that was not possible in the video dropdown because of flex position and z-index and the way [mobile browsers (particularly Safari) deal with calc() and `vh`/`vw` units](https://stackoverflow.com/a/37113430)

### Closes Issue(s)
Closes #7597
