### PR TITLE
feat: Activate waiting room permanently

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
@@ -45,12 +45,16 @@ class UserContent extends PureComponent {
       hasBreakoutRoom,
       pendingUsers,
       isWaitingRoomEnabled,
+      isGuestLobbyMessageEnabled,
       requestUserInformation,
       currentClosedChats,
       sidebarContentPanel,
       layoutContextDispatch,
       startedChats,
     } = this.props;
+
+    const showWaitingRoom = (isGuestLobbyMessageEnabled && isWaitingRoomEnabled)
+      || pendingUsers.length > 0;
 
     return (
       <div
@@ -83,7 +87,7 @@ class UserContent extends PureComponent {
             intl,
           }}
         />
-        { (isWaitingRoomEnabled || pendingUsers.length > 0) && currentUser.role === ROLE_MODERATOR
+        {showWaitingRoom && currentUser.role === ROLE_MODERATOR
           ? (
             <WaitingUsers
               {...{

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
@@ -44,6 +44,7 @@ class UserContent extends PureComponent {
       forcePollOpen,
       hasBreakoutRoom,
       pendingUsers,
+      isWaitingRoomEnabled,
       requestUserInformation,
       currentClosedChats,
       sidebarContentPanel,
@@ -82,7 +83,7 @@ class UserContent extends PureComponent {
             intl,
           }}
         />
-        {pendingUsers.length > 0 && currentUser.role === ROLE_MODERATOR
+        { (isWaitingRoomEnabled || pendingUsers.length > 0) && currentUser.role === ROLE_MODERATOR
           ? (
             <WaitingUsers
               {...{

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/container.jsx
@@ -7,6 +7,7 @@ import UserContent from './component';
 import GuestUsers from '/imports/api/guest-users/';
 import LayoutContext from '../../layout/context';
 import { UsersContext } from '/imports/ui/components/components-data/users-context/context';
+import WaitingUsersService from '/imports/ui/components/waiting-users/service';
 
 const CLOSED_CHAT_LIST_KEY = 'closedChatList';
 const STARTED_CHAT_LIST_KEY = 'startedChatList';
@@ -47,4 +48,5 @@ export default withTracker(() => ({
     approved: false,
     denied: false,
   }).fetch(),
+  isWaitingRoomEnabled: WaitingUsersService.isWaitingRoomEnabled(),
 }))(UserContentContainer);

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/container.jsx
@@ -26,11 +26,14 @@ const UserContentContainer = (props) => {
     locked: users[Auth.meetingID][Auth.userID].locked,
     role: users[Auth.meetingID][Auth.userID].role,
   };
+  const { isGuestLobbyMessageEnabled } = WaitingUsersService;
+
   return (
     <UserContent
       {...{
         layoutContextDispatch,
         sidebarContentPanel,
+        isGuestLobbyMessageEnabled,
         ...props,
       }}
       currentUser={currentUser}

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/waiting-users/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/waiting-users/component.jsx
@@ -59,11 +59,14 @@ const WaitingUsers = ({
           >
             <Icon iconName="user" />
             <span>{intl.formatMessage(intlMessages.title)}</span>
-            <div className={styles.unreadMessages}>
-              <div className={styles.unreadMessagesText}>
-                {pendingUsers.length}
-              </div>
-            </div>
+            { pendingUsers.length > 0
+              && (
+                <div className={styles.unreadMessages}>
+                  <div className={styles.unreadMessagesText}>
+                    {pendingUsers.length}
+                  </div>
+                </div>
+              )}
           </div>
         </div>
       </div>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/waiting-users/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/waiting-users/component.jsx
@@ -59,14 +59,13 @@ const WaitingUsers = ({
           >
             <Icon iconName="user" />
             <span>{intl.formatMessage(intlMessages.title)}</span>
-            { pendingUsers.length > 0
-              && (
-                <div className={styles.unreadMessages}>
-                  <div className={styles.unreadMessagesText}>
-                    {pendingUsers.length}
-                  </div>
+            {pendingUsers.length > 0 && (
+              <div className={styles.unreadMessages}>
+                <div className={styles.unreadMessagesText}>
+                  {pendingUsers.length}
                 </div>
-              )}
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/container.jsx
@@ -37,6 +37,7 @@ export default withTracker(() => {
     guestUsers,
     authenticatedUsers,
     guestUsersCall: Service.guestUsersCall,
+    isWaitingRoomEnabled: Service.isWaitingRoomEnabled(),
     changeGuestPolicy: Service.changeGuestPolicy,
     isGuestLobbyMessageEnabled: Service.isGuestLobbyMessageEnabled,
     setGuestLobbyMessage: Service.setGuestLobbyMessage,

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/service.js
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/service.js
@@ -4,7 +4,7 @@ import { makeCall } from '/imports/ui/services/api';
 
 const guestUsersCall = (guestsArray, status) => makeCall('allowPendingUsers', guestsArray, status);
 
-const changeGuestPolicy = policyRule => makeCall('changeGuestPolicy', policyRule);
+const changeGuestPolicy = (policyRule) => makeCall('changeGuestPolicy', policyRule);
 
 const getGuestPolicy = () => {
   const meeting = Meetings.findOne(
@@ -14,6 +14,8 @@ const getGuestPolicy = () => {
 
   return meeting.usersProp.guestPolicy;
 };
+
+const isWaitingRoomEnabled = () => getGuestPolicy() === 'ASK_MODERATOR';
 
 const isGuestLobbyMessageEnabled = Meteor.settings.public.app.enableGuestLobbyMessage;
 
@@ -37,6 +39,7 @@ export default {
   guestUsersCall,
   changeGuestPolicy,
   getGuestPolicy,
+  isWaitingRoomEnabled,
   isGuestLobbyMessageEnabled,
   getGuestLobbyMessage,
   setGuestLobbyMessage,

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
@@ -12,7 +12,7 @@
   display: flex;
   flex-grow: 1;
   flex-direction: column;
-  justify-content: space-around;
+  justify-content: flex-start;
   overflow: hidden;
   height: 100%;
 
@@ -156,6 +156,11 @@
   height: 100%;
   width: 100%;
   flex-direction: column;
+}
+
+.noPendingUsers {
+  text-align: center;
+  font-weight: bold;
 }
 
 .usersWrapper {

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -595,6 +595,7 @@
     "app.userList.guest.allowEveryone": "Allow everyone",
     "app.userList.guest.denyEveryone": "Deny everyone",
     "app.userList.guest.pendingUsers": "{0} Pending Users",
+    "app.userList.guest.noPendingUsers": "Currently no pending users...",
     "app.userList.guest.pendingGuestUsers": "{0} Pending Guest Users",
     "app.userList.guest.pendingGuestAlert": "Has joined the session and is waiting for your approval.",
     "app.userList.guest.rememberChoice": "Remember choice",


### PR DESCRIPTION
### What does this PR do?
This PR activates the waiting room panel permanently dependent on the current guest policy (if `ASK_MODERATOR` is enabled) and dependent on the config parameter `isGuestLobbyMessageEnabled`.

I tried to handle all of the combinations properly (config parameter, guest policy, are there pending users right now despite guest policy is not `ASK_MODERATOR` any longer etc.). I hope I covered all cases.

### Closes Issue(s)
Closes #13158

### Motivation
Waiting room is currently only active if there are waiting users which means that moderators cannot change the lobby message as long as there isn't at least one waiting user.

Use case: Moderator wants to open the session a few minutes in advance, instantly set the lobby message to inform all users about something (session starts 5min later or sth similar) so that every user immediately is being informed by the lobby message.
