### PR TITLE
feat(recording): process published polls

### DIFF
--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -27,7 +27,7 @@ require 'trollop'
 require 'yaml'
 require 'builder'
 require 'fastimage' # require fastimage to get the image size of the slides (gem install fastimage)
-
+require 'json'
 
 # This script lives in scripts/archive/steps while properties.yaml lives in scripts/
 bbb_props = BigBlueButton.read_props
@@ -1115,6 +1115,93 @@ def processDeskshareEvents(events)
   end
 end
 
+def getPollQuestion(event)
+  question = ""
+  if not event.at_xpath("question").nil?
+    question = event.at_xpath("question").text
+  end
+
+  question
+end
+
+def getPollAnswers(event)
+  answers = []
+  if not event.at_xpath("answers").nil?
+    answers = JSON.load(event.at_xpath("answers").content)
+  end
+
+  answers
+end
+
+def getPollRespondents(event)
+  respondents = 0
+  if not event.at_xpath("numRespondents").nil?
+    respondents = event.at_xpath("numRespondents").text.to_i
+  end
+
+  respondents
+end
+
+def getPollResponders(event)
+  responders = 0
+  if not event.at_xpath("numResponders").nil?
+    responders = event.at_xpath("numResponders").text.to_i
+  end
+
+  responders
+end
+
+def getPollId(event)
+  id = ""
+  if not event.at_xpath("pollId").nil?
+    id = event.at_xpath("pollId").text
+  end
+
+  id
+end
+
+def getPollType(events, published_poll_event)
+  published_poll_id = getPollId(published_poll_event)
+
+  type = ""
+  events.xpath("//event[@eventname='PollStartedRecordEvent']").each do |event|
+    poll_id = getPollId(event)
+
+    if poll_id.eql?(published_poll_id)
+      type = event.at_xpath("type").text
+      break
+    end
+  end
+
+  type
+end
+
+def processPollEvents(events, package_dir)
+  BigBlueButton.logger.info("Processing poll events")
+
+  published_polls = []
+  $rec_events.each do |re|
+    events.xpath("//event[@eventname='PollPublishedRecordEvent']").each do |event|
+      if (event[:timestamp].to_i >= re[:start_timestamp] and event[:timestamp].to_i <= re[:stop_timestamp])
+        published_polls << {
+          :timestamp => (translateTimestamp(event[:timestamp]) / 1000).to_i,
+          :type => getPollType(events, event),
+          :question => getPollQuestion(event),
+          :answers => getPollAnswers(event),
+          :respondents => getPollRespondents(event),
+          :responders => getPollResponders(event)
+        }
+      end
+    end
+  end
+
+  if not published_polls.empty?
+    File.open("#{package_dir}/polls.json", "w") do |f|
+      f.puts(published_polls.to_json)
+    end
+  end
+end
+
 $shapes_svg_filename = 'shapes.svg'
 $panzooms_xml_filename = 'panzooms.xml'
 $cursor_xml_filename = 'cursor.xml'
@@ -1311,6 +1398,8 @@ begin
         processPresentation(package_dir)
 
         processDeskshareEvents(@doc)
+
+        processPollEvents(@doc, package_dir)
 
         # Write slides.xml to file
         File.open("#{package_dir}/slides_new.xml", 'w') { |f| f.puts $slides_doc.to_xml }


### PR DESCRIPTION
Generate a poll JSON file at the recordings with an array of published
polling data:
 - type;
 - question;
 - answers;
 - number of responders; and
 - number of respondents

This file will be published along with the other presentation format files
and can be used to display the poll results at the playback.