### PR TITLE
Fix Focus Outline Clipping Buttons In Firefox

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/button/styles.scss
@@ -107,10 +107,7 @@
   display: inline-block;
   cursor: pointer;
 
-  &:-moz-focusring {
-    outline: none;
-    outline-offset: var(--border-radius);
-  }
+
 
   &:focus,
   &:hover {
@@ -120,6 +117,12 @@
   &:focus {
     outline-style: solid;
   }
+
+  &:-moz-focusring {
+    outline-color: transparent;
+    outline-offset: var(--border-radius);
+  }
+
 
   &:active {
     &:focus {

--- a/bigbluebutton-html5/imports/ui/components/button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/button/styles.scss
@@ -109,6 +109,7 @@
 
   &:-moz-focusring {
     outline: none;
+    outline-offset: var(--border-radius);
   }
 
   &:focus,


### PR DESCRIPTION
### What does this PR do?
adds `outline-offset` to buttons being clipped in Firefox by focus outline. 

### Closes Issue(s)
Closes #11970 