### PR TITLE
feat(video): set audio floor sorting as default for pagination

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -276,7 +276,7 @@ public:
     # The algorithm names are self-explanatory.
     cameraSortingModes:
       defaultSorting: LOCAL_ALPHABETICAL
-      paginationSorting: LOCAL_PRESENTER_ALPHABETICAL
+      paginationSorting: VOICE_ACTIVITY_LOCAL
     # Entry `thresholds` is an array of:
     # - threshold: minimum number of cameras being shared for profile to applied
     #   profile: a camera profile id from the cameraProfiles configuration array


### PR DESCRIPTION
### What does this PR do?

Set `paginationSorting` to VOICE_ACTIVITY_LOCAL by default (audio floors -> alphabetical -> local stream[always shown]).

### Closes Issue(s)

None

### Motivation

Rationale: a more sensible default mode for pagination that actually works a bit better for the end user than
the previous mode (presenter -> alphabetical). 

Should reduce the need for page switching by focusing on the ones that are actually active in the conference.

_Presenters are no longer pinned to first in line_.

### More

Follow up to #12004
