### PR TITLE
fix: uneven spacing - video-preview modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -598,7 +598,7 @@ class VideoPreview extends Component {
             </span>
           )
           : (
-            <span>
+            <>
               <label className={styles.label} htmlFor="setQuality">
                 {intl.formatMessage(intlMessages.qualityLabel)}
               </label>
@@ -629,7 +629,7 @@ class VideoPreview extends Component {
                   </span>
                 )
               }
-            </span>
+            </>
           )
         }
         {isVirtualBackgroundEnabled() && this.renderVirtualBgSelector()}


### PR DESCRIPTION
### What does this PR do?

Fixes wrong margin between `Camera` dropdown and `Quality` label.

#### before
![Screenshot from 2021-08-24 08-44-19](https://user-images.githubusercontent.com/3728706/130610725-2a55af91-1ccb-4f22-9a07-c117ca247562.png)

#### after
![Screenshot from 2021-08-24 08-43-53](https://user-images.githubusercontent.com/3728706/130610719-a2f46255-b9d9-4488-9e2d-1f44c1c275a4.png)



### Closes Issue(s)

Closes #13032