### PR TITLE
Remove unused imports

### DIFF
--- a/bigbluebutton-html5/imports/api/captions/server/methods/addCaptionsPads.js
+++ b/bigbluebutton-html5/imports/api/captions/server/methods/addCaptionsPads.js
@@ -1,5 +1,4 @@
 import RedisPubSub from '/imports/startup/server/redis';
-import Logger from '/imports/startup/server/logger';
 import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -13,7 +13,6 @@ import getFromUserSettings from '/imports/ui/services/users-settings';
 import deviceInfo from '/imports/utils/deviceInfo';
 import UserInfos from '/imports/api/users-infos';
 import { startBandwidthMonitoring, updateNavigatorConnection } from '/imports/ui/services/network-information/index';
-import logger from '/imports/startup/client/logger';
 
 import {
   getFontSize,

--- a/bigbluebutton-html5/imports/ui/components/captions/pad/service.js
+++ b/bigbluebutton-html5/imports/ui/components/captions/pad/service.js
@@ -1,4 +1,3 @@
-import Users from '/imports/api/users';
 import Auth from '/imports/ui/services/auth';
 import Settings from '/imports/ui/services/settings';
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/cursor/cursor-wrapper-container/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/cursor/cursor-wrapper-container/service.js
@@ -2,7 +2,6 @@ import PresentationPods from '/imports/api/presentation-pods';
 import Auth from '/imports/ui/services/auth';
 import Cursor from '/imports/ui/components/cursor/service';
 import WhiteboardService from '/imports/ui/components/whiteboard/service';
-import Users from '/imports/api/users';
 
 const getPresenterCursorId = (whiteboardId, userId) =>
   Cursor.findOne(


### PR DESCRIPTION
### What does this PR do?

Removes unused imports reported by [lgtm alerts](https://lgtm.com/projects/g/bigbluebutton/bigbluebutton/alerts)

### Motivation

*Unused local variables make code hard to read and understand. Any computation used to initialize an unused variable is wasted, which may lead to performance problems.*

*Similarly, unused imports and unused functions or classes can be confusing. They may even be a symptom of a bug caused, for example, by an incomplete refactoring.* (https://lgtm.com/rules/1780092/)
