### PR TITLE
Change end meeting call-to-action button color

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/component.jsx
@@ -77,7 +77,7 @@ class EndMeetingComponent extends PureComponent {
           <div className={styles.footer}>
             <Button
               data-test="confirmEndMeeting"
-              color="primary"
+              color="danger"
               className={styles.button}
               label={intl.formatMessage(intlMessages.yesLabel)}
               onClick={endMeeting}


### PR DESCRIPTION
### What does this PR do?

Changes background-color of the button in "end meeting" modal.

#### before
![Screenshot from 2021-09-03 13-14-01](https://user-images.githubusercontent.com/3728706/132036128-f41af4ab-2f76-4719-819b-dcfcc296ad7e.png)

#### after
![Screenshot from 2021-09-03 13-13-39](https://user-images.githubusercontent.com/3728706/132036125-704d849a-1b83-49bb-a8e6-66160a926f92.png)


### Closes Issue(s)
Closes #13148