### PR TITLE
fix: left/right webcam drag & drop for RTL languages

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/media/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/component.jsx
@@ -18,6 +18,7 @@ const propTypes = {
   disableVideo: PropTypes.bool,
   audioModalIsOpen: PropTypes.bool,
   layoutContextState: PropTypes.instanceOf(Object).isRequired,
+  isRTL: PropTypes.bool.isRequired,
 };
 
 const defaultProps = {
@@ -46,6 +47,7 @@ export default class Media extends Component {
       usersVideo,
       layoutContextState,
       isMeteorConnected,
+      isRTL,
     } = this.props;
 
     const { webcamsPlacement: placement } = layoutContextState;
@@ -117,6 +119,7 @@ export default class Media extends Component {
             disableVideo={disableVideo}
             audioModalIsOpen={audioModalIsOpen}
             usersVideo={usersVideo}
+            isRTL={isRTL}
           />
         ) : null}
       </div>

--- a/bigbluebutton-html5/imports/ui/components/media/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/container.jsx
@@ -137,6 +137,7 @@ export default withLayoutConsumer(withModalMounter(withTracker(() => {
   }
 
   data.webcamsPlacement = Storage.getItem('webcamsPlacement');
+  data.isRTL = document.documentElement.getAttribute('dir') === 'rtl';
 
   MediaContainer.propTypes = propTypes;
   return data;

--- a/bigbluebutton-html5/imports/ui/components/media/webcam-draggable-overlay/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/media/webcam-draggable-overlay/component.jsx
@@ -21,6 +21,7 @@ const propTypes = {
   refMediaContainer: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   layoutContextState: PropTypes.objectOf(Object).isRequired,
   layoutContextDispatch: PropTypes.func.isRequired,
+  isRTL: PropTypes.bool.isRequired,
 };
 
 const defaultProps = {
@@ -198,12 +199,12 @@ class WebcamDraggable extends PureComponent {
   }
 
   calculatePosition() {
-    const { layoutContextState } = this.props;
+    const { layoutContextState, isRTL } = this.props;
     const { mediaBounds } = layoutContextState;
 
     const { top: mediaTop, left: mediaLeft } = mediaBounds;
     const { top: webcamsListTop, left: webcamsListLeft } = this.getWebcamsListBounds();
-    const x = webcamsListLeft - mediaLeft;
+    const x = !isRTL ? (webcamsListLeft - mediaLeft) : webcamsListLeft;
     const y = webcamsListTop - mediaTop;
     return {
       x,
@@ -282,6 +283,7 @@ class WebcamDraggable extends PureComponent {
       hideOverlay,
       disableVideo,
       audioModalIsOpen,
+      isRTL,
     } = this.props;
 
     const { isMobile } = deviceInfo;
@@ -429,7 +431,7 @@ class WebcamDraggable extends PureComponent {
           />
         </div>
         <div
-          className={dropZoneLeftClassName}
+          className={!isRTL ? dropZoneLeftClassName : dropZoneRightClassName}
           style={{
             width: '15vh',
             height: `calc(${mediaHeight}px - (15vh * 2))`,
@@ -514,7 +516,7 @@ class WebcamDraggable extends PureComponent {
           />
         </div>
         <div
-          className={dropZoneRightClassName}
+          className={!isRTL ? dropZoneRightClassName : dropZoneLeftClassName}
           style={{
             width: '15vh',
             height: `calc(${mediaHeight}px - (15vh * 2))`,


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where dragging the camera container to right in RTL languages will place it in the left side.

#### before
![drag-drop-before](https://user-images.githubusercontent.com/3728706/124769185-a4f5ae80-df0f-11eb-8fe8-9f2295c7ed8c.gif)

#### after
![drag-drop-after](https://user-images.githubusercontent.com/3728706/124769176-a2935480-df0f-11eb-8009-3f1e369d9034.gif)

### Closes Issue(s)
Closes #12567