### PR TITLE
feat: add media server configuration via metadata and settings.yml

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
@@ -7,6 +7,7 @@ import {
   fetchWebRTCMappedStunTurnServers,
   getMappedFallbackStun
 } from '/imports/utils/fetchStunTurnServers';
+import getFromMeetingSettings from '/imports/ui/services/meeting-settings';
 
 const SFU_URL = Meteor.settings.public.kurento.wsUrl;
 const DEFAULT_LISTENONLY_MEDIA_SERVER = Meteor.settings.public.kurento.listenOnlyMediaServer;
@@ -38,8 +39,8 @@ const mapErrorCode = (error) => {
 
 // TODO Would be interesting to move this to a service along with the error mapping
 const getMediaServerAdapter = () => {
-  return DEFAULT_LISTENONLY_MEDIA_SERVER;
-}
+  return getFromMeetingSettings('media-server-listenonly', DEFAULT_LISTENONLY_MEDIA_SERVER);
+};
 
 export default class KurentoAudioBridge extends BaseAudioBridge {
   constructor(userData) {

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
@@ -9,6 +9,7 @@ import {
 } from '/imports/utils/fetchStunTurnServers';
 
 const SFU_URL = Meteor.settings.public.kurento.wsUrl;
+const DEFAULT_LISTENONLY_MEDIA_SERVER = Meteor.settings.public.kurento.listenOnlyMediaServer;
 const MEDIA = Meteor.settings.public.media;
 const MEDIA_TAG = MEDIA.mediaTag.replace(/#/g, '');
 const GLOBAL_AUDIO_PREFIX = 'GLOBAL_AUDIO_';
@@ -33,6 +34,11 @@ const mapErrorCode = (error) => {
   if (errorCode == null || mappedErrorCode == null) return error;
   error.errorCode = mappedErrorCode;
   return error;
+}
+
+// TODO Would be interesting to move this to a service along with the error mapping
+const getMediaServerAdapter = () => {
+  return DEFAULT_LISTENONLY_MEDIA_SERVER;
 }
 
 export default class KurentoAudioBridge extends BaseAudioBridge {
@@ -257,6 +263,7 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
           caleeName: `${GLOBAL_AUDIO_PREFIX}${this.voiceBridge}`,
           iceServers,
           offering: OFFERING,
+          mediaServer: getMediaServerAdapter(),
         };
 
         this.broker = new ListenOnlyBroker(

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -282,6 +282,7 @@ export default class KurentoScreenshareBridge {
         hasAudio: this.hasAudio,
         bitrate: BridgeService.BASE_BITRATE,
         offering: true,
+        mediaServer: BridgeService.getMediaServerAdapter(),
       };
 
       this.broker = new ScreenshareBroker(

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -224,6 +224,7 @@ export default class KurentoScreenshareBridge {
       userName: Auth.fullname,
       hasAudio,
       offering: OFFERING,
+      mediaServer: BridgeService.getMediaServerAdapter(),
     };
 
     this.broker = new ScreenshareBroker(

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/service.js
@@ -8,6 +8,7 @@ const {
   constraints: GDM_CONSTRAINTS,
   mediaTimeouts: MEDIA_TIMEOUTS,
   bitrate: BASE_BITRATE,
+  mediaServer: DEFAULT_SCREENSHARE_MEDIA_SERVER,
 } = Meteor.settings.public.kurento.screenshare;
 const {
   baseTimeout: BASE_MEDIA_TIMEOUT,
@@ -103,6 +104,10 @@ const getIceServers = (sessionToken) => {
   });
 }
 
+const getMediaServerAdapter = () => {
+  return DEFAULT_SCREENSHARE_MEDIA_SERVER;
+}
+
 const getNextReconnectionInterval = (oldInterval) => {
   return Math.min(
     TIMEOUT_INCREASE_FACTOR * oldInterval,
@@ -149,6 +154,7 @@ export default {
   getNextReconnectionInterval,
   streamHasAudioTrack,
   screenshareLoadAndPlayMediaStream,
+  getMediaServerAdapter,
   BASE_MEDIA_TIMEOUT,
   MAX_CONN_ATTEMPTS,
   BASE_BITRATE,

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/service.js
@@ -3,6 +3,7 @@ import logger from '/imports/startup/client/logger';
 import { fetchWebRTCMappedStunTurnServers, getMappedFallbackStun } from '/imports/utils/fetchStunTurnServers';
 import loadAndPlayMediaStream from '/imports/ui/services/bbb-webrtc-sfu/load-play';
 import { SCREENSHARING_ERRORS } from './errors';
+import getFromMeetingSettings from '/imports/ui/services/meeting-settings';
 
 const {
   constraints: GDM_CONSTRAINTS,
@@ -105,7 +106,7 @@ const getIceServers = (sessionToken) => {
 }
 
 const getMediaServerAdapter = () => {
-  return DEFAULT_SCREENSHARE_MEDIA_SERVER;
+  return getFromMeetingSettings('media-server-screenshare', DEFAULT_SCREENSHARE_MEDIA_SERVER);
 }
 
 const getNextReconnectionInterval = (oldInterval) => {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -642,6 +642,7 @@ class VideoProvider extends Component {
           userName: this.info.userName,
           bitrate,
           record: VideoService.getRecord(),
+          mediaServer: VideoService.getMediaServerAdapter(),
         };
 
         logger.info({

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -19,6 +19,7 @@ import {
   getSortingMethod,
   sortVideoStreams,
 } from '/imports/ui/components/video-provider/stream-sorting';
+import getFromMeetingSettings from '/imports/ui/services/meeting-settings';
 
 const CAMERA_PROFILES = Meteor.settings.public.kurento.cameraProfiles;
 const MULTIPLE_CAMERAS = Meteor.settings.public.app.enableMultipleCameras;
@@ -475,7 +476,7 @@ class VideoService {
   }
 
   getMediaServerAdapter() {
-    return DEFAULT_VIDEO_MEDIA_SERVER;
+    return getFromMeetingSettings('media-server-video', DEFAULT_VIDEO_MEDIA_SERVER);
   }
 
   getMyRole () {
@@ -494,12 +495,7 @@ class VideoService {
     // meta_hack-record-viewer-video is 'false' this user won't have this video
     // stream recorded.
     if (this.hackRecordViewer === null) {
-      const prop = Meetings.findOne(
-        { meetingId: Auth.meetingID },
-        { fields: { 'metadataProp': 1 } },
-      ).metadataProp;
-
-      const value = prop.metadata ? prop.metadata['hack-record-viewer-video'] : null;
+      const value = getFromMeetingSettings('hack-record-viewer-video', null);
       this.hackRecordViewer = value ? value.toLowerCase() === 'true' : true;
     }
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -41,6 +41,7 @@ const {
   paginationSorting: PAGINATION_SORTING,
   defaultSorting: DEFAULT_SORTING,
 } = Meteor.settings.public.kurento.cameraSortingModes;
+const DEFAULT_VIDEO_MEDIA_SERVER = Meteor.settings.public.kurento.videoMediaServer;
 
 const FILTER_VIDEO_STATS = [
   'outbound-rtp',
@@ -471,6 +472,10 @@ class VideoService {
 
   hasStream(streams, stream) {
     return streams.find(s => s.stream === stream);
+  }
+
+  getMediaServerAdapter() {
+    return DEFAULT_VIDEO_MEDIA_SERVER;
   }
 
   getMyRole () {
@@ -923,6 +928,7 @@ export default {
   addCandidateToPeer: (peer, candidate, cameraId) => videoService.addCandidateToPeer(peer, candidate, cameraId),
   processInboundIceQueue: (peer, cameraId) => videoService.processInboundIceQueue(peer, cameraId),
   getRole: isLocal => videoService.getRole(isLocal),
+  getMediaServerAdapter: () => videoService.getMediaServerAdapter(),
   getRecord: () => videoService.getRecord(),
   getSharedDevices: () => videoService.getSharedDevices(),
   getUserParameterProfile: () => videoService.getUserParameterProfile(),

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/listenonly-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/listenonly-broker.js
@@ -21,7 +21,7 @@ class ListenOnlyBroker extends BaseBroker {
     this.role = role;
     this.offering = true;
 
-    // Optional parameters are: userName, caleeName, iceServers, offering
+    // Optional parameters are: userName, caleeName, iceServers, offering, mediaServer
     Object.assign(this, options);
   }
 
@@ -151,6 +151,7 @@ class ListenOnlyBroker extends BaseBroker {
       userId: this.userId,
       userName: this.userName,
       sdpOffer: offer,
+      mediaServer: this.mediaServer,
     };
 
     logger.debug({

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/screenshare-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/screenshare-broker.js
@@ -24,7 +24,7 @@ class ScreenshareBroker extends BaseBroker {
     this.hasAudio = false;
     this.offering = true;
 
-    // Optional parameters are: userName, caleeName, iceServers, hasAudio, bitrate, offering
+    // Optional parameters are: userName, caleeName, iceServers, hasAudio, bitrate, offering, mediaServer
     Object.assign(this, options);
   }
 
@@ -126,6 +126,7 @@ class ScreenshareBroker extends BaseBroker {
       sdpOffer: offer,
       hasAudio: !!this.hasAudio,
       bitrate: this.bitrate,
+      mediaServer: this.mediaServer,
     };
 
     this.sendMessage(message);

--- a/bigbluebutton-html5/imports/ui/services/meeting-settings/index.js
+++ b/bigbluebutton-html5/imports/ui/services/meeting-settings/index.js
@@ -1,0 +1,12 @@
+import Auth from '/imports/ui/services/auth';
+import Meetings from '/imports/api/meetings';
+
+export default function getFromMeetingSettings(setting, defaultValue = null) {
+  const prop = Meetings.findOne(
+    { meetingId: Auth.meetingID },
+    { fields: { 'metadataProp': 1 } },
+  ).metadataProp;
+  const value = prop.metadata ? prop.metadata[setting] : null;
+
+  return value || defaultValue;
+}

--- a/bigbluebutton-html5/imports/ui/services/meeting-settings/index.js
+++ b/bigbluebutton-html5/imports/ui/services/meeting-settings/index.js
@@ -1,12 +1,12 @@
 import Auth from '/imports/ui/services/auth';
 import Meetings from '/imports/api/meetings';
 
-export default function getFromMeetingSettings(setting, defaultValue = null) {
+export default function getFromMeetingSettings(setting, defaultValue) {
   const prop = Meetings.findOne(
     { meetingId: Auth.meetingID },
     { fields: { 'metadataProp': 1 } },
   ).metadataProp;
-  const value = prop.metadata ? prop.metadata[setting] : null;
+  const value = prop.metadata ? prop.metadata[setting] : undefined;
 
   return value || defaultValue;
 }

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -208,7 +208,11 @@ public:
       # Experimental. True is the canonical behavior. Flip to false to reverse
       # the negotiation flow for subscribers.
       subscriberOffering: true
-      mediaServer: Kurento
+      # Experimental. Server wide configuration to choose which bbb-webrtc-sfu
+      # media server adapter should be used for screen sharing.
+      # Default is undefined, which means the default setting in bbb-webrtc-sfu
+      # prevails (screenshareMediaServer).
+      #mediaServer: Kurento
       bitrate: 1500
       mediaTimeouts:
         maxConnectionAttempts: 2
@@ -308,8 +312,16 @@ public:
     enableVideo: true
     enableVideoMenu: true
     enableListenOnly: true
-    listenOnlyMediaServer: Kurento
-    videoMediaServer: Kurento
+    # Experimental. Server wide configuration to choose which bbb-webrtc-sfu
+    # media server adapter should be used for listen only.
+    # Default is undefined, which means the default setting in bbb-webrtc-sfu
+    # prevails (listenOnlyMediaServer).
+    #listenOnlyMediaServer: Kurento
+    # Experimental. Server wide configuration to choose which bbb-webrtc-sfu
+    # media server adapter should be used for webcams.
+    # Default is undefined, which means the default setting in bbb-webrtc-sfu
+    # prevails (videoMediaServer).
+    #videoMediaServer: Kurento
     autoShareWebcam: false
     skipVideoPreview: false
     skipVideoPreviewOnFirstJoin: false

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -308,6 +308,7 @@ public:
     enableVideo: true
     enableVideoMenu: true
     enableListenOnly: true
+    listenOnlyMediaServer: Kurento
     autoShareWebcam: false
     skipVideoPreview: false
     skipVideoPreviewOnFirstJoin: false

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -309,6 +309,7 @@ public:
     enableVideoMenu: true
     enableListenOnly: true
     listenOnlyMediaServer: Kurento
+    videoMediaServer: Kurento
     autoShareWebcam: false
     skipVideoPreview: false
     skipVideoPreviewOnFirstJoin: false

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -208,6 +208,7 @@ public:
       # Experimental. True is the canonical behavior. Flip to false to reverse
       # the negotiation flow for subscribers.
       subscriberOffering: true
+      mediaServer: Kurento
       bitrate: 1500
       mediaTimeouts:
         maxConnectionAttempts: 2


### PR DESCRIPTION
### What does this PR do?

This is the same as https://github.com/bigbluebutton/bigbluebutton/pull/12207 with a few tweaks on top of it.

New config set at settings.yml:
  - public.kurento.screenshare.mediaServer  (e.g.: `Kurento`)
  - public.kurento.videoMediaServer 
  - public.kurento.listenOnlyMediaServer 

Add a set of metadata parameters:
  - meta_media-server-screenshare (e.g.: `Kurento`)
  - meta_media-server-video
  - meta_media-server-listenonly
 
I've also centralized metadata fetching in the client using a similar pattern from the userdata fetch.

inb4: I'm not using userdata-* because these aren't supposed to be per-user configuration parameters. These things are either meeting wide or server wide configurations.

### Closes Issue(s)

None