### PR TITLE
Make waiting users more responsiv

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
@@ -78,24 +78,23 @@ const getNameInitials = (name) => {
 
 const renderGuestUserItem = (name, color, handleAccept, handleDeny, role, sequence, userId, avatar, intl) => (
   <div key={`userlist-item-${userId}`} className={styles.listItem}>
-    <div key={`user-content-container-${userId}`} className={styles.userContentContainer}>
-      <div key={`user-avatar-container-${userId}`} className={styles.userAvatar}>
-        <UserAvatar
-          key={`user-avatar-${userId}`}
-          moderator={role === 'MODERATOR'}
-          avatar={avatar}
-          color={color}
-        >
-          {getNameInitials(name)}
-        </UserAvatar>
-      </div>
-      <p key={`user-name-${userId}`} className={styles.userName}>
-[
-        {sequence}
-]
-        {name}
-      </p>
+    <div key={`user-avatar-container-${userId}`} className={styles.userAvatar}>
+      <UserAvatar
+        key={`user-avatar-${userId}`}
+        moderator={role === 'MODERATOR'}
+        avatar={avatar}
+        color={color}
+      >
+        {getNameInitials(name)}
+      </UserAvatar>
     </div>
+    <p key={`user-name-${userId}`} className={styles.userName}>
+[
+      {sequence}
+]
+      {name}
+    </p>
+
 
     <div key={`userlist-btns-${userId}`} className={styles.buttonContainer}>
       <Button

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
@@ -96,8 +96,7 @@
   display: flex;
   flex-flow: row;
   flex-direction: row;
-  align-items: center; 
-  justify-content: space-between;
+  align-items: center;
   border-radius: 5px;
   cursor: pointer;
   :global(.animationsEnabled) & {
@@ -139,7 +138,7 @@
 
 .button {
   font-weight: 400;
-  
+
   &:focus {
     background-color: var(--list-item-bg-hover) !important;
     box-shadow: inset 0 0 0 var(--border-size) var(--item-focus-border), inset 1px 0 0 1px var(--item-focus-border) ;
@@ -184,6 +183,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  flex: 1;
 }
 
 .lobbyMessage {


### PR DESCRIPTION
Longer usernames or longer button names of accept and reject (in other languages) make the buttons disappear to the back.

Issue on: https://test23.bigbluebutton.org/ 
tested with Chrome

![image](https://user-images.githubusercontent.com/8763656/115350852-e64eab80-a1b5-11eb-9829-1346f84b1a84.png)

![image](https://user-images.githubusercontent.com/8763656/115351197-49404280-a1b6-11eb-8de6-84868efdf243.png)
