### PR TITLE
fix: breakout autojoin audio with wrong behavior

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
@@ -30,6 +30,7 @@ const intlMessages = defineMessages({
 });
 
 const propTypes = {
+  shortcuts: PropTypes.objectOf(PropTypes.string).isRequired,
   processToggleMuteFromOutside: PropTypes.func.isRequired,
   handleToggleMuteMicrophone: PropTypes.func.isRequired,
   handleJoinAudio: PropTypes.func.isRequired,
@@ -88,8 +89,11 @@ class AudioControls extends PureComponent {
     );
   }
 
-  static renderLeaveButtonWithLiveStreamSelector() {
-    return (<InputStreamLiveSelectorContainer />);
+  static renderLeaveButtonWithLiveStreamSelector(props) {
+    const { handleLeaveAudio } = props;
+    return (
+      <InputStreamLiveSelectorContainer {...{ handleLeaveAudio }} />
+    );
   }
 
   renderLeaveButtonWithoutLiveStreamSelector() {
@@ -151,7 +155,8 @@ class AudioControls extends PureComponent {
 
     if (inAudio) {
       if (_enableDynamicDeviceSelection) {
-        return AudioControls.renderLeaveButtonWithLiveStreamSelector();
+        return AudioControls.renderLeaveButtonWithLiveStreamSelector(this
+          .props);
       }
 
       return this.renderLeaveButtonWithoutLiveStreamSelector();

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/container.jsx
@@ -11,14 +11,18 @@ import Storage from '/imports/ui/services/storage/session';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import AudioControls from './component';
 import AudioModalContainer from '../audio-modal/container';
-import { invalidateCookie } from '../audio-modal/service';
+import {
+  setUserSelectedMicrophone,
+  setUserSelectedListenOnly,
+} from '../audio-modal/service';
+
 import Service from '../service';
 import AppService from '/imports/ui/components/app/service';
 
 const ROLE_VIEWER = Meteor.settings.public.user.role_viewer;
 const APP_CONFIG = Meteor.settings.public.app;
 
-const AudioControlsContainer = props => <AudioControls {...props} />;
+const AudioControlsContainer = (props) => <AudioControls {...props} />;
 
 const processToggleMuteFromOutside = (e) => {
   switch (e.data) {
@@ -46,7 +50,8 @@ const handleLeaveAudio = () => {
   const meetingIsBreakout = AppService.meetingIsBreakout();
 
   if (!meetingIsBreakout) {
-    invalidateCookie('joinedAudio');
+    setUserSelectedMicrophone(false);
+    setUserSelectedListenOnly(false);
   }
 
   const skipOnFistJoin = getFromUserSettings('bbb_skip_check_audio_on_first_join', APP_CONFIG.skipCheckOnJoin);
@@ -88,7 +93,7 @@ export default withUsersConsumer(lockContextContainer(withModalMounter(withTrack
   }
 
   return ({
-    processToggleMuteFromOutside: arg => processToggleMuteFromOutside(arg),
+    processToggleMuteFromOutside: (arg) => processToggleMuteFromOutside(arg),
     showMute: isConnected() && !isListenOnly() && !isEchoTest() && !userLocks.userMic,
     muted: isConnected() && !isListenOnly() && isMuted(),
     inAudio: isConnected() && !isEchoTest(),

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/component.jsx
@@ -50,7 +50,7 @@ const intlMessages = defineMessages({
 
 const propTypes = {
   liveChangeInputDevice: PropTypes.func.isRequired,
-  exitAudio: PropTypes.func.isRequired,
+  handleLeaveAudio: PropTypes.func.isRequired,
   liveChangeOutputDevice: PropTypes.func.isRequired,
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired,
@@ -267,7 +267,7 @@ class InputStreamLiveSelector extends Component {
 
     const {
       liveChangeInputDevice,
-      exitAudio,
+      handleLeaveAudio,
       liveChangeOutputDevice,
       intl,
       shortcuts,
@@ -299,7 +299,7 @@ class InputStreamLiveSelector extends Component {
           key="leaveAudioButtonKey"
           className={styles.stopButton}
           label={intl.formatMessage(intlMessages.leaveAudio)}
-          onClick={() => exitAudio()}
+          onClick={() => handleLeaveAudio()}
           accessKey={shortcuts.leaveaudio}
         />,
       ]);

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/container.jsx
@@ -11,14 +11,12 @@ class InputStreamLiveSelectorContainer extends PureComponent {
   }
 }
 
-export default withTracker(() => {
-  return {
-    isAudioConnected: Service.isConnected(),
-    isListenOnly: Service.isListenOnly(),
-    currentInputDeviceId: Service.inputDeviceId(),
-    currentOutputDeviceId: Service.outputDeviceId(),
-    liveChangeInputDevice: Service.liveChangeInputDevice,
-    liveChangeOutputDevice: Service.changeOutputDevice,
-    exitAudio: Service.exitAudio,
-  };
-})(InputStreamLiveSelectorContainer);
+export default withTracker(({ handleLeaveAudio }) => ({
+  isAudioConnected: Service.isConnected(),
+  isListenOnly: Service.isListenOnly(),
+  currentInputDeviceId: Service.inputDeviceId(),
+  currentOutputDeviceId: Service.outputDeviceId(),
+  liveChangeInputDevice: Service.liveChangeInputDevice,
+  liveChangeOutputDevice: Service.changeOutputDevice,
+  handleLeaveAudio,
+}))(InputStreamLiveSelectorContainer);

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -15,13 +15,11 @@ import {
   closeModal,
   joinListenOnly,
   leaveEchoTest,
-  getcookieData,
 } from './service';
 import Storage from '/imports/ui/services/storage/session';
 import Service from '../service';
 
-const AudioModalContainer = props => <AudioModal {...props} />;
-
+const AudioModalContainer = (props) => <AudioModal {...props} />;
 
 const APP_CONFIG = Meteor.settings.public.app;
 
@@ -50,7 +48,6 @@ export default lockContextContainer(withModalMounter(withTracker(({ userLocks })
   }
 
   const meetingIsBreakout = AppService.meetingIsBreakout();
-  const { joinedAudio } = getcookieData();
 
   const joinFullAudioImmediately = (autoJoin && (skipCheck || skipCheckOnJoin && !getEchoTest))
     || (skipCheck || skipCheckOnJoin && !getEchoTest);
@@ -61,14 +58,15 @@ export default lockContextContainer(withModalMounter(withTracker(({ userLocks })
   const { isChrome, isIe } = browserInfo;
 
   return ({
-    joinedAudio,
     meetingIsBreakout,
     closeModal,
-    joinMicrophone: skipEchoTest => joinMicrophone(skipEchoTest || skipCheck || skipCheckOnJoin),
+    joinMicrophone: (skipEchoTest) => joinMicrophone(skipEchoTest || skipCheck || skipCheckOnJoin),
     joinListenOnly,
     leaveEchoTest,
-    changeInputDevice: inputDeviceId => Service.changeInputDevice(inputDeviceId),
-    changeOutputDevice: outputDeviceId => Service.changeOutputDevice(outputDeviceId),
+    changeInputDevice: (inputDeviceId) => Service
+      .changeInputDevice(inputDeviceId),
+    changeOutputDevice: (outputDeviceId) => Service
+      .changeOutputDevice(outputDeviceId),
     joinEchoTest: () => Service.joinEchoTest(),
     exitAudio: () => Service.exitAudio(),
     isConnecting: Service.isConnecting(),

--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { withTracker } from 'meteor/react-meteor-data';
 import { Session } from 'meteor/session';
 import { withModalMounter } from '/imports/ui/components/modal/service';
@@ -10,7 +11,13 @@ import { notify } from '/imports/ui/services/notification';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import VideoPreviewContainer from '/imports/ui/components/video-preview/container';
 import lockContextContainer from '/imports/ui/components/lock-viewers/context/container';
-import { getcookieData, joinMicrophone } from '/imports/ui/components/audio/audio-modal/service';
+import {
+  joinMicrophone,
+  joinListenOnly,
+  didUserSelectedMicrophone,
+  didUserSelectedListenOnly,
+} from '/imports/ui/components/audio/audio-modal/service';
+
 import Service from './service';
 import AudioModalContainer from './audio-modal/container';
 import Settings from '/imports/ui/services/settings';
@@ -73,20 +80,54 @@ class AudioContainer extends PureComponent {
   }
 
   componentDidMount() {
-    const { meetingIsBreakout, joinedAudio } = this.props;
+    const { meetingIsBreakout } = this.props;
+
     this.init();
-    if (meetingIsBreakout && joinedAudio) {
-      joinMicrophone(true, true);
+
+    if (meetingIsBreakout) {
+      this.joinAudio();
     }
   }
 
   componentDidUpdate(prevProps) {
-    const { hasBreakoutRooms, joinedAudio } = this.props;
-    const { hasBreakoutRooms: hadBreakoutRooms } = prevProps;
-    if (hadBreakoutRooms && !hasBreakoutRooms && joinedAudio
-      && !Service.isConnected()) {
-      joinMicrophone(true, true);
+    if (this.userIsReturningFromBreakoutRoom(prevProps)) {
+      this.joinAudio();
     }
+  }
+
+  /**
+   * Helper function to determine wheter user is returning from breakout room
+   * to main room.
+   * @param  {[Object} prevProps prevProps param from componentDidUpdate
+   * @return {boolean}           True if user is returning from breakout room
+   *                             to main room. False, otherwise.
+   */
+  userIsReturningFromBreakoutRoom(prevProps) {
+    const { hasBreakoutRooms } = this.props;
+    const { hasBreakoutRooms: hadBreakoutRooms } = prevProps;
+    return hadBreakoutRooms && !hasBreakoutRooms;
+  }
+
+  /**
+   * Helper function that join (or not) user in audio. If user previously
+   * selected microphone, it will automatically join mic (without audio modal).
+   * If user previously selected listen only option in audio modal, then it will
+   * automatically join listen only.
+   */
+  joinAudio() {
+    if (Service.isConnected()) return;
+
+    const {
+      userSelectedMicrophone,
+      userSelectedListenOnly,
+    } = this.props;
+
+    if (userSelectedMicrophone) {
+      joinMicrophone(true);
+      return;
+    }
+
+    if (userSelectedListenOnly) joinListenOnly();
   }
 
   render() {
@@ -126,7 +167,9 @@ export default lockContextContainer(withModalMounter(injectIntl(withTracker(({ m
   const enableVideo = getFromUserSettings('bbb_enable_video', KURENTO_CONFIG.enableVideo);
   const autoShareWebcam = getFromUserSettings('bbb_auto_share_webcam', KURENTO_CONFIG.autoShareWebcam);
   const { userWebcam, userMic } = userLocks;
-  const { joinedAudio } = getcookieData();
+
+  const userSelectedMicrophone = didUserSelectedMicrophone();
+  const userSelectedListenOnly = didUserSelectedListenOnly();
   const meetingIsBreakout = AppService.meetingIsBreakout();
   const hasBreakoutRooms = AppService.getBreakoutRooms().length > 0;
   const openAudioModal = () => new Promise((resolve) => {
@@ -152,7 +195,13 @@ export default lockContextContainer(withModalMounter(injectIntl(withTracker(({ m
       // if the user joined a breakout room, the main room's audio was
       // programmatically dropped to avoid interference. On breakout end,
       // offer to rejoin main room audio only if the user is not in audio already
-      if (Service.isUsingAudio() || joinedAudio) {
+      if (Service.isUsingAudio()
+        || userSelectedMicrophone
+        || userSelectedListenOnly) {
+        if (enableVideo && autoShareWebcam) {
+          openVideoPreviewModal();
+        }
+
         return;
       }
       setTimeout(() => openAudioModal().then(() => {
@@ -166,7 +215,8 @@ export default lockContextContainer(withModalMounter(injectIntl(withTracker(({ m
   return {
     hasBreakoutRooms,
     meetingIsBreakout,
-    joinedAudio,
+    userSelectedMicrophone,
+    userSelectedListenOnly,
     init: () => {
       Service.init(messages, intl);
       const enableVideo = getFromUserSettings('bbb_enable_video', KURENTO_CONFIG.enableVideo);
@@ -180,10 +230,20 @@ export default lockContextContainer(withModalMounter(injectIntl(withTracker(({ m
       Session.set('audioModalIsOpen', true);
       if (enableVideo && autoShareWebcam) {
         openAudioModal().then(() => { openVideoPreviewModal(); didMountAutoJoin = true; });
-      } else if (!(joinedAudio && meetingIsBreakout)) {
+      } else if (!(
+        userSelectedMicrophone
+        && userSelectedListenOnly
+        && meetingIsBreakout)) {
         openAudioModal();
         didMountAutoJoin = true;
       }
     },
   };
 })(AudioContainer))));
+
+AudioContainer.propTypes = {
+  hasBreakoutRooms: PropTypes.bool.isRequired,
+  meetingIsBreakout: PropTypes.bool.isRequired,
+  userSelectedListenOnly: PropTypes.bool.isRequired,
+  userSelectedMicrophone: PropTypes.bool.isRequired,
+};


### PR DESCRIPTION
When joining/returning breakouts, audio would always connect
with full audio. This can lead to a performance problem, once
all listenonly users would join full audio, increasing the
number of streams in FreeSWITCH.

We now have a consistent behavior, which is:
1 - The choice made by the user in the main room is predominant:
    if mic is active in main room, user will automatically
    join mic in breakout room. When returning from breakout
    room, user will also join with mic again.
2 - Changes made in breakout room won't have effect when
    returning to the main room. This means if user, for example,
    change from listenonly to mic in breakout room, the returning
    will consider the option choosen previously (listenonly) and
    listenonly will be active again in the main room.
3 - If user didn't join audio in the main room, the audio modal
    will be prompted when joining the breakout room (this is
    a special case of (1))


The following is some technicall information:
InputStreamLiveSelector (component.jsx) now calls
'handleLeaveAudio' function, which is the default
function when user leaves audio (also used when
dynamic devices are inactive).

We now store information about user's choice (mic or listenonly)
using local storage, instead of the previous cookie method (this
was triggering some warnings in browser's console).

Also did a small refactoring to match eslint rules.
Fixes #11662.
