### PR TITLE
fix: breakout room managing window opening bug

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -253,7 +253,6 @@ class BreakoutRoom extends PureComponent {
         roomList.removeEventListener('keydown', this.handleMoveEvent, true);
       }
     }
-    this.handleDismiss();
   }
 
   handleShiftUser(activeListSibling) {
@@ -373,7 +372,7 @@ class BreakoutRoom extends PureComponent {
       return;
     }
 
-    this.setState({ preventClosing: false });
+    this.handleDismiss();
 
     const rooms = _.range(1, numberOfRooms + 1).map((seq) => ({
       users: this.getUserByRoom(seq).map((u) => u.userId),
@@ -403,7 +402,7 @@ class BreakoutRoom extends PureComponent {
       breakoutUsers.forEach((user) => sendInvitation(breakoutId, user.userId));
     });
 
-    this.setState({ preventClosing: false });
+    this.handleDismiss();
   }
 
   onAssignRandomly() {


### PR DESCRIPTION
### What does this PR do?

Prevents bugs related to the breakout not being completely closed on breakout room creation and when sending invitations.

### Closes Issue(s)
Closes #13143