### PR TITLE
fix: improve "meeting ended by user" message

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
@@ -220,17 +220,13 @@ class MeetingEnded extends PureComponent {
         <div className={styles.modal}>
           <div className={styles.content}>
             <h1 className={styles.title} data-test="meetingEndedModalTitle">
-              {
-                intl.formatMessage(intlMessage[code] || intlMessage[430])
-              }
+              {this.meetingEndedBy
+                ? intl.formatMessage(intlMessage.messageEndedByUser, { 0: this.meetingEndedBy })
+                : intl.formatMessage(intlMessage[code] || intlMessage[430])}
             </h1>
             {!allowRedirectToLogoutURL() ? null : (
               <div>
-                {this.meetingEndedBy ? (
-                  <div className={styles.text}>
-                    {intl.formatMessage(intlMessage.messageEndedByUser, { 0: this.meetingEndedBy })}
-                  </div>
-                ) : null}
+
                 <div className={styles.text}>
                   {intl.formatMessage(intlMessage.messageEnded)}
                 </div>
@@ -294,7 +290,7 @@ class MeetingEnded extends PureComponent {
                   />
                 ) : null}
               </div>
-            ) : null }
+            ) : null}
             {noRating && allowRedirectToLogoutURL() ? (
               <Button
                 color="primary"

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -139,7 +139,7 @@
     "app.meeting.ended": "This session has ended",
     "app.meeting.meetingTimeRemaining": "Meeting time remaining: {0}",
     "app.meeting.meetingTimeHasEnded": "Time ended. Meeting will close soon",
-    "app.meeting.endedByUserMessage": "The meeting was ended by {0}",
+    "app.meeting.endedByUserMessage": "This session was ended by {0}",
     "app.meeting.endedMessage": "You will be forwarded back to the home screen",
     "app.meeting.alertMeetingEndsUnderMinutesSingular": "Meeting is closing in one minute.",
     "app.meeting.alertMeetingEndsUnderMinutesPlural": "Meeting is closing in {0} minutes.",


### PR DESCRIPTION
### What does this PR do?

Improves the message displayed when a meeting is ended by a moderator.

#### before
![Screenshot from 2021-06-04 13-42-46](https://user-images.githubusercontent.com/3728706/120835488-c4797000-c53a-11eb-97e7-a5079f83b89e.png)

#### after
![Screenshot from 2021-06-04 13-35-52](https://user-images.githubusercontent.com/3728706/120835502-c80cf700-c53a-11eb-8666-607c2184839d.png)

### Closes Issue(s)
Closes #12515