### PR TITLE
Make waiting users more responsiv

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
@@ -96,8 +96,7 @@
   display: flex;
   flex-flow: row;
   flex-direction: row;
-  align-items: center; 
-  justify-content: space-between;
+  align-items: center;
   border-radius: 5px;
   cursor: pointer;
   :global(.animationsEnabled) & {
@@ -132,14 +131,15 @@
 
 .userContentContainer {
   display: flex;
+  flex: 1;
+  overflow: hidden;
   align-items: center;
-  width: 64%;
   flex-direction: row;
 }
 
 .button {
   font-weight: 400;
-  
+
   &:focus {
     background-color: var(--list-item-bg-hover) !important;
     box-shadow: inset 0 0 0 var(--border-size) var(--item-focus-border), inset 1px 0 0 1px var(--item-focus-border) ;


### PR DESCRIPTION
Longer usernames or longer button names of accept and reject (in other languages) make the buttons disappear to the back.

Issue on: https://test23.bigbluebutton.org/ 
tested with Chrome

![image](https://user-images.githubusercontent.com/8763656/115350852-e64eab80-a1b5-11eb-9829-1346f84b1a84.png)

![image](https://user-images.githubusercontent.com/8763656/115351197-49404280-a1b6-11eb-8de6-84868efdf243.png)
