### PR TITLE
fix: settings margin - mobile

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/settings/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/settings/styles.scss
@@ -86,14 +86,9 @@
 
   @include mq($small-only) {
     width: 100%;
-    margin-left: 1rem;
-    margin-right: inherit;
-
-   [dir="rtl"] & {
-     margin-left: inherit;
-     margin-right: 1rem;
-   }
-
+    margin: 0;
+    padding-left: 1rem;
+    padding-right: 1rem;
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

Removes margin-left and adds padding left/right into settings modal content (mobile only).

#### before / after comparison
![Screenshot from 2021-08-25 08-18-54](https://user-images.githubusercontent.com/3728706/130784088-3a3e2fc7-052f-4c32-a101-d6f6a6462375.png) ![Screenshot from 2021-08-25 08-21-11](https://user-images.githubusercontent.com/3728706/130784095-f695d7ec-0aa2-4bff-8a17-2e0097af494a.png)
