### PR TITLE
Makes bbb-web return error code 403 when uploaded file exceeds limit

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/PresentationController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/PresentationController.groovy
@@ -68,7 +68,7 @@ class PresentationController {
         PresentationUploadToken presUploadToken = meetingService.getPresentationUploadToken(presentationToken);
         meetingService.sendPresentationUploadMaxFilesizeMessage(presUploadToken, originalContentLength, maxUploadFileSize as int);
 
-        response.setStatus(404);
+        response.setStatus(403);
         response.addHeader("Cache-Control", "no-cache")
         response.addHeader("x-file-too-large", "1")
         response.contentType = 'plain/text'


### PR DESCRIPTION
It is a complement for PR #11956

After the previous PR, the Nginx expects to receive error code 403 as response for auth_request error (/presentations).
This change is necessary and was missing.