### PR TITLE
 fix(video): check if encodings array is empty before trying to apply bitrate

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -280,8 +280,7 @@ class VideoProvider extends Component {
     this.disconnectStreams(streamsToDisconnect);
 
     if (CAMERA_QUALITY_THRESHOLDS_ENABLED) {
-      const floorStream = streams.find(vs => vs.floor === true);
-      this.updateThreshold(this.props.totalNumberOfStreams, floorStream);
+      this.updateThreshold(this.props.totalNumberOfStreams);
     }
   }
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -691,11 +691,14 @@ class VideoService {
         const { track } = sender;
         if (track && track.kind === 'video') {
           const parameters = sender.getParameters();
-          if (!parameters.encodings) {
+          const normalizedBitrate = bitrate * 1000;
+
+          // The encoder parameters might not be up yet; if that's the case,
+          // add a filler object so we can alter the parameters anyways
+          if (parameters.encodings == null || parameters.encodings.length === 0) {
             parameters.encodings = [{}];
           }
 
-          const normalizedBitrate = bitrate * 1000;
           // Only reset bitrate if it changed in some way to avoid enconder fluctuations
           if (parameters.encodings[0].maxBitrate !== normalizedBitrate) {
             parameters.encodings[0].maxBitrate = normalizedBitrate;


### PR DESCRIPTION
### What does this PR do?

- Check if the encodings array of an RTCRTPSender is empty before trying to re-apply the parameter set to alter bitrate
  * Bitrate changes come from the dynamic camera profiles
  * The encodings array is spoofed like it would if it was undefined
  * Although I could not reproduce I suppose it's feasible to assume that the crash might occur due to a race condition
- Remove an unused floorStream variable in video-provider's component
  

### Closes Issue(s)

_Tentatively closes_ #12366
