### PR TITLE
fix: Settings menu tooltip open after ending the session

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/tooltip/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/tooltip/component.jsx
@@ -115,6 +115,10 @@ class Tooltip extends Component {
     if (elem && elem._tippy) elem._tippy.setProps(opts);
   }
 
+  componentWillUnmount() {
+    if (this.tooltip[0]) this.tooltip[0].hide();
+  }
+
   onShow() {
     document.addEventListener('keyup', this.handleEscapeHide);
   }


### PR DESCRIPTION
### What does this PR do?

Prevents a bug where the "Options" tooltip would stay open after a user ends the meeting.

### Closes Issue(s)
Closes #13066