### PR TITLE
refactor(webcams, screenshare, listen-only): let the server generate subscriber offers

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
@@ -13,6 +13,7 @@ const MEDIA = Meteor.settings.public.media;
 const MEDIA_TAG = MEDIA.mediaTag.replace(/#/g, '');
 const GLOBAL_AUDIO_PREFIX = 'GLOBAL_AUDIO_';
 const RECONNECT_TIMEOUT_MS = MEDIA.listenOnlyCallTimeout || 15000;
+const OFFERING = MEDIA.listenOnlyOffering;
 const RECV_ROLE = 'recv';
 const BRIDGE_NAME = 'kurento';
 
@@ -202,6 +203,7 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
               userName: this.name,
               caleeName: `${GLOBAL_AUDIO_PREFIX}${this.voiceBridge}`,
               iceServers,
+              offering: OFFERING,
             };
 
             this.broker = new ListenOnlyBroker(
@@ -252,6 +254,7 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
           userName: this.name,
           caleeName: `${GLOBAL_AUDIO_PREFIX}${this.voiceBridge}`,
           iceServers,
+          offering: OFFERING,
         };
 
         this.broker = new ListenOnlyBroker(

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -7,6 +7,7 @@ import { SCREENSHARING_ERRORS } from './errors';
 
 const SFU_CONFIG = Meteor.settings.public.kurento;
 const SFU_URL = SFU_CONFIG.wsUrl;
+const OFFERING = SFU_CONFIG.screenshare.subscriberOffering;
 
 const BRIDGE_NAME = 'kurento'
 const SCREENSHARE_VIDEO_TAG = 'screenshareVideo';
@@ -202,6 +203,7 @@ export default class KurentoScreenshareBridge {
       iceServers,
       userName: Auth.fullname,
       hasAudio,
+      offering: OFFERING,
     };
 
     this.broker = new ScreenshareBroker(
@@ -259,6 +261,7 @@ export default class KurentoScreenshareBridge {
         stream,
         hasAudio: this.hasAudio,
         bitrate: BridgeService.BASE_BITRATE,
+        offering: true,
       };
 
       this.broker = new ScreenshareBroker(

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -337,6 +337,18 @@ class VideoProvider extends Component {
     }
   }
 
+  sendLocalAnswer (peer, stream, answer) {
+    const message = {
+      id: 'subscriberAnswer',
+      type: 'video',
+      role: VideoService.getRole(peer.isPublisher),
+      cameraId: stream,
+      answer,
+    };
+
+    this.sendMessage(message);
+  }
+
   startResponse(message) {
     const { cameraId: stream, role } = message;
     const peer = this.webRtcPeers[stream];
@@ -347,10 +359,14 @@ class VideoProvider extends Component {
     }, `Camera start request accepted by SFU. Role: ${role}`);
 
     if (peer) {
-      peer.processAnswer(message.sdpAnswer, (error) => {
+      const processorFunc = peer.isPublisher
+        ? peer.processAnswer.bind(peer)
+        : peer.processOffer.bind(peer);
+
+      processorFunc(message.sdpAnswer, (error, answer) => {
         if (error) {
           logger.error({
-            logCode: 'video_provider_peerconnection_processanswer_error',
+            logCode: 'video_provider_peerconnection_process_error',
             extraInfo: {
               cameraId: stream,
               role,
@@ -361,6 +377,8 @@ class VideoProvider extends Component {
 
           return;
         }
+
+        if (answer) this.sendLocalAnswer(peer, stream, answer);
 
         peer.didSDPAnswered = true;
         this.processOutboundIceQueue(peer, role, stream);
@@ -473,9 +491,98 @@ class VideoProvider extends Component {
     }
   }
 
+  _createPublisher (stream, peerOptions) {
+    return new Promise((resolve, reject) => {
+      try {
+        const { id: profileId } = VideoService.getCameraProfile();
+        let bbbVideoStream = VideoService.getPreloadedStream();
+
+        if (bbbVideoStream) {
+          peerOptions.videoStream = bbbVideoStream.mediaStream;
+        }
+
+        const handlePubPeerCreation = (error) => {
+          const peer = this.webRtcPeers[stream];
+          peer.stream = stream;
+          peer.started = false;
+          peer.attached = false;
+          peer.didSDPAnswered = false;
+          peer.inboundIceQueue = [];
+          peer.isPublisher = true;
+          peer.originalProfileId = profileId;
+          peer.currentProfileId = profileId;
+
+          if (error) return reject(error);
+
+          // Store the media stream if necessary. The scenario here is one where
+          // there is no preloaded stream stored.
+          if (bbbVideoStream == null) {
+            bbbVideoStream = new BBBVideoStream(peer.getLocalStream());
+            VideoPreviewService.storeStream(
+              MediaStreamUtils.extractVideoDeviceId(bbbVideoStream.mediaStream),
+              bbbVideoStream
+            );
+          }
+
+          peer.bbbVideoStream = bbbVideoStream;
+          bbbVideoStream.on('streamSwapped', ({ newStream }) => {
+            if (newStream && newStream instanceof MediaStream) {
+              this.replacePCVideoTracks(stream, newStream);
+            }
+          });
+
+          peer.generateOffer((errorGenOffer, offerSdp) => {
+            if (errorGenOffer) {
+              return reject(errorGenOffer);
+            }
+
+            return resolve(offerSdp);
+          });
+        }
+
+        this.webRtcPeers[stream] = new window.kurentoUtils.WebRtcPeer.WebRtcPeerSendonly(
+          peerOptions,
+          handlePubPeerCreation,
+        );
+      } catch (error) {
+        return reject(error);
+      }
+    });
+  }
+
+  _createSubscriber (stream, peerOptions) {
+    return new Promise((resolve, reject) => {
+      try {
+        const handleSubPeerCreation = (error) => {
+          const peer = this.webRtcPeers[stream];
+          peer.stream = stream;
+          peer.started = false;
+          peer.attached = false;
+          peer.didSDPAnswered = false;
+          peer.inboundIceQueue = [];
+          peer.isPublisher = false;
+
+          if (error) return reject(error);
+
+          return resolve();
+        };
+
+        this.webRtcPeers[stream] = new window.kurentoUtils.WebRtcPeer.WebRtcPeerRecvonly(
+          peerOptions,
+          handleSubPeerCreation,
+        );
+      } catch (error) {
+        return reject(error);
+      }
+    });
+  }
+
   async createWebRTCPeer(stream, isLocal) {
     let iceServers = [];
     const role = VideoService.getRole(isLocal);
+    const peerBuilderFunc = isLocal
+      ? this._createPublisher.bind(this)
+      : this._createSubscriber.bind(this);
 
     // Check if the peer is already being processed
     if (this.webRtcPeers[stream]) {
@@ -483,7 +590,8 @@ class VideoProvider extends Component {
     }
 
     this.webRtcPeers[stream] = {};
-    const { constraints, bitrate, id: profileId } = VideoService.getCameraProfile();
+    this.outboundIceQueues[stream] = [];
+    const { constraints, bitrate, } = VideoService.getCameraProfile();
     const peerOptions = {
       mediaConstraints: {
         audio: false,
@@ -507,106 +615,50 @@ class VideoProvider extends Component {
       // Use fallback STUN server
       iceServers = getMappedFallbackStun();
     } finally {
-      this.outboundIceQueues[stream] = [];
-
       if (iceServers.length > 0) {
         peerOptions.configuration = {};
         peerOptions.configuration.iceServers = iceServers;
       }
 
-      let WebRtcPeerObj;
-      let bbbVideoStream
-      if (isLocal) {
-        WebRtcPeerObj = window.kurentoUtils.WebRtcPeer.WebRtcPeerSendonly;
-        bbbVideoStream = VideoService.getPreloadedStream();
-        if (bbbVideoStream) {
-          peerOptions.videoStream = bbbVideoStream.mediaStream;
-        }
-      } else {
-        WebRtcPeerObj = window.kurentoUtils.WebRtcPeer.WebRtcPeerRecvonly;
-      }
-
-      this.webRtcPeers[stream] = new WebRtcPeerObj(peerOptions, (error) => {
+      peerBuilderFunc(stream, peerOptions).then((offer) => {
         const peer = this.webRtcPeers[stream];
 
-        peer.stream = stream;
-        peer.started = false;
-        peer.attached = false;
-        peer.didSDPAnswered = false;
-        peer.isPublisher = isLocal;
-        peer.originalProfileId = profileId;
-        peer.currentProfileId = profileId;
-
-        if (peer.inboundIceQueue == null) {
-          peer.inboundIceQueue = [];
+        if (peer && peer.peerConnection) {
+          const conn = peer.peerConnection;
+          conn.onconnectionstatechange = () => {
+            this._handleIceConnectionStateChange(stream, isLocal);
+          };
         }
 
-        if (error) {
-          return this._onWebRTCError(error, stream, isLocal);
-        }
+        const message = {
+          id: 'start',
+          type: 'video',
+          cameraId: stream,
+          role,
+          sdpOffer: offer,
+          meetingId: this.info.meetingId,
+          voiceBridge: this.info.voiceBridge,
+          userId: this.info.userId,
+          userName: this.info.userName,
+          bitrate,
+          record: VideoService.getRecord(),
+        };
 
-        if (peer.isPublisher) {
-          // Store the media stream if necessary. The scenario here is one where
-          // there is no preloaded stream stored.
-          if (bbbVideoStream == null) {
-            bbbVideoStream = new BBBVideoStream(peer.getLocalStream());
-            VideoPreviewService.storeStream(
-              MediaStreamUtils.extractVideoDeviceId(bbbVideoStream.mediaStream),
-              bbbVideoStream
-            );
-          }
-
-          peer.bbbVideoStream = bbbVideoStream;
-          bbbVideoStream.on('streamSwapped', ({ newStream }) => {
-            if (newStream && newStream instanceof MediaStream) {
-              this.replacePCVideoTracks(stream, newStream);
-            }
-          });
-        }
-
-        peer.generateOffer((errorGenOffer, offerSdp) => {
-          if (errorGenOffer) {
-            return this._onWebRTCError(errorGenOffer, stream, isLocal);
-          }
-
-          const message = {
-            id: 'start',
-            type: 'video',
+        logger.info({
+          logCode: 'video_provider_sfu_request_start_camera',
+          extraInfo: {
             cameraId: stream,
             role,
-            sdpOffer: offerSdp,
-            meetingId: this.info.meetingId,
-            voiceBridge: this.info.voiceBridge,
-            userId: this.info.userId,
-            userName: this.info.userName,
-            bitrate,
-            record: VideoService.getRecord(),
-          };
+          },
+        }, `Camera offer generated. Role: ${role}`);
 
-          logger.info({
-            logCode: 'video_provider_sfu_request_start_camera',
-            extraInfo: {
-              cameraId: stream,
-              cameraProfile: profileId,
-              role,
-            },
-          }, `Camera offer generated. Role: ${role}`);
+        this.sendMessage(message);
+        this.setReconnectionTimeout(stream, isLocal, false);
 
-          this.sendMessage(message);
-          this.setReconnectionTimeout(stream, isLocal, false);
-
-          return false;
-        });
-        return false;
+        return;
+      }).catch(error => {
+        return this._onWebRTCError(error, stream, isLocal);
       });
-
-      const peer = this.webRtcPeers[stream];
-      if (peer && peer.peerConnection) {
-        const conn = peer.peerConnection;
-        conn.onconnectionstatechange = () => {
-          this._handleIceConnectionStateChange(stream, isLocal);
-        };
-      }
     }
   }
 

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/listenonly-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/listenonly-broker.js
@@ -2,6 +2,7 @@ import logger from '/imports/startup/client/logger';
 import BaseBroker from '/imports/ui/services/bbb-webrtc-sfu/sfu-base-broker';
 
 const ON_ICE_CANDIDATE_MSG = 'iceCandidate';
+const SUBSCRIBER_ANSWER = 'subscriberAnswer';
 const SFU_COMPONENT_NAME = 'audio';
 
 class ListenOnlyBroker extends BaseBroker {
@@ -18,8 +19,9 @@ class ListenOnlyBroker extends BaseBroker {
     this.userId = userId;
     this.internalMeetingId = internalMeetingId;
     this.role = role;
+    this.offering = true;
 
-    // Optional parameters are: userName, caleeName, iceServers
+    // Optional parameters are: userName, caleeName, iceServers, offering
     Object.assign(this, options);
   }
 
@@ -55,7 +57,12 @@ class ListenOnlyBroker extends BaseBroker {
         }
 
         this.webRtcPeer.iceQueue = [];
-        this.webRtcPeer.generateOffer(this.onOfferGenerated.bind(this));
+
+        if (this.offering) {
+          this.webRtcPeer.generateOffer(this.onOfferGenerated.bind(this));
+        } else {
+          this.sendStartReq()
+        }
       });
 
       this.webRtcPeer.peerConnection.onconnectionstatechange = this.handleConnectionStateChange.bind(this);
@@ -73,7 +80,7 @@ class ListenOnlyBroker extends BaseBroker {
 
     switch (parsedMessage.id) {
       case 'startResponse':
-        this.processAnswer(parsedMessage);
+        this.onRemoteDescriptionReceived(parsedMessage);
         break;
       case 'iceCandidate':
         this.handleIceCandidate(parsedMessage.candidate);
@@ -113,6 +120,47 @@ class ListenOnlyBroker extends BaseBroker {
     this.onerror(error);
   }
 
+  sendLocalDescription (localDescription) {
+    const message = {
+      id: SUBSCRIBER_ANSWER,
+      type: this.sfuComponent,
+      role: this.role,
+      voiceBridge: this.voiceBridge,
+      sdpOffer: localDescription,
+    };
+
+    this.sendMessage(message);
+  }
+
+  onRemoteDescriptionReceived (sfuResponse) {
+    if (this.offering) {
+      return this.processAnswer(sfuResponse);
+    }
+
+    return this.processOffer(sfuResponse);
+  }
+
+  sendStartReq (offer) {
+    const message = {
+      id: 'start',
+      type: this.sfuComponent,
+      role: this.role,
+      internalMeetingId: this.internalMeetingId,
+      voiceBridge: this.voiceBridge,
+      caleeName: this.caleeName,
+      userId: this.userId,
+      userName: this.userName,
+      sdpOffer: offer,
+    };
+
+    logger.debug({
+      logCode: `${this.logCodePrefix}_offer_generated`,
+      extraInfo: { sfuComponent: this.sfuComponent, role: this.role },
+    }, `SFU audio offer generated`);
+
+    this.sendMessage(message);
+  }
+
   onOfferGenerated (error, sdpOffer) {
     if (error) {
       logger.error({
@@ -127,24 +175,7 @@ class ListenOnlyBroker extends BaseBroker {
       return this.onerror(error);
     }
 
-    const message = {
-      id: 'start',
-      type: this.sfuComponent,
-      role: this.role,
-      internalMeetingId: this.internalMeetingId,
-      voiceBridge: this.voiceBridge,
-      caleeName: this.caleeName,
-      userId: this.userId,
-      userName: this.userName,
-      sdpOffer,
-    };
-
-    logger.debug({
-      logCode: `${this.logCodePrefix}_offer_generated`,
-      extraInfo: { sfuComponent: this.sfuComponent, role: this.role },
-    }, `SFU audio offer generated`);
-
-    this.sendMessage(message);
+    this.sendStartReq(sdpOffer);
   }
 
   onIceCandidate (candidate, role) {

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/screenshare-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/screenshare-broker.js
@@ -2,6 +2,7 @@ import logger from '/imports/startup/client/logger';
 import BaseBroker from '/imports/ui/services/bbb-webrtc-sfu/sfu-base-broker';
 
 const ON_ICE_CANDIDATE_MSG = 'iceCandidate';
+const SUBSCRIBER_ANSWER = 'subscriberAnswer';
 const SFU_COMPONENT_NAME = 'screenshare';
 
 class ScreenshareBroker extends BaseBroker {
@@ -21,8 +22,9 @@ class ScreenshareBroker extends BaseBroker {
     this.ws = null;
     this.webRtcPeer = null;
     this.hasAudio = false;
+    this.offering = true;
 
-    // Optional parameters are: userName, caleeName, iceServers, hasAudio, bitrate
+    // Optional parameters are: userName, caleeName, iceServers, hasAudio, bitrate, offering
     Object.assign(this, options);
   }
 
@@ -45,7 +47,7 @@ class ScreenshareBroker extends BaseBroker {
 
     switch (parsedMessage.id) {
       case 'startResponse':
-        this.processAnswer(parsedMessage);
+        this.onRemoteDescriptionReceived(parsedMessage);
         break;
       case 'playStart':
         this.onstart();
@@ -91,6 +93,44 @@ class ScreenshareBroker extends BaseBroker {
     this.onerror(error);
   }
 
+  sendLocalDescription (localDescription) {
+    const message = {
+      id: SUBSCRIBER_ANSWER,
+      type: this.sfuComponent,
+      role: this.role,
+      voiceBridge: this.voiceBridge,
+      callerName: this.userId,
+      answer: localDescription,
+    };
+
+    this.sendMessage(message);
+  }
+
+  onRemoteDescriptionReceived (sfuResponse) {
+    if (this.offering) {
+      return this.processAnswer(sfuResponse);
+    }
+
+    return this.processOffer(sfuResponse);
+  }
+
+  sendStartReq (offer) {
+    const message = {
+      id: 'start',
+      type: this.sfuComponent,
+      role: this.role,
+      internalMeetingId: this.internalMeetingId,
+      voiceBridge: this.voiceBridge,
+      userName: this.userName,
+      callerName: this.userId,
+      sdpOffer: offer,
+      hasAudio: !!this.hasAudio,
+      bitrate: this.bitrate,
+    };
+
+    this.sendMessage(message);
+  }
+
   onOfferGenerated (error, sdpOffer) {
     if (error) {
       logger.error({
@@ -106,20 +146,7 @@ class ScreenshareBroker extends BaseBroker {
       return this.onerror(error);
     }
 
-    const message = {
-      id: 'start',
-      type: this.sfuComponent,
-      role: this.role,
-      internalMeetingId: this.internalMeetingId,
-      voiceBridge: this.voiceBridge,
-      userName: this.userName,
-      callerName: this.userId,
-      sdpOffer,
-      hasAudio: !!this.hasAudio,
-      bitrate: this.bitrate,
-    };
-
-    this.sendMessage(message);
+    this.sendStartReq(sdpOffer);
   }
 
   startScreensharing () {
@@ -151,7 +178,12 @@ class ScreenshareBroker extends BaseBroker {
         }
 
         this.webRtcPeer.iceQueue = [];
-        this.webRtcPeer.generateOffer(this.onOfferGenerated.bind(this));
+
+        if (this.offering) {
+          this.webRtcPeer.generateOffer(this.onOfferGenerated.bind(this));
+        } else {
+          this.sendStartReq();
+        }
 
         const localStream = this.webRtcPeer.peerConnection.getLocalStreams()[0];
 
@@ -217,7 +249,12 @@ class ScreenshareBroker extends BaseBroker {
           return reject(normalizedError);
         }
         this.webRtcPeer.iceQueue = [];
-        this.webRtcPeer.generateOffer(this.onOfferGenerated.bind(this));
+
+        if (this.offering) {
+          this.webRtcPeer.generateOffer(this.onOfferGenerated.bind(this));
+        } else {
+          this.sendStartReq();
+        }
       });
 
       this.webRtcPeer.peerConnection.onconnectionstatechange = () => {

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/sfu-base-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/sfu-base-broker.js
@@ -54,6 +54,14 @@ class BaseBroker {
     // To be implemented by inheritors
   }
 
+  handleSFUError (sfuResponse) {
+    // To be implemented by inheritors
+  }
+
+  sendLocalDescription (localDescription) {
+    // To be implemented by inheritors
+  }
+
   openWSConnection () {
     return new Promise((resolve, reject) => {
       this.ws = new WebSocket(this.wsUrl);
@@ -102,39 +110,62 @@ class BaseBroker {
     this.sendMessage({ id: 'ping' });
   }
 
-  processAnswer (message) {
-    const { response, sdpAnswer, role, connectionId } = message;
+  _handleRemoteDescriptionProcessing (error, localDescription = null) {
+    if (error) {
+      logger.error({
+        logCode: `${this.logCodePrefix}_processanswer_error`,
+        extraInfo: {
+          errorMessage: error.name || error.message || 'Unknown error',
+          sfuComponent: this.sfuComponent,
+        }
+      }, `Error processing SDP answer from SFU for ${this.sfuComponent}`);
+      // 1305: "PEER_NEGOTIATION_FAILED",
+      return this.onerror(BaseBroker.assembleError(1305));
+    }
 
-    if (response !== 'accepted') return this.handleSFUError(message);
+    // There is a new local description; send it back to the server
+    if (localDescription) this.sendLocalDescription(localDescription);
+
+    // Mark the peer as negotiated and flush the ICE queue
+    this.webRtcPeer.negotiated = true;
+    this.processIceQueue();
+  }
+
+  _validateStartResponse (sfuResponse) {
+    const { response, role } = sfuResponse;
+
+    if (response !== 'accepted') {
+      this.handleSFUError(sfuResponse);
+      return false;
+    }
 
     logger.debug({
       logCode: `${this.logCodePrefix}_start_success`,
       extraInfo: {
-        sfuConnectionId: connectionId,
         role,
         sfuComponent: this.sfuComponent,
       }
     }, `Start request accepted for ${this.sfuComponent}`);
 
-    this.webRtcPeer.processAnswer(sdpAnswer, (error) => {
-      if (error) {
-        logger.error({
-          logCode: `${this.logCodePrefix}_processanswer_error`,
-          extraInfo: {
-            errorMessage: error.name || error.message || 'Unknown error',
-            sfuConnectionId: connectionId,
-            role,
-            sfuComponent: this.sfuComponent,
-          }
-        }, `Error processing SDP answer from SFU for ${this.sfuComponent}`);
-        // 1305: "PEER_NEGOTIATION_FAILED",
-        return this.onerror(BaseBroker.assembleError(1305));
-      }
+    return true;
+  }
 
-      // Mark the peer as negotiated and flush the ICE queue
-      this.webRtcPeer.negotiated = true;
-      this.processIceQueue();
-    });
+  processOffer (sfuResponse) {
+    if (this._validateStartResponse(sfuResponse)) {
+      this.webRtcPeer.processOffer(
+        sfuResponse.sdpAnswer,
+        this._handleRemoteDescriptionProcessing.bind(this)
+      );
+    }
+  }
+
+  processAnswer (sfuResponse) {
+    if (this._validateStartResponse(sfuResponse)) {
+      this.webRtcPeer.processAnswer(
+        sfuResponse.sdpAnswer,
+        this._handleRemoteDescriptionProcessing.bind(this)
+      );
+    }
   }
 
   addIceServers (options) {

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -448,6 +448,9 @@ public:
     echoTestNumber: 'echo'
     relayOnlyOnReconnect: false
     listenOnlyCallTimeout: 25000
+    # Experimental. True is the canonical behavior. Flip to false to reverse
+    # the negotiation flow for LO subscribers.
+    listenOnlyOffering: true
     #Timeout (ms) for gathering ICE candidates. When this timeout expires
     #the SDP is sent to the server with the candidates the browser gathered
     #so far. Increasing this value might help avoiding 1004 error when

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -197,6 +197,9 @@ public:
       # subscribe reattempt increases the reconnection timer up to this
       maxTimeout: 60000
     screenshare:
+      # Experimental. True is the canonical behavior. Flip to false to reverse
+      # the negotiation flow for subscribers.
+      subscriberOffering: true
       bitrate: 1500
       mediaTimeouts:
         maxConnectionAttempts: 2


### PR DESCRIPTION
### What does this PR do?

Let the server (bbb-webrtc-sfu) generate subscriber offers so that it becomes easier for us to
do RTP payload type normalization between publishers and subscribers. This involves:
  - webcams
  - listen only: configurable via `public.media.listenOnlyOffering`. Default is `true` (client as offerer).
  - screen sharing: configurable via `public.kurento.screenshare.subscriberOffering`. Default is `true` (client as offerer).


### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/12982

### Motivation

I originally did the PT normalization manually at the server-side, but that sucked. Dealing with it
by letting the server dictate the subscribers' offers is just better overall than trying to rewrite it.

Addresses the mono-PT behavior with the current mediasoup adapter,
which made it difficult to interop Firefox vs Chrome/WebKit based browser
due to pub/sub PT mismatches.

This also works properly with Kurento so no biggie.