### PR TITLE
fix(poll): Respect maxCustom property in quick-polls

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -165,7 +165,7 @@ const intlMessages = defineMessages({
 
 const POLL_SETTINGS = Meteor.settings.public.poll;
 
-const MAX_CUSTOM_FIELDS = POLL_SETTINGS.max_custom;
+const MAX_CUSTOM_FIELDS = POLL_SETTINGS.maxCustom;
 const MAX_INPUT_CHARS = POLL_SETTINGS.maxTypedAnswerLength;
 const QUESTION_MAX_INPUT_CHARS = 400;
 const FILE_DRAG_AND_DROP_ENABLED = POLL_SETTINGS.allowDragAndDropFile;
@@ -506,7 +506,7 @@ class Poll extends Component {
                           label={intl.formatMessage(intlMessages.addOptionLabel)}
                           color="default"
                           icon="add"
-                          disabled={optList.length === MAX_CUSTOM_FIELDS}
+                          disabled={optList.length >= MAX_CUSTOM_FIELDS}
                           onClick={() => this.handleAddOption()}
                         />
                       )}

--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -4,6 +4,9 @@ import { Slides, SlidePositions } from '/imports/api/slides';
 import Auth from '/imports/ui/services/auth';
 import PollService from '/imports/ui/components/poll/service';
 
+const POLL_SETTINGS = Meteor.settings.public.poll;
+const MAX_CUSTOM_FIELDS = POLL_SETTINGS.maxCustom;
+
 const getCurrentPresentation = podId => Presentations.findOne({
   podId,
   current: true,
@@ -81,7 +84,7 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
     content,
   } = currentSlide;
 
-  const pollRegex = /[1-6A-Fa-f][.)].*/g;
+  const pollRegex = /[1-9A-Ia-i][.)].*/g;
   let optionsPoll = content.match(pollRegex) || [];
   if (optionsPoll) optionsPoll = optionsPoll.map(opt => `\r${opt[0]}.`);
 
@@ -120,10 +123,22 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
     return acc;
   }, []).filter(({
     options,
-  }) => options.length > 1 && options.length < 7).forEach(poll => quickPollOptions.push({
-    type: `${pollTypes.Letter}${poll.options.length}`,
-    poll,
-  }));
+  }) => options.length > 1 && options.length < 10).forEach(poll => {
+    if (poll.options.length <= 5 || MAX_CUSTOM_FIELDS <= 5) {
+      const maxAnswer = poll.options.length > MAX_CUSTOM_FIELDS 
+        ? MAX_CUSTOM_FIELDS
+        : poll.options.length
+      quickPollOptions.push({
+        type: `${pollTypes.Letter}${maxAnswer}`,
+        poll,
+      })
+    } else {
+      quickPollOptions.push({
+        type: pollTypes.Custom,
+        poll,
+      })
+    }
+  });
 
   if (quickPollOptions.length > 0) {
     content = content.replace(new RegExp(pollRegex), '');

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -375,7 +375,7 @@ public:
     toggleSelfVoice: false
   poll:
     enabled: true
-    max_custom: 5
+    maxCustom: 5
     allowDragAndDropFile: false
     maxTypedAnswerLength: 45
   captions:


### PR DESCRIPTION
### What does this PR do?

More than 5 answers are now of Custom type poll and answers passed directly.
Increase A-I slide options detection
Rename max_custom to maxCustom in settings.yml to follow pattern.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #12608
