### PR TITLE
Add delay to userRemove

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
@@ -43,11 +43,19 @@ export default function removeUser(meetingId, userId) {
 
     clearUserInfoForRequester(meetingId, userId);
 
+    /*
+    Timeout added to reduce the probability that "userRemove" happens too close to "ejectUser",
+    redirecting user to the wrong component.
+    This is a workaround and should be removed as soon as a better fix is made
+    see: https://github.com/bigbluebutton/bigbluebutton/pull/12057
+    */
+    const DELAY_USER_REMOVAL_TIMEOUT_MS = 1000;
+
     Meteor.wrapAsync((callback) => {
       Meteor.setTimeout(() => {
         Users.remove(selector);
         callback();
-      }, 1000);
+      }, DELAY_USER_REMOVAL_TIMEOUT_MS);
     })();
 
     Logger.info(`Removed user id=${userId} meeting=${meetingId}`);

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
@@ -10,8 +10,8 @@ import ClientConnections from '/imports/startup/server/ClientConnections';
 const clearAllSessions = (sessionUserId) => {
   const serverSessions = Meteor.server.sessions;
   Object.keys(serverSessions)
-    .filter(i => serverSessions[i].userId === sessionUserId)
-    .forEach(i => serverSessions[i].close());
+    .filter((i) => serverSessions[i].userId === sessionUserId)
+    .forEach((i) => serverSessions[i].close());
 };
 
 export default function removeUser(meetingId, userId) {
@@ -43,7 +43,12 @@ export default function removeUser(meetingId, userId) {
 
     clearUserInfoForRequester(meetingId, userId);
 
-    Users.remove(selector);
+    Meteor.wrapAsync((callback) => {
+      Meteor.setTimeout(() => {
+        Users.remove(selector);
+        callback();
+      }, 1000);
+    })();
 
     Logger.info(`Removed user id=${userId} meeting=${meetingId}`);
   } catch (err) {

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
@@ -212,7 +212,8 @@ class MeetingEnded extends PureComponent {
   renderNoFeedback() {
     const { intl, code, reason } = this.props;
 
-    logger.info({ logCode: 'meeting_ended_code', extraInfo: { endedCode: code, reason } }, 'Meeting ended component, no feedback configured');
+    const logMessage = reason === 'user_requested_eject_reason' ? 'User removed from the meeting' : 'Meeting ended component, no feedback configured';
+    logger.info({ logCode: 'meeting_ended_code', extraInfo: { endedCode: code, reason } }, logMessage);
 
     return (
       <div className={styles.parent}>
@@ -259,7 +260,8 @@ class MeetingEnded extends PureComponent {
 
     const noRating = selected <= 0;
 
-    logger.info({ logCode: 'meeting_ended_code', extraInfo: { endedCode: code, reason } }, 'Meeting ended component, feedback allowed');
+    const logMessage = reason === 'user_requested_eject_reason' ? 'User removed from the meeting' : 'Meeting ended component, feedback allowed';
+    logger.info({ logCode: 'meeting_ended_code', extraInfo: { endedCode: code, reason } }, logMessage);
 
     return (
       <div className={styles.parent}>


### PR DESCRIPTION
### What does this PR do?

- Adds a timeout to the userRemove handler, preventing the user from being redirected to the wrong component in ejection
- Changes `meetingEnded` component logs to display a different message if the user was removed

#### Additional information

After a long discussion with @Tainan404 and @jfsiebel about PR #12052 we decided to try another solution, as the real problem is that we have 2 event happening when the user is removed from a meeting: one for `userEjected` and one for `removeUser`... And they happen almost at the same time.

This behavior often makes `User.remove` (from removeUser) cancel `User.update` (from userEjected), displaying the wrong component to the removed user (`ErrorScreen` instead of `MeetingEnded`).

This new solution is a workaround to stop this wrong behavior from happening. 

We think a *better* fix would be:
- If the user is ejected, send the `userEjected` message only (as the user will always be removed when ejected).
- If the user leaves by another way, send the `removeUser` message.

(Better fix part can be discussed and maybe implemented in another issue #12080  It would be nice to hear @gustavotrott and @ritzalam opinions on this.)

### Closes Issue(s)
Closes #11998