### PR TITLE
fix: restore waiting list whitespace

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
@@ -92,8 +92,7 @@ const renderGuestUserItem = (
         </UserAvatar>
       </div>
       <p key={`user-name-${userId}`} className={styles.userName}>
-        {sequence}
-        {name}
+        {`[${sequence}] ${name}`}
       </p>
     </div>
 


### PR DESCRIPTION
### What does this PR do?

Restores waiting list formatting (the way it was in 2.3, as mentioned in [PR #12876](https://github.com/bigbluebutton/bigbluebutton/pull/12876#issuecomment-903389161)).

#### before
![Screenshot from 2021-09-01 13-40-25](https://user-images.githubusercontent.com/3728706/131710242-26fcb020-4df0-4ff7-8fc0-3c77d0b73f6d.png)

#### after
![Screenshot from 2021-09-01 13-40-10](https://user-images.githubusercontent.com/3728706/131710235-c6bf78f5-e3ab-4930-97b8-55de0173577c.png)
