### PR TITLE
refactor: actions bar size calculation - new layouts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -35,14 +35,22 @@ class ActionsBar extends PureComponent {
       currentUser,
       shortcuts,
       newLayoutContextDispatch,
+      layoutManagerLoaded,
+      actionsBarStyle,
     } = this.props;
 
     return (
       <div
         className={styles.actionsbar}
-        style={{
-          height: ACTIONSBAR_HEIGHT,
-        }}
+        style={
+          layoutManagerLoaded === 'new'
+            ? {
+              height: actionsBarStyle.innerHeight,
+            }
+            : {
+              height: ACTIONSBAR_HEIGHT,
+            }
+        }
       >
         <div className={styles.left}>
           <ActionsDropdown {...{

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
@@ -23,7 +23,9 @@ const ActionsBarContainer = (props) => {
   const usingUsersContext = useContext(UsersContext);
   const { users } = usingUsersContext;
   const newLayoutContext = useContext(NLayoutContext);
-  const { newLayoutContextDispatch } = newLayoutContext;
+  const { newLayoutContextState, newLayoutContextDispatch } = newLayoutContext;
+  const { output } = newLayoutContextState;
+  const { actionBar: actionsBarStyle } = output;
 
   const currentUser = { userId: Auth.userID, emoji: users[Auth.meetingID][Auth.userID].emoji };
 
@@ -33,6 +35,7 @@ const ActionsBarContainer = (props) => {
         ...props,
         currentUser,
         newLayoutContextDispatch,
+        actionsBarStyle,
       }
     }
     />
@@ -65,4 +68,5 @@ export default withTracker(() => ({
     { fields: {} }),
   allowExternalVideo: Meteor.settings.public.externalVideoPlayer.enabled,
   setEmojiStatus: UserListService.setEmojiStatus,
+  layoutManagerLoaded: Session.get('layoutManagerLoaded'),
 }))(injectIntl(ActionsBarContainer));

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -446,6 +446,7 @@ class App extends Component {
               left: actionsBarStyle.left,
               height: actionsBarStyle.height,
               width: actionsBarStyle.width,
+              padding: actionsBarStyle.padding,
             }
             : {
               position: 'relative',

--- a/bigbluebutton-html5/imports/ui/components/layout/context/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context/context.jsx
@@ -206,14 +206,16 @@ const reducer = (state, action) => {
     // ACTION BAR
     case ACTIONS.SET_ACTIONBAR_OUTPUT: {
       const {
-        display, width, height, top, left, tabOrder, zIndex,
+        display, width, height, innerHeight, top, left, padding, tabOrder, zIndex,
       } = action.value;
       const { actionBar } = state.output;
       if (actionBar.display === display
         && actionBar.width === width
         && actionBar.height === height
+        && actionBar.innerHeight === innerHeight
         && actionBar.top === top
         && actionBar.left === left
+        && actionBar.padding === padding
         && actionBar.zIndex === zIndex
         && actionBar.tabOrder === tabOrder) {
         return state;
@@ -227,8 +229,10 @@ const reducer = (state, action) => {
             display,
             width,
             height,
+            innerHeight,
             top,
             left,
+            padding,
             tabOrder,
             zIndex,
           },

--- a/bigbluebutton-html5/imports/ui/components/layout/defaultValues.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/defaultValues.js
@@ -24,7 +24,8 @@ const DEFAULT_VALUES = {
   navBarTop: 0,
   navBarTabOrder: 3,
 
-  actionBarHeight: 65,
+  actionBarHeight: 42,
+  actionBarPadding: 11.2,
   actionBarTabOrder: 6,
 
   sidebarNavMaxWidth: 240,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -85,8 +85,9 @@ class CustomLayout extends Component {
   }
 
   calculatesDropAreas(sidebarNavWidth, sidebarContentWidth, cameraDockBounds) {
+    const { height: actionBarHeight } = this.calculatesActionbarHeight();
     const mediaAreaHeight = this.mainHeight()
-      - (DEFAULT_VALUES.navBarHeight + DEFAULT_VALUES.actionBarHeight);
+      - (DEFAULT_VALUES.navBarHeight + actionBarHeight);
     const mediaAreaWidth = this.mainWidth() - (sidebarNavWidth + sidebarContentWidth);
     const DROP_ZONE_DEFAUL_SIZE = 100;
     const dropZones = {};
@@ -222,9 +223,9 @@ class CustomLayout extends Component {
     };
   }
 
-  calculatesActionbarBounds(mediaAreaBounds) {
+  calculatesActionbarHeight() {
     const { newLayoutContextState } = this.props;
-    const { input, fontSize } = newLayoutContextState;
+    const { fontSize } = newLayoutContextState;
 
     const BASE_FONT_SIZE = 14; // 90% font size
     const BASE_HEIGHT = DEFAULT_VALUES.actionBarHeight;
@@ -233,12 +234,25 @@ class CustomLayout extends Component {
     const actionBarHeight = ((BASE_HEIGHT / BASE_FONT_SIZE) * fontSize);
 
     return {
-      display: input.actionBar.hasActionBar,
-      width: this.mainWidth() - mediaAreaBounds.left,
       height: actionBarHeight + (PADDING * 2),
       innerHeight: actionBarHeight,
       padding: PADDING,
-      top: this.mainHeight() - (actionBarHeight + (PADDING * 2)),
+    };
+  }
+
+  calculatesActionbarBounds(mediaAreaBounds) {
+    const { newLayoutContextState } = this.props;
+    const { input } = newLayoutContextState;
+
+    const actionBarHeight = this.calculatesActionbarHeight();
+
+    return {
+      display: input.actionBar.hasActionBar,
+      width: this.mainWidth() - mediaAreaBounds.left,
+      height: actionBarHeight.height,
+      innerHeight: actionBarHeight.innerHeight,
+      padding: actionBarHeight.padding,
+      top: this.mainHeight() - actionBarHeight.height,
       left: mediaAreaBounds.left,
       zIndex: 1,
     };
@@ -396,7 +410,8 @@ class CustomLayout extends Component {
     const { newLayoutContextState } = this.props;
     const { deviceType, input, layoutLoaded } = newLayoutContextState;
     const { sidebarContent } = input;
-    const { navBarHeight, actionBarHeight } = DEFAULT_VALUES;
+    const { navBarHeight } = DEFAULT_VALUES;
+    const { height: actionBarHeight } = this.calculatesActionbarHeight();
     let left = 0;
     let width = 0;
     let top = 0;
@@ -612,8 +627,9 @@ class CustomLayout extends Component {
     const { input, fullscreen } = newLayoutContextState;
     const { presentation } = input;
     const { isOpen } = presentation;
+    const { height: actionBarHeight } = this.calculatesActionbarHeight();
     const mediaAreaHeight = this.mainHeight()
-      - (DEFAULT_VALUES.navBarHeight + DEFAULT_VALUES.actionBarHeight);
+      - (DEFAULT_VALUES.navBarHeight + actionBarHeight);
     const mediaAreaWidth = this.mainWidth() - (sidebarNavWidth + sidebarContentWidth);
     const mediaBounds = {};
     const { element: fullscreenElement } = fullscreen;
@@ -707,6 +723,7 @@ class CustomLayout extends Component {
     const mediaBounds = this.calculatesMediaBounds(
       sidebarNavWidth.width, sidebarContentWidth.width, cameraDockBounds,
     );
+    const { height: actionBarHeight } = this.calculatesActionbarHeight();
 
     newLayoutContextDispatch({
       type: ACTIONS.SET_NAVBAR_OUTPUT,
@@ -794,7 +811,7 @@ class CustomLayout extends Component {
       type: ACTIONS.SET_MEDIA_AREA_SIZE,
       value: {
         width: this.mainWidth() - sidebarNavWidth.width - sidebarContentWidth.width,
-        height: this.mainHeight() - DEFAULT_VALUES.navBarHeight - DEFAULT_VALUES.actionBarHeight,
+        height: this.mainHeight() - DEFAULT_VALUES.navBarHeight - actionBarHeight,
       },
     });
 

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -226,14 +226,19 @@ class CustomLayout extends Component {
     const { newLayoutContextState } = this.props;
     const { input, fontSize } = newLayoutContextState;
 
-    const BASE_FONT_SIZE = 16;
-    const actionBarHeight = (DEFAULT_VALUES.actionBarHeight / BASE_FONT_SIZE) * fontSize;
+    const BASE_FONT_SIZE = 14; // 90% font size
+    const BASE_HEIGHT = DEFAULT_VALUES.actionBarHeight;
+    const PADDING = DEFAULT_VALUES.actionBarPadding;
+
+    const actionBarHeight = ((BASE_HEIGHT / BASE_FONT_SIZE) * fontSize);
 
     return {
       display: input.actionBar.hasActionBar,
       width: this.mainWidth() - mediaAreaBounds.left,
-      height: actionBarHeight,
-      top: this.mainHeight() - actionBarHeight,
+      height: actionBarHeight + (PADDING * 2),
+      innerHeight: actionBarHeight,
+      padding: PADDING,
+      top: this.mainHeight() - (actionBarHeight + (PADDING * 2)),
       left: mediaAreaBounds.left,
       zIndex: 1,
     };
@@ -721,8 +726,10 @@ class CustomLayout extends Component {
         display: input.actionBar.hasActionBar,
         width: actionbarBounds.width,
         height: actionbarBounds.height,
+        innerHeight: actionbarBounds.innerHeight,
         top: actionbarBounds.top,
         left: actionbarBounds.left,
+        padding: actionbarBounds.padding,
         tabOrder: DEFAULT_VALUES.actionBarTabOrder,
         zIndex: actionbarBounds.zIndex,
       },

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -163,9 +163,9 @@ class PresentationFocusLayout extends Component {
     };
   }
 
-  calculatesActionbarBounds(mediaAreaBounds) {
+  calculatesActionbarHeight() {
     const { newLayoutContextState } = this.props;
-    const { input, fontSize } = newLayoutContextState;
+    const { fontSize } = newLayoutContextState;
 
     const BASE_FONT_SIZE = 14; // 90% font size
     const BASE_HEIGHT = DEFAULT_VALUES.actionBarHeight;
@@ -174,12 +174,25 @@ class PresentationFocusLayout extends Component {
     const actionBarHeight = ((BASE_HEIGHT / BASE_FONT_SIZE) * fontSize);
 
     return {
-      display: input.actionBar.hasActionBar,
-      width: this.mainWidth() - mediaAreaBounds.left,
       height: actionBarHeight + (PADDING * 2),
       innerHeight: actionBarHeight,
       padding: PADDING,
-      top: this.mainHeight() - (actionBarHeight + (PADDING * 2)),
+    };
+  }
+
+  calculatesActionbarBounds(mediaAreaBounds) {
+    const { newLayoutContextState } = this.props;
+    const { input } = newLayoutContextState;
+
+    const actionBarHeight = this.calculatesActionbarHeight();
+
+    return {
+      display: input.actionBar.hasActionBar,
+      width: this.mainWidth() - mediaAreaBounds.left,
+      height: actionBarHeight.height,
+      innerHeight: actionBarHeight.innerHeight,
+      padding: actionBarHeight.padding,
+      top: this.mainHeight() - actionBarHeight.height,
       left: mediaAreaBounds.left,
       zIndex: 1,
     };
@@ -325,7 +338,8 @@ class PresentationFocusLayout extends Component {
     const { newLayoutContextState } = this.props;
     const { deviceType, input, layoutLoaded } = newLayoutContextState;
     const { sidebarContent } = input;
-    const { navBarHeight, actionBarHeight } = DEFAULT_VALUES;
+    const { navBarHeight } = DEFAULT_VALUES;
+    const { height: actionBarHeight } = this.calculatesActionbarHeight();
     let left = 0;
     let width = 0;
     let top = 0;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -167,14 +167,19 @@ class PresentationFocusLayout extends Component {
     const { newLayoutContextState } = this.props;
     const { input, fontSize } = newLayoutContextState;
 
-    const BASE_FONT_SIZE = 16;
-    const actionBarHeight = (DEFAULT_VALUES.actionBarHeight / BASE_FONT_SIZE) * fontSize;
+    const BASE_FONT_SIZE = 14; // 90% font size
+    const BASE_HEIGHT = DEFAULT_VALUES.actionBarHeight;
+    const PADDING = DEFAULT_VALUES.actionBarPadding;
+
+    const actionBarHeight = ((BASE_HEIGHT / BASE_FONT_SIZE) * fontSize);
 
     return {
       display: input.actionBar.hasActionBar,
       width: this.mainWidth() - mediaAreaBounds.left,
-      height: actionBarHeight,
-      top: this.mainHeight() - actionBarHeight,
+      height: actionBarHeight + (PADDING * 2),
+      innerHeight: actionBarHeight,
+      padding: PADDING,
+      top: this.mainHeight() - (actionBarHeight + (PADDING * 2)),
       left: mediaAreaBounds.left,
       zIndex: 1,
     };
@@ -486,8 +491,10 @@ class PresentationFocusLayout extends Component {
         display: input.actionBar.hasActionBar,
         width: actionbarBounds.width,
         height: actionbarBounds.height,
+        innerHeight: actionbarBounds.innerHeight,
         top: actionbarBounds.top,
         left: actionbarBounds.left,
+        padding: actionbarBounds.padding,
         tabOrder: DEFAULT_VALUES.actionBarTabOrder,
         zIndex: actionbarBounds.zIndex,
       },

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -164,9 +164,9 @@ class SmartLayout extends Component {
     };
   }
 
-  calculatesActionbarBounds(mediaAreaBounds) {
+  calculatesActionbarHeight() {
     const { newLayoutContextState } = this.props;
-    const { input, fontSize } = newLayoutContextState;
+    const { fontSize } = newLayoutContextState;
 
     const BASE_FONT_SIZE = 14; // 90% font size
     const BASE_HEIGHT = DEFAULT_VALUES.actionBarHeight;
@@ -175,12 +175,25 @@ class SmartLayout extends Component {
     const actionBarHeight = ((BASE_HEIGHT / BASE_FONT_SIZE) * fontSize);
 
     return {
-      display: input.actionBar.hasActionBar,
-      width: this.mainWidth() - mediaAreaBounds.left,
       height: actionBarHeight + (PADDING * 2),
       innerHeight: actionBarHeight,
       padding: PADDING,
-      top: this.mainHeight() - (actionBarHeight + (PADDING * 2)),
+    };
+  }
+
+  calculatesActionbarBounds(mediaAreaBounds) {
+    const { newLayoutContextState } = this.props;
+    const { input } = newLayoutContextState;
+
+    const actionBarHeight = this.calculatesActionbarHeight();
+
+    return {
+      display: input.actionBar.hasActionBar,
+      width: this.mainWidth() - mediaAreaBounds.left,
+      height: actionBarHeight.height,
+      innerHeight: actionBarHeight.innerHeight,
+      padding: actionBarHeight.padding,
+      top: this.mainHeight() - actionBarHeight.height,
       left: mediaAreaBounds.left,
       zIndex: 1,
     };
@@ -324,7 +337,8 @@ class SmartLayout extends Component {
     const { newLayoutContextState } = this.props;
     const { deviceType, input, layoutLoaded } = newLayoutContextState;
     const { sidebarContent } = input;
-    const { actionBarHeight, navBarHeight } = DEFAULT_VALUES;
+    const { navBarHeight } = DEFAULT_VALUES;
+    const { height: actionBarHeight } = this.calculatesActionbarHeight();
     let left = 0;
     let width = 0;
     let top = 0;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -168,14 +168,19 @@ class SmartLayout extends Component {
     const { newLayoutContextState } = this.props;
     const { input, fontSize } = newLayoutContextState;
 
-    const BASE_FONT_SIZE = 16;
-    const actionBarHeight = (DEFAULT_VALUES.actionBarHeight / BASE_FONT_SIZE) * fontSize;
+    const BASE_FONT_SIZE = 14; // 90% font size
+    const BASE_HEIGHT = DEFAULT_VALUES.actionBarHeight;
+    const PADDING = DEFAULT_VALUES.actionBarPadding;
+
+    const actionBarHeight = ((BASE_HEIGHT / BASE_FONT_SIZE) * fontSize);
 
     return {
       display: input.actionBar.hasActionBar,
       width: this.mainWidth() - mediaAreaBounds.left,
-      height: actionBarHeight,
-      top: this.mainHeight() - actionBarHeight,
+      height: actionBarHeight + (PADDING * 2),
+      innerHeight: actionBarHeight,
+      padding: PADDING,
+      top: this.mainHeight() - (actionBarHeight + (PADDING * 2)),
       left: mediaAreaBounds.left,
       zIndex: 1,
     };
@@ -540,8 +545,10 @@ class SmartLayout extends Component {
         display: input.actionBar.hasActionBar,
         width: actionbarBounds.width,
         height: actionbarBounds.height,
+        innerHeight: actionbarBounds.innerHeight,
         top: actionbarBounds.top,
         left: actionbarBounds.left,
+        padding: actionbarBounds.padding,
         tabOrder: DEFAULT_VALUES.actionBarTabOrder,
         zIndex: actionbarBounds.zIndex,
       },

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -174,14 +174,19 @@ class VideoFocusLayout extends Component {
     const { newLayoutContextState } = this.props;
     const { input, fontSize } = newLayoutContextState;
 
-    const BASE_FONT_SIZE = 16;
-    const actionBarHeight = (DEFAULT_VALUES.actionBarHeight / BASE_FONT_SIZE) * fontSize;
+    const BASE_FONT_SIZE = 14; // 90% font size
+    const BASE_HEIGHT = DEFAULT_VALUES.actionBarHeight;
+    const PADDING = DEFAULT_VALUES.actionBarPadding;
+
+    const actionBarHeight = ((BASE_HEIGHT / BASE_FONT_SIZE) * fontSize);
 
     return {
       display: input.actionBar.hasActionBar,
       width: this.mainWidth() - mediaAreaBounds.left,
-      height: actionBarHeight,
-      top: this.mainHeight() - actionBarHeight,
+      height: actionBarHeight + (PADDING * 2),
+      innerHeight: actionBarHeight,
+      padding: PADDING,
+      top: this.mainHeight() - (actionBarHeight + (PADDING * 2)),
       left: mediaAreaBounds.left,
       zIndex: 1,
     };
@@ -521,8 +526,10 @@ class VideoFocusLayout extends Component {
         display: input.actionBar.hasActionBar,
         width: actionbarBounds.width,
         height: actionbarBounds.height,
+        innerHeight: actionbarBounds.innerHeight,
         top: actionbarBounds.top,
         left: actionbarBounds.left,
+        padding: actionbarBounds.padding,
         tabOrder: DEFAULT_VALUES.actionBarTabOrder,
         zIndex: actionbarBounds.zIndex,
       },

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -170,9 +170,9 @@ class VideoFocusLayout extends Component {
     };
   }
 
-  calculatesActionbarBounds(mediaAreaBounds) {
+  calculatesActionbarHeight() {
     const { newLayoutContextState } = this.props;
-    const { input, fontSize } = newLayoutContextState;
+    const { fontSize } = newLayoutContextState;
 
     const BASE_FONT_SIZE = 14; // 90% font size
     const BASE_HEIGHT = DEFAULT_VALUES.actionBarHeight;
@@ -181,12 +181,25 @@ class VideoFocusLayout extends Component {
     const actionBarHeight = ((BASE_HEIGHT / BASE_FONT_SIZE) * fontSize);
 
     return {
-      display: input.actionBar.hasActionBar,
-      width: this.mainWidth() - mediaAreaBounds.left,
       height: actionBarHeight + (PADDING * 2),
       innerHeight: actionBarHeight,
       padding: PADDING,
-      top: this.mainHeight() - (actionBarHeight + (PADDING * 2)),
+    };
+  }
+
+  calculatesActionbarBounds(mediaAreaBounds) {
+    const { newLayoutContextState } = this.props;
+    const { input } = newLayoutContextState;
+
+    const actionBarHeight = this.calculatesActionbarHeight();
+
+    return {
+      display: input.actionBar.hasActionBar,
+      width: this.mainWidth() - mediaAreaBounds.left,
+      height: actionBarHeight.height,
+      innerHeight: actionBarHeight.innerHeight,
+      padding: actionBarHeight.padding,
+      top: this.mainHeight() - actionBarHeight.height,
       left: mediaAreaBounds.left,
       zIndex: 1,
     };
@@ -354,7 +367,8 @@ class VideoFocusLayout extends Component {
     const { newLayoutContextState } = this.props;
     const { deviceType, input, layoutLoaded } = newLayoutContextState;
     const { sidebarContent } = input;
-    const { navBarHeight, actionBarHeight } = DEFAULT_VALUES;
+    const { navBarHeight } = DEFAULT_VALUES;
+    const { height: actionBarHeight } = this.calculatesActionbarHeight();
     let left = 0;
     let width = 0;
     let top = 0;


### PR DESCRIPTION
### What does this PR do?

Adds new values for actions bar wrapper and inner height based on font-size and padding, preventing actions bar from being too close to the bottom of the screen

#### before
![Screenshot from 2021-07-22 11-45-00](https://user-images.githubusercontent.com/3728706/126658962-b01e9e1e-549e-47a1-ac7f-5201a1552d1d.png)

#### after
![Screenshot from 2021-07-22 11-44-40](https://user-images.githubusercontent.com/3728706/126658958-78cf9d5a-63fe-4dcc-8fb8-ef08b26a4850.png)
