### PR TITLE
fix: [a11y] Make poll question navigatable

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/polling/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/polling/component.jsx
@@ -130,9 +130,9 @@ class Polling extends Component {
           {
             question.length > 0 && (
               <span className={styles.qHeader}>
-                <div className={styles.qTitle}>
+                <h2 className={styles.qTitle}>
                   {intl.formatMessage(intlMessages.pollQuestionTitle)}
-                </div>
+                </h2>
                 <div data-test="pollQuestion" className={styles.qText}>{question}</div>
               </span>
             )

--- a/bigbluebutton-html5/imports/ui/components/polling/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/polling/styles.scss
@@ -129,6 +129,8 @@
 
 .qTitle {
   font-size: var(--font-size-small);
+  font-weight: 600;
+  margin: 0px;
 }
 
 .qText {


### PR DESCRIPTION
### What does this PR do?

It is currently difficult for screen reader users to directly navigate
to poll options. I spoke to a screen reader user, he suggested to make
the poll question title a h2 element so users can directly jump to it.

Styling was adjusted to not add extra space for the title which would be introduced by switching to an h2 tag.


