### PR TITLE
fix(closed captions): dictation mode and redis communication

### DIFF
--- a/bigbluebutton-html5/imports/api/captions/server/methods/editCaptions.js
+++ b/bigbluebutton-html5/imports/api/captions/server/methods/editCaptions.js
@@ -13,13 +13,10 @@ export default function editCaptions(padId, data) {
   const EVENT_NAME = 'EditCaptionHistoryPubMsg';
 
   try {
-    const { meetingId } = extractCredentials(this.userId);
-
     check(padId, String);
     check(data, String);
-    check(meetingId, String);
 
-    const pad = Captions.findOne({ padId, meetingId });
+    const pad = Captions.findOne({ padId });
 
     if (!pad) {
       Logger.error(`Editing captions history: ${padId}`);
@@ -27,11 +24,13 @@ export default function editCaptions(padId, data) {
     }
 
     const {
+      meetingId,
       ownerId,
       locale,
       length,
     } = pad;
 
+    check(meetingId, String);
     check(ownerId, String);
     check(locale, { locale: String, name: String });
     check(length, Number);

--- a/bigbluebutton-html5/imports/ui/components/captions/service.js
+++ b/bigbluebutton-html5/imports/ui/components/captions/service.js
@@ -69,14 +69,11 @@ const takeOwnership = (locale) => {
   makeCall('takeOwnership', locale);
 };
 
-const formatEntry = (entry) => {
-  const letterIndex = entry.charAt(0) === ' ' ? 1 : 0;
-  const formattedEntry = `${entry.charAt(letterIndex).toUpperCase() + entry.slice(letterIndex + 1)}.\n\n`;
-  return formattedEntry;
-};
-
 const appendText = (text, locale) => {
-  makeCall('appendText', formatEntry(text), locale);
+  if (typeof text !== 'string' || text.length === 0) return;
+
+  const formattedText = `${text.trim().replace(/^\w/, (c) => c.toUpperCase())}\n\n`;
+  makeCall('appendText', formattedText, locale);
 };
 
 const canIOwnThisPad = (ownerId) => {


### PR DESCRIPTION
Handles pad update on dictation reported at one of the [mailing lists](https://groups.google.com/g/bigbluebutton-dev/c/xEJFWpfG4go/m/OhgB647BAgAJ).

BigBlueButton v2.3 uses an instance prefix while generating padIds. Closed
captions was missing this information when updating pad's content for dictation
mode.

Also fixes a regression that might have broken the closed caption recording.