### PR TITLE
feat: Add warning on meeting end modal about content in meeting. 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/component.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
 import Button from '/imports/ui/components/button/component';
@@ -18,6 +18,10 @@ const intlMessages = defineMessages({
     id: 'app.endMeeting.noUserDescription',
     description: 'end meeting description',
   },
+  contentWarning: {
+    id: 'app.endMeeting.contentWarning',
+    description: 'end meeting content warning',
+  },
   yesLabel: {
     id: 'app.endMeeting.yesLabel',
     description: 'label for yes button for end meeting',
@@ -27,6 +31,8 @@ const intlMessages = defineMessages({
     description: 'label for no button for end meeting',
   },
 });
+
+const { warnAboutUnsavedContentOnMeetingEnd } = Meteor.settings.public.app;
 
 const propTypes = {
   intl: PropTypes.shape({
@@ -38,7 +44,7 @@ const propTypes = {
   users: PropTypes.number.isRequired,
 };
 
-class EndMeetingComponent extends React.PureComponent {
+class EndMeetingComponent extends PureComponent {
   render() {
     const {
       users, intl, closeModal, endMeeting, meetingTitle,
@@ -54,9 +60,18 @@ class EndMeetingComponent extends React.PureComponent {
       >
         <div className={styles.container}>
           <div className={styles.description}>
-            {users > 0
-              ? intl.formatMessage(intlMessages.endMeetingDescription, { 0: users })
-              : intl.formatMessage(intlMessages.endMeetingNoUserDescription)
+            {
+              users > 0
+                ? intl.formatMessage(intlMessages.endMeetingDescription, { 0: users })
+                : intl.formatMessage(intlMessages.endMeetingNoUserDescription)
+            }
+            {
+              warnAboutUnsavedContentOnMeetingEnd
+                ? (
+                  <p>
+                    {intl.formatMessage(intlMessages.contentWarning)}
+                  </p>
+                ) : null
             }
           </div>
           <div className={styles.footer}>

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -51,6 +51,7 @@ public:
     allowLogout: true
     allowFullscreen: true
     preloadNextSlides: 2
+    warnAboutUnsavedContentOnMeetingEnd: false
     mutedAlert:
       enabled: true
       interval: 200

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -316,6 +316,7 @@
     "app.endMeeting.title": "End {0}",
     "app.endMeeting.description": "This action will end the session for {0} active user(s). Are you sure you want to end this session?",
     "app.endMeeting.noUserDescription": "Are you sure you want to end this session?",
+    "app.endMeeting.contentWarning": "Chat messages, shared notes, whiteboard content and shared documents for this session will no longer be directly accessible",
     "app.endMeeting.yesLabel": "Yes",
     "app.endMeeting.noLabel": "No",
     "app.about.title": "About",


### PR DESCRIPTION
### What does this PR do?

Add complementary text about content generated during the meeting on meeting end.

### Closes Issue(s)
closes #10721

### More

![image](https://user-images.githubusercontent.com/2110278/117860511-c0716f80-b266-11eb-8812-160634c0bdc6.png)

