### PR TITLE
feat: fullscreen presentation in new Layout Manager

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/fullscreen-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/fullscreen-button/component.jsx
@@ -4,6 +4,7 @@ import Button from '/imports/ui/components/button/component';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import { styles } from './styles';
+import { ACTIONS } from '../layout/enums';
 
 const intlMessages = defineMessages({
   fullscreenButton: {
@@ -48,6 +49,8 @@ const FullscreenButtonComponent = ({
   handleToggleFullScreen,
   isIphone,
   isFullscreen,
+  layoutManagerLoaded,
+  newLayoutContextDispatch,
 }) => {
   if (isIphone) return null;
 
@@ -71,13 +74,24 @@ const FullscreenButtonComponent = ({
     [styles.bottom]: bottom,
   });
 
+  const handleClick = () => {
+    if(layoutManagerLoaded === 'legacy'){
+      handleToggleFullScreen(fullscreenRef);
+    }else{
+      newLayoutContextDispatch({
+        type: ACTIONS.SET_PRESENTATION_IS_FULLSCREEN,
+        value: !isFullscreen,
+      });
+    }
+  }
+
   return (
     <div className={wrapperClassName}>
       <Button
         color="default"
         icon={!isFullscreen ? 'fullscreen' : 'exit_fullscreen'}
         size="sm"
-        onClick={() => handleToggleFullScreen(fullscreenRef)}
+        onClick={() => handleClick()}
         label={formattedLabel(isFullscreen)}
         hideLabel
         className={cx(styles.button, styles.fullScreenButton, className)}

--- a/bigbluebutton-html5/imports/ui/components/fullscreen-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/fullscreen-button/component.jsx
@@ -55,7 +55,7 @@ const FullscreenButtonComponent = ({
   if (isIphone) return null;
 
   const formattedLabel = (isFullscreen) => {
-    return(isFullscreen ?
+    return (isFullscreen ?
       intl.formatMessage(
         intlMessages.fullscreenUndoButton,
         ({ 0: elementName || '' }),
@@ -75,9 +75,9 @@ const FullscreenButtonComponent = ({
   });
 
   const handleClick = () => {
-    if(layoutManagerLoaded === 'legacy'){
+    if (layoutManagerLoaded === 'legacy') {
       handleToggleFullScreen(fullscreenRef);
-    }else{
+    } else {
       newLayoutContextDispatch({
         type: ACTIONS.SET_PRESENTATION_IS_FULLSCREEN,
         value: !isFullscreen,

--- a/bigbluebutton-html5/imports/ui/components/fullscreen-button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/fullscreen-button/container.jsx
@@ -1,13 +1,29 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import FullscreenButtonComponent from './component';
 import FullscreenService from './service';
+import { NLayoutContext } from '../layout/context/context';
 
 const FullscreenButtonContainer = props => <FullscreenButtonComponent {...props} />;
 
 export default (props) => {
   const handleToggleFullScreen = ref => FullscreenService.toggleFullScreen(ref);
   const isIphone = (navigator.userAgent.match(/iPhone/i)) ? true : false;
+
+  const newLayoutContext = useContext(NLayoutContext);
+  const { newLayoutContextState, newLayoutContextDispatch } = newLayoutContext;
+  const { layoutLoaded: layoutManagerLoaded } = newLayoutContextState;
+  const { input } = newLayoutContextState;
+  const { presentation } = input;
+
+  const isFullscreen = layoutManagerLoaded === 'new' ? presentation.isFullscreen : props.isFullscreen;
+
   return (
-    <FullscreenButtonContainer {...props} {...{ handleToggleFullScreen, isIphone }} />
+    <FullscreenButtonContainer {...props} {...{
+      handleToggleFullScreen,
+      isIphone,
+      layoutManagerLoaded,
+      isFullscreen,
+      newLayoutContextDispatch
+    }} />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -401,6 +401,7 @@ class VideoFocusLayout extends Component {
       mediaBounds.top = 0;
       mediaBounds.left = 0;
       mediaBounds.zIndex = 99;
+      return mediaBounds;
     }
 
     if (deviceType === DEVICE_TYPE.MOBILE) {

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -869,7 +869,7 @@ class Presentation extends PureComponent {
           width: layoutLoaded === 'new' ? presentationBounds.width : undefined,
           height: layoutLoaded === 'new' ? presentationBounds.height : undefined,
           zIndex: layoutLoaded === 'new' && fullscreenContext ? presentationBounds.zIndex : undefined,
-          backgroundColor: layoutLoaded === 'new' ? '#06172A': undefined,
+          backgroundColor: layoutLoaded === 'new' ? '#06172A' : undefined,
         }}
       >
         {isFullscreen && <PollingContainer />}

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -492,7 +492,9 @@ class Presentation extends PureComponent {
 
   renderPresentationClose() {
     const { isFullscreen } = this.state;
-    if (!shouldEnableSwapLayout() || isFullscreen) {
+    const { layoutLoaded, fullscreenContext } = this.props;
+
+    if (!shouldEnableSwapLayout() || isFullscreen || layoutLoaded === 'new' && fullscreenContext) {
       return null;
     }
     return <PresentationCloseButton toggleSwapLayout={MediaService.toggleSwapLayout} />;

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -349,7 +349,7 @@ class Presentation extends PureComponent {
     }
     if (layoutLoaded === 'new' && newPresentationAreaSize) {
       presentationSizes.presentationWidth = newPresentationAreaSize.presentationAreaWidth;
-      presentationSizes.presentationHeight = newPresentationAreaSize.presentationAreaHeight;
+      presentationSizes.presentationHeight = newPresentationAreaSize.presentationAreaHeight - (this.getToolbarHeight() || 0);
       return presentationSizes;
     }
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -818,6 +818,7 @@ class Presentation extends PureComponent {
       slidePosition,
       presentationBounds,
       layoutLoaded,
+      fullscreenContext,
     } = this.props;
 
     const {
@@ -867,6 +868,8 @@ class Presentation extends PureComponent {
           left: layoutLoaded === 'new' ? presentationBounds.left : undefined,
           width: layoutLoaded === 'new' ? presentationBounds.width : undefined,
           height: layoutLoaded === 'new' ? presentationBounds.height : undefined,
+          zIndex: layoutLoaded === 'new' && fullscreenContext ? presentationBounds.zIndex : undefined,
+          backgroundColor: layoutLoaded === 'new' ? '#06172A': undefined,
         }}
       >
         {isFullscreen && <PollingContainer />}

--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -19,8 +19,9 @@ const ROLE_VIEWER = Meteor.settings.public.user.role_viewer;
 const PresentationContainer = ({ presentationPodIds, mountPresentation, ...props }) => {
   const newLayoutContext = useContext(NLayoutContext);
   const { newLayoutContextState, newLayoutContextDispatch } = newLayoutContext;
-  const { output, layoutLoaded } = newLayoutContextState;
+  const { input, output, layoutLoaded } = newLayoutContextState;
   const { presentation } = output;
+  const { isFullscreen: fullscreenContext } = input.presentation;
   const { layoutSwapped, podId } = props;
 
   const usingUsersContext = useContext(UsersContext);
@@ -40,6 +41,7 @@ const PresentationContainer = ({ presentationPodIds, mountPresentation, ...props
           userIsPresenter: userIsPresenter && !layoutSwapped,
           presentationBounds: presentation,
           layoutLoaded,
+          fullscreenContext,
         }
         }
       />


### PR DESCRIPTION
### What does this PR do?

Adds fullscreen presentation feature to new Layout Manager.
In the new Layout Manager, the fullscreen presentation won't be a "real" fullscreen, it will use all available space in the browser window instead.

#### before (legacy layout) 
![legacy-fullscreen](https://user-images.githubusercontent.com/3728706/123325137-0aa86a80-d50e-11eb-844a-3eb21fdd5826.gif)


#### now (new layout manager)
![new-fullscreen](https://user-images.githubusercontent.com/3728706/123325155-1005b500-d50e-11eb-99a5-b7bd256e6c21.gif)

