### PR TITLE
refactor: Remove unnecessary clippath from textarea annotation on Firefox

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/text/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/text/component.jsx
@@ -150,7 +150,6 @@ export default class TextDrawComponent extends Component {
     return (
       <g>
         <foreignObject
-          clipPath={`url(#${annotation.id})`}
           x={results.x}
           y={results.y}
           width={results.width}

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/text/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/text/component.jsx
@@ -149,16 +149,6 @@ export default class TextDrawComponent extends Component {
 
     return (
       <g>
-        <RenderInBrowser only firefox>
-          <clipPath id={annotation.id}>
-            <rect
-              x={results.x}
-              y={results.y}
-              width={results.width}
-              height={results.height}
-            />
-          </clipPath>
-        </RenderInBrowser>
         <foreignObject
           clipPath={`url(#${annotation.id})`}
           x={results.x}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Remove seemingly unnecessary code from the text annotation.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation

I am working on selectable annotations, and found out that only text annotation has a clippath with its id, which prevents my work anyhow. In my understanding, this code was added by #5532 to avoid flickering in the text area (#5467). It seems to me however, unnecessary after numerous browser updates. 

### More

<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
