### PR TITLE
update(audio): do not check for chrome in iOS devices in audio modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -41,7 +41,6 @@ const propTypes = {
   audioLocked: PropTypes.bool.isRequired,
   resolve: PropTypes.func,
   isMobileNative: PropTypes.bool.isRequired,
-  isIOSChrome: PropTypes.bool.isRequired,
   isIE: PropTypes.bool.isRequired,
   formattedTelVoice: PropTypes.string.isRequired,
   autoplayBlocked: PropTypes.bool.isRequired,
@@ -445,23 +444,9 @@ class AudioModal extends Component {
     const {
       isEchoTest,
       intl,
-      isIOSChrome,
     } = this.props;
 
     const { content } = this.state;
-
-    if (isIOSChrome) {
-      return (
-        <div>
-          <div className={styles.warning}>!</div>
-          <h4 className={styles.main}>{intl.formatMessage(intlMessages.iOSError)}</h4>
-          <div className={styles.text}>{intl.formatMessage(intlMessages.iOSErrorDescription)}</div>
-          <div className={styles.text}>
-            {intl.formatMessage(intlMessages.iOSErrorRecommendation)}
-          </div>
-        </div>
-      );
-    }
 
     if (this.skipAudioOptions()) {
       return (
@@ -554,7 +539,6 @@ class AudioModal extends Component {
     const {
       intl,
       showPermissionsOvelay,
-      isIOSChrome,
       closeModal,
       isIE,
     } = this.props;
@@ -590,16 +574,11 @@ class AudioModal extends Component {
                   data-test="audioModalHeader"
                   className={styles.header}
                 >
-                  {
-                    isIOSChrome ? null
-                      : (
-                        <h2 className={styles.title}>
-                          {content
-                            ? intl.formatMessage(this.contents[content].title)
-                            : intl.formatMessage(intlMessages.audioChoiceLabel)}
-                        </h2>
-                      )
-                  }
+                  <h2 className={styles.title}>
+                    {content
+                      ? intl.formatMessage(this.contents[content].title)
+                      : intl.formatMessage(intlMessages.audioChoiceLabel)}
+                  </h2>
                 </header>
               )
               : null

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import { withModalMounter } from '/imports/ui/components/modal/service';
-import deviceInfo from '/imports/utils/deviceInfo';
 import browserInfo from '/imports/utils/browserInfo';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import AudioModal from './component';
@@ -62,8 +61,7 @@ export default lockContextContainer(withModalMounter(withTracker(({ userLocks })
 
   const forceListenOnlyAttendee = forceListenOnly && !Service.isUserModerator();
 
-  const { isIos } = deviceInfo;
-  const { isChrome, isIe } = browserInfo;
+  const { isIe } = browserInfo;
 
   return ({
     meetingIsBreakout,
@@ -91,7 +89,6 @@ export default lockContextContainer(withModalMounter(withTracker(({ userLocks })
     audioLocked: userLocks.userMic,
     joinFullAudioImmediately,
     forceListenOnlyAttendee,
-    isIOSChrome: isIos && isChrome,
     isMobileNative: navigator.userAgent.toLowerCase().includes('bbbnative'),
     isIE: isIe,
     autoplayBlocked: Service.autoplayBlocked(),


### PR DESCRIPTION
We are now leaving the check for the minBrowserVersions object in settings.yml
If the settings enables chrome iOS, audio should allow users to be joining
with audio.

This is related to recent Chrome update (iOS 14.3+) that now allows
camera/microphone to be captured. We are looking for enabling this for
Chrome 93 in iOS (chromeMobileIOS version in settings.yml)

#### This the first browser/device check (done by `minBrowserVersions.chromeMobileIOS` in settings.yml):
<img src="https://user-images.githubusercontent.com/1780868/138728486-44f5ef2c-e927-4c3b-b57e-83972da99d45.png" width=25% height=25%>

#### This the second browser/device check (hardcoded in audio-modal component, and removed in this PR):
<img src="https://user-images.githubusercontent.com/1780868/138728616-4063c407-b9e9-4621-aebe-4ac329bfb443.png" width=25% height=25%>

