### PR TITLE
build: fix bbb-webrtc-sfu cronjob

### DIFF
--- a/build/packages-template/bbb-webrtc-sfu/bbb-restart-kms
+++ b/build/packages-template/bbb-webrtc-sfu/bbb-restart-kms
@@ -14,7 +14,7 @@ if [ -f /etc/default/bbb-restart-kms ]; then
   source /etc/default/bbb-restart-kms
 fi
 
-users=$(mongo --quiet mongodb://127.0.1.1:27017/meteor --eval "db.users.count({connectionStatus: 'online'})")
+users=$(mongo --quiet mongodb://127.0.1.1:27017/meteor --eval "db.users.count()")
 
 if [ "$users" -eq 0 ]; then
 


### PR DESCRIPTION
The cronjob queries the number of users. The query was still from BBB 2.2
and returned always 0. Now we take every user into account.