### PR TITLE
fix: restore localeChanged event handle

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/intl.jsx
+++ b/bigbluebutton-html5/imports/startup/client/intl.jsx
@@ -35,7 +35,9 @@ class IntlStartup extends Component {
       Settings.application.isRTL = false;
     }
     Session.set('isLargeFont', LARGE_FONT_LANGUAGES.includes(localeName.substring(0, 2)));
-    window.dispatchEvent(new Event('localeChanged'));
+    const localeChangedEvent = new Event('localeChanged')
+    localeChangedEvent.isRTL = Settings.application.isRTL;
+    window.dispatchEvent(localeChangedEvent);
     Settings.save();
   }
 

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -192,6 +192,12 @@ class App extends Component {
 
     this.handleWindowResize();
     window.addEventListener('resize', this.handleWindowResize, false);
+    window.addEventListener('localeChanged', (event) => {
+      layoutContextDispatch({
+        type: ACTIONS.SET_IS_RTL,
+        value: event.isRTL,
+      });
+    });
     window.ondragover = (e) => { e.preventDefault(); };
     window.ondrop = (e) => { e.preventDefault(); };
 
@@ -218,7 +224,6 @@ class App extends Component {
       layoutType,
       pushLayoutToEveryone,
       layoutContextDispatch,
-      isRTL,
     } = this.props;
 
     if (meetingLayout !== prevProps.meetingLayout) {
@@ -229,13 +234,6 @@ class App extends Component {
 
       Settings.application.selectedLayout = meetingLayout;
       Settings.save();
-    }
-
-    if (isRTL !== prevProps.isRTL) {
-      layoutContextDispatch({
-        type: ACTIONS.SET_IS_RTL,
-        value: isRTL,
-      });
     }
 
     if (settingsLayout !== prevProps.settingsLayout


### PR DESCRIPTION
### What does this PR do?

Restores `localeChanged` event listener, fixing an issue where the `isRTL` value is not updated when changing locales.

### Closes Issue(s)
Closes #12933