### PR TITLE
fix: Re-subscribe user to guestUser collection on promotion/demotion

### DIFF
--- a/bigbluebutton-html5/imports/api/guest-users/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/guest-users/server/publishers.js
@@ -6,7 +6,7 @@ import AuthTokenValidation, { ValidationStates } from '/imports/api/auth-token-v
 
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 
-function guestUsers() {
+function guestUsers(role) {
   const tokenValidation = AuthTokenValidation.findOne({ connectionId: this.connection.id });
 
   if (!tokenValidation || tokenValidation.validationStatus !== ValidationStates.VALIDATED) {
@@ -19,7 +19,7 @@ function guestUsers() {
   const User = Users.findOne({ userId, meetingId }, { fields: { role: 1 } });
   if (!User || User.role !== ROLE_MODERATOR) {
     Logger.warn(
-      'Publishing current-poll was requested by non-moderator connection',
+      'Publishing GuestUser was requested by non-moderator connection',
       { meetingId, userId, connectionId: this.connection.id },
     );
     return GuestUsers.find({ meetingId: '' });

--- a/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
@@ -71,6 +71,7 @@ export default withTracker(() => {
     subscriptionsHandlers.push(Meteor.subscribe('meetings', currentUser.role, subscriptionErrorHandler));
     subscriptionsHandlers.push(Meteor.subscribe('users', currentUser.role, subscriptionErrorHandler));
     subscriptionsHandlers.push(Meteor.subscribe('breakouts', currentUser.role, subscriptionErrorHandler));
+    subscriptionsHandlers.push(Meteor.subscribe('guestUser', currentUser.role, subscriptionErrorHandler));
   }
 
   const annotationsHandler = Meteor.subscribe('annotations', {
@@ -104,7 +105,7 @@ export default withTracker(() => {
         { meetingId, users: { $all: [requesterUserId] } },
       ],
     }).fetch();
-    
+
     const chatIds = chats.map(chat => chat.chatId);
 
     const subHandler = {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Auto-triggers subscription to Meteor collection `guestUser` for users when the user's role changes [i.e. promoted to moderator or demoted to viewer]. This allows for newlypromoted viewers to receive notifications on guests waiting.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #12890 


