### PR TITLE
fix: Check for correct directory before deploying bbb-html5

### DIFF
--- a/bigbluebutton-html5/deploy_to_usr_share.sh
+++ b/bigbluebutton-html5/deploy_to_usr_share.sh
@@ -2,13 +2,16 @@
 
 # Please check bigbluebutton/bigbluebutton-html5/dev_local_deployment/README.md
 
-echo " start "
-pwd
 UPPER_DESTINATION_DIR=/usr/share/meteor
 DESTINATION_DIR=$UPPER_DESTINATION_DIR/bundle
 
 SERVICE_FILES_DIR=/usr/lib/systemd/system
 LOCAL_PACKAGING_DIR=/home/bigbluebutton/dev/bigbluebutton/bigbluebutton-html5/dev_local_deployment
+
+if [ ! -d "$LOCAL_PACKAGING_DIR" ]; then
+  echo "Did not find LOCAL_PACKAGING_DIR=$LOCAL_PACKAGING_DIR"
+  exit
+fi
 
 sudo rm -rf "$UPPER_DESTINATION_DIR"
 sudo mkdir -p "$UPPER_DESTINATION_DIR"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
In https://github.com/bigbluebutton/bigbluebutton/pull/12589 @oktab1 raises a good point that depending on the dev env setup, the directory (absolute location) might be incorrect. In this PR I add a check, and early exit in case the setup is incorrect.



<!-- A brief description of each change being made with this pull request. -->



### Motivation
@oktab1 had a different username
In one of my setups https://github.com/bigbluebutton/docker-dev the directory is /home/bigbluebutton/src/bigbluebutton-html5...
<!-- What inspired you to submit this pull request? -->

