### PR TITLE
feat: emphasize moderator messages in public chat

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/component.jsx
@@ -13,6 +13,8 @@ import { styles } from './styles';
 const CHAT_CONFIG = Meteor.settings.public.chat;
 const CHAT_CLEAR_MESSAGE = CHAT_CONFIG.system_messages_keys.chat_clear;
 const CHAT_POLL_RESULTS_MESSAGE = CHAT_CONFIG.system_messages_keys.chat_poll_result;
+const CHAT_PUBLIC_ID = CHAT_CONFIG.public_id;
+const CHAT_EMPHASIZE_TEXT = CHAT_CONFIG.moderatorChatEmphasized;
 
 const propTypes = {
   user: PropTypes.shape({
@@ -128,6 +130,9 @@ class TimeWindowChatItem extends PureComponent {
     const regEx = /<a[^>]+>/i;
     ChatLogger.debug('TimeWindowChatItem::renderMessageItem', this.props);
     const defaultAvatarString = name?.toLowerCase().slice(0, 2) || "  ";
+    const emphasizedTextClass = isModerator && CHAT_EMPHASIZE_TEXT && chatId === CHAT_PUBLIC_ID ?
+      styles.emphasizedMessage : null;
+
     return (
       <div className={styles.item} key={`time-window-${messageKey}`}>
         <div className={styles.wrapper}>
@@ -160,7 +165,9 @@ class TimeWindowChatItem extends PureComponent {
             <div className={styles.messages}>
               {messages.map(message => (
                 <MessageChatItem
-                  className={(regEx.test(message.text) ? styles.hyperlink : styles.message)}
+                  className={regEx.test(message.text) ?
+                    cx(styles.hyperlink, emphasizedTextClass) :
+                    cx(styles.message, emphasizedTextClass)}
                   key={message.id}
                   text={message.text}
                   time={message.time}

--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/styles.scss
@@ -171,3 +171,7 @@
   padding-left: 1rem;
   margin-top: var(--chat-poll-margin-sm) !important;
 }
+
+.emphasizedMessage{
+  font-weight: bold;
+}

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -416,6 +416,7 @@ public:
       chat_poll_result: PUBLIC_CHAT_POLL_RESULT
     typingIndicator:
       enabled: true
+    moderatorChatEmphasized: true
   note:
     enabled: true
     url: ETHERPAD_HOST


### PR DESCRIPTION
### What does this PR do?

Adds `chat.moderatorChatEmphasized` in settings.yml (default: `true`). 
Setting it to `true` makes moderators messages **bold** in public chat.

#### before
![Screenshot from 2021-06-08 09-10-34](https://user-images.githubusercontent.com/3728706/121182411-71a10080-c839-11eb-8b78-a2bf98cacfba.png)

#### after
![Screenshot from 2021-06-08 09-10-13](https://user-images.githubusercontent.com/3728706/121182408-706fd380-c839-11eb-9462-c008e7d2b9f2.png)
