### PR TITLE
add focus and tooltips to virtual backgrounds

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import { styles } from './styles';
 import Button from '/imports/ui/components/button/component';
+import TooltipContainer from '/imports/ui/components/tooltip/container';
 import {
   EFFECT_TYPES,
   BLUR_FILENAME,
@@ -40,6 +41,10 @@ const intlMessages = defineMessages({
   blurLabel: {
     id: 'app.video.virtualBackground.blur',
     description: 'Label for the blurred camera option',
+  },
+  thumbnailLabel: {
+    id: 'app.video.virtualBackground.thumbnail',
+    description: 'Label for the image camera options',
   }
 });
 
@@ -54,7 +59,9 @@ const VirtualBgSelector = ({
     ...initialVirtualBgState,
   });
 
-  const _virtualBgSelected = (type, name) => {
+  const inputElementsRef = useRef([]);
+
+  const _virtualBgSelected = (type, name, index) => {
     handleVirtualBgSelected(type, name).then(switched => {
       // Reset to the base NONE_TYPE effect if it failed because the expected
       // behaviour from upstream's method is to actually stop/reset the effect
@@ -63,6 +70,9 @@ const VirtualBgSelector = ({
         return setCurrentVirtualBg({ type: EFFECT_TYPES.NONE_TYPE });
       }
 
+      if (index >= 0) {
+        inputElementsRef.current[index].focus();
+      }
       setCurrentVirtualBg({ type, name });
     });
   };
@@ -115,27 +125,40 @@ const VirtualBgSelector = ({
           onClick={() => _virtualBgSelected(EFFECT_TYPES.NONE_TYPE)}
         />
 
-      <input
-        type="image"
-        alt="image-input"
-        aria-label={EFFECT_TYPES.BLUR_TYPE}
-        src={getVirtualBackgroundThumbnail(BLUR_FILENAME)}
-        disabled={disabled}
-        onClick={() => _virtualBgSelected(EFFECT_TYPES.BLUR_TYPE)}
-      />
+        <TooltipContainer title={intl.formatMessage(intlMessages.blurLabel)} key={`blur-0`}>
+          <input
+            type="image"
+            className={styles.virtualBackgroundItem}
+            alt="image-input"
+            aria-label={EFFECT_TYPES.BLUR_TYPE}
+            src={getVirtualBackgroundThumbnail(BLUR_FILENAME)}
+            disabled={disabled}
+            ref={ref => inputElementsRef.current[0] = ref}
+            onClick={() => _virtualBgSelected(EFFECT_TYPES.BLUR_TYPE, 'Blur', 0)}
+          />
+        </TooltipContainer>
 
-    {IMAGE_NAMES.map((imageName, index) => (
-      <input
-        type="image"
-        alt="image-input"
-        aria-label={imageName}
-        key={`${imageName}-${index}`}
-        src={getVirtualBackgroundThumbnail(imageName)}
-        onClick={() => _virtualBgSelected(EFFECT_TYPES.IMAGE_TYPE, imageName)}
-        disabled={disabled}
-      />
-    ))}
-  </div>
+        {IMAGE_NAMES.map((imageName, index) => (
+          <TooltipContainer
+            title={intl.formatMessage(
+              intlMessages.thumbnailLabel,
+              ({ 0: imageName }),
+            )}
+            key={`${imageName}-${index}`}
+          >
+            <input
+              type="image"
+              className={styles.virtualBackgroundItem}
+              alt="image-input"
+              aria-label={imageName}
+              src={getVirtualBackgroundThumbnail(imageName)}
+              ref={ref => inputElementsRef.current[index + 1] = ref}
+              onClick={() => _virtualBgSelected(EFFECT_TYPES.IMAGE_TYPE, imageName, index + 1)}
+              disabled={disabled}
+            />
+          </TooltipContainer>
+        ))}
+      </div>
     );
   };
 

--- a/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/styles.scss
@@ -18,3 +18,10 @@
   @extend .virtualBackgroundRowDropdown;
   margin-top: 0.4rem;
 }
+
+.virtualBackgroundItem:focus{
+  color: var(--btn-default-color);
+  background-color: var(--btn-default-bg);
+  background-clip: padding-box;
+  box-shadow: 0 0 0 var(--border-size) var(--btn-primary-border);
+}

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -730,6 +730,7 @@
     "app.video.clientDisconnected": "Webcam cannot be shared due to connection issues",
     "app.video.virtualBackground.none": "None",
     "app.video.virtualBackground.blur": "Blur",
+    "app.video.virtualBackground.thumbnail": "Thumbnail: {0}",
     "app.video.virtualBackground.genericError": "Failed to apply camera effect. Try again.",
     "app.fullscreenButton.label": "Make {0} fullscreen",
     "app.fullscreenUndoButton.label": "Undo {0} fullscreen",


### PR DESCRIPTION
### What does this PR do?

Adds focus outline and tooltip to virtual background thumbnails.

![virtual-bg](https://user-images.githubusercontent.com/3728706/129944897-a8155598-de42-42b3-9365-a75869e9cf94.gif)

### Closes Issue(s)
Closes #12847