### PR TITLE
Instruct FreeSWITCH to announce external IP in SDP

### DIFF
--- a/bbb-voice-conference/config/freeswitch/conf/dialplan/public/bbb_webrtc.xml
+++ b/bbb-voice-conference/config/freeswitch/conf/dialplan/public/bbb_webrtc.xml
@@ -4,6 +4,7 @@
       <condition field="${sip_via_protocol}" expression="^wss?$" break="on-false">
 	<action application="set" data="bbb_authorized=true"/>
 	<action application="set" data="jb_use_timestamps=true"/>
+	<action application="set" data="include_external_ip=true"/>
         <action application="transfer" data="${destination_number} XML default"/>
       </condition>
     </extension>


### PR DESCRIPTION
### What does this PR do?

BBB HTML5 uses a websocket connection as the signalling channel between the Browser and FreeSWITCH. In order to establish the audio channels, FreeSWITCH and the Browser need to exchange some endpoint information via SDP messages, such as IP addresses and ports where each communication partner is potentially reachable for the other one (ICE candidates). In order to determine the ICE candidates for itself, the Browser typically contacts a STUN/TURN server helping the Browser to punch holes in a NAT etc. FreeSWITCH on the other side, expects to be reachable directly and thus just uses whatever it thinks is the appropriate IP as its one and only ICE candidate.

Problem is that the websocket connection between the Browser and FreeSWITCH is proxied through Nginx (TLS termination and authentication). As a result, from FreeSWITCH point of view every website connection is originating from the LAN/localhost. Since FreeSWITCH assumes that the originating Browser is calling from the LAN, it will consequently advertise an ICE candidate on its `local_ip_v4` address.

In order to work around this problem, the Nginx configuration in BBB uses the public IP as the upstream host. Like this, the connection from Nginx to FreeSWITCH will *originate* from the public IP of the BBB server. This will prompt FreeSWITCH to advertise an ICE candidate with its `external_sip_ip` address. That setup, however, does not work in most NAT configurations. This is because the connection from Nginx to FreeSWITCH will be originating from the internal IP of the NAT device. In order to work around that problem, the BBB docs recommend to setup a [dummy nic](https://docs.bigbluebutton.org/2.2/configure-firewall.html#configure-a-dummy-nic-if-required).

However, FreeSWITCH can be instructed to advertise multiple ICE candidates using the `include_external_ip` channel variable introduced in signalwire/freeswitch@15fd3f1 

With the proposed change, FreeSWITCH will generate an SDP which includes both, the internal *and* external address (if configured):

```
v=0
o=FreeSWITCH 1617265937 1617265938 IN IP4 10.0.0.10
s=FreeSWITCH
c=IN IP4 10.0.0.10
[...]
m=audio 22148 UDP/TLS/RTP/SAVPF 111 110 106
a=rtpmap:111 opus/48000/2
[...]
a=setup:active
a=rtcp-mux
a=rtcp:22148 IN IP4 10.0.0.10
[...]
a=candidate:5481274345 1 udp 659136 10.0.0.10 22148 typ host generation 0
a=candidate:3739780656 1 udp 659136 93.184.216.34 22148 typ host generation 0
a=end-of-candidates
[...]
```

### Closes Issue(s)
Closes #11743
