### PR TITLE
Make timeout configurable and log timeout errors for conversions (Pdf2Svg and Office2Pdf)

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/AbstractCommandHandler.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/AbstractCommandHandler.java
@@ -89,4 +89,9 @@ public abstract class AbstractCommandHandler extends
   public Boolean isCommandSuccessful() {
     return !exitedWithError();
   }
+
+  public Boolean isCommandTimeout() {
+    return exitCode == 124;
+  }
+
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -78,7 +78,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
             }
 
             if(pHandler.isCommandTimeout()) {
-                log.error("Command execution (convertImgToSvg) exceeded the {} secs limit for {} page {}.", convPdfToSvgTimeout, pres.getName(), page);
+                log.error("Command execution (convertImgToSvg) exceeded the {} secs timeout for {} page {}.", convPdfToSvgTimeout, pres.getName(), page);
             }
 
             // Use the intermediate PDF file as source
@@ -107,7 +107,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
         }
 
         if(pHandler.isCommandTimeout()) {
-            log.error("Command execution (convertPdfToSvg) exceeded the {} secs limit for {} page {}.", convPdfToSvgTimeout, pres.getName(), page);
+            log.error("Command execution (convertPdfToSvg) exceeded the {} secs timeout for {} page {}.", convPdfToSvgTimeout, pres.getName(), page);
         }
 
         if (!done) {
@@ -172,7 +172,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
             }
 
             if(pngHandler.isCommandTimeout()) {
-                log.error("Command execution (convertPdfToPng) exceeded the {} secs limit for {} page {}.", convPdfToSvgTimeout, pres.getName(), page);
+                log.error("Command execution (convertPdfToPng) exceeded the {} secs timeout for {} page {}.", convPdfToSvgTimeout, pres.getName(), page);
             }
 
             if(tempPng.length() > 0) {
@@ -191,7 +191,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
                 }
 
                 if(svgHandler.isCommandTimeout()) {
-                    log.error("Command execution (convertPngToSvg) exceeded the {} secs limit for {} page {}.", convPdfToSvgTimeout, pres.getName(), page);
+                    log.error("Command execution (convertPngToSvg) exceeded the {} secs timeout for {} page {}.", convPdfToSvgTimeout, pres.getName(), page);
                 }
 
                 done = svgHandler.isCommandSuccessful();
@@ -215,7 +215,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
                     }
 
                     if (namespaceHandler.isCommandTimeout()) {
-                        log.error("Command execution (addNameSpaceToSVG) exceeded the {} secs limit for {} page {}.", convPdfToSvgTimeout, pres.getName(), page);
+                        log.error("Command execution (addNameSpaceToSVG) exceeded the {} secs timeout for {} page {}.", convPdfToSvgTimeout, pres.getName(), page);
                     }
                 }
             }

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -99,7 +99,7 @@ numConversionThreads=5
 numFileProcessorThreads=2
 
 #------------------------------------
-# Timeout(secs) to wait for pdf to svg conversion (time for each page)
+# Timeout(secs) to wait for pdf to svg conversion (timeout for each tool called during the process)
 #------------------------------------
 svgConversionTimeout=60
 

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -99,6 +99,11 @@ numConversionThreads=5
 numFileProcessorThreads=2
 
 #------------------------------------
+# Timeout(secs) to wait for pdf to svg conversion (time for each page)
+#------------------------------------
+svgConversionTimeout=60
+
+#------------------------------------
 # Timeout(secs) to wait for conversion script execution
 #------------------------------------
 officeToPdfConversionTimeout=60

--- a/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
@@ -86,6 +86,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="imageTagThreshold" value="${imageTagThreshold}"/>
         <property name="pathsThreshold" value="${placementsThreshold}"/>
         <property name="blankSvg" value="${BLANK_SVG}"/>
+        <property name="convPdfToSvgTimeout" value="${svgConversionTimeout}"/>
     </bean>
 
     <bean id="generatedSlidesInfoHelper" class="org.bigbluebutton.presentation.GeneratedSlidesInfoHelperImp"/>


### PR DESCRIPTION
This PR include some improvements for previous PR #11750

- Includes config `svgConversionTimeout` to let user set the timeout for PDF to SVG conversion
- Handle timeout errors and log in console (in Pdf2Svg and Office2Pdf)

It was necessary to set `process.waitFor` with timeout + 1 second. It will guarantee that the command timeout will exceed first and return the code 124 while Java is still waiting.