### PR TITLE
correct typo: occurs here and front install page

### DIFF
--- a/build/packages-template/bigbluebutton/build.sh
+++ b/build/packages-template/bigbluebutton/build.sh
@@ -57,7 +57,7 @@ Depends: $DEPENDENCIES
 Architecture: amd64
 Copyright: license.txt
 Description: Virtual Classroom
-  BigBlueButton is a virtual classroom for online teaching and learning. It was built for online learning, has a large community of teachers and developers that constantly work to improve it, and is deeply embedded into the world’s major leanrning management system. Users run BigBlueButton within their browsers with no additional software to install.
+  BigBlueButton is a virtual classroom for online teaching and learning. It was built for online learning, has a large community of teachers and developers that constantly work to improve it, and is deeply embedded into the world’s major learning management system. Users run BigBlueButton within their browsers with no additional software to install.
 EOF
 
 equivs-build control


### PR DESCRIPTION
### What does this PR do?

Folks, I realize you may not be terrible motivated to accept a change for a typo in this build script, but I'd actually found it first at https://docs.bigbluebutton.org/2.3/install.html, and I tried to find where that text may be here in the githib repo. But I could only find this. (While the text is identical, I don't expect that you somehow pull this text into that front page.)

So I'm offering this, whether you may agree with the value of touching this build.sh file to correct a typo, as much to just get your attention so that you may get that front page fixed some other way.

And indeed, if you require me to go through the submission/acceptance of the contributor agreement before you could accept this, I'll say you can just decline/delete/ignore this and hopefully just make the change to the install.html page.  I'm just trying to help you put your best foot forward on that initial page many will see.