### PR TITLE
Dedicated locales property for shared notes locked text

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-notes/component.jsx
@@ -27,7 +27,7 @@ const intlMessages = defineMessages({
     description: 'Aria label for notes unread content',
   },
   locked: {
-    id: 'app.userList.locked',
+    id: 'app.note.locked',
     description: '',
   },
   byModerator: {

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -54,6 +54,7 @@
     "app.note.label": "Note",
     "app.note.hideNoteLabel": "Hide note",
     "app.note.tipLabel": "Press Esc to focus editor toolbar",
+    "app.note.locked": "Locked",
     "app.user.activityCheck": "User activity check",
     "app.user.activityCheck.label": "Check if user is still in meeting ({0})",
     "app.user.activityCheck.check": "Check",


### PR DESCRIPTION
### What does this PR do?

Adds property "app.notes.locked" to locales file and use it for shared notes locked status.

### Closes Issue(s)
Closes #9538
