### PR TITLE
style(layout): download presentation button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/fullscreen-button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/fullscreen-button/styles.scss
@@ -6,6 +6,7 @@
   cursor: pointer;
   border: 0;
   z-index: 2;
+  margin: 2px;
 
   [dir="rtl"] & {
     right: auto;

--- a/bigbluebutton-html5/imports/ui/components/presentation/download-presentation-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/download-presentation-button/component.jsx
@@ -23,21 +23,31 @@ const defaultProps = {
 };
 
 const DownloadPresentationButton = ({
-  intl, handleDownloadPresentation, dark,
-}) => (
-  <div className={cx(styles.wrapper, dark ? styles.dark : styles.light)}>
-    <Button
-      color="default"
-      icon="template_download"
-      size="md"
-      onClick={handleDownloadPresentation}
-      label={intl.formatMessage(intlMessages.downloadPresentationButton)}
-      hideLabel
-      circle
-      className={styles.button}
-    />
-  </div>
-);
+  intl,
+  handleDownloadPresentation,
+  dark,
+}) => {
+
+  const wrapperClassName = cx({
+    [styles.wrapper]: true,
+    [styles.dark]: dark,
+    [styles.light]: !dark
+  });
+
+  return (
+    <div className={wrapperClassName}>
+      <Button
+        color="default"
+        icon="template_download"
+        size="sm"
+        onClick={handleDownloadPresentation}
+        label={intl.formatMessage(intlMessages.downloadPresentationButton)}
+        hideLabel
+        className={cx(styles.button, styles.downloadPresentationButton)}
+      />
+    </div>
+  );
+};
 
 DownloadPresentationButton.propTypes = propTypes;
 DownloadPresentationButton.defaultProps = defaultProps;

--- a/bigbluebutton-html5/imports/ui/components/presentation/download-presentation-button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/presentation/download-presentation-button/styles.scss
@@ -1,41 +1,72 @@
 .wrapper {
   position: absolute;
-  left: 0;
   right: auto;
+  left: 0;
   background-color: var(--color-transparent);
   cursor: pointer;
-  border: none !important;
+  border: 0;
+  z-index: 2;
+  margin: 2px;
+  bottom: 0;
 
   [dir="rtl"] & {
-    left: auto;
-    right: 0;
+    right: 0;//auto;
+    left : auto;//0;
+  }
+
+  [class*="presentationZoomControls"] & {
+    position: relative !important;
   }
 }
 
 .button {
-  span, span:active, span:hover {
+
+  &,
+  &:active,
+  &:hover,
+  &:focus {
     background-color: var(--color-transparent) !important;
     border: none !important;
+
     i {
       border: none !important;
       background-color: var(--color-transparent) !important;
-      font-weight: bold !important;
     }
   }
 }
 
 .light {
-  top: 0;
+  background-color: var(--color-transparent);
 }
 
-.light .button span i {
-  color: var(--color-white);
+.light .button i {
+  color: var(--color-black);
 }
 
 .dark {
+  background-color: rgba(0,0,0,.3);
+}
+
+.dark .button i {
+  color: var(--color-white);
+}
+
+.top{
+  top: 0;
+}
+
+.bottom{
   bottom: 0;
 }
 
-.dark .button span i {
-  color: var(--color-black);
+.downloadPresentationButton {
+  padding: 5px;
+
+  &:hover {
+    border: 0;
+  }
+
+  i {
+    font-size: 1rem;
+  }
 }

--- a/bigbluebutton-html5/imports/ui/components/screenshare/switch-button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/switch-button/styles.scss
@@ -8,6 +8,7 @@
   cursor: pointer;
   border: 0;
   z-index: 2;
+  margin: 2px;
 
   [dir="rtl"] & {
     right: auto;


### PR DESCRIPTION
Add fullscreen presentation button style to download presentation
button.
![Screenshot 2021-06-14 at 15-06-01 BigBlueButton - random-6536694](https://user-images.githubusercontent.com/1778398/121938730-8e9a6f80-cd22-11eb-971b-a0f6ae660654.png)
Adds margin to presentation and screenshare buttons
in order to prevent outline cut.
![Screenshot 2021-06-14 at 15-07-04 BigBlueButton - random-6536694](https://user-images.githubusercontent.com/1778398/121938774-9d812200-cd22-11eb-9980-749a8120f434.png)

cc @Arthurk12 