### PR TITLE
refactor: remove unused state properties

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -724,7 +724,7 @@ class PresentationUploader extends Component {
   }
 
   renderPresentationItem(item) {
-    const { disableActions, hasError: stateError } = this.state;
+    const { disableActions } = this.state;
     const {
       intl,
       selectedToBeNextCurrent,
@@ -736,7 +736,7 @@ class PresentationUploader extends Component {
     const hasError = item.conversion.error || item.upload.error;
     const isProcessing = (isUploading || isConverting) && !hasError;
 
-    if (!stateError && hasError) {
+    if (hasError) {
       this.hasError = true;
     }
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -135,10 +135,6 @@ class UserOptions extends PureComponent {
   constructor(props) {
     super(props);
 
-    this.state = {
-      isUserOptionsOpen: false,
-    };
-
     this.clearStatusId = _.uniqueId('list-item-');
     this.muteId = _.uniqueId('list-item-');
     this.muteAllId = _.uniqueId('list-item-');
@@ -149,8 +145,6 @@ class UserOptions extends PureComponent {
     this.saveUsersNameId = _.uniqueId('list-item-');
     this.captionsId = _.uniqueId('list-item-');
 
-    this.onActionsShow = this.onActionsShow.bind(this);
-    this.onActionsHide = this.onActionsHide.bind(this);
     this.handleCreateBreakoutRoomClick = this.handleCreateBreakoutRoomClick.bind(this);
     this.handleCaptionsClick = this.handleCaptionsClick.bind(this);
     this.onCreateBreakouts = this.onCreateBreakouts.bind(this);
@@ -177,18 +171,6 @@ class UserOptions extends PureComponent {
       intl.formatMessage(intlMessages.sortedLastNameHeading),
     ).dispatchEvent(new MouseEvent('click',
       { bubbles: true, cancelable: true, view: window }));
-  }
-
-  onActionsShow() {
-    this.setState({
-      isUserOptionsOpen: true,
-    });
-  }
-
-  onActionsHide() {
-    this.setState({
-      isUserOptionsOpen: false,
-    });
   }
 
   onCreateBreakouts() {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -108,6 +108,11 @@ class VideoProvider extends Component {
   constructor(props) {
     super(props);
 
+    // socketOpen state is there to force update when the signaling socket opens or closes
+    this.state = {
+      socketOpen: false,
+    };
+
     this.info = VideoService.getInfo();
 
     // Set a valid bbb-webrtc-sfu application server socket in the settings
@@ -220,6 +225,8 @@ class VideoProvider extends Component {
     clearInterval(this.pingInterval);
 
     VideoService.exitVideo();
+
+    this.setState({ socketOpen: false });
   }
 
   onWsOpen() {
@@ -233,6 +240,8 @@ class VideoProvider extends Component {
     }
 
     this.pingInterval = setInterval(this.ping.bind(this), PING_INTERVAL);
+
+    this.setState({ socketOpen: true });
   }
 
   updateThreshold(numberOfPublishers) {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -108,10 +108,6 @@ class VideoProvider extends Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      socketOpen: false,
-    };
-
     this.info = VideoService.getInfo();
 
     // Set a valid bbb-webrtc-sfu application server socket in the settings
@@ -224,8 +220,6 @@ class VideoProvider extends Component {
     clearInterval(this.pingInterval);
 
     VideoService.exitVideo();
-
-    this.setState({ socketOpen: false });
   }
 
   onWsOpen() {
@@ -239,8 +233,6 @@ class VideoProvider extends Component {
     }
 
     this.pingInterval = setInterval(this.ping.bind(this), PING_INTERVAL);
-
-    this.setState({ socketOpen: true });
   }
 
   updateThreshold(numberOfPublishers) {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -14,7 +14,6 @@ import {
   subscribeToStreamStateChange,
   unsubscribeFromStreamStateChange,
 } from '/imports/ui/services/bbb-webrtc-sfu/stream-state-service';
-import deviceInfo from '/imports/utils/deviceInfo';
 import { ACTIONS } from '/imports/ui/components/layout/enums';
 
 const ALLOW_FULLSCREEN = Meteor.settings.public.app.allowFullscreen;
@@ -35,7 +34,6 @@ class VideoListItem extends Component {
     this.setVideoIsReady = this.setVideoIsReady.bind(this);
     this.onFullscreenChange = this.onFullscreenChange.bind(this);
     this.onStreamStateChange = this.onStreamStateChange.bind(this);
-    this.updateOrientation = this.updateOrientation.bind(this);
   }
 
   componentDidMount() {
@@ -45,7 +43,6 @@ class VideoListItem extends Component {
     this.videoTag.addEventListener('loadeddata', this.setVideoIsReady);
     this.videoContainer.addEventListener('fullscreenchange', this.onFullscreenChange);
     subscribeToStreamStateChange(cameraId, this.onStreamStateChange);
-    window.addEventListener('resize', this.updateOrientation);
   }
 
   componentDidUpdate() {
@@ -81,7 +78,6 @@ class VideoListItem extends Component {
     this.videoContainer.removeEventListener('fullscreenchange', this.onFullscreenChange);
     unsubscribeFromStreamStateChange(cameraId, this.onStreamStateChange);
     onVideoItemUnmount(cameraId);
-    window.removeEventListener('resize', this.updateOrientation);
 
     if (isFullscreenContext) {
       layoutContextDispatch({
@@ -154,10 +150,6 @@ class VideoListItem extends Component {
         });
     });
     return menuItems
-  }
-
-  updateOrientation() {
-    this.setState({ isPortrait: deviceInfo.isPortrait() });
   }
 
   renderFullscreenButton() {


### PR DESCRIPTION
### What does this PR do?

Removes unused component state properties reported by [lgtm alerts](https://lgtm.com/projects/g/bigbluebutton/bigbluebutton/alerts)

### Motivation

*Unused or undefined React component state properties can cause errors or make code hard to read and understand. Any computation used to initialize an unused state property is wasted, which may lead to performance problems. Any access to an undefined component state property trivially evaluates to the value undefined, which may come as a surprise.* (https://lgtm.com/rules/1506221406550/)
