### PR TITLE
fix: remove git add from linter config

### DIFF
--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -22,8 +22,7 @@
   },
   "lint-staged": {
     "*.{js,jsx}": [
-      "eslint --fix",
-      "git add"
+      "eslint --fix"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
### What does this PR do?

Removes `git add` from linter configuration.

This is a breaking change from [lint-staged 10.0.0](https://github.com/okonet/lint-staged/releases/tag/v10.0.0):

_Prior to version 10, tasks had to manually include git add as the final step. This behavior has been integrated into lint-staged itself in order to prevent race conditions with multiple tasks editing the same files. If lint-staged detects git add in task configurations, it will show a warning in the console. Please remove git add from your configuration after upgrading._
