### PR TITLE
Fix missing message in waiting room when meeting was ended before being able to join

### DIFF
--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -593,6 +593,7 @@
     "app.guest.guestWait": "Please wait for a moderator to approve you joining the meeting.",
     "app.guest.guestDeny": "Guest denied of joining the meeting.",
     "app.guest.seatWait": "Guest waiting for a seat in the meeting.",
+    "app.guest.validationError": "Meeting is not running. You are being redirected.",
     "app.userList.guest.waitingUsers": "Waiting Users",
     "app.userList.guest.waitingUsersTitle": "User Management",
     "app.userList.guest.optionTitle": "Review Pending Users",


### PR DESCRIPTION
### What does this PR do?
Adds a missing lang string to fix up the "undefined" message in the waiting room when meeting has been ended.

### Closes Issue(s)
Closes #13312

### Motivation
bugfixing <3

### More
That's a quick fix by adding a missing message. However, I feel like `validationError` is something which not only is being sent when the meeting has ended (so the message I chose wouldn't fit at all in these cases).

So maybe the issue here is not the missing message but the fact that a wrong error type is being sent back to the guest waiting page by the API. Please consider this possibilty while reviewing and close this PR if this has to be fixed on the API side.

Maybe should als go to `v2.4.x-release`