### PR TITLE
refactor: WCAG2.1 - Guest Wait Page

### DIFF
--- a/bigbluebutton-html5/private/static/guest-wait/guest-wait.html
+++ b/bigbluebutton-html5/private/static/guest-wait/guest-wait.html
@@ -326,7 +326,7 @@
 
 <body>
   <div id="content">
-    <h1>Waiting Room</h1>
+    <h1>Guest Lobby</h1>
     <div class="spinner">
       <div class="bounce1"></div>
       <div class="bounce2"></div>

--- a/bigbluebutton-html5/private/static/guest-wait/guest-wait.html
+++ b/bigbluebutton-html5/private/static/guest-wait/guest-wait.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <title>Guest Lobby</title>
+  <title>BigBlueButton - Guest Lobby</title>
   <meta charset="UTF-8">
   <style>
     :root {
@@ -24,6 +24,10 @@
       font-weight: bold;
       font-size: 24px;
       font-family: arial, sans-serif;
+    }
+
+    #content h1 {
+      font-size: 2rem;
     }
 
     .spinner {
@@ -149,6 +153,8 @@
       url.search = overrideLocale
         ? `locale=${overrideLocale}`
         : `locale=${navigator.language}&init=true`;
+      
+      document.getElementsByTagName('html')[0].lang = overrideLocale || navigator.language;
 
       const localesPath = 'locales';
 
@@ -320,12 +326,13 @@
 
 <body>
   <div id="content">
+    <h1>Waiting Room</h1>
     <div class="spinner">
       <div class="bounce1"></div>
       <div class="bounce2"></div>
       <div class="bounce3"></div>
     </div>
-    <p>Please wait for a moderator to approve you joining the meeting.</p>
+    <p aria-live="polite">Please wait for a moderator to approve you joining the meeting.</p>
   </div>
 </body>
 


### PR DESCRIPTION
### What does this PR do?
Add `h1` element.
Add `lang` attribute.
Add `aria-live` to guest wait messages.
Add `BigBlueButton` string to page title.
### Motivation
Fixes the following accessibility issues:
1) Page title fails to include the product name stating only “guest lobby”.
2) The page lacks a declared language of the page.
3) The page lacks any declared headings.
4) When a message is pushed to the guest lobby the user is not made aware of the content change.