### PR TITLE
Fix join webcam breakout room

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -341,6 +341,7 @@ class AudioManager {
         isListenOnly: this.isListenOnly,
       });
     }
+    Session.set('audioModalIsOpen', false);
   }
 
   onTransferStart() {


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where the user could not join video in breakout room after audio auto-joining 

#### Additional information
Before joining video, `audioModalIsOpen` value [is checked](https://github.com/bigbluebutton/bigbluebutton/blob/32dec42264b501e92bb70bc6dae677fceeec225e/bigbluebutton-html5/imports/ui/components/media/webcam-draggable-overlay/component.jsx#L497-L498)... but if you auto-join audio, `audioModalIsOpen` was never set to false

### Closes Issue(s)
Closes #11985