### PR TITLE
fix: couldn't reopen closed caption panel

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-captions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-captions/component.jsx
@@ -31,17 +31,13 @@ const intlMessages = defineMessages({
 class UserCaptions extends Component {
   constructor(props) {
     super(props);
-
-    this.updatedOwnledLocales = this.updatedOwnledLocales.bind(this);
   }
 
   shouldComponentUpdate(nextProps) {
-    return this.updatedOwnledLocales(nextProps);
-  }
+    const { ownedLocales, sidebarContentPanel } = this.props;
 
-  updatedOwnledLocales(nextProps) {
-    const { ownedLocales } = this.props;
-    return ownedLocales.length !== nextProps.ownedLocales.length;
+    return ownedLocales.length !== nextProps.ownedLocales.length
+      || sidebarContentPanel !== nextProps.sidebarContentPanel;
   }
 
   renderCaptions() {

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-captions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-captions/component.jsx
@@ -19,6 +19,8 @@ const propTypes = {
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
+  sidebarContentPanel: PropTypes.string.isRequired,
+  layoutContextDispatch: PropTypes.func.isRequired,
 };
 
 const intlMessages = defineMessages({
@@ -29,10 +31,6 @@ const intlMessages = defineMessages({
 });
 
 class UserCaptions extends Component {
-  constructor(props) {
-    super(props);
-  }
-
   shouldComponentUpdate(nextProps) {
     const { ownedLocales, sidebarContentPanel } = this.props;
 


### PR DESCRIPTION
### What does this PR do?

Fixes an issue with the captions toggle button not working after captions panel is manually closed.

### Closes Issue(s)
Closes #13017