### PR TITLE
fix: Client crashes when trying to remove a user

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/modal/remove-user/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/modal/remove-user/component.jsx
@@ -69,7 +69,7 @@ class RemoveUserModal extends Component {
           </Styled.Description>
 
           <Styled.Footer>
-            <Styled.ConfirmButtom
+            <Styled.ConfirmButton
               color="primary"
               label={intl.formatMessage(messages.yesLabel)}
               onClick={() => {

--- a/bigbluebutton-html5/imports/ui/components/modal/remove-user/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/modal/remove-user/styles.js
@@ -69,7 +69,7 @@ const Footer = styled.div`
   display:flex;
 `;
 
-const ConfirmButtom = styled(Button)`
+const ConfirmButton = styled(Button)`
   padding-right: ${jumboPaddingY};
   padding-left: ${jumboPaddingY};
   margin: 0 ${smPaddingX} 0 0;
@@ -79,7 +79,7 @@ const ConfirmButtom = styled(Button)`
   }
 `;
 
-const DismissButtom = styled(ConfirmButtom)`
+const DismissButton = styled(ConfirmButton)`
   box-shadow: 0 0 0 1px ${colorGray};
 `;
 
@@ -91,6 +91,6 @@ export default {
   Description,
   BanUserCheckBox,
   Footer,
-  ConfirmButtom,
-  DismissButtom,
+  ConfirmButton,
+  DismissButton,
 };


### PR DESCRIPTION
### What does this PR do?

Fix typo that causes a crash in remove-user modal: `Buttom` -> `Button`

### Closes Issue(s)
Closes #13715