### PR TITLE
fix: User can't join using microsoft edge

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -135,7 +135,11 @@ class App extends Component {
 
     const body = document.getElementsByTagName('body')[0];
 
-    body.classList.add(`browser-${browserName.toLowerCase()}`);
+    if (browserName) {
+      body.classList.add(`browser-${browserName.split(' ').pop()
+        .toLowerCase()}`);
+    }
+
     body.classList.add(`os-${osName.split(' ').shift().toLowerCase()}`);
 
     if (!validIOSVersion()) {


### PR DESCRIPTION
When browser's name string has whitespaces, we must treat it before adding to the
body class. For example Edge uses 'microsoft edge' string
This class string must match names used in css.

Tested in firefox, chrome and safari and it's corresponding mobile versions,
this is working for all.

Fixes #11865
