### PR TITLE
fix: Avoid users to be ejected due to inactivity while they are in a breakout room

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -8,6 +8,14 @@ object Users2x {
     users.toVector find (u => u.intId == intId)
   }
 
+  def findWithBreakoutRoomId(users: Users2x, breakoutRoomId: String): Option[UserState] = {
+    //userId + "-" + roomSequence
+    val userIdParts = breakoutRoomId.split("-")
+    val userExtId = userIdParts(0)
+
+    users.toVector find (u => u.extId == userExtId)
+  }
+
   def findAll(users: Users2x): Vector[UserState] = users.toVector
 
   def add(users: Users2x, user: UserState): Option[UserState] = {


### PR DESCRIPTION
This PR will fix #10822

If `userInactivityInspectTimerInMinutes` is enabled, users are ejected due to inactivity from the main meeting while they are in a breakout room.

**This PR changes will:**
- Update lastActivityTime periodically for each user that is in a breakout room (avoiding being considered inactive)




_The original issue was about `maxInactivityTimeoutMinutes`, this option is not available anymore but the problem still exists in `UsersInactivityInspection`._