### PR TITLE
test: Add Unit Tests For Meteor Polls API

### DIFF
--- a/bigbluebutton-html5/.meteor/packages
+++ b/bigbluebutton-html5/.meteor/packages
@@ -24,3 +24,5 @@ check@1.3.1
 nathantreid:css-modules@4.1.0
 rocketchat:streamer
 cfs:reactive-list
+meteortesting:mocha
+lmieulet:meteor-coverage

--- a/bigbluebutton-html5/.meteor/versions
+++ b/bigbluebutton-html5/.meteor/versions
@@ -34,9 +34,13 @@ id-map@1.1.0
 inter-process-messaging@0.1.1
 launch-screen@1.2.0
 livedata@1.0.18
+lmieulet:meteor-coverage@3.2.0
 logging@1.1.20
 meteor@1.9.3
 meteor-base@1.4.0
+meteortesting:browser-tests@1.3.4
+meteortesting:mocha@2.0.1
+meteortesting:mocha-core@8.0.1
 minifier-css@1.5.1
 minifier-js@2.6.0
 minimongo@1.6.0

--- a/bigbluebutton-html5/imports/api/polls/index.test.js
+++ b/bigbluebutton-html5/imports/api/polls/index.test.js
@@ -1,0 +1,103 @@
+import { Meteor } from 'meteor/meteor';
+import Polls from '/imports/api/polls';
+import { expect } from 'chai';
+// Modifiers
+import clearPolls from './server/modifiers/clearPolls';
+import removePoll from './server/modifiers/removePoll';
+import addPoll from './server/modifiers/addPoll';
+import updateVotes from './server/modifiers/updateVotes';
+// Handlers
+import pollStarted from './server/handlers/pollStarted';
+import pollStopped from './server/handlers/pollStopped';
+
+// mock test data
+const _id = 'sJt6JaJMsTgy64TZG';
+const meetingId = '183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1623285094106';
+const requester = 'w_iotqesmfrtqj';
+const pollType = 'TF';
+const id = 'd2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1623285094108/1/1623285145173';
+const answers = [{ id: 0, key: 'True' }, { id: 1, key: 'False' }];
+const users = [];
+const questionText = '';
+const pollObj = {
+  _id,
+  meetingId,
+  requester,
+  pollType,
+  answers,
+  id,
+  users,
+  questionText,
+};
+
+Polls.insert(pollObj);
+const poll = Polls.findOne(pollObj);
+
+if (Meteor.isServer) {
+  describe('Polls Collection', () => {
+    describe('Modifiers :', () => {
+      it('Validate (#_id, #meetingId, #requester, #pollType, #users, #answers)', () => {
+        expect(poll?._id).to.be.a('string').equal(_id);
+        expect(poll?.meetingId).to.be.a('string').equal(meetingId);
+        expect(poll?.requester).to.be.a('string').equal(requester);
+        expect(poll?.pollType).to.be.a('string').equal(pollType);
+        expect(poll?.users).to.be.an('array');
+        expect(poll?.answers).to.be.an('array');
+      });
+
+      it('addPoll(): Should have added a poll', () => {
+        addPoll(meetingId, requester, { id, answers }, pollType, questionText);
+        expect(Polls.findOne({ id, meetingId })?.id).to.be.a('string').equal(pollObj.id);
+      });
+
+      it('updateVotes(): Should update vote for a poll', () => {
+        answers[0].numVotes = 1;
+        answers[1].numVotes = 0;
+
+        updateVotes({
+          id,
+          answers,
+          numResponders: 1,
+          numRespondents: 1,
+        }, meetingId);
+
+        expect(Polls.findOne({ meetingId, id })?.answers[0]?.numVotes).to.be.a('number').equal(1);
+        expect(Polls.findOne({ meetingId, id })?.answers[1]?.numVotes).to.be.a('number').equal(0);
+      });
+
+      it('removePoll(): Should have removed specified poll', () => {
+        removePoll(meetingId, id);
+        expect(Polls.findOne({ meetingId, id })).to.be.an('undefined');
+      });
+
+      it('clearPolls(): Should have cleared all polls', () => {
+        Polls.insert(pollObj);
+        clearPolls();
+        expect(Polls.findOne({ meetingId })).to.be.an('undefined');
+      });
+    });
+
+    describe('Handlers :', () => {
+      it('pollStarted(): should add a poll and reset publishedPoll flag', () => {
+        delete answers[0].numVotes;
+        delete answers[1].numVotes;
+
+        pollStarted({
+          body: {
+            userId: requester,
+            poll: { id, answers },
+            pollType,
+            question: '',
+          },
+        }, meetingId);
+
+        expect(Polls.findOne({ meetingId, id })?.id).to.be.a('string').equal(id);
+      });
+
+      it('pollStopped(): Should have removed poll', () => {
+        pollStopped({ body: { poll: { pollId: id } } }, meetingId);
+        expect(Polls.findOne({ meetingId, id })?.id).to.be.an('undefined');
+      });
+    });
+  });
+}

--- a/bigbluebutton-html5/imports/api/polls/server/modifiers/updateVotes.js
+++ b/bigbluebutton-html5/imports/api/polls/server/modifiers/updateVotes.js
@@ -33,9 +33,9 @@ export default function updateVotes(poll, meetingId) {
     const numberAffected = Polls.update(selector, modifier);
 
     if (numberAffected) {
-      Logger.info(`Updating Polls collection (meetingId: ${meetingId}, pollId: ${id}!)`);
+      Logger.info(`Updating Polls collection vote (meetingId: ${meetingId}, pollId: ${id}!)`);
     }
   } catch (err) {
-    Logger.error(`Updating Polls collection: ${err}`);
+    Logger.error(`Updating Polls collection vote: ${err}`);
   }
 }

--- a/bigbluebutton-html5/imports/startup/server/logger.js
+++ b/bigbluebutton-html5/imports/startup/server/logger.js
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import { createLogger, format, transports } from 'winston';
 
-const LOG_CONFIG = Meteor.settings.private.serverLog || {};
+const LOG_CONFIG = Meteor?.settings?.private?.serverLog || {};
 const { level } = LOG_CONFIG;
 
 const Logger = createLogger({


### PR DESCRIPTION
### What does this PR do?

Implements server unit testing using Meteors recommendation of Mocha / Chai. 

Meteor-Mocha: https://github.com/meteortesting/meteor-mocha
Chai: https://www.chaijs.com/api/

![poll_meteor_test](https://user-images.githubusercontent.com/22058534/122321375-c4418300-cef1-11eb-9217-7f81b879c567.gif)

