### PR TITLE
[add] enable bbb-webhooks to bind nodejs localhost, and make it default

### DIFF
--- a/bbb-webhooks/application.js
+++ b/bbb-webhooks/application.js
@@ -22,7 +22,7 @@ module.exports = class Application {
       UserMapping.initialize(() => {
         IDMapping.initialize(()=> {
           async.parallel([
-            (callback) => { this.webServer.start(config.get("server.port"), callback) },
+            (callback) => { this.webServer.start(config.get("server.port"), config.get("server.bind"), callback) },
             (callback) => { this.webServer.createPermanents(callback) },
             (callback) => { this.webHooks.start(callback) }
           ], (err,results) => {

--- a/bbb-webhooks/config/custom-environment-variables.yml
+++ b/bbb-webhooks/config/custom-environment-variables.yml
@@ -12,3 +12,6 @@ hooks:
 redis:
   host: REDIS_HOST
   port: REDIS_PORT
+server:
+  bind: SERVER_BIND_IP
+  port: SERVER_PORT

--- a/bbb-webhooks/config/default.example.yml
+++ b/bbb-webhooks/config/default.example.yml
@@ -8,6 +8,7 @@ bbb:
 
 # The port in which the API server will run.
 server:
+  bind: 127.0.0.1
   port: 3005
 
 # Web hooks configs

--- a/bbb-webhooks/web_server.js
+++ b/bbb-webhooks/web_server.js
@@ -17,14 +17,15 @@ module.exports = class WebServer {
     this._registerRoutes();
   }
 
-  start(port, callback) {
-    this.server = this.app.listen(port);
-    if (this.server.address() == null) {
-      Logger.error("[WebServer] aborting, could not bind to port", port,
-      process.exit(1));
-    }
-    Logger.info("[WebServer] listening on port", port, "in", this.app.settings.env.toUpperCase(), "mode");
-    typeof callback === 'function' ? callback(null,"k") : undefined;
+  start(port, bind, callback) {
+    this.server = this.app.listen(port, bind, () => {
+      if (this.server.address() == null) {
+        Logger.error("[WebServer] aborting, could not bind to port", port,
+        process.exit(1));
+      }
+      Logger.info("[WebServer] listening on port", port, "in", this.app.settings.env.toUpperCase(), "mode");
+      typeof callback === 'function' ? callback(null,"k") : undefined;
+    });
   }
 
   _registerRoutes() {


### PR DESCRIPTION

### What does this PR do?

This PR enables bbb-webhooks to bind on localhost, which, moreover, should be default as we use nginx reverse proxying to pass request to nodejs server.
That lets us with a more secure application as nodejs was by default listening on 0.0.0.0, so server:3005 was exposed by default.

### Closes Issue(s)
No issues are related to this PR to my knowledge


### Motivation
Motivation behind this PR was to have a more secure application by default, being open to the world should be a specificity and a conscious choice, not the default.

Hope the PR will make it, and thanks you all for the work and effort
