### PR TITLE
Fix removed user log/component

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/modifiers/userEjected.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/userEjected.js
@@ -1,6 +1,6 @@
 import { check } from 'meteor/check';
 import Logger from '/imports/startup/server/logger';
-import Users from '/imports/api/users';
+import UsersPersistentData from '/imports/api/users-persistent-data';
 import clearUserInfoForRequester from '/imports/api/users-infos/server/modifiers/clearUserInfoForRequester';
 
 export default function userEjected(meetingId, userId, ejectedReason) {
@@ -21,7 +21,7 @@ export default function userEjected(meetingId, userId, ejectedReason) {
   };
 
   try {
-    const numberAffected = Users.update(selector, modifier);
+    const numberAffected = UsersPersistentData.update(selector, modifier);
 
     if (numberAffected) {
       clearUserInfoForRequester(meetingId, userId);

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
@@ -96,6 +96,11 @@ const propTypes = {
   }).isRequired,
   code: PropTypes.string.isRequired,
   reason: PropTypes.string,
+  user: PropTypes.shape({
+    role: PropTypes.string.isRequired,
+    meetingId: PropTypes.string.isRequired,
+    ejected: PropTypes.bool.isRequired,
+  }).isRequired,
 };
 
 const defaultProps = {
@@ -116,12 +121,12 @@ class MeetingEnded extends PureComponent {
       dispatched: false,
     };
 
-    const user = Users.findOne({ userId: Auth.userID });
+    const { user } = props;
     if (user) {
       this.localUserRole = user.role;
     }
 
-    const meeting = Meetings.findOne({ id: user.meetingID });
+    const meeting = Meetings.findOne({ id: user.meetingId });
     if (meeting) {
       const endedBy = Users.findOne({
         userId: meeting.meetingEndedBy,
@@ -210,9 +215,12 @@ class MeetingEnded extends PureComponent {
   }
 
   renderNoFeedback() {
-    const { intl, code, reason } = this.props;
+    const {
+      intl, code, reason, user,
+    } = this.props;
 
-    logger.info({ logCode: 'meeting_ended_code', extraInfo: { endedCode: code, reason } }, 'Meeting ended component, no feedback configured');
+    const logMessage = user.ejected ? 'User removed from the meeting' : 'Meeting ended component, no feedback configured';
+    logger.info({ logCode: 'meeting_ended_code', extraInfo: { endedCode: code, reason } }, logMessage);
 
     return (
       <div className={styles.parent}>
@@ -251,7 +259,9 @@ class MeetingEnded extends PureComponent {
   }
 
   renderFeedback() {
-    const { intl, code, reason } = this.props;
+    const {
+      intl, code, reason, user,
+    } = this.props;
     const {
       selected,
       dispatched,
@@ -259,7 +269,8 @@ class MeetingEnded extends PureComponent {
 
     const noRating = selected <= 0;
 
-    logger.info({ logCode: 'meeting_ended_code', extraInfo: { endedCode: code, reason } }, 'Meeting ended component, feedback allowed');
+    const logMessage = user.ejected ? 'User removed from the meeting' : 'Meeting ended component, feedback configured';
+    logger.info({ logCode: 'meeting_ended_code', extraInfo: { endedCode: code, reason } }, logMessage);
 
     return (
       <div className={styles.parent}>


### PR DESCRIPTION
### What does this PR do?

Redirects to the correct component when user is removed from meeting, by retrieving `ejected` data from users-context instead of `Users` collection

Changes `meetingEnded` component logs to display a different message if the user was removed

### Closes Issue(s)
Closes #11998