### PR TITLE
Improve message when hand has been lowered

### DIFF
--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -619,7 +619,7 @@
     "app.toast.meetingMuteOn.label": "All users have been muted",
     "app.toast.meetingMuteOff.label": "Meeting mute turned off",
     "app.toast.setEmoji.raiseHand": "You have raised your hand",
-    "app.toast.setEmoji.lowerHand": "You have lowered your hand",
+    "app.toast.setEmoji.lowerHand": "Your hand has been lowered",
     "app.notification.recordingStart": "This session is now being recorded",
     "app.notification.recordingStop": "This session is not being recorded",
     "app.notification.recordingPaused": "This session is not being recorded anymore",


### PR DESCRIPTION
### What does this PR do?
Improves the message when the hand has been lowered. In the case a moderator lowers the hand of a participant the viewer sees the message that he/she(!) has lowered his hand despite him/her doing nothing at all. New message includes both the case a viewer lowers his hand by him/herself and the case of the moderator does it for him/her

### Closes Issue(s)
doesn't need a separate one? :-)

### Motivation
BBB should be as non-confusing as possible...

### More
Feel free to include in 2.4 and possibly even 2.3