### PR TITLE
fix: Revert #13341 in favor of #13371

### DIFF
--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -592,7 +592,6 @@
     "app.guest.guestWait": "Please wait for a moderator to approve you joining the meeting.",
     "app.guest.guestDeny": "Guest denied of joining the meeting.",
     "app.guest.seatWait": "Guest waiting for a seat in the meeting.",
-    "app.guest.validationError": "Meeting is not running. You are being redirected.",
     "app.guest.allow": "Guest approved and redirecting to meeting.",
     "app.userList.guest.waitingUsers": "Waiting Users",
     "app.userList.guest.waitingUsersTitle": "User Management",


### PR DESCRIPTION
### What does this PR do?
As I already suspected in #13317 the root cause for #13312 seems to be a wrong return message of the API, not a missing translation message as #13312 seems to be fixed by #13371 (I tested this, it now shows the corrent "Meeting ended" message, my added language string isn't needed anymore).

### Closes Issue(s)
Closes none, reverts wrong quick fix

### More
This should be merged after #13371 has been merged. It also should be reverted in `develop` as soon as #13371 is being merged into `develop` as well.

I'm not sure if this language key I added should be kept in case the API returns a validationError message. If so, it definitely should contain a different message.