### PR TITLE
fix: Do not show unsupported browser warning for microsoft edge

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -39,7 +39,7 @@ const propTypes = {
   resolve: PropTypes.func,
   isMobileNative: PropTypes.bool.isRequired,
   isIOSChrome: PropTypes.bool.isRequired,
-  isIEOrEdge: PropTypes.bool.isRequired,
+  isIE: PropTypes.bool.isRequired,
   formattedTelVoice: PropTypes.string.isRequired,
   autoplayBlocked: PropTypes.bool.isRequired,
   handleAllowAutoplay: PropTypes.func.isRequired,
@@ -522,7 +522,7 @@ class AudioModal extends Component {
       showPermissionsOvelay,
       isIOSChrome,
       closeModal,
-      isIEOrEdge,
+      isIE,
     } = this.props;
 
     const { content } = this.state;
@@ -537,7 +537,7 @@ class AudioModal extends Component {
           hideBorder
           contentLabel={intl.formatMessage(intlMessages.ariaModalTitle)}
         >
-          {isIEOrEdge ? (
+          {isIE ? (
             <p className={cx(styles.text, styles.browserWarning)}>
               <FormattedMessage
                 id="app.audioModal.unsupportedBrowserLabel"

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -58,7 +58,7 @@ export default lockContextContainer(withModalMounter(withTracker(({ userLocks })
   const forceListenOnlyAttendee = forceListenOnly && !Service.isUserModerator();
 
   const { isIos } = deviceInfo;
-  const { isChrome, isEdge, isIe } = browserInfo;
+  const { isChrome, isIe } = browserInfo;
 
   return ({
     joinedAudio,
@@ -86,7 +86,7 @@ export default lockContextContainer(withModalMounter(withTracker(({ userLocks })
     forceListenOnlyAttendee,
     isIOSChrome: isIos && isChrome,
     isMobileNative: navigator.userAgent.toLowerCase().includes('bbbnative'),
-    isIEOrEdge: isEdge || isIe,
+    isIE: isIe,
     autoplayBlocked: Service.autoplayBlocked(),
     handleAllowAutoplay: () => Service.handleAllowAutoplay(),
     isRTL,

--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -651,11 +651,11 @@ class VideoPreview extends Component {
 
     const shared = sharedDevices.includes(webcamDeviceId);
 
-    const { isEdge, isIe } = browserInfo;
+    const { isIe } = browserInfo;
 
     return (
       <div>
-        {isEdge || isIe ? (
+        {isIe ? (
           <p className={styles.browserWarning}>
             <FormattedMessage
               id="app.audioModal.unsupportedBrowserLabel"


### PR DESCRIPTION
This was being shown in both audio in video modal.
Related to #11865.