### PR TITLE
Fix client crashing with multiple private chats

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/components-data/chat-context/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/chat-context/context.jsx
@@ -328,6 +328,7 @@ const reducer = (state, action) => {
             timeWindowIds.forEach((timeWindowId)=> {
               const timeWindow = messages[timeWindowId];
               if (timeWindow.messageType === MESSAGE_TYPES.STREAM) {
+                chat.unreadTimeWindows.delete(timeWindowId);
                 delete newState[chatId][group][timeWindowId];
               }
             });


### PR DESCRIPTION
### What does this PR do?

This PR fixes the client crash when theres several chats with unread messages, the issue is in subscription being redone and clearing the steam messages, but not the id in the unread message Set, therefore, keeping a non-existent timeWindowId in unread messages Set.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #12093