### PR TITLE
refactor: remove unused imports

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
@@ -1,6 +1,5 @@
 import BaseAudioBridge from './base';
 import Auth from '/imports/ui/services/auth';
-import playAndRetry from '/imports/utils/mediaElementPlayRetry';
 import logger from '/imports/startup/client/logger';
 import ListenOnlyBroker from '/imports/ui/services/bbb-webrtc-sfu/listenonly-broker';
 import loadAndPlayMediaStream from '/imports/ui/services/bbb-webrtc-sfu/load-play';

--- a/bigbluebutton-html5/imports/api/guest-users/index.js
+++ b/bigbluebutton-html5/imports/api/guest-users/index.js
@@ -1,4 +1,3 @@
-import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 
 const GuestUsers = new Mongo.Collection('guestUsers');

--- a/bigbluebutton-html5/imports/api/note/server/methods/addPad.js
+++ b/bigbluebutton-html5/imports/api/note/server/methods/addPad.js
@@ -1,5 +1,4 @@
 import RedisPubSub from '/imports/startup/server/redis';
-import Logger from '/imports/startup/server/logger';
 import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 

--- a/bigbluebutton-html5/imports/api/users/server/methods/setMobileUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/methods/setMobileUser.js
@@ -1,4 +1,3 @@
-import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 import Logger from '/imports/startup/server/logger';
 import setMobile from '../modifiers/setMobile';

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/container.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Meteor } from 'meteor/meteor';
 import { withTracker } from 'meteor/react-meteor-data';
 import { injectIntl } from 'react-intl';
 import QuickPollDropdown from './component';

--- a/bigbluebutton-html5/imports/ui/components/components-data/group-chat-context/adapter.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/group-chat-context/adapter.jsx
@@ -1,12 +1,10 @@
-import React, { useContext, useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import GroupChat from '/imports/api/group-chat';
 import { GroupChatContext, ACTIONS } from './context';
-
 
 const Adapter = () => {
   const usingGroupChatContext = useContext(GroupChatContext);
   const { dispatch } = usingGroupChatContext;
-
 
   useEffect(() => {
     const alreadyDispatched = new Set();

--- a/bigbluebutton-html5/imports/ui/components/modal/remove-user/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/modal/remove-user/component.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { defineMessages } from 'react-intl';
-import PropTypes from 'prop-types';
 import { withModalMounter } from '/imports/ui/components/modal/service';
 import Modal from '/imports/ui/components/modal/simple/component';
 import Button from '/imports/ui/components/button/component';


### PR DESCRIPTION
### What does this PR do?

Removes unused imports reported by [lgtm alerts](https://lgtm.com/projects/g/bigbluebutton/bigbluebutton/alerts)

### Motivation

*Unused local variables make code hard to read and understand. Any computation used to initialize an unused variable is wasted, which may lead to performance problems.*

*Similarly, unused imports and unused functions or classes can be confusing. They may even be a symptom of a bug caused, for example, by an incomplete refactoring.* (https://lgtm.com/rules/1780092/)
