### PR TITLE
Services run as starting PID

### DIFF
--- a/akka-bbb-apps/run-dev.sh
+++ b/akka-bbb-apps/run-dev.sh
@@ -2,5 +2,4 @@
 
 rm -rf src/main/resources
 cp -R src/universal/conf src/main/resources
-sbt run
-
+exec sbt run

--- a/akka-bbb-apps/run.sh
+++ b/akka-bbb-apps/run.sh
@@ -3,4 +3,4 @@
 sbt clean stage
 sudo service bbb-apps-akka stop
 cd target/universal/stage
-./bin/bbb-apps-akka
+exec ./bin/bbb-apps-akka

--- a/akka-bbb-fsesl/run-dev.sh
+++ b/akka-bbb-fsesl/run-dev.sh
@@ -2,5 +2,4 @@
 
 rm -rf src/main/resources
 cp -R src/universal/conf src/main/resources
-sbt run
-
+exec sbt run

--- a/akka-bbb-fsesl/run.sh
+++ b/akka-bbb-fsesl/run.sh
@@ -3,4 +3,4 @@
 sbt clean stage
 sudo service bbb-fsesl-akka stop
 cd target/universal/stage
-./bin/bbb-fsesl-akka
+exec ./bin/bbb-fsesl-akka

--- a/bbb-lti/docker-entrypoint.sh
+++ b/bbb-lti/docker-entrypoint.sh
@@ -9,5 +9,4 @@ if [ -f webapps/lti.war ]; then
   rm webapps/lti.war
 fi
 
-catalina.sh run
-
+exec catalina.sh run

--- a/bbb-lti/run.sh
+++ b/bbb-lti/run.sh
@@ -2,4 +2,4 @@
 rm -rf libs
 grails clean
 grails compile
-grails prod run-app --port 8181
+exec grails prod run-app --port 8181

--- a/bigbluebutton-html5/docker-entrypoint.sh
+++ b/bigbluebutton-html5/docker-entrypoint.sh
@@ -2,4 +2,4 @@
 
 export METEOR_SETTINGS=` jq "${METEOR_SETTINGS_MODIFIER}" ./programs/server/assets/app/config/settings-production.json `
 
-node main.js
+exec node main.js

--- a/bigbluebutton-web/docker-entrypoint.sh
+++ b/bigbluebutton-web/docker-entrypoint.sh
@@ -14,4 +14,4 @@ mkdir -p /var/bigbluebutton/unpublished
 export JAVA_OPTS="${JAVA_OPTS} -Djava.security.egd=file:/dev/./urandom -DsecuritySalt=${SHARED_SECRET} -Dredis.host=redis -DredisHost=redis -Dbigbluebutton.web.serverURL=https://${SERVER_DOMAIN} -DsvgImagesRequired=true"
 sed -i "s|^securerandom\.source=.*|securerandom.source=file:/dev/urandom|g" ${JAVA_HOME}/lib/security/java.security
 
-catalina.sh run
+exec catalina.sh run

--- a/bigbluebutton-web/pres-checker/run.sh
+++ b/bigbluebutton-web/pres-checker/run.sh
@@ -1,1 +1,2 @@
-java -cp "/usr/share/prescheck/lib/*" org.bigbluebutton.prescheck.Main $@
+#!/bin/sh
+exec java -cp "/usr/share/prescheck/lib/*" org.bigbluebutton.prescheck.Main $@

--- a/bigbluebutton-web/run-prod.sh
+++ b/bigbluebutton-web/run-prod.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-java -Dgrails.env=prod -Dserver.address=127.0.0.1 -Dserver.port=8090 -Xms384m -Xmx384m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/bigbluebutton/diagnostics -cp WEB-INF/lib/*:/:WEB-INF/classes/:. org.springframework.boot.loader.WarLauncher
-
+exec java -Dgrails.env=prod -Dserver.address=127.0.0.1 -Dserver.port=8090 -Xms384m -Xmx384m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/bigbluebutton/diagnostics -cp WEB-INF/lib/*:/:WEB-INF/classes/:. org.springframework.boot.loader.WarLauncher

--- a/bigbluebutton-web/run.sh
+++ b/bigbluebutton-web/run.sh
@@ -11,4 +11,4 @@ if [ "`whoami`" != "bigbluebutton" ]; then
 	exit 1
 fi
 
-grails prod run-app --port 8090
+exec grails prod run-app --port 8090


### PR DESCRIPTION
The starting scripts now `exec` the main service instead of starting
it as a subprocess. Also in line with docker-entrypoint recommendations.

Replaces #9216 (there does not seem to be a way to update a PR when the origin fork has been deleted)