### PR TITLE
WCAG2.1 - Moderator > Whiteboard Toolbar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
@@ -505,6 +505,7 @@ class WhiteboardToolbar extends Component {
         />
       ) : (
         <ToolbarMenuItem
+          expanded={currentSubmenuOpen === 'annotationList'}
           disabled={isDisabled}
           label={intl.formatMessage(intlMessages.toolbarTools)}
           icon={annotationSelected.icon}
@@ -540,6 +541,7 @@ class WhiteboardToolbar extends Component {
     return (
       <ToolbarMenuItem
         label={intl.formatMessage(intlMessages.toolbarFontSize)}
+        expanded={currentSubmenuOpen === 'fontSizeList'}
         customIcon={this.renderFontItemIcon()}
         onItemClick={this.displaySubMenu}
         objectToReturn="fontSizeList"
@@ -600,6 +602,7 @@ class WhiteboardToolbar extends Component {
     return (
       <ToolbarMenuItem
         disabled={isDisabled}
+        expanded={currentSubmenuOpen === 'thicknessList'}
         label={isDisabled
           ? intl.formatMessage(intlMessages.toolbarLineThicknessDisabled)
           : intl.formatMessage(intlMessages.toolbarLineThickness)}
@@ -690,6 +693,7 @@ class WhiteboardToolbar extends Component {
     return (
       <ToolbarMenuItem
         disabled={isDisabled}
+        expanded={currentSubmenuOpen === 'colorList'}
         label={isDisabled
           ? intl.formatMessage(intlMessages.toolbarLineColorDisabled)
           : intl.formatMessage(intlMessages.toolbarLineColor)}

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
@@ -68,6 +68,10 @@ const intlMessages = defineMessages({
     id: 'app.whiteboard.toolbar.tools.hand',
     description: 'Label for the pan toolbar item',
   },
+  toolbarAriaLabel: {
+    id: 'app.whiteboard.toolbarAriaLabel',
+    description: 'aria label for whiteboard toolbar',
+  }
 });
 
 class WhiteboardToolbar extends Component {
@@ -507,6 +511,7 @@ class WhiteboardToolbar extends Component {
         <ToolbarMenuItem
           expanded={currentSubmenuOpen === 'annotationList'}
           disabled={isDisabled}
+          haspopup={true}
           label={intl.formatMessage(intlMessages.toolbarTools)}
           icon={annotationSelected.icon}
           onItemClick={this.displaySubMenu}
@@ -542,6 +547,7 @@ class WhiteboardToolbar extends Component {
       <ToolbarMenuItem
         label={intl.formatMessage(intlMessages.toolbarFontSize)}
         expanded={currentSubmenuOpen === 'fontSizeList'}
+        haspopup={true}
         customIcon={this.renderFontItemIcon()}
         onItemClick={this.displaySubMenu}
         objectToReturn="fontSizeList"
@@ -603,6 +609,7 @@ class WhiteboardToolbar extends Component {
       <ToolbarMenuItem
         disabled={isDisabled}
         expanded={currentSubmenuOpen === 'thicknessList'}
+        haspopup={true}
         label={isDisabled
           ? intl.formatMessage(intlMessages.toolbarLineThicknessDisabled)
           : intl.formatMessage(intlMessages.toolbarLineThickness)}
@@ -694,6 +701,7 @@ class WhiteboardToolbar extends Component {
       <ToolbarMenuItem
         disabled={isDisabled}
         expanded={currentSubmenuOpen === 'colorList'}
+        haspopup={true}
         label={isDisabled
           ? intl.formatMessage(intlMessages.toolbarLineColorDisabled)
           : intl.formatMessage(intlMessages.toolbarLineColor)}
@@ -819,12 +827,12 @@ class WhiteboardToolbar extends Component {
       />
     );
   }
-
+ 
   render() {
     const { annotationSelected } = this.state;
-    const { isPresenter } = this.props;
+    const { isPresenter, intl } = this.props;
     return (
-      <div className={styles.toolbarContainer}>
+      <div className={styles.toolbarContainer} role="region" aria-label={intl.formatMessage(intlMessages.toolbarAriaLabel)}>
         <div className={styles.toolbarWrapper}>
           {this.renderToolItem()}
           {annotationSelected.value === 'text' ? this.renderFontItem() : this.renderThicknessItem()}

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-menu-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-menu-item/component.jsx
@@ -77,6 +77,7 @@ export default class ToolbarMenuItem extends Component {
       children,
       showCornerTriangle,
       expanded,
+      haspopup,
     } = this.props;
 
     return (
@@ -86,6 +87,7 @@ export default class ToolbarMenuItem extends Component {
       >
         <Button
           aria-expanded={expanded}
+          aria-haspopup={haspopup}
           hideLabel
           role="button"
           color="default"

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-menu-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-menu-item/component.jsx
@@ -76,6 +76,7 @@ export default class ToolbarMenuItem extends Component {
       className,
       children,
       showCornerTriangle,
+      expanded,
     } = this.props;
 
     return (
@@ -84,6 +85,7 @@ export default class ToolbarMenuItem extends Component {
         hidden={disabled}
       >
         <Button
+          aria-expanded={expanded}
           hideLabel
           role="button"
           color="default"

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -791,6 +791,7 @@
     "app.whiteboard.toolbar.palmRejectionOn": "Turn palm rejection on",
     "app.whiteboard.toolbar.palmRejectionOff": "Turn palm rejection off",
     "app.whiteboard.toolbar.fontSize": "Font size list",
+    "app.whiteboard.toolbarAriaLabel": "Presentation tools",
     "app.feedback.title": "You have logged out of the conference",
     "app.feedback.subtitle": "We'd love to hear about your experience with BigBlueButton (optional)",
     "app.feedback.textarea": "How can we make BigBlueButton better?",


### PR DESCRIPTION
### What does this PR do?
adds `aria-expanded` / `aria-haspopup` to whiteboard toolbar submenu items as well as region and label to the toolbar.


### Motivation
Fixes the following accessibility issues
1) The presentation tools that contain submenu items (e.g., “Tools”, “Colors”) fail to indicate their current state to screen reader users.
2) The presentation tools toolbar would benefit from additional context for screen reader users.