### PR TITLE
fix: publish button for user response polls

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
@@ -201,7 +201,7 @@ class LiveResult extends PureComponent {
           </div>
           {pollStats}
         </div>
-        {currentPoll && currentPoll.answers.length > 0
+        {currentPoll && currentPoll.answers.length >= 0
           ? (
             <div className={styles.buttonsActions}>
               <Button

--- a/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
@@ -151,7 +151,6 @@ class LiveResult extends PureComponent {
       userAnswers: null,
       pollStats: null,
       currentPollQuestion: null,
-      publishError: null,
     };
   }
 
@@ -164,7 +163,7 @@ class LiveResult extends PureComponent {
       currentPoll,
     } = this.props;
 
-    const { userAnswers, pollStats, currentPollQuestion, publishError } = this.state;
+    const { userAnswers, pollStats, currentPollQuestion } = this.state;
 
     let waiting;
     let userCount = 0;
@@ -181,12 +180,6 @@ class LiveResult extends PureComponent {
 
       waiting = respondedCount !== userAnswers.length && currentPoll;
     }
-
-    let noAnswers = false;
-    let hasPublishError = false;
-
-    noAnswers = (currentPoll && currentPoll.answers.length === 0 ? true : false);
-    hasPublishError = (noAnswers && publishError);
 
     return (
       <div>
@@ -214,8 +207,6 @@ class LiveResult extends PureComponent {
               <Button
                 disabled={!isMeteorConnected}
                 onClick={() => {
-                  if (noAnswers) return this.setState({ publishError: 'No answers yet' });
-                  this.setState({ publishError: null });
                   Session.set('pollInitiated', false);
                   Service.publishPoll();
                   stopPoll();
@@ -250,11 +241,6 @@ class LiveResult extends PureComponent {
             />
           )
         }
-        { hasPublishError ? (
-          <div className={styles.inputError}>{publishError}</div>
-        ) : (
-          <div className={styles.errorSpacer}>&nbsp;</div>
-        )}
         <div className={styles.separator} />
         { currentPoll && !currentPoll.secretPoll
           ? (

--- a/bigbluebutton-html5/imports/ui/components/poll/live-result/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/poll/live-result/styles.scss
@@ -28,18 +28,6 @@
   display: flex;
   width: 100%;
   justify-content: space-between;
-  margin-bottom: .5rem;
-}
-
-.inputError {
-  color: var(--color-danger);
-  font-size: var(--font-size-small);
-}
-
-.inputError,
-.errorSpacer {
-  position: relative;
-  height: 1.25rem;
 }
 
 .main {


### PR DESCRIPTION
### What does this PR do?

This PR fixes the missing publish button for user response polls.

For the case in which there is no answers yet, a label will be displayed when the user hits the publish button and the publication will be skipped:

![Captura de tela de 2021-11-04 10-38-55](https://user-images.githubusercontent.com/62393923/140325007-66348f76-3cfc-432a-a945-fa386414577c.png)

### Closes Issue(s)

Closes #13582 