### PR TITLE
Fix broken apt cache when installing libreoffice

### DIFF
--- a/bbb-libreoffice/docker/Dockerfile
+++ b/bbb-libreoffice/docker/Dockerfile
@@ -6,8 +6,6 @@ ENV DEBIAN_FRONTEND noninteractive
 #Required to install Libreoffice 7
 RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
 
-RUN apt update
-
-RUN apt -y install locales-all fontconfig libxt6 libxrender1 
-RUN apt install -y -t buster-backports libreoffice
+RUN apt update && apt -y install locales-all fontconfig libxt6 libxrender1
+RUN apt update && apt -y install -t buster-backports libreoffice
 


### PR DESCRIPTION
Forces an `apt update` before `apt install`.

It fixes the following error:
```
...
#
# Building bbb-libreoffice docker image
#
Sending build context to Docker daemon  2.048kB
Step 1/6 : FROM openjdk:11-jre
 ---> 57108072ce35
Step 2/6 : ENV DEBIAN_FRONTEND noninteractive
 ---> Using cache
 ---> 14ebdd7614cb
Step 3/6 : RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
 ---> Using cache
 ---> 82aea50fc615
Step 4/6 : RUN apt update
 ---> Using cache
 ---> 29c8a3bbdc48
Step 5/6 : RUN apt -y install locales-all fontconfig libxt6 libxrender1
 ---> Using cache
 ---> 420ef45b377d
Step 6/6 : RUN apt install -y -t buster-backports libreoffice
 ---> Running in 5dd64a7d4b03
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:
The following packages have unmet dependencies:
 libreoffice : Depends: libreoffice-core (= 1:7.0.4~rc2-1~bpo10+2) but it is not installable
               Depends: libreoffice-writer but it is not installable
               Depends: python3-uno (>= 4.4.0~beta2) but it is not installable
               Recommends: libreoffice-nlpsolver but it is not installable
               Recommends: libreoffice-report-builder but it is not installable
               Recommends: libreoffice-script-provider-bsh but it is not installable
               Recommends: libreoffice-script-provider-js but it is not installable
               Recommends: libreoffice-script-provider-python but it is not installable
               Recommends: libreoffice-sdbc-mysql but it is not installable
               Recommends: libreoffice-sdbc-postgresql but it is not installable
               Recommends: libreoffice-wiki-publisher but it is not installable
 libreoffice-base : Depends: libreoffice-core (= 1:7.0.4~rc2-1~bpo10+2) but it is not installable
                    Recommends: libreoffice-writer but it is not installable
                    Recommends: default-jre (>= 2:1.8) but it is not installable or
                                java8-runtime or
                                jre but it is not installable
 libreoffice-base-core : Depends: libreoffice-core-nogui (= 1:7.0.4~rc2-1~bpo10+2) but it is not installable or
                                  libreoffice-core (= 1:7.0.4~rc2-1~bpo10+2) but it is not installable
                         Depends: libboost-date-time1.67.0 but it is not installable
 libreoffice-base-drivers : Depends: libreoffice-core-nogui but it is not installable or
                                     libreoffice-core but it is not installable
                            Recommends: libreoffice-sdbc-hsqldb but it is not installable
                            Recommends: libreoffice-sdbc-firebird but it is not installable
 libreoffice-calc : Depends: libreoffice-core (= 1:7.0.4~rc2-1~bpo10+2) but it is not installable
                    Depends: libboost-filesystem1.67.0 but it is not installable
                    Depends: libboost-iostreams1.67.0 but it is not installable
                    Depends: libboost-system1.67.0 but it is not installable
                    Depends: libicu63 (>= 63.1-1~) but it is not installable
 libreoffice-draw : Depends: libreoffice-core (= 1:7.0.4~rc2-1~bpo10+2) but it is not installable
                    Depends: libicu63 (>= 63.1-1~) but it is not installable
 libreoffice-impress : Depends: libreoffice-core (= 1:7.0.4~rc2-1~bpo10+2) but it is not installable
 libreoffice-math : Depends: libreoffice-core (= 1:7.0.4~rc2-1~bpo10+2) but it is not installable
 libreoffice-report-builder-bin : Depends: libreoffice-core but it is not installable
 ure : Depends: libicu63 (>= 63.1-1~) but it is not installable
E: Unable to correct problems, you have held broken packages.
The command '/bin/sh -c apt install -y -t buster-backports libreoffice' returned a non-zero code: 100
dpkg: error processing package bbb-libreoffice-docker (--configure):
 installed bbb-libreoffice-docker package post-installation script subprocess returned error exit status 100
dpkg: dependency problems prevent configuration of bbb-web:
 bbb-web depends on bbb-libreoffice-docker; however:
  Package bbb-libreoffice-docker is not configured yet.
dpkg: error processing package bbb-web (--configure):
 dependency problems - leaving unconfigured
dpkg: dependency problems prevent configuration of bbb-html5:
 bbb-html5 depends on bbb-web; however:
  Package bbb-web is not configured yet.
dpkg: error processing package bbb-html5 (--configure):
 dependency problems - leaving unconfigured
dpkg: dependency problems prevent configuration of bbb-config:
 bbb-config depends on bbb-html5; however:
  Package bbb-html5 is not configured yet.
dpkg: error processing package bbb-config (--configure):
 dependency problems - leaving unconfigured
dpkg: dependency problems prevent configuration of bigbluebutton:
 bigbluebutton depends on bbb-config; however:
  Package bbb-config is not configured yet.
dpkg: error processing package bigbluebutton (--configure):
 dependency problemsNo apport report written because the error message indicates its a followup error from a previous failure.
                                                                                                                              No apport report written because the error message indicates its a followup error from a previous failure.
                                                                                                                                                                                                                                        No apport report written because MaxReports is reached already
                   No apport report written because MaxReports is reached already
                                                                                  - leaving unconfigured
Errors were encountered while processing:
 bbb-libreoffice-docker
 bbb-web
 bbb-html5
 bbb-config
 bigbluebutton
E: Sub-process /usr/bin/dpkg returned an error code (1)

```