### PR TITLE
Add language key for activity report column in learning dashboard

### DIFF
--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -923,6 +923,7 @@
     "app.learningDashboard.usersTable.colMessages": "Messages",
     "app.learningDashboard.usersTable.colEmojis": "Emojis",
     "app.learningDashboard.usersTable.colRaiseHands": "Raise Hands",
+    "app.learningDashboard.usersTable.colActivityScore": "Activity Score",
     "app.learningDashboard.usersTable.colStatus": "Status",
     "app.learningDashboard.usersTable.userStatusOnline": "Online",
     "app.learningDashboard.usersTable.userStatusOffline": "Offline",


### PR DESCRIPTION
### What does this PR do?
The learning-dashboard is missing out on a language key (column heading "activity score")

### Closes Issue(s)
Closes #13159

### More
#13163 was kinda messed up, so this one :-)