### PR TITLE
Fix regression: Unintentional locking of private chat with moderator, chat lock on left/ejected user not triggered

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/container.jsx
@@ -132,8 +132,8 @@ const ChatContainer = (props) => {
   let isChatLocked;
   if(!isPublicChat){
     const idUser = participants?.filter((user) => user.id !== Auth.userID)[0]?.id;
-    partnerIsLoggedOut = (users[idUser]?.loggedOut || users[idUser]?.ejected) ? true : false;
-    isChatLocked = isChatLockedPrivate && !(users[idUser]?.role === ROLE_MODERATOR);
+    partnerIsLoggedOut = (users[Auth.meetingID][idUser]?.loggedOut || users[Auth.meetingID][idUser]?.ejected) ? true : false;
+    isChatLocked = isChatLockedPrivate && !(users[Auth.meetingID][idUser]?.role === ROLE_MODERATOR);
   } else {
     isChatLocked = isChatLockedPublic;
   }


### PR DESCRIPTION
### What does this PR do?
This is a regression fix of PR  #12034 causing private chats to moderators being locked when private chat lock is enabled.
While investigating I found out that the PR also broke the locking of private chats when users were ejected or left the meeting. Fixed this as well.

### Closes Issue(s)
Closes #12073

### Motivation
End of april is coming... :-)