### PR TITLE
build: Remove node-sass rebuild (not needed for node 14)

### DIFF
--- a/build/packages-template/bbb-html5/build.sh
+++ b/build/packages-template/bbb-html5/build.sh
@@ -37,11 +37,11 @@ mkdir -p /tmp/html5-build
 
 # build the HTML5 client
 meteor npm install --production
-npm rebuild node-sass
+
 METEOR_DISABLE_OPTIMISTIC_CACHING=1 meteor build /tmp/html5-build --architecture os.linux.x86_64 --allow-superuser
 
 # extract, install the npm dependencies, then copy to staging
-tar xvfz /tmp/html5-build/bbb-html5_${VERSION}_${DISTRO}.tar.gz -C /tmp/html5-build/
+tar xfz /tmp/html5-build/bbb-html5_${VERSION}_${DISTRO}.tar.gz -C /tmp/html5-build/
 cd /tmp/html5-build/bundle/programs/server/
 npm i --production
 cd -


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Removes node-sass rebuild (used to be needed for node 12 build but now we use node 14)
Also removed the `verbose` flag for the `tar` command, so that build logs are < 5000 lines again
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
The build of bbb-html5 on branch 'develop' is not completing and on some environments I can't scroll to the bottom to see why
<!-- What inspired you to submit this pull request? -->

