### PR TITLE
fix: presentation position in breakout room - custom layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -428,6 +428,7 @@ class CustomLayout extends Component {
     const { isOpen } = presentation;
     const { camerasMargin } = DEFAULT_VALUES;
     const sidebarSize = sidebarNavWidth + sidebarContentWidth;
+    const bannerAreaHeight = this.bannerAreaHeight();
 
     const cameraDockBounds = {};
 
@@ -464,7 +465,7 @@ class CustomLayout extends Component {
               );
             }
 
-            cameraDockBounds.top = DEFAULT_VALUES.navBarHeight;
+            cameraDockBounds.top = DEFAULT_VALUES.navBarHeight + bannerAreaHeight;
             cameraDockBounds.left = cameraDockLeft;
             cameraDockBounds.right = isRTL ? sidebarSize : null;
             cameraDockBounds.minWidth = mediaAreaBounds.width;
@@ -492,7 +493,7 @@ class CustomLayout extends Component {
               );
             }
 
-            cameraDockBounds.top = DEFAULT_VALUES.navBarHeight;
+            cameraDockBounds.top = DEFAULT_VALUES.navBarHeight + bannerAreaHeight;
             const sizeValue = input.presentation.isOpen
               ? (mediaAreaBounds.left + mediaAreaBounds.width) - cameraDockWidth
               : mediaAreaBounds.left;
@@ -529,7 +530,7 @@ class CustomLayout extends Component {
             }
 
             cameraDockBounds.top = DEFAULT_VALUES.navBarHeight
-              + mediaAreaBounds.height - cameraDockHeight;
+              + mediaAreaBounds.height - cameraDockHeight + bannerAreaHeight;
             cameraDockBounds.left = cameraDockLeft;
             cameraDockBounds.right = isRTL ? sidebarSize : null;
             cameraDockBounds.minWidth = mediaAreaBounds.width;
@@ -557,7 +558,7 @@ class CustomLayout extends Component {
               );
             }
 
-            cameraDockBounds.top = DEFAULT_VALUES.navBarHeight;
+            cameraDockBounds.top = DEFAULT_VALUES.navBarHeight + bannerAreaHeight;
             cameraDockBounds.left = mediaAreaBounds.left + camerasMargin;
             cameraDockBounds.right = isRTL ? sidebarSize + (camerasMargin * 2) : null;
             cameraDockBounds.minWidth = DEFAULT_VALUES.cameraDockMinWidth;
@@ -631,8 +632,9 @@ class CustomLayout extends Component {
     const { presentation } = input;
     const { isOpen } = presentation;
     const { height: actionBarHeight } = this.calculatesActionbarHeight();
+    const bannerAreaHeight = this.bannerAreaHeight();
     const mediaAreaHeight = windowHeight()
-      - (DEFAULT_VALUES.navBarHeight + actionBarHeight);
+      - (DEFAULT_VALUES.navBarHeight + actionBarHeight + bannerAreaHeight);
     const mediaAreaWidth = windowWidth() - (sidebarNavWidth + sidebarContentWidth);
     const mediaBounds = {};
     const { element: fullscreenElement } = fullscreen;
@@ -665,7 +667,7 @@ class CustomLayout extends Component {
         case CAMERADOCK_POSITION.CONTENT_TOP: {
           mediaBounds.width = mediaAreaWidth;
           mediaBounds.height = mediaAreaHeight - cameraDockBounds.height - camerasMargin;
-          mediaBounds.top = navBarHeight + cameraDockBounds.height + camerasMargin;
+          mediaBounds.top = navBarHeight + cameraDockBounds.height + camerasMargin + bannerAreaHeight;
           mediaBounds.left = !isRTL ? sidebarSize : null;
           mediaBounds.right = isRTL ? sidebarSize : null;
           break;
@@ -673,7 +675,7 @@ class CustomLayout extends Component {
         case CAMERADOCK_POSITION.CONTENT_RIGHT: {
           mediaBounds.width = mediaAreaWidth - cameraDockBounds.width - camerasMargin;
           mediaBounds.height = mediaAreaHeight;
-          mediaBounds.top = navBarHeight;
+          mediaBounds.top = navBarHeight + bannerAreaHeight;
           mediaBounds.left = !isRTL ? sidebarSize : null;
           mediaBounds.right = isRTL ? sidebarSize - (camerasMargin * 2) : null;
           break;
@@ -681,7 +683,7 @@ class CustomLayout extends Component {
         case CAMERADOCK_POSITION.CONTENT_BOTTOM: {
           mediaBounds.width = mediaAreaWidth;
           mediaBounds.height = mediaAreaHeight - cameraDockBounds.height - camerasMargin;
-          mediaBounds.top = navBarHeight - camerasMargin;
+          mediaBounds.top = navBarHeight - camerasMargin + bannerAreaHeight;
           mediaBounds.left = !isRTL ? sidebarSize : null;
           mediaBounds.right = isRTL ? sidebarSize : null;
           break;
@@ -689,7 +691,7 @@ class CustomLayout extends Component {
         case CAMERADOCK_POSITION.CONTENT_LEFT: {
           mediaBounds.width = mediaAreaWidth - cameraDockBounds.width - camerasMargin;
           mediaBounds.height = mediaAreaHeight;
-          mediaBounds.top = navBarHeight;
+          mediaBounds.top = navBarHeight + bannerAreaHeight;
           const sizeValue = sidebarNavWidth
             + sidebarContentWidth + mediaAreaWidth - mediaBounds.width;
           mediaBounds.left = !isRTL ? sizeValue : null;
@@ -699,7 +701,7 @@ class CustomLayout extends Component {
         case CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM: {
           mediaBounds.width = mediaAreaWidth;
           mediaBounds.height = mediaAreaHeight;
-          mediaBounds.top = navBarHeight;
+          mediaBounds.top = navBarHeight + bannerAreaHeight;
           mediaBounds.left = !isRTL ? sidebarSize : null;
           mediaBounds.right = isRTL ? sidebarSize : null;
           break;
@@ -712,7 +714,7 @@ class CustomLayout extends Component {
     } else {
       mediaBounds.width = mediaAreaWidth;
       mediaBounds.height = mediaAreaHeight;
-      mediaBounds.top = DEFAULT_VALUES.navBarHeight + this.bannerAreaHeight();
+      mediaBounds.top = DEFAULT_VALUES.navBarHeight + bannerAreaHeight;
       mediaBounds.left = !isRTL ? sidebarSize : null;
       mediaBounds.right = isRTL ? sidebarSize : null;
     }


### PR DESCRIPTION
### What does this PR do?

Prevents an issue with the presentation area position in breakout rooms (customLayout only).

#### before
![Screenshot from 2021-09-13 10-19-07](https://user-images.githubusercontent.com/3728706/133090828-d097a897-bed9-4af9-b30e-d5772ad49776.png)

#### after
![Screenshot from 2021-09-13 10-19-28](https://user-images.githubusercontent.com/3728706/133090835-7bae7664-f2d3-4e48-8d81-14077e104c3c.png)

### Closes Issue(s)
Closes #13167