### PR TITLE
Make Screen Readers Auto Announce Chat Messages

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
@@ -292,6 +292,7 @@ class TimeWindowList extends PureComponent {
         className={styles.messageListWrapper}
         key="chat-list"
         data-test="chatMessages"
+        aria-live="polite"
         ref={node => this.messageListWrapper = node}
       >
         <AutoSizer>


### PR DESCRIPTION
### What does this PR do?
Adds `aria-live` to the time-window-list. This allows the screen reader to auto announce new chat messages.

![sr-chat-announce](https://user-images.githubusercontent.com/22058534/116307975-f269d880-a774-11eb-9e57-1f27933bd24a.gif)


### Motivation
Currently doesn't announce messages automatically.