### PR TITLE
fix: close poll panel if user is no longer the presenter

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -204,8 +204,21 @@ class Poll extends Component {
   }
 
   componentDidUpdate() {
+    const { amIPresenter, newLayoutContextDispatch } = this.props;
+
     if (Session.equals('resetPollPanel', true)) {
       this.handleBackClick();
+    }
+
+    if (!amIPresenter) {
+      newLayoutContextDispatch({
+        type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+        value: false,
+      });
+      newLayoutContextDispatch({
+        type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+        value: PANELS.NONE,
+      });
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

Fixes a bug that would cause the poll panel to remain open if a user loses presenter status.