### PR TITLE
fix: different navbar size for locales with large fonts

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/intl.jsx
+++ b/bigbluebutton-html5/imports/startup/client/intl.jsx
@@ -33,6 +33,7 @@ class IntlStartup extends Component {
       Settings.application.isRTL = false;
     }
     Session.set('isLargeFont', LARGE_FONT_LANGUAGES.includes(localeName.substring(0, 2)));
+    window.dispatchEvent(new Event('localeChanged'));
     Settings.save();
   }
 

--- a/bigbluebutton-html5/imports/startup/client/intl.jsx
+++ b/bigbluebutton-html5/imports/startup/client/intl.jsx
@@ -152,9 +152,9 @@ class IntlStartup extends Component {
 
         {normalizedLocale
           && (
-          <IntlProvider locale={normalizedLocale} messages={messages}>
-            {children}
-          </IntlProvider>
+            <IntlProvider locale={normalizedLocale} messages={messages}>
+              {children}
+            </IntlProvider>
           )
         }
       </>

--- a/bigbluebutton-html5/imports/startup/client/intl.jsx
+++ b/bigbluebutton-html5/imports/startup/client/intl.jsx
@@ -6,6 +6,7 @@ import Settings from '/imports/ui/services/settings';
 import LoadingScreen from '/imports/ui/components/loading-screen/component';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import _ from 'lodash';
+import { Session } from 'meteor/session';
 
 const propTypes = {
   locale: PropTypes.string,
@@ -15,6 +16,7 @@ const propTypes = {
 const DEFAULT_LANGUAGE = Meteor.settings.public.app.defaultSettings.application.fallbackLocale;
 
 const RTL_LANGUAGES = ['ar', 'he', 'fa'];
+const LARGE_FONT_LANGUAGES = ['te', 'km'];
 
 const defaultProps = {
   locale: DEFAULT_LANGUAGE,
@@ -30,6 +32,7 @@ class IntlStartup extends Component {
       document.body.parentNode.setAttribute('dir', 'ltr');
       Settings.application.isRTL = false;
     }
+    Session.set('isLargeFont', LARGE_FONT_LANGUAGES.includes(localeName.substring(0, 2)));
     Settings.save();
   }
 

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -28,7 +28,7 @@ import { withDraggableContext } from '../media/webcam-draggable-overlay/context'
 import { styles } from './styles';
 import { makeCall } from '/imports/ui/services/api';
 import ConnectionStatusService from '/imports/ui/components/connection-status/service';
-import { NAVBAR_HEIGHT } from '/imports/ui/components/layout/layout-manager/component';
+import { NAVBAR_HEIGHT, LARGE_NAVBAR_HEIGHT } from '/imports/ui/components/layout/layout-manager/component';
 
 const MOBILE_MEDIA = 'only screen and (max-width: 40em)';
 const APP_CONFIG = Meteor.settings.public.app;
@@ -268,14 +268,16 @@ class App extends Component {
 
   renderNavBar() {
     const { navbar } = this.props;
-
     if (!navbar) return null;
+
+    const isLargeFont = Session.get('isLargeFont');
+    const realNavbarHeight = isLargeFont ? LARGE_NAVBAR_HEIGHT : NAVBAR_HEIGHT;
 
     return (
       <header
         className={styles.navbar}
         style={{
-          height: NAVBAR_HEIGHT,
+          height: realNavbarHeight,
         }}
       >
         {navbar}

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -267,10 +267,9 @@ class App extends Component {
   }
 
   renderNavBar() {
-    const { navbar } = this.props;
+    const { navbar, isLargeFont } = this.props;
     if (!navbar) return null;
 
-    const isLargeFont = Session.get('isLargeFont');
     const realNavbarHeight = isLargeFont ? LARGE_NAVBAR_HEIGHT : NAVBAR_HEIGHT;
 
     return (

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -124,6 +124,7 @@ export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) 
     randomlySelectedUser,
     currentUserId: currentUser.userId,
     isPresenter: currentUser.presenter,
+    isLargeFont: Session.get('isLargeFont')
   };
 })(AppContainer)));
 

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/component.jsx
@@ -110,6 +110,10 @@ class LayoutManagerComponent extends Component {
     window.addEventListener('fullscreenchange', () => {
       setTimeout(() => this.setLayoutSizes(), 200);
     });
+
+    window.addEventListener('localeChanged', () => {
+      this.setLayoutSizes();
+    });
   }
 
   componentDidUpdate(prevProps) {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/component.jsx
@@ -24,7 +24,8 @@ const NOTE_MIN_WIDTH = 340;
 const NOTE_MAX_WIDTH = 800;
 const WAITING_MIN_WIDTH = 340;
 const WAITING_MAX_WIDTH = 800;
-const NAVBAR_HEIGHT = 170;
+const LARGE_NAVBAR_HEIGHT = 170;
+const NAVBAR_HEIGHT = 112;
 const ACTIONSBAR_HEIGHT = isMobile ? 50 : 42;
 const BREAKOUT_MIN_WIDTH = 320;
 const BREAKOUT_MAX_WIDTH = 400;
@@ -763,12 +764,15 @@ class LayoutManagerComponent extends Component {
       secondPanel = newBreakoutRoomSize;
     }
 
-    const mediaAreaHeight = windowHeight() - (NAVBAR_HEIGHT + ACTIONSBAR_HEIGHT) - 10;
+    const isLargeFont = Session.get('isLargeFont');
+    const realNavbarHeight = isLargeFont ? LARGE_NAVBAR_HEIGHT : NAVBAR_HEIGHT;
+
+    const mediaAreaHeight = windowHeight() - (realNavbarHeight + ACTIONSBAR_HEIGHT) - 10;
     const mediaAreaWidth = windowWidth() - (firstPanel.width + secondPanel.width);
     const newMediaBounds = {
       width: mediaAreaWidth,
       height: mediaAreaHeight,
-      top: NAVBAR_HEIGHT,
+      top: realNavbarHeight,
       left: firstPanel.width + secondPanel.width,
     };
 
@@ -838,6 +842,7 @@ export {
   WAITING_MIN_WIDTH,
   WAITING_MAX_WIDTH,
   NAVBAR_HEIGHT,
+  LARGE_NAVBAR_HEIGHT,
   ACTIONSBAR_HEIGHT,
   WEBCAMSAREA_MIN_PERCENT,
   WEBCAMSAREA_MAX_PERCENT,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/component.jsx
@@ -106,7 +106,7 @@ class LayoutManagerComponent extends Component {
     window.addEventListener('webcamPlacementChange', () => {
       this.setLayoutSizes(false, false, true);
     });
-    
+
     window.addEventListener('fullscreenchange', () => {
       setTimeout(() => this.setLayoutSizes(), 200);
     });


### PR DESCRIPTION
### What does this PR do?

Changes the value of navbar height based on the current locale. Locales with large fonts (`te` and `km`) will have a different value.

#### Additional information 
Navbar size impacts on the size of the presentation, so this PR tries to reduce the presentation size impact by only using the `LARGE_NAVBAR_HEIGHT` when needed.