### PR TITLE
chore(guest): pt/es guest lobby localization

### DIFF
--- a/bigbluebutton-html5/private/static/guest-wait/guest-wait.html
+++ b/bigbluebutton-html5/private/static/guest-wait/guest-wait.html
@@ -66,7 +66,6 @@
       "app.errorSeeConsole": "Error: more details in the console.",
       "app.noModeratorResponse": "No response from Moderator.",
       "app.noSessionToken": "No session Token received.",
-      "app.waitForModerator": "Please wait for a moderator to approve you joining the meeting.",
       "app.windowTitle": "Guest Lobby",
       "app.missingToken": "Guest missing session token.",
       "app.missingSession": "Guest missing session.",
@@ -80,7 +79,6 @@
       "app.errorSeeConsole": "Fehler: Mehr Details in der Konsole.",
       "app.noModeratorResponse": "Keine Antwort vom Moderator.",
       "app.noSessionToken": "Kein Sitzungstoken empfangen.",
-      "app.waitForModerator": "Bitte warten bis ein Moderator die Teilnahme bestätigt.",
       "app.windowTitle": "Warteraum",
       "app.missingToken": "Gast hat keinen Sitzungs-Token",
       "app.missingSession": "Gast-Session fehlt.",
@@ -89,6 +87,32 @@
       "app.guestWait": "Bitte warten Sie, bis ein Moderator Ihre Teilnahme bestätigt.",
       "app.guestDeny": "Gast wurde abgelehnt.",
       "app.seatWait": "Gast wartet auf einen Platz in der Konferenz.",
+    },
+    "pt": {
+      "app.errorSeeConsole": "Erro: mais detalhes no console.",
+      "app.noModeratorResponse": "Sem resposta do moderador.",
+      "app.noSessionToken": "Token de sessão não recebido.",
+      "app.windowTitle": "Sala de espera",
+      "app.missingToken": "Convidado sem token de sessão.",
+      "app.missingSession": "Convidado sem sessão.",
+      "app.missingMeeting": "Reunião não existente.",
+      "app.meetingEnded": "Reunião encerrada.",
+      "app.guestWait": "Por favor aguarde até que um moderador aprove a sua entrada.",
+      "app.guestDeny": "Convidado teve sua entrada negada.",
+      "app.seatWait": "Convidado aguardando uma vaga na reunião.",
+    },
+    "es": {
+      "app.errorSeeConsole": "Error: más detalles en la consola.",
+      "app.noModeratorResponse": "Sin respuesta del moderador.",
+      "app.noSessionToken": "No se recibió ningún token de sesión.",
+      "app.windowTitle": "Vestíbulo de invitados",
+      "app.missingToken": "Token de sesión faltante del invitado.",
+      "app.missingSession": "Sesión perdida de invitado.",
+      "app.missingMeeting": "La reunión no existe.",
+      "app.meetingEnded": "La reunión terminó.",
+      "app.guestWait": "Espere a que un moderador apruebe su participación en la reunión.",
+      "app.guestDeny": "Invitado negado de unirse a la reunión.",
+      "app.seatWait": "Invitado esperando un asiento en la reunión.",
     }
   }
 
@@ -124,7 +148,7 @@
         if (lobbyMessage.length !== 0) {
           updateMessage(lobbyMessage);
         } else {
-          updateMessage(_('app.waitForModerator'));
+          updateMessage(_('app.guestWait'));
         }
       }
     }
@@ -201,7 +225,7 @@
 
     window.onload = function() {
       window.document.title = _('app.windowTitle');
-      updateMessage(_('app.waitForModerator'));
+      updateMessage(_('app.guestWait'));
       enableAnimation();
       try {
         const ATTEMPT_EVERY_MS = 5000;


### PR DESCRIPTION
Removed duplicated `waitForModerator` localization and included translations for portuguese (the cool one) and something that could be considered spanish.