### PR TITLE
fix(chat): no grouping for system messages

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/components-data/chat-context/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/chat-context/context.jsx
@@ -117,8 +117,7 @@ const generateStateWithNewMessage = (msg, state, msgType = MESSAGE_TYPES.HISTORY
   const timewindowIndex = stateMessages.chatIndexes[keyName];
   const groupMessage = messageGroups[keyName + '-' + timewindowIndex];
   
-  if (!groupMessage || (groupMessage && groupMessage.sender !== stateMessages.lastSender)) {
-
+  if (!groupMessage || (groupMessage && groupMessage.sender !== stateMessages.lastSender) || msg.id.startsWith(SYSTEM_CHAT_TYPE)) {
     const [tempGroupMessage, sender, newIndex] = msgBuilder(msg, stateMessages);
     stateMessages.lastSender = sender;
     stateMessages.chatIndexes[keyName] = newIndex;


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where poll results could appear as unread messages and not be displayed in chat, by preventing the grouping of system messages.

### Closes Issue(s)
Closes #12160