### PR TITLE
fix: make panels use same min and max width - legacy layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/component.jsx
@@ -14,13 +14,11 @@ const { isMobile } = deviceInfo;
 // values based on sass file
 const USERLIST_MIN_WIDTH = 150;
 const USERLIST_MAX_WIDTH = 240;
-const CHAT_MIN_WIDTH = 320;
-const CHAT_MAX_WIDTH = 400;
+const PANEL_MIN_WIDTH = 320;
+const PANEL_MAX_WIDTH = 400;
 const NAVBAR_HEIGHT = 112;
 const LARGE_NAVBAR_HEIGHT = 170;
 const ACTIONSBAR_HEIGHT = isMobile ? 50 : 42;
-const BREAKOUT_MIN_WIDTH = 320;
-const BREAKOUT_MAX_WIDTH = 400;
 
 const WEBCAMSAREA_MIN_PERCENT = 0.2;
 const WEBCAMSAREA_MAX_PERCENT = 0.8;
@@ -333,7 +331,7 @@ class LayoutManagerComponent extends Component {
       };
     } else if (!storageSecondPanelWidth) {
       newPanelSize = {
-        width: min(max((this.windowWidth() * 0.2), CHAT_MIN_WIDTH), CHAT_MAX_WIDTH),
+        width: min(max((this.windowWidth() * 0.2), PANEL_MIN_WIDTH), PANEL_MAX_WIDTH),
       };
     } else {
       newPanelSize = {
@@ -558,14 +556,12 @@ export default withLayoutConsumer(NewLayoutManager.withConsumer(LayoutManagerCom
 export {
   USERLIST_MIN_WIDTH,
   USERLIST_MAX_WIDTH,
-  CHAT_MIN_WIDTH,
-  CHAT_MAX_WIDTH,
+  PANEL_MIN_WIDTH,
+  PANEL_MAX_WIDTH,
   NAVBAR_HEIGHT,
   LARGE_NAVBAR_HEIGHT,
   ACTIONSBAR_HEIGHT,
   WEBCAMSAREA_MIN_PERCENT,
   WEBCAMSAREA_MAX_PERCENT,
   PRESENTATIONAREA_MIN_WIDTH,
-  BREAKOUT_MIN_WIDTH,
-  BREAKOUT_MAX_WIDTH,
 };

--- a/bigbluebutton-html5/imports/ui/components/panel-manager/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/panel-manager/component.jsx
@@ -15,14 +15,8 @@ import { withLayoutConsumer } from '/imports/ui/components/layout/context';
 import {
   USERLIST_MIN_WIDTH,
   USERLIST_MAX_WIDTH,
-  CHAT_MIN_WIDTH,
-  CHAT_MAX_WIDTH,
-  POLL_MIN_WIDTH,
-  POLL_MAX_WIDTH,
-  NOTE_MIN_WIDTH,
-  NOTE_MAX_WIDTH,
-  BREAKOUT_MIN_WIDTH,
-  BREAKOUT_MAX_WIDTH,
+  PANEL_MIN_WIDTH,
+  PANEL_MAX_WIDTH,
 } from '/imports/ui/components/layout/layout-manager/component';
 import { PANELS } from '../layout/enums';
 
@@ -228,16 +222,17 @@ class PanelManager extends Component {
   }
 
   breakoutResizeStop(addvalue) {
-    const { breakoutRoomWidth } = this.state;
+    const { secondPanelWidth } = this.state;
     const { layoutContextDispatch } = this.props;
 
-    this.setBreakoutRoomWidth(breakoutRoomWidth + addvalue);
+    const newSecondPanelWidth = secondPanelWidth + addvalue;
+    this.setSecondPanelWidth(newSecondPanelWidth);
 
     layoutContextDispatch(
       {
         type: 'setBreakoutRoomSize',
         value: {
-          width: breakoutRoomWidth + addvalue,
+          width: newSecondPanelWidth,
         },
       },
     );
@@ -332,8 +327,8 @@ class PanelManager extends Component {
 
     return (
       <Resizable
-        minWidth={CHAT_MIN_WIDTH}
-        maxWidth={CHAT_MAX_WIDTH}
+        minWidth={PANEL_MIN_WIDTH}
+        maxWidth={PANEL_MAX_WIDTH}
         ref={(node) => { this.resizableChat = node; }}
         enable={resizableEnableOptions}
         key={this.chatKey}
@@ -379,8 +374,8 @@ class PanelManager extends Component {
 
     return (
       <Resizable
-        minWidth={NOTE_MIN_WIDTH}
-        maxWidth={NOTE_MAX_WIDTH}
+        minWidth={PANEL_MIN_WIDTH}
+        maxWidth={PANEL_MAX_WIDTH}
         ref={(node) => { this.resizableNote = node; }}
         enable={resizableEnableOptions}
         key={this.noteKey}
@@ -523,8 +518,8 @@ class PanelManager extends Component {
 
     return (
       <Resizable
-        minWidth={BREAKOUT_MIN_WIDTH}
-        maxWidth={BREAKOUT_MAX_WIDTH}
+        minWidth={PANEL_MIN_WIDTH}
+        maxWidth={PANEL_MAX_WIDTH}
         ref={(node) => { this.resizableBreakout = node; }}
         enable={resizableEnableOptions}
         key={this.breakoutroomKey}
@@ -563,8 +558,8 @@ class PanelManager extends Component {
 
     return (
       <Resizable
-        minWidth={POLL_MIN_WIDTH}
-        maxWidth={POLL_MAX_WIDTH}
+        minWidth={PANEL_MIN_WIDTH}
+        maxWidth={PANEL_MAX_WIDTH}
         ref={(node) => { this.resizablePoll = node; }}
         enable={resizableEnableOptions}
         key={this.pollKey}


### PR DESCRIPTION
### What does this PR do?

Use the same values for poll, notes, breakout and chat panel min and max width - legacy layout.

### Closes Issue(s)
Closes #12659