### PR TITLE
Remove unused properties from chat message event

### DIFF
--- a/akka-bbb-apps/project/build.properties
+++ b/akka-bbb-apps/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.2.8

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GetGroupChatMsgsReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GetGroupChatMsgsReqMsgHdlr.scala
@@ -24,7 +24,7 @@ trait GetGroupChatMsgsReqMsgHdlr {
     state.groupChats.find(msg.body.chatId) foreach { gc =>
       if (gc.access == GroupChatAccess.PUBLIC || gc.isUserMemberOf(msg.header.userId)) {
         val msgs = gc.msgs.toVector map (m => GroupChatMsgToUser(m.id, m.createdOn, m.correlationId,
-          m.sender, m.color, m.message))
+          m.sender, m.message))
         val respMsg = buildGetGroupChatMsgsRespMsg(
           liveMeeting.props.meetingProp.intId,
           msg.header.userId, msgs, gc.id

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChat.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChat.scala
@@ -18,12 +18,12 @@ object GroupChatApp {
   def toGroupChatMessage(sender: GroupChatUser, msg: GroupChatMsgFromUser): GroupChatMessage = {
     val now = System.currentTimeMillis()
     val id = GroupChatFactory.genId()
-    GroupChatMessage(id, now, msg.correlationId, now, now, sender, msg.color, msg.message)
+    GroupChatMessage(id, now, msg.correlationId, now, now, sender, msg.message)
   }
 
   def toMessageToUser(msg: GroupChatMessage): GroupChatMsgToUser = {
     GroupChatMsgToUser(id = msg.id, timestamp = msg.timestamp, correlationId = msg.correlationId,
-      sender = msg.sender, color = msg.color, message = msg.message)
+      sender = msg.sender, message = msg.message)
   }
 
   def addGroupChatMessage(chat: GroupChat, chats: GroupChats,
@@ -34,10 +34,10 @@ object GroupChatApp {
 
   def findGroupChatUser(userId: String, users: Users2x): Option[GroupChatUser] = {
     Users2x.findWithIntId(users, userId) match {
-      case Some(u) => Some(GroupChatUser(u.intId, u.name))
+      case Some(u) => Some(GroupChatUser(u.intId))
       case None =>
         if (userId == SystemUser.ID) {
-          Some(GroupChatUser(SystemUser.ID, SystemUser.ID))
+          Some(GroupChatUser(SystemUser.ID))
         } else {
           None
         }
@@ -45,12 +45,12 @@ object GroupChatApp {
   }
 
   def createDefaultPublicGroupChat(): GroupChat = {
-    val createBy = GroupChatUser(SystemUser.ID, SystemUser.ID)
+    val createBy = GroupChatUser(SystemUser.ID)
     GroupChatFactory.create(MAIN_PUBLIC_CHAT, MAIN_PUBLIC_CHAT, GroupChatAccess.PUBLIC, createBy, Vector.empty, Vector.empty)
   }
 
   def createTestPublicGroupChat(state: MeetingState2x): MeetingState2x = {
-    val createBy = GroupChatUser(SystemUser.ID, SystemUser.ID)
+    val createBy = GroupChatUser(SystemUser.ID)
     val defaultPubGroupChat = GroupChatFactory.create("TEST_GROUP_CHAT", "TEST_GROUP_CHAT",
       GroupChatAccess.PUBLIC, createBy, Vector.empty, Vector.empty)
     val groupChats = state.groupChats.add(defaultPubGroupChat)
@@ -79,13 +79,10 @@ object GroupChatApp {
       }
     }
 
-    val sender = GroupChatUser(SystemUser.ID, SystemUser.ID)
-    val h1 = GroupChatMsgFromUser(correlationId = "cor1", sender = sender,
-      color = "red", message = "Hello Foo!")
-    val h2 = GroupChatMsgFromUser(correlationId = "cor2", sender = sender,
-      color = "red", message = "Hello Bar!")
-    val h3 = GroupChatMsgFromUser(correlationId = "cor3", sender = sender,
-      color = "red", message = "Hello Baz!")
+    val sender = GroupChatUser(SystemUser.ID)
+    val h1 = GroupChatMsgFromUser(correlationId = "cor1", sender = sender, message = "Hello Foo!")
+    val h2 = GroupChatMsgFromUser(correlationId = "cor2", sender = sender, message = "Hello Bar!")
+    val h3 = GroupChatMsgFromUser(correlationId = "cor3", sender = sender, message = "Hello Baz!")
     val state1 = addH(state, SystemUser.ID, liveMeeting, h1)
     val state2 = addH(state1, SystemUser.ID, liveMeeting, h2)
     val state3 = addH(state2, SystemUser.ID, liveMeeting, h3)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SyncGetGroupChatsInfoMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SyncGetGroupChatsInfoMsgHdlr.scala
@@ -37,7 +37,7 @@ trait SyncGetGroupChatsInfoMsgHdlr {
     val allChats = chats map (pc => {
 
       val msgs = pc.msgs.toVector map (m => GroupChatMsgToUser(m.id, m.createdOn, m.correlationId,
-        m.sender, m.color, m.message))
+        m.sender, m.message))
       val respMsg = buildSyncGetGroupChatMsgsRespMsg(msgs, pc.id)
       bus.outGW.send(respMsg)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/GroupChats.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/GroupChats.scala
@@ -37,7 +37,7 @@ case class GroupChat(id: String, name: String, access: String, createdBy: GroupC
 }
 
 case class GroupChatMessage(id: String, timestamp: Long, correlationId: String, createdOn: Long,
-                            updatedOn: Long, sender: GroupChatUser, color: String, message: String)
+                            updatedOn: Long, sender: GroupChatUser, message: String)
 
 case class GroupChatWindow(windowId: String, chatIds: Vector[String], keepOpen: Boolean, openedBy: String) {
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/PublicChatRecordEvent.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/PublicChatRecordEvent.scala
@@ -24,10 +24,6 @@ class PublicChatRecordEvent extends AbstractChatRecordEvent {
 
   setEvent("PublicChatEvent")
 
-  def setSender(sender: String) {
-    eventMap.put(SENDER, sender)
-  }
-
   def setSenderId(senderId: String) {
     eventMap.put(SENDERID, senderId)
   }
@@ -35,15 +31,9 @@ class PublicChatRecordEvent extends AbstractChatRecordEvent {
   def setMessage(message: String) {
     eventMap.put(MESSAGE, message)
   }
-
-  def setColor(color: String) {
-    eventMap.put(COLOR, color)
-  }
 }
 
 object PublicChatRecordEvent {
-  private final val SENDER = "sender"
   private final val SENDERID = "senderId"
   private final val MESSAGE = "message"
-  private final val COLOR = "color"
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
@@ -137,10 +137,8 @@ class RedisRecorderActor(
     if (msg.body.chatId == GroupChatApp.MAIN_PUBLIC_CHAT) {
       val ev = new PublicChatRecordEvent()
       ev.setMeetingId(msg.header.meetingId)
-      ev.setSender(msg.body.msg.sender.name)
       ev.setSenderId(msg.body.msg.sender.id)
       ev.setMessage(msg.body.msg.message)
-      ev.setColor(msg.body.msg.color)
 
       record(msg.header.meetingId, ev.toMap.asJava)
     }

--- a/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/models/GroupsChatTests.scala
+++ b/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/models/GroupsChatTests.scala
@@ -9,13 +9,13 @@ class GroupsChatTests extends UnitSpec {
     val gcId = "gc-id"
     val chatName = "Public"
     val userId = "uid-1"
-    val createBy = GroupChatUser("groupId", "groupname")
+    val createBy = GroupChatUser("groupId")
     val gc = GroupChatFactory.create(gcId, chatName, GroupChatAccess.PUBLIC, createBy, Vector.empty, Vector.empty)
-    val user = GroupChatUser(userId, "User 1")
+    val user = GroupChatUser(userId)
     val gc2 = gc.add(user)
     assert(gc2.users.size == 1)
 
-    val gc3 = gc2.add(GroupChatUser("user-2", "User 2"))
+    val gc3 = gc2.add(GroupChatUser("user-2"))
     assert(gc3.users.size == 2)
 
     val gc4 = gc3.remove(userId)
@@ -24,7 +24,7 @@ class GroupsChatTests extends UnitSpec {
   }
 
   "A GroupChat" should "be able to add, update, and remove msg" in {
-    val createBy = GroupChatUser("groupId", "groupname")
+    val createBy = GroupChatUser("groupId")
     val gcId = "gc-id"
     val chatName = "Public"
     val gc = GroupChatFactory.create(gcId, chatName, GroupChatAccess.PUBLIC, createBy, Vector.empty, Vector.empty)
@@ -33,7 +33,7 @@ class GroupsChatTests extends UnitSpec {
     val hello = "Hello World!"
 
     val msg1 = GroupChatMessage(id = msgId1, timestamp = ts, correlationId = "cordId1", createdOn = ts,
-      updatedOn = ts, sender = createBy, color = "red", message = hello)
+      updatedOn = ts, sender = createBy, message = hello)
     val gc2 = gc.add(msg1)
 
     assert(gc2.msgs.size == 1)
@@ -42,7 +42,7 @@ class GroupsChatTests extends UnitSpec {
     val foo = "Foo bar"
     val ts2 = System.currentTimeMillis()
     val msg2 = GroupChatMessage(id = msgId2, timestamp = ts2, correlationId = "cordId2", createdOn = ts2,
-      updatedOn = ts2, sender = createBy, color = "red", message = foo)
+      updatedOn = ts2, sender = createBy, message = foo)
     val gc3 = gc2.add(msg2)
 
     assert(gc3.msgs.size == 2)
@@ -51,7 +51,7 @@ class GroupsChatTests extends UnitSpec {
     val msgId3 = "msgid-3"
     val ts3 = System.currentTimeMillis()
     val msg3 = GroupChatMessage(id = msgId3, timestamp = ts3, correlationId = "cordId3", createdOn = ts3,
-      updatedOn = ts3, sender = createBy, color = "red", message = baz)
+      updatedOn = ts3, sender = createBy, message = baz)
     val gc4 = gc3.update(msg3)
 
     gc4.findMsgWithId(msgId3) match {

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
@@ -5,10 +5,9 @@ object GroupChatAccess {
   val PRIVATE = "PRIVATE_ACCESS"
 }
 
-case class GroupChatUser(id: String, name: String)
-case class GroupChatMsgFromUser(correlationId: String, sender: GroupChatUser, color: String, message: String)
-case class GroupChatMsgToUser(id: String, timestamp: Long, correlationId: String, sender: GroupChatUser,
-                              color: String, message: String)
+case class GroupChatUser(id: String)
+case class GroupChatMsgFromUser(correlationId: String, sender: GroupChatUser, message: String)
+case class GroupChatMsgToUser(id: String, timestamp: Long, correlationId: String, sender: GroupChatUser, message: String)
 case class GroupChatInfo(id: String, name: String, access: String, createdBy: GroupChatUser, users: Vector[GroupChatUser])
 
 object OpenGroupChatWindowReqMsg { val NAME = "OpenGroupChatWindowReqMsg" }

--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addBulkGroupChatMsgs.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addBulkGroupChatMsgs.js
@@ -10,7 +10,6 @@ export default async function addBulkGroupChatMsgs(msgs) {
     .map(({ chatId, meetingId, msg }) => {
       const {
         sender,
-        color,
         ...restMsg
       } = msg;
 

--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addGroupChatMsg.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addGroupChatMsg.js
@@ -23,13 +23,11 @@ export default function addGroupChatMsg(meetingId, chatId, msg) {
     id: Match.Maybe(String),
     timestamp: Number,
     sender: Object,
-    color: String,
     message: String,
     correlationId: Match.Maybe(String),
   });
 
   const {
-    color,
     sender,
     ...restMsg
   } = msg;

--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/clearGroupChatMsg.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/clearGroupChatMsg.js
@@ -17,7 +17,6 @@ export default function clearGroupChatMsg(meetingId, chatId) {
         Logger.info(`Cleared GroupChatMsg (${meetingId}, ${chatId})`);
         const clearMsg = {
           id: `${SYSTEM_CHAT_TYPE}-${CHAT_CLEAR_MESSAGE}`,
-          color: '0',
           timestamp: Date.now(),
           correlationId: `${PUBLIC_CHAT_SYSTEM_ID}-${Date.now()}`,
           sender: {

--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/syncMeetingChatMsgs.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/syncMeetingChatMsgs.js
@@ -18,7 +18,6 @@ export default function syncMeetingChatMsgs(meetingId, chatId, msgs) {
       .forEach((msg) => {
         const {
           sender,
-          color,
           ...restMsg
         } = msg;
 

--- a/bigbluebutton-html5/imports/ui/components/chat/service.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/service.js
@@ -171,7 +171,7 @@ const sendGroupMessage = (message, idChatOpen) => {
 
   let destinationChatId = PUBLIC_GROUP_CHAT_ID;
 
-  const { fullname: senderName, userID: senderUserId } = Auth;
+  const { userID: senderUserId } = Auth;
   const receiverId = { id: chatID };
 
   if (!isPublicChat) {
@@ -185,14 +185,10 @@ const sendGroupMessage = (message, idChatOpen) => {
     }
   }
 
-  const userAvatarColor = Users.findOne({ userId: senderUserId }, { fields: { color: 1 } });
-
   const payload = {
-    color: userAvatarColor?.color || '0',
     correlationId: `${senderUserId}-${Date.now()}`,
     sender: {
       id: senderUserId,
-      name: senderName,
     },
     message,
   };


### PR DESCRIPTION
### What does this PR do?

Remove `color` and `sender.name` from `GroupChatMessageBroadcastEvtMsg` and `SendGroupChatMessageMsg` events, also update the events recording script.

### Closes Issue(s)
close #11696
