### PR TITLE
Syncing the length of poll options list with the drag and drop input

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -245,6 +245,8 @@ class Poll extends Component {
 
   setOptListLength(len) {
     const { optList } = this.state;
+
+    len = len > MAX_CUSTOM_FIELDS ? MAX_CUSTOM_FIELDS : len;
     const diff = len - optList.length;
     if (diff > 0) {
       const emptyAddition = Array(diff).fill({ val: '' });

--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -243,8 +243,21 @@ class Poll extends Component {
     this.setState({ question: validateInput(e.target.value), error: clearError ? null : error });
   }
 
+  setOptListLength(len) {
+    const { optList } = this.state;
+    const diff = len - optList.length;
+    if (diff > 0) {
+      const emptyAddition = Array(diff).fill({ val: '' });
+      optList.push(...emptyAddition);
+    } else {
+      optList.splice(len);
+    }
+    this.setState({ optList });
+  }
+
   pushToCustomPollValues(text) {
     const lines = text.split('\n');
+    this.setOptListLength(lines.length);
     for (let i = 0; i < MAX_CUSTOM_FIELDS; i += 1) {
       let line = '';
       if (i < lines.length) {

--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -245,16 +245,17 @@ class Poll extends Component {
 
   setOptListLength(len) {
     const { optList } = this.state;
-
     len = len > MAX_CUSTOM_FIELDS ? MAX_CUSTOM_FIELDS : len;
-    const diff = len - optList.length;
-    if (diff > 0) {
-      const emptyAddition = Array(diff).fill({ val: '' });
-      optList.push(...emptyAddition);
+    let diff = len - optList.length;
+    if(diff > 0) {
+      while(diff--) {
+        this.handleAddOption();
+      }
     } else {
-      optList.splice(len);
+      while(diff++) {
+        this.handleRemoveOption();
+      }
     }
-    this.setState({ optList });
   }
 
   pushToCustomPollValues(text) {


### PR DESCRIPTION
### What does this PR do?

This PR makes sure that the number of poll options is in sync with what's drag-and-dropped.

### Closes Issue(s)

Closes #11741