### PR TITLE
fix: Share screen placeholder is showing behind side menu

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -335,11 +335,14 @@ class ScreenshareComponent extends React.Component {
       || (isPresenter && !isGloballyBroadcasting)
       || (!isStreamHealthy && loaded && isGloballyBroadcasting);
 
+    const display = (width > 0 && height > 0) ? 'inherit' : 'none';
+
     return (
       <div
         style={
           {
             position: 'absolute',
+            display,
             top,
             left,
             right,


### PR DESCRIPTION
### What does this PR do?

Hides screenshare component when sidebar content is closed, preventing an issue with the screenshare component appearing behing the sidebar in focus on video layout.

### Closes Issue(s)
Closes #13115