### PR TITLE
refactor: Increase time allowed for reconnection

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -50,7 +50,7 @@ object Users2x {
   def findAllExpiredUserLeftFlags(users: Users2x, meetingExpireWhenLastUserLeftInMs: Long): Vector[UserState] = {
     if (meetingExpireWhenLastUserLeftInMs > 0) {
       users.toVector filter (u => u.userLeftFlag.left && u.userLeftFlag.leftOn != 0 &&
-        System.currentTimeMillis() - u.userLeftFlag.leftOn > 1000)
+        System.currentTimeMillis() - u.userLeftFlag.leftOn > 30000)
     } else {
       // When meetingExpireWhenLastUserLeftInMs is set zero we need to
       // remove user right away to end the meeting as soon as possible.


### PR DESCRIPTION
When a user leaves the meeting, there is a flag defined that says user has left.

Currently, bbb-akka-apps waits for 1 second before removing the user.

This PR increases this time to 30 seconds, allowing slower reconnection scenarios to succeed.

More info:

- Flag is defined [here](https://github.com/bigbluebutton/bigbluebutton/blob/develop/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala#L22).

- Flag is reseted [here](https://github.com/bigbluebutton/bigbluebutton/blob/develop/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala#L21).