### PR TITLE
fix(polls): Avoid viewer manually subscribing to current-poll

### DIFF
--- a/bigbluebutton-html5/imports/api/polls/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/polls/server/publishers.js
@@ -1,8 +1,10 @@
 import { Meteor } from 'meteor/meteor';
 import Logger from '/imports/startup/server/logger';
+import Users from '/imports/api/users';
 import Polls from '/imports/api/polls';
 import AuthTokenValidation, { ValidationStates } from '/imports/api/auth-token-validation';
 
+const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 function currentPoll() {
   const tokenValidation = AuthTokenValidation.findOne({ connectionId: this.connection.id });
 
@@ -12,6 +14,15 @@ function currentPoll() {
   }
 
   const { meetingId, userId } = tokenValidation;
+
+  const User = Users.findOne({ userId, meetingId }, { fields: { role: 1 } });
+  if (!User || User.role != ROLE_MODERATOR) {
+    Logger.warn(
+      'Publishing current-poll was requested by non-moderator connection',
+      { meetingId, userId, connectionId: this.connection.id }
+    );
+    return Polls.find({ meetingId: '' });
+  }
 
   Logger.debug('Publishing Polls', { meetingId, userId });
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Checks the subscribing user's role and only publishes data if the user is moderator.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation
We needed to do more to avoid viewers programatically trying to obtain info about polls

<!-- What inspired you to submit this pull request? -->


