### PR TITLE
Prevent addConnectionStatus log spam when not authenticated

### DIFF
--- a/bigbluebutton-html5/imports/api/connection-status/server/methods/addConnectionStatus.js
+++ b/bigbluebutton-html5/imports/api/connection-status/server/methods/addConnectionStatus.js
@@ -42,6 +42,8 @@ export default function addConnectionStatus(status, type, value) {
     check(type, String);
     check(value, Object);
 
+    if (!this.userId) return;
+
     const { meetingId, requesterUserId } = extractCredentials(this.userId);
 
     check(meetingId, String);


### PR DESCRIPTION
### What does this PR do?

Prevent spamming the logs when user is not authenticated in  `addConnectionStatus` method. 



