### PR TITLE
RAP: Use "asetpts=N" in ffmpeg audio processing

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -143,7 +143,7 @@ module BigBlueButton
 
             ffmpeg_filter << ",atempo=#{speed},atrim=start=#{ms_to_s(audio[:timestamp])}" if speed != 1
 
-            ffmpeg_filter << ",asetpts=PTS-STARTPTS"
+            ffmpeg_filter << ",asetpts=N"
           else
             BigBlueButton.logger.info "  Generating silence"
 


### PR DESCRIPTION
There's an issue sometimes where when processing the audio from a
desktop sharing file, the STARTPTS value is invalid somehow, and this
results in bad timestamps in the output stream. Depending on the
selected codec/container combination, this might result in errors such
as spam of the message:

Application provided invalid, non monotonically increasing dts to muxer in stream

or simply a hang during processing.

Since we're already using aresample in async mode to correct timestamp
gaps, we can use "asetpts=N" here to simply set the audio frame pts
values to the sample number directly, giving proper monotonic timestamps
with no gaps.