### PR TITLE
fix: handle case of freeJoin breakout with no users

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/service.js
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/service.js
@@ -24,7 +24,7 @@ const findBreakouts = () => {
 const breakoutRoomUser = (breakoutId) => {
   const breakoutRooms = findBreakouts();
   const breakoutRoom = breakoutRooms.filter(breakout => breakout.breakoutId === breakoutId).shift();
-  const breakoutUser = breakoutRoom.users.filter(user => user.userId === Auth.userID).shift();
+  const breakoutUser = breakoutRoom.users?.filter(user => user.userId === Auth.userID).shift();
   return breakoutUser;
 };
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Handles a case for breakouts join when `freeJoin: true` and the initial dialog for selecting a room has been closed by the user, resorting to the participants list Breakouts section to select and join a room.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation
![Screenshot from 2021-08-05 10-01-01](https://user-images.githubusercontent.com/6312397/128363078-48958cb3-7797-4aa6-aebc-4c8a3e520137.png)

Related to #12905 
