### PR TITLE
fix: video preview alignment

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -735,7 +735,7 @@ class VideoPreview extends Component {
     const { isIe } = browserInfo;
 
     return (
-      <div>
+      <>
         {isIe ? (
           <p className={styles.browserWarning}>
             <FormattedMessage
@@ -748,8 +748,10 @@ class VideoPreview extends Component {
             />
           </p>
         ) : null}
-        <div className={styles.title}>
-          {intl.formatMessage(intlMessages.webcamSettingsTitle)}
+        <div>
+          <div className={styles.title}>
+            {intl.formatMessage(intlMessages.webcamSettingsTitle)}
+          </div>
         </div>
 
         {this.renderContent()}
@@ -783,7 +785,7 @@ class VideoPreview extends Component {
             />
           </div>
         </div>
-      </div>
+      </>
     );
   }
 

--- a/bigbluebutton-html5/imports/ui/components/video-preview/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/styles.scss
@@ -104,6 +104,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-grow: 1;
 
   @include mq($small-only) {
     flex-direction: column;
@@ -132,6 +133,12 @@
   padding: 1rem;
   min-height: 25rem;
   max-height: 60vh;
+
+  & > [class^="content"] {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+  }
 
   @include mq($small-only) {
     height: unset;


### PR DESCRIPTION
### What does this PR do?

This PR fixes the video preview alignment when it's "finding webcams".

![Captura de tela de 2021-11-10 14-48-19](https://user-images.githubusercontent.com/62393923/141167135-f0c32f2d-f89d-4bb4-8fa0-08e2e06c27c1.png)

### Closes Issue(s)

Closes no issue(s)