### PR TITLE
fix: Poll layout errors

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -177,6 +177,14 @@ const intlMessages = defineMessages({
     id: 'app.poll.deleteRespDesc',
     description: '',
   },
+  on: {
+    id: 'app.switch.onLabel',
+    description: 'label for toggle switch on state',
+  },
+  off: {
+    id: 'app.switch.offLabel',
+    description: 'label for toggle switch off state',
+  },
 });
 
 const POLL_SETTINGS = Meteor.settings.public.poll;
@@ -209,6 +217,7 @@ class Poll extends Component {
     this.handleRemoveOption = this.handleRemoveOption.bind(this);
     this.handleTextareaChange = this.handleTextareaChange.bind(this);
     this.handleInputChange = this.handleInputChange.bind(this);
+    this.displayToggleStatus = this.displayToggleStatus.bind(this);
   }
 
   componentDidMount() {
@@ -320,6 +329,17 @@ class Poll extends Component {
         diff += 1;
       }
     }
+  }
+
+  displayToggleStatus(status) {
+    const { intl } = this.props;
+
+    return (
+      <span className={styles.toggleLabel}>
+        {status ? intl.formatMessage(intlMessages.on)
+          : intl.formatMessage(intlMessages.off)}
+      </span>
+    );
   }
 
   pushToCustomPollValues(text) {
@@ -557,7 +577,7 @@ class Poll extends Component {
                 && (
                   <div style={{
                     display: 'flex',
-                    flexFlow: 'column',
+                    flexFlow: 'wrap',
                   }}
                   >
                     {defaultPoll && this.renderInputs()}
@@ -584,11 +604,13 @@ class Poll extends Component {
                       <div className={styles.col}>
                         {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
                         <label className={styles.toggle}>
+                          {this.displayToggleStatus(secretPoll)}
                           <Toggle
                             icons={false}
                             defaultChecked={secretPoll}
                             onChange={() => this.handleToggle()}
                             ariaLabel={intl.formatMessage(intlMessages.secretPollLabel)}
+                            showToggleLabel={false}
                           />
                         </label>
                       </div>

--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -475,7 +475,7 @@ class Poll extends Component {
                 });
               }}
               className={
-                cx(styles.pBtn, styles.btnMR, {
+                cx(styles.pBtn, {
                   [styles.selectedBtnBlue]: type === pollTypes.TrueFalse,
                 })
               }
@@ -496,43 +496,43 @@ class Poll extends Component {
                 });
               }}
               className={
-                cx(styles.pBtn, styles.btnML, {
+                cx(styles.pBtn, {
                   [styles.selectedBtnBlue]: type === pollTypes.Letter,
                 })
               }
             />
-          </div>
-          <Button
-            label={intl.formatMessage(intlMessages.yna)}
-            aria-describedby="poll-config-button"
-            color="default"
-            onClick={() => {
-              this.setState({
-                type: pollTypes.YesNoAbstention,
-                optList: [
-                  { val: intl.formatMessage(intlMessages.yes) },
-                  { val: intl.formatMessage(intlMessages.no) },
-                  { val: intl.formatMessage(intlMessages.abstention) },
-                ],
-              });
-            }}
-            className={
+            <Button
+              label={intl.formatMessage(intlMessages.yna)}
+              aria-describedby="poll-config-button"
+              color="default"
+              onClick={() => {
+                this.setState({
+                  type: pollTypes.YesNoAbstention,
+                  optList: [
+                    { val: intl.formatMessage(intlMessages.yes) },
+                    { val: intl.formatMessage(intlMessages.no) },
+                    { val: intl.formatMessage(intlMessages.abstention) },
+                  ],
+                });
+              }}
+              className={
               cx(styles.pBtn, styles.yna, {
                 [styles.selectedBtnBlue]: type === pollTypes.YesNoAbstention,
               })
             }
-          />
-          <Button
-            label={intl.formatMessage(intlMessages.userResponse)}
-            aria-describedby="poll-config-button"
-            color="default"
-            onClick={() => { this.setState({ type: pollTypes.Response }); }}
-            className={
+            />
+            <Button
+              label={intl.formatMessage(intlMessages.userResponse)}
+              aria-describedby="poll-config-button"
+              color="default"
+              onClick={() => { this.setState({ type: pollTypes.Response }); }}
+              className={
               cx(styles.pBtn, styles.fullWidth, {
                 [styles.selectedBtnWhite]: type === pollTypes.Response,
               })
             }
-          />
+            />
+          </div>
         </div>
         {type
           && (

--- a/bigbluebutton-html5/imports/ui/components/poll/live-result/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/poll/live-result/styles.scss
@@ -13,6 +13,8 @@
   margin-top: var(--sm-padding-y);
   margin-bottom: var(--sm-padding-y);
   font-size: var(--font-size-base);
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
 }
 
 .main {

--- a/bigbluebutton-html5/imports/ui/components/poll/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/poll/styles.scss
@@ -203,9 +203,9 @@
 .responseType {
     display: flex;
     justify-content: space-between;
+    flex-flow: wrap;
     position: relative;
     width: 100%;
-    height: var(--poll-input-height);
     margin-bottom: var(--lg-padding-x);
 
     button {
@@ -308,21 +308,14 @@
 
 .pBtn {
     border: solid var(--color-gray-light) 1px;
-    height: var(--poll-input-height);
+    min-height: var(--poll-input-height);
     font-size: var(--font-size-base);
+    white-space: pre-wrap;
     span {
         &:hover {
             opacity: 1;
         }
     }
-}
-
-.btnML {
-    margin-left: 3%;
-}
-
-.btnMR {
-    margin-right: 3%;
 }
 
 .deleteBtn {
@@ -333,7 +326,7 @@
     }
 }
 
-.yna {
+.pBtn {
     width: 100%;
     margin-bottom: 1rem;
 }

--- a/bigbluebutton-html5/imports/ui/components/poll/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/poll/styles.scss
@@ -204,6 +204,7 @@
     display: flex;
     justify-content: space-between;
     flex-flow: wrap;
+    overflow-wrap: break-word;
     position: relative;
     width: 100%;
     margin-bottom: var(--lg-padding-x);
@@ -284,6 +285,7 @@
     padding-left: var(--md-padding-y);
     padding-right: var(--md-padding-y);
     font-size: var(--font-size-base);
+    white-space: pre-wrap;
 
     &:hover {
         span {
@@ -295,9 +297,11 @@
 .startPollBtn {
     position: relative;
     width: 100%;
-    height: var(--poll-input-height);
+    min-height: var(--poll-input-height);
     margin-top: 1rem;
     font-size: var(--font-size-base);
+    overflow-wrap: break-word;
+    white-space: pre-wrap;
 
     &:hover {
         span {
@@ -369,7 +373,7 @@
 
 .row {
   display: flex;
-  flex-flow: row;
+  flex-flow: wrap;
   flex-grow: 1;
   justify-content: space-between;
   margin-top: 0.7rem;
@@ -382,6 +386,8 @@
 
 .toggle {
     margin-left: auto;
+    display: flex;
+    align-items: center;
 }
 
 .col {
@@ -399,5 +405,13 @@
       padding-right: 0.1rem;
       padding-left: 0;
     }
+  }
+}
+
+.toggleLabel {
+  margin-right: var(--sm-padding-x);
+
+  [dir="rtl"] & {
+    margin: 0 0 0 var(--sm-padding-x);
   }
 }


### PR DESCRIPTION
### What does this PR do?

Applies the following changes to the poll panel, making it usable even with the panel size set to minimum:
- makes all response type buttons use 100% width
- moves ON or OFF label outside the 'anonymous poll' switch
- adds line-breaks to buttons content if there's not enough width to display in one line

#### before

![Screenshot from 2021-08-18 17-07-09](https://user-images.githubusercontent.com/3728706/129965051-d8e4eb0f-7873-4bbc-b5e0-e01536c899bd.png) ![Screenshot from 2021-08-18 17-07-19](https://user-images.githubusercontent.com/3728706/129965047-cf92a74d-5185-4e49-acc3-f89b3ebfdf10.png)


#### after
![Screenshot from 2021-08-18 17-04-45](https://user-images.githubusercontent.com/3728706/129964831-6c346753-879c-484c-8407-c3f35884eaeb.png) ![Screenshot from 2021-08-18 17-04-53](https://user-images.githubusercontent.com/3728706/129964830-6f73e2c7-fbdb-4f76-a22c-8afc2f7a0894.png)

### Closes Issue(s)
Closes #12928