### PR TITLE
Fix toolbar item vanish on 2.4

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
@@ -655,6 +655,8 @@ class WhiteboardToolbar extends Component {
           cy="50%"
           stroke="black"
           strokeWidth="1"
+          fill={colorSelected.value}
+          r={thicknessSelected.value}
         >
           <animate
             ref={(ref) => { this.thicknessListIconColor = ref; }}
@@ -739,7 +741,7 @@ class WhiteboardToolbar extends Component {
 
     return (
       <svg className={styles.customSvgIcon}>
-        <rect x="25%" y="25%" width="50%" height="50%" stroke="black" strokeWidth="1">
+        <rect x="25%" y="25%" width="50%" height="50%" stroke="black" strokeWidth="1" fill={colorSelected.value}>
           <animate
             ref={(ref) => { this.colorListIconColor = ref; }}
             attributeName="fill"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Set the "goal" value of the animated effect for thickness and color items of whiteboard toolbar, so that the SVG's animate tag functions properly.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #13380 


### Motivation

To fix the problem #13380 

### More
It seems the behaviour of SVG's animate tag has changed. I didn't find the document. I actually thought it's dependent only on browsers. Otherwise, did React has changed something?

Before this patch:
![toolbar2](https://user-images.githubusercontent.com/45039819/135736211-72527ad3-8eb1-48e3-8938-e7e03fb8d378.gif)

With this patch:
![toolbar1](https://user-images.githubusercontent.com/45039819/135736667-f1f4604b-eb18-4ceb-9186-1451566a9419.gif)


