### PR TITLE
WCAG2.1 - Webcam and settings

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/menu/component.jsx
@@ -9,6 +9,8 @@ import { Divider } from "@material-ui/core";
 import Icon from "/imports/ui/components/icon/component";
 import Button from "/imports/ui/components/button/component";
 
+import { ENTER, SPACE } from "/imports/utils/keyCodes";
+
 import { styles } from "./styles";
 
 const intlMessages = defineMessages({
@@ -104,6 +106,11 @@ class BBBMenu extends React.Component {
           onClick={(e) => {
             e.persist();
             this.opts.autoFocus = !(['mouse', 'touch'].includes(e.nativeEvent.pointerType));
+            this.handleClick(e);
+          }}
+          onKeyPress={(e) => {
+            e.persist();
+            if (e.which !== ENTER) return null;
             this.handleClick(e);
           }}
           accessKey={this.props?.accessKey}

--- a/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
@@ -126,7 +126,11 @@ const VirtualBgSelector = ({
 
     return (
       <div className={styles.virtualBackgroundRowThumbnail}>
-        <div className={styles.bgWrapper}>
+        <div
+          role="group"
+          aria-label={intl.formatMessage(intlMessages.virtualBackgroundSettingsLabel)}
+          className={styles.bgWrapper}
+        >
           <>
             <Button
               className={styles.bgNone}

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -245,7 +245,7 @@ class VideoListItem extends Component {
               {enableVideoMenu && availableActions.length >= 1
                 ? (
                   <BBBMenu
-                    trigger={<div className={styles.dropdownTrigger}><span>{name}</span></div>}
+                    trigger={<div tabIndex={0} className={styles.dropdownTrigger}>{name}</div>}
                     actions={this.getAvailableActions()}
                     opts={{
                       id: "default-dropdown-menu",


### PR DESCRIPTION
### What does this PR do?
Places the webcam dropdown menu in the general tab order and adds role / label to thumbnail grouping.

### Motivation
Fixes the following accessibility issues:
1) The “Share Webcam settings” contains a “Virtual background settings” group that is not made aware to screen reader users.
2) Unable to select the current user webcam dropdown using keyboard only.