### PR TITLE
fix: client crash when userlist is hidden and viewer is ejected

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/typing-indicator/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/typing-indicator/container.jsx
@@ -47,7 +47,7 @@ export default withTracker(() => {
     },
   });
 
-  if (meeting.lockSettingsProps.hideUserList && currentUser.role === USER_CONFIG.role_viewer) {
+  if (meeting.lockSettingsProps.hideUserList && currentUser?.role === USER_CONFIG.role_viewer) {
     selector.role = { $ne: USER_CONFIG.role_viewer };
   }
 


### PR DESCRIPTION
### What does this PR do?

Prevents a crash when a viewer is ejected from the meeting while userlist is hidden.

### Closes Issue(s)
Closes #12714