### PR TITLE
Remove button to Copy Dashboard Link

### DIFF
--- a/bbb-learning-dashboard/src/App.js
+++ b/bbb-learning-dashboard/src/App.js
@@ -117,21 +117,6 @@ class App extends React.Component {
     }, 10000 * (2 ** invalidSessionCount));
   }
 
-  copyPublicLink() {
-    const { learningDashboardAccessToken, meetingId, ldAccessTokenCopied } = this.state;
-    const { intl } = this.props;
-
-    let url = window.location.href.split('?')[0];
-    url += `?meeting=${meetingId}&report=${learningDashboardAccessToken}&lang=${intl.locale}`;
-    navigator.clipboard.writeText(url);
-    if (ldAccessTokenCopied === false) {
-      this.setState({ ldAccessTokenCopied: true });
-      setTimeout(() => {
-        this.setState({ ldAccessTokenCopied: false });
-      }, 3000);
-    }
-  }
-
   render() {
     const {
       activitiesJson, tab, sessionToken, loading,
@@ -237,33 +222,6 @@ class App extends React.Component {
         <div className="flex items-start justify-between pb-3">
           <h1 className="mt-3 text-2xl font-semibold whitespace-nowrap inline-block">
             <FormattedMessage id="app.learningDashboard.dashboardTitle" defaultMessage="Learning Dashboard" />
-            &nbsp;
-            {
-              learningDashboardAccessToken !== ''
-                ? (
-                  <button type="button" onClick={() => { this.copyPublicLink(); }} className="text-sm font-medium text-blue-500 ease-out">
-                    (
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      className="h-4 w-4 inline"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth="2"
-                        d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
-                      />
-                    </svg>
-                    &nbsp;
-                    <FormattedMessage id="app.learningDashboard.shareButton" defaultMessage="Share with others" />
-                    )
-                  </button>
-                )
-                : null
-            }
             {
               ldAccessTokenCopied === true
                 ? (

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -917,8 +917,6 @@
     "playback.player.video.wrapper.aria": "Video area",
     "app.learningDashboard.dashboardTitle": "Learning Dashboard",
     "app.learningDashboard.user": "User",
-    "app.learningDashboard.shareButton": "Share with others",
-    "app.learningDashboard.shareLinkCopied": "Link successfully copied!",
     "app.learningDashboard.indicators.meetingStatusEnded": "Ended",
     "app.learningDashboard.indicators.meetingStatusActive": "Active",
     "app.learningDashboard.indicators.usersOnline": "Active Users",


### PR DESCRIPTION
This PR removes the possibility to copy Dashboard link once it is not desirable.

![image](https://user-images.githubusercontent.com/5660191/143621389-21c0c6bb-d616-4ee4-91e0-9dbbc9414de0.png)
