### PR TITLE
Includes warning that forceRasterizeSlides can be removed next release

### DIFF
--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -110,6 +110,7 @@ svgPresentationResolutionPpi=300
 
 #------------------------------------
 # Force conversion of slides to PNG before converting to SVG
+## Experimental - this option can be removed in next releases
 ## This will solve problems like reported in issue #8835
 ## Disabled by default as it can affect the quality in zoom
 #------------------------------------

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -110,7 +110,7 @@ svgPresentationResolutionPpi=300
 
 #------------------------------------
 # Force conversion of slides to PNG before converting to SVG
-## Experimental - this option can be removed in next releases
+## Experimental - this option might be removed in next releases
 ## This will solve problems like reported in issue #8835
 ## Disabled by default as it can affect the quality in zoom
 #------------------------------------


### PR DESCRIPTION
`forceRasterizeSlides` was included as a workaround and possibly can be removed next release!
**This PR includes a warning about that!**


`forceRasterizeSlides` will be removed as soon as:

- pdftocairo fix the problem (PR Open): https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/152
- BBB identify PDF with "Type 3" fonts and force rasterize automatically