### PR TITLE
fix: Check for users before grabbing breakout url

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/container.jsx
@@ -7,7 +7,7 @@ import breakoutService from '/imports/ui/components/breakout-room/service';
 import AudioManager from '/imports/ui/services/audio-manager';
 import BreakoutJoinConfirmationComponent from './component';
 
-const BreakoutJoinConfirmationContrainer = props => (
+const BreakoutJoinConfirmationContrainer = (props) => (
   <BreakoutJoinConfirmationComponent
     {...props}
   />
@@ -16,7 +16,7 @@ const BreakoutJoinConfirmationContrainer = props => (
 const getURL = (breakoutId) => {
   const currentUserId = Auth.userID;
   const getBreakout = Breakouts.findOne({ breakoutId }, { fields: { users: 1 } });
-  const user = getBreakout ? getBreakout.users.find(u => u.userId === currentUserId) : '';
+  const user = getBreakout ? getBreakout.users?.find((u) => u.userId === currentUserId) : '';
   if (user) return user.redirectToHtml5JoinURL;
   return '';
 };


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Fixes a crash incroduced by https://github.com/bigbluebutton/bigbluebutton/pull/12871 - where if no users were assigned to breakouts (for example if allowing viewers to pick their own room) the viewer's client would crash due to not handling the case of no `users` in the structure where we look for `redirectToHtml5JoinURL`
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes https://github.com/bigbluebutton/bigbluebutton/issues/12901


