### PR TITLE
fix: camera resizing bug

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -472,7 +472,7 @@ class CustomLayout extends Component {
             cameraDockBounds.width = mediaAreaBounds.width;
             cameraDockBounds.maxWidth = mediaAreaBounds.width;
             cameraDockBounds.minHeight = DEFAULT_VALUES.cameraDockMinHeight;
-            cameraDockBounds.height = cameraDockHeight - camerasMargin;
+            cameraDockBounds.height = cameraDockHeight;
             cameraDockBounds.maxHeight = mediaAreaBounds.height * 0.8;
             break;
           }
@@ -497,10 +497,10 @@ class CustomLayout extends Component {
             const sizeValue = input.presentation.isOpen
               ? (mediaAreaBounds.left + mediaAreaBounds.width) - cameraDockWidth
               : mediaAreaBounds.left;
-            cameraDockBounds.left = !isRTL ? sizeValue + camerasMargin : 0;
-            cameraDockBounds.right = isRTL ? sizeValue + sidebarSize + camerasMargin : null;
+            cameraDockBounds.left = !isRTL ? sizeValue - camerasMargin : 0;
+            cameraDockBounds.right = isRTL ? sizeValue + sidebarSize - camerasMargin : null;
             cameraDockBounds.minWidth = DEFAULT_VALUES.cameraDockMinWidth;
-            cameraDockBounds.width = cameraDockWidth - (camerasMargin * 2);
+            cameraDockBounds.width = cameraDockWidth;
             cameraDockBounds.maxWidth = mediaAreaBounds.width * 0.8;
             cameraDockBounds.presenterMaxWidth = mediaAreaBounds.width
               - DEFAULT_VALUES.presentationToolbarMinWidth
@@ -539,7 +539,7 @@ class CustomLayout extends Component {
             cameraDockBounds.width = mediaAreaBounds.width;
             cameraDockBounds.maxWidth = mediaAreaBounds.width;
             cameraDockBounds.minHeight = DEFAULT_VALUES.cameraDockMinHeight;
-            cameraDockBounds.height = cameraDockHeight - camerasMargin;
+            cameraDockBounds.height = cameraDockHeight;
             cameraDockBounds.maxHeight = mediaAreaBounds.height * 0.8;
             break;
           }
@@ -564,7 +564,7 @@ class CustomLayout extends Component {
             cameraDockBounds.left = mediaAreaBounds.left + camerasMargin;
             cameraDockBounds.right = isRTL ? sidebarSize + (camerasMargin * 2) : null;
             cameraDockBounds.minWidth = DEFAULT_VALUES.cameraDockMinWidth;
-            cameraDockBounds.width = cameraDockWidth - (camerasMargin * 2);
+            cameraDockBounds.width = cameraDockWidth;
             cameraDockBounds.maxWidth = mediaAreaBounds.width * 0.8;
             cameraDockBounds.presenterMaxWidth = mediaAreaBounds.width
               - DEFAULT_VALUES.presentationToolbarMinWidth
@@ -677,7 +677,7 @@ class CustomLayout extends Component {
           break;
         }
         case CAMERADOCK_POSITION.CONTENT_RIGHT: {
-          mediaBounds.width = mediaAreaWidth - cameraDockBounds.width - camerasMargin;
+          mediaBounds.width = mediaAreaWidth - cameraDockBounds.width - (camerasMargin * 2);
           mediaBounds.height = mediaAreaHeight;
           mediaBounds.top = navBarHeight + bannerAreaHeight;
           mediaBounds.left = !isRTL ? sidebarSize : null;
@@ -693,7 +693,7 @@ class CustomLayout extends Component {
           break;
         }
         case CAMERADOCK_POSITION.CONTENT_LEFT: {
-          mediaBounds.width = mediaAreaWidth - cameraDockBounds.width - camerasMargin;
+          mediaBounds.width = mediaAreaWidth - cameraDockBounds.width - (camerasMargin * 2);
           mediaBounds.height = mediaAreaHeight;
           mediaBounds.top = navBarHeight + bannerAreaHeight;
           const sizeValue = sidebarNavWidth


### PR DESCRIPTION
### What does this PR do?

Prevents camera position bug when resizing, by removing cameras width/height manipulation in customLayout.

#### before
![resize-before](https://user-images.githubusercontent.com/3728706/134242193-8c857cf7-7212-4f6f-ac8e-03f17693c44a.gif)
#### after
![resize-after](https://user-images.githubusercontent.com/3728706/134242188-cac669f8-da9e-471a-9d1e-d4f0d348a16f.gif)
