### PR TITLE
Fix unread message indicator remaining visible

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/container.jsx
@@ -137,22 +137,22 @@ const ChatContainer = (props) => {
       prevSync = contextChat?.syncing;
       const timeWindowsValues = isPublicChat
         ? [
-          ...(
-            !contextChat?.syncing ? Object.values(contextChat?.preJoinMessages || {}) : [
-              {
-                id: sysMessagesIds.syncId,
-                content: [{
-                  id: 'synced',
-                  text: intl.formatMessage(intlMessages.loading, { 0: contextChat?.syncedPercent}),
-                  time: loginTime + 1,
-                }],
-                key: sysMessagesIds.syncId,
-                time: loginTime + 1,
-                sender: null,
-              }
-            ]
-          )
-          , ...systemMessagesIds.map((item) => systemMessages[item]),
+          // ...(
+          //   !contextChat?.syncing ? Object.values(contextChat?.preJoinMessages || {}) : [
+          //     {
+          //       id: sysMessagesIds.syncId,
+          //       content: [{
+          //         id: 'synced',
+          //         text: intl.formatMessage(intlMessages.loading, { 0: contextChat?.syncedPercent}),
+          //         time: loginTime + 1,
+          //       }],
+          //       key: sysMessagesIds.syncId,
+          //       time: loginTime + 1,
+          //       sender: null,
+          //     }
+          //   ]
+          // )
+          // , ...systemMessagesIds.map((item) => systemMessages[item]),
         ...Object.values(contextChat?.posJoinMessages || {})]
         : [...Object.values(contextChat?.messageGroups || {})];
       if (previousChatId !== chatID) {

--- a/bigbluebutton-html5/imports/ui/components/chat/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/container.jsx
@@ -137,22 +137,22 @@ const ChatContainer = (props) => {
       prevSync = contextChat?.syncing;
       const timeWindowsValues = isPublicChat
         ? [
-          // ...(
-          //   !contextChat?.syncing ? Object.values(contextChat?.preJoinMessages || {}) : [
-          //     {
-          //       id: sysMessagesIds.syncId,
-          //       content: [{
-          //         id: 'synced',
-          //         text: intl.formatMessage(intlMessages.loading, { 0: contextChat?.syncedPercent}),
-          //         time: loginTime + 1,
-          //       }],
-          //       key: sysMessagesIds.syncId,
-          //       time: loginTime + 1,
-          //       sender: null,
-          //     }
-          //   ]
-          // )
-          // , ...systemMessagesIds.map((item) => systemMessages[item]),
+          ...(
+            !contextChat?.syncing ? Object.values(contextChat?.preJoinMessages || {}) : [
+              {
+                id: sysMessagesIds.syncId,
+                content: [{
+                  id: 'synced',
+                  text: intl.formatMessage(intlMessages.loading, { 0: contextChat?.syncedPercent}),
+                  time: loginTime + 1,
+                }],
+                key: sysMessagesIds.syncId,
+                time: loginTime + 1,
+                sender: null,
+              }
+            ]
+          )
+          , ...systemMessagesIds.map((item) => systemMessages[item]),
         ...Object.values(contextChat?.posJoinMessages || {})]
         : [...Object.values(contextChat?.messageGroups || {})];
       if (previousChatId !== chatID) {

--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/message-chat-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/message-chat-item/component.jsx
@@ -27,12 +27,12 @@ const eventsToBeBound = [
 const isElementInViewport = (el) => {
   if (!el) return false;
   const rect = el.getBoundingClientRect();
+  console.log('rect', rect);
 
   return (
     rect.top >= 0
-    && rect.left >= 0
-    && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight)
-    && rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+    // This condition is for large messages that are bigger than client height
+    || rect.top + rect.height >= 0
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/message-chat-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/message-chat-item/component.jsx
@@ -27,7 +27,6 @@ const eventsToBeBound = [
 const isElementInViewport = (el) => {
   if (!el) return false;
   const rect = el.getBoundingClientRect();
-  console.log('rect', rect);
 
   return (
     rect.top >= 0


### PR DESCRIPTION
### What does this PR do?

This PR fixes the issue of the chat indicator doesn't disapearing, it is caused because the condition only works for messages smaller than the screen.

### Closes Issue(s)
Closes #11617

