### PR TITLE
Adjust poll results annotations

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
@@ -16,6 +16,8 @@ const intlMessages = defineMessages({
   },
 });
 
+const MAX_DISPLAYED_CHARS = 15;
+
 class PollDrawComponent extends Component {
   constructor(props) {
     super(props);
@@ -277,6 +279,19 @@ class PollDrawComponent extends Component {
         _result.key = intl.formatMessage({ id: `app.poll.answer.${_result.key.toLowerCase()}` });
       }
 
+      if (_result.key.length > MAX_DISPLAYED_CHARS) {
+        // find closest end of word
+        const before = _result.key.lastIndexOf(' ', MAX_DISPLAYED_CHARS);
+        const after = _result.key.indexOf(' ', MAX_DISPLAYED_CHARS + 1);
+
+        const breakpoint = (MAX_DISPLAYED_CHARS - before < after - MAX_DISPLAYED_CHARS) ? before : after;
+
+        if (breakpoint === -1) {
+          _result.key = `${_result.key.substr(0, MAX_DISPLAYED_CHARS)}...`;
+        } else {
+          _result.key = `${_result.key.substr(0, breakpoint)}...`;
+        }
+      }
       _tempArray.push(_result.key, `${_result.numVotes}`);
       if (votesTotal === 0) {
         _tempArray.push('0%');
@@ -299,7 +314,7 @@ class PollDrawComponent extends Component {
 
     // calculating the maximum possible width and height of the each line
     // 25% of the height goes to the padding
-    const maxLineWidth = innerWidth / 3;
+    const maxLineWidth = innerWidth / 2;
     const maxLineHeight = (innerHeight * 0.75) / textArray.length;
 
     const lineToMeasure = textArray[0];


### PR DESCRIPTION
### What does this PR do?

This should prevent long poll answers from making poll results unreadable in whiteboard

Adjustments made:
- Add constant to set a maximum length for answers displayed in whiteboard
- Increase of answers column width (and decrease of votes bar column width)


#### Before
![Screenshot from 2021-05-06 15-47-52](https://user-images.githubusercontent.com/3728706/117350059-7cefbd80-ae82-11eb-89fc-68f78ec6cd5d.png)

#### After
![Screenshot from 2021-05-06 15-47-28](https://user-images.githubusercontent.com/3728706/117350048-79f4cd00-ae82-11eb-938e-853e0717fbfd.png)

### Closes Issue(s)
Closes #6782
Closes #12111
Closes #10226