### PR TITLE
Handle multiple default routes in bbb-conf

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -199,7 +199,7 @@ fi
 if LANG=c ifconfig | grep -q 'venet0:0'; then
     IP=$(ifconfig | grep -v '127.0.0.1' | grep -E "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | tail -1 | cut -d: -f2 | awk '{ print $1}')
 else
-    IP=$(ifconfig $(route | grep ^default | sed "s/.* //") | awk '/inet /{ print $2}' | cut -d: -f2)
+    IP=$(ifconfig $(route | grep ^default | head -1 | sed "s/.* //") | awk '/inet /{ print $2}' | cut -d: -f2)
 fi
 
 if [ -z "$IP" ]; then


### PR DESCRIPTION
This is the same fix that was made in bbb-install: https://github.com/bigbluebutton/bbb-install/pull/327/

Fix https://github.com/bigbluebutton/bigbluebutton/issues/11452

### What does this PR do?

If there are multiple default routes on a system, we only care for the first one.

### Closes Issue(s)
Closes #11452

### Motivation
Just fixing my own issue here and hope it's useful for others.