### PR TITLE
Add missing option to record-and-playback

### DIFF
--- a/record-and-playback/screenshare/scripts/screenshare.yml
+++ b/record-and-playback/screenshare/scripts/screenshare.yml
@@ -4,6 +4,7 @@ playback_dir: /usr/local/bigbluebutton/core/playback/screenshare
 layout:
   :width: 1280
   :height: 720
+  :framerate: 24
   :areas:
     - :name: :deskshare
       :x: 0


### PR DESCRIPTION
The option `framerate` must be supplied in `screenshare.yml` or the script will crash. This commit adds it to the default settings file, so that the script works again out of the box.

### What does this PR do?

Add the option `framerate` with a default of 24 to the settings file of the record-and-playback script.

### Motivation

Simply installing record-and-playback in bbb 2.3 did not work anymore. It took a long dive into debuggin it until I found that it crashes, since the script tries to use an option `framerate` that is not set in `screenshare.yml`.