### PR TITLE
fix: Fix public chat being cleared when starting a new private chat

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
@@ -72,7 +72,13 @@ export default withTracker(() => {
 
   if (currentUser) {
     subscriptionsHandlers.push(Meteor.subscribe('meetings', currentUser.role, subscriptionErrorHandler));
-    subscriptionsHandlers.push(Meteor.subscribe('users', currentUser.role, subscriptionErrorHandler));
+    subscriptionsHandlers.push(Meteor.subscribe('users', currentUser.role, {
+      ...subscriptionErrorHandler,
+      onStop: () => {
+        const event = new Event(EVENT_NAME);
+        window.dispatchEvent(event);
+      },
+    }));
     subscriptionsHandlers.push(Meteor.subscribe('breakouts', currentUser.role, subscriptionErrorHandler));
     subscriptionsHandlers.push(Meteor.subscribe('guestUser', currentUser.role, subscriptionErrorHandler));
   }
@@ -113,10 +119,6 @@ export default withTracker(() => {
 
     const subHandler = {
       ...subscriptionErrorHandler,
-      onStop: () => {
-        const event = new Event(EVENT_NAME);
-        window.dispatchEvent(event);
-      },
     };
 
     groupChatMessageHandler = Meteor.subscribe('group-chat-msg', chatIds, subHandler);


### PR DESCRIPTION
### What does this PR do?

When a viewer was promoted to moderator, and after that the user starting a new private chat thae clear steam was called deleting the messages, now the clear stream messages is only called when the user changes the role keeping the messages when the new chat is created.

### Closes Issue(s)
Closes #13192
