### PR TITLE
Fix settings modal z-index

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -284,6 +284,7 @@ class SettingsDropdown extends PureComponent {
 
     return (
       <Dropdown
+        className={styles.dropdown}
         autoFocus
         keepOpen={isSettingOpen}
         onShow={this.onActionsShow}

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/styles.scss
@@ -120,5 +120,6 @@
   }
 }
 
-.btnSettings {
+.dropdown{
+  z-index: 5;
 }


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where actionbar buttons and chat/userlist panel would appear over settings modal on mobile devices, by adding z-index CSS for settings modal component.

### Closes Issue(s)
Closes #11833
Closes #11834
