### PR TITLE
fix: create breakout room form improvements

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -480,18 +480,18 @@ class BreakoutRoom extends PureComponent {
 
   increaseDurationTime() {
     const { durationTime } = this.state;
-    const durationIsValid = durationTime >= MIN_BREAKOUT_TIME;
+    const number = ((1 * durationTime) + 1);
+    const newDurationTime = number > MIN_BREAKOUT_TIME ? number : MIN_BREAKOUT_TIME;
 
-    this.setState({ durationTime: (1 * durationTime) + 1, durationIsValid });
+    this.setState({ durationTime: newDurationTime, durationIsValid: true });
   }
 
   decreaseDurationTime() {
     const { durationTime } = this.state;
     const number = ((1 * durationTime) - 1);
-    const newDurationTime = number < MIN_BREAKOUT_TIME ? MIN_BREAKOUT_TIME : number;
-    const durationIsValid = durationTime >= MIN_BREAKOUT_TIME;
+    const newDurationTime = number > MIN_BREAKOUT_TIME ? number : MIN_BREAKOUT_TIME;
 
-    this.setState({ durationTime: newDurationTime, durationIsValid });
+    this.setState({ durationTime: newDurationTime, durationIsValid: true });
   }
 
   changeDurationTime(event) {


### PR DESCRIPTION
### What does this PR do?

Makes improvements based on [feedback from PR #12560:](https://github.com/bigbluebutton/bigbluebutton/pull/12560#issuecomment-861477847)
- When the input value is null or set to a value below the mininum, the increase and decrease duration buttons will now set the duration to the mininum value.