### PR TITLE
Fix Screen Reader Access To Tethered Dropdown Menu's

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
@@ -7,6 +7,7 @@ import { defineMessages, injectIntl } from 'react-intl';
 import deviceInfo from '/imports/utils/deviceInfo';
 import Button from '/imports/ui/components/button/component';
 import screenreaderTrap from 'makeup-screenreader-trap';
+import { Session } from 'meteor/session';
 import { styles } from './styles';
 import DropdownTrigger from './trigger/component';
 import DropdownContent from './content/component';
@@ -90,14 +91,29 @@ class Dropdown extends Component {
       onShow,
       onHide,
       keepOpen,
+      tethered,
     } = this.props;
 
     const { isOpen } = this.state;
 
-    if (isOpen) {
+    const openPanel = Session.get('openPanel');
+    const panelRef = document.getElementById(`${openPanel}Panel`);
+    const enableSRTrap = isOpen && !tethered;
+
+    if (enableSRTrap) {
       screenreaderTrap.trap(this.dropdown);
     } else {
       screenreaderTrap.untrap();
+    }
+
+    if (isOpen && tethered) {
+      if (!openPanel.includes('userlist') && panelRef) {
+        panelRef.setAttribute("aria-hidden", true);
+      }
+    }else if (!isOpen && tethered) {
+      if (panelRef) {
+        panelRef.setAttribute("aria-hidden", false);
+      }
     }
 
     if (isOpen && !prevState.isOpen) { onShow(); }

--- a/bigbluebutton-html5/imports/ui/components/panel-manager/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/panel-manager/component.jsx
@@ -344,6 +344,7 @@ class PanelManager extends Component {
 
     return (
       <section
+        id="chatPanel"
         className={styles.chat}
         aria-label={intl.formatMessage(intlMessages.chatLabel)}
         key={enableResize ? null : this.chatKey}
@@ -390,6 +391,7 @@ class PanelManager extends Component {
 
     return (
       <section
+        id="notePanel"
         className={styles.note}
         aria-label={intl.formatMessage(intlMessages.noteLabel)}
         key={enableResize ? null : this.noteKey}
@@ -436,6 +438,7 @@ class PanelManager extends Component {
 
     return (
       <section
+        id="captionsPanel"
         className={styles.captions}
         aria-label={intl.formatMessage(intlMessages.captionsLabel)}
         key={enableResize ? null : this.captionsKey}
@@ -482,6 +485,7 @@ class PanelManager extends Component {
 
     return (
       <section
+        id="waitingUsersPanelPanel"
         className={styles.note}
         aria-label={intl.formatMessage(intlMessages.noteLabel)}
         key={enableResize ? null : this.waitingUsers}
@@ -527,6 +531,7 @@ class PanelManager extends Component {
     const { breakoutRoomWidth } = this.state;
     return (
       <div
+        id="breakoutroomPanel"
         className={styles.breakoutRoom}
         key={this.breakoutroomKey}
         style={{
@@ -540,7 +545,7 @@ class PanelManager extends Component {
 
   renderPoll() {
     return (
-      <div className={styles.poll} key={this.pollKey}>
+      <div className={styles.poll} key={this.pollKey} id="pollPanel">
         <PollContainer />
       </div>
     );


### PR DESCRIPTION
### What does this PR do?
This PR solves 2 problems with the interactions between screen readers and the tethered dropdown menus. 
- Allows screen readers access to tethered dropdown menu content.
- Reduces the amount of navigation needed to reach the menu content. 

### Motivation
Previously, screen readers did not have access to tethered dropdown menu content. This was due to the screen-reader-trap restricting the screen reader to the dropdown menu which was an element containing the menu trigger and content. With the addition of the tethered dropdown the content was moved out of the menu and attached to the body of the document. The new placement of the content in the DOM also included extra navigation for screen readers to get to the menu content, this was an attempt to reduce / improve that..