### PR TITLE
change leave meeting color

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -259,6 +259,7 @@ class SettingsDropdown extends PureComponent {
           icon: 'logout',
           label: intl.formatMessage(intlMessages.leaveSessionLabel),
           // description: intl.formatMessage(intlMessages.leaveSessionDesc),
+          className: styles.leaveMeetingButton,
           onClick: () => this.leaveSession(),
         },
       );

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/styles.scss
@@ -140,3 +140,7 @@
     display: none;
   }
 }
+
+.leaveMeetingButton {
+  color: var(--color-danger) !important;
+}


### PR DESCRIPTION
### What does this PR do?

Changes the color of the Leave Meeting action in options dropdown.

#### before
![Screenshot from 2021-09-29 16-46-55](https://user-images.githubusercontent.com/3728706/135338167-99ccf174-7058-4181-bd29-3b4df5493161.png)

#### after
![Screenshot from 2021-09-29 16-42-27](https://user-images.githubusercontent.com/3728706/135338116-6f0eeb86-0807-4568-936a-0a14a4e7751e.png)
