### PR TITLE
feat(recording): record role change event

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
@@ -85,6 +85,7 @@ class RedisRecorderActor(
       case m: UserLeftMeetingEvtMsg                 => handleUserLeftMeetingEvtMsg(m)
       case m: PresenterAssignedEvtMsg               => handlePresenterAssignedEvtMsg(m)
       case m: UserEmojiChangedEvtMsg                => handleUserEmojiChangedEvtMsg(m)
+      case m: UserRoleChangedEvtMsg                 => handleUserRoleChangedEvtMsg(m)
       case m: UserBroadcastCamStartedEvtMsg         => handleUserBroadcastCamStartedEvtMsg(m)
       case m: UserBroadcastCamStoppedEvtMsg         => handleUserBroadcastCamStoppedEvtMsg(m)
 
@@ -355,6 +356,10 @@ class RedisRecorderActor(
   }
   private def handleUserEmojiChangedEvtMsg(msg: UserEmojiChangedEvtMsg) {
     handleUserStatusChange(msg.header.meetingId, msg.body.userId, "emojiStatus", msg.body.emoji)
+  }
+
+  private def handleUserRoleChangedEvtMsg(msg: UserRoleChangedEvtMsg) {
+    handleUserStatusChange(msg.header.meetingId, msg.body.userId, "role", msg.body.role)
   }
 
   private def handleUserBroadcastCamStartedEvtMsg(msg: UserBroadcastCamStartedEvtMsg) {


### PR DESCRIPTION
Reuse `ParticipantStatusChangeEvent` record event, already used by emojis and
webcam streams, to record `UserRoleChangedEvtMsg`.

Role change is stored at `events.xml` as:

- promotion
```
  <event timestamp="2068340" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
    <timestampUTC>1622384175759</timestampUTC>
    <date>2021-05-30T14:16:15.759Z</date>
    <status>role</status>
    <userId>w_fowyht7g0tfi</userId>
    <value>MODERATOR</value>
  </event>
```

- demotion
```
  <event timestamp="2071437" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
    <timestampUTC>1622384178855</timestampUTC>
    <date>2021-05-30T14:16:18.855Z</date>
    <status>role</status>
    <userId>w_fowyht7g0tfi</userId>
    <value>VIEWER</value>
  </event>
```

Important to achieve #9789