### PR TITLE
fix: learning dashboard's favicon

### DIFF
--- a/bbb-learning-dashboard/public/index.html
+++ b/bbb-learning-dashboard/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Dashboard with BigBlueButton meeting activities" />


### PR DESCRIPTION
### What does this PR do?

This PR changes the Learning Dashboard's favicon to the default one.

### Closes Issue(s)

Closes #13683