### PR TITLE
fix: poll panel position - new LM

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
@@ -103,7 +103,7 @@ const SidebarContent = (props) => {
       {sidebarContentPanel === PANELS.CAPTIONS && <CaptionsContainer />}
       {sidebarContentPanel === PANELS.POLL
         && (
-          <div className={styles.poll} style={{ minWidth }} id="pollPanel">
+          <div className={styles.poll} style={{ minWidth, top: '0' }} id="pollPanel">
             <PollContainer />
           </div>
         )}


### PR DESCRIPTION
### What does this PR do?

Fix poll panel position in new layout manager - mobile

### before
![Screenshot from 2021-06-17 15-39-43](https://user-images.githubusercontent.com/3728706/122454953-424d6a80-cf82-11eb-9ea0-b4f6d330b957.png)

### after
![Screenshot from 2021-06-17 15-41-11](https://user-images.githubusercontent.com/3728706/122455146-788aea00-cf82-11eb-80e3-98b80f944094.png)

