### PR TITLE
Post-publish presentation script to export PDF with annotations

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/interval_tree.rb
+++ b/record-and-playback/core/lib/recordandplayback/interval_tree.rb
@@ -105,9 +105,10 @@ module IntervalTree
         node_left_node = node.left_node
         node_right_node = node.right_node
         node_x_center = node.x_center
+        node_s_center_end = node.s_center_end
         traverse_left = (point < node_x_center)
 
-        if point < node.s_center_end
+        if node_s_center_end && point < node_s_center_end
           node.s_center.each do |k|
             break if k.begin > point
 

--- a/record-and-playback/core/lib/recordandplayback/interval_tree.rb
+++ b/record-and-playback/core/lib/recordandplayback/interval_tree.rb
@@ -1,0 +1,179 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Copyright (c) 2011-2021 MISHIMA, Hiroyuki; Simeon Simeonov; Carlos Alonsol; Sam Davies; amarzot-yesware; Daniel Petri Rocha
+
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+module IntervalTree
+    class Tree
+      def initialize(ranges, &range_factory)
+        range_factory = ->(l, r) { (l...r + 1) } unless block_given?
+        ranges_excl = ensure_exclusive_end([ranges].flatten, range_factory)
+        @top_node = divide_intervals(ranges_excl)
+      end
+      attr_reader :top_node
+
+      def divide_intervals(intervals)
+        return nil if intervals.empty?
+        x_center = center(intervals)
+        s_center = []
+        s_left = []
+        s_right = []
+
+        intervals.each do |k|
+          if k.end.to_r < x_center
+            s_left << k
+          elsif k.begin.to_r > x_center
+            s_right << k
+          else
+            s_center << k
+          end
+        end
+
+        s_center.sort_by! { |x| [x.begin, x.end] }
+
+        Node.new(x_center, s_center,
+          divide_intervals(s_left), divide_intervals(s_right))
+      end
+
+      # Search by range or point
+      DEFAULT_OPTIONS = { unique: true, sort: true }
+      def search(query, options = {})
+        options = DEFAULT_OPTIONS.merge(options)
+        return nil unless @top_node
+
+        if query.respond_to?(:begin)
+          result = top_node.search(query)
+          options[:unique] ? result.uniq! : result
+        else
+          result = point_search(top_node, query, [], options[:unique])
+        end
+        options[:sort] ? result.sort_by { |x| [x.begin, x.end] } : result
+      end
+
+      def ==(other)
+        top_node == other.top_node
+      end
+
+      private
+
+      def ensure_exclusive_end(ranges, range_factory)
+        ranges.map do |range|
+          if !range.respond_to?(:exclude_end?)
+            range
+          elsif range.exclude_end?
+            range
+          else
+            range_factory.call(range.begin, range.end)
+          end
+        end
+      end
+
+      def center(intervals)
+        (
+          intervals.map(&:begin).min.to_r +
+          intervals.map(&:end).max.to_r
+        ) / 2
+      end
+
+      def point_search(node, point, result, unique)
+        stack = [node]
+        point_r = point.to_r
+
+        until stack.empty?
+          node = stack.pop
+
+          node.s_center.each do |k|
+            break if k.begin > point
+            result << k if point < k.end
+          end
+
+          if node.left_node && (point_r < node.x_center)
+            stack << node.left_node
+
+          elsif node.right_node && (point_r >= node.x_center)
+            stack << node.right_node
+          end
+
+        end
+        if unique
+          result.uniq
+        else
+          result
+        end
+      end
+    end
+
+    class Node
+      def initialize(x_center, s_center, left_node, right_node)
+        @x_center = x_center
+        @s_center = s_center
+        @left_node = left_node
+        @right_node = right_node
+      end
+      attr_reader :x_center, :s_center, :left_node, :right_node
+
+      def ==(other)
+        x_center == other.x_center &&
+          s_center == other.s_center &&
+          left_node == other.left_node &&
+          right_node == other.right_node
+      end
+
+      # Search by range only
+      def search(query)
+        search_s_center(query) +
+          (left_node && query.begin.to_r < x_center && left_node.search(query) || []) +
+          (right_node && query.end.to_r > x_center && right_node.search(query) || [])
+      end
+
+      private
+
+      def search_s_center(query)
+        result = []
+
+        s_center.each do |k|
+          break if k.begin > query.end
+
+          next unless (
+            # k is entirely contained within the query
+            (k.begin >= query.begin) &&
+            (k.end <= query.end)
+          ) || (
+            # k's start overlaps with the query
+            (k.begin >= query.begin) &&
+            (k.begin < query.end)
+          ) || (
+            # k's end overlaps with the query
+            (k.end > query.begin) &&
+            (k.end <= query.end)
+          ) || (
+            # k is bigger than the query
+            (k.begin < query.begin) &&
+            (k.end > query.end)
+          )
+          result << k
+        end
+
+        result
+      end
+    end
+  end

--- a/record-and-playback/core/lib/recordandplayback/interval_tree.rb
+++ b/record-and-playback/core/lib/recordandplayback/interval_tree.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Copyright (c) 2011-2021 MISHIMA, Hiroyuki; Simeon Simeonov; Carlos Alonsol; Sam Davies; amarzot-yesware; Daniel Petri Rocha
+# Copyright (c) 2011-2021 MISHIMA, Hiroyuki; Simeon Simeonov; Carlos Alonso; Sam Davies; amarzot-yesware; Daniel Petri Rocha
 
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -23,157 +23,177 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 module IntervalTree
-    class Tree
-      def initialize(ranges, &range_factory)
-        range_factory = ->(l, r) { (l...r + 1) } unless block_given?
-        ranges_excl = ensure_exclusive_end([ranges].flatten, range_factory)
-        @top_node = divide_intervals(ranges_excl)
-      end
-      attr_reader :top_node
+  class Tree
+    def initialize(ranges, &range_factory)
+      range_factory = ->(l, r) { (l...r + 1) } unless block_given?
+      ranges_excl = ensure_exclusive_end([ranges].flatten, range_factory)
+      ranges_excl.sort_by! { |x| [x.begin, x.end] }
+      @top_node = divide_intervals(ranges_excl)
+    end
+    attr_reader :top_node
 
-      def divide_intervals(intervals)
-        return nil if intervals.empty?
-        x_center = center(intervals)
-        s_center = []
-        s_left = []
-        s_right = []
+    def divide_intervals(intervals)
+      return nil if intervals.empty?
 
-        intervals.each do |k|
-          if k.end.to_r < x_center
-            s_left << k
-          elsif k.begin.to_r > x_center
-            s_right << k
-          else
-            s_center << k
-          end
-        end
+      x_center = center(intervals)
+      s_center = []
+      s_left = []
+      s_right = []
 
-        s_center.sort_by! { |x| [x.begin, x.end] }
-
-        Node.new(x_center, s_center,
-          divide_intervals(s_left), divide_intervals(s_right))
-      end
-
-      # Search by range or point
-      DEFAULT_OPTIONS = { unique: true, sort: true }
-      def search(query, options = {})
-        options = DEFAULT_OPTIONS.merge(options)
-        return nil unless @top_node
-
-        if query.respond_to?(:begin)
-          result = top_node.search(query)
-          options[:unique] ? result.uniq! : result
+      intervals.each do |k|
+        if k.end < x_center
+          s_left << k
+        elsif k.begin > x_center
+          s_right << k
         else
-          result = point_search(top_node, query, [], options[:unique])
-        end
-        options[:sort] ? result.sort_by { |x| [x.begin, x.end] } : result
-      end
-
-      def ==(other)
-        top_node == other.top_node
-      end
-
-      private
-
-      def ensure_exclusive_end(ranges, range_factory)
-        ranges.map do |range|
-          if !range.respond_to?(:exclude_end?)
-            range
-          elsif range.exclude_end?
-            range
-          else
-            range_factory.call(range.begin, range.end)
-          end
+          s_center << k
         end
       end
 
-      def center(intervals)
-        (
-          intervals.map(&:begin).min.to_r +
-          intervals.map(&:end).max.to_r
-        ) / 2
+      s_center.sort_by! { |x| [x.begin, x.end] }
+
+      Node.new(x_center, s_center,
+               divide_intervals(s_left), divide_intervals(s_right))
+    end
+
+    # Search by range or point
+    DEFAULT_OPTIONS = { unique: true, sort: true }.freeze
+    def search(query, options = {})
+      options = DEFAULT_OPTIONS.merge(options)
+
+      return nil unless @top_node
+
+      if query.respond_to?(:begin)
+        result = top_node.search(query)
+        options[:unique] ? result.uniq! : result
+      else
+        result = point_search(top_node, query, [], options[:unique])
       end
+      options[:sort] ? result.sort_by { |x| [x.begin, x.end] } : result
+    end
 
-      def point_search(node, point, result, unique)
-        stack = [node]
-        point_r = point.to_r
+    def ==(other)
+      top_node == other.top_node
+    end
 
-        until stack.empty?
-          node = stack.pop
+    private
 
-          node.s_center.each do |k|
-            break if k.begin > point
-            result << k if point < k.end
-          end
-
-          if node.left_node && (point_r < node.x_center)
-            stack << node.left_node
-
-          elsif node.right_node && (point_r >= node.x_center)
-            stack << node.right_node
-          end
-
-        end
-        if unique
-          result.uniq
+    def ensure_exclusive_end(ranges, range_factory)
+      ranges.map do |range|
+        if !range.respond_to?(:exclude_end?)
+          range
+        elsif range.exclude_end?
+          range
         else
-          result
+          range_factory.call(range.begin, range.end)
         end
       end
     end
 
-    class Node
-      def initialize(x_center, s_center, left_node, right_node)
-        @x_center = x_center
-        @s_center = s_center
-        @left_node = left_node
-        @right_node = right_node
-      end
-      attr_reader :x_center, :s_center, :left_node, :right_node
+    def center(intervals)
+      (
+        intervals.map(&:begin).min +
+        intervals.map(&:end).max
+      ) / 2
+    end
 
-      def ==(other)
-        x_center == other.x_center &&
-          s_center == other.s_center &&
-          left_node == other.left_node &&
-          right_node == other.right_node
-      end
+    def point_search(node, point, result, unique)
+      stack = [node]
 
-      # Search by range only
-      def search(query)
-        search_s_center(query) +
-          (left_node && query.begin.to_r < x_center && left_node.search(query) || []) +
-          (right_node && query.end.to_r > x_center && right_node.search(query) || [])
-      end
+      until stack.empty?
+        node = stack.pop
+        node_left_node = node.left_node
+        node_right_node = node.right_node
+        node_x_center = node.x_center
+        traverse_left = (point < node_x_center)
 
-      private
+        if point < node.s_center_end
+          node.s_center.each do |k|
+            break if k.begin > point
 
-      def search_s_center(query)
-        result = []
-
-        s_center.each do |k|
-          break if k.begin > query.end
-
-          next unless (
-            # k is entirely contained within the query
-            (k.begin >= query.begin) &&
-            (k.end <= query.end)
-          ) || (
-            # k's start overlaps with the query
-            (k.begin >= query.begin) &&
-            (k.begin < query.end)
-          ) || (
-            # k's end overlaps with the query
-            (k.end > query.begin) &&
-            (k.end <= query.end)
-          ) || (
-            # k is bigger than the query
-            (k.begin < query.begin) &&
-            (k.end > query.end)
-          )
-          result << k
+            result << k if point < k.end
+          end
         end
 
+        if node_left_node && traverse_left
+          stack << node_left_node
+
+        elsif node_right_node && !traverse_left
+          stack << node_right_node
+        end
+
+      end
+      if unique
+        result.uniq
+      else
         result
       end
     end
   end
+
+  class Node
+    def initialize(x_center, s_center, left_node, right_node)
+      @x_center = x_center
+      @s_center = s_center
+      @s_center_end = s_center.map(&:end).max
+      @left_node = left_node
+      @right_node = right_node
+    end
+    attr_reader :x_center, :s_center, :s_center_end, :left_node, :right_node
+
+    def ==(other)
+      x_center == other.x_center &&
+        s_center == other.s_center &&
+        left_node == other.left_node &&
+        right_node == other.right_node
+    end
+
+    # Search by range only
+    def search(query)
+      search_s_center(query) +
+        (left_node && query.begin < x_center && left_node.search(query) || []) +
+        (right_node && query.end > x_center && right_node.search(query) || [])
+    end
+
+    private
+
+    def search_s_center(query)
+      result = []
+
+      s_center.each do |k|
+        k_begin = k.begin
+        query_end = query.end
+
+        break if k_begin > query_end
+
+        k_end = k.end
+        query_begin = query.begin
+
+        k_begin_gte_q_begin = k_begin >= query_begin
+        k_end_lte_q_end = k_end <= query_end
+        next unless
+        (
+          # k is entirely contained within the query
+          k_begin_gte_q_begin &&
+          k_end_lte_q_end
+        ) || (
+          # k's start overlaps with the query
+          k_begin_gte_q_begin &&
+          (k_begin < query_end)
+        ) || (
+          # k's end overlaps with the query
+          (k_end > query_begin) &&
+          k_end_lte_q_end
+        ) || (
+          # k is bigger than the query
+          (k_begin < query_begin) &&
+          (k_end > query_end)
+        )
+
+        result << k
+      end
+
+      result
+    end
+  end
+end

--- a/record-and-playback/core/scripts/post_publish/export_slides.rb
+++ b/record-and-playback/core/scripts/post_publish/export_slides.rb
@@ -1,27 +1,36 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: false
 
-require "trollop"
-require File.expand_path('../../../lib/recordandplayback', __FILE__)
+require 'base64'
+require 'builder'
+require 'combine_pdf'
+require 'csv'
+require 'fileutils'
+require 'loofah'
+require 'nokogiri'
+require 'optimist'
 
-require "nokogiri"
-require "builder"
-require "combine_pdf"
-require "csv"
-require "fileutils"
-require "loofah"
-require File.expand_path('../../../lib/recordandplayback/interval_tree', __FILE__)
+# For PRODUCTION
+require File.expand_path('../../lib/recordandplayback/interval_tree', __dir__)
+require File.expand_path('../../lib/recordandplayback', __dir__)
+
+# For DEVELOPMENT
+# require File.expand_path('../../../../core/lib/recordandplayback', __FILE__)
+# require File.expand_path('../../../../core/lib/recordandplayback/interval_tree', __FILE__)
 
 include IntervalTree
 
-opts = Trollop.options do
-  opt :meeting_id, "Meeting id to archive", type: String
-  opt :format, "Playback format name", type: String
+opts = Optimist.options do
+  opt :meeting_id, 'Meeting id to archive', type: String
+  opt :format, 'Playback format name', type: String
 end
 
 meeting_id = opts[:meeting_id]
 
-logger = Logger.new("/var/log/bigbluebutton/post_publish.log", 'weekly')
+# Only run after the presentation format finished
+exit(0) unless opts[:format].eql?('presentation')
+
+logger = Logger.new('/var/log/bigbluebutton/post_publish.log', 'weekly')
 logger.level = Logger::INFO
 BigBlueButton.logger = logger
 
@@ -35,7 +44,7 @@ FileUtils.mkdir_p(["#{@published_files}/presentation", "/var/bigbluebutton/publi
 # Setting the SVGZ option to true will write less data on the disk.
 SVGZ_COMPRESSION = false
 
-FILE_EXTENSION = SVGZ_COMPRESSION ? "svgz" : "svg"
+FILE_EXTENSION = SVGZ_COMPRESSION ? 'svgz' : 'svg'
 
 # Leave it as false for BBB >= 2.3 as it stopped supporting live whiteboard
 REMOVE_REDUNDANT_SHAPES = false
@@ -44,73 +53,91 @@ WhiteboardElement = Struct.new(:begin, :end, :value, :id)
 WhiteboardSlide = Struct.new(:href, :begin, :end, :width, :height)
 
 def add_greenlight_buttons(metadata)
-  bbb_props = YAML.safe_load(File.open(File.join(__dir__, '../bigbluebutton.yml')))
+  bbb_props = File.open(File.join(__dir__, '../bigbluebutton.yml')) { |f| YAML.safe_load(f) }
   playback_protocol = bbb_props['playback_protocol']
   playback_host = bbb_props['playback_host']
 
   meeting_id = metadata.xpath('recording/id').inner_text
 
-  metadata.xpath('recording/playback/format').children.first.content = "document"
+  metadata.xpath('recording/playback/format').children.first.content = 'document'
   metadata.xpath('recording/playback/link').children.first.content = "#{playback_protocol}://#{playback_host}/presentation/#{meeting_id}/annotated_slides.pdf"
 
-  File.open("/var/bigbluebutton/published/document/#{meeting_id}/metadata.xml", "w") do |file|
+  File.open("/var/bigbluebutton/published/document/#{meeting_id}/metadata.xml", 'w') do |file|
     file.write(metadata)
   end
 end
 
+def base64_encode(path)
+  return '' if File.directory?(path)
+
+  data = File.open(path).read
+  "data:image/#{File.extname(path).delete('.')};base64,#{Base64.strict_encode64(data)}"
+end
+
 def convert_whiteboard_shapes(whiteboard)
   # Find shape elements
-  whiteboard.xpath("svg/g/g").each do |annotation|
+  whiteboard.xpath('svg/g/g').each do |annotation|
     # Make all annotations visible
-    style = annotation.attr("style")
-    style.sub! "visibility:hidden", ""
-    annotation.set_attribute("style", style)
+    style = annotation.attr('style')
+    style.sub! 'visibility:hidden', ''
+    annotation.set_attribute('style', style)
 
-    shape = annotation.attribute("shape").to_s
+    shape = annotation.attribute('shape').to_s
 
-    if shape.include? "poll"
+    if shape.include? 'poll'
       poll = annotation.element_children.first
-      poll.remove_attribute("href")
-      poll.add_namespace_definition("xlink", "http://www.w3.org/1999/xlink")
 
-      poll.set_attribute("xlink:href", "#{@published_files}/#{poll.attribute('href')}")
+      path = "#{@published_files}/#{poll.attribute('href')}"
+      poll.remove_attribute('href')
+      poll.add_namespace_definition('xlink', 'http://www.w3.org/1999/xlink')
+
+      poll.set_attribute('xlink:href', base64_encode(path))
     end
 
     # Convert XHTML to SVG so that text can be shown
-    next unless shape.include? "text"
+    next unless shape.include? 'text'
 
     # Turn style attributes into a hash
-    style_values = Hash[*CSV.parse(style, col_sep: ":", row_sep: ";").flatten]
+    style_values = Hash[*CSV.parse(style, col_sep: ':', row_sep: ';').flatten]
 
-    text_color = style_values["color"]
-    font_size = style_values["font-size"].to_f
+    text_color = style_values['color']
+    font_size = style_values['font-size'].to_f
 
-    annotation.set_attribute("style", "#{style};fill:currentcolor")
+    annotation.set_attribute('style', "#{style};fill:currentcolor")
 
-    foreign_object = annotation.xpath("switch/foreignObject")
+    foreign_object = annotation.xpath('switch/foreignObject')
 
     # Obtain X and Y coordinates of the text
-    x = foreign_object.attr("x").to_s
-    y = foreign_object.attr("y").to_s
-    text_box_width = foreign_object.attr("width").to_s.to_f
+    x = foreign_object.attr('x').to_s
+    y = foreign_object.attr('y').to_s
+    text_box_width = foreign_object.attr('width').to_s.to_f
 
     text = foreign_object.children.children
 
     builder = Builder::XmlMarkup.new
-    builder.text(x: x, y: y, fill: text_color, "xml:space" => "preserve") do
-      text.each do |line|
-        line = Loofah.fragment(line.to_s).scrub!(:strip).text.unicode_normalize
+    builder.text(x: x, y: y, fill: text_color, 'xml:space' => 'preserve') do
+      previous_line_was_text = true
 
-        if line == "<br/>"
-          builder.tspan(x: x, dy: "0.9em") { builder << "<br/>" }
+      text.each do |line|
+        line = line.to_s
+
+        if line == '<br/>'
+          if previous_line_was_text
+            previous_line_was_text = false
+          else
+            builder.tspan(x: x, dy: '1.0em') { builder << '<br/>' }
+          end
         else
-          # Assumes a width to height aspect ratio of 0.52 for Arial
-          line_breaks = line.chars.each_slice((text_box_width / (font_size * 0.52)).to_i).map(&:join)
+          line = Loofah.fragment(line).scrub!(:strip).text.unicode_normalize
+
+          line_breaks = pack_up_string(line, ' ', font_size, text_box_width)
 
           line_breaks.each do |row|
             safe_message = Loofah.fragment(row).scrub!(:escape)
-            builder.tspan(x: x, dy: "0.9em") { builder << safe_message }
+            builder.tspan(x: x, dy: '1.0em') { builder << safe_message }
           end
+
+          previous_line_was_text = true
         end
       end
     end
@@ -118,13 +145,56 @@ def convert_whiteboard_shapes(whiteboard)
     annotation.add_child(builder.target!)
 
     # Remove the <switch> tag
-    annotation.xpath("switch").remove
+    annotation.xpath('switch').remove
   end
 
   # Save new shapes.svg copy
-  File.open("#{@published_files}/shapes_modified.svg", "w", 0o600) do |file|
+  File.open("#{@published_files}/shapes_modified.svg", 'w', 0o600) do |file|
     file.write(whiteboard)
   end
+end
+
+def measure_string(s, font_size)
+  # https://stackoverflow.com/a/4081370
+  # DejaVuSans, the default truefont of Debian, can be used here
+  # /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf
+  # use ImageMagick to measure the string in pixels
+  command = "convert xc: -font /usr/share/fonts/truetype/msttcorefonts/Arial.ttf -pointsize #{font_size} -debug annotate -annotate 0 '#{s}' null: 2>&1"
+  _, output = run_command(command, true)
+  output.match(/; width: (\d+);/)[1].to_f
+end
+
+def pack_up_string(s, separator, font_size, text_box_width)
+  # Split the line on whitespaces, and measure the line to fit into the text_box_width
+  line_breaks = []
+  queued_words = []
+  s.split(separator).each do |word|
+    # First consider queued word and the current word in the line
+    test_string = (queued_words + [word]).join(separator)
+
+    width = measure_string(test_string, font_size)
+
+    if width > text_box_width
+      # Line exceeded, so consider the queued words as a line break and queue the current word
+      line_breaks += [queued_words.join(separator)]
+      if measure_string(word, font_size) > text_box_width
+        # If the word alone exceeds the box width, then we pack the word maximizing the amount of characters on each line
+        res = pack_up_string(word, '', font_size, text_box_width)
+        # Queue last line break, other words might fit
+        queued_words = [res.pop]
+        line_breaks += res
+      else
+        queued_words = [word]
+      end
+    else
+      # Current word fits the text box, so keep enqueueing new words
+      queued_words += [word]
+    end
+  end
+  # Make sure we release the final queued words as the final line break
+  line_breaks += [queued_words.join(separator)] unless queued_words.empty?
+
+  line_breaks
 end
 
 def parse_whiteboard_shapes(shape_reader)
@@ -138,22 +208,22 @@ def parse_whiteboard_shapes(shape_reader)
     next unless node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
 
     node_name = node.name
-    node_class = node.attribute("class")
+    node_class = node.attribute('class')
 
-    if node_name == "image" && node_class == "slide"
-      slide_in = node.attribute("in").to_f
-      slide_out = node.attribute("out").to_f
+    if node_name == 'image' && node_class == 'slide'
+      slide_in = node.attribute('in').to_f
+      slide_out = node.attribute('out').to_f
 
       path = "#{@published_files}/#{node.attribute('href')}"
       next if path.include?('deskshare')
 
-      slides << WhiteboardSlide.new(path, slide_in, slide_out, node.attribute("width").to_f, node.attribute("height"))
+      slides << WhiteboardSlide.new(path, slide_in, slide_out, node.attribute('width').to_f, node.attribute('height'))
     end
 
-    next unless node_name == "g" && node_class == "shape"
+    next unless node_name == 'g' && node_class == 'shape'
 
-    shape_timestamp = node.attribute("timestamp").to_f
-    shape_undo = node.attribute("undo").to_f
+    shape_timestamp = node.attribute('timestamp').to_f
+    shape_undo = node.attribute('undo').to_f
 
     shape_undo = slide_out if shape_undo.negative?
 
@@ -161,7 +231,7 @@ def parse_whiteboard_shapes(shape_reader)
     shape_leave = [[shape_undo, slide_in].max, slide_out].min
 
     xml = "<g style=\"#{node.attribute('style')}\">#{node.inner_xml}</g>"
-    id = node.attribute("shape").split("-").last
+    id = node.attribute('shape').split('-').last
 
     shapes << WhiteboardElement.new(shape_enter, shape_leave, xml, id)
   end
@@ -194,10 +264,8 @@ def render_whiteboard(slides, shapes)
 
     svg_export(draw, slide.href, slide.width, slide.height, frame_number)
 
-    cmd = "rsvg-convert -f pdf -o #{@published_files}/presentation/frame#{frame_number}.pdf " \
-          "#{@published_files}/presentation/frame#{frame_number}.#{FILE_EXTENSION}"
-
-    pdf = system(cmd)
+    pdf = run_command("rsvg-convert -f pdf -o #{@published_files}/presentation/frame#{frame_number}.pdf " \
+                      "#{@published_files}/presentation/frame#{frame_number}.#{FILE_EXTENSION}")
 
     unless pdf
       warn("An error occurred generating the PDF for slide #{frame_number}")
@@ -212,12 +280,18 @@ def render_whiteboard(slides, shapes)
   merged.save "#{@published_files}/annotated_slides.pdf"
 end
 
+def run_command(command, silent = false)
+  BigBlueButton.logger.info("Running: #{command}") unless silent
+  output = `#{command}`
+  [$CHILD_STATUS.success?, output]
+end
+
 def svg_export(draw, slide_href, width, height, frame_number)
   # Builds SVG frame
   builder = Builder::XmlMarkup.new
 
   builder.svg(width: width, height: height, viewBox: "0 0 #{width} #{height}",
-              "xmlns:xlink" => "http://www.w3.org/1999/xlink", 'xmlns' => 'http://www.w3.org/2000/svg') do
+              'xmlns:xlink' => 'http://www.w3.org/1999/xlink', 'xmlns' => 'http://www.w3.org/2000/svg') do
     # Display background image
     builder.image('xlink:href': slide_href, width: width, height: height)
 
@@ -227,7 +301,7 @@ def svg_export(draw, slide_href, width, height, frame_number)
     end
   end
 
-  File.open("#{@published_files}/presentation/frame#{frame_number}.#{FILE_EXTENSION}", "w", 0o600) do |svg|
+  File.open("#{@published_files}/presentation/frame#{frame_number}.#{FILE_EXTENSION}", 'w', 0o600) do |svg|
     if SVGZ_COMPRESSION
       svgz = Zlib::GzipWriter.new(svg, Zlib::BEST_SPEED)
       svgz.write(builder.target!)
@@ -245,6 +319,7 @@ def unique_slides(slides)
   (0..slides_size).each do |i|
     ((i + 1)..slides_size).each do |j|
       next if slides[i].nil? || slides[j].nil?
+
       if slides[i].href == slides[j].href
         slides[i] = slides[j]
         slides[j] = nil
@@ -259,16 +334,18 @@ def export_pdf
   # Benchmark
   start = Time.now
 
-  convert_whiteboard_shapes(Nokogiri::XML(File.open("#{@published_files}/shapes.svg")).remove_namespaces!)
-  metadata = Nokogiri::XML(File.open("#{@published_files}/metadata.xml"))
+  convert_whiteboard_shapes(File.open("#{@published_files}/shapes.svg") { |f| Nokogiri::XML(f).remove_namespaces! })
 
-  shapes, slides = parse_whiteboard_shapes(Nokogiri::XML::Reader(File.open("#{@published_files}/shapes_modified.svg")))
+  metadata = File.open("#{@published_files}/metadata.xml") { |f| Nokogiri::XML(f) }
+
+  shapes, slides = parse_whiteboard_shapes(Nokogiri::XML::Reader(File.read("#{@published_files}/shapes_modified.svg")))
+
   slides = unique_slides(slides)
 
   render_whiteboard(slides, shapes)
 
   BigBlueButton.logger.info("Finished exporting PDF. Total: #{Time.now - start}")
-  
+
   add_greenlight_buttons(metadata)
 end
 

--- a/record-and-playback/core/scripts/post_publish/export_slides.rb
+++ b/record-and-playback/core/scripts/post_publish/export_slides.rb
@@ -12,12 +12,12 @@ require 'optimist'
 require 'yaml'
 
 # For PRODUCTION
-require File.expand_path('../../lib/recordandplayback/interval_tree', __FILE__)
-require File.expand_path('../../lib/recordandplayback', __FILE__)
+require File.expand_path('../../lib/recordandplayback/interval_tree', __dir__)
+require File.expand_path('../../lib/recordandplayback', __dir__)
 
 # For DEVELOPMENT
-# require File.expand_path('../../../../core/lib/recordandplayback', __FILE__)
-# require File.expand_path('../../../../core/lib/recordandplayback/interval_tree', __FILE__)
+# require File.expand_path('../../../core/lib/recordandplayback', __dir__)
+# require File.expand_path('../../../core/lib/recordandplayback/interval_tree', __dir__)
 
 include IntervalTree
 
@@ -216,7 +216,7 @@ def parse_whiteboard_shapes(shape_reader)
       slide_out = node.attribute('out').to_f
 
       path = "#{@published_files}/#{node.attribute('href')}"
-      next if path.include?('deskshare')
+      next if path.include?('deskshare') || path.include?('logo.png')
 
       slides << WhiteboardSlide.new(path, slide_in, slide_out, node.attribute('width').to_f, node.attribute('height'))
     end

--- a/record-and-playback/core/scripts/post_publish/export_slides.rb
+++ b/record-and-playback/core/scripts/post_publish/export_slides.rb
@@ -9,10 +9,11 @@ require 'fileutils'
 require 'loofah'
 require 'nokogiri'
 require 'optimist'
+require 'yaml'
 
 # For PRODUCTION
-require File.expand_path('../../lib/recordandplayback/interval_tree', __dir__)
-require File.expand_path('../../lib/recordandplayback', __dir__)
+require File.expand_path('../../lib/recordandplayback/interval_tree', __FILE__)
+require File.expand_path('../../lib/recordandplayback', __FILE__)
 
 # For DEVELOPMENT
 # require File.expand_path('../../../../core/lib/recordandplayback', __FILE__)
@@ -159,7 +160,7 @@ def measure_string(s, font_size)
   # DejaVuSans, the default truefont of Debian, can be used here
   # /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf
   # use ImageMagick to measure the string in pixels
-  command = "convert xc: -font /usr/share/fonts/truetype/msttcorefonts/Arial.ttf -pointsize #{font_size} -debug annotate -annotate 0 '#{s}' null: 2>&1"
+  command = "convert xc: -font /usr/share/fonts/truetype/msttcorefonts/Arial.ttf -pointsize #{font_size} -debug annotate -annotate 0 #{Shellwords.escape(s)} null: 2>&1"
   _, output = run_command(command, true)
   output.match(/; width: (\d+);/)[1].to_f
 end

--- a/record-and-playback/core/scripts/post_publish/export_slides.rb
+++ b/record-and-playback/core/scripts/post_publish/export_slides.rb
@@ -50,10 +50,10 @@ def add_greenlight_buttons(metadata)
 
   meeting_id = metadata.xpath('recording/id').inner_text
 
-  metadata.xpath('recording/playback/format').children.first.content = "video"
+  metadata.xpath('recording/playback/format').children.first.content = "document"
   metadata.xpath('recording/playback/link').children.first.content = "#{playback_protocol}://#{playback_host}/presentation/#{meeting_id}/meeting.mp4"
 
-  File.open("/var/bigbluebutton/published/video/#{meeting_id}/metadata.xml", "w") do |file|
+  File.open("/var/bigbluebutton/published/document/#{meeting_id}/metadata.xml", "w") do |file|
     file.write(metadata)
   end
 end

--- a/record-and-playback/core/scripts/post_publish/export_slides.rb
+++ b/record-and-playback/core/scripts/post_publish/export_slides.rb
@@ -51,7 +51,7 @@ def add_greenlight_buttons(metadata)
   meeting_id = metadata.xpath('recording/id').inner_text
 
   metadata.xpath('recording/playback/format').children.first.content = "document"
-  metadata.xpath('recording/playback/link').children.first.content = "#{playback_protocol}://#{playback_host}/presentation/#{meeting_id}/meeting.mp4"
+  metadata.xpath('recording/playback/link').children.first.content = "#{playback_protocol}://#{playback_host}/presentation/#{meeting_id}/annotated_slides.pdf"
 
   File.open("/var/bigbluebutton/published/document/#{meeting_id}/metadata.xml", "w") do |file|
     file.write(metadata)

--- a/record-and-playback/core/scripts/post_publish/export_slides.rb
+++ b/record-and-playback/core/scripts/post_publish/export_slides.rb
@@ -1,0 +1,276 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: false
+
+require "trollop"
+require File.expand_path('../../../lib/recordandplayback', __FILE__)
+
+require "nokogiri"
+require "base64"
+require "builder"
+require "combine_pdf"
+require "csv"
+require "fileutils"
+require "loofah"
+require File.expand_path('../../../lib/recordandplayback/interval_tree', __FILE__)
+
+include IntervalTree
+
+opts = Trollop.options do
+  opt :meeting_id, "Meeting id to archive", type: String
+  opt :format, "Playback format name", type: String
+end
+
+meeting_id = opts[:meeting_id]
+
+logger = Logger.new("/var/log/bigbluebutton/post_publish.log", 'weekly')
+logger.level = Logger::INFO
+BigBlueButton.logger = logger
+
+BigBlueButton.logger.info("Started exporting PDF for [#{meeting_id}]")
+
+@published_files = "/var/bigbluebutton/published/presentation/#{meeting_id}"
+
+# Creates scratch directories
+Dir.mkdir("#{@published_files}/frames") unless File.exist?("#{@published_files}/frames")
+Dir.mkdir("#{@published_files}/presentation") unless File.exist?("#{@published_files}/presentation")
+
+# Setting the SVGZ option to true will write less data on the disk.
+SVGZ_COMPRESSION = false
+
+FILE_EXTENSION = SVGZ_COMPRESSION ? "svgz" : "svg"
+
+# Leave it as false for BBB >= 2.3 as it stopped supporting live whiteboard
+REMOVE_REDUNDANT_SHAPES = false
+
+WhiteboardElement = Struct.new(:begin, :end, :value, :id)
+WhiteboardSlide = Struct.new(:href, :begin, :end, :width, :height)
+
+def base64_encode(path)
+  return "" if File.directory?(path)
+
+  data = File.open(path).read
+  "data:image/#{File.extname(path).delete('.')};base64,#{Base64.strict_encode64(data)}"
+end
+
+def convert_whiteboard_shapes(whiteboard)
+  # Find shape elements
+  whiteboard.xpath("svg/g/g").each do |annotation|
+    # Make all annotations visible
+    style = annotation.attr("style")
+    style.sub! "visibility:hidden", ""
+    annotation.set_attribute("style", style)
+
+    shape = annotation.attribute("shape").to_s
+    # Convert polls to data schema
+    if shape.include? "poll"
+      poll = annotation.element_children.first
+
+      path = "#{@published_files}/#{poll.attribute('href')}"
+      poll.remove_attribute("href")
+
+      poll.add_namespace_definition("xlink", "http://www.w3.org/1999/xlink")
+
+      data = base64_encode(path)
+
+      poll.set_attribute("xlink:href", data)
+    end
+
+    # Convert XHTML to SVG so that text can be shown
+    next unless shape.include? "text"
+
+    # Turn style attributes into a hash
+    style_values = Hash[*CSV.parse(style, col_sep: ":", row_sep: ";").flatten]
+
+    text_color = style_values["color"]
+    font_size = style_values["font-size"].to_f
+
+    annotation.set_attribute("style", "#{style};fill:currentcolor")
+
+    foreign_object = annotation.xpath("switch/foreignObject")
+
+    # Obtain X and Y coordinates of the text
+    x = foreign_object.attr("x").to_s
+    y = foreign_object.attr("y").to_s
+    text_box_width = foreign_object.attr("width").to_s.to_f
+
+    text = foreign_object.children.children
+
+    builder = Builder::XmlMarkup.new
+    builder.text(x: x, y: y, fill: text_color, "xml:space" => "preserve") do
+      text.each do |line|
+        line = Loofah.fragment(line.to_s).scrub!(:strip).text.unicode_normalize
+
+        if line == "<br/>"
+          builder.tspan(x: x, dy: "0.9em") { builder << "<br/>" }
+        else
+          # Assumes a width to height aspect ratio of 0.52 for Arial
+          line_breaks = line.chars.each_slice((text_box_width / (font_size * 0.52)).to_i).map(&:join)
+
+          line_breaks.each do |row|
+            safe_message = Loofah.fragment(row).scrub!(:escape)
+            builder.tspan(x: x, dy: "0.9em") { builder << safe_message }
+          end
+        end
+      end
+    end
+
+    annotation.add_child(builder.target!)
+
+    # Remove the <switch> tag
+    annotation.xpath("switch").remove
+  end
+
+  # Save new shapes.svg copy
+  File.open("#{@published_files}/shapes_modified.svg", "w", 0o600) do |file|
+    file.write(whiteboard)
+  end
+end
+
+def parse_whiteboard_shapes(shape_reader)
+  slide_in = 0
+  slide_out = 0
+
+  shapes = []
+  slides = []
+
+  shape_reader.each do |node|
+    next unless node.node_type == Nokogiri::XML::Reader::TYPE_ELEMENT
+
+    node_name = node.name
+    node_class = node.attribute("class")
+
+    if node_name == "image" && node_class == "slide"
+      slide_in = node.attribute("in").to_f
+      slide_out = node.attribute("out").to_f
+
+      # Image paths need to follow the URI Data Scheme (for slides and polls)
+      path = "#{@published_files}/#{node.attribute('href')}"
+
+      next if path.include?('deskshare')
+
+      data = base64_encode(path)
+
+      slides << WhiteboardSlide.new(data, slide_in, slide_out, node.attribute("width").to_f, node.attribute("height"))
+    end
+
+    next unless node_name == "g" && node_class == "shape"
+
+    shape_timestamp = node.attribute("timestamp").to_f
+    shape_undo = node.attribute("undo").to_f
+
+    shape_undo = slide_out if shape_undo.negative?
+
+    shape_enter = [shape_timestamp, slide_in].max
+    shape_leave = [[shape_undo, slide_in].max, slide_out].min
+
+    xml = "<g style=\"#{node.attribute('style')}\">#{node.inner_xml}</g>"
+    id = node.attribute("shape").split("-").last
+
+    shapes << WhiteboardElement.new(shape_enter, shape_leave, xml, id)
+  end
+
+  [shapes, slides]
+end
+
+def remove_adjacent(array)
+  index = 0
+
+  until array[index + 1].nil?
+    array[index] = nil if array[index].id == array[index + 1].id
+    index += 1
+  end
+
+  array.compact
+end
+
+def render_whiteboard(slides, shapes)
+  shapes_interval_tree = IntervalTree::Tree.new(shapes)
+  frame_number = 0
+
+  merged = CombinePDF.new
+
+  slides.each do |slide|
+    draw = shapes_interval_tree.search(slide.end - 0.05, unique: false, sort: false)
+    draw = [] if draw.nil?
+
+    draw = remove_adjacent(draw) if REMOVE_REDUNDANT_SHAPES && !draw.empty?
+
+    svg_export(draw, slide.href, slide.width, slide.height, frame_number)
+
+    pdf = system("rsvg-convert -f pdf -o #{@published_files}/frames/frame#{frame_number}.pdf #{@published_files}/frames/frame#{frame_number}.#{FILE_EXTENSION}")
+
+    unless pdf
+      warn("An error occurred generating the PDF for slide #{frame_number}")
+      exit(false)
+    end
+
+    merged << CombinePDF.load("#{@published_files}/frames/frame#{frame_number}.pdf")
+
+    frame_number += 1
+  end
+
+  merged.save "#{@published_files}/annotated_slides.pdf"
+end
+
+def svg_export(draw, slide_href, width, height, frame_number)
+  # Builds SVG frame
+  builder = Builder::XmlMarkup.new
+
+  builder.svg(width: width, height: height, viewBox: "0 0 #{width} #{height}",
+              "xmlns:xlink" => "http://www.w3.org/1999/xlink", 'xmlns' => 'http://www.w3.org/2000/svg') do
+    # Display background image
+    builder.image('xlink:href': slide_href, width: width, height: height)
+
+    # Adds annotations
+    draw.each do |shape|
+      builder << shape.value
+    end
+  end
+
+  File.open("#{@published_files}/frames/frame#{frame_number}.#{FILE_EXTENSION}", "w", 0o600) do |svg|
+    if SVGZ_COMPRESSION
+      svgz = Zlib::GzipWriter.new(svg)
+      svgz.write(builder.target!)
+      svgz.close
+    else
+      svg.write(builder.target!)
+    end
+  end
+end
+
+def unique_slides(slides)
+  # Only keep the last state of the slides, maintaining original order
+  (0..slides.size - 1).each do |i|
+    ((i + 1)..slides.size - 1).each do |j|
+      next if slides[i].nil? || slides[j].nil?
+      if slides[i].href == slides[j].href
+        slides[i] = slides[j]
+        slides[j] = nil
+      end
+    end
+  end
+
+  slides.compact
+end
+
+def export_pdf
+  # Benchmark
+  start = Time.now
+
+  convert_whiteboard_shapes(Nokogiri::XML(File.open("#{@published_files}/shapes.svg")).remove_namespaces!)
+
+  shapes, slides = parse_whiteboard_shapes(Nokogiri::XML::Reader(File.open("#{@published_files}/shapes_modified.svg")))
+  slides = unique_slides(slides)
+
+  render_whiteboard(slides, shapes)
+
+  BigBlueButton.logger.info("Finished exporting PDF. Total: #{Time.now - start}")
+end
+
+export_pdf
+
+# Delete the contents of the scratch directories
+FileUtils.rm_rf(["#{@published_files}/frames", "#{@published_files}/shapes_modified.svg"])
+
+exit(0)
+


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
This PR is similar to [#12533](https://github.com/bigbluebutton/bigbluebutton/pull/12533). It outputs a PDF file containing the annotations and text drawn over the slides. For each slide, the last state of the whiteboard state is kept, maintaining the original order. Only recorded slides appear in the `annotated_slides.pdf`, which can be found in the `published_files` directory of a given meeting.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #4882 
-->
Closes #4882 

### Usage
1. Deploy the script and the data structure by running `deploy.sh` in `record-and-playback`
2. Create a recorded meeting
3. End the meeting and wait for the recording to be processed
4. A link to the file will be available in `/var/bigbluebutton/published/document/metadata.xml` or directly in Moodle / Greenlight / etc.

### Motivation
By downloading the annotated PDF file, a future lesson can continue from where the teacher last left the whiteboard.
Most of the code was already implemented in the video exporting script.
This PR is the cornerstone of #13484.

### More
Requires `librsvg (sudo apt-get install librsvg2-bin)` and the `combine_pdf` gem (`gem install combine_pdf`). The latter is required for now due to an [issue](https://gitlab.gnome.org/GNOME/librsvg/-/issues/783) in rsvg-convert which occurs with PDFs containing different page sizes.

Thanks to @fcecagno for the text positioning fix