### PR TITLE
fix: toolbar crash with presenter changes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
@@ -313,8 +313,8 @@ class WhiteboardToolbar extends Component {
         }
         // 1st case a)
         this.colorListIconColor.beginElement();
-        // 2nd case - never happens when the text tool is selected
-      } else if (thicknessSelected.value !== prevState.thicknessSelected.value) {
+        // 2nd case
+      } else if (thicknessSelected.value !== prevState.thicknessSelected.value && annotationSelected.value !== 'text') {
         this.thicknessListIconRadius.beginElement();
         // 3rd case
       } else if (annotationSelected.value !== 'text'


### PR DESCRIPTION
### What does this PR do?

Fixes a crash that would happen in a particular case:

1. join a meeting with moderators A (first, gets presenter status) and B
2. user A changes tool to any tool except text
3. user A changes tool thickness
4. user A changes tool to text
5. user B clicks "take presenter" button, gets presenter status
6. user A clicks "take presenter" button, gets error message

![presenter-toolbar-crash](https://user-images.githubusercontent.com/3728706/117195938-4485ac00-adbc-11eb-98d4-b6bd7c24960f.gif)
