### PR TITLE
fix: client may crash when loading develop version

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -17,7 +17,6 @@ import Breakouts from '/imports/api/breakouts';
 import AudioService from '/imports/ui/components/audio/service';
 import { notify } from '/imports/ui/services/notification';
 import deviceInfo from '/imports/utils/deviceInfo';
-import { invalidateCookie } from '/imports/ui/components/audio/audio-modal/service';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import LayoutManagerContainer from '/imports/ui/components/layout/layout-manager/container';
 import { withLayoutContext } from '/imports/ui/components/layout/context';
@@ -145,7 +144,6 @@ class Base extends Component {
       ejected,
       isMeteorConnected,
       subscriptionsReady,
-      meetingIsBreakout,
       layoutContextDispatch,
       usersVideo,
     } = this.props;
@@ -153,10 +151,6 @@ class Base extends Component {
       loading,
       meetingExisted,
     } = this.state;
-
-    if (prevProps.meetingIsBreakout === undefined && !meetingIsBreakout) {
-      invalidateCookie('joinedAudio');
-    }
 
     if (usersVideo !== prevProps.usersVideo) {
       layoutContextDispatch(


### PR DESCRIPTION
Removed the reference for invalidateCookie, since it doesn't exist anymore.