### PR TITLE
refactor: remove unused variables

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/peertube.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/peertube.jsx
@@ -68,7 +68,7 @@ export class PeerTubePlayer extends Component {
   }
 
   getEmbedUrl = () => {
-    const { config, url } = this.props;
+    const { url } = this.props;
     const m = MATCH_URL.exec(url);
 
     return `${m[1]}://${m[2]}/videos/embed/${m[3]}?api=1&controls=${true}`;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -639,7 +639,6 @@ class VideoService {
   }
 
   disableReason() {
-    const { viewParticipantsWebcams } = Settings.dataSaving;
     const locks = {
       videoLocked: this.isUserLocked(),
       videoConnecting: this.isConnecting,


### PR DESCRIPTION
### What does this PR do?

Removes unused variables reported by [lgtm alerts](https://lgtm.com/projects/g/bigbluebutton/bigbluebutton/alerts)

### Motivation

*Unused local variables make code hard to read and understand. Any computation used to initialize an unused variable is wasted, which may lead to performance problems.*

*Similarly, unused imports and unused functions or classes can be confusing. They may even be a symptom of a bug caused, for example, by an incomplete refactoring.* (https://lgtm.com/rules/1780092/)
