### PR TITLE
Fix new poll key warning

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -313,9 +313,8 @@ class Poll extends Component {
       if (o.val.length > 0) hasVal = true;
       const pollOptionKey = `poll-option-${i}`;
       return (
-        <span>
+        <span key={pollOptionKey}>
           <div
-            key={pollOptionKey}
             style={{
               display: 'flex',
               justifyContent: 'spaceBetween',


### PR DESCRIPTION
### What does this PR do?

Moves `key` attribute in the poll component from `div` to `span`
This will remove the warning that appears while creating a new poll, after setting a response type.

![Screenshot from 2021-04-08 15-40-53](https://user-images.githubusercontent.com/3728706/114079950-2aba7d00-9881-11eb-8fc8-e88a142eba9f.png)
