### PR TITLE
Fix for pushing layout: attempting to push while already using chosen layout locally

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -233,9 +233,10 @@ class App extends Component {
       deviceType,
       isPresenter,
       meetingLayout,
-      settingsLayout,
+      selectedLayout, // full layout name
+      settingsLayout, // shortened layout name (without Push)
       layoutType,
-      pushLayoutToEveryone,
+      pushLayoutToEveryone, // is layout pushed
       layoutContextDispatch,
     } = this.props;
 
@@ -249,7 +250,7 @@ class App extends Component {
       Settings.save();
     }
 
-    if (settingsLayout !== prevProps.settingsLayout
+    if (selectedLayout !== prevProps.selectedLayout
       || settingsLayout !== layoutType) {
       layoutContextDispatch({
         type: ACTIONS.SET_LAYOUT_TYPE,

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -57,6 +57,7 @@ const AppContainer = (props) => {
   const {
     actionsbar,
     meetingLayout,
+    selectedLayout,
     settingsLayout,
     pushLayoutToEveryone,
     currentUserId,
@@ -90,6 +91,7 @@ const AppContainer = (props) => {
           currentUserId,
           layoutType,
           meetingLayout,
+          selectedLayout,
           settingsLayout,
           pushLayoutToEveryone,
           deviceType,
@@ -196,6 +198,7 @@ export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) 
     currentUserId: currentUser?.userId,
     isPresenter: currentUser?.presenter,
     meetingLayout: layout,
+    selectedLayout,
     settingsLayout: selectedLayout?.replace('Push', ''),
     pushLayoutToEveryone: selectedLayout?.includes('Push'),
     audioAlertEnabled: AppSettings.chatAudioAlerts,


### PR DESCRIPTION
This PR fixes the bug that prevented new layout from being pushed if the user who triggered it already had the same layout chosen locally.
If you are using "Focus on presentation" and then you decide to push the same layout to others, it doesn't trigger the push, because your front-end thinks nothing changed. Same happens for other types of layout.