### PR TITLE
fix: navbar z-index - new LM

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -205,7 +205,6 @@ class CustomLayout extends Component {
       height: DEFAULT_VALUES.navBarHeight,
       top,
       left: mediaAreaBounds.left,
-      zIndex: 1,
     };
   }
 
@@ -666,7 +665,6 @@ class CustomLayout extends Component {
         top: navbarBounds.top,
         left: navbarBounds.left,
         tabOrder: DEFAULT_VALUES.navBarTabOrder,
-        zIndex: navbarBounds.zIndex,
       },
     });
 

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -145,7 +145,6 @@ class NavBar extends Component {
               left: style.left,
               height: style.height,
               width: style.width,
-              zIndex: style.zIndex,
             }
             : {
               position: 'relative',


### PR DESCRIPTION
### What does this PR do?

Remove z-index property from navbar in new Layout Manager, to prevent settings dropdown bugs.

#### before
![Screenshot from 2021-05-31 15-38-40](https://user-images.githubusercontent.com/3728706/120230925-b2d85580-c226-11eb-9432-5fcafb863f4c.png) ![Screenshot from 2021-05-31 15-38-47](https://user-images.githubusercontent.com/3728706/120230927-b4098280-c226-11eb-8e08-bdd319d2e442.png)

#### after
![Screenshot from 2021-05-31 15-42-20](https://user-images.githubusercontent.com/3728706/120230980-cdaaca00-c226-11eb-8a70-99dfc4dfb0a4.png)
