### PR TITLE
Add config overrides for FreeSWITCH

### DIFF
--- a/bbb-voice-conference/config/freeswitch/conf/autoload_configs/sofia.conf.xml
+++ b/bbb-voice-conference/config/freeswitch/conf/autoload_configs/sofia.conf.xml
@@ -24,6 +24,7 @@
   -->
   <profiles>
     <X-PRE-PROCESS cmd="include" data="../sip_profiles/*.xml"/>
+    <X-PRE-PROCESS cmd="include" data="/etc/bigbluebutton/freeswitch/sip_profiles/*.xml"/>
   </profiles>
 
 </configuration>

--- a/bbb-voice-conference/config/freeswitch/conf/freeswitch.xml
+++ b/bbb-voice-conference/config/freeswitch/conf/freeswitch.xml
@@ -37,13 +37,16 @@
       vars.xml contains all the #set directives for the preprocessor.
   -->
   <X-PRE-PROCESS cmd="include" data="vars.xml"/>
+  <X-PRE-PROCESS cmd="include" data="/etc/bigbluebutton/freeswitch/vars.xml"/>
 
   <section name="configuration" description="Various Configuration">
     <X-PRE-PROCESS cmd="include" data="autoload_configs/*.xml"/>
+    <X-PRE-PROCESS cmd="include" data="/etc/bigbluebutton/freeswitch/autoload_configs/*.xml"/>
   </section>
 
   <section name="dialplan" description="Regex/XML Dialplan">
     <X-PRE-PROCESS cmd="include" data="dialplan/*.xml"/>
+    <X-PRE-PROCESS cmd="include" data="/etc/bigbluebutton/freeswitch/dialplan/*.xml"/>
   </section>
 
   <!-- mod_dingaling is reliant on the vcard data in the "directory" section. -->

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -117,6 +117,10 @@ fi
 
 # Common to Ubuntu and CentOS
 FREESWITCH_VARS=/opt/freeswitch/etc/freeswitch/vars.xml
+FREESWITCH_ETC_VARS=/etc/bigbluebutton/freeswitch/vars.xml
+if [ -f "$FREESWITCH_ETC_VARS" ]; then
+    FREESWITCH_VARS=$FREESWITCH_ETC_VARS
+fi
 FREESWITCH_EXTERNAL=/opt/freeswitch/etc/freeswitch/sip_profiles/external.xml
 FREESWITCH_PID=/opt/freeswitch/var/run/freeswitch/freeswitch.pid
 FREESWITCH_EVENT_SOCKET=/opt/freeswitch/etc/freeswitch/autoload_configs/event_socket.conf.xml


### PR DESCRIPTION
### What does this PR do?

Fixes #12791 by adding additional `<X-PRE-PROCESS cmd="include" ...>` commands into the main `freeswitch.xml` config file.

Note that the `include` preprocessor instruction silently skips / ignores non-existing files. The result of the config preprocessing can be checked by inspecting `/opt/freeswitch/var/log/freeswitch/freeswitch.xml.fsxml`.

### Closes Issue(s)

Closes #12791

### More

After the this PR is merged, the `postinst` script of the `bbb-freeswitch-core` package should be extended with the following snipped:

```shell
mkdir -p /etc/bigbluebutton/freeswitch
if [ ! -f /etc/bigbluebutton/freeswitch ]; then
  cp /opt/freeswitch/etc/freeswitch/vars.xml /etc/bigbluebutton/freeswitch/vars.xml
fi
```