### PR TITLE
refactor(poll): improve poll types code

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -43,19 +43,19 @@ const propTypes = {
   amIPresenter: PropTypes.bool.isRequired,
 };
 
-const getLocalizedAnswers = (type, intl) => {
+const getLocalizedAnswers = (type, intl, pollTypes) => {
   switch (type) {
-    case 'TF':
+    case pollTypes.TrueFalse:
       return [
         intl.formatMessage(intlMessages.trueOptionLabel),
         intl.formatMessage(intlMessages.falseOptionLabel),
       ];
-    case 'YN':
+    case pollTypes.YesNo:
       return [
         intl.formatMessage(intlMessages.yesOptionLabel),
         intl.formatMessage(intlMessages.noOptionLabel),
       ];
-    case 'YNA':
+    case pollTypes.YesNoAbstention:
       return [
         intl.formatMessage(intlMessages.yesOptionLabel),
         intl.formatMessage(intlMessages.noOptionLabel),
@@ -66,18 +66,21 @@ const getLocalizedAnswers = (type, intl) => {
   }
 };
 
-const getAvailableQuickPolls = (slideId, parsedSlides, startPoll, intl) => {
+const getAvailableQuickPolls = (slideId, parsedSlides, startPoll, intl, pollTypes) => {
   const pollItemElements = parsedSlides.map((poll) => {
     let { poll: label, type } = poll;
     let itemLabel = label;
     let answers = null;
 
-    if (type !== 'YN' && type !== 'YNA' && type !== 'TF') {
+    if (type !== pollTypes.YesNo && 
+        type !== pollTypes.YesNoAbstention && 
+        type !== pollTypes.TrueFalse) 
+    {
       const { options } = itemLabel;
       itemLabel = options.join('/').replace(/[\n.)]/g, '');
     } else {
-      answers = getLocalizedAnswers(type, intl);
-      type = 'custom';
+      answers = getLocalizedAnswers(type, intl, pollTypes);
+      type = pollTypes.Custom;
     }
 
     // removes any whitespace from the label
@@ -119,6 +122,7 @@ class QuickPollDropdown extends Component {
       currentSlide,
       activePoll,
       className,
+      pollTypes,
     } = this.props;
 
     const parsedSlide = parseCurrentSlideContent(
@@ -130,7 +134,7 @@ class QuickPollDropdown extends Component {
     );
 
     const { slideId, quickPollOptions } = parsedSlide;
-    const quickPolls = getAvailableQuickPolls(slideId, quickPollOptions, startPoll, intl);
+    const quickPolls = getAvailableQuickPolls(slideId, quickPollOptions, startPoll, intl, pollTypes);
 
     if (quickPollOptions.length === 0) return null;
 
@@ -147,9 +151,12 @@ class QuickPollDropdown extends Component {
       singlePollType = type;
     }
 
-    if (singlePollType === 'TF' || singlePollType === 'YN' || singlePollType === 'YNA') {
-      answers = getLocalizedAnswers(singlePollType, intl);
-      singlePollType = 'custom';
+    if (singlePollType === pollTypes.TrueFalse || 
+        singlePollType === pollTypes.YesNo || 
+        singlePollType === pollTypes.YesNoAbstention) 
+    {
+      answers = getLocalizedAnswers(singlePollType, intl, pollTypes);
+      singlePollType = pollTypes.Custom;
     }
 
     let btn = (

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/container.jsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import { injectIntl } from 'react-intl';
 import QuickPollDropdown from './component';
+import PollService from '/imports/ui/components/poll/service';
 
 const QuickPollDropdownContainer = props => <QuickPollDropdown {...props} />;
 
 export default withTracker(() => ({
   activePoll: Session.get('pollInitiated') || false,
+  pollTypes: PollService.pollTypes,
 }))(injectIntl(QuickPollDropdownContainer));

--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -227,17 +227,19 @@ class Poll extends Component {
 
   handleInputChange(e, index) {
     const { optList, type, error } = this.state;
+    const { pollTypes } = this.props;
     const list = [...optList];
     const validatedVal = validateInput(e.target.value).replace(/\s{2,}/g, ' ');
-    const clearError = validatedVal.length > 0 && type !== 'R-';
+    const clearError = validatedVal.length > 0 && type !== pollTypes.Response;
     list[index] = { val: validatedVal };
     this.setState({ optList: list, error: clearError ? null : error });
   }
 
   handleTextareaChange(e) {
     const { type, error } = this.state;
+    const { pollTypes } = this.props;
     const validatedQuestion = validateInput(e.target.value);
-    const clearError = validatedQuestion.length > 0 && type === 'R-';
+    const clearError = validatedQuestion.length > 0 && type === pollTypes.Response;
     this.setState({ question: validateInput(e.target.value), error: clearError ? null : error });
   }
 
@@ -290,40 +292,8 @@ class Poll extends Component {
     }
   }
 
-  checkPollType() {
-    const { type, optList } = this.state;
-    let _type = type;
-    let pollString = '';
-    let defaultMatch = null;
-    let isDefault = null;
-
-    switch (_type) {
-      case 'A-':
-        pollString = optList.map((x) => x.val).sort().join('');
-        defaultMatch = pollString.match(/^(ABCDEFG)|(ABCDEF)|(ABCDE)|(ABCD)|(ABC)|(AB)$/gi);
-        isDefault = defaultMatch && pollString.length === defaultMatch[0].length;
-        _type = isDefault ? `${_type}${defaultMatch[0].length}` : 'custom';
-        break;
-      case 'TF':
-        pollString = optList.map((x) => x.val).join('');
-        defaultMatch = pollString.match(/^(TRUEFALSE)|(FALSETRUE)$/gi);
-        isDefault = defaultMatch && pollString.length === defaultMatch[0].length;
-        if (!isDefault) _type = 'custom';
-        break;
-      case 'YNA':
-        pollString = optList.map((x) => x.val).join('');
-        defaultMatch = pollString.match(/^(YesNoAbstention)$/gi);
-        isDefault = defaultMatch && pollString.length === defaultMatch[0].length;
-        if (!isDefault) _type = 'custom';
-        break;
-      default:
-        break;
-    }
-    return _type;
-  }
-
   renderInputs() {
-    const { intl } = this.props;
+    const { intl, pollTypes } = this.props;
     const { optList, type, error } = this.state;
     let hasVal = false;
     return optList.map((o, i) => {
@@ -363,7 +333,7 @@ class Poll extends Component {
               )
               : <div style={{ width: '40px' }} />}
           </div>
-          {!hasVal && type !== 'R-' && error ? (
+          {!hasVal && type !== pollTypes.Response && error ? (
             <div className={styles.inputError}>{error}</div>
           ) : (
             <div className={styles.errorSpacer}>&nbsp;</div>
@@ -406,8 +376,8 @@ class Poll extends Component {
     const {
       type, optList, question, error,
     } = this.state;
-    const { startPoll, startCustomPoll, intl } = this.props;
-    const defaultPoll = type === 'TF' || type === 'A-' || type === 'YNA';
+    const { startPoll, startCustomPoll, intl, pollTypes, isDefaultPoll, checkPollType } = this.props;
+    const defaultPoll = isDefaultPoll(type);
     return (
       <div>
         <div className={styles.instructions}>
@@ -425,7 +395,7 @@ class Poll extends Component {
             maxLength={QUESTION_MAX_INPUT_CHARS}
             placeholder={intl.formatMessage(intlMessages.questionLabel)}
           />
-          {(type === 'R-' && question.length === 0 && error) ? (
+          {(type === pollTypes.Response && question.length === 0 && error) ? (
             <div className={styles.inputError}>{error}</div>
           ) : (
             <div className={styles.errorSpacer}>&nbsp;</div>
@@ -439,21 +409,21 @@ class Poll extends Component {
               color="default"
               onClick={() => {
                 this.setState({
-                  type: 'TF',
+                  type: pollTypes.TrueFalse,
                   optList: [
                     { val: intl.formatMessage(intlMessages.true) },
                     { val: intl.formatMessage(intlMessages.false) },
                   ],
                 });
               }}
-              className={cx(styles.pBtn, styles.btnMR, { [styles.selectedBtnBlue]: type === 'TF' })}
+              className={cx(styles.pBtn, styles.btnMR, { [styles.selectedBtnBlue]: type === pollTypes.TrueFalse })}
             />
             <Button
               label={intl.formatMessage(intlMessages.a4)}
               color="default"
               onClick={() => {
                 this.setState({
-                  type: 'A-',
+                  type: pollTypes.Letter,
                   optList: [
                     { val: intl.formatMessage(intlMessages.a) },
                     { val: intl.formatMessage(intlMessages.b) },
@@ -462,7 +432,7 @@ class Poll extends Component {
                   ],
                 });
               }}
-              className={cx(styles.pBtn, styles.btnML, { [styles.selectedBtnBlue]: type === 'A-' })}
+              className={cx(styles.pBtn, styles.btnML, { [styles.selectedBtnBlue]: type === pollTypes.Letter })}
             />
           </div>
           <Button
@@ -470,7 +440,7 @@ class Poll extends Component {
             color="default"
             onClick={() => {
               this.setState({
-                type: 'YNA',
+                type: pollTypes.YesNoAbstention,
                 optList: [
                   { val: intl.formatMessage(intlMessages.yes) },
                   { val: intl.formatMessage(intlMessages.no) },
@@ -478,13 +448,13 @@ class Poll extends Component {
                 ],
               });
             }}
-            className={cx(styles.pBtn, styles.yna, { [styles.selectedBtnBlue]: type === 'YNA' })}
+            className={cx(styles.pBtn, styles.yna, { [styles.selectedBtnBlue]: type === pollTypes.YesNoAbstention })}
           />
           <Button
             label={intl.formatMessage(intlMessages.userResponse)}
             color="default"
-            onClick={() => { this.setState({ type: 'R-' }); }}
-            className={cx(styles.pBtn, styles.fullWidth, { [styles.selectedBtnWhite]: type === 'R-' })}
+            onClick={() => { this.setState({ type: pollTypes.Response }); }}
+            className={cx(styles.pBtn, styles.fullWidth, { [styles.selectedBtnWhite]: type === pollTypes.Response })}
           />
         </div>
         { type
@@ -492,7 +462,7 @@ class Poll extends Component {
             <div data-test="responseChoices">
               <h4>{intl.formatMessage(intlMessages.responseChoices)}</h4>
               {
-                type === 'R-'
+                type === pollTypes.Response
                 && (
                   <div>
                     <span>{intl.formatMessage(intlMessages.typedResponseDesc)}</span>
@@ -506,7 +476,7 @@ class Poll extends Component {
                 )
               }
               {
-                (defaultPoll || type === 'R-')
+                (defaultPoll || type === pollTypes.Response)
                 && (
                   <div style={{
                     display: 'flex',
@@ -538,17 +508,25 @@ class Poll extends Component {
                         });
 
                         let err = null;
-                        if (type === 'R-' && question.length === 0) err = intl.formatMessage(intlMessages.questionErr);
-                        if (!hasVal && type !== 'R-') err = intl.formatMessage(intlMessages.optionErr);
+                        if (type === pollTypes.Response && question.length === 0) err = intl.formatMessage(intlMessages.questionErr);
+                        if (!hasVal && type !== pollTypes.Response) err = intl.formatMessage(intlMessages.optionErr);
                         if (err) return this.setState({ error: err });
 
                         return this.setState({ isPolling: true }, () => {
-                          const verifiedPollType = this.checkPollType();
+                          const verifiedPollType = checkPollType(
+                            type,
+                            optList,
+                            intl.formatMessage(intlMessages.yes),
+                            intl.formatMessage(intlMessages.no),
+                            intl.formatMessage(intlMessages.abstention),
+                            intl.formatMessage(intlMessages.true),
+                            intl.formatMessage(intlMessages.false)
+                          );
                           const verifiedOptions = optList.map((o) => {
                             if (o.val.length > 0) return o.val;
                             return null;
                           });
-                          if (verifiedPollType === 'custom') {
+                          if (verifiedPollType === pollTypes.Custom) {
                             startCustomPoll(
                               verifiedPollType,
                               question,
@@ -561,7 +539,7 @@ class Poll extends Component {
                       }}
                     />
                     {
-                      FILE_DRAG_AND_DROP_ENABLED && type !== 'R-' && this.renderDragDrop()
+                      FILE_DRAG_AND_DROP_ENABLED && type !== pollTypes.Response && this.renderDragDrop()
                     }
                   </div>
                 )
@@ -675,7 +653,7 @@ Poll.propTypes = {
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
   amIPresenter: PropTypes.bool.isRequired,
-  pollTypes: PropTypes.instanceOf(Array).isRequired,
+  pollTypes: PropTypes.instanceOf(Object).isRequired,
   startPoll: PropTypes.func.isRequired,
   startCustomPoll: PropTypes.func.isRequired,
   stopPoll: PropTypes.func.isRequired,

--- a/bigbluebutton-html5/imports/ui/components/poll/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/container.jsx
@@ -50,6 +50,8 @@ export default withTracker(() => {
     stopPoll,
     publishPoll: Service.publishPoll,
     currentPoll: Service.currentPoll(),
+    isDefaultPoll: Service.isDefaultPoll,
+    checkPollType: Service.checkPollType,
     resetPollPanel: Session.get('resetPollPanel') || false,
     pollAnswerIds: Service.pollAnswerIds,
     isMeteorConnected: Meteor.status().connected,

--- a/bigbluebutton-html5/imports/ui/components/polling/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/polling/component.jsx
@@ -92,6 +92,7 @@ class Polling extends Component {
       handleVote,
       handleTypedVote,
       pollAnswerIds,
+      pollTypes
     } = this.props;
 
     const {
@@ -129,7 +130,7 @@ class Polling extends Component {
             )
           }
           {
-            poll.pollType !== 'R-' && (
+            poll.pollType !== pollTypes.Response && (
               <span>
                 {
                   question.length === 0
@@ -184,7 +185,7 @@ class Polling extends Component {
             )
           }
           {
-            poll.pollType === 'R-'
+            poll.pollType === pollTypes.Response
             && (
               <div className={styles.typedResponseWrapper}>
                 <input

--- a/bigbluebutton-html5/imports/ui/components/polling/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/polling/container.jsx
@@ -37,6 +37,7 @@ export default withTracker(() => {
     handleTypedVote,
     poll,
     pollAnswerIds: PollService.pollAnswerIds,
+    pollTypes: PollService.pollTypes,
     isMeteorConnected: Meteor.status().connected,
   });
 })(PollingContainer);


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Define pollTypes constants and use them everywhere.
Use same regexes from quickpoll detection to detect the poll type when creating normal poll. Extract as a method in the Service file. 
This fixes certain poll type detection for other languages than english, so that the correct poll type is sent in the events (they were being detected as custom)

### Motivation

Better code readability/reuse
