### PR TITLE
fix(screenshare): broken maximized ui before fully loaded

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -263,7 +263,7 @@ class ScreenshareComponent extends React.Component {
   }
 
   renderScreensharePresenter() {
-    const { loaded, switched } = this.state;
+    const { switched } = this.state;
     const { isGloballyBroadcasting, intl } = this.props;
 
     return (
@@ -272,7 +272,7 @@ class ScreenshareComponent extends React.Component {
         key="screenshareContainer"
         ref={(ref) => { this.screenshareContainer = ref; }}
       >
-        {loaded && this.renderSwitchButton()}
+        {isGloballyBroadcasting && this.renderSwitchButton()}
         {this.renderVideo(switched)}
 
         {isGloballyBroadcasting


### PR DESCRIPTION
Fixes a small bug which allows the user to use the
shrink/expand button before the display it is
fully loaded

closes: https://github.com/bigbluebutton/bigbluebutton/issues/12895