### PR TITLE
fix(guests): Propagate list of pending guests only to mods

### DIFF
--- a/bigbluebutton-html5/imports/api/guest-users/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/guest-users/server/publishers.js
@@ -1,17 +1,29 @@
 import GuestUsers from '/imports/api/guest-users/';
+import Users from '/imports/api/users';
 import { Meteor } from 'meteor/meteor';
 import Logger from '/imports/startup/server/logger';
 import AuthTokenValidation, { ValidationStates } from '/imports/api/auth-token-validation';
+
+const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 
 function guestUsers() {
   const tokenValidation = AuthTokenValidation.findOne({ connectionId: this.connection.id });
 
   if (!tokenValidation || tokenValidation.validationStatus !== ValidationStates.VALIDATED) {
-    Logger.warn(`Publishing GuestUsers was requested by unauth connection ${this.connection.id}`);
+    Logger.warn(`Publishing GuestUser was requested by unauth connection ${this.connection.id}`);
     return GuestUsers.find({ meetingId: '' });
   }
 
   const { meetingId, userId } = tokenValidation;
+
+  const User = Users.findOne({ userId, meetingId }, { fields: { role: 1 } });
+  if (!User || User.role !== ROLE_MODERATOR) {
+    Logger.warn(
+      'Publishing current-poll was requested by non-moderator connection',
+      { meetingId, userId, connectionId: this.connection.id },
+    );
+    return GuestUsers.find({ meetingId: '' });
+  }
 
   Logger.debug(`Publishing GuestUsers for ${meetingId} ${userId}`);
 

--- a/bigbluebutton-html5/imports/api/polls/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/polls/server/publishers.js
@@ -16,10 +16,10 @@ function currentPoll() {
   const { meetingId, userId } = tokenValidation;
 
   const User = Users.findOne({ userId, meetingId }, { fields: { role: 1 } });
-  if (!User || User.role != ROLE_MODERATOR) {
+  if (!User || User.role !== ROLE_MODERATOR) {
     Logger.warn(
       'Publishing current-poll was requested by non-moderator connection',
-      { meetingId, userId, connectionId: this.connection.id }
+      { meetingId, userId, connectionId: this.connection.id },
     );
     return Polls.find({ meetingId: '' });
   }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Limits the visibility of pending guests, so that viewers cannot programatically obtain info about them
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation
The guestUser collection is subscribed to by default but only moderators should see the list of pending guests
<!-- What inspired you to submit this pull request? -->


