### PR TITLE
fix: RTL language - external video, wrong position on client interface

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
@@ -464,6 +464,7 @@ class VideoPlayer extends Component {
       intl,
       top,
       left,
+      right,
       height,
       width,
     } = this.props;
@@ -485,6 +486,7 @@ class VideoPlayer extends Component {
           position: 'absolute',
           top,
           left,
+          right,
           height,
           width,
         }}


### PR DESCRIPTION
### What does this PR do?

Fixes video position in RTL languages by adding missing props to external video component.

### Closes Issue(s)
Closes #12934