### PR TITLE
Add Popout Icon To Learning Dashboard Menu Item

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -308,6 +308,7 @@ class UserOptions extends PureComponent {
         if (activityReportAccessToken != null) {
           this.menuItems.push({
             icon: "multi_whiteboard",
+            iconRight: "popout_window",
             label: intl.formatMessage(intlMessages.activityReportLabel),
             description: intl.formatMessage(intlMessages.activityReportDesc),
             key: this.activityReportId,


### PR DESCRIPTION
### What does this PR do?

Adds a pop out icon to the activity Report menu item

### Motivation

For accessibility this item required the pop out icon since it opens a new window. Similar to the Help option in the Settings menu.
