### PR TITLE
feat: add setting to enable/disable raise hand action button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -27,6 +27,7 @@ class ActionsBar extends PureComponent {
       isMeteorConnected,
       isPollingEnabled,
       isSelectRandomUserEnabled,
+      isRaiseHandButtonEnabled,
       isPresentationDisabled,
       isThereCurrentPresentation,
       allowExternalVideo,
@@ -84,30 +85,34 @@ class ActionsBar extends PureComponent {
               />
             )
             : null}
-          <Button
-            icon="hand"
-            label={intl.formatMessage({
-              id: `app.actionsBar.emojiMenu.${
-                currentUser.emoji === 'raiseHand'
-                  ? 'lowerHandLabel'
-                  : 'raiseHandLabel'
-              }`,
-            })}
-            accessKey={shortcuts.raisehand}
-            color={currentUser.emoji === 'raiseHand' ? 'primary' : 'default'}
-            data-test={currentUser.emoji === 'raiseHand' ? 'lowerHandLabel' : 'raiseHandLabel'}
-            ghost={currentUser.emoji !== 'raiseHand'}
-            className={cx(currentUser.emoji === 'raiseHand' || styles.btn)}
-            hideLabel
-            circle
-            size="lg"
-            onClick={() => {
-              setEmojiStatus(
-                currentUser.userId,
-                currentUser.emoji === 'raiseHand' ? 'none' : 'raiseHand',
-              );
-            }}
-          />
+          {isRaiseHandButtonEnabled
+            ? (
+              <Button
+                icon="hand"
+                label={intl.formatMessage({
+                  id: `app.actionsBar.emojiMenu.${
+                    currentUser.emoji === 'raiseHand'
+                      ? 'lowerHandLabel'
+                      : 'raiseHandLabel'
+                  }`,
+                })}
+                accessKey={shortcuts.raisehand}
+                color={currentUser.emoji === 'raiseHand' ? 'primary' : 'default'}
+                data-test={currentUser.emoji === 'raiseHand' ? 'lowerHandLabel' : 'raiseHandLabel'}
+                ghost={currentUser.emoji !== 'raiseHand'}
+                className={cx(currentUser.emoji === 'raiseHand' || styles.btn)}
+                hideLabel
+                circle
+                size="lg"
+                onClick={() => {
+                  setEmojiStatus(
+                    currentUser.userId,
+                    currentUser.emoji === 'raiseHand' ? 'none' : 'raiseHand',
+                  );
+                }}
+              />
+            )
+            : null}
         </div>
       </div>
     );

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
@@ -38,6 +38,7 @@ const ActionsBarContainer = (props) => {
 const POLLING_ENABLED = Meteor.settings.public.poll.enabled;
 const PRESENTATION_DISABLED = Meteor.settings.public.layout.hidePresentation;
 const SELECT_RANDOM_USER_ENABLED = Meteor.settings.public.selectRandomUser.enabled;
+const RAISE_HAND_BUTTON_ENABLED = Meteor.settings.public.app.raiseHandActionButton.enabled;
 
 export default withTracker(() => ({
   amIPresenter: Service.amIPresenter(),
@@ -55,6 +56,7 @@ export default withTracker(() => ({
   isPollingEnabled: POLLING_ENABLED,
   isPresentationDisabled: PRESENTATION_DISABLED,
   isSelectRandomUserEnabled: SELECT_RANDOM_USER_ENABLED,
+  isRaiseHandButtonEnabled: RAISE_HAND_BUTTON_ENABLED,
   isThereCurrentPresentation: Presentations.findOne({ meetingId: Auth.meetingID, current: true },
     { fields: {} }),
   allowExternalVideo: Meteor.settings.public.externalVideoPlayer.enabled,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -77,6 +77,8 @@ public:
     # For more info, see 'microphoneConstraints' option in this config.
     # If not set, default value is true.
     showAudioFilters: true
+    raiseHandActionButton:
+      enabled: true
     defaultSettings:
       application:
         animations: true


### PR DESCRIPTION
### What does this PR do?

Adds `public.app.raiseHandActionButton.enabled` (default: true) in settings file to enable/disable raise hand button in actions bar.

### Closes Issue(s)
Closes #12396