### PR TITLE
Implemented the fix regarding mongod error messages

### DIFF
--- a/build/packages-template/bbb-html5/mongod_start_pre.sh
+++ b/build/packages-template/bbb-html5/mongod_start_pre.sh
@@ -9,4 +9,8 @@ if [ ! -f /.dockerenv ]; then
   mount -t tmpfs -o size=512m tmpfs /mnt/mongo-ramdisk
 fi
 
-chown -R mongodb:mongodb /mnt/mongo-ramdisk
+if id mongod &> /dev/null; then
+  chown -R mongod:mongod /mnt/mongo-ramdisk
+else
+  chown -R mongodb:mongodb /mnt/mongo-ramdisk
+fi


### PR DESCRIPTION
Closes#13257
<h3> What does this PR do? </h3>
The main purpose of this change is to  get rid of misleading error messages of mongod by redirecting them to /dev/null.

Before - id: ‘mongod’: no such user
Currently no message is received.

<h3> References </h3>
It was suggested by https://github.com/playernine