### PR TITLE
fix: viewing shared screen in full screen mode will break the interface when screen share closes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -214,8 +214,20 @@ class Presentation extends PureComponent {
   }
 
   componentWillUnmount() {
+    const { fullscreenContext, layoutContextDispatch } = this.props;
+
     window.removeEventListener('resize', this.onResize, false);
     this.refPresentationContainer.removeEventListener('fullscreenchange', this.onFullscreenChange);
+
+    if (fullscreenContext) {
+      layoutContextDispatch({
+        type: ACTIONS.SET_FULLSCREEN_ELEMENT,
+        value: {
+          element: '',
+          group: '',
+        },
+      });
+    }
   }
 
   handleResize() {

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -23,6 +23,7 @@ import {
   subscribeToStreamStateChange,
   unsubscribeFromStreamStateChange,
 } from '/imports/ui/services/bbb-webrtc-sfu/stream-state-service';
+import { ACTIONS } from '/imports/ui/components/layout/enums';
 
 const intlMessages = defineMessages({
   screenShareLabel: {
@@ -114,6 +115,7 @@ class ScreenshareComponent extends React.Component {
       shouldEnableSwapLayout,
       toggleSwapLayout,
       layoutContextDispatch,
+      fullscreenContext,
       intl,
     } = this.props;
     const layoutSwapped = getSwapLayout() && shouldEnableSwapLayout();
@@ -124,6 +126,16 @@ class ScreenshareComponent extends React.Component {
     unsubscribeFromStreamStateChange('screenshare', this.onStreamStateChange);
 
     notify(intl.formatMessage(intlMessages.screenshareEnded), 'info', 'desktop');
+
+    if (fullscreenContext) {
+      layoutContextDispatch({
+        type: ACTIONS.SET_FULLSCREEN_ELEMENT,
+        value: {
+          element: '',
+          group: '',
+        },
+      });
+    }
   }
 
   handleAllowAutoplay() {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -16,6 +16,7 @@ import {
   unsubscribeFromStreamStateChange,
 } from '/imports/ui/services/bbb-webrtc-sfu/stream-state-service';
 import deviceInfo from '/imports/utils/deviceInfo';
+import { ACTIONS } from '/imports/ui/components/layout/enums';
 
 const ALLOW_FULLSCREEN = Meteor.settings.public.app.allowFullscreen;
 
@@ -70,13 +71,28 @@ class VideoListItem extends Component {
   }
 
   componentWillUnmount() {
-    const { cameraId, onVideoItemUnmount } = this.props;
+    const {
+      cameraId,
+      onVideoItemUnmount,
+      isFullscreenContext,
+      layoutContextDispatch,
+    } = this.props;
 
     this.videoTag.removeEventListener('loadeddata', this.setVideoIsReady);
     this.videoContainer.removeEventListener('fullscreenchange', this.onFullscreenChange);
     unsubscribeFromStreamStateChange(cameraId, this.onStreamStateChange);
     onVideoItemUnmount(cameraId);
     window.removeEventListener('resize', this.updateOrientation);
+
+    if (isFullscreenContext) {
+      layoutContextDispatch({
+        type: ACTIONS.SET_FULLSCREEN_ELEMENT,
+        value: {
+          element: '',
+          group: '',
+        },
+      });
+    }
   }
 
   onStreamStateChange(e) {


### PR DESCRIPTION
### What does this PR do?

- removes fullscreen-related code from screenshare component state;
- adds context call to end fullscreen if the fullscreen component is unmounted (presentation, webcam, screenshare);

### Closes Issue(s)
Closes #12953