### PR TITLE
Installs LibreOffice 7 and MS fonts for presentation conversions

### DIFF
--- a/bbb-libreoffice/docker/Dockerfile
+++ b/bbb-libreoffice/docker/Dockerfile
@@ -2,12 +2,21 @@ FROM openjdk:11-jre
 
 ENV DEBIAN_FRONTEND noninteractive
 
+
+#Required to install Libreoffice 7
+RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
+#Required to install MS fonts
+RUN echo "deb http://deb.debian.org/debian buster contrib" >> /etc/apt/sources.list
+
 RUN apt update
 
 RUN apt -y install locales-all fontconfig libxt6 libxrender1 
-RUN apt -y install  --no-install-recommends libreoffice fonts-crosextra-carlito fonts-crosextra-caladea fonts-noto fonts-noto-cjk
+RUN apt install -y -t buster-backports libreoffice
+RUN apt -y install  --no-install-recommends fonts-crosextra-carlito fonts-crosextra-caladea fonts-noto fonts-noto-cjk
 
+#MS fonts
+RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections
+RUN apt-get install -y --no-install-recommends fontconfig ttf-mscorefonts-installer
 
 RUN dpkg-reconfigure fontconfig && fc-cache -f -s -v
-
 


### PR DESCRIPTION
This PR will fix problems of issue #11779 

It changes the Libreoffice Docker with:
- Installs LibreOffice 7 (instead of 6)
- Installs MS fonts