### PR TITLE
fix: handle additional cases for locales

### DIFF
--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -209,17 +209,31 @@ WebApp.connectHandlers.use('/locale', (req, res) => {
 
   let normalizedLocale;
 
+  const regionDefault = usableLocales.find(locale => browserLocale[0] === locale);
+
   if (browserLocale.length > 1) {
+    // browser asks for specific locale
     normalizedLocale = `${browserLocale[0]}_${browserLocale[1].toUpperCase()}`;
 
     const normDefault = usableLocales.find(locale => normalizedLocale === locale);
-    if (normDefault) localeFile = normDefault;
-  }
-
-  const regionDefault = usableLocales.find(locale => browserLocale[0] === locale);
-
-  if (localeFile === fallback && regionDefault !== localeFile) {
-    localeFile = regionDefault;
+    if (normDefault) {
+      localeFile = normDefault;
+    }else{
+      if (regionDefault) {
+        localeFile = regionDefault;
+      } else {
+        const specFallback = usableLocales.find(locale => browserLocale[0] === locale.split("_")[0]);
+        if (specFallback) localeFile = specFallback;
+      }
+    }
+  } else {
+    // browser asks for region default locale
+    if (regionDefault && localeFile === fallback && regionDefault !== localeFile) {
+      localeFile = regionDefault;
+    } else {
+      const normFallback = usableLocales.find(locale => browserLocale[0] === locale.split("_")[0]);
+      if (normFallback) localeFile = normFallback;
+    }
   }
 
   res.setHeader('Content-Type', 'application/json');

--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -218,7 +218,7 @@ WebApp.connectHandlers.use('/locale', (req, res) => {
     const normDefault = usableLocales.find(locale => normalizedLocale === locale);
     if (normDefault) {
       localeFile = normDefault;
-    }else{
+    } else {
       if (regionDefault) {
         localeFile = regionDefault;
       } else {


### PR DESCRIPTION
### What does this PR do?

Adds 2 additional cases in browser locale check:
1. browser locale is a region locale but we only have a specific locale of that language available
2. browser locale is a specific locale but we only have another specific locale of that language available

Both cases will return a specific locale that is not the same as the one asked by the browser, but is the same language

#### examples:

##### Case 1: 
browser locale is `cs` and bbb has no `cs` in locales, but has `cs-CZ`
**current behavior:** bbb will return `en.json` (fallback)
**new behavior:** bbb will return `cs-CZ`

##### Case 2: 
browser locale is `zh-SG` and bbb has no `zh` in locales, but has `zh-CN`
**current behavior:** bbb will return `en.json` (fallback)
**new behavior:** bbb will return `zh-CN`


### Closes Issue(s)
Closes #12413