### PR TITLE
fix(webcams): add error feedback when media is ejected by the server

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -36,6 +36,10 @@ const intlClientErrors = defineMessages({
     id: 'app.video.mediaFlowTimeout1020',
     description: 'Media flow timeout',
   },
+  mediaTimedOutError: {
+    id: 'app.video.mediaTimedOutError',
+    description: 'Media was ejected by the server due to lack of valid media',
+  },
 });
 
 const intlSFUErrors = defineMessages({
@@ -791,6 +795,7 @@ class VideoProvider extends Component {
   }
 
   handlePlayStop(message) {
+    const { intl } = this.props;
     const { cameraId: stream, role } = message;
 
     logger.info({
@@ -800,6 +805,8 @@ class VideoProvider extends Component {
         role,
       },
     }, `Received request from SFU to stop camera. Role: ${role}`);
+
+    VideoService.notify(intl.formatMessage(intlClientErrors.mediaTimedOutError));
     this.stopWebRTCPeer(stream, false);
   }
 

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -697,6 +697,7 @@
     "app.video.notReadableError": "Could not get webcam video. Please make sure another program is not using the webcam ",
     "app.video.timeoutError": "Browser did not respond in time.",
     "app.video.genericError": "An unknown error has occurred with the device ({0})",
+    "app.video.mediaTimedOutError": "Your webcam stream has been interrupted. Try sharing it again",
     "app.video.mediaFlowTimeout1020": "Media could not reach the server (error 1020)",
     "app.video.suggestWebcamLock": "Enforce lock setting to viewers webcams?",
     "app.video.suggestWebcamLockReason": "(this will improve the stability of the meeting)",


### PR DESCRIPTION
### What does this PR do?

Add error feedback (via toasts) when webcams are ejected by the server due to lack of valid incoming media.

### Closes Issue(s)

Closes #12732