### PR TITLE
fix: hidden chat on resize

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -179,9 +179,7 @@ class CustomLayout extends Component {
             isOpen: true,
           },
           sidebarContent: {
-            isOpen: sidebarContentPanel !== PANELS.NONE
-              && (deviceType === DEVICE_TYPE.TABLET_LANDSCAPE
-                || deviceType === DEVICE_TYPE.DESKTOP),
+            isOpen: sidebarContentPanel !== PANELS.NONE,
             sidebarContentPanel,
           },
           sidebarContentHorizontalResizer: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -381,16 +381,14 @@ class CustomLayout extends Component {
 
     return {
       top,
-      left: deviceType === DEVICE_TYPE.MOBILE
-        || deviceType === DEVICE_TYPE.TABLET_PORTRAIT ? 0 : sidebarNavWidth,
+      left: deviceType === DEVICE_TYPE.MOBILE ? 0 : sidebarNavWidth,
       zIndex: deviceType === DEVICE_TYPE.MOBILE ? 11 : 1,
     };
   }
 
   calculatesMediaAreaBounds(sidebarNavWidth, sidebarContentWidth) {
     const { newLayoutContextState } = this.props;
-    const { deviceType, input, layoutLoaded } = newLayoutContextState;
-    const { sidebarContent } = input;
+    const { deviceType, layoutLoaded } = newLayoutContextState;
     const { navBarHeight, actionBarHeight } = DEFAULT_VALUES;
     let left = 0;
     let width = 0;
@@ -398,14 +396,6 @@ class CustomLayout extends Component {
     if (deviceType === DEVICE_TYPE.MOBILE) {
       left = 0;
       width = this.mainWidth();
-    } else if (deviceType === DEVICE_TYPE.TABLET_PORTRAIT) {
-      if (sidebarContent.isOpen) {
-        left = sidebarContentWidth;
-        width = this.mainWidth() - sidebarContentWidth;
-      } else {
-        left = sidebarNavWidth;
-        width = this.mainWidth() - sidebarNavWidth;
-      }
     } else {
       left = sidebarNavWidth + sidebarContentWidth;
       width = this.mainWidth() - sidebarNavWidth - sidebarContentWidth;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -310,16 +310,14 @@ class PresentationFocusLayout extends Component {
 
     return {
       top,
-      left: deviceType === DEVICE_TYPE.MOBILE
-        || deviceType === DEVICE_TYPE.TABLET_PORTRAIT ? 0 : sidebarNavWidth,
+      left: deviceType === DEVICE_TYPE.MOBILE ? 0 : sidebarNavWidth,
       zIndex: deviceType === DEVICE_TYPE.MOBILE ? 11 : 1,
     };
   }
 
   calculatesMediaAreaBounds(sidebarNavWidth, sidebarContentWidth) {
     const { newLayoutContextState } = this.props;
-    const { deviceType, input, layoutLoaded } = newLayoutContextState;
-    const { sidebarContent } = input;
+    const { deviceType, layoutLoaded } = newLayoutContextState;
     const { navBarHeight, actionBarHeight } = DEFAULT_VALUES;
     let left = 0;
     let width = 0;
@@ -327,14 +325,6 @@ class PresentationFocusLayout extends Component {
     if (deviceType === DEVICE_TYPE.MOBILE) {
       left = 0;
       width = this.mainWidth();
-    } else if (deviceType === DEVICE_TYPE.TABLET_PORTRAIT) {
-      if (sidebarContent.isOpen) {
-        left = sidebarContentWidth;
-        width = this.mainWidth() - sidebarContentWidth;
-      } else {
-        left = sidebarNavWidth;
-        width = this.mainWidth() - sidebarNavWidth;
-      }
     } else {
       left = sidebarNavWidth + sidebarContentWidth;
       width = this.mainWidth() - sidebarNavWidth - sidebarContentWidth;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -119,9 +119,7 @@ class PresentationFocusLayout extends Component {
             isOpen: true,
           },
           sidebarContent: {
-            isOpen: sidebarContentPanel !== PANELS.NONE
-              && (deviceType === DEVICE_TYPE.TABLET_LANDSCAPE
-                || deviceType === DEVICE_TYPE.DESKTOP),
+            isOpen: sidebarContentPanel !== PANELS.NONE,
             sidebarContentPanel,
           },
           SidebarContentHorizontalResizer: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -309,16 +309,14 @@ class SmartLayout extends Component {
 
     return {
       top,
-      left: deviceType === DEVICE_TYPE.MOBILE
-        || deviceType === DEVICE_TYPE.TABLET_PORTRAIT ? 0 : sidebarNavWidth,
+      left: deviceType === DEVICE_TYPE.MOBILE ? 0 : sidebarNavWidth,
       zIndex: deviceType === DEVICE_TYPE.MOBILE ? 11 : 1,
     };
   }
 
   calculatesMediaAreaBounds(sidebarNavWidth, sidebarContentWidth) {
     const { newLayoutContextState } = this.props;
-    const { deviceType, input, layoutLoaded } = newLayoutContextState;
-    const { sidebarContent } = input;
+    const { deviceType, layoutLoaded } = newLayoutContextState;
     const { actionBarHeight, navBarHeight } = DEFAULT_VALUES;
     let left = 0;
     let width = 0;
@@ -326,14 +324,6 @@ class SmartLayout extends Component {
     if (deviceType === DEVICE_TYPE.MOBILE) {
       left = 0;
       width = this.mainWidth();
-    } else if (deviceType === DEVICE_TYPE.TABLET_PORTRAIT) {
-      if (sidebarContent.isOpen) {
-        left = sidebarContentWidth;
-        width = this.mainWidth() - sidebarContentWidth;
-      } else {
-        left = sidebarNavWidth;
-        width = this.mainWidth() - sidebarNavWidth;
-      }
     } else {
       left = sidebarNavWidth + sidebarContentWidth;
       width = this.mainWidth() - sidebarNavWidth - sidebarContentWidth;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -120,9 +120,7 @@ class SmartLayout extends Component {
             isOpen: true,
           },
           sidebarContent: {
-            isOpen: sidebarContentPanel !== PANELS.NONE
-              && (deviceType === DEVICE_TYPE.TABLET_LANDSCAPE
-                || deviceType === DEVICE_TYPE.DESKTOP),
+            isOpen: sidebarContentPanel !== PANELS.NONE,
             sidebarContentPanel,
           },
           SidebarContentHorizontalResizer: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -124,9 +124,7 @@ class VideoFocusLayout extends Component {
               isOpen: true,
             },
             sidebarContent: {
-              isOpen: sidebarContentPanel !== PANELS.NONE
-              && (deviceType === DEVICE_TYPE.TABLET_LANDSCAPE
-                || deviceType === DEVICE_TYPE.DESKTOP),
+              isOpen: sidebarContentPanel !== PANELS.NONE,
               sidebarContentPanel,
             },
             SidebarContentHorizontalResizer: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -339,16 +339,14 @@ class VideoFocusLayout extends Component {
 
     return {
       top,
-      left: deviceType === DEVICE_TYPE.MOBILE
-        || deviceType === DEVICE_TYPE.TABLET_PORTRAIT ? 0 : sidebarNavWidth,
+      left: deviceType === DEVICE_TYPE.MOBILE ? 0 : sidebarNavWidth,
       zIndex: deviceType === DEVICE_TYPE.MOBILE ? 11 : 1,
     };
   }
 
   calculatesMediaAreaBounds(sidebarNavWidth, sidebarContentWidth) {
     const { newLayoutContextState } = this.props;
-    const { deviceType, input, layoutLoaded } = newLayoutContextState;
-    const { sidebarContent } = input;
+    const { deviceType, layoutLoaded } = newLayoutContextState;
     const { navBarHeight, actionBarHeight } = DEFAULT_VALUES;
     let left = 0;
     let width = 0;
@@ -356,14 +354,6 @@ class VideoFocusLayout extends Component {
     if (deviceType === DEVICE_TYPE.MOBILE) {
       left = 0;
       width = this.mainWidth();
-    } else if (deviceType === DEVICE_TYPE.TABLET_PORTRAIT) {
-      if (sidebarContent.isOpen) {
-        left = sidebarContentWidth;
-        width = this.mainWidth() - sidebarContentWidth;
-      } else {
-        left = sidebarNavWidth;
-        width = this.mainWidth() - sidebarNavWidth;
-      }
     } else {
       left = sidebarNavWidth + sidebarContentWidth;
       width = this.mainWidth() - sidebarNavWidth - sidebarContentWidth;


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where the chat panel would get stuck behind the userlist after the following steps:
1. join a meeting in desktop
2. reduce window size until it enters mobile mode and hides userlist and chat panel
3. increase window size until it enters tablet mode
4. increase window size to desktop

![Screenshot from 2021-07-21 15-41-31](https://user-images.githubusercontent.com/3728706/126542819-04f32ccf-57d5-4b5f-b1f1-dde6b1860e01.png)
