### PR TITLE
add label for when the user does not have breakout URL

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
@@ -43,13 +43,17 @@ const intlMessages = defineMessages({
     id: 'app.createBreakoutRoom.returnAudio',
     description: 'label for option to return audio',
   },
+  generateURL: {
+    id: 'app.createBreakoutRoom.generateURL',
+    description: 'label for generate breakout room url',
+  },
   generatingURL: {
     id: 'app.createBreakoutRoom.generatingURL',
     description: 'label for generating breakout room url',
   },
   generatedURL: {
     id: 'app.createBreakoutRoom.generatedURL',
-    description: 'label for generate breakout room url',
+    description: 'label for generated breakout room url',
   },
   endAllBreakouts: {
     id: 'app.createBreakoutRoom.endAllBreakouts',
@@ -94,6 +98,7 @@ class BreakoutRoom extends PureComponent {
     super(props);
     this.renderBreakoutRooms = this.renderBreakoutRooms.bind(this);
     this.getBreakoutURL = this.getBreakoutURL.bind(this);
+    this.getBreakoutLabel = this.getBreakoutLabel.bind(this);
     this.renderDuration = this.renderDuration.bind(this);
     this.transferUserToBreakoutRoom = this.transferUserToBreakoutRoom.bind(this);
     this.changeExtendTime = this.changeExtendTime.bind(this);
@@ -173,6 +178,23 @@ class BreakoutRoom extends PureComponent {
       this.setState({ waiting: false, generated: false });
     }
     return null;
+  }
+
+  getBreakoutLabel(breakoutId) {
+    const { intl, breakoutRoomUser } = this.props;
+    const { requestedBreakoutId, generated } = this.state;
+
+    const hasUser = breakoutRoomUser(breakoutId);
+
+    if (generated && requestedBreakoutId === breakoutId) {
+      return intl.formatMessage(intlMessages.generatedURL);
+    }
+
+    if (hasUser) {
+      return intl.formatMessage(intlMessages.breakoutJoin);
+    }
+
+    return intl.formatMessage(intlMessages.generateURL);
   }
 
   clearJoinedAudioOnly() {
@@ -285,11 +307,7 @@ class BreakoutRoom extends PureComponent {
             )
             : (
               <Button
-                label={
-                  generated && requestedBreakoutId === breakoutId
-                    ? intl.formatMessage(intlMessages.generatedURL)
-                    : intl.formatMessage(intlMessages.breakoutJoin)
-                }
+                label={this.getBreakoutLabel(breakoutId)}
                 data-test="breakoutJoin"
                 aria-label={`${intl.formatMessage(intlMessages.breakoutJoin)} ${number}`}
                 onClick={() => {

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -807,6 +807,7 @@
     "app.createBreakoutRoom.title": "Breakout Rooms",
     "app.createBreakoutRoom.ariaTitle": "Hide Breakout Rooms",
     "app.createBreakoutRoom.breakoutRoomLabel": "Breakout Rooms {0}",
+    "app.createBreakoutRoom.generateURL": "Generate URL",
     "app.createBreakoutRoom.generatingURL": "Generating URL",
     "app.createBreakoutRoom.generatingURLMessage": "We are generating a join URL for the selected breakout room. It may take a few seconds...",
     "app.createBreakoutRoom.generatedURL": "Generated",


### PR DESCRIPTION
### What does this PR do?

Adds a new label (Generate URL) in breakout room list, for when the user does not have join URL for that room.

In the example, the user does not have breakout room URL for Room 2
#### before
![Screenshot from 2021-09-03 08-53-56](https://user-images.githubusercontent.com/3728706/132001164-8a7795ba-e21e-4d69-a807-44208466d958.png)
#### after
![Screenshot from 2021-09-03 08-53-34](https://user-images.githubusercontent.com/3728706/132001158-5a70d9ba-c6b2-4d8a-8d5a-e65edbcc03fe.png)


### Closes Issue(s)
Closes #13140