### PR TITLE
GIT-13615: fix for 0.81 and 0.9.0 slides not displayed in new browsers

### DIFF
--- a/record-and-playback/presentation/playback/presentation/0.81/lib/writing.js
+++ b/record-and-playback/presentation/playback/presentation/0.81/lib/writing.js
@@ -133,6 +133,7 @@ function runPopcorn() {
 
   // PROCESS SHAPES.SVG (in XML format).
   xmlhttp.open("GET", shapes_svg, false);
+  xmlhttp.overrideMimeType('text/xml');
   xmlhttp.send();
   var xmlDoc = xmlhttp.responseXML;
   //getting all the event tags
@@ -183,6 +184,7 @@ function runPopcorn() {
 
   // PROCESS PANZOOMS.XML
   xmlhttp.open("GET", events_xml, false);
+  xmlhttp.overrideMimeType('text/xml');
   xmlhttp.send();
   xmlDoc = xmlhttp.responseXML;
   //getting all the event tags

--- a/record-and-playback/presentation/playback/presentation/0.9.0/lib/writing.js
+++ b/record-and-playback/presentation/playback/presentation/0.9.0/lib/writing.js
@@ -242,6 +242,7 @@ function runPopcorn() {
   // PROCESS SHAPES.SVG (in XML format).
   console.log("** Getting shapes_svg");
   xmlhttp.open("GET", shapes_svg, false);
+  xmlhttp.overrideMimeType('text/xml');
   xmlhttp.send();
   var xmlDoc = xmlhttp.responseXML;
 
@@ -277,6 +278,7 @@ function runPopcorn() {
   // PROCESS PANZOOMS.XML
   console.log("** Getting panzooms.xml");
   xmlhttp.open("GET", events_xml, false);
+  xmlhttp.overrideMimeType('text/xml');
   xmlhttp.send();
   xmlDoc = xmlhttp.responseXML;
   //getting all the event tags


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->
According to the report, there is a problem rendering old recordings in some browsers. The solution was suggested by the reporter and the recipe comes from here https://blog.yeshere.org/2010/11/xmlhttprequestresponsexml-returns-null.html

Not sure if it would have an unintended effect with some browsers. Did not have the means to reproduce it.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #13615


### Motivation

<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
