### PR TITLE
fix: language override does not apply in learning dashboard

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/activity-report/service.js
+++ b/bigbluebutton-html5/imports/ui/components/activity-report/service.js
@@ -28,8 +28,8 @@ const getActivityReportAccessToken = () => ((
     },
   ) || {}).password || {}).activityReportAccessToken || null;
 
-const openActivityReportUrl = () => {
-  window.open(`/learning-dashboard/?meeting=${Auth.meetingID}&report=${getActivityReportAccessToken()}`, '_blank');
+const openActivityReportUrl = (lang) => {
+  window.open(`/learning-dashboard/?meeting=${Auth.meetingID}&report=${getActivityReportAccessToken()}&lang=${lang}`, '_blank');
 };
 
 export default {

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
@@ -250,6 +250,8 @@ class MeetingEnded extends PureComponent {
   renderNoFeedback() {
     const { intl, code, ejectedReason } = this.props;
 
+    const { locale } = intl;
+
     const logMessage = ejectedReason === 'user_requested_eject_reason' ? 'User removed from the meeting' : 'Meeting ended component, no feedback configured';
     logger.info({ logCode: 'meeting_ended_code', extraInfo: { endedCode: code, reason: ejectedReason } }, logMessage);
 
@@ -270,7 +272,7 @@ class MeetingEnded extends PureComponent {
                         <Button
                           icon="multi_whiteboard"
                           color="default"
-                          onClick={ActivityReportService.openActivityReportUrl}
+                          onClick={() => ActivityReportService.openActivityReportUrl(locale)}
                           className={styles.button}
                           label={intl.formatMessage(intlMessage.open_activity_report_btn)}
                           description={intl.formatMessage(intlMessage.open_activity_report_btn)}

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -250,6 +250,7 @@ class UserOptions extends PureComponent {
       && hasBreakoutRoom
       && getUsersNotAssigned(users).length;
 
+    const { locale } = intl;
 
     this.menuItems = [];
     
@@ -311,7 +312,7 @@ class UserOptions extends PureComponent {
             label: intl.formatMessage(intlMessages.activityReportLabel),
             description: intl.formatMessage(intlMessages.activityReportDesc),
             key: this.activityReportId,
-            onClick: openActivityReportUrl,
+            onClick: () => openActivityReportUrl(locale),
           })
         }
       }


### PR DESCRIPTION
### What does this PR do?

Adds locale parameter to learning dashboard links.

### Closes Issue(s)
Closes #13057