### PR TITLE
fix: incomplete text in dropdown menus

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/menu/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/menu/styles.scss
@@ -7,9 +7,7 @@
   line-height: 1;
   margin-right: 1.65rem;
   margin-left: .5rem;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
+  white-space: normal;
   padding: .1rem 0;
 
   [dir="rtl"] & {


### PR DESCRIPTION
### What does this PR do?

Changes overflow styles for 2.4 dropdown menu. It will now break lines (same behavior as in 2.3).

#### before
![Screen Shot 2021-10-11 at 13 35 29](https://user-images.githubusercontent.com/3728706/136826798-d73316fa-6314-4eef-9f55-0286c49ff0c0.png)

#### after
![Screen Shot 2021-10-11 at 13 37 28](https://user-images.githubusercontent.com/3728706/136826800-8ac6ccae-f6ed-4d74-8138-e728d22e925e.png)

### Closes Issue(s)
Closes #13457