### PR TITLE
fix(polling): stop current running poll

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Polls.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Polls.scala
@@ -68,7 +68,9 @@ object Polls {
     stoppedPoll match {
       case None => {
         for {
-          curPoll <- getRunningPollThatStartsWith("public", lm.polls)
+          // Assuming there's only one running poll at a time, fallback to the
+          // current running poll without indexing by a presentation page.
+          curPoll <- getRunningPoll(lm.polls)
         } yield {
           stopPoll(curPoll.id, lm.polls)
           curPoll.id
@@ -305,6 +307,12 @@ object Polls {
 
     shape += "points" -> mapA
     shape.toMap
+  }
+
+  def getRunningPoll(polls: Polls): Option[PollVO] = {
+    for {
+      poll <- polls.polls.values find { poll => poll.isRunning() }
+    } yield poll.toPollVO()
   }
 
   def getRunningPollThatStartsWith(pollId: String, polls: Polls): Option[PollVO] = {


### PR DESCRIPTION
As far as I could understand, polls are tightly coupled with the meeting
main content area, or at least they were and we still have to deal with
this close relation between them. Not sure if it's something we'll keep
this way forever but, from my candid perspective, looks like this is already
diverging inside the poll model. Polls are indexed by presentation pages,
screenshare or even something called "public" that I'm not 100% what
actually means. My best guess is anything besides the first and the second.

The polling stop process lacks to inform which pollId is scoped at source
so it relies on akka-apps to discover based on the current state of other
apps. This looks like the major problem over this polling termination issue.

Made a few changes at the running poll getter fallback at the polling stop
process. Following the premise that there is only one running poll available,
we make sure to return a valid running poll (if there's one).

Closes #13054 

PS.: targeting this to v2.3 because the missing stop event also happens at that
branch. The difference there is that looks like there is a client based solution that
hides the problem.