### PR TITLE
video: voice activity video sorting

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserConnectedToGlobalAudioMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserConnectedToGlobalAudioMsgHdlr.scala
@@ -40,7 +40,9 @@ trait UserConnectedToGlobalAudioMsgHdlr {
         talking = false,
         listenOnly = true,
         "kms",
-        System.currentTimeMillis()
+        System.currentTimeMillis(),
+        floor = false,
+        lastFloorTime = "0",
       )
 
       VoiceUsers.add(liveMeeting.voiceUsers, vu)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorChangedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorChangedVoiceConfEvtMsgHdlr.scala
@@ -1,0 +1,61 @@
+package org.bigbluebutton.core.apps.voice
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.models.{ VoiceUserState, VoiceUsers }
+import org.bigbluebutton.core.running.{ BaseMeetingActor, LiveMeeting, OutMsgRouter }
+
+trait AudioFloorChangedVoiceConfEvtMsgHdlr {
+  this: BaseMeetingActor =>
+
+  val liveMeeting: LiveMeeting
+  val outGW: OutMsgRouter
+
+  def handleAudioFloorChangedVoiceConfEvtMsg(msg: AudioFloorChangedVoiceConfEvtMsg): Unit = {
+
+    def broadcastEvent(vu: VoiceUserState): Unit = {
+      val routing = Routing.addMsgToClientRouting(
+        MessageTypes.BROADCAST_TO_MEETING,
+        liveMeeting.props.meetingProp.intId,
+        vu.intId
+      )
+      val envelope = BbbCoreEnvelope(AudioFloorChangedEvtMsg.NAME, routing)
+      val header = BbbClientMsgHeader(
+        AudioFloorChangedEvtMsg.NAME,
+        liveMeeting.props.meetingProp.intId, vu.intId
+      )
+
+      val body = AudioFloorChangedEvtMsgBody(
+        voiceConf = msg.header.voiceConf,
+        intId = vu.intId,
+        voiceUserId = vu.voiceUserId,
+        floor = vu.floor,
+        lastFloorTime = msg.body.floorTimestamp
+      )
+
+      val event = AudioFloorChangedEvtMsg(header, body)
+      val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+      outGW.send(msgEvent)
+    }
+
+    for {
+      oldFloorUser <- VoiceUsers.releasedFloor(
+        liveMeeting.voiceUsers,
+        msg.body.oldVoiceUserId,
+        floor = false
+      )
+    } yield {
+      broadcastEvent(oldFloorUser)
+    }
+
+    for {
+      newFloorUser <- VoiceUsers.becameFloor(
+        liveMeeting.voiceUsers,
+        msg.body.voiceUserId,
+        true,
+        msg.body.floorTimestamp
+      )
+    } yield {
+      broadcastEvent(newFloorUser)
+    }
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
@@ -268,7 +268,9 @@ object VoiceApp extends SystemConfiguration {
       talking,
       listenOnly = isListenOnly,
       callingInto,
-      System.currentTimeMillis()
+      System.currentTimeMillis(),
+      floor = false,
+      lastFloorTime = "0"
     )
     VoiceUsers.add(liveMeeting.voiceUsers, voiceUserState)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp2x.scala
@@ -18,6 +18,7 @@ trait VoiceApp2x extends UserJoinedVoiceConfEvtMsgHdlr
   with RecordingStartedVoiceConfEvtMsgHdlr
   with VoiceConfRunningEvtMsgHdlr
   with SyncGetVoiceUsersMsgHdlr
+  with AudioFloorChangedVoiceConfEvtMsgHdlr
   with VoiceConfCallStateEvtMsgHdlr
   with UserStatusVoiceConfEvtMsgHdlr {
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/VoiceUsers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/VoiceUsers.scala
@@ -67,6 +67,29 @@ object VoiceUsers {
     }
   }
 
+  def becameFloor(users: VoiceUsers, voiceUserId: String, floor: Boolean, timestamp: String): Option[VoiceUserState] = {
+    for {
+      u <- findWithVoiceUserId(users, voiceUserId)
+    } yield {
+      val vu = u.modify(_.floor).setTo(floor)
+        .modify(_.lastFloorTime).setTo(timestamp)
+        .modify(_.lastStatusUpdateOn).setTo(System.currentTimeMillis())
+      users.save(vu)
+      vu
+    }
+  }
+
+  def releasedFloor(users: VoiceUsers, voiceUserId: String, floor: Boolean): Option[VoiceUserState] = {
+    for {
+      u <- findWithVoiceUserId(users, voiceUserId)
+    } yield {
+      val vu = u.modify(_.floor).setTo(floor)
+        .modify(_.lastStatusUpdateOn).setTo(System.currentTimeMillis())
+      users.save(vu)
+      vu
+    }
+  }
+
   def setLastStatusUpdate(users: VoiceUsers, user: VoiceUserState): VoiceUserState = {
     val vu = user.copy(lastStatusUpdateOn = System.currentTimeMillis())
     users.save(vu)
@@ -130,16 +153,18 @@ case class VoiceUser2x(
     voiceUserId: String
 )
 case class VoiceUserVO2x(
-    intId:       String,
-    voiceUserId: String,
-    callerName:  String,
-    callerNum:   String,
-    joined:      Boolean,
-    locked:      Boolean,
-    muted:       Boolean,
-    talking:     Boolean,
-    callingWith: String,
-    listenOnly:  Boolean
+    intId:         String,
+    voiceUserId:   String,
+    callerName:    String,
+    callerNum:     String,
+    joined:        Boolean,
+    locked:        Boolean,
+    muted:         Boolean,
+    talking:       Boolean,
+    callingWith:   String,
+    listenOnly:    Boolean,
+    floor:         Boolean,
+    lastFloorTime: String
 )
 
 case class VoiceUserState(
@@ -152,5 +177,7 @@ case class VoiceUserState(
     talking:            Boolean,
     listenOnly:         Boolean,
     calledInto:         String,
-    lastStatusUpdateOn: Long
+    lastStatusUpdateOn: Long,
+    floor:              Boolean,
+    lastFloorTime:      String
 )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -167,6 +167,8 @@ class ReceivedJsonMsgHandlerActor(
         routeGenericMsg[MuteMeetingCmdMsg](envelope, jsonNode)
       case IsMeetingMutedReqMsg.NAME =>
         routeGenericMsg[IsMeetingMutedReqMsg](envelope, jsonNode)
+      case AudioFloorChangedVoiceConfEvtMsg.NAME =>
+        routeVoiceMsg[AudioFloorChangedVoiceConfEvtMsg](envelope, jsonNode)
       case CheckRunningAndRecordingVoiceConfEvtMsg.NAME =>
         routeVoiceMsg[CheckRunningAndRecordingVoiceConfEvtMsg](envelope, jsonNode)
       case UserStatusVoiceConfEvtMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -381,9 +381,10 @@ class MeetingActor(
       case m: UserTalkingInVoiceConfEvtMsg =>
         updateVoiceUserLastActivity(m.body.voiceUserId)
         handleUserTalkingInVoiceConfEvtMsg(m)
-      case m: VoiceConfCallStateEvtMsg        => handleVoiceConfCallStateEvtMsg(m)
+      case m: VoiceConfCallStateEvtMsg         => handleVoiceConfCallStateEvtMsg(m)
 
-      case m: RecordingStartedVoiceConfEvtMsg => handleRecordingStartedVoiceConfEvtMsg(m)
+      case m: RecordingStartedVoiceConfEvtMsg  => handleRecordingStartedVoiceConfEvtMsg(m)
+      case m: AudioFloorChangedVoiceConfEvtMsg => handleAudioFloorChangedVoiceConfEvtMsg(m)
       case m: MuteUserCmdMsg =>
         usersApp.handleMuteUserCmdMsg(m)
         updateUserLastActivity(m.body.mutedBy)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
@@ -60,19 +60,21 @@ object FakeUserGenerator {
   }
 
   def createFakeVoiceUser(user: RegisteredUser, callingWith: String, muted: Boolean, talking: Boolean,
-                          listenOnly: Boolean): VoiceUserState = {
+                          listenOnly: Boolean, floor: Boolean = false): VoiceUserState = {
     val voiceUserId = RandomStringGenerator.randomAlphanumericString(8)
+    val lastFloorTime = System.currentTimeMillis().toString();
     VoiceUserState(intId = user.id, voiceUserId = voiceUserId, callingWith, callerName = user.name,
-      callerNum = user.name, muted, talking, listenOnly, "freeswitch", System.currentTimeMillis())
+      callerNum = user.name, muted, talking, listenOnly, "freeswitch", System.currentTimeMillis(), floor, lastFloorTime)
   }
 
   def createFakeVoiceOnlyUser(callingWith: String, muted: Boolean, talking: Boolean,
-                              listenOnly: Boolean): VoiceUserState = {
+                              listenOnly: Boolean, floor: Boolean = false): VoiceUserState = {
     val voiceUserId = RandomStringGenerator.randomAlphanumericString(8)
     val intId = "v_" + RandomStringGenerator.randomAlphanumericString(16)
     val name = getRandomElement(firstNames, random) + " " + getRandomElement(lastNames, random)
+    val lastFloorTime = System.currentTimeMillis().toString();
     VoiceUserState(intId, voiceUserId = voiceUserId, callingWith, callerName = name,
-      callerNum = name, muted, talking, listenOnly, "freeswitch", System.currentTimeMillis())
+      callerNum = name, muted, talking, listenOnly, "freeswitch", System.currentTimeMillis(), floor, lastFloorTime)
   }
 
   def createFakeWebcamStreamFor(userId: String, viewers: Set[String]): WebcamStream = {

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/FreeswitchConferenceEventListener.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/FreeswitchConferenceEventListener.java
@@ -89,6 +89,14 @@ public class FreeswitchConferenceEventListener implements ConferenceEventListene
             vcs.deskShareRTMPBroadcastStopped(evt.getRoom(), evt.getBroadcastingStreamUrl(),
               evt.getVideoWidth(), evt.getVideoHeight(), evt.getTimestamp());
           }
+        } else if (event instanceof AudioFloorChangedEvent) {
+          AudioFloorChangedEvent evt = (AudioFloorChangedEvent) event;
+          vcs.audioFloorChanged(
+            evt.getRoom(),
+            evt.getVoiceUserId(),
+            evt.getOldVoiceUserId(),
+            evt.getFloorTimestamp()
+          );
         } else if (event instanceof VoiceConfRunningAndRecordingEvent) {
           VoiceConfRunningAndRecordingEvent evt = (VoiceConfRunningAndRecordingEvent) event;
           if (evt.running && ! evt.recording) {

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/IVoiceConferenceService.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/IVoiceConferenceService.java
@@ -64,6 +64,11 @@ public interface IVoiceConferenceService {
                                      Integer videoHeight,
                                      String timestamp);
 
+  void audioFloorChanged(String room,
+                         String voiceUserId,
+                         String oldVoiceUserId,
+                         String floorTimestamp);
+
   void voiceConfRunningAndRecording(String room,
                                     Boolean isRunning,
                                     Boolean isRecording,

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/events/AudioFloorChangedEvent.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/events/AudioFloorChangedEvent.java
@@ -1,0 +1,50 @@
+/**
+* BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+*
+* Copyright (c) 2018 BigBlueButton Inc. and by respective authors (see below).
+*
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License as published by the Free Software
+* Foundation; either version 3.0 of the License, or (at your option) any later
+* version.
+*
+* BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License along
+* with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+*
+*/
+package org.bigbluebutton.freeswitch.voice.events;
+
+public class AudioFloorChangedEvent extends VoiceConferenceEvent {
+
+	private final String voiceUserId;
+	private final String oldVoiceUserId;
+	private final String floorTimestamp;
+
+	public AudioFloorChangedEvent(
+			String room,
+			String voiceUserId,
+			String oldVoiceUserId,
+			String floorTimestamp
+		) {
+		super(room);
+		this.voiceUserId = voiceUserId;
+		this.oldVoiceUserId = oldVoiceUserId;
+		this.floorTimestamp = floorTimestamp;
+	}
+
+	public String getVoiceUserId() {
+		return voiceUserId;
+	}
+
+	public String getOldVoiceUserId() {
+		return oldVoiceUserId;
+	}
+
+	public String getFloorTimestamp() {
+		return floorTimestamp;
+	}
+}

--- a/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/ESLEventListener.java
+++ b/akka-bbb-fsesl/src/main/java/org/bigbluebutton/freeswitch/voice/freeswitch/ESLEventListener.java
@@ -26,6 +26,7 @@ public class ESLEventListener implements IEslEventListener {
     private static final String STOP_RECORDING_EVENT = "stop-recording";
     private static final String CONFERENCE_CREATED_EVENT = "conference-create";
     private static final String CONFERENCE_DESTROYED_EVENT = "conference-destroy";
+    private static final String FLOOR_CHANGE_EVENT = "video-floor-change";
 
     private static final String SCREENSHARE_CONFERENCE_NAME_SUFFIX = "-SCREENSHARE";
 
@@ -197,6 +198,12 @@ public class ESLEventListener implements IEslEventListener {
         } else if (action.equals(CONFERENCE_DESTROYED_EVENT)) {
             VoiceConfRunningEvent pt = new VoiceConfRunningEvent(confName, false);
             conferenceEventListener.handleConferenceEvent(pt);
+        } else if (action.equals(FLOOR_CHANGE_EVENT)) {
+            String holderMemberId = this.getNewFloorHolderMemberIdFromEvent(event);
+            String oldHolderMemberId = this.getOldFloorHolderMemberIdFromEvent(event);
+            String floorTimestamp = event.getEventHeaders().get("Event-Date-Timestamp");
+            AudioFloorChangedEvent vFloor= new AudioFloorChangedEvent(confName, holderMemberId, oldHolderMemberId, floorTimestamp);
+            conferenceEventListener.handleConferenceEvent(vFloor);
         } else {
             log.warn("Unknown conference Action [" + action + "]");
         }
@@ -505,6 +512,22 @@ public class ESLEventListener implements IEslEventListener {
 
     private String getRecordFilenameFromEvent(EslEvent e) {
         return e.getEventHeaders().get("Path");
+    }
+
+    private String getOldFloorHolderMemberIdFromEvent(EslEvent e) {
+        String oldFloorHolder = e.getEventHeaders().get("Old-ID");
+        if(oldFloorHolder == null || oldFloorHolder.equalsIgnoreCase("none")) {
+            oldFloorHolder= "";
+        }
+        return oldFloorHolder;
+    }
+
+    private String getNewFloorHolderMemberIdFromEvent(EslEvent e) {
+        String newHolder = e.getEventHeaders().get("New-ID");
+        if(newHolder == null || newHolder.equalsIgnoreCase("none")) {
+            newHolder = "";
+        }
+        return newHolder;
     }
 
     // Distinguish between recording to a file:

--- a/akka-bbb-fsesl/src/main/scala/org/bigbluebutton/freeswitch/VoiceConferenceService.scala
+++ b/akka-bbb-fsesl/src/main/scala/org/bigbluebutton/freeswitch/VoiceConferenceService.scala
@@ -276,6 +276,28 @@ class VoiceConferenceService(healthz: HealthzService,
     sender.publish(fromVoiceConfRedisChannel, json)
   }
 
+  def audioFloorChanged(
+      voiceConfId: String,
+      voiceUserId: String,
+      oldVoiceUserId: String,
+      floorTimestamp: String
+  ) {
+    val header = BbbCoreVoiceConfHeader(AudioFloorChangedVoiceConfEvtMsg.NAME, voiceConfId)
+    val body = AudioFloorChangedVoiceConfEvtMsgBody(
+      voiceConfId,
+      voiceUserId,
+      oldVoiceUserId,
+      floorTimestamp
+    );
+    val envelope = BbbCoreEnvelope(AudioFloorChangedVoiceConfEvtMsg.NAME, Map("voiceConf" -> voiceConfId))
+
+    val msg = new AudioFloorChangedVoiceConfEvtMsg(header, body)
+    val msgEvent = BbbCommonEnvCoreMsg(envelope, msg)
+
+    val json = JsonUtil.toJson(msgEvent)
+    sender.publish(fromVoiceConfRedisChannel, json)
+  }
+
   def voiceCallStateEvent(
       conf:             String,
       callSession:      String,

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
@@ -496,6 +496,24 @@ case class SyncGetVoiceUsersRespMsg(header: BbbClientMsgHeader, body: SyncGetVoi
 case class SyncGetVoiceUsersRespMsgBody(voiceUsers: Vector[VoiceConfUser])
 
 /**
+ * Received from FS that a user has become a floor holder
+ */
+object AudioFloorChangedVoiceConfEvtMsg { val NAME = "AudioFloorChangedVoiceConfEvtMsg" }
+case class AudioFloorChangedVoiceConfEvtMsg(
+    header: BbbCoreVoiceConfHeader,
+    body:   AudioFloorChangedVoiceConfEvtMsgBody
+) extends VoiceStandardMsg
+case class AudioFloorChangedVoiceConfEvtMsgBody(voiceConf: String, voiceUserId: String, oldVoiceUserId: String, floorTimestamp: String)
+
+/**
+ * Sent to a client that an user has become a floor holder
+ */
+
+object AudioFloorChangedEvtMsg { val NAME = "AudioFloorChangedEvtMsg" }
+case class AudioFloorChangedEvtMsg(header: BbbClientMsgHeader, body: AudioFloorChangedEvtMsgBody) extends BbbCoreMsg
+case class AudioFloorChangedEvtMsgBody(voiceConf: String, intId: String, voiceUserId: String, floor: Boolean, lastFloorTime: String)
+
+/**
  * Received from FS call state events.
  */
 object VoiceConfCallStateEvtMsg { val NAME = "VoiceConfCallStateEvtMsg" }

--- a/bbb-fsesl-client/src/main/java/org/freeswitch/esl/client/inbound/Client.java
+++ b/bbb-fsesl-client/src/main/java/org/freeswitch/esl/client/inbound/Client.java
@@ -519,6 +519,12 @@ public class Client
                                     } else if (eventFunc.equals("conference_loop_input")) {
                                         listener.conferenceEventAction(uniqueId, confName, confSize, eventAction, event);
                                         return;
+                                    } else if (eventFunc.equals("conference_member_set_floor_holder")) {
+                                        listener.conferenceEventAction(uniqueId, confName, confSize, eventAction, event);
+                                        return;
+                                    } else if (eventFunc.equals("conference_video_set_floor_holder")) {
+                                        listener.conferenceEventAction(uniqueId, confName, confSize, eventAction, event);
+                                        return;
                                     } else if (eventFunc.equals("stop_talking_handler")) {
                                         listener.conferenceEventAction(uniqueId, confName, confSize, eventAction, event);
                                         return;

--- a/bigbluebutton-html5/imports/api/video-streams/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/video-streams/server/eventHandlers.js
@@ -1,6 +1,8 @@
 import RedisPubSub from '/imports/startup/server/redis';
 import handleUserSharedHtml5Webcam from './handlers/userSharedHtml5Webcam';
 import handleUserUnsharedHtml5Webcam from './handlers/userUnsharedHtml5Webcam';
+import handleFloorChanged from './handlers/floorChanged';
 
 RedisPubSub.on('UserBroadcastCamStartedEvtMsg', handleUserSharedHtml5Webcam);
 RedisPubSub.on('UserBroadcastCamStoppedEvtMsg', handleUserUnsharedHtml5Webcam);
+RedisPubSub.on('AudioFloorChangedEvtMsg', handleFloorChanged);

--- a/bigbluebutton-html5/imports/api/video-streams/server/handlers/floorChanged.js
+++ b/bigbluebutton-html5/imports/api/video-streams/server/handlers/floorChanged.js
@@ -1,0 +1,12 @@
+import { check } from 'meteor/check';
+import floorChanged from '../modifiers/floorChanged';
+
+export default function handleFloorChanged({ header, body }, meetingId) {
+  const { intId, floor, lastFloorTime } = body;
+  check(meetingId, String);
+  check(intId, String);
+  check(floor, Boolean);
+  check(lastFloorTime, String);
+
+  return floorChanged(meetingId, intId, floor, lastFloorTime);
+}

--- a/bigbluebutton-html5/imports/api/video-streams/server/modifiers/floorChanged.js
+++ b/bigbluebutton-html5/imports/api/video-streams/server/modifiers/floorChanged.js
@@ -1,0 +1,32 @@
+import Logger from '/imports/startup/server/logger';
+import VideoStreams from '/imports/api/video-streams';
+import { check } from 'meteor/check';
+
+export default function floorChanged(meetingId, userId, floor, lastFloorTime) {
+  check(meetingId, String);
+  check(userId, String);
+  check(floor, Boolean);
+  check(lastFloorTime, String);
+
+  const selector = {
+    meetingId,
+    userId,
+  }
+
+  const modifier = {
+    $set: {
+      floor,
+      lastFloorTime: floor ? lastFloorTime : undefined,
+    },
+  };
+
+  try {
+    const numberAffected = VideoStreams.update(selector, modifier);
+
+    if (numberAffected) {
+      Logger.info(`Updated user streams floor times userId=${userId} floor=${floor} lastFloorTime=${lastFloorTime}`);
+    }
+  } catch (error) {
+    return Logger.error(`Error updating stream floor status: ${error}`);
+  }
+}

--- a/bigbluebutton-html5/imports/api/video-streams/server/modifiers/sharedWebcam.js
+++ b/bigbluebutton-html5/imports/api/video-streams/server/modifiers/sharedWebcam.js
@@ -5,6 +5,9 @@ import {
   getDeviceId,
   getUserName,
 } from '/imports/api/video-streams/server/helpers';
+import VoiceUsers from '/imports/api/voice-users/';
+
+const BASE_FLOOR_TIME = "0";
 
 export default function sharedWebcam(meetingId, userId, stream) {
   check(meetingId, String);
@@ -13,6 +16,12 @@ export default function sharedWebcam(meetingId, userId, stream) {
 
   const deviceId = getDeviceId(stream);
   const name = getUserName(userId);
+  const vu = VoiceUsers.findOne(
+    { meetingId, intId: userId },
+    { fields: { floor: 1, lastFloorTime: 1 }}
+  ) || {};
+  const floor = vu.floor || false;
+  const lastFloorTime = vu.lastFloorTime || BASE_FLOOR_TIME;
 
   const selector = {
     meetingId,
@@ -24,6 +33,8 @@ export default function sharedWebcam(meetingId, userId, stream) {
     $set: {
       stream,
       name,
+      lastFloorTime,
+      floor,
     },
   };
 

--- a/bigbluebutton-html5/imports/api/voice-users/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/voice-users/server/eventHandlers.js
@@ -7,6 +7,7 @@ import handleMutedVoiceUser from './handlers/mutedVoiceUser';
 import handleGetVoiceUsers from './handlers/getVoiceUsers';
 import handleVoiceUsers from './handlers/voiceUsers';
 import handleMeetingMuted from './handlers/meetingMuted';
+import handleFloorChange from './handlers/floorChanged';
 
 RedisPubSub.on('UserLeftVoiceConfToClientEvtMsg', handleLeftVoiceUser);
 RedisPubSub.on('UserJoinedVoiceConfToClientEvtMsg', handleJoinVoiceUser);
@@ -15,3 +16,4 @@ RedisPubSub.on('UserMutedVoiceEvtMsg', handleMutedVoiceUser);
 RedisPubSub.on('GetVoiceUsersMeetingRespMsg', processForHTML5ServerOnly(handleGetVoiceUsers));
 RedisPubSub.on('SyncGetVoiceUsersRespMsg', handleVoiceUsers);
 RedisPubSub.on('MeetingMutedEvtMsg', handleMeetingMuted);
+RedisPubSub.on('AudioFloorChangedEvtMsg', handleFloorChange);

--- a/bigbluebutton-html5/imports/api/voice-users/server/handlers/floorChanged.js
+++ b/bigbluebutton-html5/imports/api/voice-users/server/handlers/floorChanged.js
@@ -1,0 +1,10 @@
+import { check } from 'meteor/check';
+import updateVoiceUser from '../modifiers/updateVoiceUser';
+
+export default function handleFloorChange({ header, body }, meetingId) {
+  const voiceUser = body;
+
+  check(meetingId, String);
+
+  return updateVoiceUser(meetingId, voiceUser);
+}

--- a/bigbluebutton-html5/imports/api/voice-users/server/modifiers/updateVoiceUser.js
+++ b/bigbluebutton-html5/imports/api/voice-users/server/modifiers/updateVoiceUser.js
@@ -15,6 +15,8 @@ export default function updateVoiceUser(meetingId, voiceUser) {
     muted: Match.Maybe(Boolean),
     voiceConf: String,
     joined: Match.Maybe(Boolean),
+    floor: Match.Maybe(Boolean),
+    lastFloorTime: Match.Maybe(String),
   });
 
   const { intId } = voiceUser;

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -702,4 +702,5 @@ export default {
   amIPresenter,
   getUsersProp,
   getUserCount,
+  sortUsersByCurrent,
 };

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -16,6 +16,10 @@ import VideoPreviewService from '../video-preview/service';
 import Storage from '/imports/ui/services/storage/session';
 import logger from '/imports/startup/client/logger';
 import _ from 'lodash';
+import {
+  getSortingMethod,
+  sortVideoStreams,
+} from '/imports/ui/components/video-provider/stream-sorting';
 
 const CAMERA_PROFILES = Meteor.settings.public.kurento.cameraProfiles;
 const MULTIPLE_CAMERAS = Meteor.settings.public.app.enableMultipleCameras;
@@ -35,33 +39,15 @@ const {
 const PAGINATION_THRESHOLDS_CONF = Meteor.settings.public.kurento.paginationThresholds;
 const PAGINATION_THRESHOLDS = PAGINATION_THRESHOLDS_CONF.thresholds.sort((t1, t2) => t1.users - t2.users);
 const PAGINATION_THRESHOLDS_ENABLED = PAGINATION_THRESHOLDS_CONF.enabled;
+const {
+  paginationSorting: PAGINATION_SORTING,
+  defaultSorting: DEFAULT_SORTING,
+} = Meteor.settings.public.kurento.cameraSortingModes;
 
 const TOKEN = '_';
 const ENABLE_PAGINATION_SESSION_VAR = 'enablePagination';
 
 class VideoService {
-  // Paginated streams: sort with following priority: local -> presenter -> alphabetic
-  static sortPaginatedStreams(s1, s2) {
-    if (UserListService.isUserPresenter(s1.userId) && !UserListService.isUserPresenter(s2.userId)) {
-      return -1;
-    } else if (UserListService.isUserPresenter(s2.userId) && !UserListService.isUserPresenter(s1.userId)) {
-      return 1;
-    } else {
-      return UserListService.sortUsersByName(s1, s2);
-    }
-  }
-
-  // Full mesh: sort with the following priority: local -> alphabetic
-  static sortMeshStreams(s1, s2) {
-    if (s1.userId === Auth.userID && s2.userId !== Auth.userID) {
-      return -1;
-    } else if (s2.userId === Auth.userID && s1.userId !== Auth.userID) {
-      return 1;
-    } else {
-      return UserListService.sortUsersByName(s1, s2);
-    }
-  }
-
   constructor() {
     this.defineProperties({
       isConnecting: false,
@@ -379,50 +365,46 @@ class VideoService {
     // Recalculate total number of pages
     this.setNumberOfPages(mine.length, others.length, pageSize);
     const chunkIndex = this.currentVideoPageIndex * pageSize;
-    const paginatedStreams = others
-      .sort(VideoService.sortPaginatedStreams)
+    const paginatedStreams = sortVideoStreams(others, PAGINATION_SORTING)
       .slice(chunkIndex, (chunkIndex + pageSize)) || [];
-    const streamsOnPage = [...mine, ...paginatedStreams];
 
-    return streamsOnPage;
+    if (getSortingMethod(PAGINATION_SORTING).localFirst) {
+      return [...mine, ...paginatedStreams];
+    }
+
+    return [...paginatedStreams, ...mine];
   }
 
   getVideoStreams() {
+    const pageSize = this.getMyPageSize();
+    const isPaginationDisabled = !this.isPaginationEnabled() || pageSize === 0;
+    const { neededDataTypes } = isPaginationDisabled
+      ? getSortingMethod(DEFAULT_SORTING)
+      : getSortingMethod(PAGINATION_SORTING);
+
     let streams = VideoStreams.find(
       { meetingId: Auth.meetingID },
-      {
-        fields: {
-          userId: 1, stream: 1, name: 1,
-        },
-      },
+      { fields: neededDataTypes },
     ).fetch();
 
     const moderatorOnly = this.webcamsOnlyForModerator();
     if (moderatorOnly) streams = this.filterModeratorOnly(streams);
-
     const connectingStream = this.getConnectingStream(streams);
     if (connectingStream) streams.push(connectingStream);
-
-    const mappedStreams = streams.map(vs => ({
-      cameraId: vs.stream,
-      userId: vs.userId,
-      name: vs.name,
-    }));
-
-    const pageSize = this.getMyPageSize();
 
     // Pagination is either explictly disabled or pagination is set to 0 (which
     // is equivalent to disabling it), so return the mapped streams as they are
     // which produces the original non paginated behaviour
-    if (!this.isPaginationEnabled() || pageSize === 0) {
+    if (isPaginationDisabled) {
       return {
-        streams: mappedStreams.sort(VideoService.sortMeshStreams),
-        totalNumberOfStreams: mappedStreams.length
+        streams: sortVideoStreams(streams, DEFAULT_SORTING),
+        totalNumberOfStreams: streams.length
       };
     }
 
-    const paginatedStreams = this.getVideoPage(mappedStreams, pageSize);
-    return { streams: paginatedStreams, totalNumberOfStreams: mappedStreams.length };
+    const paginatedStreams = this.getVideoPage(streams, pageSize);
+
+    return { streams: paginatedStreams, totalNumberOfStreams: streams.length };
   }
 
   stopConnectingStream () {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/stream-sorting.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/stream-sorting.js
@@ -1,0 +1,127 @@
+import UserListService from '/imports/ui/components/user-list/service';
+import Auth from '/imports/ui/services/auth';
+
+const DEFAULT_SORTING_MODE = 'LOCAL_ALPHABETICAL';
+
+// lastFloorTime, descending
+export const sortVoiceActivity = (s1, s2) => {
+  if (s2.lastFloorTime < s1.lastFloorTime) {
+    return -1;
+  } else if (s2.lastFloorTime > s1.lastFloorTime) {
+    return 1;
+  } else return 0;
+};
+
+// lastFloorTime (descending) -> alphabetical -> local
+export const sortVoiceActivityLocal = (s1, s2) => {
+  if (s1.userId === Auth.userID) {
+    return 1;
+  } if (s2.userId === Auth.userID) {
+    return -1;
+  }
+
+  return sortVoiceActivity(s1, s2)
+    || UserListService.sortUsersByName(s1, s2);
+}
+
+// local -> lastFloorTime (descending) -> alphabetical
+export const sortLocalVoiceActivity = (s1, s2) => {
+  return UserListService.sortUsersByCurrent(s1, s2)
+    || sortVoiceActivity(s1, s2)
+    || UserListService.sortUsersByName(s1, s2);
+}
+
+// local -> alphabetic
+export const sortLocalAlphabetical = (s1, s2) => {
+  return UserListService.sortUsersByCurrent(s1, s2)
+    || UserListService.sortUsersByName(s1, s2);
+};
+
+export const sortPresenter = (s1, s2) => {
+  if (UserListService.isUserPresenter(s1.userId)) {
+    return -1;
+  } else if (UserListService.isUserPresenter(s2.userId)) {
+    return 1;
+  } else return 0;
+};
+
+// local -> presenter -> alphabetical
+export const sortLocalPresenterAlphabetical = (s1, s2) => {
+  return UserListService.sortUsersByCurrent(s1, s2)
+    || sortPresenter(s1, s2)
+    || UserListService.sortUsersByName(s1, s2);
+};
+
+// SORTING_METHODS: registrar of configurable video stream sorting modes
+// Keys are the method name (String) which are to be configured in settings.yml
+// ${streamSortingMethod} flag.
+//
+// Values are a objects which describe the sorting mode:
+//   - sortingMethod (function): a sorting function defined in this module
+//   - neededData (Object): data members that will be fetched from the server's
+//       video-streams collection
+//   - filter (Boolean): whether the sorted stream list has to be post processed
+//       to remove uneeded attributes. The needed attributes are: userId, streams
+//       and name. Anything other than that is superfluous.
+//   - localFirst (Boolean): true pushes local streams to the beginning of the list,
+//       false to the end
+//       The reason why this flags exists is due to pagination: local streams are
+//       stripped out of the streams list prior to sorting+partiotioning. They're
+//       added (pushed) afterwards. To avoid re-sorting the page, this flag indicates
+//       where it should go.
+//
+// To add a new sorting flavor:
+//   1 - implement a sorting function, add it here (like eg sortPresenterAlphabetical)
+//     1.1.: the sorting function has the same behaviour as a regular .sort callback
+//   2 - add an entry to SORTING_METHODS, the key being the name to be used
+//   in settings.yml and the value object like the aforementioned
+const SORTING_METHODS = Object.freeze({
+  // Default
+  LOCAL_ALPHABETICAL: {
+    sortingMethod: sortLocalAlphabetical,
+    neededDataTypes: {
+      userId: 1, stream: 1, name: 1,
+    },
+    localFirst: true,
+  },
+  VOICE_ACTIVITY_LOCAL: {
+    sortingMethod: sortVoiceActivityLocal,
+    neededDataTypes: {
+      userId: 1, stream: 1, name: 1, lastFloorTime: 1, floor: 1,
+    },
+    filter: true,
+    localFirst: false,
+  },
+  LOCAL_VOICE_ACTIVITY: {
+    sortingMethod: sortLocalVoiceActivity,
+    neededDataTypes: {
+      userId: 1, stream: 1, name: 1, lastFloorTime: 1, floor: 1,
+    },
+    filter: true,
+    localFirst: true,
+  },
+  LOCAL_PRESENTER_ALPHABETICAL: {
+    sortingMethod: sortLocalPresenterAlphabetical,
+    neededDataTypes: {
+      userId: 1, stream: 1, name: 1,
+    },
+    localFirst: true,
+  }
+});
+
+export const getSortingMethod = (identifier) => {
+  return SORTING_METHODS[identifier] || SORTING_METHODS[DEFAULT_SORTING_MODE];
+};
+
+export const sortVideoStreams = (streams, mode) => {
+  const { sortingMethod, filter } = getSortingMethod(mode);
+  const sorted = streams.sort(sortingMethod);
+
+  if (!filter) return sorted;
+
+  return sorted.map(videoStream => ({
+    stream: videoStream.stream,
+    userId: videoStream.userId,
+    name: videoStream.name,
+  }));
+};

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
@@ -219,22 +219,22 @@ class VideoList extends Component {
     window.dispatchEvent(new Event('videoFocusChange'));
   }
 
-  mirrorCamera(cameraId) {
+  mirrorCamera(stream) {
     const { mirroredCameras } = this.state;
-    if (this.cameraIsMirrored(cameraId)) {
+    if (this.cameraIsMirrored(stream)) {
       this.setState({
-        mirroredCameras: mirroredCameras.filter(x => x != cameraId),
+        mirroredCameras: mirroredCameras.filter(x => x != stream),
       });
     } else {
       this.setState({
-        mirroredCameras: mirroredCameras.concat([cameraId]),
+        mirroredCameras: mirroredCameras.concat([stream]),
       });
     }
   }
 
-  cameraIsMirrored(cameraId) {
+  cameraIsMirrored(stream) {
     const { mirroredCameras } = this.state;
-    return mirroredCameras.indexOf(cameraId) >= 0;
+    return mirroredCameras.indexOf(stream) >= 0;
   }
 
   handleCanvasResize() {
@@ -306,16 +306,16 @@ class VideoList extends Component {
     const { focusedId } = this.state;
 
     const numOfStreams = streams.length;
-    return streams.map((stream) => {
-      const { cameraId, userId, name } = stream;
-      const isFocused = focusedId === cameraId;
+    return streams.map((vs) => {
+      const { stream, userId, name } = vs;
+      const isFocused = focusedId === stream;
       const isFocusedIntlKey = !isFocused ? 'focus' : 'unfocus';
-      const isMirrored = this.cameraIsMirrored(cameraId);
+      const isMirrored = this.cameraIsMirrored(stream);
       let actions = [{
         actionName: ACTION_NAME_MIRROR,
         label: intl.formatMessage(intlMessages['mirrorLabel']),
         description: intl.formatMessage(intlMessages['mirrorDesc']),
-        onClick: () => this.mirrorCamera(cameraId),
+        onClick: () => this.mirrorCamera(stream),
       }];
 
       if (numOfStreams > 2) {
@@ -323,28 +323,28 @@ class VideoList extends Component {
           actionName: ACTION_NAME_FOCUS,
           label: intl.formatMessage(intlMessages[`${isFocusedIntlKey}Label`]),
           description: intl.formatMessage(intlMessages[`${isFocusedIntlKey}Desc`]),
-          onClick: () => this.handleVideoFocus(cameraId),
+          onClick: () => this.handleVideoFocus(stream),
         });
       }
 
       return (
         <div
-          key={cameraId}
+          key={stream}
           className={cx({
             [styles.videoListItem]: true,
-            [styles.focused]: focusedId === cameraId && numOfStreams > 2,
+            [styles.focused]: focusedId === stream && numOfStreams > 2,
           })}
         >
           <VideoListItemContainer
             numOfStreams={numOfStreams}
-            cameraId={cameraId}
+            cameraId={stream}
             userId={userId}
             name={name}
             mirrored={isMirrored}
             actions={actions}
             onVideoItemMount={(videoRef) => {
               this.handleCanvasResize();
-              onVideoItemMount(cameraId, videoRef);
+              onVideoItemMount(stream, videoRef);
             }}
             onVideoItemUnmount={onVideoItemUnmount}
             swapLayout={swapLayout}

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/container.jsx
@@ -13,6 +13,7 @@ export default withTracker((props) => {
   } = props;
 
   return {
-    voiceUser: VoiceUsers.findOne({ intId: userId }),
+    voiceUser: VoiceUsers.findOne({ intId: userId },
+      { fields: { 'muted': 1, 'listenOnly': 1, 'talking': 1 } }),
   };
 })(VideoListItemContainer);

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -269,6 +269,14 @@ public:
     autoShareWebcam: false
     skipVideoPreview: false
     skipVideoPreviewOnFirstJoin: false
+    # cameraSortingModes.paginationSorting: sorting mode to be applied when pagination is active
+    # cameraSortingModes.defaultSorting: sorting mode when pagination is not active (full mesh)
+    # Current implemented modes are:
+    # 'LOCAL_ALPHABETICAL' | 'VOICE_ACTIVITY_LOCAL' | 'LOCAL_VOICE_ACTIVITY' | 'LOCAL_PRESENTER_ALPHABETICAL'
+    # The algorithm names are self-explanatory.
+    cameraSortingModes:
+      defaultSorting: LOCAL_ALPHABETICAL
+      paginationSorting: LOCAL_PRESENTER_ALPHABETICAL
     # Entry `thresholds` is an array of:
     # - threshold: minimum number of cameras being shared for profile to applied
     #   profile: a camera profile id from the cameraProfiles configuration array


### PR DESCRIPTION
### What does this PR do?

- Added stream sorting based on voice activity (voice switching, last N, paginated last N, call it what you want)
  * Works with or without pagination enabled, transparently
  * Based on video **floor** heuristics from FS with configurable transition timers (based on number of audio frames) rather than the trigger happy _talking_ events from FS
- Made video stream sorting extensible and configurable
  * The sorting modes for when pagination is enabled or disabled can be configured in settings.yml
  * New sorting modes can be added to the stream sorting util under video-provider. Inline docs explain how to do that.
  * Different sorting modes can be set when pagination is toggled on or off
- Changed how the stream ID attribute from the video-streams collection was passed to downstream components
  * We had an array map that was executed every change just to map `stream` to `cameraId`, which is bizarre. So I changed the `cameraId` usage in downstream components to be conformant with the collection attributes and shaved off the map where it wasn't needed
- Added better selectors to video-list-item container´s VoiceUser fetch (it wasn't using any)

### Closes Issue(s)

None, really. I guess the closest one is https://github.com/bigbluebutton/bigbluebutton/issues/9392, but that thing is a meta issue by now and it's not about active speaker handling anymore.

### Additional details

Adds the foundation necessary to implement:
  - https://github.com/bigbluebutton/bigbluebutton/issues/8388 (auto focus active speaker/floor)
  - https://github.com/bigbluebutton/bigbluebutton/issues/11764 (prioritize active speaker/floor camera quality)
  
Available sorting modes:
  -  'LOCAL_ALPHABETICAL': local streams -> alphabetical sorting
  -  'VOICE_ACTIVITY_LOCAL': last N audio floors -> local streams
  -  'LOCAL_VOICE_ACTIVITY'  local streams -> last N floors
  -  'LOCAL_PRESENTER_ALPHABETICAL' -> local streams -> presenter -> alphabetical sorting
  
**Heads-up**: works with peer renegotiation if switching involves off-page streams coming in. If it's an "intra-page" stream shuffle, it's just UI. I've always avoided shipping this until we figured out how to do 100% reliable server-side stream switching. I worked on that a few weeks. It wasn't 100% reliable. But times change and we're shipping it with renegotiation in a first pass.
  - What that means: the video switching itself might not be as fast as possible
  - What that also means: it's incredibly important to properly configure all candidate trimming options in Kurento (networkInterfaces (MUST), no STUN server (prefer externalIPv4), niceAgentIceTcp=0)