### PR TITLE
fix(screenshare): bad isPresenter transition check

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -114,7 +114,7 @@ class ScreenshareComponent extends React.Component {
     const {
       isPresenter,
     } = this.props;
-    if (isPresenter && !prevProps.isPresenter) {
+    if (prevProps.isPresenter && !isPresenter) {
       screenshareHasEnded();
     }
   }


### PR DESCRIPTION
### What does this PR do?

Lifting #13639 into 2.4.
SFU will also have some safeguards added to reduce the number of scenarios where state can get inconsistent, but what screen sharing really needs is a re-do of it's server side state management RPCs and that is slated for 2.5.

### Closes Issue(s)

Closes #13245