### PR TITLE
Fix Keyboard Navigation Skipping Users In Userlist

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
@@ -94,14 +94,7 @@ class UserParticipants extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { compact } = this.props;
-    const { selectedUser, scrollArea } = this.state;
-    if (!compact && (!prevState.scrollArea && scrollArea)) {
-      scrollArea.addEventListener(
-        'keydown',
-        this.rove,
-      );
-    }
+    const { selectedUser } = this.state;
 
     if (selectedUser) {
       const { firstChild } = selectedUser;


### PR DESCRIPTION
### What does this PR do?
Remove a duplicate event listener that was causing the keyboard navigation to skip users in the userlist

### Closes Issue(s)
Closes #11839


