### PR TITLE
fix(screenshare): avoid stopping screensharing on UI remounts

### DIFF
--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -53,6 +53,10 @@ export default class KurentoScreenshareBridge {
     this._gdmStream = stream;
   }
 
+  getPeerConnection() {
+    return this.broker ? this.broker.webRtcPeer : null;
+  }
+
   outboundStreamReconnect() {
     const currentRestartIntervalMs = this.restartIntervalMs;
     const stream = this.gdmStream;

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -16,6 +16,7 @@ import {
   screenshareHasEnded,
   screenshareHasStarted,
   getMediaElement,
+  getPeerConnectionState,
   attachLocalPreviewStream,
 } from '/imports/ui/components/screenshare/service';
 import {
@@ -46,7 +47,7 @@ class ScreenshareComponent extends React.Component {
       loaded: false,
       isFullscreen: false,
       autoplayBlocked: false,
-      isStreamHealthy: false,
+      isStreamHealthy: !isStreamStateUnhealthy(getPeerConnectionState()),
     };
 
     this.onLoadedData = this.onLoadedData.bind(this);
@@ -85,7 +86,6 @@ class ScreenshareComponent extends React.Component {
     } = this.props;
     const layoutSwapped = getSwapLayout() && shouldEnableSwapLayout();
     if (layoutSwapped) toggleSwapLayout();
-    screenshareHasEnded();
     this.screenshareContainer.removeEventListener('fullscreenchange', this.onFullscreenChange);
     window.removeEventListener('screensharePlayFailed', this.handlePlayElementFailed);
     unsubscribeFromStreamStateChange('screenshare', this.onStreamStateChange);

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -80,6 +80,12 @@ const getMediaElement = () => {
   return document.getElementById(SCREENSHARE_MEDIA_ELEMENT_NAME);
 }
 
+const getPeerConnectionState = () => {
+  const pc = KurentoBridge.getPeerConnection();
+  if (pc == null) return 'closed';
+  return pc.connectionState;
+}
+
 const attachLocalPreviewStream = (mediaElement) => {
   const stream = KurentoBridge.gdmStream;
   if (stream && mediaElement) {
@@ -155,6 +161,7 @@ export {
   isSharingScreen,
   setSharingScreen,
   getMediaElement,
+  getPeerConnectionState,
   attachLocalPreviewStream,
   isGloballyBroadcasting,
 };


### PR DESCRIPTION
### What does this PR do?

- Remove the screen sharing stop trigger from it's component unmount callback
- Make the screen sharing UI component fetch the initial stream state from the peer connection (if it exists, else `closed`) instead of presuming it's always unhealthy

### Closes Issue(s)

None

### Motivation

Screen sharing lifecycle was closely tied to Meteor's and the UI's lifecycle. That means a hiccup in Meteor`s connection would always close screen sharing due to full component re-mounts.

So the motivation is really trying to keep screen sharing up in "not fatal" client only re-connections.


### More

We have to watch out for UI and meeting wide state inconsistencies.

I may regret doing this, profoundly.
