### PR TITLE
fix: Breakout room assignment only working first time

### DIFF
--- a/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutJoinURL.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutJoinURL.js
@@ -15,13 +15,26 @@ export default function handleBreakoutJoinURL({ body }) {
     breakoutId,
   };
 
+  // only keep each users' last invitation
+  const newUsers = [];
+
+  const currentBreakout = Breakouts.findOne({ breakoutId }, { fields: { users: 1 } });
+
+  currentBreakout.users.forEach((item) => {
+    if (item.userId !== userId) {
+      newUsers.push(item);
+    }
+  });
+
+  newUsers.push({
+    userId,
+    redirectToHtml5JoinURL,
+    insertedTime: new Date().getTime(),
+  });
+
   const modifier = {
-    $push: {
-      users: {
-        userId,
-        redirectToHtml5JoinURL,
-        insertedTime: new Date().getTime(),
-      },
+    $set: {
+      users: newUsers,
     },
   };
 


### PR DESCRIPTION
### What does this PR do?

Allows sending of more breakout room invitations if viewers do not accept the first one.


#### Additional information
After investigating the issue, I found the "cause": [$elemMatch](https://github.com/bigbluebutton/bigbluebutton/pull/12871/files#diff-11194f8c3661fb45f66950ede48b85e35dcb81f34a9ad69a74bfafc2c540781eR51) (used in breakout publisher so each viewer only has access to its own joinURL) [returns only the first matching element](https://docs.mongodb.com/manual/reference/operator/projection/elemMatch/#proj._S_elemMatch). So, even if a moderator keeps sending more invites, the viewer will only get the first one.

With the changes made in this PR, only the last invitation of each user will be kept in the collection.

### Closes Issue(s)
Closes #13223