### PR TITLE
fix!(recording): moderator only webcams

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/WebcamsOnlyForModeratorRecordEvent.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/WebcamsOnlyForModeratorRecordEvent.scala
@@ -35,5 +35,5 @@ class WebcamsOnlyForModeratorRecordEvent extends AbstractParticipantRecordEvent 
 
 object WebcamsOnlyForModeratorRecordEvent {
   protected final val USER_ID = "userId"
-  protected final val WEBCAMS_ONLY_FOR_MODERATOR = "webacmsOnlyForModerator"
+  protected final val WEBCAMS_ONLY_FOR_MODERATOR = "webcamsOnlyForModerator"
 }


### PR DESCRIPTION
BREAKING CHANGE: fix typo at moderator only webcams recorded event.

I noticed this while investigating on how to include this event at the recordings.

Left a `BREAKING CHANGE` mark since folks might be already processing this
event at some third party application. Could not find anything within BigBlueButton's
main repository or [bbb-events](https://github.com/bigbluebutton/bbb-events).