### PR TITLE
Postpone chat message sync

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
@@ -16,6 +16,7 @@ const CHAT_CLEAR_MESSAGE = CHAT_CONFIG.system_messages_keys.chat_clear;
 const ITENS_PER_PAGE = CHAT_CONFIG.itemsPerPage;
 const TIME_BETWEEN_FETCHS = CHAT_CONFIG.timeBetweenFetchs;
 const EVENT_NAME = 'bbb-group-chat-messages-subscription-has-stoppped';
+const EVENT_NAME_SUBSCRIPTION_READY = 'bbb-group-chat-messages-subscriptions-ready';
 
 const getMessagesBeforeJoinCounter = async () => {
   const counter = await makeCall('chatMessageBeforeJoinCounter');
@@ -24,7 +25,8 @@ const getMessagesBeforeJoinCounter = async () => {
 
 const startSyncMessagesbeforeJoin = async (dispatch) => {
   const chatsMessagesCount = await getMessagesBeforeJoinCounter();
-  const pagesPerChat = chatsMessagesCount.map(chat => ({ ...chat, pages: Math.ceil(chat.count / ITENS_PER_PAGE), syncedPages: 0 }));
+  const pagesPerChat = chatsMessagesCount
+    .map((chat) => ({ ...chat, pages: Math.ceil(chat.count / ITENS_PER_PAGE), syncedPages: 0 }));
 
   const syncRoutine = async (chatsToSync) => {
     if (!chatsToSync.length) return;
@@ -49,9 +51,8 @@ const startSyncMessagesbeforeJoin = async (dispatch) => {
       });
     }
 
-
-    await new Promise(r => setTimeout(r, TIME_BETWEEN_FETCHS));
-    syncRoutine(pagesToFetch.filter(chat => !(chat.syncedPages > chat.pages)));
+    await new Promise((r) => setTimeout(r, TIME_BETWEEN_FETCHS));
+    syncRoutine(pagesToFetch.filter((chat) => !(chat.syncedPages > chat.pages)));
   };
   syncRoutine(pagesPerChat);
 };
@@ -62,6 +63,7 @@ const Adapter = () => {
   const usingUsersContext = useContext(UsersContext);
   const { users } = usingUsersContext;
   const [syncStarted, setSync] = useState(true);
+  const [subscriptionReady, setSubscriptionReady] = useState(false);
   ChatLogger.trace('chatAdapter::body::users', users[Auth.meetingID]);
 
   useEffect(() => {
@@ -74,22 +76,28 @@ const Adapter = () => {
         });
       }
     });
+
+    window.addEventListener(EVENT_NAME_SUBSCRIPTION_READY, () => {
+      console.log('aconteceu');
+      setSubscriptionReady(true);
+    });
   }, []);
 
   useEffect(() => {
     const connectionStatus = Meteor.status();
-    if (connectionStatus.connected && !syncStarted && Auth.userID) {
-      setSync(true);
-
-      startSyncMessagesbeforeJoin(dispatch);
+    if (connectionStatus.connected && !syncStarted && Auth.userID && subscriptionReady) {
+      setTimeout(() => {
+        setSync(true);
+        console.log('iniciou o sync');
+        startSyncMessagesbeforeJoin(dispatch);
+      }, 1000);
     }
-  }, [Meteor.status().connected, syncStarted, Auth.userID]);
-
+  }, [Meteor.status().connected, syncStarted, Auth.userID, subscriptionReady]);
 
   /* needed to prevent an issue with dupĺicated messages when user role is changed
   more info: https://github.com/bigbluebutton/bigbluebutton/issues/11842 */
   useEffect(() => {
-    if (users[Auth.meetingID] && users[Auth.meetingID][Auth.userID]) {
+    if (users[Auth.meetingID]) {
       if (currentUserData?.role !== users[Auth.meetingID][Auth.userID].role) {
         prevUserData = currentUserData;
       }
@@ -114,7 +122,7 @@ const Adapter = () => {
     }, 1000, { trailing: true, leading: true });
 
     Meteor.connection._stream.socket.addEventListener('message', (msg) => {
-      if (msg.data.indexOf('{"msg":"added","collection":"group-chat-msg"') != -1) {
+      if (msg.data.indexOf('{"msg":"added","collection":"group-chat-msg"') !== -1) {
         const parsedMsg = JSON.parse(msg.data);
         if (parsedMsg.msg === 'added') {
           const { fields } = parsedMsg;

--- a/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
@@ -78,7 +78,6 @@ const Adapter = () => {
     });
 
     window.addEventListener(EVENT_NAME_SUBSCRIPTION_READY, () => {
-      console.log('aconteceu');
       setSubscriptionReady(true);
     });
   }, []);
@@ -88,7 +87,6 @@ const Adapter = () => {
     if (connectionStatus.connected && !syncStarted && Auth.userID && subscriptionReady) {
       setTimeout(() => {
         setSync(true);
-        console.log('iniciou o sync');
         startSyncMessagesbeforeJoin(dispatch);
       }, 1000);
     }

--- a/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
@@ -23,12 +23,15 @@ const SUBSCRIPTIONS = [
 ];
 
 const EVENT_NAME = 'bbb-group-chat-messages-subscription-has-stoppped';
+const EVENT_NAME_SUBSCRIPTION_READY = 'bbb-group-chat-messages-subscriptions-ready';
 
 class Subscriptions extends Component {
   componentDidUpdate() {
     const { subscriptionsReady } = this.props;
     if (subscriptionsReady) {
       Session.set('subscriptionsReady', true);
+      const event = new Event(EVENT_NAME_SUBSCRIPTION_READY);
+      window.dispatchEvent(event);
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

This PR adds an event to notify when subscriptions are ready and a condition to start synchronizing chat messages after this event, it is made so the websocket is not flooded with old chat messages while essential data of the meeting are synchronized

One might ask why I'm using an event and not Meteor.session, in my testing I realized that the session stores data between client refresh and it would allow synchronization to start before the subscriptions are ready.

### More
I made a few tests using the [BBB websocket traffic measurer](https://github.com/iMDT/bigbluebutton-pupeteer-measure-websocket-traffic) using different amount of messages and I can notice a improvement and meeting sync load.

(fresh meeting)
```
Wait for audio modal
Audio modal detected. Total websocket traffic: 0.06 mb
Click on close audio modal
Exiting

```
(Sending 10k messages)
```
Wait for audio modal
Audio modal detected. Total websocket traffic: 0.06 mb
Click on close audio modal
Fill input
Hit enter
Last message ( 10000 ) not yet received... 
Last message ( 10000 ) not yet received... 
Last message ( 10000 ) not yet received... 
(Theres a few more one until receive all messages)
Last message ( 10000 ) not yet received... 
Last bomber message 10000 detected. Total websocket traffic: 3.91 mb

```
(re-joining)
```
Wait for audio modal
Audio modal detected. Total websocket traffic: 0.06
Click on close audio modal
Exiting

```
