### PR TITLE
Shortcut key help: Enter key is currently disabled

### DIFF
--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -645,7 +645,7 @@
     "app.shortcut-help.openDebugWindow": "Open debug window",
     "app.shortcut-help.openStatus": "Open status menu",
     "app.shortcut-help.togglePan": "Activate Pan tool (Presenter)",
-    "app.shortcut-help.toggleFullscreen": "Toggle Full-screen (Presenter)",
+    "app.shortcut-help.toggleFullscreen": "Toggle Full-screen (Presenter) - currently disabled",
     "app.shortcut-help.nextSlideDesc": "Next slide (Presenter)",
     "app.shortcut-help.previousSlideDesc": "Previous slide (Presenter)",
     "app.lock-viewers.title": "Lock viewers",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

States that Enter key shortcut is currently disabled in the help window.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation

With #13074, enter key shortcut to toggle fullscreen is not working anymore. 

### More

Is this a temporary change? I would like to have this shortcut back in the following release. 
