### PR TITLE
fix: Attendee join with mic-ish permission even though mic is Locked

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -169,10 +169,9 @@ class AudioModal extends Component {
     } = this.props;
 
     if (!isUsingAudio) {
-      if (forceListenOnlyAttendee) return this.handleJoinListenOnly();
+      if (forceListenOnlyAttendee || audioLocked) return this.handleJoinListenOnly();
 
-      if ((joinFullAudioImmediately && !listenOnlyMode)
-        || audioLocked) return this.handleJoinMicrophone();
+      if (joinFullAudioImmediately && !listenOnlyMode) return this.handleJoinMicrophone();
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

Prevents a condition that would happen to viewers when trying to join audio with `skipCheck` enabled and Lock Viewers -> Share microphone set to `locked`.

### Closes Issue(s)
Closes #12511