### PR TITLE
refactor: remove unused class from component

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
@@ -73,7 +73,7 @@ class AudioControls extends PureComponent {
 
     return (
       <Button
-        className={cx(styles.button, styles.btn)}
+        className={styles.btn}
         onClick={handleJoinAudio}
         disabled={disable}
         hideLabel


### PR DESCRIPTION
### What does this PR do?

Removes unused CSS class in `AudioControls` component

![Screenshot from 2021-04-29 14-18-09](https://user-images.githubusercontent.com/3728706/116591986-d9d4fc00-a8f5-11eb-8e07-cf9a575aecd3.png)
