### PR TITLE
refactor: removing unused imports/exports

### DIFF
--- a/bigbluebutton-html5/imports/api/captions/server/methods/editCaptions.js
+++ b/bigbluebutton-html5/imports/api/captions/server/methods/editCaptions.js
@@ -1,7 +1,6 @@
 import RedisPubSub from '/imports/startup/server/redis';
 import Captions from '/imports/api/captions';
 import Logger from '/imports/startup/server/logger';
-import { extractCredentials } from '/imports/api/common/server/helpers';
 import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/errors.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/errors.js
@@ -1,5 +1,4 @@
 import {
-  SFU_CLIENT_SIDE_ERRORS,
   SFU_SERVER_SIDE_ERRORS
 } from '/imports/ui/services/bbb-webrtc-sfu/broker-base-errors';
 
@@ -53,8 +52,6 @@ const SCREENSHARING_ERRORS = expandErrors();
 
 export {
   GDM_ERRORS,
-  BRIDGE_SERVER_SIDE_ERRORS,
-  BRIDGE_CLIENT_SIDE_ERRORS,
   // All errors, [code]: [message]
   // Expanded errors. It's AGGREGATED + message: { errorCode, errorMessage }
   SCREENSHARING_ERRORS,


### PR DESCRIPTION
### What does this PR do?

Removes unused imports and exports reported by [lgtm alerts](https://lgtm.com/projects/g/bigbluebutton/bigbluebutton/alerts)

### Motivation

*Unused local variables make code hard to read and understand. Any computation used to initialize an unused variable is wasted, which may lead to performance problems.*

*Similarly, unused imports and unused functions or classes can be confusing. They may even be a symptom of a bug caused, for example, by an incomplete refactoring.* (https://lgtm.com/rules/1780092/)
