### PR TITLE
Quick poll showing option texts (up to 99 answers) #2

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -97,7 +97,7 @@ const getAvailableQuickPolls = (slideId, parsedSlides, startPoll, pollTypes) => 
   const sizes = [];
   return pollItemElements.filter((el) => {
     const { label } = el.props;
-    if (label.length === sizes[sizes.length - 1]) return;
+    //if (label.length === sizes[sizes.length - 1]) return;
     sizes.push(label.length);
     return el;
   });

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -67,19 +67,22 @@ const getAvailableQuickPolls = (slideId, parsedSlides, startPoll, pollTypes) => 
             break;
           }
         }
+        itemLabel = options.map(function(item){ return item.slice(0,1); }).slice(0,MAX_CUSTOM_FIELDS).join('/');
       }
     }
 
     // removes any whitespace from the label
     itemLabel = itemLabel.replace(/\s+/g, '').toUpperCase();
 
+    /*
     const numChars = {
-      1: 'A', 2: 'B', 3: 'C', 4: 'D', 5: 'E',
+      1: 'A', 2: 'B', 3: 'C', 4: 'D', 5: 'E', 6: 'F', 7: 'G', 8: 'H', 9: 'I',
     };
     itemLabel = itemLabel.split('').map((c) => {
       if (numChars[c]) return numChars[c];
       return c;
     }).join('');
+    */
 
     return (
       <DropdownListItem

--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -111,7 +111,7 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
 
     if (isLastOptionInteger === isCurrentValueInteger) {
       if (isCurrentValueInteger){
-        if (parseInt(currentValue.replace(/[\r.]g/,'')) > parseInt(lastOption.replace(/[\r.]g/,''))) {
+        if (parseInt(currentValue.replace(/[\r.]g/,'')) == parseInt(lastOption.replace(/[\r.]g/,'')) + 1) {
           options.push(currentValue);
         } else {
           acc.push({
@@ -119,7 +119,7 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
           });
         }
       } else {
-        if (currentValue.toLowerCase().charCodeAt(1) > lastOption.toLowerCase().charCodeAt(1)) {
+        if (currentValue.toLowerCase().charCodeAt(1) == lastOption.toLowerCase().charCodeAt(1) + 1) {
           options.push(currentValue);
         } else {
           acc.push({

--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -142,20 +142,10 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
   }).filter(({
     options,
   }) => options.length > 1 && options.length < 99).forEach(poll => {
-    //if (poll.options.length <= 5 || MAX_CUSTOM_FIELDS <= 5) {
-    //  const maxAnswer = poll.options.length > MAX_CUSTOM_FIELDS 
-    //    ? MAX_CUSTOM_FIELDS
-    //    : poll.options.length
-    //  quickPollOptions.push({
-    //    type: `${pollTypes.Letter}${maxAnswer}`,
-    //    poll,
-    //  })
-    //} else {
       quickPollOptions.push({
         type: pollTypes.Custom,
         poll,
       })
-    //}
   });
 
   if (quickPollOptions.length > 0) {

--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -84,9 +84,11 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
     content,
   } = currentSlide;
 
-  const pollRegex = /[1-9A-Ia-i][.)].*/g;
+  const pollRegex = /(\d{1,2}|[A-Za-z])[.)].*/g;
   let optionsPoll = content.match(pollRegex) || [];
-  if (optionsPoll) optionsPoll = optionsPoll.map(opt => `\r${opt[0]}.`);
+  let optionsPollStrings = [];
+  if (optionsPoll) optionsPollStrings = optionsPoll.map(opt => `${opt.replace(/^[^.)]{1,2}[.)]/,'').replace(/^\s+/, '')}`);
+  if (optionsPoll) optionsPoll = optionsPoll.map(opt => `\r${opt.replace(/[.)].*/,'')}.`);
 
   optionsPoll.reduce((acc, currentValue) => {
     const lastElement = acc[acc.length - 1];
@@ -108,12 +110,22 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
     const isCurrentValueInteger = !!parseInt(currentValue.charAt(1), 10);
 
     if (isLastOptionInteger === isCurrentValueInteger) {
-      if (currentValue.toLowerCase().charCodeAt(1) > lastOption.toLowerCase().charCodeAt(1)) {
-        options.push(currentValue);
+      if (isCurrentValueInteger){
+        if (parseInt(currentValue.replace(/[\r.]g/,'')) > parseInt(lastOption.replace(/[\r.]g/,''))) {
+          options.push(currentValue);
+        } else {
+          acc.push({
+            options: [currentValue],
+          });
+        }
       } else {
-        acc.push({
-          options: [currentValue],
-        });
+        if (currentValue.toLowerCase().charCodeAt(1) > lastOption.toLowerCase().charCodeAt(1)) {
+          options.push(currentValue);
+        } else {
+          acc.push({
+            options: [currentValue],
+          });
+        }
       }
     } else {
       acc.push({
@@ -121,23 +133,29 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
       });
     }
     return acc;
-  }, []).filter(({
+  }, []).map(poll => {
+    for (let i = 0 ; i < poll.options.length ; i++) {
+      poll.options.shift();
+      poll.options.push(optionsPollStrings.shift());
+    }
+    return poll;
+  }).filter(({
     options,
-  }) => options.length > 1 && options.length < 10).forEach(poll => {
-    if (poll.options.length <= 5 || MAX_CUSTOM_FIELDS <= 5) {
-      const maxAnswer = poll.options.length > MAX_CUSTOM_FIELDS 
-        ? MAX_CUSTOM_FIELDS
-        : poll.options.length
-      quickPollOptions.push({
-        type: `${pollTypes.Letter}${maxAnswer}`,
-        poll,
-      })
-    } else {
+  }) => options.length > 1 && options.length < 99).forEach(poll => {
+    //if (poll.options.length <= 5 || MAX_CUSTOM_FIELDS <= 5) {
+    //  const maxAnswer = poll.options.length > MAX_CUSTOM_FIELDS 
+    //    ? MAX_CUSTOM_FIELDS
+    //    : poll.options.length
+    //  quickPollOptions.push({
+    //    type: `${pollTypes.Letter}${maxAnswer}`,
+    //    poll,
+    //  })
+    //} else {
       quickPollOptions.push({
         type: pollTypes.Custom,
         poll,
       })
-    }
+    //}
   });
 
   if (quickPollOptions.length > 0) {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
@@ -220,6 +220,10 @@ class PollDrawComponent extends Component {
     const reducedResult = result.reduce(caseInsensitiveReducer, []);
     const reducedResultRatio = reducedResult.length * 100 / result.length;
 
+    for (const r of result) {
+      r.key = r.key.slice(0,10); //To make poll text visible.
+    }
+    
     // x1 and y1 - coordinates of the top left corner of the annotation
     // initial width and height are the width and height of the annotation
     // all the points are given as percentages of the slide


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Shows option texts for quick polling.
This is a resubmission of #10854, which has been broken after mistakenly following the 2.4.x development, and a revised version of #12590 after conflicting with #12692.

### Closes Issue(s)

closes #10631

### Motivation

Current (until 2.3.4?) quick polling does not show the option (answer) text, and sometimes hides the slide (where the questions and options are written) on the smartphone, so students cannot answer when they forget their choice. I, as a professor, have to warn them "Do you already know your choice? Please don't forget it, OK, let's move to the poll, put your choice before you forget it" ;-)
This PR enables BBB to read the slide text and show the poll option texts, by simply using the BBB's custom polling function. 
Furthermore, BBB would now accept 1. - 99., A. - Z., and a. - z. numbering of poll options, while the final poll is restricted by the maxCustom parameter in setting.yml.

### More

<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
![名称未設定 1のコピー](https://user-images.githubusercontent.com/45039819/124353775-72179600-dc43-11eb-9326-a055e3930c63.jpg)
