### PR TITLE
chore: Enable by default enableNetworkStats

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -92,9 +92,9 @@ public:
     #
     # Shows stats about download and upload rates, audio jitter, lost packets
     # and turn information
-    enableNetworkStats: false
+    enableNetworkStats: true
     # Enable the button to allow users to copy network stats to clipboard
-    enableCopyNetworkStatsButton: false
+    enableCopyNetworkStatsButton: true
     defaultSettings:
       application:
         animations: true
@@ -728,4 +728,3 @@ private:
       version: 10
     - browser: YandexBrowser
       version: 19
-


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Enabled by default https://github.com/bigbluebutton/bigbluebutton/pull/13085 on BBB 2.4+
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation
The network stats feature was added on 2.3 last week to address some support challenges. Since it was late into the 2.3 cycle, the feature landed disabled by default. 2.4 is still in beta/rc stage, so we enable by default.
<!-- What inspired you to submit this pull request? -->


