### PR TITLE
Prevent unnecessary file copying in presentation recording processing

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -49,7 +49,7 @@ module BigBlueButton
       BigBlueButton.logger.info("Task: Getting meeting metadata")
       doc = Nokogiri::XML(File.open(events_xml))
       metadata = {}
-      doc.xpath("//metadata").each do |e|
+      doc.xpath("recording/metadata").each do |e|
         e.keys.each do |k|
           metadata[k] = e.attribute(k)
         end
@@ -613,7 +613,7 @@ module BigBlueButton
     def self.get_record_status_events(events_xml)
       BigBlueButton.logger.info "Getting record status events"
       rec_events = []
-      events_xml.xpath("//event[@eventname='RecordStatusEvent']").each do |event|
+      events_xml.xpath("recording/event[@eventname='RecordStatusEvent']").each do |event|
         s = { :timestamp => event['timestamp'].to_i }
         rec_events << s
       end
@@ -623,14 +623,14 @@ module BigBlueButton
     def self.get_external_video_events(events_xml)
       BigBlueButton.logger.info "Getting external video events"
       external_videos_events = []
-      events_xml.xpath("//event[@eventname='StartExternalVideoRecordEvent']").each do |event|
+      events_xml.xpath("recording/event[@eventname='StartExternalVideoRecordEvent']").each do |event|
         s = {
           :timestamp => event['timestamp'].to_i,
           :external_video_url => event.at_xpath("externalVideoUrl").text
         }
         external_videos_events << s
       end
-      events_xml.xpath("//event[@eventname='StopExternalVideoRecordEvent']").each do |event|
+      events_xml.xpath("recording/event[@eventname='StopExternalVideoRecordEvent']").each do |event|
         s = { :timestamp => event['timestamp'].to_i }
         external_videos_events << s
       end

--- a/record-and-playback/core/lib/recordandplayback/generators/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/video.rb
@@ -28,16 +28,17 @@ require File.expand_path('../../edl', __FILE__)
 module BigBlueButton
 
 
-  def BigBlueButton.process_webcam_videos(target_dir, temp_dir, meeting_id, output_width, output_height, output_framerate, audio_offset, processed_audio_file, video_formats=['webm'])
+  def BigBlueButton.process_webcam_videos(target_dir, raw_archive_dir, output_width, output_height, output_framerate, audio_offset, processed_audio_file, video_formats=['webm'])
     BigBlueButton.logger.info("Processing webcam videos")
 
-    events = Nokogiri::XML(File.open("#{temp_dir}/#{meeting_id}/events.xml"))
+    # raw_archive_dir already contains meeting_id
+    events = Nokogiri::XML(File.open("#{raw_archive_dir}/events.xml"))
 
     # Process user video (camera)
     start_time = BigBlueButton::Events.first_event_timestamp(events)
     end_time = BigBlueButton::Events.last_event_timestamp(events)
     webcam_edl = BigBlueButton::Events.create_webcam_edl(
-                    events, "#{temp_dir}/#{meeting_id}")
+                    events, raw_archive_dir)
     user_video_edl = BigBlueButton::Events.edl_match_recording_marks_video(
                     webcam_edl, events, start_time, end_time)
     BigBlueButton::EDL::Video.dump(user_video_edl)
@@ -91,15 +92,16 @@ module BigBlueButton
     end
   end
 
-  def BigBlueButton.process_deskshare_videos(target_dir, temp_dir, meeting_id, output_width, output_height, output_framerate, video_formats=['webm'])
+  def BigBlueButton.process_deskshare_videos(target_dir, raw_archive_dir, output_width, output_height, output_framerate, video_formats=['webm'])
     BigBlueButton.logger.info("Processing deskshare videos")
 
-    events = Nokogiri::XML(File.open("#{temp_dir}/#{meeting_id}/events.xml"))
+    # raw_archive_dir already contains meeting_id
+    events = Nokogiri::XML(File.open("#{raw_archive_dir}/events.xml"))
 
     start_time = BigBlueButton::Events.first_event_timestamp(events)
     end_time = BigBlueButton::Events.last_event_timestamp(events)
     deskshare_edl = BigBlueButton::Events.create_deskshare_edl(
-                    events, "#{temp_dir}/#{meeting_id}")
+                    events, raw_archive_dir)
     deskshare_video_edl = BigBlueButton::Events.edl_match_recording_marks_video(
                     deskshare_edl, events, start_time, end_time)
 
@@ -168,5 +170,3 @@ module BigBlueButton
   end
 
 end
-
-

--- a/record-and-playback/presentation/scripts/process/presentation.rb
+++ b/record-and-playback/presentation/scripts/process/presentation.rb
@@ -87,12 +87,10 @@ unless FileTest.directory?(target_dir)
     FileUtils.mkdir_p processed_pres_dir
 
     # Get the real-time start and end timestamp
-    @doc = Nokogiri::XML(File.read("#{target_dir}/events.xml")) 
+    @doc = Nokogiri::XML(File.read("#{target_dir}/events.xml"))
 
-    event_timestamps = @doc.xpath('recording/event/@timestamp')
-
-    meeting_start = event_timestamps.first.text.to_i
-    meeting_end = event_timestamps.last.text.to_i
+    meeting_start = BigBlueButton::Events.first_event_timestamp(@doc)
+    meeting_end = BigBlueButton::Events.last_event_timestamp(@doc)
     match = /.*-(\d+)$/.match(meeting_id)
     real_start_time = match[1].to_i
     real_end_time = real_start_time + (meeting_end - meeting_start)

--- a/record-and-playback/presentation/scripts/process/presentation.rb
+++ b/record-and-playback/presentation/scripts/process/presentation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Set encoding to utf-8
 # encoding: UTF-8
 
@@ -31,15 +32,15 @@ require 'trollop'
 require 'yaml'
 require 'json'
 
-opts = Trollop::options do
-  opt :meeting_id, "Meeting id to archive", :default => '58f4a6b3-cd07-444d-8564-59116cb53974', :type => String
+opts = Trollop.options do
+  opt :meeting_id, 'Meeting id to archive', default: '58f4a6b3-cd07-444d-8564-59116cb53974', type: String
 end
 
 meeting_id = opts[:meeting_id]
 
 # This script lives in scripts/archive/steps while properties.yaml lives in scripts/
 props = BigBlueButton.read_props
-presentation_props = YAML::load(File.open('presentation.yml'))
+presentation_props = YAML.safe_load(File.open('presentation.yml'))
 presentation_props['audio_offset'] = 0 if presentation_props['audio_offset'].nil?
 presentation_props['include_deskshare'] = false if presentation_props['include_deskshare'].nil?
 
@@ -48,56 +49,53 @@ raw_archive_dir = "#{recording_dir}/raw/#{meeting_id}"
 log_dir = props['log_dir']
 
 target_dir = "#{recording_dir}/process/presentation/#{meeting_id}"
-if not FileTest.directory?(target_dir)
+unless FileTest.directory?(target_dir)
   FileUtils.mkdir_p "#{log_dir}/presentation"
-  logger = Logger.new("#{log_dir}/presentation/process-#{meeting_id}.log", 'daily' )
+  logger = Logger.new("#{log_dir}/presentation/process-#{meeting_id}.log", 'daily')
   BigBlueButton.logger = logger
-  BigBlueButton.logger.info("Processing script presentation.rb")
+  BigBlueButton.logger.info('Processing script presentation.rb')
   FileUtils.mkdir_p target_dir
 
   begin
-    # Create a copy of the raw archives
-    temp_dir = "#{target_dir}/temp"
-    FileUtils.mkdir_p temp_dir
-    FileUtils.cp_r(raw_archive_dir, temp_dir)
-
     # Create initial metadata.xml
-    b = Builder::XmlMarkup.new(:indent => 2)
-    metaxml = b.recording {
+    b = Builder::XmlMarkup.new(indent: 2)
+    metaxml = b.recording do
       b.id(meeting_id)
-      b.state("processing")
+      b.state('processing')
       b.published(false)
       b.start_time
       b.end_time
       b.participants
       b.playback
       b.meta
-    }
-    metadata_xml = File.new("#{target_dir}/metadata.xml","w")
+    end
+    metadata_xml = File.new("#{target_dir}/metadata.xml", 'w')
     metadata_xml.write(metaxml)
     metadata_xml.close
-    BigBlueButton.logger.info("Created inital metadata.xml")
+    BigBlueButton.logger.info('Created inital metadata.xml')
 
-    BigBlueButton::AudioProcessor.process("#{temp_dir}/#{meeting_id}", "#{target_dir}/audio")
-    events_xml = "#{temp_dir}/#{meeting_id}/events.xml"
+    BigBlueButton::AudioProcessor.process(raw_archive_dir, "#{target_dir}/audio")
+    events_xml = "#{raw_archive_dir}/events.xml"
+
+    # TODO: Don't copy events.xml to target directory
     FileUtils.cp(events_xml, target_dir)
 
-    presentation_dir = "#{temp_dir}/#{meeting_id}/presentation"
+    presentation_dir = "#{raw_archive_dir}/presentation"
     presentations = BigBlueButton::Presentation.get_presentations(events_xml)
 
     processed_pres_dir = "#{target_dir}/presentation"
     FileUtils.mkdir_p processed_pres_dir
 
     # Get the real-time start and end timestamp
-    @doc = Nokogiri::XML(File.read("#{target_dir}/events.xml"))
+    @doc = Nokogiri::XML(File.read("#{target_dir}/events.xml")) 
 
-    meeting_start = @doc.xpath("//event")[0][:timestamp]
-    meeting_end = @doc.xpath("//event").last()[:timestamp]
+    event_timestamps = @doc.xpath('recording/event/@timestamp')
 
+    meeting_start = event_timestamps.first.text.to_i
+    meeting_end = event_timestamps.last.text.to_i
     match = /.*-(\d+)$/.match(meeting_id)
-    real_start_time = match[1]
-    real_end_time = (real_start_time.to_i + (meeting_end.to_i - meeting_start.to_i)).to_s
-
+    real_start_time = match[1].to_i
+    real_end_time = real_start_time + (meeting_end - meeting_start)
 
     # Add start_time, end_time and meta to metadata.xml
     ## Load metadata.xml
@@ -105,48 +103,41 @@ if not FileTest.directory?(target_dir)
     ## Add start_time and end_time
     recording = metadata.root
     ### Date Format for recordings: Thu Mar 04 14:05:56 UTC 2010
-    start_time = recording.at_xpath("start_time")
+    start_time = recording.at_xpath('start_time')
     start_time.content = real_start_time
-    end_time = recording.at_xpath("end_time")
+    end_time = recording.at_xpath('end_time')
     end_time.content = real_end_time
 
     ## Copy the breakout and breakout rooms node from
     ## events.xml if present.
-    breakout_xpath = @doc.xpath("//breakout")
-    breakout_rooms_xpath = @doc.xpath("//breakoutRooms")
-    meeting_xpath = @doc.xpath("//meeting")
+    breakout_xpath = @doc.xpath('recording/breakout')
+    breakout_rooms_xpath = @doc.xpath('recording/breakoutRooms')
+    meeting_xpath = @doc.xpath('recording/meeting')
 
-    if (meeting_xpath != nil)
-      recording << meeting_xpath
-    end
+    recording << meeting_xpath unless meeting_xpath.nil?
 
-    if (breakout_xpath != nil)
-      recording << breakout_xpath
-    end
+    recording << breakout_xpath unless breakout_xpath.nil?
 
-    if (breakout_rooms_xpath != nil)
-      recording << breakout_rooms_xpath
-    end
+    recording << breakout_rooms_xpath unless breakout_rooms_xpath.nil?
 
-    participants = recording.at_xpath("participants")
+    participants = recording.at_xpath('participants')
     participants.content = BigBlueButton::Events.get_num_participants(@doc)
 
     ## Remove empty meta
-    metadata.search('//recording/meta').each do |meta|
-      meta.remove
-    end
+    ## TODO: Clarify reasoning behind creating an empty node to then remove it
+    metadata.search('recording/meta').each(&:remove)
     ## Add the actual meta
-    metadata_with_playback = Nokogiri::XML::Builder.with(metadata.at('recording')) do |xml|
-      xml.meta {
-        BigBlueButton::Events.get_meeting_metadata("#{target_dir}/events.xml").each { |k,v| xml.method_missing(k,v) }
-      }
+    Nokogiri::XML::Builder.with(metadata.at('recording')) do |xml|
+      xml.meta do
+        BigBlueButton::Events.get_meeting_metadata("#{target_dir}/events.xml").each { |k, v| xml.method_missing(k, v) }
+      end
     end
     ## Write the new metadata.xml
-    metadata_file = File.new("#{target_dir}/metadata.xml","w")
-    metadata = Nokogiri::XML(metadata.to_xml) { |x| x.noblanks }
+    metadata_file = File.new("#{target_dir}/metadata.xml", 'w')
+    metadata = Nokogiri::XML(metadata.to_xml, &:noblanks)
     metadata_file.write(metadata.root)
     metadata_file.close
-    BigBlueButton.logger.info("Created an updated metadata.xml with start_time and end_time")
+    BigBlueButton.logger.info('Created an updated metadata.xml with start_time and end_time')
 
     # Start processing raw files
     presentation_text = {}
@@ -158,56 +149,54 @@ if not FileTest.directory?(target_dir)
       FileUtils.mkdir_p target_pres_dir
       FileUtils.mkdir_p "#{target_pres_dir}/textfiles"
 
-      images=Dir.glob("#{pres_dir}/#{pres}.{jpg,jpeg,png,gif,JPG,JPEG,PNG,GIF}")
+      images = Dir.glob("#{pres_dir}/#{pres}.{jpg,jpeg,png,gif,JPG,JPEG,PNG,GIF}")
       if images.empty?
         pres_name = "#{pres_dir}/#{pres}"
-        if File.exists?("#{pres_name}.pdf")
+        if File.exist?("#{pres_name}.pdf")
           pres_pdf = "#{pres_name}.pdf"
           BigBlueButton.logger.info("Found pdf file for presentation #{pres_pdf}")
-        elsif File.exists?("#{pres_name}.PDF")
+        elsif File.exist?("#{pres_name}.PDF")
           pres_pdf = "#{pres_name}.PDF"
           BigBlueButton.logger.info("Found PDF file for presentation #{pres_pdf}")
-        elsif File.exists?("#{pres_name}")
+        elsif File.exist?(pres_name.to_s)
           pres_pdf = pres_name
           BigBlueButton.logger.info("Falling back to old presentation filename #{pres_pdf}")
         else
-          pres_pdf = ""
+          pres_pdf = ''
           BigBlueButton.logger.warn("Could not find pdf file for presentation #{pres}")
         end
 
-        if !pres_pdf.empty?
+        unless pres_pdf.empty?
           text = {}
           1.upto(num_pages) do |page|
             BigBlueButton::Presentation.extract_png_page_from_pdf(
-              page, pres_pdf, "#{target_pres_dir}/slide-#{page}.png", '1600x1600')
-            if File.exist?("#{pres_dir}/textfiles/slide-#{page}.txt") then
-              t = File.read("#{pres_dir}/textfiles/slide-#{page}.txt", encoding: 'UTF-8')
-              text["slide-#{page}"] = t.encode('UTF-8', invalid: :replace)
-              FileUtils.cp("#{pres_dir}/textfiles/slide-#{page}.txt", "#{target_pres_dir}/textfiles")
-            end
+              page, pres_pdf, "#{target_pres_dir}/slide-#{page}.png", '1600x1600'
+            )
+            next unless File.exist?("#{pres_dir}/textfiles/slide-#{page}.txt")
+            t = File.read("#{pres_dir}/textfiles/slide-#{page}.txt", encoding: 'UTF-8')
+            text["slide-#{page}"] = t.encode('UTF-8', invalid: :replace)
+            FileUtils.cp("#{pres_dir}/textfiles/slide-#{page}.txt", "#{target_pres_dir}/textfiles")
           end
           presentation_text[pres] = text
         end
       else
-        ext = File.extname("#{images[0]}")
         BigBlueButton::Presentation.convert_image_to_png(
-          images[0], "#{target_pres_dir}/slide-1.png", '1600x1600')
+          images[0], "#{target_pres_dir}/slide-1.png", '1600x1600'
+        )
       end
 
       # Copy thumbnails from raw files
       FileUtils.cp_r("#{pres_dir}/thumbnails", "#{target_pres_dir}/thumbnails") if File.exist?("#{pres_dir}/thumbnails")
     end
 
-    BigBlueButton.logger.info("Generating closed captions")
+    BigBlueButton.logger.info('Generating closed captions')
     ret = BigBlueButton.exec_ret('utils/gen_webvtt', '-i', raw_archive_dir, '-o', target_dir)
-    if ret != 0
-      raise "Generating closed caption files failed"
-    end
-    captions = JSON.load(File.new("#{target_dir}/captions.json", 'r'))
+    raise 'Generating closed caption files failed' if ret != 0
+    captions = JSON.parse(File.read("#{target_dir}/captions.json"))
 
-    if not presentation_text.empty?
+    unless presentation_text.empty?
       # Write presentation_text.json to file
-      File.open("#{target_dir}/presentation_text.json","w") { |f| f.puts presentation_text.to_json }
+      File.open("#{target_dir}/presentation_text.json", 'w') { |f| f.puts presentation_text.to_json }
     end
 
     # We have to decide whether to actually generate the webcams video file
@@ -215,40 +204,38 @@ if not FileTest.directory?(target_dir)
     # - There is webcam video present, or
     # - There's broadcast video present, or
     # - There are closed captions present (they need a video stream to be rendered on top of)
-    if !Dir["#{raw_archive_dir}/video/*"].empty? or
-        !Dir["#{raw_archive_dir}/video-broadcast/*"].empty? or
-        captions.length > 0
+    if !Dir["#{raw_archive_dir}/video/*"].empty? ||
+       !Dir["#{raw_archive_dir}/video-broadcast/*"].empty? ||
+       !captions.empty?
       webcam_width = presentation_props['video_output_width']
       webcam_height = presentation_props['video_output_height']
       webcam_framerate = presentation_props['video_output_framerate']
 
       # Use a higher resolution video canvas if there's broadcast video streams
-      if !Dir["#{raw_archive_dir}/video-broadcast/*"].empty?
+      unless Dir["#{raw_archive_dir}/video-broadcast/*"].empty?
         webcam_width = presentation_props['deskshare_output_width']
         webcam_height = presentation_props['deskshare_output_height']
         webcam_framerate = presentation_props['deskshare_output_framerate']
       end
 
       webcam_framerate = 15 if webcam_framerate.nil?
-      processed_audio_file = BigBlueButton::AudioProcessor.get_processed_audio_file("#{temp_dir}/#{meeting_id}", "#{target_dir}/audio")
-      BigBlueButton.process_webcam_videos(target_dir, temp_dir, meeting_id, webcam_width, webcam_height, webcam_framerate, presentation_props['audio_offset'], processed_audio_file, presentation_props['video_formats'])
+      processed_audio_file = BigBlueButton::AudioProcessor.get_processed_audio_file(raw_archive_dir, "#{target_dir}/audio")
+      BigBlueButton.process_webcam_videos(target_dir, raw_archive_dir, webcam_width, webcam_height, webcam_framerate, presentation_props['audio_offset'], processed_audio_file, presentation_props['video_formats'])
     end
 
-    if !Dir["#{raw_archive_dir}/deskshare/*"].empty? and presentation_props['include_deskshare']
+    if !Dir["#{raw_archive_dir}/deskshare/*"].empty? && presentation_props['include_deskshare']
       deskshare_width = presentation_props['deskshare_output_width']
       deskshare_height = presentation_props['deskshare_output_height']
       deskshare_framerate = presentation_props['deskshare_output_framerate']
       deskshare_framerate = 5 if deskshare_framerate.nil?
 
-      BigBlueButton.process_deskshare_videos(target_dir, temp_dir, meeting_id, deskshare_width, deskshare_height, deskshare_framerate, presentation_props['video_formats'])
+      BigBlueButton.process_deskshare_videos(target_dir, raw_archive_dir, deskshare_width, deskshare_height, deskshare_framerate, presentation_props['video_formats'])
     end
 
     # Copy shared notes from raw files
-    if !Dir["#{raw_archive_dir}/notes/*"].empty?
-      FileUtils.cp_r("#{raw_archive_dir}/notes", target_dir)
-    end
+    FileUtils.cp_r("#{raw_archive_dir}/notes", target_dir) unless Dir["#{raw_archive_dir}/notes/*"].empty?
 
-    process_done = File.new("#{recording_dir}/status/processed/#{meeting_id}-presentation.done", "w")
+    process_done = File.new("#{recording_dir}/status/processed/#{meeting_id}-presentation.done", 'w')
     process_done.write("Processed #{meeting_id}")
     process_done.close
 
@@ -257,15 +244,14 @@ if not FileTest.directory?(target_dir)
     metadata = Nokogiri::XML(File.read("#{target_dir}/metadata.xml"))
     ## Update status
     recording = metadata.root
-    state = recording.at_xpath("state")
-    state.content = "processed"
+    state = recording.at_xpath('state')
+    state.content = 'processed'
     ## Write the new metadata.xml
-    metadata_file = File.new("#{target_dir}/metadata.xml","w")
+    metadata_file = File.new("#{target_dir}/metadata.xml", 'w')
     metadata_file.write(metadata.root)
     metadata_file.close
-    BigBlueButton.logger.info("Created an updated metadata.xml with state=processed")
-
-  rescue Exception => e
+    BigBlueButton.logger.info('Created an updated metadata.xml with state=processed')
+  rescue StandardError => e
     BigBlueButton.logger.error(e.message)
     e.backtrace.each do |traceline|
       BigBlueButton.logger.error(traceline)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Uses archived raw files directly instead of copying them over.
Specifies paths in XPATH expressions for faster query speeds instead of using the `//` operator.

Linting changes:
Removes useless assignments to `ext`, `metadata_with_playback` variables
Use YAML safe load and JSON parse over load
Rescue `StandardError` instead of `Exception`
Use frozen string literals
Uniform formatting

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #5635


### Motivation
Improving the performance, readability and security of the presentation recording processing script.

Developed for TU Munich's Open Source Lab course.
<!-- What inspired you to submit this pull request? -->

### More
Example benchmark of this PR's impact:

1. Record a short meeting in BBB
2. Add a large file to the meeting's raw data to simulate a long recording:

    `curl https://speed.hetzner.de/10GB.bin --output 10GB_File` **Warning - 10 GB download** 

3. Run processing script:

```
time ruby process/presentation.rb -m <meeting_id>

Current implementation:
real	2m4.382s
user	0m8.109s
sys	0m30.770s

Using raw files:
real	0m8.298s
user	0m8.005s
sys	0m1.349s
```

While captions should still be working, I couldn't properly test them given the feature is missing in my HTML5 client for now.