### PR TITLE
fix: second level of accessible menu only opens if language is set to english

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/menu/component.jsx
@@ -63,7 +63,7 @@ class BBBMenu extends React.Component {
         style={{ paddingLeft: '4px',paddingRight: '4px',paddingTop: '8px', paddingBottom: '8px', marginLeft: '4px', marginRight: '4px' }}
         onClick={() => { 
           onClick();
-          const close = !label.includes('Set status') && !label.includes('Back');
+          const close = !key.includes('setstatus') && !key.includes('back');
           // prevent menu close for sub menu actions
           if (close) this.handleClose();
         }}>


### PR DESCRIPTION
### What does this PR do?

Fix for an issue that prevents the second level of the accessible menu (PR #12745) from opening in languages different from english.

### Closes Issue(s)
Closes #12826