### PR TITLE
fix: poll panel styles - new LM

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
@@ -8,6 +8,7 @@ import PollContainer from '/imports/ui/components/poll/container';
 import CaptionsContainer from '/imports/ui/components/captions/pad/container';
 import BreakoutRoomContainer from '/imports/ui/components/breakout-room/container';
 import WaitingUsersPanel from '/imports/ui/components/waiting-users/container';
+import { styles } from '/imports/ui/components/app/styles';
 
 const propTypes = {
   top: PropTypes.number.isRequired,
@@ -21,7 +22,6 @@ const propTypes = {
   resizableEdge: PropTypes.objectOf(PropTypes.bool).isRequired,
   contextDispatch: PropTypes.func.isRequired,
 };
-
 
 const SidebarContent = (props) => {
   const {
@@ -101,7 +101,12 @@ const SidebarContent = (props) => {
       {sidebarContentPanel === PANELS.CHAT && <ChatContainer />}
       {sidebarContentPanel === PANELS.SHARED_NOTES && <NoteContainer />}
       {sidebarContentPanel === PANELS.CAPTIONS && <CaptionsContainer />}
-      {sidebarContentPanel === PANELS.POLL && <PollContainer />}
+      {sidebarContentPanel === PANELS.POLL
+        && (
+          <div className={styles.poll} style={{ minWidth }} id="pollPanel">
+            <PollContainer />
+          </div>
+        )}
       {sidebarContentPanel === PANELS.BREAKOUT && <BreakoutRoomContainer />}
       {sidebarContentPanel === PANELS.WAITING_USERS && <WaitingUsersPanel />}
     </Resizable>


### PR DESCRIPTION
### What does this PR do?

Adds missing `div` element with `pollPanel` styles to new Layout Manager.

#### before

![Screenshot from 2021-05-28 15-58-11](https://user-images.githubusercontent.com/3728706/120030190-870e6300-bfcd-11eb-8c98-3e8b479c2df0.png)

#### after

![Screenshot from 2021-05-28 15-57-42](https://user-images.githubusercontent.com/3728706/120030198-8970bd00-bfcd-11eb-9ba2-f811c8e626ae.png)
