### PR TITLE
fix(layout): unable resize side panel

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -338,6 +338,7 @@ class ScreenshareComponent extends React.Component {
       width,
       height,
       zIndex,
+      fullscreenContext,
     } = this.props;
 
     // Conditions to render the (re)connecting dots and the unhealthy stream
@@ -363,7 +364,7 @@ class ScreenshareComponent extends React.Component {
             right,
             height,
             width,
-            zIndex,
+            zIndex: fullscreenContext ? zIndex : undefined,
             backgroundColor: '#06172A',
           }
         }


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->
Sets z-index attribute to screen share component, only when it is in full screen mode.
This is the same way it is done for presentation component.

### Closes Issue(s)
Closes #13710
