### PR TITLE
WCAG2.1 - Breakout Room Management

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -127,7 +127,10 @@ const intlMessages = defineMessages({
     id: 'app.createBreakoutRoom.minimumDurationWarnBreakout',
     description: 'minimum duration warning message label',
   },
-
+  roomNameInputDesc: {
+    id: 'app.createBreakoutRoom.roomNameInputDesc',
+    description: 'aria description for room name change',
+  }
 });
 
 const BREAKOUT_LIM = Meteor.settings.public.app.breakouts.breakoutRoomLimit;
@@ -647,8 +650,12 @@ class BreakoutRoom extends PureComponent {
                   value={this.getRoomName(value)}
                   onChange={changeRoomName(value)}
                   onBlur={changeRoomName(value)}
-                  aria-label={intl.formatMessage(intlMessages.duration)}
+                  aria-label={`${this.getRoomName(value)}`}
+                  aria-describedby={this.getRoomName(value).length === 0 ? `room-error-${value}` : `room-input-${value}`}
                 />
+                <div aria-hidden id={`room-input-${value}`} className={"sr-only"}>
+                  {intl.formatMessage(intlMessages.roomNameInputDesc)}
+                </div>
               </p>
               <div className={styles.breakoutBox} onDrop={drop(value)} onDragOver={allowDrop} tabIndex={0}>
                 {this.renderUserItemByRoom(value)}
@@ -660,7 +667,7 @@ class BreakoutRoom extends PureComponent {
                 </span>
               ) : null}
               {this.getRoomName(value).length === 0 ? (
-                <span className={styles.spanWarn}>
+                <span aria-hidden id={`room-error-${value}`} className={styles.spanWarn}>
                   {intl.formatMessage(intlMessages.roomNameEmptyIsValid)}
                 </span>
               ) : null}
@@ -786,7 +793,7 @@ class BreakoutRoom extends PureComponent {
         >
           {intl.formatMessage(intlMessages.numberOfRoomsIsValid)}
         </span>
-        <span id="randomlyAssignDesc" className="sr-only">
+        <span aria-hidden id="randomlyAssignDesc" className="sr-only">
           {intl.formatMessage(intlMessages.randomlyAssignDesc)}
         </span>
       </React.Fragment>

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -619,7 +619,7 @@ class BreakoutRoom extends PureComponent {
 
     return (
       <div className={styles.boxContainer} key="rooms-grid-" ref={(r) => { this.listOfUsers = r; }}>
-        <div className={!leastOneUserIsValid ? styles.changeToWarn : null}>
+        <div role="alert" className={!leastOneUserIsValid ? styles.changeToWarn : null}>
           <p className={styles.freeJoinLabel}>
             <input
               type="text"

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -620,7 +620,7 @@ class BreakoutRoom extends PureComponent {
     return (
       <div className={styles.boxContainer} key="rooms-grid-" ref={(r) => { this.listOfUsers = r; }}>
         <div role="alert" className={!leastOneUserIsValid ? styles.changeToWarn : null}>
-          <p className={styles.freeJoinLabel}>
+          <span className={styles.freeJoinLabel}>
             <input
               type="text"
               readOnly
@@ -629,7 +629,7 @@ class BreakoutRoom extends PureComponent {
                 intl.formatMessage(intlMessages.notAssigned, { 0: this.getUserByRoom(0).length })
               }
             />
-          </p>
+          </span>
           <div className={styles.breakoutBox} onDrop={drop(0)} onDragOver={allowDrop} tabIndex={0}>
             {this.renderUserItemByRoom(0)}
           </div>
@@ -640,7 +640,7 @@ class BreakoutRoom extends PureComponent {
         {
           _.range(1, rooms + 1).map((value) => (
             <div key={`room-${value}`}>
-              <p className={styles.freeJoinLabel}>
+              <span className={styles.freeJoinLabel}>
                 <input
                   type="text"
                   maxLength="255"
@@ -656,7 +656,7 @@ class BreakoutRoom extends PureComponent {
                 <div aria-hidden id={`room-input-${value}`} className={"sr-only"}>
                   {intl.formatMessage(intlMessages.roomNameInputDesc)}
                 </div>
-              </p>
+              </span>
               <div className={styles.breakoutBox} onDrop={drop(value)} onDragOver={allowDrop} tabIndex={0}>
                 {this.renderUserItemByRoom(value)}
                 {isInvitation && this.renderJoinedUsers(value)}

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
@@ -119,6 +119,10 @@ class BreakoutRoom extends PureComponent {
     };
   }
 
+  componentDidMount() {
+    if (this.panel) this.panel.firstChild.focus();
+  }
+
   componentDidUpdate() {
     const {
       breakoutRoomUser,
@@ -513,7 +517,7 @@ class BreakoutRoom extends PureComponent {
       amIModerator,
     } = this.props;
     return (
-      <div className={styles.panel}>
+      <div className={styles.panel} ref={(n) => this.panel = n}>
         <Button
           icon="left_arrow"
           label={intl.formatMessage(intlMessages.breakoutTitle)}

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
@@ -313,7 +313,7 @@ class BreakoutRoom extends PureComponent {
               <Button
                 label={this.getBreakoutLabel(breakoutId)}
                 data-test="breakoutJoin"
-                aria-label={`${intl.formatMessage(intlMessages.breakoutJoin)} ${number}`}
+                aria-label={`${this.getBreakoutLabel(breakoutId)} ${this.props.breakoutRooms[number - 1]?.shortName }`}
                 onClick={() => {
                   this.getBreakoutURL(breakoutId);
                   // leave main room's audio,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -347,7 +347,7 @@ class UserOptions extends PureComponent {
     return (
       <BBBMenu
         trigger={(
-          <Button
+          <Button          
             label={intl.formatMessage(intlMessages.optionsLabel)}
             data-test="manageUsers"
             icon="settings"

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -347,7 +347,7 @@ class UserOptions extends PureComponent {
     return (
       <BBBMenu
         trigger={(
-          <Button          
+          <Button
             label={intl.formatMessage(intlMessages.optionsLabel)}
             data-test="manageUsers"
             icon="settings"

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -845,6 +845,7 @@
     "app.createBreakoutRoom.extendTimeLabel": "Extend",
     "app.createBreakoutRoom.extendTimeCancel": "Cancel",
     "app.createBreakoutRoom.extendTimeHigherThanMeetingTimeError": "The breakout rooms duration can't exceed the meeting remaining time.",
+    "app.createBreakoutRoom.roomNameInputDesc": "Updates breakout room name",
     "app.externalVideo.start": "Share a new video",
     "app.externalVideo.title": "Share an external video",
     "app.externalVideo.input": "External Video URL",


### PR DESCRIPTION

### What does this PR do?
Moves focus to the breakout room panel when opened.
updates the breakout room name input fields aria labels.
Notify screen reader of errors presented in breakout room management.
Update `Join Room` and `Generate` button `aria-label` to use room name.


### Motivation
Fixes the following accessibility issues
1) Selecting the breakout rooms button fails to move the user’s focus into the newly-presented breakout rooms flyout.
2) The name fields for each room identify as “Duration (minutes)”, thus failing to adequately identify the field purpose.
3) The Error dialog regarding the room name is not made aware to screen reader users.
4) The “Join room” action announces as “Join room 1”, “Join room 2” to screen reader users, regardless of the room name provided.

