### PR TITLE
feat(guests): notification settings

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/component.jsx
@@ -164,6 +164,7 @@ class Settings extends Component {
     const {
       intl,
       isModerator,
+      showGuestNotification,
       showToggleLabel,
     } = this.props;
 
@@ -219,6 +220,7 @@ class Settings extends Component {
           <Notification
             handleUpdateSettings={this.handleUpdateSettings}
             settings={current.application}
+            showGuestNotification={showGuestNotification}
             showToggleLabel={showToggleLabel}
             displaySettingsStatus={this.displaySettingsStatus}
             {...{ isModerator }}

--- a/bigbluebutton-html5/imports/ui/components/settings/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/container.jsx
@@ -5,6 +5,7 @@ import Settings from './component';
 
 import {
   getUserRoles,
+  showGuestNotification,
   updateSettings,
   getAvailableLocales,
 } from './service';
@@ -20,5 +21,6 @@ export default withTracker(() => ({
   updateSettings,
   availableLocales: getAvailableLocales(),
   isModerator: getUserRoles() === 'MODERATOR',
+  showGuestNotification: showGuestNotification(),
   showToggleLabel: false,
 }))(SettingsContainer);

--- a/bigbluebutton-html5/imports/ui/components/settings/service.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/service.js
@@ -2,6 +2,7 @@ import Users from '/imports/api/users';
 import Auth from '/imports/ui/services/auth';
 import Settings from '/imports/ui/services/settings';
 import { notify } from '/imports/ui/services/notification';
+import GuestService from '/imports/ui/components/waiting-users/service';
 
 const getUserRoles = () => {
   const user = Users.findOne({
@@ -9,6 +10,14 @@ const getUserRoles = () => {
   });
 
   return user.role;
+};
+
+const showGuestNotification = () => {
+  const guestPolicy = GuestService.getGuestPolicy();
+
+  // Guest notification only makes sense when guest
+  // entrance is being controlled by moderators
+  return guestPolicy === 'ASK_MODERATOR';
 };
 
 const updateSettings = (obj, msg) => {
@@ -31,6 +40,7 @@ const getAvailableLocales = () => fetch('./locale-list').then(locales => locales
 
 export {
   getUserRoles,
+  showGuestNotification,
   updateSettings,
   getAvailableLocales,
 };

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/notification/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/notification/component.jsx
@@ -54,8 +54,13 @@ class NotificationMenu extends BaseMenu {
 
   render() {
     const {
-      intl, isModerator, showToggleLabel, displaySettingsStatus,
+      intl,
+      isModerator,
+      showGuestNotification,
+      showToggleLabel,
+      displaySettingsStatus,
     } = this.props;
+
     const { settings } = this.state;
 
     return (
@@ -144,7 +149,7 @@ class NotificationMenu extends BaseMenu {
             </div>
           </div>
 
-          {isModerator ? (
+          {isModerator && showGuestNotification ? (
             <div className={styles.row}>
               <div className={styles.col}>
                 <label className={styles.label}>


### PR DESCRIPTION
Avoid showing the guest's notification toggles at client's settings if the guest
policy isn't `ASK_MODERATOR`.

Closes #12444