### PR TITLE
Create custom cursor for current poll and user

### DIFF
--- a/bigbluebutton-html5/imports/api/polls/index.js
+++ b/bigbluebutton-html5/imports/api/polls/index.js
@@ -1,6 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 
 const Polls = new Mongo.Collection('polls');
+export const CurrentPoll = new Mongo.Collection('current-poll');
 
 if (Meteor.isServer) {
   // We can have just one active poll per meeting

--- a/bigbluebutton-html5/imports/api/polls/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/polls/server/publishers.js
@@ -14,11 +14,11 @@ function currentPoll(secretPoll) {
   });
 
   if (
-    !tokenValidation ||
-    tokenValidation.validationStatus !== ValidationStates.VALIDATED
+    !tokenValidation
+    || tokenValidation.validationStatus !== ValidationStates.VALIDATED
   ) {
     Logger.warn(
-      `Publishing Polls was requested by unauth connection ${this.connection.id}`
+      `Publishing Polls was requested by unauth connection ${this.connection.id}`,
     );
     return Polls.find({ meetingId: '' });
   }
@@ -41,15 +41,16 @@ function currentPoll(secretPoll) {
     if ((hasPoll && hasPoll.secretPoll) || secretPoll) {
       options.fields.responses = 0;
     }
-
-    return Polls.find(selector, options);
+    Mongo.Collection._publishCursor(Polls.find(selector, options), this, 'current-poll');
+    return this.ready();
   }
 
   Logger.warn(
     'Publishing current-poll was requested by non-moderator connection',
     { meetingId, userId, connectionId: this.connection.id },
   );
-  return Polls.find({ meetingId: '' });
+  Mongo.Collection._publishCursor(Polls.find({ meetingId: '' }), this, 'current-poll');
+  return this.ready();
 }
 
 function publishCurrentPoll(...args) {
@@ -65,11 +66,11 @@ function polls() {
   });
 
   if (
-    !tokenValidation ||
-    tokenValidation.validationStatus !== ValidationStates.VALIDATED
+    !tokenValidation
+    || tokenValidation.validationStatus !== ValidationStates.VALIDATED
   ) {
     Logger.warn(
-      `Publishing Polls was requested by unauth connection ${this.connection.id}`
+      `Publishing Polls was requested by unauth connection ${this.connection.id}`,
     );
     return Polls.find({ meetingId: '' });
   }

--- a/bigbluebutton-html5/imports/api/users/index.js
+++ b/bigbluebutton-html5/imports/api/users/index.js
@@ -1,6 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 
 const Users = new Mongo.Collection('users');
+export const CurrentUser = new Mongo.Collection('current-user');
 
 if (Meteor.isServer) {
   // types of queries for the users:

--- a/bigbluebutton-html5/imports/api/users/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/users/server/publishers.js
@@ -9,7 +9,8 @@ const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 
 function currentUser() {
   if (!this.userId) {
-    return Users.find({ meetingId: '' });
+    Mongo.Collection._publishCursor(Users.find({ meetingId: '' }), this, 'current-user');
+    return this.ready();
   }
   const { meetingId, requesterUserId } = extractCredentials(this.userId);
 
@@ -28,8 +29,8 @@ function currentUser() {
       authToken: false, // Not asking for authToken from client side but also not exposing it
     },
   };
-
-  return Users.find(selector, options);
+  Mongo.Collection._publishCursor(Users.find(selector, options), this, 'current-user');
+  return this.ready();
 }
 
 function publishCurrentUser(...args) {
@@ -39,7 +40,7 @@ function publishCurrentUser(...args) {
 
 Meteor.publish('current-user', publishCurrentUser);
 
-function users(role) {
+function users() {
   const tokenValidation = AuthTokenValidation.findOne({ connectionId: this.connection.id });
 
   if (!tokenValidation || tokenValidation.validationStatus !== ValidationStates.VALIDATED) {

--- a/bigbluebutton-html5/imports/ui/components/components-data/users-context/adapter.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/users-context/adapter.jsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect } from 'react';
-import Users from '/imports/api/users';
+import Users, { CurrentUser } from '/imports/api/users';
 import UsersPersistentData from '/imports/api/users-persistent-data';
 import { UsersContext, ACTIONS } from './context';
 import ChatLogger from '/imports/ui/components/chat/chat-logger/ChatLogger';
@@ -8,11 +8,11 @@ const Adapter = () => {
   const usingUsersContext = useContext(UsersContext);
   const { dispatch } = usingUsersContext;
 
-  useEffect(()=> {
+  useEffect(() => {
     const usersPersistentDataCursor = UsersPersistentData.find({}, { sort: { timestamp: 1 } });
     usersPersistentDataCursor.observe({
       added: (obj) => {
-        ChatLogger.debug("usersAdapter::observe::added_persistent_user", obj);
+        ChatLogger.debug('usersAdapter::observe::added_persistent_user', obj);
         dispatch({
           type: ACTIONS.ADDED_USER_PERSISTENT_DATA,
           value: {
@@ -21,7 +21,7 @@ const Adapter = () => {
         });
       },
       changed: (obj) => {
-        ChatLogger.debug("usersAdapter::observe::changed_persistent_user", obj);
+        ChatLogger.debug('usersAdapter::observe::changed_persistent_user', obj);
         dispatch({
           type: ACTIONS.CHANGED_USER_PERSISTENT_DATA,
           value: {
@@ -29,15 +29,16 @@ const Adapter = () => {
           },
         });
       },
-      removed: (obj) => {},
+      removed: () => {},
     });
   }, []);
 
   useEffect(() => {
     const usersCursor = Users.find({}, { sort: { timestamp: 1 } });
+    const CurrentUserCursor = CurrentUser.find({});
     usersCursor.observe({
       added: (obj) => {
-        ChatLogger.debug("usersAdapter::observe::added", obj);
+        ChatLogger.debug('usersAdapter::observe::added', obj);
         dispatch({
           type: ACTIONS.ADDED,
           value: {
@@ -48,6 +49,18 @@ const Adapter = () => {
       changed: (obj) => {
         dispatch({
           type: ACTIONS.CHANGED,
+          value: {
+            user: obj,
+          },
+        });
+      },
+    });
+
+    CurrentUserCursor.observe({
+      added: (obj) => {
+        ChatLogger.debug('usersAdapter::observe::current-user::added', obj);
+        dispatch({
+          type: ACTIONS.ADDED,
           value: {
             user: obj,
           },

--- a/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
@@ -7,7 +7,7 @@ import { setCustomLogoUrl, setModeratorOnlyMessage } from '/imports/ui/component
 import { makeCall } from '/imports/ui/services/api';
 import logger from '/imports/startup/client/logger';
 import LoadingScreen from '/imports/ui/components/loading-screen/component';
-import Users from '/imports/api/users';
+import { CurrentUser } from '/imports/api/users';
 
 const propTypes = {
   children: PropTypes.element.isRequired,
@@ -162,7 +162,7 @@ class JoinHandler extends Component {
 
       return new Promise((resolve) => {
         if (customdata.length) {
-          makeCall('addUserSettings', customdata).then(r => resolve(r));
+          makeCall('addUserSettings', customdata).then((r) => resolve(r));
         }
         resolve(true);
       });
@@ -190,8 +190,8 @@ class JoinHandler extends Component {
       setModOnlyMessage(response);
 
       Tracker.autorun(async (cd) => {
-        const user = Users.findOne({ userId: Auth.userID, approved: true }, { fields: { _id: 1 } });
-
+        const user = CurrentUser
+          .findOne({ userId: Auth.userID, approved: true }, { fields: { _id: 1 } });
         if (user) {
           await setCustomData(response);
           cd.stop();

--- a/bigbluebutton-html5/imports/ui/components/poll/service.js
+++ b/bigbluebutton-html5/imports/ui/components/poll/service.js
@@ -1,6 +1,6 @@
 import Users from '/imports/api/users';
 import Auth from '/imports/ui/services/auth';
-import Polls from '/imports/api/polls';
+import { CurrentPoll } from '/imports/api/polls';
 import caseInsensitiveReducer from '/imports/utils/caseInsensitiveReducer';
 import { defineMessages } from 'react-intl';
 
@@ -217,7 +217,7 @@ export default {
     { fields: { presenter: 1 } },
   ).presenter,
   pollTypes,
-  currentPoll: () => Polls.findOne({ meetingId: Auth.meetingID }),
+  currentPoll: () => CurrentPoll.findOne({ meetingId: Auth.meetingID }),
   pollAnswerIds,
   POLL_AVATAR_COLOR,
   isDefaultPoll,


### PR DESCRIPTION
### What does this PR do?

This PR Creates a custom cursor for the `current-poll` and `current-user` to avoid the merge of information and handle the data separately

### Motivation

Make easy the use of the [`local-collections`](https://github.com/bigbluebutton/bigbluebutton/pull/13174/files#diff-08851df058fe549758f0be2caed9d522811e129e59c6943724e3f21acbd6b3deR1) and then smooth reconnection of the client.
