### PR TITLE
remove tooltip focus when closing menu/modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/menu/component.jsx
@@ -37,9 +37,19 @@ class BBBMenu extends React.Component {
     this.setState({ anchorEl: event.currentTarget });
   };
 
-  handleClose() {
+  handleClose(event) {
     const { onCloseCallback } = this.props;
     this.setState({ anchorEl: null }, onCloseCallback());
+
+    if (event) {
+      event.persist();
+
+      if (event.type === 'click') {
+        setTimeout(() => {
+          document.activeElement.blur();
+        }, 0);
+      }
+    }
   };
 
   setAnchorEl(el) {
@@ -67,11 +77,11 @@ class BBBMenu extends React.Component {
           disableGutters={true}
           disabled={disabled}
           style={{ paddingLeft: '4px',paddingRight: '4px',paddingTop: '8px', paddingBottom: '8px', marginLeft: '4px', marginRight: '4px' }}
-          onClick={() => { 
+          onClick={(event) => {
             onClick();
             const close = !key.includes('setstatus') && !key.includes('back');
             // prevent menu close for sub menu actions
-            if (close) this.handleClose();
+            if (close) this.handleClose(event);
           }}>
           <div style={{ display: 'flex', flexFlow: 'row', width: '100%'}}>
             {a.icon ? <Icon iconName={a.icon} key="icon" /> : null}

--- a/bigbluebutton-html5/imports/ui/components/modal/simple/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/modal/simple/component.jsx
@@ -59,13 +59,26 @@ class ModalSimple extends Component {
       ...otherProps
     } = this.props;
 
-    const closeModel = (onRequestClose || this.handleDismiss);
+    const closeModal = (onRequestClose || this.handleDismiss);
 
+    const handleRequestClose = (event) => {
+      closeModal();
+
+      if (event) {
+        event.persist();
+
+        if (event.type === 'click') {
+          setTimeout(() => {
+            document.activeElement.blur();
+          }, 0);
+        }
+      }
+    }
     return (
       <ModalBase
         isOpen={modalisOpen}
         className={cx(className, styles.modal)}
-        onRequestClose={closeModel}
+        onRequestClose={handleRequestClose}
         contentLabel={title || contentLabel}
         {...otherProps}
       >
@@ -79,7 +92,7 @@ class ModalSimple extends Component {
               icon="close"
               circle
               hideLabel
-              onClick={closeModel}
+              onClick={handleRequestClose}
               aria-describedby="modalDismissDescription"
             />
           ) : null}


### PR DESCRIPTION
### What does this PR do?

Prevents an issue where the tooltip of a button would appear after closing a menu/modal. 

The issue happened because the default behavior when closing a menu or modal is to restore focus to the element that triggered the opening of that menu/modal. 

My solution only removes focus of the element on `click` events, so it does not break keyboard navigation.

### Closes Issue(s)
Closes #11814
Closes #13102