### PR TITLE
Fix: endWhenNoModerator not ending the meeting after all moderators left

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -311,7 +311,8 @@ class MeetingActor(
         state = state.update(tracker)
       }
     } else {
-      if (state.expiryTracker.moderatorHasJoined == true) {
+      if (state.expiryTracker.moderatorHasJoined == true &&
+        state.expiryTracker.lastModeratorLeftOnInMs == 0) {
         log.info("All moderators have left. Setting setLastModeratorLeftOn(). meetingId=" + props.meetingProp.intId)
         val tracker = state.expiryTracker.setLastModeratorLeftOn(TimeUtil.timeNowInMs())
         state = state.update(tracker)


### PR DESCRIPTION
This PR fix the following problem related by @ritzalam:

When `endWhenNoModerator` is `true`, since all moderators have left the meeting the server start a countdown to end the meeting.
But this countdown is being restarted every time another user (non-moderator) leave the meeting.
This change will fix this problem.
