### PR TITLE
Fixed issue with guests not joining meeting after being approved

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/request/GuestWait.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/request/GuestWait.java
@@ -23,7 +23,7 @@ public class GuestWait implements Request<GuestWait.Params> {
 
     @NotNull(message = "You must provide the session token")
     @UserSessionConstraint
-    @MaxParticipantsConstraint
+   // @MaxParticipantsConstraint
     private String sessionToken;
 
     @MeetingExistsConstraint

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -735,12 +735,14 @@ class ApiController {
       case GuestPolicy.ALLOW:
         // IF the user was allowed to join but there is no room available in
         // the meeting we must hold his approval
-        meetingService.guestIsWaiting(us.meetingID, us.internalUserId)
-        destURL = guestURL
-        msgKey = "seatWait"
-        msgValue = "Guest waiting for a seat in the meeting."
-        redirectClient = false
-        status = GuestPolicy.WAIT
+        if (hasReachedMaxParticipants(meeting, us)) {
+          meetingService.guestIsWaiting(us.meetingID, us.internalUserId)
+          destURL = guestURL
+          msgKey = "seatWait"
+          msgValue = "Guest waiting for a seat in the meeting."
+          redirectClient = false
+          status = GuestPolicy.WAIT
+        }
         break
       default:
         break


### PR DESCRIPTION
### What does this PR do?

Fixed an issue with the 'guestWait' API that prevented guests from joining meetings after being approved by a moderator. 