### PR TITLE
Remove Menu Items Not Applicable For Dial-In-Users

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
@@ -244,6 +244,8 @@ class UserDropdown extends PureComponent {
       layoutContextDispatch,
     } = this.props;
     const { showNestedOptions } = this.state;
+    const { clientType } = user;
+    const isDialInUser = clientType === 'dial-in-user';
 
     const amIPresenter = currentUser.presenter;
     const amIModerator = currentUser.role === ROLE_MODERATOR;
@@ -317,7 +319,7 @@ class UserDropdown extends PureComponent {
 
     const showChatOption = CHAT_ENABLED
       && enablePrivateChat
-      && user.clientType !== 'dial-in-user'
+      && !isDialInUser
       && !meetingIsBreakout
       && isMeteorConnected;
 
@@ -381,7 +383,7 @@ class UserDropdown extends PureComponent {
       });
     }
 
-    if (allowedToChangeWhiteboardAccess && !user.presenter && isMeteorConnected) {
+    if (allowedToChangeWhiteboardAccess && !user.presenter && isMeteorConnected && !isDialInUser) {
       const label = user.whiteboardAccess
         ? intl.formatMessage(messages.removeWhiteboardAccess)
         : intl.formatMessage(messages.giveWhiteboardAccess);
@@ -397,7 +399,7 @@ class UserDropdown extends PureComponent {
       });
     }
 
-    if (allowedToSetPresenter && isMeteorConnected) {
+    if (allowedToSetPresenter && isMeteorConnected && !isDialInUser) {
       actions.push({
         key: 'setPresenter',
         label: isMe(user.userId)


### PR DESCRIPTION
### What does this PR do?
Prevents the make presentation and give whiteboard access menu items being rendered for `dail-in-users`.

### Closes Issue(s)
Closes #12952 
