### PR TITLE
fix: panels z-index for mobile

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.scss
@@ -100,7 +100,7 @@
   @extend %text-elipsis;
   @extend %highContrastOutline;
   outline-style: solid;
-  z-index: 4;
+  z-index: 5;
   overflow: visible;
   order: 1;
 
@@ -140,7 +140,7 @@
   order: 2;
   height: 100%;
   @include mq($small-only) {
-    z-index: 4;
+    z-index: 5;
     height: auto;
     top: var(--navbar-height);
     overflow: visible;


### PR DESCRIPTION
### What does this PR do?

Changes panels' z-index to prevent the presenter menu button from appearing over the panels on mobile devices.

![Screenshot from 2021-05-10 11-03-43](https://user-images.githubusercontent.com/3728706/117671964-bde81a80-b17f-11eb-8b0d-94d1c9b596c4.png) ![Screenshot from 2021-05-10 11-03-52](https://user-images.githubusercontent.com/3728706/117671970-be80b100-b17f-11eb-9a84-23eba701e1d7.png)


### Motivation

Found while working on #12323