### PR TITLE
fix: captions button crash

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/captions-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/captions-list-item/component.jsx
@@ -33,7 +33,7 @@ const CaptionsListItem = (props) => {
 
   const handleClickToggleCaptions = () => {
     if (sidebarContentPanel !== PANELS.CAPTIONS) {
-      Session.set('captionsLocale', locale);
+      Session.set('captionsLocale', locale.locale);
       newLayoutContextDispatch({
         type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
         value: true,
@@ -44,8 +44,8 @@ const CaptionsListItem = (props) => {
       });
     } else {
       const captionsLocale = Session.get('captionsLocale');
-      if (captionsLocale !== locale) {
-        Session.set('captionsLocale', locale);
+      if (captionsLocale !== locale.locale) {
+        Session.set('captionsLocale', locale.locale);
       } else {
         newLayoutContextDispatch({
           type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,


### PR DESCRIPTION
### What does this PR do?

Prevents a crash when clicking in a language in captions list.

![Screenshot from 2021-05-28 17-18-12](https://user-images.githubusercontent.com/3728706/120037931-d1491180-bfd8-11eb-82c8-f3beec2116c3.png)
![Screenshot from 2021-05-28 17-18-24](https://user-images.githubusercontent.com/3728706/120037934-d27a3e80-bfd8-11eb-9b14-bae6c9361b4c.png)
