### PR TITLE
Implements CollectionEventsBroker for chat context - develop

### DIFF
--- a/bigbluebutton-html5/client/main.jsx
+++ b/bigbluebutton-html5/client/main.jsx
@@ -18,6 +18,7 @@
 /* eslint no-unused-vars: 0 */
 
 import './wdyr';
+import '../imports/ui/services/collection-hooks/collection-hooks';
 
 import React from 'react';
 import { Meteor } from 'meteor/meteor';

--- a/bigbluebutton-html5/imports/api/group-chat-msg/index.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/index.js
@@ -8,4 +8,8 @@ if (Meteor.isServer) {
   UsersTyping._ensureIndex({ meetingId: 1, isTypingTo: 1 });
 }
 
+if (Meteor.isClient) {
+  GroupChatMsg.onAdded = () => false;
+}
+
 export { GroupChatMsg, UsersTyping };

--- a/bigbluebutton-html5/imports/api/group-chat-msg/index.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/index.js
@@ -8,6 +8,7 @@ if (Meteor.isServer) {
   UsersTyping._ensureIndex({ meetingId: 1, isTypingTo: 1 });
 }
 
+// As we store chat in context, skip adding to mini mongo
 if (Meteor.isClient) {
   GroupChatMsg.onAdded = () => false;
 }

--- a/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
@@ -5,6 +5,7 @@ import { UsersContext } from '../users-context/context';
 import { makeCall } from '/imports/ui/services/api';
 import ChatLogger from '/imports/ui/components/chat/chat-logger/ChatLogger';
 import Auth from '/imports/ui/services/auth';
+import CollectionHooksCallbacks from '/imports/ui/services/collection-hooks-callbacks/collection-hooks-callbacks';
 
 let prevUserData = {};
 let currentUserData = {};
@@ -119,23 +120,19 @@ const Adapter = () => {
       });
     }, 1000, { trailing: true, leading: true });
 
-    Meteor.connection._stream.socket.addEventListener('message', (msg) => {
-      if (msg.data.indexOf('{"msg":"added","collection":"group-chat-msg"') !== -1) {
-        const parsedMsg = JSON.parse(msg.data);
-        if (parsedMsg.msg === 'added') {
-          const { fields } = parsedMsg;
-          if (fields.id === `${SYSTEM_CHAT_TYPE}-${CHAT_CLEAR_MESSAGE}`) {
-            messageQueue = [];
-            dispatch({
-              type: ACTIONS.REMOVED,
-            });
-          }
-
-          messageQueue.push(fields);
-          throttledDispatch();
-        }
+    const insertToContext = (fields) => {
+      if (fields.id === `${SYSTEM_CHAT_TYPE}-${CHAT_CLEAR_MESSAGE}`) {
+        messageQueue = [];
+        dispatch({
+          type: ACTIONS.REMOVED,
+        });
       }
-    });
+
+      messageQueue.push(fields);
+      throttledDispatch();
+    };
+
+    CollectionHooksCallbacks.addCallback('group-chat-msg', 'added', insertToContext);
   }, [Meteor.status().connected, Meteor.connection._lastSessionId]);
 
   return null;

--- a/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
@@ -5,7 +5,7 @@ import { UsersContext } from '../users-context/context';
 import { makeCall } from '/imports/ui/services/api';
 import ChatLogger from '/imports/ui/components/chat/chat-logger/ChatLogger';
 import Auth from '/imports/ui/services/auth';
-import CollectionHooksCallbacks from '/imports/ui/services/collection-hooks-callbacks/collection-hooks-callbacks';
+import CollectionEventsBroker from '/imports/ui/services/collection-hooks-callbacks/collection-hooks-callbacks';
 
 let prevUserData = {};
 let currentUserData = {};
@@ -132,7 +132,7 @@ const Adapter = () => {
       throttledDispatch();
     };
 
-    CollectionHooksCallbacks.addCallback('group-chat-msg', 'added', insertToContext);
+    CollectionEventsBroker.addListener('group-chat-msg', 'added', insertToContext);
   }, [Meteor.status().connected, Meteor.connection._lastSessionId]);
 
   return null;

--- a/bigbluebutton-html5/imports/ui/services/collection-hooks-callbacks/collection-hooks-callbacks.js
+++ b/bigbluebutton-html5/imports/ui/services/collection-hooks-callbacks/collection-hooks-callbacks.js
@@ -1,0 +1,39 @@
+class CollectionHooksCallbacks {
+  static buildIndex(msg, updates) {
+    // the msg.msg has the collection event,
+    // see the collection hooks event object for more information
+    return `/${msg.collection}/${msg.msg}/`;
+    // TODO: also process the updates object
+  }
+
+  constructor() {
+    this.callbacks = {};
+  }
+
+  addCallback(collection, event, callback) {
+    try {
+      const index = CollectionHooksCallbacks.buildIndex({ collection, msg: event });
+      const TheresCallback = this.callbacks[index];
+      if (TheresCallback) {
+        throw new Error('There is already an associated callback for this event');
+      }
+      this.callbacks[index] = callback;
+      return true;
+    } catch (err) {
+      console.error(err);
+      return false;
+    }
+  }
+
+  callByMsg(msg, updates) {
+    const msgIndex = CollectionHooksCallbacks.buildIndex(msg, updates);
+    const { fields } = msg;
+    const callback = this.callbacks[msgIndex];
+    if (callback) {
+      callback(fields);
+    }
+    // TODO: also process the updates object
+  }
+}
+
+export default new CollectionHooksCallbacks();

--- a/bigbluebutton-html5/imports/ui/services/collection-hooks-callbacks/collection-hooks-callbacks.js
+++ b/bigbluebutton-html5/imports/ui/services/collection-hooks-callbacks/collection-hooks-callbacks.js
@@ -1,5 +1,5 @@
-class CollectionHooksCallbacks {
-  static buildIndex(msg, updates) {
+class CollectionEventsBroker {
+  static getKey(msg, updates) {
     // the msg.msg has the collection event,
     // see the collection hooks event object for more information
     return `/${msg.collection}/${msg.msg}/`;
@@ -10,9 +10,9 @@ class CollectionHooksCallbacks {
     this.callbacks = {};
   }
 
-  addCallback(collection, event, callback) {
+  addListener(collection, event, callback) {
     try {
-      const index = CollectionHooksCallbacks.buildIndex({ collection, msg: event });
+      const index = CollectionEventsBroker.getKey({ collection, msg: event });
       const TheresCallback = this.callbacks[index];
       if (TheresCallback) {
         throw new Error('There is already an associated callback for this event');
@@ -25,8 +25,8 @@ class CollectionHooksCallbacks {
     }
   }
 
-  callByMsg(msg, updates) {
-    const msgIndex = CollectionHooksCallbacks.buildIndex(msg, updates);
+  dispatchEvent(msg, updates) {
+    const msgIndex = CollectionEventsBroker.getKey(msg, updates);
     const { fields } = msg;
     const callback = this.callbacks[msgIndex];
     if (callback) {
@@ -36,4 +36,4 @@ class CollectionHooksCallbacks {
   }
 }
 
-export default new CollectionHooksCallbacks();
+export default new CollectionEventsBroker();

--- a/bigbluebutton-html5/imports/ui/services/collection-hooks/collection-hooks.js
+++ b/bigbluebutton-html5/imports/ui/services/collection-hooks/collection-hooks.js
@@ -1,4 +1,4 @@
-import CollectionHooksCallbacks from '/imports/ui/services/collection-hooks-callbacks/collection-hooks-callbacks';
+import CollectionEventsBroker from '/imports/ui/services/collection-hooks-callbacks/collection-hooks-callbacks';
 
 Meteor.connection._processOneDataMessage = function (msg, updates) {
   const messageType = msg.msg;
@@ -7,7 +7,7 @@ Meteor.connection._processOneDataMessage = function (msg, updates) {
   if (msg.collection && msg.collection.indexOf('stream-cursor') === -1) {
     col = Meteor.connection._stores[msg.collection]?._getCollection();
   }
-  CollectionHooksCallbacks.callByMsg(msg, updates);
+  CollectionEventsBroker.dispatchEvent(msg, updates);
   // msg is one of ['added', 'changed', 'removed', 'ready', 'updated']
   if (messageType === 'added') {
     if (!col || !col.onAdded || col.onAdded(msg, updates)) {

--- a/bigbluebutton-html5/imports/ui/services/collection-hooks/collection-hooks.js
+++ b/bigbluebutton-html5/imports/ui/services/collection-hooks/collection-hooks.js
@@ -1,0 +1,37 @@
+import CollectionHooksCallbacks from '/imports/ui/services/collection-hooks-callbacks/collection-hooks-callbacks';
+
+Meteor.connection._processOneDataMessage = function (msg, updates) {
+  const messageType = msg.msg;
+
+  let col = null;
+  if (msg.collection && msg.collection.indexOf('stream-cursor') === -1) {
+    col = Meteor.connection._stores[msg.collection]?._getCollection();
+  }
+  CollectionHooksCallbacks.callByMsg(msg, updates);
+  // msg is one of ['added', 'changed', 'removed', 'ready', 'updated']
+  if (messageType === 'added') {
+    if (!col || !col.onAdded || col.onAdded(msg, updates)) {
+      this._process_added(msg, updates);
+    }
+  } else if (messageType === 'changed') {
+    if (!col || !col.onChanged || col.onChanged(msg, updates)) {
+      this._process_changed(msg, updates);
+    }
+  } else if (messageType === 'removed') {
+    if (!col || !col.onRemoved || col.onRemoved(msg, updates)) {
+      this._process_removed(msg, updates);
+    }
+  } else if (messageType === 'ready') {
+    if (!col || !col.onReady || col.onReady(msg, updates)) {
+      this._process_ready(msg, updates);
+    }
+  } else if (messageType === 'updated') {
+    if (!col || !col.onUpdated || col.onUpdated(msg, updates)) {
+      this._process_updated(msg, updates);
+    }
+  } else if (messageType === 'nosub') {
+    // ignore this
+  } else {
+    Meteor._debug('discarding unknown livedata data message type', msg);
+  }
+};


### PR DESCRIPTION


### What does this PR do?

Implements the CollectionEventsBroker which directly listens for the collection event and skips the insertion in the minimongo, this reduces memory usage, as the item is now stored in one place only, it also reduces CPU usage because the event parse occurs only once, removes the eventListener which makes the application more robust because it doesn't need workarounds for the client reconnect
