### PR TITLE
fix: Moderator options still open after user being demoted

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/captions/writer-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/writer-menu/component.jsx
@@ -70,6 +70,12 @@ class WriterMenu extends PureComponent {
     this.handleStart = this.handleStart.bind(this);
   }
 
+  componentWillUnmount() {
+    const { closeModal } = this.props;
+
+    closeModal();
+  }
+
   handleChange(event) {
     this.setState({ locale: event.target.value });
   }

--- a/bigbluebutton-html5/imports/ui/components/captions/writer-menu/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/writer-menu/container.jsx
@@ -4,11 +4,20 @@ import { withModalMounter } from '/imports/ui/components/modal/service';
 import CaptionsService from '/imports/ui/components/captions/service';
 import WriterMenu from './component';
 import LayoutContext from '../../layout/context';
+import Auth from '/imports/ui/services/auth';
+import { UsersContext } from '/imports/ui/components/components-data/users-context/context';
+
+const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 
 const WriterMenuContainer = (props) => {
   const layoutContext = useContext(LayoutContext);
   const { layoutContextDispatch } = layoutContext;
-  return <WriterMenu {...{ layoutContextDispatch, ...props }} />;
+  const usingUsersContext = useContext(UsersContext);
+  const { users } = usingUsersContext;
+  const currentUser = users[Auth.meetingID][Auth.userID];
+  const amIModerator = currentUser.role === ROLE_MODERATOR;
+
+  return amIModerator && <WriterMenu {...{ layoutContextDispatch, ...props }} />;
 };
 
 export default withModalMounter(withTracker(({ mountModal }) => ({

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
@@ -140,6 +140,12 @@ class LockViewersComponent extends Component {
     );
   }
 
+  componentWillUnmount() {
+    const { closeModal } = this.props;
+
+    closeModal();
+  }
+
   render() {
     const {
       closeModal,

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/container.jsx
@@ -1,12 +1,22 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import { withModalMounter } from '/imports/ui/components/modal/service';
 import Meetings from '/imports/api/meetings';
 import Auth from '/imports/ui/services/auth';
 import LockViewersComponent from './component';
 import { updateLockSettings, updateWebcamsOnlyForModerator } from './service';
+import { UsersContext } from '../components-data/users-context/context';
 
-const LockViewersContainer = props => <LockViewersComponent {...props} />;
+const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
+
+const LockViewersContainer = (props) => {
+  const usingUsersContext = useContext(UsersContext);
+  const { users } = usingUsersContext;
+  const currentUser = users[Auth.meetingID][Auth.userID];
+  const amIModerator = currentUser.role === ROLE_MODERATOR;
+
+  return amIModerator && <LockViewersComponent {...props} />
+}
 
 export default withModalMounter(withTracker(({ mountModal }) => ({
   closeModal: () => mountModal(null),

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/guest-policy/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/guest-policy/component.jsx
@@ -46,6 +46,12 @@ const propTypes = {
 };
 
 class GuestPolicyComponent extends PureComponent {
+  componentWillUnmount() {
+    const { closeModal } = this.props;
+
+    closeModal();
+  }
+
   render() {
     const {
       closeModal,

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/guest-policy/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/guest-policy/container.jsx
@@ -1,10 +1,21 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import { withModalMounter } from '/imports/ui/components/modal/service';
 import GuestPolicyComponent from './component';
 import Service from '../service';
+import Auth from '/imports/ui/services/auth';
+import { UsersContext } from '/imports/ui/components/components-data/users-context/context';
 
-const guestPolicyContainer = props => <GuestPolicyComponent {...props} />;
+const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
+
+const guestPolicyContainer = (props) => {
+  const usingUsersContext = useContext(UsersContext);
+  const { users } = usingUsersContext;
+  const currentUser = users[Auth.meetingID][Auth.userID];
+  const amIModerator = currentUser.role === ROLE_MODERATOR;
+
+  return amIModerator && <GuestPolicyComponent {...props} />;
+};
 
 export default withModalMounter(withTracker(({ mountModal }) => ({
   closeModal: () => mountModal(null),


### PR DESCRIPTION
### What does this PR do?

Prevents an issue where _Lock viewers_, _Guest policy_ and _Write closed caption_ modals would stay open if the user loses moderator status.

### Closes Issue(s)
Closes #13116