### PR TITLE
WCAG2.1 - Connection Status Modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
@@ -321,7 +321,7 @@ class ConnectionStatusComponent extends PureComponent {
                 {conn.offline ? ` (${intl.formatMessage(intlMessages.offline)})` : null}
               </div>
             </div>
-            <div className={styles.status}>
+            <div aria-label={`${intl.formatMessage(intlMessages.title)} ${conn.level}`} className={styles.status}>
               <div className={styles.icon}>
                 <Icon level={conn.level} />
               </div>


### PR DESCRIPTION
### What does this PR do?
Makes the connection strength image visible to the screen readers.

### Motivation
Currently the screen reader is not aware of the connection strengths displayed in the connection status modal.