### PR TITLE
Update deploy_to_usr_share.sh

### DIFF
--- a/bigbluebutton-html5/deploy_to_usr_share.sh
+++ b/bigbluebutton-html5/deploy_to_usr_share.sh
@@ -33,7 +33,7 @@ tar -xzf $UPPER_DESTINATION_DIR/bigbluebutton-html5.tar.gz -C $UPPER_DESTINATION
 
 
 cd "$DESTINATION_DIR"/programs/server/ || exit
-npm i --production
+sudo npm i --production
 echo "deployed to $DESTINATION_DIR/programs/server\n\n\n"
 
 echo "writing $DESTINATION_DIR/mongod_start_pre.sh"


### PR DESCRIPTION
After updating npm from 6.5.x to 7.x I have had to add `sudo` to install npm dependencies. A few lines below file ownership and permissions are corrected, so I think all should be fine. This should work well even with npm 6.x

This is still only meant for developer use
