### PR TITLE
fix: client crashes when quickly clicking start/stop captions dictation button 3 times

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/captions/pad/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/pad/component.jsx
@@ -9,6 +9,7 @@ import CaptionsService from '/imports/ui/components/captions/service';
 import { notify } from '/imports/ui/services/notification';
 import { styles } from './styles';
 import { PANELS, ACTIONS } from '../../layout/enums';
+import _ from 'lodash';
 
 const intlMessages = defineMessages({
   hide: {
@@ -65,6 +66,12 @@ const propTypes = {
   }).isRequired,
 };
 
+const DEBOUNCE_TIMEOUT = 500;
+const DEBOUNCE_OPTIONS = {
+  leading: true,
+  trailing: false,
+};
+
 class Pad extends PureComponent {
   static getDerivedStateFromProps(nextProps) {
     if (nextProps.ownerId !== nextProps.currentUserId) {
@@ -83,7 +90,7 @@ class Pad extends PureComponent {
     const { locale, intl } = props;
     this.recognition = CaptionsService.initSpeechRecognition(locale);
 
-    this.toggleListen = this.toggleListen.bind(this);
+    this.toggleListen = _.debounce(this.toggleListen.bind(this), DEBOUNCE_TIMEOUT, DEBOUNCE_OPTIONS);
     this.handleListen = this.handleListen.bind(this);
 
     if (this.recognition) {


### PR DESCRIPTION
### What does this PR do?

Adds debounce to captions start/stop dictation button in order to prevent a crash that happens if a user clicks the button too quickly.

### Closes Issue(s)
Closes #13035