### PR TITLE
Initialize the start/stop dictation button when speech recognition stops after some silence

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/captions/pad/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/pad/component.jsx
@@ -88,8 +88,11 @@ class Pad extends PureComponent {
     this.handleListen = this.handleListen.bind(this);
     
     this.recognition.addEventListener('end', () => {
-      notify(intl.formatMessage(intlMessages.speechRecognitionStop), 'info', 'warning');
-      this.stopListen();
+      const { listening } = this.state;
+      if (listening) {
+        notify(intl.formatMessage(intlMessages.speechRecognitionStop), 'info', 'warning');
+        this.stopListen();
+      }
     });
   }
 

--- a/bigbluebutton-html5/imports/ui/components/captions/pad/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/pad/component.jsx
@@ -7,6 +7,7 @@ import Button from '/imports/ui/components/button/component';
 import logger from '/imports/startup/client/logger';
 import PadService from './service';
 import CaptionsService from '/imports/ui/components/captions/service';
+import { notify } from '/imports/ui/services/notification';
 import { styles } from './styles';
 
 const intlMessages = defineMessages({
@@ -46,6 +47,10 @@ const intlMessages = defineMessages({
     id: 'app.captions.pad.dictationOffDesc',
     description: 'Aria description for button that turns off speech recognition',
   },
+  speechRecognitionStop: {
+    id: 'app.captions.pad.speechRecognitionStop',
+    description: 'Notification for stopped speech recognition',
+  },  
 });
 
 const propTypes = {
@@ -76,11 +81,16 @@ class Pad extends PureComponent {
       listening: false,
     };
 
-    const { locale } = props;
+    const { locale, intl } = props;
     this.recognition = CaptionsService.initSpeechRecognition(locale);
 
     this.toggleListen = this.toggleListen.bind(this);
     this.handleListen = this.handleListen.bind(this);
+    
+    this.recognition.addEventListener('end', () => {
+      notify(intl.formatMessage(intlMessages.speechRecognitionStop), 'info', 'warning');
+      this.stopListen();
+    });
   }
 
   componentDidUpdate() {
@@ -167,6 +177,10 @@ class Pad extends PureComponent {
     this.setState({
       listening: !listening,
     }, this.handleListen);
+  }
+  
+  stopListen() {
+    this.setState({ listening: false });
   }
 
   render() {

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -49,6 +49,7 @@
     "app.captions.pad.dictationStop": "Stop dictation",
     "app.captions.pad.dictationOnDesc": "Turns speech recognition on",
     "app.captions.pad.dictationOffDesc": "Turns speech recognition off",
+    "app.captions.pad.speechRecognitionStop": "Speech recognition stopped due to some time of silence",
     "app.textInput.sendLabel": "Send",
     "app.note.title": "Shared Notes",
     "app.note.label": "Note",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -49,7 +49,7 @@
     "app.captions.pad.dictationStop": "Stop dictation",
     "app.captions.pad.dictationOnDesc": "Turns speech recognition on",
     "app.captions.pad.dictationOffDesc": "Turns speech recognition off",
-    "app.captions.pad.speechRecognitionStop": "Speech recognition stopped due to some time of silence",
+    "app.captions.pad.speechRecognitionStop": "Speech recognition stopped due to the browser incompatibility or some time of silence",
     "app.textInput.sendLabel": "Send",
     "app.note.title": "Shared Notes",
     "app.note.label": "Note",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Change the 'stop dictation' button to 'start dictation' button when the speech recognition stops after some silence. A notification also appears.

### Closes Issue(s)

Closes #12782 

### Motivation

After the stop of speech recognition due to the API's restriction, we need to click the button twice to make it work again. Moreover we cannot know that it stops because there is no notification.

Some discussion is https://groups.google.com/g/bigbluebutton-dev/c/zqhHDz56ag8/m/P-MW2XlpAQAJ

### More

A screenshot with this PR:
![dictation](https://user-images.githubusercontent.com/45039819/126058094-f8bc95bf-c86e-4202-9b06-93fcb3d813cc.gif)

