### PR TITLE
build: Specify meteor version before building

### DIFF
--- a/build/packages-template/bbb-html5/build.sh
+++ b/build/packages-template/bbb-html5/build.sh
@@ -35,8 +35,13 @@ mkdir -p staging/usr/share/meteor
 rm -rf /tmp/html5-build
 mkdir -p /tmp/html5-build
 
+meteor npm -v
+meteor node -v
+cat .meteor/release
+meteor update --allow-superuser --release 2.3.6
+
 # build the HTML5 client
-meteor npm install --production
+meteor npm ci --production
 
 METEOR_DISABLE_OPTIMISTIC_CACHING=1 meteor build /tmp/html5-build --architecture os.linux.x86_64 --allow-superuser
 


### PR DESCRIPTION
### What does this PR do?
This resolves an issue where we were building the npm dependencies against Meteor matching Node 12 but were trying to install locally for Node 14.

An additional change to consider could be to include the correct Meteor version in the Dockerfile for BBB but that may mean different images per BBB version.

I also leave here some simple outputs for node, npm and meteor versions, to hopefully allow us to catch such discrepancies more easily in the future

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
Get bbb-html5 building on branch 'develop'. Follow up from #13332 
<!-- What inspired you to submit this pull request? -->


