### PR TITLE
Update users persistent data

### DIFF
--- a/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/setloggedOutStatus.js
+++ b/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/setloggedOutStatus.js
@@ -21,6 +21,6 @@ export default function setloggedOutStatus(userId, meetingId, status = true) {
   try {
     UsersPersistentData.update(selector, modifier);
   } catch (err) {
-    Logger.error(`Adding note to the collection: ${err}`);
+    Logger.error(`Setting users persistent data's logged out status to the collection: ${err}`);
   }
 }

--- a/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/updateRole.js
+++ b/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/updateRole.js
@@ -1,0 +1,26 @@
+import { check } from 'meteor/check';
+import UsersPersistentData from '/imports/api/users-persistent-data';
+import Logger from '/imports/startup/server/logger';
+
+export default function updateRole(userId, meetingId, role) {
+  check(userId, String);
+  check(meetingId, String);
+  check(role, String);
+
+  const selector = {
+    userId,
+    meetingId,
+  };
+
+  const modifier = {
+    $set: {
+      role,
+    },
+  };
+
+  try {
+    UsersPersistentData.update(selector, modifier);
+  } catch (err) {
+    Logger.error(`Updating users persistent data's role to the collection: ${err}`);
+  }
+}

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/changeRole.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/changeRole.js
@@ -1,4 +1,5 @@
 import Logger from '/imports/startup/server/logger';
+import updateRole from '/imports/api/users-persistent-data/server/modifiers/updateRole';
 import Users from '/imports/api/users';
 
 export default function changeRole(role, userId, meetingId, changedBy) {
@@ -17,6 +18,7 @@ export default function changeRole(role, userId, meetingId, changedBy) {
     const numberAffected = Users.update(selector, modifier);
 
     if (numberAffected) {
+      updateRole(userId, meetingId, role);
       Logger.info(`Changed user role=${role} id=${userId} meeting=${meetingId}`
         + `${changedBy ? ` changedBy=${changedBy}` : ''}`);
     }

--- a/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
@@ -36,7 +36,6 @@ class Subscriptions extends Component {
   }
 }
 
-let usersPersistentDataHandler = null;
 
 export default withTracker(() => {
   const { credentials } = Auth;
@@ -107,7 +106,10 @@ export default withTracker(() => {
     const chatIds = chats.map(chat => chat.chatId);
     groupChatMessageHandler = Meteor.subscribe('group-chat-msg', chatIds, subscriptionErrorHandler);
   }
-  if (ready && !usersPersistentDataHandler) {
+
+  // TODO: Refactor all the late subscribers
+  let usersPersistentDataHandler = {};
+  if (ready) {
     usersPersistentDataHandler = Meteor.subscribe('users-persistent-data');
   }
 


### PR DESCRIPTION
Made these modifications to handle a problem that role change was dropping users-persistent-data subscriber and not putting it back up again.

There is some points here that I would like to register though. While trying to understand why there was this issue on role change I got at this problem https://github.com/bigbluebutton/bigbluebutton/issues/9733 . As I could understand, since then some collections depend on the user role to control access but this seem to be forcing all the collections to resubscribe when the role changes. 

**IMPORTANT**: although this solves a problem, I'm not sure if it isn't adding something @Tainan404 was trying to avoid. So I recommend him to take a good look and propose anything different if needed.