### PR TITLE
fix: Grant current-poll access to attendee presenter too

### DIFF
--- a/bigbluebutton-html5/imports/api/polls/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/polls/server/publishers.js
@@ -15,22 +15,23 @@ function currentPoll() {
 
   const { meetingId, userId } = tokenValidation;
 
-  const User = Users.findOne({ userId, meetingId }, { fields: { role: 1 } });
-  if (!User || User.role !== ROLE_MODERATOR) {
-    Logger.warn(
-      'Publishing current-poll was requested by non-moderator connection',
-      { meetingId, userId, connectionId: this.connection.id },
-    );
-    return Polls.find({ meetingId: '' });
+  const User = Users.findOne({ userId, meetingId }, { fields: { role: 1, presenter: 1 } });
+
+  if (!!User && (User.role === ROLE_MODERATOR || User.presenter)) {
+    Logger.debug('Publishing Polls', { meetingId, userId });
+
+    const selector = {
+      meetingId,
+    };
+
+    return Polls.find(selector);
   }
 
-  Logger.debug('Publishing Polls', { meetingId, userId });
-
-  const selector = {
-    meetingId,
-  };
-
-  return Polls.find(selector);
+  Logger.warn(
+    'Publishing current-poll was requested by non-moderator connection',
+    { meetingId, userId, connectionId: this.connection.id },
+  );
+  return Polls.find({ meetingId: '' });
 }
 
 function publishCurrentPoll(...args) {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Modifies the constraints introduced by https://github.com/bigbluebutton/bigbluebutton/pull/12872 so that non-moderator presenters also can receive data for `current-poll` collection

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #12888 

