### PR TITLE
feat: Add push option for smart and custom layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -96,6 +96,14 @@ const intlMessages = defineMessages({
     id: 'app.layout.style.videoFocusPush',
     description: 'label for videoFocus layout style (push to all)',
   },
+  smartPushLayout: {
+    id: 'app.layout.style.smartPush',
+    description: 'label for smart layout style (push to all)',
+  },
+  customPushLayout: {
+    id: 'app.layout.style.customPush',
+    description: 'label for custom layout style (push to all)',
+  },
 });
 
 class ApplicationMenu extends BaseMenu {
@@ -317,6 +325,8 @@ class ApplicationMenu extends BaseMenu {
 
     if (isModerator) {
       const pushLayouts = {
+        CUSTOM_PUSH: 'customPush',
+        SMART_PUSH: 'smartPush',
         PRESENTATION_FOCUS_PUSH: 'presentationFocusPush',
         VIDEO_FOCUS_PUSH: 'videoFocusPush',
       };

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -880,6 +880,8 @@
     "app.layout.style.smart": "Smart layout",
     "app.layout.style.presentationFocus": "Focus on presentation",
     "app.layout.style.videoFocus": "Focus on video",
+    "app.layout.style.customPush": "Custom (push layout to all)",
+    "app.layout.style.smartPush": "Smart layout (push layout to all)",
     "app.layout.style.presentationFocusPush": "Focus on presentation (push layout to all)",
     "app.layout.style.videoFocusPush": "Focus on video (push layout to all)",
     "playback.button.about.aria": "About",


### PR DESCRIPTION
### What does this PR do?
Allows the moderator of a session to also push smart and custom layout.

### Closes Issue(s)
Closes #13559

### Motivation
It's tough to tell users how to reset their layout to the "known" one. Moderators should have the ability to reset the layouts when having used the "focus on presentation" or "focus on video" layout.

### More
There has probably been a decision making process which resulted in not adding these two to the pushable layouts, but IMHO these should be there.

I'm not sure about the order of the layouts. If you have a different opinion on that let me know, I'm happy to change it, I don't really care much :-)