### PR TITLE
Fix random user modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -177,12 +177,11 @@ class App extends Component {
       intl,
       hasPublishedPoll,
       randomlySelectedUser,
-      currentUserId,
       mountModal,
       isPresenter,
     } = this.props;
 
-    if (!isPresenter) mountModal(<RandomUserSelectContainer />);
+    if (!isPresenter && randomlySelectedUser.length > 0) mountModal(<RandomUserSelectContainer />);
 
     if (prevProps.currentUserEmoji.status !== currentUserEmoji.status) {
       const formattedEmojiStatus = intl.formatMessage({ id: `app.actionsBar.emojiMenu.${currentUserEmoji.status}Label` })


### PR DESCRIPTION
### What does this PR do?

Stops random user modal from triggering in every update of the component (and only appearing when the Select Random User feature is used)

### Closes Issue(s)
Closes #11985
