### PR TITLE
fix: MEDIA_ERROR when joining room using Firefox

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -89,7 +89,7 @@ class SIPSession {
     this.reconnectAttempt = reconnectAttempt;
     this.currentSession = null;
     this.remoteStream = null;
-    this._inputDeviceId = DEFAULT_INPUT_DEVICE_ID;
+    this._inputDeviceId = null;
     this._outputDeviceId = null;
     this._hangupFlag = false;
     this._reconnecting = false;
@@ -169,7 +169,7 @@ class SIPSession {
   get outputDeviceId() {
     if (!this._outputDeviceId) {
       const audioElement = document.querySelector(MEDIA_TAG);
-      if (audioElement && audioElement.sinkId) {
+      if (audioElement) {
         return audioElement.sinkId;
       }
     }

--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -169,7 +169,6 @@ export default lockContextContainer(withModalMounter(injectIntl(withTracker(({ m
     joinedAudio,
     init: () => {
       Service.init(messages, intl);
-      Service.changeOutputDevice(document.querySelector('#remote-media').sinkId);
       const enableVideo = getFromUserSettings('bbb_enable_video', KURENTO_CONFIG.enableVideo);
       const autoShareWebcam = getFromUserSettings('bbb_auto_share_webcam', KURENTO_CONFIG.autoShareWebcam);
       if ((!autoJoin || didMountAutoJoin)) {

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -57,7 +57,6 @@ class AudioManager {
       isTalking: false,
       isWaitingPermissions: false,
       error: null,
-      outputDeviceId: null,
       muteHandle: null,
       autoplayBlocked: false,
       isReconnecting: false,
@@ -506,7 +505,7 @@ class AudioManager {
   }
 
   async changeOutputDevice(deviceId, isLive) {
-    this.outputDeviceId = await this
+    await this
       .bridge
       .changeOutputDevice(deviceId || DEFAULT_OUTPUT_DEVICE_ID, isLive);
   }
@@ -528,6 +527,11 @@ class AudioManager {
   get inputDeviceId() {
     return (this.bridge && this.bridge.inputDeviceId)
       ? this.bridge.inputDeviceId : DEFAULT_INPUT_DEVICE_ID;
+  }
+
+  get outputDeviceId() {
+    return (this.bridge && this.bridge.outputDeviceId)
+      ? this.bridge.outputDeviceId : DEFAULT_OUTPUT_DEVICE_ID;
   }
 
   /**
@@ -656,7 +660,7 @@ class AudioManager {
     this.setSenderTrackEnabled(true);
   }
 
-  playAlertSound (url) {
+  playAlertSound(url) {
     if (!url) {
       return Promise.resolve();
     }
@@ -665,9 +669,12 @@ class AudioManager {
 
     audioAlert.addEventListener('ended', () => { audioAlert.src = null; });
 
-    if (this.outputDeviceId && (typeof audioAlert.setSinkId === 'function')) {
+
+    const { outputDeviceId } = this.bridge;
+
+    if (outputDeviceId && (typeof audioAlert.setSinkId === 'function')) {
       return audioAlert
-        .setSinkId(this.outputDeviceId)
+        .setSinkId(outputDeviceId)
         .then(() => audioAlert.play());
     }
 


### PR DESCRIPTION
Firefox doesn't create a  device called 'default' and we were trying
to set this when user is joining the room. We don't do this anymore, letting
devices to be changed when there's some user request.

Moved outputDeviceId inputDeviceId information to be managed in bridge
(just like we do with inputDeviceId), we don't store this duplicated
information in audio container anymore.

Fixed the eslint warning in "playAlertSound(url) { ..."

We are safe to let users try to change input/output devices because the
device list is retrieved from enumerateDevices.
