### PR TITLE
chore(connection status): Connection status logs enhancement

### DIFF
--- a/bigbluebutton-html5/imports/api/connection-status/server/methods/addConnectionStatus.js
+++ b/bigbluebutton-html5/imports/api/connection-status/server/methods/addConnectionStatus.js
@@ -8,7 +8,7 @@ const STATS = Meteor.settings.public.stats;
 const logConnectionStatus = (meetingId, userId, status, type, value) => {
   switch (status) {
     case 'normal':
-      Logger.info(`Connection status updated: meetingId=${meetingId} userId=${userId} type=${type}`);
+      Logger.info(`Connection status updated: meetingId=${meetingId} userId=${userId} status=${status} type=${type}`);
       break;
     case 'warning':
       // Skip
@@ -21,11 +21,11 @@ const logConnectionStatus = (meetingId, userId, status, type, value) => {
             jitter,
             loss,
           } = value;
-          Logger.info(`Connection status updated: meetingId=${meetingId} userId=${userId} jitter=${jitter} loss=${loss}`);
+          Logger.info(`Connection status updated: meetingId=${meetingId} userId=${userId} status=${status} type=${type} jitter=${jitter} loss=${loss}`);
           break;
         case 'socket':
           const { rtt } = value;
-          Logger.info(`Connection status updated: meetingId=${meetingId} userId=${userId} rtt=${rtt}`);
+          Logger.info(`Connection status updated: meetingId=${meetingId} userId=${userId} status=${status} type=${type} rtt=${rtt}`);
           break;
         default:
       }

--- a/bigbluebutton-html5/imports/api/connection-status/server/modifiers/updateConnectionStatus.js
+++ b/bigbluebutton-html5/imports/api/connection-status/server/modifiers/updateConnectionStatus.js
@@ -24,9 +24,9 @@ export default function updateConnectionStatus(meetingId, userId, level) {
     const { numberAffected } = ConnectionStatus.upsert(selector, modifier);
 
     if (numberAffected) {
-      Logger.verbose(`Updated connection status userId=${userId} level=${level}`);
+      Logger.verbose(`Updated connection status meetingId=${meetingId} userId=${userId} level=${level}`);
     }
   } catch (err) {
-    Logger.error(`Updating connection status: ${err}`);
+    Logger.error(`Updating connection status meetingId=${meetingId} userId=${userId}: ${err}`);
   }
 }

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -435,7 +435,7 @@ public:
     enabled: true
     interval: 10000
     timeout: 30000
-    log: false
+    log: true
     notification:
       warning: false
       error: true


### PR DESCRIPTION
### What does this PR do?
Makes connection status logs a bit easier to parse
Enables connection status logging by default

Continuation from #12139
<!-- A brief description of each change being made with this pull request. -->


```
I20210426-21:15:02.670(0)? info: Connection status updated: meetingId=183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1619467657473 userId=w_xn9xolkepaoo status=danger type=socket rtt=1000
I20210426-21:15:05.373(0)? info: Connection status updated: meetingId=183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1619467657473 userId=w_xn9xolkepaoo status=critical type=socket rtt=2000


I20210426-21:06:42.955(0)? verbose: Updated connection status meetingId=183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1619467657473 userId=w_xn9xolkepaoo level=warning
I20210426-21:06:50.141(0)? info: Connection status updated: meetingId=183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1619467657473 userId=w_xn9xolkepaoo status=critical type=audio jitter=30 loss=0.22
I20210426-21:06:50.143(0)? verbose: Updated connection status meetingId=183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1619467657473 userId=w_xn9xolkepaoo level=critical
I20210426-21:07:20.142(0)? info: Connection status updated: meetingId=183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1619467657473 userId=w_xn9xolkepaoo status=normal type=recovery
```

