### PR TITLE
refactor: Bbb-conf warn about sip.js if sipjsHackViaWs is null or undefined

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -1178,7 +1178,7 @@ check_state() {
         echo "#"
     fi
 
-    if [ "$(echo "$HTML5_CONFIG" | yq r - public.media.sipjsHackViaWs)" == "false" ]; then
+    if [ "$(echo "$HTML5_CONFIG" | yq r - public.media.sipjsHackViaWs)" != "true" ]; then
       if [ "$PROTOCOL" == "https" ]; then
         if ! cat $SIP_CONFIG |  grep -v '#' | grep proxy_pass | head -n 1 | grep -q https; then
           echo "# Warning: You have this server defined for https, but in"


### PR DESCRIPTION
`Bbb-conf --check` warns about sip.js only if `sipjsHackViaWs=false`. And not for `null` or `undefined` values.
Once bbb-html5 consider `null` and `undefined` as `false`, bbb-conf should warn in this cases too.

This PR makes a small change to consider `false`, `null` and `undefined` values in the condition to warn about sip.js.