### PR TITLE
fix: webcam dock isn't visible in certain scenarios

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -78,7 +78,12 @@ class Base extends Component {
   }
 
   componentDidMount() {
-    const { animations } = this.props;
+    const { animations, usersVideo, layoutContextDispatch } = this.props;
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_NUM_CAMERAS,
+      value: usersVideo.length,
+    });
 
     const {
       userID: localUserId,


### PR DESCRIPTION
### What does this PR do?

Fixes an issue with cameras [sometimes] not being displayed if a user joins the meeting when cameras are already shared.

### Closes Issue(s)
Closes #13218