### PR TITLE
Fix active poll refresh crash

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -661,7 +661,7 @@ class AudioManager {
   }
 
   playAlertSound(url) {
-    if (!url) {
+    if (!url || !this.bridge) {
       return Promise.resolve();
     }
 


### PR DESCRIPTION
### What does this PR do?

Prevents a crash that would happen if there's an active poll and the user refreshes the page without voting

### Closes Issue(s)
Closes #11968