### PR TITLE
fix: Breakout generation URL keeps loading even after it has finished

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
@@ -171,6 +171,7 @@ class BreakoutRoom extends PureComponent {
       this.setState(
         {
           waiting: true,
+          generated: false,
           requestedBreakoutId: breakoutId,
         },
         () => requestJoinURL(breakoutId),


### PR DESCRIPTION
### What does this PR do?

Prevents an issue with the breakout room panel where UI gets stuck at **Generating URL...** if a user tries to generate more than one join URL without closing the breakout panel.

### Closes Issue(s)
Closes #13249