### PR TITLE
fix: presentation toolbar size in focus on video layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -823,7 +823,7 @@ class Presentation extends PureComponent {
     const { presentationToolbarMinWidth } = DEFAULT_VALUES;
 
     const isLargePresentation = (svgWidth > presentationToolbarMinWidth || isMobile)
-      && !(layoutType === LAYOUT_TYPE.VIDEO_FOCUS && numCameras > 0);
+      && !(layoutType === LAYOUT_TYPE.VIDEO_FOCUS && numCameras > 0 && !fullscreenContext);
 
     const containerWidth = isLargePresentation
       ? svgWidth


### PR DESCRIPTION
### What does this PR do?

Prevents an issue with the presentation toolbar size in specific conditions:
- layout is set to focus on video layout
- 1 or more cameras are being shared
- presentation is fullscreen


#### before
![Screenshot from 2021-09-27 09-22-38](https://user-images.githubusercontent.com/3728706/134907198-3e8d00b8-0ff5-4d63-ba36-7e5736efcbd8.png)
#### after
![Screenshot from 2021-09-27 09-20-01](https://user-images.githubusercontent.com/3728706/134907191-187ff6ee-90ba-4682-90d7-cd9e340c389d.png)
