### PR TITLE
feat: keep webcam resize in storage

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/webcam/drop-areas/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/drop-areas/container.jsx
@@ -10,7 +10,7 @@ const DropAreaContainer = () => {
 
   return (
     Object.keys(dropZoneAreas).map((objectKey) => (
-      <DropArea id={objectKey} style={dropZoneAreas[objectKey]} />
+      <DropArea key={objectKey} id={objectKey} style={dropZoneAreas[objectKey]} />
     ))
   );
 };


### PR DESCRIPTION
### What does this PR do?

Add webcam resize values to Storage in order to restore them after dragging/refreshing (custom layout)

#### before
![keep-res-before](https://user-images.githubusercontent.com/3728706/125495139-b7279b4c-6b5e-4c9c-b970-1f7a63a09c2a.gif)


#### after
![res-keep-after](https://user-images.githubusercontent.com/3728706/125495318-58a56081-d6e5-42bd-ba04-8427d3cc861e.gif)
