### PR TITLE
Automatically rasterize if slide contains font Type 3

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/AbstractCommandHandler.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/AbstractCommandHandler.java
@@ -82,6 +82,10 @@ public abstract class AbstractCommandHandler extends
     return stdoutBuilder.indexOf(value) > -1;
   }
 
+  protected Boolean stdoutEquals(String value) {
+    return stdoutBuilder.toString().trim().equals(value);
+  }
+
   protected Boolean stderrContains(String value) {
     return stderrBuilder.indexOf(value) > -1;
   }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/PdfFontType3DetectorHandler.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/PdfFontType3DetectorHandler.java
@@ -1,0 +1,42 @@
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ * 
+ * Copyright (c) 2015 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ * 
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.bigbluebutton.presentation.handlers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PdfFontType3DetectorHandler extends AbstractCommandHandler {
+
+  private static Logger log = LoggerFactory
+      .getLogger(PdfFontType3DetectorHandler.class);
+
+  /**
+   *
+   * @return If pdf page contains one or more texts with font Type 3.
+   */
+  public boolean hasFontType3() {
+    if (stdoutEquals("1")) {
+      return true;
+    }
+
+    return false;
+  }
+
+}


### PR DESCRIPTION
The option `forceRasterizeSlides ` was implemented in #12124 to solve #8835.
When this option is enabled all presentations are rasterized, even those that don't need (already have good quality without rasterize).

As identified by @GhaziTriki, only PDF pages that contains text with font Type 3 have poor quality after conversion.
With this PR, bbb-web will automatically detects when the slide contain this font Type 3 and force rasterize for this cases.