### PR TITLE
fix: when muted alert is active, can't click on 'Leave audio'

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/muted-alert/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/muted-alert/styles.scss
@@ -12,7 +12,7 @@
   top: -50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  z-index: 5;
+  z-index: 1;
 
   > span {
     white-space: nowrap;


### PR DESCRIPTION
Refs #11913

![screen](https://user-images.githubusercontent.com/1780868/114069048-f214a680-9874-11eb-9c05-96a2852527f9.gif)
