### PR TITLE
fix: pagination buttons appearing when camera dock is hidden

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
@@ -284,10 +284,21 @@ class VideoList extends Component {
     return mirroredCameras.indexOf(stream) >= 0;
   }
 
+  displayPageButtons() {
+    const { numberOfPages, cameraDock } = this.props;
+    const { width: cameraDockWidth } = cameraDock;
+
+    if (!VideoService.isPaginationEnabled() || numberOfPages <= 1 || cameraDockWidth === 0) {
+      return false;
+    }
+
+    return true;
+  }
+
   renderNextPageButton() {
     const { intl, numberOfPages, currentVideoPageIndex } = this.props;
 
-    if (!VideoService.isPaginationEnabled() || numberOfPages <= 1) return null;
+    if (!this.displayPageButtons()) return null;
 
     const currentPage = currentVideoPageIndex + 1;
     const nextPageLabel = intl.formatMessage(intlMessages.nextPageLabel);
@@ -311,7 +322,7 @@ class VideoList extends Component {
   renderPreviousPageButton() {
     const { intl, currentVideoPageIndex, numberOfPages } = this.props;
 
-    if (!VideoService.isPaginationEnabled() || numberOfPages <= 1) return null;
+    if (!this.displayPageButtons()) return null;
 
     const currentPage = currentVideoPageIndex + 1;
     const prevPageLabel = intl.formatMessage(intlMessages.prevPageLabel);


### PR DESCRIPTION
### What does this PR do?

Prevents an issue with the pagination button appearing in "focus on presentation" layout when chat panel is closed, by including an additional check to video-list pagination buttons.

![Screenshot from 2021-07-21 09-00-15](https://user-images.githubusercontent.com/3728706/126485345-38a7a85b-776f-4c3a-839d-effdfac2dd06.png)