### PR TITLE
Prevent loggedOut property to be undefined

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/methods/userLeaving.js
+++ b/bigbluebutton-html5/imports/api/users/server/methods/userLeaving.js
@@ -40,7 +40,7 @@ export default function userLeaving(meetingId, userId, connectionId) {
     const payload = {
       userId,
       sessionId: meetingId,
-      loggedOut: user.loggedOut,
+      loggedOut: user.loggedOut || false,
     };
 
     ClientConnections.removeClientConnection(`${meetingId}--${userId}`, connectionId);


### PR DESCRIPTION
### What does this PR do?

Prevent `loggedOut` property to be undefined in `UserLeaveReqMsg` message.

### Closes Issue(s)
Closes #12656 