### PR TITLE
fix(virtual-backgrounds): disable on Safari

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/virtual-background/service.js
+++ b/bigbluebutton-html5/imports/ui/services/virtual-background/service.js
@@ -1,4 +1,5 @@
 import deviceInfo from '/imports/utils/deviceInfo';
+import browserInfo from '/imports/utils/browserInfo';
 import { createVirtualBackgroundService } from '/imports/ui/services/virtual-background';
 
 const BLUR_FILENAME = 'blur.jpg';
@@ -82,9 +83,8 @@ const getSessionVirtualBackgroundInfoWithDefault = () => {
   };
 }
 
-const isVirtualBackgroundEnabled = () => {
-  return VIRTUAL_BACKGROUND_ENABLED && !deviceInfo.isIOS;
-}
+const isVirtualBackgroundEnabled = () => VIRTUAL_BACKGROUND_ENABLED
+  && !(deviceInfo.isIOS || browserInfo.isSafari);
 
 const getVirtualBgImagePath = () => {
   return (IS_STORED_ON_BBB ? BASE_PATH : '') + IMAGES_PATH;


### PR DESCRIPTION
### What does this PR do?

Forcefully disables camera effects on Safari (macOS; iOS was already blocked).

### Closes Issue(s)

None

### Motivation

Safari (even macOS) is not properly supported with this feature (yet) and I don't intend on spending time tinkering with that right now.
