### PR TITLE
fix(events): keep events using resque workflow

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/workers/events_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/events_worker.rb
@@ -20,10 +20,10 @@
 module BigBlueButton
   module Resque
     class EventsWorker < BaseWorker
-      @queue = 'rap:archive'
+      @queue = 'rap:events'
 
       def store_events(target_dir)
-        @logger.info("Keeping events for #{meeting_id}")
+        @logger.info("Keeping events for #{@meeting_id}")
         redis = BigBlueButton::RedisWrapper.new(@props['redis_host'], @props['redis_port'], @props['redis_password'])
         events_archiver = BigBlueButton::RedisEventsArchiver.new(redis)
 
@@ -32,7 +32,7 @@ module BigBlueButton
 
         # When the events script is responsible for archiving events, the sanity script (which normally clears the events
         # from redis) will not get run, so we have to clear them here.
-        events_archiver.delete_events(meeting_id) if @break_timestamp.nil?
+        events_archiver.delete_events(@meeting_id) if @break_timestamp.nil?
       end
 
       def perform
@@ -43,19 +43,20 @@ module BigBlueButton
             next true # We're inside a block and want to return to the block's caller, not return from perform
           end
 
+          remove_status_files
+
           target_dir = "#{@events_dir}/#{@meeting_id}"
           FileUtils.mkdir_p(target_dir)
 
+          raw_events_xml = "#{@recording_dir}/raw/#{@meeting_id}/events.xml"
           if File.exist?(raw_events_xml)
             # This is a recorded meeting. The archive step should have already run, so copy the events.xml from the raw
             # recording directory.
-            FileUtils.cp("#{@recording_dir}/raw/#{@meeting_id}/events.xml", "#{target_dir}/events.xml")
+            FileUtils.cp(raw_events_xml, "#{target_dir}/events.xml")
           else
             # This meeting was not recorded. We need to run the (incremental, if break_timestamp was provided) events archiving.
             store_events(target_dir)
           end
-
-          FileUtils.rm_f(@ended_done)
 
           # Only run post events scripts after full meeting ends, not during segments
           run_post_scripts(@post_scripts_path) if @break_timestamp.nil?
@@ -64,8 +65,13 @@ module BigBlueButton
         end
       end
 
+      def remove_status_files
+        FileUtils.rm_f(@ended_done)
+      end
+
       def initialize(opts)
         super(opts)
+        @single_step = true
         @step_name = 'events'
         @events_dir = @props['events_dir']
         @post_scripts_path = File.join(BigBlueButton.rap_scripts_path, 'post_events')

--- a/record-and-playback/core/systemd/bbb-rap-resque-worker.service
+++ b/record-and-playback/core/systemd/bbb-rap-resque-worker.service
@@ -5,7 +5,7 @@ Description=BigBlueButton resque worker for recordings
 Type=simple
 ExecStart=/bin/sh -c '/usr/bin/rake -f ../Rakefile resque:workers >> /var/log/bigbluebutton/bbb-rap-worker.log'
 WorkingDirectory=/usr/local/bigbluebutton/core/scripts
-Environment=QUEUE=rap:archive,rap:publish,rap:process,rap:sanity,rap:captions
+Environment=QUEUE=rap:archive,rap:publish,rap:process,rap:sanity,rap:captions,rap:events
 Environment=COUNT=1
 # Environment=VVERBOSE=1
 User=bigbluebutton


### PR DESCRIPTION
Something was already done at rap-starter using `INotify` to trigger the events
worker. It looked like a reasonable approach so I included the missing pieces to
cover all `keepEvents` scenarios:
 - ended
 - ended, recorded with recording marks
 - ended, recorded without recording marks

Also updated with Etherpad events fetching (.etherpad file) as implemented and
running at BigBlueButton v2.2.

Closes #12196
