### PR TITLE
Fix Screen Reader Announcement Of Toasts In Firefox

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/notification/index.js
+++ b/bigbluebutton-html5/imports/ui/services/notification/index.js
@@ -33,13 +33,13 @@ export function notify(message, type = 'default', icon, options, content, small)
       toast.update(
         lastToast.id,
         {
-          render: <Toast {...toastProps} />,
+          render: <div role="alert"><Toast {...toastProps} /></div>,
           autoClose: options.autoClose,
           ...toastProps,
         },
       );
     } else {
-      const id = toast(<Toast {...toastProps} />, settings);
+      const id = toast(<div role="alert"><Toast {...toastProps} /></div>, settings);
 
       lastToast = { id, ...toastProps };
 


### PR DESCRIPTION
### What does this PR do?

Adds a div wrapper with `role="alert"` to  notification service.

### Closes Issue(s)
Closes #12572 