### PR TITLE
fix: polling component position - new LM

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.scss
@@ -16,6 +16,7 @@
 }
 
 .newLayout{
+  @extend %flex-column;
   background-color: #06172A;
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds missing styles required for correct display of `pollingContainer` in new layout manager.

![Screenshot from 2021-06-25 11-24-07](https://user-images.githubusercontent.com/3728706/123439227-e5683a80-d5a7-11eb-9406-5834f198dd86.png)
