### PR TITLE
fix: sidebar height - focus on video layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -315,6 +315,10 @@ class VideoFocusLayout extends Component {
         }
         maxHeight = this.mainHeight() * 0.75 - this.bannerAreaHeight();
         minHeight = this.mainHeight() * 0.25 - this.bannerAreaHeight();
+
+        if (height > maxHeight) {
+          height = maxHeight;
+        }
       } else {
         height = this.mainHeight() - this.bannerAreaHeight();
         maxHeight = height;


### PR DESCRIPTION
### What does this PR do?

Prevents an issue with sidebarContent height calculation that could lead to the presentation not being correctly displayed.