### PR TITLE
fix: incorrect camera position in mobile - smart layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -433,7 +433,9 @@ class SmartLayout extends Component {
 
   calculatesMediaBounds(mediaAreaBounds, slideSize, sidebarSize) {
     const { layoutContextState } = this.props;
-    const { input, fullscreen, isRTL } = layoutContextState;
+    const {
+      input, fullscreen, isRTL, deviceType,
+    } = layoutContextState;
     const { presentation } = input;
     const { isOpen } = presentation;
     const mediaBounds = {};
@@ -461,7 +463,7 @@ class SmartLayout extends Component {
 
     if (input.cameraDock.numCameras > 0 && !input.cameraDock.isDragging) {
       if (slideSize.width !== 0 && slideSize.height !== 0) {
-        if (slideSize.width < mediaAreaBounds.width) {
+        if (slideSize.width < mediaAreaBounds.width && deviceType !== DEVICE_TYPE.MOBILE) {
           if (slideSize.width < (mediaAreaBounds.width * 0.8)) {
             mediaBounds.width = slideSize.width;
           } else {


### PR DESCRIPTION
### What does this PR do?

Prevents an issue with the camera position in mobile devices when a portrait presentation is used.

### Closes Issue(s)
Closes #12383