### PR TITLE
fix: Reimplement presentation.allowDownloadable

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -739,6 +739,7 @@ class PresentationUploader extends Component {
     const {
       intl,
       selectedToBeNextCurrent,
+      allowDownloadable
     } = this.props;
 
     const isActualCurrent = selectedToBeNextCurrent ? item.id === selectedToBeNextCurrent : item.isCurrent;
@@ -757,6 +758,10 @@ class PresentationUploader extends Component {
       [styles.tableItemConverting]: isConverting,
       [styles.tableItemError]: hasError,
       [styles.tableItemAnimated]: isProcessing,
+    };
+	
+    const itemActions = {
+        [styles.notDownloadable]: !allowDownloadable,
     };
 
     const formattedDownloadableLabel = !item.isDownloadable
@@ -795,18 +800,21 @@ class PresentationUploader extends Component {
           {this.renderPresentationItemStatus(item)}
         </td>
         {hasError ? null : (
-          <td className={styles.tableItemActions}>
-            <Button
-              disabled={disableActions}
-              className={isDownloadableStyle}
-              label={formattedDownloadableLabel}
-              data-test={item.isDownloadable ? 'disallowPresentationDownload' : 'allowPresentationDownload'}
-              aria-label={formattedDownloadableAriaLabel}
-              hideLabel
-              size="sm"
-              icon={item.isDownloadable ? 'download' : 'download-off'}
-              onClick={() => this.handleToggleDownloadable(item)}
-            />
+          <td className={cx(styles.tableItemActions, itemActions)}>
+            {allowDownloadable ? (
+              <Button
+                disabled={disableActions}
+                className={isDownloadableStyle}
+                label={formattedDownloadableLabel}
+                data-test={item.isDownloadable ? 'disallowPresentationDownload' : 'allowPresentationDownload'}
+                aria-label={formattedDownloadableAriaLabel}
+                hideLabel
+                size="sm"
+                icon={item.isDownloadable ? 'download' : 'download-off'}
+                onClick={() => this.handleToggleDownloadable(item)}
+              />
+              ) : null
+            }
             <Checkbox
               ariaLabel={`${intl.formatMessage(intlMessages.setAsCurrentPresentation)} ${item.filename}`}
               checked={item.isCurrent}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/container.jsx
@@ -21,14 +21,15 @@ const PresentationUploaderContainer = (props) => (
 export default withTracker(() => {
   const currentPresentations = Service.getPresentations();
   const {
-    dispatchDisableDownloadable,
-    dispatchEnableDownloadable,
-    dispatchTogglePresentationDownloadable,
-  } = Service;
+	  dispatchDisableDownloadable,
+	  dispatchEnableDownloadable,
+	  dispatchTogglePresentationDownloadable,
+        } = Service;
 
   return {
     presentations: currentPresentations,
     fileValidMimeTypes: PRESENTATION_CONFIG.uploadValidMimeTypes,
+    allowDownloadable: PRESENTATION_CONFIG.allowDownloadable,
     handleSave: (presentations) => Service.persistPresentationChanges(
       currentPresentations,
       presentations,

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.scss
@@ -103,6 +103,10 @@
   }
 }
 
+.notDownloadable {
+	  min-width: 48px;
+}
+
 .tableItemIcon > i {
   font-size: 1.35rem;
 }


### PR DESCRIPTION
Closes #13235
<h3>What does this PR do?</h3>
It reimplements the feature of making the presence of the download presentation button dependant on a presentation.allowDownloadable variable in settings.yml file.

<h3>Motivation</h3>

This feature has been accidentally lost in process of removing bugs.

<h3>More</h3>
The presentation.allowDownloadable variable has already been there so settings.yml is not modified.
