### PR TITLE
Improvised PeerTube MATCH_URL RegEx

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/peertube.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/peertube.jsx
@@ -1,7 +1,8 @@
 import loadScript from 'load-script';
 import React, { Component } from 'react'
 
-const MATCH_URL = new RegExp("(https?)://(.*)/videos/watch/(.*)");
+//To work with PeerTube >=v3.3 URL patterns
+const MATCH_URL = new RegExp("(https?)://(.*)(/videos/watch/|/w/)(.*)");
 
 const SDK_URL = 'https://unpkg.com/@peertube/embed-api/build/player.min.js';
 


### PR DESCRIPTION


<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

In PeerTube v3.3, URL routing path is changed. Unable to upload the URL with new pattern. Thus, improvised MATCH_URL to upload URLs of new and old PeerTube versions.
Refer- https://joinpeertube.org/news#release-3.3

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation
Recently found an issue while playing external videos of PeerTube in a conference and then realised there need to be a support of new URLs.

### More

<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
