### PR TITLE
fix: add missing styles to buttons

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/button/styles.js
@@ -599,9 +599,55 @@ const ButtonSpan = styled.span`
 `;
 
 const Button = styled(BaseButton)`
+  border: none;
+  overflow: visible;
+  display: inline-block;
+  border-radius: ${borderSize};
   font-weight: ${btnFontWeight};
   line-height: 1;
   text-align: center;
+  white-space: nowrap;
+  vertical-align: middle;
+  cursor: pointer;
+  user-select: none;
+
+  &:-moz-focusring {
+    outline: none;
+  }
+
+  &:hover,
+  &:focus {
+    outline: transparent;
+    outline-style: dotted;
+    outline-width: ${borderSize};
+    text-decoration: none;
+  }
+
+  &:active,
+  &:focus {
+    outline: transparent;
+    outline-width: ${borderSize};
+    outline-style: solid;
+  }
+
+  &:active {
+    background-image: none;
+  }
+
+  &[aria-disabled="true"] {
+    cursor: not-allowed;
+    opacity: .65;
+    box-shadow: none;
+  }
+
+  &,
+  &:active {
+    &:focus {
+      span:first-of-type::before {
+        border-radius: ${borderSize};
+      }
+    }
+  }
 
   ${({ size }) => size === 'sm' && `
     font-size: calc(${fontSizeSmall} * .85);


### PR DESCRIPTION
### What does this PR do?

Add missing (from sass -> styled-components conversion) styles to buttons.

#### before
<img width="296" alt="Screen Shot 2021-11-18 at 08 44 41" src="https://user-images.githubusercontent.com/3728706/142409448-e67e06ce-7d8e-439a-b1a7-b25fa81837c7.png">

#### after
<img width="281" alt="Screen Shot 2021-11-18 at 08 44 16" src="https://user-images.githubusercontent.com/3728706/142409442-3f771baf-8395-4fa2-b672-ed5a4ce71d85.png">
