### PR TITLE
fix: publication for user response polls

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
@@ -14,6 +14,10 @@ const intlMessages = defineMessages({
     id: 'app.whiteboard.annotations.pollResult',
     description: 'aria label used in poll result string',
   },
+  noResponsesFromUserResponsePoll: {
+    id: 'app.whiteboard.annotations.noResponses',
+    description: 'aria label used when there is no responses',
+  },
 });
 
 const MAX_DISPLAYED_CHARS = 15;
@@ -73,6 +77,10 @@ class PollDrawComponent extends Component {
   }
 
   componentDidMount() {
+    const { annotation } = this.props;
+    const { pollType, numResponders } = annotation;
+    if (pollType === PollService.pollTypes.Response && numResponders === 0) return;
+
     const isLayoutSwapped = getSwapLayout() && shouldEnableSwapLayout();
     if (isLayoutSwapped) return;
 
@@ -619,10 +627,20 @@ class PollDrawComponent extends Component {
   }
 
   render() {
-    const { intl } = this.props;
+    const { intl, annotation } = this.props;
     const { prepareToDisplay, textArray } = this.state;
+    let ariaResultLabel;
 
-    let ariaResultLabel = `${intl.formatMessage(intlMessages.pollResultAria)}: `;
+    const { pollType, numResponders } = annotation;
+    if (pollType === PollService.pollTypes.Response && numResponders === 0) {
+      const noResponseLabel = intl.formatMessage(intlMessages.noResponsesFromUserResponsePoll);
+      ariaResultLabel = `${intl.formatMessage(intlMessages.pollResultAria)}: ${noResponseLabel}}`;
+      return (
+        <g aria-label={ariaResultLabel} data-test="pollResultAria"></g>
+      );
+    }
+
+    ariaResultLabel = `${intl.formatMessage(intlMessages.pollResultAria)}: `;
     textArray.map((t, idx) => {
       const pollLine = t.slice(0, -1);
       ariaResultLabel += `${idx > 0 ? ' |' : ''} ${pollLine.join(' | ')}`;

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -769,6 +769,7 @@
     "app.meeting.endNotification.ok.label": "OK",
     "app.whiteboard.annotations.poll": "Poll results were published",
     "app.whiteboard.annotations.pollResult": "Poll Result",
+    "app.whiteboard.annotations.noResponses": "No responses",
     "app.whiteboard.toolbar.tools": "Tools",
     "app.whiteboard.toolbar.tools.hand": "Pan",
     "app.whiteboard.toolbar.tools.pencil": "Pencil",


### PR DESCRIPTION
### What does this PR do?

This PR fixes the following error when publishing a user response poll with no responses:

![Screenshot from 2021-11-04 15-21-46](https://user-images.githubusercontent.com/62393923/140524637-c2715bb1-0bc4-4016-93bc-fe69f252a58a.png)

### Closes Issue(s)

Closes no issue(s).