### PR TITLE
Fix new poll button sizes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -442,7 +442,7 @@ class Poll extends Component {
                   ],
                 });
               }}
-              className={cx(styles.pBtn, { [styles.selectedBtnBlue]: type === 'TF' })}
+              className={cx(styles.pBtn, styles.btnMR, { [styles.selectedBtnBlue]: type === 'TF' })}
             />
             <Button
               label={intl.formatMessage(intlMessages.a4)}
@@ -458,7 +458,7 @@ class Poll extends Component {
                   ],
                 });
               }}
-              className={cx(styles.pBtn, { [styles.selectedBtnBlue]: type === 'A-' })}
+              className={cx(styles.pBtn, styles.btnML, { [styles.selectedBtnBlue]: type === 'A-' })}
             />
           </div>
           <Button

--- a/bigbluebutton-html5/imports/ui/components/poll/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/poll/styles.scss
@@ -6,7 +6,7 @@
     --poll-column-amount: 2;
     --poll-blue: #1A73D4;
     --poll-header-offset: -0.875rem;
-    --poll-addItem-width: 6rem;
+    --poll-addItem-width: 100%;
     --poll-input-height: 2.5rem;
 }
 
@@ -223,7 +223,7 @@
 
     button {
         position: relative;
-        width: 47%;
+        width: 100%;
     }
 }
 
@@ -328,6 +328,14 @@
             opacity: 1;
         }
     }
+}
+
+.btnML {
+    margin-left: 3%;
+}
+
+.btnMR {
+    margin-right: 3%;
 }
 
 .deleteBtn {


### PR DESCRIPTION
### What does this PR do?

Changes new poll buttons CSS:
- true/false and A/B/C/D buttons will now adapt to text size
- Add item button will now have 100% width

#### true/false - before
![Screenshot from 2021-04-23 13-17-09](https://user-images.githubusercontent.com/3728706/115902622-ffb35a00-a438-11eb-9c43-58aad8cf5729.png)

#### true/false - after changes
![Screenshot from 2021-04-23 13-30-00](https://user-images.githubusercontent.com/3728706/115902671-0d68df80-a439-11eb-8116-7385d349c4da.png)

#### add item - before
![Screenshot from 2021-04-23 13-39-27](https://user-images.githubusercontent.com/3728706/115903018-781a1b00-a439-11eb-82ac-69a0df474f3f.png)

#### add item - after changes
![Screenshot from 2021-04-23 13-05-28](https://user-images.githubusercontent.com/3728706/115903192-adbf0400-a439-11eb-9aed-683fde0e3f7f.png)


### Closes Issue(s)
Closes #12117