### PR TITLE
fix: persist settings layout after refresh

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -156,6 +156,7 @@ class App extends Component {
       validIOSVersion,
       newLayoutContextDispatch,
       meetingLayout,
+      settingsLayout,
     } = this.props;
     const { browserName } = browserInfo;
     const { osName } = deviceInfo;
@@ -172,12 +173,9 @@ class App extends Component {
       value: parseInt(fontSize.slice(0, -2)),
     });
 
-    newLayoutContextDispatch({
-      type: ACTIONS.SET_LAYOUT_TYPE,
-      value: meetingLayout,
-    });
+    const currentLayout = settingsLayout ? settingsLayout : meetingLayout;
 
-    Settings.application.selectedLayout = meetingLayout;
+    Settings.application.selectedLayout = currentLayout;
     Settings.save();
 
     const body = document.getElementsByTagName('body')[0];


### PR DESCRIPTION
### What does this PR do?

This PR fixes a problem introduced in PR #12805: meeting layout is always set as default on join (even if the user sets another layout and refreshes the page). It also removes unnecessary `newLayoutContextDispatch` call