### PR TITLE
Stop viewer play/stop actions on external videos

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
@@ -396,6 +396,10 @@ class VideoPlayer extends Component {
     this.setState({ playing: true });
 
     this.handleFirstPlay();
+
+    if (!isPresenter && !playing) {
+      this.setState({ playing: false });
+    }
   }
 
   handleOnPause() {
@@ -410,6 +414,10 @@ class VideoPlayer extends Component {
     this.setState({ playing: false });
 
     this.handleFirstPlay();
+
+    if (!isPresenter && playing) {
+      this.setState({ playing: true });
+    }
   }
 
   render() {


### PR DESCRIPTION
### What does this PR do?

Prevents viewers from play/stop external videos.

### Closes Issue(s)
Closes #11708