### PR TITLE
feat(recording): process published external videos

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -492,6 +492,23 @@ module BigBlueButton
       rec_events.sort_by {|a| a[:timestamp]}
     end
 
+    def self.get_external_video_events(events_xml)
+      BigBlueButton.logger.info "Getting external video events"
+      external_videos_events = []
+      events_xml.xpath("//event[@eventname='StartExternalVideoRecordEvent']").each do |event|
+        s = { 
+          :timestamp => event['timestamp'].to_i, 
+          :external_video_url => event.at_xpath("externalVideoUrl").text
+        }
+        external_videos_events << s
+      end
+      events_xml.xpath("//event[@eventname='StopExternalVideoRecordEvent']").each do |event|
+        s = { :timestamp => event['timestamp'].to_i }
+        external_videos_events << s
+      end
+      external_videos_events.sort_by {|a| a[:timestamp]}
+    end
+
     # Get events when the moderator wants the recording to start or stop
     def self.get_start_and_stop_rec_events(events_xml, allow_empty_events=false)
       BigBlueButton.logger.info "Getting start and stop rec button events"
@@ -507,6 +524,17 @@ module BigBlueButton
       rec_events.sort_by {|a| a[:timestamp]}
     end
     
+    # Get events when the moderator wants the recording to start or stop
+    def self.get_start_and_stop_external_video_events(events_xml)
+      BigBlueButton.logger.info "Getting start and stop externalvideo events"
+      external_video_events = BigBlueButton::Events.get_external_video_events(events_xml)
+      if external_video_events.size.odd?
+        # user did not click to stop external video before ending meeting
+        external_video_events << { :timestamp => BigBlueButton::Events.last_event_timestamp(events_xml) }
+      end
+      external_video_events.sort_by {|a| a[:timestamp]}
+    end
+    
     # Match recording start and stop events
     def self.match_start_and_stop_rec_events(rec_events)
       BigBlueButton.logger.info ("Matching record events")
@@ -520,6 +548,22 @@ module BigBlueButton
         end
       end
       matched_rec_events
+    end
+
+    # Match external video start and stop events
+    def self.match_start_and_stop_external_video_events(external_video_events)
+      BigBlueButton.logger.info ("Matching external video events")
+      matched_external_video_events = []
+      external_video_events.each_with_index do |evt,i|
+        if i.even?
+          matched_external_video_events << {
+            :start_timestamp => evt[:timestamp],
+            :stop_timestamp => external_video_events[i + 1][:timestamp],
+            :external_video_url => evt[:external_video_url],
+          }
+        end
+      end
+      matched_external_video_events
     end
 
     # Adjust the recoding start and stop events to trim them to a meeting


### PR DESCRIPTION
Generate a external_videos.json file at the recordings with an array of
played external videos url and timestamp.

This file will be published along with the other presentation format files
and can be used to display at the playback.
