### PR TITLE
fix: avoid leaving dangling HTMLMediaElements in paused state (#12806)

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
@@ -277,8 +277,16 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
   }
 
   exitAudio() {
+    const mediaElement = document.getElementById(MEDIA_TAG);
+
     this.broker.stop();
     this.clearReconnectionTimeout();
+
+    if (mediaElement && typeof mediaElement.pause === 'function') {
+      mediaElement.pause();
+      mediaElement.srcObject = null;
+    }
+
     return Promise.resolve();
   }
 }

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -283,6 +283,8 @@ export default class KurentoScreenshareBridge {
   };
 
   stop() {
+    const mediaElement = document.getElementById(SCREENSHARE_VIDEO_TAG);
+
     if (this.broker) {
       this.broker.stop();
       // Checks if this session is a sharer and if it's not reconnecting
@@ -292,6 +294,12 @@ export default class KurentoScreenshareBridge {
       if (this.broker.role === SEND_ROLE && !this.reconnecting) setSharingScreen(false);
       this.broker = null;
     }
+
+    if (mediaElement && typeof mediaElement.pause === 'function') {
+      mediaElement.pause();
+      mediaElement.srcObject = null;
+    }
+
     this.gdmStream = null;
     this.clearReconnectionTimeout();
   }

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -787,7 +787,16 @@ class VideoProvider extends Component {
   }
 
   destroyVideoTag(stream) {
-    delete this.videoTags[stream]
+    const videoElement = this.videoTags[stream];
+
+    if (videoElement == null) return;
+
+    if (typeof videoElement.pause === 'function') {
+      videoElement.pause();
+      videoElement.srcObject = null;
+    }
+
+    delete this.videoTags[stream];
   }
 
   handlePlayStop(message) {


### PR DESCRIPTION
### What does this PR do?

Properly cleans up HTMLMediaElement's source medias when necessary for cameras, screen sharing and listen only.

### Closes Issue(s)

Closes #12806

### Motivation

As described in #12806, Chrome 92 kicked in an intervention that hard limits the number of concurrent players per session to 75/40, and `paused` (for sure) and `suspended` (I _think_) elements count towards those limits.

The problem: webcam video players were left dangling in paused state despite the _video elements_ themselves being cleaned up from the page. That generated a skewed accounting of WebMediaPlayers in a session, even with pagination. And since webcam media elements are dynamic and fluctuate in number, it could hit the hard limit.

I also took the opportunity to review screen sharing and listen only tear off procedures. They would also leave paused players dangling. However, since their media elements are static (one per session), it isn't a problem. Just did it for the sake of cleanliness.

Microphone also leaves a player dangling, but the element is not that easily exposed and it isn't a problem (same as listen/screen), so I left it alone.


### More

Should be lifted to 2.4.
