### PR TITLE
Add override locale support - guest wait page

### DIFF
--- a/bigbluebutton-html5/private/static/guest-wait/guest-wait.html
+++ b/bigbluebutton-html5/private/static/guest-wait/guest-wait.html
@@ -114,7 +114,7 @@
       const DEFAULT_LANGUAGE = 'en';
       const LOCALES_ENDPOINT = '/html5client/locale';
       const url = new URL(`${window.location.origin}${LOCALES_ENDPOINT}`);
-      url.search = `locale=${navigator.language}`;
+      url.search = `locale=${navigator.language}&init=true`;
 
       const localesPath = 'locales';
 

--- a/bigbluebutton-html5/private/static/guest-wait/guest-wait.html
+++ b/bigbluebutton-html5/private/static/guest-wait/guest-wait.html
@@ -110,11 +110,45 @@
         });
     };
 
-    function fetchLocalizedMessages() {
+    async function fetchOverrideLocale() {
+      const token = findSessionToken();
+      let overrideLocale = false;
+
+      if (token) {
+        const sessionToken = token.split('=')[1];
+
+        // use enter api to get params for the client
+        const ENTER_ENDPOINT = `/bigbluebutton/api/enter?sessionToken=${sessionToken}`;
+        const url = new URL(`${window.location.origin}${ENTER_ENDPOINT}`);
+
+        const fetchContent = await fetch(url, { credentials: 'same-origin' });
+        const parseToJson = await fetchContent.json();
+        const { response } = parseToJson;
+
+        if (response.returncode !== 'FAILED') {
+          const { customdata } = response;
+
+          customdata.forEach((el) => {
+            const settingKey = Object.keys(el).shift();
+
+            if (settingKey === 'bbb_override_default_locale') {
+              overrideLocale = el[settingKey];
+            }
+          });
+        }
+      }
+      return overrideLocale;
+    }
+
+    async function fetchLocalizedMessages() {
       const DEFAULT_LANGUAGE = 'en';
       const LOCALES_ENDPOINT = '/html5client/locale';
       const url = new URL(`${window.location.origin}${LOCALES_ENDPOINT}`);
-      url.search = `locale=${navigator.language}&init=true`;
+      const overrideLocale = await fetchOverrideLocale();
+
+      url.search = overrideLocale
+        ? `locale=${overrideLocale}`
+        : `locale=${navigator.language}&init=true`;
 
       const localesPath = 'locales';
 


### PR DESCRIPTION
### What does this PR do?

Adds `userdata-bbb_override_default_locale` (API) and `application.overrideLocale` (settings.yml) support to guest wait page.

### Closes Issue(s)
Closes #12887