### PR TITLE
Minor enhancement in Libreoffice conversion scripts

### DIFF
--- a/bbb-libreoffice/assets/convert-local.sh
+++ b/bbb-libreoffice/assets/convert-local.sh
@@ -23,8 +23,8 @@ fi;
 mkdir -p "/tmp/bbb-soffice-$(whoami)/"
 tempDir="$(mktemp -d -p /tmp/bbb-soffice-$(whoami)/)"
 
-source=${1}
-dest=${2}
+source="$1"
+dest="$2"
 
 #If output format is missing, define PDF
 convertTo="${3:-pdf}"

--- a/bbb-libreoffice/assets/convert-remote.sh
+++ b/bbb-libreoffice/assets/convert-remote.sh
@@ -21,12 +21,12 @@ elif (( $# == 1 )); then
 fi;
 
 
-source=${1}
-dest=${2}
+source="$1"
+dest="$2"
 
 #If output format is missing, define PDF
 convertTo="${3:-pdf}"
 
-curl -X POST "http://127.0.0.1:8080/lool/convert-to/$convertTo" -H "accept: application/octet-stream" -H "Content-Type: multipart/form-data" -F "data=@${source}" > ${dest}
+curl -X POST "http://127.0.0.1:8080/lool/convert-to/$convertTo" -H "accept: application/octet-stream" -H "Content-Type: multipart/form-data" -F "data=@${source}" > "${dest}"
 
 exit 0


### PR DESCRIPTION
Minor enhancements in Libreoffice conversion scripts as suggested by @uka-support in https://github.com/bigbluebutton/bigbluebutton/issues/12066#issuecomment-823306145.

Changes:
- Uses quotes to get parameters variable instead of brackets 

> Rationale: curly brackets are not required there (quote from manual: _"The braces are required when parameter is a positional parameter with more than one digit, or when parameter is followed by a character that is not to be interpreted as part of its name."_), but quotes should be used to protect against spaces in the file names.