### PR TITLE
build: bbb-html5 npm deps improvements

### DIFF
--- a/bigbluebutton-html5/deploy_to_usr_share.sh
+++ b/bigbluebutton-html5/deploy_to_usr_share.sh
@@ -6,7 +6,7 @@ UPPER_DESTINATION_DIR=/usr/share/meteor
 DESTINATION_DIR=$UPPER_DESTINATION_DIR/bundle
 
 SERVICE_FILES_DIR=/usr/lib/systemd/system
-LOCAL_PACKAGING_DIR=/home/bigbluebutton/src/build/packages-template/bbb-html5
+LOCAL_PACKAGING_DIR=/home/bigbluebutton/dev/bigbluebutton/build/packages-template/bbb-html5
 
 if [ ! -d "$LOCAL_PACKAGING_DIR" ]; then
   echo "Did not find LOCAL_PACKAGING_DIR=$LOCAL_PACKAGING_DIR"
@@ -32,7 +32,6 @@ echo 'stage3'
 
 
 cd "$DESTINATION_DIR"/programs/server/ || exit
-
 sudo npm i
 
 echo "deployed to $DESTINATION_DIR/programs/server\n\n\n"

--- a/bigbluebutton-html5/deploy_to_usr_share.sh
+++ b/bigbluebutton-html5/deploy_to_usr_share.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh -ex
 
 # Please check bigbluebutton/bigbluebutton-html5/dev_local_deployment/README.md
 
@@ -6,7 +6,7 @@ UPPER_DESTINATION_DIR=/usr/share/meteor
 DESTINATION_DIR=$UPPER_DESTINATION_DIR/bundle
 
 SERVICE_FILES_DIR=/usr/lib/systemd/system
-LOCAL_PACKAGING_DIR=/home/bigbluebutton/dev/bigbluebutton/build/packages-template/bbb-html5
+LOCAL_PACKAGING_DIR=/home/bigbluebutton/src/build/packages-template/bbb-html5
 
 if [ ! -d "$LOCAL_PACKAGING_DIR" ]; then
   echo "Did not find LOCAL_PACKAGING_DIR=$LOCAL_PACKAGING_DIR"
@@ -22,21 +22,19 @@ if [ -d "node_modules" ]; then
    rm -r node_modules/
 fi
 meteor reset
-meteor npm install --production
-
+meteor npm ci --production
 
 sudo chmod 777 /usr/share/meteor
-METEOR_DISABLE_OPTIMISTIC_CACHING=1 meteor build $UPPER_DESTINATION_DIR --architecture os.linux.x86_64 --allow-superuser
+METEOR_DISABLE_OPTIMISTIC_CACHING=1 meteor build $UPPER_DESTINATION_DIR --architecture os.linux.x86_64 --allow-superuser --directory
 
 sudo chown -R meteor:meteor "$UPPER_DESTINATION_DIR"/
 echo 'stage3'
 
 
-tar -xzf $UPPER_DESTINATION_DIR/bigbluebutton-html5.tar.gz -C $UPPER_DESTINATION_DIR
-
-
 cd "$DESTINATION_DIR"/programs/server/ || exit
-sudo npm i --production
+
+sudo npm i
+
 echo "deployed to $DESTINATION_DIR/programs/server\n\n\n"
 
 echo "writing $DESTINATION_DIR/mongod_start_pre.sh"

--- a/build/packages-template/bbb-html5/build.sh
+++ b/build/packages-template/bbb-html5/build.sh
@@ -35,6 +35,7 @@ mkdir -p staging/usr/share/meteor
 rm -rf /tmp/html5-build
 mkdir -p /tmp/html5-build
 
+npm -v
 meteor npm -v
 meteor node -v
 cat .meteor/release
@@ -42,18 +43,28 @@ cat .meteor/release
 # meteor version control was moved to the Dockerfile of the image used in .gitlab-ci.yml
 # meteor update --allow-superuser --release 2.3.6
 
-# build the HTML5 client
+# Install the npm dependencies needed for the HTML5 client.
+# Argument 'c' means package-lock.json will be respected
+# --production means we won't be installing devDependencies
 meteor npm ci --production
 
-METEOR_DISABLE_OPTIMISTIC_CACHING=1 meteor build /tmp/html5-build --architecture os.linux.x86_64 --allow-superuser
+# Build the HTML5 client https://guide.meteor.com/deployment.html#custom-deployment
+# https://docs.meteor.com/environment-variables.html#METEOR-DISABLE-OPTIMISTIC-CACHING - disable caching because we're only building once
+# --allow-superuser
+# --directory - instead of creating tar.gz and then extracting (which is the default option)
+METEOR_DISABLE_OPTIMISTIC_CACHING=1 meteor build /tmp/html5-build --architecture os.linux.x86_64 --allow-superuser --directory
 
-# extract, install the npm dependencies, then copy to staging
-tar xfz /tmp/html5-build/bbb-html5_${VERSION}_${DISTRO}.tar.gz -C /tmp/html5-build/
+# Install the npm dependencies, then copy to staging
 cd /tmp/html5-build/bundle/programs/server/
-npm i --production
+
+# Install Meteor related dependencies
+# Note that we don't use "c" argument as there is no package-lock.json here
+# only package.json. The dependencies for bbb-html5 are already installed in
+# /usr/share/meteor/bundle/programs/server/npm/node_modules/ and not in
+# /usr/share/meteor/bundle/programs/server/node_modules
+npm i
 cd -
 cp -r /tmp/html5-build/bundle staging/usr/share/meteor
-
 
 cp $DISTRO/systemd_start.sh staging/usr/share/meteor/bundle
 chmod +x staging/usr/share/meteor/bundle/systemd_start.sh


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
(does pretty much the same for both packaging and development deploy of `bbb-html5`)
* Drops the `--production` flag when installing meteor dependencies
* Adds lots of inline comments explaining why we pass what we pass and why we run two different variations of `npm install` at different times
* Removes the unnecessary step of creating an archive and then extracting

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
When building bbb-html5 with the `build/package-templates` scripts we were seeing the following error (as of lately)

```
/root/.meteor/packages/meteor-tool/.2.3.6.f552aq.1g2ai++os.linux.x86_64+web.browser+web.browser.legacy+web.cordova/mt-os.linux.x86_64/dev_bundle/lib/node_modules/meteor-promise/promise_server.js:218
      throw error;
      ^

Error: Broken symbolic link encountered at /tmp/build/bbb-html5_2.4~rc+20211028T103319-git.local-build-8898b93b61_bionic/node_modules/.bin/jsesc
    at isWithinProdPackage (/tools/isobuild/bundler.js:497:19)
    at /tools/isobuild/builder.js:724:15
    at Array.forEach (<anonymous>)
    at walk (/tools/isobuild/builder.js:656:34)
    at /tools/isobuild/builder.js:734:11
    at Array.forEach (<anonymous>)
    at walk (/tools/isobuild/builder.js:656:34)
    at Builder._copyDirectory (/tools/isobuild/builder.js:788:5)
    at Builder.copyNodeModulesDirectory (/tools/isobuild/builder.js:550:17)
    at /tools/isobuild/bundler.js:2544:17
    at Function.each (/root/.meteor/packages/meteor-tool/.2.3.6.f552aq.1g2ai++os.linux.x86_64+web.browser+web.browser.legacy+web.cordova/mt-os.linux.x86_64/dev_bundle/lib/node_modules/underscore/underscore-node-f-pre.js:1321:7)
    at JsImage.write (/tools/isobuild/bundler.js:2501:7)
    at ServerTarget.write (/tools/isobuild/bundler.js:2756:13)
    at /tools/isobuild/bundler.js:2924:30
    at /tools/isobuild/bundler.js:3063:11
    at Array.forEach (<anonymous>)
    at /tools/isobuild/bundler.js:3058:26
    at /tools/isobuild/bundler.js:3424:22
    at Object.capture (/tools/utils/buildmessage.js:283:5)
    at bundle (/tools/isobuild/bundler.js:3237:31)
    at /tools/isobuild/bundler.js:3180:32
    at Slot.withValue (/root/.meteor/packages/meteor-tool/.2.3.6.f552aq.1g2ai++os.linux.x86_64+web.browser+web.browser.legacy+web.cordova/mt-os.linux.x86_64/dev_bundle/lib/node_modules/@wry/context/lib/context.esm.js:69:29)
    at Object.withCache (/root/.meteor/packages/meteor-tool/.2.3.6.f552aq.1g2ai++os.linux.x86_64+web.browser+web.browser.legacy+web.cordova/mt-os.linux.x86_64/tools/fs/tools/fs/files.ts:1662:39)
    at Object.bundle (/tools/isobuild/bundler.js:3180:16)
    at buildCommand (/tools/cli/commands.js:1115:30)
    at /tools/cli/commands.js:944:25
    at Function.run (/root/.meteor/packages/meteor-tool/.2.3.6.f552aq.1g2ai++os.linux.x86_64+web.browser+web.browser.legacy+web.cordova/mt-os.linux.x86_64/tools/tool-env/tools/tool-env/profile.ts:289:14)
    at /tools/cli/commands.js:942:18
    at /root/.meteor/packages/meteor-tool/.2.3.6.f552aq.1g2ai++os.linux.x86_64+web.browser+web.browser.legacy+web.cordova/mt-os.linux.x86_64/dev_bundle/lib/node_modules/meteor-promise/fiber_pool.js:43:40
 => awaited here:
    at Promise.await (/root/.meteor/packages/meteor-tool/.2.3.6.f552aq.1g2ai++os.linux.x86_64+web.browser+web.browser.legacy+web.cordova/mt-os.linux.x86_64/dev_bundle/lib/node_modules/meteor-promise/promise_server.js:60:12)
    at /tools/cli/main.js:1529:7

```

<!-- What inspired you to submit this pull request? -->


