### PR TITLE
fix: Focus on presentation - Minimizing presentation/screenshare working incorrectly

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -479,6 +479,8 @@ class PresentationFocusLayout extends Component {
   calculatesLayout() {
     const { layoutContextState, layoutContextDispatch } = this.props;
     const { deviceType, input, isRTL } = layoutContextState;
+    const { presentation } = input;
+    const { isOpen } = presentation;
     const { captionsMargin } = DEFAULT_VALUES;
 
     const sidebarNavWidth = this.calculatesSidebarNavWidth();
@@ -654,7 +656,7 @@ class PresentationFocusLayout extends Component {
       type: ACTIONS.SET_SCREEN_SHARE_OUTPUT,
       value: {
         width: mediaBounds.width,
-        height: mediaBounds.height,
+        height: isOpen ? mediaBounds.height : 0,
         top: mediaBounds.top,
         left: mediaBounds.left,
         right: mediaBounds.right,
@@ -666,7 +668,7 @@ class PresentationFocusLayout extends Component {
       type: ACTIONS.SET_EXTERNAL_VIDEO_OUTPUT,
       value: {
         width: mediaBounds.width,
-        height: mediaBounds.height,
+        height: isOpen ? mediaBounds.height : 0,
         top: mediaBounds.top,
         left: mediaBounds.left,
         right: mediaBounds.right,


### PR DESCRIPTION
### What does this PR do?

Prevents issues with camera, screenshare and external video position when the presentation is minimized (focus on presentation layout).

### Closes Issue(s)
Closes #13555