### PR TITLE
fix: Learning Dashboard not setting RTL for some languages

### DIFF
--- a/bbb-learning-dashboard/src/index.js
+++ b/bbb-learning-dashboard/src/index.js
@@ -60,7 +60,7 @@ class Dashboard extends React.Component {
   setRtl() {
     const { intlLocale } = this.state;
 
-    if (RTL_LANGUAGES.includes(intlLocale)) {
+    if (RTL_LANGUAGES.includes(intlLocale.substring(0, 2))) {
       document.body.parentNode.setAttribute('dir', 'rtl');
     }
   }


### PR DESCRIPTION
This PR copy to Dashboard the same rule used in BBB Client to apply RTL direction.
https://github.com/bigbluebutton/bigbluebutton/blob/3b7b5fd72f8cd27647debe1a36ae25e66027b841/bigbluebutton-html5/imports/startup/client/intl.jsx#L139

In previous condition RTL was not being applied for some languages like `fa_IR`.
Thanks @Rahimimojtaba for report in: https://github.com/bigbluebutton/bigbluebutton/pull/13222#issuecomment-942285990