### PR TITLE
feat(video): indicate who is sharing webcam

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -10,6 +10,7 @@ import { makeCall } from '/imports/ui/services/api';
 import _ from 'lodash';
 import KEY_CODES from '/imports/utils/keyCodes';
 import AudioService from '/imports/ui/components/audio/service';
+import VideoService from '/imports/ui/components/video-provider/service';
 import logger from '/imports/startup/client/logger';
 import WhiteboardService from '/imports/ui/components/whiteboard/service';
 import { Session } from 'meteor/session';
@@ -178,6 +179,19 @@ const addWhiteboardAccess = (users) => {
   });
 };
 
+const addIsSharingWebcam = (users) => {
+  const usersId = VideoService.getUsersIdFromVideoStreams();
+
+  return users.map((user) => {
+    const isSharingWebcam = usersId.includes(user.userId);
+
+    return {
+      ...user,
+      isSharingWebcam,
+    };
+  });
+};
+
 const getUsers = () => {
   let users = Users
     .find({
@@ -195,7 +209,7 @@ const getUsers = () => {
     }
   }
 
-  return addWhiteboardAccess(users).sort(sortUsers);
+  return addIsSharingWebcam(addWhiteboardAccess(users)).sort(sortUsers);
 };
 
 const getUserCount = () => Users.find({ meetingId: Auth.meetingID }).count();

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-name/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-name/component.jsx
@@ -33,6 +33,10 @@ const messages = defineMessages({
     id: 'app.userList.menuTitleContext',
     description: 'adds context to userListItem menu title',
   },
+  sharingWebcam: {
+    id: 'app.userList.sharingWebcam',
+    description: 'Text for identifying who is sharing webcam',
+  },
   userAriaLabel: {
     id: 'app.userList.userAriaLabel',
     description: 'aria label for each user in the userlist',
@@ -73,10 +77,25 @@ const UserName = (props) => {
 
   const userNameSub = [];
 
+  if (compact) {
+    return null;
+  }
+
+  if (user.isSharingWebcam && LABEL.sharingWebcam) {
+    userNameSub.push(
+      <span>
+        <Icon iconName="video" />
+        &nbsp;
+        {intl.formatMessage(messages.sharingWebcam)}
+      </span>,
+    );
+  }
+
   if (isThisMeetingLocked && user.locked && user.role !== ROLE_MODERATOR) {
     userNameSub.push(
       <span>
         <Icon iconName="lock" />
+        &nbsp;
         {intl.formatMessage(messages.locked)}
       </span>,
     );

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -379,6 +379,15 @@ class VideoService {
     return [...paginatedStreams, ...mine];
   }
 
+  getUsersIdFromVideoStreams() {
+    const usersId = VideoStreams.find(
+      { meetingId: Auth.meetingID },
+      { fields: { userId: 1 } },
+    ).fetch().map(user => user.userId);
+
+    return usersId;
+  }
+
   getVideoStreams() {
     const pageSize = this.getMyPageSize();
     const isPaginationDisabled = !this.isPaginationEnabled() || pageSize === 0;
@@ -842,5 +851,6 @@ export default {
   getPreviousVideoPage: () => videoService.getPreviousVideoPage(),
   getNextVideoPage: () => videoService.getNextVideoPage(),
   getPageChangeDebounceTime: () => { return PAGE_CHANGE_DEBOUNCE_TIME },
+  getUsersIdFromVideoStreams: () => videoService.getUsersIdFromVideoStreams(),
   shouldRenderPaginationToggle: () => videoService.shouldRenderPaginationToggle(),
 };

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -533,6 +533,7 @@ public:
       moderator: false
       mobile: true
       guest: true
+      sharingWebcam: true
   whiteboard:
     annotationsQueueProcessInterval: 60
     cursorInterval: 150

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -73,6 +73,7 @@
     "app.userList.moderator": "Moderator",
     "app.userList.mobile": "Mobile",
     "app.userList.guest": "Guest",
+    "app.userList.sharingWebcam": "Webcam",
     "app.userList.menuTitleContext": "Available options",
     "app.userList.chatListItem.unreadSingular": "{0} New Message",
     "app.userList.chatListItem.unreadPlural": "{0} New Messages",


### PR DESCRIPTION
Add the `camera` icon in the user list for whoever is sharing,
in order to improve the understanding of who is sharing the webcam.
It is possible to enable/disable this indication in the settings.yml

![Screenshot 2021-06-12 at 13-39-07 BigBlueButton - random-328316](https://user-images.githubusercontent.com/1778398/121783304-2877e600-cb84-11eb-8fa6-b6ebac92dd9e.png)

Closes #12479

cc @frankemax 