### PR TITLE
Removed memoryMonitoring from settings.yml

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -638,16 +638,6 @@ private:
   serverLog:
     level: info
     streamerLog: false
-  memoryMonitoring:
-    stat:
-      enabled: false
-    leak:
-      enabled: false
-    heapdump:
-      thresholdMb: 1024
-      enabled: false
-      heapdumpFolderPath: HEAPDUMP_FOLDER
-      heapdumpIntervalMs: 3600000
   minBrowserVersions:
     - browser: chrome
       version: 72


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Removes settings.yml block for `memoryMonitoring`


<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->



### Motivation
`heapdump` and `memwatch` were removed in https://github.com/bigbluebutton/bigbluebutton/pull/8390 as they we not supported in Node12

I did not find any code in the repo using these properties.
<!-- What inspired you to submit this pull request? -->


