### PR TITLE
Playwright tests: multi-user test + testing locales

### DIFF
--- a/bigbluebutton-tests/playwright/README.md
+++ b/bigbluebutton-tests/playwright/README.md
@@ -8,6 +8,7 @@ You need to install the dependencies:
 ```bash
 $ cd ../bigbluebutton-tests/playwright
 $ npm install
+$ npx playwright install
 ```
 To run these tests with an existing BigBlueButton server, you need to find the server's URL and secret (can be done with `bbb-conf --secret` command). You need to put them into the `.env` file inside `bigbluebutton-tests/playwright` folder (variables `BBB_URL` and `BBB_SECRET`).
 

--- a/bigbluebutton-tests/playwright/chat/chat.spec.js
+++ b/bigbluebutton-tests/playwright/chat/chat.spec.js
@@ -4,21 +4,21 @@ const { Clear } = require('./clear');
 const { Save } = require('./save');
 
 test.describe.parallel('Chat test suite', () => {
-  test('Send public message', async ({ page }) => {
-    const send = new Send(page);
+  test('Send public message', async ({ browser, page }) => {
+    const send = new Send(browser, page);
     await send.init(true, true);
     await send.test();
   });
   
-  test('Clear chat', async ({ page }) => {
-    const clear = new Clear(page);
+  test('Clear chat', async ({ browser, page }) => {
+    const clear = new Clear(browser, page);
     await clear.init(true, true);
     await clear.test();
   });
 
-  test('Save chat', async ({ page }) => {
+  test('Save chat', async ({ browser, page }) => {
     test.fixme();
-    const save = new Save(page);
+    const save = new Save(browser, page);
     await save.init(true, true);
     await save.test();
   });

--- a/bigbluebutton-tests/playwright/chat/clear.js
+++ b/bigbluebutton-tests/playwright/chat/clear.js
@@ -1,31 +1,31 @@
 const { expect } = require('@playwright/test');
 const Page = require('../page');
 const util = require('./util');
-const selectors = require('../selectors');
+const elements = require('../elements');
 
 class Clear extends Page {
 
-  constructor(page, browser) {
-    super(page, browser);
+  constructor(browser, page) {
+    super(browser, page);
   }
 
   async test() {
     
     await util.openChat(this.page);
-    const message = this.page.locator(selectors.chatUserMessageText);
+    const message = this.page.locator(elements.chatUserMessageText);
     
     // send a message
-    await this.type(selectors.chatBox, selectors.message);
-    await this.waitAndClick(selectors.sendButton);
-    await this.page.waitForSelector(selectors.chatUserMessageText);
+    await this.type(elements.chatBox, elements.message);
+    await this.waitAndClick(elements.sendButton);
+    await this.page.waitForSelector(elements.chatUserMessageText);
   
     // 1 message
     await expect(message).toHaveCount(1);
 
     // clear
-    await this.waitAndClick(selectors.chatOptions);
-    await this.waitAndClick(selectors.chatClear);
-    const clearMessage = this.page.locator(selectors.chatClearMessageText);
+    await this.waitAndClick(elements.chatOptions);
+    await this.waitAndClick(elements.chatClear);
+    const clearMessage = this.page.locator(elements.chatClearMessageText);
     await expect(clearMessage).toBeVisible();
   }
 }

--- a/bigbluebutton-tests/playwright/chat/save.js
+++ b/bigbluebutton-tests/playwright/chat/save.js
@@ -1,18 +1,18 @@
 const Page = require('../page');
 const util = require('./util');
-const selectors = require('../selectors');
+const elements = require('../elements');
 
 class Save extends Page {
 
-  constructor(page, browser) {
-    super(page, browser);
+  constructor(browser, page) {
+    super(browser, page);
   }
 
   async test() {
     
     await util.openChat(this.page);
-    await this.waitAndClick(selectors.chatOptions);
-    await this.waitAndClick(selectors.chatSave);
+    await this.waitAndClick(elements.chatOptions);
+    await this.waitAndClick(elements.chatSave);
     await this.page.waitForEvent('click');
 
   }

--- a/bigbluebutton-tests/playwright/chat/send.js
+++ b/bigbluebutton-tests/playwright/chat/send.js
@@ -1,26 +1,26 @@
 const { expect } = require('@playwright/test');
 const Page = require('../page');
 const util = require('./util');
-const selectors = require('../selectors');
+const elements = require('../elements');
 
 class Send extends Page {
 
-  constructor(page, browser) {
-    super(page, browser);
+  constructor(browser, page) {
+    super(browser, page);
   }
 
   async test() {
     
     await util.openChat(this.page);
-    const message = this.page.locator(selectors.chatUserMessageText);
+    const message = this.page.locator(elements.chatUserMessageText);
   
     // 0 messages
     await expect(message).toHaveCount(0);
     
     // send a message
-    await this.type(selectors.chatBox, selectors.message);
-    await this.waitAndClick(selectors.sendButton);
-    await this.page.waitForSelector(selectors.chatUserMessageText);
+    await this.type(elements.chatBox, elements.message);
+    await this.waitAndClick(elements.sendButton);
+    await this.page.waitForSelector(elements.chatUserMessageText);
   
     // 1 message
     await expect(message).toHaveCount(1);

--- a/bigbluebutton-tests/playwright/chat/util.js
+++ b/bigbluebutton-tests/playwright/chat/util.js
@@ -1,8 +1,8 @@
-const selectors = require('../selectors');
+const elements = require('../elements');
 
 async function openChat(page) {
-  await page.waitForSelector(selectors.chatBox);
-  await page.waitForSelector(selectors.chatMessages);
+  await page.waitForSelector(elements.chatBox);
+  await page.waitForSelector(elements.chatMessages);
 }
 
 exports.openChat = openChat;

--- a/bigbluebutton-tests/playwright/elements.js
+++ b/bigbluebutton-tests/playwright/elements.js
@@ -22,3 +22,19 @@ exports.awayIcon = `${this.userAvatar} > div > i[class="icon-bbb-time"]`;
 exports.setStatus = '[data-test="setstatus"]';
 exports.away = '[data-test="away"]';
 exports.applaud = '[data-test="applause"]';
+exports.userListItem = 'div[data-test="userListItem"]';
+exports.firstUser = '[data-test="userListItemCurrent"]';
+
+// Common
+exports.options = 'button[aria-label="Options"]';
+exports.settings = 'li[data-test="settings"]';
+exports.modalConfirmButton = 'button[data-test="modalConfirmButton"]';
+
+// Locales
+exports.locales = ['af', 'ar', 'az', 'bg-BG', 'bn', 'ca', 'cs-CZ', 'da', 'de',
+  'dv', 'el-GR', 'en', 'eo', 'es', 'es-419', 'es-ES', 'es-MX', 'et', 'eu',
+  'fa-IR', 'fi', 'fr', 'gl', 'he', 'hi-IN', 'hr', 'hu-HU', 'hy', 'id', 'it-IT',
+  'ja', 'ka', 'km', 'kn', 'ko-KR', 'lo-LA', 'lt-LT', 'lv', 'ml', 'mn-MN',
+  'nb-NO', 'nl', 'oc', 'pl-PL', 'pt', 'pt-BR', 'ro-RO', 'ru', 'sk-SK', 'sl',
+  'sr', 'sv-SE', 'ta', 'te', 'th', 'tr-TR', 'uk-UA', 'vi-VN', 'zh-CN', 'zh-TW'
+];

--- a/bigbluebutton-tests/playwright/page.js
+++ b/bigbluebutton-tests/playwright/page.js
@@ -2,27 +2,28 @@ require('dotenv').config();
 const { expect } = require('@playwright/test');
 const parameters = require('./parameters');
 const helpers = require('./helpers');
-const selectors = require('./selectors');
+const elements = require('./elements');
 
 class Page {
-  constructor(page, browser) {
-    this.page = page;
+  constructor(browser, page) {
     this.browser = browser;
+    this.page = page;
     this.initParameters = Object.assign({}, parameters);
   }
 
   async init(isModerator, shouldCloseAudioModal, fullName, meetingId, customParameter) {
     if(!isModerator) this.initParameters.moderatorPW = '';
     if(fullName) this.initParameters.fullName = fullName;
-    this.meetingId = await helpers.createMeeting(parameters, meetingId, customParameter);
+    if(meetingId) this.meetingId = meetingId;
+    else this.meetingId = await helpers.createMeeting(parameters, meetingId, customParameter);
     const joinUrl = helpers.getJoinURL(this.meetingId, this.initParameters, isModerator, customParameter);
     await this.page.goto(joinUrl);
     if (shouldCloseAudioModal) await this.closeAudioModal();
   }
 
   async closeAudioModal() {
-    await this.page.waitForSelector(selectors.audioModal);
-    await this.page.click(selectors.closeAudioButton);
+    await this.page.waitForSelector(elements.audioModal);
+    await this.page.click(elements.closeAudioButton);
   }
 
   async type(selector, text) {

--- a/bigbluebutton-tests/playwright/settings/language.js
+++ b/bigbluebutton-tests/playwright/settings/language.js
@@ -1,0 +1,23 @@
+const { expect } = require('@playwright/test');
+const Page = require('../page');
+const util = require('./util');
+const elements = require('../elements');
+
+class Language extends Page {
+
+  constructor(browser, page) {
+    super(browser, page);
+  }
+
+  async test(locale) {
+    await util.openSettings(this.page);
+    await this.page.waitForSelector('#langSelector');
+    const langDropdown = await this.page.$('#langSelector');
+    const langOptions = await langDropdown.$$('option');
+    await langDropdown.selectOption({ value: locale });
+    await this.page.click(elements.modalConfirmButton);
+    await util.openSettings(this.page);
+  }
+}
+
+exports.Language = Language;

--- a/bigbluebutton-tests/playwright/settings/settings.spec.js
+++ b/bigbluebutton-tests/playwright/settings/settings.spec.js
@@ -1,0 +1,14 @@
+const { test } = require('@playwright/test');
+const { Language } = require('./language');
+const elements = require('../elements');
+
+test.describe.parallel('Settings test suite', () => {
+  for(let locale of elements.locales) {
+    test.skip(`Test ${locale} locale`, async ({ browser, page }) => {
+      console.log(browser);
+      const language = new Language(browser, page);
+      await language.init(true, true);
+      await language.test(locale);
+    });
+  }
+});

--- a/bigbluebutton-tests/playwright/settings/util.js
+++ b/bigbluebutton-tests/playwright/settings/util.js
@@ -1,0 +1,10 @@
+const elements = require('../elements');
+
+async function openSettings(page) {
+  await page.waitForSelector(elements.options);
+  await page.click(elements.options);
+  await page.waitForSelector(elements.settings);
+  await page.click(elements.settings);
+}
+
+exports.openSettings = openSettings;

--- a/bigbluebutton-tests/playwright/user/multiusers.js
+++ b/bigbluebutton-tests/playwright/user/multiusers.js
@@ -1,0 +1,29 @@
+const { expect } = require('@playwright/test');
+const Page = require('../page');
+const elements = require('../elements');
+
+class MultiUsers {
+
+  constructor(browser, page1, page2) {
+    this.page1 = new Page(browser, page1);
+    this.page2 = new Page(browser, page2);
+  }
+
+  async init(testFolderName) {
+    await this.page1.init(true, true, 'User1');
+    await this.page2.init(true, true, 'User2', this.page1.meetingId); // joining the same meeting
+  }
+
+  async test() {
+    const firstUserOnPage1 = this.page1.page.locator(elements.firstUser);
+    const secondUserOnPage1 = this.page1.page.locator(elements.userListItem);
+    const firstUserOnPage2 = this.page2.page.locator(elements.firstUser);
+    const secondUserOnPage2 = this.page2.page.locator(elements.userListItem);
+    await expect(firstUserOnPage1).toHaveCount(1);
+    await expect(secondUserOnPage1).toHaveCount(1);
+    await expect(firstUserOnPage2).toHaveCount(1);
+    await expect(secondUserOnPage2).toHaveCount(1);
+  }
+}
+
+exports.MultiUsers = MultiUsers;

--- a/bigbluebutton-tests/playwright/user/status.js
+++ b/bigbluebutton-tests/playwright/user/status.js
@@ -1,23 +1,23 @@
 const Page = require('../page');
 const util = require('./util');
-const selectors = require('../selectors');
+const elements = require('../elements');
 
 class Status extends Page {
 
-  constructor(page, browser) {
-    super(page, browser);
+  constructor(browser, page) {
+    super(browser, page);
   }
 
   async test() {
     
-    await util.setStatus(this.page, selectors.applaud);
-    await this.page.waitForSelector(selectors.applauseIcon);
-    const applauseIconLocator = this.page.locator(selectors.applauseIcon);
+    await util.setStatus(this.page, elements.applaud);
+    await this.page.waitForSelector(elements.applauseIcon);
+    const applauseIconLocator = this.page.locator(elements.applauseIcon);
     await expect(applauseIconLocator).toBeVisible();
 
-    await util.setStatus(this.page, selectors.away);
-    await this.page.waitForSelector(selectors.awayIcon);
-    const awayIconLocator = this.page.locator(selectors.awayIcon);
+    await util.setStatus(this.page, elements.away);
+    await this.page.waitForSelector(elements.awayIcon);
+    const awayIconLocator = this.page.locator(elements.awayIcon);
     await expect(awayIconLocator).toBeVisible();
   }
 }

--- a/bigbluebutton-tests/playwright/user/user.spec.js
+++ b/bigbluebutton-tests/playwright/user/user.spec.js
@@ -1,11 +1,19 @@
 const { test } = require('@playwright/test');
 const { Status } = require('./status');
+const { MultiUsers } = require('./multiusers');
 
 test.describe.parallel('User test suite', () => {
-  test('Change status', async ({ page }) => {
+  test('Change status', async ({ browser, page }) => {
     test.fixme();
-    const status = new Status(page);
+    const status = new Status(browser, page);
     await status.init(true, true);
     await status.test();
+  });
+  test('User presence check (multiple users)', async ({ browser, context, page }) => {
+    const page1 = await context.newPage();
+    const page2 = await context.newPage();
+    const multiusers = new MultiUsers(browser, page1, page2);
+    await multiusers.init(true, true);
+    await multiusers.test();
   });
 });

--- a/bigbluebutton-tests/playwright/user/util.js
+++ b/bigbluebutton-tests/playwright/user/util.js
@@ -1,10 +1,10 @@
-const selectors = require('../selectors');
+const elements = require('../elements');
 
 async function setStatus(page, status) {
-    await page.waitForSelector(selectors.firstUser);
-    await page.click(selectors.firstUser);
-    await page.waitForSelector(selectors.setStatus);
-    await page.click(selectors.setStatus);
+    await page.waitForSelector(elements.firstUser);
+    await page.click(elements.firstUser);
+    await page.waitForSelector(elements.setStatus);
+    await page.click(elements.setStatus);
     await page.waitForSelector(status);
     await page.click(status);
 }


### PR DESCRIPTION
This PR does the following:
- adds the first multi-page test in Playwright
- tests the locales selection (`settings` tests)
- adds a minor fix for the documentation (missing command).

Some of this code is based on the existing Puppeteer tests.