### PR TITLE
feat: Allow non-mod presenters to see raised hands dialog and lower raised hands

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/status-notifier/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/status-notifier/component.jsx
@@ -49,10 +49,10 @@ class StatusNotifier extends Component {
 
   componentDidUpdate(prevProps) {
     const {
-      emojiUsers, raiseHandAudioAlert, raiseHandPushAlert, status, isViewer,
+      emojiUsers, raiseHandAudioAlert, raiseHandPushAlert, status, isViewer, isPresenter,
     } = this.props;
 
-    if (isViewer) {
+    if (isViewer && !isPresenter) {
       if (this.statusNotifierId) toast.dismiss(this.statusNotifierId);
       return false;
     }

--- a/bigbluebutton-html5/imports/ui/components/status-notifier/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/status-notifier/container.jsx
@@ -14,10 +14,12 @@ const StatusNotifierContainer = (props) => {
   const { users } = usingUsersContext;
   const currentUser = users[Auth.meetingID][Auth.userID];
   const isViewer = currentUser.role === ROLE_VIEWER;
+  const isPresenter = currentUser.presenter;
   return (
     <StatusNotifier {...{
       ...props,
       isViewer,
+      isPresenter,
     }}
     />
   );


### PR DESCRIPTION
### What does this PR do?
This PR enables viewers being presenter to see the raised hand dialog and lower hands of other viewers in this case.

### Closes Issue(s)
Closes #12357

### Motivation
A presenter usually is the one interacting with the participants, so he should be notified about raised hands and also being able to lower the hands if the viewers don't do it themselves.

### More
As there are 5 "thumbs up" for the feature that presenters should also be able to lower hands, I decided to implement that :-)

Additional thoughts for the reviewer of this PR:
- A viewer usually isn't allowed to influence the emoji state of other viewers. So this PR breaks this basic rule mentioned in #12357 by @ffdixon.
- To keep this break as small as possible I only allowed this very specific case of "lowering hand" by a viewer who is presenter which leads to some ugly logic expressions. I tried to "fix" that by adding a comment ;-)
- This also makes me use some magic strings for the emojis which is at least suboptimal, but akka-apps doesn't seem to handle the different kinds of emojis somewhere, sorry for that. This would be the trade-off for being very specific on the exact permissions. I also considered allowing a viewer (being presenter) to change someone else's emoji status in general from akka-apps side but decided against it. Let me know if you see that differently.
- I opened that for `develop` branch, but of course feel free to consider if this should be going into `2.4.x-release` as well