### PR TITLE
fix(bbb-conf):Only show status for multi kurento if that is configured

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -420,11 +420,14 @@ display_bigbluebutton_status () {
 
     if [ -f /usr/lib/systemd/system/bbb-html5.service ]; then
         units="$units mongod bbb-html5 bbb-webrtc-sfu kurento-media-server"
-		
+
 	for i in `seq 8888 8890`; do
-          if systemctl is-enabled kurento-media-server-${i}.service > /dev/null; then
-            units="$units kurento-media-server-${i}"
-          fi
+	  # check if multi-kurento setup is configured
+	  if [ -f /usr/lib/systemd/system/kurento-media-server-${i}.service ]; then
+            if systemctl is-enabled kurento-media-server-${i}.service > /dev/null; then
+              units="$units kurento-media-server-${i}"
+            fi
+	  fi
         done
 
 	source /usr/share/meteor/bundle/bbb-html5-with-roles.conf


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Checks whether multiple kurento's per server are set up prior to checking and printing their status

https://github.com/bigbluebutton/bigbluebutton/pull/12372 works great if multiple kurento media servers are set up, but if they are not (default), three lines of warnings are displayed every time we check status / restart BBB / etc
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #12442


### Motivation

<!-- What inspired you to submit this pull request? -->
before:

```
$ bbb-conf --status
Failed to get unit file state for kurento-media-server-8888.service: No such file or directory
Failed to get unit file state for kurento-media-server-8889.service: No such file or directory
Failed to get unit file state for kurento-media-server-8890.service: No such file or directory
nginx —————————————————► [✔ - active]
freeswitch ————————————► [✔ - active]
redis-server ——————————► [✔ - active]
bbb-apps-akka —————————► [✔ - active]
bbb-fsesl-akka ————————► [✔ - active]
tomcat8 ———————————————► [✔ - active]
mongod ————————————————► [✔ - active]
bbb-html5 —————————————► [✔ - active]
bbb-webrtc-sfu ————————► [✔ - active]
kurento-media-server ——► [✔ - active]
bbb-html5-backend@1 ———► [✔ - active]
bbb-html5-backend@2 ———► [✔ - active]
bbb-html5-frontend@1 ——► [✔ - active]
bbb-html5-frontend@2 ——► [✔ - active]
etherpad ——————————————► [✔ - active]
bbb-web ———————————————► [✔ - active]
```

after:

```
$ bbb-conf --status
nginx —————————————————► [✔ - active]
freeswitch ————————————► [✔ - active]
redis-server ——————————► [✔ - active]
bbb-apps-akka —————————► [✔ - active]
bbb-fsesl-akka ————————► [✔ - active]
tomcat8 ———————————————► [✔ - active]
mongod ————————————————► [✔ - active]
bbb-html5 —————————————► [✔ - active]
bbb-webrtc-sfu ————————► [✔ - active]
kurento-media-server ——► [✔ - active]
bbb-html5-backend@1 ———► [✔ - active]
bbb-html5-backend@2 ———► [✔ - active]
bbb-html5-frontend@1 ——► [✔ - active]
bbb-html5-frontend@2 ——► [✔ - active]
etherpad ——————————————► [✔ - active]
bbb-web ———————————————► [✔ - active]
```
### More

<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
