### PR TITLE
refactor: Makes LearningDashboard data be provided by bbb-web (avoid demoted user to receive updates)

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
@@ -28,6 +28,14 @@ public class LearningDashboardService {
     private static Logger log = LoggerFactory.getLogger(LearningDashboardService.class);
     private static String learningDashboardFilesDir = "/var/bigbluebutton/learning-dashboard";
 
+    public File getJsonDataFile(String meetingId, String learningDashboardAccessToken) {
+        File baseDir = new File(this.getDestinationBaseDirectoryName(meetingId,learningDashboardAccessToken));
+        if (!baseDir.exists()) baseDir.mkdirs();
+
+        File jsonFile = new File(baseDir.getAbsolutePath() + File.separatorChar + "learning_dashboard_data.json");
+        return jsonFile;
+    }
+
     public void writeJsonDataFile(String meetingId, String learningDashboardAccessToken, String activityJson) {
 
         try {
@@ -36,10 +44,7 @@ public class LearningDashboardService {
                 return;
             }
 
-            File baseDir = new File(this.getDestinationBaseDirectoryName(meetingId,learningDashboardAccessToken));
-            if (!baseDir.exists()) baseDir.mkdirs();
-
-            File jsonFile = new File(baseDir.getAbsolutePath() + File.separatorChar + "learning_dashboard_data.json");
+            File jsonFile = this.getJsonDataFile(meetingId,learningDashboardAccessToken);
 
             FileOutputStream fileOutput = new FileOutputStream(jsonFile);
             fileOutput.write(activityJson.getBytes());

--- a/bigbluebutton-html5/imports/api/meetings/server/handlers/meetingEnd.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/handlers/meetingEnd.js
@@ -23,9 +23,18 @@ export default function handleMeetingEnd({ header, body }) {
     }
   };
 
-  Meetings.update({ meetingId },
-    { $set: { meetingEnded: true, meetingEndedBy: userId, meetingEndedReason: reason } },
-    (err, num) => { cb(err, num, 'Meeting'); });
+  Meetings.find({ meetingId }).forEach((doc) => {
+    Meetings.update({ meetingId },
+      {
+        $set: {
+          meetingEnded: true,
+          meetingEndedBy: userId,
+          meetingEndedReason: reason,
+          learningDashboardAccessToken: doc.password.learningDashboardAccessToken,
+        },
+      },
+      (err, num) => { cb(err, num, 'Meeting'); });
+  });
 
   Breakouts.update({ parentMeetingId: meetingId },
     { $set: { meetingEnded: true } },

--- a/bigbluebutton-html5/imports/api/meetings/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/publishers.js
@@ -43,10 +43,8 @@ function meetings(role) {
     },
   };
 
-  if (User.role === ROLE_MODERATOR) {
-    delete options.fields.password;
-    options.fields['password.viewerPass'] = false;
-    options.fields['password.moderatorPass'] = false;
+  if (User.role !== ROLE_MODERATOR) {
+    options.fields.learningDashboardAccessToken = false;
   }
 
   return Meetings.find(selector, options);

--- a/bigbluebutton-html5/imports/ui/components/learning-dashboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/learning-dashboard/service.js
@@ -20,23 +20,45 @@ const isModerator = () => {
   return false;
 };
 
-const getLearningDashboardAccessToken = () => ((
+const isLearningDashboardEnabled = () => (((
   Meetings.findOne(
     { meetingId: Auth.meetingID },
     {
-      fields: { 'password.learningDashboardAccessToken': 1 },
+      fields: { 'meetingProp.learningDashboardEnabled': 1 },
     },
-  ) || {}).password || {}).learningDashboardAccessToken || null;
+  ) || {}).meetingProp || {}).learningDashboardEnabled || false);
+
+const getLearningDashboardAccessToken = () => ((
+  Meetings.findOne(
+    { meetingId: Auth.meetingID, learningDashboardAccessToken: { $exists: true } },
+    {
+      fields: { learningDashboardAccessToken: 1 },
+    },
+  ) || {}).learningDashboardAccessToken || null);
+
+const setLearningDashboardCookie = () => {
+  const learningDashboardAccessToken = getLearningDashboardAccessToken();
+  if (learningDashboardAccessToken !== null) {
+    const cookieExpiresDate = new Date();
+    cookieExpiresDate.setTime(cookieExpiresDate.getTime() + (3600000 * 24 * 30)); // keep cookie 30d
+    document.cookie = `learningDashboardAccessToken-${Auth.meetingID}=${getLearningDashboardAccessToken()}; expires=${cookieExpiresDate.toGMTString()}; path=/`;
+    return true;
+  }
+  return false;
+};
 
 const openLearningDashboardUrl = (lang) => {
-  const cookieExpiresDate = new Date();
-  cookieExpiresDate.setTime(cookieExpiresDate.getTime() + (3600000 * 24 * 30)); // keep cookie 30d
-  document.cookie = `learningDashboardAccessToken-${Auth.meetingID}=${getLearningDashboardAccessToken()}; expires=${cookieExpiresDate.toGMTString()}; path=/`;
-  window.open(`/learning-dashboard/?meeting=${Auth.meetingID}&lang=${lang}`, '_blank');
+  if (getLearningDashboardAccessToken() && setLearningDashboardCookie()) {
+    window.open(`/learning-dashboard/?meeting=${Auth.meetingID}&lang=${lang}`, '_blank');
+  } else {
+    window.open(`/learning-dashboard/?meeting=${Auth.meetingID}&sessionToken=${Auth.sessionToken}&lang=${lang}`, '_blank');
+  }
 };
 
 export default {
   isModerator,
+  isLearningDashboardEnabled,
   getLearningDashboardAccessToken,
+  setLearningDashboardCookie,
   openLearningDashboardUrl,
 };

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
@@ -266,7 +266,9 @@ class MeetingEnded extends PureComponent {
               <div>
                 {
                   LearningDashboardService.isModerator()
-                  && LearningDashboardService.getLearningDashboardAccessToken() != null
+                  && LearningDashboardService.isLearningDashboardEnabled() === true
+                  // Always set cookie in case Dashboard is already opened
+                  && LearningDashboardService.setLearningDashboardCookie() === true
                     ? (
                       <div className={styles.text}>
                         <Button

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -214,7 +214,7 @@ class UserOptions extends PureComponent {
       hasBreakoutRoom,
       isBreakoutEnabled,
       getUsersNotAssigned,
-      learningDashboardAccessToken,
+      learningDashboardEnabled,
       openLearningDashboardUrl,
       amIModerator,
       users,
@@ -326,7 +326,7 @@ class UserOptions extends PureComponent {
         });
       }
       if (amIModerator) {
-        if (learningDashboardAccessToken != null) {
+        if (learningDashboardEnabled === true) {
           this.menuItems.push({
             icon: 'multi_whiteboard',
             iconRight: 'popout_window',
@@ -336,7 +336,7 @@ class UserOptions extends PureComponent {
             onClick: () => { openLearningDashboardUrl(locale); },
             dividerTop: true,
           });
-         }
+        }
       }
     }
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/container.jsx
@@ -92,7 +92,7 @@ const UserOptionsContainer = withTracker((props) => {
     guestPolicy: WaitingUsersService.getGuestPolicy(),
     isMeteorConnected: Meteor.status().connected,
     meetingName: getMeetingName(),
-    learningDashboardAccessToken: LearningDashboardService.getLearningDashboardAccessToken(),
+    learningDashboardEnabled: LearningDashboardService.isLearningDashboardEnabled(),
     openLearningDashboardUrl: LearningDashboardService.openLearningDashboardUrl,
     dynamicGuestPolicy,
   };

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -910,6 +910,8 @@
     "playback.player.video.wrapper.aria": "Video area",
     "app.learningDashboard.dashboardTitle": "Learning Dashboard",
     "app.learningDashboard.user": "User",
+    "app.learningDashboard.shareButton": "Share with others",
+    "app.learningDashboard.shareLinkCopied": "Link successfully copied",
     "app.learningDashboard.indicators.meetingStatusEnded": "Ended",
     "app.learningDashboard.indicators.meetingStatusActive": "Active",
     "app.learningDashboard.indicators.usersOnline": "Active Users",

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1056,6 +1056,120 @@ class ApiController {
     }
   }
 
+  /***********************************************
+   * LEARNING DASHBOARD DATA
+   ***********************************************/
+  def learningDashboard = {
+    String API_CALL = 'learningDashboard'
+    log.debug CONTROLLER_NAME + "#${API_CALL}"
+
+    String respMessage = ""
+    boolean reject = false
+
+    String sessionToken
+    UserSession us
+    Meeting meeting
+
+    String validationResponse = validateRequest(
+            ValidationService.ApiCall.ENTER,
+            request.getParameterMap(),
+            request.getQueryString(),
+    )
+
+    //Validate Session
+    if(!validationResponse.isEmpty()) {
+      respMessage = validationResponse
+      reject = true
+    } else {
+      sessionToken = sanitizeSessionToken(params.sessionToken)
+      if (!hasValidSession(sessionToken)) {
+        reject = true
+        respMessage = "Invalid Session"
+      }
+    }
+
+    //Validate User
+    if(reject == false) {
+      us = getUserSession(sessionToken)
+
+      if(us == null) {
+        reject = true;
+        respMessage = "Access denied"
+      } else if(!us.role.equals(ROLE_MODERATOR)) {
+        reject = true
+        respMessage = "Access denied"
+      }
+    }
+
+    //Validate Meeting
+    if(reject == false) {
+      meeting = meetingService.getMeeting(us.meetingID)
+      boolean isRunning = meeting != null && meeting.isRunning();
+      if(!isRunning) {
+        reject = true
+        respMessage = "Meeting not found"
+      }
+
+      if(meeting.getLearningDashboardEnabled() == false) {
+        reject = true
+        respMessage = "Learning Dashboard disabled for this meeting"
+      }
+    }
+
+    //Validate File
+    File jsonDataFile
+    if(reject == false) {
+      jsonDataFile = meetingService.learningDashboardService.getJsonDataFile(us.meetingID,meeting.getLearningDashboardAccessToken());
+      if (!jsonDataFile.exists()) {
+        reject = true
+        respMessage = "Learning Dashboard data not found"
+      }
+    }
+
+    if (reject) {
+      response.addHeader("Cache-Control", "no-cache")
+      withFormat {
+        json {
+          def builder = new JsonBuilder()
+          builder.response {
+            returncode RESP_CODE_FAILED
+            message respMessage
+            sessionToken
+          }
+          render(contentType: "application/json", text: builder.toPrettyString())
+        }
+      }
+    } else {
+      Map<String, Object> logData = new HashMap<String, Object>();
+      logData.put("meetingid", us.meetingID);
+      logData.put("extMeetingid", us.externMeetingID);
+      logData.put("name", us.fullname);
+      logData.put("userid", us.internalUserId);
+      logData.put("sessionToken", sessionToken);
+      logData.put("logCode", "learningDashboard");
+      logData.put("description", "Request Learning Dashboard data.");
+
+      Gson gson = new Gson();
+      String logStr = gson.toJson(logData);
+
+      log.info(" --analytics-- data=" + logStr);
+
+      response.addHeader("Cache-Control", "no-cache")
+
+      withFormat {
+        json {
+          def builder = new JsonBuilder()
+          builder.response {
+            returncode RESP_CODE_SUCCESS
+            data jsonDataFile.getText()
+            sessionToken
+          }
+          render(contentType: "application/json", text: builder.toPrettyString())
+        }
+      }
+    }
+  }
+
   def uploadDocuments(conf) { //
     log.debug("ApiController#uploadDocuments(${conf.getInternalId()})");
 

--- a/bigbluebutton-web/test/postman/invalid_session_token.postman_collection.json
+++ b/bigbluebutton-web/test/postman/invalid_session_token.postman_collection.json
@@ -151,6 +151,30 @@
 				}
 			},
 			"response": []
+		},
+		{
+			"name": "learningDashboard",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{base_url}}/{{path}}/learningDashboard?{{param_session_token}}=",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"{{path}}",
+						"learningDashboard"
+					],
+					"query": [
+						{
+							"key": "{{param_session_token}}",
+							"value": ""
+						}
+					]
+				}
+			},
+			"response": []
 		}
 	]
 }


### PR DESCRIPTION
This PR will avoid demoted user to receive updates for Dashboard.

![demote_user_dashboard](https://user-images.githubusercontent.com/5660191/137368778-91d7471f-4195-4ad5-824c-c495ee9b6820.gif)


### Details
In previous approach, LearningDashboard always requested data directly from `nginx` through the following URL:
`https://...../learning-dashboard/$meetingId/$learningDashboardAccessToken/learning_dashboard_data.json`

With the new approach, moderators will receive `$learningDashboardAccessToken` **ONLY** after the meeting is ended.
And before that, Dashboard will request data from `bbb-web` through the following URL:
`https://...../bigbluebutton/api/learningDashboard?sessionToken=26ht3i5f3uvqshem`

The advantage to let `bbb-web` provide the data is the requiring of user authentication.
Thus if some user be demoted from moderator throughout the meeting, `bbb-web` will identify and stop providing data to that user.

It is necessary to keep the old approach working too, since `bbb-web` can't authenticate users after meeting is ended. 
So after this point moderators will receive the token (via cookies) that allow them to request data directly from `nginx`.