### PR TITLE
Add scroll to poll question container

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/polling/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/polling/styles.scss
@@ -52,6 +52,8 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+    max-height: 95%;
+    overflow-y: auto;
 
     [dir="rtl"] & {
       left: 50%;


### PR DESCRIPTION
### What does this PR do?

Adds scroll to poll question container when the window height is too small.

#### further information
I chose to add scroll to the whole container (and not only for the question) because it's possible to create a poll with many answers (buttons). 
A poll with A/B/C/D/E answers could take more than 50% of the screen in that case, making the question unreadable even with a scroll bar.

![poll-scroll](https://user-images.githubusercontent.com/3728706/117494468-bf7ccd00-af4a-11eb-9d20-3f3415d3c9a8.gif)


### Closes Issue(s)
Closes #12069