### PR TITLE
fix: increase audio menu width

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/styles.scss
@@ -76,7 +76,11 @@
 }
 
 .dropdownListContainer {
-  min-width: 10rem;
+  width: max-content;
+
+  @include mq($small-only) {
+    width: 100%;
+  }
 }
 
 .stopButton {


### PR DESCRIPTION
### What does this PR do?

Increases audio selector menu width

#### before

![Screenshot from 2021-05-12 08-24-48](https://user-images.githubusercontent.com/3728706/117970115-ad11e300-b2fe-11eb-8ed0-543c05d190a3.png)

#### after
![Screenshot from 2021-05-12 09-28-54](https://user-images.githubusercontent.com/3728706/117975699-52c85080-b305-11eb-9d6b-c13028f283d8.png)


### Closes Issue(s)
Closes #12089