### PR TITLE
refactor: Remove user-list unused code

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -23,19 +23,6 @@ const DIAL_IN_CLIENT_TYPE = 'dial-in-user';
 // session for closed chat list
 const CLOSED_CHAT_LIST_KEY = 'closedChatList';
 
-const mapActiveChats = (chat) => {
-  const currentUserId = Auth.userID;
-
-  const { chatId } = chat;
-
-  const userId = GroupChat
-    .findOne({ chatId })
-    .participants
-    .filter(user => user.id !== currentUserId);
-
-  return userId[0];
-};
-
 const CUSTOM_LOGO_URL_KEY = 'CustomLogoUrl';
 
 export const setCustomLogoUrl = path => Storage.setItem(CUSTOM_LOGO_URL_KEY, path);
@@ -53,9 +40,6 @@ const sortByWhiteboardAccess = (a, b) => {
 };
 
 const sortUsersByUserId = (a, b) => {
-  const aUserId = a.userId;
-  const bUserId = b.userId;
-
   if (a.userId > b.userId) {
     return -1;
   } if (a.userId < b.userId) {
@@ -184,24 +168,6 @@ const sortByRecentActivity = (a, b) => {
 const isPublicChat = chat => (
   chat.userId === 'public'
 );
-
-const sortChats = (a, b) => {
-  let sort = sortChatsByIcon(a, b);
-
-  if (sort === 0) {
-    sort = sortByRecentActivity(a, b);
-  }
-
-  if (sort === 0) {
-    sort = sortChatsByName(a, b);
-  }
-
-  if (sort === 0) {
-    sort = sortChatsByUserId(a, b);
-  }
-
-  return sort;
-};
 
 const userFindSorting = {
   emojiTime: 1,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
@@ -31,15 +31,6 @@ const defaultProps = {
   compact: false,
 };
 
-const listTransition = {
-  enter: styles.enter,
-  enterActive: styles.enterActive,
-  appear: styles.appear,
-  appearActive: styles.appearActive,
-  leave: styles.leave,
-  leaveActive: styles.leaveActive,
-};
-
 const intlMessages = defineMessages({
   usersTitle: {
     id: 'app.userList.usersTitle',

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
@@ -584,7 +584,6 @@ class UserDropdown extends PureComponent {
       isActionsOpen,
       dropdownVisible,
       dropdownDirection,
-      dropdownOffset,
       showNestedOptions,
     } = this.state;
 


### PR DESCRIPTION
### What does this PR do?

Removes user-list unused code reported by [lgtm alerts](https://lgtm.com/projects/g/bigbluebutton/bigbluebutton/alerts)

### Motivation

*Unused local variables make code hard to read and understand. Any computation used to initialize an unused variable is wasted, which may lead to performance problems.*

*Similarly, unused imports and unused functions or classes can be confusing. They may even be a symptom of a bug caused, for example, by an incomplete refactoring.* (https://lgtm.com/rules/1780092/)
