### PR TITLE
Allow tags in meeting and user name

### DIFF
--- a/bbb-common-web/project/Dependencies.scala
+++ b/bbb-common-web/project/Dependencies.scala
@@ -26,11 +26,12 @@ object Dependencies {
 
     // Server
     val servlet = "3.1.0"
-    
+
     // Apache Commons
     val lang = "3.9"
     val io = "2.6"
     val pool = "2.8.0"
+    val text = "1.9"
 
     // BigBlueButton
     val bbbCommons = "0.0.20-SNAPSHOT"
@@ -57,10 +58,11 @@ object Dependencies {
     val nuProcess = "com.zaxxer" % "nuprocess" % Versions.nuProcess
 
     val servletApi = "javax.servlet" % "javax.servlet-api" % Versions.servlet
-    
+
     val apacheLang = "org.apache.commons" % "commons-lang3" % Versions.lang
     val apacheIo = "commons-io" % "commons-io" % Versions.io
     val apachePool2 = "org.apache.commons" % "commons-pool2" % Versions.pool
+    val apacheText = "org.apache.commons" % "commons-text" % Versions.text
 
     val bbbCommons = "org.bigbluebutton" % "bbb-common-message_2.12" % Versions.bbbCommons excludeAll (
       ExclusionRule(organization = "org.red5"))
@@ -96,5 +98,6 @@ object Dependencies {
     Compile.apacheLang,
     Compile.apacheIo,
     Compile.apachePool2,
+    Compile.apacheText,
     Compile.bbbCommons) ++ testing
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -1,13 +1,13 @@
 /**
 * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
-* 
+*
 * Copyright (c) 2012 BigBlueButton Inc. and by respective authors (see below).
 *
 * This program is free software; you can redistribute it and/or modify it under the
 * terms of the GNU Lesser General Public License as published by the Free Software
 * Foundation; either version 3.0 of the License, or (at your option) any later
 * version.
-* 
+*
 * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
 * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
@@ -52,7 +52,7 @@ public class ParamsProcessorUtil {
     private static final String URLDECODER_SEPARATOR=",";
     private static final String FILTERDECODER_SEPARATOR_ELEMENTS=":";
     private static final String FILTERDECODER_SEPARATOR_OPERATORS="\\|";
-    
+
     private static final String SERVER_URL = "%%SERVERURL%%";
     private static final String DIAL_NUM = "%%DIALNUM%%";
     private static final String CONF_NUM = "%%CONFNUM%%";
@@ -149,7 +149,7 @@ public class ParamsProcessorUtil {
             } else if (keyword.equals(CONF_NAME)) {
                 welcomeMessage = welcomeMessage.replaceAll(
                         Pattern.quote(CONF_NAME),
-                        Matcher.quoteReplacement(meetingName));
+                        Matcher.quoteReplacement(ParamsUtil.escapeHTMLTags(meetingName)));
             } else if (keyword.equals(SERVER_URL)) {
                 welcomeMessage = welcomeMessage.replaceAll(
                         Pattern.quote(SERVER_URL),
@@ -179,10 +179,10 @@ public class ParamsProcessorUtil {
             errors.missingParamError(ApiParams.MEETING_ID);
         }
     }
-	
+
 	public Map<String, Object> processUpdateCreateParams(Map<String, String> params) {
 		Map<String, Object> newParams = new HashMap<>();
-		
+
         String[] createParams = { ApiParams.NAME, ApiParams.ATTENDEE_PW, ApiParams.MODERATOR_PW, ApiParams.VOICE_BRIDGE,
                 ApiParams.WEB_VOICE, ApiParams.DIAL_NUMBER, ApiParams.LOGOUT_URL, ApiParams.RECORD,
                 ApiParams.MAX_PARTICIPANTS, ApiParams.DURATION, ApiParams.WELCOME };
@@ -193,7 +193,7 @@ public class ParamsProcessorUtil {
                 newParams.put(paramName, parameter);
             }
         }
-		
+
 	    // Collect metadata for this meeting that the third-party application wants to store if meeting is recorded.
 	    Map<String, String> meetingInfo = new HashMap<>();
 	    for (Map.Entry<String, String> entry : params.entrySet()) {
@@ -202,17 +202,17 @@ public class ParamsProcessorUtil {
 			    if(meta.length == 2){
 			    	meetingInfo.put(meta[1], entry.getValue());
 			    }
-			}   
+			}
 	    }
 
         if (!meetingInfo.isEmpty()) {
             newParams.put("metadata", meetingInfo);
         }
-	    
+
 	    return newParams;
 	}
-	
-	private static final Pattern META_VAR_PATTERN = Pattern.compile("meta_[a-zA-Z][a-zA-Z0-9-]*$");	
+
+	private static final Pattern META_VAR_PATTERN = Pattern.compile("meta_[a-zA-Z][a-zA-Z0-9-]*$");
 	public static Boolean isMetaValid(String param) {
 		Matcher metaMatcher = META_VAR_PATTERN.matcher(param);
     if (metaMatcher.matches()) {
@@ -220,11 +220,11 @@ public class ParamsProcessorUtil {
     }
 		return false;
 	}
-	
+
 	public static String removeMetaString(String param) {
 		return StringUtils.removeStart(param, "meta_");
 	}
-	
+
     public static Map<String, String> processMetaParam(Map<String, String> params) {
         Map<String, String> metas = new HashMap<>();
         for (Map.Entry<String, String> entry : params.entrySet()) {
@@ -336,7 +336,7 @@ public class ParamsProcessorUtil {
             meetingName = "";
         }
 
-        meetingName = ParamsUtil.stripHTMLTags(ParamsUtil.stripControlChars(meetingName));
+        meetingName = ParamsUtil.stripControlChars(meetingName);
 
         String externalMeetingId = params.get(ApiParams.MEETING_ID);
 
@@ -366,11 +366,11 @@ public class ParamsProcessorUtil {
         int maxUsers = processMaxUser(params.get(ApiParams.MAX_PARTICIPANTS));
         int meetingDuration = processMeetingDuration(params.get(ApiParams.DURATION));
         int logoutTimer = processLogoutTimer(params.get(ApiParams.LOGOUT_TIMER));
-        
+
         // Banner parameters
         String bannerText = params.get(ApiParams.BANNER_TEXT);
         String bannerColor = params.get(ApiParams.BANNER_COLOR);
-        
+
         // set is breakout room property
         boolean isBreakout = false;
         if (!StringUtils.isEmpty(params.get(ApiParams.IS_BREAKOUT))) {
@@ -551,15 +551,15 @@ public class ParamsProcessorUtil {
 
         return meeting;
     }
-	
+
 	public String getApiVersion() {
 		return apiVersion;
 	}
-	
+
 	public boolean isServiceEnabled() {
 		return serviceEnabled;
 	}
-	
+
 	public String getDefaultHTML5ClientUrl() {
 		return defaultHTML5ClientUrl;
 	}
@@ -579,7 +579,7 @@ public class ParamsProcessorUtil {
      		return defaultLogoutUrl;
      	}
 	}
-	
+
     public String processWelcomeMessage(String message, Boolean isBreakout) {
         String welcomeMessage = message;
         if (StringUtils.isEmpty(message)) {
@@ -593,7 +593,7 @@ public class ParamsProcessorUtil {
 	public String convertToInternalMeetingId(String extMeetingId) {
 		return DigestUtils.sha1Hex(extMeetingId);
 	}
-	
+
 	public String processPassword(String pass) {
 		return StringUtils.isEmpty(pass) ? RandomStringUtils.randomAlphanumeric(8) : pass;
 	}
@@ -605,39 +605,39 @@ public class ParamsProcessorUtil {
 	public String processTelVoice(String telNum) {
 		return StringUtils.isEmpty(telNum) ? RandomStringUtils.randomNumeric(defaultNumDigitsForTelVoice) : telNum;
 	}
-		
+
 	public String processDialNumber(String dial) {
-		return StringUtils.isEmpty(dial) ? defaultDialAccessNumber : dial;	
+		return StringUtils.isEmpty(dial) ? defaultDialAccessNumber : dial;
 	}
-	
+
 	public String processLogoutUrl(String logoutUrl) {
 		if (StringUtils.isEmpty(logoutUrl)) {
 	        if ((StringUtils.isEmpty(defaultLogoutUrl)) || "default".equalsIgnoreCase(defaultLogoutUrl)) {
         		return defaultServerUrl;
         	} else {
         		return defaultLogoutUrl;
-        	}	
+        	}
 		}
-		
+
 		return logoutUrl;
 	}
-	
+
 	public boolean processRecordMeeting(String record) {
 		// The administrator has turned off recording for all meetings.
 		if (disableRecordingDefault) {
 			log.info("Recording is turned OFF by default.");
 			return false;
 		}
-		
-		boolean rec = false;			
+
+		boolean rec = false;
 		if(! StringUtils.isEmpty(record)){
 			try {
 				rec = Boolean.parseBoolean(record);
-			} catch(Exception ex){ 
+			} catch(Exception ex){
 				rec = false;
 			}
 		}
-		
+
 		return rec;
 	}
 
@@ -651,28 +651,28 @@ public class ParamsProcessorUtil {
 
 		return html5InstanceId;
 	}
-		
+
 	public int processMaxUser(String maxUsers) {
 		int mUsers = -1;
-		
+
 		try {
 			mUsers = Integer.parseInt(maxUsers);
-		} catch(Exception ex) { 
+		} catch(Exception ex) {
 			mUsers = defaultMaxUsers;
-		}		
-		
+		}
+
 		return mUsers;
-	}	
+	}
 
   public int processMeetingDuration(String duration) {
     int mDuration = -1;
-    
+
     try {
       mDuration = Integer.parseInt(duration);
-    } catch(Exception ex) { 
+    } catch(Exception ex) {
       mDuration = defaultMeetingDuration;
-    }   
-    
+    }
+
     return mDuration;
   }
 
@@ -692,7 +692,7 @@ public class ParamsProcessorUtil {
         return ((!StringUtils.isEmpty(telVoice)) && (!StringUtils.isEmpty(testVoiceBridge))
                 && (telVoice.equals(testVoiceBridge)));
     }
-		
+
     public String getIntMeetingIdForTestMeeting(String telVoice) {
         if ((testVoiceBridge != null) && (testVoiceBridge.equals(telVoice))
                 && StringUtils.isEmpty(testConferenceMock)) {
@@ -732,9 +732,9 @@ public class ParamsProcessorUtil {
 			return false;
 		}
 
-		return true; 
+		return true;
 	}
-	
+
 	public boolean isPostChecksumSame(String apiCall, Map<String, String[]> params) {
 		if (StringUtils.isEmpty(securitySalt)) {
 			log.warn("Security is disabled in this service. Make sure this is intentional.");
@@ -743,9 +743,9 @@ public class ParamsProcessorUtil {
 
 		StringBuilder csbuf = new StringBuilder();
 		csbuf.append(apiCall);
- 
+
 		SortedSet<String> keys = new TreeSet<>(params.keySet());
- 
+
 		boolean first = true;
 		String checksum = null;
 		for (String key: keys) {
@@ -754,7 +754,7 @@ public class ParamsProcessorUtil {
 				checksum = params.get(key)[0];
 				continue;
 			}
- 
+
 			for (String value: params.get(key)) {
 				if (first) {
 					first = false;
@@ -766,26 +766,26 @@ public class ParamsProcessorUtil {
 				String encResult;
 
 				encResult = value;
-				
+
 /*****
  * Seems like Grails 2.3.6 decodes the string. So we need to re-encode it.
- * We'll remove this later. richard (aug 5, 2014)						
-*/				try {       
+ * We'll remove this later. richard (aug 5, 2014)
+*/				try {
 					// we need to re-encode the values because Grails unencoded it
 					// when it received the 'POST'ed data. Might not need to do in a GET request.
-					encResult = URLEncoder.encode(value, StandardCharsets.UTF_8.name());  
-				} catch (UnsupportedEncodingException e) {       
-					encResult = value;     
-				} 					
+					encResult = URLEncoder.encode(value, StandardCharsets.UTF_8.name());
+				} catch (UnsupportedEncodingException e) {
+					encResult = value;
+				}
 
 				csbuf.append(encResult);
 			}
 		}
 		csbuf.append(securitySalt);
 
-		String baseString = csbuf.toString();				
+		String baseString = csbuf.toString();
 		String cs = DigestUtils.sha1Hex(baseString);
-		
+
 		if (cs == null || !cs.equals(checksum)) {
 			log.info("POST basestring = {}", baseString);
 			log.info("checksumError: failed checksum. our checksum: [{}], client: [{}]", cs, checksum);
@@ -798,7 +798,7 @@ public class ParamsProcessorUtil {
 	/*************************************************
 	 * Setters
 	 ************************************************/
-	
+
 	public void setApiVersion(String apiVersion) {
 		this.apiVersion = apiVersion;
 	}
@@ -806,7 +806,7 @@ public class ParamsProcessorUtil {
 	public void setServiceEnabled(boolean e) {
 		serviceEnabled = e;
 	}
-	
+
 	public void setSecuritySalt(String securitySalt) {
 		this.securitySalt = securitySalt;
 	}
@@ -818,7 +818,7 @@ public class ParamsProcessorUtil {
 	public void setDefaultWelcomeMessage(String defaultWelcomeMessage) {
 		this.defaultWelcomeMessage = defaultWelcomeMessage;
 	}
-	
+
 	public void setDefaultWelcomeMessageFooter(String defaultWelcomeMessageFooter) {
 	    this.defaultWelcomeMessageFooter = defaultWelcomeMessageFooter;
 	}
@@ -866,7 +866,7 @@ public class ParamsProcessorUtil {
 	public void setDisableRecordingDefault(boolean disabled) {
 		this.disableRecordingDefault = disabled;
 	}
-	
+
 	public void setAutoStartRecording(boolean start) {
 		this.autoStartRecording = start;
 	}
@@ -874,11 +874,11 @@ public class ParamsProcessorUtil {
     public void setAllowStartStopRecording(boolean allowStartStopRecording) {
         this.allowStartStopRecording = allowStartStopRecording;
     }
-	
+
     public void setWebcamsOnlyForModerator(boolean webcamsOnlyForModerator) {
         this.webcamsOnlyForModerator = webcamsOnlyForModerator;
     }
-	
+
 	public void setUseDefaultAvatar(Boolean value) {
 		this.useDefaultAvatar = value;
 	}
@@ -910,7 +910,7 @@ public class ParamsProcessorUtil {
 	public void setMeetingExpireIfNoUserJoinedInMinutes(Integer value) {
 		meetingExpireIfNoUserJoinedInMinutes = value;
 	}
-	
+
 	public Integer getUserInactivityInspectTimerInMinutes() {
         return userInactivityInspectTimerInMinutes;
     }
@@ -918,7 +918,7 @@ public class ParamsProcessorUtil {
     public void setUserInactivityInspectTimerInMinutes(Integer userInactivityInspectTimerInMinutes) {
         this.userInactivityInspectTimerInMinutes = userInactivityInspectTimerInMinutes;
     }
-    
+
     public Integer getUserInactivityThresholdInMinutes() {
         return userInactivityThresholdInMinutes;
     }
@@ -970,7 +970,7 @@ public class ParamsProcessorUtil {
 		} catch (UnsupportedEncodingException e) {
 			log.error("Couldn't decode the IDs");
 		}
-		
+
 		return ids;
 	}
 
@@ -981,7 +981,7 @@ public class ParamsProcessorUtil {
         }
         return internalMeetingIds;
     }
-	
+
     public Map<String, String> getUserCustomData(Map<String, String> params) {
         Map<String, String> resp = new HashMap<>();
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ParamsUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ParamsUtil.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 public class ParamsUtil {
   private static Logger log = LoggerFactory.getLogger(ParamsUtil.class);
@@ -19,9 +20,13 @@ public class ParamsUtil {
   public static String stripControlChars(String text) {
     return text.replaceAll("\\p{Cc}", "");
   }
-  
+
   public static String stripHTMLTags(String value) {
     return value.replaceAll("\\<.*?>","");
+  }
+
+  public static String escapeHTMLTags(String value) {
+    return StringEscapeUtils.escapeHtml4(value);
   }
 
   public static boolean isValidMeetingId(String meetingId) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ParamsUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ParamsUtil.java
@@ -21,10 +21,6 @@ public class ParamsUtil {
     return text.replaceAll("\\p{Cc}", "");
   }
 
-  public static String stripHTMLTags(String value) {
-    return value.replaceAll("\\<.*?>","");
-  }
-
   public static String escapeHTMLTags(String value) {
     return StringEscapeUtils.escapeHtml4(value);
   }

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/addUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/addUser.js
@@ -3,8 +3,6 @@ import Logger from '/imports/startup/server/logger';
 import Users from '/imports/api/users';
 import Meetings from '/imports/api/meetings';
 import VoiceUsers from '/imports/api/voice-users/';
-import _ from 'lodash';
-import SanitizeHTML from 'sanitize-html';
 import addUserPsersistentData from '/imports/api/users-persistent-data/server/modifiers/addUserPersistentData';
 import stringHash from 'string-hash';
 import flat from 'flat';
@@ -19,14 +17,6 @@ const COLOR_LIST = [
 
 export default function addUser(meetingId, userData) {
   const user = userData;
-  const sanitizedName = SanitizeHTML(userData.name, {
-    allowedTags: [],
-    allowedAttributes: {},
-  });
-  // if user typed only tags
-  user.name = sanitizedName.length === 0
-    ? _.escape(userData.name)
-    : sanitizedName;
 
   check(meetingId, String);
 

--- a/bigbluebutton-html5/imports/ui/components/tooltip/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/tooltip/component.jsx
@@ -48,6 +48,7 @@ class Tooltip extends Component {
 
     const options = {
       aria: null,
+      allowHTML: false,
       animation: animations ? DEFAULT_ANIMATION : ANIMATION_NONE,
       arrow: roundArrow,
       boundary: 'window',
@@ -60,7 +61,7 @@ class Tooltip extends Component {
       placement: position,
       touch: 'hold',
       theme: 'bbbtip',
-      multiple:	false,
+      multiple: false,
       onBeforeUpdate: () => {
         hideAll();
       },

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -280,7 +280,8 @@ class ApiController {
     } else {
       errors.missingParamError("fullName");
     }
-    String fullName = ParamsUtil.stripHTMLTags(params.fullName)
+
+    String fullName = ParamsUtil.stripControlChars(params.fullName)
 
     // Do we have a meeting id? If none, complain.
     if (!StringUtils.isEmpty(params.meetingID)) {


### PR DESCRIPTION
### What does this PR do?

Allow html tags or text between `<>` in meeting and user name

### Closes Issue(s)
closes #10221
closes #12370

#### Meeting name:
![meeting-name-tag](https://user-images.githubusercontent.com/2110278/120197403-498d1e00-c1f7-11eb-8f13-37fd39c5dde4.png)

#### User name:
![user-name-tag](https://user-images.githubusercontent.com/2110278/120197407-4abe4b00-c1f7-11eb-8109-cc221aabb94c.png)

### More:
After discussing about escaping meeting and user name and how to store this information in backend, it was decided to store those values in raw form. e.g: `<strong>Sinforoso</strong>`, and only when the information is needed it will be escaped.