### PR TITLE
fix: only change presentation isDownloadable state after confirmation 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -450,12 +450,26 @@ class PresentationUploader extends Component {
 
   handleConfirm(hasNewUpload) {
     const {
-      handleSave, selectedToBeNextCurrent,
+      handleSave,
+      selectedToBeNextCurrent,
+      presentations: propPresentations,
+      dispatchTogglePresentationDownloadable,
     } = this.props;
     const { disableActions, presentations } = this.state;
     const presentationsToSave = presentations;
 
     this.setState({ disableActions: true });
+
+    presentations.forEach(item => {
+      if (item.upload.done) {
+        const didDownloadableStateChange = propPresentations.some(
+          (p) => p.id === item.id && p.isDownloadable !== item.isDownloadable
+        );
+        if (didDownloadableStateChange) {
+          dispatchTogglePresentationDownloadable(item, item.isDownloadable);
+        }
+      }
+    });
 
     if (hasNewUpload) {
       this.toastId = toast.info(this.renderToastList(), {
@@ -522,7 +536,6 @@ class PresentationUploader extends Component {
   }
 
   handleToggleDownloadable(item) {
-    const { dispatchTogglePresentationDownloadable } = this.props;
     const { presentations } = this.state;
 
     const oldDownloadableState = item.isDownloadable;
@@ -541,12 +554,6 @@ class PresentationUploader extends Component {
     this.setState({
       presentations: presentationsUpdated,
     });
-
-    // If the presentation has not be uploaded yet, adjusting the state suffices
-    // otherwise set previously uploaded presentation to [not] be downloadable
-    if (item.upload.done) {
-      dispatchTogglePresentationDownloadable(item, !oldDownloadableState);
-    }
   }
 
   updateFileKey(id, key, value, operation = '$set') {


### PR DESCRIPTION
### What does this PR do?

Makes presentation `isDownloadable` state change only apply after confirmation button is pressed.

### Closes Issue(s)
Closes #12676
