### PR TITLE
fix: removeUser - handle connections in frontends, db changes in backend

### DIFF
--- a/bigbluebutton-html5/imports/api/auth-token-validation/server/modifiers/clearAuthTokenValidation.js
+++ b/bigbluebutton-html5/imports/api/auth-token-validation/server/modifiers/clearAuthTokenValidation.js
@@ -8,7 +8,9 @@ export default function clearAuthTokenValidation(meetingId) {
       Logger.info(`Error when removing auth-token-validation for meeting=${meetingId}`);
     }
 
-    ClientConnections.removeMeeting(meetingId);
+    if (!process.env.BBB_HTML5_ROLE || process.env.BBB_HTML5_ROLE === 'frontend') {
+      ClientConnections.removeMeeting(meetingId);
+    }
     Logger.info(`Cleared AuthTokenValidation (${meetingId})`);
   });
 }

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
@@ -18,45 +18,39 @@ export default function removeUser(meetingId, userId) {
   check(meetingId, String);
   check(userId, String);
 
-  const userToRemove = Users.findOne({ userId, meetingId });
-
-  if (userToRemove) {
-    const { presenter } = userToRemove;
-    if (presenter) {
-      stopWatchingExternalVideoSystemCall({ meetingId, requesterUserId: 'system-presenter-was-removed' });
-    }
-  }
-
-  const selector = {
-    meetingId,
-    userId,
-  };
-
   try {
+    if (!process.env.BBB_HTML5_ROLE || process.env.BBB_HTML5_ROLE === 'frontend') {
+      const sessionUserId = `${meetingId}-${userId}`;
+      ClientConnections.removeClientConnection(`${meetingId}--${userId}`);
+      clearAllSessions(sessionUserId);
+
+      // we don't want to fully process the redis message in frontend
+      // since the backend is supposed to update Mongo
+      if (process.env.BBB_HTML5_ROLE === 'frontend') {
+        return;
+      }
+    }
+
+    const selector = {
+      meetingId,
+      userId,
+    };
+
+    const userToRemove = Users.findOne({ userId, meetingId });
+
+    if (userToRemove) {
+      const { presenter } = userToRemove;
+      if (presenter) {
+        stopWatchingExternalVideoSystemCall({ meetingId, requesterUserId: 'system-presenter-was-removed' });
+      }
+    }
+
     setloggedOutStatus(userId, meetingId, true);
     VideoStreams.remove({ meetingId, userId });
-    const sessionUserId = `${meetingId}-${userId}`;
-
-    ClientConnections.removeClientConnection(`${meetingId}--${userId}`);
-
-    clearAllSessions(sessionUserId);
 
     clearUserInfoForRequester(meetingId, userId);
 
-    /*
-    Timeout added to reduce the probability that "userRemove" happens too close to "ejectUser",
-    redirecting user to the wrong component.
-    This is a workaround and should be removed as soon as a better fix is made
-    see: https://github.com/bigbluebutton/bigbluebutton/pull/12057
-    */
-    const DELAY_USER_REMOVAL_TIMEOUT_MS = 1000;
-
-    Meteor.wrapAsync((callback) => {
-      Meteor.setTimeout(() => {
-        Users.remove(selector);
-        callback();
-      }, DELAY_USER_REMOVAL_TIMEOUT_MS);
-    })();
+    Users.remove(selector);
 
     Logger.info(`Removed user id=${userId} meeting=${meetingId}`);
   } catch (err) {

--- a/bigbluebutton-html5/imports/startup/server/ClientConnections.js
+++ b/bigbluebutton-html5/imports/startup/server/ClientConnections.js
@@ -171,6 +171,10 @@ class ClientConnections {
 
 }
 
-const ClientConnectionsSingleton = new ClientConnections();
+if (!process.env.BBB_HTML5_ROLE || process.env.BBB_HTML5_ROLE === 'frontend') {
+  Logger.info("ClientConnectionsSingleton was created")
 
-export default ClientConnectionsSingleton;
+  const ClientConnectionsSingleton = new ClientConnections();
+
+  export default ClientConnectionsSingleton;
+}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Reorganized the handling of `UserLeftMeetingEvtMsg` by bbb-html5 so that the backends handle processing to update MongoDB and the frontends handle processing to update the ClientConnections. This way there's no overlap/unpredictability

- split the handling of logic for UserLeft message - backend handles the updates for Mongo, frontend handles the updates to ClientConnections

- removed the 1 second delay since now only backend handles the userleft+user ejected messages and they are syncronous

- no longer initialize ClientConnections on backend instances

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #12080 since we are now guaranteed to be processing sequentially the two relevant events in a single NodeJS instance:

```
Jun 30 20:04:35 anton.vm systemd_start.sh[36803]: warn: Received event to handle {"date":"2021-06-30T20:04:35.385Z","eventName":"UserEjectedFromMeetingEvtMsg"}
Jun 30 20:04:35 anton.vm systemd_start.sh[36803]: warn: Received event to handle {"date":"2021-06-30T20:04:35.386Z","eventName":"UserLeftMeetingEvtMsg"}
```

### Motivation
We were looking into ways to remove the 1000 ms delay added in https://github.com/bigbluebutton/bigbluebutton/pull/12057 and particularly why the re-ordering of events processing was happening.


