### PR TITLE
Remove unused user data on leave

### DIFF
--- a/bigbluebutton-html5/imports/api/auth-token-validation/server/modifiers/upsertValidationState.js
+++ b/bigbluebutton-html5/imports/api/auth-token-validation/server/modifiers/upsertValidationState.js
@@ -17,6 +17,7 @@ export default function upsertValidationState(meetingId, userId, validationStatu
   };
 
   try {
+    AuthTokenValidation.remove({ meetingId, userId, connectionId: { $ne: connectionId } });
     const { numberAffected } = AuthTokenValidation.upsert(selector, modifier);
 
     if (numberAffected) {

--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addGroupChatMsg.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addGroupChatMsg.js
@@ -2,6 +2,7 @@ import { Match, check } from 'meteor/check';
 import Logger from '/imports/startup/server/logger';
 import { GroupChatMsg } from '/imports/api/group-chat-msg';
 import { BREAK_LINE } from '/imports/utils/lineEndings';
+import changeHasMessages from '/imports/api/users/server/modifiers/changeHasMessages';
 
 export function parseMessage(message) {
   let parsedMessage = message || '';
@@ -47,6 +48,8 @@ export default function addGroupChatMsg(meetingId, chatId, msg) {
 
     if (insertedId) {
       Logger.info(`Added group-chat-msg msgId=${msg.id} chatId=${chatId} meetingId=${meetingId}`);
+
+      changeHasMessages(true, sender.id, meetingId);
     }
   } catch (err) {
     Logger.error(`Error on adding group-chat-msg to collection: ${err}`);

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/changeHasMessages.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/changeHasMessages.js
@@ -1,0 +1,25 @@
+import Logger from '/imports/startup/server/logger';
+import Users from '/imports/api/users';
+
+export default function changeHasMessages(hasMessages, userId, meetingId) {
+  const selector = {
+    meetingId,
+    userId,
+  };
+
+  const modifier = {
+    $set: {
+      hasMessages,
+    },
+  };
+
+  try {
+    const numberAffected = Users.update(selector, modifier);
+
+    if (numberAffected) {
+      Logger.info(`Changed hasMessages=${hasMessages} id=${userId} meeting=${meetingId}`);
+    }
+  } catch (err) {
+    Logger.error(`Change hasMessages error: ${err}`);
+  }
+}

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
@@ -1,5 +1,6 @@
 import { check } from 'meteor/check';
 import Users from '/imports/api/users';
+import UsersPersistentData from '/imports/api/users-persistent-data';
 import VideoStreams from '/imports/api/video-streams';
 import Logger from '/imports/startup/server/logger';
 import setloggedOutStatus from '/imports/api/users-persistent-data/server/modifiers/setloggedOutStatus';
@@ -44,6 +45,12 @@ export default function removeUser(meetingId, userId) {
 
     clearUserInfoForRequester(meetingId, userId);
 
+    const currentUser = Users.findOne({ userId, meetingId });
+    const hasMessages = currentUser?.hasMessages;
+
+    if (!hasMessages) {
+      UsersPersistentData.remove(selector);
+    }
     Users.remove(selector);
 
     Logger.info(`Removed user id=${userId} meeting=${meetingId}`);

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
@@ -1,6 +1,7 @@
 import { check } from 'meteor/check';
 import Users from '/imports/api/users';
 import UsersPersistentData from '/imports/api/users-persistent-data';
+import VoiceUsers from '/imports/api/voice-users/';
 import VideoStreams from '/imports/api/video-streams';
 import Logger from '/imports/startup/server/logger';
 import setloggedOutStatus from '/imports/api/users-persistent-data/server/modifiers/setloggedOutStatus';
@@ -52,6 +53,7 @@ export default function removeUser(meetingId, userId) {
       UsersPersistentData.remove(selector);
     }
     Users.remove(selector);
+    VoiceUsers.remove({ intId: userId, meetingId })
 
     Logger.info(`Removed user id=${userId} meeting=${meetingId}`);
   } catch (err) {


### PR DESCRIPTION
### What does this PR do?

- Removes user data from `voiceUsers` on leave;
- Removes user data from `users-persistent-data` on leave (only if the user did not send any messages in the chat);
- Removes `auth-token-validation` data from previous connections.