### PR TITLE
Recording: Fix handling of recordings without recording marks

### DIFF
--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -79,10 +79,8 @@ mark_for_rebuild() {
      rm -rf /var/bigbluebutton/deleted/$type/$MEETING_ID
   done
 
-  # touch the file so rap-starter starts the process
-  touch $STATUS/recorded/$MEETING_ID.done
-  # In the future it could simply schedule a job on resque
-  # redis-cli rpush resque:queue:rap:sanity "{\"class\":\"BigBlueButton::Resque::SanityWorker\",\"args\":[{\"meeting_id\":\"$MEETING_ID\"}]}"
+  # Restart processing at the 'sanity' step
+  /usr/local/bigbluebutton/core/scripts/rap-enqueue.rb sanity "$MEETING_ID"
 }
 
 mark_for_republish() {
@@ -105,7 +103,7 @@ mark_for_republish() {
       rm -rf /var/bigbluebutton/deleted/$type/$MEETING_ID
 
       # Restart processing at the 'publish' step
-      redis-cli rpush resque:queue:rap:publish "{\"class\":\"BigBlueButton::Resque::PublishWorker\",\"args\":[{\"meeting_id\":\"$MEETING_ID\",\"format_name\":\"$type\"}]}"
+      /usr/local/bigbluebutton/core/scripts/rap-enqueue.rb "publish:$type" "$MEETING_ID"
    done
 }
 

--- a/record-and-playback/core/lib/recordandplayback/workers/archive_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/archive_worker.rb
@@ -42,9 +42,8 @@ module BigBlueButton
             !File.exist?(@archived_fail)
           )
 
-          if File.exist?(@archived_norecord)
-            @publisher.put_archive_norecord(@meeting_id)
-          end
+          norecord = File.exist?(@archived_norecord)
+          @publisher.put_archive_norecord(@meeting_id) if norecord
 
           @publisher.put_archive_ended(@meeting_id, success: step_succeeded, step_time: step_time)
 
@@ -55,6 +54,8 @@ module BigBlueButton
             FileUtils.touch(@archived_fail)
           end
           @logger.debug("Finished archive worker for #{@full_id}")
+
+          raise WorkerNoRecordHalt, "Meeting #{@full_id} had no recording marks" if norecord
 
           step_succeeded
         end

--- a/record-and-playback/core/lib/recordandplayback/workers/sanity_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/sanity_worker.rb
@@ -47,10 +47,7 @@ module BigBlueButton
             FileUtils.touch(@sanity_fail)
           end
 
-          # Avoid the regular process flow if it's a norecord meeting
-          process = !File.exist?(@archived_norecord)
-
-          step_succeeded && process
+          step_succeeded
         end
       end
 
@@ -63,7 +60,6 @@ module BigBlueButton
         super(opts)
         @step_name = 'sanity'
         @post_scripts_path = File.join(BigBlueButton.rap_scripts_path, 'post_archive')
-        @archived_norecord = "#{@recording_dir}/status/archived/#{@full_id}.norecord"
         @sanity_fail = "#{@recording_dir}/status/sanity/#{@full_id}.fail"
         @sanity_done = "#{@recording_dir}/status/sanity/#{@full_id}.done"
       end

--- a/record-and-playback/core/scripts/rap-enqueue.rb
+++ b/record-and-playback/core/scripts/rap-enqueue.rb
@@ -1,0 +1,75 @@
+#!/usr/bin/ruby
+# frozen_string_literal: true
+
+# Copyright © 2021 BigBlueButton Inc. and by respective authors.
+#
+# This file is part of BigBlueButton open source conferencing system.
+#
+# BigBlueButton is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# BigBlueButton is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with BigBlueButton.  If not, see <http://www.gnu.org/licenses/>.
+
+require_relative '../lib/recordandplayback'
+
+require 'recordandplayback/workers'
+require 'rubygems'
+require 'yaml'
+require 'resque'
+
+def meeting_id_valid?(meeting_id)
+  /\A[0-9a-f]+-[0-9]+\z/.match?(meeting_id)
+end
+
+begin
+  if ARGV.length < 2
+    warn 'Usage: rap-enqueue.rb STEP[:FORMAT] MEETING_ID [MEETING_ID ...]'
+    warn ''
+    warn 'Enqueue a recording task for MEETING_ID, starting at step STEP,'
+    warn 'optionally with processing format FORMAT (required for the process'
+    warn 'and publish steps)'
+    exit 1
+  end
+
+  props = BigBlueButton.read_props
+
+  redis_host = props['redis_workers_host'] || props['redis_host']
+  redis_port = props['redis_workers_port'] || props['redis_port']
+  Resque.redis = "#{redis_host}:#{redis_port}"
+
+  common_opts = {
+    'single_step': false
+  }
+
+  step = ARGV.shift
+  step_name, step_format = step.split(':')
+  common_opts['format_name'] = step_format unless step_format.nil?
+
+  klass = \
+    begin
+      Object.const_get("BigBlueButton::Resque::#{step_name.capitalize}Worker")
+    rescue NameError
+      warn "Worker for step name #{step_name} was not found."
+      exit 1
+    end
+
+  ARGV.each do |meeting_id|
+    unless meeting_id_valid?(meeting_id)
+      warn "Meeting ID #{meeting_id} is not correctly formatted"
+      next
+    end
+
+    opts = common_opts.merge('meeting_id': meeting_id)
+
+    warn "Enqueing #{step_name} worker with #{opts.inspect}"
+    ::Resque.enqueue(klass, opts)
+  end
+end


### PR DESCRIPTION
This PR includes 3 closely related fixes for handling of recorded meetings without recording marks:

- Stop processing after the 'archive' step instead of after the 'sanity' step. This fixes the issue where post_archive scripts (which are actually run after the sanity step) were getting run for non-recorded meetings, a behaviour change from 2.2
- Halt recording processing on meetings without recording marks cleanly (without causing a failed resque job). This is done by creating a new exception type which can be raised by a worker to indicate that the job completed successfully, but that processing should not continue.
- Fix the `bbb-record --rebuild` command to restart processing at the 'sanity' step. Previously it restarted at the 'archive' step, which caused the `.norecord` file to be re-created, which then stopped processing again. I've added a ruby helper script for triggering resque jobs instead of manually inserting them with redis-cli.

These changes need some more testing before they're mergable, I'm working on that now.