### PR TITLE
Fix and update virtualized list test suite

### DIFF
--- a/bigbluebutton-html5/tests/puppeteer/core/page.js
+++ b/bigbluebutton-html5/tests/puppeteer/core/page.js
@@ -415,8 +415,8 @@ class Page {
     }
     await this.waitForSelector(ue.anyUser, ELEMENT_WAIT_TIME);
     const totalNumberOfUsersMongo = await this.page.evaluate(() => {
-      const collection = require('/imports/api/users/index.js');
-      const users = collection.default._collection.find({ connectionStatus: 'online' }).count();
+      const collection = require('/imports/api/users-persistent-data/index.js');
+      const users = collection.default._collection.find({}, {}, {}, {}, {}, { loggedOut: 'false' }).count();
       return users;
     });
     const totalNumberOfUsersDom = await this.page.evaluate(() => document.querySelectorAll('[data-test^="userListItem"]').length);

--- a/bigbluebutton-html5/tests/puppeteer/virtualizedlist/virtualize.js
+++ b/bigbluebutton-html5/tests/puppeteer/virtualizedlist/virtualize.js
@@ -33,8 +33,8 @@ class VirtualizeList {
     try {
       const USER_LIST_VLIST_VISIBLE_USERS = await this.page1.page.evaluate(async () => await document.querySelectorAll('[data-test^="userListItem"]').length);
       const totalNumberOfUsersMongo = await this.page1.page.evaluate(() => {
-        const collection = require('/imports/api/users/index.js');
-        const users = collection.default._collection.find({ connectionStatus: 'online' }).count();
+        const collection = require('/imports/api/users-persistent-data/index.js');
+        const users = collection.default._collection.find({}, {}, {}, {}, {}, { loggedOut: 'false' }).count();
         return users;
       });
       if (USER_LIST_VLIST_VISIBLE_USERS === totalNumberOfUsersMongo) {

--- a/bigbluebutton-html5/tests/puppeteer/virtualizedlist/virtualize.js
+++ b/bigbluebutton-html5/tests/puppeteer/virtualizedlist/virtualize.js
@@ -33,8 +33,8 @@ class VirtualizeList {
     try {
       const USER_LIST_VLIST_VISIBLE_USERS = await this.page1.page.evaluate(async () => await document.querySelectorAll('[data-test^="userListItem"]').length);
       const totalNumberOfUsersMongo = await this.page1.page.evaluate(() => {
-        const collection = require('/imports/api/users-persistent-data/index.js');
-        const users = collection.default._collection.find({}, {}, {}, {}, {}, { loggedOut: 'false' }).count();
+        const collection = require('/imports/api/users/index.js');
+        const users = collection.default._collection.find().count();
         return users;
       });
       if (USER_LIST_VLIST_VISIBLE_USERS === totalNumberOfUsersMongo) {


### PR DESCRIPTION
After the implementation of the new collection `users-persistent-data` and after removing `connectionStatus` from `users` collection, the virtualized userslist automated test got outdated. So this PR is a fix and update for it.