### PR TITLE
Fix: toolbar item vanish (2.4)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
@@ -655,6 +655,8 @@ class WhiteboardToolbar extends Component {
           cy="50%"
           stroke="black"
           strokeWidth="1"
+          fill={colorSelected.value}
+          r={thicknessSelected.value}
         >
           <animate
             ref={(ref) => { this.thicknessListIconColor = ref; }}
@@ -739,7 +741,7 @@ class WhiteboardToolbar extends Component {
 
     return (
       <svg className={styles.customSvgIcon}>
-        <rect x="25%" y="25%" width="50%" height="50%" stroke="black" strokeWidth="1">
+        <rect x="25%" y="25%" width="50%" height="50%" stroke="black" strokeWidth="1" fill={colorSelected.value}>
           <animate
             ref={(ref) => { this.colorListIconColor = ref; }}
             attributeName="fill"


### PR DESCRIPTION
### What does this PR do?

PR #13381 port to 2.4

_Set the "goal" value of the animated effect for thickness and color items of whiteboard toolbar, so that the SVG's animate tag functions properly._