### PR TITLE
Client authentication refactoring

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/handlers/validateAuthToken.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/validateAuthToken.js
@@ -37,7 +37,6 @@ export default function handleValidateAuthToken({ body }, meetingId) {
   check(reasonCode, String);
 
   const pendingAuths = pendingAuthenticationsStore.take(meetingId, userId, authToken);
-
   Logger.info(`PendingAuths length [${pendingAuths.length}]`);
   if (pendingAuths.length === 0) return;
 

--- a/bigbluebutton-html5/imports/api/users/server/methods/validateAuthToken.js
+++ b/bigbluebutton-html5/imports/api/users/server/methods/validateAuthToken.js
@@ -2,32 +2,77 @@ import { Meteor } from 'meteor/meteor';
 import RedisPubSub from '/imports/startup/server/redis';
 import Logger from '/imports/startup/server/logger';
 import upsertValidationState from '/imports/api/auth-token-validation/server/modifiers/upsertValidationState';
-import { ValidationStates } from '/imports/api/auth-token-validation';
+import AuthTokenValidation, { ValidationStates } from '/imports/api/auth-token-validation';
 import pendingAuthenticationsStore from '../store/pendingAuthentications';
 
-export default function validateAuthToken(meetingId, requesterUserId, requesterToken, externalId) {
-  try {
-    const REDIS_CONFIG = Meteor.settings.private.redis;
-    const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
-    const EVENT_NAME = 'ValidateAuthTokenReqMsg';
+const AUTH_TIMEOUT = 120000;
 
-    Logger.debug('ValidateAuthToken method called', { meetingId, requesterUserId, requesterToken, externalId });
-
-    if (!meetingId) return false;
-
-    // Store reference of methodInvocationObject ( to postpone the connection userId definition )
-    pendingAuthenticationsStore.add(meetingId, requesterUserId, requesterToken, this);
-    upsertValidationState(meetingId, requesterUserId, ValidationStates.VALIDATING, this.connection.id);
-
-    const payload = {
-      userId: requesterUserId,
-      authToken: requesterToken,
+async function validateAuthToken(meetingId, requesterUserId, requesterToken, externalId) {
+  let setTimeoutRef = null;
+  const userValidation = await new Promise((res, rej) => {
+    const observeFunc = (obj) => {
+      if (obj.validationStatus === ValidationStates.VALIDATED) {
+        clearTimeout(setTimeoutRef);
+        return res(obj);
+      }
+      if (obj.validationStatus === ValidationStates.INVALID) {
+        clearTimeout(setTimeoutRef);
+        return res(obj);
+      }
     };
+    const authTokenValidationObserver = AuthTokenValidation.find({
+      connectionId: this.connection.id,
+    }).observe({
+      added: observeFunc,
+      changed: observeFunc,
+    });
 
-    Logger.info(`User '${requesterUserId}' is trying to validate auth token for meeting '${meetingId}' from connection '${this.connection.id}'`);
+    setTimeoutRef = setTimeout(() => {
+      observeFunc.stop();
+      rej();
+    }, AUTH_TIMEOUT);
 
-    return RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);
-  } catch (err) {
-    Logger.error(`Exception while invoking method validateAuthToken ${err.stack}`);
-  }
+    try {
+      const REDIS_CONFIG = Meteor.settings.private.redis;
+      const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
+      const EVENT_NAME = 'ValidateAuthTokenReqMsg';
+
+      Logger.debug('ValidateAuthToken method called', { meetingId, requesterUserId, requesterToken, externalId });
+
+      if (!meetingId) return false;
+
+      // Store reference of methodInvocationObject ( to postpone the connection userId definition )
+      pendingAuthenticationsStore.add(meetingId, requesterUserId, requesterToken, this);
+      upsertValidationState(
+        meetingId,
+        requesterUserId,
+        ValidationStates.VALIDATING,
+        this.connection.id,
+      );
+
+      const payload = {
+        userId: requesterUserId,
+        authToken: requesterToken,
+      };
+
+      Logger.info(`User '${requesterUserId}' is trying to validate auth token for meeting '${meetingId}' from connection '${this.connection.id}'`);
+
+      return RedisPubSub.publishUserMessage(
+        CHANNEL,
+        EVENT_NAME,
+        meetingId,
+        requesterUserId,
+        payload,
+      );
+    } catch (err) {
+      const errMsg = `Exception while invoking method validateAuthToken ${err}`;
+      Logger.error(errMsg);
+      rej(errMsg);
+      clearTimeout(setTimeoutRef);
+      authTokenValidationObserver.stop();
+    }
+  });
+  return userValidation;
 }
+
+export default validateAuthToken;

--- a/bigbluebutton-html5/imports/api/users/server/store/pendingAuthentications.js
+++ b/bigbluebutton-html5/imports/api/users/server/store/pendingAuthentications.js
@@ -35,7 +35,6 @@ class PendingAuthentitcations {
 
     // find matches
     const matches = this.store.filter(e => e.key === key);
-
     // remove matches (if any)
     if (matches.length) {
       this.store = this.store.filter(e => e.key !== key);

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -3,7 +3,6 @@ import { withTracker } from 'meteor/react-meteor-data';
 import { defineMessages, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import Auth from '/imports/ui/services/auth';
-import AuthTokenValidation from '/imports/api/auth-token-validation';
 import Users from '/imports/ui/local-collections/users-collection/users';
 import Meetings from '/imports/ui/local-collections/meetings-collection/meetings';
 import { notify } from '/imports/ui/services/notification';
@@ -120,9 +119,7 @@ const currentUserEmoji = (currentUser) => (currentUser
 );
 
 export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) => {
-  const authTokenValidation = AuthTokenValidation.findOne({}, { sort: { updatedAt: -1 } });
-
-  if (authTokenValidation.connectionId !== Meteor.connection._lastSessionId) {
+  if (Auth.connectionID !== Meteor.connection._lastSessionId) {
     endMeeting('403');
   }
 

--- a/bigbluebutton-html5/imports/ui/components/authenticated-handler/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/authenticated-handler/component.jsx
@@ -94,5 +94,4 @@ class AuthenticatedHandler extends Component {
   }
 }
 
-
 export default AuthenticatedHandler;


### PR DESCRIPTION
### What does this PR do?

this PR refactors the functioning of the authToken validation function on the client-side, using the return values from meteor.call and no longer depending on any subscription or collection to validate this information

### Motivation

On some reconnections, the client was not reauthenticating the user, because it created more than one reference to the `auth-token-validation` subscription and could not find the one that was ready

