### PR TITLE
fix: chat popup alerts in open private chat

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/alert/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/alert/component.jsx
@@ -82,10 +82,10 @@ class ChatAlert extends PureComponent {
     const unalertedMessagesByChatId = {};
 
     activeChats
-      .filter(chat => chat.userId !== idChatOpen)
+      .filter(chat => chat.chatId !== idChatOpen)
       .filter(chat => chat.unreadCounter > 0)
       .forEach((chat) => {
-        const chatId = (chat.userId === 'public') ? publicChatId : chat.chatId;
+        const chatId = (chat.chatId === 'public') ? publicChatId : chat.chatId;
         const thisChatUnreadMessages = UnreadMessages.getUnreadMessages(chatId, messages);
 
         unalertedMessagesByChatId[chatId] = thisChatUnreadMessages.filter((msg) => {


### PR DESCRIPTION
### What does this PR do?

Fixes chat popup alerts appearing when private chat is open.

### Closes Issue(s)
Closes #12287