### PR TITLE
fix: close breakout creation modal if user loses moderator status

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -287,6 +287,7 @@ class BreakoutRoom extends PureComponent {
         roomList.removeEventListener('keydown', this.handleMoveEvent, true);
       }
     }
+    this.handleDismiss();
   }
 
   componentDidUpdate(prevProps, prevstate) {

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/container.jsx
@@ -1,7 +1,15 @@
+import React from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import ActionsBarService from '/imports/ui/components/actions-bar/service';
 
 import CreateBreakoutRoomModal from './component';
+
+const CreateBreakoutRoomContainer = (props) => (
+  props.amIModerator
+  && (
+    <CreateBreakoutRoomModal {...props} />
+  )
+);
 
 export default withTracker(() => ({
   createBreakoutRoom: ActionsBarService.createBreakoutRoom,
@@ -12,4 +20,5 @@ export default withTracker(() => ({
   users: ActionsBarService.users(),
   isMe: ActionsBarService.isMe,
   meetingName: ActionsBarService.meetingName(),
-}))(CreateBreakoutRoomModal);
+  amIModerator: ActionsBarService.amIModerator(),
+}))(CreateBreakoutRoomContainer);


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where the "create breakout rooms" modal will stay open even if the user loses moderator status.

### Closes Issue(s)
Closes #12622