### PR TITLE
Increase chat min/max width values

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager.jsx
@@ -16,8 +16,8 @@ const { isMobile } = deviceInfo;
 // values based on sass file
 const USERLIST_MIN_WIDTH = 150;
 const USERLIST_MAX_WIDTH = 240;
-const CHAT_MIN_WIDTH = 150;
-const CHAT_MAX_WIDTH = 335;
+const CHAT_MIN_WIDTH = 320;
+const CHAT_MAX_WIDTH = 400;
 const POLL_MIN_WIDTH = 320;
 const POLL_MAX_WIDTH = 400;
 const NOTE_MIN_WIDTH = 340;


### PR DESCRIPTION
### What does this PR do?

Increases chat panel min/max width to match poll panel size.

### Motivation

When I was working on #12039, I tried to find out why is the minimum chat panel width so small and could not find a reason (these values are desktop/tablets only - phone users will always have 100% width panels). 

With this PR the chat values are increased to the same values we already have in polling creation panel.

The current minimum value is so small that you can't even read the user name at this size:
![Screenshot from 2021-04-15 15-18-55](https://user-images.githubusercontent.com/3728706/114918822-eb9aa780-9dfd-11eb-8168-2bfca3c7a92a.png)

