### PR TITLE
Make Breakout Rooms User Assignment Keyboard Accessible

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { findDOMNode } from 'react-dom';
 import { defineMessages, injectIntl } from 'react-intl';
 import _ from 'lodash';
 import cx from 'classnames';
@@ -221,6 +220,15 @@ class BreakoutRoom extends PureComponent {
       if (event.key.includes('ArrowRight')) this.handleShiftUser(parentElement.nextSibling);
       if (event.key.includes('ArrowLeft')) this.handleShiftUser(parentElement.previousSibling);
       this.setRoomUsers();
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.listOfUsers) {
+      for(let i = 0; i < this.listOfUsers.children.length; i++) {
+        const roomList = this.listOfUsers.children[i].getElementsByTagName('div')[0];
+        roomList.removeEventListener('keydown', this.handleMoveEvent, true);
+      }
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
This PR adds the ability to manage assigning users to breakout rooms via the keyboard only. 
![accessible-br-assignment](https://user-images.githubusercontent.com/22058534/115229741-66571180-a0e1-11eb-9d2d-aa40f4c0bf8f.gif)


### Motivation
Previously there was no way to assign users to breakout rooms without a mouse or using the random assign option.