### PR TITLE
fix: fullscreen webcam video crash - legacy layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -17,7 +17,6 @@ import {
   unsubscribeFromStreamStateChange,
 } from '/imports/ui/services/bbb-webrtc-sfu/stream-state-service';
 import deviceInfo from '/imports/utils/deviceInfo';
-import { ACTIONS } from '../../../layout/enums';
 
 const ALLOW_FULLSCREEN = Meteor.settings.public.app.allowFullscreen;
 
@@ -101,7 +100,7 @@ class VideoListItem extends Component {
   }
 
   onFullscreenChange() {
-    const { webcamDraggableDispatch, newLayoutContextDispatch } = this.props;
+    const { webcamDraggableDispatch } = this.props;
     const { isFullscreen } = this.state;
     const serviceIsFullscreen = FullscreenService.isFullScreen(this.videoContainer);
 
@@ -113,9 +112,6 @@ class VideoListItem extends Component {
           value: serviceIsFullscreen,
         },
       );
-      newLayoutContextDispatch({
-        type: ACTIONS.SET_FULLSCREEN_ELEMENT
-      })
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

Prevents crash when setting a camera to fullscreen in legacy layout.

### Closes Issue(s)
Closes #12828