### PR TITLE
Fix re-renders when another chat receives new messages

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/component.jsx
@@ -144,7 +144,7 @@ const Chat = (props) => {
   );
 };
 
-export default withShortcutHelper(injectWbResizeEvent(injectIntl(memo(Chat))), ['hidePrivateChat', 'closePrivateChat']);
+export default memo(withShortcutHelper(injectWbResizeEvent(injectIntl(Chat)), ['hidePrivateChat', 'closePrivateChat']));
 
 const propTypes = {
   chatID: PropTypes.string.isRequired,


### PR DESCRIPTION
### What does this PR do?

The bug was caused because the reference of some variables were changed, some of them are injected, so to avoid unnecessary re-renders I used the react memo.

### Closes Issue(s)
Closes #7926
