### PR TITLE
Store FreeSWITCH databases fully in memory

### DIFF
--- a/bbb-voice-conference/config/freeswitch/conf/autoload_configs/switch.conf.xml
+++ b/bbb-voice-conference/config/freeswitch/conf/autoload_configs/switch.conf.xml
@@ -158,20 +158,7 @@
     -->
     <!-- <param name="rtp-retain-crypto-keys" value="true"/> -->
 
-    <!-- <param name="core-db-dsn" value="pgsql://hostaddr=127.0.0.1 dbname=freeswitch user=freeswitch password='' options='-c client_min_messages=NOTICE'" /> -->
-    <!-- <param name="core-db-dsn" value="dsn:username:password" /> -->
-    <!--
-         Allow to specify the sqlite db at a different location (In this example, move it to ramdrive for
-         better performance on most linux distro (note, you loose the data if you reboot))
-    -->
-    <param name="core-db-name" value="/dev/shm/core.db" /> 
-
-    <!-- The system will create all the db schemas automatically, set this to false to avoid this behaviour -->
-    <!-- <param name="auto-create-schemas" value="true"/> -->
-    <!-- <param name="auto-clear-sql" value="true"/> -->
-    <!-- <param name="enable-early-hangup" value="true"/> -->
-
-    <!-- <param name="core-dbtype" value="MSSQL"/> -->
+    <param name="core-db-dsn" value="sqlite://memory://file:core?mode=memory&amp;cache=shared"/>
 
     <!-- Allow multiple registrations to the same account in the central registration table -->
     <!-- <param name="multiple-registrations" value="true"/> -->

--- a/bbb-voice-conference/config/freeswitch/conf/sip_profiles/external-ipv6.xml
+++ b/bbb-voice-conference/config/freeswitch/conf/sip_profiles/external-ipv6.xml
@@ -54,7 +54,7 @@
          for presence.
     -->
     <!-- Name of the db to use for this profile -->
-    <!--<param name="dbname" value="share_presence"/>-->
+    <param name="dbname" value="sqlite://memory://file:external-ipv6?mode=memory&amp;cache=shared"/>
     <!--<param name="presence-hosts" value="$${domain}"/>-->
     <!--<param name="force-register-domain" value="$${domain}"/>-->
     <!--all inbound reg will stored in the db using this domain -->

--- a/bbb-voice-conference/config/freeswitch/conf/sip_profiles/external.xml
+++ b/bbb-voice-conference/config/freeswitch/conf/sip_profiles/external.xml
@@ -52,7 +52,7 @@
          for presence.
     -->
     <!-- Name of the db to use for this profile -->
-    <!--<param name="dbname" value="share_presence"/>-->
+    <param name="dbname" value="sqlite://memory://file:external?mode=memory&amp;cache=shared"/>
     <!--<param name="presence-hosts" value="$${domain}"/>-->
     <!--<param name="force-register-domain" value="$${domain}"/>-->
     <!--all inbound reg will stored in the db using this domain -->


### PR DESCRIPTION
### What does this PR do?

Change FreeSWITCH configuration such that the core database as well as profile databases are stored fully in memory.

### Closes Issue(s)

Closes #11887

### Motivation

From a FreeSWITCH [release notes](https://signalwire.com/blogs/product/signalwire-stack-release-20-19-7):

> ## New Features
> * [FS-11827](https://freeswitch.org/jira/browse/FS-11827) - Add feature allowing FreeSWITCH to store CORE DB (SQLite) fully in memory

We should use that mechanism in order to make the FreeSWITCH setup more robust. Moving core and profile databases into the memory removes the risk of db file corruption and permission issues.
