### PR TITLE
feat: Add button to close mute alert

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
@@ -206,7 +206,7 @@ class AudioControls extends PureComponent {
 
     return (
       <span className={styles.container}>
-        {isVoiceUser && inputStream && muteAlertEnabled && !listenOnly ? (
+        {isVoiceUser && inputStream && muteAlertEnabled && !listenOnly && muted ? (
           <MutedAlert {...{
             muted, inputStream, isViewer, isPresenter,
           }}

--- a/bigbluebutton-html5/imports/ui/components/muted-alert/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/muted-alert/styles.scss
@@ -13,6 +13,7 @@
   left: 50%;
   transform: translate(-50%, -50%);
   z-index: 1;
+  cursor: pointer;
 
   > span {
     white-space: nowrap;

--- a/bigbluebutton-html5/imports/ui/components/tooltip/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/tooltip/component.jsx
@@ -17,7 +17,7 @@ const TIP_OFFSET = '0, 10';
 
 const propTypes = {
   title: PropTypes.string,
-  position: PropTypes.oneOf(['bottom']),
+  position: PropTypes.oneOf(['bottom','top']),
   children: PropTypes.element.isRequired,
   className: PropTypes.string,
 };

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -284,6 +284,8 @@
     "app.waitingMessage": "Disconnected. Trying to reconnect in {0} seconds ...",
     "app.retryNow": "Retry now",
     "app.muteWarning.label": "Click {0} to unmute yourself.",
+    "app.muteWarning.disableMessage": "Mute alerts disabled until unmute",
+    "app.muteWarning.tooltip": "Click to close and disable warning until next unmute",
     "app.navBar.settingsDropdown.optionsLabel": "Options",
     "app.navBar.settingsDropdown.fullscreenLabel": "Make fullscreen",
     "app.navBar.settingsDropdown.settingsLabel": "Settings",


### PR DESCRIPTION
### What does this PR do?

Adds a way for the user to close and stop mute alerts until the next time it mutes itself.

![mute-alerts](https://user-images.githubusercontent.com/3728706/116563525-7c7f8180-a8da-11eb-92db-52a9f62855a1.gif)


### Closes Issue(s)
Closes #12024
