### PR TITLE
fix: off-by-one index check

### DIFF
--- a/bigbluebutton-html5/public/compatibility/adapter.js
+++ b/bigbluebutton-html5/public/compatibility/adapter.js
@@ -2460,7 +2460,7 @@
    */
   function extractVersion(uastring, expr, pos) {
     var match = uastring.match(expr);
-    return match && match.length >= pos && parseInt(match[pos], 10);
+    return match && match.length > pos && parseInt(match[pos], 10);
   }
   
   // Wraps the peerconnection event eventNameToWrap in a function


### PR DESCRIPTION
### What does this PR do?

Fixes off-by-one comparison against length reported by [lgtm alerts](https://lgtm.com/projects/g/bigbluebutton/bigbluebutton/alerts)

### Motivation

*Reading an array element from an index that is greater than the array length always returns undefined. If the index is compared to the array length using the less-than-or-equal operator <= instead of the less-than operator <, the index could be out of bounds, which may not be intentional and may adversely affect performance.* (https://lgtm.com/rules/1923170218/)
