### PR TITLE
 feat: add media server configuration via metadata and settings.yml

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
@@ -10,6 +10,7 @@ import {
 } from '/imports/utils/fetchStunTurnServers';
 
 const SFU_URL = Meteor.settings.public.kurento.wsUrl;
+const DEFAULT_LISTENONLY_MEDIA_SERVER = Meteor.settings.public.kurento.listenOnlyMediaServer;
 const MEDIA = Meteor.settings.public.media;
 const MEDIA_TAG = MEDIA.mediaTag.replace(/#/g, '');
 const GLOBAL_AUDIO_PREFIX = 'GLOBAL_AUDIO_';
@@ -33,6 +34,11 @@ const mapErrorCode = (error) => {
   if (errorCode == null || mappedErrorCode == null) return error;
   error.errorCode = mappedErrorCode;
   return error;
+}
+
+// TODO Would be interesting to move this to a service along with the error mapping
+const getMediaServerAdapter = () => {
+  return DEFAULT_LISTENONLY_MEDIA_SERVER;
 }
 
 export default class KurentoAudioBridge extends BaseAudioBridge {
@@ -211,6 +217,7 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
           userName: this.name,
           caleeName: `${GLOBAL_AUDIO_PREFIX}${this.voiceBridge}`,
           iceServers,
+          mediaServer: getMediaServerAdapter(),
         };
 
         this.broker = new ListenOnlyBroker(

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
@@ -8,6 +8,7 @@ import {
   fetchWebRTCMappedStunTurnServers,
   getMappedFallbackStun
 } from '/imports/utils/fetchStunTurnServers';
+import getFromMeetingSettings from '/imports/ui/services/meeting-settings';
 
 const SFU_URL = Meteor.settings.public.kurento.wsUrl;
 const DEFAULT_LISTENONLY_MEDIA_SERVER = Meteor.settings.public.kurento.listenOnlyMediaServer;
@@ -38,8 +39,8 @@ const mapErrorCode = (error) => {
 
 // TODO Would be interesting to move this to a service along with the error mapping
 const getMediaServerAdapter = () => {
-  return DEFAULT_LISTENONLY_MEDIA_SERVER;
-}
+  return getFromMeetingSettings('media-server-listenonly', DEFAULT_LISTENONLY_MEDIA_SERVER);
+};
 
 export default class KurentoAudioBridge extends BaseAudioBridge {
   constructor(userData) {

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -259,6 +259,7 @@ export default class KurentoScreenshareBridge {
         stream,
         hasAudio: this.hasAudio,
         bitrate: BridgeService.BASE_BITRATE,
+        mediaServer: BridgeService.getMediaServerAdapter(),
       };
 
       this.broker = new ScreenshareBroker(

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/service.js
@@ -8,6 +8,7 @@ const {
   constraints: GDM_CONSTRAINTS,
   mediaTimeouts: MEDIA_TIMEOUTS,
   bitrate: BASE_BITRATE,
+  mediaServer: DEFAULT_SCREENSHARE_MEDIA_SERVER,
 } = Meteor.settings.public.kurento.screenshare;
 const {
   baseTimeout: BASE_MEDIA_TIMEOUT,
@@ -103,6 +104,10 @@ const getIceServers = (sessionToken) => {
   });
 }
 
+const getMediaServerAdapter = () => {
+  return DEFAULT_SCREENSHARE_MEDIA_SERVER;
+}
+
 const getNextReconnectionInterval = (oldInterval) => {
   return Math.min(
     TIMEOUT_INCREASE_FACTOR * oldInterval,
@@ -149,6 +154,7 @@ export default {
   getNextReconnectionInterval,
   streamHasAudioTrack,
   screenshareLoadAndPlayMediaStream,
+  getMediaServerAdapter,
   BASE_MEDIA_TIMEOUT,
   MAX_CONN_ATTEMPTS,
   BASE_BITRATE,

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/service.js
@@ -3,6 +3,7 @@ import logger from '/imports/startup/client/logger';
 import { fetchWebRTCMappedStunTurnServers, getMappedFallbackStun } from '/imports/utils/fetchStunTurnServers';
 import loadAndPlayMediaStream from '/imports/ui/services/bbb-webrtc-sfu/load-play';
 import { SCREENSHARING_ERRORS } from './errors';
+import getFromMeetingSettings from '/imports/ui/services/meeting-settings';
 
 const {
   constraints: GDM_CONSTRAINTS,
@@ -105,7 +106,7 @@ const getIceServers = (sessionToken) => {
 }
 
 const getMediaServerAdapter = () => {
-  return DEFAULT_SCREENSHARE_MEDIA_SERVER;
+  return getFromMeetingSettings('media-server-screenshare', DEFAULT_SCREENSHARE_MEDIA_SERVER);
 }
 
 const getNextReconnectionInterval = (oldInterval) => {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -539,6 +539,7 @@ class VideoProvider extends Component {
             userName: this.info.userName,
             bitrate,
             record: VideoService.getRecord(),
+            mediaServer: VideoService.getMediaServerAdapter(),
           };
 
           logger.info({

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -20,6 +20,7 @@ import {
   getSortingMethod,
   sortVideoStreams,
 } from '/imports/ui/components/video-provider/stream-sorting';
+import getFromMeetingSettings from '/imports/ui/services/meeting-settings';
 
 const CAMERA_PROFILES = Meteor.settings.public.kurento.cameraProfiles;
 const MULTIPLE_CAMERAS = Meteor.settings.public.app.enableMultipleCameras;
@@ -453,7 +454,7 @@ class VideoService {
   }
 
   getMediaServerAdapter() {
-    return DEFAULT_VIDEO_MEDIA_SERVER;
+    return getFromMeetingSettings('media-server-video', DEFAULT_VIDEO_MEDIA_SERVER);
   }
 
   getMyRole () {
@@ -472,12 +473,7 @@ class VideoService {
     // meta_hack-record-viewer-video is 'false' this user won't have this video
     // stream recorded.
     if (this.hackRecordViewer === null) {
-      const prop = Meetings.findOne(
-        { meetingId: Auth.meetingID },
-        { fields: { 'metadataProp': 1 } },
-      ).metadataProp;
-
-      const value = prop.metadata ? prop.metadata['hack-record-viewer-video'] : null;
+      const value = getFromMeetingSettings('hack-record-viewer-video', null);
       this.hackRecordViewer = value ? value.toLowerCase() === 'true' : true;
     }
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -43,6 +43,7 @@ const {
   paginationSorting: PAGINATION_SORTING,
   defaultSorting: DEFAULT_SORTING,
 } = Meteor.settings.public.kurento.cameraSortingModes;
+const DEFAULT_VIDEO_MEDIA_SERVER = Meteor.settings.public.kurento.videoMediaServer;
 
 const TOKEN = '_';
 
@@ -451,6 +452,10 @@ class VideoService {
     return streams.find(s => s.stream === stream);
   }
 
+  getMediaServerAdapter() {
+    return DEFAULT_VIDEO_MEDIA_SERVER;
+  }
+
   getMyRole () {
     return Users.findOne({ userId: Auth.userID },
       { fields: { role: 1 } })?.role;
@@ -817,6 +822,7 @@ export default {
   addCandidateToPeer: (peer, candidate, cameraId) => videoService.addCandidateToPeer(peer, candidate, cameraId),
   processInboundIceQueue: (peer, cameraId) => videoService.processInboundIceQueue(peer, cameraId),
   getRole: isLocal => videoService.getRole(isLocal),
+  getMediaServerAdapter: () => videoService.getMediaServerAdapter(),
   getRecord: () => videoService.getRecord(),
   getSharedDevices: () => videoService.getSharedDevices(),
   getUserParameterProfile: () => videoService.getUserParameterProfile(),

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/listenonly-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/listenonly-broker.js
@@ -19,7 +19,7 @@ class ListenOnlyBroker extends BaseBroker {
     this.internalMeetingId = internalMeetingId;
     this.role = role;
 
-    // Optional parameters are: userName, caleeName, iceServers
+    // Optional parameters are: userName, caleeName, iceServers, mediaServer
     Object.assign(this, options);
   }
 
@@ -137,6 +137,7 @@ class ListenOnlyBroker extends BaseBroker {
       userId: this.userId,
       userName: this.userName,
       sdpOffer,
+      mediaServer: this.mediaServer,
     };
 
     logger.debug({

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/screenshare-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/screenshare-broker.js
@@ -22,7 +22,8 @@ class ScreenshareBroker extends BaseBroker {
     this.webRtcPeer = null;
     this.hasAudio = false;
 
-    // Optional parameters are: userName, caleeName, iceServers, hasAudio, bitrate
+    // Optional parameters are:
+    // userName, caleeName, iceServers, hasAudio, bitrate, mediaServer
     Object.assign(this, options);
   }
 
@@ -117,6 +118,7 @@ class ScreenshareBroker extends BaseBroker {
       sdpOffer,
       hasAudio: !!this.hasAudio,
       bitrate: this.bitrate,
+      mediaServer: this.mediaServer,
     };
 
     this.sendMessage(message);

--- a/bigbluebutton-html5/imports/ui/services/meeting-settings/index.js
+++ b/bigbluebutton-html5/imports/ui/services/meeting-settings/index.js
@@ -1,0 +1,12 @@
+import Auth from '/imports/ui/services/auth';
+import Meetings from '/imports/api/meetings';
+
+export default function getFromMeetingSettings(setting, defaultValue = null) {
+  const prop = Meetings.findOne(
+    { meetingId: Auth.meetingID },
+    { fields: { 'metadataProp': 1 } },
+  ).metadataProp;
+  const value = prop.metadata ? prop.metadata[setting] : null;
+
+  return value || defaultValue;
+}

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -268,6 +268,7 @@ public:
     enableVideo: true
     enableVideoMenu: true
     enableListenOnly: true
+    listenOnlyMediaServer: Kurento
     autoShareWebcam: false
     skipVideoPreview: false
     skipVideoPreviewOnFirstJoin: false

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -168,6 +168,7 @@ public:
       # subscribe reattempt increases the reconnection timer up to this
       maxTimeout: 60000
     screenshare:
+      mediaServer: Kurento
       bitrate: 1500
       mediaTimeouts:
         maxConnectionAttempts: 2

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -269,6 +269,7 @@ public:
     enableVideoMenu: true
     enableListenOnly: true
     listenOnlyMediaServer: Kurento
+    videoMediaServer: Kurento
     autoShareWebcam: false
     skipVideoPreview: false
     skipVideoPreviewOnFirstJoin: false


### PR DESCRIPTION
### What does this PR do?

New config set at settings.yml:
  - public.kurento.screenshare.mediaServer: String (e.g.: `Kurento`)
  - public.kurento.videoMediaServer: String
  - public.kurento.listenOnlyMediaServer: String

Add a set of metadata parameters:
  - meta_media-server-screenshare: String (e.g.: `Kurento`)
  - meta_media-server-video
  - meta_media-server-listenonly
 
I've also centralized metadata fetching in the client using a similar pattern from the userdata fetch.

### Closes Issue(s)

None (yet)

### Motivation

Preparing the terrain to untagle the client-side bridges from Kurento.
