### PR TITLE
build: Set worker_rlimit_nofile only once in nginx.conf

### DIFF
--- a/build/packages-template/bbb-config/after-install.sh
+++ b/build/packages-template/bbb-config/after-install.sh
@@ -124,7 +124,12 @@ fi
 
 sed -i 's/worker_connections 768/worker_connections 4000/g' /etc/nginx/nginx.conf
 
-if ! grep "worker_rlimit_nofile 10000;" /etc/nginx/nginx.conf; then
+if grep "worker_rlimit_nofile" /etc/nginx/nginx.conf; then
+  num=$(grep worker_rlimit_nofile /etc/nginx/nginx.conf | grep -o '[0-9]*')
+  if [[ "$num" -lt 10000 ]]; then
+    sed -i 's/worker_rlimit_nofile [0-9 ]*;/worker_rlimit_nofile 10000;/g' /etc/nginx/nginx.conf
+  fi
+else
   sed -i 's/events {/worker_rlimit_nofile 10000;\n\nevents {/g' /etc/nginx/nginx.conf
 fi
 


### PR DESCRIPTION
worker_rlimit_nofile may only be set once in nginx.conf. So far there was no check whether it is already set to a value different than 10000. This results in the option beeing set twice in the config file, if it was already set by. This caused nginx to fail startup. Now it is checked that the limit is at least 10000 and only if not it is set to 10000.

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation
Backport of https://github.com/bigbluebutton/bigbluebutton/pull/13248 to BBB 2.4
<!-- What inspired you to submit this pull request? -->

