### PR TITLE
Remove recording button text on phones

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/component.jsx
@@ -4,6 +4,7 @@ import humanizeSeconds from '/imports/utils/humanizeSeconds';
 import Tooltip from '/imports/ui/components/tooltip/component';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
+import cx from 'classnames';
 import { styles } from './styles';
 
 const intlMessages = defineMessages({
@@ -103,6 +104,7 @@ class RecordingIndicator extends PureComponent {
       allowStartStopRecording,
       notify,
       micUser,
+      isPhone,
     } = this.props;
 
     const { time } = this.state;
@@ -116,12 +118,15 @@ class RecordingIndicator extends PureComponent {
       : intlMessages.recordingIndicatorOff);
 
     let recordTitle = '';
-    if (!recording) {
-      recordTitle = time > 0
-        ? intl.formatMessage(intlMessages.resumeTitle)
-        : intl.formatMessage(intlMessages.startTitle);
-    } else {
-      recordTitle = intl.formatMessage(intlMessages.stopTitle);
+
+    if (!isPhone) {
+      if (!recording) {
+        recordTitle = time > 0
+          ? intl.formatMessage(intlMessages.resumeTitle)
+          : intl.formatMessage(intlMessages.startTitle);
+      } else {
+        recordTitle = intl.formatMessage(intlMessages.stopTitle);
+      }
     }
 
     const recordingToggle = () => {
@@ -169,7 +174,7 @@ class RecordingIndicator extends PureComponent {
       >
         {recordingIndicatorIcon}
 
-        <div className={styles.presentationTitle}>
+        <div className={cx(styles.presentationTitle, (!isPhone || recording) && styles.presentationTitleMargin)}>
           {recording
             ? (
               <span className={styles.visuallyHidden}>

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/container.jsx
@@ -5,6 +5,7 @@ import Auth from '/imports/ui/services/auth';
 import { notify } from '/imports/ui/services/notification';
 import VoiceUsers from '/imports/api/voice-users';
 import RecordIndicator from './component';
+import deviceInfo from '/imports/utils/deviceInfo';
 
 const RecordIndicatorContainer = props => (
   <RecordIndicator {...props} />
@@ -40,5 +41,6 @@ export default withTracker(() => {
     time: recordObeject && recordObeject.time,
     notify,
     micUser,
+    isPhone: deviceInfo.isPhone,
   };
 })(RecordIndicatorContainer);

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/styles.scss
@@ -65,7 +65,6 @@
   color: var(--color-white);
   font-size: var(--font-size-base);
   padding: 0;
-  margin-left: var(--sm-padding-x);
   margin-right: 0;
   white-space: nowrap;
   overflow: hidden;
@@ -84,6 +83,10 @@
   span {
     vertical-align: middle;
   }
+}
+
+.presentationTitleMargin {
+  margin-left: var(--sm-padding-x);
 }
 
 .recordingStatusViewOnly {


### PR DESCRIPTION
### What does this PR do?

Removes RecordingIndicator component text from mobile (phones only) view.

#### before changes
![Screenshot from 2021-04-08 08-41-32](https://user-images.githubusercontent.com/3728706/114020725-481e2580-9846-11eb-8817-0b2f60271e7f.png)

#### after changes
![Screenshot from 2021-04-08 10-37-54](https://user-images.githubusercontent.com/3728706/114036590-96d3bb80-9856-11eb-8cc6-c8fdee0743a8.png)
![Screenshot from 2021-04-08 10-38-07](https://user-images.githubusercontent.com/3728706/114036612-9affd900-9856-11eb-821f-2d98b6e972bb.png)


### Closes Issue(s)
Closes #7934
Closes #11816