### PR TITLE
Allow for Mac OS to trigger debug shortcut

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/debug-window/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/debug-window/component.jsx
@@ -56,8 +56,10 @@ class DebugWindow extends Component {
 
   componentDidMount() {
     document.addEventListener('keyup', (event) => {
-      const key = event.key.toUpperCase();
-      if (DEBUG_WINDOW_ENABLED && event.altKey && key === SHOW_DEBUG_WINDOW_ACCESSKEY) {
+      const { key, code } = event;
+      const eventKey = key.toUpperCase();
+      const eventCode = code;
+      if (DEBUG_WINDOW_ENABLED && event.altKey && (eventKey === SHOW_DEBUG_WINDOW_ACCESSKEY || eventCode === `Key${SHOW_DEBUG_WINDOW_ACCESSKEY}`)) {
         this.debugWindowToggle();
       }
     });


### PR DESCRIPTION
This PR implements a shortcut (command + K) to access the debug window in Mac OS.
Today we only able to access by the (Alt + K) in Windows.