### PR TITLE
fix: keep changed layout after refresh

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -206,6 +206,8 @@ class App extends Component {
       isPresenter,
       meetingLayout,
       settingsLayout,
+      layoutType,
+      layoutLoaded,
       pushLayoutToEveryone,
       newLayoutContextDispatch,
     } = this.props;
@@ -221,8 +223,12 @@ class App extends Component {
       Settings.save();
     }
 
-    if (settingsLayout !== prevProps.settingsLayout) {
-      const newLayoutManager = settingsLayout === 'legacy' ? 'legacy' : 'new';
+    const newLayoutManager = settingsLayout === 'legacy' ? 'legacy' : 'new';
+
+    if (settingsLayout !== prevProps.settingsLayout ||
+      settingsLayout !== layoutType ||
+      newLayoutManager !== layoutLoaded
+    ) {
       Session.set('layoutManagerLoaded', newLayoutManager);
 
       newLayoutContextDispatch({

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -67,6 +67,7 @@ const AppContainer = (props) => {
     input,
     output,
     layoutType,
+    layoutLoaded,
     deviceType,
   } = newLayoutContextState;
   const { sidebarContent, sidebarNavigation } = input;
@@ -83,6 +84,7 @@ const AppContainer = (props) => {
         actionsBarStyle,
         media,
         layoutType,
+        layoutLoaded,
         meetingLayout,
         settingsLayout,
         pushLayoutToEveryone,


### PR DESCRIPTION
### What does this PR do?

Adds additional checks to prevent custom layout settings from being ignored on page refresh. 