### PR TITLE
fix(accessibility): Improve Tab Order Flow

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -353,7 +353,8 @@ class App extends Component {
       <ActivityCheckContainer
         inactivityCheck={inactivityCheck}
         responseDelay={responseDelay}
-      />) : null);
+      />
+    ) : null);
   }
 
   renderUserInformation() {
@@ -364,7 +365,8 @@ class App extends Component {
         UserInfo={UserInfo}
         requesterUserId={User.userId}
         meetingId={User.meetingId}
-      />) : null);
+      />
+    ) : null);
   }
 
   render() {
@@ -379,13 +381,13 @@ class App extends Component {
         <BannerBarContainer />
         <NotificationsBarContainer />
         <section className={styles.wrapper}>
+          {this.renderSidebar()}
+          {this.renderPanel()}
           <div className={openPanel ? styles.content : styles.noPanelContent}>
             {this.renderNavBar()}
             {this.renderMedia()}
             {this.renderActionsBar()}
           </div>
-          {this.renderPanel()}
-          {this.renderSidebar()}
         </section>
         <UploaderContainer />
         <BreakoutRoomInvitation />


### PR DESCRIPTION
### What does this PR do?
Moves the position side panel in the DOM to improve the tab order flow.

### Motivation
Before: 
![tabOrder-incorrect](https://user-images.githubusercontent.com/22058534/116928995-d0b49980-ac2b-11eb-8aea-6ac37fe4f061.png)

After:
![tabOrder-correct](https://user-images.githubusercontent.com/22058534/116929015-d316f380-ac2b-11eb-809e-dd7b37395bb3.png)
