### PR TITLE
Fix a case where default presentation doesn't show in breakouts

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PageToConvert.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PageToConvert.java
@@ -67,6 +67,10 @@ public class PageToConvert {
     return pres.getId();
   }
 
+  public String getMeetingId() {
+    return pres.getMeetingId();
+  }
+
   public PageToConvert convert() {
 
     // Only create SWF files if the configuration requires it

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PdfToSwfSlidesGenerationService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PdfToSwfSlidesGenerationService.java
@@ -1,13 +1,13 @@
 /**
  * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
- * 
+ *
  * Copyright (c) 2015 BigBlueButton Inc. and by respective authors (see below).
  *
  * This program is free software; you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
  * Foundation; either version 3.0 of the License, or (at your option) any later
  * version.
- * 
+ *
  * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
  * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
@@ -46,6 +46,7 @@ public class PdfToSwfSlidesGenerationService {
         PageConvertProgressMessage msg = new PageConvertProgressMessage(
                 pageToConvert.getPageNumber(),
                 pageToConvert.getPresId(),
+                pageToConvert.getMeetingId(),
                 new ArrayList<>());
         presentationConversionCompletionService.handle(msg);
         pageToConvert.getPageFile().delete();

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationConversionCompletionService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationConversionCompletionService.java
@@ -36,11 +36,16 @@ public class PresentationConversionCompletionService {
         if (msg instanceof PresentationConvertMessage) {
             PresentationConvertMessage m = (PresentationConvertMessage) msg;
             PresentationToConvert p = new PresentationToConvert(m.pres);
-            presentationsToConvert.put(p.getKey(), p);
-        } else if (msg instanceof PageConvertProgressMessage) {
 
+            String presentationToConvertKey = p.getKey() + "_" + m.pres.getMeetingId();
+
+            presentationsToConvert.put(presentationToConvertKey, p);
+        } else if (msg instanceof PageConvertProgressMessage) {
             PageConvertProgressMessage m = (PageConvertProgressMessage) msg;
-            PresentationToConvert p = presentationsToConvert.get(m.presId);
+
+            String presentationToConvertKey = m.presId + "_" + m.meetingId;
+
+            PresentationToConvert p = presentationsToConvert.get(presentationToConvertKey);
             if (p != null) {
                 p.incrementPagesCompleted();
                 notifier.sendConversionUpdateMessage(p.getPagesCompleted(), p.pres, m.page);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationConversionCompletionService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationConversionCompletionService.java
@@ -57,7 +57,9 @@ public class PresentationConversionCompletionService {
     }
 
     private void handleEndProcessing(PresentationToConvert p) {
-        presentationsToConvert.remove(p.getKey());
+        String presentationToConvertKey = p.getKey() + "_" + p.pres.getMeetingId();
+
+        presentationsToConvert.remove(presentationToConvertKey);
 
         Map<String, Object> logData = new HashMap<String, Object>();
         logData = new HashMap<String, Object>();

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/messages/PageConvertProgressMessage.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/messages/PageConvertProgressMessage.java
@@ -7,9 +7,11 @@ public class PageConvertProgressMessage implements IPresentationCompletionMessag
     public final String presId;
     public final int page;
     public final List<String> errors;
+    public final String meetingId;
 
-    public PageConvertProgressMessage(int page, String presId, List<String> errors) {
+    public PageConvertProgressMessage(int page, String presId, String meetingId, List<String> errors) {
         this.presId = presId;
+        this.meetingId = meetingId;
         this.page = page;
         this.errors = errors;
     }


### PR DESCRIPTION
### What does this PR do?

In some cases the default presentation isn't showed for a breakout room., this happened because the `presentation_end_conversion` service isn't called for that breakout room.

### Closes Issue(s)
Closes #13109


### More
Thanks to @gustavotrott for helping on debugging the problem