### PR TITLE
Avoid race condition between redis and bbb-rap-resque-worker

### DIFF
--- a/record-and-playback/core/systemd/bbb-rap-resque-worker.service
+++ b/record-and-playback/core/systemd/bbb-rap-resque-worker.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=BigBlueButton resque worker for recordings
+Wants=redis.service
+After=redis.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
Redis must be started before bbb-rap-resque-worker.service which will connect to Redis