### PR TITLE
fix(closed captions): avoid padId subscription (2.4)

### DIFF
--- a/bigbluebutton-html5/imports/api/captions/server/methods.js
+++ b/bigbluebutton-html5/imports/api/captions/server/methods.js
@@ -1,8 +1,10 @@
 import { Meteor } from 'meteor/meteor';
 import takeOwnership from '/imports/api/captions/server/methods/takeOwnership';
 import appendText from '/imports/api/captions/server/methods/appendText';
+import getPadId from '/imports/api/captions/server/methods/getPadId';
 
 Meteor.methods({
   takeOwnership,
   appendText,
+  getPadId,
 });

--- a/bigbluebutton-html5/imports/api/captions/server/methods/getPadId.js
+++ b/bigbluebutton-html5/imports/api/captions/server/methods/getPadId.js
@@ -1,0 +1,49 @@
+import Captions from '/imports/api/captions';
+import Users from '/imports/api/users';
+import { extractCredentials } from '/imports/api/common/server/helpers';
+
+const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
+
+const hasPadAccess = (meetingId, userId) => {
+  const user = Users.findOne(
+    { meetingId, userId },
+    { fields: { role: 1 }},
+  );
+
+  if (!user) return false;
+
+  if (user.role === ROLE_MODERATOR) return true;
+
+  return false;
+};
+
+export default function getPadId(locale) {
+  try {
+    const { meetingId, requesterUserId } = extractCredentials(this.userId);
+
+    const caption = Captions.findOne(
+      { meetingId, locale },
+      {
+        fields: {
+          padId: 1,
+          ownerId: 1,
+          readOnlyPadId: 1,
+        }
+      },
+    );
+
+    if (caption) {
+      if (hasPadAccess(meetingId, requesterUserId)) {
+        if (requesterUserId === caption.ownerId) return caption.padId;
+
+        return caption.readOnlyPadId;
+      } else {
+        return null;
+      }
+    }
+
+    return null;
+  } catch (err) {
+    return null;;
+  }
+}

--- a/bigbluebutton-html5/imports/api/captions/server/methods/takeOwnership.js
+++ b/bigbluebutton-html5/imports/api/captions/server/methods/takeOwnership.js
@@ -2,7 +2,6 @@ import { check } from 'meteor/check';
 import Captions from '/imports/api/captions';
 import updateOwnerId from '/imports/api/captions/server/modifiers/updateOwnerId';
 import { extractCredentials } from '/imports/api/common/server/helpers';
-import { CAPTIONS_TOKEN } from '/imports/api/captions/server/helpers';
 import Logger from '/imports/startup/server/logger';
 
 export default function takeOwnership(locale) {
@@ -10,12 +9,10 @@ export default function takeOwnership(locale) {
     const { meetingId, requesterUserId } = extractCredentials(this.userId);
 
     check(locale, String);
+    check(meetingId, String);
+    check(requesterUserId, String);
 
-    const pad = Captions.findOne({ meetingId, padId: { $regex: `${CAPTIONS_TOKEN}${locale}$` } });
-
-    if (pad) {
-      updateOwnerId(meetingId, requesterUserId, pad.padId);
-    }
+    updateOwnerId(meetingId, requesterUserId, locale);
   } catch (err) {
     Logger.error(`Exception while invoking method takeOwnership ${err.stack}`);
   }

--- a/bigbluebutton-html5/imports/api/captions/server/methods/updateOwner.js
+++ b/bigbluebutton-html5/imports/api/captions/server/methods/updateOwner.js
@@ -4,7 +4,7 @@ import Logger from '/imports/startup/server/logger';
 import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 
-export default function updateOwner(meetingId, userId, padId) { // TODO
+export default function updateOwner(meetingId, userId, locale) {
   const REDIS_CONFIG = Meteor.settings.private.redis;
   const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
   const EVENT_NAME = 'UpdateCaptionOwnerPubMsg';
@@ -12,23 +12,19 @@ export default function updateOwner(meetingId, userId, padId) { // TODO
   try {
     check(meetingId, String);
     check(userId, String);
-    check(padId, String);
+    check(locale, String);
 
-    const pad = Captions.findOne({ meetingId, padId });
+    const pad = Captions.findOne({ meetingId, locale });
 
     if (!pad) {
       Logger.error(`Editing captions owner: ${padId}`);
       return;
     }
 
-    const { locale } = pad;
-
-    check(locale, { locale: String, name: String });
-
     const payload = {
       ownerId: userId,
-      locale: locale.name,
-      localeCode: locale.locale,
+      locale: pad.name,
+      localeCode: pad.locale,
     };
 
     RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, userId, payload);

--- a/bigbluebutton-html5/imports/api/captions/server/modifiers/addCaption.js
+++ b/bigbluebutton-html5/imports/api/captions/server/modifiers/addCaption.js
@@ -18,7 +18,8 @@ export default function addCaption(meetingId, padId, locale) {
   const modifier = {
     meetingId,
     padId,
-    locale,
+    locale: locale.locale,
+    name: locale.name,
     ownerId: '',
     readOnlyPadId: '',
     data: '',

--- a/bigbluebutton-html5/imports/api/captions/server/modifiers/updateOwnerId.js
+++ b/bigbluebutton-html5/imports/api/captions/server/modifiers/updateOwnerId.js
@@ -3,14 +3,14 @@ import Logger from '/imports/startup/server/logger';
 import updateOwner from '/imports/api/captions/server/methods/updateOwner';
 import { check } from 'meteor/check';
 
-export default function updateOwnerId(meetingId, userId, padId) {
+export default function updateOwnerId(meetingId, userId, locale) {
   check(meetingId, String);
   check(userId, String);
-  check(padId, String);
+  check(locale, String);
 
   const selector = {
     meetingId,
-    padId,
+    locale,
   };
 
   const modifier = {
@@ -23,8 +23,8 @@ export default function updateOwnerId(meetingId, userId, padId) {
     const numberAffected = Captions.update(selector, modifier, { multi: true });
 
     if (numberAffected) {
-      updateOwner(meetingId, userId, padId);
-      Logger.verbose('Captions: updated caption', { padId, ownerId: userId });
+      updateOwner(meetingId, userId, locale);
+      Logger.verbose('Captions: updated caption', { locale, ownerId: userId });
     }
   } catch (err) {
     Logger.error('Captions: error while updating pad', { err });

--- a/bigbluebutton-html5/imports/api/captions/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/captions/server/publishers.js
@@ -14,7 +14,14 @@ function captions() {
   const { meetingId, userId } = tokenValidation;
   Logger.debug('Publishing Captions', { meetingId, requestedBy: userId });
 
-  return Captions.find({ meetingId });
+  const options = {
+    fields: {
+      padId: 0,
+      readOnlyPadId: 0,
+    },
+  };
+
+  return Captions.find({ meetingId }, options);
 }
 
 function publish(...args) {

--- a/bigbluebutton-html5/imports/ui/components/captions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/component.jsx
@@ -23,11 +23,11 @@ class Captions extends React.Component {
 
   shouldComponentUpdate(nextProps, nextState) {
     const {
-      padId,
+      locale,
       revs,
     } = this.props;
 
-    if (padId === nextProps.padId) {
+    if (locale === nextProps.locale) {
       if (revs === nextProps.revs && !nextState.clear) return false;
     }
     return true;
@@ -124,7 +124,7 @@ class Captions extends React.Component {
 export default Captions;
 
 Captions.propTypes = {
-  padId: PropTypes.string.isRequired,
+  locale: PropTypes.string.isRequired,
   revs: PropTypes.number.isRequired,
   data: PropTypes.string.isRequired,
 };

--- a/bigbluebutton-html5/imports/ui/components/captions/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/container.jsx
@@ -9,13 +9,13 @@ const CaptionsContainer = props => (
 
 export default withTracker(() => {
   const {
-    padId,
+    locale,
     revs,
     data,
   } = CaptionsService.getCaptionsData();
 
   return {
-    padId,
+    locale,
     revs,
     data,
   };

--- a/bigbluebutton-html5/imports/ui/components/captions/pad/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/pad/component.jsx
@@ -58,8 +58,6 @@ const propTypes = {
   locale: PropTypes.string.isRequired,
   ownerId: PropTypes.string.isRequired,
   currentUserId: PropTypes.string.isRequired,
-  padId: PropTypes.string.isRequired,
-  readOnlyPadId: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired,
@@ -85,6 +83,7 @@ class Pad extends PureComponent {
 
     this.state = {
       listening: false,
+      url: null,
     };
 
     const { locale, intl } = props;
@@ -104,7 +103,13 @@ class Pad extends PureComponent {
     }
   }
 
-  componentDidUpdate() {
+  componentDidMount() {
+    const { locale } = this.props;
+
+    this.updatePadURL(locale);
+  }
+
+  componentDidUpdate(prevProps) {
     const {
       locale,
       ownerId,
@@ -122,6 +127,16 @@ class Pad extends PureComponent {
       }
       this.recognition.lang = locale;
     }
+
+    if (prevProps.ownerId !== ownerId || prevProps.locale !== locale) {
+      this.updatePadURL(locale);
+    }
+  }
+
+  updatePadURL(locale) {
+    PadService.getPadId(locale).then(response => {
+      this.setState({ url: PadService.buildPadURL(response) });
+    });
   }
 
   handleListen() {
@@ -212,16 +227,16 @@ class Pad extends PureComponent {
     const {
       locale,
       intl,
-      padId,
-      readOnlyPadId,
       ownerId,
       name,
       layoutContextDispatch,
       isResizing,
     } = this.props;
 
-    const { listening } = this.state;
-    const url = PadService.getPadURL(padId, readOnlyPadId, ownerId);
+    const {
+      listening,
+      url,
+    } = this.state;
 
     return (
       <div className={styles.pad}>

--- a/bigbluebutton-html5/imports/ui/components/captions/pad/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/pad/container.jsx
@@ -42,19 +42,14 @@ export default withTracker(() => {
   const locale = Session.get('captionsLocale');
   const caption = CaptionsService.getCaptions(locale);
   const {
-    padId,
+    name,
     ownerId,
-    readOnlyPadId,
   } = caption;
-
-  const { name } = caption ? caption.locale : '';
 
   return {
     locale,
     name,
     ownerId,
-    padId,
-    readOnlyPadId,
     currentUserId: Auth.userID,
     amIModerator: CaptionsService.amIModerator(),
   };

--- a/bigbluebutton-html5/imports/ui/components/captions/pad/service.js
+++ b/bigbluebutton-html5/imports/ui/components/captions/pad/service.js
@@ -1,4 +1,5 @@
 import Auth from '/imports/ui/services/auth';
+import { makeCall } from '/imports/ui/services/api';
 import Settings from '/imports/ui/services/settings';
 
 const NOTE_CONFIG = Meteor.settings.public.note;
@@ -21,18 +22,19 @@ const getPadParams = () => {
   return params.join('&');
 };
 
-const getPadURL = (padId, readOnlyPadId, ownerId) => {
-  const userId = Auth.userID;
-  const params = getPadParams();
-  let url;
-  if (!ownerId || userId === ownerId) {
-    url = Auth.authenticateURL(`${NOTE_CONFIG.url}/p/${padId}?${params}`);
-  } else {
-    url = Auth.authenticateURL(`${NOTE_CONFIG.url}/p/${readOnlyPadId}?${params}`);
+const getPadId = (locale) => makeCall('getPadId', locale);
+
+const buildPadURL = (padId) => {
+  if (padId) {
+    const params = getPadParams();
+    const url = Auth.authenticateURL(`${NOTE_CONFIG.url}/p/${padId}?${params}`);
+    return url;
   }
-  return url;
+
+  return null;;
 };
 
 export default {
-  getPadURL,
+  getPadId,
+  buildPadURL,
 };

--- a/bigbluebutton-html5/imports/ui/components/captions/service.js
+++ b/bigbluebutton-html5/imports/ui/components/captions/service.js
@@ -19,24 +19,24 @@ const getActiveCaptions = () => {
 
 const getCaptions = locale => Captions.findOne({
   meetingId: Auth.meetingID,
-  padId: { $regex: `${CAPTIONS_TOKEN}${locale}$` },
+  locale,
 });
 
 const getCaptionsData = () => {
   const activeCaptions = getActiveCaptions();
-  let padId = '';
+  let locale = '';
   let revs = 0;
   let data = '';
   if (activeCaptions) {
     const captions = getCaptions(activeCaptions);
     if (!_.isEmpty(captions)) {
-      padId = captions.padId; // eslint-disable-line prefer-destructuring
+      locale = activeCaptions;
       revs = captions.revs; // eslint-disable-line prefer-destructuring
       data = captions.data; // eslint-disable-line prefer-destructuring
     }
   }
 
-  return { padId, revs, data };
+  return { locale, revs, data };
 };
 
 const getAvailableLocales = () => {
@@ -44,10 +44,13 @@ const getAvailableLocales = () => {
   const locales = [];
   Captions.find({ meetingId: meetingID },
     { sort: { locale: 1 } },
-    { fields: { ownerId: 1, locale: 1 } })
+    { fields: { ownerId: 1, locale: 1, name: 1 } })
     .forEach((caption) => {
       if (caption.ownerId === '') {
-        locales.push(caption.locale);
+        locales.push({
+          locale: caption.locale,
+          name: caption.name,
+        });
       }
     });
   return locales;
@@ -56,10 +59,14 @@ const getAvailableLocales = () => {
 const getOwnedLocales = () => {
   const { meetingID } = Auth;
   const locales = [];
-  Captions.find({ meetingId: meetingID }, { fields: { ownerId: 1, locale: 1 } })
+  Captions.find({ meetingId: meetingID },
+    { fields: { ownerId: 1, locale: 1, name: 1 } })
     .forEach((caption) => {
       if (caption.ownerId !== '') {
-        locales.push(caption.locale);
+        locales.push({
+          locale: caption.locale,
+          name: caption.name,
+        });
       }
     });
   return locales;


### PR DESCRIPTION
### What does this PR do?

PR #13396 port to 2.4

_Remove padIds from the closed captions MongoDB collection subscription._

_Users now have to fetch the padId from Meteor when needed. Meteor is
responsible for checking the user's access level and return the
proper id._