### PR TITLE
fix(screenshare): fix client crash on presenter change

### DIFF
--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -289,7 +289,9 @@ export default class KurentoScreenshareBridge {
       // If that's the case, clear the local sharing state in screen sharing UI
       // component tracker to be extra sure we won't have any client-side state
       // inconsistency - prlanzarin
-      if (this.broker.role === SEND_ROLE && !this.reconnecting) setSharingScreen(false);
+      if (this.broker && this.broker.role === SEND_ROLE && !this.reconnecting) {
+        setSharingScreen(false);
+      }
       this.broker = null;
     }
     this.gdmStream = null;

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -182,7 +182,7 @@ export default class KurentoScreenshareBridge {
         reconnecting: this.reconnecting,
         bridge: BRIDGE_NAME
       },
-    }, 'Screenshare broker failure');
+    }, `Screenshare broker failure: ${errorMessage}`);
 
     // Screensharing was already successfully negotiated and error occurred during
     // during call; schedule a reconnect


### PR DESCRIPTION
### What does this PR do?

- Fix a client crash on the presenter's side when a screen was being shared and the presenter changed (https://github.com/bigbluebutton/bigbluebutton/issues/12742)
- Append error messages to screenshare's broker failure log message to make it easier to read

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/12742

### More

Scenario: presenter's client could crash when the presenter changed while they were sharing their screen.
That is due to a race condition on the stop procedure in the bridge: two stops can be triggered (one from the server-side websocket tear off and another from the client itself detecting the presenter change).
That could create a scenario where the broker was cleaned in one stop procedure after the second had checked its availability, causing an attribute access of a null member