### PR TITLE
Remove linefeed for polling option

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/service.js
+++ b/bigbluebutton-html5/imports/ui/components/poll/service.js
@@ -147,14 +147,14 @@ const getPollResultString = (pollResultData, intl) => {
 const matchYesNoPoll = (yesValue, noValue, contentString) => {
   const ynPollString = `(${yesValue}\\s*\\/\\s*${noValue})|(${noValue}\\s*\\/\\s*${yesValue})`;
   const ynOptionsRegex = new RegExp(ynPollString, 'gi');
-  const ynPoll = contentString.match(ynOptionsRegex) || [];
+  const ynPoll = contentString.replace(/\n/g,'').match(ynOptionsRegex) || [];
   return ynPoll;
 }
 
 const matchYesNoAbstentionPoll = (yesValue, noValue, abstentionValue, contentString) => {
   const ynaPollString = `(${yesValue}\\s*\\/\\s*${noValue}\\s*\\/\\s*${abstentionValue})|(${yesValue}\\s*\\/\\s*${abstentionValue}\\s*\\/\\s*${noValue})|(${abstentionValue}\\s*\\/\\s*${yesValue}\\s*\\/\\s*${noValue})|(${abstentionValue}\\s*\\/\\s*${noValue}\\s*\\/\\s*${yesValue})|(${noValue}\\s*\\/\\s*${yesValue}\\s*\\/\\s*${abstentionValue})|(${noValue}\\s*\\/\\s*${abstentionValue}\\s*\\/\\s*${yesValue})`;
   const ynaOptionsRegex = new RegExp(ynaPollString, 'gi');
-  const ynaPoll = contentString.match(ynaOptionsRegex) || [];
+  const ynaPoll = contentString.replace(/\n/g,'').match(ynaOptionsRegex) || [];
   return ynaPoll;
 }
 


### PR DESCRIPTION
### What does this PR do?

Remove linefeed letters from the yes / no (/abstention) options for quick poll. 

### Motivation

For some Asian languages such as Japanese, words are not separated by spaces. Thus even the word "abstention" can be folded in two lines (i.e., abs \n tention) . This leads to a failure of parsing the slide text for the quick polling.

In the following figure, はい / いいえ / どちらでもない corresponds to Yes / No / Abstention. Note that "Abstention" is not parsed correctly.
![poll](https://user-images.githubusercontent.com/45039819/122392287-b3a31280-cfae-11eb-97d7-d89dee18d67b.jpg)
