### PR TITLE
fix: Hide presentation custom parameter not working

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -124,6 +124,7 @@ class ActionsDropdown extends PureComponent {
       stopExternalVideoShare,
       mountModal,
       layoutContextDispatch,
+      hidePresentation,
     } = this.props;
 
     const {
@@ -138,7 +139,7 @@ class ActionsDropdown extends PureComponent {
 
     const actions = [];
 
-    if (amIPresenter) {
+    if (amIPresenter && !hidePresentation) {
       actions.push({
         icon: "presentation",
         dataTest: "uploadPresentation",

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/container.jsx
@@ -5,6 +5,7 @@ import PresentationUploaderService from '/imports/ui/components/presentation/pre
 import PresentationPodService from '/imports/ui/components/presentation-pod/service';
 import ActionsDropdown from './component';
 import LayoutContext from '../../layout/context';
+import getFromUserSettings from '/imports/ui/services/users-settings';
 
 const ActionsDropdownContainer = (props) => {
   const layoutContext = useContext(LayoutContext);
@@ -23,6 +24,8 @@ const ActionsDropdownContainer = (props) => {
   );
 };
 
+const LAYOUT_CONFIG = Meteor.settings.public.layout;
+
 export default withTracker(() => {
   const presentations = Presentations.find({ 'conversion.done': true }).fetch();
   return ({
@@ -30,5 +33,6 @@ export default withTracker(() => {
     isDropdownOpen: Session.get('dropdownOpen'),
     setPresentation: PresentationUploaderService.setPresentation,
     podIds: PresentationPodService.getPresentationPodIds(),
+    hidePresentation: getFromUserSettings('bbb_hide_presentation', LAYOUT_CONFIG.hidePresentation),
   });
 })(ActionsDropdownContainer);

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -154,6 +154,7 @@ class App extends Component {
       meetingLayout,
       settingsLayout,
       isRTL,
+      hidePresentation,
     } = this.props;
     const { browserName } = browserInfo;
     const { osName } = deviceInfo;
@@ -163,6 +164,11 @@ class App extends Component {
     layoutContextDispatch({
       type: ACTIONS.SET_IS_RTL,
       value: isRTL,
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_PRESENTATION_IS_OPEN,
+      value: !hidePresentation,
     });
 
     MediaService.setSwapLayout(layoutContextDispatch);

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -175,6 +175,8 @@ export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) 
     customStyleUrl = CUSTOM_STYLE_URL;
   }
 
+  const LAYOUT_CONFIG = Meteor.settings.public.layout;
+
   return {
     captions: CaptionsService.isCaptionsActive() ? <CaptionsContainer /> : null,
     fontSize: getFontSize(),
@@ -205,6 +207,7 @@ export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) 
       'bbb_force_restore_presentation_on_new_events',
       Meteor.settings.public.presentation.restoreOnUpdate,
     ),
+    hidePresentation: getFromUserSettings('bbb_hide_presentation', LAYOUT_CONFIG.hidePresentation),
   };
 })(AppContainer)));
 

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
@@ -20,6 +20,7 @@ import ReloadButton from '/imports/ui/components/reload-button/component';
 
 import ArcPlayer from '/imports/ui/components/external-video-player/custom-players/arc-player';
 import PeerTubePlayer from '/imports/ui/components/external-video-player/custom-players/peertube';
+import { ACTIONS } from '/imports/ui/components/layout/enums';
 
 import { styles } from './styles';
 
@@ -142,6 +143,7 @@ class VideoPlayer extends Component {
       getSwapLayout,
       toggleSwapLayout,
       layoutContextDispatch,
+      hidePresentation,
     } = this.props;
 
     window.addEventListener('beforeunload', this.onBeforeUnload);
@@ -153,6 +155,13 @@ class VideoPlayer extends Component {
     this.registerVideoListeners();
 
     if (getSwapLayout()) toggleSwapLayout(layoutContextDispatch);
+
+    if (hidePresentation) {
+      layoutContextDispatch({
+        type: ACTIONS.SET_PRESENTATION_IS_OPEN,
+        value: true,
+      });
+    }
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -182,6 +191,7 @@ class VideoPlayer extends Component {
   }
 
   componentWillUnmount() {
+    const { hidePresentation } = this.props;
     window.removeEventListener('beforeunload', this.onBeforeUnload);
 
     VideoPlayer.clearVideoListeners();
@@ -190,6 +200,13 @@ class VideoPlayer extends Component {
     clearTimeout(this.autoPlayTimeout);
 
     this.player = null;
+
+    if (hidePresentation) {
+      layoutContextDispatch({
+        type: ACTIONS.SET_PRESENTATION_IS_OPEN,
+        value: false,
+      });
+    }
   }
 
   handleOnReady() {

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/container.jsx
@@ -5,6 +5,7 @@ import { getVideoUrl } from './service';
 import ExternalVideoComponent from './component';
 import LayoutContext from '../layout/context';
 import MediaService, { getSwapLayout } from '/imports/ui/components/media/service';
+import getFromUserSettings from '/imports/ui/services/users-settings';
 
 const ExternalVideoContainer = (props) => {
   const layoutManager = useContext(LayoutContext);
@@ -27,6 +28,8 @@ const ExternalVideoContainer = (props) => {
   );
 };
 
+const LAYOUT_CONFIG = Meteor.settings.public.layout;
+
 export default withTracker(({ isPresenter }) => {
   const inEchoTest = Session.get('inEchoTest');
   return {
@@ -35,5 +38,6 @@ export default withTracker(({ isPresenter }) => {
     videoUrl: getVideoUrl(),
     getSwapLayout,
     toggleSwapLayout: MediaService.toggleSwapLayout,
+    hidePresentation: getFromUserSettings('bbb_hide_presentation', LAYOUT_CONFIG.hidePresentation),
   };
 })(ExternalVideoContainer);

--- a/bigbluebutton-html5/imports/ui/components/media/service.js
+++ b/bigbluebutton-html5/imports/ui/components/media/service.js
@@ -48,13 +48,17 @@ const swapLayout = {
 };
 
 const setSwapLayout = (layoutContextDispatch) => {
+  const hidePresentation = getFromUserSettings('bbb_hide_presentation', LAYOUT_CONFIG.hidePresentation);
+
   swapLayout.value = getFromUserSettings('bbb_auto_swap_layout', LAYOUT_CONFIG.autoSwapLayout);
   swapLayout.tracker.changed();
 
-  layoutContextDispatch({
-    type: ACTIONS.SET_PRESENTATION_IS_OPEN,
-    value: !swapLayout.value,
-  });
+  if (!hidePresentation) {
+    layoutContextDispatch({
+      type: ACTIONS.SET_PRESENTATION_IS_OPEN,
+      value: !swapLayout.value,
+    });
+  }
 };
 
 const toggleSwapLayout = (layoutContextDispatch) => {

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -87,6 +87,7 @@ class ScreenshareComponent extends React.Component {
       toggleSwapLayout,
       layoutContextDispatch,
       intl,
+      hidePresentation,
     } = this.props;
 
     screenshareHasStarted();
@@ -100,6 +101,13 @@ class ScreenshareComponent extends React.Component {
     notify(intl.formatMessage(intlMessages.screenshareStarted), 'info', 'desktop');
 
     if (getSwapLayout()) toggleSwapLayout(layoutContextDispatch);
+
+    if (hidePresentation) {
+      layoutContextDispatch({
+        type: ACTIONS.SET_PRESENTATION_IS_OPEN,
+        value: true,
+      });
+    }
   }
 
   componentDidUpdate(prevProps) {
@@ -112,7 +120,7 @@ class ScreenshareComponent extends React.Component {
   }
 
   componentWillUnmount() {
-    const { intl, fullscreenContext, layoutContextDispatch } = this.props;
+    const { intl, fullscreenContext, layoutContextDispatch, hidePresentation } = this.props;
     screenshareHasEnded();
     window.removeEventListener('screensharePlayFailed', this.handlePlayElementFailed);
     unsubscribeFromStreamStateChange('screenshare', this.onStreamStateChange);
@@ -126,6 +134,13 @@ class ScreenshareComponent extends React.Component {
           element: '',
           group: '',
         },
+      });
+    }
+
+    if (hidePresentation) {
+      layoutContextDispatch({
+        type: ACTIONS.SET_PRESENTATION_IS_OPEN,
+        value: false,
       });
     }
   }

--- a/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
@@ -9,6 +9,7 @@ import {
 } from './service';
 import ScreenshareComponent from './component';
 import LayoutContext from '../layout/context';
+import getFromUserSettings from '/imports/ui/services/users-settings';
 
 const ScreenshareContainer = (props) => {
   const fullscreenElementId = 'Screenshare';
@@ -37,6 +38,8 @@ const ScreenshareContainer = (props) => {
   return null;
 };
 
+const LAYOUT_CONFIG = Meteor.settings.public.layout;
+
 export default withTracker(() => {
   const user = Users.findOne({ userId: Auth.userID }, { fields: { presenter: 1 } });
   return {
@@ -45,5 +48,6 @@ export default withTracker(() => {
     getSwapLayout,
     shouldEnableSwapLayout,
     toggleSwapLayout: MediaService.toggleSwapLayout,
+    hidePresentation: getFromUserSettings('bbb_hide_presentation', LAYOUT_CONFIG.hidePresentation),
   };
 })(ScreenshareContainer);


### PR DESCRIPTION
### What does this PR do?

- restores `hidePresentation` feature
- removes "Your presentation will begin shortly ..." message when `hidePresentation=true`
- removes `Manage Presentations` from actions bar when `hidePresentation=true`

### Closes Issue(s)
Closes #13256