### PR TITLE
feat: Add new /join param excludeFromDashboard

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
@@ -5,7 +5,7 @@ import com.softwaremill.quicklens._
 object RegisteredUsers {
   def create(userId: String, extId: String, name: String, roles: String,
              token: String, avatar: String, guest: Boolean, authenticated: Boolean,
-             guestStatus: String, loggedOut: Boolean): RegisteredUser = {
+             guestStatus: String, excludeFromDashboard: Boolean, loggedOut: Boolean): RegisteredUser = {
     new RegisteredUser(
       userId,
       extId,
@@ -16,12 +16,13 @@ object RegisteredUsers {
       guest,
       authenticated,
       guestStatus,
+      excludeFromDashboard,
       System.currentTimeMillis(),
       0,
       false,
       false,
       false,
-      loggedOut
+      loggedOut,
     )
   }
 
@@ -177,6 +178,7 @@ case class RegisteredUser(
     guest:                    Boolean,
     authed:                   Boolean,
     guestStatus:              String,
+    excludeFromDashboard:     Boolean,
     registeredOn:             Long,
     lastAuthTokenValidatedOn: Long,
     joined:                   Boolean,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
@@ -54,7 +54,7 @@ object FakeUserGenerator {
       RandomStringGenerator.randomAlphanumericString(10) + ".png"
 
     val ru = RegisteredUsers.create(userId = id, extId, name, role,
-      authToken, avatarURL, guest, authed, guestStatus = GuestStatus.ALLOW, false)
+      authToken, avatarURL, guest, authed, guestStatus = GuestStatus.ALLOW, false, false)
     RegisteredUsers.add(users, ru)
     ru
   }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
@@ -15,14 +15,15 @@ case class RegisterUserReqMsg(
 ) extends BbbCoreMsg
 case class RegisterUserReqMsgBody(meetingId: String, intUserId: String, name: String, role: String,
                                   extUserId: String, authToken: String, avatarURL: String,
-                                  guest: Boolean, authed: Boolean, guestStatus: String)
+                                  guest: Boolean, authed: Boolean, guestStatus: String, excludeFromDashboard: Boolean)
 
 object UserRegisteredRespMsg { val NAME = "UserRegisteredRespMsg" }
 case class UserRegisteredRespMsg(
     header: BbbCoreHeaderWithMeetingId,
     body:   UserRegisteredRespMsgBody
 ) extends BbbCoreMsg
-case class UserRegisteredRespMsgBody(meetingId: String, userId: String, name: String, role: String, registeredOn: Long)
+case class UserRegisteredRespMsgBody(meetingId: String, userId: String, name: String,
+                                     role: String, excludeFromDashboard: Boolean, registeredOn: Long)
 
 object RegisteredUserJoinTimeoutMsg { val NAME = "RegisteredUserJoinTimeoutMsg" }
 case class RegisteredUserJoinTimeoutMsg(

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -139,13 +139,13 @@ public class MeetingService implements MessageListener {
   public void registerUser(String meetingID, String internalUserId,
                            String fullname, String role, String externUserID,
                            String authToken, String avatarURL, Boolean guest,
-                           Boolean authed, String guestStatus) {
+                           Boolean authed, String guestStatus, Boolean excludeFromDashboard) {
     handle(new RegisterUser(meetingID, internalUserId, fullname, role,
-      externUserID, authToken, avatarURL, guest, authed, guestStatus));
+      externUserID, authToken, avatarURL, guest, authed, guestStatus, excludeFromDashboard));
 
     Meeting m = getMeeting(meetingID);
     if (m != null) {
-      RegisteredUser ruser = new RegisteredUser(authToken, internalUserId, guestStatus);
+      RegisteredUser ruser = new RegisteredUser(authToken, internalUserId, guestStatus, excludeFromDashboard);
       m.userRegistered(ruser);
     }
   }
@@ -460,7 +460,7 @@ public class MeetingService implements MessageListener {
     gw.registerUser(message.meetingID,
       message.internalUserId, message.fullname, message.role,
       message.externUserID, message.authToken, message.avatarURL, message.guest,
-            message.authed, message.guestStatus);
+            message.authed, message.guestStatus, message.excludeFromDashboard);
   }
 
     public Meeting getMeeting(String meetingId) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/RegisteredUser.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/RegisteredUser.java
@@ -6,12 +6,14 @@ public class RegisteredUser {
     public final Long registeredOn;
 
     private String guestStatus;
+    private Boolean excludeFromDashboard;
     private Long guestWaitedOn;
 
-    public RegisteredUser(String authToken, String userId, String guestStatus) {
+    public RegisteredUser(String authToken, String userId, String guestStatus, Boolean excludeFromDashboard) {
         this.authToken = authToken;
         this.userId = userId;
         this.guestStatus = guestStatus;
+        this.excludeFromDashboard = excludeFromDashboard;
 
         Long currentTimeMillis = System.currentTimeMillis();
         this.registeredOn = currentTimeMillis;
@@ -24,6 +26,14 @@ public class RegisteredUser {
 
     public String getGuestStatus() {
         return guestStatus;
+    }
+
+    public void setExcludeFromDashboard(Boolean excludeFromDashboard) {
+        this.excludeFromDashboard = excludeFromDashboard;
+    }
+
+    public Boolean getExcludeFromDashboard() {
+        return excludeFromDashboard;
     }
 
     public void updateGuestWaitedOn() {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/UserSession.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/UserSession.java
@@ -44,6 +44,7 @@ public class UserSession {
   public String avatarURL;
   public String guestStatus = GuestPolicy.ALLOW;
   public String clientUrl = null;
+  public Boolean excludeFromDashboard = false;
 
   private AtomicInteger connections = new AtomicInteger(0);
   

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/RegisterUser.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/RegisterUser.java
@@ -13,10 +13,11 @@ public class RegisterUser implements IMessage {
 	public final Boolean guest;
 	public final Boolean authed;
 	public final String guestStatus;
+	public final Boolean excludeFromDashboard;
 	
 	public RegisterUser(String meetingID, String internalUserId, String fullname, String role, String externUserID,
 						String authToken, String avatarURL, Boolean guest,
-						Boolean authed, String guestStatus) {
+						Boolean authed, String guestStatus, Boolean excludeFromDashboard) {
 		this.meetingID = meetingID;
 		this.internalUserId = internalUserId;
 		this.fullname = fullname;
@@ -27,5 +28,6 @@ public class RegisterUser implements IMessage {
 		this.guest = guest;
 		this.authed = authed;
 		this.guestStatus = guestStatus;
+		this.excludeFromDashboard = excludeFromDashboard;
 	}
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/pub/IPublisherService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/pub/IPublisherService.java
@@ -18,7 +18,7 @@ public interface IPublisherService {
     void endMeeting(String meetingId);
     void send(String channel, String message);
     void registerUser(String meetingID, String internalUserId, String fullname, String role, String externUserID,
-                      String authToken, String avatarURL, Boolean guest, Boolean authed);
+                      String authToken, String avatarURL, Boolean guest, Boolean excludeFromDashboard, Boolean authed);
     void sendKeepAlive(String system, Long bbbWebTimestamp, Long akkaAppsTimestamp);
     void sendStunTurnInfo(String meetingId, String internalUserId, Set<StunServer> stuns, Set<TurnEntry> turns);
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
@@ -37,7 +37,7 @@ public interface IBbbWebApiGWApp {
 
   void registerUser(String meetingID, String internalUserId, String fullname, String role,
                     String externUserID, String authToken, String avatarURL,
-                    Boolean guest, Boolean authed, String guestStatus);
+                    Boolean guest, Boolean authed, String guestStatus, Boolean excludeFromDashboard);
   void ejectDuplicateUser(String meetingID, String internalUserId, String fullname,
                     String externUserID);
   void guestWaitingLeft(String meetingID, String internalUserId);

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -226,7 +226,7 @@ class BbbWebApiGWApp(
   def registerUser(meetingId: String, intUserId: String, name: String,
                    role: String, extUserId: String, authToken: String, avatarURL: String,
                    guest: java.lang.Boolean, authed: java.lang.Boolean,
-                   guestStatus: String): Unit = {
+                   guestStatus: String, excludeFromDashboard: java.lang.Boolean): Unit = {
 
     //    meetingManagerActorRef ! new RegisterUser(meetingId = meetingId, intUserId = intUserId, name = name,
     //      role = role, extUserId = extUserId, authToken = authToken, avatarURL = avatarURL,
@@ -234,7 +234,8 @@ class BbbWebApiGWApp(
 
     val regUser = new RegisterUser(meetingId = meetingId, intUserId = intUserId, name = name,
       role = role, extUserId = extUserId, authToken = authToken, avatarURL = avatarURL,
-      guest = guest.booleanValue(), authed = authed.booleanValue(), guestStatus = guestStatus)
+      guest = guest.booleanValue(), authed = authed.booleanValue(), guestStatus = guestStatus,
+      excludeFromDashboard = excludeFromDashboard)
 
     val event = MsgBuilder.buildRegisterUserRequestToAkkaApps(regUser)
     msgToAkkaAppsEventBus.publish(MsgToAkkaApps(toAkkaAppsChannel, event))

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -50,7 +50,8 @@ object MsgBuilder {
     val header = BbbCoreHeaderWithMeetingId(RegisterUserReqMsg.NAME, msg.meetingId)
     val body = RegisterUserReqMsgBody(meetingId = msg.meetingId, intUserId = msg.intUserId,
       name = msg.name, role = msg.role, extUserId = msg.extUserId, authToken = msg.authToken,
-      avatarURL = msg.avatarURL, guest = msg.guest, authed = msg.authed, guestStatus = msg.guestStatus)
+      avatarURL = msg.avatarURL, guest = msg.guest, authed = msg.authed, guestStatus = msg.guestStatus,
+      excludeFromDashboard = msg.excludeFromDashboard)
     val req = RegisterUserReqMsg(header, body)
     BbbCommonEnvCoreMsg(envelope, req)
   }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/MeetingsManagerActor.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/MeetingsManagerActor.scala
@@ -17,7 +17,7 @@ case class CreateBreakoutRoomMsg(meetingId: String, parentMeetingId: String,
 case class AddUserSession(token: String, session: UserSession)
 case class RegisterUser(meetingId: String, intUserId: String, name: String, role: String,
                         extUserId: String, authToken: String, avatarURL: String,
-                        guest: Boolean, authed: Boolean, guestStatus: String)
+                        guest: Boolean, authed: Boolean, guestStatus: String, excludeFromDashboard: Boolean)
 
 case class CreateMeetingMsg(defaultProps: DefaultProps)
 

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/ToAkkaAppsSendersTrait.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/ToAkkaAppsSendersTrait.scala
@@ -28,7 +28,8 @@ trait ToAkkaAppsSendersTrait extends SystemConfiguration {
     val header = BbbCoreHeaderWithMeetingId(RegisterUserReqMsg.NAME, msg.meetingId)
     val body = RegisterUserReqMsgBody(meetingId = msg.meetingId, intUserId = msg.intUserId,
       name = msg.name, role = msg.role, extUserId = msg.extUserId, authToken = msg.authToken,
-      avatarURL = msg.avatarURL, guest = msg.guest, authed = msg.authed, guestStatus = msg.guestStatus)
+      avatarURL = msg.avatarURL, guest = msg.guest, authed = msg.authed, guestStatus = msg.guestStatus,
+      excludeFromDashboard = msg.excludeFromDashboard)
     val req = RegisterUserReqMsg(header, body)
     val message = BbbCommonEnvCoreMsg(envelope, req)
     sendToBus(message)

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -317,6 +317,14 @@ class ApiController {
       us.avatarURL = meeting.defaultAvatarURL
     }
 
+    if (!StringUtils.isEmpty(params.excludeFromDashboard)) {
+      try {
+        us.excludeFromDashboard = Boolean.parseBoolean(params.excludeFromDashboard)
+      } catch (Exception e) {
+        // Do nothing, prop excludeFromDashboard was already initialized
+      }
+    }
+
     String meetingId = meeting.getInternalId()
 
     if (hasReachedMaxParticipants(meeting, us)) {
@@ -341,7 +349,8 @@ class ApiController {
         us.avatarURL,
         us.guest,
         us.authed,
-        guestStatusVal
+        guestStatusVal,
+        us.excludeFromDashboard
     )
 
     session.setMaxInactiveInterval(SESSION_TIMEOUT);


### PR DESCRIPTION
This PR introduces a new param `excludeFromDashboard` to be set as parameter in API `/join` (bbb-web).
Valid values:
- **false:** Default value. User will be present in the Dashboard.
- **true:** All data related to this user will be ignored by the Dashboard. Absent even from the `.json` file.

Closes #13653.

----
### Test using API Mate
1. **User 1** (none params)
![user-1](https://user-images.githubusercontent.com/5660191/143613209-9e501932-a202-4b54-8346-b4fe01699403.png)
2. **User 2** (excludeFromDashboard=true)
![user-2](https://user-images.githubusercontent.com/5660191/143613215-34502277-e947-455d-a8a6-e88c7b778979.png)
3. **User 3** (excludeFromDashboard=false)
![user-3](https://user-images.githubusercontent.com/5660191/143613222-0ebf825a-5199-4cb0-baac-6094719f4c34.png)
4. **Result** (User 2 absent from Dashboard):
![user-2-absent](https://user-images.githubusercontent.com/5660191/143613227-df9dccae-7639-4b5a-8182-24ee28a36e2d.png)