### PR TITLE
Set breakoutRoomLimit to 16

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -51,9 +51,9 @@ public:
     enableDebugWindow: true
     # Warning: increasing the limit of breakout rooms per meeting
     # can generate excessive overhead to the server. We recommend
-    # this value to be kept under 12.
+    # this value to be kept under 16.
     breakouts:
-      breakoutRoomLimit: 8
+      breakoutRoomLimit: 16
       sendInvitationToIncludedModerators: false
     # https://github.com/bigbluebutton/bigbluebutton/pull/10826
     customHeartbeat: false


### PR DESCRIPTION
With defaults of 2 backend and 2 frontend bbb-html5 nodejs processes we can handle more breakouts. @ritzalam confirmed no audio changes are needed
