### PR TITLE
fix: options button appearing in save chat

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -278,6 +278,7 @@ class SettingsDropdown extends PureComponent {
     const {
       intl,
       shortcuts: OPEN_OPTIONS_AK,
+      isDropdownOpen,
     } = this.props;
 
     const { isSettingOpen } = this.state;
@@ -297,7 +298,7 @@ class SettingsDropdown extends PureComponent {
             ghost
             circle
             hideLabel
-            className={styles.btn}
+            className={isDropdownOpen ? styles.hideDropdownButton : styles.btn}
 
             // FIXME: Without onClick react proptypes keep warning
             // even after the DropdownTrigger inject an onClick handler

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/container.jsx
@@ -23,5 +23,6 @@ export default withTracker((props) => {
     noIOSFullscreen,
     isMeteorConnected: Meteor.status().connected,
     isBreakoutRoom: meetingIsBreakout(),
+    isDropdownOpen: Session.get('dropdownOpen'),
   };
 })(SettingsDropdownContainer);

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/styles.scss
@@ -123,3 +123,9 @@
 .dropdown{
   z-index: 5;
 }
+
+.hideDropdownButton {
+  @include mq($small-only) {
+    display: none;
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Hides the options button when save chat dropdown is open in mobile devices.

Adding CSS to hide the button when the dropdown is active instead of changing z-index values (similar to #12360), as we had many z-index issues lately and changing these values seems to cause more problems than it solves.

#### before
![Screenshot from 2021-05-14 09-51-13](https://user-images.githubusercontent.com/3728706/118273166-02cec280-b49a-11eb-9f00-b37fd6c384d9.png)

#### after
![Screenshot from 2021-05-14 09-50-37](https://user-images.githubusercontent.com/3728706/118273163-019d9580-b49a-11eb-8d9b-a4accc46e0f7.png)

### Closes Issue(s)
Closes #12373
