### PR TITLE
Fix private public chat lock interference

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/container.jsx
@@ -229,15 +229,15 @@ const ChatContainer = (props) => {
 
 export default lockContextContainer(injectIntl(withTracker(({ intl, userLocks }) => {
   const chatID = Session.get('idChatOpen');
-  const isChatLocked = (userLocks.userPrivateChat && chatID !== PUBLIC_CHAT_KEY)
-      || (userLocks.userPublicChat && chatID === PUBLIC_CHAT_KEY);
-
   if (!chatID) {
     // No chatID is set so the panel is closed, about to close, or wasn't opened correctly
     return {
       unmounting: true,
     };
   }
+
+  const isChatLocked = (userLocks.userPrivateChat && chatID !== PUBLIC_CHAT_KEY)
+    || (userLocks.userPublicChat && chatID === PUBLIC_CHAT_KEY);
 
   const { connected: isMeteorConnected } = Meteor.status();
 

--- a/bigbluebutton-html5/imports/ui/components/chat/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/container.jsx
@@ -229,7 +229,8 @@ const ChatContainer = (props) => {
 
 export default lockContextContainer(injectIntl(withTracker(({ intl, userLocks }) => {
   const chatID = Session.get('idChatOpen');
-  const isChatLocked = userLocks.userPrivateChat || userLocks.userPublicChat;
+  const isChatLocked = (userLocks.userPrivateChat && chatID !== PUBLIC_CHAT_KEY)
+      || (userLocks.userPublicChat && chatID === PUBLIC_CHAT_KEY);
 
   if (!chatID) {
     // No chatID is set so the panel is closed, about to close, or wasn't opened correctly


### PR DESCRIPTION
### What does this PR do?
Fixes the problem that locking public chat also locks private chat and locking private chat also locks public chat.

### Closes Issue(s)
Closes #11986

### Motivation
I really want to go productive with 2.3-beta as soon as possible :-)

### More
I'm not super deep into the whole chat implementation, so I'm not 100% sure about the PUBLIC_CHAT_KEY comparison to differ public from private chats, but it worked in my dev environment, so... :-)