### PR TITLE
Polling panel to remember "Work In Progress" polls

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
@@ -82,6 +82,7 @@ const SidebarContent = (props) => {
   };
 
   const smallSidebar = width < (maxWidth / 2);
+  const pollDisplay = sidebarContentPanel === PANELS.POLL ? 'inherit' : 'none';
 
   return (
     <Resizable
@@ -124,14 +125,11 @@ const SidebarContent = (props) => {
       {sidebarContentPanel === PANELS.CHAT && <ChatContainer />}
       {sidebarContentPanel === PANELS.SHARED_NOTES && <NoteContainer />}
       {sidebarContentPanel === PANELS.CAPTIONS && <CaptionsContainer />}
-      {sidebarContentPanel === PANELS.POLL
-        && (
-          <Styled.Poll style={{ minWidth, top: '0' }} id="pollPanel">
-            <PollContainer smallSidebar={smallSidebar} />
-          </Styled.Poll>
-        )}
       {sidebarContentPanel === PANELS.BREAKOUT && <BreakoutRoomContainer />}
       {sidebarContentPanel === PANELS.WAITING_USERS && <WaitingUsersPanel />}
+      <Styled.Poll style={{ minWidth, top: '0', display: pollDisplay }} id="pollPanel">
+        <PollContainer smallSidebar={smallSidebar} />
+      </Styled.Poll>
     </Resizable>
   );
 };


### PR DESCRIPTION
### What does this PR do?

Keeps polling panel active when switching to other panels, adding the possibility to navigate to chat/shared notes without losing input values of a poll that has not been started.

### Closes Issue(s)
Closes #13512
