### PR TITLE
duplicate voice bridge now returns the proper error

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -126,6 +126,8 @@ class ApiController {
 
     Meeting newMeeting = paramsProcessorUtil.processCreateParams(params)
 
+    ApiErrors errors = new ApiErrors()
+
     if (meetingService.createMeeting(newMeeting)) {
       // See if the request came with pre-uploading of presentation.
       uploadDocuments(newMeeting);  //


### PR DESCRIPTION
### What does this PR do?

Creating a meeting with an existing voicebridge now returns the proper error.

### Closes Issue(s)
Closes #13556
