### PR TITLE
Fix Text Area's Not Opening IOS Virtual Keyboard

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/text-draw-listener/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/text-draw-listener/component.jsx
@@ -132,7 +132,7 @@ export default class TextDrawListener extends Component {
     const textarea = document.getElementById(getCurrentShapeId());
 
     if (textarea) {
-      if (document.activeElement === textarea) {
+      if (document.activeElement === textarea && document.activeElement.value.length > 0) {
         return true;
       }
       textarea.focus();


### PR DESCRIPTION
### What does this PR do?
IOS keyboards are triggered by the text area's 
![iOS-keyboard](https://user-images.githubusercontent.com/22058534/114034087-e06ad900-984b-11eb-8f81-d813ed98d681.gif)

### Closes Issue(s)
Closes #11647