### PR TITLE
fix: presenter position in breakout room userlist

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
@@ -624,7 +624,7 @@ class UserDropdown extends PureComponent {
     const contents = (
       <div
         data-test={isMe(user.userId) ? 'userListItemCurrent' : 'userListItem'}
-        className={!actions.length ? styles.userListItem : null}
+        className={!actions.length ? styles.noActionsListItem : null}
         style={{ direction: isRTL ? 'rtl' : 'ltr', width: '100%' }}
       >
         <div className={styles.userItemContents}>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/styles.scss
@@ -138,6 +138,11 @@
   flex-shrink: 0;
 }
 
+.noActionsListItem {
+  margin-left: 0.5rem;
+  padding: .45rem;
+}
+
 .userAvatar {
   flex: 0 0 2.25rem;
 }


### PR DESCRIPTION
### What does this PR do?

Adds missing styles for items with no available action in userlist.
 
#### before
![Screenshot from 2021-07-30 08-56-32](https://user-images.githubusercontent.com/3728706/127649514-b73c7359-ef4b-4c06-85d3-a92c6e96e292.png)

#### after
![Screenshot from 2021-07-30 08-56-10](https://user-images.githubusercontent.com/3728706/127649511-bc6107b1-e419-40de-8421-9eed802e3855.png)

### Closes Issue(s)
Closes #12817