### PR TITLE
fix: translate poll answer key for default polls in chat message

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/message-chat-item/poll-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/message-chat-item/poll-list-item/component.jsx
@@ -45,7 +45,7 @@ function PollListItem(props) {
   };
 
   const { answers, numRespondents } = pollResultData;
-  let { resultString, optionsString } = getPollResultString(isDefaultPoll, answers, numRespondents)
+  let { resultString, optionsString } = getPollResultString(isDefaultPoll, answers, numRespondents, intl)
   resultString = sanitize(resultString);
   optionsString = sanitize(optionsString);
 

--- a/bigbluebutton-html5/imports/ui/components/poll/service.js
+++ b/bigbluebutton-html5/imports/ui/components/poll/service.js
@@ -58,7 +58,7 @@ const pollAnswerIds = {
   },
 };
 
-const getPollResultString = (isDefaultPoll, answers, numRespondents) => {
+const getPollResultString = (isDefaultPoll, answers, numRespondents, intl) => {
   let responded = 0;
   let resultString = '';
   let optionsString = '';
@@ -72,7 +72,8 @@ const getPollResultString = (isDefaultPoll, answers, numRespondents) => {
     const pctBars = "|".repeat(pct * MAX_POLL_RESULT_BARS / 100);
     const pctFotmatted = `${Number.isNaN(pct) ? 0 : pct}%`;
     if (isDefaultPoll) {
-      resultString += `${item.key}: ${item.numVotes || 0} |${pctBars} ${pctFotmatted}\n`;
+      const translatedKey = intl.formatMessage(pollAnswerIds[item.key.toLowerCase()]);
+      resultString += `${translatedKey}: ${item.numVotes || 0} |${pctBars} ${pctFotmatted}\n`;
     } else {
       resultString += `${item.id+1}: ${item.numVotes || 0} |${pctBars} ${pctFotmatted}\n`;
       optionsString += `${item.id+1}: ${item.key}\n`;

--- a/bigbluebutton-html5/imports/ui/components/polling/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/polling/component.jsx
@@ -20,7 +20,7 @@ const intlMessages = defineMessages({
   pollAnswerDesc: {
     id: 'app.polling.pollAnswerDesc',
   },
-  pollQestionTitle: {
+  pollQuestionTitle: {
     id: 'app.polling.pollQuestionTitle',
   },
   submitLabel: {
@@ -122,7 +122,7 @@ class Polling extends Component {
             question.length > 0 && (
               <span className={styles.qHeader}>
                 <div className={styles.qTitle}>
-                  {intl.formatMessage(intlMessages.pollQestionTitle)}
+                  {intl.formatMessage(intlMessages.pollQuestionTitle)}
                 </div>
                 <div data-test="pollQuestion" className={styles.qText}>{question}</div>
               </span>


### PR DESCRIPTION
### What does this PR do?

Show the translated answers for default polls in the poll result chat message.