### PR TITLE
fix(webcams): check for component state after peer creation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -111,6 +111,7 @@ class VideoProvider extends Component {
     this.state = {
       socketOpen: false,
     };
+    this._isMounted = false;
 
     this.info = VideoService.getInfo();
 
@@ -141,6 +142,7 @@ class VideoProvider extends Component {
   }
 
   componentDidMount() {
+    this._isMounted = true;
     this.ws.onopen = this.onWsOpen;
     this.ws.onclose = this.onWsClose;
 
@@ -182,6 +184,7 @@ class VideoProvider extends Component {
 
     // Close websocket connection to prevent multiple reconnects from happening
     this.ws.close();
+    this._isMounted = false;
   }
 
   onWsMessage(message) {
@@ -621,6 +624,9 @@ class VideoProvider extends Component {
       }
 
       peerBuilderFunc(stream, peerOptions).then((offer) => {
+        if (!this._isMounted) {
+          return this.stopWebRTCPeer(stream, false);
+        }
         const peer = this.webRtcPeers[stream];
 
         if (peer && peer.peerConnection) {


### PR DESCRIPTION
### What does this PR do?

Check for video-provider's mounted state after peer creation calls. If the provider got unmounted while the procedure was still being processed, clean up the resulting peer.

### Closes Issue(s)

Closes #13130 

### Motivation

There could be a race condition where a peer creation (async) would resolve after the provider was unmounted.
That would lead to a state inconsistency which could generate all sorts of cryptic problems (see https://github.com/bigbluebutton/bigbluebutton/issues/13130).