### PR TITLE
fix(audio): prevent audio to hang when user is transferred to breakout room

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -82,11 +82,11 @@ class AudioContainer extends PureComponent {
   componentDidMount() {
     const { meetingIsBreakout } = this.props;
 
-    this.init();
-
-    if (meetingIsBreakout && !Service.isUsingAudio()) {
-      this.joinAudio();
-    }
+    this.init().then(() => {
+      if (meetingIsBreakout && !Service.isUsingAudio()) {
+        this.joinAudio();
+      }
+    });
   }
 
   componentDidUpdate(prevProps) {
@@ -217,15 +217,15 @@ export default lockContextContainer(withModalMounter(injectIntl(withTracker(({ m
     meetingIsBreakout,
     userSelectedMicrophone,
     userSelectedListenOnly,
-    init: () => {
-      Service.init(messages, intl);
+    init: async () => {
+      await Service.init(messages, intl);
       const enableVideo = getFromUserSettings('bbb_enable_video', KURENTO_CONFIG.enableVideo);
       const autoShareWebcam = getFromUserSettings('bbb_auto_share_webcam', KURENTO_CONFIG.autoShareWebcam);
       if ((!autoJoin || didMountAutoJoin)) {
         if (enableVideo && autoShareWebcam) {
           openVideoPreviewModal();
         }
-        return;
+        return Promise.resolve(false);
       }
       Session.set('audioModalIsOpen', true);
       if (enableVideo && autoShareWebcam) {
@@ -237,6 +237,7 @@ export default lockContextContainer(withModalMounter(injectIntl(withTracker(({ m
         openAudioModal();
         didMountAutoJoin = true;
       }
+      return Promise.resolve(true);
     },
   };
 })(AudioContainer))));

--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -42,7 +42,7 @@ const audioEventHandler = (event) => {
 
 const init = (messages, intl) => {
   AudioManager.setAudioMessages(messages, intl);
-  if (AudioManager.initialized) return;
+  if (AudioManager.initialized) return Promise.resolve(false);
   const meetingId = Auth.meetingID;
   const userId = Auth.userID;
   const { sessionToken } = Auth;
@@ -63,7 +63,7 @@ const init = (messages, intl) => {
     microphoneLockEnforced,
   };
 
-  AudioManager.init(userData, audioEventHandler);
+  return AudioManager.init(userData, audioEventHandler);
 };
 
 const isVoiceUser = () => {

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -89,11 +89,11 @@ class AudioManager {
     this.BREAKOUT_AUDIO_TRANSFER_STATES = BREAKOUT_AUDIO_TRANSFER_STATES;
   }
 
-  init(userData, audioEventHandler) {
-    this.loadBridges(userData);
+  async init(userData, audioEventHandler) {
     this.userData = userData;
     this.initialized = true;
     this.audioEventHandler = audioEventHandler;
+    await this.loadBridges(userData);
   }
 
   /**


### PR DESCRIPTION
When joining breakouts, we now wait for the bridge to be loaded before
automatically start user's audio.
This problems happens only in the fullaudio bridge.
