### PR TITLE
Remove max-width from polling options container

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/polling/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/polling/styles.scss
@@ -27,7 +27,6 @@
 .pollingContainer {
   pointer-events:auto;
   min-width: var(--poll-width);
-  max-width: var(--poll-width);
   position: absolute;
 
   z-index: var(--poll-index);


### PR DESCRIPTION
### What does this PR do?

Removes `max-width` styles from polling container

### Closes Issue(s)
Closes #11999