### PR TITLE
Center modal title (exit confirmation dialog)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/modal/simple/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/modal/simple/styles.scss
@@ -37,6 +37,7 @@
   font-size: var(--font-size-large);
   text-align: center;
   align-self: flex-end;
+  margin-left: 35px;
 }
 
 .dismiss {


### PR DESCRIPTION
### What does this PR do?

Modal title has not been centered because of 35px button on the right: https://postimg.cc/McLhdzVL
After: https://postimg.cc/gX6171K2

### Closes Issue(s)
Closes # none


### Motivation

For all perfectionists around here