### PR TITLE
Modified regex pattern to allow international characters

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/constraint/MeetingIDConstraint.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/constraint/MeetingIDConstraint.java
@@ -13,7 +13,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @NotEmpty(message = "You must provide a meeting ID")
 @Size(min = 2, max = 256, message = "Meeting ID must be between 2 and 256 characters")
-@Pattern(regexp = "^[a-zA-Z0-9\\s!@#$%^&*()_\\-+=\\[\\]{};:.'\"<>?\\\\|\\/]+$", message = "Meeting ID cannot contain ','")
+@Pattern(regexp = "^[^,]+$", message = "Meeting ID cannot contain ','")
 @Constraint(validatedBy = {})
 @Target(FIELD)
 @Retention(RUNTIME)

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/constraint/MeetingNameConstraint.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/constraint/MeetingNameConstraint.java
@@ -13,7 +13,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @NotEmpty(message = "You must provide a meeting name")
 @Size(min = 2, max = 256, message = "Meeting name must be between 2 and 256 characters")
-@Pattern(regexp = "^[a-zA-Z0-9\\s!@#$%^&*()_\\-+=\\[\\]{};:.'\"<>?\\\\|\\/]+$", message = "Meeting name cannot contain ','")
+@Pattern(regexp = "^[^,]+$", message = "Meeting name cannot contain ','")
 @Constraint(validatedBy = {})
 @Target(FIELD)
 @Retention(RUNTIME)


### PR DESCRIPTION
### What does this PR do?

Modified the regex pattern in the meeting name and ID constraints that was incorrectly rejecting meeting names that contain international characters.
