### PR TITLE
Remove unused imports/variables

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -19,7 +19,6 @@ import { notify } from '/imports/ui/services/notification';
 import deviceInfo from '/imports/utils/deviceInfo';
 import { invalidateCookie } from '/imports/ui/components/audio/audio-modal/service';
 import getFromUserSettings from '/imports/ui/services/users-settings';
-import LayoutManagerComponent from '/imports/ui/components/layout/layout-manager/component';
 import LayoutManagerContainer from '/imports/ui/components/layout/layout-manager/container';
 import { withLayoutContext } from '/imports/ui/components/layout/context';
 import VideoService from '/imports/ui/components/video-provider/service';

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/container.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
-import Auth from '/imports/ui/services/auth';
-import Screenshare from '/imports/api/screenshare';
 import { isVideoBroadcasting } from '/imports/ui/components/screenshare/service';
 import LayoutManagerComponent from '/imports/ui/components/layout/layout-manager/component';
 

--- a/bigbluebutton-html5/imports/ui/components/modal/random-user/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/modal/random-user/component.jsx
@@ -107,7 +107,6 @@ class RandomUserSelect extends Component {
       intl,
       mountModal,
       numAvailableViewers,
-      randomUserReq,
       currentUser,
       clearRandomlySelectedUser,
       mappedRandomlySelectedUsers,

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -242,7 +242,7 @@ class PresentationUploader extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { selectedToBeNextCurrent, isOpen, presentations: propPresentations } = this.props;
+    const { isOpen, presentations: propPresentations } = this.props;
     const { presentations } = this.state;
 
     // cleared local presetation state errors and set to presentations available on the server
@@ -355,10 +355,6 @@ class PresentationUploader extends Component {
     const isConverting = !item.conversion.done && item.upload.done;
     const hasError = item.conversion.error || item.upload.error;
     const isProcessing = (isUploading || isConverting) && !hasError;
-
-    const {
-      intl, selectedToBeNextCurrent,
-    } = this.props;
 
     const itemClassName = {
       [styles.done]: !isProcessing && !hasError,

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -189,7 +189,7 @@ class ScreenshareComponent extends React.Component {
 
   render() {
     const { loaded, autoplayBlocked, isFullscreen, isStreamHealthy } = this.state;
-    const { intl, isPresenter, isGloballyBroadcasting } = this.props;
+    const { isPresenter, isGloballyBroadcasting } = this.props;
 
     // Conditions to render the (re)connecting spinner and the unhealthy stream
     // grayscale:

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -45,7 +45,6 @@ const {
 } = Meteor.settings.public.kurento.cameraSortingModes;
 
 const TOKEN = '_';
-const ENABLE_PAGINATION_SESSION_VAR = 'enablePagination';
 
 class VideoService {
   constructor() {


### PR DESCRIPTION
### What does this PR do?

Removes unused imports reported by [lgtm alerts](https://lgtm.com/projects/g/bigbluebutton/bigbluebutton/alerts)

### Motivation

*Unused local variables make code hard to read and understand. Any computation used to initialize an unused variable is wasted, which may lead to performance problems.*

*Similarly, unused imports and unused functions or classes can be confusing. They may even be a symptom of a bug caused, for example, by an incomplete refactoring.* (https://lgtm.com/rules/1780092/)
