### PR TITLE
Modified how the checksum is removed from the query string

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/shared/GetChecksum.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/shared/GetChecksum.java
@@ -1,14 +1,9 @@
 package org.bigbluebutton.api.model.shared;
 
-import org.apache.http.NameValuePair;
-import org.apache.http.client.utils.URLEncodedUtils;
 import org.bigbluebutton.api.model.constraint.GetChecksumConstraint;
 import org.bigbluebutton.api.util.ParamsUtil;
 
 import javax.validation.constraints.NotEmpty;
-import java.nio.charset.StandardCharsets;
-import java.util.Iterator;
-import java.util.List;
 
 @GetChecksumConstraint(message = "Checksums do not match")
 public class GetChecksum extends Checksum {
@@ -23,17 +18,10 @@ public class GetChecksum extends Checksum {
     }
 
     private void removeChecksumFromQueryString() {
-        List<NameValuePair> params = URLEncodedUtils.parse(queryString, StandardCharsets.UTF_8);
-
-        Iterator<NameValuePair> itr = params.iterator();
-        while(itr.hasNext()) {
-            NameValuePair pair = itr.next();
-            if(pair.getName().equals("checksum")) {
-                itr.remove();
-            }
-        }
-
-        queryStringWithoutChecksum = URLEncodedUtils.format(params, '&', StandardCharsets.UTF_8);
+        queryStringWithoutChecksum = queryString;
+        queryStringWithoutChecksum = queryStringWithoutChecksum.replace("&checksum=" + checksum, "");
+        queryStringWithoutChecksum = queryStringWithoutChecksum.replace("checksum=" + checksum + "&", "");
+        queryStringWithoutChecksum = queryStringWithoutChecksum.replace("checksum=" + checksum, "");
     }
 
     public String getQueryString() {


### PR DESCRIPTION
### What does this PR do?

Changed how the checksum is removed from the query string back to the old method. Checksums constructed from percent encoded URLs should no longer fail validation.

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #12919
-->
Closes #12919
