### PR TITLE
fix(webcams): only fetch streams from storage when the peer is a publisher

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -475,7 +475,9 @@ class VideoProvider extends Component {
         video: constraints,
       },
       onicecandidate: this._getOnIceCandidateCallback(stream, isLocal),
-      videoStream: VideoService.getPreloadedStream(),
+      // Only try to fetch a stored MediaStream if this is a publisher to avoid
+      // using a publisher's media stream accidentally
+      videoStream: isLocal ? VideoService.getPreloadedStream() : undefined,
     };
 
     try {


### PR DESCRIPTION
### What does this PR do?

Avoids a theoretical race condition where subscriber peers could accidentally re-use publisher media streams

### Closes Issue(s)

None

### Motivation

Cannot really reproduce that, but it's something I noticed while refactoring parts of video-provider for #12495.
If a subscriber peer reaches the peerOption code block while a publisher is being set up and the service has a valid deviceId set, it could re-use the publisher's media stream.

It doesn't really blow things up. The subscriber and publisher will work with a multi-track MediaStream, but if the publisher stops then the subscriber would be stopped as well, potentially triggering a subscriber reconnection.