### PR TITLE
feat(guests): Introduce dynamicGuestPolicy in setting.yml

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -33,6 +33,7 @@ const propTypes = {
   hasBreakoutRoom: PropTypes.bool.isRequired,
   isBreakoutEnabled: PropTypes.bool.isRequired,
   isBreakoutRecordable: PropTypes.bool.isRequired,
+  dynamicGuestPolicy: PropTypes.bool.isRequired,
 };
 
 const intlMessages = defineMessages({
@@ -228,6 +229,7 @@ class UserOptions extends PureComponent {
       amIModerator,
       users,
       isMeteorConnected,
+      dynamicGuestPolicy,
     } = this.props;
 
     const canCreateBreakout = amIModerator
@@ -292,7 +294,7 @@ class UserOptions extends PureComponent {
         />
       ) : null
       ),
-      (!meetingIsBreakout && isMeteorConnected ? (
+      (!meetingIsBreakout && isMeteorConnected && dynamicGuestPolicy ? (
         <DropdownListItem
           key={this.guestPolicyId}
           icon="user"

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/container.jsx
@@ -23,6 +23,8 @@ const intlMessages = defineMessages({
   },
 });
 
+const dynamicGuestPolicy = Meteor.settings.public.app.dynamicGuestPolicy;
+
 const meetingMuteDisabledLog = () => logger.info({
   logCode: 'useroptions_unmute_all',
   extraInfo: { logType: 'moderator_action' },
@@ -89,6 +91,7 @@ const UserOptionsContainer = withTracker((props) => {
     guestPolicy: WaitingUsersService.getGuestPolicy(),
     isMeteorConnected: Meteor.status().connected,
     meetingName: getMeetingName(),
+    dynamicGuestPolicy,
   };
 })(UserOptions);
 

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
@@ -169,6 +169,7 @@ const WaitingUsers = (props) => {
     setGuestLobbyMessage,
     guestLobbyMessage,
     authenticatedGuest,
+    allowRememberChoice,
   } = props;
 
   const onCheckBoxChange = (e) => {
@@ -227,7 +228,7 @@ const WaitingUsers = (props) => {
     },
   ];
 
-  const buttonsData = authenticatedGuest ? _.concat(authGuestButtonsData , guestButtonsData) : guestButtonsData;
+  const buttonsData = authenticatedGuest ? _.concat(authGuestButtonsData, guestButtonsData) : guestButtonsData;
 
   return (
     <div
@@ -270,12 +271,15 @@ const WaitingUsers = (props) => {
             ))
           }
         </div>
-        <div className={styles.rememberContainer}>
-          <input id="rememderCheckboxId" type="checkbox" onChange={onCheckBoxChange} />
-          <label htmlFor="rememderCheckboxId">
-            {intl.formatMessage(intlMessages.rememberChoice)}
-          </label>
-        </div>
+
+        {allowRememberChoice ? (
+          <div className={styles.rememberContainer}>
+            <input id="rememderCheckboxId" type="checkbox" onChange={onCheckBoxChange} />
+            <label htmlFor="rememderCheckboxId">
+              {intl.formatMessage(intlMessages.rememberChoice)}
+            </label>
+          </div>
+        ) : null}
       </div>
       {renderPendingUsers(
         intl.formatMessage(intlMessages.pendingUsers,

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/container.jsx
@@ -42,5 +42,6 @@ export default withTracker(() => {
     setGuestLobbyMessage: Service.setGuestLobbyMessage,
     guestLobbyMessage: Service.getGuestLobbyMessage(),
     authenticatedGuest,
+    allowRememberChoice: Service.allowRememberChoice,
   };
 })(WaitingContainer);

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/service.js
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/service.js
@@ -17,6 +17,9 @@ const getGuestPolicy = () => {
 
 const isGuestLobbyMessageEnabled = Meteor.settings.public.app.enableGuestLobbyMessage;
 
+// We use the dynamicGuestPolicy rule for allowing the rememberChoice checkbox
+const allowRememberChoice = Meteor.settings.public.app.dynamicGuestPolicy;
+
 const getGuestLobbyMessage = () => {
   const meeting = Meetings.findOne(
     { meetingId: Auth.meetingID },
@@ -37,4 +40,5 @@ export default {
   isGuestLobbyMessageEnabled,
   getGuestLobbyMessage,
   setGuestLobbyMessage,
+  allowRememberChoice,
 };

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -40,6 +40,7 @@ public:
     # in some cases we want only custom logoutUrl to be used when provided on meeting create. Default value: true
     allowDefaultLogoutUrl: true
     allowUserLookup: false
+    dynamicGuestPolicy: true
     enableGuestLobbyMessage: true
     enableNetworkInformation: false
     enableLimitOfViewersInWebcam: false


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Allows for hiding of 'Remember choice' checkbox in User management AND hiding of gear icon menu 'Guest policy'.

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->


### Motivation
In certain deployments the Guest management feature is not desired. However, on BBB 2.3 moderators have the 'Guest policy' menu for dynamically changing the policy which makes hiding of Guest management feature difficult.
However, simply hiding the row is not sufficient because 'Remember choice' in User Management would be out of reach if previously checked. That's why I had to hide both at the same time. 

<!-- What inspired you to submit this pull request? -->

### More
The default is 'true' - keeping the behaviour of 2.3.0 intact
