### PR TITLE
build: adjust bbb-html5.nginx to make sure nginx serves static assets

### DIFF
--- a/build/packages-template/bbb-html5/bionic/bbb-html5.nginx
+++ b/build/packages-template/bbb-html5/bionic/bbb-html5.nginx
@@ -1,3 +1,11 @@
+location @html5client {
+  # proxy_pass http://127.0.0.1:4100; # use for development
+  proxy_pass http://poolhtml5servers; # use for production
+  proxy_http_version 1.1;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection "Upgrade";
+}
+
 location /html5client/locales {
   alias /usr/share/meteor/bundle/programs/web.browser/app/locales;
 }
@@ -26,10 +34,7 @@ location /html5client/wasm {
   alias /usr/share/meteor/bundle/programs/web.browser/app/wasm;
 }
 
-location ~ ^/html5client/ {
-  # proxy_pass http://127.0.0.1:4100; # use for development
-  proxy_pass http://poolhtml5servers; # use for production
-  proxy_http_version 1.1;
-  proxy_set_header Upgrade $http_upgrade;
-  proxy_set_header Connection "Upgrade";
+location /html5client {
+  alias /usr/share/meteor/bundle/programs/web.browser;
+  try_files $uri @html5client;
 }


### PR DESCRIPTION
### What does this PR do?

Adjust bbb-html5.nginx to make sure nginx serves the client's static assets.

### Closes Issue(s)

None. I stumbled upon this.

### Motivation

Somewhere along the line since 2.3 the packaged bbb-html5.nginx regressed to a
state where the upstream for /html5client was Meteor itself, which means nginx
wasn't serving static assets as it was supposed to.