### PR TITLE
improvement: video preview modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/modal/simple/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/modal/simple/styles.scss
@@ -13,7 +13,7 @@
 }
 
 .content {
-  overflow: auto;
+  overflow: visible;
   color: var(--color-text);
   font-weight: normal;
   padding: var(--line-height-computed) 0;

--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -812,7 +812,10 @@ class VideoPreview extends Component {
     return (
       <Modal
         overlayClassName={styles.overlay}
-        className={styles.modal}
+        className={cx({
+          [styles.modal]: true,
+          [styles.modalPhone]: deviceInfo.isPhone,
+        })}
         onRequestClose={this.handleProceed}
         hideBorder
         contentLabel={intl.formatMessage(intlMessages.webcamSettingsTitle)}

--- a/bigbluebutton-html5/imports/ui/components/video-preview/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/styles.scss
@@ -94,21 +94,20 @@
 .videoCol {
   @extend .col;
   align-items: center;
+
+  @include mq($landscape) {
+    width: 33.3%;
+  }
 }
 
 .content {
   display: flex;
-  min-height: 14rem;
-  max-height: 50vh;
   justify-content: center;
   align-items: center;
 
   @include mq($small-only) {
     flex-direction: column;
-    height: unset;
     margin: 0;
-    min-height: 12rem;
-    max-height: unset;
   }
 }
 
@@ -129,8 +128,22 @@
 }
 
 .modal {
-  padding: 1rem;
   @extend .modal;
+  padding: 1rem;
+  min-height: 25rem;
+  max-height: 60vh;
+
+  @include mq($small-only) {
+    height: unset;
+    min-height: 22.5rem;
+    max-height: unset;
+  }
+}
+
+.modalPhone {
+  min-height: 100%;
+  min-width: 100%;
+  border-radius: 0;
 }
 
 .overlay {


### PR DESCRIPTION
### What does this PR do?

This PR improves the video preview modal.

- Removes the undesirable inner scrollbar.
- Makes the video preview modal "full screen" in phones.

**Samsung Galaxy S20:**
![Captura de tela de 2021-11-08 14-15-26](https://user-images.githubusercontent.com/62393923/140788556-2f989a22-7b5b-4dc1-8f84-147e0049406b.png)
![Captura de tela de 2021-11-08 14-15-53](https://user-images.githubusercontent.com/62393923/140788588-4d693273-8b63-44e9-9c70-4f9a3b062424.png)
![Captura de tela de 2021-11-08 14-15-58](https://user-images.githubusercontent.com/62393923/140788612-15acf6aa-8981-4d4b-9399-257a77cf77f9.png)

### Closes Issue(s)

Closes #12840