### PR TITLE
test: Adds Meteor reconnection test

### DIFF
--- a/bigbluebutton-tests/puppeteer/core/page.js
+++ b/bigbluebutton-tests/puppeteer/core/page.js
@@ -39,9 +39,9 @@ class Page {
   }
 
   // Join BigBlueButton meeting
-  async init(isModerator, shouldCloseAudioModal, testFolderName, fullName, meetingId, customParameter, connectionPreset, deviceX) {
+  async init(isModerator, shouldCloseAudioModal, testFolderName, fullName, meetingId, customParameter, connectionPreset, deviceX, extraFlags) {
     try {
-      const args = this.getArgs();
+      const args = this.getArgs(extraFlags?.length > 0 ? extraFlags : null);
       this.effectiveParams = Object.assign({}, params);
       if (!isModerator) this.effectiveParams.moderatorPW = '';
       if (fullName) this.effectiveParams.fullName = fullName;
@@ -180,7 +180,7 @@ class Page {
   }
 
   // Get the default arguments for creating a page
-  getArgs() {
+  getArgs(extraFlags) {
     if (process.env.BROWSERLESS_ENABLED === 'true') {
       const args = [
         '--no-sandbox',
@@ -189,6 +189,7 @@ class Page {
         '--window-size=1024,720',
         '--lang=en-US',
       ];
+      if (extraFlags) args.push(...extraFlags);
       return {
         headless: true,
         args,
@@ -202,8 +203,8 @@ class Page {
       '--window-size=1150,980',
       '--allow-file-access',
       '--lang=en-US',
-      '--disable-features=IsolateOrigins,site-per-process',
     ];
+    if (extraFlags) args.push(...extraFlags);
     return {
       headless: false,
       args,

--- a/bigbluebutton-tests/puppeteer/presentation/presentation.js
+++ b/bigbluebutton-tests/puppeteer/presentation/presentation.js
@@ -10,17 +10,17 @@ class Presentation {
     this.userPage = new Page();
   }
 
-  async initPages(testName) {
-    await this.initModPage(testName);
-    await this.initUserPage(testName);
+  async initPages(testName, extraFlags) {
+    await this.initModPage(testName, extraFlags);
+    await this.initUserPage(testName, extraFlags);
   }
 
-  async initModPage(testName) {
-    await this.modPage.init(true, true, testName, 'Mod');
+  async initModPage(testName, extraFlags) {
+    await this.modPage.init(true, true, testName, 'Mod', undefined, undefined, undefined, undefined, extraFlags);
   }
 
-  async initUserPage(testName) {
-    await this.userPage.init(false, true, testName, 'Attendee', this.modPage.meetingId);
+  async initUserPage(testName, extraFlags) {
+    await this.userPage.init(false, true, testName, 'Attendee', this.modPage.meetingId, undefined, undefined, undefined, extraFlags);
   }
 
   async skipSlide() {

--- a/bigbluebutton-tests/puppeteer/presentation/presentation.obj.js
+++ b/bigbluebutton-tests/puppeteer/presentation/presentation.obj.js
@@ -128,7 +128,7 @@ const presentationTest = () => {
     try {
       const testName = 'startExternalVideo';
       await test.modPage.logger('begin of ', testName);
-      await test.initPages(testName);
+      await test.initPages(testName, ['--disable-features=IsolateOrigins,site-per-process']);
       await test.modPage.startRecording(testName);
       response = await test.startExternalVideo(testName);
       await test.modPage.stopRecording();

--- a/bigbluebutton-tests/puppeteer/trigger/trigger.js
+++ b/bigbluebutton-tests/puppeteer/trigger/trigger.js
@@ -1,8 +1,10 @@
 const Page = require('../core/page');
 const { exec } = require("child_process");
-const { CLIENT_RECONNECTION_TIMEOUT } = require('../core/constants'); // core constants (Timeouts vars imported)
+const { CLIENT_RECONNECTION_TIMEOUT, ELEMENT_WAIT_TIME } = require('../core/constants'); // core constants (Timeouts vars imported)
 const { sleep } = require('../core/helper');
+const screenshareUtil = require('../screenshare/util');
 const e = require('../core/elements');
+const { checkElement } = require('../core/util');
 
 class Trigger extends Page {
   constructor() {
@@ -90,6 +92,96 @@ class Trigger extends Page {
       await this.logger(err);
       return false;
     }
+  }
+
+  async meteorReconnection(testName) {
+    try {
+      const checkSudo = await this.runScript('timeout -k 1 1 sudo id', {
+        handleOutput: (output) => output ? true : false
+      })
+      if (!checkSudo) {
+        await this.logger('Sudo failed: need to run this test with sudo (can be fixed by running "sudo -v" and entering the password)');
+        return false;
+      }
+
+      const checkTcpKill = await this.runScript('tcpkill', {
+        handleError: (output) => output.includes('not found') ? false : true
+      })
+      if (!checkTcpKill) {
+        await this.logger('tcpkill failed: must have the "dsniff" package installed');
+        return false;
+      }
+
+      await this.init(true, false, testName, 'Moderator', undefined, undefined, undefined, undefined, ['--disable-http2']);
+      await this.screenshot(testName, '01-after-close-audio-modal');
+      await this.page.setRequestInterception(true);
+      this.page.on('request', (request) => {
+        const headers = request.headers();
+        headers['connection'] = 'close';
+        request.continue({
+          headers
+        });
+      });
+
+      const hostname = new URL(this.page.url()).hostname;
+      const remoteIp = await this.runScript(`ping ${hostname}`, {
+        timeout: 1000,
+        handleOutput: (output) => {
+          const splitLog = output.split(/\s+/)[2];
+          const ip = splitLog.slice(1, -1);
+
+          return ip;
+        }
+      })
+
+      const modPid = this.browser.process().pid;
+      await sleep(7000);
+      const ipArgs = await this.runScript(`lsof -n -p ${modPid} | grep ${remoteIp}`, {
+        handleOutput: (output) => {
+          const completeLog = output.trim().split(/\s+/);
+
+          const ips = completeLog[8].split('->');
+          const [localIp, port] = ips[0].split(':');
+
+          return { localIp, port };
+        }
+      })
+
+      const tcpInterface = await this.runScript(`ip addr | grep ${ipArgs.localIp}`, {
+        handleOutput: (output) => {
+          const outputArray = output.trim().split(/\s+/);
+          return outputArray[outputArray.length - 1];
+        }
+      })
+
+      // Media connections
+      await this.joinMicrophone();
+      await this.screenshot(testName, '02-after-join-microphone');
+      await this.shareWebcam(true);
+      await this.screenshot(testName, '03-after-share-webcam');
+      await screenshareUtil.startScreenshare(this);
+      await this.screenshot(testName, '04-after-start-screenshare');
+
+      await this.runScript(`sudo tcpkill -i ${tcpInterface} port ${ipArgs.port} and host ${remoteIp}`, { timeout: 7500 });
+      await this.screenshot(testName, '05-after-kill-connection');
+
+      const isTalking = await this.page.evaluate(checkElement, e.isTalking);
+      const isSharingWebcam = await this.page.evaluate(checkElement, e.webcamVideo);
+      const isSharingScreen = await this.page.evaluate(checkElement, e.stopScreenSharing);
+
+      return isTalking && isSharingWebcam && isSharingScreen;
+    } catch (err) {
+      await this.logger(err);
+      return false;
+    }
+  }
+
+  async runScript(script, { handleError, handleOutput, timeout }) {
+    return new Promise((res, rej) => {
+      return exec(script, { timeout }, (err, stdout, stderr) => {
+        res(handleError ? handleError(stderr) : handleOutput ? handleOutput(stdout) : null)
+      })
+    })
   }
 }
 

--- a/bigbluebutton-tests/puppeteer/trigger/trigger.obj.js
+++ b/bigbluebutton-tests/puppeteer/trigger/trigger.obj.js
@@ -47,6 +47,24 @@ const triggerTest = () => {
     expect(response).toBe(true);
     Page.checkRegression(0.1, screenshot);
   });
+
+  test('Meteor Reconnection', async () => {
+    const test = new Trigger();
+    let response;
+    let screenshot;
+    try {
+      const testName = 'MeteorReconnection';
+      await test.logger('begin of ', testName);
+      response = await test.meteorReconnection(testName);
+      screenshot = await test.page.screenshot();
+    } catch (err) {
+      await test.logger(err);
+    } finally {
+      await test.close();
+    }
+    expect(response).toBe(true);
+    Page.checkRegression(0.1, screenshot);
+  });
 };
 
 module.exports = exports = triggerTest;


### PR DESCRIPTION
### What does this PR do?
Adds a test that simulates a forced disconnection from Meteor, checking the behavior after reconnection.

- For this test it must have previous `sudo` permission and preinstalled external `dsniff` package - this is what breaks the tcp connection.
- Must pass after the improvements applied in #13574;
- This PR also improves how extra browser flags/arguments are added;