### PR TITLE
fix: add padding to action bar dropdowns

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
@@ -161,6 +161,7 @@
   outline-width: 1px !important;
   outline-color: transparent !important;
   max-height: 50vh;
+  padding: 0.25rem;
 
   @include mq($small-only) {
     max-height: 100%;


### PR DESCRIPTION
### What does this PR do?

Adds padding to actions bar dropdowns

#### before
![action-drop-before](https://user-images.githubusercontent.com/3728706/119358069-9fede000-bc7e-11eb-9bc2-a012f9164e9e.png)

#### after
![action-drop-after](https://user-images.githubusercontent.com/3728706/119358078-a3816700-bc7e-11eb-9413-c2ec02f124dc.png)


### Closes Issue(s)
Closes #12348