### PR TITLE
fix(poll): remove wrong argument in quick-polls

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -108,7 +108,7 @@ class QuickPollDropdown extends Component {
     );
 
     const { slideId, quickPollOptions } = parsedSlide;
-    const quickPolls = getAvailableQuickPolls(slideId, quickPollOptions, startPoll, intl, pollTypes);
+    const quickPolls = getAvailableQuickPolls(slideId, quickPollOptions, startPoll, pollTypes);
 
     if (quickPollOptions.length === 0) return null;
 


### PR DESCRIPTION

### What does this PR do?

Fix wrong extra argument in quick-polls (introduced in https://github.com/bigbluebutton/bigbluebutton/pull/12534/)

