### PR TITLE
Do not show real font-size in whiteboard text tool button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
@@ -543,7 +543,7 @@ class WhiteboardToolbar extends Component {
       <p
         className={styles.textThickness}
         style={{
-          fontSize: fontSizeSelected.value,
+          fontSize: fontSizeSelected.value <= 32 ? fontSizeSelected.value : 32,
           color: colorSelected.value,
           WebkitTransition: `color ${TRANSITION_DURATION}, font-size ${TRANSITION_DURATION}`, /* Safari */
           transition: `color ${TRANSITION_DURATION}, font-size ${TRANSITION_DURATION}`,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-submenu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-submenu/component.jsx
@@ -101,7 +101,7 @@ class ToolbarSubmenu extends Component {
       );
     } if (type === 'font-size') {
       return (
-        <p className={styles.textThickness} style={{ fontSize: obj.value }}>
+        <p className={styles.textThickness} style={{ fontSize: obj.value <= 32 ? obj.value : 32 }}>
           Aa
         </p>
       );


### PR DESCRIPTION
### What does this PR do?

Alternative to #11908 based on feedback from @antobinary:

> Would it be an option to not show the 'real' font size in the button if larger than 32?
> 28 - show 28
> 32 - show 32
> 36 - **show 32**



### Closes Issue(s)
Closes #7426
