### PR TITLE
Update Language On Html After Locale Change

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/component.jsx
@@ -240,6 +240,7 @@ class Settings extends Component {
         confirm={{
           callback: () => {
             this.updateSettings(current, intl.formatMessage(intlMessages.savedAlertLabel));
+            document.getElementsByTagName('html')[0].lang = current.application.locale;
             /* We need to use mountModal(null) here to prevent submenu state updates,
             *  from re-opening the modal.
             */
@@ -251,6 +252,7 @@ class Settings extends Component {
         dismiss={{
           callback: () => {
             Settings.setHtmlFontSize(saved.application.fontSize);
+            document.getElementsByTagName('html')[0].lang = saved.application.locale;
             mountModal(null);
           },
           label: intl.formatMessage(intlMessages.CancelLabel),


### PR DESCRIPTION
### What does this PR do?
Updates the `lang` attribute on `html` when the client's locale changes.
### Closes Issue(s)
Closes #12092 