### PR TITLE
build: Build libks before FreeSWITCH

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,8 +11,8 @@ stages:
 
 # define which docker image to use for builds
 default:
-  image: gitlab.senfcall.de:5050/senfcall-public/docker-bbb-build:v2021-10-17
-  
+  image: gitlab.senfcall.de:5050/senfcall-public/docker-bbb-build:v2021-10-25
+
 # This stage uses git to find out since when each package has been unmodified.
 # it then checks an API endpoint on the package server to find out for which of
 # these versions a build exists. If a viable build (from a commit where the

--- a/build/packages-template/bbb-freeswitch-core/build.sh
+++ b/build/packages-template/bbb-freeswitch-core/build.sh
@@ -87,6 +87,22 @@ fi
 popd
 # spandsp end
 
+
+
+# libks start
+if [ ! -d libks ]; then
+  git clone https://github.com/signalwire/libks.git
+fi
+cd libks/
+git pull
+
+cmake .
+make
+
+make install
+cd ..
+# libks end
+
 ldconfig
 
 # we already cloned the FS repo in freeswitch.placeholder.sh


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Adds a step to the `bbb-freeswitch-core` packaging to pull and compile `libks` before `freeswitch` is built
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
Starting with commit https://github.com/signalwire/freeswitch/commit/ed9851666615d283effb76edc7028cc08b07eff9 from FreeSWITCH 1.10.7 we were unable to build due to missing reference ks.h when building `mod_verto`.
We seem to be building `mod_verto` despite not using it but I did not spot a way to not build it.

`libks` from SignalWire repository needed `cmake` which I added to be installed in `Dockerfile` 
https://gitlab.senfcall.de/senfcall-public/docker-bbb-build/-/commit/a49269e1f22a85b016de6a01071b438809e4e0ad , and in order to use this change, I re-tagged and set the tag to be used for BBB here.


<!-- What inspired you to submit this pull request? -->

### More
Identical changes were made on the packagaing scripts used for the 2.3 and 2.4 BigBlueButton packages

Thanks to @mariogasparoni for assisting with identifying that we need libks and where to obtain it!