### PR TITLE
fix: Preload fonts

### DIFF
--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -83,6 +83,17 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
   <script src="compatibility/adapter.js?v=VERSION" language="javascript"></script>
   <script src="compatibility/sip.js?v=VERSION" language="javascript"></script>
   <script src="compatibility/kurento-utils.js?v=VERSION" language="javascript"></script>
+  <!-- fonts -->
+  <link rel="preload" href="fonts/BbbIcons/bbb-icons.woff?j1ntjp" as="font" crossorigin="anonymous"/>
+  <link rel="preload" href="fonts/SourceSansPro/SourceSansPro-Light.woff" as="font" crossorigin="anonymous"/>
+  <link rel="preload" href="fonts/SourceSansPro/SourceSansPro-Regular.woff" as="font" crossorigin="anonymous"/>
+  <link rel="preload" href="fonts/SourceSansPro/SourceSansPro-Semibold.woff" as="font" crossorigin="anonymous"/>
+  <link rel="preload" href="fonts/SourceSansPro/SourceSansPro-Bold.woff" as="font" crossorigin="anonymous"/>
+  <link rel="preload" href="fonts/SourceSansPro/SourceSansPro-LightItalic.woff" as="font" crossorigin="anonymous"/>
+  <link rel="preload" href="fonts/SourceSansPro/SourceSansPro-Italic.woff" as="font" crossorigin="anonymous"/>
+  <link rel="preload" href="fonts/SourceSansPro/SourceSansPro-SemiboldItalic.woff" as="font" crossorigin="anonymous"/>
+  <link rel="preload" href="fonts/SourceSansPro/SourceSansPro-BoldItalic.woff" as="font" crossorigin="anonymous"/>
+  <!-- fonts -->
 </head>
 <body style="background-color: #06172A">
   <div id="app" role="document"></div>


### PR DESCRIPTION
### What does this PR do?

The PR changes the font import, placing it in the html to preload them, previously this was made in css which caused the late loading of some elements on screen (such as icons and messages) which caused the need for some workarounds ([sample](https://github.com/bigbluebutton/bigbluebutton/blob/develop/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx#L200)) in the code that can now be removed

### Closes Issue(s)
Currently no one


### More
without preload (icons aren't shown and message changes its size):

https://user-images.githubusercontent.com/15806883/121376207-b602ce00-c917-11eb-8011-d3fd9205cfea.mp4

With preload:

https://user-images.githubusercontent.com/15806883/121376694-1abe2880-c918-11eb-8e0f-3a1a886d492a.mp4




