### PR TITLE
Fix version on API Demo index.html

### DIFF
--- a/bigbluebutton-config/web/index.html
+++ b/bigbluebutton-config/web/index.html
@@ -274,8 +274,8 @@
 
 	      <div class="row">
 	      	<div class="span twelve center">
-		        <p>Copyright &copy; 2020 BigBlueButton Inc.<br>
-		        <small>Version <a href="http://docs.bigbluebutton.org/">2.2</a></small>
+		        <p>Copyright &copy; 2021 BigBlueButton Inc.<br>
+		        <small>Version <a href="http://docs.bigbluebutton.org/">2.3</a></small>
 		        </p>
 	      	</div>
 	      </div>


### PR DESCRIPTION
As a food for thought: if the path should be changed in the documentation for the new version, it must also be adjusted in the API demo, among other things. 
I think for 2.2 to change the date is no longer worth it? I hope that the 2.3 will soon be ready.
```
https://docs.bigbluebutton.org/2.2/install.html#5-install-api-demos-optional
                               ^^
```