### PR TITLE
fix: screen sharing does not show up when presentation is hidden

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
 import Button from '/imports/ui/components/button/component';
-import MediaService from '/imports/ui/components/media/service';
 
 const propTypes = {
   intl: PropTypes.shape({
@@ -22,33 +21,26 @@ const intlMessages = defineMessages({
   },
 });
 
-const shouldUnswapLayout = () => (
-  MediaService.shouldShowScreenshare() || MediaService.shouldShowExternalVideo()
-);
-
 const PresentationOptionsContainer = ({
   intl,
   toggleSwapLayout,
   isThereCurrentPresentation,
   layoutContextDispatch,
-}) => {
-  if (shouldUnswapLayout()) toggleSwapLayout();
-  return (
-    <Button
-      icon="presentation"
-      data-test="restorePresentationButton"
-      label={intl.formatMessage(intlMessages.restorePresentationLabel)}
-      description={intl.formatMessage(intlMessages.restorePresentationDesc)}
-      color="primary"
-      hideLabel
-      circle
-      size="lg"
-      onClick={() => toggleSwapLayout(layoutContextDispatch)}
-      id="restore-presentation"
-      disabled={!isThereCurrentPresentation}
-    />
-  );
-};
+}) => (
+  <Button
+    icon="presentation"
+    data-test="restorePresentationButton"
+    label={intl.formatMessage(intlMessages.restorePresentationLabel)}
+    description={intl.formatMessage(intlMessages.restorePresentationDesc)}
+    color="primary"
+    hideLabel
+    circle
+    size="lg"
+    onClick={() => toggleSwapLayout(layoutContextDispatch)}
+    id="restore-presentation"
+    disabled={!isThereCurrentPresentation}
+  />
+);
 
 PresentationOptionsContainer.propTypes = propTypes;
 export default injectIntl(PresentationOptionsContainer);

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
@@ -138,6 +138,12 @@ class VideoPlayer extends Component {
   }
 
   componentDidMount() {
+    const {
+      getSwapLayout,
+      toggleSwapLayout,
+      layoutContextDispatch,
+    } = this.props;
+
     window.addEventListener('beforeunload', this.onBeforeUnload);
 
     clearInterval(this.syncInterval);
@@ -145,6 +151,8 @@ class VideoPlayer extends Component {
 
     VideoPlayer.clearVideoListeners();
     this.registerVideoListeners();
+
+    if (getSwapLayout()) toggleSwapLayout(layoutContextDispatch);
   }
 
   shouldComponentUpdate(nextProps, nextState) {

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/container.jsx
@@ -4,13 +4,24 @@ import { Session } from 'meteor/session';
 import { getVideoUrl } from './service';
 import ExternalVideoComponent from './component';
 import LayoutContext from '../layout/context';
+import MediaService, { getSwapLayout } from '/imports/ui/components/media/service';
 
 const ExternalVideoContainer = (props) => {
   const layoutManager = useContext(LayoutContext);
-  const { layoutContextState } = layoutManager;
+  const { layoutContextState, layoutContextDispatch } = layoutManager;
   const { output } = layoutContextState;
   const { externalVideo } = output;
-  return <ExternalVideoComponent {...{ ...props }} {...externalVideo} />;
+  return (
+    <ExternalVideoComponent
+      {
+      ...{
+        layoutContextDispatch,
+        ...props,
+        ...externalVideo,
+      }
+      }
+    />
+  );
 };
 
 export default withTracker(({ isPresenter }) => {
@@ -19,5 +30,7 @@ export default withTracker(({ isPresenter }) => {
     inEchoTest,
     isPresenter,
     videoUrl: getVideoUrl(),
+    getSwapLayout,
+    toggleSwapLayout: MediaService.toggleSwapLayout,
   };
 })(ExternalVideoContainer);

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -85,7 +85,12 @@ class ScreenshareComponent extends React.Component {
   }
 
   componentDidMount() {
-    const { intl } = this.props;
+    const {
+      getSwapLayout,
+      toggleSwapLayout,
+      layoutContextDispatch,
+      intl,
+    } = this.props;
 
     screenshareHasStarted();
     this.screenshareContainer.addEventListener('fullscreenchange', this.onFullscreenChange);
@@ -97,6 +102,8 @@ class ScreenshareComponent extends React.Component {
     attachLocalPreviewStream(getMediaElement());
 
     notify(intl.formatMessage(intlMessages.screenshareStarted), 'info', 'desktop');
+
+    if (getSwapLayout()) toggleSwapLayout(layoutContextDispatch);
   }
 
   componentDidUpdate(prevProps) {
@@ -109,15 +116,7 @@ class ScreenshareComponent extends React.Component {
   }
 
   componentWillUnmount() {
-    const {
-      getSwapLayout,
-      shouldEnableSwapLayout,
-      toggleSwapLayout,
-      layoutContextDispatch,
-      intl,
-    } = this.props;
-    const layoutSwapped = getSwapLayout() && shouldEnableSwapLayout();
-    if (layoutSwapped) toggleSwapLayout(layoutContextDispatch);
+    const { intl } = this.props;
     screenshareHasEnded();
     this.screenshareContainer.removeEventListener('fullscreenchange', this.onFullscreenChange);
     window.removeEventListener('screensharePlayFailed', this.handlePlayElementFailed);


### PR DESCRIPTION
### What does this PR do?

Prevents an issue where screenshare and external video would not appear if presentation is hidden (custom and smart layouts).

### Closes Issue(s)
Closes #12942