### PR TITLE
style(logo): centralize image

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/custom-logo/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/user-list/custom-logo/styles.scss
@@ -1,15 +1,17 @@
 .separator {
   height: 1px;
   background-color: var(--color-gray-lighter);
-  margin-top: calc(var(--line-height-computed) * .5);
   margin-bottom: calc(var(--line-height-computed) * .5);
 }
 
 .branding {
-  padding: 0 var(--sm-padding-x);
+  padding: var(--sm-padding-x);
   width: 100%;
   & > img {
     max-height: 2rem;
     max-width: 100%;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
   }
 }


### PR DESCRIPTION
Change the custom logo style to centralize the logo image.

![Screenshot 2021-08-19 at 15-32-07 BigBlueButton - random-9629860](https://user-images.githubusercontent.com/1778398/130125216-9708d766-9c6f-455c-b69b-157bc4e807b4.png)
