### PR TITLE
feat(webrtc): add EXPERIMENTAL option to disable ICE candidate signaling

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
@@ -11,6 +11,7 @@ import getFromMeetingSettings from '/imports/ui/services/meeting-settings';
 
 const SFU_URL = Meteor.settings.public.kurento.wsUrl;
 const DEFAULT_LISTENONLY_MEDIA_SERVER = Meteor.settings.public.kurento.listenOnlyMediaServer;
+const SIGNAL_CANDIDATES = Meteor.settings.public.kurento.signalCandidates;
 const MEDIA = Meteor.settings.public.media;
 const MEDIA_TAG = MEDIA.mediaTag.replace(/#/g, '');
 const GLOBAL_AUDIO_PREFIX = 'GLOBAL_AUDIO_';
@@ -265,6 +266,7 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
           iceServers,
           offering: OFFERING,
           mediaServer: getMediaServerAdapter(),
+          signalCandidates: SIGNAL_CANDIDATES,
         };
 
         this.broker = new ListenOnlyBroker(

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -8,6 +8,7 @@ import { SCREENSHARING_ERRORS } from './errors';
 const SFU_CONFIG = Meteor.settings.public.kurento;
 const SFU_URL = SFU_CONFIG.wsUrl;
 const OFFERING = SFU_CONFIG.screenshare.subscriberOffering;
+const SIGNAL_CANDIDATES = Meteor.settings.public.kurento.signalCandidates;
 
 const BRIDGE_NAME = 'kurento'
 const SCREENSHARE_VIDEO_TAG = 'screenshareVideo';
@@ -225,6 +226,7 @@ export default class KurentoScreenshareBridge {
       hasAudio,
       offering: OFFERING,
       mediaServer: BridgeService.getMediaServerAdapter(),
+      signalCandidates: SIGNAL_CANDIDATES,
     };
 
     this.broker = new ScreenshareBroker(
@@ -284,6 +286,7 @@ export default class KurentoScreenshareBridge {
         bitrate: BridgeService.BASE_BITRATE,
         offering: true,
         mediaServer: BridgeService.getMediaServerAdapter(),
+        signalCandidates: SIGNAL_CANDIDATES,
       };
 
       this.broker = new ScreenshareBroker(

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -28,6 +28,7 @@ const {
 } = Meteor.settings.public.kurento.cameraTimeouts || {};
 const CAMERA_QUALITY_THRESHOLDS_ENABLED = Meteor.settings.public.kurento.cameraQualityThresholds.enabled;
 const PING_INTERVAL = 15000;
+const SIGNAL_CANDIDATES = Meteor.settings.public.kurento.signalCandidates;
 
 const intlClientErrors = defineMessages({
   permissionError: {
@@ -782,17 +783,21 @@ class VideoProvider extends Component {
   }
 
   _getOnIceCandidateCallback(stream, isLocal) {
-    return (candidate) => {
-      const peer = this.webRtcPeers[stream];
-      const role = VideoService.getRole(isLocal);
+    if (SIGNAL_CANDIDATES) {
+      return (candidate) => {
+        const peer = this.webRtcPeers[stream];
+        const role = VideoService.getRole(isLocal);
 
-      if (peer && !peer.didSDPAnswered) {
-        this.outboundIceQueues[stream].push(candidate);
-        return;
-      }
+        if (peer && !peer.didSDPAnswered) {
+          this.outboundIceQueues[stream].push(candidate);
+          return;
+        }
 
-      this.sendIceCandidateToSFU(peer, role, candidate, stream);
-    };
+        this.sendIceCandidateToSFU(peer, role, candidate, stream);
+      };
+    }
+
+    return null;
   }
 
   sendIceCandidateToSFU(peer, role, candidate, stream) {

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/listenonly-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/listenonly-broker.js
@@ -22,6 +22,7 @@ class ListenOnlyBroker extends BaseBroker {
     this.offering = true;
 
     // Optional parameters are: userName, caleeName, iceServers, offering, mediaServer
+    // signalCandidates
     Object.assign(this, options);
   }
 
@@ -32,9 +33,7 @@ class ListenOnlyBroker extends BaseBroker {
           audio: true,
           video: false,
         },
-        onicecandidate: (candidate) => {
-          this.onIceCandidate(candidate, this.role);
-        },
+        onicecandidate: this.signalCandidates ? this.onIceCandidate.bind(this) : null,
       };
 
       this.addIceServers(options);
@@ -179,10 +178,10 @@ class ListenOnlyBroker extends BaseBroker {
     this.sendStartReq(sdpOffer);
   }
 
-  onIceCandidate (candidate, role) {
+  onIceCandidate (candidate) {
     const message = {
       id: ON_ICE_CANDIDATE_MSG,
-      role,
+      role: this.role,
       type: this.sfuComponent,
       voiceBridge: this.voiceBridge,
       candidate,

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/screenshare-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/screenshare-broker.js
@@ -23,8 +23,10 @@ class ScreenshareBroker extends BaseBroker {
     this.webRtcPeer = null;
     this.hasAudio = false;
     this.offering = true;
+    this.signalCandidates = true;
 
-    // Optional parameters are: userName, caleeName, iceServers, hasAudio, bitrate, offering, mediaServer
+    // Optional parameters are: userName, caleeName, iceServers, hasAudio,
+    // bitrate, offering, mediaServer, signalCandidates
     Object.assign(this, options);
   }
 
@@ -153,9 +155,7 @@ class ScreenshareBroker extends BaseBroker {
   startScreensharing () {
     return new Promise((resolve, reject) => {
       const options = {
-        onicecandidate: (candidate) => {
-          this.onIceCandidate(candidate, this.role);
-        },
+        onicecandidate: this.signalCandidates ? this.onIceCandidate.bind(this) : null,
         videoStream: this.stream,
       };
 
@@ -206,10 +206,10 @@ class ScreenshareBroker extends BaseBroker {
     });
   }
 
-  onIceCandidate (candidate, role) {
+  onIceCandidate (candidate) {
     const message = {
       id: ON_ICE_CANDIDATE_MSG,
-      role,
+      role: this.role,
       type: this.sfuComponent,
       voiceBridge: this.voiceBridge,
       candidate,
@@ -225,9 +225,7 @@ class ScreenshareBroker extends BaseBroker {
         mediaConstraints: {
           audio: !!this.hasAudio,
         },
-        onicecandidate: (candidate) => {
-          this.onIceCandidate(candidate, this.role);
-        },
+        onicecandidate: this.signalCandidates ? this.onIceCandidate.bind(this) : null,
       };
 
       this.addIceServers(options);

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -197,6 +197,9 @@ public:
     wsConnectionTimeout: 4000
     # Time in milis to wait for the browser to return a gUM call (used in video-preview)
     gUMTimeout: 20000
+    # Experiment(al). Controls whether ICE candidates should be signaled.
+    # Applies to webcams, listen only and screen sharing. True is "stable behavior".
+    signalCandidates: true
     cameraTimeouts:
       # Base camera timeout: used as the camera *sharing* timeout and
       # as the minimum camera subscribe reconnection timeout


### PR DESCRIPTION
### What does this PR do?

- feat(webrtc): add EXPERIMENTAL option to disable ICE candidate signaling 2eadf94
  * ICE Lite implementations (eg mediasoup) don't need candidates signaled out-of-band; neither does KMS in certain scenarios
  * Disabling their signaling saves us some ticks in bbb-webrtc-sfu and some bandwidth all around
  * Default behavior is `true` (i.e.: status quo)

### Closes Issue(s)

None (this is a experiment)

### Motivation

`Disabling their signaling saves us some ticks in bbb-webrtc-sfu and some bandwidth all around`

### More

KMS in certain scenarios => use at your own risk. One is more likely to blow their feet off by disabling candidate signaling with KMS.