### PR TITLE
fix: Remove sender object from message payload in poll result

### DIFF
--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addSystemMsg.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addSystemMsg.js
@@ -28,6 +28,7 @@ export default function addSystemMsg(meetingId, chatId, msg) {
   });
   const msgDocument = {
     ...msg,
+    sender: msg.sender.id,
     meetingId,
     chatId,
     message: parseMessage(msg.message),


### PR DESCRIPTION
### What does this PR do?

Prevents client crash when sending poll results popup alert by removing sender object from message.

### Closes Issue(s)
Closes #12149