### PR TITLE
refactor: remove unused variables

### DIFF
--- a/bigbluebutton-html5/imports/api/cursor/server/handlers/cursorUpdate.js
+++ b/bigbluebutton-html5/imports/api/cursor/server/handlers/cursorUpdate.js
@@ -3,8 +3,6 @@ import CursorStreamer from '/imports/api/cursor/server/streamer';
 import Logger from '/imports/startup/server/logger';
 import _ from 'lodash';
 
-const { streamerLog } = Meteor.settings.private.serverLog;
-
 const CURSOR_PROCCESS_INTERVAL = 30;
 
 const cursorQueue = {};

--- a/bigbluebutton-html5/imports/ui/components/checkbox/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/checkbox/component.jsx
@@ -62,7 +62,7 @@ export default class Checkbox extends PureComponent {
 
   render() {
     const {
-      ariaLabel, ariaLabelledBy, ariaDesc, ariaDescribedBy,
+      ariaLabel, ariaDesc, ariaDescribedBy,
       className, checked, disabled,
     } = this.props;
 

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/peertube.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/peertube.jsx
@@ -71,8 +71,6 @@ export class PeerTubePlayer extends Component {
     const { config, url } = this.props;
     const m = MATCH_URL.exec(url);
 
-    const isPresenter = config && config.peertube && config.peertube.isPresenter;
-
     return `${m[1]}://${m[2]}/videos/embed/${m[3]}?api=1&controls=${true}`;
   };
 

--- a/bigbluebutton-html5/imports/ui/components/media/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/component.jsx
@@ -69,7 +69,6 @@ export default class Media extends Component {
     });
     const { viewParticipantsWebcams } = Settings.dataSaving;
     const showVideo = usersVideo.length > 0 && viewParticipantsWebcams && isMeteorConnected;
-    const fullHeight = !showVideo || (webcamsPlacement === 'floating');
 
     return (
       <div

--- a/bigbluebutton-html5/imports/ui/components/presentation/default-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/default-content/component.jsx
@@ -4,8 +4,6 @@ import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import cx from 'classnames';
 import { styles } from './styles.scss';
 
-const LAYOUT_CONFIG = Meteor.settings.public.layout;
-
 export default (props) => {
   const { autoSwapLayout, hidePresentation } = props;
   return (


### PR DESCRIPTION
### What does this PR do?

Removes unused variables reported by [lgtm alerts](https://lgtm.com/projects/g/bigbluebutton/bigbluebutton/alerts)

### Motivation

*Unused local variables make code hard to read and understand. Any computation used to initialize an unused variable is wasted, which may lead to performance problems.*

*Similarly, unused imports and unused functions or classes can be confusing. They may even be a symptom of a bug caused, for example, by an incomplete refactoring.* (https://lgtm.com/rules/1780092/)
