### PR TITLE
Set new labels to templates and workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/core-issue.md
+++ b/.github/ISSUE_TEMPLATE/core-issue.md
@@ -2,7 +2,7 @@
 name: Server Core Issue
 about: Template for creating an issue with bbb-web, akka-apps, or other server component
 title: ''
-labels: Core
+labels: 'module: core'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: Enhancement
+labels: 'type: enhancement'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/html5-issue.md
+++ b/.github/ISSUE_TEMPLATE/html5-issue.md
@@ -2,7 +2,7 @@
 name: HTML5 Issue
 about: Template for creating HTML5 Issue (frontend which you see during a session, not Greenlight).
 title: ''
-labels: HTML5 Client
+labels: 'module: client'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/installation-issue.md
+++ b/.github/ISSUE_TEMPLATE/installation-issue.md
@@ -2,7 +2,7 @@
 name: Installation issue (not a support question)
 about: Template for issues encountered during installation
 title: ''
-labels: Installation
+labels: 'deploy: installation'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/recording-issue.md
+++ b/.github/ISSUE_TEMPLATE/recording-issue.md
@@ -2,7 +2,7 @@
 name: Recording Issue
 about: Template for creating a recording issue
 title: ''
-labels: Recording
+labels: 'module: recording'
 assignees: ''
 
 ---

--- a/.github/workflows/check-merge-conflict.yml
+++ b/.github/workflows/check-merge-conflict.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check for dirty pull requests
         uses: eps1lon/actions-label-merge-conflict@releases/2.x
         with:
-          dirtyLabel: has-conflicts
+          dirtyLabel: "status: conflict"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           commentOnDirty: |
               This pull request has conflicts ☹


### PR DESCRIPTION
Replaces the previous label format with the new one.

Finding labels and trying to understand their usage was getting complicated. I decided to set prefixed topics to gather labels by groups and build a better indicative on how to compose them.

e.g.:
 - an `enhancement` can target `robustness` of the `whiteboard` component in the `client`;
 - a `bug` related to a `performance` issue can be identified at `core`'s `polling` handler; or
 - a `recording` `refactor` can improve the `stability` of the `chat` events processing.