### PR TITLE
fix: z-index issue in firefox for captions

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.scss
@@ -211,7 +211,7 @@
   height: auto;
   bottom: 100px;
   left: 20%;
-  z-index: 2;
+  z-index: 5;
 }
 
 .actionsbar {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Some parts of text wasn't show if webcams are on. This is happening only with Firefox. 

Tested on: 90.0.2 (64-bit)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation

<!-- What inspired you to submit this pull request? -->

### More

**Before:**

<img width="959" alt="Screenshot at Aug 06 22-05-52" src="https://user-images.githubusercontent.com/6080277/128541352-47fb4262-2f10-4552-b8c4-b09e1512b084.png">


**After:**

<img width="840" alt="Screenshot at Aug 06 22-06-22" src="https://user-images.githubusercontent.com/6080277/128541379-972d5db0-a50b-4a15-b745-22e2eaa61436.png">
