### PR TITLE
fix: Toggle list button missing tooltip when list hidden

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -163,7 +163,7 @@ class NavBar extends Component {
               circle
               hideLabel
               data-test={hasNotification ? 'hasUnreadMessages' : null}
-              label={intl.formatMessage(intlMessages.toggleUserListLabel)}
+              tooltipLabel={intl.formatMessage(intlMessages.toggleUserListLabel)}
               aria-label={ariaLabel}
               icon="user"
               className={cx(toggleBtnClasses)}


### PR DESCRIPTION
### What does this PR do?

Display userlist toggle tooltip when userlist is hidden.

### Closes Issue(s)
Closes #12412