### PR TITLE
Update order of presentation lists

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -216,24 +216,26 @@ class ActionsDropdown extends PureComponent {
     // about the first one because it's the default.
     const { podId } = podIds[0];
 
-    const presentationItemElements = presentations.map((p) => {
-      const itemStyles = {};
-      itemStyles[styles.presentationItem] = true;
-      itemStyles[styles.isCurrent] = p.current;
+    const presentationItemElements = presentations
+      .sort((a, b) => (a.name.localeCompare(b.name)))
+      .map((p) => {
+        const itemStyles = {};
+        itemStyles[styles.presentationItem] = true;
+        itemStyles[styles.isCurrent] = p.current;
 
-      return (<DropdownListItem
-        className={cx(itemStyles)}
-        icon="file"
-        iconRight={p.current ? 'check' : null}
-        label={p.name}
-        description="uploaded presentation file"
-        key={`uploaded-presentation-${p.id}`}
-        onClick={() => {
-          setPresentation(p.id, podId);
-        }}
-      />
-      );
-    });
+        return (<DropdownListItem
+          className={cx(itemStyles)}
+          icon="file"
+          iconRight={p.current ? 'check' : null}
+          label={p.name}
+          description="uploaded presentation file"
+          key={`uploaded-presentation-${p.id}`}
+          onClick={() => {
+            setPresentation(p.id, podId);
+          }}
+        />
+        );
+      });
 
     presentationItemElements.push(<DropdownListSeparator key={_.uniqueId('list-separator-')} />);
     return presentationItemElements;

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -599,7 +599,15 @@ class PresentationUploader extends Component {
     const { intl } = this.props;
 
     const presentationsSorted = presentations
-      .sort((a, b) => a.uploadTimestamp - b.uploadTimestamp);
+      .sort((a, b) => a.uploadTimestamp - b.uploadTimestamp)
+      .sort((a, b) => a.filename.localeCompare(b.filename))
+      .sort((a, b) => b.upload.progress - a.upload.progress)
+      .sort((a, b) => b.conversion.done - a.conversion.done)
+      .sort((a, b) => {
+        const aUploadNotTriggeredYet = !a.upload.done && a.upload.progress === 0;
+        const bUploadNotTriggeredYet = !b.upload.done && b.upload.progress === 0;
+        return bUploadNotTriggeredYet - aUploadNotTriggeredYet;
+      });
 
     return (
       <div className={styles.fileList}>


### PR DESCRIPTION
### What does this PR do?

This PR changes the order of the presentation lists both in the action bar dropdown menu and the presentation uploader.

### Closes Issue(s)

Closes #11917

### Motivation

Inspired by the use case of having many presentations with similar names (numbered), for example when wanting to show many pictures which are numbered as a presentation. See also use case mentioned in #11916.

### More

In action bar dropdown presentations are now sorted alphabetically by name.

In presentation uploader it's a bit more "complicated":
First of all, **CARE: This PR changes the current behavior of showing presentations ordered by their upload timestamp**

New order:
- Presentations are generally sorted alphabetically
- Presentations with identical name are sorted like it was before (latest one bottom)
- Newly added (not yet uploaded) presentations are shown in the top (user wants to see instantly if the drag&drop has worked and which presentations he is going to upload)
- While the newly added presentations are uploading/converting they are shown at the bottom of the list (because usually when you are opening presentation uploader again you want to choose presentations which are ready to select from the top, not completely sure if you agree with me there, feedback welcome)
- Presentations with uploading in progress are sorted by upload status (highest progress top, lowest bottom)

I was thinking about showing the current selected presentation always in the top, but chose not to.
Reason: You usually don't want to re-select it. In addition to that this would lead to the strange behavior that a not yet fully uploaded/converted presentation would be shown in the top because the isCurrent flag is set instantly when upload ist started, not when upload is finished as far as I could see.

Feedback on my suggested sorting is very welcome.

I know this is a lot of sorting, but it's done completely on client side, so there shouldn't be any bad influence on server performance. Client performance may be influenced in some way, but it's only presenter's client and it's only relevant when the presenter switches/uploads many presentations, so I don't think this has a remarkable negative impact.