### PR TITLE
style: Improve Audio Control Chevron Alignment

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/component.jsx
@@ -302,6 +302,7 @@ class InputStreamLiveSelector extends Component {
               }}
             />
             <ButtonEmoji
+              className={styles.audioDropdown}
               emoji="device_list_selector"
               label={intl.formatMessage(intlMessages.changeAudioDevice)}
               hideLabel

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/styles.scss
@@ -101,3 +101,12 @@
 .selectedDevice {
   font-weight: bold !important;
 }
+
+.audioDropdown {
+  span {
+    i {
+      width: 0px !important;
+      bottom: 1px;
+    }
+  }
+}

--- a/bigbluebutton-html5/imports/ui/components/button/button-emoji/ButtonEmoji.jsx
+++ b/bigbluebutton-html5/imports/ui/components/button/button-emoji/ButtonEmoji.jsx
@@ -23,6 +23,8 @@ const propTypes = {
   tabIndex: PropTypes.number,
 
   hideLabel: PropTypes.bool,
+
+  className: PropTypes.string,
 };
 
 const defaultProps = {
@@ -33,11 +35,13 @@ const defaultProps = {
   tabIndex: -1,
   hideLabel: false,
   onClick: null,
+  className: '',
 };
 
 const ButtonEmoji = (props) => {
   const {
     hideLabel,
+    className,
     ...newProps
   } = props;
 
@@ -62,7 +66,7 @@ const ButtonEmoji = (props) => {
           type="button"
           tabIndex={tabIndex}
           {...newProps}
-          className={styles.emojiButton}
+          className={[styles.emojiButton, className].join(' ')}
           aria-label={label}
           onClick={onClick}
         >


### PR DESCRIPTION
### What does this PR do?
Improves the alignment of the chevron in the audio control button.
Before:
![image](https://user-images.githubusercontent.com/22058534/138330695-993c16d9-69a6-4e0f-9499-6c49db2f617c.png)

After:
![image](https://user-images.githubusercontent.com/22058534/138328215-d44ae621-d521-40cb-b64a-0bdf93c94c8e.png)
