### PR TITLE
feat(audio): use kurento's trickle-ice to improve mic negotiation

### DIFF
--- a/bigbluebutton-html5/imports/utils/sdpUtils.js
+++ b/bigbluebutton-html5/imports/utils/sdpUtils.js
@@ -65,6 +65,40 @@ const stripMDnsCandidates = (sdp) => {
   return { sdp: transform.write(parsedSDP), type: sdp.type };
 };
 
+const filterValidIceCandidates = (validIceCandidates, sdp) => {
+  if (!validIceCandidates.length) return sdp;
+
+  const matchCandidatesIp = (candidate, mediaCandidate) => (
+    (candidate.address && candidate.address.includes(mediaCandidate.ip))
+    || (candidate.relatedAddress
+      && candidate.relatedAddress.includes(mediaCandidate.ip))
+  );
+
+  const parsedSDP = transform.parse(sdp.sdp);
+  let strippedCandidates = 0;
+  parsedSDP.media.forEach((media) => {
+    if (media.candidates) {
+      media.candidates = media.candidates.filter((candidate) => {
+        if (candidate.ip
+          && candidate.type
+          && candidate.transport
+          && validIceCandidates.find((c) => (c.protocol === candidate.transport)
+              && matchCandidatesIp(c, candidate))
+        ) {
+          return true;
+        }
+        strippedCandidates += 1;
+        return false;
+      });
+    }
+  });
+  if (strippedCandidates > 0) {
+    logger.info({ logCode: 'sdp_utils_mdns_candidate_strip' },
+      `Filtered ${strippedCandidates} invalid candidates from trickle SDP`);
+  }
+  return { sdp: transform.write(parsedSDP), type: sdp.type };
+};
+
 const isPublicIpv4 = (ip) => {
   const ipParts = ip.split('.');
   switch (ipParts[0]) {
@@ -305,6 +339,7 @@ export {
   toPlanB,
   toUnifiedPlan,
   stripMDnsCandidates,
+  filterValidIceCandidates,
   analyzeSdp,
   logSelectedCandidate,
 };

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -79,6 +79,15 @@ public:
     showAudioFilters: true
     raiseHandActionButton:
       enabled: true
+    # If enabled, before joining microphone the client will perform a trickle
+    # ICE against Kurento and use the information about successfull
+    # candidate-pairs to filter out local candidates in SIP.js's SDP.
+    # Try enabling this setting in scenarios where the listenonly mode works,
+    # but microphone doesn't (for example, when using VPN).
+    # For compatibility check "Browser compatbility" section in:
+    # https://developer.mozilla.org/en-US/docs/Web/API/RTCDtlsTransport/iceTransport
+    # This is an EXPERIMENTAL setting and the default value is false
+    # experimentalUseKmsTrickleIceForMicrophone: false
     defaultSettings:
       application:
         animations: true


### PR DESCRIPTION
Here's what we do when user activates mic:
1 - We do something similar to listenonly's joining process
until we find a valid candidate-pair. The information about this
local candidate is stored.
2 - We then start a new userAgent, and as soon as browser finds
a candidate with the same local ip address. We leave only this
candidate in the SDP and send this to FreeSWITCH. SDP should
contain only a single candidate.
3 - The rest of signaling process is basically the same.