### PR TITLE
Fit conversion error message in toast notification

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.scss
@@ -370,8 +370,6 @@
 .uploadRow {
   display: flex;
   flex-direction: column;
-  margin-bottom: var(--statusInfoHeight);
-  margin-top: var(--statusInfoHeight);
 }
 
 .textErr,
@@ -389,8 +387,6 @@
   bottom: var(--toast-md-margin);
   position: relative;
   left: var(--border-size-large);
-  max-height: var(--statusInfoHeight);
-  height: var(--statusInfoHeight);
   
   [dir="rtl"] & {
     right: var(--border-size-large);
@@ -490,7 +486,7 @@
   height: 100%;
   max-height: var(--uploadListHeight);
   overflow-y: auto;
-  padding-right: 1rem;
+  padding-right: 1.5rem;
   box-sizing: content-box;
   background: none;
 }


### PR DESCRIPTION
### What does this PR do?

Fit conversion error message in toast notification

### Closes Issue(s)
closes #12293



#### Before:
![](https://user-images.githubusercontent.com/6312397/117162104-7da82700-ad90-11eb-9a1d-313e781d00a9.png)

#### After:
![image](https://user-images.githubusercontent.com/2110278/117454952-0d7adc00-af1d-11eb-9fa7-34162b4e9d5c.png)
