### PR TITLE
feat(audio): add showAudioFilters option in settings.yml

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -9,6 +9,10 @@ import { styles } from '../styles';
 import VideoService from '/imports/ui/components/video-provider/service';
 
 const MIN_FONTSIZE = 0;
+const SHOW_AUDIO_FILTERS = (Meteor.settings.public.app
+  .showAudioFilters === undefined)
+  ? true
+  : Meteor.settings.public.app.showAudioFilters;
 
 const intlMessages = defineMessages({
   applicationSectionTitle: {
@@ -204,6 +208,43 @@ class ApplicationMenu extends BaseMenu {
     this.handleUpdateSettings('application', obj.settings);
   }
 
+  renderAudioFilters() {
+    let audioFilterOption = null;
+
+    if (SHOW_AUDIO_FILTERS) {
+      const { intl, showToggleLabel, displaySettingsStatus } = this.props;
+      const { settings } = this.state;
+      const audioFilterStatus = ApplicationMenu
+        .isAudioFilterEnabled(settings.microphoneConstraints);
+
+      audioFilterOption = (
+        <div className={styles.row}>
+          <div className={styles.col} aria-hidden="true">
+            <div className={styles.formElement}>
+              <span className={styles.label}>
+                {intl.formatMessage(intlMessages.audioFilterLabel)}
+              </span>
+            </div>
+          </div>
+          <div className={styles.col}>
+            <div className={cx(styles.formElement, styles.pullContentRight)}>
+              {displaySettingsStatus(audioFilterStatus)}
+              <Toggle
+                icons={false}
+                defaultChecked={this.state.audioFilterEnabled}
+                onChange={() => this.handleAudioFilterChange()}
+                ariaLabel={intl.formatMessage(intlMessages.audioFilterLabel)}
+                showToggleLabel={showToggleLabel}
+              />
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return audioFilterOption;
+  }
+
   renderPaginationToggle() {
     // See VideoService's method for an explanation
     if (!VideoService.shouldRenderPaginationToggle()) return;
@@ -290,28 +331,7 @@ class ApplicationMenu extends BaseMenu {
             </div>
           </div>
 
-          <div className={styles.row}>
-            <div className={styles.col} aria-hidden="true">
-              <div className={styles.formElement}>
-                <label className={styles.label}>
-                  {intl.formatMessage(intlMessages.audioFilterLabel)}
-                </label>
-              </div>
-            </div>
-            <div className={styles.col}>
-              <div className={cx(styles.formElement, styles.pullContentRight)}>
-                {displaySettingsStatus(ApplicationMenu.isAudioFilterEnabled(settings.microphoneConstraints))}
-                <Toggle
-                  icons={false}
-                  defaultChecked={this.state.audioFilterEnabled}
-                  onChange={() => this.handleAudioFilterChange()}
-                  ariaLabel={intl.formatMessage(intlMessages.audioFilterLabel)}
-                  showToggleLabel={showToggleLabel}
-                />
-              </div>
-            </div>
-          </div>
-
+          {this.renderAudioFilters()}
           {this.renderPaginationToggle()}
 
           <div className={styles.row}>

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -74,7 +74,7 @@ public:
     # are used.
     # For more info, see 'microphoneConstraints' option in this config.
     # If not set, default value is true.
-    # showAudioFilters: true
+    showAudioFilters: true
     defaultSettings:
       application:
         animations: true

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -68,6 +68,13 @@ public:
     # https://github.com/bigbluebutton/bigbluebutton/pull/10826
     customHeartbeat: false
     showAllAvailableLocales: true
+    # Show "Audio Filters for Microphone" option in settings menu.
+    # When set to true, users are able to enable/disable microphone constraints,
+    # otherwise default values for 'microphoneConstraints' option
+    # are used.
+    # For more info, see 'microphoneConstraints' option in this config.
+    # If not set, default value is true.
+    # showAudioFilters: true
     defaultSettings:
       application:
         animations: true


### PR DESCRIPTION
This allows showing (or hiding) the option from users in the conference.
Default value is true (show this option to users).
Fixed some eslint warnings.

This commit is compatible with older versions of `settings.yml`. This means  if `showAudioFilters` is not set, it will assume the default value.


#### When **enable** (default value, `showAudioFilters:true`), this is what is shown in settings menu:
![1](https://user-images.githubusercontent.com/1780868/117319257-81f04500-ae61-11eb-870b-498fb05f79fd.png)

#### When **disabled** (`showAudioFilters: false`), this is what is shown in settings menu:
![2](https://user-images.githubusercontent.com/1780868/117319334-92082480-ae61-11eb-96df-0176131584b4.png)
