### PR TITLE
Bring content back from breakout rooms to main room for presenter

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -1,6 +1,7 @@
 package org.bigbluebutton.core.apps.breakout
 
 import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.apps.presentationpod.PresentationPodsApp
 import org.bigbluebutton.core.apps.{ BreakoutModel, PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.domain.{ BreakoutRoom2x, MeetingState2x }
 import org.bigbluebutton.core.models.PresentationInPod
@@ -52,6 +53,9 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
     }
 
     for (breakout <- rooms.values.toVector) {
+      // Generate token if breakout room is recorded
+      val presentationUploadToken = if (msg.body.record) (PresentationPodsApp.generateToken("DEFAULT_PRESENTATION_POD", msg.header.userId)) else null
+
       val roomDetail = new BreakoutRoomDetail(
         breakout.id, breakout.name,
         liveMeeting.props.meetingProp.intId,
@@ -65,15 +69,31 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
         liveMeeting.props.password.moderatorPass,
         liveMeeting.props.password.viewerPass,
         presId, presSlide, msg.body.record,
-        liveMeeting.props.breakoutProps.privateChatEnabled
+        liveMeeting.props.breakoutProps.privateChatEnabled,
+        // Add generated presentationUploadToken
+        presentationUploadToken
       )
 
       val event = buildCreateBreakoutRoomSysCmdMsg(liveMeeting.props.meetingProp.intId, roomDetail)
-      outGW.send(event)
+      outGW.send(event) // Send message to bbb-web
+
+      // Informs bbb-web about the token so that when we use it to upload the presentation, it is able to look it up in the list of tokens
+      if (msg.body.record) {
+        outGW.send(buildPresentationUploadTokenSysPubMsg(parentId, msg.header.userId, presentationUploadToken, breakout.name))
+      }
     }
 
     val breakoutModel = new BreakoutModel(None, msg.body.durationInMinutes, rooms)
     state.update(Some(breakoutModel))
+  }
+
+  def buildPresentationUploadTokenSysPubMsg(parentId: String, userId: String, presentationUploadToken: String, filename: String): BbbCommonEnvCoreMsg = {
+    val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
+    val envelope = BbbCoreEnvelope(PresentationUploadTokenSysPubMsg.NAME, routing)
+    val header = BbbClientMsgHeader(PresentationUploadTokenSysPubMsg.NAME, parentId, userId)
+    val body = PresentationUploadTokenSysPubMsgBody("DEFAULT_PRESENTATION_POD", presentationUploadToken, filename, parentId)
+    val event = PresentationUploadTokenSysPubMsg(header, body)
+    BbbCommonEnvCoreMsg(envelope, event)
   }
 
   def buildCreateBreakoutRoomSysCmdMsg(meetingId: String, breakout: BreakoutRoomDetail): BbbCommonEnvCoreMsg = {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -20,7 +20,8 @@
 package org.bigbluebutton.api;
 
 public class ApiParams {
-
+    
+    public static final String PRESENTATION_UPLOAD_TOKEN = "presentationUploadToken";
     public static final String ALLOW_START_STOP_RECORDING = "allowStartStopRecording";
     public static final String ATTENDEE_PW = "attendeePW";
     public static final String AUTO_START_RECORDING = "autoStartRecording";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -378,6 +378,9 @@ public class MeetingService implements MessageListener {
         breakoutMetadata.put("sequence", m.getSequence().toString());
         breakoutMetadata.put("freeJoin", m.isFreeJoin().toString());
         breakoutMetadata.put("parentMeetingId", m.getParentMeetingId());
+
+        // Store the token in the breakout metadata
+        breakoutMetadata.put("presentationUploadToken", m.getPresentationUploadToken());
         storeService.recordBreakoutInfo(m.getInternalId(), breakoutMetadata);
       }
     }
@@ -646,6 +649,7 @@ public class MeetingService implements MessageListener {
       params.put(ApiParams.DURATION, message.durationInMinutes.toString());
       params.put(ApiParams.RECORD, message.record.toString());
       params.put(ApiParams.WELCOME, getMeeting(message.parentMeetingId).getWelcomeMessageTemplate());
+      params.put(ApiParams.PRESENTATION_UPLOAD_TOKEN, message.presentationUploadToken);
 
       Map<String, String> parentMeetingMetadata = parentMeeting.getMetadata();
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -36,13 +36,14 @@ public class Meeting {
 	public static final String ROLE_MODERATOR = "MODERATOR";
 	public static final String ROLE_ATTENDEE = "VIEWER";
 
+	private String presentationUploadToken;
 	private String name;
 	private String extMeetingId;
 	private String intMeetingId;
 	private String parentMeetingId = "bbb-none"; // Initialize so we don't send null in the json message.
 	private Integer sequence = 0;
 	private Boolean freeJoin = false;
-  private Integer duration = 0;
+  	private Integer duration = 0;
 	private long createdTime = 0;
 	private long startTime = 0;
 	private long endTime = 0;
@@ -106,6 +107,7 @@ public class Meeting {
 	private Integer html5InstanceId;
 
     public Meeting(Meeting.Builder builder) {
+		presentationUploadToken = builder.presentationUploadToken;
         name = builder.name;
         extMeetingId = builder.externalId;
         intMeetingId = builder.internalId;
@@ -135,7 +137,7 @@ public class Meeting {
         isBreakout = builder.isBreakout;
         guestPolicy = builder.guestPolicy;
         authenticatedGuest = builder.authenticatedGuest;
-				meetingLayout = builder.meetingLayout;
+		meetingLayout = builder.meetingLayout;
         breakoutRoomsParams = builder.breakoutRoomsParams;
         lockSettingsParams = builder.lockSettingsParams;
         allowDuplicateExtUserid = builder.allowDuplicateExtUserid;
@@ -218,6 +220,10 @@ public class Meeting {
 		}
 
 		return GuestPolicy.DENY;
+	}
+
+	public String getPresentationUploadToken() {
+		return presentationUploadToken;
 	}
 
 	public int getHtml5InstanceId() { return html5InstanceId; }
@@ -722,6 +728,8 @@ public class Meeting {
 	 *
 	 */
 	public static class Builder {
+		private String presentationUploadToken;
+
     	private String name;
     	private String externalId;
     	private String internalId;
@@ -751,7 +759,7 @@ public class Meeting {
     	private boolean isBreakout;
     	private String guestPolicy;
     	private Boolean authenticatedGuest;
-			private String meetingLayout;
+		private String meetingLayout;
     	private BreakoutRoomsParams breakoutRoomsParams;
     	private LockSettingsParams lockSettingsParams;
 		private Boolean allowDuplicateExtUserid;
@@ -774,6 +782,11 @@ public class Meeting {
     		duration = minutes;
     		return this;
     	}
+
+		public Builder withPresentationUploadToken(String token){
+			presentationUploadToken = token;
+			return this;
+		}
 
     	public Builder withMaxUsers(int n) {
     		maxUsers = n;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/CreateBreakoutRoom.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/CreateBreakoutRoom.java
@@ -19,6 +19,7 @@ public class CreateBreakoutRoom implements IMessage {
     public final Integer sourcePresentationSlide;
     public final Boolean record;
     public final Boolean privateChatEnabled;
+    public final String presentationUploadToken; // Token that allows upload of slides in the main room
 
     public CreateBreakoutRoom(String meetingId,
 															String parentMeetingId,
@@ -35,7 +36,8 @@ public class CreateBreakoutRoom implements IMessage {
 															String sourcePresentationId,
 															Integer sourcePresentationSlide,
 															Boolean record,
-															Boolean privateChatEnabled) {
+															Boolean privateChatEnabled,
+                                                            String presentationUploadToken) {
         this.meetingId = meetingId;
         this.parentMeetingId = parentMeetingId;
         this.name = name;
@@ -52,5 +54,6 @@ public class CreateBreakoutRoom implements IMessage {
         this.sourcePresentationSlide = sourcePresentationSlide;
         this.record = record;
         this.privateChatEnabled = privateChatEnabled;
+        this.presentationUploadToken = presentationUploadToken;
     }
 }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
@@ -99,7 +99,8 @@ class OldMeetingMsgHdlrActor(val olgMsgGW: OldMessageReceivedGW)
       msg.body.room.sourcePresentationId,
       msg.body.room.sourcePresentationSlide,
       msg.body.room.record,
-      msg.body.room.privateChatEnabled
+      msg.body.room.privateChatEnabled,
+      msg.body.room.presentationUploadToken
     ))
 
   }

--- a/record-and-playback/core/scripts/post_publish/upload_breakout_pdf_main_room.rb
+++ b/record-and-playback/core/scripts/post_publish/upload_breakout_pdf_main_room.rb
@@ -1,0 +1,104 @@
+#!/usr/bin/ruby
+# frozen_string_literal: true
+
+#
+# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+#
+# Copyright (c) 2012 BigBlueButton Inc. and by respective authors (see below).
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 3.0 of the License, or (at your option)
+# any later version.
+#
+# BigBlueButton is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+#
+
+require 'java_properties'
+require 'jwt'
+require 'net/http'
+require 'nokogiri'
+require 'trollop'
+
+require File.expand_path('../../../lib/recordandplayback', __FILE__)
+
+logger = Logger.new('/var/log/bigbluebutton/post_publish.log', 'weekly')
+logger.level = Logger::INFO
+BigBlueButton.logger = logger
+
+opts = Trollop.options do
+  opt :meeting_id, 'Meeting id to archive', type: String
+  opt :format, "Playback format name", type: String
+end
+
+# Breakout room meeting ID
+meeting_id = opts[:meeting_id]
+
+props = JavaProperties::Properties.new('/etc/bigbluebutton/bbb-web.properties')
+
+published_files = "/var/bigbluebutton/published/presentation/#{meeting_id}"
+metadata = Nokogiri::XML(File.open("#{published_files}/metadata.xml"))
+
+#
+# Main code
+#
+
+BigBlueButton.logger.info("Breakout PDF upload for [#{meeting_id}] starts")
+
+begin
+  room_name = metadata.xpath('recording/meta/meetingName').text
+  presentation_upload_token = metadata.xpath('recording/breakout/@presentationUploadToken').to_s
+  parent_meeting_id = metadata.xpath('recording/breakout/@parentMeetingId').to_s
+
+  callback_url = "#{props[:"bigbluebutton.web.serverURL"]}/bigbluebutton/presentation/#{presentation_upload_token}/upload"
+
+  unless callback_url.nil?
+    BigBlueButton.logger.info('Making callback for PDF upload')
+
+    file = "#{published_files}/#{room_name}.pdf"
+
+    params = [['presentation_name', "#{room_name}.pdf"],
+              ['Filename', "#{room_name}.pdf"],
+              ['fileUpload', File.open(file)],
+              ['conference', parent_meeting_id],
+              ['room', parent_meeting_id],
+              %w[pod_id DEFAULT_PRESENTATION_POD],
+              %w[is_downloadable false]]
+
+    uri = URI.parse(callback_url)
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = (uri.scheme == 'https')
+
+    BigBlueButton.logger.info("Sending request to #{uri.scheme}://#{uri.host}#{uri.request_uri}")
+
+    request = Net::HTTP::Post.new(uri.request_uri)
+    request.set_form(params, 'multipart/form-data')
+
+    response = http.request(request)
+    code = response.code.to_i
+
+    if code == 410
+      BigBlueButton.logger.info("Notified for deleted meeting: #{meeting_id}")
+    elsif code == 404
+      BigBlueButton.logger.info("404 error when notifying for PDF upload: #{meeting_id}, ignoring")
+    elsif code < 200 || code >= 300
+      BigBlueButton.logger.info("PDF upload HTTP request failed: #{response.code} #{response.message} (code #{code})")
+    else
+      BigBlueButton.logger.info("PDF upload successful: #{meeting_id} (code #{code})")
+    end
+  end
+rescue StandardError => e
+  BigBlueButton.logger.info('Rescued')
+  BigBlueButton.logger.info(e.to_s)
+end
+
+BigBlueButton.logger.info('Breakout PDF export ready notify ends')
+
+exit 0


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->
Implements the message flow to bring back content from breakout rooms.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #13484

### Motivation
Fullfilling the workflow set out in #13484.

Current state of the desired workflow:

https://user-images.githubusercontent.com/33319791/141126863-49cb2536-6ac7-4db6-b3e8-b0415164862b.mp4

1. Moderator creates breakout rooms
    i. Moderator enables breakout room recording
    ii. Moderator starts breakout rooms
    iii. Students are put into breakout rooms

2. Students collaborate and annotate slides
    i. Students press record in the breakout room

3. Break rooms end
    i. Recording workers process recording (presentation -> PDF)
    ii. PDF upload script is executed

4. Instructor can choose an annotated presentation from each breakout room

### More
Currently uses the PDF exporting script from #13016. 

### To Dos:
- [ ] Make instructor see toast messages as incoming PDF files from breakout rooms are processed
- [ ] Change PDF exporting / upload script so that it does not rely on the presentation format (removes need to press record in breakout room)