### PR TITLE
fix: MEDIA_ERROR when joining room using Firefox

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -142,7 +142,6 @@ export default lockContextContainer(withModalMounter(injectIntl(withTracker(({ m
   return {
     init: () => {
       Service.init(messages, intl);
-      Service.changeOutputDevice(document.querySelector('#remote-media').sinkId);
       const enableVideo = getFromUserSettings('bbb_enable_video', KURENTO_CONFIG.enableVideo);
       const autoShareWebcam = getFromUserSettings('bbb_auto_share_webcam', KURENTO_CONFIG.autoShareWebcam);
       if (!autoJoin || didMountAutoJoin) {

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -687,7 +687,7 @@ class AudioManager {
     this.setSenderTrackEnabled(true);
   }
 
-  playAlertSound (url) {
+  playAlertSound(url) {
     if (!url) {
       return Promise.resolve();
     }


### PR DESCRIPTION
Firefox doesn't create a  device called 'default' and we were trying
to set this when user is joining the room. We don't do this anymore, letting
devices to be changed when there's some user request.

Moved outputDeviceId inputDeviceId information to be managed in bridge
(just like we do with inputDeviceId), we don't store this duplicated
information in audio container anymore.

Fixed the eslint warning in "playAlertSound(url) { ..."

We are safe to let users try to change input/output devices because the
device list is retrieved from enumerateDevices.

#11849 backport