### PR TITLE
Set worker_rlimit_nofile only once in nginx.conf

### DIFF
--- a/build/packages-template/bbb-config/after-install.sh
+++ b/build/packages-template/bbb-config/after-install.sh
@@ -110,7 +110,12 @@ fi
 
 sed -i 's/worker_connections 768/worker_connections 4000/g' /etc/nginx/nginx.conf
 
-if ! grep "worker_rlimit_nofile 10000;" /etc/nginx/nginx.conf; then
+if grep "worker_rlimit_nofile" /etc/nginx/nginx.conf; then
+  num=$(grep worker_rlimit_nofile /etc/nginx/nginx.conf | grep -o '[0-9]*')
+  if [[ "$num" -lt 10000 ]]; then
+    sed -i 's/worker_rlimit_nofile [0-9 ]*;/worker_rlimit_nofile 10000;/g' /etc/nginx/nginx.conf
+  fi
+else
   sed -i 's/events {/worker_rlimit_nofile 10000;\n\nevents {/g' /etc/nginx/nginx.conf
 fi
 


### PR DESCRIPTION
`worker_rt_nofile` may only be set once in nginx.conf. So far there was no check whether it is already set to a value different than 10000. This results in the option being set twice in the config file, if it was already set by. This caused nginx to fail startup.

### What does this PR do?
Check that the limit `worker_rlimit_nofile` is at least 10000. Only if is below 10000 or not set at all, it is set to 10000.

### Closes Issue(s)
Closes  #11521

### Motivation
Causes nginx (and therefore bbb) to crash on system where someone or something already configured `worker_rt_nofile`.
