### PR TITLE
Smaller bg for "online" & "offline" on Learning Dashboard

### DIFF
--- a/bbb-learning-dashboard/src/components/UsersTable.jsx
+++ b/bbb-learning-dashboard/src/components/UsersTable.jsx
@@ -395,12 +395,12 @@ class UsersTable extends React.Component {
                     {
                                       user.leftOn > 0
                                         ? (
-                                          <span className="px-2 py-1 font-semibold leading-tight text-red-700 bg-red-100 rounded-full">
+                                          <span className="px-2 py-0 font-semibold leading-tight text-red-700 bg-red-100 rounded-full">
                                             <FormattedMessage id="app.learningDashboard.usersTable.userStatusOffline" defaultMessage="Offline" />
                                           </span>
                                         )
                                         : (
-                                          <span className="px-2 py-1 font-semibold leading-tight text-green-700 bg-green-100 rounded-full">
+                                          <span className="px-2 py-0 font-semibold leading-tight text-green-700 bg-green-100 rounded-full">
                                             <FormattedMessage id="app.learningDashboard.usersTable.userStatusOnline" defaultMessage="Online" />
                                           </span>
                                         )


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Makes the background shadow for "online" and "offline" letters on Learning Dashboard.

### Motivation

For some Asian languages such as Japanese does not have the concept of spacing between words. Thus a word can be easily arranged in multiple lines. This sometimes makes problems. See below. 

In English:
![Image 1](https://user-images.githubusercontent.com/45039819/134832224-e6733384-8a29-4a2f-9446-deb97dcbca0a.png)

In Japanese:
![Image 0](https://user-images.githubusercontent.com/45039819/134832229-54ad3233-e8b0-41bc-a482-9f6c3910862d.png)


