### PR TITLE
Improvements in muted banner

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
@@ -168,6 +168,7 @@ class AudioControls extends PureComponent {
       intl,
       shortcuts,
       isVoiceUser,
+      listenOnly,
       inputStream,
       isViewer,
       isPresenter,
@@ -198,7 +199,7 @@ class AudioControls extends PureComponent {
 
     return (
       <span className={styles.container}>
-        {isVoiceUser && inputStream && muteAlertEnabled ? (
+        {isVoiceUser && inputStream && muteAlertEnabled && !listenOnly ? (
           <MutedAlert {...{
             muted, inputStream, isViewer, isPresenter,
           }}

--- a/bigbluebutton-html5/imports/ui/components/muted-alert/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/muted-alert/component.jsx
@@ -9,7 +9,7 @@ import { styles } from './styles';
 const MUTE_ALERT_CONFIG = Meteor.settings.public.app.mutedAlert;
 
 const propTypes = {
-  inputStream: PropTypes.objectOf(PropTypes.object).isRequired,
+  inputStream: PropTypes.objectOf(PropTypes.any).isRequired,
   isPresenter: PropTypes.bool.isRequired,
   isViewer: PropTypes.bool.isRequired,
   muted: PropTypes.bool.isRequired,
@@ -33,6 +33,9 @@ class MutedAlert extends Component {
 
   componentDidMount() {
     this._isMounted = true;
+
+    if (!this.hasValidInputStream()) return;
+
     this.cloneMediaStream();
     if (this.inputStream) {
       const { interval, threshold, duration } = MUTE_ALERT_CONFIG;
@@ -73,6 +76,17 @@ class MutedAlert extends Component {
   resetTimer() {
     if (this.timer) clearTimeout(this.timer);
     this.timer = null;
+  }
+
+  hasValidInputStream() {
+    const { inputStream } = this.props;
+
+    if (inputStream
+      && (typeof inputStream.getAudioTracks === 'function')
+      && (inputStream.getAudioTracks().length > 0)
+    ) return true;
+
+    return false;
   }
 
   render() {

--- a/bigbluebutton-html5/imports/ui/components/muted-alert/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/muted-alert/component.jsx
@@ -9,7 +9,7 @@ import { styles } from './styles';
 const MUTE_ALERT_CONFIG = Meteor.settings.public.app.mutedAlert;
 
 const propTypes = {
-  inputStream: PropTypes.object.isRequired,
+  inputStream: PropTypes.objectOf(PropTypes.object).isRequired,
   isPresenter: PropTypes.bool.isRequired,
   isViewer: PropTypes.bool.isRequired,
   muted: PropTypes.bool.isRequired,
@@ -58,10 +58,14 @@ class MutedAlert extends Component {
   componentWillUnmount() {
     this._isMounted = false;
     if (this.speechEvents) this.speechEvents.stop();
+    if (this.inputStream) {
+      this.inputStream.getTracks().forEach(t => t.stop());
+    }
     this.resetTimer();
   }
 
   cloneMediaStream() {
+    if (this.inputStream) return;
     const { inputStream, muted } = this.props;
     if (inputStream && !muted) this.inputStream = inputStream.clone();
   }


### PR DESCRIPTION
#### Commit 1: Improvements in muted banner

We now stop the MediaStream (cloned/dummy input stream) when this is not
needed anymore.
We don't create/clone a new MediaStream when it already exists.
Fixed eslint warning in muted-alert/component.jsx


#### Commit 2: Fix muted banner being created for listen-only fallback stream
When listen only fallbacks from Kurento to FreeSWITCH, we must guarantee
the muted alert won't be created, speciallly because listen-only's fallback
uses a flow similar to microphone's. Client currently crashes when this
happens: this commit fixes this peoblem.
