### PR TITLE
chore(recording): track mediasoup raw media files locations

### DIFF
--- a/record-and-playback/core/scripts/archive/archive.rb
+++ b/record-and-playback/core/scripts/archive/archive.rb
@@ -177,6 +177,8 @@ presentation_dir = props['raw_presentation_src']
 video_dir = props['raw_video_src']
 kurento_video_dir = props['kurento_video_src']
 kurento_screenshare_dir = props['kurento_screenshare_src']
+mediasoup_video_dir = props['mediasoup_video_src']
+mediasoup_screenshare_dir = props['mediasoup_screenshare_src']
 log_dir = props['log_dir']
 notes_endpoint = props['notes_endpoint']
 notes_formats = props['notes_formats']
@@ -207,6 +209,9 @@ archive_directory("#{video_dir}/#{meeting_id}", "#{target_dir}/video/#{meeting_i
 # Kurento media
 archive_directory("#{kurento_screenshare_dir}/#{meeting_id}", "#{target_dir}/deskshare")
 archive_directory("#{kurento_video_dir}/#{meeting_id}", "#{target_dir}/video/#{meeting_id}")
+# mediasoup media
+archive_directory("#{mediasoup_screenshare_dir}/#{meeting_id}", "#{target_dir}/deskshare")
+archive_directory("#{mediasoup_video_dir}/#{meeting_id}", "#{target_dir}/video/#{meeting_id}")
 
 # If this was the last (or only) segment in a recording, delete the original media files
 if break_timestamp.nil?
@@ -221,6 +226,9 @@ if break_timestamp.nil?
   # Kurento media
   FileUtils.rm_rf("#{kurento_screenshare_dir}/#{meeting_id}")
   FileUtils.rm_rf("#{kurento_video_dir}/#{meeting_id}")
+  # mediasoup media
+  FileUtils.rm_rf("#{mediasoup_screenshare_dir}/#{meeting_id}")
+  FileUtils.rm_rf("#{mediasoup_video_dir}/#{meeting_id}")
 end
 
 if not archive_has_recording_marks?(meeting_id, raw_archive_dir, break_timestamp)

--- a/record-and-playback/core/scripts/bigbluebutton.yml
+++ b/record-and-playback/core/scripts/bigbluebutton.yml
@@ -3,6 +3,8 @@ raw_audio_src: /var/freeswitch/meetings
 raw_video_src: /usr/share/red5/webapps/video/streams
 kurento_video_src: /var/kurento/recordings
 kurento_screenshare_src: /var/kurento/screenshare
+mediasoup_video_src: /var/mediasoup/recordings
+mediasoup_screenshare_src: /var/mediasoup/screenshare
 raw_screenshare_src: /usr/share/red5/webapps/screenshare/streams
 raw_webrtc_deskshare_src: /usr/share/red5/webapps/video-broadcast/streams
 raw_deskshare_src: /var/bigbluebutton/deskshare


### PR DESCRIPTION
### What does this PR do?

Track the raw media files directory used by webrtc-sfu/mediasoup in the record-and-playback scripts.

### Closes Issue(s)

None (although related to #12894)

### Motivation

I was going to resort to some trickery to make mediasoup raw files end up in the
same directory as KMS to reduce changes, but it ended up being too dirty.

I am adding a third directory (/var/mediasoup) to be tracked by the rap scripts
which is where the new raw files end up in.

There are still changes in other places to be done (packaging, bbb-conf et al) to make
sure /var/mediasoup is up, owned by `bigbluebutton` and writable.
