### PR TITLE
WIP(breakout-rooms): fix breakout invitation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/component.jsx
@@ -214,6 +214,7 @@ class BreakoutJoinConfirmation extends Component {
         dismiss={{
           label: intl.formatMessage(intlMessages.dismissLabel),
           description: intl.formatMessage(intlMessages.dismissDesc),
+          disabled: waiting,
         }}
       >
         { isFreeJoin ? this.renderSelectMeeting() : `${intl.formatMessage(intlMessages.message)} ${breakoutName}?`}

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/invitation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/invitation/component.jsx
@@ -34,14 +34,6 @@ const openBreakoutJoinConfirmation = (breakout, breakoutName, mountModal) => mou
 );
 
 class BreakoutRoomInvitation extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      didSendBreakoutInvite: false,
-    };
-  }
-
   componentDidMount() {
     // use dummy old data on mount so it works if no data changes
     this.checkBreakouts({ breakouts: [] });
@@ -59,10 +51,6 @@ class BreakoutRoomInvitation extends Component {
       breakoutUserIsIn,
     } = this.props;
 
-    const {
-      didSendBreakoutInvite,
-    } = this.state;
-
     const hasBreakouts = breakouts.length > 0;
 
     if (hasBreakouts && !breakoutUserIsIn && BreakoutService.checkInviteModerators()) {
@@ -71,10 +59,7 @@ class BreakoutRoomInvitation extends Component {
       const breakoutRoom = getBreakoutByUrlData(currentBreakoutUrlData);
       const freeJoinBreakout = breakouts.find((breakout) => breakout.freeJoin);
       if (freeJoinBreakout) {
-        if (!didSendBreakoutInvite) {
-          this.inviteUserToBreakout(breakoutRoom || freeJoinBreakout);
-          this.setState({ didSendBreakoutInvite: true });
-        }
+        this.inviteUserToBreakout(breakoutRoom || freeJoinBreakout);
       } else if (currentBreakoutUrlData) {
         const currentInsertedTime = currentBreakoutUrlData.insertedTime;
         const oldCurrentUrlData = oldProps.currentBreakoutUrlData || {};
@@ -86,10 +71,6 @@ class BreakoutRoomInvitation extends Component {
           }
         }
       }
-    }
-
-    if (!hasBreakouts && didSendBreakoutInvite) {
-      this.setState({ didSendBreakoutInvite: false });
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

After creating breakout rooms allowing users to choose one, users are now
receiving the invitation through manage users > breakout invitation.

There is a major problem that the modal is re-rendered 2 times, and flashes
into user UI.


### More information

The reason the modal doesn't appear a second time is because of a conditional 
that prevented this modal from being displayed more than once while the component 
was alive, preventing new invites from appearing if the user had the FreeJoin option. 

Removing this conditional allows the problem to be resolved. However, the way the 
breakout rooms are implemented requires this modal to be rendered more than once, 
which leads to a visual problem where the modal quick flashes into user UI when it's 
called for the first time.



- If the breakouts are freeJoin and you change the option in the select there's a flash from the modal re-opening https://github.com/bigbluebutton/bigbluebutton/pull/8131


![Peek 2021-11-12 10-00](https://user-images.githubusercontent.com/42683590/141472135-3224ffd9-c861-4872-961b-555ed697f10d.gif)


### Closes Issue(s)
Closes #13480