### PR TITLE
WIP Prevent spam of assign presenter role

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetPresenterInPodReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetPresenterInPodReqMsgHdlr.scala
@@ -17,6 +17,7 @@ trait SetPresenterInPodReqMsgHdlr {
   ): MeetingState2x = {
     if (msg.body.podId == PresentationPod.DEFAULT_PRESENTATION_POD) {
       // Swith presenter as default presenter pod has changed.
+      log.info("Presenter pod change will trigger a presenter change")
       AssignPresenterActionHandler.handleAction(liveMeeting, bus.outGW, msg.header.userId, msg.body.nextPresenterId)
     }
     SetPresenterInPodActionHandler.handleAction(state, liveMeeting, bus.outGW, msg.header.userId, msg.body.podId, msg.body.nextPresenterId)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
@@ -62,6 +62,7 @@ object UsersApp {
       moderator <- Users2x.findModerator(liveMeeting.users2x)
       newPresenter <- Users2x.makePresenter(liveMeeting.users2x, moderator.intId)
     } yield {
+      // println(s"automaticallyAssignPresenter: moderator=${moderator} newPresenter=${newPresenter.intId}");
       sendPresenterAssigned(outGW, meetingId, newPresenter.intId, newPresenter.name, newPresenter.intId)
     }
   }
@@ -115,6 +116,7 @@ object UsersApp {
       sendUserEjectedMessageToClient(outGW, meetingId, userId, ejectedBy, reason, reasonCode)
       sendUserLeftMeetingToAllClients(outGW, meetingId, userId)
       if (user.presenter) {
+        // println(s"ejectUserFromMeeting will cause a automaticallyAssignPresenter for user=${user}")
         automaticallyAssignPresenter(outGW, liveMeeting)
       }
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -84,6 +84,7 @@ trait HandlerHelpers extends SystemConfiguration {
             outGW.send(event)
             val newState = startRecordingIfAutoStart2x(outGW, liveMeeting, state)
             if (!Users2x.hasPresenter(liveMeeting.users2x)) {
+              // println(s"userJoinMeeting will trigger an automaticallyAssignPresenter for user=${newUser}")
               UsersApp.automaticallyAssignPresenter(outGW, liveMeeting)
             }
             newState.update(newState.expiryTracker.setUserHasJoined())

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -872,6 +872,7 @@ class MeetingActor(
         outGW.send(userLeftMeetingEvent)
 
         if (u.presenter) {
+          log.info("removeUsersWithExpiredUserLeftFlag will cause an automaticallyAssignPresenter because user={} left", u)
           UsersApp.automaticallyAssignPresenter(outGW, liveMeeting)
 
           // request screenshare to end


### PR DESCRIPTION
### What does this PR do?

Prevent spam of `PresenterAssignedEvtMsg` and `PresenterUnassignedEvtMsg` events, also add more logs to the process of assign and unassig presenter role.

### Motivation

For some reason `akka-apps` could get stuck in assigning and unassigned presenter role, causing disk and cpu usage problems.

### Others

To test the PR it will be needed to build and run akka-apps from [code source ](https://docs.bigbluebutton.org/2.3/dev.html#developing-akka-apps).

related to #12284 