### PR TITLE
fix: Fixes the validation of banned users

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
@@ -108,10 +108,9 @@ object UsersApp {
                            reasonCode: String, ban: Boolean): Unit = {
 
     val meetingId = liveMeeting.props.meetingProp.intId
-
+    RegisteredUsers.eject(userId, liveMeeting.registeredUsers, ban)
     for {
       user <- Users2x.ejectFromMeeting(liveMeeting.users2x, userId)
-      reguser <- RegisteredUsers.eject(userId, liveMeeting.registeredUsers, ban)
     } yield {
       sendUserEjectedMessageToClient(outGW, meetingId, userId, ejectedBy, reason, reasonCode)
       sendUserLeftMeetingToAllClients(outGW, meetingId, userId)


### PR DESCRIPTION
### What does this PR do?

When a user join the meeting but not validate the token the user isn't added to Users2x, so, when user is ejected (due to have a shared extId) the user isn't ejected because the condition to the `for` runs is have a full joined user. The PR make the ejection runs every time and the full user only when we have the Users2x data