### PR TITLE
fix: layout issues on mobile with portrait presentation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/component.jsx
@@ -306,7 +306,7 @@ class LayoutManagerComponent extends Component {
       return;
     }
 
-    if ((mediaAreaWidth - presentationWidth) > (mediaAreaHeight - presentationHeight)) {
+    if (!isMobile && ((mediaAreaWidth - presentationWidth) > (mediaAreaHeight - presentationHeight))) {
       layoutContextDispatch(
         {
           type: 'setWebcamsPlacement',


### PR DESCRIPTION
### What does this PR do?

Makes webcam position on mobile not dependent to the orientation of presentation file.

#### before
![Screenshot from 2021-07-05 09-58-48](https://user-images.githubusercontent.com/3728706/124475142-c3c13d00-dd77-11eb-9027-9a8ddad946fe.png)

#### after
![Screenshot from 2021-07-05 09-57-32](https://user-images.githubusercontent.com/3728706/124475135-c2901000-dd77-11eb-97f0-70ab213a214d.png)

### Closes Issue(s)
Closes #12708
