### PR TITLE
Closed captions / shared notes resizing improvements

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/captions/pad/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/pad/component.jsx
@@ -203,6 +203,7 @@ class Pad extends PureComponent {
       ownerId,
       name,
       layoutContextDispatch,
+      isResizing,
     } = this.props;
 
     const { listening } = this.state;
@@ -275,6 +276,9 @@ class Pad extends PureComponent {
           title="etherpad"
           src={url}
           aria-describedby="padEscapeHint"
+          style={{
+            pointerEvents: isResizing ? 'none' : 'inherit',
+          }}
         />
         <span id="padEscapeHint" className={styles.hint} aria-hidden>
           {intl.formatMessage(intlMessages.tip)}

--- a/bigbluebutton-html5/imports/ui/components/captions/pad/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/pad/container.jsx
@@ -9,7 +9,11 @@ import { ACTIONS, PANELS } from '../../layout/enums';
 
 const PadContainer = (props) => {
   const layoutContext = useContext(LayoutContext);
-  const { layoutContextDispatch } = layoutContext;
+  const { layoutContextDispatch, layoutContextState } = layoutContext;
+  const { input } = layoutContextState;
+  const { cameraDock } = input;
+  const { isResizing } = cameraDock;
+
   const {
     amIModerator,
     children,
@@ -28,7 +32,7 @@ const PadContainer = (props) => {
   }
 
   return (
-    <Pad {...{ layoutContextDispatch, ...props }}>
+    <Pad {...{ layoutContextDispatch, isResizing, ...props }}>
       {children}
     </Pad>
   );

--- a/bigbluebutton-html5/imports/ui/components/captions/pad/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/captions/pad/styles.scss
@@ -29,7 +29,6 @@
   display: flex;
   flex-grow: 1;
   flex-direction: column;
-  justify-content: space-around;
   overflow: hidden;
   height: 100%;
 

--- a/bigbluebutton-html5/imports/ui/components/note/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/note/component.jsx
@@ -48,6 +48,7 @@ class Note extends Component {
       intl,
       isRTL,
       layoutContextDispatch,
+      isResizing,
     } = this.props;
 
     const url = isLocked ? this.readOnlyURL : this.noteURL;
@@ -84,6 +85,9 @@ class Note extends Component {
           title="etherpad"
           src={url}
           aria-describedby="sharedNotesEscapeHint"
+          style={{
+            pointerEvents: isResizing ? 'none' : 'inherit',
+          }}
         />
         <span id="sharedNotesEscapeHint" className={styles.hint} aria-hidden>
           {intl.formatMessage(intlMessages.tipLabel)}

--- a/bigbluebutton-html5/imports/ui/components/note/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/note/container.jsx
@@ -6,9 +6,12 @@ import LayoutContext from '../layout/context';
 
 const NoteContainer = ({ children, ...props }) => {
   const layoutContext = useContext(LayoutContext);
-  const { layoutContextDispatch } = layoutContext;
+  const { layoutContextDispatch, layoutContextState } = layoutContext;
+  const { input } = layoutContextState;
+  const { cameraDock } = input;
+  const { isResizing } = cameraDock;
   return (
-    <Note {...{ layoutContextDispatch, ...props }}>
+    <Note {...{ layoutContextDispatch, isResizing, ...props }}>
       {children}
     </Note>
   );

--- a/bigbluebutton-html5/imports/ui/components/note/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/note/styles.scss
@@ -13,7 +13,6 @@
   display: flex;
   flex-grow: 1;
   flex-direction: column;
-  justify-content: space-around;
   overflow: hidden;
   height: 100%;
 


### PR DESCRIPTION
### What does this PR do?

Prevents panel resizing issues with etherpad's iframe (used in captions and shared notes).

### Closes Issue(s)

Closes #13021
