### PR TITLE
Fixes poll option misalignment in mobile device

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/polling/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/polling/styles.scss
@@ -90,14 +90,6 @@
   display: grid;
   grid-template-columns: repeat(var(--col-amount), 1fr);
 
-  > .pollButtonWrapper:nth-child(odd) {
-      grid-column: 1;
-  }
-
-  > .pollButtonWrapper:nth-child(even) {
-      grid-column: var(--col-amount);
-  }
-
   @include mq($hasPhoneDimentions) {
     grid-template-columns: repeat(1, 1fr);
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fixes a problem of alignment of polling options in mobile device.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #12709


### Motivation

<!-- What inspired you to submit this pull request? -->

### More

In the issue, aligning options in two columns suggested, but I guess aligning in one column is the intended design for mobile devices.
