### PR TITLE
fix: Fix Active Style For Current Chat

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
@@ -82,10 +82,9 @@ const ChatListItem = (props) => {
     chatPanelOpen,
   } = props;
 
-  
-
-  const isCurrentChat = chat.userId === activeChatId && chatPanelOpen;
+  const isCurrentChat = chat.chatId === activeChatId && chatPanelOpen;
   const linkClasses = {};
+
   linkClasses[styles.active] = isCurrentChat;
 
   const [stateUreadCount, setStateUreadCount] = useState(0);

--- a/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/styles.scss
@@ -101,5 +101,4 @@
 
 .active {
   background-color: var(--list-item-bg-hover);
-  box-shadow: inset 0 0 0 var(--border-size) var(--item-focus-border), inset 1px 0 0 1px var(--item-focus-border);
 }


### PR DESCRIPTION
### What does this PR do?
Removes the `box-shadow` from the active class.  It also fixes the `active` style for chat items only being applied to the public chat.

After talking with @tylercopeland it was decided to only remove the outline from the active style. 

before:
![old_active_style](https://user-images.githubusercontent.com/22058534/116288404-7dd86f00-a75f-11eb-8b9d-b9a30021ab17.gif)

after:
![updated_active_style](https://user-images.githubusercontent.com/22058534/116288422-8335b980-a75f-11eb-8005-ba6f0a942de8.gif)


### Closes Issue(s)
Closes #7746
