### PR TITLE
Formatting of PIN number within client

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-dial/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-dial/component.jsx
@@ -36,6 +36,8 @@ class AudioDial extends React.PureComponent {
       telVoice,
     } = this.props;
 
+    const formattedTelVoice = telVoice.replace(/(?=(\d{3})+(?!\d))/g, ' ');
+
     return (
       <span className={styles.help}>
         <div className={styles.text}>
@@ -45,7 +47,7 @@ class AudioDial extends React.PureComponent {
         <div className={styles.conferenceText}>
           {intl.formatMessage(intlMessages.audioDialConfrenceText)}
         </div>
-        <div className={styles.telvoice}>{telVoice}</div>
+        <div className={styles.telvoice}>{formattedTelVoice}</div>
         <div className={styles.tipBox}>
           <span className={styles.tipIndicator}>
             {`${intl.formatMessage(intlMessages.tipIndicator)}: `}


### PR DESCRIPTION
### What does this PR do?

Formats a 9 digit PIN number to make it easier to read.

#### current behavior
![current](https://user-images.githubusercontent.com/290351/113933808-685cce80-97cb-11eb-889f-1a58897158b4.png)

#### after changes
![Screenshot from 2021-04-09 08-39-34](https://user-images.githubusercontent.com/3728706/114175390-5fc1e080-9910-11eb-9e73-76446c50f46e.png)

### Closes Issue(s)
Closes #11935