### PR TITLE
WCAG2.1 - Moderator > Start a poll

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -190,6 +190,10 @@ const intlMessages = defineMessages({
     id: 'app.poll.removePollOpt',
     description: 'screen reader alert for removed poll option',
   },
+  emptyPollOpt: {
+    id: 'app.poll.emptyPollOpt',
+    description: 'screen reader for blank poll option',
+  },
 });
 
 const POLL_SETTINGS = Meteor.settings.public.poll;
@@ -306,7 +310,8 @@ class Poll extends Component {
     const removed = list[index];
     list.splice(index, 1);
     this.setState({ optList: list }, () => {
-      alertScreenReader(`${intl.formatMessage(intlMessages.removePollOpt, { 0: removed.val })}`);
+      alertScreenReader(`${intl.formatMessage(intlMessages.removePollOpt,
+        { 0: removed.val || intl.formatMessage(intlMessages.emptyPollOpt) })}`);
     });
   }
 
@@ -404,7 +409,10 @@ class Poll extends Component {
                       this.handleRemoveOption(i);
                     }}
                   />
-                  <span className="sr-only" id={`option-${i}`}>{intl.formatMessage(intlMessages.deleteRespDesc, { 0: o.val })}</span>
+                  <span className="sr-only" id={`option-${i}`}>
+                    {intl.formatMessage(intlMessages.deleteRespDesc,
+                      { 0: (o.val || intl.formatMessage(intlMessages.emptyPollOpt)) })}
+                  </span>
                 </>
               )
               : <div style={{ width: '40px' }} />}

--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -11,6 +11,7 @@ import LiveResult from './live-result/component';
 import { styles } from './styles.scss';
 import { PANELS, ACTIONS } from '../layout/enums';
 import DragAndDrop from './dragAndDrop/component';
+import { alertScreenReader } from '/imports/utils/dom-utils';
 
 const intlMessages = defineMessages({
   pollPaneTitle: {
@@ -185,6 +186,10 @@ const intlMessages = defineMessages({
     id: 'app.switch.offLabel',
     description: 'label for toggle switch off state',
   },
+  removePollOpt: {
+    id: 'app.poll.removePollOpt',
+    description: 'screen reader alert for removed poll option',
+  },
 });
 
 const POLL_SETTINGS = Meteor.settings.public.poll;
@@ -295,10 +300,14 @@ class Poll extends Component {
   }
 
   handleRemoveOption(index) {
+    const { intl } = this.props;
     const { optList } = this.state;
     const list = [...optList];
+    const removed = list[index];
     list.splice(index, 1);
-    this.setState({ optList: list });
+    this.setState({ optList: list }, () => {
+      alertScreenReader(`${intl.formatMessage(intlMessages.removePollOpt, { 0: removed.val })}`);
+    });
   }
 
   handleAddOption() {

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -290,6 +290,7 @@
     "app.poll.liveResult.usersTitle": "Users",
     "app.poll.liveResult.responsesTitle": "Response",
     "app.poll.liveResult.secretLabel": "This is an anonymous poll. Individual responses are not shown.",
+    "app.poll.removePollOpt": "Removed Poll option {0}",
     "app.polling.pollingTitle": "Polling options",
     "app.polling.pollQuestionTitle": "Polling Question",
     "app.polling.submitLabel": "Submit",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -291,6 +291,7 @@
     "app.poll.liveResult.responsesTitle": "Response",
     "app.poll.liveResult.secretLabel": "This is an anonymous poll. Individual responses are not shown.",
     "app.poll.removePollOpt": "Removed Poll option {0}",
+    "app.poll.emptyPollOpt": "Blank",
     "app.polling.pollingTitle": "Polling options",
     "app.polling.pollQuestionTitle": "Polling Question",
     "app.polling.submitLabel": "Submit",


### PR DESCRIPTION
### What does this PR do?
Updates the delete poll option button to reflect current input option, Also alerts the SR when an option is deleted.

### Motivation
1) Multiple delete buttons exist when adding multiple custom answer options that fail to differentiate.
2) When an option is deleted, there is no feedback given to the user that the item was removed.