### PR TITLE
fix(chat): auto scroll to bottom for new users

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/component.jsx
@@ -10,6 +10,8 @@ import { styles } from './styles.scss';
 import MessageForm from './message-form/container';
 import TimeWindowList from './time-window-list/container';
 import ChatDropdownContainer from './chat-dropdown/container';
+import { UserSentMessageCollection } from './service';
+import Auth from '/imports/ui/services/auth';
 
 const ELEMENT_ID = 'chat-messages';
 
@@ -50,6 +52,8 @@ const Chat = (props) => {
     syncedPercent,
     lastTimeWindowValuesBuild,
   } = props;
+
+  const userSentMessage = UserSentMessageCollection.findOne({ userId: Auth.userID, sent: true });
 
   const HIDE_CHAT_AK = shortcuts.hidePrivateChat;
   const CLOSE_CHAT_AK = shortcuts.closePrivateChat;
@@ -122,6 +126,7 @@ const Chat = (props) => {
           syncing,
           syncedPercent,
           lastTimeWindowValuesBuild,
+          userSentMessage
         }}
       />
       <MessageForm

--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
@@ -109,7 +109,7 @@ class TimeWindowList extends PureComponent {
 
     const { userScrolledBack } = this.state;
 
-    if((count > 0 && !userScrolledBack) || userSentMessage){
+    if((count > 0 && !userScrolledBack) || userSentMessage || !scrollProps){
       const lastItemIndex = timeWindowsValues.length - 1;
 
       this.setState({

--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/container.jsx
@@ -1,15 +1,13 @@
 import React, { PureComponent } from 'react';
 import TimeWindowList from './component';
-import Auth from '/imports/ui/services/auth';
 import ChatLogger from '/imports/ui/components/chat/chat-logger/ChatLogger';
-import ChatService, { UserSentMessageCollection } from '../service';
+import ChatService from '../service';
 
 export default class TimeWindowListContainer extends PureComponent {
   render() {
-    const { chatId } = this.props;
+    const { chatId, userSentMessage } = this.props;
     const scrollPosition = ChatService.getScrollPosition(chatId);
     const lastReadMessageTime = ChatService.lastReadMessageTime(chatId);
-    const userSentMessage = UserSentMessageCollection.findOne({ userId: Auth.userID, sent: true });
     ChatLogger.debug('TimeWindowListContainer::render', { ...this.props }, new Date());
     return (
       <TimeWindowList


### PR DESCRIPTION
### What does this PR do?

- Adds auto scroll to bottom when a new user enters an ongoing meeting
- Fixes a bug that could prevent auto scroll if the user sends a message and scrolls back twice

### Closes Issue(s)
Closes #12399