### PR TITLE
fix: Button to extend breakout rooms time is being shown for normal users

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
@@ -490,7 +490,7 @@ class BreakoutRoom extends PureComponent {
             messageDuration={intlMessages.breakoutDuration}
             breakoutRoom={breakoutRooms[0]}
           />
-          {!visibleExtendTimeForm
+          {amIModerator && !visibleExtendTimeForm
             ? (
               <Button
                 onClick={this.showExtendTimeForm}


### PR DESCRIPTION
### What does this PR do?
Show button to extend breakout rooms time for moderators only.

**Before**:

https://user-images.githubusercontent.com/56703993/134987368-81da6d92-5590-4c8e-809f-fefeab3e7e5f.mp4

**After**:

https://user-images.githubusercontent.com/56703993/134987686-8a233376-f979-4a62-8f3c-46c718f67629.mp4
