### PR TITLE
fix: z-ordering puts menu behind notifications

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/menu/component.jsx
@@ -117,6 +117,7 @@ class BBBMenu extends React.Component {
           open={Boolean(anchorEl)}
           onClose={this.handleClose}
           className={menuClasses.join(' ')}
+          style={{ zIndex: 9999 }}
         >
           {actionsItems}
           {anchorEl && window.innerWidth < MAX_WIDTH &&


### PR DESCRIPTION
### What does this PR do?

Changes BBBMenu z-index value, making the dropdown menus appear in front of the toast notifications.

#### before
![Screenshot from 2021-09-03 15-27-30](https://user-images.githubusercontent.com/3728706/132051184-8c8f4096-6e13-4cf8-895c-95daf5d084d7.png)

#### after
![Screenshot from 2021-09-03 15-26-51](https://user-images.githubusercontent.com/3728706/132051177-2a8b591f-8e2d-4cb4-bac1-98821487b138.png)


### Closes Issue(s)
Closes #13146
