### PR TITLE
feat: Webcam area size change when presentation is hidden - new layouts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -34,6 +34,7 @@ class ActionsBar extends PureComponent {
       setEmojiStatus,
       currentUser,
       shortcuts,
+      newLayoutContextDispatch,
     } = this.props;
 
     return (
@@ -81,6 +82,7 @@ class ActionsBar extends PureComponent {
             ? (
               <PresentationOptionsContainer
                 toggleSwapLayout={toggleSwapLayout}
+                newLayoutContextDispatch={newLayoutContextDispatch}
                 isThereCurrentPresentation={isThereCurrentPresentation}
               />
             )

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
@@ -12,6 +12,7 @@ import Service from './service';
 import UserListService from '/imports/ui/components/user-list/service';
 import ExternalVideoService from '/imports/ui/components/external-video-player/service';
 import CaptionsService from '/imports/ui/components/captions/service';
+import { NLayoutContext } from '../layout/context/context';
 
 import MediaService, {
   getSwapLayout,
@@ -21,6 +22,8 @@ import MediaService, {
 const ActionsBarContainer = (props) => {
   const usingUsersContext = useContext(UsersContext);
   const { users } = usingUsersContext;
+  const newLayoutContext = useContext(NLayoutContext);
+  const { newLayoutContextDispatch } = newLayoutContext;
 
   const currentUser = { userId: Auth.userID, emoji: users[Auth.meetingID][Auth.userID].emoji };
 
@@ -29,6 +32,7 @@ const ActionsBarContainer = (props) => {
       ...{
         ...props,
         currentUser,
+        newLayoutContextDispatch,
       }
     }
     />

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
@@ -22,7 +22,12 @@ const intlMessages = defineMessages({
 
 const shouldUnswapLayout = () => MediaService.shouldShowScreenshare() || MediaService.shouldShowExternalVideo();
 
-const PresentationOptionsContainer = ({ intl, toggleSwapLayout, isThereCurrentPresentation }) => {
+const PresentationOptionsContainer = ({
+  intl,
+  toggleSwapLayout,
+  isThereCurrentPresentation,
+  newLayoutContextDispatch
+}) => {
   if (shouldUnswapLayout()) toggleSwapLayout();
   return (
     <Button
@@ -34,7 +39,7 @@ const PresentationOptionsContainer = ({ intl, toggleSwapLayout, isThereCurrentPr
       hideLabel
       circle
       size="lg"
-      onClick={toggleSwapLayout}
+      onClick={() => toggleSwapLayout(newLayoutContextDispatch)}
       id="restore-presentation"
       disabled={!isThereCurrentPresentation}
     />

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -425,166 +425,175 @@ class CustomLayout extends Component {
   calculatesCameraDockBounds(sidebarNavWidth, sidebarContentWidth, mediaAreaBounds) {
     const { newLayoutContextState } = this.props;
     const { input, fullscreen } = newLayoutContextState;
+    const { presentation } = input;
+    const { isOpen } = presentation;
 
     const cameraDockBounds = {};
 
     if (input.cameraDock.numCameras > 0) {
-      let cameraDockLeft = 0;
-      let cameraDockHeight = 0;
-      let cameraDockWidth = 0;
-      switch (input.cameraDock.position) {
-        case CAMERADOCK_POSITION.CONTENT_TOP:
-          cameraDockLeft = mediaAreaBounds.left;
+      if (!isOpen) {
+        cameraDockBounds.width = mediaAreaBounds.width;
+        cameraDockBounds.maxWidth = mediaAreaBounds.width;
+        cameraDockBounds.height = mediaAreaBounds.height;
+        cameraDockBounds.maxHeight = mediaAreaBounds.height;
+      } else {
+        let cameraDockLeft = 0;
+        let cameraDockHeight = 0;
+        let cameraDockWidth = 0;
+        switch (input.cameraDock.position) {
+          case CAMERADOCK_POSITION.CONTENT_TOP:
+            cameraDockLeft = mediaAreaBounds.left;
 
-          if (input.cameraDock.height === 0) {
-            if (input.presentation.isOpen) {
+            if (input.cameraDock.height === 0) {
+              if (input.presentation.isOpen) {
+                cameraDockHeight = min(
+                  max((mediaAreaBounds.height * 0.2), DEFAULT_VALUES.cameraDockMinHeight),
+                  (mediaAreaBounds.height - DEFAULT_VALUES.cameraDockMinHeight),
+                );
+              } else {
+                cameraDockHeight = mediaAreaBounds.height;
+              }
+            } else {
               cameraDockHeight = min(
-                max((mediaAreaBounds.height * 0.2), DEFAULT_VALUES.cameraDockMinHeight),
+                max(input.cameraDock.height, DEFAULT_VALUES.cameraDockMinHeight),
                 (mediaAreaBounds.height - DEFAULT_VALUES.cameraDockMinHeight),
               );
-            } else {
-              cameraDockHeight = mediaAreaBounds.height;
             }
-          } else {
-            cameraDockHeight = min(
-              max(input.cameraDock.height, DEFAULT_VALUES.cameraDockMinHeight),
-              (mediaAreaBounds.height - DEFAULT_VALUES.cameraDockMinHeight),
-            );
-          }
 
-          cameraDockBounds.top = DEFAULT_VALUES.navBarHeight;
-          cameraDockBounds.left = cameraDockLeft;
-          cameraDockBounds.minWidth = mediaAreaBounds.width;
-          cameraDockBounds.width = mediaAreaBounds.width;
-          cameraDockBounds.maxWidth = mediaAreaBounds.width;
-          cameraDockBounds.minHeight = DEFAULT_VALUES.cameraDockMinHeight;
-          cameraDockBounds.height = cameraDockHeight;
-          cameraDockBounds.maxHeight = mediaAreaBounds.height * 0.8;
-          break;
-        case CAMERADOCK_POSITION.CONTENT_RIGHT:
-          if (input.cameraDock.width === 0) {
-            if (input.presentation.isOpen) {
+            cameraDockBounds.top = DEFAULT_VALUES.navBarHeight;
+            cameraDockBounds.left = cameraDockLeft;
+            cameraDockBounds.minWidth = mediaAreaBounds.width;
+            cameraDockBounds.width = mediaAreaBounds.width;
+            cameraDockBounds.maxWidth = mediaAreaBounds.width;
+            cameraDockBounds.minHeight = DEFAULT_VALUES.cameraDockMinHeight;
+            cameraDockBounds.height = cameraDockHeight;
+            cameraDockBounds.maxHeight = mediaAreaBounds.height * 0.8;
+            break;
+          case CAMERADOCK_POSITION.CONTENT_RIGHT:
+            if (input.cameraDock.width === 0) {
+              if (input.presentation.isOpen) {
+                cameraDockWidth = min(
+                  max((mediaAreaBounds.width * 0.2), DEFAULT_VALUES.cameraDockMinWidth),
+                  (mediaAreaBounds.width - DEFAULT_VALUES.cameraDockMinWidth),
+                );
+              } else {
+                cameraDockWidth = mediaAreaBounds.width;
+              }
+            } else {
               cameraDockWidth = min(
-                max((mediaAreaBounds.width * 0.2), DEFAULT_VALUES.cameraDockMinWidth),
+                max(input.cameraDock.width, DEFAULT_VALUES.cameraDockMinWidth),
                 (mediaAreaBounds.width - DEFAULT_VALUES.cameraDockMinWidth),
               );
-            } else {
-              cameraDockWidth = mediaAreaBounds.width;
             }
-          } else {
-            cameraDockWidth = min(
-              max(input.cameraDock.width, DEFAULT_VALUES.cameraDockMinWidth),
-              (mediaAreaBounds.width - DEFAULT_VALUES.cameraDockMinWidth),
-            );
-          }
 
-          cameraDockBounds.top = DEFAULT_VALUES.navBarHeight;
-          cameraDockBounds.left = input.presentation.isOpen
-            ? (mediaAreaBounds.left + mediaAreaBounds.width) - cameraDockWidth
-            : mediaAreaBounds.left;
-          cameraDockBounds.minWidth = DEFAULT_VALUES.cameraDockMinWidth;
-          cameraDockBounds.width = cameraDockWidth;
-          cameraDockBounds.maxWidth = mediaAreaBounds.width * 0.8;
-          cameraDockBounds.minHeight = DEFAULT_VALUES.cameraDockMinHeight;
-          cameraDockBounds.height = mediaAreaBounds.height;
-          cameraDockBounds.maxHeight = mediaAreaBounds.height;
-          break;
-        case CAMERADOCK_POSITION.CONTENT_BOTTOM:
-          cameraDockLeft = mediaAreaBounds.left;
+            cameraDockBounds.top = DEFAULT_VALUES.navBarHeight;
+            cameraDockBounds.left = input.presentation.isOpen
+              ? (mediaAreaBounds.left + mediaAreaBounds.width) - cameraDockWidth
+              : mediaAreaBounds.left;
+            cameraDockBounds.minWidth = DEFAULT_VALUES.cameraDockMinWidth;
+            cameraDockBounds.width = cameraDockWidth;
+            cameraDockBounds.maxWidth = mediaAreaBounds.width * 0.8;
+            cameraDockBounds.minHeight = DEFAULT_VALUES.cameraDockMinHeight;
+            cameraDockBounds.height = mediaAreaBounds.height;
+            cameraDockBounds.maxHeight = mediaAreaBounds.height;
+            break;
+          case CAMERADOCK_POSITION.CONTENT_BOTTOM:
+            cameraDockLeft = mediaAreaBounds.left;
 
-          if (input.cameraDock.height === 0) {
-            if (input.presentation.isOpen) {
+            if (input.cameraDock.height === 0) {
+              if (input.presentation.isOpen) {
+                cameraDockHeight = min(
+                  max((mediaAreaBounds.height * 0.2), DEFAULT_VALUES.cameraDockMinHeight),
+                  (mediaAreaBounds.height - DEFAULT_VALUES.cameraDockMinHeight),
+                );
+              } else {
+                cameraDockHeight = mediaAreaBounds.height;
+              }
+            } else {
               cameraDockHeight = min(
-                max((mediaAreaBounds.height * 0.2), DEFAULT_VALUES.cameraDockMinHeight),
+                max(input.cameraDock.height, DEFAULT_VALUES.cameraDockMinHeight),
                 (mediaAreaBounds.height - DEFAULT_VALUES.cameraDockMinHeight),
               );
-            } else {
-              cameraDockHeight = mediaAreaBounds.height;
             }
-          } else {
-            cameraDockHeight = min(
-              max(input.cameraDock.height, DEFAULT_VALUES.cameraDockMinHeight),
-              (mediaAreaBounds.height - DEFAULT_VALUES.cameraDockMinHeight),
-            );
-          }
 
-          cameraDockBounds.top = DEFAULT_VALUES.navBarHeight
-            + mediaAreaBounds.height - cameraDockHeight;
-          cameraDockBounds.left = cameraDockLeft;
-          cameraDockBounds.minWidth = mediaAreaBounds.width;
-          cameraDockBounds.width = mediaAreaBounds.width;
-          cameraDockBounds.maxWidth = mediaAreaBounds.width;
-          cameraDockBounds.minHeight = DEFAULT_VALUES.cameraDockMinHeight;
-          cameraDockBounds.height = cameraDockHeight;
-          cameraDockBounds.maxHeight = mediaAreaBounds.height * 0.8;
-          break;
-        case CAMERADOCK_POSITION.CONTENT_LEFT:
-          if (input.cameraDock.width === 0) {
-            if (input.presentation.isOpen) {
+            cameraDockBounds.top = DEFAULT_VALUES.navBarHeight
+              + mediaAreaBounds.height - cameraDockHeight;
+            cameraDockBounds.left = cameraDockLeft;
+            cameraDockBounds.minWidth = mediaAreaBounds.width;
+            cameraDockBounds.width = mediaAreaBounds.width;
+            cameraDockBounds.maxWidth = mediaAreaBounds.width;
+            cameraDockBounds.minHeight = DEFAULT_VALUES.cameraDockMinHeight;
+            cameraDockBounds.height = cameraDockHeight;
+            cameraDockBounds.maxHeight = mediaAreaBounds.height * 0.8;
+            break;
+          case CAMERADOCK_POSITION.CONTENT_LEFT:
+            if (input.cameraDock.width === 0) {
+              if (input.presentation.isOpen) {
+                cameraDockWidth = min(
+                  max((mediaAreaBounds.width * 0.2), DEFAULT_VALUES.cameraDockMinWidth),
+                  (mediaAreaBounds.width - DEFAULT_VALUES.cameraDockMinWidth),
+                );
+              } else {
+                cameraDockWidth = mediaAreaBounds.width;
+              }
+            } else {
               cameraDockWidth = min(
-                max((mediaAreaBounds.width * 0.2), DEFAULT_VALUES.cameraDockMinWidth),
+                max(input.cameraDock.width, DEFAULT_VALUES.cameraDockMinWidth),
                 (mediaAreaBounds.width - DEFAULT_VALUES.cameraDockMinWidth),
               );
-            } else {
-              cameraDockWidth = mediaAreaBounds.width;
             }
-          } else {
-            cameraDockWidth = min(
-              max(input.cameraDock.width, DEFAULT_VALUES.cameraDockMinWidth),
-              (mediaAreaBounds.width - DEFAULT_VALUES.cameraDockMinWidth),
-            );
-          }
 
-          cameraDockBounds.top = DEFAULT_VALUES.navBarHeight;
-          cameraDockBounds.left = mediaAreaBounds.left;
-          cameraDockBounds.minWidth = DEFAULT_VALUES.cameraDockMinWidth;
-          cameraDockBounds.width = cameraDockWidth;
-          cameraDockBounds.maxWidth = mediaAreaBounds.width * 0.8;
-          cameraDockBounds.minHeight = mediaAreaBounds.height;
-          cameraDockBounds.height = mediaAreaBounds.height;
-          cameraDockBounds.maxHeight = mediaAreaBounds.height;
-          break;
-        case CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM:
-          if (input.cameraDock.height === 0) {
-            cameraDockHeight = min(
-              max((this.mainHeight() * 0.2), DEFAULT_VALUES.cameraDockMinHeight),
-              (this.mainHeight() - DEFAULT_VALUES.cameraDockMinHeight),
-            );
-          } else {
-            cameraDockHeight = min(
-              max(input.cameraDock.height, DEFAULT_VALUES.cameraDockMinHeight),
-              (this.mainHeight() - DEFAULT_VALUES.cameraDockMinHeight),
-            );
-          }
+            cameraDockBounds.top = DEFAULT_VALUES.navBarHeight;
+            cameraDockBounds.left = mediaAreaBounds.left;
+            cameraDockBounds.minWidth = DEFAULT_VALUES.cameraDockMinWidth;
+            cameraDockBounds.width = cameraDockWidth;
+            cameraDockBounds.maxWidth = mediaAreaBounds.width * 0.8;
+            cameraDockBounds.minHeight = mediaAreaBounds.height;
+            cameraDockBounds.height = mediaAreaBounds.height;
+            cameraDockBounds.maxHeight = mediaAreaBounds.height;
+            break;
+          case CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM:
+            if (input.cameraDock.height === 0) {
+              cameraDockHeight = min(
+                max((this.mainHeight() * 0.2), DEFAULT_VALUES.cameraDockMinHeight),
+                (this.mainHeight() - DEFAULT_VALUES.cameraDockMinHeight),
+              );
+            } else {
+              cameraDockHeight = min(
+                max(input.cameraDock.height, DEFAULT_VALUES.cameraDockMinHeight),
+                (this.mainHeight() - DEFAULT_VALUES.cameraDockMinHeight),
+              );
+            }
 
-          cameraDockBounds.top = this.mainHeight() - cameraDockHeight;
-          cameraDockBounds.left = sidebarNavWidth;
-          cameraDockBounds.minWidth = sidebarContentWidth;
-          cameraDockBounds.width = sidebarContentWidth;
-          cameraDockBounds.maxWidth = sidebarContentWidth;
-          cameraDockBounds.minHeight = DEFAULT_VALUES.cameraDockMinHeight;
-          cameraDockBounds.height = cameraDockHeight;
-          cameraDockBounds.maxHeight = this.mainHeight() * 0.8;
-          break;
-        default:
-          console.log('default');
+            cameraDockBounds.top = this.mainHeight() - cameraDockHeight;
+            cameraDockBounds.left = sidebarNavWidth;
+            cameraDockBounds.minWidth = sidebarContentWidth;
+            cameraDockBounds.width = sidebarContentWidth;
+            cameraDockBounds.maxWidth = sidebarContentWidth;
+            cameraDockBounds.minHeight = DEFAULT_VALUES.cameraDockMinHeight;
+            cameraDockBounds.height = cameraDockHeight;
+            cameraDockBounds.maxHeight = this.mainHeight() * 0.8;
+            break;
+          default:
+            console.log('default');
+        }
+
+        if (fullscreen.group === 'webcams') {
+          cameraDockBounds.width = windowWidth();
+          cameraDockBounds.minWidth = windowWidth();
+          cameraDockBounds.maxWidth = windowWidth();
+          cameraDockBounds.height = windowHeight();
+          cameraDockBounds.minHeight = windowHeight();
+          cameraDockBounds.maxHeight = windowHeight();
+          cameraDockBounds.top = 0;
+          cameraDockBounds.left = 0;
+          cameraDockBounds.zIndex = 99;
+          return cameraDockBounds;
+        }
+
+        if (input.cameraDock.isDragging) cameraDockBounds.zIndex = 99;
+        else cameraDockBounds.zIndex = 1;
       }
-
-      if (fullscreen.group === 'webcams') {
-        cameraDockBounds.width = windowWidth();
-        cameraDockBounds.minWidth = windowWidth();
-        cameraDockBounds.maxWidth = windowWidth();
-        cameraDockBounds.height = windowHeight();
-        cameraDockBounds.minHeight = windowHeight();
-        cameraDockBounds.maxHeight = windowHeight();
-        cameraDockBounds.top = 0;
-        cameraDockBounds.left = 0;
-        cameraDockBounds.zIndex = 99;
-        return cameraDockBounds;
-      }
-
-      if (input.cameraDock.isDragging) cameraDockBounds.zIndex = 99;
-      else cameraDockBounds.zIndex = 1;
     } else {
       cameraDockBounds.width = 0;
       cameraDockBounds.height = 0;
@@ -596,11 +605,22 @@ class CustomLayout extends Component {
   calculatesMediaBounds(sidebarNavWidth, sidebarContentWidth, cameraDockBounds) {
     const { newLayoutContextState } = this.props;
     const { input, fullscreen } = newLayoutContextState;
+    const { presentation } = input;
+    const { isOpen } = presentation;
     const mediaAreaHeight = this.mainHeight()
       - (DEFAULT_VALUES.navBarHeight + DEFAULT_VALUES.actionBarHeight);
     const mediaAreaWidth = this.mainWidth() - (sidebarNavWidth + sidebarContentWidth);
     const mediaBounds = {};
     const { element: fullscreenElement } = fullscreen;
+
+    if (!isOpen) {
+      mediaBounds.width = 0;
+      mediaBounds.height = 0;
+      mediaBounds.top = 0;
+      mediaBounds.left = 0;
+      mediaBounds.zIndex = 0;
+      return mediaBounds;
+    }
 
     if (fullscreenElement === 'Presentation' || fullscreenElement === 'Screenshare') {
       mediaBounds.width = this.mainWidth();

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -353,6 +353,8 @@ class SmartLayout extends Component {
   calculatesCameraDockBounds(mediaAreaBounds, mediaBounds) {
     const { newLayoutContextState } = this.props;
     const { input, fullscreen } = newLayoutContextState;
+    const { presentation } = input;
+    const { isOpen } = presentation;
 
     const cameraDockBounds = {};
 
@@ -361,7 +363,12 @@ class SmartLayout extends Component {
       cameraDockBounds.left = mediaAreaBounds.left;
       cameraDockBounds.zIndex = 1;
 
-      if (mediaBounds.width < mediaAreaBounds.width) {
+      if (!isOpen) {
+        cameraDockBounds.width = mediaAreaBounds.width;
+        cameraDockBounds.maxWidth = mediaAreaBounds.width;
+        cameraDockBounds.height = mediaAreaBounds.height;
+        cameraDockBounds.maxHeight = mediaAreaBounds.height;
+      } else if (mediaBounds.width < mediaAreaBounds.width) {
         cameraDockBounds.width = mediaAreaBounds.width - mediaBounds.width;
         cameraDockBounds.maxWidth = mediaAreaBounds.width * 0.8;
         cameraDockBounds.height = mediaAreaBounds.height;
@@ -428,10 +435,21 @@ class SmartLayout extends Component {
   calculatesMediaBounds(mediaAreaBounds, slideSize) {
     const { newLayoutContextState } = this.props;
     const { input, fullscreen } = newLayoutContextState;
+    const { presentation } = input;
+    const { isOpen } = presentation;
     const mediaBounds = {};
     const { element: fullscreenElement } = fullscreen;
 
     // TODO Adicionar min e max para a apresentação
+
+    if (!isOpen) {
+      mediaBounds.width = 0;
+      mediaBounds.height = 0;
+      mediaBounds.top = 0;
+      mediaBounds.left = 0;
+      mediaBounds.zIndex = 0;
+      return mediaBounds;
+    }
 
     if (fullscreenElement === 'Presentation' || fullscreenElement === 'Screenshare') {
       mediaBounds.width = this.mainWidth();

--- a/bigbluebutton-html5/imports/ui/components/media/service.js
+++ b/bigbluebutton-html5/imports/ui/components/media/service.js
@@ -5,6 +5,7 @@ import Auth from '/imports/ui/services/auth';
 import Users from '/imports/api/users';
 import Settings from '/imports/ui/services/settings';
 import getFromUserSettings from '/imports/ui/services/users-settings';
+import { ACTIONS } from '../layout/enums';
 
 const LAYOUT_CONFIG = Meteor.settings.public.layout;
 const KURENTO_CONFIG = Meteor.settings.public.kurento;
@@ -51,10 +52,15 @@ const setSwapLayout = () => {
   swapLayout.tracker.changed();
 };
 
-const toggleSwapLayout = () => {
+const toggleSwapLayout = (newLayoutContextDispatch) => {
   window.dispatchEvent(new Event('togglePresentationHide'));
   swapLayout.value = !swapLayout.value;
   swapLayout.tracker.changed();
+
+  newLayoutContextDispatch({
+    type: ACTIONS.SET_PRESENTATION_IS_OPEN,
+    value: !swapLayout.value,
+  });
 };
 
 export const shouldEnableSwapLayout = () => !shouldShowScreenshare() && !shouldShowExternalVideo();

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -170,6 +170,7 @@ class Presentation extends PureComponent {
       restoreOnUpdate,
       layoutContextDispatch,
       layoutContextState,
+      newLayoutContextDispatch,
       userIsPresenter,
       layoutManagerLoaded,
       presentationBounds,
@@ -267,7 +268,7 @@ class Presentation extends PureComponent {
           || slidePosition.viewBoxWidth !== prevProps.slidePosition.viewBoxWidth;
         const pollPublished = publishedPoll && !prevProps.publishedPoll;
         if (slideChanged || positionChanged || pollPublished) {
-          toggleSwapLayout();
+          toggleSwapLayout(newLayoutContextDispatch);
         }
       }
 
@@ -492,12 +493,19 @@ class Presentation extends PureComponent {
 
   renderPresentationClose() {
     const { isFullscreen } = this.state;
-    const { layoutLoaded, fullscreenContext } = this.props;
+    const {
+      layoutLoaded,
+      fullscreenContext,
+      newLayoutContextDispatch,
+    } = this.props;
 
     if (!shouldEnableSwapLayout() || isFullscreen || layoutLoaded === 'new' && fullscreenContext) {
       return null;
     }
-    return <PresentationCloseButton toggleSwapLayout={MediaService.toggleSwapLayout} />;
+    return <PresentationCloseButton
+      toggleSwapLayout={MediaService.toggleSwapLayout}
+      newLayoutContextDispatch={newLayoutContextDispatch}
+    />;
   }
 
   renderOverlays(slideObj, svgDimensions, viewBoxPosition, viewBoxDimensions, physicalDimensions) {

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -21,7 +21,7 @@ import { withDraggableConsumer } from '../media/webcam-draggable-overlay/context
 import Icon from '/imports/ui/components/icon/component';
 import { withLayoutConsumer } from '/imports/ui/components/layout/context';
 import PollingContainer from '/imports/ui/components/polling/container';
-import { ACTIONS } from '../layout/enums';
+import { ACTIONS, LAYOUT_TYPE } from '../layout/enums';
 
 const intlMessages = defineMessages({
   presentationLabel: {
@@ -495,11 +495,14 @@ class Presentation extends PureComponent {
     const { isFullscreen } = this.state;
     const {
       layoutLoaded,
+      layoutType,
       fullscreenContext,
       newLayoutContextDispatch,
     } = this.props;
 
-    if (!shouldEnableSwapLayout() || isFullscreen || layoutLoaded === 'new' && fullscreenContext) {
+    if (!shouldEnableSwapLayout() ||
+      isFullscreen ||
+      (layoutLoaded === 'new' && (fullscreenContext || layoutType === LAYOUT_TYPE.PRESENTATION_FOCUS))) {
       return null;
     }
     return <PresentationCloseButton

--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -20,7 +20,7 @@ const PresentationContainer = ({ presentationPodIds, mountPresentation, ...props
   const fullscreenElementId = 'Presentation';
   const newLayoutContext = useContext(NLayoutContext);
   const { newLayoutContextState, newLayoutContextDispatch } = newLayoutContext;
-  const { output, layoutLoaded, fullscreen } = newLayoutContextState;
+  const { output, layoutLoaded, layoutType, fullscreen } = newLayoutContextState;
   const { presentation } = output;
   const { element } = fullscreen;
   const fullscreenContext = (element === fullscreenElementId);
@@ -43,6 +43,7 @@ const PresentationContainer = ({ presentationPodIds, mountPresentation, ...props
           userIsPresenter: userIsPresenter && !layoutSwapped,
           presentationBounds: presentation,
           layoutLoaded,
+          layoutType,
           fullscreenContext,
           fullscreenElementId,
         }

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-close-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-close-button/component.jsx
@@ -10,13 +10,13 @@ const intlMessages = defineMessages({
   },
 });
 
-const ClosePresentationComponent = ({ intl, toggleSwapLayout }) => (
+const ClosePresentationComponent = ({ intl, toggleSwapLayout, newLayoutContextDispatch }) => (
   <Button
     color="primary"
     icon="minus"
     size="sm"
     data-test="hidePresentationButton"
-    onClick={toggleSwapLayout}
+    onClick={() => toggleSwapLayout(newLayoutContextDispatch)}
     label={intl.formatMessage(intlMessages.closePresentationLabel)}
     aria-label={intl.formatMessage(intlMessages.closePresentationLabel)}
     hideLabel

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -93,9 +93,10 @@ class ScreenshareComponent extends React.Component {
       getSwapLayout,
       shouldEnableSwapLayout,
       toggleSwapLayout,
+      newLayoutContextDispatch,
     } = this.props;
     const layoutSwapped = getSwapLayout() && shouldEnableSwapLayout();
-    if (layoutSwapped) toggleSwapLayout();
+    if (layoutSwapped) toggleSwapLayout(newLayoutContextDispatch);
     screenshareHasEnded();
     this.screenshareContainer.removeEventListener('fullscreenchange', this.onFullscreenChange);
     window.removeEventListener('screensharePlayFailed', this.handlePlayElementFailed);

--- a/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
@@ -172,10 +172,10 @@ const WebcamComponent = ({
             setTimeout(() => setIsResizing(false), 500);
           }}
           enable={{
-            top: !isFullscreen && !isDragging && cameraDock.resizableEdge.top,
-            bottom: !isFullscreen && !isDragging && cameraDock.resizableEdge.bottom,
-            left: !isFullscreen && !isDragging && cameraDock.resizableEdge.left,
-            right: !isFullscreen && !isDragging && cameraDock.resizableEdge.right,
+            top: !isFullscreen && !isDragging && !swapLayout && cameraDock.resizableEdge.top,
+            bottom: !isFullscreen && !isDragging && !swapLayout && cameraDock.resizableEdge.bottom,
+            left: !isFullscreen && !isDragging && !swapLayout && cameraDock.resizableEdge.left,
+            right: !isFullscreen && !isDragging && !swapLayout && cameraDock.resizableEdge.right,
             topLeft: false,
             topRight: false,
             bottomLeft: false,


### PR DESCRIPTION
### What does this PR do?

- Makes webcam area use all available space when presentation is hidden (Smart and Custom layouts).
- Removes "Hide presentation" button in Focus on presentation layout

#### before
![hide-presentation-cam-before](https://user-images.githubusercontent.com/3728706/126002785-4336f60e-b603-48dd-baa1-06326b14401c.gif)

#### after
![hide-presentation-cam-after](https://user-images.githubusercontent.com/3728706/126002642-4e79734c-51b8-4f47-a8eb-35e6705a987b.gif)
