### PR TITLE
fix: Selected presentation icon not visible for a long file name

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/menu/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/menu/styles.scss
@@ -8,6 +8,7 @@
   margin-right: 1.65rem;
   margin-left: .5rem;
   white-space: normal;
+  overflow-wrap: anywhere;
   padding: .1rem 0;
 
   [dir="rtl"] & {


### PR DESCRIPTION
### What does this PR do?

Prevents an issue with the presentation name and "presentation selected" icon not being correctly displayed in files with long names, by adding `overflow-wrap: anywhere` to dropdown menus.

#### before
<img width="264" alt="Screen Shot 2021-10-22 at 14 14 50" src="https://user-images.githubusercontent.com/3728706/138496350-ba30881f-d8b4-439e-bf96-fb48fae84846.png">

#### after
<img width="274" alt="Screen Shot 2021-10-22 at 14 14 30" src="https://user-images.githubusercontent.com/3728706/138496348-40471829-104b-4c70-9695-90a37e35e87a.png">


### Closes Issue(s)
Closes #13506
