### PR TITLE
Do not install Microsoft fonts in bbb-libreoffice

### DIFF
--- a/bbb-libreoffice/EULA.txt
+++ b/bbb-libreoffice/EULA.txt
@@ -1,0 +1,100 @@
+ END-USER LICENSE AGREEMENT FOR
+ MICROSOFT SOFTWARE
+
+ IMPORTANT-READ CAREFULLY: This Microsoft End-User License Agreement
+ ("EULA") is a legal agreement between you (either an individual or a
+ single entity) and Microsoft Corporation for the Microsoft software
+ accompanying this EULA, which includes computer software and may
+ include associated media, printed materials, and "on-line" or
+ electronic documentation ("SOFTWARE PRODUCT" or "SOFTWARE"). By
+ exercising your rights to make and use copies of the SOFTWARE
+ PRODUCT, you agree to be bound by the terms of this EULA. If you do
+ not agree to the terms of this EULA, you may not use the SOFTWARE
+ PRODUCT.
+
+ SOFTWARE PRODUCT LICENSE
+ The SOFTWARE PRODUCT is protected by copyright laws and international
+ copyright treaties, as well as other intellectual property laws and
+ treaties. The SOFTWARE PRODUCT is licensed, not sold.
+
+ 1. GRANT OF LICENSE. This EULA grants you the following rights:
+
+  • Installation and Use. You may install and use an unlimited number
+    of copies of the SOFTWARE PRODUCT.
+  • Reproduction and Distribution. You may reproduce and distribute
+    an unlimited number of copies of the SOFTWARE PRODUCT; provided
+    that each copy shall be a true and complete copy, including all
+    copyright and trademark notices, and shall be accompanied by a
+    copy of this EULA. Copies of the SOFTWARE PRODUCT may not be
+    distributed for profit either on a standalone basis or included
+    as part of your own product.
+
+ 2. DESCRIPTION OF OTHER RIGHTS AND LIMITATIONS.
+
+  • Limitations on Reverse Engineering, Decompilation, and
+    Disassembly. You may not reverse engineer, decompile, or
+    disassemble the SOFTWARE PRODUCT, except and only to the extent
+    that such activity is expressly permitted by applicable law
+    notwithstanding this limitation.
+  • Restrictions on Alteration. You may not rename, edit or create
+    any derivative works from the SOFTWARE PRODUCT, other than
+    subsetting when embedding them in documents.
+  • Software Transfer. You may permanently transfer all of your
+    rights under this EULA, provided the recipient agrees to the
+    terms of this EULA.
+  • Termination. Without prejudice to any other rights, Microsoft may
+    terminate this EULA if you fail to comply with the terms and
+    conditions of this EULA. In such event, you must destroy all
+    copies of the SOFTWARE PRODUCT and all of its component parts.
+ .
+ 3. COPYRIGHT. All title and copyrights in and to the SOFTWARE PRODUCT
+ (including but not limited to any images, text, and "applets"
+ incorporated into the SOFTWARE PRODUCT), the accompanying printed
+ materials, and any copies of the SOFTWARE PRODUCT are owned by
+ Microsoft or its suppliers. The SOFTWARE PRODUCT is protected by
+ copyright laws and international treaty provisions. Therefore, you
+ must treat the SOFTWARE PRODUCT like any other copyrighted material.
+
+ 4. U.S. GOVERNMENT RESTRICTED RIGHTS. The SOFTWARE PRODUCT and
+ documentation are provided with RESTRICTED RIGHTS. Use, duplication,
+ or disclosure by the Government is subject to restrictions as set
+ forth in subparagraph (c)(1)(ii) of the Rights in Technical Data and
+ Computer Software clause at DFARS 252.227-7013 or subparagraphs (c)
+ (1) and (2) of the Commercial Computer Software - Restricted Rights
+ at 48 CFR 52.227-19, as applicable. Manufacturer is Microsoft
+ Corporation/One Microsoft Way/Redmond, WA 98052-6399.
+
+ LIMITED WARRANTY
+
+ NO WARRANTIES. Microsoft expressly disclaims any warranty for the
+ SOFTWARE PRODUCT. The SOFTWARE PRODUCT and any related documentation
+ is provided "as is" without warranty of any kind, either express or
+ implied, including, without limitation, the implied warranties or
+ merchantability, fitness for a particular purpose, or
+ noninfringement. The entire risk arising out of use or performance of
+ the SOFTWARE PRODUCT remains with you.
+
+ NO LIABILITY FOR CONSEQUENTIAL DAMAGES. In no event shall Microsoft
+ or its suppliers be liable for any damages whatsoever (including,
+ without limitation, damages for loss of business profits, business
+ interruption, loss of business information, or any other pecuniary
+ loss) arising out of the use of or inability to use this Microsoft
+ product, even if Microsoft has been advised of the possibility of
+ such damages. Because some states/jurisdictions do not allow the
+ exclusion or limitation of liability for consequential or incidental
+ damages, the above limitation may not apply to you.
+
+ MISCELLANEOUS
+
+ If you acquired this product in the United States, this EULA is
+ governed by the laws of the State of Washington.
+
+ If this product was acquired outside the United States, then local
+ laws may apply.
+
+ Should you have any questions concerning this EULA, or if you desire
+ to contact Microsoft for any reason, please contact the Microsoft
+ subsidiary serving your country, or write: Microsoft Sales
+ Information Center/One Microsoft Way/Redmond, WA 98052-6399.
+
+ Reference: http://www.microsoft.com/typography/fontpack/eula.htm

--- a/bbb-libreoffice/docker/Dockerfile
+++ b/bbb-libreoffice/docker/Dockerfile
@@ -1,18 +1,23 @@
-FROM openjdk:11-jre
+FROM openjdk:11-jre AS soffice-free
 
 ENV DEBIAN_FRONTEND noninteractive
 
 
 #Required to install Libreoffice 7
 RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
+
+RUN apt -y install locales-all fontconfig libxt6 libxrender1 
+RUN apt install -y -t buster-backports libreoffice
+RUN apt -y install  --no-install-recommends fonts-crosextra-carlito fonts-crosextra-caladea fonts-noto fonts-noto-cjk fonts-liberation fonts-arkpandora
+
+RUN dpkg-reconfigure fontconfig && fc-cache -f -s -v
+
+FROM soffice-free AS soffice-nonfree
+
 #Required to install MS fonts
 RUN echo "deb http://deb.debian.org/debian buster contrib" >> /etc/apt/sources.list
 
 RUN apt update
-
-RUN apt -y install locales-all fontconfig libxt6 libxrender1 
-RUN apt install -y -t buster-backports libreoffice
-RUN apt -y install  --no-install-recommends fonts-crosextra-carlito fonts-crosextra-caladea fonts-noto fonts-noto-cjk
 
 #MS fonts
 RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections

--- a/bbb-libreoffice/install-local.sh
+++ b/bbb-libreoffice/install-local.sh
@@ -6,6 +6,20 @@ fi;
 
 cd "$(dirname "$0")"
 
+: ${SOFFICE_VARIANT:=free}
+
+if [ "$SOFFICE_VARIANT" = "nonfree" ]; then
+    echo "You will now be presented with the EULA governing Microsoft Core Fonts."
+    echo "Press Enter to start pager..."
+    read -s
+    pager EULA.txt
+    echo "Press Enter to accept the EULA, or Ctrl-C to abort installation..."
+    read -s
+else
+    echo "By default, free replacements for the Microsoft Core Fonts are installed."
+    echo "To install the non-free fonts under Microsoft's EULA, set SOFFICE_VARIANT=nonfree in the environment."
+fi
+
 DOCKER_CHECK=`docker --version &> /dev/null && echo 1 || echo 0`
 
 if [ "$DOCKER_CHECK"  = "0" ]; then
@@ -26,7 +40,7 @@ fi
 IMAGE_CHECK=`docker image inspect bbb-soffice &> /dev/null && echo 1 || echo 0`
 if [ "$IMAGE_CHECK"  = "0" ]; then
 	echo "Docker image doesn't exists, building"
-	docker build -t bbb-soffice docker/
+	docker build --target soffice-$SOFFICE_VARIANT -t bbb-soffice docker/
 else
 	echo "Docker image already exists";
 fi


### PR DESCRIPTION
As laid out in #12035, it is illegal to install these fonts without
the end-user installing it explicitly accepting the EULA, plus, shipping
the fonts by default makes the image essentially non-free.

The packages fonts-liberation and fonts-arkpandora contain
drop-in replacements for Arial, Courier, Verdana and Times.

To install the original Microsoft fonts, the end user/administrator,
or some mechanism in bbb-install, can set SOFFICE_VARIANT=nonfree
in the environment.

**NOTE**: No package or image must ever be shipped including these fonts. They must only ever be installed after displaying the EULA to the user.