### PR TITLE
fix: reduce padding/margin in network popup

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/styles.scss
@@ -24,11 +24,15 @@
 
 .container {
   margin: 0 var(--modal-margin) var(--lg-padding-x);
+
+  @include mq($hasPhoneDimentions) {
+    margin: 0 1rem;
+  }
 }
 
 .modal {
   @extend .modal;
-  padding: var(--jumbo-padding-y);
+  padding: var(--sm-padding-y);
 }
 
 .overlay {


### PR DESCRIPTION
### What does this PR do?

Reduces padding and margin in network popup for a better mobile experience.

#### before

font size: 100% - mobile
![network-100-before](https://user-images.githubusercontent.com/3728706/117708708-85a80280-b1a6-11eb-8b5f-269e3cdcf3dd.png) 
font size: 125% - mobile
![network-125-before](https://user-images.githubusercontent.com/3728706/117708746-8e98d400-b1a6-11eb-82dc-290fc628a034.png) 
font size: 100% - desktop
![desktop-before](https://user-images.githubusercontent.com/3728706/117708755-9193c480-b1a6-11eb-9c53-f71b66da1b97.png)


#### after

font size: 100% - mobile
![network-100-after](https://user-images.githubusercontent.com/3728706/117708952-cacc3480-b1a6-11eb-9e26-4e26787721e8.png)
font size: 125% - mobile
![network-125-after](https://user-images.githubusercontent.com/3728706/117708955-cb64cb00-b1a6-11eb-96e4-b9ae2e59c98e.png)
font size: 100% - desktop
![desktop-after](https://user-images.githubusercontent.com/3728706/117708948-ca339e00-b1a6-11eb-9a00-32e773e5c89a.png)

### Closes Issue(s)
Closes #11972