### PR TITLE
Waiting room panel: Hitting enter sends message

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/text-input/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/text-input/component.jsx
@@ -35,6 +35,13 @@ class TextInput extends PureComponent {
     this.setState({ message });
   }
 
+  handleOnKeyDown(e) {
+    if (e.keyCode === 13 && e.shiftKey === false) {
+      e.preventDefault();
+      this.handleOnClick();
+    }
+  }
+
   handleOnClick() {
     const { send } = this.props;
     const { message } = this.state;
@@ -58,6 +65,7 @@ class TextInput extends PureComponent {
           className={styles.textarea}
           maxLength={maxLength}
           onChange={(e) => this.handleOnChange(e)}
+          onKeyDown={(e) => this.handleOnKeyDown(e)}
           placeholder={placeholder}
           value={message}
         />


### PR DESCRIPTION
### What does this PR do?
Enter key will send the message to the waiting room instead of adding a newline to the textarea.

### Closes Issue(s)
no open issue, just very little UX improvement

### Motivation
Waiting room messages aren't usually longer texts. So if the user hits the enter key he most likely wants to send the message instead of adding another line. Line breaks in the message are being ignored anyway when message is being sent to the waiting room, so this makes it more clear.

### More
Shift+Enter still makes it possible to enter a linebreak