### PR TITLE
refactor(screenshare): remove unused extension/support checks

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/media/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/container.jsx
@@ -20,7 +20,6 @@ import Auth from '/imports/ui/services/auth';
 import breakoutService from '/imports/ui/components/breakout-room/service';
 
 const LAYOUT_CONFIG = Meteor.settings.public.layout;
-const KURENTO_CONFIG = Meteor.settings.public.kurento;
 
 const propTypes = {
   isScreensharing: PropTypes.bool.isRequired,
@@ -40,19 +39,10 @@ const intlMessages = defineMessages({
     id: 'app.media.screenshare.notSupported',
     description: 'Error message for screenshare not supported',
   },
-  chromeExtensionError: {
-    id: 'app.video.chromeExtensionError',
-    description: 'Error message for Chrome Extension not installed',
-  },
-  chromeExtensionErrorLink: {
-    id: 'app.video.chromeExtensionErrorLink',
-    description: 'Error message for Chrome Extension not installed',
-  },
 });
 
 class MediaContainer extends Component {
   componentDidMount() {
-    document.addEventListener('installChromeExtension', this.installChromeExtension.bind(this));
     document.addEventListener('screenshareNotSupported', this.screenshareNotSupported.bind(this));
   }
 
@@ -75,27 +65,7 @@ class MediaContainer extends Component {
   }
 
   componentWillUnmount() {
-    document.removeEventListener('installChromeExtension', this.installChromeExtension.bind(this));
     document.removeEventListener('screenshareNotSupported', this.screenshareNotSupported.bind(this));
-  }
-
-  installChromeExtension() {
-    const { intl } = this.props;
-
-    const CHROME_DEFAULT_EXTENSION_LINK = KURENTO_CONFIG.chromeDefaultExtensionLink;
-    const CHROME_CUSTOM_EXTENSION_LINK = KURENTO_CONFIG.chromeExtensionLink;
-    const CHROME_EXTENSION_LINK = CHROME_CUSTOM_EXTENSION_LINK === 'LINK' ? CHROME_DEFAULT_EXTENSION_LINK : CHROME_CUSTOM_EXTENSION_LINK;
-
-    const chromeErrorElement = (
-      <div>
-        {intl.formatMessage(intlMessages.chromeExtensionError)}
-        {' '}
-        <a href={CHROME_EXTENSION_LINK} target="_blank" rel="noopener noreferrer">
-          {intl.formatMessage(intlMessages.chromeExtensionErrorLink)}
-        </a>
-      </div>
-    );
-    notify(chromeErrorElement, 'error', 'desktop');
   }
 
   screenshareNotSupported() {

--- a/bigbluebutton-html5/imports/ui/components/media/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/container.jsx
@@ -35,17 +35,9 @@ const intlMessages = defineMessages({
     id: 'app.media.screenshare.end',
     description: 'toast to show when a screenshare has ended',
   },
-  screenshareNotSupported: {
-    id: 'app.media.screenshare.notSupported',
-    description: 'Error message for screenshare not supported',
-  },
 });
 
 class MediaContainer extends Component {
-  componentDidMount() {
-    document.addEventListener('screenshareNotSupported', this.screenshareNotSupported.bind(this));
-  }
-
   componentDidUpdate(prevProps) {
     const {
       isScreensharing,
@@ -62,15 +54,6 @@ class MediaContainer extends Component {
         notify(intl.formatMessage(intlMessages.screenshareEnded), 'info', 'desktop');
       }
     }
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('screenshareNotSupported', this.screenshareNotSupported.bind(this));
-  }
-
-  screenshareNotSupported() {
-    const { intl } = this.props;
-    notify(intl.formatMessage(intlMessages.screenshareNotSupported), 'error', 'desktop');
   }
 
   render() {

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -684,8 +684,6 @@
     "app.video.videoMenu": "Video menu",
     "app.video.videoMenuDisabled": "Video menu Webcam is disabled in settings",
     "app.video.videoMenuDesc": "Open video menu dropdown",
-    "app.video.chromeExtensionError": "You must install",
-    "app.video.chromeExtensionErrorLink": "this Chrome extension",
     "app.video.pagination.prevPage": "See previous videos",
     "app.video.pagination.nextPage": "See next videos",
     "app.video.clientDisconnected": "Webcam cannot be shared due to connection issues",


### PR DESCRIPTION
### What does this PR do?

Remove leftover code from https://github.com/bigbluebutton/bigbluebutton/pull/11622, including:
  - getUserMedia/extension based screen sharing support checks
  - Chrome screen sharing extension checks

### Closes Issue(s)

None

### More

Ref.: https://github.com/bigbluebutton/bigbluebutton/issues/11666#issuecomment-808726642