### PR TITLE
fix: update trim-newlines dependency

### DIFF
--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -8379,6 +8379,13 @@
         "read-pkg-up": "^1.0.1",
         "redent": "^1.0.0",
         "trim-newlines": "^1.0.0"
+      },
+      "dependencies": {
+        "trim-newlines": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
+          "integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew=="
+        }
       }
     },
     "merge-stream": {
@@ -12138,11 +12145,6 @@
       "requires": {
         "punycode": "^2.1.1"
       }
-    },
-    "trim-newlines": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
     },
     "triple-beam": {
       "version": "1.3.0",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -11,7 +11,8 @@
     "test:recording": "export WITH_RECORD=true;export REGRESSION_TESTING=false;env $(cat tests/puppeteer/.env | xargs)  jest all.test.js --color --detectOpenHandles --forceExit",
     "test-visual-regression": "export REGRESSION_TESTING=true;env $(cat tests/puppeteer/.env | xargs)  jest all.test.js --color --detectOpenHandles --forceExit",
     "test-visual-regression:recording": "export WITH_RECORD=true;export REGRESSION_TESTING=true;env $(cat tests/puppeteer/.env | xargs)  jest all.test.js --color --detectOpenHandles --forceExit",
-    "lint": "eslint . --ext .jsx,.js"
+    "lint": "eslint . --ext .jsx,.js",
+    "preinstall": "npx npm-force-resolutions"
   },
   "meteor": {
     "mainModule": {
@@ -100,6 +101,9 @@
     "postcss-modules-values": "1.3.0",
     "puppeteer": "3.0.0",
     "sha1": "^1.1.1"
+  },
+  "resolutions": {
+    "trim-newlines": "^4.0.1"
   },
   "cssModules": {
     "cssClassNamingConvention": {


### PR DESCRIPTION
### What does this PR do?

Use `npm-force-resolutions` to force update dependency `trim-newlines` and remove vulnerability (https://www.npmjs.com/advisories/1753)