### PR TITLE
fix: public chat being cleared when starting a new private chat (2.3)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
@@ -69,7 +69,13 @@ export default withTracker(() => {
 
   if (currentUser) {
     subscriptionsHandlers.push(Meteor.subscribe('meetings', currentUser.role, subscriptionErrorHandler));
-    subscriptionsHandlers.push(Meteor.subscribe('users', currentUser.role, subscriptionErrorHandler));
+    subscriptionsHandlers.push(Meteor.subscribe('users', currentUser.role, {
+      ...subscriptionErrorHandler,
+      onStop: () => {
+        const event = new Event(EVENT_NAME);
+        window.dispatchEvent(event);
+      },
+    }));
     subscriptionsHandlers.push(Meteor.subscribe('breakouts', currentUser.role, subscriptionErrorHandler));
     subscriptionsHandlers.push(Meteor.subscribe('guestUser', currentUser.role, subscriptionErrorHandler));
   }
@@ -110,10 +116,6 @@ export default withTracker(() => {
 
     const subHandler = {
       ...subscriptionErrorHandler,
-      onStop: () => {
-        const event = new Event(EVENT_NAME);
-        window.dispatchEvent(event);
-      },
     };
 
     groupChatMessageHandler = Meteor.subscribe('group-chat-msg', chatIds, subHandler);


### PR DESCRIPTION
### What does this PR do?

This is a port of PR #13193 from 2.4 to 2.3.

_When a viewer was promoted to moderator, and after that the user starting a new private chat thae clear steam was called deleting the messages, now the clear stream messages is only called when the user changes the role keeping the messages when the new chat is created._