### PR TITLE
Fix user icons alignment for Microsoft Edge browser

### DIFF
--- a/bigbluebutton-html5/imports/ui/stylesheets/mixins/_indicators.scss
+++ b/bigbluebutton-html5/imports/ui/stylesheets/mixins/_indicators.scss
@@ -16,20 +16,9 @@
   }
 
   :global(.browser-chrome) &:before,
-  :global(.browser-firefox) &:before {
-    padding: .45rem;
-  }
-
+  :global(.browser-firefox) &:before,
   :global(.browser-edge) &:before {
-    padding-top: var(--indicator-padding-top);
-    padding-left: var(--indicator-padding-left);
-    padding-right: var(--indicator-padding-right);
-    padding-bottom: var(--indicator-padding-bottom);
-
-    [dir="rtl"] & {
-      padding-right: var(--indicator-padding-left);
-      padding-left: var(--indicator-padding-right);
-    }
+      padding: var(--indicator-padding);
   }
 }
 
@@ -38,13 +27,6 @@
     opacity: 1;
     width: 1.2rem;
     height: 1.2rem;
-  }
-
-  :global(.browser-edge) &:after {
-    padding-top: var(--indicator-padding-top);
-    padding-left: var(--indicator-padding-left);
-    padding-right: var(--indicator-padding-right);
-    padding-bottom: var(--indicator-padding-bottom);
   }
 }
 

--- a/bigbluebutton-html5/imports/ui/stylesheets/variables/general.scss
+++ b/bigbluebutton-html5/imports/ui/stylesheets/variables/general.scss
@@ -16,14 +16,8 @@
   --jumbo-padding-x: 3.025rem;
   --jumbo-padding-y: 1.5rem;
 
-  //used to center presenter indicator icon in Chrome / Firefox
-  --indicator-padding: .425rem;
-
-  //used to center indicator icons in Edge
-  --indicator-padding-right: .55em;
-  --indicator-padding-left: 1em;
-  --indicator-padding-top: 0.7em;
-  --indicator-padding-bottom: 0.7em;
+  //used to center presenter indicator icon in Chrome / Firefox / Edge
+  --indicator-padding: .45rem;
 
   //Miscellaneous
   --user-indicators-offset: -5px;


### PR DESCRIPTION
### What does this PR do?

Removes user icon styles that are specific for Microsoft Edge browser.

### Closes Issue(s)
Closes #11898