### PR TITLE
poll live result - layout improvements

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/live-result/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/poll/live-result/styles.scss
@@ -25,7 +25,7 @@
 
 .center {
   position: relative;
-  flex: 1 1 auto;
+  flex: 3;
   border-left: 1px solid var(--color-gray-lighter);
   border-right : none;
   width: 100%;
@@ -42,12 +42,14 @@
   max-width: var(--poll-result-width);
   min-width: var(--poll-stats-element-width);
   word-wrap: break-word;
+  flex: 6;
 }
 
 .right {
   text-align: right;
   max-width: var(--poll-stats-element-width);
   min-width: var(--poll-stats-element-width);
+  flex: 1;
 
   [dir="rtl"] & {
     text-align: left;
@@ -65,7 +67,6 @@
 
 .left,
 .right {
-  flex: 0 0 auto;
   position: relative;
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds new styles to poll live-results, with columns having the same size in each row (60% of available width to answers, 30% to number of votes and 10% to vote percentage).

#### before
![Screenshot from 2021-08-30 13-46-18](https://user-images.githubusercontent.com/3728706/131374774-7d06d320-341f-4517-a16e-db51b63ec158.png)

#### after
![Screenshot from 2021-08-30 13-44-55](https://user-images.githubusercontent.com/3728706/131374769-774231d4-f7b2-4bad-9673-f7797513e967.png)


### Closes Issue(s)
Closes #12445