### PR TITLE
Remove duplicated property from nav-bar button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -102,7 +102,6 @@ class NavBar extends Component {
               : <Icon iconName="left_arrow" className={styles.arrowLeft} />
             }
             <Button
-              data-test="userListToggleButton"
               onClick={NavBar.handleToggleUserList}
               ghost
               circle


### PR DESCRIPTION
### What does this PR do?

Removes duplicated property `data-test` from nav-bar button.
