### PR TITLE
fix: Keyboard Access To Assign Users To Breakout Room Broken

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -255,7 +255,7 @@ class BreakoutRoom extends PureComponent {
   handleShiftUser(activeListSibling) {
     const { users } = this.state;
     if (activeListSibling) {
-      const text = activeListSibling.getElementsByTagName('p')[0].innerText;
+      const text = activeListSibling.getElementsByTagName('input')[0].value;
       const roomNumber = text.match(/\d/g).join('');
       users.forEach((u, index) => {
         if (u.userId === document.activeElement.id) {
@@ -624,7 +624,7 @@ class BreakoutRoom extends PureComponent {
               }
             />
           </p>
-          <div className={styles.breakoutBox} onDrop={drop(0)} onDragOver={allowDrop}>
+          <div className={styles.breakoutBox} onDrop={drop(0)} onDragOver={allowDrop} tabIndex={0}>
             {this.renderUserItemByRoom(0)}
           </div>
           <span className={leastOneUserIsValid ? styles.dontShow : styles.spanWarn}>
@@ -647,7 +647,7 @@ class BreakoutRoom extends PureComponent {
                   aria-label={intl.formatMessage(intlMessages.duration)}
                 />
               </p>
-              <div className={styles.breakoutBox} onDrop={drop(value)} onDragOver={allowDrop}>
+              <div className={styles.breakoutBox} onDrop={drop(value)} onDragOver={allowDrop} tabIndex={0}>
                 {this.renderUserItemByRoom(value)}
                 {isInvitation && this.renderJoinedUsers(value)}
               </div>
@@ -871,6 +871,7 @@ class BreakoutRoom extends PureComponent {
     return this.getUserByRoom(room)
       .map((user) => (
         <p
+          tabIndex={0}
           id={user.userId}
           key={user.userId}
           className={cx(

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -871,7 +871,7 @@ class BreakoutRoom extends PureComponent {
     return this.getUserByRoom(room)
       .map((user) => (
         <p
-          tabIndex={0}
+          tabIndex={-1}
           id={user.userId}
           key={user.userId}
           className={cx(


### PR DESCRIPTION
### What does this PR do?

Restores keyboard access in breakout room modal.

### Closes Issue(s)
Closes #13003