### PR TITLE
Fix presentation moving down when someone is talking

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/component.jsx
@@ -24,7 +24,7 @@ const NOTE_MIN_WIDTH = 340;
 const NOTE_MAX_WIDTH = 800;
 const WAITING_MIN_WIDTH = 340;
 const WAITING_MAX_WIDTH = 800;
-const NAVBAR_HEIGHT = 85;
+const NAVBAR_HEIGHT = 170;
 const ACTIONSBAR_HEIGHT = isMobile ? 50 : 42;
 
 const WEBCAMSAREA_MIN_PERCENT = 0.2;
@@ -32,7 +32,6 @@ const WEBCAMSAREA_MAX_PERCENT = 0.8;
 // const PRESENTATIONAREA_MIN_PERCENT = 0.2;
 const PRESENTATIONAREA_MIN_WIDTH = 385; // Value based on presentation toolbar
 // const PRESENTATIONAREA_MAX_PERCENT = 0.8;
-
 const storageLayoutData = () => Storage.getItem('layoutData');
 
 class LayoutManagerComponent extends Component {


### PR DESCRIPTION
### What does this PR do?

This Pr fix the presentaitons moving down when someone is talking, this happens because the talking indicator appears in the screen changing the navbar height causing as side effect the decrease of the presentations area height, my first solutions was put the talking indicator floating in the screen, but it lead in the issue of it overlaps the presntations in some cases, talking to @vitormateusalmeida  he gaves the idea of increase the nav bar height so avoid it changing in real time.

### Closes Issue(s)
Closes #12251 

