### PR TITLE
fix: set slide size when changing presentation - smart layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -214,6 +214,13 @@ class Presentation extends PureComponent {
             height: currHeight,
           },
         });
+        newLayoutContextDispatch({
+          type: ACTIONS.SET_PRESENTATION_CURRENT_SLIDE_SIZE,
+          value: {
+            width: currWidth,
+            height: currHeight,
+          },
+        });
         if (currWidth > currHeight || currWidth === currHeight) {
           layoutContextDispatch({
             type: 'setPresentationOrientation',


### PR DESCRIPTION
### What does this PR do?

Sets slide size when the presenter changes presentation, fixing an issue that would prevent recalculation of camera position.

#### before
![presentation-change-smart](https://user-images.githubusercontent.com/3728706/126815590-25cc4205-b3f5-41dc-b8c3-76e63ed97e56.gif)

#### after
![presentation-change-after](https://user-images.githubusercontent.com/3728706/126827139-7926fd30-fb7c-4d4c-95e1-2c093593058e.gif)
