### PR TITLE
Fix: making allowModsToUnmuteUsers=true work again

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -392,7 +392,7 @@ const getAvailableActions = (amIModerator, isBreakoutRoom, subjectUser, subjectV
     && subjectVoiceUser.isVoiceUser
     && !subjectVoiceUser.isListenOnly
     && subjectVoiceUser.isMuted
-    && (amISubjectUser || usersProp.allowedToUnmuteAudio);
+    && (amISubjectUser || usersProp.allowModsToUnmuteUsers);
 
   const allowedToResetStatus = hasAuthority
     && subjectUser.emoji !== EMOJI_STATUSES.none


### PR DESCRIPTION
### What does this PR do?

The option `allowModsToUnmuteUsers=true` doesn't work anymore due to a change in PR #11215 by @pedrobmarin (as far as I could see): commit bd15f14ca01bb362843bb2f75146276acd4ba65b

https://github.com/bigbluebutton/bigbluebutton/blob/bd15f14ca01bb362843bb2f75146276acd4ba65b/bigbluebutton-html5/imports/ui/components/user-list/service.js#L362

### Closes Issue(s)

Closes #11820

### Motivation

I've been using this option in 2.2 and now tried it in 2.3-beta1. Figured out it's not working, wanted to make it work again.

### More

I couldn't figure out if this bug was introduced by the attempt of a bigger refactoring (userProps) and parts of it have been forgotten to implement. This PR is just a quick fix for it. If a bigger refactoring was intended feel free to drop this PR, of course, and fix the issue in the PR which does the refactoring.

Please test again before merging. I only have a limited dev environment right now so I couldn't fully test vs current develop branch, I did vs 2.3-beta1 though.