### PR TITLE
fix: Breakout room invitation bug

### DIFF
--- a/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutJoinURL.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutJoinURL.js
@@ -26,13 +26,27 @@ export default function handleBreakoutJoinURL({ body }) {
   };
 
   try {
-    const { insertedId, numberAffected } = Breakouts.upsert(selector, modifier);
+    const ATTEMPT_EVERY_MS = 1000;
 
-    if (insertedId) {
-      Logger.info(`Added breakout id=${breakoutId}`);
-    } else if (numberAffected) {
+    let numberAffected = 0;
+
+    const updateBreakout = Meteor.bindEnvironment(() => {
+      numberAffected = Breakouts.update(selector, modifier);
+    });
+
+    const updateBreakoutPromise = new Promise((resolve) => {
+      const updateBreakoutInterval = setInterval(() => {
+        updateBreakout();
+
+        if (numberAffected) {
+          resolve(clearInterval(updateBreakoutInterval));
+        }
+      }, ATTEMPT_EVERY_MS);
+    });
+
+    updateBreakoutPromise.then(() => {
       Logger.info(`Upserted breakout id=${breakoutId}`);
-    }
+    });
   } catch (err) {
     Logger.error(`Adding breakout to collection: ${err}`);
   }


### PR DESCRIPTION
### What does this PR do?

Prevents a bug in breakout invitation, where both `handleBreakoutJoinURL` and `handleBreakoutRoomStarted` were able to insert a record in `Breakouts` collection. 

After the changes, `handleBreakoutJoinURL` will only be able to update the collection (and only after the insertion has been made by `handleBreakoutRoomStarted`).

### Closes Issue(s)
Closes #13022