### PR TITLE
fix: poll vote percent calculation - live result

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
@@ -56,7 +56,7 @@ class LiveResult extends PureComponent {
     if (!currentPoll) return null;
 
     const {
-      answers, responses, users, numRespondents, pollType
+      answers, responses, users, numResponders, pollType
     } = currentPoll;
 
     const defaultPoll = isDefaultPoll(pollType);
@@ -105,7 +105,7 @@ class LiveResult extends PureComponent {
 
     answers.reduce(caseInsensitiveReducer, []).map((obj) => {
       const formattedMessageIndex = obj.key.toLowerCase();
-      const pct = Math.round(obj.numVotes / numRespondents * 100);
+      const pct = Math.round(obj.numVotes / numResponders * 100);
       const pctFotmatted = `${Number.isNaN(pct) ? 0 : pct}%`;
 
       const calculatedWidth = {


### PR DESCRIPTION
### What does this PR do?

Changes the way vote percent is calculated in poll live-result.

#### before
% of votes is based on total number of users able to vote (not on current votes)

<img width="345" alt="Screen Shot 2021-10-08 at 08 47 16" src="https://user-images.githubusercontent.com/3728706/136551595-3320d45e-4255-4d98-b125-3531999896bf.png">

#### after
% of votes is based on current votes

<img width="348" alt="Screen Shot 2021-10-08 at 08 46 52" src="https://user-images.githubusercontent.com/3728706/136551584-dc55e214-1125-44d7-812c-162bcb5d79d1.png">

### Closes Issue(s)
Closes #13430