### PR TITLE
feat(screenshare): add screen bitrate config in bbb-html5

### DIFF
--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -258,6 +258,7 @@ export default class KurentoScreenshareBridge {
         userName: Auth.fullname,
         stream,
         hasAudio: this.hasAudio,
+        bitrate: BridgeService.BASE_BITRATE,
       };
 
       this.broker = new ScreenshareBroker(

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/service.js
@@ -7,6 +7,7 @@ import { SCREENSHARING_ERRORS } from './errors';
 const {
   constraints: GDM_CONSTRAINTS,
   mediaTimeouts: MEDIA_TIMEOUTS,
+  bitrate: BASE_BITRATE,
 } = Meteor.settings.public.kurento.screenshare;
 const {
   baseTimeout: BASE_MEDIA_TIMEOUT,
@@ -150,4 +151,5 @@ export default {
   screenshareLoadAndPlayMediaStream,
   BASE_MEDIA_TIMEOUT,
   MAX_CONN_ATTEMPTS,
+  BASE_BITRATE,
 };

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/screenshare-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/screenshare-broker.js
@@ -22,7 +22,7 @@ class ScreenshareBroker extends BaseBroker {
     this.webRtcPeer = null;
     this.hasAudio = false;
 
-    // Optional parameters are: userName, caleeName, iceServers, hasAudio
+    // Optional parameters are: userName, caleeName, iceServers, hasAudio, bitrate
     Object.assign(this, options);
   }
 
@@ -116,6 +116,7 @@ class ScreenshareBroker extends BaseBroker {
       callerName: this.userId,
       sdpOffer,
       hasAudio: !!this.hasAudio,
+      bitrate: this.bitrate,
     };
 
     this.sendMessage(message);

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -168,6 +168,7 @@ public:
       # subscribe reattempt increases the reconnection timer up to this
       maxTimeout: 60000
     screenshare:
+      bitrate: 1500
       mediaTimeouts:
         maxConnectionAttempts: 2
         # Base screen media timeout (send|recv)


### PR DESCRIPTION
### What does this PR do?

Add screen sharing bitrate configuration to bbb-html5's settings.yml.
New config: `public.kurento.screenshare.bitrate`.

### Closes Issue(s)

None.

### Motivation

Make it easier to configure screen sharing bitrate/bandwidth usage.

Camera bitrates are already configurable in bbb-html5, which is good because it's easier than dealing directly with bbb-webrtc-sfu. Just doing the same to screen sharing (with the same mechanisms).

### More

- [ ] Added/updated documentation
  * would be good to add this to the docs after it is tagged
