### PR TITLE
Get locale value from settings in export usernames

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -17,6 +17,7 @@ import CaptionsWriterMenu from '/imports/ui/components/captions/writer-menu/cont
 import DropdownListSeparator from '/imports/ui/components/dropdown/list/separator/component';
 import { styles } from './styles';
 import { getUserNamesLink } from '/imports/ui/components/user-list/service';
+import Settings from '/imports/ui/services/settings';
 
 const propTypes = {
   intl: PropTypes.shape({
@@ -156,16 +157,17 @@ class UserOptions extends PureComponent {
 
   onSaveUserNames() {
     const { intl, meetingName } = this.props;
+    const lang = Settings.application.locale;
     const date = new Date();
+
+    const dateString = lang ? date.toLocaleDateString(lang) : date.toLocaleDateString();
+    const timeString = lang ? date.toLocaleTimeString(lang) : date.toLocaleTimeString();
+
     getUserNamesLink(
       intl.formatMessage(intlMessages.savedNamesListTitle,
         {
           0: meetingName,
-          1: `${date.toLocaleDateString(
-            document.documentElement.lang,
-          )}:${date.toLocaleTimeString(
-            document.documentElement.lang,
-          )}`,
+          1: `${dateString}:${timeString}`,
         }),
       intl.formatMessage(intlMessages.sortedFirstNameHeading),
       intl.formatMessage(intlMessages.sortedLastNameHeading),


### PR DESCRIPTION
### What does this PR do?

- Makes save user names feature use the locale value from Settings instead of the property in HTML tag to format date and time. 
- Adds fallback if value is not available.

### Closes Issue(s)
Closes #12689