### PR TITLE
Makes configurable the delay to clean up Learning Dashboard

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -56,7 +56,7 @@ public class ApiParams {
     public static final String VOICE_BRIDGE = "voiceBridge";
     public static final String WEB_VOICE = "webVoice";
     public static final String LEARNING_DASHBOARD_ENABLED = "learningDashboardEnabled";
-    public static final String LEARNING_DASHBOARD_CLEANUP_IN_MINUTES = "learningDashboardCleanupInMinutes";
+    public static final String LEARNING_DASHBOARD_CLEANUP_DELAY_IN_MINUTES = "learningDashboardCleanupDelayInMinutes";
     public static final String WEBCAMS_ONLY_FOR_MODERATOR = "webcamsOnlyForModerator";
     public static final String WELCOME = "welcome";
     public static final String HTML5_INSTANCE_ID = "html5InstanceId";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -56,7 +56,7 @@ public class ApiParams {
     public static final String VOICE_BRIDGE = "voiceBridge";
     public static final String WEB_VOICE = "webVoice";
     public static final String LEARNING_DASHBOARD_ENABLED = "learningDashboardEnabled";
-    public static final String LEARNING_DASHBOARD_CLEANUP_ENABLED = "learningDashboardCleanupEnabled";
+    public static final String LEARNING_DASHBOARD_CLEANUP_IN_MINUTES = "learningDashboardCleanupInMinutes";
     public static final String WEBCAMS_ONLY_FOR_MODERATOR = "webcamsOnlyForModerator";
     public static final String WELCOME = "welcome";
     public static final String HTML5_INSTANCE_ID = "html5InstanceId";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
@@ -27,7 +27,6 @@ import java.io.FileOutputStream;
 public class LearningDashboardService {
     private static Logger log = LoggerFactory.getLogger(LearningDashboardService.class);
     private static String learningDashboardFilesDir = "/var/bigbluebutton/learning-dashboard";
-    private static int cleanUpDelaySeconds = 120;
 
     public void writeJsonDataFile(String meetingId, String learningDashboardAccessToken, String activityJson) {
 
@@ -53,8 +52,8 @@ public class LearningDashboardService {
         }
     }
 
-    public void removeActivityJsonFile(String meetingId) {
-        //Delay `cleanUpDelaySeconds` then moderators can open the Dashboard before files has been removed
+    public void removeJsonDataFile(String meetingId, int cleanUpDelayMinutes) {
+        //Delay `cleanUpDelayMinutes` then moderators can open the Dashboard before files has been removed
         new java.util.Timer().schedule(
                 new java.util.TimerTask() {
                     @Override
@@ -64,7 +63,7 @@ public class LearningDashboardService {
                         log.info("Learning Dashboard files removed for meeting {}.",meetingId);
                     }
                 },
-                LearningDashboardService.cleanUpDelaySeconds * 1000
+                (cleanUpDelayMinutes * 60) * 1000
         );
     }
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
@@ -29,7 +29,7 @@ public class LearningDashboardService {
     private static String learningDashboardFilesDir = "/var/bigbluebutton/learning-dashboard";
     private static int cleanUpDelaySeconds = 120;
 
-    public void writeActivityJsonFile(String meetingId, String learningDashboardAccessToken, String activityJson) {
+    public void writeJsonDataFile(String meetingId, String learningDashboardAccessToken, String activityJson) {
 
         try {
             if(learningDashboardAccessToken.length() == 0) {
@@ -40,7 +40,7 @@ public class LearningDashboardService {
             File baseDir = new File(this.getDestinationBaseDirectoryName(meetingId,learningDashboardAccessToken));
             if (!baseDir.exists()) baseDir.mkdirs();
 
-            File jsonFile = new File(baseDir.getAbsolutePath() + File.separatorChar + "activity_report.json");
+            File jsonFile = new File(baseDir.getAbsolutePath() + File.separatorChar + "learning_dashboard_data.json");
 
             FileOutputStream fileOutput = new FileOutputStream(jsonFile);
             fileOutput.write(activityJson.getBytes());

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -860,8 +860,8 @@ public class MeetingService implements MessageListener {
       }
 
       //Remove Learning Dashboard files
-      if(m.getLearningDashboardCleanupEnabled() == true) {
-        learningDashboardService.removeActivityJsonFile(message.meetingId);
+      if(m.getLearningDashboardCleanupInMinutes() > 0) {
+        learningDashboardService.removeJsonDataFile(message.meetingId, m.getLearningDashboardCleanupInMinutes());
       }
 
       processRemoveEndedMeeting(message);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -975,7 +975,7 @@ public class MeetingService implements MessageListener {
 
     log.info(" --analytics-- data={}", logStr);
 
-    learningDashboardService.writeActivityJsonFile(message.meetingId, learningDashboardAccessToken, message.activityJson);
+    learningDashboardService.writeJsonDataFile(message.meetingId, learningDashboardAccessToken, message.activityJson);
   }
 
   @Override

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -860,8 +860,8 @@ public class MeetingService implements MessageListener {
       }
 
       //Remove Learning Dashboard files
-      if(m.getLearningDashboardCleanupInMinutes() > 0) {
-        learningDashboardService.removeJsonDataFile(message.meetingId, m.getLearningDashboardCleanupInMinutes());
+      if(m.getLearningDashboardCleanupDelayInMinutes() > 0) {
+        learningDashboardService.removeJsonDataFile(message.meetingId, m.getLearningDashboardCleanupDelayInMinutes());
       }
 
       processRemoveEndedMeeting(message);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -83,7 +83,7 @@ public class ParamsProcessorUtil {
     private boolean autoStartRecording;
     private boolean allowStartStopRecording;
     private boolean learningDashboardEnabled;
-    private boolean learningDashboardCleanupEnabled;
+    private int learningDashboardCleanupInMinutes;
     private boolean webcamsOnlyForModerator;
     private boolean defaultMuteOnStart = false;
     private boolean defaultAllowModsToUnmuteUsers = false;
@@ -431,14 +431,14 @@ public class ParamsProcessorUtil {
             }
         }
 
-        boolean learningDashboardCleanupEn = learningDashboardCleanupEnabled;
-        if (!StringUtils.isEmpty(params.get(ApiParams.LEARNING_DASHBOARD_CLEANUP_ENABLED))) {
+        int learningDashboardCleanupMins = learningDashboardCleanupInMinutes;
+        if (!StringUtils.isEmpty(params.get(ApiParams.LEARNING_DASHBOARD_CLEANUP_IN_MINUTES))) {
             try {
-                learningDashboardCleanupEn = Boolean.parseBoolean(params
-                        .get(ApiParams.LEARNING_DASHBOARD_CLEANUP_ENABLED));
+                learningDashboardCleanupMins = Integer.parseInt(params
+                        .get(ApiParams.LEARNING_DASHBOARD_CLEANUP_IN_MINUTES));
             } catch (Exception ex) {
                 log.warn(
-                        "Invalid param [learningDashboardCleanupEnabled] for meeting=[{}]",
+                        "Invalid param [learningDashboardCleanupInMinutes] for meeting=[{}]",
                         internalMeetingId);
             }
         }
@@ -546,8 +546,8 @@ public class ParamsProcessorUtil {
 				.withLockSettingsParams(lockSettingsParams)
 				.withAllowDuplicateExtUserid(defaultAllowDuplicateExtUserid)
                 .withHTML5InstanceId(html5InstanceId)
-                .withlearningDashboardEnabled(learningDashboardEn)
-                .withlearningDashboardCleanupEnabled(learningDashboardCleanupEn)
+                .withLearningDashboardEnabled(learningDashboardEn)
+                .withLearningDashboardCleanupInMinutes(learningDashboardCleanupMins)
                 .withLearningDashboardAccessToken(learningDashboardAccessToken)
                 .build();
 
@@ -960,8 +960,8 @@ public class ParamsProcessorUtil {
         this.learningDashboardEnabled = learningDashboardEnabled;
     }
 
-    public void setLearningDashboardCleanupEnabled(boolean learningDashboardCleanupEnabled) {
-        this.learningDashboardCleanupEnabled = learningDashboardCleanupEnabled;
+    public void setlearningDashboardCleanupInMinutes(int learningDashboardCleanupInMinutes) {
+        this.learningDashboardCleanupInMinutes = learningDashboardCleanupInMinutes;
     }
 
     public void setWebcamsOnlyForModerator(boolean webcamsOnlyForModerator) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -83,7 +83,7 @@ public class ParamsProcessorUtil {
     private boolean autoStartRecording;
     private boolean allowStartStopRecording;
     private boolean learningDashboardEnabled;
-    private int learningDashboardCleanupInMinutes;
+    private int learningDashboardCleanupDelayInMinutes;
     private boolean webcamsOnlyForModerator;
     private boolean defaultMuteOnStart = false;
     private boolean defaultAllowModsToUnmuteUsers = false;
@@ -431,14 +431,14 @@ public class ParamsProcessorUtil {
             }
         }
 
-        int learningDashboardCleanupMins = learningDashboardCleanupInMinutes;
-        if (!StringUtils.isEmpty(params.get(ApiParams.LEARNING_DASHBOARD_CLEANUP_IN_MINUTES))) {
+        int learningDashboardCleanupMins = learningDashboardCleanupDelayInMinutes;
+        if (!StringUtils.isEmpty(params.get(ApiParams.LEARNING_DASHBOARD_CLEANUP_DELAY_IN_MINUTES))) {
             try {
                 learningDashboardCleanupMins = Integer.parseInt(params
-                        .get(ApiParams.LEARNING_DASHBOARD_CLEANUP_IN_MINUTES));
+                        .get(ApiParams.LEARNING_DASHBOARD_CLEANUP_DELAY_IN_MINUTES));
             } catch (Exception ex) {
                 log.warn(
-                        "Invalid param [learningDashboardCleanupInMinutes] for meeting=[{}]",
+                        "Invalid param [learningDashboardCleanupDelayInMinutes] for meeting=[{}]",
                         internalMeetingId);
             }
         }
@@ -547,7 +547,7 @@ public class ParamsProcessorUtil {
 				.withAllowDuplicateExtUserid(defaultAllowDuplicateExtUserid)
                 .withHTML5InstanceId(html5InstanceId)
                 .withLearningDashboardEnabled(learningDashboardEn)
-                .withLearningDashboardCleanupInMinutes(learningDashboardCleanupMins)
+                .withLearningDashboardCleanupDelayInMinutes(learningDashboardCleanupMins)
                 .withLearningDashboardAccessToken(learningDashboardAccessToken)
                 .build();
 
@@ -960,8 +960,8 @@ public class ParamsProcessorUtil {
         this.learningDashboardEnabled = learningDashboardEnabled;
     }
 
-    public void setlearningDashboardCleanupInMinutes(int learningDashboardCleanupInMinutes) {
-        this.learningDashboardCleanupInMinutes = learningDashboardCleanupInMinutes;
+    public void setlearningDashboardCleanupDelayInMinutes(int learningDashboardCleanupDelayInMinutes) {
+        this.learningDashboardCleanupDelayInMinutes = learningDashboardCleanupDelayInMinutes;
     }
 
     public void setWebcamsOnlyForModerator(boolean webcamsOnlyForModerator) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -52,7 +52,7 @@ public class Meeting {
 	private String moderatorPass;
 	private String viewerPass;
 	private Boolean learningDashboardEnabled;
-	private Boolean learningDashboardCleanupEnabled;
+	private int learningDashboardCleanupInMinutes;
 	private String learningDashboardAccessToken;
 	private String welcomeMsgTemplate;
 	private String welcomeMsg;
@@ -112,7 +112,7 @@ public class Meeting {
         viewerPass = builder.viewerPass;
         moderatorPass = builder.moderatorPass;
 		learningDashboardEnabled = builder.learningDashboardEnabled;
-		learningDashboardCleanupEnabled = builder.learningDashboardCleanupEnabled;
+		learningDashboardCleanupInMinutes = builder.learningDashboardCleanupInMinutes;
 		learningDashboardAccessToken = builder.learningDashboardAccessToken;
         maxUsers = builder.maxUsers;
         bannerColor = builder.bannerColor;
@@ -336,8 +336,8 @@ public class Meeting {
 		return learningDashboardEnabled;
 	}
 
-	public Boolean getLearningDashboardCleanupEnabled() {
-		return learningDashboardCleanupEnabled;
+	public int getLearningDashboardCleanupInMinutes() {
+		return learningDashboardCleanupInMinutes;
 	}
 
 	public String getLearningDashboardAccessToken() {
@@ -733,7 +733,7 @@ public class Meeting {
     	private String moderatorPass;
     	private String viewerPass;
     	private Boolean learningDashboardEnabled;
-    	private Boolean learningDashboardCleanupEnabled;
+    	private int learningDashboardCleanupInMinutes;
     	private String learningDashboardAccessToken;
     	private int duration;
     	private String webVoice;
@@ -825,13 +825,13 @@ public class Meeting {
 	    	return this;
 	    }
     	
-    	public Builder withlearningDashboardEnabled(Boolean e) {
+    	public Builder withLearningDashboardEnabled(Boolean e) {
 	    	this.learningDashboardEnabled = e;
 	    	return this;
 	    }
 
-    	public Builder withlearningDashboardCleanupEnabled(Boolean e) {
-	    	this.learningDashboardCleanupEnabled = e;
+    	public Builder withLearningDashboardCleanupInMinutes(int m) {
+	    	this.learningDashboardCleanupInMinutes = m;
 	    	return this;
 	    }
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -52,7 +52,7 @@ public class Meeting {
 	private String moderatorPass;
 	private String viewerPass;
 	private Boolean learningDashboardEnabled;
-	private int learningDashboardCleanupInMinutes;
+	private int learningDashboardCleanupDelayInMinutes;
 	private String learningDashboardAccessToken;
 	private String welcomeMsgTemplate;
 	private String welcomeMsg;
@@ -112,7 +112,7 @@ public class Meeting {
         viewerPass = builder.viewerPass;
         moderatorPass = builder.moderatorPass;
 		learningDashboardEnabled = builder.learningDashboardEnabled;
-		learningDashboardCleanupInMinutes = builder.learningDashboardCleanupInMinutes;
+		learningDashboardCleanupDelayInMinutes = builder.learningDashboardCleanupDelayInMinutes;
 		learningDashboardAccessToken = builder.learningDashboardAccessToken;
         maxUsers = builder.maxUsers;
         bannerColor = builder.bannerColor;
@@ -336,8 +336,8 @@ public class Meeting {
 		return learningDashboardEnabled;
 	}
 
-	public int getLearningDashboardCleanupInMinutes() {
-		return learningDashboardCleanupInMinutes;
+	public int getLearningDashboardCleanupDelayInMinutes() {
+		return learningDashboardCleanupDelayInMinutes;
 	}
 
 	public String getLearningDashboardAccessToken() {
@@ -733,7 +733,7 @@ public class Meeting {
     	private String moderatorPass;
     	private String viewerPass;
     	private Boolean learningDashboardEnabled;
-    	private int learningDashboardCleanupInMinutes;
+    	private int learningDashboardCleanupDelayInMinutes;
     	private String learningDashboardAccessToken;
     	private int duration;
     	private String webVoice;
@@ -830,8 +830,8 @@ public class Meeting {
 	    	return this;
 	    }
 
-    	public Builder withLearningDashboardCleanupInMinutes(int m) {
-	    	this.learningDashboardCleanupInMinutes = m;
+    	public Builder withLearningDashboardCleanupDelayInMinutes(int m) {
+	    	this.learningDashboardCleanupDelayInMinutes = m;
 	    	return this;
 	    }
 

--- a/bbb-learning-dashboard/src/App.js
+++ b/bbb-learning-dashboard/src/App.js
@@ -41,7 +41,7 @@ class App extends React.Component {
     }
 
     if (learningDashboardAccessToken !== '') {
-      fetch(`${params.meeting}/${learningDashboardAccessToken}/activity_report.json`)
+      fetch(`${params.meeting}/${learningDashboardAccessToken}/learning_dashboard_data.json`)
         .then((response) => response.json())
         .then((json) => {
           this.setState({ activitiesJson: json });

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -250,7 +250,7 @@ learningDashboardEnabled=true
 # Number of minutes that Learning Dashboard will be available after the end of the meeting
 # if 0, the Learning Dashboard will keep available permanently
 # this is the default value, can be customized using the create API
-learningDashboardCleanupInMinutes=2
+learningDashboardCleanupDelayInMinutes=2
 
 # Allow webcams streaming reception only to and from moderators
 webcamsOnlyForModerator=false

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -243,14 +243,14 @@ autoStartRecording=false
 # Allow the user to start/stop recording.
 allowStartStopRecording=true
 
-# Provide moderator with a Dashboard with live summary of meeting activities in real time (available after end of meeting too)
+# Provide moderator with a Dashboard with live summary of meeting activities in real time
 # this is the default value, can be customized using the create API
 learningDashboardEnabled=true
 
-# Clean Learning Dashboard files when meeting ends
-# if enabled, the Learning Dashboard will become unavailable 2 minutes after meeting ends
-# if disabled, the Learning Dashboard will remain available even after meeting ends
-learningDashboardCleanupEnabled=true
+# Number of minutes that Learning Dashboard will be available after the end of the meeting
+# if 0, the Learning Dashboard will keep available permanently
+# this is the default value, can be customized using the create API
+learningDashboardCleanupInMinutes=2
 
 # Allow webcams streaming reception only to and from moderators
 webcamsOnlyForModerator=false

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -154,7 +154,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="autoStartRecording" value="${autoStartRecording}"/>
         <property name="allowStartStopRecording" value="${allowStartStopRecording}"/>
         <property name="learningDashboardEnabled" value="${learningDashboardEnabled}"/>
-        <property name="learningDashboardCleanupEnabled" value="${learningDashboardCleanupEnabled}"/>
+        <property name="learningDashboardCleanupInMinutes" value="${learningDashboardCleanupInMinutes}"/>
         <property name="webcamsOnlyForModerator" value="${webcamsOnlyForModerator}"/>
         <property name="useDefaultAvatar" value="${useDefaultAvatar}"/>
         <property name="defaultAvatarURL" value="${defaultAvatarURL}"/>

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -154,7 +154,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="autoStartRecording" value="${autoStartRecording}"/>
         <property name="allowStartStopRecording" value="${allowStartStopRecording}"/>
         <property name="learningDashboardEnabled" value="${learningDashboardEnabled}"/>
-        <property name="learningDashboardCleanupInMinutes" value="${learningDashboardCleanupInMinutes}"/>
+        <property name="learningDashboardCleanupDelayInMinutes" value="${learningDashboardCleanupDelayInMinutes}"/>
         <property name="webcamsOnlyForModerator" value="${webcamsOnlyForModerator}"/>
         <property name="useDefaultAvatar" value="${useDefaultAvatar}"/>
         <property name="defaultAvatarURL" value="${defaultAvatarURL}"/>


### PR DESCRIPTION
This PR will:
- Remove config `learningDashboardCleanupEnabled` (now to disable set `learningDashboardCleanupDelayInMinutes=0`)
- Include config `learningDashboardCleanupDelayInMinutes` that makes configurable the delay to remove Learning Dashboard (after the end of the meeting) (default value is 2 minutes) (0=disabled).

Also,
- Rename json filename from `activity_report.json` to `learning_dashboard_data.json`