### PR TITLE
Avoid BBB to convert presentation with a problematic image/transparent pixel

### DIFF
--- a/bigbluebutton-web/pres-checker/src/main/java/org/bigbluebutton/prescheck/Main.java
+++ b/bigbluebutton-web/pres-checker/src/main/java/org/bigbluebutton/prescheck/Main.java
@@ -99,9 +99,10 @@ public class Main {
   private final class TinyTileBackgroundPredicate
       implements Predicate<XSLFPictureData> {
     public boolean evaluate(XSLFPictureData img) {
-      return img.getContentType() != null
-          && img.getContentType().equals("image/jpeg")
-          && LittleEndian.getLong(img.getChecksum()) == 4114937224L;
+
+        return img.getContentType() != null
+                && ((img.getContentType().equals("image/jpeg") && LittleEndian.getLong(img.getChecksum()) == 4114937224L) ||
+                (img.getContentType().equals("image/png") && LittleEndian.getLong(img.getChecksum()) == 3207965638L));
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
This PR is a complement for #13316
Includes to Presentation-Checker a new checksum of a PNG that makes LibreOffice crashes.

### Motivation

LibreOffice can't handle with a transparent pixel used in some PowerPoint templates.
This PR makes the Pres Checker identify this pixel and avoid BBB to try to convert that presentations to PDF.