### PR TITLE
fix: restore camera unfocus label

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -147,7 +147,7 @@ class VideoListItem extends Component {
         if (i === 0 && fullWidthMenu) topDivider = true;
         menuItems.push({
           key: `${cameraId}-${a?.actionName}`,
-          label: a?.actionName,
+          label: a?.label,
           description: a?.description,
           onClick: a?.onClick,
           dividerTop: topDivider,


### PR DESCRIPTION
### What does this PR do?

Restore `Unfocus` label in focused video.

#### before
![Screenshot from 2021-09-01 14-10-07](https://user-images.githubusercontent.com/3728706/131716025-15876741-4e1e-411b-87d1-5f73a4fa4c5f.png)

#### after
![Screenshot from 2021-09-01 14-09-29](https://user-images.githubusercontent.com/3728706/131716023-6cacfb61-7431-4cce-ac33-47f6010eb63c.png)

### Closes Issue(s)
Closes #13127
