### PR TITLE
feat(audio): add bridge configurable scheme

### DIFF
--- a/bigbluebutton-html5/client/main.jsx
+++ b/bigbluebutton-html5/client/main.jsx
@@ -33,6 +33,10 @@ import ChatAdapter from '/imports/ui/components/components-data/chat-context/ada
 import UsersAdapter from '/imports/ui/components/components-data/users-context/adapter';
 import GroupChatAdapter from '/imports/ui/components/components-data/group-chat-context/adapter';
 
+import('/imports/api/audio/client/bridge/bridge-whitelist').catch(() => {
+  // bridge loading
+});
+
 Meteor.startup(() => {
   // Logs all uncaught exceptions to the client logger
   window.addEventListener('error', (e) => {

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/bridge-whitelist.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/bridge-whitelist.js
@@ -1,0 +1,16 @@
+/**
+ * Bridge whitelist, needed for dynamically importing bridges (as modules).
+ *
+ * The code is intentionally unreachable, but its trigger Meteor's static
+ * analysis, which makes bridge module available to build process.
+ *
+ * For new bridges, we must append an import statement here.
+ *
+ * More information here:
+ *https://docs.meteor.com/packages/dynamic-import.html
+ */
+
+throw new Error();
+
+/* eslint-disable no-unreachable */
+// BRIDGES LIST

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
@@ -293,3 +293,5 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
     return Promise.resolve();
   }
 }
+
+module.exports = KurentoAudioBridge;

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -1493,3 +1493,5 @@ export default class SIPBridge extends BaseAudioBridge {
     return this.activeSession.updateAudioConstraints(constraints);
   }
 }
+
+module.exports = SIPBridge;

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -106,8 +106,8 @@ class AudioManager {
 
       await Promise.all(Object.values(bridges).map(async (bridge) => {
         // eslint-disable-next-line import/no-dynamic-require, global-require
-        this.bridges[bridge.name] = await import(DEFAULT_AUDIO_BRIDGES_PATH
-          + bridge.path);
+        this.bridges[bridge.name] = (await import(DEFAULT_AUDIO_BRIDGES_PATH
+          + bridge.path) || {}).default;
       }));
 
       if (defaultFullAudioBridge && (this.bridges[defaultFullAudioBridge])) {

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -104,9 +104,9 @@ class AudioManager {
 
       this.bridges = {};
 
-      Object.values(bridges).forEach((bridge) => {
+      Object.values(bridges).forEach(async (bridge) => {
         // eslint-disable-next-line import/no-dynamic-require, global-require
-        this.bridges[bridge.name] = require(DEFAULT_AUDIO_BRIDGES_PATH
+        this.bridges[bridge.name] = await import(DEFAULT_AUDIO_BRIDGES_PATH
           + bridge.path);
       });
 

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -91,7 +91,7 @@ class AudioManager {
    * @param {Object} userData The Object representing user data to be passed to
    *                      the bridge.
    */
-  loadBridges(userData) {
+  async loadBridges(userData) {
     let FullAudioBridge = SIPBridge;
     let ListenOnlyBridge = KurentoBridge;
 
@@ -104,11 +104,11 @@ class AudioManager {
 
       this.bridges = {};
 
-      Object.values(bridges).forEach(async (bridge) => {
+      await Promise.all(Object.values(bridges).map(async (bridge) => {
         // eslint-disable-next-line import/no-dynamic-require, global-require
         this.bridges[bridge.name] = await import(DEFAULT_AUDIO_BRIDGES_PATH
           + bridge.path);
-      });
+      }));
 
       if (defaultFullAudioBridge && (this.bridges[defaultFullAudioBridge])) {
         FullAudioBridge = this.bridges[defaultFullAudioBridge];

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -24,6 +24,7 @@ const DEFAULT_OUTPUT_DEVICE_ID = 'default';
 const EXPERIMENTAL_USE_KMS_TRICKLE_ICE_FOR_MICROPHONE = Meteor.settings
   .public.app.experimentalUseKmsTrickleIceForMicrophone;
 
+const DEFAULT_AUDIO_BRIDGES_PATH = '/imports/api/audio/client/';
 const CALL_STATES = {
   STARTED: 'started',
   ENDED: 'ended',
@@ -77,13 +78,51 @@ class AudioManager {
   }
 
   init(userData, audioEventHandler) {
-    this.bridge = new SIPBridge(userData); // no alternative as of 2019-03-08
-    if (this.useKurento) {
-      this.listenOnlyBridge = new KurentoBridge(userData);
-    }
+    this.loadBridges(userData);
     this.userData = userData;
     this.initialized = true;
     this.audioEventHandler = audioEventHandler;
+  }
+
+  /**
+   * Load audio bridges modules to be used the manager.
+   *
+   * Bridges can be configured in settings.yml file.
+   * @param {Object} userData The Object representing user data to be passed to
+   *                      the bridge.
+   */
+  loadBridges(userData) {
+    let FullAudioBridge = SIPBridge;
+    let ListenOnlyBridge = KurentoBridge;
+
+    if (MEDIA.audio) {
+      const {
+        bridges,
+        defaultFullAudioBridge,
+        defaultListenOnlyBridge,
+      } = MEDIA.audio;
+
+      this.bridges = {};
+
+      Object.values(bridges).forEach((bridge) => {
+        // eslint-disable-next-line import/no-dynamic-require, global-require
+        this.bridges[bridge.name] = require(DEFAULT_AUDIO_BRIDGES_PATH
+          + bridge.path);
+      });
+
+      if (defaultFullAudioBridge && (this.bridges[defaultFullAudioBridge])) {
+        FullAudioBridge = this.bridges[defaultFullAudioBridge];
+      }
+
+      if (defaultListenOnlyBridge && (this.bridges[defaultListenOnlyBridge])) {
+        ListenOnlyBridge = this.bridges[defaultListenOnlyBridge];
+      }
+    }
+
+    this.bridge = new FullAudioBridge(userData);
+    if (this.useKurento) {
+      this.listenOnlyBridge = new ListenOnlyBridge(userData);
+    }
   }
 
   setAudioMessages(messages, intl) {

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -440,6 +440,36 @@ public:
     hidePresentation: false
     showParticipantsOnLogin: true
   media:
+    audio:
+      #
+      #
+      # Default bridge to be used by full audio mechanism.
+      # This is the bridge's name as contained in 'bridges' array
+      defaultFullAudioBridge: sipjs
+      #
+      #
+      # Same as above, but for listen only mechanism
+      defaultListenOnlyBridge: kurento
+      #
+      #
+      # Bridge array, here's where we list our bridges.
+      # To add new bridges, simply add the corresponding .js file in
+      # /imports/api/audio/client/bridge/ and add it to this list.
+      #
+      # Each bridge in this list, must have a name and path attribute.
+      # The name is the desired name/string you can set for your bridge, while
+      # the path specifies the file path, relative to
+      # '/imports/api/audio/client' dir.
+      #
+      bridges:
+          #
+          # The name of the bridge
+        - name: sipjs
+          #
+          # The bridge file path , relative to /imports/api/audio/client
+          path: 'bridge/sip'
+        - name: kurento
+          path: 'bridge/kurento'
     stunTurnServersFetchAddress: '/bigbluebutton/api/stuns'
     cacheStunTurnServers: true
     fallbackStunServer: ''


### PR DESCRIPTION
We are now able to switch between audio bridges, by selecting it in
config files. We don't recommend doing it now because this won't work
without some updates that will come later.

This is one of the first steps to allow adding audio bridges for existing
or new media servers (kurento, mediasoup, etc..). By switching default
bridges, we can switch the media server that is going to be used
by fullaudio (microphone)