### PR TITLE
Fix action button appearing over userlist and dropdown

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.scss
@@ -100,7 +100,7 @@
   @extend %text-elipsis;
   @extend %highContrastOutline;
   outline-style: solid;
-  z-index: 3;
+  z-index: 4;
   overflow: visible;
   order: 1;
 


### PR DESCRIPTION
### What does this PR do?

Fix an issue where the action button would appear over the userlist panel and dropdown, by changing userlist z-index value.

### Closes Issue(s)
Closes #11903
