### PR TITLE
fix(audio): prevent mute notification to be triggered when mic is locked

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
@@ -206,7 +206,7 @@ class AudioControls extends PureComponent {
 
     return (
       <span className={styles.container}>
-        {isVoiceUser && inputStream && muteAlertEnabled && !listenOnly && muted ? (
+        {isVoiceUser && inputStream && muteAlertEnabled && !listenOnly && muted && showMute ? (
           <MutedAlert {...{
             muted, inputStream, isViewer, isPresenter,
           }}


### PR DESCRIPTION
When mic is locked, user is not able to talk so it doesn't make sense
to alert the user about unmute (mute button is also disabled when mic
is locked).

Closes #12048