### PR TITLE
Minimum width of confirm button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.scss
@@ -475,6 +475,7 @@
 
 .confirm,
 .dismiss {
+  min-width: 6rem;
   height: 1.875rem;
 }
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.scss
@@ -475,7 +475,6 @@
 
 .confirm,
 .dismiss {
-  width: 6rem;
   height: 1.875rem;
 }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Unset the width of confirm button of presentation uploader.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation

With non-English languages. sometime the button labelling is broken.

### More

With this change the button seems to be OK on mobile devices.

Screenshot of a PC (before the change)
![名称未設定 1のコピー](https://user-images.githubusercontent.com/45039819/113372419-a610c000-93a3-11eb-9feb-0ac95a36feaa.jpg)
