### PR TITLE
Stop ScreenShare when External Video is started (handling it in Akka)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/ScreenshareModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/ScreenshareModel.scala
@@ -1,5 +1,8 @@
 package org.bigbluebutton.core.apps
 
+import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
+
 object ScreenshareModel {
   def resetDesktopSharingParams(status: ScreenshareModel) = {
     status.broadcastingRTMP = false
@@ -88,6 +91,24 @@ object ScreenshareModel {
   def getHasAudio(status: ScreenshareModel): Boolean = {
     status.hasAudio
   }
+
+  def stop(outGW: OutMsgRouter, liveMeeting: LiveMeeting): Unit = {
+    if (isBroadcastingRTMP(liveMeeting.screenshareModel)) {
+      this.resetDesktopSharingParams(liveMeeting.screenshareModel)
+
+      val event = MsgBuilder.buildStopScreenshareRtmpBroadcastEvtMsg(
+        liveMeeting.props.meetingProp.intId,
+        getVoiceConf(liveMeeting.screenshareModel),
+        getScreenshareConf(liveMeeting.screenshareModel),
+        getRTMPBroadcastingUrl(liveMeeting.screenshareModel),
+        getScreenshareVideoWidth(liveMeeting.screenshareModel),
+        getScreenshareVideoHeight(liveMeeting.screenshareModel),
+        getTimestamp(liveMeeting.screenshareModel)
+      )
+      outGW.send(event)
+    }
+  }
+
 }
 
 class ScreenshareModel {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/externalvideo/StartExternalVideoPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/externalvideo/StartExternalVideoPubMsgHdlr.scala
@@ -1,9 +1,9 @@
 package org.bigbluebutton.core.apps.externalvideo
 
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait, ExternalVideoModel }
+import org.bigbluebutton.core.apps.{ ExternalVideoModel, PermissionCheck, RightsManagementTrait, ScreenshareModel }
 import org.bigbluebutton.core.bus.MessageBus
-import org.bigbluebutton.core.running.{ LiveMeeting }
+import org.bigbluebutton.core.running.LiveMeeting
 
 trait StartExternalVideoPubMsgHdlr extends RightsManagementTrait {
   this: ExternalVideoApp2x =>
@@ -28,6 +28,10 @@ trait StartExternalVideoPubMsgHdlr extends RightsManagementTrait {
       val reason = "You need to be the presenter to start external videos"
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
     } else {
+
+      //Stop ScreenShare if it's running
+      ScreenshareModel.stop(bus.outGW, liveMeeting)
+
       ExternalVideoModel.setURL(liveMeeting.externalVideoModel, msg.body.externalVideoUrl)
       broadcastEvent(msg)
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/externalvideo/StopExternalVideoPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/externalvideo/StopExternalVideoPubMsgHdlr.scala
@@ -1,9 +1,10 @@
 package org.bigbluebutton.core.apps.externalvideo
 
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait, ExternalVideoModel }
+import org.bigbluebutton.core.apps.{ ExternalVideoModel, PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.MessageBus
-import org.bigbluebutton.core.running.{ LiveMeeting }
+import org.bigbluebutton.core.running.LiveMeeting
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait StopExternalVideoPubMsgHdlr extends RightsManagementTrait {
   this: ExternalVideoApp2x =>
@@ -11,25 +12,16 @@ trait StopExternalVideoPubMsgHdlr extends RightsManagementTrait {
   def handle(msg: StopExternalVideoPubMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
     log.info("Received StopExternalVideoPubMsgr meetingId={}", liveMeeting.props.meetingProp.intId)
 
-    def broadcastEvent() {
-
-      val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, liveMeeting.props.meetingProp.intId, "nodeJSapp")
-      val envelope = BbbCoreEnvelope(StopExternalVideoEvtMsg.NAME, routing)
-      val header = BbbClientMsgHeader(StopExternalVideoEvtMsg.NAME, liveMeeting.props.meetingProp.intId, msg.header.userId)
-
-      val body = StopExternalVideoEvtMsgBody()
-      val event = StopExternalVideoEvtMsg(header, body)
-      val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
-      bus.outGW.send(msgEvent)
-    }
-
     if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "You need to be the presenter to stop external video"
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
     } else {
       ExternalVideoModel.clear(liveMeeting.externalVideoModel)
-      broadcastEvent()
+
+      //broadcastEvent
+      val msgEvent = MsgBuilder.buildStopExternalVideoEvtMsg(liveMeeting.props.meetingProp.intId, msg.header.userId)
+      bus.outGW.send(msgEvent)
     }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr.scala
@@ -4,31 +4,12 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.ScreenshareModel
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.running.LiveMeeting
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr {
   this: ScreenshareApp2x =>
 
   def handle(msg: ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
-
-    def broadcastEvent(voiceConf: String, screenshareConf: String,
-                       stream: String, vidWidth: Int, vidHeight: Int,
-                       timestamp: String): BbbCommonEnvCoreMsg = {
-
-      val routing = Routing.addMsgToClientRouting(
-        MessageTypes.BROADCAST_TO_MEETING,
-        liveMeeting.props.meetingProp.intId, "not-used"
-      )
-      val envelope = BbbCoreEnvelope(ScreenshareRtmpBroadcastStoppedEvtMsg.NAME, routing)
-      val header = BbbClientMsgHeader(
-        ScreenshareRtmpBroadcastStoppedEvtMsg.NAME,
-        liveMeeting.props.meetingProp.intId, "not-used"
-      )
-
-      val body = ScreenshareRtmpBroadcastStoppedEvtMsgBody(voiceConf, screenshareConf,
-        stream, vidWidth, vidHeight, timestamp)
-      val event = ScreenshareRtmpBroadcastStoppedEvtMsg(header, body)
-      BbbCommonEnvCoreMsg(envelope, event)
-    }
 
     log.info("handleScreenshareRTMPBroadcastStoppedRequest: isBroadcastingRTMP=" +
       ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel) + " URL:" +
@@ -40,8 +21,12 @@ trait ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr {
       ScreenshareModel.broadcastingRTMPStopped(liveMeeting.screenshareModel)
 
       // notify viewers that RTMP broadcast stopped
-      val msgEvent = broadcastEvent(msg.body.voiceConf, msg.body.screenshareConf, msg.body.stream,
-        msg.body.vidWidth, msg.body.vidHeight, msg.body.timestamp)
+      val msgEvent = MsgBuilder.buildStopScreenshareRtmpBroadcastEvtMsg(
+        liveMeeting.props.meetingProp.intId,
+        msg.body.voiceConf, msg.body.screenshareConf, msg.body.stream,
+        msg.body.vidWidth, msg.body.vidHeight, msg.body.timestamp
+      )
+
       bus.outGW.send(msgEvent)
     } else {
       log.info("STOP broadcast NOT ALLOWED when isBroadcastingRTMP=false")

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -160,14 +160,29 @@ object MsgBuilder {
     BbbCommonEnvCoreMsg(envelope, event)
   }
 
-  def buildStopExternalVideoEvtMsg(meetingId: String): BbbCommonEnvCoreMsg = {
+  def buildStopExternalVideoEvtMsg(meetingId: String, userId: String = "not-used"): BbbCommonEnvCoreMsg = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, meetingId, "nodeJSapp")
     val envelope = BbbCoreEnvelope(StopExternalVideoEvtMsg.NAME, routing)
 
     val body = StopExternalVideoEvtMsgBody()
-    val header = BbbClientMsgHeader(StopExternalVideoEvtMsg.NAME, meetingId, "not-used")
+    val header = BbbClientMsgHeader(StopExternalVideoEvtMsg.NAME, meetingId, userId)
     val event = StopExternalVideoEvtMsg(header, body)
 
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
+
+  def buildStopScreenshareRtmpBroadcastEvtMsg(
+      meetingId: String,
+      voiceConf: String, screenshareConf: String,
+      stream: String, vidWidth: Int, vidHeight: Int,
+      timestamp: String
+  ): BbbCommonEnvCoreMsg = {
+
+    val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, "not-used")
+    val envelope = BbbCoreEnvelope(ScreenshareRtmpBroadcastStoppedEvtMsg.NAME, routing)
+    val header = BbbClientMsgHeader(ScreenshareRtmpBroadcastStoppedEvtMsg.NAME, meetingId, "not-used")
+    val body = ScreenshareRtmpBroadcastStoppedEvtMsgBody(voiceConf, screenshareConf, stream, vidWidth, vidHeight, timestamp)
+    val event = ScreenshareRtmpBroadcastStoppedEvtMsg(header, body)
     BbbCommonEnvCoreMsg(envelope, event)
   }
 

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -166,7 +166,7 @@ export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) 
   const { viewScreenshare } = Settings.dataSaving;
   const shouldShowExternalVideo = MediaService.shouldShowExternalVideo();
   const shouldShowScreenshare = MediaService.shouldShowScreenshare()
-    && (viewScreenshare || MediaService.isUserPresenter()) && !shouldShowExternalVideo;
+    && (viewScreenshare || MediaService.isUserPresenter());
   let customStyleUrl = getFromUserSettings('bbb_custom_style_url', false);
 
   if (!customStyleUrl && CUSTOM_STYLE_URL) {


### PR DESCRIPTION
This PR solves #12803 

- Makes Akaa stop ScreenShare streaming when a External Video is started
- Change the client `shouldShowScreenshare` removing externalVideo check once now it is handled by Akka
- Reuse stop msgs from `MsgBuilder` instead of duplicate