### PR TITLE
fix: private chat shortcuts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/component.jsx
@@ -55,8 +55,8 @@ const Chat = (props) => {
 
   const userSentMessage = UserSentMessageCollection.findOne({ userId: Auth.userID, sent: true });
 
-  const HIDE_CHAT_AK = shortcuts.hidePrivateChat;
-  const CLOSE_CHAT_AK = shortcuts.closePrivateChat;
+  const HIDE_CHAT_AK = shortcuts.hideprivatechat;
+  const CLOSE_CHAT_AK = shortcuts.closeprivatechat;
   ChatLogger.debug('ChatComponent::render', props);
   return (
     <div
@@ -75,7 +75,7 @@ const Chat = (props) => {
               window.dispatchEvent(new Event('panelChanged'));
             }}
             aria-label={intl.formatMessage(intlMessages.hideChatLabel, { 0: title })}
-            accessKey={HIDE_CHAT_AK}
+            accessKey={chatID !== 'public' ? HIDE_CHAT_AK : null}
             label={title}
             icon="left_arrow"
             className={styles.hideBtn}


### PR DESCRIPTION
### What does this PR do?

Fix  hide (`Alt + H`) and close (`Alt + G`) private chat shortcuts.

### Closes Issue(s)
Closes #12644 