### PR TITLE
 fix: bug in playAudioAlert method 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/activity-check/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/activity-check/component.jsx
@@ -78,7 +78,7 @@ class ActivityCheck extends Component {
 
   playAudioAlert() {
     this.alert = new Audio(`${Meteor.settings.public.app.cdn + Meteor.settings.public.app.basename + Meteor.settings.public.app.instanceId}/resources/sounds/notify.mp3`);
-    alert.addEventListener('ended', () => { alert.src = null; });
+    this.alert.addEventListener('ended', () => { this.alert.src = null; });
     this.alert.play();
   }
 


### PR DESCRIPTION
Removed the wrong reference to alert.
Probably it wasn't caught by eslint because 'alert' name is also present
in browser's scope.

Closes #12228