### PR TITLE
fix: external video position on layout change

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
@@ -155,6 +155,12 @@ class VideoPlayer extends Component {
   }
 
   componentDidUpdate(prevProp, prevState) {
+    const { top, left, layoutLoaded } = this.props;
+
+    if (layoutLoaded === 'new' && (top !== prevProp.top || left !== prevProp.left)) {
+      this.handleResize();
+    }
+
     // Detect presenter change and redo the sync and listeners to reassign video to the new one
     if (this.props.isPresenter !== prevProp.isPresenter) {
       this.clearVideoListeners();

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -325,7 +325,11 @@ class VideoFocusLayout extends Component {
             maxHeight = this.mainHeight() - this.bannerAreaHeight();
           } else {
             const { size: slideSize } = input.presentation.currentSlide;
-            const calculatedHeight = (slideSize.height * outputContent.width) / slideSize.width;
+            let calculatedHeight = (this.mainHeight() - this.bannerAreaHeight()) * 0.3;
+
+            if (slideSize.height > 0 && slideSize.width > 0) {
+              calculatedHeight = (slideSize.height * outputContent.width) / slideSize.width;
+            }
             height = this.mainHeight() - calculatedHeight - this.bannerAreaHeight();
             maxHeight = height;
           }


### PR DESCRIPTION
### What does this PR do?

Prevents the following external video position issues in new layouts:
- external video appearing in the wrong position when switching between 'focus on presentation' and 'focus on video' while webcam is being shared
- external video crash when switching from 'focus on presentation' to 'focus on video' while sharing video and then start sharing webcam

#### before
https://user-images.githubusercontent.com/56703993/126557591-dec7d2dd-18d8-4d64-9fe8-783201a51d18.mp4

#### after
![fix-video](https://user-images.githubusercontent.com/3728706/127331016-2513e461-9fbf-461d-a38c-4c5077e5e6d6.gif)
