### PR TITLE
fix: webcam alignment in RTL languages - smart layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -357,7 +357,7 @@ class SmartLayout extends Component {
     if (input.cameraDock.numCameras > 0) {
       cameraDockBounds.top = mediaAreaBounds.top;
       cameraDockBounds.left = mediaAreaBounds.left;
-      cameraDockBounds.right = isRTL ? sidebarSize + (camerasMargin * 2) : null;
+      cameraDockBounds.right = isRTL ? sidebarSize : null;
       cameraDockBounds.zIndex = 1;
 
       if (!isOpen) {
@@ -377,6 +377,7 @@ class SmartLayout extends Component {
         cameraDockBounds.position = CAMERADOCK_POSITION.CONTENT_LEFT;
         // button size in vertical position
         cameraDockBounds.height -= 20;
+        cameraDockBounds.right = isRTL ? sidebarSize + (camerasMargin * 2) : null;
       } else {
         cameraDockBounds.width = mediaAreaBounds.width;
         cameraDockBounds.maxWidth = mediaAreaBounds.width;


### PR DESCRIPTION
### What does this PR do?

Fix wrong camera position in RTL languages (smart layout only).
`camerasMargin` value should not be applied when cameras are on top. 

### Closes Issue(s)
Closes #13730
