### PR TITLE
fix: prevent an extra audio channel to be created when skipCheckOnJoin is true

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/service.js
@@ -26,12 +26,15 @@ export const joinMicrophone = (skipEchoTest = false) => {
   Storage.setItem(CLIENT_DID_USER_SELECTED_LISTEN_ONLY_KEY, false);
 
   const call = new Promise((resolve, reject) => {
-    if (skipEchoTest) {
-      resolve(Service.joinMicrophone());
-    } else {
-      resolve(Service.transferCall());
+    try {
+      if (skipEchoTest && !Service.isConnected()) {
+        return resolve(Service.joinMicrophone());
+      }
+
+      return resolve(Service.transferCall());
+    } catch {
+      return reject(Service.exitAudio);
     }
-    reject(Service.exitAudio);
   });
 
   return call.then(() => {


### PR DESCRIPTION
When setting skipCheckOnJoin to true, an extra audio channel is created in
FreeSWITCH, after user accepts the echo test. The extra channel is removed
when user leaves the room, but this still may affect performance.
