### PR TITLE
fix(screenshare): fullscreen status from state

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -271,11 +271,11 @@ class ScreenshareComponent extends React.Component {
   }
 
   renderScreenshareDefault() {
+    const { intl } = this.props;
     const {
-      intl,
       isFullscreen,
-    } = this.props;
-    const { loaded } = this.state;
+      loaded,
+    } = this.state;
 
     return (
       <div


### PR DESCRIPTION
isFullscreen is a state property and is being fetched from the component
props. I think this is something I messed up while resolving a cherry-pick
conflict.