### PR TITLE
Don't tie connecting audio to echo test

### DIFF
--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -486,7 +486,7 @@
     "app.audioDial.tipIndicator": "Tip",
     "app.audioDial.tipMessage": "Press the '0' key on your phone to mute/unmute yourself.",
     "app.audioModal.connecting": "Connecting",
-    "app.audioModal.connectingEchoTest": "Connecting to echo test",
+    "app.audioModal.connectingEchoTest": "Connecting",
     "app.audioManager.joinedAudio": "You have joined the audio conference",
     "app.audioManager.joinedEcho": "You have joined the echo test",
     "app.audioManager.leftAudio": "You have left the audio conference",


### PR DESCRIPTION
Users sometimes think that the connecting time is setting up the echo test and will ask to remove the echo test to shorten the time.

In reality, the time is used to setup a FreeSWITCH connection to a channel.

Propose changing this to generic "Connecting".