### PR TITLE
fix(poll): fix client crash with A-F as options and quick-poll type

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -80,7 +80,6 @@ const getAvailableQuickPolls = (slideId, parsedSlides, startPoll, intl, pollType
       itemLabel = options.join('/').replace(/[\n.)]/g, '');
     } else {
       answers = getLocalizedAnswers(type, intl, pollTypes);
-      type = pollTypes.Custom;
     }
 
     // removes any whitespace from the label

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -43,30 +43,7 @@ const propTypes = {
   amIPresenter: PropTypes.bool.isRequired,
 };
 
-const getLocalizedAnswers = (type, intl, pollTypes) => {
-  switch (type) {
-    case pollTypes.TrueFalse:
-      return [
-        intl.formatMessage(intlMessages.trueOptionLabel),
-        intl.formatMessage(intlMessages.falseOptionLabel),
-      ];
-    case pollTypes.YesNo:
-      return [
-        intl.formatMessage(intlMessages.yesOptionLabel),
-        intl.formatMessage(intlMessages.noOptionLabel),
-      ];
-    case pollTypes.YesNoAbstention:
-      return [
-        intl.formatMessage(intlMessages.yesOptionLabel),
-        intl.formatMessage(intlMessages.noOptionLabel),
-        intl.formatMessage(intlMessages.abstentionOptionLabel),
-      ];
-    default:
-      return null;
-  }
-};
-
-const getAvailableQuickPolls = (slideId, parsedSlides, startPoll, intl, pollTypes) => {
+const getAvailableQuickPolls = (slideId, parsedSlides, startPoll, pollTypes) => {
   const pollItemElements = parsedSlides.map((poll) => {
     let { poll: label, type } = poll;
     let itemLabel = label;
@@ -78,8 +55,6 @@ const getAvailableQuickPolls = (slideId, parsedSlides, startPoll, intl, pollType
     {
       const { options } = itemLabel;
       itemLabel = options.join('/').replace(/[\n.)]/g, '');
-    } else {
-      answers = getLocalizedAnswers(type, intl, pollTypes);
     }
 
     // removes any whitespace from the label
@@ -148,14 +123,6 @@ class QuickPollDropdown extends Component {
     if (quickPolls.length === 1 && quickPollOptions.length) {
       const { type } = quickPollOptions[0];
       singlePollType = type;
-    }
-
-    if (singlePollType === pollTypes.TrueFalse || 
-        singlePollType === pollTypes.YesNo || 
-        singlePollType === pollTypes.YesNoAbstention) 
-    {
-      answers = getLocalizedAnswers(singlePollType, intl, pollTypes);
-      singlePollType = pollTypes.Custom;
     }
 
     let btn = (

--- a/bigbluebutton-html5/imports/ui/components/poll/service.js
+++ b/bigbluebutton-html5/imports/ui/components/poll/service.js
@@ -95,7 +95,9 @@ const getPollResultsText = (isDefaultPoll, answers, numRespondents, intl) => {
     const pctBars = "|".repeat(pct * MAX_POLL_RESULT_BARS / 100);
     const pctFotmatted = `${Number.isNaN(pct) ? 0 : pct}%`;
     if (isDefaultPoll) {
-      const translatedKey = intl.formatMessage(pollAnswerIds[item.key.toLowerCase()]);
+      const translatedKey = pollAnswerIds[item.key.toLowerCase()] 
+        ? intl.formatMessage(pollAnswerIds[item.key.toLowerCase()])
+        : item.key;
       resultString += `${translatedKey}: ${item.numVotes || 0} |${pctBars} ${pctFotmatted}\n`;
     } else {
       resultString += `${item.id+1}: ${item.numVotes || 0} |${pctBars} ${pctFotmatted}\n`;


### PR DESCRIPTION
### What does this PR do?

 Fix client crash with A-F options due to missing translation.
Correctly set poll type for YN/YNA/TF quick polls.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #12531


