### PR TITLE
fix: action buttons in audio selector - mobile

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -255,6 +255,7 @@ class ActionsDropdown extends PureComponent {
       amIModerator,
       shortcuts: OPEN_ACTIONS_AK,
       isMeteorConnected,
+      isDropdownOpen,
     } = this.props;
 
     const availableActions = this.getAvailableActions();
@@ -272,6 +273,7 @@ class ActionsDropdown extends PureComponent {
       <Dropdown className={styles.dropdown} ref={(ref) => { this._dropdown = ref; }}>
         <DropdownTrigger tabIndex={0} accessKey={OPEN_ACTIONS_AK}>
           <Button
+            className={isDropdownOpen ? styles.hideDropdownButton : ''}
             hideLabel
             aria-label={intl.formatMessage(intlMessages.actionsLabel)}
             label={intl.formatMessage(intlMessages.actionsLabel)}

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/container.jsx
@@ -8,6 +8,7 @@ export default withTracker(() => {
   const presentations = Presentations.find({ 'conversion.done': true }).fetch();
   return ({
     presentations,
+    isDropdownOpen: Session.get('dropdownOpen'),
     setPresentation: PresentationUploaderService.setPresentation,
     podIds: PresentationPodService.getPresentationPodIds(),
   });

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
@@ -111,12 +111,16 @@
   }
 }
 
-.btn {
-  z-index: 3;
-}
 .dropdown{
   z-index: 4;
 }
+
+.hideDropdownButton {
+  @include mq($small-only) {
+    display:none;
+  }
+}
+
 .presentationItem {
   span {
     text-overflow: ellipsis;


### PR DESCRIPTION
### What does this PR do?

Hides the action buttons when audio selector is open in mobile devices

#### before

![Screenshot from 2021-05-12 11-08-56](https://user-images.githubusercontent.com/3728706/117989414-ae4d0b00-b312-11eb-9d66-d53442ab9946.png)

#### after

![Screenshot from 2021-05-12 11-08-22](https://user-images.githubusercontent.com/3728706/117989425-b147fb80-b312-11eb-800f-15023f13d872.png)
