### PR TITLE
fix(breakouts): Do not allow users to obtain 'redirectToHtml5JoinURL' for others

### DIFF
--- a/bigbluebutton-html5/imports/api/breakouts/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/publishers.js
@@ -45,7 +45,28 @@ function breakouts(role) {
     ],
   };
 
-  return Breakouts.find(selector);
+  const fields = {
+    fields: {
+      users: {
+        $elemMatch: {
+          // do not allow users to obtain 'redirectToHtml5JoinURL' for others
+          userId,
+        },
+      },
+      breakoutId: 1,
+      externalId: 1,
+      freeJoin: 1,
+      isDefaultName: 1,
+      joinedUsers: 1,
+      name: 1,
+      parentMeetingId: 1,
+      sequence: 1,
+      shortName: 1,
+      timeRemaining: 1,
+    },
+  };
+
+  return Breakouts.find(selector, fields);
 }
 
 function publish(...args) {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
This PR limits the link from being sent to others, just to the user it relates to.

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation
After specific set of steps one user in the meeting could obtain the link to join as another user in the breakouts. 
<!-- What inspired you to submit this pull request? -->


