### PR TITLE
Fix: Eject user from meeting after inactivity warning timeout

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -68,7 +68,13 @@ object Users2x {
   }
 
   def updateLastUserActivity(users: Users2x, u: UserState): UserState = {
-    val newUserState = modify(u)(_.lastActivityTime).setTo(TimeUtil.timeNowInMs())
+    val newUserState = modify(u)(_.lastActivityTime).setTo(System.currentTimeMillis())
+    users.save(newUserState)
+    newUserState
+  }
+
+  def updateLastInactivityInspect(users: Users2x, u: UserState): UserState = {
+    val newUserState = modify(u)(_.lastInactivityInspect).setTo(System.currentTimeMillis())
     users.save(newUserState)
     newUserState
   }
@@ -257,21 +263,22 @@ case class OldPresenter(userId: String, changedPresenterOn: Long)
 case class UserLeftFlag(left: Boolean, leftOn: Long)
 
 case class UserState(
-    intId:            String,
-    extId:            String,
-    name:             String,
-    role:             String,
-    guest:            Boolean,
-    authed:           Boolean,
-    guestStatus:      String,
-    emoji:            String,
-    locked:           Boolean,
-    presenter:        Boolean,
-    avatar:           String,
-    roleChangedOn:    Long         = System.currentTimeMillis(),
-    lastActivityTime: Long         = TimeUtil.timeNowInMs(),
-    clientType:       String,
-    userLeftFlag:     UserLeftFlag
+    intId:                 String,
+    extId:                 String,
+    name:                  String,
+    role:                  String,
+    guest:                 Boolean,
+    authed:                Boolean,
+    guestStatus:           String,
+    emoji:                 String,
+    locked:                Boolean,
+    presenter:             Boolean,
+    avatar:                String,
+    roleChangedOn:         Long         = System.currentTimeMillis(),
+    lastActivityTime:      Long         = System.currentTimeMillis(),
+    lastInactivityInspect: Long         = 0,
+    clientType:            String,
+    userLeftFlag:          UserLeftFlag
 )
 
 case class UserIdAndName(id: String, name: String)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -1,7 +1,6 @@
 package org.bigbluebutton.core.running
 
 import java.io.{ PrintWriter, StringWriter }
-
 import akka.actor._
 import akka.actor.SupervisorStrategy.Resume
 import org.bigbluebutton.SystemConfiguration
@@ -40,6 +39,7 @@ import org.bigbluebutton.core.apps.meeting.{ SyncGetMeetingInfoRespMsgHdlr, Vali
 import org.bigbluebutton.core.apps.users.ChangeLockSettingsInMeetingCmdMsgHdlr
 import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object MeetingActor {
@@ -295,6 +295,14 @@ class MeetingActor(
       user <- Users2x.findWithIntId(liveMeeting.users2x, userId)
     } yield {
       Users2x.updateLastUserActivity(liveMeeting.users2x, user)
+    }
+  }
+
+  private def updateUserLastInactivityInspect(userId: String) {
+    for {
+      user <- Users2x.findWithIntId(liveMeeting.users2x, userId)
+    } yield {
+      Users2x.updateLastInactivityInspect(liveMeeting.users2x, user)
     }
   }
 
@@ -610,7 +618,7 @@ class MeetingActor(
   var lastRecBreakSentOn = expiryTracker.startedOnInMs
 
   def setRecordingChapterBreak(): Unit = {
-    val now = TimeUtil.timeNowInMs()
+    val now = System.currentTimeMillis()
     val elapsedInMs = now - lastRecBreakSentOn
     val elapsedInMin = TimeUtil.millisToMinutes(elapsedInMs)
 
@@ -723,34 +731,39 @@ class MeetingActor(
     }
   }
 
-  var lastUserInactivityInspectSentOn = TimeUtil.timeNowInMs()
-  var checkInactiveUsers = false
+  var lastUsersInactivityInspection = System.currentTimeMillis()
 
   def processUserInactivityAudit(): Unit = {
-    val now = TimeUtil.timeNowInMs()
+
+    val now = System.currentTimeMillis()
 
     // Check if user is inactive. We only do the check is user inactivity
     // is not disabled (0).
     if ((expiryTracker.userInactivityInspectTimerInMs > 0) &&
-      (now > lastUserInactivityInspectSentOn + expiryTracker.userInactivityInspectTimerInMs)) {
-      lastUserInactivityInspectSentOn = now
-      checkInactiveUsers = true
-      warnPotentiallyInactiveUsers()
-    }
+      (now > lastUsersInactivityInspection + expiryTracker.userInactivityInspectTimerInMs)) {
+      lastUsersInactivityInspection = now
 
-    if (checkInactiveUsers && now > lastUserInactivityInspectSentOn + expiryTracker.userActivitySignResponseDelayInMs) {
-      checkInactiveUsers = false
+      warnPotentiallyInactiveUsers()
       disconnectInactiveUsers()
     }
+
   }
 
   def warnPotentiallyInactiveUsers(): Unit = {
     log.info("Checking for inactive users.")
     val users = Users2x.findAll(liveMeeting.users2x)
     users foreach { u =>
-      val active = (lastUserInactivityInspectSentOn - expiryTracker.userInactivityThresholdInMs) < u.lastActivityTime
+
+      if (u.lastInactivityInspect > u.lastActivityTime) return
+
+      val active = (lastUsersInactivityInspection - expiryTracker.userInactivityThresholdInMs) < u.lastActivityTime
       if (!active) {
-        Sender.sendUserInactivityInspectMsg(liveMeeting.props.meetingProp.intId, u.intId, TimeUtil.minutesToSeconds(props.durationProps.userActivitySignResponseDelayInMinutes), outGW)
+
+        log.info("User has been inactive for " + TimeUnit.MILLISECONDS.toMinutes(expiryTracker.userInactivityThresholdInMs) + " minutes. Sending inactivity warning. meetingId=" + props.meetingProp.intId + " userId=" + u.intId + " user=" + u)
+
+        val secsToDisconnect = TimeUnit.MILLISECONDS.toSeconds(expiryTracker.userActivitySignResponseDelayInMs);
+        Sender.sendUserInactivityInspectMsg(liveMeeting.props.meetingProp.intId, u.intId, secsToDisconnect, outGW)
+        updateUserLastInactivityInspect(u.intId)
       }
     }
   }
@@ -759,8 +772,14 @@ class MeetingActor(
     log.info("Check for users who haven't responded to user inactivity warning.")
     val users = Users2x.findAll(liveMeeting.users2x)
     users foreach { u =>
-      val respondedOnTime = (lastUserInactivityInspectSentOn - expiryTracker.userInactivityThresholdInMs) < u.lastActivityTime && (lastUserInactivityInspectSentOn + expiryTracker.userActivitySignResponseDelayInMs) > u.lastActivityTime
+
+      if (u.lastInactivityInspect == 0 ||
+        u.lastActivityTime > u.lastInactivityInspect) return
+
+      val respondedOnTime = (lastUsersInactivityInspection - expiryTracker.userActivitySignResponseDelayInMs) < u.lastInactivityInspect
       if (!respondedOnTime) {
+        log.info("User didn't response the inactivity warning within " + TimeUnit.MILLISECONDS.toSeconds(expiryTracker.userActivitySignResponseDelayInMs) + " seconds. Ejecting from meeting. meetingId=" + props.meetingProp.intId + " userId=" + u.intId + " user=" + u)
+
         UsersApp.ejectUserFromMeeting(
           outGW,
           liveMeeting,

--- a/bigbluebutton-html5/imports/ui/components/activity-check/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/activity-check/component.jsx
@@ -64,6 +64,8 @@ class ActivityCheck extends Component {
     const { responseDelay } = this.state;
 
     return setInterval(() => {
+      if(responseDelay == 0) return;
+
       const remainingTime = responseDelay - 1;
 
       this.setState({


### PR DESCRIPTION
**What it solves?**
This PR fix #11062.

Also, this PR will improve `meetingExpireWhenLastUserLeftInMinutes`. Because there were a problem while ejecting inactives users from meeting. Thus if some user forgot to close the window, the meeting would remains running. Now all users will be ejected (_if set  in conf_) and after that the meeting will be destroyed.

**What does it do?**
- This PR fix a problem that users were never being ejected from meeting even after the countdown of warning message was 0.

**Working now:**

![image](https://user-images.githubusercontent.com/5660191/117707709-40370580-b1a5-11eb-8538-7aef03a7df28.png)

![image](https://user-images.githubusercontent.com/5660191/117707715-43ca8c80-b1a5-11eb-9d10-b0f57f62a5c8.png)

