### PR TITLE
fix: openjdk image tag used in libreoffice-Dockerfile

### DIFF
--- a/bbb-libreoffice/docker/Dockerfile
+++ b/bbb-libreoffice/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre
+FROM openjdk:11-jre-buster
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Openjdk set the default debian version of image tag `11-jre` from buster to bullseye (https://github.com/docker-library/openjdk/pull/464). Therefore the installation cannot work. I updated the image tag to `11-jre-buster`.

### Closes Issue(s)
Closes #13077
Closes bigbluebutton/bbb-install#413


### Motivation

### More