### PR TITLE
fix: handle deletion of multiple files with default filename

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -18,7 +18,6 @@ const { isMobile } = deviceInfo;
 
 const propTypes = {
   intl: PropTypes.object.isRequired,
-  defaultFileName: PropTypes.string.isRequired,
   handleSave: PropTypes.func.isRequired,
   dispatchTogglePresentationDownloadable: PropTypes.func.isRequired,
   fileValidMimeTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -226,6 +225,7 @@ class PresentationUploader extends Component {
       toUploadCount: 0,
     };
 
+    this.defaultPresentationId = null;
     this.toastId = null;
     this.hasError = null;
 
@@ -279,6 +279,15 @@ class PresentationUploader extends Component {
       }
     }
 
+
+    // Get the very first uploaded presentation's ID (default)
+    if (propPresentations.length > 0) {
+      const defaultPresentation = propPresentations.reduce(
+        (pres1, pres2) => (pres1.uploadTimestamp < pres2.uploadTimestamp ? pres1 : pres2)
+      );
+      this.defaultPresentationId = defaultPresentation.id;
+    }
+
     if (presentations.length > 0) {
       const selected = propPresentations.filter((p) => p.isCurrent);
       if (selected.length > 0) Session.set('selectedToBeNextCurrent', selected[0].id);
@@ -300,9 +309,7 @@ class PresentationUploader extends Component {
   }
 
   isDefault(presentation) {
-    const { defaultFileName } = this.props;
-    return presentation.filename === defaultFileName
-      && !presentation.id.includes(defaultFileName);
+    return presentation.id === this.defaultPresentationId;
   }
 
   handleDismissToast() {

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/container.jsx
@@ -28,7 +28,6 @@ export default withTracker(() => {
 
   return {
     presentations: currentPresentations,
-    defaultFileName: PRESENTATION_CONFIG.defaultPresentationFile,
     fileValidMimeTypes: PRESENTATION_CONFIG.uploadValidMimeTypes,
     handleSave: (presentations) => Service.persistPresentationChanges(
       currentPresentations,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -493,7 +493,6 @@ public:
     help: STATS_HELP_URL
   presentation:
     allowDownloadable: true
-    defaultPresentationFile: default.pdf
     panZoomThrottle: 32
     restoreOnUpdate: false
     uploadEndpoint: '/bigbluebutton/presentation/upload'


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

- Uploading a presentation with name, same as default presentation name (for e.g default.pdf) couldn't be deleted after conversion. We store the default presentation id to ensure only that can't be deleted.

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #7720

#### More

I had messed up the commits in #12884 😅. So created a new PR with all the suggestions @jfsiebel applied.