### PR TITLE
fix(webcams): avoid leaking media streams on webcam profile changes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -401,10 +401,7 @@ class VideoPreview extends Component {
   }
 
   getInitialCameraStream(deviceId) {
-    const { webcamDeviceId } = this.state;
     const defaultProfile = PreviewService.getDefaultProfile();
-
-    PreviewService.terminateCameraStream(this.deviceStream, webcamDeviceId);
 
     return this.getCameraStream(deviceId, defaultProfile).then(() => {
       this.updateDeviceId(deviceId);
@@ -412,6 +409,8 @@ class VideoPreview extends Component {
   }
 
   getCameraStream(deviceId, profile) {
+    const { webcamDeviceId } = this.state;
+
     this.setState({
       selectedProfile: profile.id,
       isStartSharingDisabled: true,
@@ -419,6 +418,7 @@ class VideoPreview extends Component {
     });
 
     PreviewService.changeProfile(profile.id);
+    PreviewService.terminateCameraStream(this.deviceStream, webcamDeviceId);
     this.cleanupStreamAndVideo();
 
     return PreviewService.doGUM(deviceId, profile).then((stream) => {


### PR DESCRIPTION
### What does this PR do?

Properly clean up temporary webcam streams in video-preview when changing webcam quality profiles.
Fix regression introduced by commit 0ddf02e (#12700).

### Closes Issue(s)

None

### More

Context: temporary media streams (which were not stored, hence are not in use by video-provider) were supposed to be stopped and cleaned up in video-preview before every new gUM request.

Webcam profile switching wasn't doing that cleanup, so it leaked media streams. I centralized that in the `getCameraStream` method to be a bit more robust.