### PR TITLE
build(deps): update reconnecting-websocket to 4.4.0 (bbb-html5)

### DIFF
--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -9755,9 +9755,9 @@
       }
     },
     "reconnecting-websocket": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-4.1.10.tgz",
-      "integrity": "sha512-x6vgqa8q9KRuJyFkOvBKH1TfyTmN5OWQUf1MIsblfOSY29VE+iI9cKqmIuPvg9TO/hUBxdmUIVutDkcdbqFwZg=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz",
+      "integrity": "sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng=="
     },
     "redent": {
       "version": "1.0.0",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -70,7 +70,7 @@
     "react-toggle": "~4.0.2",
     "react-transition-group": "^2.9.0",
     "react-virtualized": "^9.22.3",
-    "reconnecting-websocket": "~v4.1.10",
+    "reconnecting-websocket": "~v4.4.0",
     "redis": "^3.1.2",
     "sanitize-html": "2.3.3",
     "sdp-transform": "2.7.0",


### PR DESCRIPTION
### What does this PR do?

Update `reconnecting-websocket` in bbb-html5 to 4.4.0

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/12727

### Motivation

[v4.2.0](https://github.com/pladaria/reconnecting-websocket/releases/tag/v4.2.0) fixed the problem outlined in #12727. Bumped to 4.4.0 as I've detected no regressions of any sorts.
