### PR TITLE
build: Update the Maintainer field for bigblutbutton

### DIFF
--- a/build/packages-template/bigbluebutton/build.sh
+++ b/build/packages-template/bigbluebutton/build.sh
@@ -52,7 +52,7 @@ Standards-Version: 3.9.2
 
 Package: bigbluebutton
 Version: $VERSION
-Maintainer: Senfcall IT <it@senfcall.de>
+Maintainer: ffdixon@bigbluebutton.org
 Depends: $DEPENDENCIES
 Architecture: amd64
 Copyright: license.txt


### PR DESCRIPTION
Updates the Maintainer field visible when inspecting packages build via the build scripts