### PR TITLE
feat(screenshare): volume control

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -89,7 +89,7 @@ class ScreenshareComponent extends React.Component {
     this.handleOnMuted = this.handleOnMuted.bind(this);
 
     this.isMobile = isMobile() || isTablet();
-    this.volume = 0.5;
+    this.volume = getVolume();
   }
 
   componentDidMount() {
@@ -340,7 +340,7 @@ class ScreenshareComponent extends React.Component {
   }
 
   renderScreenshareDefault() {
-    const { intl, hasAudio } = this.props;
+    const { intl, enableVolumeControl } = this.props;
     const { loaded } = this.state;
 
     return (
@@ -353,7 +353,7 @@ class ScreenshareComponent extends React.Component {
       >
         {loaded && this.renderFullscreenButton()}
         {this.renderVideo(true)}
-        {loaded && hasAudio && this.renderVolumeSlider() }
+        {loaded && enableVolumeControl && this.renderVolumeSlider() }
 
         <div className={styles.screenshareContainerDefault}>
           {
@@ -437,5 +437,5 @@ ScreenshareComponent.propTypes = {
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
   isPresenter: PropTypes.bool.isRequired,
-  hasAudio: PropTypes.bool.isRequired,
+  enableVolumeControl: PropTypes.bool.isRequired,
 };

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -16,6 +16,8 @@ import {
   screenshareHasStarted,
   getMediaElement,
   attachLocalPreviewStream,
+  setVolume,
+  getVolume,
 } from '/imports/ui/components/screenshare/service';
 import {
   isStreamStateUnhealthy,
@@ -87,7 +89,7 @@ class ScreenshareComponent extends React.Component {
     this.handleOnMuted = this.handleOnMuted.bind(this);
 
     this.isMobile = isMobile() || isTablet();
-    this.volume = 1;
+    this.volume = 0.5;
   }
 
   componentDidMount() {
@@ -216,10 +218,15 @@ class ScreenshareComponent extends React.Component {
 
   handleOnVolumeChanged(volume) {
     this.volume = volume;
+    setVolume(volume);
   }
 
   handleOnMuted(muted) {
-    this.volume = 0;
+    if (muted) {
+      setVolume(0);
+    } else {
+      setVolume(this.volume);
+    }
   }
 
   renderFullscreenButton() {
@@ -267,13 +274,12 @@ class ScreenshareComponent extends React.Component {
   renderVolumeSlider() {
     const mobileHoverToolBarStyle = styles.showMobileHoverToolbar;
     const desktopHoverToolBarStyle = styles.hoverToolbar;
-
     const hoverToolbarStyle = this.isMobile ? mobileHoverToolBarStyle : desktopHoverToolBarStyle;
     return (
       <div className={hoverToolbarStyle}>
         <VolumeSlider
-          volume={this.volume}
-          muted={this.volume === 0}
+          volume={getVolume()}
+          muted={getVolume() === 0}
           onVolumeChanged={this.handleOnVolumeChanged}
           onMuted={this.handleOnMuted}
         />

--- a/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
@@ -13,7 +13,7 @@ import {
 import ScreenshareComponent from './component';
 import LayoutContext from '../layout/context';
 import getFromUserSettings from '/imports/ui/services/users-settings';
-import { screenshareHasAudio } from './service';
+import { shouldEnableVolumeControl } from './service';
 
 const ScreenshareContainer = (props) => {
   const fullscreenElementId = 'Screenshare';
@@ -53,6 +53,6 @@ export default withTracker(() => {
     shouldEnableSwapLayout,
     toggleSwapLayout: MediaService.toggleSwapLayout,
     hidePresentation: getFromUserSettings('bbb_hide_presentation', LAYOUT_CONFIG.hidePresentation),
-    hasAudio: screenshareHasAudio(),
+    enableVolumeControl: shouldEnableVolumeControl(),
   };
 })(ScreenshareContainer);

--- a/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
@@ -13,6 +13,7 @@ import {
 import ScreenshareComponent from './component';
 import LayoutContext from '../layout/context';
 import getFromUserSettings from '/imports/ui/services/users-settings';
+import { screenshareHasAudio } from './service';
 
 const ScreenshareContainer = (props) => {
   const fullscreenElementId = 'Screenshare';
@@ -52,5 +53,6 @@ export default withTracker(() => {
     shouldEnableSwapLayout,
     toggleSwapLayout: MediaService.toggleSwapLayout,
     hidePresentation: getFromUserSettings('bbb_hide_presentation', LAYOUT_CONFIG.hidePresentation),
+    hasAudio: screenshareHasAudio(),
   };
 })(ScreenshareContainer);

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -11,9 +11,8 @@ import AudioService from '/imports/ui/components/audio/service';
 import { Meteor } from "meteor/meteor";
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
 
+const VOLUME_CONTROL_ENABLED = Meteor.settings.public.kurento.screenshare.enableVolumeControl;
 const SCREENSHARE_MEDIA_ELEMENT_NAME = 'screenshareVideo';
-
-const MAX_GAIN = 2;
 
 /**
  * Screenshare status to be filtered in getStats()
@@ -95,7 +94,9 @@ const setVolume = (volume) => {
   KurentoBridge.setVolume(volume);
 };
 
-const getVolume = () => KurentoBridge.getVolume() / MAX_GAIN;
+const getVolume = () => KurentoBridge.getVolume();
+
+const shouldEnableVolumeControl = () => VOLUME_CONTROL_ENABLED && screenshareHasAudio();
 
 const attachLocalPreviewStream = (mediaElement) => {
   const stream = KurentoBridge.gdmStream;
@@ -203,4 +204,5 @@ export {
   getStats,
   setVolume,
   getVolume,
+  shouldEnableVolumeControl,
 };

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -13,6 +13,8 @@ import MediaStreamUtils from '/imports/utils/media-stream-utils';
 
 const SCREENSHARE_MEDIA_ELEMENT_NAME = 'screenshareVideo';
 
+const MAX_GAIN = 2;
+
 /**
  * Screenshare status to be filtered in getStats()
  */
@@ -88,6 +90,12 @@ const screenshareHasEnded = () => {
 const getMediaElement = () => {
   return document.getElementById(SCREENSHARE_MEDIA_ELEMENT_NAME);
 }
+
+const setVolume = (volume) => {
+  KurentoBridge.setVolume(volume);
+};
+
+const getVolume = () => KurentoBridge.getVolume() / MAX_GAIN;
 
 const attachLocalPreviewStream = (mediaElement) => {
   const stream = KurentoBridge.gdmStream;
@@ -193,4 +201,6 @@ export {
   attachLocalPreviewStream,
   isGloballyBroadcasting,
   getStats,
+  setVolume,
+  getVolume,
 };

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -183,6 +183,7 @@ export {
   isVideoBroadcasting,
   screenshareHasEnded,
   screenshareHasStarted,
+  screenshareHasAudio,
   shareScreen,
   screenShareEndAlert,
   dataSavingSetting,

--- a/bigbluebutton-html5/imports/ui/components/screenshare/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/styles.scss
@@ -1,11 +1,34 @@
 @import "/imports/ui/components/media/styles";
 @import '/imports/ui/components/loading-screen/styles';
 
-.screenshareContainer {
+.hoverToolbar {
+  display: none;
+
+  :hover > & {
+    display: flex;
+  }
+}
+
+.mobileControlsOverlay {
+  position: absolute;
+  top:0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: transparent;
+}
+
+.showMobileHoverToolbar {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: var(--color-content-background);
+  z-index: 2;
+}
+
+.dontShowMobileHoverToolbar {
+  display: none;
+}
+
+.screenshareContainer {
+  position: relative;
   width: 100%;
   height: 100%;
 }

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -208,6 +208,8 @@ public:
       # subscribe reattempt increases the reconnection timer up to this
       maxTimeout: 60000
     screenshare:
+      # Whether volume control should be allowed if screen sharing has audio
+      enableVolumeControl: false
       # Experimental. True is the canonical behavior. Flip to false to reverse
       # the negotiation flow for subscribers.
       subscriberOffering: false


### PR DESCRIPTION
### What does this PR do?

- Adds a volume slider to screen share container when it has audio.
  * ~Adds a gain node to screen share audio stream with gain interval between 0(muted) and 2(boost).~ 
  * Edits by @prlanzarin: 
    - Volume control is done via HTMLMediaElement's `volume` property. Gain node usage was put on hold until we can assert there are no audio quality regressions;
    - Range is [0-1]; default, starting values are `1`.
- Volume control availability can be controlled via settings.yml => `public.kurento.screenshare.enableVolumeControl`
  * Default is `false` (I'd prefer testing this in the wild a bit before making it available by default)


### Closes Issue(s)

Closes #13519 
