### PR TITLE
Implements forceRasterizeSlides and pngWidthRasterizedSlides

### DIFF
--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -109,6 +109,23 @@ svgConversionTimeout=60
 svgPresentationResolutionPpi=300
 
 #------------------------------------
+# Force conversion of slides to PNG before converting to SVG
+## This will solve problems like reported in issue #8835
+## Disabled by default as it can affect the quality in zoom
+#------------------------------------
+forceRasterizeSlides=false
+
+#------------------------------------
+# Presentation will be resized to this width (in pixels) when rasterizing (converting to PNG)
+## Applied in these situations:
+##  a) the source can't be converted directly to SVG ;
+##  b) option "forceRasterizeSlides" is defined as true ;
+## To disable this constraint (and keep source resolution) define this property as 0.
+#------------------------------------
+pngWidthRasterizedSlides=2048
+
+
+#------------------------------------
 # Timeout(secs) to wait for conversion script execution
 #------------------------------------
 officeToPdfConversionTimeout=60

--- a/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
@@ -88,6 +88,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="blankSvg" value="${BLANK_SVG}"/>
         <property name="convPdfToSvgTimeout" value="${svgConversionTimeout}"/>
         <property name="svgResolutionPpi" value="${svgPresentationResolutionPpi}"/>
+        <property name="forceRasterizeSlides" value="${forceRasterizeSlides}"/>
+        <property name="pngWidthRasterizedSlides" value="${pngWidthRasterizedSlides}"/>
     </bean>
 
     <bean id="generatedSlidesInfoHelper" class="org.bigbluebutton.presentation.GeneratedSlidesInfoHelperImp"/>


### PR DESCRIPTION
This PR will solve #8835 (Presentation have low quality when converting LaTeX-PDF to SVG).
And will reduce impact of #12087 (default resolution ppi as 300 can generate too large files for slides)

It implements to new configs:
- **forceRasterizeSlides**: Force conversion of slides to PNG before converting to SVG
- **pngWidthRasterizedSlides**: Presentation will be resized to this width (in pixels) when rasterizing (converting to PNG). By default will be set 2048px (this width keep presentation with good quality and it is not heavy for the browser to render).


**forceRasterizeSlides** motivation:
If the PDF->SVG conversion is generating bad quality SVGs, the user will have an option to force the conversion to PNG first! And as image the presentation will have better quality.

**pngWidthRasterizedSlides** motivation:
High resolution PDFs generates too large files after converted to PNG (with 300ppi). So the `pngWidthRasterizedSlides` config will solve this problem because the image will be resized with a smaller resolution.