### PR TITLE
fix: mic selection (firefox/all browsers) and muted alert when mic is changed

### DIFF
--- a/bigbluebutton-html5/.eslintrc.js
+++ b/bigbluebutton-html5/.eslintrc.js
@@ -25,7 +25,6 @@ module.exports = {
     'jsx-a11y/no-access-key': 0,
     'react/jsx-props-no-spreading': 'off',
     'max-classes-per-file': ['error', 2],
-    'no-param-reassign': ['error', { props: false }],
   },
   globals: {
     browser: 'writable',

--- a/bigbluebutton-html5/.eslintrc.js
+++ b/bigbluebutton-html5/.eslintrc.js
@@ -24,6 +24,8 @@ module.exports = {
     'react/prop-types': 1,
     'jsx-a11y/no-access-key': 0,
     'react/jsx-props-no-spreading': 'off',
+    'max-classes-per-file': ['error', 2],
+    'no-param-reassign': ['error', { props: false }],
   },
   globals: {
     browser: 'writable',

--- a/bigbluebutton-html5/imports/ui/components/muted-alert/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/muted-alert/component.jsx
@@ -62,15 +62,24 @@ class MutedAlert extends Component {
     this._isMounted = false;
     if (this.speechEvents) this.speechEvents.stop();
     if (this.inputStream) {
-      this.inputStream.getTracks().forEach(t => t.stop());
+      this.inputStream.getTracks().forEach((t) => t.stop());
     }
     this.resetTimer();
   }
 
   cloneMediaStream() {
     if (this.inputStream) return;
-    const { inputStream, muted } = this.props;
-    if (inputStream && !muted) this.inputStream = inputStream.clone();
+    const { inputStream } = this.props;
+
+    if (inputStream) {
+      this.inputStream = inputStream.clone();
+      this.enableInputStreamAudioTracks(this.inputStream);
+    }
+  }
+
+  enableInputStreamAudioTracks() {
+    if (!this.inputStream) return;
+    this.inputStream.getAudioTracks().forEach((t) => { t.enabled = true; });
   }
 
   resetTimer() {

--- a/bigbluebutton-html5/imports/ui/components/muted-alert/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/muted-alert/component.jsx
@@ -77,10 +77,12 @@ class MutedAlert extends Component {
     }
   }
 
+  /* eslint-disable no-param-reassign */
   enableInputStreamAudioTracks() {
     if (!this.inputStream) return;
     this.inputStream.getAudioTracks().forEach((t) => { t.enabled = true; });
   }
+  /* eslint-enable no-param-reassign */
 
   resetTimer() {
     if (this.timer) clearTimeout(this.timer);


### PR DESCRIPTION
This commit contains three fixes: one already reported and two detected
during the investigation of the solution.
This started as a fix for firefox (#12023), but i also fixed the muted
alert/banner when device changes: the banner wasn't detecting device changes,
unless audio was deactived/actived.

There's another fix for the microphone stream: we now keep sender's track
disabled if it was already disabled for the sender's track of the previous
selected device.

Also did small refactor for eslint checking.

Some technical information: in sip bridge (bridge/sip.js), setInputStream and
liveChangeInputDevice function were both fully turned into promises, which
guarantees we have everything ready when it resolves to the respective values.
This helps AudioManager (audio-manager/index.js) to sequentially sets and
tracks the state of the current microphone stream (inputStream), when calling
liveChangeInputDevice function: we first set the current stream to null,
creats a new one and then set it to the newly created value - this is needed
because MutedAlert (muted-alert/component.jsx) can then gracefully
allocate/deallocate the cloned stream when it is set to a non-null/null value
(the cloned stream is used for speech detection with hark).
In MutedAlert we also make sure to enable the cloned stream's audio
tracks, just in case the user change the device when muted (audio track is
disabled in this case), which also leaves the cloned stream muted (we then
enable the track to allow speech detection).

Closes #12023