### PR TITLE
Remove unused chat-related variables

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/container.jsx
@@ -20,7 +20,6 @@ const PUBLIC_GROUP_CHAT_KEY = CHAT_CONFIG.public_group_id;
 const CHAT_CLEAR = CHAT_CONFIG.system_messages_keys.chat_clear;
 const SYSTEM_CHAT_TYPE = CHAT_CONFIG.type_system;
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
-const CONNECTION_STATUS = 'online';
 const DEBOUNCE_TIME = 1000;
 
 const sysMessagesIds = {

--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
@@ -267,7 +267,6 @@ class MessageForm extends PureComponent {
       title,
       disabled,
       className,
-      chatAreaId,
     } = this.props;
 
     const { hasErrors, error, message } = this.state;

--- a/bigbluebutton-html5/imports/ui/components/chat/service.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/service.js
@@ -17,12 +17,8 @@ const SYSTEM_CHAT_TYPE = CHAT_CONFIG.type_system;
 const PUBLIC_CHAT_ID = CHAT_CONFIG.public_id;
 const PUBLIC_GROUP_CHAT_ID = CHAT_CONFIG.public_group_id;
 const PRIVATE_CHAT_TYPE = CHAT_CONFIG.type_private;
-const PUBLIC_CHAT_USER_ID = CHAT_CONFIG.system_userid;
-const PUBLIC_CHAT_CLEAR = CHAT_CONFIG.system_messages_keys.chat_clear;
 
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
-
-const CONNECTION_STATUS_ONLINE = 'online';
 
 const ScrollCollection = new Mongo.Collection(null);
 
@@ -371,7 +367,7 @@ const removePackagedClassAttribute = (classnames, attribute) => {
   classnames.map(c => {
     const elements = document.getElementsByClassName(c);
       if (elements) {
-        for (const [k, v] of Object.entries(elements)) {
+        for (const [,v] of Object.entries(elements)) {
           v.removeAttribute(attribute);
       }
     }

--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/container.jsx
@@ -1,5 +1,4 @@
-import React, { PureComponent, useContext } from 'react';
-import { withTracker } from 'meteor/react-meteor-data';
+import React, { useContext } from 'react';
 import TimeWindowChatItem from './component';
 import { UsersContext } from '/imports/ui/components/components-data/users-context/context';
 import ChatLogger from '/imports/ui/components/chat/chat-logger/ChatLogger';

--- a/bigbluebutton-html5/imports/ui/components/components-data/chat-context/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/chat-context/context.jsx
@@ -27,8 +27,6 @@ export const ACTIONS = {
   CLEAR_ALL: 'clear_all',
 };
 
-const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
-
 export const getGroupingTime = () => Meteor.settings.public.chat.grouping_messages_window;
 export const getGroupChatId = () => Meteor.settings.public.chat.public_group_id;
 export const getLoginTime = () => (Users.findOne({ userId: Auth.userID }) || {}).authTokenValidatedTime || 0;


### PR DESCRIPTION
### What does this PR do?

Removes unused variables from chat-related files reported by [lgtm alerts](https://lgtm.com/projects/g/bigbluebutton/bigbluebutton/alerts)

### Motivation

*Unused local variables make code hard to read and understand. Any computation used to initialize an unused variable is wasted, which may lead to performance problems.*

*Similarly, unused imports and unused functions or classes can be confusing. They may even be a symptom of a bug caused, for example, by an incomplete refactoring.* (https://lgtm.com/rules/1780092/)
