### PR TITLE
feat(poll): add option to disable poll chat message

### DIFF
--- a/bigbluebutton-html5/imports/api/polls/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/polls/server/eventHandlers.js
@@ -2,13 +2,11 @@ import RedisPubSub from '/imports/startup/server/redis';
 import handlePollStarted from './handlers/pollStarted';
 import handlePollStopped from './handlers/pollStopped';
 import handlePollPublished from './handlers/pollPublished';
-import handleSendSystemChatForPublishedPoll from './handlers/sendPollChatMsg';
 import handleUserVoted from './handlers/userVoted';
 import handleUserResponded from './handlers/userResponded';
 import handleUserTypedResponse from './handlers/userTypedResponse';
 
 RedisPubSub.on('PollShowResultEvtMsg', handlePollPublished);
-RedisPubSub.on('PollShowResultEvtMsg', handleSendSystemChatForPublishedPoll);
 RedisPubSub.on('PollStartedEvtMsg', handlePollStarted);
 RedisPubSub.on('PollStoppedEvtMsg', handlePollStopped);
 RedisPubSub.on('PollUpdatedEvtMsg', handleUserVoted);

--- a/bigbluebutton-html5/imports/api/polls/server/handlers/pollPublished.js
+++ b/bigbluebutton-html5/imports/api/polls/server/handlers/pollPublished.js
@@ -1,5 +1,8 @@
 import { check } from 'meteor/check';
 import setPublishedPoll from '../../../meetings/server/modifiers/setPublishedPoll';
+import handleSendSystemChatForPublishedPoll from './sendPollChatMsg';
+
+const POLL_CHAT_MESSAGE = Meteor.settings.public.poll.chatMessage;
 
 export default function pollPublished({ body }, meetingId) {
   const { pollId } = body;
@@ -8,4 +11,8 @@ export default function pollPublished({ body }, meetingId) {
   check(pollId, String);
 
   setPublishedPoll(meetingId, true);
+
+  if (POLL_CHAT_MESSAGE) {
+    handleSendSystemChatForPublishedPoll({ body }, meetingId);
+  }
 }

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -378,6 +378,7 @@ public:
     max_custom: 5
     allowDragAndDropFile: false
     maxTypedAnswerLength: 45
+    chatMessage: true
   captions:
     enabled: true
     enableDictation: false


### PR DESCRIPTION
### What does this PR do?
Added chatMessage in settings.yml to allow disabling publish poll results in the cat.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #12592


### Motivation
from: #12592
> Since version 2.3 poll results are reported in chat. This is an awesome feature and generally the conference benefits from it.
> 
> At my university BigBlueButton is also getting used for political gettogethers and the poll feature is being used to vote on proposals. In this setting pariticpants sometimes hold more than one vote because the voting rights have been transfered. The poll feature is not able to represent this and it doesnt have to.
> In version 2.2 the results were only being reported on the presentation and were easily removable. A chat message is non removable.
> 
> This leads to the following Problem:
> 
> The actual result of the poll for the reason stated above, is different from the result that is in chat. Because of this participants may get confused.
> 
> Workaround that has been tried:
> 
> Ending the poll by clicking on the "X" in the top right corner. This only sometimes work, if it does not work the poll feature is unusable for the presenter.
> 
> Suggested Implementation:
> 
> Adding an option to /usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml that disables the reporting of poll results completly.
> 
> Additional context:
> 
> I know that this is or might be a rather niche usage of BBB therefore i dont expect this to be a huge priority on the list of features, but maybe there is a rather simple way to implement this and make poll result reporting configurable.
