### PR TITLE
Remove default layout override from settings file

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -155,6 +155,7 @@ class App extends Component {
       intl,
       validIOSVersion,
       newLayoutContextDispatch,
+      meetingLayout,
     } = this.props;
     const { browserName } = browserInfo;
     const { osName } = deviceInfo;
@@ -170,6 +171,14 @@ class App extends Component {
       type: ACTIONS.SET_FONT_SIZE,
       value: parseInt(fontSize.slice(0, -2)),
     });
+
+    newLayoutContextDispatch({
+      type: ACTIONS.SET_LAYOUT_TYPE,
+      value: meetingLayout,
+    });
+
+    Settings.application.selectedLayout = meetingLayout;
+    Settings.save();
 
     const body = document.getElementsByTagName('body')[0];
 
@@ -216,7 +225,6 @@ class App extends Component {
       pushLayoutToEveryone,
       newLayoutContextDispatch,
     } = this.props;
-
 
     if (meetingLayout !== prevProps.meetingLayout) {
       newLayoutContextDispatch({

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -100,7 +100,6 @@ public:
         guestWaitingPushAlerts: true
         paginationEnabled: true
         pushLayoutToEveryone: false
-        selectedLayout: 'smart'
         # fallbackLocale: if the locale the client is loaded in does not have a
         # translation a string, it will use the translation from the locale
         # specified in fallbackLocale. Note that fallbackLocale should be a


### PR DESCRIPTION
### What does this PR do?

This PR complements #12789, and fixes the issues mentioned in @antobinary's [comment](https://github.com/bigbluebutton/bigbluebutton/pull/12789#pullrequestreview-711052637): 

_"Did not work as expected for me:_

_1. I added defaultMeetingLayout=PRESENTATION_FOCUS in /etc/bigbluebutton/bbb-web.properties and restarted bbb-web. Creating a new meeting had Smart layout preselected rather than the presentation focus
2. I tried to pass meetingLayout=PRESENTATION_FOCUS on meeting create but it did not seem to take effect_

_Looking deeper at this, for both 1) and 2) the value is correctly propagated to Mongo, so the issue lies in the client using the layout. I will proceed to merge this PR and we will resolve the update of the value in the client separately."_