### PR TITLE
fix(video): annotate ALL streams from an user on floor updates

### DIFF
--- a/bigbluebutton-html5/imports/api/video-streams/server/modifiers/floorChanged.js
+++ b/bigbluebutton-html5/imports/api/video-streams/server/modifiers/floorChanged.js
@@ -21,7 +21,7 @@ export default function floorChanged(meetingId, userId, floor, lastFloorTime) {
   };
 
   try {
-    const numberAffected = VideoStreams.update(selector, modifier);
+    const numberAffected = VideoStreams.update(selector, modifier, { multi: true });
 
     if (numberAffected) {
       Logger.info(`Updated user streams floor times userId=${userId} floor=${floor} lastFloorTime=${lastFloorTime}`);


### PR DESCRIPTION
### What does this PR do?

Add the `multi: true` option to `VideoStream`'s update on floor changes to account for users who are sharing _multiple_ cameras at once.

That fixes the scenario where audio floor sorting is _active_ and the floor has multiple cameras, but only their _first_ camera would be re-ordered first. The rest of their cameras wouldn't be annotated with neither `lastFloorTime` nor `floor: true`.

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/12278
