### PR TITLE
refactor: Notify Screen Reader When Network Data Is Copied

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
@@ -9,7 +9,8 @@ import Service from '../service';
 import Modal from '/imports/ui/components/modal/simple/component';
 import { styles } from './styles';
 
-const NETWORK_MONITORING_INTERVAL_MS = 2000;
+const NETWORK_MONITORING_INTERVAL_MS = 2000; 
+const MIN_TIMEOUT = 3000;
 
 const intlMessages = defineMessages({
   ariaTitle: {
@@ -275,7 +276,7 @@ class ConnectionStatusComponent extends PureComponent {
 
     this.copyNetworkDataTimeout = setTimeout(() => {
       copyButton.innerHTML = intl.formatMessage(intlMessages.copy);
-    }, 1000);
+    }, MIN_TIMEOUT);
   }
 
   renderConnections() {
@@ -498,7 +499,7 @@ class ConnectionStatusComponent extends PureComponent {
 
     const { hasNetworkData } = this.state;
     return (
-      <div className={styles.copyContainer}>
+      <div aria-live="polite" className={styles.copyContainer}>
         <span
           className={cx(styles.copy, !hasNetworkData ? styles.disabled : '')}
           role="button"


### PR DESCRIPTION
### What does this PR do?
* increases the notification timer from `1s` to `3s` 
* add `aria-live` region to announce copied message in connection status to screen reader.

### Motivation

1) the previous timeout did not meet the `3s` minimum requirement.
2) Screen readers were not notified when the network details are copied.