### PR TITLE
fix: only play audio alert if there are new messages

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/alert/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/alert/component.jsx
@@ -183,6 +183,7 @@ class ChatAlert extends PureComponent {
       idChatOpen,
       pushAlertDisabled,
       intl,
+      activeChats,
     } = this.props;
 
     const {
@@ -192,7 +193,9 @@ class ChatAlert extends PureComponent {
     const notCurrentTabOrMinimized = document.hidden;
     const hasPendingNotifications = Object.keys(pendingNotificationsByChat).length > 0;
 
-    const shouldPlayChatAlert = notCurrentTabOrMinimized
+    const unreadMessages = activeChats.reduce((a, b) => a + b.unreadCounter, 0);
+
+    const shouldPlayChatAlert = (notCurrentTabOrMinimized && unreadMessages > 0)
       || (hasPendingNotifications && !idChatOpen);
 
     return (


### PR DESCRIPTION
### What does this PR do?

This PR changes the condition for the audio alert to be played when the window is not in focus. Now it will check if there are new messages in chat.

### Closes Issue(s)
Closes #12253