### PR TITLE
Improve Start A Poll button after publishing poll results

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
@@ -211,7 +211,7 @@ class LiveResult extends PureComponent {
                 handleBackClick();
               }}
               label={intl.formatMessage(intlMessages.backLabel)}
-              color="default"
+              color="primary"
               className={styles.btn}
             />
           )


### PR DESCRIPTION
### What does this PR do?

Improve Start A Poll button after publishing poll results

### More

#### Before:
![image](https://user-images.githubusercontent.com/2110278/117833621-de31db00-b24c-11eb-97a2-9acc94506e9b.png)

#### After:
![image](https://user-images.githubusercontent.com/2110278/117833699-f1dd4180-b24c-11eb-85a3-6d5f09eb1f65.png)
