### PR TITLE
Fix auto assigned presenter

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/handlers/presenterAssigned.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/presenterAssigned.js
@@ -31,22 +31,24 @@ export default function handlePresenterAssigned({ body }, meetingId) {
 
   const prevPresenter = Users.findOne(selector);
 
+  const defaultPodSelector = {
+    meetingId,
+    podId: 'DEFAULT_PRESENTATION_POD',
+  };
+
+  const currentDefaultPod = PresentationPods.findOne(defaultPodSelector);
+
   // no previous presenters
   // The below code is responsible for set Meeting presenter to be default pod presenter as well.
   // It's been handled here because right now akka-apps don't handle all cases scenarios.
-  if (!prevPresenter) {
+  if (!prevPresenter || currentDefaultPod?.currentPresenterId !== presenterId) {
     const setPresenterPayload = {
       meetingId,
       requesterUserId: assignedBy,
       presenterId,
     };
 
-    const defaultPodSelector = {
-      meetingId,
-      podId: 'DEFAULT_PRESENTATION_POD',
-    };
-    const currentDefaultPodPresenter = PresentationPods.findOne(defaultPodSelector);
-    const { currentPresenterId } = currentDefaultPodPresenter;
+    const { currentPresenterId } = currentDefaultPod;
 
     if (currentPresenterId === '') {
       return setPresenterInPodReqMsg(setPresenterPayload);


### PR DESCRIPTION
### What does this PR do?

Fix a problem where the new auto assigned presenter couldn't open the upload modal. The problem was caused because the new presenter was not set as presenter in pod.

### Closes Issue(s)
Closes #12679