### PR TITLE
Fix open new private chat

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
@@ -99,12 +99,6 @@ const ChatListItem = (props) => {
     setStateUreadCount(chat.unreadCounter);
   }
 
-  useEffect(() => {
-    if (chat.userId !== PUBLIC_CHAT_KEY && chat.userId === activeChatId) {
-      Session.set('idChatOpen', chat.chatId);
-    }
-  }, [activeChatId]);
-
   return (
     <div
       data-test="chatButton"

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -318,6 +318,7 @@ const getActiveChats = ({ groupChatsMessages, groupChats, users }) => {
       chatId,
       unreadCounter: unreadMessagesCount,
       userId: user?.userId || otherParticipant.id,
+      createdBy: groupChats[chatId].createdBy,
     };
     }
 
@@ -593,6 +594,7 @@ const getGroupChatPrivate = (senderUserId, receiver) => {
     if (_.indexOf(currentClosedChats, chat.chatId) > -1) {
       Storage.setItem(CLOSED_CHAT_LIST_KEY, _.without(currentClosedChats, chat.chatId));
     }
+    return chat.chatId;
   }
 };
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/component.jsx
@@ -6,6 +6,7 @@ import cx from 'classnames';
 import { styles } from '/imports/ui/components/user-list/user-list-content/styles';
 import { findDOMNode } from 'react-dom';
 import ChatListItemContainer from '../../chat-list-item/container';
+import Auth from '/imports/ui/services/auth';
 
 const propTypes = {
   activeChats: PropTypes.arrayOf(String).isRequired,
@@ -63,10 +64,22 @@ class UserMessages extends PureComponent {
 
   componentDidUpdate(prevProps, prevState) {
     const { selectedChat } = this.state;
+    const { activeChats } = this.props;
 
     if (selectedChat && selectedChat !== prevState.selectedChat) {
       const { firstChild } = selectedChat;
       if (firstChild) firstChild.focus();
+    }
+
+    // if the user started a new private chat, open it
+    if (activeChats.length > prevProps.activeChats.length) {
+      const createdPrivateChat = Session.get('createdPrivateChat');
+      const newChat = activeChats.slice(-1)[0];
+
+      if (createdPrivateChat && newChat?.createdBy === Auth.userID) {
+        Session.set('idChatOpen', newChat.chatId);
+        Session.set('createdPrivateChat', false);
+      }
     }
   }
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
@@ -333,9 +333,14 @@ class UserDropdown extends PureComponent {
         'activeChat',
         intl.formatMessage(messages.StartPrivateChat),
         () => {
-          getGroupChatPrivate(currentUser.userId, user);
-          Session.set('openPanel', 'chat');
-          Session.set('idChatOpen', user.userId);
+          const privateChatId = getGroupChatPrivate(currentUser.userId, user);
+
+          if (privateChatId) {
+            Session.set('openPanel', 'chat');
+            Session.set('idChatOpen', privateChatId);
+          } else {
+            Session.set('createdPrivateChat', true);
+          }
         },
         'chat',
       ));


### PR DESCRIPTION
### What does this PR do?

Replaces old code that uses `userId` for the private chat id with the correct `chatId`, and adds new code to open the chat for the user who created it

#### Additional information

Previous code checked if the `idChatOpen` was the same as the userId and then changed it to the correct id, causing a re-render (and hiding the "chat locked" warning).

New code will only open the newly created private chat after the `chatId` is available.

### Closes Issue(s)
Closes #12014
