### PR TITLE
Fix: Allow open private chats with mods if private chats are disabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/container.jsx
@@ -78,6 +78,8 @@ const ChatContainer = (props) => {
     intl,
     userLocks,
     lockSettings,
+    isChatLockedPublic,
+    isChatLockedPrivate,
     users: propUsers,
     ...restProps
   } = props;
@@ -127,9 +129,13 @@ const ChatContainer = (props) => {
 
   let partnerIsLoggedOut = false;
 
+  let isChatLocked;
   if(!isPublicChat){
     const idUser = participants?.filter((user) => user.id !== Auth.userID)[0]?.id;
     partnerIsLoggedOut = (users[idUser]?.loggedOut || users[idUser]?.ejected) ? true : false;
+    isChatLocked = isChatLockedPrivate && !(users[idUser]?.role === ROLE_MODERATOR);
+  } else {
+    isChatLocked = isChatLockedPublic;
   }
 
   if (unmounting === true) {
@@ -210,6 +216,7 @@ const ChatContainer = (props) => {
   return (
     <Chat {...{
       ...restProps,
+      isChatLocked,
       chatID,
       amIModerator,
       count: (contextChat?.unreadTimeWindows.size || 0),
@@ -236,15 +243,16 @@ export default lockContextContainer(injectIntl(withTracker(({ intl, userLocks })
     };
   }
 
-  const isChatLocked = (userLocks.userPrivateChat && chatID !== PUBLIC_CHAT_KEY)
-    || (userLocks.userPublicChat && chatID === PUBLIC_CHAT_KEY);
+  const isChatLockedPublic = userLocks.userPublicChat;
+  const isChatLockedPrivate = userLocks.userPrivateChat;
 
   const { connected: isMeteorConnected } = Meteor.status();
 
   return {
     chatID,
     intl,
-    isChatLocked,
+    isChatLockedPublic,
+    isChatLockedPrivate,
     isMeteorConnected,
     meetingIsBreakout: meetingIsBreakout(),
     loginTime: getLoginTime(),


### PR DESCRIPTION
### What does this PR do?

PR #11989 wasn't completely doing what it was supposed to do:
If private chat lock was enabled attendees couldn't open private chats with mods anymore (which is the current behavior in 2.2 and IMO also the intended behavior).
This PR fixes that problem.

### Closes Issue(s)
Follow up PR on #11989, an issue wasn't opened.
Problem was mentioned by @GyR4uk: https://github.com/bigbluebutton/bigbluebutton/pull/11989#issuecomment-818247917
Thank you for that!

### Motivation
Correcting my incomplete PR.

### More
As information about the conversation partner is needed to differ private chat with attendees from private chat with mods my idea of solving this was to move the implementation of the isChatLocked property into the ChatContainer. Therefore I had to split up the property in the lockContextContainer. If there is a better option, please let me know.
