### PR TITLE
RAP: Use "asetpts=N" in ffmpeg audio processing (v2.3 backport)

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -143,7 +143,7 @@ module BigBlueButton
 
             ffmpeg_filter << ",atempo=#{speed},atrim=start=#{ms_to_s(audio[:timestamp])}" if speed != 1
 
-            ffmpeg_filter << ",asetpts=PTS-STARTPTS"
+            ffmpeg_filter << ",asetpts=N"
           else
             BigBlueButton.logger.info "  Generating silence"
 


### PR DESCRIPTION
This is a backport of the fix from #13540 to BigBlueButton 2.3.

There's an issue sometimes where when processing the audio from a
desktop sharing file, the STARTPTS value is invalid somehow, and this
results in bad timestamps in the output stream. Depending on the
selected codec/container combination, this might result in errors such
as spam of the message:

Application provided invalid, non monotonically increasing dts to muxer in stream

or simply a hang during processing.

Since we're already using aresample in async mode to correct timestamp
gaps, we can use "asetpts=N" here to simply set the audio frame pts
values to the sample number directly, giving proper monotonic timestamps
with no gaps.

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation

<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
