### PR TITLE
fix: change firefox legacy warning + add media query for mobile

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/legacy/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/legacy/component.jsx
@@ -149,15 +149,15 @@ export default class Legacy extends Component {
   }
 
   render() {
-    const { browserName, isChrome } = browserInfo;
+    const { browserName, isSafari } = browserInfo;
     const { isIos } = deviceInfo;
 
     const { messages, normalizedLocale, viewState } = this.state;
     const isSupportedBrowser = supportedBrowsers.includes(browserName);
-    const isChromeIos = isIos && isChrome;
+    const isUnsupportedIos = isIos && !isSafari;
 
     let messageId = isSupportedBrowser ? 'app.legacy.upgradeBrowser' : 'app.legacy.unsupportedBrowser';
-    if (isChromeIos) messageId = 'app.legacy.criosBrowser';
+    if (isUnsupportedIos) messageId = 'app.legacy.criosBrowser';
 
     switch (viewState) {
       case READY:
@@ -178,7 +178,7 @@ export default class Legacy extends Component {
       case FALLBACK:
         return (
           <p className="browserWarning">
-            {isChromeIos ? (
+            {isUnsupportedIos ? (
               <span>Please use Safari on iOS for full support.</span>
             ) : (
               <span>

--- a/bigbluebutton-html5/imports/ui/components/legacy/styles.css
+++ b/bigbluebutton-html5/imports/ui/components/legacy/styles.css
@@ -16,3 +16,11 @@
   font-size: 1.5rem;
   padding: 10px;
 }
+
+@media only screen and (max-width: 40em) {
+  .browserWarning {
+    width: 95%;
+    left: 2.5%;
+    margin-left: 0;
+  }
+}


### PR DESCRIPTION
### What does this PR do?

- Changes warning for Firefox on iOS to "Please use Safari on iOS for full support." (same as Chrome on iOS).
- Adds media query to legacy client - mobile

#### before
![Screenshot from 2021-05-12 14-32-39](https://user-images.githubusercontent.com/3728706/118019053-ed895500-b32e-11eb-91d9-cb75290fea80.png)


#### after
![Screenshot from 2021-05-12 13-59-36](https://user-images.githubusercontent.com/3728706/118019067-f11cdc00-b32e-11eb-9a9e-33642dc9d259.png)

### Closes Issue(s)
Closes #8414