### PR TITLE
fix: don't show empty line when poll have 7 answers

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Polls.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Polls.scala
@@ -268,7 +268,7 @@ object Polls {
 
     // Limit the number of answers displayed to minimize
     // squishing the display.
-    if (sorted_answers.length < 7) {
+    if (sorted_answers.length <= 7) {
       sorted_answers.foreach(ans => {
         answers += SimpleVoteOutVO(ans.id, ans.key, ans.numVotes)
       })


### PR DESCRIPTION
![Sem título](https://user-images.githubusercontent.com/2726293/119031861-ee9b3180-b981-11eb-8016-e33201305dc1.png)
