### PR TITLE
Fix - biggest text size tool bigger than its container

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -549,7 +549,6 @@ public:
         - value: 2
         - value: 1
       font_sizes:
-        - value: 36
         - value: 32
         - value: 28
         - value: 24


### PR DESCRIPTION
### What does this PR do?

Removes 36px option from whiteboard font sizes

### Closes Issue(s)
Closes #7426
