### PR TITLE
Makes presentation svg resolution configurable, and improve default quality

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -30,6 +30,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
     private long imageTagThreshold;
     private long pathsThreshold;
     private int convPdfToSvgTimeout = 60;
+    private int svgResolutionPpi = 300;
 	private String BLANK_SVG;
 
     @Override
@@ -253,7 +254,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
 
     private NuProcessBuilder createConversionProcess(String format, int page, String source, String destFile,
             boolean analyze) {
-        String rawCommand = "pdftocairo -r " + (analyze ? " 300 " : " 150 ") + format + (analyze ? "" : " -singlefile")
+        String rawCommand = "pdftocairo -r " + this.svgResolutionPpi + " " + format + (analyze ? "" : " -singlefile")
                 + " -q -f " + String.valueOf(page) + " -l " + String.valueOf(page) + " " + source + " " + destFile;
         if (analyze) {
             rawCommand += " && cat " + destFile;
@@ -310,4 +311,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
         this.convPdfToSvgTimeout = convPdfToSvgTimeout;
     }
 
+    public void setSvgResolutionPpi(int svgResolutionPpi) {
+        this.svgResolutionPpi = svgResolutionPpi;
+    }
 }

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -104,6 +104,11 @@ numFileProcessorThreads=2
 svgConversionTimeout=60
 
 #------------------------------------
+# Presentation resolution, in PPI (will be set to generated svg)
+#------------------------------------
+svgPresentationResolutionPpi=300
+
+#------------------------------------
 # Timeout(secs) to wait for conversion script execution
 #------------------------------------
 officeToPdfConversionTimeout=60

--- a/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
@@ -87,6 +87,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="pathsThreshold" value="${placementsThreshold}"/>
         <property name="blankSvg" value="${BLANK_SVG}"/>
         <property name="convPdfToSvgTimeout" value="${svgConversionTimeout}"/>
+        <property name="svgResolutionPpi" value="${svgPresentationResolutionPpi}"/>
     </bean>
 
     <bean id="generatedSlidesInfoHelper" class="org.bigbluebutton.presentation.GeneratedSlidesInfoHelperImp"/>


### PR DESCRIPTION
This PR will solve #11651. The Png was being generated with poor quality because it was using resolution 150 ppi. Now it will be possible to set a higher quality (and by default will be better).

- Creates `svgPresentationResolutionPpi` config in `bigbluebutton.properties`
- Set default `svgPresentationResolutionPpi = 300` (before it was using 150 when needed to convert to png)