### PR TITLE
Fix the behavior of "bbb-conf --check" when multiple STUN servers are defined

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -177,7 +177,7 @@ TURN_ETC_CONFIG=/etc/bigbluebutton/turn-stun-servers.xml
 if [ -f "$TURN_ETC_CONFIG" ]; then
     TURN=$TURN_ETC_CONFIG
 fi
-STUN="$(xmlstarlet sel -N x="http://www.springframework.org/schema/beans" -t -m '_:beans/_:bean[@class="org.bigbluebutton.web.services.turn.StunTurnService"]/_:property[@name="stunServers"]/_:set/_:ref' -v @bean $TURN)"
+STUN="$(xmlstarlet sel -N x="http://www.springframework.org/schema/beans" -t -m '_:beans/_:bean[@class="org.bigbluebutton.web.services.turn.StunTurnService"]/_:property[@name="stunServers"]/_:set/_:ref' -v @bean -nl $TURN)"
 
 PROTOCOL=http
 if [ -f $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties ]; then
@@ -1269,29 +1269,31 @@ check_state() {
     fi
 
     if [ ! -z "$STUN" ]; then
-      STUN_SERVER="$(xmlstarlet sel -N x="http://www.springframework.org/schema/beans" -t -m "_:beans/_:bean[@id=\"$STUN\"]/_:constructor-arg[@index=\"0\"]" -v @value $TURN | sed 's/stun://g')"
-      if echo $STUN_SERVER | grep -q ':'; then
-        STUN_SERVER="$(echo $STUN_SERVER | sed 's/:.*//g') $(echo $STUN_SERVER | sed 's/.*://g')"
-      else
-	STUN_SERVER="$STUN_SERVER 3478"
-      fi
-     
-      if which stunclient > /dev/null 2>&1; then 
-        if stunclient --mode full --localport 30000 $STUN_SERVER | grep -q fail; then
-          echo
-          echo "#"
-          echo "# Warning: Failed to verify STUN server at $STUN_SERVER with command"
-          echo "#"
-          echo "#    stunclient --mode full --localport 30000 $STUN_SERVER"
-          echo "#"
+      for i in $STUN; do
+        STUN_SERVER="$(xmlstarlet sel -N x="http://www.springframework.org/schema/beans" -t -m "_:beans/_:bean[@id=\"$i\"]/_:constructor-arg[@index=\"0\"]" -v @value $TURN | sed 's/stun://g')"
+        if echo $STUN_SERVER | grep -q ':'; then
+          STUN_SERVER="$(echo $STUN_SERVER | sed 's/:.*//g') $(echo $STUN_SERVER | sed 's/.*://g')"
+        else
+          STUN_SERVER="$STUN_SERVER 3478"
         fi
-      fi
+     
+        if which stunclient > /dev/null 2>&1; then 
+          if stunclient --mode full --localport 30000 $STUN_SERVER | grep -q "fail\|Unable\ to\ resolve"; then
+            echo
+            echo "#"
+            echo "# Warning: Failed to verify STUN server at $STUN_SERVER with command"
+            echo "#"
+            echo "#    stunclient --mode full --localport 30000 $STUN_SERVER"
+            echo "#"
+          fi
+        fi
+      done
     fi
 
     stunServerAddress=$(cat /etc/kurento/modules/kurento/WebRtcEndpoint.conf.ini | sed -n '/^stunServerAddress/{s/.*=//;p}')
     stunServerPort=$(cat /etc/kurento/modules/kurento/WebRtcEndpoint.conf.ini | sed -n '/^stunServerPort/{s/.*=//;p}')
     if [ ! -z "$stunServerAddress" ]; then
-      if stunclient --mode full --localport 30000 $stunServerAddress $stunServerPort | grep -q fail; then
+      if stunclient --mode full --localport 30000 $stunServerAddress $stunServerPort | grep -q "fail\|Unable\ to\ resolve"; then
         echo
         echo "#"
         echo "# Warning: Failed to verify STUN server at $stunServerAddress:$stunServerPort with command"
@@ -1414,9 +1416,11 @@ if [ $CHECK ]; then
      fi
 
      if [ ! -z "$STUN" ]; then
-        echo
-        echo "$TURN (STUN Server)"
-	echo "                              stun: $(xmlstarlet sel -N x="http://www.springframework.org/schema/beans" -t -m "_:beans/_:bean[@id=\"$STUN\"]/_:constructor-arg[@index=\"0\"]" -v @value $TURN | sed 's/stun://g')"
+       for i in $STUN; do
+         echo
+         echo "$TURN (STUN Server)"
+         echo "                              stun: $(xmlstarlet sel -N x="http://www.springframework.org/schema/beans" -t -m "_:beans/_:bean[@id=\"$i\"]/_:constructor-arg[@index=\"0\"]" -v @value $TURN | sed 's/stun://g')"
+       done
      fi
 
      stunServerAddress=$(cat /etc/kurento/modules/kurento/WebRtcEndpoint.conf.ini | sed -n '/^stunServerAddress/{s/.*=//;p}')


### PR DESCRIPTION
### What does this PR do?
This PR puts "bbb-conf --check" in place to correctly handle checking for one or more than one STUN server declared in "$SERVLET_DIR/WEB-INF/classes/spring/turn-stun-servers.xml" or "/etc/bigbluebutton/turn-stun-servers.xml" respectively. 

The PR also adds an additional check to the output of "stunclient" in order to result in an error condition when the hostname is just misspelled (and therefore not resolvable by DNS). 

### Closes Issue(s)
It closes bigbluebutton/bbb-install#363 and also most probably #12638, and #12407.

### Motivation
It is recommended to operate more than one STUN (and TURN) server. Without this patch, "bbb-conf --check" returns an error if more than one STUN server is configured. At the same time, misspellings in the STUN's hostname, are going to be ignored.