### PR TITLE
fix(shared notes): avoid padId subscription

### DIFF
--- a/bigbluebutton-html5/imports/api/note/server/index.js
+++ b/bigbluebutton-html5/imports/api/note/server/index.js
@@ -1,2 +1,3 @@
 import './publishers';
+import './methods';
 import './eventHandlers';

--- a/bigbluebutton-html5/imports/api/note/server/methods.js
+++ b/bigbluebutton-html5/imports/api/note/server/methods.js
@@ -1,0 +1,6 @@
+import { Meteor } from 'meteor/meteor';
+import getNoteId from './methods/getNoteId';
+
+Meteor.methods({
+  getNoteId,
+});

--- a/bigbluebutton-html5/imports/api/note/server/methods/getNoteId.js
+++ b/bigbluebutton-html5/imports/api/note/server/methods/getNoteId.js
@@ -1,0 +1,66 @@
+import Note from '/imports/api/note';
+import Users from '/imports/api/users';
+import Meetings from '/imports/api/meetings';
+import { extractCredentials } from '/imports/api/common/server/helpers';
+
+const ROLE_VIEWER = Meteor.settings.public.user.role_viewer;
+
+const hasNoteAccess = (meetingId, userId) => {
+  const user = Users.findOne(
+    { meetingId, userId },
+    {
+      fields: {
+        role: 1,
+        locked: 1,
+      }
+    },
+  );
+
+  if (!user) return false;
+
+  if (user.role === ROLE_VIEWER && user.locked) {
+    const meeting = Meetings.findOne(
+      { meetingId },
+      { fields: { 'lockSettingsProps.disableNote': 1 }},
+    );
+
+    if (!meeting) return false;
+
+    const { lockSettingsProps } = meeting;
+    if (lockSettingsProps) {
+      if (lockSettingsProps.disableNote) return false;
+    } else {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+export default function getNoteId() {
+  try {
+    const { meetingId, requesterUserId } = extractCredentials(this.userId);
+
+    const note = Note.findOne(
+      { meetingId },
+      {
+        fields: {
+          noteId: 1,
+          readOnlyNoteId: 1,
+        }
+      },
+    );
+
+    if (note) {
+      if (hasNoteAccess(meetingId, requesterUserId)) {
+        return note.noteId;
+      } else {
+        return note.readOnlyNoteId;
+      }
+    }
+
+    return null;
+  } catch (err) {
+    return null;;
+  }
+}

--- a/bigbluebutton-html5/imports/api/note/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/note/server/publishers.js
@@ -15,7 +15,14 @@ function note() {
 
   Logger.info(`Publishing Note for ${meetingId} ${userId}`);
 
-  return Note.find({ meetingId });
+  const options = {
+    fields: {
+      noteId: 0,
+      readOnlyNoteId: 0,
+    },
+  };
+
+  return Note.find({ meetingId }, options);
 }
 
 function publish(...args) {

--- a/bigbluebutton-html5/imports/ui/components/note/service.js
+++ b/bigbluebutton-html5/imports/ui/components/note/service.js
@@ -1,22 +1,13 @@
 import Users from '/imports/api/users';
 import Meetings from '/imports/api/meetings';
 import Note from '/imports/api/note';
+import { makeCall } from '/imports/ui/services/api';
 import Auth from '/imports/ui/services/auth';
 import Settings from '/imports/ui/services/settings';
 import { Session } from 'meteor/session';
 
 const NOTE_CONFIG = Meteor.settings.public.note;
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
-
-const getNoteId = () => {
-  const note = Note.findOne({ meetingId: Auth.meetingID }, { fields: { noteId: 1 } });
-  return note ? note.noteId : '';
-};
-
-const getReadOnlyNoteId = () => {
-  const note = Note.findOne({ meetingId: Auth.meetingID }, { fields: { readOnlyNoteId: 1 } });
-  return note ? note.readOnlyNoteId : '';
-};
 
 const getLang = () => {
   const { locale } = Settings.application;
@@ -48,18 +39,16 @@ const isLocked = () => {
   return false;
 };
 
-const getReadOnlyURL = () => {
-  const readOnlyNoteId = getReadOnlyNoteId();
-  const params = getNoteParams();
-  const url = Auth.authenticateURL(`${NOTE_CONFIG.url}/p/${readOnlyNoteId}?${params}`);
-  return url;
-};
+const getNoteId = () => makeCall('getNoteId');
 
-const getNoteURL = () => {
-  const noteId = getNoteId();
-  const params = getNoteParams();
-  const url = Auth.authenticateURL(`${NOTE_CONFIG.url}/p/${noteId}?${params}`);
-  return url;
+const buildNoteURL = (noteId) => {
+  if (noteId) {
+    const params = getNoteParams();
+    const url = Auth.authenticateURL(`${NOTE_CONFIG.url}/p/${noteId}?${params}`);
+    return url;
+  }
+
+  return null;
 };
 
 const getRevs = () => {
@@ -74,7 +63,8 @@ const getLastRevs = () => {
   return lastRevs;
 };
 
-const setLastRevs = (revs) => {
+const setLastRevs = () => {
+  const revs = getRevs();
   const lastRevs = getLastRevs();
 
   if (revs !== 0 && revs > lastRevs) {
@@ -108,8 +98,8 @@ const toggleNotePanel = () => {
 };
 
 export default {
-  getNoteURL,
-  getReadOnlyURL,
+  getNoteId,
+  buildNoteURL,
   toggleNotePanel,
   isLocked,
   isEnabled,


### PR DESCRIPTION
Remove padIds from the shared notes MongoDB collection subscription.

Users now have to fetch the padId from Meteor when needed. Meteor is
responsible for checking the user's access level and return the
proper id.