### PR TITLE
remove active css from chat-nav

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/styles.scss
@@ -98,8 +98,3 @@
     padding: 0 var(--lg-padding-y) 0 0;
   }
 }
-
-.active {
-  background-color: var(--list-item-bg-hover);
-  box-shadow: inset 0 0 0 var(--border-size) var(--item-focus-border), inset 1px 0 0 1px var(--item-focus-border);
-}


### PR DESCRIPTION
fixes #7746

I left the CSS class, because I don't know if anything is triggered by it.