### PR TITLE
Show the status of multiple nodejs workers and kurento media servers in bbb-conf status

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -420,6 +420,20 @@ display_bigbluebutton_status () {
 
     if [ -f /usr/lib/systemd/system/bbb-html5.service ]; then
         units="$units mongod bbb-html5 bbb-webrtc-sfu kurento-media-server"
+		
+	  source /usr/share/meteor/bundle/bbb-html5-with-roles.conf
+
+        if [ -f /etc/bigbluebutton/bbb-html5-with-roles.conf ]; then
+          source /etc/bigbluebutton/bbb-html5-with-roles.conf
+        fi
+
+        for ((i = 1 ; i <= $NUMBER_OF_BACKEND_NODEJS_PROCESSES; i++)); do
+          units="$units bbb-html5-backend@$i"
+        done
+		
+        for ((i = 1; i <= NUMBER_OF_FRONTEND_NODEJS_PROCESSES; i++)); do
+          units="$units bbb-html5-frontend@$i"
+        done
     fi
 
     if [ -f /usr/share/etherpad-lite/settings.json ]; then

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -421,7 +421,13 @@ display_bigbluebutton_status () {
     if [ -f /usr/lib/systemd/system/bbb-html5.service ]; then
         units="$units mongod bbb-html5 bbb-webrtc-sfu kurento-media-server"
 		
-	  source /usr/share/meteor/bundle/bbb-html5-with-roles.conf
+	for i in `seq 8888 8890`; do
+          if systemctl is-enabled kurento-media-server-${i}.service > /dev/null; then
+            units="$units kurento-media-server-${i}"
+          fi
+        done
+
+	source /usr/share/meteor/bundle/bbb-html5-with-roles.conf
 
         if [ -f /etc/bigbluebutton/bbb-html5-with-roles.conf ]; then
           source /etc/bigbluebutton/bbb-html5-with-roles.conf
@@ -431,7 +437,7 @@ display_bigbluebutton_status () {
           units="$units bbb-html5-backend@$i"
         done
 		
-        for ((i = 1; i <= NUMBER_OF_FRONTEND_NODEJS_PROCESSES; i++)); do
+        for ((i = 1; i <= $NUMBER_OF_FRONTEND_NODEJS_PROCESSES; i++)); do
           units="$units bbb-html5-frontend@$i"
         done
     fi


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

```bbb-conf --status```  command outputs the status of each of the frontend and backend nodejs workers and parallel kurento media servers (if they exist).


<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #11299


### Motivation

Moving from BBB v2.2 where bbb-html5.service's status gave an idea of the actual status, people might be interested in knowing if all the backend and frontend workers are active (as in BBB v2.3, bbb-html5.service's status doesn't express this and may give a false impression sometimes.)
<!-- What inspired you to submit this pull request? -->


### Screenshot

![image](https://user-images.githubusercontent.com/43332436/118085928-cf7c2d00-b3e0-11eb-8958-7e57d022c219.png)
