### PR TITLE
fix: first audio join in breakout fails with specific config

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -28,6 +28,7 @@ const propTypes = {
   isEchoTest: PropTypes.bool.isRequired,
   isConnecting: PropTypes.bool.isRequired,
   isConnected: PropTypes.bool.isRequired,
+  isUsingAudio: PropTypes.bool.isRequired,
   inputDeviceId: PropTypes.string,
   outputDeviceId: PropTypes.string,
   formattedDialNum: PropTypes.string.isRequired,
@@ -164,10 +165,15 @@ class AudioModal extends Component {
       joinFullAudioImmediately,
       listenOnlyMode,
       audioLocked,
+      isUsingAudio,
     } = this.props;
 
-    if (forceListenOnlyAttendee) return this.handleJoinListenOnly();
-    if ((joinFullAudioImmediately && !listenOnlyMode) || audioLocked) return this.handleJoinMicrophone();
+    if (!isUsingAudio) {
+      if (forceListenOnlyAttendee) return this.handleJoinListenOnly();
+
+      if ((joinFullAudioImmediately && !listenOnlyMode)
+        || audioLocked) return this.handleJoinMicrophone();
+    }
   }
 
   componentDidUpdate(prevProps) {

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -71,6 +71,7 @@ export default lockContextContainer(withModalMounter(withTracker(({ userLocks })
     exitAudio: () => Service.exitAudio(),
     isConnecting: Service.isConnecting(),
     isConnected: Service.isConnected(),
+    isUsingAudio: Service.isUsingAudio(),
     isEchoTest: Service.isEchoTest(),
     inputDeviceId: Service.inputDeviceId(),
     outputDeviceId: Service.outputDeviceId(),

--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -84,7 +84,7 @@ class AudioContainer extends PureComponent {
 
     this.init();
 
-    if (meetingIsBreakout) {
+    if (meetingIsBreakout && !Service.isUsingAudio()) {
       this.joinAudio();
     }
   }

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -3,10 +3,20 @@ public:
     mobileFontSize: 16px
     desktopFontSize: 14px
     audioChatNotification: false
+    # Shows the audio modal when user joins the room. The audio modal prompts
+    # user to select an option ("Microphone" and/or "Listen only") for joining
+    # audio
     autoJoin: true
+    # Disables the listen only option in audio modal.
     listenOnlyMode: true
     forceListenOnly: false
+    # Skips the echo test when connecting with microphone.
     skipCheck: false
+    # Skips the echo test when connecting with microphone right after user
+    # joins the room the first time. Subsequents joins  to microphone won't
+    # have echo test skipped, for example if user leave and join mic again
+    # or reloading page and joining mic again.
+    # This setting won't have effect if skipCheck = true
     skipCheckOnJoin: false
     #
     # Allow users to change microphone/speaker dinamically


### PR DESCRIPTION
When listenOnlyMode=false, skipCheck=true and skipCheckOnJoin=true, the
audio tries to start a session more than one time, causing it to fail
at the first one (and reconnect after that).

Now we check if user is already connecting before trying to start a new
audio session.

Added some info in settings.yml for the options related to this commit
Closes #12190