### PR TITLE
refactor: Let bbb try to open BreakoutRoom automatically (when receive the URL asked by user)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
@@ -144,6 +144,7 @@ class BreakoutRoom extends PureComponent {
 
       if (!breakoutUrlData) return false;
       if (breakoutUrlData.redirectToHtml5JoinURL !== '') {
+        window.open(breakoutUrlData.redirectToHtml5JoinURL, '_blank');
         _.delay(() => this.setState({ generated: true, waiting: false }), 1000);
       }
     }


### PR DESCRIPTION
Fix #13354
Once #13363 reduced the time to generate Breakout URL.

**This PR does not change the current steps to open a Breakout Room. 
It only include a try to open the URL automatically.**

This "automatically opener" was removed to avoid problems with PopupBlocker of the browsers.
But after a lot of tests, the try to open automatically seems to worth:
- When the URL is opened automatically is very convenient for the users.
- When Popup is blocked, the warning is very unobtrusive and doesn't disturbs.
- Users can "allow popups to this site" and benefit of open automatically afterwards.

### Result of tests:
- In Chrome, the Breakout Room will most of times be opened automatically without problems.
- In Firefox, the user will usually have to manually click to "Join room" or add exception to "Allow this site".

### Example of tests:

- **Chrome** opening automatically! (99% of times)
![chrome-ok](https://user-images.githubusercontent.com/5660191/136429453-9fc27fcf-3edf-4983-a7ff-42fa39ad728f.gif)

- **Chrome** Popup blocked and user click manually "Join room"
![chrome-allow](https://user-images.githubusercontent.com/5660191/136429504-26904546-f06b-4e76-81a3-ea1a3f5ebef6.gif)

- **Chrome** Popup blocked and user "Allow this site" to open popups
![chrome-allow-popup](https://user-images.githubusercontent.com/5660191/136429512-1412edd3-24f2-4698-b2a8-528c898b6e0e.gif)

- **Firefox** Popup blocked and user click manually "Join room"
![firefox-join](https://user-images.githubusercontent.com/5660191/136429362-e1a4d733-5fd4-4aad-8f03-a3c143951c53.gif)

- **Firefox** Popup blocked and user "Allow this site" to open popups
![firefox-allow](https://user-images.githubusercontent.com/5660191/136429376-f3bf9e40-7604-4c93-a5fb-6e78554be7ea.gif)



