### PR TITLE
chore(webrtc): let the server generate subscriber offers by default (backports #13254)

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -210,7 +210,7 @@ public:
     screenshare:
       # Experimental. True is the canonical behavior. Flip to false to reverse
       # the negotiation flow for subscribers.
-      subscriberOffering: true
+      subscriberOffering: false
       # Experimental. Server wide configuration to choose which bbb-webrtc-sfu
       # media server adapter should be used for screen sharing.
       # Default is undefined, which means the default setting in bbb-webrtc-sfu
@@ -476,7 +476,7 @@ public:
     listenOnlyCallTimeout: 25000
     # Experimental. True is the canonical behavior. Flip to false to reverse
     # the negotiation flow for LO subscribers.
-    listenOnlyOffering: true
+    listenOnlyOffering: false
     #Timeout (ms) for gathering ICE candidates. When this timeout expires
     #the SDP is sent to the server with the candidates the browser gathered
     #so far. Increasing this value might help avoiding 1004 error when


### PR DESCRIPTION
### What does this PR do?

This is a backport of #13254 to v2.4.x-release.

> 
> This is a follow up to https://github.com/bigbluebutton/bigbluebutton/pull/12983.
> 
> Webcams already did that by default. Screen sharing and listen only were generating offers in the client, though.
> 
> After further testing I'm toggling the defaults for screen sharing/listen only as well.

### Closes Issue(s)

None

### Motivation

> Refer to #12983