### PR TITLE
recording: Anonymize names in chat

### DIFF
--- a/record-and-playback/core/.gitignore
+++ b/record-and-playback/core/.gitignore
@@ -1,0 +1,2 @@
+.bundle
+vendor/bundle

--- a/record-and-playback/core/Gemfile
+++ b/record-and-playback/core/Gemfile
@@ -34,7 +34,9 @@ gem 'rubyzip', '~> 2.0'
 gem 'trollop', '2.1.3'
 gem 'resque', '~> 2.0.0'
 gem 'bbbevents', '~> 1.2'
+gem 'rake', '>= 12.3', '<14'
 
 group :test, optional: true do
   gem 'rubocop', '~> 0.79.0'
+  gem 'minitest', '~> 5.14.1'
 end

--- a/record-and-playback/core/Gemfile.lock
+++ b/record-and-playback/core/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     rack-protection (2.0.8.1)
       rack
     rainbow (3.0.0)
+    rake (13.0.6)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redis (4.1.3)
@@ -93,8 +94,10 @@ DEPENDENCIES
   jwt (~> 2.2)
   locale (~> 2.1)
   loofah (~> 2.3)
+  minitest (~> 5.14.1)
   nokogiri (~> 1.11)
   open4 (~> 1.3)
+  rake (>= 12.3, < 14)
   rb-inotify (~> 0.10)
   redis (~> 4.1)
   resque (~> 2.0.0)

--- a/record-and-playback/core/Rakefile
+++ b/record-and-playback/core/Rakefile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'resque/tasks'
+require 'rake/testtask'
 
 task 'resque:setup' => :environment do
   props = BigBlueButton.read_props
@@ -16,4 +17,10 @@ end
 task :environment do
   require_relative 'lib/boot'
   require 'recordandplayback/workers'
+end
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/test_*.rb']
 end

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -21,13 +21,14 @@
 
 
 require 'rubygems'
+require 'time'
 require 'nokogiri'
 require 'loofah'
 require 'set'
 
 module BigBlueButton
   module Events
-  
+
     # Get the total number of participants
     def self.get_num_participants(events)
       participants_ids = Set.new
@@ -75,31 +76,31 @@ module BigBlueButton
       external_meeting_id = metadata['meetingId'] if !metadata['meetingId'].nil?
       external_meeting_id
     end
-    
+
     # Get the timestamp of the first event.
     def self.first_event_timestamp(events)
       first_event = events.at_xpath('/recording/event[position() = 1]')
       first_event['timestamp'].to_i if first_event && first_event.key?('timestamp')
     end
-    
+
     # Get the timestamp of the last event.
     def self.last_event_timestamp(events)
       last_event = events.at_xpath('/recording/event[position() = last()]')
       last_event['timestamp'].to_i if last_event && last_event.key?('timestamp')
-    end  
-    
+    end
+
     # Determine if the start and stop event matched.
-    def self.find_video_event_matched(start_events, stop)      
+    def self.find_video_event_matched(start_events, stop)
       BigBlueButton.logger.info("Task: Finding video events that match")
       start_events.each do |start|
         if (start[:stream] == stop[:stream])
           return start
-        end      
+        end
       end
       return nil
     end
-    
-    # Get start video events  
+
+    # Get start video events
     def self.get_start_video_events(events)
       start_events = []
       events.xpath("/recording/event[@eventname='StartWebcamShareEvent']").each do |start_event|
@@ -235,7 +236,7 @@ module BigBlueButton
     end
 
     def self.get_stop_deskshare_events(events)
-      BigBlueButton.logger.info("Task: Getting stop DESKSHARE events")      
+      BigBlueButton.logger.info("Task: Getting stop DESKSHARE events")
       stop_events = []
       events.xpath('/recording/event[@module="Deskshare" or (@module="bbb-webrtc-sfu" and @eventname="StopWebRTCDesktopShareEvent")]').each do |stop_event|
         case stop_event['eventname']
@@ -476,10 +477,132 @@ module BigBlueButton
       node['href'] = node['href'][6..-1] if node.name == 'a' && node['href'] && node['href'].start_with?('event:')
     end
 
-    def self.linkify( text )
+    def self.linkify(text)
       html = Loofah.fragment(text)
       html.scrub!(@remove_link_event_prefix).scrub!(:strip).scrub!(:nofollow).scrub!(:unprintable)
       html.to_html
+    end
+
+    # Build a map of internal user IDs to anonymized names. This can be used to anonymize users in
+    # chat, cursor overlays, etc.
+    def self.anonymous_user_map(events, moderators: false)
+      viewer_count = 0
+      moderator_count = 0
+
+      external_map = {}
+      map = {}
+
+      events.xpath('/recording/event[@module="PARTICIPANT" and @eventname="ParticipantJoinEvent"]').each do |event|
+        internal_id = event.at_xpath('./userId')&.content
+        next if internal_id.nil?
+
+        external_id = event.at_xpath('./externalUserId')&.content || internal_id
+        name = external_map.fetch(external_id) do
+          role = event.at_xpath('./role').content
+          new_name = \
+            if role == 'MODERATOR' && moderators
+              moderator_count += 1
+              "Moderator #{moderator_count}"
+            elsif role == 'MODERATOR'
+              event.at_xpath('./name')&.content
+            else
+              viewer_count += 1
+              "Viewer #{viewer_count}"
+            end
+          external_map[external_id] = new_name unless new_name.nil?
+        end
+        map[internal_id] = name unless name.nil?
+      end
+
+      map
+    end
+
+    # Get a list of chat events, with start/end time for segments and recording marks applied.
+    # Optionally anonymizes chat participant names.
+    # Reads the keys 'anonymize_chat' and 'anonymize_chat_moderators' from bbb_props, but allows
+    # per-meeting override using the create meta params 'meta_bbb-anonymize-chat' and
+    # 'meta_bbb-anonymize-chat-moderators'
+    # Each event in the return value has the following properties:
+    #   in: 0-based milliseconds timestamp of when chat was sent
+    #   out: 0-based milliseconds timestamp of when chat was cleared (or nil if chat was never cleared)
+    #   sender_id: The internal user id of the sender (can be nil on really old BBB versions)
+    #   sender: The display name of the sender
+    #   message: The chat message, with link cleanup already applied
+    #   date: The real time of when the message was sent (if available) as a DateTime
+    #   text_color: The RGB color value of the chat message text as an integer (old BBB versions only)
+    #   avatar_color: The color of the user's avatar (initials) box (newer BBB versions only)
+    def self.get_chat_events(events, start_time, end_time, bbb_props = {})
+      BigBlueButton.logger.info('Getting chat events')
+
+      initial_timestamp = first_event_timestamp(events)
+      start_time -= initial_timestamp
+      end_time -= initial_timestamp
+
+      last_stop_timestamp = start_time
+      offset = start_time
+      # Recordings without status events are assumed to have been recorded from the beginning
+      record = events.at_xpath('/recording/event[@eventname="RecordStatusEvent"]').nil?
+
+      # Load the anonymize settings; defaults from bigbluebutton.yml, override with meta params
+      metadata = events.at_xpath('/recording/metadata')
+      anonymize_senders = metadata['bbb-anonymize-chat'] unless metadata.nil?
+      anonymize_senders = bbb_props['anonymize_chat'] if anonymize_senders.nil?
+      anonymize_senders = anonymize_senders.to_s.casecmp?('true')
+      anonymize_moderators = metadata['bbb-anonymize-chat-moderators'] unless metadata.nil?
+      anonymize_moderators = bbb_props['anonymize_chat_moderators'] if anonymize_moderators.nil?
+      anonymize_moderators = anonymize_moderators.to_s.casecmp?('true')
+
+      user_map = anonymize_senders ? anonymous_user_map(events, moderators: anonymize_moderators) : {}
+
+      chats = []
+      events.xpath('/recording/event').each do |event|
+        timestamp = event[:timestamp].to_i - initial_timestamp
+        break if timestamp >= end_time
+
+        case [event[:module], event[:eventname]]
+        when %w[CHAT PublicChatEvent]
+          next if timestamp < start_time || !record
+
+          date = event.at_xpath('./date')&.content
+          date = DateTime.iso8601(date) unless date.nil?
+          sender_id = event.at_xpath('./senderId')&.content
+          color = event.at_xpath('./color')&.content
+          if color&.start_with?('#')
+            avatar_color = color
+          else
+            text_color = color.to_i
+          end
+
+          chats << {
+            in: timestamp - offset,
+            out: nil,
+            sender_id: sender_id,
+            sender: user_map.fetch(sender_id) { event.at_xpath('./sender').content },
+            message: linkify(event.at_xpath('./message').content.strip),
+            avatar_color: avatar_color,
+            text_color: text_color,
+            date: date,
+          }
+        when %w[CHAT ClearPublicChatEvent]
+          next if timestamp < start_time
+
+          clear_timestamp = (record ? timestamp : last_stop_timestamp) - offset
+          chats.each do |chat|
+            chat[:out] = clear_timestamp if chat[:out].nil?
+          end
+        when %w[PARTICIPANT RecordStatusEvent]
+          record = event.at_xpath('status').content == 'true'
+          next if timestamp < start_time
+
+          if record
+            offset += timestamp - last_stop_timestamp
+          else
+            last_stop_timestamp = timestamp
+          end
+        end
+      end
+
+      chats
     end
 
     def self.get_record_status_events(events_xml)
@@ -496,8 +619,8 @@ module BigBlueButton
       BigBlueButton.logger.info "Getting external video events"
       external_videos_events = []
       events_xml.xpath("//event[@eventname='StartExternalVideoRecordEvent']").each do |event|
-        s = { 
-          :timestamp => event['timestamp'].to_i, 
+        s = {
+          :timestamp => event['timestamp'].to_i,
           :external_video_url => event.at_xpath("externalVideoUrl").text
         }
         external_videos_events << s
@@ -523,7 +646,7 @@ module BigBlueButton
       end
       rec_events.sort_by {|a| a[:timestamp]}
     end
-    
+
     # Get events when the moderator wants the recording to start or stop
     def self.get_start_and_stop_external_video_events(events_xml)
       BigBlueButton.logger.info "Getting start and stop externalvideo events"
@@ -534,7 +657,7 @@ module BigBlueButton
       end
       external_video_events.sort_by {|a| a[:timestamp]}
     end
-    
+
     # Match recording start and stop events
     def self.match_start_and_stop_rec_events(rec_events)
       BigBlueButton.logger.info ("Matching record events")

--- a/record-and-playback/core/resources/raw/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/events.xml
+++ b/record-and-playback/core/resources/raw/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/events.xml
@@ -1,0 +1,12300 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<recording meeting_id="183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889" bbb_version="2.1.0">
+  <meeting id="183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889" externalId="Demo Meeting" name="Demo Meeting" breakout="false"/>
+  <metadata isBreakout="false" meetingId="Demo Meeting" meetingName="Demo Meeting"/>
+  <event timestamp="13749525124" module="PRESENTATION" eventname="CreatePresentationPodEvent">
+    <currentPresenter/>
+    <timestampUTC>1630430006895</timestampUTC>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <date>2021-08-31T17:13:26.895Z</date>
+  </event>
+  <event timestamp="13749525519" module="PAD" eventname="AddPadEvent">
+    <timestampUTC>1630430007291</timestampUTC>
+    <date>2021-08-31T17:13:27.291Z</date>
+    <padId>[1]a0bac88f0f25ad916d8e53fa7f8bb3a3fbe0</padId>
+  </event>
+  <event timestamp="13749531095" module="PRESENTATION" eventname="ConversionCompletedEvent">
+    <originalFilename>default.pdf</originalFilename>
+    <timestampUTC>1630430012867</timestampUTC>
+    <presentationName>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentationName>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <date>2021-08-31T17:13:32.867Z</date>
+  </event>
+  <event timestamp="13749531097" module="PRESENTATION" eventname="SharePresentationEvent">
+    <timestampUTC>1630430012869</timestampUTC>
+    <presentationName>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentationName>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <share>true</share>
+    <date>2021-08-31T17:13:32.869Z</date>
+  </event>
+  <event timestamp="13749531098" module="PRESENTATION" eventname="SetPresentationDownloadable">
+    <timestampUTC>1630430012870</timestampUTC>
+    <presentationName>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentationName>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <date>2021-08-31T17:13:32.870Z</date>
+    <downloadable>false</downloadable>
+  </event>
+  <event timestamp="13749531331" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>dsadsa</name>
+    <timestampUTC>1630430013103</timestampUTC>
+    <role>MODERATOR</role>
+    <date>2021-08-31T17:13:33.103Z</date>
+    <externalUserId>w_hm71zphugfzo</externalUserId>
+    <userId>w_hm71zphugfzo</userId>
+  </event>
+  <event timestamp="13749531336" module="PARTICIPANT" eventname="AssignPresenterEvent">
+    <name>dsadsa</name>
+    <timestampUTC>1630430013108</timestampUTC>
+    <userid>w_hm71zphugfzo</userid>
+    <assignedBy>w_hm71zphugfzo</assignedBy>
+    <date>2021-08-31T17:13:33.108Z</date>
+  </event>
+  <event timestamp="13749531356" module="PARTICIPANT" eventname="AssignPresenterEvent">
+    <name>dsadsa</name>
+    <timestampUTC>1630430013128</timestampUTC>
+    <userid>w_hm71zphugfzo</userid>
+    <assignedBy>w_hm71zphugfzo</assignedBy>
+    <date>2021-08-31T17:13:33.128Z</date>
+  </event>
+  <event timestamp="13749531359" module="PRESENTATION" eventname="SetPresenterInPodEvent">
+    <timestampUTC>1630430013131</timestampUTC>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <date>2021-08-31T17:13:33.131Z</date>
+    <nextPresenterId>w_hm71zphugfzo</nextPresenterId>
+  </event>
+  <event timestamp="13749532418" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430014190</timestampUTC>
+    <xOffset>69.52294667561848</xOffset>
+    <date>2021-08-31T17:13:34.190Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>17.004549944842303</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749532439" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430014211</timestampUTC>
+    <xOffset>70.40215174357097</xOffset>
+    <date>2021-08-31T17:13:34.211Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>17.77033911810981</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749532449" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430014221</timestampUTC>
+    <xOffset>70.40215174357097</xOffset>
+    <date>2021-08-31T17:13:34.221Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>17.77033911810981</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749532490" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430014262</timestampUTC>
+    <xOffset>70.40215174357097</xOffset>
+    <date>2021-08-31T17:13:34.262Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>17.77033911810981</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749532499" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430014271</timestampUTC>
+    <xOffset>70.40215174357097</xOffset>
+    <date>2021-08-31T17:13:34.271Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>17.77033911810981</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749532525" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430014296</timestampUTC>
+    <xOffset>70.40215174357097</xOffset>
+    <date>2021-08-31T17:13:34.296Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>17.77033911810981</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749532530" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430014301</timestampUTC>
+    <xOffset>70.40215174357097</xOffset>
+    <date>2021-08-31T17:13:34.301Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>17.77033911810981</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749532537" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430014308</timestampUTC>
+    <xOffset>70.40215174357097</xOffset>
+    <date>2021-08-31T17:13:34.308Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>17.77033911810981</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749532542" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430014314</timestampUTC>
+    <xOffset>70.40215174357097</xOffset>
+    <date>2021-08-31T17:13:34.314Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>17.77033911810981</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749532550" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430014322</timestampUTC>
+    <xOffset>58.42086791992187</xOffset>
+    <date>2021-08-31T17:13:34.322Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>17.77033911810981</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749532555" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430014327</timestampUTC>
+    <xOffset>58.42086791992187</xOffset>
+    <date>2021-08-31T17:13:34.327Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>17.77033911810981</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749532571" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430014343</timestampUTC>
+    <xOffset>58.42086791992187</xOffset>
+    <date>2021-08-31T17:13:34.343Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>17.77033911810981</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749532593" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430014365</timestampUTC>
+    <xOffset>-44.4360891977946</xOffset>
+    <date>2021-08-31T17:13:34.365Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>-16.405597262912327</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749534654" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430016425</timestampUTC>
+    <xOffset>47.4436092376709</xOffset>
+    <date>2021-08-31T17:13:36.425Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>34.25438492386429</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749534803" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430016575</timestampUTC>
+    <xOffset>31.052630742390953</xOffset>
+    <date>2021-08-31T17:13:36.575Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>37.59607385706018</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749534953" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430016725</timestampUTC>
+    <xOffset>-44.4360891977946</xOffset>
+    <date>2021-08-31T17:13:36.725Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>-16.405597262912327</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749544034" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430025806</timestampUTC>
+    <xOffset>-31.278196970621746</xOffset>
+    <date>2021-08-31T17:13:45.806Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>-16.405597262912327</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749544170" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430025942</timestampUTC>
+    <xOffset>2.4853740135828652</xOffset>
+    <date>2021-08-31T17:13:45.942Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>13.63204108344184</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749544321" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430026093</timestampUTC>
+    <xOffset>11.591151555379232</xOffset>
+    <date>2021-08-31T17:13:46.093Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>16.431477864583332</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749544471" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430026242</timestampUTC>
+    <xOffset>10.15339692433675</xOffset>
+    <date>2021-08-31T17:13:46.242Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>16.431477864583332</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749544621" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430026392</timestampUTC>
+    <xOffset>-24.010384877522785</xOffset>
+    <date>2021-08-31T17:13:46.392Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>-10.467460067183882</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749545139" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430026911</timestampUTC>
+    <xOffset>0.9791552027066549</xOffset>
+    <date>2021-08-31T17:13:46.911Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>10.102316538492838</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749545288" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430027059</timestampUTC>
+    <xOffset>9.879539012908936</xOffset>
+    <date>2021-08-31T17:13:47.059Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>16.91833637378834</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749545454" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430027226</timestampUTC>
+    <xOffset>10.084932645161947</xOffset>
+    <date>2021-08-31T17:13:47.226Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>17.16176633481626</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749545519" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430027291</timestampUTC>
+    <xOffset>10.15339692433675</xOffset>
+    <date>2021-08-31T17:13:47.291Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>17.16176633481626</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749546073" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430027845</timestampUTC>
+    <xOffset>10.221861998240152</xOffset>
+    <date>2021-08-31T17:13:47.845Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>17.16176633481626</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749546640" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430028412</timestampUTC>
+    <xOffset>10.290326277414957</xOffset>
+    <date>2021-08-31T17:13:48.412Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>17.16176633481626</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749546791" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430028563</timestampUTC>
+    <xOffset>12.823512554168701</xOffset>
+    <date>2021-08-31T17:13:48.563Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>17.526910569932724</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749546959" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430028731</timestampUTC>
+    <xOffset>12.207332452138266</xOffset>
+    <date>2021-08-31T17:13:48.731Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>17.526910569932724</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749547110" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430028882</timestampUTC>
+    <xOffset>6.935566266377767</xOffset>
+    <date>2021-08-31T17:13:48.882Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>16.066335042317707</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749547271" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430029043</timestampUTC>
+    <xOffset>-24.010384877522785</xOffset>
+    <date>2021-08-31T17:13:49.043Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>-10.467460067183882</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749548538" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430030310</timestampUTC>
+    <xOffset>-35.991671880086265</xOffset>
+    <date>2021-08-31T17:13:50.310Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>-10.467460067183882</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749549597" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430031369</timestampUTC>
+    <xOffset>-44.4360891977946</xOffset>
+    <date>2021-08-31T17:13:51.369Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>-16.405597262912327</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749549610" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430031382</timestampUTC>
+    <xOffset>-44.4360891977946</xOffset>
+    <date>2021-08-31T17:13:51.382Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>-16.405597262912327</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749549620" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430031392</timestampUTC>
+    <xOffset>-31.278196970621746</xOffset>
+    <date>2021-08-31T17:13:51.392Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>-16.405597262912327</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749549955" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430031726</timestampUTC>
+    <xOffset>0.6368327140808105</xOffset>
+    <date>2021-08-31T17:13:51.726Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>22.517211348922164</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749550104" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430031876</timestampUTC>
+    <xOffset>-24.010384877522785</xOffset>
+    <date>2021-08-31T17:13:51.876Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>-10.467460067183882</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749550752" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430032523</timestampUTC>
+    <xOffset>-35.991671880086265</xOffset>
+    <date>2021-08-31T17:13:52.523Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>-10.467460067183882</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749552138" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430033909</timestampUTC>
+    <xOffset>0.676691730817159</xOffset>
+    <date>2021-08-31T17:13:53.909Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>24.630324752242476</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13749552289" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630430034061</timestampUTC>
+    <xOffset>-44.4360891977946</xOffset>
+    <date>2021-08-31T17:13:54.061Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_hm71zphugfzo</userId>
+    <yOffset>-16.405597262912327</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751023882" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>Tainan</name>
+    <timestampUTC>1630431505653</timestampUTC>
+    <role>MODERATOR</role>
+    <date>2021-08-31T17:38:25.653Z</date>
+    <externalUserId>w_etmphvzxcogu</externalUserId>
+    <userId>w_etmphvzxcogu</userId>
+  </event>
+  <event timestamp="13751358625" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>João</name>
+    <timestampUTC>1630431840397</timestampUTC>
+    <role>MODERATOR</role>
+    <date>2021-08-31T17:44:00.397Z</date>
+    <externalUserId>w_pwxbcsf5jfuq</externalUserId>
+    <userId>w_pwxbcsf5jfuq</userId>
+  </event>
+  <event timestamp="13751360126" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <timestampUTC>1630431841897</timestampUTC>
+    <date>2021-08-31T17:44:01.897Z</date>
+    <userId>w_hm71zphugfzo</userId>
+  </event>
+  <event timestamp="13751360129" module="PARTICIPANT" eventname="AssignPresenterEvent">
+    <name>João</name>
+    <timestampUTC>1630431841901</timestampUTC>
+    <userid>w_pwxbcsf5jfuq</userid>
+    <assignedBy>w_pwxbcsf5jfuq</assignedBy>
+    <date>2021-08-31T17:44:01.901Z</date>
+  </event>
+  <event timestamp="13751360135" module="PARTICIPANT" eventname="AssignPresenterEvent">
+    <name>João</name>
+    <timestampUTC>1630431841907</timestampUTC>
+    <userid>w_pwxbcsf5jfuq</userid>
+    <assignedBy>w_pwxbcsf5jfuq</assignedBy>
+    <date>2021-08-31T17:44:01.907Z</date>
+  </event>
+  <event timestamp="13751360137" module="PRESENTATION" eventname="SetPresenterInPodEvent">
+    <timestampUTC>1630431841909</timestampUTC>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <date>2021-08-31T17:44:01.909Z</date>
+    <nextPresenterId>w_pwxbcsf5jfuq</nextPresenterId>
+  </event>
+  <event timestamp="13751360501" module="PRESENTATION" eventname="ResizeAndMoveSlideEvent">
+    <timestampUTC>1630431842273</timestampUTC>
+    <xOffset>0.0</xOffset>
+    <presentationName>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentationName>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <heightRatio>100.0</heightRatio>
+    <id>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</id>
+    <date>2021-08-31T17:44:02.273Z</date>
+    <yOffset>0.0</yOffset>
+    <widthRatio>100.0</widthRatio>
+  </event>
+  <event timestamp="13751360699" module="PRESENTATION" eventname="ResizeAndMoveSlideEvent">
+    <timestampUTC>1630431842471</timestampUTC>
+    <xOffset>0.0</xOffset>
+    <presentationName>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentationName>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <heightRatio>100.0</heightRatio>
+    <id>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</id>
+    <date>2021-08-31T17:44:02.471Z</date>
+    <yOffset>0.0</yOffset>
+    <widthRatio>100.0</widthRatio>
+  </event>
+  <event timestamp="13751364271" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630431846043</timestampUTC>
+    <xOffset>45.78408241271973</xOffset>
+    <date>2021-08-31T17:44:06.043Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>34.61824770326968</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751364421" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630431846192</timestampUTC>
+    <xOffset>31.59968376159668</xOffset>
+    <date>2021-08-31T17:44:06.192Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>58.15383911132812</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751364573" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630431846345</timestampUTC>
+    <xOffset>21.197794278462727</xOffset>
+    <date>2021-08-31T17:44:06.345Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>86.17240058051216</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751364721" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630431846493</timestampUTC>
+    <xOffset>20.252167383829754</xOffset>
+    <date>2021-08-31T17:44:06.493Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>90.93555591724537</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751364873" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630431846645</timestampUTC>
+    <xOffset>19.936958948771156</xOffset>
+    <date>2021-08-31T17:44:06.645Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>92.47658058449075</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751365021" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630431846793</timestampUTC>
+    <xOffset>18.75492572784424</xOffset>
+    <date>2021-08-31T17:44:06.793Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>98.64065664785879</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751365194" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630431846965</timestampUTC>
+    <xOffset>18.67612361907959</xOffset>
+    <date>2021-08-31T17:44:06.965Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>98.92084192346644</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751365223" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630431846995</timestampUTC>
+    <xOffset>19.464144706726074</xOffset>
+    <date>2021-08-31T17:44:06.995Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>98.92084192346644</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751365372" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630431847144</timestampUTC>
+    <xOffset>56.816393534342446</xOffset>
+    <date>2021-08-31T17:44:07.144Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>47.927065248842595</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751365523" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630431847295</timestampUTC>
+    <xOffset>65.09062449137369</xOffset>
+    <date>2021-08-31T17:44:07.295Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>31.39611138237847</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751365670" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630431847442</timestampUTC>
+    <xOffset>65.4058329264323</xOffset>
+    <date>2021-08-31T17:44:07.442Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>28.173977887188943</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751365839" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630431847611</timestampUTC>
+    <xOffset>67.45468775431314</xOffset>
+    <date>2021-08-31T17:44:07.611Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>0.9959723331310131</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751365998" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630431847769</timestampUTC>
+    <xOffset>-46.57210350036621</xOffset>
+    <date>2021-08-31T17:44:07.769Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-17.916557877152055</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751366052" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630431847824</timestampUTC>
+    <xOffset>87.62805302937825</xOffset>
+    <date>2021-08-31T17:44:07.824Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>0.8558795187208387</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751366204" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630431847975</timestampUTC>
+    <xOffset>88.73128255208333</xOffset>
+    <date>2021-08-31T17:44:07.975Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>1.4162507763615362</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751366360" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630431848132</timestampUTC>
+    <xOffset>-46.57210350036621</xOffset>
+    <date>2021-08-31T17:44:08.132Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-17.916557877152055</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751366588" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630431848360</timestampUTC>
+    <xOffset>42.39558855692545</xOffset>
+    <date>2021-08-31T17:44:08.360Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>0.5756938899004901</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751366739" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630431848510</timestampUTC>
+    <xOffset>32.387708028157554</xOffset>
+    <date>2021-08-31T17:44:08.510Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>19.62831567834925</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751366888" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630431848660</timestampUTC>
+    <xOffset>-46.57210350036621</xOffset>
+    <date>2021-08-31T17:44:08.660Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-17.916557877152055</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13751383880" module="VOICE" eventname="ParticipantJoinedEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630431865652</timestampUTC>
+    <bridge>79134</bridge>
+    <callername>Tainan</callername>
+    <talking>false</talking>
+    <callernumber>w_etmphvzxcogu_1-bbbID-Tainan</callernumber>
+    <date>2021-08-31T17:44:25.652Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13751383900" module="VOICE" eventname="StartRecordingEvent">
+    <filename>/var/freeswitch/meetings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889-13751383876.opus</filename>
+    <date>2021-08-31T17:44:25.672Z</date>
+    <timestampUTC>1630431865672</timestampUTC>
+    <bridge>79134</bridge>
+    <recordingTimestamp>13751383899</recordingTimestamp>
+  </event>
+  <event timestamp="13751385005" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630431866777</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T17:44:26.777Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13751814000" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>Vitor</name>
+    <timestampUTC>1630432295772</timestampUTC>
+    <role>MODERATOR</role>
+    <date>2021-08-31T17:51:35.772Z</date>
+    <externalUserId>w_k6547g2umh6j</externalUserId>
+    <userId>w_k6547g2umh6j</userId>
+  </event>
+  <event timestamp="13751839167" module="VOICE" eventname="ParticipantJoinedEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432320939</timestampUTC>
+    <bridge>79134</bridge>
+    <callername>Vitor</callername>
+    <talking>false</talking>
+    <callernumber>w_k6547g2umh6j_1-bbbID-Vitor</callernumber>
+    <date>2021-08-31T17:52:00.939Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13751841135" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432322907</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:52:02.907Z</date>
+  </event>
+  <event timestamp="13751844004" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432325776</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:52:05.776Z</date>
+  </event>
+  <event timestamp="13751844161" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432325933</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T17:52:05.933Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752131286" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>Tiago</name>
+    <timestampUTC>1630432613058</timestampUTC>
+    <role>MODERATOR</role>
+    <date>2021-08-31T17:56:53.058Z</date>
+    <externalUserId>w_a6odtbi2lzzl</externalUserId>
+    <userId>w_a6odtbi2lzzl</userId>
+  </event>
+  <event timestamp="13752132610" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432614382</timestampUTC>
+    <xOffset>28.999210993448894</xOffset>
+    <date>2021-08-31T17:56:54.382Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>95.41853162977431</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752132759" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432614531</timestampUTC>
+    <xOffset>-46.57210350036621</xOffset>
+    <date>2021-08-31T17:56:54.531Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-17.916557877152055</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752133226" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432614997</timestampUTC>
+    <xOffset>0.7092198729515076</xOffset>
+    <date>2021-08-31T17:56:54.997Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>92.61667322229457</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752133376" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432615148</timestampUTC>
+    <xOffset>-46.57210350036621</xOffset>
+    <date>2021-08-31T17:56:55.148Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-17.916557877152055</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752134212" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432615984</timestampUTC>
+    <xOffset>1.0244287053744</xOffset>
+    <date>2021-08-31T17:56:55.984Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>83.93091837565105</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752134361" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432616132</timestampUTC>
+    <xOffset>15.445232391357422</xOffset>
+    <date>2021-08-31T17:56:56.132Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>94.15769223813658</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752134583" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432616355</timestampUTC>
+    <xOffset>15.524034500122069</xOffset>
+    <date>2021-08-31T17:56:56.355Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>94.2977848759404</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752134735" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432616507</timestampUTC>
+    <xOffset>15.996847152709961</xOffset>
+    <date>2021-08-31T17:56:56.507Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>96.39917444299768</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752134895" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432616666</timestampUTC>
+    <xOffset>-46.57210350036621</xOffset>
+    <date>2021-08-31T17:56:56.666Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-17.916557877152055</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752144569" module="VOICE" eventname="ParticipantJoinedEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432626341</timestampUTC>
+    <bridge>79134</bridge>
+    <callername>João</callername>
+    <talking>false</talking>
+    <callernumber>w_pwxbcsf5jfuq_1-bbbID-João</callernumber>
+    <date>2021-08-31T17:57:06.341Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752145466" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432627238</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T17:57:07.238Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752154004" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432635776</timestampUTC>
+    <xOffset>12.68715540568034</xOffset>
+    <date>2021-08-31T17:57:15.776Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>69.08107616283276</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752154180" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432635952</timestampUTC>
+    <xOffset>12.450748284657797</xOffset>
+    <date>2021-08-31T17:57:15.952Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>69.08107616283276</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752154331" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432636103</timestampUTC>
+    <xOffset>82.58471171061198</xOffset>
+    <date>2021-08-31T17:57:16.103Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>64.17782818829572</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752154485" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432636257</timestampUTC>
+    <xOffset>99.92119471232095</xOffset>
+    <date>2021-08-31T17:57:16.257Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>52.41003530996817</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752154636" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432636408</timestampUTC>
+    <xOffset>99.92119471232095</xOffset>
+    <date>2021-08-31T17:57:16.408Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>52.12985003436054</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752154838" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432636610</timestampUTC>
+    <xOffset>99.60598627726237</xOffset>
+    <date>2021-08-31T17:57:16.610Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>37.420103285047745</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752155002" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432636774</timestampUTC>
+    <xOffset>82.03309377034506</xOffset>
+    <date>2021-08-31T17:57:16.774Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>61.516068070023145</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752155151" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432636923</timestampUTC>
+    <xOffset>70.52797317504883</xOffset>
+    <date>2021-08-31T17:57:16.923Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>70.06173027886284</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752155304" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432637076</timestampUTC>
+    <xOffset>-46.57210350036621</xOffset>
+    <date>2021-08-31T17:57:17.076Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-17.916557877152055</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752182784" module="VOICE" eventname="ParticipantJoinedEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432664556</timestampUTC>
+    <bridge>79134</bridge>
+    <callername>Tiago</callername>
+    <talking>false</talking>
+    <callernumber>w_a6odtbi2lzzl_1-bbbID-Tiago</callernumber>
+    <date>2021-08-31T17:57:44.556Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752183045" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432664817</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:57:44.817Z</date>
+  </event>
+  <event timestamp="13752184750" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432666522</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:57:46.522Z</date>
+  </event>
+  <event timestamp="13752188923" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432670694</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:57:50.694Z</date>
+  </event>
+  <event timestamp="13752189953" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432671724</timestampUTC>
+    <xOffset>5.752561092376709</xOffset>
+    <date>2021-08-31T17:57:51.724Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>67.9603350604022</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752190104" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432671875</timestampUTC>
+    <xOffset>41.52876218159994</xOffset>
+    <date>2021-08-31T17:57:51.875Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>85.75212266710069</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752190271" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432672043</timestampUTC>
+    <xOffset>42.4743906656901</xOffset>
+    <date>2021-08-31T17:57:52.043Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>86.87286376953125</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752190419" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432672191</timestampUTC>
+    <xOffset>-46.57210350036621</xOffset>
+    <date>2021-08-31T17:57:52.191Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-17.916557877152055</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752191900" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432673672</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T17:57:53.672Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752192263" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432674034</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:57:54.034Z</date>
+  </event>
+  <event timestamp="13752192864" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432674636</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:57:54.636Z</date>
+  </event>
+  <event timestamp="13752194812" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432676584</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T17:57:56.584Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752197105" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432678877</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:57:58.877Z</date>
+  </event>
+  <event timestamp="13752200794" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432682566</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:58:02.566Z</date>
+  </event>
+  <event timestamp="13752201075" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432682847</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:58:02.847Z</date>
+  </event>
+  <event timestamp="13752202359" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432684130</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T17:58:04.130Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752203723" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432685494</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:58:05.494Z</date>
+  </event>
+  <event timestamp="13752203905" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432685677</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:58:05.677Z</date>
+  </event>
+  <event timestamp="13752209077" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432690849</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:58:10.849Z</date>
+  </event>
+  <event timestamp="13752210682" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432692454</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:58:12.454Z</date>
+  </event>
+  <event timestamp="13752221139" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432702910</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:58:22.910Z</date>
+  </event>
+  <event timestamp="13752221461" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432703232</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:58:23.232Z</date>
+  </event>
+  <event timestamp="13752224632" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432706404</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:58:26.404Z</date>
+  </event>
+  <event timestamp="13752226578" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432708350</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:58:28.350Z</date>
+  </event>
+  <event timestamp="13752227440" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432709212</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:58:29.212Z</date>
+  </event>
+  <event timestamp="13752227922" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432709694</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:58:29.694Z</date>
+  </event>
+  <event timestamp="13752229000" module="bbb-webrtc-sfu" eventname="StartWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_a6odtbi2lzzl-1630432710714.webm</filename>
+    <timestampUTC>1630432710772</timestampUTC>
+  </event>
+  <event timestamp="13752229120" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T17:58:30.892Z</date>
+    <timestampUTC>1630432710892</timestampUTC>
+    <userId>w_a6odtbi2lzzl</userId>
+    <value>true,stream=w_a6odtbi2lzzl_1382b70a7007c500b9ad0b552047cca6d3e6390e3a931108798353f7f53d0c1a</value>
+  </event>
+  <event timestamp="13752229528" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432711300</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:58:31.300Z</date>
+  </event>
+  <event timestamp="13752229750" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432711522</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:58:31.522Z</date>
+  </event>
+  <event timestamp="13752231093" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432712865</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:58:32.865Z</date>
+  </event>
+  <event timestamp="13752231253" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432713025</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:58:33.025Z</date>
+  </event>
+  <event timestamp="13752231796" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432713568</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:58:33.568Z</date>
+  </event>
+  <event timestamp="13752231896" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432713668</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:58:33.668Z</date>
+  </event>
+  <event timestamp="13752235956" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432717728</timestampUTC>
+    <xOffset>0.4539274672667185</xOffset>
+    <date>2021-08-31T17:58:37.728Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>15.553848831741899</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752236106" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432717878</timestampUTC>
+    <xOffset>5.181028842926025</xOffset>
+    <date>2021-08-31T17:58:37.878Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>13.01687169958044</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752236239" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432718011</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:58:38.011Z</date>
+  </event>
+  <event timestamp="13752236383" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432718155</timestampUTC>
+    <xOffset>6.786460081736247</xOffset>
+    <date>2021-08-31T17:58:38.155Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>13.01687169958044</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752236460" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432718232</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:58:38.232Z</date>
+  </event>
+  <event timestamp="13752236532" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432718304</timestampUTC>
+    <xOffset>85.36337534586589</xOffset>
+    <date>2021-08-31T17:58:38.304Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>9.845650990804037</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752236826" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432718598</timestampUTC>
+    <xOffset>85.36337534586589</xOffset>
+    <date>2021-08-31T17:58:38.598Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>9.528528849283854</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752236976" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432718748</timestampUTC>
+    <xOffset>84.29308573404948</xOffset>
+    <date>2021-08-31T17:58:38.748Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>7.942918141682943</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752237139" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432718911</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T17:58:38.911Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752239394" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432721166</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:58:41.166Z</date>
+  </event>
+  <event timestamp="13752243062" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432724834</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:58:44.834Z</date>
+  </event>
+  <event timestamp="13752244871" module="bbb-webrtc-sfu" eventname="StartWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_etmphvzxcogu-1630432726544.webm</filename>
+    <timestampUTC>1630432726643</timestampUTC>
+  </event>
+  <event timestamp="13752244934" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T17:58:46.706Z</date>
+    <timestampUTC>1630432726706</timestampUTC>
+    <userId>w_etmphvzxcogu</userId>
+    <value>true,stream=w_etmphvzxcogu_ae5b1a9be7cc947bd01c57dddbd9c5109e7cc2a53463ab825d673174790d9d4b</value>
+  </event>
+  <event timestamp="13752245101" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432726873</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:58:46.873Z</date>
+  </event>
+  <event timestamp="13752245703" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432727475</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:58:47.475Z</date>
+  </event>
+  <event timestamp="13752247269" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432729041</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:58:49.041Z</date>
+  </event>
+  <event timestamp="13752248032" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432729804</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:58:49.804Z</date>
+  </event>
+  <event timestamp="13752249819" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432731591</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:58:51.591Z</date>
+  </event>
+  <event timestamp="13752250020" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432731792</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:58:51.792Z</date>
+  </event>
+  <event timestamp="13752252613" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432734385</timestampUTC>
+    <xOffset>41.392412185668945</xOffset>
+    <date>2021-08-31T17:58:54.385Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>58.52389300311053</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752252813" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432734585</timestampUTC>
+    <xOffset>42.19512621561686</xOffset>
+    <date>2021-08-31T17:58:54.585Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>58.52389300311053</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752252964" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432734736</timestampUTC>
+    <xOffset>48.08170636494955</xOffset>
+    <date>2021-08-31T17:58:54.736Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>52.65713727032697</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752253130" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432734902</timestampUTC>
+    <xOffset>49.77632522583008</xOffset>
+    <date>2021-08-31T17:58:54.902Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>63.439285843460645</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752253280" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432735052</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T17:58:55.052Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752255378" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432737150</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:58:57.150Z</date>
+  </event>
+  <event timestamp="13752257907" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432739679</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:58:59.679Z</date>
+  </event>
+  <event timestamp="13752259271" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432741043</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:59:01.043Z</date>
+  </event>
+  <event timestamp="13752260109" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432741881</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:59:01.881Z</date>
+  </event>
+  <event timestamp="13752260584" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432742356</timestampUTC>
+    <xOffset>51.114184061686196</xOffset>
+    <date>2021-08-31T17:59:02.356Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>99.11552146629052</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752260739" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432742511</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T17:59:02.511Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752265246" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432747018</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:59:07.018Z</date>
+  </event>
+  <event timestamp="13752266411" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432748183</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:59:08.183Z</date>
+  </event>
+  <event timestamp="13752267540" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432749312</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:59:09.312Z</date>
+  </event>
+  <event timestamp="13752268042" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432749814</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:59:09.814Z</date>
+  </event>
+  <event timestamp="13752268685" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432750457</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:59:10.457Z</date>
+  </event>
+  <event timestamp="13752268866" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432750638</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:59:10.638Z</date>
+  </event>
+  <event timestamp="13752269007" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432750779</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:59:10.779Z</date>
+  </event>
+  <event timestamp="13752269570" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432751342</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:59:11.342Z</date>
+  </event>
+  <event timestamp="13752273700" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432755472</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:59:15.472Z</date>
+  </event>
+  <event timestamp="13752274602" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432756374</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:59:16.374Z</date>
+  </event>
+  <event timestamp="13752274643" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432756415</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:59:16.415Z</date>
+  </event>
+  <event timestamp="13752276104" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432757876</timestampUTC>
+    <xOffset>43.44379425048828</xOffset>
+    <date>2021-08-31T17:59:17.876Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>58.99957727502893</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752276253" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432758025</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T17:59:18.025Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752277376" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432759147</timestampUTC>
+    <xOffset>42.64108022054037</xOffset>
+    <date>2021-08-31T17:59:19.147Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>88.33337289315682</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752277587" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432759358</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T17:59:19.358Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752277841" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432759613</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:59:19.613Z</date>
+  </event>
+  <event timestamp="13752278000" module="bbb-webrtc-sfu" eventname="StartWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_pwxbcsf5jfuq-1630432759671.webm</filename>
+    <timestampUTC>1630432759772</timestampUTC>
+  </event>
+  <event timestamp="13752278073" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T17:59:19.844Z</date>
+    <timestampUTC>1630432759844</timestampUTC>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <value>true,stream=w_pwxbcsf5jfuq_0c8f802440175390ed202a4084da8b6b7e60a4a5a9931094622059986514dd42</value>
+  </event>
+  <event timestamp="13752280747" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432762519</timestampUTC>
+    <xOffset>8.30269972483317</xOffset>
+    <date>2021-08-31T17:59:22.519Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>8.894284566243488</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752280898" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432762670</timestampUTC>
+    <xOffset>62.97653198242188</xOffset>
+    <date>2021-08-31T17:59:22.670Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>36.00822448730469</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752281509" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432763281</timestampUTC>
+    <xOffset>63.06572596232096</xOffset>
+    <date>2021-08-31T17:59:23.281Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>35.84966306333189</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752281658" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432763430</timestampUTC>
+    <xOffset>62.70896275838216</xOffset>
+    <date>2021-08-31T17:59:23.430Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>36.64247018319589</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752281845" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432763617</timestampUTC>
+    <xOffset>56.64400100708008</xOffset>
+    <date>2021-08-31T17:59:23.617Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>44.253401579680265</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752282013" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432763785</timestampUTC>
+    <xOffset>29.708442687988278</xOffset>
+    <date>2021-08-31T17:59:23.785Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>71.20877866391783</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752282164" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432763935</timestampUTC>
+    <xOffset>25.15972296396891</xOffset>
+    <date>2021-08-31T17:59:23.935Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>73.58719437210648</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752282326" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432764098</timestampUTC>
+    <xOffset>27.032725016276043</xOffset>
+    <date>2021-08-31T17:59:24.098Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>74.22144006799769</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752282496" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432764268</timestampUTC>
+    <xOffset>35.951782862345375</xOffset>
+    <date>2021-08-31T17:59:24.268Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>90.71178860134549</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752282662" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432764434</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T17:59:24.434Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752285094" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432766866</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T17:59:26.866Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752285794" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432767566</timestampUTC>
+    <xOffset>40.14374097188314</xOffset>
+    <date>2021-08-31T17:59:27.566Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>92.93164288556135</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752285944" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432767716</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T17:59:27.716Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752286569" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432768341</timestampUTC>
+    <xOffset>31.1354923248291</xOffset>
+    <date>2021-08-31T17:59:28.341Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>29.50722305862992</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752286723" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432768495</timestampUTC>
+    <xOffset>36.57611846923828</xOffset>
+    <date>2021-08-31T17:59:28.495Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>52.18145299840856</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752286922" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432768694</timestampUTC>
+    <xOffset>34.70311482747396</xOffset>
+    <date>2021-08-31T17:59:28.694Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>44.57052160192419</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752287076" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432768848</timestampUTC>
+    <xOffset>30.9571107228597</xOffset>
+    <date>2021-08-31T17:59:28.848Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>35.05685876916956</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752287212" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432768984</timestampUTC>
+    <xOffset>30.154396692911785</xOffset>
+    <date>2021-08-31T17:59:28.984Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>34.422615898980034</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752287241" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432769012</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:59:29.012Z</date>
+  </event>
+  <event timestamp="13752287383" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432769155</timestampUTC>
+    <xOffset>23.019148508707683</xOffset>
+    <date>2021-08-31T17:59:29.155Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>42.98491301359954</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752287571" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432769342</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T17:59:29.342Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752287802" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432769574</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:59:29.574Z</date>
+  </event>
+  <event timestamp="13752288191" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432769962</timestampUTC>
+    <xOffset>29.26248868306478</xOffset>
+    <date>2021-08-31T17:59:29.962Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>69.46460865162038</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752288367" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432770139</timestampUTC>
+    <xOffset>18.64880879720052</xOffset>
+    <date>2021-08-31T17:59:30.139Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>42.03354446976273</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752288521" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432770293</timestampUTC>
+    <xOffset>65.2954928080241</xOffset>
+    <date>2021-08-31T17:59:30.293Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>35.05685876916956</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752288697" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432770469</timestampUTC>
+    <xOffset>60.568389892578125</xOffset>
+    <date>2021-08-31T17:59:30.469Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>53.13282154224537</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752288746" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432770518</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:59:30.518Z</date>
+  </event>
+  <event timestamp="13752288879" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432770651</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T17:59:30.651Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752289288" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432771060</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:59:31.060Z</date>
+  </event>
+  <event timestamp="13752290919" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T17:59:32.690Z</date>
+    <timestampUTC>1630432772690</timestampUTC>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <value>false,stream=w_pwxbcsf5jfuq_0c8f802440175390ed202a4084da8b6b7e60a4a5a9931094622059986514dd42</value>
+  </event>
+  <event timestamp="13752291208" module="bbb-webrtc-sfu" eventname="StopWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_pwxbcsf5jfuq-1630432759671.webm</filename>
+    <timestampUTC>1630432772980</timestampUTC>
+  </event>
+  <event timestamp="13752291317" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432773089</timestampUTC>
+    <xOffset>52.18447367350261</xOffset>
+    <date>2021-08-31T17:59:33.089Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>98.00559714988427</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752291465" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432773237</timestampUTC>
+    <xOffset>52.0060920715332</xOffset>
+    <date>2021-08-31T17:59:33.237Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>88.01625004521124</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752291615" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432773387</timestampUTC>
+    <xOffset>51.827710469563804</xOffset>
+    <date>2021-08-31T17:59:33.387Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>88.96761858904803</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752291783" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432773555</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T17:59:33.555Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752292123" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432773895</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:59:33.895Z</date>
+  </event>
+  <event timestamp="13752292814" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432774586</timestampUTC>
+    <xOffset>48.52765719095866</xOffset>
+    <date>2021-08-31T17:59:34.586Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>99.11552146629052</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752292963" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432774735</timestampUTC>
+    <xOffset>34.79230562845866</xOffset>
+    <date>2021-08-31T17:59:34.735Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>50.1201601381655</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752293134" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432774906</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T17:59:34.906Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752293167" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432774939</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:59:34.939Z</date>
+  </event>
+  <event timestamp="13752294457" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>Anton B.</name>
+    <timestampUTC>1630432776229</timestampUTC>
+    <role>MODERATOR</role>
+    <date>2021-08-31T17:59:36.229Z</date>
+    <externalUserId>w_hpfopjzrpvf5</externalUserId>
+    <userId>w_hpfopjzrpvf5</userId>
+  </event>
+  <event timestamp="13752295653" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432777425</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:59:37.425Z</date>
+  </event>
+  <event timestamp="13752295799" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432777571</timestampUTC>
+    <xOffset>46.833038330078125</xOffset>
+    <date>2021-08-31T17:59:37.571Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>58.20677580656829</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752295948" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432777720</timestampUTC>
+    <xOffset>44.246508280436196</xOffset>
+    <date>2021-08-31T17:59:37.720Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>57.09684583875868</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752296098" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432777870</timestampUTC>
+    <xOffset>34.79230562845866</xOffset>
+    <date>2021-08-31T17:59:37.870Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>50.75440583405671</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752296269" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432778041</timestampUTC>
+    <xOffset>34.43554560343424</xOffset>
+    <date>2021-08-31T17:59:38.041Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>50.75440583405671</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752296296" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432778068</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:59:38.068Z</date>
+  </event>
+  <event timestamp="13752296406" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432778178</timestampUTC>
+    <xOffset>34.34635480244955</xOffset>
+    <date>2021-08-31T17:59:38.178Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>50.75440583405671</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752296556" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432778328</timestampUTC>
+    <xOffset>34.16797320048015</xOffset>
+    <date>2021-08-31T17:59:38.328Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>50.59584441008391</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752297139" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432778911</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:59:38.911Z</date>
+  </event>
+  <event timestamp="13752297345" module="bbb-webrtc-sfu" eventname="StartWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_pwxbcsf5jfuq-1630432779067.webm</filename>
+    <timestampUTC>1630432779117</timestampUTC>
+  </event>
+  <event timestamp="13752297475" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T17:59:39.247Z</date>
+    <timestampUTC>1630432779247</timestampUTC>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <value>true,stream=w_pwxbcsf5jfuq_0c8f802440175390ed202a4084da8b6b7e60a4a5a9931094622059986514dd42</value>
+  </event>
+  <event timestamp="13752298243" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432780015</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:59:40.015Z</date>
+  </event>
+  <event timestamp="13752298525" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432780297</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:59:40.297Z</date>
+  </event>
+  <event timestamp="13752298726" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432780498</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:59:40.498Z</date>
+  </event>
+  <event timestamp="13752299000" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432780771</timestampUTC>
+    <xOffset>34.078782399495445</xOffset>
+    <date>2021-08-31T17:59:40.771Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>50.43728298611111</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752299801" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432781573</timestampUTC>
+    <xOffset>33.98959159851074</xOffset>
+    <date>2021-08-31T17:59:41.573Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>50.27872156213831</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752299952" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432781724</timestampUTC>
+    <xOffset>28.72734705607096</xOffset>
+    <date>2021-08-31T17:59:41.724Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>18.090825963903356</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752300118" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432781889</timestampUTC>
+    <xOffset>28.281393051147464</xOffset>
+    <date>2021-08-31T17:59:41.889Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>16.505214549877024</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752300283" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432782055</timestampUTC>
+    <xOffset>28.281393051147464</xOffset>
+    <date>2021-08-31T17:59:42.055Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>15.553848831741899</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752300491" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432782263</timestampUTC>
+    <xOffset>28.281393051147464</xOffset>
+    <date>2021-08-31T17:59:42.263Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>15.236727396647135</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752300582" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432782354</timestampUTC>
+    <xOffset>28.19220225016276</xOffset>
+    <date>2021-08-31T17:59:42.354Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>15.078165972674334</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752300733" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432782505</timestampUTC>
+    <xOffset>27.211106618245445</xOffset>
+    <date>2021-08-31T17:59:42.505Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>14.44392168963397</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752300884" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432782656</timestampUTC>
+    <xOffset>26.408390998840332</xOffset>
+    <date>2021-08-31T17:59:42.656Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>13.809677406593604</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752301036" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432782808</timestampUTC>
+    <xOffset>24.535388946533203</xOffset>
+    <date>2021-08-31T17:59:42.808Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>12.382627416540075</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752301186" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432782958</timestampUTC>
+    <xOffset>21.41371726989746</xOffset>
+    <date>2021-08-31T17:59:42.958Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>10.797017415364584</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752301354" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432783126</timestampUTC>
+    <xOffset>20.61100165049235</xOffset>
+    <date>2021-08-31T17:59:43.126Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>10.3213338498716</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752301521" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432783293</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T17:59:43.293Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752304190" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432785962</timestampUTC>
+    <xOffset>59.587294260660805</xOffset>
+    <date>2021-08-31T17:59:45.962Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>97.37135145399306</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752304340" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432786112</timestampUTC>
+    <xOffset>54.59261576334635</xOffset>
+    <date>2021-08-31T17:59:46.112Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>23.323340239348234</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752304503" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432786274</timestampUTC>
+    <xOffset>54.14666493733724</xOffset>
+    <date>2021-08-31T17:59:46.274Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>22.68909595630787</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752305003" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432786775</timestampUTC>
+    <xOffset>54.05747731526692</xOffset>
+    <date>2021-08-31T17:59:46.775Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>23.323340239348234</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752305154" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432786926</timestampUTC>
+    <xOffset>59.14133707682292</xOffset>
+    <date>2021-08-31T17:59:46.926Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>67.56187721535012</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752305308" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432787079</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T17:59:47.079Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752306801" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432788572</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:59:48.572Z</date>
+  </event>
+  <event timestamp="13752307625" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432789397</timestampUTC>
+    <xOffset>52.4520460764567</xOffset>
+    <date>2021-08-31T17:59:49.397Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>97.21279568142361</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752307773" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432789545</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T17:59:49.545Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752307884" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432789656</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:59:49.656Z</date>
+  </event>
+  <event timestamp="13752307974" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432789746</timestampUTC>
+    <xOffset>31.938206354777016</xOffset>
+    <date>2021-08-31T17:59:49.746Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>6.515868151629413</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752308128" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432789900</timestampUTC>
+    <xOffset>42.373507817586265</xOffset>
+    <date>2021-08-31T17:59:49.900Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>63.1221686469184</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752308305" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432790077</timestampUTC>
+    <xOffset>42.105935414632164</xOffset>
+    <date>2021-08-31T17:59:50.077Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>63.2807300708912</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752308464" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432790235</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T17:59:50.235Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752308747" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432790519</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:59:50.519Z</date>
+  </event>
+  <event timestamp="13752309429" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432791201</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:59:51.201Z</date>
+  </event>
+  <event timestamp="13752309638" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T17:59:51.410Z</date>
+    <timestampUTC>1630432791410</timestampUTC>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <value>false,stream=w_pwxbcsf5jfuq_0c8f802440175390ed202a4084da8b6b7e60a4a5a9931094622059986514dd42</value>
+  </event>
+  <event timestamp="13752309790" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>Maxim</name>
+    <timestampUTC>1630432791561</timestampUTC>
+    <role>MODERATOR</role>
+    <date>2021-08-31T17:59:51.561Z</date>
+    <externalUserId>w_wwbw89colslo</externalUserId>
+    <userId>w_wwbw89colslo</userId>
+  </event>
+  <event timestamp="13752309915" module="bbb-webrtc-sfu" eventname="StopWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_pwxbcsf5jfuq-1630432779067.webm</filename>
+    <timestampUTC>1630432791686</timestampUTC>
+  </event>
+  <event timestamp="13752310231" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432792003</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:59:52.003Z</date>
+  </event>
+  <event timestamp="13752310793" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432792565</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:59:52.565Z</date>
+  </event>
+  <event timestamp="13752311615" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432793387</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:59:53.387Z</date>
+  </event>
+  <event timestamp="13752312798" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432794570</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:59:54.570Z</date>
+  </event>
+  <event timestamp="13752314121" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432795893</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:59:55.893Z</date>
+  </event>
+  <event timestamp="13752314403" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432796174</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T17:59:56.174Z</date>
+  </event>
+  <event timestamp="13752317733" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432799505</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T17:59:59.505Z</date>
+  </event>
+  <event timestamp="13752318920" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432800691</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:00.691Z</date>
+  </event>
+  <event timestamp="13752319541" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432801313</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:01.313Z</date>
+  </event>
+  <event timestamp="13752319608" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>Anton G</name>
+    <timestampUTC>1630432801380</timestampUTC>
+    <role>MODERATOR</role>
+    <date>2021-08-31T18:00:01.380Z</date>
+    <externalUserId>w_vk0ebqjxox9d</externalUserId>
+    <userId>w_vk0ebqjxox9d</userId>
+  </event>
+  <event timestamp="13752322660" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432804432</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:04.432Z</date>
+  </event>
+  <event timestamp="13752324422" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432806194</timestampUTC>
+    <xOffset>45.76274871826172</xOffset>
+    <date>2021-08-31T18:00:06.194Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>58.99957727502893</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752324571" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432806343</timestampUTC>
+    <xOffset>43.35460344950358</xOffset>
+    <date>2021-08-31T18:00:06.343Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>57.73109153464988</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752324756" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432806527</timestampUTC>
+    <xOffset>32.20577875773112</xOffset>
+    <date>2021-08-31T18:00:06.527Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>37.118151629412615</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752324911" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432806683</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:00:06.683Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752326187" module="bbb-webrtc-sfu" eventname="StartWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_pwxbcsf5jfuq-1630432807888.webm</filename>
+    <timestampUTC>1630432807959</timestampUTC>
+  </event>
+  <event timestamp="13752326325" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:00:08.097Z</date>
+    <timestampUTC>1630432808097</timestampUTC>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <value>true,stream=w_pwxbcsf5jfuq_0c8f802440175390ed202a4084da8b6b7e60a4a5a9931094622059986514dd42</value>
+  </event>
+  <event timestamp="13752326541" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432808313</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:08.313Z</date>
+  </event>
+  <event timestamp="13752326722" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432808493</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:08.493Z</date>
+  </event>
+  <event timestamp="13752327063" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432808835</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:08.835Z</date>
+  </event>
+  <event timestamp="13752327330" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432809102</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:09.102Z</date>
+  </event>
+  <event timestamp="13752327817" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432809589</timestampUTC>
+    <xOffset>29.88682428995768</xOffset>
+    <date>2021-08-31T18:00:09.589Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>0.3319872087902493</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752327967" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432809739</timestampUTC>
+    <xOffset>53.522332509358726</xOffset>
+    <date>2021-08-31T18:00:09.739Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>14.761043124728731</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752328155" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432809927</timestampUTC>
+    <xOffset>53.70071411132813</xOffset>
+    <date>2021-08-31T18:00:09.927Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>14.761043124728731</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752328254" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432810026</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:10.026Z</date>
+  </event>
+  <event timestamp="13752328395" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432810167</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:10.167Z</date>
+  </event>
+  <event timestamp="13752329404" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432811176</timestampUTC>
+    <xOffset>53.34395090738933</xOffset>
+    <date>2021-08-31T18:00:11.176Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>14.761043124728731</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752329571" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432811343</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:00:11.343Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752331803" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432813575</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:13.575Z</date>
+  </event>
+  <event timestamp="13752331863" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432813635</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:13.635Z</date>
+  </event>
+  <event timestamp="13752332346" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432814118</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:14.118Z</date>
+  </event>
+  <event timestamp="13752332496" module="VOICE" eventname="ParticipantJoinedEvent">
+    <participant>w_hpfopjzrpvf5</participant>
+    <timestampUTC>1630432814268</timestampUTC>
+    <bridge>79134</bridge>
+    <callername>Anton B.</callername>
+    <talking>false</talking>
+    <callernumber>w_hpfopjzrpvf5_1-bbbID-Anton B.</callernumber>
+    <date>2021-08-31T18:00:14.268Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752334630" module="VOICE" eventname="ParticipantJoinedEvent">
+    <participant>w_wwbw89colslo</participant>
+    <timestampUTC>1630432816402</timestampUTC>
+    <bridge>79134</bridge>
+    <callername>Maxim</callername>
+    <talking>false</talking>
+    <callernumber>w_wwbw89colslo_1-bbbID-Maxim</callernumber>
+    <date>2021-08-31T18:00:16.402Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752334870" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432816642</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:16.642Z</date>
+  </event>
+  <event timestamp="13752335091" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_hpfopjzrpvf5</participant>
+    <timestampUTC>1630432816863</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:16.863Z</date>
+  </event>
+  <event timestamp="13752336074" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_hpfopjzrpvf5</participant>
+    <timestampUTC>1630432817846</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:17.846Z</date>
+  </event>
+  <event timestamp="13752336115" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432817886</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:17.886Z</date>
+  </event>
+  <event timestamp="13752336540" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_wwbw89colslo</participant>
+    <timestampUTC>1630432818312</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:00:18.312Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752336608" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_hpfopjzrpvf5</participant>
+    <timestampUTC>1630432818380</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:00:18.380Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752337512" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432819284</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:19.284Z</date>
+  </event>
+  <event timestamp="13752338174" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432819946</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:19.946Z</date>
+  </event>
+  <event timestamp="13752338215" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432819987</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:19.987Z</date>
+  </event>
+  <event timestamp="13752341749" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432823521</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:23.521Z</date>
+  </event>
+  <event timestamp="13752342211" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432823983</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:23.983Z</date>
+  </event>
+  <event timestamp="13752342598" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432824370</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:24.370Z</date>
+  </event>
+  <event timestamp="13752343388" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>Calvin</name>
+    <timestampUTC>1630432825160</timestampUTC>
+    <role>MODERATOR</role>
+    <date>2021-08-31T18:00:25.160Z</date>
+    <externalUserId>w_szgcfhvhfhdb</externalUserId>
+    <userId>w_szgcfhvhfhdb</userId>
+  </event>
+  <event timestamp="13752344045" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432825816</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:25.816Z</date>
+  </event>
+  <event timestamp="13752352530" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432834302</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:34.302Z</date>
+  </event>
+  <event timestamp="13752355197" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432836969</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:36.969Z</date>
+  </event>
+  <event timestamp="13752355511" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432837283</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:00:37.283Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752357998" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432839769</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:39.769Z</date>
+  </event>
+  <event timestamp="13752358699" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432840471</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:40.471Z</date>
+  </event>
+  <event timestamp="13752358780" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432840552</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:40.552Z</date>
+  </event>
+  <event timestamp="13752358995" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432840767</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:40.767Z</date>
+  </event>
+  <event timestamp="13752359503" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432841275</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:41.275Z</date>
+  </event>
+  <event timestamp="13752359984" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432841756</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:41.756Z</date>
+  </event>
+  <event timestamp="13752360005" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432841777</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:41.777Z</date>
+  </event>
+  <event timestamp="13752360206" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432841977</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:41.977Z</date>
+  </event>
+  <event timestamp="13752360567" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432842339</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:42.339Z</date>
+  </event>
+  <event timestamp="13752361157" module="VOICE" eventname="ParticipantJoinedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630432842929</timestampUTC>
+    <bridge>79134</bridge>
+    <callername>Anton G</callername>
+    <talking>false</talking>
+    <callernumber>w_vk0ebqjxox9d_2-bbbID-Anton G</callernumber>
+    <date>2021-08-31T18:00:42.929Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752361579" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432843351</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:43.351Z</date>
+  </event>
+  <event timestamp="13752361581" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432843353</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:43.353Z</date>
+  </event>
+  <event timestamp="13752362507" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630432844279</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:00:44.279Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752362697" module="VOICE" eventname="ParticipantJoinedEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630432844469</timestampUTC>
+    <bridge>79134</bridge>
+    <callername>Calvin</callername>
+    <talking>false</talking>
+    <callernumber>w_szgcfhvhfhdb_1-bbbID-Calvin</callernumber>
+    <date>2021-08-31T18:00:44.469Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752362818" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432844590</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:44.590Z</date>
+  </event>
+  <event timestamp="13752363431" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432845203</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:45.203Z</date>
+  </event>
+  <event timestamp="13752364289" module="bbb-webrtc-sfu" eventname="StartWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_hpfopjzrpvf5-1630432845990.webm</filename>
+    <timestampUTC>1630432846060</timestampUTC>
+  </event>
+  <event timestamp="13752364377" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:00:46.149Z</date>
+    <timestampUTC>1630432846149</timestampUTC>
+    <userId>w_hpfopjzrpvf5</userId>
+    <value>true,stream=w_hpfopjzrpvf5_586b2ee51194839d7428e25f7cf7dd37cbf253841ada0581b42e7da1e999bd40</value>
+  </event>
+  <event timestamp="13752366200" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432847972</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:47.972Z</date>
+  </event>
+  <event timestamp="13752366682" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432848454</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:48.454Z</date>
+  </event>
+  <event timestamp="13752366763" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432848534</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:48.534Z</date>
+  </event>
+  <event timestamp="13752367485" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432849257</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:49.257Z</date>
+  </event>
+  <event timestamp="13752368028" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432849800</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:49.800Z</date>
+  </event>
+  <event timestamp="13752368148" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432849920</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:49.920Z</date>
+  </event>
+  <event timestamp="13752368290" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432850061</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:50.061Z</date>
+  </event>
+  <event timestamp="13752369472" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432851244</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:51.244Z</date>
+  </event>
+  <event timestamp="13752369532" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432851304</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:51.304Z</date>
+  </event>
+  <event timestamp="13752369734" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432851506</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:51.506Z</date>
+  </event>
+  <event timestamp="13752370996" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432852768</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:52.768Z</date>
+  </event>
+  <event timestamp="13752371617" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432853389</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:53.389Z</date>
+  </event>
+  <event timestamp="13752375940" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432857712</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:00:57.712Z</date>
+  </event>
+  <event timestamp="13752376823" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432858595</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:00:58.595Z</date>
+  </event>
+  <event timestamp="13752378328" module="bbb-webrtc-sfu" eventname="StartWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_k6547g2umh6j-1630432860050.webm</filename>
+    <timestampUTC>1630432860100</timestampUTC>
+  </event>
+  <event timestamp="13752378433" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:01:00.205Z</date>
+    <timestampUTC>1630432860205</timestampUTC>
+    <userId>w_k6547g2umh6j</userId>
+    <value>true,stream=w_k6547g2umh6j_1168421dd8fddc53a4181c1abd419e22b79bbfed160bca0d495b90aa085428c9</value>
+  </event>
+  <event timestamp="13752379489" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432861261</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:01.261Z</date>
+  </event>
+  <event timestamp="13752380452" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432862224</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:02.224Z</date>
+  </event>
+  <event timestamp="13752382599" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432864371</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:04.371Z</date>
+  </event>
+  <event timestamp="13752384223" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432865995</timestampUTC>
+    <xOffset>15.348757108052572</xOffset>
+    <date>2021-08-31T18:01:05.995Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>32.519881637008105</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752384282" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432866054</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:06.054Z</date>
+  </event>
+  <event timestamp="13752384423" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432866195</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:01:06.195Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752385244" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432867016</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:07.016Z</date>
+  </event>
+  <event timestamp="13752385418" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432867190</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:01:07.190Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752385853" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:01:07.625Z</date>
+    <timestampUTC>1630432867625</timestampUTC>
+    <userId>w_szgcfhvhfhdb</userId>
+    <value>true,stream=w_szgcfhvhfhdb_qw68aW1HLTK0SUCNudZWxRWtEqLQo0M8uFQOOQiklXM=</value>
+  </event>
+  <event timestamp="13752385925" module="bbb-webrtc-sfu" eventname="StartWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_szgcfhvhfhdb-1630432867598.webm</filename>
+    <timestampUTC>1630432867697</timestampUTC>
+  </event>
+  <event timestamp="13752386341" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432868112</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:08.112Z</date>
+  </event>
+  <event timestamp="13752387224" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432868996</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:08.996Z</date>
+  </event>
+  <event timestamp="13752388146" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432869917</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:09.917Z</date>
+  </event>
+  <event timestamp="13752390200" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432871972</timestampUTC>
+    <xOffset>5.8945536613464355</xOffset>
+    <date>2021-08-31T18:01:11.972Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>8.418601000750506</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752390354" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432872126</timestampUTC>
+    <xOffset>52.719615300496415</xOffset>
+    <date>2021-08-31T18:01:12.126Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>19.67643596507885</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752390505" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432872277</timestampUTC>
+    <xOffset>53.61152013142904</xOffset>
+    <date>2021-08-31T18:01:12.277Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>19.042191682038485</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752390774" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432872546</timestampUTC>
+    <xOffset>52.63042449951172</xOffset>
+    <date>2021-08-31T18:01:12.546Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>20.469241672092014</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752390924" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432872696</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:01:12.696Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752391568" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>Ramon</name>
+    <timestampUTC>1630432873340</timestampUTC>
+    <role>MODERATOR</role>
+    <date>2021-08-31T18:01:13.340Z</date>
+    <externalUserId>w_lo2vd8rkvicu</externalUserId>
+    <userId>w_lo2vd8rkvicu</userId>
+  </event>
+  <event timestamp="13752391803" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432873574</timestampUTC>
+    <xOffset>69.57663853963216</xOffset>
+    <date>2021-08-31T18:01:13.574Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>18.88363167091652</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752391978" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432873750</timestampUTC>
+    <xOffset>52.36285527547201</xOffset>
+    <date>2021-08-31T18:01:13.750Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>67.08619294343171</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752392131" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432873903</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:01:13.903Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752392818" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432874589</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:14.589Z</date>
+  </event>
+  <event timestamp="13752392873" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432874645</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:01:14.645Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752393094" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432874866</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:14.866Z</date>
+  </event>
+  <event timestamp="13752393198" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432874970</timestampUTC>
+    <xOffset>63.24410756429037</xOffset>
+    <date>2021-08-31T18:01:14.970Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>48.851668746383105</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752393432" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432875204</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:01:15.204Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752394946" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432876717</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:16.717Z</date>
+  </event>
+  <event timestamp="13752396217" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432877989</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:17.989Z</date>
+  </event>
+  <event timestamp="13752398250" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432880022</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:20.022Z</date>
+  </event>
+  <event timestamp="13752399072" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432880844</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:20.844Z</date>
+  </event>
+  <event timestamp="13752400279" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>Kert</name>
+    <timestampUTC>1630432882051</timestampUTC>
+    <role>MODERATOR</role>
+    <date>2021-08-31T18:01:22.051Z</date>
+    <externalUserId>w_2txocgzrz5qa</externalUserId>
+    <userId>w_2txocgzrz5qa</userId>
+  </event>
+  <event timestamp="13752401862" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432883634</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:23.634Z</date>
+  </event>
+  <event timestamp="13752402324" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432884096</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:24.096Z</date>
+  </event>
+  <event timestamp="13752402946" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432884718</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:24.718Z</date>
+  </event>
+  <event timestamp="13752403416" module="VOICE" eventname="ParticipantJoinedEvent">
+    <participant>w_lo2vd8rkvicu</participant>
+    <timestampUTC>1630432885188</timestampUTC>
+    <bridge>79134</bridge>
+    <callername>Ramon</callername>
+    <talking>false</talking>
+    <callernumber>w_lo2vd8rkvicu_1-bbbID-Ramon</callernumber>
+    <date>2021-08-31T18:01:25.188Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752403836" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432885608</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:25.608Z</date>
+  </event>
+  <event timestamp="13752404054" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>Mario</name>
+    <timestampUTC>1630432885826</timestampUTC>
+    <role>MODERATOR</role>
+    <date>2021-08-31T18:01:25.826Z</date>
+    <externalUserId>w_kmm96j1as24f</externalUserId>
+    <userId>w_kmm96j1as24f</userId>
+  </event>
+  <event timestamp="13752404497" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_lo2vd8rkvicu</participant>
+    <timestampUTC>1630432886269</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:01:26.269Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752404860" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432886632</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:26.632Z</date>
+  </event>
+  <event timestamp="13752405490" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432887262</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:27.262Z</date>
+  </event>
+  <event timestamp="13752406537" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432888309</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:28.309Z</date>
+  </event>
+  <event timestamp="13752406753" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432888524</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:28.524Z</date>
+  </event>
+  <event timestamp="13752407796" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432889568</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:29.568Z</date>
+  </event>
+  <event timestamp="13752407837" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432889609</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:29.609Z</date>
+  </event>
+  <event timestamp="13752408599" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432890371</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:30.371Z</date>
+  </event>
+  <event timestamp="13752409321" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432891093</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:31.093Z</date>
+  </event>
+  <event timestamp="13752409895" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432891667</timestampUTC>
+    <xOffset>77.51460393269856</xOffset>
+    <date>2021-08-31T18:01:31.667Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>0.8076703989947284</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752410077" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432891849</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:01:31.849Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752410444" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432892216</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:32.216Z</date>
+  </event>
+  <event timestamp="13752410572" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432892343</timestampUTC>
+    <xOffset>55.93048095703125</xOffset>
+    <date>2021-08-31T18:01:32.343Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>0.49054825747454606</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752410754" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432892526</timestampUTC>
+    <xOffset>57.6250966389974</xOffset>
+    <date>2021-08-31T18:01:32.526Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>10.004211708351418</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752410965" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432892737</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:01:32.737Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752411668" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432893440</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:33.440Z</date>
+  </event>
+  <event timestamp="13752412510" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432894282</timestampUTC>
+    <xOffset>57.89267222086588</xOffset>
+    <date>2021-08-31T18:01:34.282Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>0.6491093282346372</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752412674" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432894445</timestampUTC>
+    <xOffset>57.17914581298829</xOffset>
+    <date>2021-08-31T18:01:34.445Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>1.2833535229718243</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752412912" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432894684</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:34.684Z</date>
+  </event>
+  <event timestamp="13752412952" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432894724</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:34.724Z</date>
+  </event>
+  <event timestamp="13752412973" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432894745</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:34.745Z</date>
+  </event>
+  <event timestamp="13752413105" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432894877</timestampUTC>
+    <xOffset>57.53590901692708</xOffset>
+    <date>2021-08-31T18:01:34.877Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>0.014865099004021396</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752413331" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432895102</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:01:35.102Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752414277" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432896049</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:36.049Z</date>
+  </event>
+  <event timestamp="13752414318" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432896090</timestampUTC>
+    <xOffset>56.37643178304036</xOffset>
+    <date>2021-08-31T18:01:36.090Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>0.014865099004021396</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752414472" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432896244</timestampUTC>
+    <xOffset>56.287237803141274</xOffset>
+    <date>2021-08-31T18:01:36.244Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>0.1734261601059525</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752415216" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432896988</timestampUTC>
+    <xOffset>56.108856201171875</xOffset>
+    <date>2021-08-31T18:01:36.988Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>0.1734261601059525</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752415408" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432897180</timestampUTC>
+    <xOffset>53.968283335367836</xOffset>
+    <date>2021-08-31T18:01:37.180Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>5.881624221801758</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752415564" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432897336</timestampUTC>
+    <xOffset>52.98718770345052</xOffset>
+    <date>2021-08-31T18:01:37.336Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>9.528528849283854</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752415753" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432897525</timestampUTC>
+    <xOffset>52.273664474487305</xOffset>
+    <date>2021-08-31T18:01:37.525Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>13.01687169958044</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752415936" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432897707</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:37.707Z</date>
+  </event>
+  <event timestamp="13752415943" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432897715</timestampUTC>
+    <xOffset>52.0060920715332</xOffset>
+    <date>2021-08-31T18:01:37.715Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>15.078165972674334</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752415956" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432897728</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:37.728Z</date>
+  </event>
+  <event timestamp="13752416057" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432897829</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:37.829Z</date>
+  </event>
+  <event timestamp="13752416127" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432897899</timestampUTC>
+    <xOffset>57.26833979288737</xOffset>
+    <date>2021-08-31T18:01:37.899Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>89.44330286096644</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752416177" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432897949</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:37.949Z</date>
+  </event>
+  <event timestamp="13752416332" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432898103</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:01:38.103Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752416559" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432898331</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:38.331Z</date>
+  </event>
+  <event timestamp="13752417683" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432899455</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:39.455Z</date>
+  </event>
+  <event timestamp="13752418975" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>Gustavo</name>
+    <timestampUTC>1630432900747</timestampUTC>
+    <role>MODERATOR</role>
+    <date>2021-08-31T18:01:40.747Z</date>
+    <externalUserId>w_xhsnzrp5gjsw</externalUserId>
+    <userId>w_xhsnzrp5gjsw</userId>
+  </event>
+  <event timestamp="13752419137" module="VOICE" eventname="ParticipantJoinedEvent">
+    <participant>w_2txocgzrz5qa</participant>
+    <timestampUTC>1630432900909</timestampUTC>
+    <bridge>79134</bridge>
+    <callername>Kert</callername>
+    <talking>false</talking>
+    <callernumber>w_2txocgzrz5qa_1-bbbID-Kert</callernumber>
+    <date>2021-08-31T18:01:40.909Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752419161" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432900933</timestampUTC>
+    <xOffset>61.37110392252604</xOffset>
+    <date>2021-08-31T18:01:40.933Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>18.40794739899812</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752419196" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432900968</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:40.968Z</date>
+  </event>
+  <event timestamp="13752419317" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432901089</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:41.089Z</date>
+  </event>
+  <event timestamp="13752419408" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432901180</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:01:41.180Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752420380" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_2txocgzrz5qa</participant>
+    <timestampUTC>1630432902152</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:01:42.152Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752420382" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432902154</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:42.154Z</date>
+  </event>
+  <event timestamp="13752421470" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432903242</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:43.242Z</date>
+  </event>
+  <event timestamp="13752421812" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432903584</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:43.584Z</date>
+  </event>
+  <event timestamp="13752421893" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432903665</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:43.665Z</date>
+  </event>
+  <event timestamp="13752423887" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432905659</timestampUTC>
+    <xOffset>26.67596181233724</xOffset>
+    <date>2021-08-31T18:01:45.659Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>12.224065992567274</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752424107" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432905879</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:01:45.879Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752424259" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432906031</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:46.031Z</date>
+  </event>
+  <event timestamp="13752425175" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432906947</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:46.947Z</date>
+  </event>
+  <event timestamp="13752425436" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432907208</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:47.208Z</date>
+  </event>
+  <event timestamp="13752425703" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:01:47.474Z</date>
+    <timestampUTC>1630432907474</timestampUTC>
+    <userId>w_k6547g2umh6j</userId>
+    <value>false,stream=w_k6547g2umh6j_1168421dd8fddc53a4181c1abd419e22b79bbfed160bca0d495b90aa085428c9</value>
+  </event>
+  <event timestamp="13752425840" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432907611</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:47.611Z</date>
+  </event>
+  <event timestamp="13752425891" module="bbb-webrtc-sfu" eventname="StopWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_k6547g2umh6j-1630432860050.webm</filename>
+    <timestampUTC>1630432907663</timestampUTC>
+  </event>
+  <event timestamp="13752426115" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432907887</timestampUTC>
+    <xOffset>52.36285527547201</xOffset>
+    <date>2021-08-31T18:01:47.887Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>93.09020430953414</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752426478" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432908250</timestampUTC>
+    <xOffset>52.273664474487305</xOffset>
+    <date>2021-08-31T18:01:48.250Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>91.02891144929109</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752426663" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432908435</timestampUTC>
+    <xOffset>51.470947265625</xOffset>
+    <date>2021-08-31T18:01:48.435Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>86.27208003291378</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752426833" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432908604</timestampUTC>
+    <xOffset>43.62217585245769</xOffset>
+    <date>2021-08-31T18:01:48.604Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>64.39065438729745</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752427016" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432908788</timestampUTC>
+    <xOffset>42.90864944458008</xOffset>
+    <date>2021-08-31T18:01:48.788Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>62.805045798972806</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752427260" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432909032</timestampUTC>
+    <xOffset>43.08703104654948</xOffset>
+    <date>2021-08-31T18:01:49.032Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>62.805045798972806</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752427323" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432909095</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:49.095Z</date>
+  </event>
+  <event timestamp="13752427434" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432909206</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:01:49.206Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752427504" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432909276</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:49.276Z</date>
+  </event>
+  <event timestamp="13752427745" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432909517</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:49.517Z</date>
+  </event>
+  <event timestamp="13752428459" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432910231</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:50.231Z</date>
+  </event>
+  <event timestamp="13752428610" module="VOICE" eventname="ParticipantJoinedEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630432910381</timestampUTC>
+    <bridge>79134</bridge>
+    <callername>Mario</callername>
+    <talking>false</talking>
+    <callernumber>w_kmm96j1as24f_1-bbbID-Mario</callernumber>
+    <date>2021-08-31T18:01:50.381Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752429509" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630432911281</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:01:51.281Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752429862" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432911634</timestampUTC>
+    <xOffset>51.114184061686196</xOffset>
+    <date>2021-08-31T18:01:51.634Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>86.43064145688658</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752430044" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432911816</timestampUTC>
+    <xOffset>48.973611195882164</xOffset>
+    <date>2021-08-31T18:01:51.816Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>10.479895273844402</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752430252" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432912024</timestampUTC>
+    <xOffset>50.93580563863118</xOffset>
+    <date>2021-08-31T18:01:52.024Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>8.101478859230324</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752430410" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432912182</timestampUTC>
+    <xOffset>58.6953862508138</xOffset>
+    <date>2021-08-31T18:01:52.182Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>1.917597806012189</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752430666" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432912438</timestampUTC>
+    <xOffset>61.727867126464844</xOffset>
+    <date>2021-08-31T18:01:52.438Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>9.845650990804037</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752430819" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432912591</timestampUTC>
+    <xOffset>66.45497004191081</xOffset>
+    <date>2021-08-31T18:01:52.591Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>28.080173068576386</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752430969" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432912741</timestampUTC>
+    <xOffset>66.45497004191081</xOffset>
+    <date>2021-08-31T18:01:52.741Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>28.714415938765914</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752431140" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432912912</timestampUTC>
+    <xOffset>63.422489166259766</xOffset>
+    <date>2021-08-31T18:01:52.912Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>31.885638766818573</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752431297" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432913069</timestampUTC>
+    <xOffset>63.24410756429037</xOffset>
+    <date>2021-08-31T18:01:53.069Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>31.885638766818573</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752432661" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432914433</timestampUTC>
+    <xOffset>62.88734436035156</xOffset>
+    <date>2021-08-31T18:01:54.433Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>32.519881637008105</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752432857" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432914628</timestampUTC>
+    <xOffset>62.61977513631185</xOffset>
+    <date>2021-08-31T18:01:54.628Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>33.312688756872106</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752433232" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432915004</timestampUTC>
+    <xOffset>62.53058115641276</xOffset>
+    <date>2021-08-31T18:01:55.004Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>33.47124735514323</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752433393" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432915165</timestampUTC>
+    <xOffset>61.727867126464844</xOffset>
+    <date>2021-08-31T18:01:55.165Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>34.105493051034436</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752433587" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432915359</timestampUTC>
+    <xOffset>61.63867314656576</xOffset>
+    <date>2021-08-31T18:01:55.359Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>34.264054475007235</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752434366" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432916137</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:56.137Z</date>
+  </event>
+  <event timestamp="13752434572" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432916344</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:56.344Z</date>
+  </event>
+  <event timestamp="13752434593" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432916365</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:56.365Z</date>
+  </event>
+  <event timestamp="13752434750" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432916522</timestampUTC>
+    <xOffset>62.61977513631185</xOffset>
+    <date>2021-08-31T18:01:56.522Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>34.422615898980034</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752434902" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432916674</timestampUTC>
+    <xOffset>71.7172114054362</xOffset>
+    <date>2021-08-31T18:01:56.674Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>36.00822448730469</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752435089" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432916861</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:01:56.861Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752435535" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432917306</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:57.306Z</date>
+  </event>
+  <event timestamp="13752435715" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432917487</timestampUTC>
+    <xOffset>52.98718770345052</xOffset>
+    <date>2021-08-31T18:01:57.487Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>89.28474143699363</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752435866" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432917637</timestampUTC>
+    <xOffset>53.968283335367836</xOffset>
+    <date>2021-08-31T18:01:57.637Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>44.88764444986979</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752436048" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432917820</timestampUTC>
+    <xOffset>53.968283335367836</xOffset>
+    <date>2021-08-31T18:01:57.820Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>42.03354446976273</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752436199" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432917971</timestampUTC>
+    <xOffset>54.14666493733724</xOffset>
+    <date>2021-08-31T18:01:57.971Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>40.44793588143808</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752436355" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432918127</timestampUTC>
+    <xOffset>54.681809743245445</xOffset>
+    <date>2021-08-31T18:01:58.127Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>38.54520161946615</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752436531" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432918303</timestampUTC>
+    <xOffset>55.03857294718425</xOffset>
+    <date>2021-08-31T18:01:58.303Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>37.75239732530382</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752436696" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432918468</timestampUTC>
+    <xOffset>54.77099736531576</xOffset>
+    <date>2021-08-31T18:01:58.468Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>37.75239732530382</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752436698" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432918470</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:58.470Z</date>
+  </event>
+  <event timestamp="13752436786" module="VOICE" eventname="ParticipantJoinedEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630432918558</timestampUTC>
+    <bridge>79134</bridge>
+    <callername>Gustavo</callername>
+    <talking>false</talking>
+    <callernumber>w_xhsnzrp5gjsw_1-bbbID-Gustavo</callernumber>
+    <date>2021-08-31T18:01:58.558Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752436847" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432918619</timestampUTC>
+    <xOffset>53.07637850443522</xOffset>
+    <date>2021-08-31T18:01:58.619Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>35.21542019314236</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752436927" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432918699</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:58.699Z</date>
+  </event>
+  <event timestamp="13752436967" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432918739</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:58.739Z</date>
+  </event>
+  <event timestamp="13752437014" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432918786</timestampUTC>
+    <xOffset>52.63042449951172</xOffset>
+    <date>2021-08-31T18:01:58.786Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>35.21542019314236</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752437028" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630432918800</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:58.800Z</date>
+  </event>
+  <event timestamp="13752437186" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432918958</timestampUTC>
+    <xOffset>51.381756464640304</xOffset>
+    <date>2021-08-31T18:01:58.958Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>35.21542019314236</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752437359" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432919131</timestampUTC>
+    <xOffset>50.668233235677086</xOffset>
+    <date>2021-08-31T18:01:59.131Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>35.84966306333189</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752437482" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432919254</timestampUTC>
+    <xOffset>50.579042434692376</xOffset>
+    <date>2021-08-31T18:01:59.254Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>36.00822448730469</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752437510" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432919282</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:01:59.282Z</date>
+  </event>
+  <event timestamp="13752437643" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432919415</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:01:59.415Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752437737" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630432919509</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:01:59.509Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752437752" module="bbb-webrtc-sfu" eventname="StartWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_k6547g2umh6j-1630432919471.webm</filename>
+    <timestampUTC>1630432919524</timestampUTC>
+  </event>
+  <event timestamp="13752437852" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:01:59.624Z</date>
+    <timestampUTC>1630432919624</timestampUTC>
+    <userId>w_k6547g2umh6j</userId>
+    <value>true,stream=w_k6547g2umh6j_1168421dd8fddc53a4181c1abd419e22b79bbfed160bca0d495b90aa085428c9</value>
+  </event>
+  <event timestamp="13752437938" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630432919710</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:01:59.710Z</date>
+  </event>
+  <event timestamp="13752437942" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432919714</timestampUTC>
+    <xOffset>70.82530975341797</xOffset>
+    <date>2021-08-31T18:01:59.714Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>97.68847430193865</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752438356" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432920128</timestampUTC>
+    <xOffset>67.97121047973633</xOffset>
+    <date>2021-08-31T18:02:00.128Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>88.80905716507523</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752438439" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432920211</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:00.211Z</date>
+  </event>
+  <event timestamp="13752438701" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432920473</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:00.473Z</date>
+  </event>
+  <event timestamp="13752438822" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432920594</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:00.594Z</date>
+  </event>
+  <event timestamp="13752439644" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432921416</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:01.416Z</date>
+  </event>
+  <event timestamp="13752441049" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432922821</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:02.821Z</date>
+  </event>
+  <event timestamp="13752441667" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432923438</timestampUTC>
+    <xOffset>67.70363489786784</xOffset>
+    <date>2021-08-31T18:02:03.438Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>87.54057142469618</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752441841" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432923613</timestampUTC>
+    <xOffset>66.36577606201172</xOffset>
+    <date>2021-08-31T18:02:03.613Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>81.83237146448205</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752442024" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432923796</timestampUTC>
+    <xOffset>66.18739446004231</xOffset>
+    <date>2021-08-31T18:02:03.796Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>81.51524861653647</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752442331" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432924103</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:04.103Z</date>
+  </event>
+  <event timestamp="13752443202" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432924973</timestampUTC>
+    <xOffset>66.098206837972</xOffset>
+    <date>2021-08-31T18:02:04.973Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>81.19812576859086</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752443352" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432925124</timestampUTC>
+    <xOffset>66.18739446004231</xOffset>
+    <date>2021-08-31T18:02:05.124Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>72.00158578378183</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752443664" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432925436</timestampUTC>
+    <xOffset>66.90092086791992</xOffset>
+    <date>2021-08-31T18:02:05.436Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>70.57453861942997</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752443833" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432925605</timestampUTC>
+    <xOffset>66.81173324584961</xOffset>
+    <date>2021-08-31T18:02:05.605Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>67.08619294343171</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752444268" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432926040</timestampUTC>
+    <xOffset>66.63335164388022</xOffset>
+    <date>2021-08-31T18:02:06.040Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>67.08619294343171</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752444373" module="bbb-webrtc-sfu" eventname="StartWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_xhsnzrp5gjsw-1630432926054.webm</filename>
+    <timestampUTC>1630432926145</timestampUTC>
+  </event>
+  <event timestamp="13752444428" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432926200</timestampUTC>
+    <xOffset>66.45497004191081</xOffset>
+    <date>2021-08-31T18:02:06.200Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>66.76907009548611</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752444455" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:02:06.227Z</date>
+    <timestampUTC>1630432926227</timestampUTC>
+    <userId>w_xhsnzrp5gjsw</userId>
+    <value>true,stream=w_xhsnzrp5gjsw_RqxO4OFyznQZtquSjpPzW3dB8y9izRZw65V0b7JOdPc=</value>
+  </event>
+  <event timestamp="13752444590" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432926362</timestampUTC>
+    <xOffset>41.03564898173014</xOffset>
+    <date>2021-08-31T18:02:06.362Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>39.813690185546875</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752444826" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432926598</timestampUTC>
+    <xOffset>40.14374097188314</xOffset>
+    <date>2021-08-31T18:02:06.598Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>38.06952017324942</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752446030" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432927802</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:07.802Z</date>
+  </event>
+  <event timestamp="13752446551" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432928323</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:08.323Z</date>
+  </event>
+  <event timestamp="13752446692" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432928464</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:08.464Z</date>
+  </event>
+  <event timestamp="13752446840" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432928612</timestampUTC>
+    <xOffset>40.85726737976074</xOffset>
+    <date>2021-08-31T18:02:08.612Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>40.13081303349248</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752446913" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432928685</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:08.685Z</date>
+  </event>
+  <event timestamp="13752447031" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432928803</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:02:08.803Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752447289" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432929061</timestampUTC>
+    <xOffset>45.1384162902832</xOffset>
+    <date>2021-08-31T18:02:09.061Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>65.9762629756221</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752447478" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432929250</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:02:09.250Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752447776" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432929548</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:09.548Z</date>
+  </event>
+  <event timestamp="13752448137" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432929909</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:09.909Z</date>
+  </event>
+  <event timestamp="13752448238" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432930010</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:10.010Z</date>
+  </event>
+  <event timestamp="13752448439" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432930210</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:10.210Z</date>
+  </event>
+  <event timestamp="13752448600" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432930372</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:10.372Z</date>
+  </event>
+  <event timestamp="13752449643" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432931415</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:11.415Z</date>
+  </event>
+  <event timestamp="13752451579" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432933351</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:13.351Z</date>
+  </event>
+  <event timestamp="13752452110" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432933882</timestampUTC>
+    <xOffset>21.94886048634847</xOffset>
+    <date>2021-08-31T18:02:13.882Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>3.027525301332827</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752452314" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432934086</timestampUTC>
+    <xOffset>46.20870272318522</xOffset>
+    <date>2021-08-31T18:02:14.086Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>3.8203306551332825</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752452492" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432934264</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:02:14.264Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752452893" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432934665</timestampUTC>
+    <xOffset>54.05747731526692</xOffset>
+    <date>2021-08-31T18:02:14.665Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>2.07615887677228</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752453049" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432934821</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:02:14.821Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752453224" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432934996</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:14.996Z</date>
+  </event>
+  <event timestamp="13752456851" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432938623</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:18.623Z</date>
+  </event>
+  <event timestamp="13752457032" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432938804</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:18.804Z</date>
+  </event>
+  <event timestamp="13752461136" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:02:22.908Z</date>
+    <timestampUTC>1630432942908</timestampUTC>
+    <userId>w_vk0ebqjxox9d</userId>
+    <value>true,stream=w_vk0ebqjxox9d_f66882b1979bd7ab36358419b8681c9b4ab15eacb294c961c6240bec39a1ec06</value>
+  </event>
+  <event timestamp="13752461240" module="bbb-webrtc-sfu" eventname="StartWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_vk0ebqjxox9d-1630432942869.webm</filename>
+    <timestampUTC>1630432943012</timestampUTC>
+  </event>
+  <event timestamp="13752462263" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432944035</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:24.035Z</date>
+  </event>
+  <event timestamp="13752462785" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432944557</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:24.557Z</date>
+  </event>
+  <event timestamp="13752463147" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432944919</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:24.919Z</date>
+  </event>
+  <event timestamp="13752464391" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432946162</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:26.162Z</date>
+  </event>
+  <event timestamp="13752465012" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432946784</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:26.784Z</date>
+  </event>
+  <event timestamp="13752465655" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432947427</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:27.427Z</date>
+  </event>
+  <event timestamp="13752465896" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432947668</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:27.668Z</date>
+  </event>
+  <event timestamp="13752466678" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432948450</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:28.450Z</date>
+  </event>
+  <event timestamp="13752466799" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432948571</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:28.571Z</date>
+  </event>
+  <event timestamp="13752467008" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432948780</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:28.780Z</date>
+  </event>
+  <event timestamp="13752467950" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432949721</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:29.721Z</date>
+  </event>
+  <event timestamp="13752469073" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432950845</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:30.845Z</date>
+  </event>
+  <event timestamp="13752469394" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432951166</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:31.166Z</date>
+  </event>
+  <event timestamp="13752469436" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432951208</timestampUTC>
+    <xOffset>6.697269280751546</xOffset>
+    <date>2021-08-31T18:02:31.208Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>58.365337230541094</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752469593" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432951365</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:02:31.365Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752470096" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432951867</timestampUTC>
+    <xOffset>53.34395090738933</xOffset>
+    <date>2021-08-31T18:02:31.867Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>98.00559714988427</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752470271" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432952043</timestampUTC>
+    <xOffset>47.63575236002604</xOffset>
+    <date>2021-08-31T18:02:32.043Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>87.54057142469618</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752470430" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432952202</timestampUTC>
+    <xOffset>47.72494316101074</xOffset>
+    <date>2021-08-31T18:02:32.202Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>81.99093288845486</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752470478" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432952249</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:32.249Z</date>
+  </event>
+  <event timestamp="13752470783" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432952555</timestampUTC>
+    <xOffset>48.61684799194336</xOffset>
+    <date>2021-08-31T18:02:32.555Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>80.2467628761574</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752470944" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432952716</timestampUTC>
+    <xOffset>48.260087966918945</xOffset>
+    <date>2021-08-31T18:02:32.716Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>77.86834716796875</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752471373" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630432953145</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:02:33.145Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752471615" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432953387</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:33.387Z</date>
+  </event>
+  <event timestamp="13752471732" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432953504</timestampUTC>
+    <xOffset>48.260087966918945</xOffset>
+    <date>2021-08-31T18:02:33.504Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>77.55122432002315</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752471902" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432953674</timestampUTC>
+    <xOffset>48.260087966918945</xOffset>
+    <date>2021-08-31T18:02:33.674Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>76.91697862413194</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752472357" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432954129</timestampUTC>
+    <xOffset>48.17089716593424</xOffset>
+    <date>2021-08-31T18:02:34.129Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>76.75841720015914</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752472526" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432954297</timestampUTC>
+    <xOffset>47.814133961995445</xOffset>
+    <date>2021-08-31T18:02:34.297Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>85.95495718496818</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752472558" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432954330</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:34.330Z</date>
+  </event>
+  <event timestamp="13752472659" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432954431</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:34.431Z</date>
+  </event>
+  <event timestamp="13752472709" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432954481</timestampUTC>
+    <xOffset>45.0492254892985</xOffset>
+    <date>2021-08-31T18:02:34.481Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>99.74976716218171</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752472893" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432954665</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:02:34.665Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752473341" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630432955113</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:02:35.113Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752474299" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432956071</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:36.071Z</date>
+  </event>
+  <event timestamp="13752475282" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432957054</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:37.054Z</date>
+  </event>
+  <event timestamp="13752475663" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432957435</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:37.435Z</date>
+  </event>
+  <event timestamp="13752476646" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630432958418</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:38.418Z</date>
+  </event>
+  <event timestamp="13752476812" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432958583</timestampUTC>
+    <xOffset>13.297373453776043</xOffset>
+    <date>2021-08-31T18:02:38.583Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>48.05886727792245</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752476847" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630432958619</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:02:38.619Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752477079" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432958851</timestampUTC>
+    <xOffset>17.75690237681071</xOffset>
+    <date>2021-08-31T18:02:38.851Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>45.36332872178819</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752478199" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432959970</timestampUTC>
+    <xOffset>18.381236394246418</xOffset>
+    <date>2021-08-31T18:02:39.970Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>45.36332872178819</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752478374" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432960145</timestampUTC>
+    <xOffset>54.503428141276046</xOffset>
+    <date>2021-08-31T18:02:40.145Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>68.35467868381076</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752478531" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432960302</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:40.302Z</date>
+  </event>
+  <event timestamp="13752478541" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432960313</timestampUTC>
+    <xOffset>52.4520460764567</xOffset>
+    <date>2021-08-31T18:02:40.313Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>83.57654147677951</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752478723" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432960495</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:02:40.495Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752478751" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630432960523</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:40.523Z</date>
+  </event>
+  <event timestamp="13752479454" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432961225</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:41.225Z</date>
+  </event>
+  <event timestamp="13752480656" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432962428</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:42.428Z</date>
+  </event>
+  <event timestamp="13752481578" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432963350</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:43.350Z</date>
+  </event>
+  <event timestamp="13752481887" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630432963659</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:02:43.659Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752482296" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432964068</timestampUTC>
+    <xOffset>27.211106618245445</xOffset>
+    <date>2021-08-31T18:02:44.068Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>91.6631571451823</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752482444" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630432964216</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:02:44.216Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752482750" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630432964522</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:02:44.522Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752488320" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630432970091</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:02:50.091Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752490289" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630432972060</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:52.060Z</date>
+  </event>
+  <event timestamp="13752493675" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630432975446</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:02:55.446Z</date>
+  </event>
+  <event timestamp="13752493735" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630432975507</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:02:55.507Z</date>
+  </event>
+  <event timestamp="13752501354" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630432983126</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:03:03.126Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752503172" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630432984944</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:03:04.944Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752504497" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630432986269</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:03:06.269Z</date>
+  </event>
+  <event timestamp="13752505555" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630432987327</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:03:07.327Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752521220" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630433002992</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:03:22.992Z</date>
+  </event>
+  <event timestamp="13752522083" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630433003854</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:03:23.854Z</date>
+  </event>
+  <event timestamp="13752527907" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433009679</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:03:29.679Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752530234" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433012005</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:03:32.005Z</date>
+  </event>
+  <event timestamp="13752531497" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433013269</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:03:33.269Z</date>
+  </event>
+  <event timestamp="13752531938" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433013710</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:03:33.710Z</date>
+  </event>
+  <event timestamp="13752538402" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433020174</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:03:40.174Z</date>
+  </event>
+  <event timestamp="13752538824" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433020595</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:03:40.595Z</date>
+  </event>
+  <event timestamp="13752540537" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433022309</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:03:42.309Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752542087" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_2txocgzrz5qa</participant>
+    <timestampUTC>1630433023858</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:03:43.858Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752542215" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433023987</timestampUTC>
+    <xOffset>17.667713165283203</xOffset>
+    <date>2021-08-31T18:03:43.987Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>90.71178860134549</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752542257" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433024029</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:03:44.029Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752542367" module="bbb-webrtc-sfu" eventname="StartWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_kmm96j1as24f-1630433024002.webm</filename>
+    <timestampUTC>1630433024139</timestampUTC>
+  </event>
+  <event timestamp="13752542394" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433024166</timestampUTC>
+    <xOffset>37.646404902140304</xOffset>
+    <date>2021-08-31T18:03:44.166Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>96.41999421296296</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752542427" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:03:44.199Z</date>
+    <timestampUTC>1630433024199</timestampUTC>
+    <userId>w_kmm96j1as24f</userId>
+    <value>true,stream=w_kmm96j1as24f_64d81ff78b2bdf6281c12cf4adfa7c1f0a44f2b27e98b654c68c7adc9b38402a</value>
+  </event>
+  <event timestamp="13752542458" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433024230</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:03:44.230Z</date>
+  </event>
+  <event timestamp="13752542576" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433024347</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:03:44.347Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752543079" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433024851</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:03:44.851Z</date>
+  </event>
+  <event timestamp="13752543259" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433025031</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:03:45.031Z</date>
+  </event>
+  <event timestamp="13752543320" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_2txocgzrz5qa</participant>
+    <timestampUTC>1630433025092</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:03:45.092Z</date>
+  </event>
+  <event timestamp="13752544914" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433026685</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:03:46.685Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752544947" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630433026719</timestampUTC>
+    <color>#303f9f</color>
+    <senderId>w_szgcfhvhfhdb</senderId>
+    <date>2021-08-31T18:03:46.719Z</date>
+    <sender>Calvin</sender>
+    <message>same thing here</message>
+  </event>
+  <event timestamp="13752544996" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433026768</timestampUTC>
+    <xOffset>36.75450007120768</xOffset>
+    <date>2021-08-31T18:03:46.768Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>99.11552146629052</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752545202" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433026974</timestampUTC>
+    <xOffset>33.98959159851074</xOffset>
+    <date>2021-08-31T18:03:46.974Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>86.11351860894098</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752545295" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_2txocgzrz5qa</participant>
+    <timestampUTC>1630433027067</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:03:47.067Z</date>
+  </event>
+  <event timestamp="13752545374" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433027146</timestampUTC>
+    <xOffset>33.98959159851074</xOffset>
+    <date>2021-08-31T18:03:47.146Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>85.95495718496818</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752545644" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_2txocgzrz5qa</participant>
+    <timestampUTC>1630433027416</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:03:47.416Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752545665" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630433027437</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:03:47.437Z</date>
+  </event>
+  <event timestamp="13752545671" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433027443</timestampUTC>
+    <xOffset>33.98959159851074</xOffset>
+    <date>2021-08-31T18:03:47.443Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>86.27208003291378</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752545844" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433027616</timestampUTC>
+    <xOffset>33.98959159851074</xOffset>
+    <date>2021-08-31T18:03:47.616Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>86.58920288085938</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752545965" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433027736</timestampUTC>
+    <xOffset>33.98959159851074</xOffset>
+    <date>2021-08-31T18:03:47.736Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>87.85769427264178</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752546151" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433027923</timestampUTC>
+    <xOffset>28.816537857055664</xOffset>
+    <date>2021-08-31T18:03:47.923Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>89.76042570891204</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752546331" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433028102</timestampUTC>
+    <xOffset>12.762229442596434</xOffset>
+    <date>2021-08-31T18:03:48.102Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>84.36934859664352</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752546508" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433028280</timestampUTC>
+    <xOffset>13.11899185180664</xOffset>
+    <date>2021-08-31T18:03:48.280Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>86.90632572880497</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752546609" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630433028381</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:03:48.381Z</date>
+  </event>
+  <event timestamp="13752546665" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433028437</timestampUTC>
+    <xOffset>18.91638120015462</xOffset>
+    <date>2021-08-31T18:03:48.437Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>95.31005859375</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752546851" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433028623</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:03:48.623Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752547544" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433029316</timestampUTC>
+    <xOffset>46.20870272318522</xOffset>
+    <date>2021-08-31T18:03:49.316Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>75.64848723234954</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752547719" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433029491</timestampUTC>
+    <xOffset>47.90332476298014</xOffset>
+    <date>2021-08-31T18:03:49.491Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>26.494561654550058</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752547867" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433029638</timestampUTC>
+    <xOffset>47.90332476298014</xOffset>
+    <date>2021-08-31T18:03:49.638Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>29.824343080873845</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752548017" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433029789</timestampUTC>
+    <xOffset>40.14374097188314</xOffset>
+    <date>2021-08-31T18:03:49.789Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>70.09885434751158</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752548135" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433029907</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:03:49.907Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752548182" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433029953</timestampUTC>
+    <xOffset>37.735595703125</xOffset>
+    <date>2021-08-31T18:03:49.953Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>85.47927291304977</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752548347" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433030119</timestampUTC>
+    <xOffset>37.735595703125</xOffset>
+    <date>2021-08-31T18:03:50.119Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>99.43264431423611</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752548456" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433030228</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:03:50.228Z</date>
+  </event>
+  <event timestamp="13752548507" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433030279</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:03:50.279Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752548678" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630433030450</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:03:50.450Z</date>
+  </event>
+  <event timestamp="13752548765" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433030537</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:03:50.537Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752549529" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630433031301</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:03:51.301Z</date>
+  </event>
+  <event timestamp="13752551248" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433033020</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:03:53.020Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752551980" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433033752</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:03:53.752Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752553793" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:03:55.564Z</date>
+    <timestampUTC>1630433035564</timestampUTC>
+    <userId>w_etmphvzxcogu</userId>
+    <value>false,stream=w_etmphvzxcogu_ae5b1a9be7cc947bd01c57dddbd9c5109e7cc2a53463ab825d673174790d9d4b</value>
+  </event>
+  <event timestamp="13752554117" module="bbb-webrtc-sfu" eventname="StopWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_etmphvzxcogu-1630432726544.webm</filename>
+    <timestampUTC>1630433035889</timestampUTC>
+  </event>
+  <event timestamp="13752554757" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630433036529</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:03:56.529Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752556279" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630433038051</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:03:58.051Z</date>
+  </event>
+  <event timestamp="13752557734" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433039506</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:03:59.506Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752557855" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630433039627</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:03:59.627Z</date>
+  </event>
+  <event timestamp="13752558316" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630433040088</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:04:00.088Z</date>
+  </event>
+  <event timestamp="13752558592" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630433040364</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:04:00.364Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752561876" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433043648</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:04:03.648Z</date>
+  </event>
+  <event timestamp="13752563685" module="bbb-webrtc-sfu" eventname="StartWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_etmphvzxcogu-1630433045364.webm</filename>
+    <timestampUTC>1630433045457</timestampUTC>
+  </event>
+  <event timestamp="13752563754" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:04:05.526Z</date>
+    <timestampUTC>1630433045526</timestampUTC>
+    <userId>w_etmphvzxcogu</userId>
+    <value>true,stream=w_etmphvzxcogu_ae5b1a9be7cc947bd01c57dddbd9c5109e7cc2a53463ab825d673174790d9d4b</value>
+  </event>
+  <event timestamp="13752565751" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630433047522</timestampUTC>
+    <color>#1565c0</color>
+    <senderId>w_a6odtbi2lzzl</senderId>
+    <date>2021-08-31T18:04:07.522Z</date>
+    <sender>Tiago</sender>
+    <message>i switched my background</message>
+  </event>
+  <event timestamp="13752566224" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433047996</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:04:07.996Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752566947" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433048719</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:04:08.719Z</date>
+  </event>
+  <event timestamp="13752568428" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433050200</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:04:10.200Z</date>
+  </event>
+  <event timestamp="13752569203" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:04:10.975Z</date>
+    <timestampUTC>1630433050975</timestampUTC>
+    <userId>w_lo2vd8rkvicu</userId>
+    <value>true,stream=w_lo2vd8rkvicu_682f9e12269e303016054c2c3213447b3bb4c73c5ccd271d68e2887bfbfb92d8</value>
+  </event>
+  <event timestamp="13752569467" module="bbb-webrtc-sfu" eventname="StartWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_lo2vd8rkvicu-1630433050796.webm</filename>
+    <timestampUTC>1630433051239</timestampUTC>
+  </event>
+  <event timestamp="13752570113" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433051885</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:04:11.885Z</date>
+  </event>
+  <event timestamp="13752571175" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433052947</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:04:12.947Z</date>
+  </event>
+  <event timestamp="13752572198" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433053970</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:04:13.970Z</date>
+  </event>
+  <event timestamp="13752572585" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433054357</timestampUTC>
+    <xOffset>57.71429061889648</xOffset>
+    <date>2021-08-31T18:04:14.357Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>23.640463087293835</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752572808" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433054580</timestampUTC>
+    <xOffset>77.78217315673828</xOffset>
+    <date>2021-08-31T18:04:14.580Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>32.8370044849537</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752574282" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433056054</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:04:16.054Z</date>
+  </event>
+  <event timestamp="13752574399" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433056170</timestampUTC>
+    <xOffset>77.24702835083008</xOffset>
+    <date>2021-08-31T18:04:16.170Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>32.8370044849537</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752574673" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433056445</timestampUTC>
+    <xOffset>75.19564946492513</xOffset>
+    <date>2021-08-31T18:04:16.445Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>35.05685876916956</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752574916" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433056688</timestampUTC>
+    <xOffset>74.92807388305664</xOffset>
+    <date>2021-08-31T18:04:16.688Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>35.69110446506076</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752575020" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433056792</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:04:16.792Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752575099" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433056871</timestampUTC>
+    <xOffset>71.44964218139648</xOffset>
+    <date>2021-08-31T18:04:16.871Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>40.13081303349248</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752575300" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433057072</timestampUTC>
+    <xOffset>35.951782862345375</xOffset>
+    <date>2021-08-31T18:04:17.072Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>50.27872156213831</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752575478" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433057249</timestampUTC>
+    <xOffset>21.14614486694336</xOffset>
+    <date>2021-08-31T18:04:17.249Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>47.58318300600405</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752575682" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433057454</timestampUTC>
+    <xOffset>4.110742012659709</xOffset>
+    <date>2021-08-31T18:04:17.454Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>40.765055903682004</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752575871" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433057643</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:04:17.643Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752576465" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630433058237</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:04:18.237Z</date>
+  </event>
+  <event timestamp="13752577268" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630433059040</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:04:19.040Z</date>
+  </event>
+  <event timestamp="13752578231" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433060003</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:04:20.003Z</date>
+  </event>
+  <event timestamp="13752578752" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433060524</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:04:20.524Z</date>
+  </event>
+  <event timestamp="13752580237" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433062008</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:04:22.008Z</date>
+  </event>
+  <event timestamp="13752580839" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433062610</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:04:22.610Z</date>
+  </event>
+  <event timestamp="13752581240" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433063012</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:04:23.012Z</date>
+  </event>
+  <event timestamp="13752581461" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433063232</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:04:23.232Z</date>
+  </event>
+  <event timestamp="13752582077" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:04:23.849Z</date>
+    <timestampUTC>1630433063849</timestampUTC>
+    <userId>w_a6odtbi2lzzl</userId>
+    <value>false,stream=w_a6odtbi2lzzl_1382b70a7007c500b9ad0b552047cca6d3e6390e3a931108798353f7f53d0c1a</value>
+  </event>
+  <event timestamp="13752582260" module="bbb-webrtc-sfu" eventname="StopWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_a6odtbi2lzzl-1630432710714.webm</filename>
+    <timestampUTC>1630433064031</timestampUTC>
+  </event>
+  <event timestamp="13752584173" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433065945</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:04:25.945Z</date>
+  </event>
+  <event timestamp="13752584795" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433066567</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:04:26.567Z</date>
+  </event>
+  <event timestamp="13752585978" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433067750</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:04:27.750Z</date>
+  </event>
+  <event timestamp="13752586600" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433068372</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:04:28.372Z</date>
+  </event>
+  <event timestamp="13752586605" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433068377</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:04:28.377Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752587867" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433069639</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:04:29.639Z</date>
+  </event>
+  <event timestamp="13752587948" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433069720</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:04:29.720Z</date>
+  </event>
+  <event timestamp="13752588831" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433070602</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:04:30.602Z</date>
+  </event>
+  <event timestamp="13752589055" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433070827</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:04:30.827Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752589243" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:04:31.015Z</date>
+    <timestampUTC>1630433071015</timestampUTC>
+    <userId>w_a6odtbi2lzzl</userId>
+    <value>true,stream=w_a6odtbi2lzzl_1382b70a7007c500b9ad0b552047cca6d3e6390e3a931108798353f7f53d0c1a</value>
+  </event>
+  <event timestamp="13752589472" module="bbb-webrtc-sfu" eventname="StartWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_a6odtbi2lzzl-1630433070836.webm</filename>
+    <timestampUTC>1630433071244</timestampUTC>
+  </event>
+  <event timestamp="13752591172" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433072944</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:04:32.944Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752592216" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433073987</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:04:33.987Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752593158" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433074930</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:04:34.930Z</date>
+  </event>
+  <event timestamp="13752595785" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433077557</timestampUTC>
+    <xOffset>79.74436442057292</xOffset>
+    <date>2021-08-31T18:04:37.557Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>1.1247925405149106</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752595977" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433077749</timestampUTC>
+    <xOffset>78.5848871866862</xOffset>
+    <date>2021-08-31T18:04:37.749Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>5.881624221801758</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752596130" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433077902</timestampUTC>
+    <xOffset>77.69298553466797</xOffset>
+    <date>2021-08-31T18:04:37.902Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>8.260040283203125</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752596287" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433078059</timestampUTC>
+    <xOffset>77.51460393269856</xOffset>
+    <date>2021-08-31T18:04:38.059Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>8.418601000750506</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752596438" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433078210</timestampUTC>
+    <xOffset>77.42540995279948</xOffset>
+    <date>2021-08-31T18:04:38.210Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>8.577162424723307</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752596619" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433078391</timestampUTC>
+    <xOffset>77.24702835083008</xOffset>
+    <date>2021-08-31T18:04:38.391Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>9.211406707763672</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752596772" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433078543</timestampUTC>
+    <xOffset>77.06864674886069</xOffset>
+    <date>2021-08-31T18:04:38.543Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>9.211406707763672</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752597166" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433078938</timestampUTC>
+    <xOffset>76.89026514689128</xOffset>
+    <date>2021-08-31T18:04:38.938Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>9.211406707763672</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752597316" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433079088</timestampUTC>
+    <xOffset>76.17674509684245</xOffset>
+    <date>2021-08-31T18:04:39.088Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>9.211406707763672</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752597476" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433079248</timestampUTC>
+    <xOffset>74.92807388305664</xOffset>
+    <date>2021-08-31T18:04:39.248Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>9.211406707763672</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752597656" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433079428</timestampUTC>
+    <xOffset>73.5010274251302</xOffset>
+    <date>2021-08-31T18:04:39.428Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>10.162773132324219</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752597824" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433079596</timestampUTC>
+    <xOffset>69.48745091756184</xOffset>
+    <date>2021-08-31T18:04:39.596Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>13.651115982620803</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752598016" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433079788</timestampUTC>
+    <xOffset>50.48985163370768</xOffset>
+    <date>2021-08-31T18:04:39.788Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>92.77308146158855</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752598162" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433079934</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:04:39.934Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752598184" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433079956</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:04:39.956Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752598563" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433080335</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:04:40.335Z</date>
+  </event>
+  <event timestamp="13752598724" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433080496</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:04:40.496Z</date>
+  </event>
+  <event timestamp="13752598996" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433080767</timestampUTC>
+    <xOffset>47.814133961995445</xOffset>
+    <date>2021-08-31T18:04:40.767Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>87.69913284866898</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752599166" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433080938</timestampUTC>
+    <xOffset>53.70071411132813</xOffset>
+    <date>2021-08-31T18:04:40.938Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>26.494561654550058</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752599430" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433081202</timestampUTC>
+    <xOffset>53.70071411132813</xOffset>
+    <date>2021-08-31T18:04:41.202Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>26.177438806604457</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752599579" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433081351</timestampUTC>
+    <xOffset>53.70071411132813</xOffset>
+    <date>2021-08-31T18:04:41.351Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>25.384634512442126</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752599752" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433081524</timestampUTC>
+    <xOffset>53.25476010640462</xOffset>
+    <date>2021-08-31T18:04:41.524Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>24.591830218279803</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752599910" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433081682</timestampUTC>
+    <xOffset>53.16556930541992</xOffset>
+    <date>2021-08-31T18:04:41.682Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>24.1161459463614</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752599911" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630433081683</timestampUTC>
+    <color>#1565c0</color>
+    <senderId>w_a6odtbi2lzzl</senderId>
+    <date>2021-08-31T18:04:41.683Z</date>
+    <sender>Tiago</sender>
+    <message>I reshared mine</message>
+  </event>
+  <event timestamp="13752600079" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433081851</timestampUTC>
+    <xOffset>52.98718770345052</xOffset>
+    <date>2021-08-31T18:04:41.851Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>23.640463087293835</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752600690" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433082462</timestampUTC>
+    <xOffset>52.80880610148112</xOffset>
+    <date>2021-08-31T18:04:42.462Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>23.640463087293835</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752600847" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433082619</timestampUTC>
+    <xOffset>52.719615300496415</xOffset>
+    <date>2021-08-31T18:04:42.619Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>23.640463087293835</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752600935" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433082707</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:04:42.707Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752600997" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433082769</timestampUTC>
+    <xOffset>48.260087966918945</xOffset>
+    <date>2021-08-31T18:04:42.769Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>24.274707370334202</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752601170" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433082942</timestampUTC>
+    <xOffset>24.535388946533203</xOffset>
+    <date>2021-08-31T18:04:42.942Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>26.336000230577255</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752601427" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433083199</timestampUTC>
+    <xOffset>-59.303773244222</xOffset>
+    <date>2021-08-31T18:04:43.199Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <yOffset>-40.10108382613571</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752604801" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433086573</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:04:46.573Z</date>
+  </event>
+  <event timestamp="13752605639" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433087411</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:04:47.411Z</date>
+  </event>
+  <event timestamp="13752605760" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433087532</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:04:47.532Z</date>
+  </event>
+  <event timestamp="13752606603" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433088375</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:04:48.375Z</date>
+  </event>
+  <event timestamp="13752607124" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433088896</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:04:48.896Z</date>
+  </event>
+  <event timestamp="13752608107" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630433089879</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:04:49.879Z</date>
+  </event>
+  <event timestamp="13752608568" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433090340</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:04:50.340Z</date>
+  </event>
+  <event timestamp="13752609811" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630433091583</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:04:51.583Z</date>
+  </event>
+  <event timestamp="13752610331" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433092102</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:04:52.102Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752611782" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630433093553</timestampUTC>
+    <color>#7b1fa2</color>
+    <senderId>w_kmm96j1as24f</senderId>
+    <date>2021-08-31T18:04:53.553Z</date>
+    <sender>Mario</sender>
+    <message>i can see Tainan</message>
+  </event>
+  <event timestamp="13752612654" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630433094426</timestampUTC>
+    <color>#1565c0</color>
+    <senderId>w_a6odtbi2lzzl</senderId>
+    <date>2021-08-31T18:04:54.426Z</date>
+    <sender>Tiago</sender>
+    <message>but i see you @Tainan</message>
+  </event>
+  <event timestamp="13752616587" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433098359</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:04:58.359Z</date>
+  </event>
+  <event timestamp="13752616888" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433098660</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:04:58.660Z</date>
+  </event>
+  <event timestamp="13752617054" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433098825</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:04:58.825Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752618979" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433100751</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:00.751Z</date>
+  </event>
+  <event timestamp="13752619422" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433101194</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:05:01.194Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752619750" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:05:01.522Z</date>
+    <timestampUTC>1630433101522</timestampUTC>
+    <userId>w_etmphvzxcogu</userId>
+    <value>false,stream=w_etmphvzxcogu_ae5b1a9be7cc947bd01c57dddbd9c5109e7cc2a53463ab825d673174790d9d4b</value>
+  </event>
+  <event timestamp="13752620080" module="bbb-webrtc-sfu" eventname="StopWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_etmphvzxcogu-1630433045364.webm</filename>
+    <timestampUTC>1630433101852</timestampUTC>
+  </event>
+  <event timestamp="13752623231" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433105003</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:05.003Z</date>
+  </event>
+  <event timestamp="13752623893" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433105664</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:05.664Z</date>
+  </event>
+  <event timestamp="13752624704" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433106476</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:05:06.476Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752625607" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433107379</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:07.379Z</date>
+  </event>
+  <event timestamp="13752625678" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433107450</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:05:07.450Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752625724" module="bbb-webrtc-sfu" eventname="StartWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_etmphvzxcogu-1630433107384.webm</filename>
+    <timestampUTC>1630433107496</timestampUTC>
+  </event>
+  <event timestamp="13752626125" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:05:07.897Z</date>
+    <timestampUTC>1630433107897</timestampUTC>
+    <userId>w_etmphvzxcogu</userId>
+    <value>true,stream=w_etmphvzxcogu_ae5b1a9be7cc947bd01c57dddbd9c5109e7cc2a53463ab825d673174790d9d4b</value>
+  </event>
+  <event timestamp="13752628038" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433109810</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:09.810Z</date>
+  </event>
+  <event timestamp="13752628940" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433110712</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:10.712Z</date>
+  </event>
+  <event timestamp="13752630364" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433112136</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:05:12.136Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752630755" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433112527</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:12.527Z</date>
+  </event>
+  <event timestamp="13752633020" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433114792</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:14.792Z</date>
+  </event>
+  <event timestamp="13752633622" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433115394</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:15.394Z</date>
+  </event>
+  <event timestamp="13752633884" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433115655</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:15.655Z</date>
+  </event>
+  <event timestamp="13752634966" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433116738</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:16.738Z</date>
+  </event>
+  <event timestamp="13752635519" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433117291</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:17.291Z</date>
+  </event>
+  <event timestamp="13752636161" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433117933</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:17.933Z</date>
+  </event>
+  <event timestamp="13752636482" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433118254</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:18.254Z</date>
+  </event>
+  <event timestamp="13752636744" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433118515</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:18.515Z</date>
+  </event>
+  <event timestamp="13752637746" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433119518</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:19.518Z</date>
+  </event>
+  <event timestamp="13752638423" module="PARTICIPANT" eventname="RecordStatusEvent">
+    <timestampUTC>1630433120195</timestampUTC>
+    <date>2021-08-31T18:05:20.195Z</date>
+    <status>true</status>
+    <userId>w_vk0ebqjxox9d</userId>
+  </event>
+  <event timestamp="13752640071" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433121843</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:21.843Z</date>
+  </event>
+  <event timestamp="13752640955" module="PARTICIPANT" eventname="AssignPresenterEvent">
+    <name>Anton G</name>
+    <timestampUTC>1630433122726</timestampUTC>
+    <userid>w_vk0ebqjxox9d</userid>
+    <assignedBy>w_vk0ebqjxox9d</assignedBy>
+    <date>2021-08-31T18:05:22.726Z</date>
+  </event>
+  <event timestamp="13752640957" module="PRESENTATION" eventname="SetPresenterInPodEvent">
+    <timestampUTC>1630433122729</timestampUTC>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <date>2021-08-31T18:05:22.729Z</date>
+    <nextPresenterId>w_vk0ebqjxox9d</nextPresenterId>
+  </event>
+  <event timestamp="13752641108" module="PRESENTATION" eventname="ResizeAndMoveSlideEvent">
+    <timestampUTC>1630433122879</timestampUTC>
+    <xOffset>0.0</xOffset>
+    <presentationName>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentationName>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <heightRatio>100.0</heightRatio>
+    <id>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</id>
+    <date>2021-08-31T18:05:22.879Z</date>
+    <yOffset>0.0</yOffset>
+    <widthRatio>100.0</widthRatio>
+  </event>
+  <event timestamp="13752641322" module="PRESENTATION" eventname="ResizeAndMoveSlideEvent">
+    <timestampUTC>1630433123094</timestampUTC>
+    <xOffset>0.0</xOffset>
+    <presentationName>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentationName>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <heightRatio>100.0</heightRatio>
+    <id>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</id>
+    <date>2021-08-31T18:05:23.094Z</date>
+    <yOffset>0.0</yOffset>
+    <widthRatio>100.0</widthRatio>
+  </event>
+  <event timestamp="13752644529" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433126301</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:26.301Z</date>
+  </event>
+  <event timestamp="13752645825" module="PARTICIPANT" eventname="RecordStatusEvent">
+    <timestampUTC>1630433127597</timestampUTC>
+    <date>2021-08-31T18:05:27.597Z</date>
+    <status>false</status>
+    <userId>w_vk0ebqjxox9d</userId>
+  </event>
+  <event timestamp="13752645838" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433127610</timestampUTC>
+    <xOffset>7.236842314402263</xOffset>
+    <date>2021-08-31T18:05:27.610Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>62.39818431712963</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752645990" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433127762</timestampUTC>
+    <xOffset>3.9473684628804526</xOffset>
+    <date>2021-08-31T18:05:27.762Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>63.06651927806713</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752646155" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433127927</timestampUTC>
+    <xOffset>-80.54511388142903</xOffset>
+    <date>2021-08-31T18:05:27.927Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651178430628</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752646530" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433128301</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:28.301Z</date>
+  </event>
+  <event timestamp="13752648554" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433130326</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:30.326Z</date>
+  </event>
+  <event timestamp="13752648575" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433130346</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:30.346Z</date>
+  </event>
+  <event timestamp="13752649717" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433131489</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:31.489Z</date>
+  </event>
+  <event timestamp="13752653433" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433135205</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:35.205Z</date>
+  </event>
+  <event timestamp="13752653798" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433135570</timestampUTC>
+    <xOffset>36.84210459391276</xOffset>
+    <date>2021-08-31T18:05:35.570Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>8.429929238778573</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752653943" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433135715</timestampUTC>
+    <xOffset>42.9511292775472</xOffset>
+    <date>2021-08-31T18:05:35.715Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>29.148392853913485</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752654016" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433135788</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:35.788Z</date>
+  </event>
+  <event timestamp="13752654116" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433135888</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:35.888Z</date>
+  </event>
+  <event timestamp="13752654285" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433136056</timestampUTC>
+    <xOffset>42.669172286987305</xOffset>
+    <date>2021-08-31T18:05:36.056Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>29.31547659414786</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752654436" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433136208</timestampUTC>
+    <xOffset>38.43984921773275</xOffset>
+    <date>2021-08-31T18:05:36.208Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>91.80503562644677</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752654612" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433136384</timestampUTC>
+    <xOffset>-80.54511388142903</xOffset>
+    <date>2021-08-31T18:05:36.384Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651178430628</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752654879" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433136651</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:36.651Z</date>
+  </event>
+  <event timestamp="13752654920" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433136692</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:36.692Z</date>
+  </event>
+  <event timestamp="13752655060" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433136832</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:36.832Z</date>
+  </event>
+  <event timestamp="13752655442" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433137214</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:37.214Z</date>
+  </event>
+  <event timestamp="13752656381" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433138153</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:05:38.153Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752658024" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433139796</timestampUTC>
+    <xOffset>-102.08969751993816</xOffset>
+    <date>2021-08-31T18:05:39.796Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>10.267857445610893</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752658042" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433139814</timestampUTC>
+    <xOffset>-102.08969751993816</xOffset>
+    <date>2021-08-31T18:05:39.814Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>10.267857445610893</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752658313" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433140085</timestampUTC>
+    <xOffset>-102.08969751993816</xOffset>
+    <date>2021-08-31T18:05:40.085Z</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>10.267857445610893</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630430006893</presentation>
+  </event>
+  <event timestamp="13752658926" module="PRESENTATION" eventname="ConversionCompletedEvent">
+    <originalFilename>Developer Call (54).pdf</originalFilename>
+    <timestampUTC>1630433140697</timestampUTC>
+    <presentationName>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentationName>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <date>2021-08-31T18:05:40.697Z</date>
+  </event>
+  <event timestamp="13752658934" module="PRESENTATION" eventname="SetPresentationDownloadable">
+    <timestampUTC>1630433140706</timestampUTC>
+    <presentationName>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentationName>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <date>2021-08-31T18:05:40.706Z</date>
+    <downloadable>false</downloadable>
+  </event>
+  <event timestamp="13752658961" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433140733</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:40.733Z</date>
+  </event>
+  <event timestamp="13752659007" module="PRESENTATION" eventname="SharePresentationEvent">
+    <timestampUTC>1630433140779</timestampUTC>
+    <presentationName>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentationName>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <share>true</share>
+    <date>2021-08-31T18:05:40.779Z</date>
+  </event>
+  <event timestamp="13752660205" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433141977</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:41.977Z</date>
+  </event>
+  <event timestamp="13752663275" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433145046</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:45.046Z</date>
+  </event>
+  <event timestamp="13752664358" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433146130</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:46.130Z</date>
+  </event>
+  <event timestamp="13752667966" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630433149738</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:49.738Z</date>
+  </event>
+  <event timestamp="13752668167" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433149939</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:49.939Z</date>
+  </event>
+  <event timestamp="13752668985" module="CHAT" eventname="PublicChatEvent">
+    <color>#303f9f</color>
+    <date>2021-08-31T18:05:50.756Z</date>
+    <message>would it be ok if i pull the events from the meeting to use as a test for recording chat processing?</message>
+    <sender>Calvin</sender>
+    <senderId>w_szgcfhvhfhdb</senderId>
+    <timestampUTC>1630433150756</timestampUTC>
+  </event>
+  <event timestamp="13752669070" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433150842</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:50.842Z</date>
+  </event>
+  <event timestamp="13752670072" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630433151843</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:51.843Z</date>
+  </event>
+  <event timestamp="13752672819" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433154591</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:54.591Z</date>
+  </event>
+  <event timestamp="13752674770" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433156542</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:56.542Z</date>
+  </event>
+  <event timestamp="13752676041" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433157813</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:57.813Z</date>
+  </event>
+  <event timestamp="13752676555" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433158327</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:58.327Z</date>
+  </event>
+  <event timestamp="13752676956" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433158728</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:58.728Z</date>
+  </event>
+  <event timestamp="13752677378" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433159150</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:05:59.150Z</date>
+  </event>
+  <event timestamp="13752677679" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433159451</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:05:59.451Z</date>
+  </event>
+  <event timestamp="13752678500" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433160272</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:06:00.272Z</date>
+  </event>
+  <event timestamp="13752679302" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433161074</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:06:01.074Z</date>
+  </event>
+  <event timestamp="13752680145" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433161917</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:06:01.917Z</date>
+  </event>
+  <event timestamp="13752680807" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433162579</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:06:02.579Z</date>
+  </event>
+  <event timestamp="13752681820" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433163592</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:06:03.592Z</date>
+  </event>
+  <event timestamp="13752682161" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433163933</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:06:03.933Z</date>
+  </event>
+  <event timestamp="13752682948" module="PARTICIPANT" eventname="RecordStatusEvent">
+    <timestampUTC>1630433164720</timestampUTC>
+    <date>2021-08-31T18:06:04.720Z</date>
+    <status>true</status>
+    <userId>w_vk0ebqjxox9d</userId>
+  </event>
+  <event timestamp="13752683305" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433165077</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:06:05.077Z</date>
+  </event>
+  <event timestamp="13752685530" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433167302</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:06:07.302Z</date>
+  </event>
+  <event timestamp="13752686953" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433168725</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:06:08.725Z</date>
+  </event>
+  <event timestamp="13752691214" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433172985</timestampUTC>
+    <xOffset>37.03007592095269</xOffset>
+    <date>2021-08-31T18:06:12.985Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>67.41071536217207</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752691371" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433173143</timestampUTC>
+    <xOffset>1.0338346163431802</xOffset>
+    <date>2021-08-31T18:06:13.143Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>70.75240523726852</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752691522" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433173294</timestampUTC>
+    <xOffset>-80.54511176215277</xOffset>
+    <date>2021-08-31T18:06:13.294Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651225525656</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752692559" module="CHAT" eventname="PublicChatEvent">
+    <color>#7b1fa2</color>
+    <date>2021-08-31T18:06:14.330Z</date>
+    <message>i get  logs of these: 
+
+ ERROR: clientLogger: Camera VIEWER failed. Reconnecting. &lt;a href='event:https://develop.bigbluebutton.org/html5client/8fb14b479570f65105c7ff9a2960b679501f34ff.js?meteor_js_resource=true:348:579447'&gt;&lt;u&gt;https://develop.bigbluebutton.org/html5client/8fb14b479570f65105c7ff9a2960b679501f34ff.js?meteor_js_resource=true:348:579447&lt;/u&gt;&lt;/a&gt;</message>
+    <sender>Mario</sender>
+    <senderId>w_kmm96j1as24f</senderId>
+    <timestampUTC>1630433174330</timestampUTC>
+  </event>
+  <event timestamp="13752692792" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433174563</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:06:14.563Z</date>
+  </event>
+  <event timestamp="13752693876" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433175648</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:06:15.648Z</date>
+  </event>
+  <event timestamp="13752697898" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433179670</timestampUTC>
+    <xOffset>41.25939687093099</xOffset>
+    <date>2021-08-31T18:06:19.670Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>99.49091405044366</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752698047" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433179818</timestampUTC>
+    <xOffset>42.01127794053819</xOffset>
+    <date>2021-08-31T18:06:19.818Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>99.32382842640818</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752698219" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433179990</timestampUTC>
+    <xOffset>-80.54511176215277</xOffset>
+    <date>2021-08-31T18:06:19.990Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651225525656</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752699080" module="PRESENTATION" eventname="GotoSlideEvent">
+    <timestampUTC>1630433180851</timestampUTC>
+    <presentationName>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentationName>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <id>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</id>
+    <slide>1</slide>
+    <date>2021-08-31T18:06:20.851Z</date>
+  </event>
+  <event timestamp="13752700011" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433181783</timestampUTC>
+    <xOffset>52.16165330674913</xOffset>
+    <date>2021-08-31T18:06:21.783Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>99.49091405044366</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752700157" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433181929</timestampUTC>
+    <xOffset>46.522555881076386</xOffset>
+    <date>2021-08-31T18:06:21.929Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>82.28122287326389</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752700317" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433182089</timestampUTC>
+    <xOffset>32.800752851698135</xOffset>
+    <date>2021-08-31T18:06:22.089Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>43.68473382643712</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752701735" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433183507</timestampUTC>
+    <xOffset>32.70676718817817</xOffset>
+    <date>2021-08-31T18:06:23.507Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>43.517648202401624</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752701886" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433183658</timestampUTC>
+    <xOffset>23.120301564534504</xOffset>
+    <date>2021-08-31T18:06:23.658Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>26.976295753761576</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752702250" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433184021</timestampUTC>
+    <xOffset>23.02631590101454</xOffset>
+    <date>2021-08-31T18:06:24.021Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>26.976295753761576</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752702400" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433184172</timestampUTC>
+    <xOffset>17.481203079223633</xOffset>
+    <date>2021-08-31T18:06:24.172Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>29.148391912012922</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752703201" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433184973</timestampUTC>
+    <xOffset>17.199248207939995</xOffset>
+    <date>2021-08-31T18:06:24.973Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>28.981308171778547</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752703206" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630433184978</timestampUTC>
+    <color>#7b1fa2</color>
+    <senderId>w_kmm96j1as24f</senderId>
+    <date>2021-08-31T18:06:24.978Z</date>
+    <sender>Mario</sender>
+    <message>lots* of</message>
+  </event>
+  <event timestamp="13752703357" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433185129</timestampUTC>
+    <xOffset>11.18421024746365</xOffset>
+    <date>2021-08-31T18:06:25.129Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>30.652151225525653</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752703506" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433185278</timestampUTC>
+    <xOffset>7.706766658359104</xOffset>
+    <date>2021-08-31T18:06:25.278Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>30.150898121021413</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752703656" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433185428</timestampUTC>
+    <xOffset>6.578947173224556</xOffset>
+    <date>2021-08-31T18:06:25.428Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>29.315475652247297</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752703820" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433185592</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:06:25.592Z</date>
+  </event>
+  <event timestamp="13752703839" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433185610</timestampUTC>
+    <xOffset>6.203007698059082</xOffset>
+    <date>2021-08-31T18:06:25.610Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>28.981308171778547</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752704027" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433185799</timestampUTC>
+    <xOffset>6.296992301940918</xOffset>
+    <date>2021-08-31T18:06:25.799Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>28.981308171778547</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752704156" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433185928</timestampUTC>
+    <xOffset>7.048872311909994</xOffset>
+    <date>2021-08-31T18:06:25.928Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>28.981308171778547</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752704574" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433186346</timestampUTC>
+    <xOffset>7.14285691579183</xOffset>
+    <date>2021-08-31T18:06:26.346Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>28.981308171778547</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752704718" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433186490</timestampUTC>
+    <xOffset>7.706766658359104</xOffset>
+    <date>2021-08-31T18:06:26.490Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>29.482561276282794</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752705901" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433187673</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:06:27.673Z</date>
+  </event>
+  <event timestamp="13752707816" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433189588</timestampUTC>
+    <xOffset>7.706766658359104</xOffset>
+    <date>2021-08-31T18:06:29.588Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>29.816728756751544</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752707963" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433189735</timestampUTC>
+    <xOffset>9.21052614847819</xOffset>
+    <date>2021-08-31T18:06:29.735Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>33.32550048828125</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752708135" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433189907</timestampUTC>
+    <xOffset>9.304510752360025</xOffset>
+    <date>2021-08-31T18:06:29.907Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>33.65967173635224</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752708257" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433190029</timestampUTC>
+    <xOffset>9.398496415879992</xOffset>
+    <date>2021-08-31T18:06:30.029Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>33.826753592785494</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752708344" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433190116</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:06:30.116Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752708424" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433190196</timestampUTC>
+    <xOffset>9.68045128716363</xOffset>
+    <date>2021-08-31T18:06:30.196Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>37.00135784384645</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752708571" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433190343</timestampUTC>
+    <xOffset>10.620300504896376</xOffset>
+    <date>2021-08-31T18:06:30.343Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>38.003864052854944</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752708722" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433190494</timestampUTC>
+    <xOffset>13.34586461385091</xOffset>
+    <date>2021-08-31T18:06:30.494Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>38.17094967689043</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752708745" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433190517</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:06:30.517Z</date>
+  </event>
+  <event timestamp="13752710631" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433192403</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:06:32.403Z</date>
+  </event>
+  <event timestamp="13752712524" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433194296</timestampUTC>
+    <xOffset>13.627819485134548</xOffset>
+    <date>2021-08-31T18:06:34.296Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>38.338031533323694</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752712683" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433194454</timestampUTC>
+    <xOffset>13.909774356418186</xOffset>
+    <date>2021-08-31T18:06:34.454Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>41.011382679880406</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752716603" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433198375</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:06:38.375Z</date>
+  </event>
+  <event timestamp="13752717405" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433199177</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:06:39.177Z</date>
+  </event>
+  <event timestamp="13752718084" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433199856</timestampUTC>
+    <xOffset>13.81578975253635</xOffset>
+    <date>2021-08-31T18:06:39.856Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>41.345550160349156</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752718231" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433200003</timestampUTC>
+    <xOffset>12.781954871283638</xOffset>
+    <date>2021-08-31T18:06:40.003Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>42.34805636935764</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752718636" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433200407</timestampUTC>
+    <xOffset>12.687970267401802</xOffset>
+    <date>2021-08-31T18:06:40.407Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>42.51514199339314</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752718771" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433200543</timestampUTC>
+    <xOffset>14.943609237670898</xOffset>
+    <date>2021-08-31T18:06:40.543Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>48.697264871479554</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752719028" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630433200800</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:06:40.800Z</date>
+  </event>
+  <event timestamp="13752719850" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630433201621</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:06:41.621Z</date>
+  </event>
+  <event timestamp="13752721068" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433202840</timestampUTC>
+    <xOffset>14.943609237670898</xOffset>
+    <date>2021-08-31T18:06:42.840Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>48.86434672791281</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752722012" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433203784</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:06:43.784Z</date>
+  </event>
+  <event timestamp="13752723016" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433204788</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:06:44.788Z</date>
+  </event>
+  <event timestamp="13752723842" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630433205614</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:06:45.614Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752727335" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433209107</timestampUTC>
+    <xOffset>14.943609237670898</xOffset>
+    <date>2021-08-31T18:06:49.107Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>49.031432351948304</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752727482" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433209254</timestampUTC>
+    <xOffset>14.66165436638726</xOffset>
+    <date>2021-08-31T18:06:49.254Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>52.373118459442516</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752727639" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433209411</timestampUTC>
+    <xOffset>13.157894346449112</xOffset>
+    <date>2021-08-31T18:06:49.411Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>50.201024184992285</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752728120" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433209891</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:06:49.891Z</date>
+  </event>
+  <event timestamp="13752728556" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433210328</timestampUTC>
+    <xOffset>12.781954871283638</xOffset>
+    <date>2021-08-31T18:06:50.328Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>49.8668529369213</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752728712" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433210484</timestampUTC>
+    <xOffset>12.687970267401802</xOffset>
+    <date>2021-08-31T18:06:50.484Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>49.69977108048804</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752728878" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433210650</timestampUTC>
+    <xOffset>13.157894346449112</xOffset>
+    <date>2021-08-31T18:06:50.650Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>49.031432351948304</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752728939" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433210711</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:06:50.711Z</date>
+  </event>
+  <event timestamp="13752729023" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433210794</timestampUTC>
+    <xOffset>13.251880009969074</xOffset>
+    <date>2021-08-31T18:06:50.794Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>49.031432351948304</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752729677" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630433211449</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:06:51.449Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752731853" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433213625</timestampUTC>
+    <xOffset>13.251880009969074</xOffset>
+    <date>2021-08-31T18:06:53.625Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>49.365599832417054</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752732002" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433213774</timestampUTC>
+    <xOffset>8.834586673312717</xOffset>
+    <date>2021-08-31T18:06:53.774Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>50.03393856095679</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752732190" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433213962</timestampUTC>
+    <xOffset>8.740601539611816</xOffset>
+    <date>2021-08-31T18:06:53.962Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>50.201024184992285</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752732331" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433214103</timestampUTC>
+    <xOffset>8.646616405910915</xOffset>
+    <date>2021-08-31T18:06:54.103Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>53.709795916522</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752732552" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433214324</timestampUTC>
+    <xOffset>8.646616405910915</xOffset>
+    <date>2021-08-31T18:06:54.324Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>54.87938774956598</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752732709" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433214481</timestampUTC>
+    <xOffset>8.646616405910915</xOffset>
+    <date>2021-08-31T18:06:54.481Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>56.21606143904321</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752733511" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433215283</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:06:55.283Z</date>
+  </event>
+  <event timestamp="13752734132" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630433215903</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:06:55.903Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752734935" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433216706</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:06:56.706Z</date>
+  </event>
+  <event timestamp="13752735286" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630433217058</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:06:57.058Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752737352" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630433219124</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:06:59.124Z</date>
+  </event>
+  <event timestamp="13752737392" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433219164</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:06:59.164Z</date>
+  </event>
+  <event timestamp="13752738276" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433220048</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:00.048Z</date>
+  </event>
+  <event timestamp="13752738417" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433220189</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:00.189Z</date>
+  </event>
+  <event timestamp="13752738745" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433220517</timestampUTC>
+    <xOffset>8.834586673312717</xOffset>
+    <date>2021-08-31T18:07:00.517Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>57.218567648051696</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752738899" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433220670</timestampUTC>
+    <xOffset>-80.54511176215277</xOffset>
+    <date>2021-08-31T18:07:00.670Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651225525656</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752739079" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433220851</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:00.851Z</date>
+  </event>
+  <event timestamp="13752739420" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630433221192</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:01.192Z</date>
+  </event>
+  <event timestamp="13752739575" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433221347</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:07:01.347Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752739669" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630433221440</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:01.440Z</date>
+  </event>
+  <event timestamp="13752739677" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433221449</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:01.449Z</date>
+  </event>
+  <event timestamp="13752739765" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433221537</timestampUTC>
+    <xOffset>34.492482079399956</xOffset>
+    <date>2021-08-31T18:07:01.537Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>98.48840784143519</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752739916" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433221687</timestampUTC>
+    <xOffset>49.436090257432724</xOffset>
+    <date>2021-08-31T18:07:01.687Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>77.10160620418596</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752740520" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433222292</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:02.292Z</date>
+  </event>
+  <event timestamp="13752740551" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433222323</timestampUTC>
+    <xOffset>49.53007592095269</xOffset>
+    <date>2021-08-31T18:07:02.323Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>76.93452058015046</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752740937" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433222708</timestampUTC>
+    <xOffset>65.69548712836372</xOffset>
+    <date>2021-08-31T18:07:02.708Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>51.03644476996527</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752741022" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433222794</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:02.794Z</date>
+  </event>
+  <event timestamp="13752741026" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433222798</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:02.798Z</date>
+  </event>
+  <event timestamp="13752741644" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630433223415</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:07:03.415Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752742025" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433223797</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:03.797Z</date>
+  </event>
+  <event timestamp="13752743381" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433225153</timestampUTC>
+    <xOffset>65.78947279188368</xOffset>
+    <date>2021-08-31T18:07:05.153Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>50.70227728949652</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752743529" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433225301</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:05.301Z</date>
+  </event>
+  <event timestamp="13752743541" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433225313</timestampUTC>
+    <xOffset>61.37218051486545</xOffset>
+    <date>2021-08-31T18:07:05.313Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>53.04145718798225</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752743666" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433225438</timestampUTC>
+    <xOffset>60.902256435818146</xOffset>
+    <date>2021-08-31T18:07:05.438Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>52.373118459442516</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752743970" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433225741</timestampUTC>
+    <xOffset>60.80827077229818</xOffset>
+    <date>2021-08-31T18:07:05.741Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>52.20603660300925</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752744129" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433225900</timestampUTC>
+    <xOffset>60.71428510877821</xOffset>
+    <date>2021-08-31T18:07:05.900Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>52.540204083478</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752744279" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433226051</timestampUTC>
+    <xOffset>61.09022352430556</xOffset>
+    <date>2021-08-31T18:07:06.051Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>52.540204083478</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752744431" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433226203</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:06.203Z</date>
+  </event>
+  <event timestamp="13752744437" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433226209</timestampUTC>
+    <xOffset>61.27819485134549</xOffset>
+    <date>2021-08-31T18:07:06.209Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>52.540204083478</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752745233" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433227005</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:07.005Z</date>
+  </event>
+  <event timestamp="13752745273" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433227045</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:07.045Z</date>
+  </event>
+  <event timestamp="13752745595" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433227367</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:07.367Z</date>
+  </event>
+  <event timestamp="13752745946" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433227718</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:07:07.718Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752746766" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433228538</timestampUTC>
+    <xOffset>61.466166178385414</xOffset>
+    <date>2021-08-31T18:07:08.538Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>52.540204083478</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752746920" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433228692</timestampUTC>
+    <xOffset>61.09022352430556</xOffset>
+    <date>2021-08-31T18:07:08.692Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>55.380640854070215</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752746943" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433228715</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:08.715Z</date>
+  </event>
+  <event timestamp="13752747179" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433228950</timestampUTC>
+    <xOffset>60.996242099338104</xOffset>
+    <date>2021-08-31T18:07:08.950Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>55.380640854070215</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752747334" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433229106</timestampUTC>
+    <xOffset>18.04511176215278</xOffset>
+    <date>2021-08-31T18:07:09.106Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>25.305450816213348</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752747496" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433229268</timestampUTC>
+    <xOffset>7.518796920776367</xOffset>
+    <date>2021-08-31T18:07:09.268Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>22.79918529369213</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752747642" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433229414</timestampUTC>
+    <xOffset>11.936090257432726</xOffset>
+    <date>2021-08-31T18:07:09.414Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>29.148391912012922</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752747794" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433229566</timestampUTC>
+    <xOffset>6.860902044508192</xOffset>
+    <date>2021-08-31T18:07:09.566Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>22.632101553457755</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752747958" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433229730</timestampUTC>
+    <xOffset>8.176691797044542</xOffset>
+    <date>2021-08-31T18:07:09.730Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>32.65716552734375</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752748103" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433229875</timestampUTC>
+    <xOffset>7.14285691579183</xOffset>
+    <date>2021-08-31T18:07:09.875Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>18.622076717423806</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752748257" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433230028</timestampUTC>
+    <xOffset>9.86842155456543</xOffset>
+    <date>2021-08-31T18:07:10.028Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>45.85682810088735</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752748423" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433230195</timestampUTC>
+    <xOffset>9.86842155456543</xOffset>
+    <date>2021-08-31T18:07:10.195Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>48.19601176697531</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752749670" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433231442</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:11.442Z</date>
+  </event>
+  <event timestamp="13752750577" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433232349</timestampUTC>
+    <xOffset>10.056390762329102</xOffset>
+    <date>2021-08-31T18:07:12.349Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>48.53017924744406</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752750600" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433232372</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:12.372Z</date>
+  </event>
+  <event timestamp="13752750700" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433232472</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:12.472Z</date>
+  </event>
+  <event timestamp="13752750741" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433232513</timestampUTC>
+    <xOffset>9.86842155456543</xOffset>
+    <date>2021-08-31T18:07:12.513Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>49.69977108048804</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752750858" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433232629</timestampUTC>
+    <xOffset>9.774435891045465</xOffset>
+    <date>2021-08-31T18:07:12.629Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>49.53268545645255</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752751361" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433233133</timestampUTC>
+    <xOffset>12.218045128716362</xOffset>
+    <date>2021-08-31T18:07:13.133Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>53.20854281201775</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752751524" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433233296</timestampUTC>
+    <xOffset>12.687970267401802</xOffset>
+    <date>2021-08-31T18:07:13.296Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>54.211049021026234</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752751755" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433233527</timestampUTC>
+    <xOffset>12.875939475165474</xOffset>
+    <date>2021-08-31T18:07:13.527Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>54.545216501494984</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752751803" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433233575</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:13.575Z</date>
+  </event>
+  <event timestamp="13752751908" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433233680</timestampUTC>
+    <xOffset>19.830826653374565</xOffset>
+    <date>2021-08-31T18:07:13.680Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>93.30879117235725</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752752072" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433233844</timestampUTC>
+    <xOffset>-80.54511176215277</xOffset>
+    <date>2021-08-31T18:07:13.844Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651225525656</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752752647" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433234419</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:14.419Z</date>
+  </event>
+  <event timestamp="13752755292" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433237064</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:17.064Z</date>
+  </event>
+  <event timestamp="13752757423" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630433239194</timestampUTC>
+    <color>#5e35b1</color>
+    <senderId>w_etmphvzxcogu</senderId>
+    <date>2021-08-31T18:07:19.194Z</date>
+    <sender>Tainan</sender>
+    <message>test</message>
+  </event>
+  <event timestamp="13752757537" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433239309</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:19.309Z</date>
+  </event>
+  <event timestamp="13752757738" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433239510</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:19.510Z</date>
+  </event>
+  <event timestamp="13752758960" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433240732</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:20.732Z</date>
+  </event>
+  <event timestamp="13752759719" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>richard</name>
+    <timestampUTC>1630433241491</timestampUTC>
+    <role>MODERATOR</role>
+    <date>2021-08-31T18:07:21.491Z</date>
+    <externalUserId>w_or8rfls1s4ya</externalUserId>
+    <userId>w_or8rfls1s4ya</userId>
+  </event>
+  <event timestamp="13752760102" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433241874</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:21.874Z</date>
+  </event>
+  <event timestamp="13752765304" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433247076</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:27.076Z</date>
+  </event>
+  <event timestamp="13752766148" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433247920</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:27.920Z</date>
+  </event>
+  <event timestamp="13752766950" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433248722</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:28.722Z</date>
+  </event>
+  <event timestamp="13752767231" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433249003</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:29.003Z</date>
+  </event>
+  <event timestamp="13752768690" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433250461</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:30.461Z</date>
+  </event>
+  <event timestamp="13752769308" module="VOICE" eventname="ParticipantJoinedEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433251080</timestampUTC>
+    <bridge>79134</bridge>
+    <callername>richard</callername>
+    <talking>false</talking>
+    <callernumber>w_or8rfls1s4ya_1-bbbID-richard</callernumber>
+    <date>2021-08-31T18:07:31.080Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752769588" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433251359</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:31.359Z</date>
+  </event>
+  <event timestamp="13752769728" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433251500</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:31.500Z</date>
+  </event>
+  <event timestamp="13752770751" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433252523</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:32.523Z</date>
+  </event>
+  <event timestamp="13752771012" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433252784</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:32.784Z</date>
+  </event>
+  <event timestamp="13752771313" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433253085</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:33.085Z</date>
+  </event>
+  <event timestamp="13752771655" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433253427</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:33.427Z</date>
+  </event>
+  <event timestamp="13752772382" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433254154</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:07:34.154Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752772743" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433254515</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:34.515Z</date>
+  </event>
+  <event timestamp="13752777746" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433259518</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:39.518Z</date>
+  </event>
+  <event timestamp="13752778107" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433259879</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:39.879Z</date>
+  </event>
+  <event timestamp="13752778208" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433259980</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:39.980Z</date>
+  </event>
+  <event timestamp="13752778609" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433260381</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:40.381Z</date>
+  </event>
+  <event timestamp="13752780768" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433262540</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:07:42.540Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752786908" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433268680</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:07:48.680Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752789991" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433271763</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:07:51.763Z</date>
+  </event>
+  <event timestamp="13752790814" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433272585</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:07:52.585Z</date>
+  </event>
+  <event timestamp="13752799371" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433281143</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:08:01.143Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752804345" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433286117</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:08:06.117Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752810820" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433292592</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:08:12.592Z</date>
+  </event>
+  <event timestamp="13752810962" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433292734</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:08:12.734Z</date>
+  </event>
+  <event timestamp="13752811651" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433293423</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:08:13.423Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752815561" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433297333</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:08:17.333Z</date>
+  </event>
+  <event timestamp="13752815571" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433297343</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:08:17.343Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752816192" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433297964</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:08:17.964Z</date>
+  </event>
+  <event timestamp="13752818097" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433299869</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:08:19.869Z</date>
+  </event>
+  <event timestamp="13752818238" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433300010</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:08:20.010Z</date>
+  </event>
+  <event timestamp="13752818520" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433300292</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:08:20.292Z</date>
+  </event>
+  <event timestamp="13752819580" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433301352</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:08:21.352Z</date>
+  </event>
+  <event timestamp="13752821205" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433302977</timestampUTC>
+    <xOffset>8.646616405910915</xOffset>
+    <date>2021-08-31T18:08:22.977Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>89.4658519603588</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752821363" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433303135</timestampUTC>
+    <xOffset>-80.54511176215277</xOffset>
+    <date>2021-08-31T18:08:23.135Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651225525656</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752821473" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433303245</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:08:23.245Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752822074" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433303846</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:08:23.846Z</date>
+  </event>
+  <event timestamp="13752824247" module="CHAT" eventname="ClearPublicChatEvent">
+    <timestampUTC>1630433306019</timestampUTC>
+    <date>2021-08-31T18:08:26.019Z</date>
+  </event>
+  <event timestamp="13752825084" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433306856</timestampUTC>
+    <xOffset>1.0338346163431802</xOffset>
+    <date>2021-08-31T18:08:26.856Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>73.2586669921875</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752825237" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433307009</timestampUTC>
+    <xOffset>-80.54511176215277</xOffset>
+    <date>2021-08-31T18:08:27.009Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651225525656</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752825340" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433307112</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:08:27.112Z</date>
+  </event>
+  <event timestamp="13752826456" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433308228</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:08:28.228Z</date>
+  </event>
+  <event timestamp="13752828840" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433310612</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:08:30.612Z</date>
+  </event>
+  <event timestamp="13752829362" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433311133</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:08:31.133Z</date>
+  </event>
+  <event timestamp="13752834124" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433315896</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:08:35.896Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752837107" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433318879</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:08:38.879Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752838049" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433319821</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:08:39.821Z</date>
+  </event>
+  <event timestamp="13752841236" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433323008</timestampUTC>
+    <xOffset>28.007517920600044</xOffset>
+    <date>2021-08-31T18:08:43.008Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>99.15674280237269</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752841390" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433323162</timestampUTC>
+    <xOffset>22.83834669325087</xOffset>
+    <date>2021-08-31T18:08:43.162Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>87.9620964144483</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752861807" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433343579</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:09:03.579Z</date>
+  </event>
+  <event timestamp="13752862068" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433343840</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:09:03.840Z</date>
+  </event>
+  <event timestamp="13752869467" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433351238</timestampUTC>
+    <xOffset>22.55639182196723</xOffset>
+    <date>2021-08-31T18:09:11.238Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>91.97212125048225</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752869608" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433351380</timestampUTC>
+    <xOffset>-80.54511176215277</xOffset>
+    <date>2021-08-31T18:09:11.380Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/2</whiteboardId>
+    <pageNumber>1</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651225525656</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13752874938" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433356710</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:09:16.710Z</date>
+  </event>
+  <event timestamp="13752875940" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433357712</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:09:17.712Z</date>
+  </event>
+  <event timestamp="13752880670" module="PRESENTATION" eventname="GotoSlideEvent">
+    <timestampUTC>1630433362441</timestampUTC>
+    <presentationName>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentationName>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <id>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/3</id>
+    <slide>2</slide>
+    <date>2021-08-31T18:09:22.441Z</date>
+  </event>
+  <event timestamp="13752881570" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433363342</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:09:23.342Z</date>
+  </event>
+  <event timestamp="13752882753" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433364525</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:09:24.525Z</date>
+  </event>
+  <event timestamp="13752888812" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630433370584</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:09:30.584Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752889218" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433370990</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:09:30.990Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752889980" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630433371752</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:09:31.752Z</date>
+  </event>
+  <event timestamp="13752921933" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:10:03.704Z</date>
+    <timestampUTC>1630433403704</timestampUTC>
+    <userId>w_a6odtbi2lzzl</userId>
+    <value>false,stream=w_a6odtbi2lzzl_1382b70a7007c500b9ad0b552047cca6d3e6390e3a931108798353f7f53d0c1a</value>
+  </event>
+  <event timestamp="13752922183" module="bbb-webrtc-sfu" eventname="StopWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_a6odtbi2lzzl-1630433070836.webm</filename>
+    <timestampUTC>1630433403955</timestampUTC>
+  </event>
+  <event timestamp="13752935582" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630433417354</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:10:17.354Z</date>
+  </event>
+  <event timestamp="13752935743" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630433417515</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:10:17.515Z</date>
+  </event>
+  <event timestamp="13752942047" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:10:23.819Z</date>
+    <timestampUTC>1630433423819</timestampUTC>
+    <userId>w_lo2vd8rkvicu</userId>
+    <value>false,stream=w_lo2vd8rkvicu_682f9e12269e303016054c2c3213447b3bb4c73c5ccd271d68e2887bfbfb92d8</value>
+  </event>
+  <event timestamp="13752942240" module="bbb-webrtc-sfu" eventname="StopWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_lo2vd8rkvicu-1630433050796.webm</filename>
+    <timestampUTC>1630433424012</timestampUTC>
+  </event>
+  <event timestamp="13752947448" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630433429220</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:10:29.220Z</date>
+  </event>
+  <event timestamp="13752947509" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630433429281</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:10:29.281Z</date>
+  </event>
+  <event timestamp="13752948428" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:10:30.200Z</date>
+    <timestampUTC>1630433430200</timestampUTC>
+    <userId>w_a6odtbi2lzzl</userId>
+    <value>true,stream=w_a6odtbi2lzzl_1382b70a7007c500b9ad0b552047cca6d3e6390e3a931108798353f7f53d0c1a</value>
+  </event>
+  <event timestamp="13752948462" module="bbb-webrtc-sfu" eventname="StartWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_a6odtbi2lzzl-1630433430027.webm</filename>
+    <timestampUTC>1630433430234</timestampUTC>
+  </event>
+  <event timestamp="13752955444" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630433437216</timestampUTC>
+    <color>#1565c0</color>
+    <senderId>w_a6odtbi2lzzl</senderId>
+    <date>2021-08-31T18:10:37.216Z</date>
+    <sender>Tiago</sender>
+    <message>and cookies</message>
+  </event>
+  <event timestamp="13752961366" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:10:43.137Z</date>
+    <timestampUTC>1630433443137</timestampUTC>
+    <userId>w_etmphvzxcogu</userId>
+    <value>false,stream=w_etmphvzxcogu_ae5b1a9be7cc947bd01c57dddbd9c5109e7cc2a53463ab825d673174790d9d4b</value>
+  </event>
+  <event timestamp="13752961540" module="bbb-webrtc-sfu" eventname="StopWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_etmphvzxcogu-1630433107384.webm</filename>
+    <timestampUTC>1630433443312</timestampUTC>
+  </event>
+  <event timestamp="13752981420" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:11:03.191Z</date>
+    <timestampUTC>1630433463191</timestampUTC>
+    <userId>w_lo2vd8rkvicu</userId>
+    <value>true,stream=w_lo2vd8rkvicu_682f9e12269e303016054c2c3213447b3bb4c73c5ccd271d68e2887bfbfb92d8</value>
+  </event>
+  <event timestamp="13752982016" module="bbb-webrtc-sfu" eventname="StartWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_lo2vd8rkvicu-1630433463000.webm</filename>
+    <timestampUTC>1630433463788</timestampUTC>
+  </event>
+  <event timestamp="13752983877" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630433465649</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:11:05.649Z</date>
+  </event>
+  <event timestamp="13752984399" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630433466170</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:11:06.170Z</date>
+  </event>
+  <event timestamp="13752988968" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630433470740</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:11:10.740Z</date>
+  </event>
+  <event timestamp="13752990259" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433472031</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:11:12.031Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13752991401" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433473173</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:11:13.173Z</date>
+  </event>
+  <event timestamp="13752991743" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630433473515</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:11:13.515Z</date>
+  </event>
+  <event timestamp="13752992726" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630433474498</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:11:14.498Z</date>
+  </event>
+  <event timestamp="13752995171" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630433476943</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:11:16.943Z</date>
+  </event>
+  <event timestamp="13752996488" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630433478260</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:11:18.260Z</date>
+  </event>
+  <event timestamp="13752997031" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630433478803</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:11:18.803Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13752999097" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433480869</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:11:20.869Z</date>
+  </event>
+  <event timestamp="13753000325" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433482097</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:11:22.097Z</date>
+  </event>
+  <event timestamp="13753000327" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433482099</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:11:22.099Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753003471" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433485243</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:11:25.243Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753003832" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433485604</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:11:25.604Z</date>
+  </event>
+  <event timestamp="13753030346" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433512118</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:11:52.118Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753030387" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433512159</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:11:52.159Z</date>
+  </event>
+  <event timestamp="13753031830" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433513602</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:11:53.602Z</date>
+  </event>
+  <event timestamp="13753037464" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433519235</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:11:59.235Z</date>
+  </event>
+  <event timestamp="13753038607" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433520379</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:12:00.379Z</date>
+  </event>
+  <event timestamp="13753044492" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433526264</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:12:06.264Z</date>
+  </event>
+  <event timestamp="13753045916" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433527688</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:12:07.688Z</date>
+  </event>
+  <event timestamp="13753046457" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433528229</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:12:08.229Z</date>
+  </event>
+  <event timestamp="13753047339" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433529111</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:12:09.111Z</date>
+  </event>
+  <event timestamp="13753050376" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630433532147</timestampUTC>
+    <color>#512da8</color>
+    <senderId>w_xhsnzrp5gjsw</senderId>
+    <date>2021-08-31T18:12:12.147Z</date>
+    <sender>Gustavo</sender>
+    <message>yes, token uses cookie instead of URL param</message>
+  </event>
+  <event timestamp="13753051844" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433533616</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:12:13.616Z</date>
+  </event>
+  <event timestamp="13753052345" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433534117</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:12:14.117Z</date>
+  </event>
+  <event timestamp="13753056479" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433538251</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:12:18.251Z</date>
+  </event>
+  <event timestamp="13753056579" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433538351</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:12:18.351Z</date>
+  </event>
+  <event timestamp="13753057723" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433539495</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:12:19.495Z</date>
+  </event>
+  <event timestamp="13753058005" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433539777</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:12:19.777Z</date>
+  </event>
+  <event timestamp="13753059189" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433540961</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:12:20.961Z</date>
+  </event>
+  <event timestamp="13753059531" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433541302</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:12:21.302Z</date>
+  </event>
+  <event timestamp="13753061350" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433543122</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:12:23.122Z</date>
+  </event>
+  <event timestamp="13753061933" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433543705</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:12:23.705Z</date>
+  </event>
+  <event timestamp="13753064280" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433546052</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:12:26.052Z</date>
+  </event>
+  <event timestamp="13753065199" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433546971</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:12:26.971Z</date>
+  </event>
+  <event timestamp="13753065577" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433547349</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:12:27.349Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753075708" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433557479</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:12:37.479Z</date>
+  </event>
+  <event timestamp="13753076630" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433558401</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:12:38.401Z</date>
+  </event>
+  <event timestamp="13753082901" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433564673</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:12:44.673Z</date>
+  </event>
+  <event timestamp="13753082942" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433564714</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:12:44.714Z</date>
+  </event>
+  <event timestamp="13753087082" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433568854</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:12:48.854Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753088856" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433570627</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:12:50.627Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753090780" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433572551</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:12:52.551Z</date>
+  </event>
+  <event timestamp="13753112151" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433593923</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:13:13.923Z</date>
+  </event>
+  <event timestamp="13753112612" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433594384</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:13:14.384Z</date>
+  </event>
+  <event timestamp="13753117207" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433598979</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:13:18.979Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753130569" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433612341</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:13:32.341Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753132234" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433614006</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:13:34.006Z</date>
+  </event>
+  <event timestamp="13753133157" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433614929</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:13:34.929Z</date>
+  </event>
+  <event timestamp="13753133238" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433615010</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:13:35.010Z</date>
+  </event>
+  <event timestamp="13753133430" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433615202</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:13:35.202Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753134511" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433616283</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:13:36.283Z</date>
+  </event>
+  <event timestamp="13753139862" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433621633</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:13:41.633Z</date>
+  </event>
+  <event timestamp="13753140082" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433621854</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:13:41.854Z</date>
+  </event>
+  <event timestamp="13753144401" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433626173</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:13:46.173Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753148031" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433629803</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:13:49.803Z</date>
+  </event>
+  <event timestamp="13753148312" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433630084</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:13:50.084Z</date>
+  </event>
+  <event timestamp="13753150648" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433632419</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:13:52.419Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753151029" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433632801</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:13:52.801Z</date>
+  </event>
+  <event timestamp="13753151792" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433633564</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:13:53.564Z</date>
+  </event>
+  <event timestamp="13753151833" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433633605</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:13:53.605Z</date>
+  </event>
+  <event timestamp="13753152716" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433634488</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:13:54.488Z</date>
+  </event>
+  <event timestamp="13753160849" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433642621</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:14:02.621Z</date>
+  </event>
+  <event timestamp="13753161752" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433643524</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:14:03.524Z</date>
+  </event>
+  <event timestamp="13753165300" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433647072</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:14:07.072Z</date>
+  </event>
+  <event timestamp="13753166483" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433648255</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:14:08.255Z</date>
+  </event>
+  <event timestamp="13753175880" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433657652</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:14:17.652Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753176562" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433658334</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:14:18.334Z</date>
+  </event>
+  <event timestamp="13753177084" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433658856</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:14:18.856Z</date>
+  </event>
+  <event timestamp="13753182333" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433664105</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:14:24.105Z</date>
+  </event>
+  <event timestamp="13753182948" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433664720</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:14:24.720Z</date>
+  </event>
+  <event timestamp="13753186940" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433668712</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:14:28.712Z</date>
+  </event>
+  <event timestamp="13753188442" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433670214</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:14:30.214Z</date>
+  </event>
+  <event timestamp="13753188663" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433670435</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:14:30.435Z</date>
+  </event>
+  <event timestamp="13753189947" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433671718</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:14:31.718Z</date>
+  </event>
+  <event timestamp="13753193535" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433675307</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:14:35.307Z</date>
+  </event>
+  <event timestamp="13753194397" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433676169</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:14:36.169Z</date>
+  </event>
+  <event timestamp="13753202504" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:14:44.276Z</date>
+    <timestampUTC>1630433684276</timestampUTC>
+    <userId>w_a6odtbi2lzzl</userId>
+    <value>false,stream=w_a6odtbi2lzzl_1382b70a7007c500b9ad0b552047cca6d3e6390e3a931108798353f7f53d0c1a</value>
+  </event>
+  <event timestamp="13753202518" module="VOICE" eventname="ParticipantLeftEvent">
+    <participant>w_a6odtbi2lzzl</participant>
+    <timestampUTC>1630433684289</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:14:44.289Z</date>
+  </event>
+  <event timestamp="13753202729" module="bbb-webrtc-sfu" eventname="StopWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_a6odtbi2lzzl-1630433430027.webm</filename>
+    <timestampUTC>1630433684501</timestampUTC>
+  </event>
+  <event timestamp="13753203589" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433685361</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:14:45.361Z</date>
+  </event>
+  <event timestamp="13753203669" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433685441</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:14:45.441Z</date>
+  </event>
+  <event timestamp="13753208058" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433689830</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:14:49.830Z</date>
+  </event>
+  <event timestamp="13753208138" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433689910</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:14:49.910Z</date>
+  </event>
+  <event timestamp="13753208408" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433690180</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:14:50.180Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753210135" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <timestampUTC>1630433691907</timestampUTC>
+    <date>2021-08-31T18:14:51.907Z</date>
+    <userId>w_a6odtbi2lzzl</userId>
+  </event>
+  <event timestamp="13753210185" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>Tiago</name>
+    <timestampUTC>1630433691956</timestampUTC>
+    <role>MODERATOR</role>
+    <date>2021-08-31T18:14:51.956Z</date>
+    <externalUserId>w_yh2geczxx285</externalUserId>
+    <userId>w_yh2geczxx285</userId>
+  </event>
+  <event timestamp="13753215408" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433697180</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:14:57.180Z</date>
+  </event>
+  <event timestamp="13753216876" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433698648</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:14:58.648Z</date>
+  </event>
+  <event timestamp="13753217035" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433698807</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:14:58.807Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753218365" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433700137</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:15:00.137Z</date>
+  </event>
+  <event timestamp="13753218946" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433700718</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:15:00.718Z</date>
+  </event>
+  <event timestamp="13753222285" module="VOICE" eventname="ParticipantJoinedEvent">
+    <participant>w_yh2geczxx285</participant>
+    <timestampUTC>1630433704057</timestampUTC>
+    <bridge>79134</bridge>
+    <callername>Tiago</callername>
+    <talking>false</talking>
+    <callernumber>w_yh2geczxx285_2-bbbID-Tiago</callernumber>
+    <date>2021-08-31T18:15:04.057Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753222476" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_yh2geczxx285</participant>
+    <timestampUTC>1630433704248</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:15:04.248Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753223398" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433705170</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:15:05.170Z</date>
+  </event>
+  <event timestamp="13753223859" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433705631</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:15:05.631Z</date>
+  </event>
+  <event timestamp="13753224356" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_yh2geczxx285</participant>
+    <timestampUTC>1630433706128</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:15:06.128Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753225440" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_yh2geczxx285</participant>
+    <timestampUTC>1630433707212</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:15:07.212Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753233579" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433715351</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:15:15.351Z</date>
+  </event>
+  <event timestamp="13753234982" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433716754</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:15:16.754Z</date>
+  </event>
+  <event timestamp="13753235011" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:15:16.783Z</date>
+    <timestampUTC>1630433716783</timestampUTC>
+    <userId>w_yh2geczxx285</userId>
+    <value>true,stream=w_yh2geczxx285_1382b70a7007c500b9ad0b552047cca6d3e6390e3a931108798353f7f53d0c1a</value>
+  </event>
+  <event timestamp="13753235228" module="bbb-webrtc-sfu" eventname="StartWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_yh2geczxx285-1630433716605.webm</filename>
+    <timestampUTC>1630433717000</timestampUTC>
+  </event>
+  <event timestamp="13753237147" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433718919</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:15:18.919Z</date>
+  </event>
+  <event timestamp="13753239873" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433721645</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:15:21.645Z</date>
+  </event>
+  <event timestamp="13753240251" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630433722023</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:15:22.023Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753240874" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433722646</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:15:22.646Z</date>
+  </event>
+  <event timestamp="13753241456" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433723227</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:15:23.227Z</date>
+  </event>
+  <event timestamp="13753250410" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433732182</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:15:32.182Z</date>
+  </event>
+  <event timestamp="13753251072" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433732844</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:15:32.844Z</date>
+  </event>
+  <event timestamp="13753255739" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433737511</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:15:37.511Z</date>
+  </event>
+  <event timestamp="13753255760" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433737531</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:15:37.531Z</date>
+  </event>
+  <event timestamp="13753256139" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433737911</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:15:37.911Z</date>
+  </event>
+  <event timestamp="13753257641" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433739413</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:15:39.413Z</date>
+  </event>
+  <event timestamp="13753268733" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433750505</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:15:50.505Z</date>
+  </event>
+  <event timestamp="13753269014" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433750786</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:15:50.786Z</date>
+  </event>
+  <event timestamp="13753273390" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433755162</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:15:55.162Z</date>
+  </event>
+  <event timestamp="13753273831" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433755603</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:15:55.603Z</date>
+  </event>
+  <event timestamp="13753277619" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433759391</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:15:59.391Z</date>
+  </event>
+  <event timestamp="13753277900" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433759672</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:15:59.672Z</date>
+  </event>
+  <event timestamp="13753278801" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433760573</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:16:00.573Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753285226" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433766998</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:16:06.998Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753289274" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433771046</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:16:11.046Z</date>
+  </event>
+  <event timestamp="13753290877" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433772649</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:16:12.649Z</date>
+  </event>
+  <event timestamp="13753292075" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630433773847</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:16:13.847Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753307131" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433788903</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:16:28.903Z</date>
+  </event>
+  <event timestamp="13753307242" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433789014</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:16:29.014Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753308159" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630433789931</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:16:29.931Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753309983" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630433791754</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:16:31.754Z</date>
+  </event>
+  <event timestamp="13753312949" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630433794720</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:16:34.720Z</date>
+  </event>
+  <event timestamp="13753313115" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433794887</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:16:34.887Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753313525" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630433795296</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:16:35.296Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753314247" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433796019</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:16:36.019Z</date>
+  </event>
+  <event timestamp="13753315912" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433797684</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:16:37.684Z</date>
+  </event>
+  <event timestamp="13753316013" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433797785</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:16:37.785Z</date>
+  </event>
+  <event timestamp="13753316956" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433798728</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:16:38.728Z</date>
+  </event>
+  <event timestamp="13753317317" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433799089</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:16:39.089Z</date>
+  </event>
+  <event timestamp="13753322777" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433804549</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:16:44.549Z</date>
+  </event>
+  <event timestamp="13753323238" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433805010</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:16:45.010Z</date>
+  </event>
+  <event timestamp="13753326620" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433808392</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:16:48.392Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753326798" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_yh2geczxx285</participant>
+    <timestampUTC>1630433808570</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:16:48.570Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753329003" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_yh2geczxx285</participant>
+    <timestampUTC>1630433810775</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:16:50.775Z</date>
+  </event>
+  <event timestamp="13753342719" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433824491</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:17:04.491Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753343773" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_yh2geczxx285</participant>
+    <timestampUTC>1630433825544</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:17:05.544Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753344717" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433826488</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:17:06.488Z</date>
+  </event>
+  <event timestamp="13753345426" module="PRESENTATION" eventname="GotoSlideEvent">
+    <timestampUTC>1630433827198</timestampUTC>
+    <presentationName>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentationName>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <id>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/4</id>
+    <slide>3</slide>
+    <date>2021-08-31T18:17:07.198Z</date>
+  </event>
+  <event timestamp="13753345532" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433827304</timestampUTC>
+    <xOffset>-80.54511176215277</xOffset>
+    <date>2021-08-31T18:17:07.304Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/3</whiteboardId>
+    <pageNumber>2</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651225525656</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753345975" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433827747</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:17:07.747Z</date>
+  </event>
+  <event timestamp="13753347369" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433829141</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:17:09.141Z</date>
+  </event>
+  <event timestamp="13753350402" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433832174</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:17:12.174Z</date>
+  </event>
+  <event timestamp="13753353640" module="PRESENTATION" eventname="GotoSlideEvent">
+    <timestampUTC>1630433835412</timestampUTC>
+    <presentationName>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentationName>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <id>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</id>
+    <slide>4</slide>
+    <date>2021-08-31T18:17:15.412Z</date>
+  </event>
+  <event timestamp="13753353716" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630433835488</timestampUTC>
+    <xOffset>-80.54511176215277</xOffset>
+    <date>2021-08-31T18:17:15.488Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/4</whiteboardId>
+    <pageNumber>3</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651225525656</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753354751" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433836522</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:17:16.522Z</date>
+  </event>
+  <event timestamp="13753359385" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433841157</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:17:21.157Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753359991" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433841763</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:17:21.763Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753360694" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433842465</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:17:22.465Z</date>
+  </event>
+  <event timestamp="13753387388" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433869160</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:17:49.160Z</date>
+  </event>
+  <event timestamp="13753388346" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433870118</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:17:50.118Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753389388" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433871160</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:17:51.160Z</date>
+  </event>
+  <event timestamp="13753390080" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433871852</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:17:51.852Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753392825" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433874597</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:17:54.597Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753394599" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433876370</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:17:56.370Z</date>
+  </event>
+  <event timestamp="13753395681" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433877453</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:17:57.453Z</date>
+  </event>
+  <event timestamp="13753399789" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433881561</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:18:01.561Z</date>
+  </event>
+  <event timestamp="13753403417" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433885189</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:18:05.189Z</date>
+  </event>
+  <event timestamp="13753404099" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433885871</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:18:05.871Z</date>
+  </event>
+  <event timestamp="13753404902" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433886674</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:18:06.674Z</date>
+  </event>
+  <event timestamp="13753407769" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433889541</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:18:09.541Z</date>
+  </event>
+  <event timestamp="13753409132" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433890904</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:18:10.904Z</date>
+  </event>
+  <event timestamp="13753409253" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433891025</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:18:11.025Z</date>
+  </event>
+  <event timestamp="13753409294" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433891066</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:18:11.066Z</date>
+  </event>
+  <event timestamp="13753409609" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630433891381</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:18:11.381Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753410449" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433892220</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:18:12.220Z</date>
+  </event>
+  <event timestamp="13753411737" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433893509</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:18:13.509Z</date>
+  </event>
+  <event timestamp="13753412943" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433894715</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:18:14.715Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753413078" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433894850</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:18:14.850Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753414582" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433896353</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:18:16.353Z</date>
+  </event>
+  <event timestamp="13753416428" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433898200</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:18:18.200Z</date>
+  </event>
+  <event timestamp="13753416809" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433898580</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:18:18.580Z</date>
+  </event>
+  <event timestamp="13753432877" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433914649</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:18:34.649Z</date>
+  </event>
+  <event timestamp="13753433179" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433914950</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:18:34.950Z</date>
+  </event>
+  <event timestamp="13753451500" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433933272</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:18:53.272Z</date>
+  </event>
+  <event timestamp="13753451801" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433933573</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:18:53.573Z</date>
+  </event>
+  <event timestamp="13753458503" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433940275</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:19:00.275Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753459346" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433941118</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:19:01.118Z</date>
+  </event>
+  <event timestamp="13753461131" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433942903</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:19:02.903Z</date>
+  </event>
+  <event timestamp="13753462005" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433943776</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:19:03.776Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753463430" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433945202</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:19:05.202Z</date>
+  </event>
+  <event timestamp="13753463911" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433945683</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:19:05.683Z</date>
+  </event>
+  <event timestamp="13753480310" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433962082</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:19:22.082Z</date>
+  </event>
+  <event timestamp="13753481193" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433962965</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:19:22.965Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753481458" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433963230</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:19:23.230Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753482400" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433964172</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:19:24.172Z</date>
+  </event>
+  <event timestamp="13753485944" module="CHAT" eventname="PublicChatEvent">
+    <color>#303f9f</color>
+    <date>2021-08-31T18:19:27.716Z</date>
+    <message>i wonder if we should have a separate user status for breakout room users with different privileges?</message>
+    <sender>Calvin</sender>
+    <senderId>w_szgcfhvhfhdb</senderId>
+    <timestampUTC>1630433967716</timestampUTC>
+  </event>
+  <event timestamp="13753503631" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433985402</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:19:45.402Z</date>
+  </event>
+  <event timestamp="13753504132" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433985903</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:19:45.903Z</date>
+  </event>
+  <event timestamp="13753506781" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433988553</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:19:48.553Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753508080" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433989852</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:19:49.852Z</date>
+  </event>
+  <event timestamp="13753508321" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433990093</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:19:50.093Z</date>
+  </event>
+  <event timestamp="13753514736" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433996508</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:19:56.508Z</date>
+  </event>
+  <event timestamp="13753515048" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630433996820</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:19:56.820Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753515890" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630433997662</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:19:57.662Z</date>
+  </event>
+  <event timestamp="13753520474" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630434002246</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:20:02.246Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753522018" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434003790</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:20:03.790Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753523904" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630434005676</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:20:05.676Z</date>
+  </event>
+  <event timestamp="13753525459" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630434007231</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:20:07.231Z</date>
+  </event>
+  <event timestamp="13753525640" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630434007412</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:20:07.412Z</date>
+  </event>
+  <event timestamp="13753529086" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630434010858</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:20:10.858Z</date>
+  </event>
+  <event timestamp="13753532010" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434013782</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:20:13.782Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753533441" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434015213</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:20:15.213Z</date>
+  </event>
+  <event timestamp="13753534605" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434016377</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:20:16.377Z</date>
+  </event>
+  <event timestamp="13753535348" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434017120</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:20:17.120Z</date>
+  </event>
+  <event timestamp="13753535882" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630434017654</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:20:17.654Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753543600" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434025372</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:20:25.372Z</date>
+  </event>
+  <event timestamp="13753544502" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434026274</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:20:26.274Z</date>
+  </event>
+  <event timestamp="13753546367" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434028139</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:20:28.139Z</date>
+  </event>
+  <event timestamp="13753546827" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434028599</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:20:28.599Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753548700" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434030471</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:20:30.471Z</date>
+  </event>
+  <event timestamp="13753550752" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434032524</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:20:32.524Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753580490" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630434062262</timestampUTC>
+    <color>#1a237e</color>
+    <senderId>w_yh2geczxx285</senderId>
+    <date>2021-08-31T18:21:02.262Z</date>
+    <sender>Tiago</sender>
+    <message>most of cameras are now black for me</message>
+  </event>
+  <event timestamp="13753587226" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434068998</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:21:08.998Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753589349" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434071121</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:21:11.121Z</date>
+  </event>
+  <event timestamp="13753589585" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434071357</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:21:11.357Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753589766" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434071538</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:21:11.538Z</date>
+  </event>
+  <event timestamp="13753596532" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434078304</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:21:18.304Z</date>
+  </event>
+  <event timestamp="13753597050" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434078822</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:21:18.822Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753598243" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434080015</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:21:20.015Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753599928" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434081700</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:21:21.700Z</date>
+  </event>
+  <event timestamp="13753609381" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434091153</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:21:31.153Z</date>
+  </event>
+  <event timestamp="13753610044" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434091815</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:21:31.815Z</date>
+  </event>
+  <event timestamp="13753611268" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434093040</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:21:33.040Z</date>
+  </event>
+  <event timestamp="13753612302" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_yh2geczxx285</participant>
+    <timestampUTC>1630434094074</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:21:34.074Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753612591" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434094363</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:21:34.363Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753613535" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_yh2geczxx285</participant>
+    <timestampUTC>1630434095306</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:21:35.306Z</date>
+  </event>
+  <event timestamp="13753617595" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_yh2geczxx285</participant>
+    <timestampUTC>1630434099367</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:21:39.367Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753619689" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434101461</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:21:41.461Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753620090" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434101861</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:21:41.861Z</date>
+  </event>
+  <event timestamp="13753636292" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434118063</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:21:58.063Z</date>
+  </event>
+  <event timestamp="13753637029" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434118801</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:21:58.801Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753637785" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434119557</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:21:59.557Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753639670" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434121442</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:22:01.442Z</date>
+  </event>
+  <event timestamp="13753655051" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434136823</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:22:16.823Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753655653" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434137424</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:22:17.424Z</date>
+  </event>
+  <event timestamp="13753655993" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434137765</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:22:17.765Z</date>
+  </event>
+  <event timestamp="13753664757" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434146529</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:22:26.529Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753666963" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434148735</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:22:28.735Z</date>
+  </event>
+  <event timestamp="13753673403" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434155175</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:22:35.175Z</date>
+  </event>
+  <event timestamp="13753673443" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434155215</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:22:35.215Z</date>
+  </event>
+  <event timestamp="13753675008" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_yh2geczxx285</participant>
+    <timestampUTC>1630434156780</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:22:36.780Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753675029" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434156801</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:22:36.801Z</date>
+  </event>
+  <event timestamp="13753675852" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_yh2geczxx285</participant>
+    <timestampUTC>1630434157623</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:22:37.623Z</date>
+  </event>
+  <event timestamp="13753681083" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434162855</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:22:42.855Z</date>
+  </event>
+  <event timestamp="13753682406" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434164178</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:22:44.178Z</date>
+  </event>
+  <event timestamp="13753682883" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434164655</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:22:44.655Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753694889" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434176661</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:22:56.661Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753699699" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434181471</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:23:01.471Z</date>
+  </event>
+  <event timestamp="13753700200" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_yh2geczxx285</participant>
+    <timestampUTC>1630434181972</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:23:01.972Z</date>
+  </event>
+  <event timestamp="13753702524" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434184296</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:23:04.296Z</date>
+  </event>
+  <event timestamp="13753702625" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434184397</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:23:04.397Z</date>
+  </event>
+  <event timestamp="13753703186" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_yh2geczxx285</participant>
+    <timestampUTC>1630434184958</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:23:04.958Z</date>
+  </event>
+  <event timestamp="13753704929" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434186701</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:23:06.701Z</date>
+  </event>
+  <event timestamp="13753714322" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434196094</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:23:16.094Z</date>
+  </event>
+  <event timestamp="13753715364" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434197136</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:23:17.136Z</date>
+  </event>
+  <event timestamp="13753722016" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434203788</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:23:23.788Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753727272" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434209044</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:23:29.044Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753729178" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_yh2geczxx285</participant>
+    <timestampUTC>1630434210950</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:23:30.950Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753729739" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434211510</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:23:31.510Z</date>
+  </event>
+  <event timestamp="13753733084" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434214856</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:23:34.856Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753733674" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_lo2vd8rkvicu</participant>
+    <timestampUTC>1630434215446</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:23:35.446Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753734457" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_lo2vd8rkvicu</participant>
+    <timestampUTC>1630434216229</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:23:36.229Z</date>
+  </event>
+  <event timestamp="13753746757" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_lo2vd8rkvicu</participant>
+    <timestampUTC>1630434228528</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:23:48.528Z</date>
+  </event>
+  <event timestamp="13753746797" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_lo2vd8rkvicu</participant>
+    <timestampUTC>1630434228569</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:23:48.569Z</date>
+  </event>
+  <event timestamp="13753752852" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_lo2vd8rkvicu</participant>
+    <timestampUTC>1630434234624</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:23:54.624Z</date>
+  </event>
+  <event timestamp="13753753253" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434235025</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:23:55.025Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753753755" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_lo2vd8rkvicu</participant>
+    <timestampUTC>1630434235527</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:23:55.527Z</date>
+  </event>
+  <event timestamp="13753754974" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_lo2vd8rkvicu</participant>
+    <timestampUTC>1630434236746</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:23:56.746Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753755396" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434237168</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:23:57.168Z</date>
+  </event>
+  <event timestamp="13753758698" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434240470</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:24:00.470Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753759613" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_hpfopjzrpvf5</participant>
+    <timestampUTC>1630434241385</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:24:01.385Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753760616" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_hpfopjzrpvf5</participant>
+    <timestampUTC>1630434242388</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:24:02.388Z</date>
+  </event>
+  <event timestamp="13753761961" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_hpfopjzrpvf5</participant>
+    <timestampUTC>1630434243733</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:24:03.733Z</date>
+  </event>
+  <event timestamp="13753762219" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_hpfopjzrpvf5</participant>
+    <timestampUTC>1630434243991</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:24:03.991Z</date>
+  </event>
+  <event timestamp="13753766748" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_hpfopjzrpvf5</participant>
+    <timestampUTC>1630434248520</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:24:08.520Z</date>
+  </event>
+  <event timestamp="13753766909" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_hpfopjzrpvf5</participant>
+    <timestampUTC>1630434248681</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:24:08.681Z</date>
+  </event>
+  <event timestamp="13753774243" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_hpfopjzrpvf5</participant>
+    <timestampUTC>1630434256015</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:24:16.015Z</date>
+  </event>
+  <event timestamp="13753774284" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_hpfopjzrpvf5</participant>
+    <timestampUTC>1630434256055</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:24:16.055Z</date>
+  </event>
+  <event timestamp="13753784021" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_hpfopjzrpvf5</participant>
+    <timestampUTC>1630434265793</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:24:25.793Z</date>
+  </event>
+  <event timestamp="13753784101" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_hpfopjzrpvf5</participant>
+    <timestampUTC>1630434265873</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:24:25.873Z</date>
+  </event>
+  <event timestamp="13753785338" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434267110</timestampUTC>
+    <xOffset>28.383458455403648</xOffset>
+    <date>2021-08-31T18:24:27.110Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>98.48840784143519</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753785388" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_hpfopjzrpvf5</participant>
+    <timestampUTC>1630434267160</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:24:27.160Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753785509" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434267281</timestampUTC>
+    <xOffset>35.52631590101454</xOffset>
+    <date>2021-08-31T18:24:27.281Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>95.8150604624807</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753785553" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434267325</timestampUTC>
+    <xOffset>35.62029944525825</xOffset>
+    <date>2021-08-31T18:24:27.325Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>95.8150604624807</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753785709" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434267481</timestampUTC>
+    <xOffset>-80.54511176215277</xOffset>
+    <date>2021-08-31T18:24:27.481Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651225525656</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753786728" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434268500</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:24:28.500Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753789095" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434270867</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:24:30.867Z</date>
+  </event>
+  <event timestamp="13753833704" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434315476</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:25:15.476Z</date>
+  </event>
+  <event timestamp="13753834507" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434316279</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:25:16.279Z</date>
+  </event>
+  <event timestamp="13753837934" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_2txocgzrz5qa</participant>
+    <timestampUTC>1630434319706</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:25:19.706Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753838356" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434320128</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:25:20.128Z</date>
+  </event>
+  <event timestamp="13753838928" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_2txocgzrz5qa</participant>
+    <timestampUTC>1630434320699</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:25:20.699Z</date>
+  </event>
+  <event timestamp="13753839307" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434321079</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:25:21.079Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753853150" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_2txocgzrz5qa</participant>
+    <timestampUTC>1630434334922</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:25:34.922Z</date>
+  </event>
+  <event timestamp="13753853370" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_2txocgzrz5qa</participant>
+    <timestampUTC>1630434335142</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:25:35.142Z</date>
+  </event>
+  <event timestamp="13753875709" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434357480</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:25:57.480Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753878660" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434360432</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:26:00.432Z</date>
+  </event>
+  <event timestamp="13753878681" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_2txocgzrz5qa</participant>
+    <timestampUTC>1630434360453</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:26:00.453Z</date>
+  </event>
+  <event timestamp="13753879451" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_2txocgzrz5qa</participant>
+    <timestampUTC>1630434361223</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:26:01.223Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753883749" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_2txocgzrz5qa</participant>
+    <timestampUTC>1630434365521</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:26:05.521Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753887637" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_2txocgzrz5qa</participant>
+    <timestampUTC>1630434369409</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:26:09.409Z</date>
+  </event>
+  <event timestamp="13753887899" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434369670</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:26:09.670Z</date>
+  </event>
+  <event timestamp="13753890385" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_2txocgzrz5qa</participant>
+    <timestampUTC>1630434372157</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:26:12.157Z</date>
+  </event>
+  <event timestamp="13753890575" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_2txocgzrz5qa</participant>
+    <timestampUTC>1630434372347</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:26:12.347Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753891017" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434372789</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:26:12.789Z</date>
+  </event>
+  <event timestamp="13753892734" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434374506</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:26:14.506Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753893114" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_wwbw89colslo</participant>
+    <timestampUTC>1630434374886</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:26:14.886Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753894698" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_wwbw89colslo</participant>
+    <timestampUTC>1630434376470</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:26:16.470Z</date>
+  </event>
+  <event timestamp="13753916560" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630434398332</timestampUTC>
+    <color>#0277bd</color>
+    <senderId>w_vk0ebqjxox9d</senderId>
+    <date>2021-08-31T18:26:38.332Z</date>
+    <sender>Anton G</sender>
+    <message>Nice!</message>
+  </event>
+  <event timestamp="13753920407" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434402179</timestampUTC>
+    <xOffset>37.68797132703993</xOffset>
+    <date>2021-08-31T18:26:42.179Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>99.82508529851467</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753920878" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434402650</timestampUTC>
+    <xOffset>37.875938415527344</xOffset>
+    <date>2021-08-31T18:26:42.650Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>99.65799967447917</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753921031" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434402803</timestampUTC>
+    <xOffset>-80.54511176215277</xOffset>
+    <date>2021-08-31T18:26:42.803Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651225525656</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753926484" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_wwbw89colslo</participant>
+    <timestampUTC>1630434408256</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:26:48.256Z</date>
+  </event>
+  <event timestamp="13753926486" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_wwbw89colslo</participant>
+    <timestampUTC>1630434408258</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:26:48.258Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753927912" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434409684</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:26:49.684Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753929717" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434411489</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:26:51.489Z</date>
+  </event>
+  <event timestamp="13753931371" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434413143</timestampUTC>
+    <xOffset>28.759398990207245</xOffset>
+    <date>2021-08-31T18:26:53.143Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>99.49091405044366</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753931487" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434413259</timestampUTC>
+    <xOffset>-80.54511176215277</xOffset>
+    <date>2021-08-31T18:26:53.259Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651225525656</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753941178" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434422950</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:27:02.950Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13753941399" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434423171</timestampUTC>
+    <xOffset>15.601503584120008</xOffset>
+    <date>2021-08-31T18:27:03.171Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>98.82257908950616</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753941547" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434423319</timestampUTC>
+    <xOffset>14.003758960300022</xOffset>
+    <date>2021-08-31T18:27:03.319Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>96.65048104745371</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753943275" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434425047</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:27:05.047Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13753945300" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434427072</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:27:07.072Z</date>
+  </event>
+  <event timestamp="13753951738" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434433510</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:27:13.510Z</date>
+  </event>
+  <event timestamp="13753952099" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434433871</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:27:13.871Z</date>
+  </event>
+  <event timestamp="13753961484" module="CHAT" eventname="PublicChatEvent">
+    <color>#1a237e</color>
+    <date>2021-08-31T18:27:23.256Z</date>
+    <message>@Vitor / Anton. B -&amp;gt; let&amp;#39;s meet later to discuss the &amp;quot;render count&amp;quot; tests</message>
+    <sender>Tiago</sender>
+    <senderId>w_yh2geczxx285</senderId>
+    <timestampUTC>1630434443256</timestampUTC>
+  </event>
+  <event timestamp="13753964345" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434446117</timestampUTC>
+    <xOffset>14.66165436638726</xOffset>
+    <date>2021-08-31T18:27:26.117Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>95.64797483844522</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753964510" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434446282</timestampUTC>
+    <xOffset>99.90601433648003</xOffset>
+    <date>2021-08-31T18:27:26.282Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>31.65465931833526</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753964651" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434446423</timestampUTC>
+    <xOffset>99.90601433648003</xOffset>
+    <date>2021-08-31T18:27:26.423Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>9.766603634681232</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753964823" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434446595</timestampUTC>
+    <xOffset>-80.54511176215277</xOffset>
+    <date>2021-08-31T18:27:26.595Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651225525656</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753968200" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434449972</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:27:29.972Z</date>
+  </event>
+  <event timestamp="13753968240" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434450012</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:27:30.012Z</date>
+  </event>
+  <event timestamp="13753979613" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434461385</timestampUTC>
+    <xOffset>38.62781948513455</xOffset>
+    <date>2021-08-31T18:27:41.385Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>1.078216411449291</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753979774" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434461546</timestampUTC>
+    <xOffset>36.936090257432724</xOffset>
+    <date>2021-08-31T18:27:41.546Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>7.260338112160011</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753981953" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434463725</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:27:43.725Z</date>
+  </event>
+  <event timestamp="13753982074" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434463845</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:27:43.845Z</date>
+  </event>
+  <event timestamp="13753985989" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434467761</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:27:47.761Z</date>
+  </event>
+  <event timestamp="13753986382" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434468154</timestampUTC>
+    <xOffset>36.84210459391276</xOffset>
+    <date>2021-08-31T18:27:48.154Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>7.427422794294946</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13753986451" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434468223</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:27:48.223Z</date>
+  </event>
+  <event timestamp="13753986547" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434468319</timestampUTC>
+    <xOffset>35.80827077229818</xOffset>
+    <date>2021-08-31T18:27:48.319Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>8.764097425672743</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754002446" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434484218</timestampUTC>
+    <xOffset>35.80827077229818</xOffset>
+    <date>2021-08-31T18:28:04.218Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>8.931182107807679</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754002589" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434484361</timestampUTC>
+    <xOffset>35.05639182196723</xOffset>
+    <date>2021-08-31T18:28:04.361Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>27.477548858265816</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754003478" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434485249</timestampUTC>
+    <xOffset>34.304510752360024</xOffset>
+    <date>2021-08-31T18:28:05.249Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>27.477548858265816</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754003629" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434485401</timestampUTC>
+    <xOffset>32.800752851698135</xOffset>
+    <date>2021-08-31T18:28:05.401Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>27.310463234230326</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754003799" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434485571</timestampUTC>
+    <xOffset>30.827066633436417</xOffset>
+    <date>2021-08-31T18:28:05.571Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>24.804197711709104</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754003951" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434485723</timestampUTC>
+    <xOffset>29.041353861490887</xOffset>
+    <date>2021-08-31T18:28:05.723Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>18.287907353153933</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754004451" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434486223</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:28:06.223Z</date>
+  </event>
+  <event timestamp="13754004571" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434486343</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:28:06.343Z</date>
+  </event>
+  <event timestamp="13754004919" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434486691</timestampUTC>
+    <xOffset>28.947368197970917</xOffset>
+    <date>2021-08-31T18:28:06.691Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>17.619570508415315</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754005068" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434486840</timestampUTC>
+    <xOffset>28.759398990207245</xOffset>
+    <date>2021-08-31T18:28:06.840Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>16.617064299406827</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754005233" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434487005</timestampUTC>
+    <xOffset>28.759398990207245</xOffset>
+    <date>2021-08-31T18:28:07.005Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>16.28289493513696</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754005398" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434487169</timestampUTC>
+    <xOffset>39.09774356418186</xOffset>
+    <date>2021-08-31T18:28:07.169Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>24.63711397147473</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754005579" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434487351</timestampUTC>
+    <xOffset>39.003757900661896</xOffset>
+    <date>2021-08-31T18:28:07.351Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>24.470028347439236</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754005737" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434487508</timestampUTC>
+    <xOffset>37.5</xOffset>
+    <date>2021-08-31T18:28:07.508Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>26.80921012972608</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754005898" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434487670</timestampUTC>
+    <xOffset>37.406014336480034</xOffset>
+    <date>2021-08-31T18:28:07.670Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>27.310463234230326</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754006063" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434487835</timestampUTC>
+    <xOffset>36.56015184190538</xOffset>
+    <date>2021-08-31T18:28:07.835Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>27.310463234230326</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754006283" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434488055</timestampUTC>
+    <xOffset>36.27819485134548</xOffset>
+    <date>2021-08-31T18:28:08.055Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>27.14337949399595</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754006335" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434488107</timestampUTC>
+    <xOffset>36.18420918782552</xOffset>
+    <date>2021-08-31T18:28:08.107Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>27.14337949399595</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754006599" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434488371</timestampUTC>
+    <xOffset>36.09022352430556</xOffset>
+    <date>2021-08-31T18:28:08.371Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>27.14337949399595</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754006747" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434488519</timestampUTC>
+    <xOffset>35.996242099338104</xOffset>
+    <date>2021-08-31T18:28:08.519Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>26.976295753761576</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754006769" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434488541</timestampUTC>
+    <xOffset>36.27819485134548</xOffset>
+    <date>2021-08-31T18:28:08.541Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>26.976295753761576</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754006921" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434488693</timestampUTC>
+    <xOffset>37.875938415527344</xOffset>
+    <date>2021-08-31T18:28:08.693Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>21.629595344449267</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754007082" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434488854</timestampUTC>
+    <xOffset>36.936090257432724</xOffset>
+    <date>2021-08-31T18:28:08.854Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>21.128342239945024</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754007243" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434489015</timestampUTC>
+    <xOffset>37.31202867296007</xOffset>
+    <date>2021-08-31T18:28:09.015Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>21.462509720413774</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754007397" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434489169</timestampUTC>
+    <xOffset>37.68797132703993</xOffset>
+    <date>2021-08-31T18:28:09.169Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>21.462509720413774</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754007547" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434489319</timestampUTC>
+    <xOffset>37.96992407904731</xOffset>
+    <date>2021-08-31T18:28:09.319Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>21.462509720413774</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754007747" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434489519</timestampUTC>
+    <xOffset>37.96992407904731</xOffset>
+    <date>2021-08-31T18:28:09.519Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>21.629595344449267</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754007885" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434489657</timestampUTC>
+    <xOffset>37.96992407904731</xOffset>
+    <date>2021-08-31T18:28:09.657Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>21.796679084683642</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754011284" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434493056</timestampUTC>
+    <xOffset>37.593985663519966</xOffset>
+    <date>2021-08-31T18:28:13.056Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>21.963762824918017</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754011441" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434493213</timestampUTC>
+    <xOffset>-80.54511176215277</xOffset>
+    <date>2021-08-31T18:28:13.213Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651225525656</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754014778" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434496550</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:28:16.550Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13754018887" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434500659</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:28:20.659Z</date>
+  </event>
+  <event timestamp="13754019110" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434500882</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:28:20.882Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13754019532" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434501304</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:28:21.304Z</date>
+  </event>
+  <event timestamp="13754027559" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630434509331</timestampUTC>
+    <color>#1976d2</color>
+    <senderId>w_hpfopjzrpvf5</senderId>
+    <date>2021-08-31T18:28:29.331Z</date>
+    <sender>Anton B.</sender>
+    <message>Ok!</message>
+  </event>
+  <event timestamp="13754028975" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434510747</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:28:30.747Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13754029076" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434510848</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:28:30.848Z</date>
+  </event>
+  <event timestamp="13754030500" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434512272</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:28:32.272Z</date>
+  </event>
+  <event timestamp="13754030910" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434512682</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:28:32.682Z</date>
+  </event>
+  <event timestamp="13754031954" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434513726</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:28:33.726Z</date>
+  </event>
+  <event timestamp="13754033218" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434514989</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:28:34.989Z</date>
+  </event>
+  <event timestamp="13754033336" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434515108</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:28:35.108Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13754033577" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434515349</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:28:35.349Z</date>
+  </event>
+  <event timestamp="13754037749" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434519521</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:28:39.521Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13754038919" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434520691</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:28:40.691Z</date>
+  </event>
+  <event timestamp="13754039100" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434520872</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:28:40.872Z</date>
+  </event>
+  <event timestamp="13754054330" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434536102</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:28:56.102Z</date>
+  </event>
+  <event timestamp="13754055352" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434537124</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:28:57.124Z</date>
+  </event>
+  <event timestamp="13754055613" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434537385</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:28:57.385Z</date>
+  </event>
+  <event timestamp="13754055894" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434537666</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:28:57.666Z</date>
+  </event>
+  <event timestamp="13754056657" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434538429</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:28:58.429Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13754059534" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434541306</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:29:01.306Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13754060418" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434542190</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:29:02.190Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13754063115" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434544887</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:29:04.887Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13754066251" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434548023</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:29:08.023Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13754067794" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434549566</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:29:09.566Z</date>
+  </event>
+  <event timestamp="13754070360" module="VOICE" eventname="ParticipantLeftEvent">
+    <participant>w_wwbw89colslo</participant>
+    <timestampUTC>1630434552132</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:29:12.132Z</date>
+  </event>
+  <event timestamp="13754071402" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434553174</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:29:13.174Z</date>
+  </event>
+  <event timestamp="13754071503" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434553275</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:29:13.275Z</date>
+  </event>
+  <event timestamp="13754076564" module="VOICE" eventname="ParticipantJoinedEvent">
+    <participant>w_wwbw89colslo</participant>
+    <timestampUTC>1630434558336</timestampUTC>
+    <bridge>79134</bridge>
+    <callername>Maxim</callername>
+    <talking>false</talking>
+    <callernumber>Maxim</callernumber>
+    <date>2021-08-31T18:29:18.336Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13754085188" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434566960</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:29:26.960Z</date>
+  </event>
+  <event timestamp="13754085269" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434567041</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:29:27.041Z</date>
+  </event>
+  <event timestamp="13754089337" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434571108</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:29:31.108Z</date>
+  </event>
+  <event timestamp="13754089377" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434571149</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:29:31.149Z</date>
+  </event>
+  <event timestamp="13754104797" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434586569</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:29:46.569Z</date>
+  </event>
+  <event timestamp="13754105478" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434587250</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:29:47.250Z</date>
+  </event>
+  <event timestamp="13754107195" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630434588967</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:29:48.967Z</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="13754111664" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630434593436</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:29:53.436Z</date>
+  </event>
+  <event timestamp="13754111825" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434593597</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:29:53.597Z</date>
+  </event>
+  <event timestamp="13754111926" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434593697</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>true</talking>
+    <date>2021-08-31T18:29:53.697Z</date>
+  </event>
+  <event timestamp="13754112924" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434594696</timestampUTC>
+    <xOffset>31.766916910807293</xOffset>
+    <date>2021-08-31T18:29:54.696Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>98.65549346547068</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754113008" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630434594780</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:29:54.780Z</date>
+  </event>
+  <event timestamp="13754113065" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434594837</timestampUTC>
+    <xOffset>43.32706875271267</xOffset>
+    <date>2021-08-31T18:29:54.837Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>8.764097425672743</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754113223" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434594994</timestampUTC>
+    <xOffset>-80.54511176215277</xOffset>
+    <date>2021-08-31T18:29:54.994Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651225525656</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754113583" module="VOICE" eventname="ParticipantLeftEvent">
+    <participant>w_wwbw89colslo</participant>
+    <timestampUTC>1630434595354</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:29:55.354Z</date>
+  </event>
+  <event timestamp="13754114000" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630434595771</timestampUTC>
+    <color>#01579b</color>
+    <senderId>w_2txocgzrz5qa</senderId>
+    <date>2021-08-31T18:29:55.771Z</date>
+    <sender>Kert</sender>
+    <message>cya</message>
+  </event>
+  <event timestamp="13754114113" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434595884</timestampUTC>
+    <bridge>79134</bridge>
+    <talking>false</talking>
+    <date>2021-08-31T18:29:55.884Z</date>
+  </event>
+  <event timestamp="13754115236" module="VOICE" eventname="ParticipantLeftEvent">
+    <participant>w_or8rfls1s4ya</participant>
+    <timestampUTC>1630434597008</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:29:57.008Z</date>
+  </event>
+  <event timestamp="13754115557" module="PARTICIPANT" eventname="RecordStatusEvent">
+    <timestampUTC>1630434597329</timestampUTC>
+    <date>2021-08-31T18:29:57.329Z</date>
+    <status>false</status>
+    <userId>w_vk0ebqjxox9d</userId>
+  </event>
+  <event timestamp="13754115581" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630434597353</timestampUTC>
+    <color>#1976d2</color>
+    <senderId>w_pwxbcsf5jfuq</senderId>
+    <date>2021-08-31T18:29:57.353Z</date>
+    <sender>João</sender>
+    <message>Bye</message>
+  </event>
+  <event timestamp="13754115719" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434597491</timestampUTC>
+    <xOffset>5.16917281680637</xOffset>
+    <date>2021-08-31T18:29:57.491Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>60.8944250036169</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754115877" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434597648</timestampUTC>
+    <xOffset>-80.54511176215277</xOffset>
+    <date>2021-08-31T18:29:57.648Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651225525656</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754116612" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:29:58.384Z</date>
+    <timestampUTC>1630434598384</timestampUTC>
+    <userId>w_lo2vd8rkvicu</userId>
+    <value>false,stream=w_lo2vd8rkvicu_682f9e12269e303016054c2c3213447b3bb4c73c5ccd271d68e2887bfbfb92d8</value>
+  </event>
+  <event timestamp="13754116640" module="VOICE" eventname="ParticipantLeftEvent">
+    <participant>w_lo2vd8rkvicu</participant>
+    <timestampUTC>1630434598412</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:29:58.412Z</date>
+  </event>
+  <event timestamp="13754116647" module="bbb-webrtc-sfu" eventname="StopWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_lo2vd8rkvicu-1630433463000.webm</filename>
+    <timestampUTC>1630434598419</timestampUTC>
+  </event>
+  <event timestamp="13754116666" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:29:58.438Z</date>
+    <timestampUTC>1630434598438</timestampUTC>
+    <userId>w_k6547g2umh6j</userId>
+    <value>false,stream=w_k6547g2umh6j_1168421dd8fddc53a4181c1abd419e22b79bbfed160bca0d495b90aa085428c9</value>
+  </event>
+  <event timestamp="13754116681" module="VOICE" eventname="ParticipantLeftEvent">
+    <participant>w_k6547g2umh6j</participant>
+    <timestampUTC>1630434598453</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:29:58.453Z</date>
+  </event>
+  <event timestamp="13754116722" module="bbb-webrtc-sfu" eventname="StopWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_k6547g2umh6j-1630432919471.webm</filename>
+    <timestampUTC>1630434598494</timestampUTC>
+  </event>
+  <event timestamp="13754117659" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630434599431</timestampUTC>
+    <color>#512da8</color>
+    <senderId>w_xhsnzrp5gjsw</senderId>
+    <date>2021-08-31T18:29:59.431Z</date>
+    <sender>Gustavo</sender>
+    <message>cyya</message>
+  </event>
+  <event timestamp="13754117927" module="bbb-webrtc-sfu" eventname="StopWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_hpfopjzrpvf5-1630432845990.webm</filename>
+    <timestampUTC>1630434599699</timestampUTC>
+  </event>
+  <event timestamp="13754117937" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:29:59.709Z</date>
+    <timestampUTC>1630434599709</timestampUTC>
+    <userId>w_hpfopjzrpvf5</userId>
+    <value>false,stream=w_hpfopjzrpvf5_586b2ee51194839d7428e25f7cf7dd37cbf253841ada0581b42e7da1e999bd40</value>
+  </event>
+  <event timestamp="13754117947" module="VOICE" eventname="ParticipantLeftEvent">
+    <participant>w_hpfopjzrpvf5</participant>
+    <timestampUTC>1630434599719</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:29:59.719Z</date>
+  </event>
+  <event timestamp="13754118751" module="VOICE" eventname="ParticipantLeftEvent">
+    <participant>w_2txocgzrz5qa</participant>
+    <timestampUTC>1630434600523</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:30:00.523Z</date>
+  </event>
+  <event timestamp="13754118811" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434600583</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:30:00.583Z</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="13754120134" module="VOICE" eventname="ParticipantLeftEvent">
+    <participant>w_etmphvzxcogu</participant>
+    <timestampUTC>1630434601906</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:30:01.906Z</date>
+  </event>
+  <event timestamp="13754120140" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <timestampUTC>1630434601912</timestampUTC>
+    <date>2021-08-31T18:30:01.912Z</date>
+    <userId>w_or8rfls1s4ya</userId>
+  </event>
+  <event timestamp="13754120141" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <timestampUTC>1630434601912</timestampUTC>
+    <date>2021-08-31T18:30:01.912Z</date>
+    <userId>w_lo2vd8rkvicu</userId>
+  </event>
+  <event timestamp="13754120141" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <timestampUTC>1630434601913</timestampUTC>
+    <date>2021-08-31T18:30:01.913Z</date>
+    <userId>w_hpfopjzrpvf5</userId>
+  </event>
+  <event timestamp="13754120142" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <timestampUTC>1630434601914</timestampUTC>
+    <date>2021-08-31T18:30:01.914Z</date>
+    <userId>w_2txocgzrz5qa</userId>
+  </event>
+  <event timestamp="13754120142" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <timestampUTC>1630434601914</timestampUTC>
+    <date>2021-08-31T18:30:01.914Z</date>
+    <userId>w_k6547g2umh6j</userId>
+  </event>
+  <event timestamp="13754120143" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <timestampUTC>1630434601915</timestampUTC>
+    <date>2021-08-31T18:30:01.915Z</date>
+    <userId>w_wwbw89colslo</userId>
+  </event>
+  <event timestamp="13754120216" module="VOICE" eventname="ParticipantLeftEvent">
+    <participant>w_kmm96j1as24f</participant>
+    <timestampUTC>1630434601988</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:30:01.988Z</date>
+  </event>
+  <event timestamp="13754120221" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:30:01.993Z</date>
+    <timestampUTC>1630434601993</timestampUTC>
+    <userId>w_kmm96j1as24f</userId>
+    <value>false,stream=w_kmm96j1as24f_64d81ff78b2bdf6281c12cf4adfa7c1f0a44f2b27e98b654c68c7adc9b38402a</value>
+  </event>
+  <event timestamp="13754120312" module="bbb-webrtc-sfu" eventname="StopWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_kmm96j1as24f-1630433024002.webm</filename>
+    <timestampUTC>1630434602084</timestampUTC>
+  </event>
+  <event timestamp="13754120832" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:30:02.604Z</date>
+    <timestampUTC>1630434602604</timestampUTC>
+    <userId>w_pwxbcsf5jfuq</userId>
+    <value>false,stream=w_pwxbcsf5jfuq_0c8f802440175390ed202a4084da8b6b7e60a4a5a9931094622059986514dd42</value>
+  </event>
+  <event timestamp="13754120839" module="VOICE" eventname="ParticipantLeftEvent">
+    <participant>w_pwxbcsf5jfuq</participant>
+    <timestampUTC>1630434602611</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:30:02.611Z</date>
+  </event>
+  <event timestamp="13754121177" module="bbb-webrtc-sfu" eventname="StopWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_pwxbcsf5jfuq-1630432807888.webm</filename>
+    <timestampUTC>1630434602948</timestampUTC>
+  </event>
+  <event timestamp="13754121890" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:30:03.662Z</date>
+    <timestampUTC>1630434603662</timestampUTC>
+    <userId>w_xhsnzrp5gjsw</userId>
+    <value>false,stream=w_xhsnzrp5gjsw_RqxO4OFyznQZtquSjpPzW3dB8y9izRZw65V0b7JOdPc=</value>
+  </event>
+  <event timestamp="13754121922" module="VOICE" eventname="ParticipantLeftEvent">
+    <participant>w_xhsnzrp5gjsw</participant>
+    <timestampUTC>1630434603694</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:30:03.694Z</date>
+  </event>
+  <event timestamp="13754122023" module="bbb-webrtc-sfu" eventname="StopWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_xhsnzrp5gjsw-1630432926054.webm</filename>
+    <timestampUTC>1630434603795</timestampUTC>
+  </event>
+  <event timestamp="13754124984" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:30:06.756Z</date>
+    <timestampUTC>1630434606756</timestampUTC>
+    <userId>w_vk0ebqjxox9d</userId>
+    <value>false,stream=w_vk0ebqjxox9d_f66882b1979bd7ab36358419b8681c9b4ab15eacb294c961c6240bec39a1ec06</value>
+  </event>
+  <event timestamp="13754125094" module="bbb-webrtc-sfu" eventname="StopWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_vk0ebqjxox9d-1630432942869.webm</filename>
+    <timestampUTC>1630434606866</timestampUTC>
+  </event>
+  <event timestamp="13754126241" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434608012</timestampUTC>
+    <xOffset>42.199249267578125</xOffset>
+    <date>2021-08-31T18:30:08.012Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>93.47587679639274</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754126377" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434608149</timestampUTC>
+    <xOffset>-80.54511176215277</xOffset>
+    <date>2021-08-31T18:30:08.149Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651225525656</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754130135" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <timestampUTC>1630434611907</timestampUTC>
+    <date>2021-08-31T18:30:11.907Z</date>
+    <userId>w_pwxbcsf5jfuq</userId>
+  </event>
+  <event timestamp="13754130139" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <timestampUTC>1630434611911</timestampUTC>
+    <date>2021-08-31T18:30:11.911Z</date>
+    <userId>w_kmm96j1as24f</userId>
+  </event>
+  <event timestamp="13754130142" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <timestampUTC>1630434611914</timestampUTC>
+    <date>2021-08-31T18:30:11.914Z</date>
+    <userId>w_etmphvzxcogu</userId>
+  </event>
+  <event timestamp="13754130143" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <timestampUTC>1630434611915</timestampUTC>
+    <date>2021-08-31T18:30:11.915Z</date>
+    <userId>w_xhsnzrp5gjsw</userId>
+  </event>
+  <event timestamp="13754132429" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:30:14.201Z</date>
+    <timestampUTC>1630434614201</timestampUTC>
+    <userId>w_yh2geczxx285</userId>
+    <value>false,stream=w_yh2geczxx285_1382b70a7007c500b9ad0b552047cca6d3e6390e3a931108798353f7f53d0c1a</value>
+  </event>
+  <event timestamp="13754132446" module="VOICE" eventname="ParticipantLeftEvent">
+    <participant>w_yh2geczxx285</participant>
+    <timestampUTC>1630434614218</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:30:14.218Z</date>
+  </event>
+  <event timestamp="13754132920" module="bbb-webrtc-sfu" eventname="StopWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_yh2geczxx285-1630433716605.webm</filename>
+    <timestampUTC>1630434614692</timestampUTC>
+  </event>
+  <event timestamp="13754136268" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
+    <status>hasStream</status>
+    <date>2021-08-31T18:30:18.039Z</date>
+    <timestampUTC>1630434618039</timestampUTC>
+    <userId>w_szgcfhvhfhdb</userId>
+    <value>false,stream=w_szgcfhvhfhdb_qw68aW1HLTK0SUCNudZWxRWtEqLQo0M8uFQOOQiklXM=</value>
+  </event>
+  <event timestamp="13754136298" module="VOICE" eventname="ParticipantLeftEvent">
+    <participant>w_szgcfhvhfhdb</participant>
+    <timestampUTC>1630434618069</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:30:18.069Z</date>
+  </event>
+  <event timestamp="13754136405" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630434618177</timestampUTC>
+    <xOffset>-68.04511176215277</xOffset>
+    <date>2021-08-31T18:30:18.177Z</date>
+    <whiteboardId>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000/5</whiteboardId>
+    <pageNumber>4</pageNumber>
+    <userId>w_vk0ebqjxox9d</userId>
+    <yOffset>-22.14651225525656</yOffset>
+    <presentation>edd9bf9dae67277f9f2168b7d40529b7167e7c68-1630433135000</presentation>
+  </event>
+  <event timestamp="13754136433" module="bbb-webrtc-sfu" eventname="StopWebRTCShareEvent">
+    <meeting_id>183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889</meeting_id>
+    <filename>file:///var/kurento/recordings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/medium-w_szgcfhvhfhdb-1630432867598.webm</filename>
+    <timestampUTC>1630434618205</timestampUTC>
+  </event>
+  <event timestamp="13754140135" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <timestampUTC>1630434621907</timestampUTC>
+    <date>2021-08-31T18:30:21.907Z</date>
+    <userId>w_szgcfhvhfhdb</userId>
+  </event>
+  <event timestamp="13754140139" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <timestampUTC>1630434621911</timestampUTC>
+    <date>2021-08-31T18:30:21.911Z</date>
+    <userId>w_yh2geczxx285</userId>
+  </event>
+  <event timestamp="13754268510" module="VOICE" eventname="ParticipantLeftEvent">
+    <participant>w_vk0ebqjxox9d</participant>
+    <timestampUTC>1630434750282</timestampUTC>
+    <bridge>79134</bridge>
+    <date>2021-08-31T18:32:30.282Z</date>
+  </event>
+  <event timestamp="13754268511" module="VOICE" eventname="StopRecordingEvent">
+    <filename>/var/freeswitch/meetings/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889-13751383876.opus</filename>
+    <date>2021-08-31T18:32:30.283Z</date>
+    <timestampUTC>1630434750283</timestampUTC>
+    <bridge>79134</bridge>
+    <recordingTimestamp>13754268509</recordingTimestamp>
+  </event>
+  <event timestamp="13754270136" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <timestampUTC>1630434751908</timestampUTC>
+    <date>2021-08-31T18:32:31.908Z</date>
+    <userId>w_vk0ebqjxox9d</userId>
+  </event>
+  <event timestamp="13754340135" module="PARTICIPANT" eventname="EndAndKickAllEvent">
+    <timestampUTC>1630434821907</timestampUTC>
+    <reason>ENDED_WHEN_LAST_USER_LEFT</reason>
+    <date>2021-08-31T18:33:41.907Z</date>
+  </event>
+</recording>

--- a/record-and-playback/core/resources/raw/2a1de53edf0543d950056bf3c0d4d357eba3383f-1630607370684/events.xml
+++ b/record-and-playback/core/resources/raw/2a1de53edf0543d950056bf3c0d4d357eba3383f-1630607370684/events.xml
@@ -1,0 +1,422 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<recording meeting_id="2a1de53edf0543d950056bf3c0d4d357eba3383f-1630607370684" bbb_version="2.1.0">
+  <meeting id="2a1de53edf0543d950056bf3c0d4d357eba3383f-1630607370684" externalId="random-9678161_calvin_" name="random-9678161" breakout="false"/>
+  <metadata bbb-anonymize-chat="true" isBreakout="false" meetingId="random-9678161_calvin_" meetingName="random-9678161"/>
+  <event timestamp="1131799575" module="PRESENTATION" eventname="CreatePresentationPodEvent">
+    <currentPresenter/>
+    <timestampUTC>1630607370704</timestampUTC>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <date>2021-09-02T14:29:30.704-04</date>
+  </event>
+  <event timestamp="1131799900" module="PAD" eventname="AddPadEvent">
+    <timestampUTC>1630607371029</timestampUTC>
+    <date>2021-09-02T14:29:31.029-04</date>
+    <padId>[2]cfe107fd5780210103d9d4017f8c751d5594</padId>
+  </event>
+  <event timestamp="1131803050" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>User 7520456</name>
+    <timestampUTC>1630607374179</timestampUTC>
+    <role>MODERATOR</role>
+    <date>2021-09-02T14:29:34.179-04</date>
+    <externalUserId>w_jw2fcjeovwa6</externalUserId>
+    <userId>w_jw2fcjeovwa6</userId>
+  </event>
+  <event timestamp="1131803051" module="PARTICIPANT" eventname="AssignPresenterEvent">
+    <name>User 7520456</name>
+    <timestampUTC>1630607374180</timestampUTC>
+    <userid>w_jw2fcjeovwa6</userid>
+    <assignedBy>w_jw2fcjeovwa6</assignedBy>
+    <date>2021-09-02T14:29:34.180-04</date>
+  </event>
+  <event timestamp="1131803066" module="PARTICIPANT" eventname="AssignPresenterEvent">
+    <name>User 7520456</name>
+    <timestampUTC>1630607374195</timestampUTC>
+    <userid>w_jw2fcjeovwa6</userid>
+    <assignedBy>w_jw2fcjeovwa6</assignedBy>
+    <date>2021-09-02T14:29:34.195-04</date>
+  </event>
+  <event timestamp="1131803067" module="PRESENTATION" eventname="SetPresenterInPodEvent">
+    <timestampUTC>1630607374196</timestampUTC>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <date>2021-09-02T14:29:34.196-04</date>
+    <nextPresenterId>w_jw2fcjeovwa6</nextPresenterId>
+  </event>
+  <event timestamp="1131803071" module="PARTICIPANT" eventname="AssignPresenterEvent">
+    <name>User 7520456</name>
+    <timestampUTC>1630607374200</timestampUTC>
+    <userid>w_jw2fcjeovwa6</userid>
+    <assignedBy>w_jw2fcjeovwa6</assignedBy>
+    <date>2021-09-02T14:29:34.200-04</date>
+  </event>
+  <event timestamp="1131803072" module="PRESENTATION" eventname="SetPresenterInPodEvent">
+    <timestampUTC>1630607374201</timestampUTC>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <date>2021-09-02T14:29:34.201-04</date>
+    <nextPresenterId>w_jw2fcjeovwa6</nextPresenterId>
+  </event>
+  <event timestamp="1131805474" module="PRESENTATION" eventname="ConversionCompletedEvent">
+    <originalFilename>default.pdf</originalFilename>
+    <timestampUTC>1630607376603</timestampUTC>
+    <presentationName>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentationName>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <date>2021-09-02T14:29:36.603-04</date>
+  </event>
+  <event timestamp="1131805477" module="PRESENTATION" eventname="SharePresentationEvent">
+    <timestampUTC>1630607376606</timestampUTC>
+    <presentationName>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentationName>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <share>true</share>
+    <date>2021-09-02T14:29:36.606-04</date>
+  </event>
+  <event timestamp="1131805479" module="PRESENTATION" eventname="SetPresentationDownloadable">
+    <timestampUTC>1630607376608</timestampUTC>
+    <presentationName>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentationName>
+    <podId>DEFAULT_PRESENTATION_POD</podId>
+    <date>2021-09-02T14:29:36.608-04</date>
+    <downloadable>false</downloadable>
+  </event>
+  <event timestamp="1131824162" module="VOICE" eventname="ParticipantJoinedEvent">
+    <participant>w_jw2fcjeovwa6</participant>
+    <timestampUTC>1630607395291</timestampUTC>
+    <bridge>578447737</bridge>
+    <callername>User 7520456</callername>
+    <talking>false</talking>
+    <callernumber>w_jw2fcjeovwa6_1-bbbID-User 7520456</callernumber>
+    <date>2021-09-02T14:29:55.291-04</date>
+    <muted>false</muted>
+  </event>
+  <event timestamp="1131824186" module="VOICE" eventname="StartRecordingEvent">
+    <filename>/var/freeswitch/meetings/2a1de53edf0543d950056bf3c0d4d357eba3383f-1630607370684-1131824162.opus</filename>
+    <bridge>578447737</bridge>
+    <timestampUTC>1630607395314</timestampUTC>
+    <date>2021-09-02T14:29:55.314-04</date>
+    <recordingTimestamp>1131824184</recordingTimestamp>
+  </event>
+  <event timestamp="1131824226" module="VOICE" eventname="ParticipantTalkingEvent">
+    <participant>w_jw2fcjeovwa6</participant>
+    <timestampUTC>1630607395355</timestampUTC>
+    <bridge>578447737</bridge>
+    <talking>true</talking>
+    <date>2021-09-02T14:29:55.355-04</date>
+  </event>
+  <event timestamp="1131825122" module="VOICE" eventname="ParticipantMutedEvent">
+    <participant>w_jw2fcjeovwa6</participant>
+    <timestampUTC>1630607396250</timestampUTC>
+    <bridge>578447737</bridge>
+    <date>2021-09-02T14:29:56.250-04</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="1131825327" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607396456</timestampUTC>
+    <xOffset>42.81167030334473</xOffset>
+    <date>2021-09-02T14:29:56.456-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>87.12742558232061</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1131825473" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607396602</timestampUTC>
+    <xOffset>-62.891248067220054</xOffset>
+    <date>2021-09-02T14:29:56.602-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>-60.94213415075232</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1131834887" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607406015</timestampUTC>
+    <xOffset>34.58885828653971</xOffset>
+    <date>2021-09-02T14:30:06.015-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>75.1026690447772</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1131835039" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607406168</timestampUTC>
+    <xOffset>-62.891248067220054</xOffset>
+    <date>2021-09-02T14:30:06.168-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>-60.94213415075232</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1131839891" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607411020</timestampUTC>
+    <xOffset>40.557028452555336</xOffset>
+    <date>2021-09-02T14:30:11.020-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>0.8321106875384296</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1131840041" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607411169</timestampUTC>
+    <xOffset>-62.891248067220054</xOffset>
+    <date>2021-09-02T14:30:11.169-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>-60.94213415075232</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1131841537" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607412665</timestampUTC>
+    <xOffset>50.63660303751628</xOffset>
+    <date>2021-09-02T14:30:12.665-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>9.084394949453849</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1131841691" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607412819</timestampUTC>
+    <xOffset>-62.891248067220054</xOffset>
+    <date>2021-09-02T14:30:12.819-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>-60.94213415075232</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1131841840" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607412969</timestampUTC>
+    <xOffset>36.57824834187826</xOffset>
+    <date>2021-09-02T14:30:12.969-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>33.60546818485967</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1131842003" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607413131</timestampUTC>
+    <xOffset>-62.891248067220054</xOffset>
+    <date>2021-09-02T14:30:13.131-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>-60.94213415075232</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1131882243" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>(guest) Calvin</name>
+    <timestampUTC>1630607453372</timestampUTC>
+    <role>VIEWER</role>
+    <date>2021-09-02T14:30:53.372-04</date>
+    <externalUserId>3ff859e3-1c2e-48e9-860d-cf230648cfca</externalUserId>
+    <userId>w_tvumguamxhhs</userId>
+  </event>
+  <event timestamp="1131885821" module="VOICE" eventname="ParticipantJoinedEvent">
+    <participant>w_tvumguamxhhs</participant>
+    <timestampUTC>1630607456950</timestampUTC>
+    <bridge>578447737</bridge>
+    <callername>(guest) Calvin</callername>
+    <talking>false</talking>
+    <callernumber>(guest) Calvin</callernumber>
+    <date>2021-09-02T14:30:56.950-04</date>
+    <muted>true</muted>
+  </event>
+  <event timestamp="1131895190" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630607466319</timestampUTC>
+    <color>#6a1b9a</color>
+    <senderId>w_jw2fcjeovwa6</senderId>
+    <date>2021-09-02T14:31:06.319-04</date>
+    <sender>User 7520456</sender>
+    <message>Hello, moderator chat message!</message>
+  </event>
+  <event timestamp="1131905701" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630607476829</timestampUTC>
+    <color>#4a148c</color>
+    <senderId>w_tvumguamxhhs</senderId>
+    <date>2021-09-02T14:31:16.829-04</date>
+    <sender>(guest) Calvin</sender>
+    <message>Hello, guest chat message!</message>
+  </event>
+  <event timestamp="1131908051" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630607479180</timestampUTC>
+    <color>#4a148c</color>
+    <senderId>w_tvumguamxhhs</senderId>
+    <date>2021-09-02T14:31:19.180-04</date>
+    <sender>(guest) Calvin</sender>
+    <message>yay!</message>
+  </event>
+  <event timestamp="1131949647" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607520776</timestampUTC>
+    <xOffset>10.185674826304119</xOffset>
+    <date>2021-09-02T14:32:00.776-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>96.79438838252314</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1131949798" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607520927</timestampUTC>
+    <xOffset>14.297080039978027</xOffset>
+    <date>2021-09-02T14:32:00.927-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>90.1925602665654</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1131949893" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607521022</timestampUTC>
+    <xOffset>14.297080039978027</xOffset>
+    <date>2021-09-02T14:32:01.022-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>89.95677806712963</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1131950258" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607521387</timestampUTC>
+    <xOffset>14.297080039978027</xOffset>
+    <date>2021-09-02T14:32:01.387-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>90.1925602665654</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1131950408" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607521537</timestampUTC>
+    <xOffset>-62.891248067220054</xOffset>
+    <date>2021-09-02T14:32:01.537-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>-60.94213415075232</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1131955635" module="CHAT" eventname="ClearPublicChatEvent">
+    <timestampUTC>1630607526763</timestampUTC>
+    <date>2021-09-02T14:32:06.763-04</date>
+  </event>
+  <event timestamp="1131964123" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630607535252</timestampUTC>
+    <color>#6a1b9a</color>
+    <senderId>w_jw2fcjeovwa6</senderId>
+    <date>2021-09-02T14:32:15.252-04</date>
+    <sender>User 7520456</sender>
+    <message>Chat was cleared</message>
+  </event>
+  <event timestamp="1131994645" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607565774</timestampUTC>
+    <xOffset>43.34217389424642</xOffset>
+    <date>2021-09-02T14:32:45.774-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>96.55861183449073</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1131994767" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607565896</timestampUTC>
+    <xOffset>-62.891248067220054</xOffset>
+    <date>2021-09-02T14:32:45.896-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>-60.94213415075232</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1131997197" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607568326</timestampUTC>
+    <xOffset>32.20158894856771</xOffset>
+    <date>2021-09-02T14:32:48.326-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>96.55861183449073</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1131997346" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607568475</timestampUTC>
+    <xOffset>-62.891248067220054</xOffset>
+    <date>2021-09-02T14:32:48.475-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>-60.94213415075232</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1131999450" module="PARTICIPANT" eventname="RecordStatusEvent">
+    <timestampUTC>1630607570579</timestampUTC>
+    <date>2021-09-02T14:32:50.579-04</date>
+    <status>true</status>
+    <userId>w_jw2fcjeovwa6</userId>
+  </event>
+  <event timestamp="1131999466" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607570595</timestampUTC>
+    <xOffset>13.501324653625488</xOffset>
+    <date>2021-09-02T14:32:50.595-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>59.77699562355324</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1132001481" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607572610</timestampUTC>
+    <xOffset>13.103446960449219</xOffset>
+    <date>2021-09-02T14:32:52.610-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>59.77699562355324</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1132001799" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607572927</timestampUTC>
+    <xOffset>-62.891248067220054</xOffset>
+    <date>2021-09-02T14:32:52.927-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>-60.94213415075232</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1132011085" module="CHAT" eventname="PublicChatEvent">
+    <timestampUTC>1630607582214</timestampUTC>
+    <color>#4a148c</color>
+    <senderId>w_tvumguamxhhs</senderId>
+    <date>2021-09-02T14:33:02.214-04</date>
+    <sender>(guest) Calvin</sender>
+    <message>whoops, forgot to start recording…</message>
+  </event>
+  <event timestamp="1132049253" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607620382</timestampUTC>
+    <xOffset>36.180369059244796</xOffset>
+    <date>2021-09-02T14:33:40.382-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>97.9732824254919</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1132049403" module="WHITEBOARD" eventname="WhiteboardCursorMoveEvent">
+    <timestampUTC>1630607620531</timestampUTC>
+    <xOffset>-62.891248067220054</xOffset>
+    <date>2021-09-02T14:33:40.531-04</date>
+    <whiteboardId>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702/1</whiteboardId>
+    <pageNumber>0</pageNumber>
+    <userId>w_jw2fcjeovwa6</userId>
+    <yOffset>-60.94213415075232</yOffset>
+    <presentation>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1630607370702</presentation>
+  </event>
+  <event timestamp="1132053637" module="PARTICIPANT" eventname="EndAndKickAllEvent">
+    <timestampUTC>1630607624766</timestampUTC>
+    <reason>ENDED_AFTER_USER_LOGGED_OUT</reason>
+    <date>2021-09-02T14:33:44.766-04</date>
+  </event>
+</recording>

--- a/record-and-playback/core/resources/raw/chat_0_9.xml
+++ b/record-and-playback/core/resources/raw/chat_0_9.xml
@@ -1,0 +1,344 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<recording meeting_id="afa22bf4e2a55835006a0016776f700dcf8e981e-1630339972856" bbb_version="0.9.0">
+  <meeting
+    id="afa22bf4e2a55835006a0016776f700dcf8e981e-1630339972856"
+    externalId="chat_0_9" name="Chat 0.9 Test"
+    breakout="false"/>
+  <metadata
+    meetingName="Chat 0.9 Test"
+    meetingId="chat_0_9"
+    isBreakout="false"/>
+  <event timestamp="1061316615" module="PRESENTATION" eventname="SharePresentationEvent">
+    <presentationName>d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1503524575790</presentationName>
+    <share>true</share>
+    <originalFilename>default.pdf</originalFilename>
+  </event>
+  <event timestamp="1061329979" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>Marinda Collins</name>
+    <role>MODERATOR</role>
+    <userId>9izxq660i7vr_1</userId>
+    <externalUserId>1000</externalUserId>
+  </event>
+  <event timestamp="1061397065" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <userId>vvyha6umxoyt_1</userId>
+    <externalUserId>1001</externalUserId>
+    <name>Phelix Fishman</name>
+    <role>VIEWER</role>
+  </event>
+  <event timestamp="1061511972" module="PARTICIPANT" eventname="RecordStatusEvent">
+    <userId>9izxq660i7vr_1</userId>
+    <status>true</status>
+  </event>
+  <event timestamp="1061536072" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <role>VIEWER</role>
+    <externalUserId>1002</externalUserId>
+    <userId>hs7iskkr7xrt_1</userId>
+    <name>Isaías Seelen</name>
+  </event>
+  <event timestamp="1061574575" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <role>VIEWER</role>
+    <userId>7m940cic73r3_1</userId>
+    <name>Mireia Castell</name>
+    <externalUserId>1003</externalUserId>
+  </event>
+  <event timestamp="1061629575" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <role>VIEWER</role>
+    <externalUserId>1004</externalUserId>
+    <userId>tgfbj6f828sp_1</userId>
+    <name>Liborius Hayes</name>
+  </event>
+  <event timestamp="1061703579" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <role>VIEWER</role>
+    <externalUserId>1005</externalUserId>
+    <userId>bepguk6d7dza_1</userId>
+    <name>Eva Aquino</name>
+  </event>
+  <event timestamp="1061749302" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <role>VIEWER</role>
+    <externalUserId>1006</externalUserId>
+    <userId>66ntqzexswc2_1</userId>
+    <name>Rodge Palazzo</name>
+  </event>
+  <event timestamp="1061825270" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <externalUserId>1007</externalUserId>
+    <role>VIEWER</role>
+    <name>Elias Stablum</name>
+    <userId>0q1hkmla9asu_1</userId>
+  </event>
+  <event timestamp="1061881172" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <userId>yyynfpyca09g_1</userId>
+    <externalUserId>1008</externalUserId>
+    <role>VIEWER</role>
+    <name>Evelina Keller</name>
+  </event>
+  <event timestamp="1061933105" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <userId>dmsj3897dwss_1</userId>
+    <role>VIEWER</role>
+    <name>Xhesika De Lange</name>
+    <externalUserId>1009</externalUserId>
+  </event>
+  <event timestamp="1061952342" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>Nimue Harlan</name>
+    <role>VIEWER</role>
+    <externalUserId>1010</externalUserId>
+    <userId>42dnty7rovjt_1</userId>
+  </event>
+  <event timestamp="1061962737" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>Elpidio O'Gorman</name>
+    <role>VIEWER</role>
+    <externalUserId>1011</externalUserId>
+    <userId>7ur69btts657_1</userId>
+  </event>
+  <event timestamp="1061998179" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>dmsj3897dwss_1</userId>
+  </event>
+  <event timestamp="1062008158" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>66ntqzexswc2_1</userId>
+  </event>
+  <event timestamp="1062013094" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <externalUserId>1012</externalUserId>
+    <role>VIEWER</role>
+    <userId>23uydbo9nauq_1</userId>
+    <name>Asa Darby</name>
+  </event>
+  <event timestamp="1062017073" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <externalUserId>1006</externalUserId>
+    <userId>12ipastd9pw1_1</userId>
+    <role>VIEWER</role>
+    <name>Rodge Palazzo</name>
+  </event>
+  <event timestamp="1062026555" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>Xhesika De Lange</name>
+    <role>VIEWER</role>
+    <externalUserId>1009</externalUserId>
+    <userId>ainnu65fiycz_1</userId>
+  </event>
+  <event timestamp="1062058796" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <externalUserId>1013</externalUserId>
+    <role>VIEWER</role>
+    <name>Arethusa Mann</name>
+    <userId>j73nq5k8xcaa_1</userId>
+  </event>
+  <event timestamp="1062142085" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <name>Ninel Mac Ruaidhrí</name>
+    <role>VIEWER</role>
+    <userId>nfuklna24flg_1</userId>
+    <externalUserId>1014</externalUserId>
+  </event>
+  <event timestamp="1062159696" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>ainnu65fiycz_1</userId>
+  </event>
+  <event timestamp="1062170527" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <externalUserId>1009</externalUserId>
+    <name>Xhesika De Lange</name>
+    <role>VIEWER</role>
+    <userId>2dc8jctma0nj_1</userId>
+  </event>
+  <event timestamp="1062260997" module="CHAT" eventname="PublicChatEvent">
+    <sender>Xhesika De Lange</sender>
+    <senderId>2dc8jctma0nj_1</senderId>
+    <message>
+      <![CDATA[Public chat 1]]>
+    </message>
+    <color>0</color>
+  </event>
+  <event timestamp="1062483994" module="CHAT" eventname="PublicChatEvent">
+    <color>0</color>
+    <senderId>23uydbo9nauq_1</senderId>
+    <message>
+      <![CDATA[Public chat 2]]>
+    </message>
+    <sender>Asa Darby</sender>
+  </event>
+  <event timestamp="1062500000" module="CHAT" eventname="ClearPublicChatEvent">
+  </event>
+  <event timestamp="1062914576" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>j73nq5k8xcaa_1</userId>
+  </event>
+  <event timestamp="1063007465" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <userId>fzlsahcijxo4_1</userId>
+    <externalUserId>1013</externalUserId>
+    <role>VIEWER</role>
+    <name>Arethusa Mann</name>
+  </event>
+  <event timestamp="1063309296" module="CHAT" eventname="PublicChatEvent">
+    <color>0</color>
+    <senderId>hs7iskkr7xrt_1</senderId>
+    <message>
+      <![CDATA[Public chat 3]]>
+    </message>
+    <sender>Isaías Seelen</sender>
+  </event>
+  <event timestamp="1064118099" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>fzlsahcijxo4_1</userId>
+  </event>
+  <event timestamp="1064118099" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <userId>fzlsahcijxo4_1</userId>
+    <externalUserId>1013</externalUserId>
+    <name>Arethusa Mann</name>
+    <role>VIEWER</role>
+  </event>
+  <event timestamp="1064123456" module="PARTICIPANT" eventname="RecordStatusEvent">
+    <userId>9izxq660i7vr_1</userId>
+    <status>false</status>
+  </event>
+  <event timestamp="1064181418" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>hs7iskkr7xrt_1</userId>
+  </event>
+  <event timestamp="1064370077" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <externalUserId>1002</externalUserId>
+    <role>VIEWER</role>
+    <userId>y096bmb53yu5_1</userId>
+    <name>Isaías Seelen</name>
+  </event>
+  <event timestamp="1064621935" module="CHAT" eventname="PublicChatEvent">
+    <color>0</color>
+    <senderId>nfuklna24flg_1</senderId>
+    <message>
+      <![CDATA[Public chat 4]]>
+    </message>
+    <sender>Ninel Mac Ruaidhrí</sender>
+  </event>
+  <event timestamp="1064635147" module="CHAT" eventname="PublicChatEvent">
+    <senderId>bepguk6d7dza_1</senderId>
+    <sender>Eva Aquino</sender>
+    <message>
+      <![CDATA[Public chat 5]]>
+    </message>
+    <color>0</color>
+  </event>
+  <event timestamp="1064645678" module="PARTICIPANT" eventname="RecordStatusEvent">
+    <userId>9izxq660i7vr_1</userId>
+    <status>true</status>
+  </event>
+  <event timestamp="1064656291" module="CHAT" eventname="PublicChatEvent">
+    <sender>Elias Stablum</sender>
+    <senderId>0q1hkmla9asu_1</senderId>
+    <color>0</color>
+    <message>
+      <![CDATA[Public chat 6]]>
+    </message>
+  </event>
+  <event timestamp="1064660118" module="CHAT" eventname="PublicChatEvent">
+    <senderId>fzlsahcijxo4_1</senderId>
+    <message>
+      <![CDATA[Public chat 7]]>
+    </message>
+    <sender>Arethusa Mann</sender>
+    <color>0</color>
+  </event>
+  <event timestamp="1064669521" module="CHAT" eventname="PublicChatEvent">
+    <message>
+      <![CDATA[Public chat 8]]>
+    </message>
+    <senderId>nfuklna24flg_1</senderId>
+    <sender>Ninel Mac Ruaidhrí</sender>
+    <color>0</color>
+  </event>
+  <event timestamp="1064671034" module="CHAT" eventname="PublicChatEvent">
+    <message>
+      <![CDATA[Public chat 9]]>
+    </message>
+    <color>0</color>
+    <sender>Mireia Castell</sender>
+    <senderId>7m940cic73r3_1</senderId>
+  </event>
+  <event timestamp="1064679602" module="CHAT" eventname="PublicChatEvent">
+    <sender>Ninel Mac Ruaidhrí</sender>
+    <message>
+      <![CDATA[Public chat 10]]>
+    </message>
+    <color>0</color>
+    <senderId>nfuklna24flg_1</senderId>
+  </event>
+  <event timestamp="1066752701" module="CHAT" eventname="PublicChatEvent">
+    <sender>Xhesika De Lange</sender>
+    <color>0</color>
+    <senderId>2dc8jctma0nj_1</senderId>
+    <message>
+      <![CDATA[Public chat 11]]>
+    </message>
+  </event>
+  <event timestamp="1066777963" module="CHAT" eventname="PublicChatEvent">
+    <sender>Arethusa Mann</sender>
+    <senderId>fzlsahcijxo4_1</senderId>
+    <color>0</color>
+    <message>
+      <![CDATA[Public chat 12]]>
+    </message>
+  </event>
+  <event timestamp="1066909573" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <userId>y096bmb53yu5_2</userId>
+    <role>VIEWER</role>
+    <name>Isaías Seelen</name>
+    <externalUserId>1002</externalUserId>
+  </event>
+  <event timestamp="1066966371" module="CHAT" eventname="PublicChatEvent">
+    <message>
+      <![CDATA[Public chat 13]]>
+    </message>
+    <color>0</color>
+    <senderId>2dc8jctma0nj_1</senderId>
+    <sender>Xhesika De Lange</sender>
+  </event>
+  <event timestamp="1069500636" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>0q1hkmla9asu_1</userId>
+  </event>
+  <event timestamp="1069502806" module="PARTICIPANT" eventname="ParticipantJoinEvent">
+    <role>VIEWER</role>
+    <externalUserId>1008</externalUserId>
+    <userId>yyynfpyca09g_1</userId>
+    <name>Evelina Keller</name>
+  </event>
+  <event timestamp="1069502545" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>nfuklna24flg_1</userId>
+  </event>
+  <event timestamp="1069502806" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>yyynfpyca09g_1</userId>
+  </event>
+  <event timestamp="1069504995" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>2dc8jctma0nj_1</userId>
+  </event>
+  <event timestamp="1069505733" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>bepguk6d7dza_1</userId>
+  </event>
+  <event timestamp="1069507663" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>fzlsahcijxo4_1</userId>
+  </event>
+  <event timestamp="1069508668" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>7ur69btts657_1</userId>
+  </event>
+  <event timestamp="1069509022" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>23uydbo9nauq_1</userId>
+  </event>
+  <event timestamp="1069512636" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>12ipastd9pw1_1</userId>
+  </event>
+  <event timestamp="1069514445" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>7m940cic73r3_1</userId>
+  </event>
+  <event timestamp="1069595144" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>42dnty7rovjt_1</userId>
+  </event>
+  <event timestamp="1069686925" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>vvyha6umxoyt_1</userId>
+  </event>
+  <event timestamp="1069700912" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>y096bmb53yu5_2</userId>
+  </event>
+  <event timestamp="1069717589" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>tgfbj6f828sp_1</userId>
+  </event>
+  <event timestamp="1069722053" module="PARTICIPANT" eventname="RecordStatusEvent">
+    <userId>9izxq660i7vr_1</userId>
+    <status>false</status>
+  </event>
+  <event timestamp="1069746114" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>9izxq660i7vr_1</userId>
+  </event>
+  <event timestamp="1069802390" module="PARTICIPANT" eventname="ParticipantLeftEvent">
+    <userId>yyynfpyca09g_1</userId>
+  </event>
+  <event timestamp="1069897986" module="PARTICIPANT" eventname="EndAndKickAllEvent">
+  </event>
+</recording>

--- a/record-and-playback/core/scripts/bigbluebutton.yml
+++ b/record-and-playback/core/scripts/bigbluebutton.yml
@@ -28,6 +28,16 @@ redis_port: 6379
 # and have another script process it.
 store_recording_status: false
 
+# Whether to anonymize the sender of chat messages in the processed
+# recordings. The settings here are the defaults; they can be overridden
+# by passing meta parameters on the meeting create call.
+# meta param: meta_bbb-anonymize-chat (true/false)
+anonymize_chat: false
+# By default only names of viewers are anonymized - if you would also
+# like to anonymize moderators, you can set this to true:
+# meta param: meta_bbb-anonymize-chat-moderators (true/false)
+anonymize_chat_moderators: false
+
 # Sequence of recording steps. Keys are the current step, values
 # are the next step(s). Examples:
 #   current_step: next_step

--- a/record-and-playback/core/test/recordandplayback/generators/test_events.rb
+++ b/record-and-playback/core/test/recordandplayback/generators/test_events.rb
@@ -1,0 +1,273 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'nokogiri'
+
+require 'recordandplayback'
+
+class TestEvents < Minitest::Test
+  def setup
+    @events_legacy = File.open('resources/raw/1b199e88-7df7-4842-a5f1-0e84b781c5c8/events.xml') do |io|
+      Nokogiri::XML(io)
+    end
+    @events_chat09 = File.open('resources/raw/chat_0_9.xml') do |io|
+      Nokogiri::XML(io)
+    end
+    @events_devcall = File.open('resources/raw/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/events.xml') do |io|
+      Nokogiri::XML(io)
+    end
+    @events_meta_edt = File.open('resources/raw/2a1de53edf0543d950056bf3c0d4d357eba3383f-1630607370684/events.xml') do |io|
+      Nokogiri::XML(io)
+    end
+  end
+
+  def test_anonymous_user_map_legacy
+    map = BigBlueButton::Events.anonymous_user_map(@events_legacy)
+    assert_empty(map)
+  end
+
+  def test_anonymous_user_map_legacy_no_viewer_only
+    map = BigBlueButton::Events.anonymous_user_map(@events_legacy, moderators: true)
+    assert_equal(1, map.length)
+    assert_equal('Moderator 1', map['1'])
+  end
+
+  def test_anonymous_user_map_bbb_0_9
+    map = BigBlueButton::Events.anonymous_user_map(@events_chat09)
+    assert_equal(21, map.length)
+    assert_equal('Marinda Collins', map['9izxq660i7vr_1']) # Moderator
+    assert_equal('Viewer 1', map['vvyha6umxoyt_1'])
+    assert_equal('Viewer 2', map['hs7iskkr7xrt_1'])
+    assert_equal('Viewer 3', map['7m940cic73r3_1'])
+    assert_equal('Viewer 4', map['tgfbj6f828sp_1'])
+    assert_equal('Viewer 5', map['bepguk6d7dza_1'])
+    assert_equal('Viewer 6', map['66ntqzexswc2_1'])
+    assert_equal('Viewer 7', map['0q1hkmla9asu_1'])
+    assert_equal('Viewer 8', map['yyynfpyca09g_1'])
+    assert_equal('Viewer 9', map['dmsj3897dwss_1'])
+    assert_equal('Viewer 10', map['42dnty7rovjt_1'])
+    assert_equal('Viewer 11', map['7ur69btts657_1'])
+    assert_equal('Viewer 12', map['23uydbo9nauq_1'])
+    assert_equal('Viewer 6', map['12ipastd9pw1_1'])
+    assert_equal('Viewer 9', map['ainnu65fiycz_1'])
+    assert_equal('Viewer 13', map['j73nq5k8xcaa_1'])
+    assert_equal('Viewer 14', map['nfuklna24flg_1'])
+    assert_equal('Viewer 9', map['2dc8jctma0nj_1'])
+    assert_equal('Viewer 13', map['fzlsahcijxo4_1'])
+    assert_equal('Viewer 2', map['y096bmb53yu5_1'])
+    assert_equal('Viewer 2', map['y096bmb53yu5_2'])
+    assert_equal('Viewer 8', map['yyynfpyca09g_1'])
+  end
+
+  def test_anonymous_user_map_bbb_0_9_no_viewer_only
+    map = BigBlueButton::Events.anonymous_user_map(@events_chat09, moderators: true)
+    assert_equal(21, map.length)
+    assert_equal('Moderator 1', map['9izxq660i7vr_1'])
+    assert_equal('Viewer 1', map['vvyha6umxoyt_1'])
+    assert_equal('Viewer 2', map['hs7iskkr7xrt_1'])
+    assert_equal('Viewer 3', map['7m940cic73r3_1'])
+    assert_equal('Viewer 4', map['tgfbj6f828sp_1'])
+    assert_equal('Viewer 5', map['bepguk6d7dza_1'])
+    assert_equal('Viewer 6', map['66ntqzexswc2_1'])
+    assert_equal('Viewer 7', map['0q1hkmla9asu_1'])
+    assert_equal('Viewer 8', map['yyynfpyca09g_1'])
+    assert_equal('Viewer 9', map['dmsj3897dwss_1'])
+    assert_equal('Viewer 10', map['42dnty7rovjt_1'])
+    assert_equal('Viewer 11', map['7ur69btts657_1'])
+    assert_equal('Viewer 12', map['23uydbo9nauq_1'])
+    assert_equal('Viewer 6', map['12ipastd9pw1_1'])
+    assert_equal('Viewer 9', map['ainnu65fiycz_1'])
+    assert_equal('Viewer 13', map['j73nq5k8xcaa_1'])
+    assert_equal('Viewer 14', map['nfuklna24flg_1'])
+    assert_equal('Viewer 9', map['2dc8jctma0nj_1'])
+    assert_equal('Viewer 13', map['fzlsahcijxo4_1'])
+    assert_equal('Viewer 2', map['y096bmb53yu5_1'])
+    assert_equal('Viewer 2', map['y096bmb53yu5_2'])
+    assert_equal('Viewer 8', map['yyynfpyca09g_1'])
+  end
+
+  def test_get_chat_events_legacy
+    start_time = BigBlueButton::Events.first_event_timestamp(@events_legacy)
+    end_time = BigBlueButton::Events.last_event_timestamp(@events_legacy)
+    bbb_props = { 'anonymize_chat' => true, 'anonymize_chat_moderators' => true }
+    chats_enum = BigBlueButton::Events.get_chat_events(@events_legacy, start_time, end_time, bbb_props).each
+    chat = chats_enum.next
+    assert_equal(34_876, chat[:in])
+    assert_nil(chat.fetch(:out))
+    assert_nil(chat.fetch(:sender_id))
+    # Anonymization doesn't work on really old recordings since there's no connection between
+    # chat user names and user ids
+    assert_equal('FRED', chat[:sender])
+    assert_equal('hello', chat[:message])
+    assert_nil(chat.fetch(:date))
+    assert_equal(0, chat[:text_color])
+    chat = chats_enum.next
+    assert_equal(42_388, chat[:in])
+    assert_nil(chat.fetch(:out))
+    assert_equal('FRED', chat[:sender])
+    assert_equal('how are you?', chat[:message])
+    chat = chats_enum.next
+    assert_equal(90_561, chat[:in])
+    assert_nil(chat.fetch(:out))
+    assert_equal('FRED', chat[:sender])
+    assert_equal('hi fred', chat[:message])
+    assert_raises(StopIteration) { chats_enum.next }
+  end
+
+  def test_get_chat_events_0_9
+    start_time = BigBlueButton::Events.first_event_timestamp(@events_chat09)
+    end_time = BigBlueButton::Events.last_event_timestamp(@events_chat09)
+    chats_enum = BigBlueButton::Events.get_chat_events(@events_chat09, start_time, end_time).each
+    chat = chats_enum.next
+    assert_equal(749_025, chat[:in])
+    assert_equal(988_028, chat[:out])
+    assert_equal('2dc8jctma0nj_1', chat[:sender_id])
+    assert_equal('Xhesika De Lange', chat[:sender])
+    assert_equal('Public chat 1', chat[:message])
+    assert_nil(chat.fetch(:date))
+    assert_equal(0, chat[:text_color])
+    chat = chats_enum.next
+    assert_equal(972_022, chat[:in])
+    assert_equal(988_028, chat[:out])
+    assert_equal('23uydbo9nauq_1', chat[:sender_id])
+    assert_equal('Asa Darby', chat[:sender])
+    assert_equal('Public chat 2', chat[:message])
+    chat = chats_enum.next
+    assert_equal(1_797_324, chat[:in])
+    assert_nil(chat.fetch(:out))
+    assert_equal('hs7iskkr7xrt_1', chat[:sender_id])
+    assert_equal('Isaías Seelen', chat[:sender])
+    assert_equal('Public chat 3', chat[:message])
+    chat = chats_enum.next
+    assert_equal(3_144_319 - 522_222, chat[:in])
+    assert_equal('0q1hkmla9asu_1', chat[:sender_id])
+    assert_equal('Elias Stablum', chat[:sender])
+    assert_equal('Public chat 6', chat[:message])
+    chat = chats_enum.next
+    assert_equal(3_148_146 - 522_222, chat[:in])
+    assert_equal('fzlsahcijxo4_1', chat[:sender_id])
+    assert_equal('Arethusa Mann', chat[:sender])
+    assert_equal('Public chat 7', chat[:message])
+    chat = chats_enum.next
+    assert_equal(3_157_549 - 522_222, chat[:in])
+    assert_equal('nfuklna24flg_1', chat[:sender_id])
+    assert_equal('Ninel Mac Ruaidhrí', chat[:sender])
+    assert_equal('Public chat 8', chat[:message])
+    chat = chats_enum.next
+    assert_equal(3_159_062 - 522_222, chat[:in])
+    assert_equal('7m940cic73r3_1', chat[:sender_id])
+    assert_equal('Mireia Castell', chat[:sender])
+    assert_equal('Public chat 9', chat[:message])
+    chat = chats_enum.next
+    assert_equal(3_167_630 - 522_222, chat[:in])
+    assert_equal('nfuklna24flg_1', chat[:sender_id])
+    assert_equal('Ninel Mac Ruaidhrí', chat[:sender])
+    assert_equal('Public chat 10', chat[:message])
+    chat = chats_enum.next
+    assert_equal(5_240_729 - 522_222, chat[:in])
+    assert_equal('2dc8jctma0nj_1', chat[:sender_id])
+    assert_equal('Xhesika De Lange', chat[:sender])
+    assert_equal('Public chat 11', chat[:message])
+    chat = chats_enum.next
+    assert_equal(5_265_991 - 522_222, chat[:in])
+    assert_equal('fzlsahcijxo4_1', chat[:sender_id])
+    assert_equal('Arethusa Mann', chat[:sender])
+    assert_equal('Public chat 12', chat[:message])
+    chat = chats_enum.next
+    assert_equal(5_454_399 - 522_222, chat[:in])
+    assert_equal('2dc8jctma0nj_1', chat[:sender_id])
+    assert_equal('Xhesika De Lange', chat[:sender])
+    assert_equal('Public chat 13', chat[:message])
+    assert_raises(StopIteration) { chats_enum.next }
+  end
+
+  def test_get_chat_events_0_9_anonymized
+    start_time = BigBlueButton::Events.first_event_timestamp(@events_chat09)
+    end_time = BigBlueButton::Events.last_event_timestamp(@events_chat09)
+    bbb_props = { 'anonymize_chat' => true }
+    chats_enum = BigBlueButton::Events.get_chat_events(@events_chat09, start_time, end_time, bbb_props).each
+    assert_equal('Viewer 9', chats_enum.next[:sender])
+    assert_equal('Viewer 12', chats_enum.next[:sender])
+    assert_equal('Viewer 2', chats_enum.next[:sender])
+    assert_equal('Viewer 7', chats_enum.next[:sender])
+    assert_equal('Viewer 13', chats_enum.next[:sender])
+    assert_equal('Viewer 14', chats_enum.next[:sender])
+    assert_equal('Viewer 3', chats_enum.next[:sender])
+    assert_equal('Viewer 14', chats_enum.next[:sender])
+    assert_equal('Viewer 9', chats_enum.next[:sender])
+    assert_equal('Viewer 13', chats_enum.next[:sender])
+    assert_equal('Viewer 9', chats_enum.next[:sender])
+    assert_raises(StopIteration) { chats_enum.next }
+  end
+
+  def test_get_chat_events_0_9_start_time
+    end_time = BigBlueButton::Events.last_event_timestamp(@events_chat09)
+    chats = BigBlueButton::Events.get_chat_events(@events_chat09, 1_063_007_465, end_time)
+    chat = chats.first
+    assert_equal(301_831, chat[:in])
+    assert_equal('hs7iskkr7xrt_1', chat[:sender_id])
+    assert_equal('Isaías Seelen', chat[:sender])
+    assert_equal('Public chat 3', chat[:message])
+  end
+
+  def test_get_chat_events_0_9_end_time
+    start_time = BigBlueButton::Events.first_event_timestamp(@events_chat09)
+    chats = BigBlueButton::Events.get_chat_events(@events_chat09, start_time, 1_062_490_000)
+    chat = chats.last
+    assert_equal(972_022, chat[:in])
+    assert_nil(chat.fetch(:out))
+    assert_equal('23uydbo9nauq_1', chat[:sender_id])
+    assert_equal('Asa Darby', chat[:sender])
+    assert_equal('Public chat 2', chat[:message])
+  end
+
+  def test_get_chat_events_devcall
+    start_time = BigBlueButton::Events.first_event_timestamp(@events_devcall)
+    end_time = BigBlueButton::Events.last_event_timestamp(@events_devcall)
+    chats = BigBlueButton::Events.get_chat_events(@events_devcall, start_time, end_time)
+
+    assert_equal(11, chats.length)
+
+    chat = chats[0]
+    assert_equal(17_013, chat[:in])
+    assert_equal(148_701, chat[:out])
+    assert_equal('w_kmm96j1as24f', chat[:sender_id])
+    assert_equal('Mario', chat[:sender])
+    assert_equal('#7b1fa2', chat[:avatar_color])
+    assert_nil(chat.fetch(:text_color))
+    assert_equal(DateTime.rfc3339('2021-08-31T18:06:14.330+00:00'), chat[:date])
+    # rubocop:disable Layout/LineLength
+    assert_equal(
+      "i get  logs of these: \n\n ERROR: clientLogger: Camera VIEWER failed. Reconnecting. <a href=\"https://develop.bigbluebutton.org/html5client/8fb14b479570f65105c7ff9a2960b679501f34ff.js?meteor_js_resource=true:348:579447\" rel=\"nofollow\"><u>https://develop.bigbluebutton.org/html5client/8fb14b479570f65105c7ff9a2960b679501f34ff.js?meteor_js_resource=true:348:579447</u></a>",
+      chat[:message]
+    )
+    # rubocop:enable Layout/LineLength
+
+    chat = chats[7]
+    assert_equal(1_241_014, chat[:in])
+    assert_nil(chat.fetch(:out))
+    assert_equal('w_vk0ebqjxox9d', chat[:sender_id])
+    assert_equal('Anton G', chat[:sender])
+    assert_equal('#0277bd', chat[:avatar_color])
+    assert_nil(chat.fetch(:text_color))
+    assert_equal(DateTime.rfc3339('2021-08-31T18:26:38.332+00:00'), chat[:date])
+    assert_equal('Nice!', chat[:message])
+  end
+
+  def test_get_chat_events_meta_edt
+    start_time = BigBlueButton::Events.first_event_timestamp(@events_meta_edt)
+    end_time = BigBlueButton::Events.last_event_timestamp(@events_meta_edt)
+    chats = BigBlueButton::Events.get_chat_events(@events_meta_edt, start_time, end_time)
+
+    assert_equal(1, chats.length)
+
+    chat = chats[0]
+    assert_equal(11_635, chat[:in])
+    assert_nil(chat.fetch(:out))
+    assert_equal('w_tvumguamxhhs', chat[:sender_id])
+    # This recording has the meta_bbb-anonymize-chat param set
+    assert_equal('Viewer 1', chat[:sender])
+    assert_equal(DateTime.rfc3339('2021-09-02T14:33:02.214-04:00'), chat[:date])
+    assert_equal('whoops, forgot to start recording…', chat[:message])
+  end
+end


### PR DESCRIPTION
Move the handling of chat events into the shared library so it can be
used by multiple recording formats.

The anonymization of names is based on the external user id, if
available, so users have a consistent name through the meeting. Note
that no effort is made to edit chat messages - if someone is mentioned
by name in a chat message, that will still be visible.

Default settings for anonymization can be controlled in
bigbluebutton.yml, and per-meeting overrides can be done using meta
parameters on the create call.

Fixes #13073

This PR should target BBB 2.4; please switch the branch if appropriate.