### PR TITLE
fix: extract poll question crash

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/container.jsx
@@ -19,7 +19,7 @@ const extractPollQuestion = (pollText) => {
 };
 
 const isDefaultPoll = (pollText) => {
-  const { pollText: newPollText } = extractPollQuestion(pollText);
+  const { newPollText } = extractPollQuestion(pollText);
 
   const pollValue = newPollText.replace(/<br\/>|[ :|%\n\d+]/g, '');
   switch (pollValue) {

--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/message-chat-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/message-chat-item/component.jsx
@@ -183,7 +183,7 @@ class MessageChatItem extends PureComponent {
 
     let _text = text.replace('bbb-published-poll-<br/>', '');
 
-    const { pollQuestion, pollText: newPollText } = extractPollQuestion(_text);
+    const { pollQuestion, newPollText } = extractPollQuestion(_text);
     _text = newPollText;
 
     if (!isDefaultPoll) {


### PR DESCRIPTION
### What does this PR do?

Fixes a crash with the displaying of poll results after a change in a function return.

![Screenshot from 2021-05-25 15-50-30](https://user-images.githubusercontent.com/3728706/119552350-f5a2b500-bd70-11eb-97a2-58d33f03db64.png)
