### PR TITLE
Fix previous messages chat alerts and remove unused code

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/alert/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/alert/component.jsx
@@ -73,7 +73,7 @@ class ChatAlert extends PureComponent {
 
     // Avoid alerting messages received before enabling alerts
     if (prevProps.pushAlertDisabled && !pushAlertDisabled) {
-      const newAlertEnabledTimestamp = Service.getLastMessageTimestampFromChatList(activeChats);
+      const newAlertEnabledTimestamp = Service.getLastMessageTimestampFromChatList(activeChats, messages);
       this.setAlertEnabledTimestamp(newAlertEnabledTimestamp);
       return;
     }
@@ -93,6 +93,7 @@ class ChatAlert extends PureComponent {
             && msg.timestamp > alertEnabledTimestamp
             && msg.timestamp > joinTimestamp
             && msg.timestamp > (lastAlertTimestampByChat[chatId] || 0)
+            && !pushAlertDisabled
           );
           return retorno;
         });


### PR DESCRIPTION
### What does this PR do?

- Fixes *Avoid alerting messages received before enabling alerts* on chat alerts (PR #11992)
- Removes unused `chatService` code 