### PR TITLE
fix: Add margin between record button and time

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/component.jsx
@@ -138,7 +138,7 @@ class RecordingIndicator extends PureComponent {
     };
 
     const recordingIndicatorIcon = (
-      <span data-test="mainWhiteboard" className={styles.recordingIndicatorIcon}>
+      <span data-test="mainWhiteboard" className={cx(styles.recordingIndicatorIcon, (!isPhone || recording) && styles.presentationTitleMargin)}>
         <svg xmlns="http://www.w3.org/2000/svg" height="100%" version="1" viewBox="0 0 20 20">
           <g stroke="#FFF" fill="#FFF" strokeLinecap="square">
             <circle
@@ -174,7 +174,7 @@ class RecordingIndicator extends PureComponent {
       >
         {recordingIndicatorIcon}
 
-        <div className={cx(styles.presentationTitle, (!isPhone || recording) && styles.presentationTitleMargin)}>
+        <div className={styles.presentationTitle}>
           {recording
             ? (
               <span className={styles.visuallyHidden}>

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/styles.scss
@@ -86,7 +86,9 @@
 }
 
 .presentationTitleMargin {
-  margin-left: var(--sm-padding-x);
+  [dir="ltr"] & {
+    margin-right: var(--sm-padding-x);
+  }
 }
 
 .recordingStatusViewOnly {


### PR DESCRIPTION
### What does this PR do?

Adds margin between record button and time passed.

#### before

![Screenshot from 2021-05-03 17-37-45](https://user-images.githubusercontent.com/3728706/116930638-635a3600-ac36-11eb-80ff-7dfa1f2dd655.png)

#### after
![Screenshot from 2021-05-03 17-37-17](https://user-images.githubusercontent.com/3728706/116930645-681eea00-ac36-11eb-94fd-e912e03f9d55.png)
