### PR TITLE
fix: incorrect layout when a focused webcam is unshared

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
@@ -118,6 +118,7 @@ class VideoList extends Component {
   }
 
   componentDidUpdate(prevProps) {
+    const { focusedId } = this.state;
     const { layoutType, cameraDock, streams } = this.props;
     const { width: cameraDockWidth, height: cameraDockHeight } = cameraDock;
     const {
@@ -127,6 +128,11 @@ class VideoList extends Component {
     } = prevProps;
     const { width: prevCameraDockWidth, height: prevCameraDockHeight } = prevCameraDock;
 
+    const focusedStream = streams.filter((item) => item.stream === focusedId);
+
+    if (focusedId && focusedStream.length === 0) {
+      this.handleVideoFocus(focusedId);
+    }
     if (layoutType !== prevLayoutType
       || cameraDockWidth !== prevCameraDockWidth
       || cameraDockHeight !== prevCameraDockHeight


### PR DESCRIPTION
### What does this PR do?

Removes focus state if a webcam is unshared.

### Closes Issue(s)
Closes #12475