### PR TITLE
fix(video): check if pagination is in effect before choosing sort

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -364,10 +364,15 @@ class VideoService {
     // Recalculate total number of pages
     this.setNumberOfPages(mine.length, others.length, pageSize);
     const chunkIndex = this.currentVideoPageIndex * pageSize;
-    const paginatedStreams = sortVideoStreams(others, PAGINATION_SORTING)
+
+    // This is an extra check because pagination is globally in effect (hard
+    // limited page sizes, toggles on), but we might still only have one page.
+    // Use the default sorting method if that's the case.
+    const sortingMethod = (this.numberOfPages > 1) ? PAGINATION_SORTING : DEFAULT_SORTING;
+    const paginatedStreams = sortVideoStreams(others, sortingMethod)
       .slice(chunkIndex, (chunkIndex + pageSize)) || [];
 
-    if (getSortingMethod(PAGINATION_SORTING).localFirst) {
+    if (getSortingMethod(sortingMethod).localFirst) {
       return [...mine, ...paginatedStreams];
     }
 


### PR DESCRIPTION
### What does this PR do?

Add an extra check when choosing the video sort algorithm to see if pagination is _in effect_ instead of only checking if it's _enabled_ via config.

That fixes the scenario where pagination hasn't actually kicked in yet (due to the number of cameras being smaller than page size), but the sorting algorithm chosen still ends up being pagination's.

### Closes Issue(s)

Closes #12270 