### PR TITLE
fix: raise hand notification order

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/status-notifier/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/status-notifier/container.jsx
@@ -30,10 +30,11 @@ export default withTracker((props) => {
     fields: {
       emojiTime: 1, emoji: 1, userId: 1, name: 1, color: 1,
     },
+    sort: { emojiTime: 1 },
   })
     .fetch()
-    .filter(u => u.emoji === status && u.userId !== Auth.userID);
-  const clearUserStatus = userId => makeCall('setEmojiStatus', userId, 'none');
+    .filter((u) => u.emoji === status && u.userId !== Auth.userID);
+  const clearUserStatus = (userId) => makeCall('setEmojiStatus', userId, 'none');
 
   return {
     clearUserStatus,


### PR DESCRIPTION
### What does this PR do?

Makes raise hand notification list names in the correct order. 

### Closes Issue(s)
Closes #12549