### PR TITLE
Refactor: Move Learning Dashboard entry to bottom of menu #13201 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -326,17 +326,17 @@ class UserOptions extends PureComponent {
         });
       }
       if (amIModerator) {
-	if (learningDashboardAccessToken != null) {
-	  this.menuItems.push({
+        if (learningDashboardAccessToken != null) {
+          this.menuItems.push({
             icon: 'multi_whiteboard',
-	    iconRight: 'popout_window',
-	    label: intl.formatMessage(intlMessages.learningDashboardLabel),
-	    description: intl.formatMessage(intlMessages.learningDashboardDesc),
-	    key: this.learningDashboardId,
-	    onClick: () => { openLearningDashboardUrl(locale); },
-	    dividerTop: true,
-	  });
-	 }
+            iconRight: 'popout_window',
+            label: intl.formatMessage(intlMessages.learningDashboardLabel),
+            description: intl.formatMessage(intlMessages.learningDashboardDesc),
+            key: this.learningDashboardId,
+            onClick: () => { openLearningDashboardUrl(locale); },
+            dividerTop: true,
+          });
+         }
       }
     }
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -284,17 +284,6 @@ class UserOptions extends PureComponent {
           onClick: this.onSaveUserNames,
           icon: 'download',
         });
-
-        if (learningDashboardAccessToken != null) {
-          this.menuItems.push({
-            icon: 'multi_whiteboard',
-            iconRight: 'popout_window',
-            label: intl.formatMessage(intlMessages.learningDashboardLabel),
-            description: intl.formatMessage(intlMessages.learningDashboardDesc),
-            key: this.learningDashboardId,
-            onClick: () => { openLearningDashboardUrl(locale); },
-          });
-        }
       }
 
       this.menuItems.push({
@@ -335,6 +324,19 @@ class UserOptions extends PureComponent {
           onClick: this.handleCaptionsClick,
           dataTest: 'inviteBreakoutRooms',
         });
+      }
+      if (amIModerator) {
+	if (learningDashboardAccessToken != null) {
+	  this.menuItems.push({
+            icon: 'multi_whiteboard',
+	    iconRight: 'popout_window',
+	    label: intl.formatMessage(intlMessages.learningDashboardLabel),
+	    description: intl.formatMessage(intlMessages.learningDashboardDesc),
+	    key: this.learningDashboardId,
+	    onClick: () => { openLearningDashboardUrl(locale); },
+	    dividerTop: true,
+	  });
+	 }
       }
     }
 


### PR DESCRIPTION
Closes #13201

<h3>What does this PR do?</h3>

Puts the Learning Dashboard button at the bottom of the dropdown menu and adds a divider on top of it.

Motivation

Learning Dashboard is a new feature so it should be in a place where it is easy to notice.

