### PR TITLE
style: Center modal title

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/modal/simple/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/modal/simple/component.jsx
@@ -81,7 +81,7 @@ class ModalSimple extends Component {
         {...otherProps}
       >
         <Styled.Header hideBorder={hideBorder}>
-          <Styled.Title>{title}</Styled.Title>
+          <Styled.Title hasLeftMargin={shouldShowCloseButton}>{title}</Styled.Title>
           {shouldShowCloseButton ? (
             <Styled.DismissButton
               label={intl.formatMessage(intlMessages.modalClose)}

--- a/bigbluebutton-html5/imports/ui/components/modal/simple/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/modal/simple/styles.js
@@ -45,6 +45,10 @@ const Title = styled.h1`
   font-size: ${fontSizeLarge};
   text-align: center;
   align-self: flex-end;
+
+  ${({ hasLeftMargin }) => hasLeftMargin && `
+    margin-left: 35px;
+  `}
 `;
 
 const DismissButton = styled(Button)`


### PR DESCRIPTION
### What does this PR do?

Adds margin-left to modal title (only when the close button is displayed) to make it centered.

This is based on @Buda9's PR (#13694), which had to be done in a different way due to [recent changes to styles](https://github.com/bigbluebutton/bigbluebutton/pull/13680)