### PR TITLE
Commas are again allowed in meeting names

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/constraint/MeetingNameConstraint.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/constraint/MeetingNameConstraint.java
@@ -13,7 +13,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @NotEmpty(message = "You must provide a meeting name")
 @Size(min = 2, max = 256, message = "Meeting name must be between 2 and 256 characters")
-@Pattern(regexp = "^[^,]+$", message = "Meeting name cannot contain ','")
+//@Pattern(regexp = "^[^,]+$", message = "Meeting name cannot contain ','")
 @Constraint(validatedBy = {})
 @Target(FIELD)
 @Retention(RUNTIME)


### PR DESCRIPTION
### What does this PR do?

Modified the meeting name constraint to allow commas.