### PR TITLE
Add role parameter in join url

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -60,6 +60,7 @@ public class ApiParams {
     public static final String WEBCAMS_ONLY_FOR_MODERATOR = "webcamsOnlyForModerator";
     public static final String WELCOME = "welcome";
     public static final String HTML5_INSTANCE_ID = "html5InstanceId";
+    public static final String ROLE = "role";
 
     public static final String BREAKOUT_ROOMS_ENABLED = "breakoutRoomsEnabled";
     public static final String BREAKOUT_ROOMS_RECORD = "breakoutRoomsRecord";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/request/JoinMeeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/request/JoinMeeting.java
@@ -14,7 +14,8 @@ public class JoinMeeting extends RequestWithChecksum<JoinMeeting.Params> {
         PASSWORD("password"),
         GUEST("guest"),
         AUTH("auth"),
-        CREATE_TIME("createTime");
+        CREATE_TIME("createTime"),
+        ROLE("role");
 
         private final String value;
 
@@ -48,6 +49,9 @@ public class JoinMeeting extends RequestWithChecksum<JoinMeeting.Params> {
     @IsIntegralConstraint
     private String createTimeString;
     private Long createTime;
+
+    @NotEmpty(key = "missingRoleParam", message = "Role parameter is missing")
+    private String role;
 
     public JoinMeeting(Checksum checksum) {
         super(checksum);
@@ -115,6 +119,14 @@ public class JoinMeeting extends RequestWithChecksum<JoinMeeting.Params> {
         this.createTime = createTime;
     }
 
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
     @Override
     public void populateFromParamsMap(Map<String, String[]> params) {
         if(params.containsKey(Params.MEETING_ID.getValue())) {
@@ -127,6 +139,7 @@ public class JoinMeeting extends RequestWithChecksum<JoinMeeting.Params> {
         if(params.containsKey(Params.GUEST.getValue())) setGuestString(params.get(Params.GUEST.getValue())[0]);
         if(params.containsKey(Params.AUTH.getValue())) setAuthString(params.get(Params.AUTH.getValue())[0]);
         if(params.containsKey(Params.CREATE_TIME.getValue())) setCreateTimeString(params.get(Params.CREATE_TIME.getValue())[0]);
+        if(params.containsKey(Params.ROLE.getValue())) setFullName(params.get(Params.ROLE.getValue())[0]);
     }
 
     @Override

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/request/JoinMeeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/request/JoinMeeting.java
@@ -50,7 +50,6 @@ public class JoinMeeting extends RequestWithChecksum<JoinMeeting.Params> {
     private String createTimeString;
     private Long createTime;
 
-    @NotEmpty(key = "missingRoleParam", message = "Role parameter is missing")
     private String role;
 
     public JoinMeeting(Checksum checksum) {
@@ -139,7 +138,7 @@ public class JoinMeeting extends RequestWithChecksum<JoinMeeting.Params> {
         if(params.containsKey(Params.GUEST.getValue())) setGuestString(params.get(Params.GUEST.getValue())[0]);
         if(params.containsKey(Params.AUTH.getValue())) setAuthString(params.get(Params.AUTH.getValue())[0]);
         if(params.containsKey(Params.CREATE_TIME.getValue())) setCreateTimeString(params.get(Params.CREATE_TIME.getValue())[0]);
-        if(params.containsKey(Params.ROLE.getValue())) setFullName(params.get(Params.ROLE.getValue())[0]);
+        if(params.containsKey(Params.ROLE.getValue())) setRole(params.get(Params.ROLE.getValue())[0]);
     }
 
     @Override

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -183,6 +183,11 @@ class ApiController {
             request.getQueryString()
     )
 
+    HashMap<String, String> roles = new HashMap<String, String>();
+
+    roles.put("moderator", ROLE_MODERATOR);
+    roles.put("viewer", ROLE_ATTENDEE);
+
     if(!(validationResponse == null)) {
       invalid(validationResponse.getKey(), validationResponse.getValue(), REDIRECT_RESPONSE)
       return
@@ -245,6 +250,10 @@ class ApiController {
       role = Meeting.ROLE_MODERATOR
     } else if (meeting.getViewerPassword().equals(attPW)) {
       role = Meeting.ROLE_ATTENDEE
+    }
+
+    if (!StringUtils.isEmpty(params.role) && roles.containsKey(params.role.toLowerCase())) {
+        role = roles.get(params.role.toLowerCase());
     }
 
     // We preprend "w_" to our internal meeting Id to indicate that this is a web user.


### PR DESCRIPTION
### What does this PR do?

Add a new parameter `role` in join url. The `role` parameter will take over the password. e.g. if the url have `role=viewer` and used the password for moderator, the new user will join as viewer.

### Motivation

Currently the user role is defined by the password information passed on join url, this PR introduce a new way to define an user role.
