### PR TITLE
chore: add stale bot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,19 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 270
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 90
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - "status: accepted"
+  - "status: verify"
+  - "target: security"
+  - "type: discussion"
+# Label to use when marking an issue as stale
+staleLabel: "status: stale"
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
> In an ideal world with infinite resources, there would be no need for
> this app.
>
> But in any successful software project, there's always more work to do
> than people to do it. As more and more work piles up, it becomes
> paralyzing. Just making decisions about what work should and shouldn't
> get done can exhaust all available resources. In the experience of the
> maintainers of this app—and the hundreds of other projects and
> organizations that use it—focusing on issues that are actively affecting
> humans is an effective method for prioritizing work.
>
> To some, a robot trying to close stale issues may seem inhospitable or
> offensive to contributors. But the alternative is to disrespect them by
> setting false expectations and implicitly ignoring their work. This app
> makes it explicit: if work is not progressing, then it's stale. A
> comment is all it takes to keep the conversation alive.

https://github.com/probot/stale#is-closing-stale-issues-really-a-good-idea

This file add the configuration needed for stale issues and pull requests
to be automatically closed. Defined as follows:

 - issues and pull requests with no activity for 270 days will be marked as "status: stale";
 - after that, there will be a period of 90 days for the issue or pull request to be claimed, otherwise will be closed.

The bot will never interact/close with issues and pull requests marked as:
 - status: verify
 - status: accepted
 - target: security
 - type: discussion

For this setup to be effective, add https://probot.github.io/apps/stale/
to BigBlueButton's repository.