### PR TITLE
Add missing components to new layout manager

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -528,6 +528,16 @@ class App extends Component {
                 {shouldShowPresentation ? <PresentationAreaContainer /> : null}
                 {shouldShowScreenshare ? <ScreenshareContainer /> : null}
                 {shouldShowExternalVideo ? <ExternalVideoContainer isPresenter={isPresenter} /> : null}
+                <UploaderContainer />
+                <ToastContainer rtl />
+                {(audioAlertEnabled || pushAlertEnabled)
+                  && (
+                    <ChatAlertContainer
+                      audioAlertEnabled={audioAlertEnabled}
+                      pushAlertEnabled={pushAlertEnabled}
+                    />
+                  )}
+                <PollingContainer />
                 <ModalContainer />
                 {this.renderActionsBar()}
               </div>


### PR DESCRIPTION
### What does this PR do?

Adds the following components to the new layout manager:
- presentation uploader
- toast (notifications)
- chat alerts
- polling container