### PR TITLE
build: set mediasoup IPs in webrtc-sfu post install

### DIFF
--- a/build/packages-template/bbb-webrtc-sfu/after-install.sh
+++ b/build/packages-template/bbb-webrtc-sfu/after-install.sh
@@ -16,6 +16,10 @@ case "$1" in
       # https://github.com/bigbluebutton/bbb-webrtc-sfu/pull/37
       # yq w -i $TARGET kurento[0].url "ws://$SERVER_URL:8888/kurento"
 
+      # Set mediasoup IPs
+      yq w -i $TARGET mediasoup.webrtc.listenIps[0].announcedIp "$IP"
+      yq w -i $TARGET mediasoup.plainRtp.listenIp.announcedIp "$IP"
+
       FREESWITCH_IP=$(xmlstarlet sel -t -v '//X-PRE-PROCESS[@cmd="set" and starts-with(@data, "local_ip_v4=")]/@data' /opt/freeswitch/conf/vars.xml | sed 's/local_ip_v4=//g')
       if [ "$FREESWITCH_IP" != "" ]; then
         yq w -i $TARGET freeswitch.ip $FREESWITCH_IP


### PR DESCRIPTION
### What does this PR do?

Configures mediasoup IPs (as provided by the deb-helper script) in bbb-webrtc-sfu's post-install script.

### Closes Issue(s)

None

### Motivation

This should be a baseline step to get it working and it makes the post-install consistent with what it already does for KMS/FS in bbb-webrtc-sfu.

### Additional information

This might "fail" in a few scenarios: NAT servers, no dual stack support. Those are covered in the docs and the mediasoup equivalent steps should be amended there. The main intent here is just making things consistent.