### PR TITLE
fix: check for presenter status at presentation upload modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -295,6 +295,10 @@ class PresentationUploader extends Component {
     }
   }
 
+  componentWillUnmount() {
+    Session.set('showUploadPresentationView', false);
+  }
+
   isDefault(presentation) {
     const { defaultFileName } = this.props;
     return presentation.filename === defaultFileName
@@ -312,8 +316,8 @@ class PresentationUploader extends Component {
     const validExtentions = fileValidMimeTypes.map((fileValid) => fileValid.extension);
     const [accepted, rejected] = _.partition(files
       .concat(files2), (f) => (
-      validMimes.includes(f.type) || validExtentions.includes(`.${f.name.split('.').pop()}`)
-    ));
+        validMimes.includes(f.type) || validExtentions.includes(`.${f.name.split('.').pop()}`)
+      ));
 
     const presentationsToUpload = accepted.map((file) => {
       const id = _.uniqueId(file.name);

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/container.jsx
@@ -4,9 +4,8 @@ import { withTracker } from 'meteor/react-meteor-data';
 import ErrorBoundary from '/imports/ui/components/error-boundary/component';
 import FallbackModal from '/imports/ui/components/fallback-errors/fallback-modal/component';
 import Service from './service';
+import PresentationService from '../service';
 import PresentationUploader from './component';
-import { withUsersConsumer } from '/imports/ui/components/components-data/users-context/context';
-import Auth from '/imports/ui/services/auth';
 
 const PRESENTATION_CONFIG = Meteor.settings.public.presentation;
 
@@ -19,15 +18,13 @@ const PresentationUploaderContainer = (props) => (
   )
 );
 
-export default withUsersConsumer(withTracker(({ users }) => {
+export default withTracker(() => {
   const currentPresentations = Service.getPresentations();
   const {
     dispatchDisableDownloadable,
     dispatchEnableDownloadable,
     dispatchTogglePresentationDownloadable,
   } = Service;
-
-  const currentUser = users[Auth.meetingID][Auth.userID];
 
   return {
     presentations: currentPresentations,
@@ -44,6 +41,6 @@ export default withUsersConsumer(withTracker(({ users }) => {
     dispatchTogglePresentationDownloadable,
     isOpen: Session.get('showUploadPresentationView') || false,
     selectedToBeNextCurrent: Session.get('selectedToBeNextCurrent') || null,
-    isPresenter: currentUser.presenter,
+    isPresenter: PresentationService.isPresenter('DEFAULT_PRESENTATION_POD'),
   };
-})(PresentationUploaderContainer));
+})(PresentationUploaderContainer);

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/container.jsx
@@ -4,27 +4,30 @@ import { withTracker } from 'meteor/react-meteor-data';
 import ErrorBoundary from '/imports/ui/components/error-boundary/component';
 import FallbackModal from '/imports/ui/components/fallback-errors/fallback-modal/component';
 import Service from './service';
-import PresentationService from '../service';
 import PresentationUploader from './component';
+import { withUsersConsumer } from '/imports/ui/components/components-data/users-context/context';
+import Auth from '/imports/ui/services/auth';
 
 const PRESENTATION_CONFIG = Meteor.settings.public.presentation;
 
 const PresentationUploaderContainer = (props) => (
   props.isPresenter
   && (
-  <ErrorBoundary Fallback={() => <FallbackModal />}>
-    <PresentationUploader {...props} />
-  </ErrorBoundary>
+    <ErrorBoundary Fallback={() => <FallbackModal />}>
+      <PresentationUploader {...props} />
+    </ErrorBoundary>
   )
 );
 
-export default withTracker(() => {
+export default withUsersConsumer(withTracker(({ users }) => {
   const currentPresentations = Service.getPresentations();
   const {
     dispatchDisableDownloadable,
     dispatchEnableDownloadable,
     dispatchTogglePresentationDownloadable,
   } = Service;
+
+  const currentUser = users[Auth.meetingID][Auth.userID];
 
   return {
     presentations: currentPresentations,
@@ -41,6 +44,6 @@ export default withTracker(() => {
     dispatchTogglePresentationDownloadable,
     isOpen: Session.get('showUploadPresentationView') || false,
     selectedToBeNextCurrent: Session.get('selectedToBeNextCurrent') || null,
-    isPresenter: PresentationService.isPresenter('DEFAULT_PRESENTATION_POD'),
+    isPresenter: currentUser.presenter,
   };
-})(PresentationUploaderContainer);
+})(PresentationUploaderContainer));

--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -155,17 +155,12 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
 };
 
 const isPresenter = (podId) => {
-  // a main presenter in the meeting always owns a default pod
-  if (podId !== 'DEFAULT_PRESENTATION_POD') {
-    // if a pod is not default, then we check whether this user owns a current pod
-    const selector = {
-      meetingId: Auth.meetingID,
-      podId,
-    };
-    const pod = PresentationPods.findOne(selector);
-    return pod.currentPresenterId === Auth.userID;
-  }
-  return true;
+  const selector = {
+    meetingId: Auth.meetingID,
+    podId,
+  };
+  const pod = PresentationPods.findOne(selector);
+  return pod?.currentPresenterId === Auth.userID;
 };
 
 export default {


### PR DESCRIPTION
### What does this PR do?

Fix for the `isPresenter` check at presentation upload modal.

The modal will now only be mounted if the current user is the presenter, preventing [a bug mentioned in issue #12532](https://github.com/bigbluebutton/bigbluebutton/issues/12532#issuecomment-859737404):
If a presenter opens the presentation upload modal and another moderator presses "Take presenter" button, the upload modal won't close for the first user.