### PR TITLE
Fix: Api/learningDashboard validation error

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/request/LearningDashboard.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/request/LearningDashboard.java
@@ -1,0 +1,40 @@
+package org.bigbluebutton.api.model.request;
+
+import org.bigbluebutton.api.model.constraint.UserSessionConstraint;
+
+import javax.validation.constraints.NotNull;
+import java.util.Map;
+
+public class LearningDashboard implements Request<LearningDashboard.Params> {
+
+    public enum Params implements RequestParameters {
+        SESSION_TOKEN("sessionToken");
+
+        private final String value;
+
+        Params(String value) { this.value = value; }
+
+        public String getValue() { return value; }
+    }
+
+    @UserSessionConstraint
+    private String sessionToken;
+
+    public String getSessionToken() {
+        return sessionToken;
+    }
+
+    public void setSessionToken(String sessionToken) {
+        this.sessionToken = sessionToken;
+    }
+
+    @Override
+    public void populateFromParamsMap(Map<String, String[]> params) {
+        if(params.containsKey(LearningDashboard.Params.SESSION_TOKEN.getValue())) setSessionToken(params.get(LearningDashboard.Params.SESSION_TOKEN.getValue())[0]);
+    }
+
+    @Override
+    public void convertParamsFromString() {
+
+    }
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/ValidationService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/ValidationService.java
@@ -39,7 +39,8 @@ public class ValidationService {
         GUEST_WAIT("guestWait", RequestType.GET),
         ENTER("enter", RequestType.GET),
         STUNS("stuns", RequestType.GET),
-        SIGN_OUT("signOut", RequestType.GET);
+        SIGN_OUT("signOut", RequestType.GET),
+        LEARNING_DASHBOARD("learningDashboard", RequestType.GET);
 
         private final String name;
         private final RequestType requestType;
@@ -132,6 +133,9 @@ public class ValidationService {
                         break;
                     case SIGN_OUT:
                         request = new SignOut();
+                        break;
+                    case LEARNING_DASHBOARD:
+                        request = new LearningDashboard();
                         break;
                 }
             case POST:

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1071,7 +1071,7 @@ class ApiController {
     Meeting meeting
 
     Map.Entry<String, String> validationResponse = validateRequest(
-            ValidationService.ApiCall.ENTER,
+            ValidationService.ApiCall.LEARNING_DASHBOARD,
             request.getParameterMap(),
             request.getQueryString(),
     )


### PR DESCRIPTION
Fix session validation in API/learningDashboard.
This is necessary since #13371 changed validation error messages.