### PR TITLE
Consider /etc/bigbluebutton/turn-stun-servers.xml overlay config file in bbb-conf

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -173,6 +173,10 @@ NCPU=$(nproc --all)
 BBB_USER=bigbluebutton
 
 TURN=$SERVLET_DIR/WEB-INF/classes/spring/turn-stun-servers.xml
+TURN_ETC_CONFIG=/etc/bigbluebutton/turn-stun-servers.xml
+if [ -f "$TURN_ETC_CONFIG" ]; then
+    TURN=$TURN_ETC_CONFIG
+fi
 STUN="$(xmlstarlet sel -N x="http://www.springframework.org/schema/beans" -t -m '_:beans/_:bean[@class="org.bigbluebutton.web.services.turn.StunTurnService"]/_:property[@name="stunServers"]/_:set/_:ref' -v @bean $TURN)"
 
 PROTOCOL=http


### PR DESCRIPTION
### What does this PR do?

Since #11804 (already live in beta2) an overlay config for `turn-stun-servers.xml` in `/etc/bigbluebutton` is possible. This PR makes `bbb-conf` consider this case:
Take `/etc/bigbluebutton/turn-stun-servers.xml` for reading stun server if it exists. Default config file `/usr/share/bbb-conf/WEB-INF/classes/spring/turn-stun-servers.xml` is only considered if `/etc/bigbluebutton/turn-stun-servers.xml` doesn't exist.

### Closes Issue(s)

Closes #11929

### Motivation

As I were the one sending in the PR for the overlay config I see it as my duty to fix this follow up issue ;-)

### More

In PR #11804 there is no merging between config files: If the overlay config file exists, it replaces the default config file as a whole, so for this PR it's sufficient to just check if the overlay config file exists and replace the corresponding config file path.
