### PR TITLE
refactor: Replace arrays in configuration override file

### DIFF
--- a/bigbluebutton-html5/imports/startup/server/settings.js
+++ b/bigbluebutton-html5/imports/startup/server/settings.js
@@ -7,7 +7,6 @@ import _ from 'lodash';
 const DEFAULT_SETTINGS_FILE_PATH = process.env.BBB_HTML5_SETTINGS || 'assets/app/config/settings.yml';
 const LOCAL_SETTINGS_FILE_PATH = process.env.BBB_HTML5_LOCAL_SETTINGS || '/etc/bigbluebutton/bbb-html5.yml';
 
-
 try {
   if (fs.existsSync(DEFAULT_SETTINGS_FILE_PATH)) {
     const SETTINGS = YAML.parse(fs.readFileSync(DEFAULT_SETTINGS_FILE_PATH, 'utf-8'));
@@ -15,7 +14,7 @@ try {
     if (fs.existsSync(LOCAL_SETTINGS_FILE_PATH)) {
       console.log('Local configuration found! Merging with default configuration...');
       const LOCAL_CONFIG = YAML.parse(fs.readFileSync(LOCAL_SETTINGS_FILE_PATH, 'utf-8'));
-      _.merge(SETTINGS, LOCAL_CONFIG);
+      _.mergeWith(SETTINGS, LOCAL_CONFIG, (a, b) => (_.isArray(b) ? b : undefined));
     } else console.log('Local Configuration not found! Loading default configuration...');
 
     Meteor.settings = SETTINGS;


### PR DESCRIPTION
### What does this PR do?

Changes the way configuration override file (/etc/bigbluebutton/bbb-html5.yml) is merged with default settings.

#### Before
Arrays are merged, making the removal of unneeded settings impossible.

#### After
Default configuration arrays are replaced with the ones from override file (when present).

### Closes Issue(s)
Closes #13597