### PR TITLE
Do not play random user alert when a viewer joins

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/modal/random-user/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/modal/random-user/component.jsx
@@ -82,9 +82,13 @@ class RandomUserSelect extends Component {
     }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps, prevState) {
     if (this.props.currentUser.presenter && this.state.count == 0) {
       this.iterateSelection();
+    }
+
+    if (prevState.count !== this.state.count) {
+      this.play();
     }
   }
 
@@ -116,8 +120,6 @@ class RandomUserSelect extends Component {
 
     const selectedUser = mappedRandomlySelectedUsers[this.state.count][0];
     const countDown = mappedRandomlySelectedUsers.length - this.state.count - 1;
-
-    this.play();
 
     let viewElement;
 


### PR DESCRIPTION
### What does this PR do?

Prevents the random user picker audio alert from playing after a new viewer joins.

### Closes Issue(s)
Closes #12137