### PR TITLE
fix(webcam): key list not provided

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-name/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-name/component.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages } from 'react-intl';
 import Icon from '/imports/ui/components/icon/component';
+import _ from 'lodash';
 import { styles } from './styles';
 
 const messages = defineMessages({
@@ -83,7 +84,7 @@ const UserName = (props) => {
 
   if (user.isSharingWebcam && LABEL.sharingWebcam) {
     userNameSub.push(
-      <span>
+      <span key={_.uniqueId('video-')}>
         <Icon iconName="video" />
         &nbsp;
         {intl.formatMessage(messages.sharingWebcam)}
@@ -93,7 +94,7 @@ const UserName = (props) => {
 
   if (isThisMeetingLocked && user.locked && user.role !== ROLE_MODERATOR) {
     userNameSub.push(
-      <span>
+      <span key={_.uniqueId('lock-')}>
         <Icon iconName="lock" />
         &nbsp;
         {intl.formatMessage(messages.locked)}
@@ -123,7 +124,7 @@ const UserName = (props) => {
       <span aria-hidden className={styles.userNameMain}>
         <span>
           {user.name}
-&nbsp;
+          &nbsp;
         </span>
         <i>{(isMe(user.userId)) ? `(${intl.formatMessage(messages.you)})` : ''}</i>
       </span>


### PR DESCRIPTION
userName is a list, and its contents must have an unique key.

```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `UserName`. See https://fb.me/react-warning-keys for more information.
    in span (created by UserName)
    in UserName (created by UserDropdown)
    in div (created by UserDropdown)
    in div (created by UserDropdown)
    in div (created by UserDropdown)
    in div (created by BBBMenu)
    in div (created by BBBMenu)
    in BBBMenu (created by Context.Consumer)
    in injectIntl(BBBMenu) (created by UserDropdown)
    in UserDropdown (created by Context.Consumer)
```

**To Reproduce**
Steps to reproduce the behavior:

1. Join as desktop user
2. Join as mobile user
3. The mobile user then shares his webcam
4. The desktop user now see two labels underneath 
his name: Webcam | Mobile
5. The desktop user's console shows a warning

cc @frankemax 