### PR TITLE
Fix export messages throwing a error

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/service.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/service.js
@@ -257,9 +257,11 @@ const exportChat = (timeWindowList, users, intl) => {
       const hour = date.getHours().toString().padStart(2, 0);
       const min = date.getMinutes().toString().padStart(2, 0);
       const hourMin = `[${hour}:${min}]`;
-      // It skip the reduce aggregation for the sync messages because they aren't localizated causing an error in line 266
-      // Also they're temporary message, so, doesn't make sanse export it
+
+      // Skip the reduce aggregation for the sync messages because they aren't localized, causing an error in line 268
+      // Also they're temporary (preliminary) messages, so it doesn't make sense export them
       if (['SYSTEM_MESSAGE-sync-msg', 'synced'].includes(message.id)) return acc;
+
       let userName = message.id.startsWith(SYSTEM_CHAT_TYPE)
         ? ''
         : `${users[timeWindow.sender].name}: `;

--- a/bigbluebutton-html5/imports/ui/components/chat/service.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/service.js
@@ -257,6 +257,7 @@ const exportChat = (timeWindowList, users, intl) => {
       const hour = date.getHours().toString().padStart(2, 0);
       const min = date.getMinutes().toString().padStart(2, 0);
       const hourMin = `[${hour}:${min}]`;
+      if (['SYSTEM_MESSAGE-sync-msg', 'synced'].includes(message.id)) return acc;
       let userName = message.id.startsWith(SYSTEM_CHAT_TYPE)
         ? ''
         : `${users[timeWindow.sender].name}: `;
@@ -276,10 +277,10 @@ const exportChat = (timeWindowList, users, intl) => {
     });
 
     return [...acc, ...msgs];
-  }, [])
+  }, []);
 
   return messageList.join('\n');
-}
+};
 
 const getAllMessages = (chatID, messages) => {
   if(!messages[chatID]){

--- a/bigbluebutton-html5/imports/ui/components/chat/service.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/service.js
@@ -257,6 +257,8 @@ const exportChat = (timeWindowList, users, intl) => {
       const hour = date.getHours().toString().padStart(2, 0);
       const min = date.getMinutes().toString().padStart(2, 0);
       const hourMin = `[${hour}:${min}]`;
+      // It skip the reduce aggregation for the sync messages because they aren't localizated causing an error in line 266
+      // Also they're temporary message, so, doesn't make sanse export it
       if (['SYSTEM_MESSAGE-sync-msg', 'synced'].includes(message.id)) return acc;
       let userName = message.id.startsWith(SYSTEM_CHAT_TYPE)
         ? ''


### PR DESCRIPTION
### What does this PR do?

The error occurs because the syncing and synced messages are not mapped in the export function

### Closes Issue(s)
Closes #12597
