### PR TITLE
fix: resize / drag & drop won't stop if user switches tabs

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
@@ -34,6 +34,20 @@ const WebcamComponent = ({
   const isCameraSidebar = cameraDock.position === CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM;
 
   useEffect(() => {
+    const handleVisibility = () => {
+      if (document.hidden) {
+        document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, []);
+
+  useEffect(() => {
     setIsFullScreen(fullscreen.group === 'webcams');
   }, [fullscreen]);
 


### PR DESCRIPTION
### What does this PR do?

Adds an event to stop video/presentation area resize/drag (custom layout) if user switches browser tabs.

### Closes Issue(s)
Closes #11971
Closes #7991