### PR TITLE
fix(breakout-room): avoid muteOnStart at breakout room

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -555,6 +555,12 @@ public class ParamsProcessorUtil {
         	muteOnStart = Boolean.parseBoolean(params.get(ApiParams.MUTE_ON_START));
         }
 
+		// when a moderator joins in a breakout room only with the audio, and the muteOnStart is set to true,
+		// the moderator is unable to unmute himself, because they don't have an icon to do so
+		if (isBreakout) {
+			muteOnStart = false;
+		}
+
 		meeting.setMuteOnStart(muteOnStart);
 
     Boolean meetingKeepEvents = defaultKeepEvents;


### PR DESCRIPTION
Quick fix to prevent the moderator who joins the
breakout room from being unable to unmute himself

Closes #12579

cc @frankemax 