### PR TITLE
Fix service bbb-rap-caption-inbox and captions uploaded with api putRecordingTextTrack

### DIFF
--- a/record-and-playback/core/scripts/bigbluebutton.yml
+++ b/record-and-playback/core/scripts/bigbluebutton.yml
@@ -59,6 +59,7 @@ events_dir: /var/bigbluebutton/events
 recording_dir: /var/bigbluebutton/recording
 published_dir: /var/bigbluebutton/published
 captions_dir: /var/bigbluebutton/captions
+presentation_dir: /var/bigbluebutton/published/presentation
 playback_host: 127.0.0.1
 playback_protocol: http
 

--- a/record-and-playback/core/scripts/rap-caption-inbox.rb
+++ b/record-and-playback/core/scripts/rap-caption-inbox.rb
@@ -101,7 +101,7 @@ caption_file_notify = proc do |json_filename|
         'lang'   => langtag.to_s,
         'source' => 'upload',
         'localeName'  => new_caption_info['label'],
-		    'locale'      => new_caption_info['lang'],
+        'locale'      => new_caption_info['lang'],
       }
 
       captions_work = File.join(captions_work_base, record_id)
@@ -134,7 +134,7 @@ caption_file_notify = proc do |json_filename|
       presentation_dest_dir = "#{presentation_dir}/#{record_id}/caption_#{new_caption_info['lang']}.vtt"
       caption_json_file = "#{presentation_dir}/#{record_id}/captions.json"
       FileUtils.cp(final_dest, presentation_dest_dir)
-	    FileUtils.cp(index_filename, caption_json_file)
+      FileUtils.cp(index_filename, caption_json_file)
 
       Dir.glob(File.expand_path('captions/*', __dir__)) do |caption_script|
         next unless File.file?(caption_script) && File.executable?(caption_script)


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug with service `bbb-rap-caption-inbox` failing to start and fixes captions uploaded with api `putRecordingTextTrack`.

This fixes #13362 and fixes the bugs introduced in #8277.

### Closes Issue(s)
Closes #13362

### More

1)  First of all, a variable named `presentation_dir` was missing in [bigbluebutton.yml](https://github.com/bigbluebutton/bigbluebutton/blob/develop/record-and-playback/core/scripts/bigbluebutton.yml), and service `bbb-rap-caption-inbox` failed to start. This PR adds that variable and now the service starts successfully.

2) Subtitles are being created in two folders, as explained in #13362. The first one is the expected behaviour but the second one is the one actually being used. #8277 tried to solve that by creating another subtitle file but forced its name to `en-US` language, and the file `captions.json` was overwritten by new uploads. This PR just copy those files from one folder to another.

3) As `captions.json` uses different keys for caption file name and location name in either folder, this PR adds new keys to the original index. I kept the original keys too because I don't know what that index or those keys are being used for.

This changes were tested with version 2.3.10 in Ubuntu 18.04.5.