### PR TITLE
Add new /join param userdata-exclude_from_dashboard

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingAfterReconnectReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingAfterReconnectReqMsgHdlr.scala
@@ -25,7 +25,7 @@ trait UserJoinMeetingAfterReconnectReqMsgHdlr extends HandlerHelpers with UserJo
         }
         state
       case None =>
-        val newState = userJoinMeeting(outGW, msg.body.authToken, msg.body.clientType, liveMeeting, state)
+        val newState = userJoinMeeting(outGW, msg.body.authToken, msg.body.clientType, false, liveMeeting, state)
         if (liveMeeting.props.meetingProp.isBreakout) {
           BreakoutHdlrHelpers.updateParentMeetingWithUsers(liveMeeting, eventBus)
         }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
@@ -24,7 +24,7 @@ trait UserJoinMeetingReqMsgHdlr extends HandlerHelpers {
         }
         state
       case None =>
-        val newState = userJoinMeeting(outGW, msg.body.authToken, msg.body.clientType, liveMeeting, state)
+        val newState = userJoinMeeting(outGW, msg.body.authToken, msg.body.clientType, msg.body.excludeDashboard, liveMeeting, state)
 
         if (liveMeeting.props.meetingProp.isBreakout) {
           BreakoutHdlrHelpers.updateParentMeetingWithUsers(liveMeeting, eventBus)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -290,6 +290,7 @@ case class UserState(
     lastActivityTime:      Long         = System.currentTimeMillis(),
     lastInactivityInspect: Long         = 0,
     clientType:            String,
+    excludeDashboard:      Boolean,
     userLeftFlag:          UserLeftFlag
 )
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -37,7 +37,7 @@ trait HandlerHelpers extends SystemConfiguration {
     }
   }
 
-  def userJoinMeeting(outGW: OutMsgRouter, authToken: String, clientType: String,
+  def userJoinMeeting(outGW: OutMsgRouter, authToken: String, clientType: String, excludeDashboard: Boolean,
                       liveMeeting: LiveMeeting, state: MeetingState2x): MeetingState2x = {
 
     val nu = for {
@@ -64,6 +64,7 @@ trait HandlerHelpers extends SystemConfiguration {
         locked = MeetingStatus2x.getPermissions(liveMeeting.status).lockOnJoin,
         avatar = regUser.avatarURL,
         clientType = clientType,
+        excludeDashboard = excludeDashboard,
         userLeftFlag = UserLeftFlag(false, 0)
       )
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/UserJoinedMeetingEvtMsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/UserJoinedMeetingEvtMsgBuilder.scala
@@ -13,7 +13,8 @@ object UserJoinedMeetingEvtMsgBuilder {
       guestStatus = userState.guestStatus,
       emoji = userState.emoji,
       presenter = userState.presenter, locked = userState.locked, avatar = userState.avatar,
-      clientType = userState.clientType)
+      clientType = userState.clientType,
+      excludeDashboard = userState.excludeDashboard)
 
     val event = UserJoinedMeetingEvtMsg(meetingId, userState.intId, body)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeTestData.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeTestData.scala
@@ -69,7 +69,7 @@ trait FakeTestData {
     UserState(intId = regUser.id, extId = regUser.externId, name = regUser.name, role = regUser.role,
       guest = regUser.guest, authed = regUser.authed, guestStatus = regUser.guestStatus,
       emoji = "none", locked = false, presenter = false, avatar = regUser.avatarURL, clientType = "unknown",
-      userLeftFlag = UserLeftFlag(false, 0))
+      excludeDashboard = false, userLeftFlag = UserLeftFlag(false, 0))
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
@@ -152,16 +152,18 @@ class LearningDashboardActor(
   }
 
   private def handleUserJoinedMeetingEvtMsg(msg: UserJoinedMeetingEvtMsg): Unit = {
-    for {
-      meeting <- meetings.values.find(m => m.intId == msg.header.meetingId)
-    } yield {
-      val user: User = meeting.users.values.find(u => u.intId == msg.body.intId).getOrElse({
-        User(
-          msg.body.intId, msg.body.extId, msg.body.name, (msg.body.role == Roles.MODERATOR_ROLE)
-        )
-      })
+    if(msg.body.excludeDashboard == false) {
+      for {
+        meeting <- meetings.values.find(m => m.intId == msg.header.meetingId)
+      } yield {
+        val user: User = meeting.users.values.find(u => u.intId == msg.body.intId).getOrElse({
+          User(
+            msg.body.intId, msg.body.extId, msg.body.name, (msg.body.role == Roles.MODERATOR_ROLE)
+          )
+        })
 
-      meetings += (meeting.intId -> meeting.copy(users = meeting.users + (user.intId -> user.copy(leftOn = 0))))
+        meetings += (meeting.intId -> meeting.copy(users = meeting.users + (user.intId -> user.copy(leftOn = 0))))
+      }
     }
   }
 

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
@@ -91,7 +91,8 @@ case class UserJoinedMeetingEvtMsg(
 case class UserJoinedMeetingEvtMsgBody(intId: String, extId: String, name: String, role: String,
                                        guest: Boolean, authed: Boolean, guestStatus: String,
                                        emoji:     String,
-                                       presenter: Boolean, locked: Boolean, avatar: String, clientType: String)
+                                       presenter: Boolean, locked: Boolean, avatar: String, clientType: String,
+                                       excludeDashboard: Boolean)
 
 /**
  * Sent by client to get all users in a meeting.
@@ -288,7 +289,7 @@ case class LogoutAndEndMeetingCmdMsgBody(userId: String)
 
 object UserJoinMeetingReqMsg { val NAME = "UserJoinMeetingReqMsg" }
 case class UserJoinMeetingReqMsg(header: BbbClientMsgHeader, body: UserJoinMeetingReqMsgBody) extends StandardMsg
-case class UserJoinMeetingReqMsgBody(userId: String, authToken: String, clientType: String)
+case class UserJoinMeetingReqMsgBody(userId: String, authToken: String, clientType: String, excludeDashboard: Boolean)
 
 /**
  * Sent from Flash client to rejoin meeting after reconnection

--- a/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/addUserPersistentData.js
+++ b/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/addUserPersistentData.js
@@ -25,6 +25,7 @@ export default function addUserPersistentData(user) {
     locked: Boolean,
     avatar: String,
     clientType: String,
+    excludeDashboard: Boolean,
     effectiveConnectionType: null,
   });
 

--- a/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
+++ b/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
@@ -1,7 +1,6 @@
 import { check } from 'meteor/check';
 import addUserSetting from '/imports/api/users-settings/server/modifiers/addUserSetting';
 import logger from '/imports/startup/server/logger';
-import { extractCredentials } from '/imports/api/common/server/helpers';
 
 const oldParameters = {
   askForFeedbackOnLogout: 'bbb_ask_for_feedback_on_logout',
@@ -70,6 +69,8 @@ const currentParameters = [
   // OUTSIDE COMMANDS
   'bbb_outside_toggle_self_voice',
   'bbb_outside_toggle_recording',
+  // LEARNING DASHBOARD
+  'exclude_from_dashboard',
 ];
 
 function valueParser(val) {
@@ -82,12 +83,9 @@ function valueParser(val) {
   }
 }
 
-export default function addUserSettings(settings) {
+export default function addUserSettings(meetingId, userId, settings) {
   try {
     check(settings, [Object]);
-
-    const { meetingId, requesterUserId: userId } = extractCredentials(this.userId);
-
     check(meetingId, String);
     check(userId, String);
 

--- a/bigbluebutton-html5/imports/api/users/server/handlers/userJoin.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/userJoin.js
@@ -2,6 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 import RedisPubSub from '/imports/startup/server/redis';
 import Logger from '/imports/startup/server/logger';
+import UserSettings from '/imports/api/users-settings';
 
 export default function userJoin(meetingId, userId, authToken) {
   const REDIS_CONFIG = Meteor.settings.private.redis;
@@ -10,10 +11,17 @@ export default function userJoin(meetingId, userId, authToken) {
 
   check(authToken, String);
 
+  const excludeDashboard = (UserSettings.findOne({
+    meetingId,
+    userId,
+    setting: 'exclude_from_dashboard',
+  }) || {}).value || false;
+
   const payload = {
     userId,
     authToken,
     clientType: 'HTML5',
+    excludeDashboard,
   };
 
   Logger.info(`User='${userId}' is joining meeting='${meetingId}' authToken='${authToken}'`);

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/addUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/addUser.js
@@ -34,6 +34,7 @@ export default function addUser(meetingId, userData) {
     locked: Boolean,
     avatar: String,
     clientType: String,
+    excludeDashboard: Boolean,
   });
 
   const userId = user.intId;


### PR DESCRIPTION
This PR introduces a new param `userdata-exclude_from_dashboard` to be set as parameter in API `/join` (bbb-web).
Valid values:
- **false:** Default value. User will be present in the Dashboard.
- **true:** All data related to this user will be ignored by the Dashboard. Absent even from the `.json` file.

Closes #13653.

----
### Test using API Mate
1. **User 1** (none params)
![user-1](https://user-images.githubusercontent.com/5660191/143450206-4cd4b1a7-85d5-4e82-a12c-77f9bbb2c584.png)
2. **User 2** (userdata-exclude_from_dashboard=true)
![user-2](https://user-images.githubusercontent.com/5660191/143450227-1fcba472-fbd4-4899-9da5-ca5cd73fcf0c.png)
3. **User 3** (userdata-exclude_from_dashboard=false)
![user-3](https://user-images.githubusercontent.com/5660191/143450241-a1182c17-889c-4e4e-bad2-7920568c89d3.png)
4. **Result** (User 2 absent from Dashboard):
![user-2-absent](https://user-images.githubusercontent.com/5660191/143450340-b683fdca-9d47-4447-8604-046135c76e97.png)
----
### Point to pay attention
After a lot of tests.. I couldn't identify any problem inherited by this change in `join-handler/component.jsx`.
But it deserves a double check! I acknowledge it possibly can cause some impact.

![image](https://user-images.githubusercontent.com/5660191/143450978-79eba5ac-d3cf-4d0f-9087-aac1dee896a7.png)

This change was needed since all `userdata-*` params is set during within the `setCustomData`.
And  this new param is used in the return of `setAuth`.
Therefore, it is necessary to firstly set params and after do authenticate.