### PR TITLE
fix: ConnectionStatus - log info on 'warning'

### DIFF
--- a/bigbluebutton-html5/imports/api/connection-status/server/methods/addConnectionStatus.js
+++ b/bigbluebutton-html5/imports/api/connection-status/server/methods/addConnectionStatus.js
@@ -11,8 +11,6 @@ const logConnectionStatus = (meetingId, userId, status, type, value) => {
       Logger.info(`Connection status updated: meetingId=${meetingId} userId=${userId} status=${status} type=${type}`);
       break;
     case 'warning':
-      // Skip
-      break;
     case 'danger':
     case 'critical':
       switch (type) {


### PR DESCRIPTION
### What does this PR do?
Until now we only logged for `normal`, `danger` and `critical` leading to some ambiguity in log analysis

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation
Allows for clearer picture when debugging on a production server
<!-- What inspired you to submit this pull request? -->


