### PR TITLE
fix: camera position when presentation is hidden

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -350,12 +350,15 @@ class CustomLayout extends Component {
   calculatesSidebarContentHeight(cameraDockHeight) {
     const { newLayoutContextState } = this.props;
     const { deviceType, input } = newLayoutContextState;
+    const { presentation } = input;
+    const { isOpen } = presentation;
     let sidebarContentHeight = 0;
     if (input.sidebarContent.isOpen) {
       if (deviceType === DEVICE_TYPE.MOBILE) {
         sidebarContentHeight = this.mainHeight() - DEFAULT_VALUES.navBarHeight;
       } else if (input.cameraDock.numCameras > 0
-        && input.cameraDock.position === CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM) {
+        && input.cameraDock.position === CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM
+        && isOpen) {
         sidebarContentHeight = this.mainHeight() - cameraDockHeight;
       } else {
         sidebarContentHeight = this.mainHeight();

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -424,6 +424,8 @@ class CustomLayout extends Component {
         cameraDockBounds.maxWidth = mediaAreaBounds.width;
         cameraDockBounds.height = mediaAreaBounds.height;
         cameraDockBounds.maxHeight = mediaAreaBounds.height;
+        cameraDockBounds.top = DEFAULT_VALUES.navBarHeight;
+        cameraDockBounds.left = mediaAreaBounds.left;
       } else {
         let cameraDockLeft = 0;
         let cameraDockHeight = 0;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -289,8 +289,9 @@ class VideoFocusLayout extends Component {
     const { newLayoutContextState } = this.props;
     const { deviceType, input, output } = newLayoutContextState;
     const { sidebarContentMinHeight } = DEFAULT_VALUES;
-    const { sidebarContent: inputContent } = input;
+    const { sidebarContent: inputContent, presentation } = input;
     const { sidebarContent: outputContent } = output;
+    const { isOpen } = presentation;
     let minHeight = 0;
     let height = 0;
     let maxHeight = 0;
@@ -300,7 +301,7 @@ class VideoFocusLayout extends Component {
         minHeight = this.mainHeight() - this.bannerAreaHeight();
         maxHeight = this.mainHeight() - this.bannerAreaHeight();
       } else {
-        if (input.cameraDock.numCameras > 0) {
+        if (input.cameraDock.numCameras > 0 && isOpen) {
           if (inputContent.height > 0 && inputContent.height < this.mainHeight()) {
             height = inputContent.height - this.bannerAreaHeight();
             maxHeight = this.mainHeight() - this.bannerAreaHeight();


### PR DESCRIPTION
### What does this PR do?

Fixes camera position issues when presentation is hidden (custom and focus on video layouts).

#### before
https://user-images.githubusercontent.com/56703993/126561973-3e18184a-3e2e-410e-a469-cc6674ef37a2.mp4

#### after

![camera-custom](https://user-images.githubusercontent.com/3728706/126707754-d49da613-2907-4210-9eee-1b8c01a8788b.gif)
