### PR TITLE
Fix: Learning Dashboard eslint no-alert problem

### DIFF
--- a/bbb-learning-dashboard/src/App.js
+++ b/bbb-learning-dashboard/src/App.js
@@ -253,8 +253,7 @@ class App extends React.Component {
               ldAccessTokenCopied === true
                 ? (
                   <span className="text-xs text-gray-500 font-normal ml-2">
-                    <FormattedMessage id="app.learningDashboard.linkCopied" defaultMessage="Link successfully copied" />
-                    !
+                    <FormattedMessage id="app.learningDashboard.linkCopied" defaultMessage="Link successfully copied!" />
                   </span>
                 )
                 : null

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -913,7 +913,7 @@
     "app.learningDashboard.dashboardTitle": "Learning Dashboard",
     "app.learningDashboard.user": "User",
     "app.learningDashboard.shareButton": "Share with others",
-    "app.learningDashboard.shareLinkCopied": "Link successfully copied",
+    "app.learningDashboard.shareLinkCopied": "Link successfully copied!",
     "app.learningDashboard.indicators.meetingStatusEnded": "Ended",
     "app.learningDashboard.indicators.meetingStatusActive": "Active",
     "app.learningDashboard.indicators.usersOnline": "Active Users",


### PR DESCRIPTION
Fix an eslint `no-alert` problem introduced in #13488 

This PR replaces the `alert` with an inline message for "Link copied".