### PR TITLE
fix: swap layout camera dock size

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -158,7 +158,7 @@ class App extends Component {
       value: isRTL,
     });
 
-    MediaService.setSwapLayout();
+    MediaService.setSwapLayout(layoutContextDispatch);
     Modal.setAppElement('#app');
 
     const fontSize = isMobile() ? MOBILE_FONT_SIZE : DESKTOP_FONT_SIZE;

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -60,6 +60,7 @@ const AppContainer = (props) => {
     settingsLayout,
     pushLayoutToEveryone,
     currentUserId,
+    shouldShowPresentation: propsShouldShowPresentation,
     ...otherProps
   } = props;
   const {
@@ -68,12 +69,14 @@ const AppContainer = (props) => {
     layoutType,
     deviceType,
   } = layoutContextState;
-  const { sidebarContent, sidebarNavigation } = input;
+  const { sidebarContent, sidebarNavigation, presentation } = input;
   const { actionBar: actionsBarStyle, captions: captionsStyle } = output;
   const { sidebarNavPanel } = sidebarNavigation;
   const { sidebarContentPanel } = sidebarContent;
   const sidebarNavigationIsOpen = sidebarNavigation.isOpen;
   const sidebarContentIsOpen = sidebarContent.isOpen;
+  const presentationIsOpen = presentation.isOpen;
+  const shouldShowPresentation = propsShouldShowPresentation && presentationIsOpen;
 
   return currentUserId
     ? (
@@ -93,6 +96,7 @@ const AppContainer = (props) => {
           sidebarNavigationIsOpen,
           sidebarContentPanel,
           sidebarContentIsOpen,
+          shouldShowPresentation,
         }}
         {...otherProps}
       />

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -147,6 +147,7 @@ class CustomLayout extends Component {
             isOpen: false,
           },
           presentation: {
+            isOpen: input.presentation.isOpen,
             slidesLength: input.presentation.slidesLength,
             currentSlide: {
               ...input.presentation.currentSlide,
@@ -174,6 +175,7 @@ class CustomLayout extends Component {
             isOpen: false,
           },
           presentation: {
+            isOpen: input.presentation.isOpen,
             slidesLength: input.presentation.slidesLength,
             currentSlide: {
               ...input.presentation.currentSlide,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -81,6 +81,7 @@ class PresentationFocusLayout extends Component {
             isOpen: false,
           },
           presentation: {
+            isOpen: input.presentation.isOpen,
             slidesLength: input.presentation.slidesLength,
             currentSlide: {
               ...input.presentation.currentSlide,
@@ -108,6 +109,7 @@ class PresentationFocusLayout extends Component {
             isOpen: false,
           },
           presentation: {
+            isOpen: input.presentation.isOpen,
             slidesLength: input.presentation.slidesLength,
             currentSlide: {
               ...input.presentation.currentSlide,
@@ -276,6 +278,8 @@ class PresentationFocusLayout extends Component {
   calculatesSidebarContentHeight() {
     const { layoutContextState } = this.props;
     const { deviceType, input } = layoutContextState;
+    const { presentation } = input;
+    const { isOpen } = presentation;
     const {
       navBarHeight,
       sidebarContentMinHeight,
@@ -288,7 +292,7 @@ class PresentationFocusLayout extends Component {
         height = windowHeight() - navBarHeight - this.bannerAreaHeight();
         minHeight = height;
         maxHeight = height;
-      } else if (input.cameraDock.numCameras > 0) {
+      } else if (input.cameraDock.numCameras > 0 && isOpen) {
         if (input.sidebarContent.height === 0) {
           height = (windowHeight() * 0.75) - this.bannerAreaHeight();
         } else {
@@ -368,57 +372,70 @@ class PresentationFocusLayout extends Component {
     const {
       deviceType, input, fullscreen, isRTL,
     } = layoutContextState;
+    const { presentation } = input;
+    const { isOpen } = presentation;
     const cameraDockBounds = {};
+    const sidebarSize = sidebarNavWidth + sidebarContentWidth;
 
     if (input.cameraDock.numCameras > 0) {
-      let cameraDockHeight = 0;
-
-      if (fullscreen.group === 'webcams') {
-        cameraDockBounds.width = windowWidth();
-        cameraDockBounds.minWidth = windowWidth();
-        cameraDockBounds.maxWidth = windowWidth();
-        cameraDockBounds.height = windowHeight();
-        cameraDockBounds.minHeight = windowHeight();
-        cameraDockBounds.maxHeight = windowHeight();
-        cameraDockBounds.top = 0;
-        cameraDockBounds.left = 0;
-        cameraDockBounds.right = 0;
-        cameraDockBounds.zIndex = 99;
-        return cameraDockBounds;
-      }
-
-      if (deviceType === DEVICE_TYPE.MOBILE) {
-        cameraDockBounds.top = mediaAreaBounds.top + mediaBounds.height;
-        cameraDockBounds.left = 0;
-        cameraDockBounds.right = 0;
-        cameraDockBounds.minWidth = mediaAreaBounds.width;
+      if (!isOpen) {
         cameraDockBounds.width = mediaAreaBounds.width;
         cameraDockBounds.maxWidth = mediaAreaBounds.width;
-        cameraDockBounds.minHeight = DEFAULT_VALUES.cameraDockMinHeight;
-        cameraDockBounds.height = mediaAreaBounds.height - mediaBounds.height;
-        cameraDockBounds.maxHeight = mediaAreaBounds.height - mediaBounds.height;
+        cameraDockBounds.height = mediaAreaBounds.height;
+        cameraDockBounds.maxHeight = mediaAreaBounds.height;
+        cameraDockBounds.top = DEFAULT_VALUES.navBarHeight;
+        cameraDockBounds.left = !isRTL ? mediaAreaBounds.left : 0;
+        cameraDockBounds.right = isRTL ? sidebarSize : null;
       } else {
-        if (input.cameraDock.height === 0) {
-          cameraDockHeight = min(
-            max((windowHeight() - sidebarContentHeight), DEFAULT_VALUES.cameraDockMinHeight),
-            (windowHeight() - DEFAULT_VALUES.cameraDockMinHeight),
-          );
-        } else {
-          cameraDockHeight = min(
-            max(input.cameraDock.height, DEFAULT_VALUES.cameraDockMinHeight),
-            (windowHeight() - DEFAULT_VALUES.cameraDockMinHeight),
-          );
+        let cameraDockHeight = 0;
+
+        if (fullscreen.group === 'webcams') {
+          cameraDockBounds.width = windowWidth();
+          cameraDockBounds.minWidth = windowWidth();
+          cameraDockBounds.maxWidth = windowWidth();
+          cameraDockBounds.height = windowHeight();
+          cameraDockBounds.minHeight = windowHeight();
+          cameraDockBounds.maxHeight = windowHeight();
+          cameraDockBounds.top = 0;
+          cameraDockBounds.left = 0;
+          cameraDockBounds.right = 0;
+          cameraDockBounds.zIndex = 99;
+          return cameraDockBounds;
         }
-        cameraDockBounds.top = windowHeight() - cameraDockHeight;
-        cameraDockBounds.left = !isRTL ? sidebarNavWidth : 0;
-        cameraDockBounds.right = isRTL ? sidebarNavWidth : 0;
-        cameraDockBounds.minWidth = sidebarContentWidth;
-        cameraDockBounds.width = sidebarContentWidth;
-        cameraDockBounds.maxWidth = sidebarContentWidth;
-        cameraDockBounds.minHeight = DEFAULT_VALUES.cameraDockMinHeight;
-        cameraDockBounds.height = cameraDockHeight;
-        cameraDockBounds.maxHeight = windowHeight() - sidebarContentHeight;
-        cameraDockBounds.zIndex = 1;
+
+        if (deviceType === DEVICE_TYPE.MOBILE) {
+          cameraDockBounds.top = mediaAreaBounds.top + mediaBounds.height;
+          cameraDockBounds.left = 0;
+          cameraDockBounds.right = 0;
+          cameraDockBounds.minWidth = mediaAreaBounds.width;
+          cameraDockBounds.width = mediaAreaBounds.width;
+          cameraDockBounds.maxWidth = mediaAreaBounds.width;
+          cameraDockBounds.minHeight = DEFAULT_VALUES.cameraDockMinHeight;
+          cameraDockBounds.height = mediaAreaBounds.height - mediaBounds.height;
+          cameraDockBounds.maxHeight = mediaAreaBounds.height - mediaBounds.height;
+        } else {
+          if (input.cameraDock.height === 0) {
+            cameraDockHeight = min(
+              max((windowHeight() - sidebarContentHeight), DEFAULT_VALUES.cameraDockMinHeight),
+              (windowHeight() - DEFAULT_VALUES.cameraDockMinHeight),
+            );
+          } else {
+            cameraDockHeight = min(
+              max(input.cameraDock.height, DEFAULT_VALUES.cameraDockMinHeight),
+              (windowHeight() - DEFAULT_VALUES.cameraDockMinHeight),
+            );
+          }
+          cameraDockBounds.top = windowHeight() - cameraDockHeight;
+          cameraDockBounds.left = !isRTL ? sidebarNavWidth : 0;
+          cameraDockBounds.right = isRTL ? sidebarNavWidth : 0;
+          cameraDockBounds.minWidth = sidebarContentWidth;
+          cameraDockBounds.width = sidebarContentWidth;
+          cameraDockBounds.maxWidth = sidebarContentWidth;
+          cameraDockBounds.minHeight = DEFAULT_VALUES.cameraDockMinHeight;
+          cameraDockBounds.height = cameraDockHeight;
+          cameraDockBounds.maxHeight = windowHeight() - sidebarContentHeight;
+          cameraDockBounds.zIndex = 1;
+        }
       }
     } else {
       cameraDockBounds.width = 0;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -81,6 +81,7 @@ class SmartLayout extends Component {
             isOpen: false,
           },
           presentation: {
+            isOpen: input.presentation.isOpen,
             slidesLength: input.presentation.slidesLength,
             currentSlide: {
               ...input.presentation.currentSlide,
@@ -108,6 +109,7 @@ class SmartLayout extends Component {
             isOpen: false,
           },
           presentation: {
+            isOpen: input.presentation.isOpen,
             slidesLength: input.presentation.slidesLength,
             currentSlide: {
               ...input.presentation.currentSlide,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -83,6 +83,7 @@ class VideoFocusLayout extends Component {
               isOpen: false,
             },
             presentation: {
+              isOpen: input.presentation.isOpen,
               slidesLength: input.presentation.slidesLength,
               currentSlide: {
                 ...input.presentation.currentSlide,
@@ -113,6 +114,7 @@ class VideoFocusLayout extends Component {
               isOpen: false,
             },
             presentation: {
+              isOpen: input.presentation.isOpen,
               slidesLength: input.presentation.slidesLength,
               currentSlide: {
                 ...input.presentation.currentSlide,
@@ -374,42 +376,52 @@ class VideoFocusLayout extends Component {
     const {
       deviceType, input, fullscreen, isRTL,
     } = layoutContextState;
-    const { cameraDock } = input;
+    const { cameraDock, presentation } = input;
+    const { isOpen } = presentation;
     const { numCameras } = cameraDock;
 
     const cameraDockBounds = {};
 
     if (numCameras > 0) {
-      if (deviceType === DEVICE_TYPE.MOBILE) {
-        cameraDockBounds.minHeight = mediaAreaBounds.height * 0.7;
-        cameraDockBounds.height = mediaAreaBounds.height * 0.7;
-        cameraDockBounds.maxHeight = mediaAreaBounds.height * 0.7;
-      } else {
-        cameraDockBounds.minHeight = mediaAreaBounds.height;
+      if (!isOpen) {
+        cameraDockBounds.width = mediaAreaBounds.width;
+        cameraDockBounds.maxWidth = mediaAreaBounds.width;
         cameraDockBounds.height = mediaAreaBounds.height;
         cameraDockBounds.maxHeight = mediaAreaBounds.height;
+        cameraDockBounds.top = DEFAULT_VALUES.navBarHeight;
+        cameraDockBounds.left = !isRTL ? mediaAreaBounds.left : 0;
+        cameraDockBounds.right = isRTL ? sidebarSize : null;
+      } else {
+        if (deviceType === DEVICE_TYPE.MOBILE) {
+          cameraDockBounds.minHeight = mediaAreaBounds.height * 0.7;
+          cameraDockBounds.height = mediaAreaBounds.height * 0.7;
+          cameraDockBounds.maxHeight = mediaAreaBounds.height * 0.7;
+        } else {
+          cameraDockBounds.minHeight = mediaAreaBounds.height;
+          cameraDockBounds.height = mediaAreaBounds.height;
+          cameraDockBounds.maxHeight = mediaAreaBounds.height;
+        }
+
+        cameraDockBounds.top = DEFAULT_VALUES.navBarHeight;
+        cameraDockBounds.left = !isRTL ? mediaAreaBounds.left : null;
+        cameraDockBounds.right = isRTL ? sidebarSize : null;
+        cameraDockBounds.minWidth = mediaAreaBounds.width;
+        cameraDockBounds.width = mediaAreaBounds.width;
+        cameraDockBounds.maxWidth = mediaAreaBounds.width;
+        cameraDockBounds.zIndex = 1;
+
+        if (fullscreen.group === 'webcams') {
+          cameraDockBounds.width = windowWidth();
+          cameraDockBounds.minWidth = windowWidth();
+          cameraDockBounds.maxWidth = windowWidth();
+          cameraDockBounds.height = windowHeight();
+          cameraDockBounds.minHeight = windowHeight();
+          cameraDockBounds.maxHeight = windowHeight();
+          cameraDockBounds.top = 0;
+          cameraDockBounds.left = 0;
+          cameraDockBounds.zIndex = 99;
+        }
       }
-
-      cameraDockBounds.top = DEFAULT_VALUES.navBarHeight;
-      cameraDockBounds.left = !isRTL ? mediaAreaBounds.left : null;
-      cameraDockBounds.right = isRTL ? sidebarSize : null;
-      cameraDockBounds.minWidth = mediaAreaBounds.width;
-      cameraDockBounds.width = mediaAreaBounds.width;
-      cameraDockBounds.maxWidth = mediaAreaBounds.width;
-      cameraDockBounds.zIndex = 1;
-
-      if (fullscreen.group === 'webcams') {
-        cameraDockBounds.width = windowWidth();
-        cameraDockBounds.minWidth = windowWidth();
-        cameraDockBounds.maxWidth = windowWidth();
-        cameraDockBounds.height = windowHeight();
-        cameraDockBounds.minHeight = windowHeight();
-        cameraDockBounds.maxHeight = windowHeight();
-        cameraDockBounds.top = 0;
-        cameraDockBounds.left = 0;
-        cameraDockBounds.zIndex = 99;
-      }
-
       return cameraDockBounds;
     }
 

--- a/bigbluebutton-html5/imports/ui/components/media/service.js
+++ b/bigbluebutton-html5/imports/ui/components/media/service.js
@@ -47,9 +47,14 @@ const swapLayout = {
   tracker: new Tracker.Dependency(),
 };
 
-const setSwapLayout = () => {
+const setSwapLayout = (layoutContextDispatch) => {
   swapLayout.value = getFromUserSettings('bbb_auto_swap_layout', LAYOUT_CONFIG.autoSwapLayout);
   swapLayout.tracker.changed();
+
+  layoutContextDispatch({
+    type: ACTIONS.SET_PRESENTATION_IS_OPEN,
+    value: !swapLayout.value,
+  });
 };
 
 const toggleSwapLayout = (layoutContextDispatch) => {

--- a/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
@@ -98,7 +98,7 @@ const WebcamComponent = ({
       );
       Storage.setItem('webcamSize', { width: newCameraMaxWidth, height: lastHeight });
     }
-  }, [cameraDock.position, isPresenter, displayPresentation]);
+  }, [cameraDock.position, cameraDock.maxWidth, isPresenter, displayPresentation]);
 
   const onResizeHandle = (deltaWidth, deltaHeight) => {
     if (cameraDock.resizableEdge.top || cameraDock.resizableEdge.bottom) {


### PR DESCRIPTION
### What does this PR do?

Prevents an issue with the camera dock size not being correct when `autoSwapLayout` is set to `true`.

#### before
![Screenshot from 2021-09-02 16-25-28](https://user-images.githubusercontent.com/3728706/131904324-4d2152f9-05fa-4c89-93ff-08d39a0346bd.png)

#### after
![Screenshot from 2021-09-02 16-24-47](https://user-images.githubusercontent.com/3728706/131904318-7c299b59-d02e-4d93-8c7a-c73f3ade4f3e.png)

### Closes Issue(s)
Closes #12947