### PR TITLE
Consider overlay file /etc/bigbluebutton/bbb-html5-with-roles.conf when self-deploying bbb-html5

### DIFF
--- a/bigbluebutton-html5/dev_local_deployment/workers-start.sh
+++ b/bigbluebutton-html5/dev_local_deployment/workers-start.sh
@@ -3,6 +3,10 @@
 
 source /usr/share/meteor/bundle/bbb-html5-with-roles.conf
 
+if [ -f /etc/bigbluebutton/bbb-html5-with-roles.conf ]; then
+  source /etc/bigbluebutton/bbb-html5-with-roles.conf
+fi
+
 MIN_NUMBER_OF_BACKEND_PROCESSES=1
 MAX_NUMBER_OF_BACKEND_PROCESSES=4
 


### PR DESCRIPTION
### What does this PR do?
When self-deploying bbb-html5 using the `deploy_to_usr_share.sh` script, the newly generated/copied `workers-start.sh` file is missing the statement to consider overlay config file `/etc/bigbluebutton/bbb-html5-with-roles.conf` like the packaged version does. This PR adds this real quick.

### Closes Issue(s)
No issue to close, this isn't affecting a default installation.

### Motivation
stumbled across it as I self-deployed a patched html5 client, want others not to trip over it...