### PR TITLE
Makes hand raised message differentiate between one and multiple users

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/status-notifier/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/status-notifier/component.jsx
@@ -20,7 +20,11 @@ const messages = defineMessages({
   },
   raisedHandDesc: {
     id: 'app.statusNotifier.raisedHandDesc',
-    description: 'label for user with raised hands',
+    description: 'label for multiple users with raised hands',
+  },
+  raisedHandDescOneUser: {
+    id: 'app.statusNotifier.raisedHandDescOneUser',
+    description: 'label for a single user with raised hand',
   },
   and: {
     id: 'app.statusNotifier.and',
@@ -110,7 +114,9 @@ class StatusNotifier extends Component {
         break;
     }
 
-    return intl.formatMessage(messages.raisedHandDesc, { 0: formattedNames });
+    const raisedHandMessageString
+        = length === 1 ? messages.raisedHandDescOneUser : messages.raisedHandDesc;
+    return intl.formatMessage(raisedHandMessageString, { 0: formattedNames });
   }
 
   raisedHandAvatars() {

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -374,7 +374,7 @@
     "app.settings.save-notification.label": "Settings have been saved",
     "app.statusNotifier.lowerHands": "Lower Hands",
     "app.statusNotifier.raisedHandsTitle": "Raised Hands",
-    "app.statusNotifier.raisedHandDesc": "{0} raised their hand",
+    "app.statusNotifier.raisedHandDesc": "{0} raised their hands",
     "app.statusNotifier.raisedHandDescOneUser": "{0} raised the hand",
     "app.statusNotifier.and": "and",
     "app.switch.onLabel": "ON",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -375,7 +375,7 @@
     "app.statusNotifier.lowerHands": "Lower Hands",
     "app.statusNotifier.raisedHandsTitle": "Raised Hands",
     "app.statusNotifier.raisedHandDesc": "{0} raised their hands",
-    "app.statusNotifier.raisedHandDescOneUser": "{0} raised the hand",
+    "app.statusNotifier.raisedHandDescOneUser": "{0} raised hand",
     "app.statusNotifier.and": "and",
     "app.switch.onLabel": "ON",
     "app.switch.offLabel": "OFF",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -375,6 +375,7 @@
     "app.statusNotifier.lowerHands": "Lower Hands",
     "app.statusNotifier.raisedHandsTitle": "Raised Hands",
     "app.statusNotifier.raisedHandDesc": "{0} raised their hand",
+    "app.statusNotifier.raisedHandDescOneUser": "{0} raised the hand",
     "app.statusNotifier.and": "and",
     "app.switch.onLabel": "ON",
     "app.switch.offLabel": "OFF",


### PR DESCRIPTION
### What does this PR do?
Makes hand raised notification message differentiate between one and multiple users.

### Closes Issue(s)
no separate issue opened: Label showed "USERNAME has raised **_their_** hand", even if just one user was raising **_his/her_** hand.

### Motivation
annoyed me, fixed it