### PR TITLE
improvement: virtual background customization

### DIFF
--- a/bigbluebutton-html5/imports/startup/server/customVirtualBackground.js
+++ b/bigbluebutton-html5/imports/startup/server/customVirtualBackground.js
@@ -13,6 +13,7 @@ import {
 } from 'fs';
 import Logger from './logger';
 
+const extensions = ['jpg', 'png'];
 const DEFAULT_VIRTUAL_BACKGROUNDS = Meteor.settings.public.virtualBackgrounds.fileNames;
 const meteorRoot = realpathSync(`${process.cwd()}/../`);
 const env = Meteor.isDevelopment ? 'development' : 'production';
@@ -91,7 +92,7 @@ function updateProgramJson(configs) {
 function addCustomVirtualBackgrounds() {
   if (existsSync(CUSTOM_BACKGROUND_DIR)) {
     const files = readdirSync(CUSTOM_BACKGROUND_DIR, { withFileTypes: true })
-      .filter((file) => !file.isDirectory())
+      .filter((file) => !file.isDirectory() && extensions.includes(file.name.split('.').pop()))
       .slice(0, 10);
 
     if (files.length === 10) {

--- a/bigbluebutton-html5/imports/startup/server/customVirtualBackground.js
+++ b/bigbluebutton-html5/imports/startup/server/customVirtualBackground.js
@@ -1,0 +1,167 @@
+import { Meteor } from 'meteor/meteor';
+import { createHash } from 'crypto';
+import {
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  existsSync,
+  statSync,
+  copyFileSync,
+  writeFileSync,
+  chmodSync,
+  rmSync,
+} from 'fs';
+import Logger from './logger';
+
+const DEFAULT_VIRTUAL_BACKGROUNDS = Meteor.settings.public.virtualBackgrounds.fileNames;
+const meteorRoot = realpathSync(`${process.cwd()}/../`);
+const env = Meteor.isDevelopment ? 'development' : 'production';
+const CUSTOM_BACKGROUND_DIR = process.env.BBB_HTML5_CUSTOM_VIRTUAL_BACKGROUNDS
+  || '/var/www/bigbluebutton/client/images/virtual-backgrounds';
+const virtualBackgroundDir = (env === 'development')
+  ? realpathSync(`${meteorRoot}'/../../../../public/resources/images/virtual-backgrounds/`)
+  : realpathSync(`${meteorRoot}/../programs/web.browser/app/resources/images/virtual-backgrounds/`);
+
+function cleanProgramJson() {
+  const programJsonPath = realpathSync(`${meteorRoot}/../programs/web.browser/program.json`);
+
+  if (existsSync(programJsonPath)) {
+    Logger.debug('Cleaning program.json...');
+    const { mode } = statSync(programJsonPath);
+    chmodSync(programJsonPath, 0o700);
+    const programJsonData = readFileSync(programJsonPath);
+    const programJson = JSON.parse(programJsonData);
+    programJson.manifest = programJson.manifest.filter((config) => !config.custom);
+    writeFileSync(programJsonPath, JSON.stringify(programJson));
+    chmodSync(programJsonPath, mode);
+    Logger.debug('program.json cleaned!');
+  }
+}
+
+function cleanNonDefaultVirtualBackgrounds() {
+  Logger.debug('Removing non-default virtual backgrounds...');
+
+  readdirSync(virtualBackgroundDir, { withFileTypes: true })
+    .forEach((entry) => {
+      try {
+        if (entry.isDirectory()) return;
+        if ([...DEFAULT_VIRTUAL_BACKGROUNDS, 'architecture.jpg', 'brickwall.jpg'].indexOf(entry.name) === -1) {
+          rmSync(`${virtualBackgroundDir}/${entry.name}`);
+          rmSync(`${virtualBackgroundDir}/thumbnails/${entry.name}`, { force: true });
+        }
+      } catch (error) {
+        Logger.error('Error on remove non-default virtual backgrounds.',
+          { logCode: 'custom_virtual_background_cleaning', extraInfo: { error } });
+      }
+    });
+
+  if (env === 'production') cleanProgramJson();
+  Logger.debug('Non-default virtual backgrounds removed!');
+}
+
+function updateProgramJson(configs) {
+  if (configs.length > 0 && env === 'production') {
+    const programJsonPath = realpathSync(`${meteorRoot}/../programs/web.browser/program.json`);
+
+    if (existsSync(programJsonPath)) {
+      const { mode } = statSync(programJsonPath);
+      chmodSync(programJsonPath, 0o700);
+      const programJsonData = readFileSync(programJsonPath);
+      const programJson = JSON.parse(programJsonData);
+
+      configs.forEach((config) => {
+        if (!config) return;
+        programJson.manifest = [
+          ...programJson.manifest,
+          ...config,
+        ];
+      });
+
+      writeFileSync(programJsonPath, JSON.stringify(programJson));
+      chmodSync(programJsonPath, mode);
+    }
+  }
+}
+
+function addCustomBackgrounds() {
+  if (existsSync(CUSTOM_BACKGROUND_DIR)) {
+    const files = readdirSync(CUSTOM_BACKGROUND_DIR, { withFileTypes: true })
+      .filter((file) => !file.isDirectory());
+
+    if (files.length > 0) {
+      const configs = files.map((file) => {
+        try {
+          // Background
+          const bgPath = `${CUSTOM_BACKGROUND_DIR}/${file.name}`;
+          copyFileSync(bgPath, `${virtualBackgroundDir}/${file.name}`);
+          const bgData = readFileSync(`${virtualBackgroundDir}/${file.name}`, 'utf-8');
+          const bgStats = statSync(`${virtualBackgroundDir}/${file.name}`);
+          const bgHash = createHash('sha256')
+            .update(bgData)
+            .digest('hex');
+
+          Meteor.settings.public.virtualBackgrounds.fileNames.push(file.name);
+
+          // Thumbnail
+          const thumbPath = `${CUSTOM_BACKGROUND_DIR}/thumbnails/${file.name}`;
+          copyFileSync(thumbPath, `${virtualBackgroundDir}/thumbnails/${file.name}`);
+          const thumbData = readFileSync(`${virtualBackgroundDir}/thumbnails/${file.name}`, 'utf-8');
+          const thumbStats = statSync(`${virtualBackgroundDir}/thumbnails/${file.name}`);
+          const thumbHash = createHash('sha256')
+            .update(thumbData)
+            .digest('hex');
+
+          // Config
+          return [
+            {
+              custom: true,
+              path: `app/resources/images/virtual-backgrounds/thumbnails/${file.name}`,
+              where: 'client',
+              type: 'asset',
+              cacheable: false,
+              url: `/resources/images/virtual-backgrounds/thumbnails/${file.name}`,
+              size: thumbStats.size,
+              hash: thumbHash,
+              sri: null,
+            },
+            {
+              custom: true,
+              path: `app/resources/images/virtual-backgrounds/${file.name}`,
+              where: 'client',
+              type: 'asset',
+              cacheable: false,
+              url: `/resources/images/virtual-backgrounds/${file.name}`,
+              size: bgStats.size,
+              hash: bgHash,
+              sri: null,
+            },
+          ];
+        } catch (error) {
+          const fileIndex = Meteor.settings.public.virtualBackgrounds.fileNames.indexOf(file.name);
+          if (fileIndex !== -1) {
+            Meteor.settings.public.virtualBackgrounds.fileNames.splice(fileIndex, 1);
+          }
+          rmSync(`${virtualBackgroundDir}/${file.name}`, { force: true });
+          rmSync(`${virtualBackgroundDir}/thumbnails/${file.name}`, { force: true });
+          Logger.error('Error on add custom virtual background.',
+            {
+              logCode: 'custom_virtual_background_add',
+              extraInfo: { file: `${CUSTOM_BACKGROUND_DIR}/${file.name}`, error },
+            });
+          Logger.info(`Files of ${file.name} were removed.`);
+          return null;
+        }
+      });
+
+      updateProgramJson(configs);
+      Logger.info('Custom virtual backgrounds updated!');
+    } else {
+      Logger.info('No custom virtual background found!');
+    }
+  } else {
+    Logger.info('Custom virtual background directory does not exist!');
+  }
+}
+
+cleanNonDefaultVirtualBackgrounds();
+addCustomBackgrounds();

--- a/bigbluebutton-html5/imports/startup/server/customVirtualBackground.js
+++ b/bigbluebutton-html5/imports/startup/server/customVirtualBackground.js
@@ -91,7 +91,12 @@ function updateProgramJson(configs) {
 function addCustomVirtualBackgrounds() {
   if (existsSync(CUSTOM_BACKGROUND_DIR)) {
     const files = readdirSync(CUSTOM_BACKGROUND_DIR, { withFileTypes: true })
-      .filter((file) => !file.isDirectory());
+      .filter((file) => !file.isDirectory())
+      .slice(0, 10);
+
+    if (files.length === 10) {
+      Logger.info('Maximum background number reached. Skipping others...');
+    }
 
     if (files.length > 0) {
       const configs = files.map((file) => {

--- a/bigbluebutton-html5/imports/startup/server/customVirtualBackground.js
+++ b/bigbluebutton-html5/imports/startup/server/customVirtualBackground.js
@@ -26,19 +26,24 @@ function cleanProgramJson() {
   const programJsonPath = realpathSync(`${meteorRoot}/../programs/web.browser/program.json`);
 
   if (existsSync(programJsonPath)) {
-    Logger.debug('Cleaning program.json...');
-    const { mode } = statSync(programJsonPath);
-    chmodSync(programJsonPath, 0o700);
-    const programJsonData = readFileSync(programJsonPath);
-    const programJson = JSON.parse(programJsonData);
-    programJson.manifest = programJson.manifest.filter((config) => !config.custom);
-    writeFileSync(programJsonPath, JSON.stringify(programJson));
-    chmodSync(programJsonPath, mode);
-    Logger.debug('program.json cleaned!');
+    try {
+      Logger.debug('Cleaning program.json...');
+      const { mode } = statSync(programJsonPath);
+      chmodSync(programJsonPath, 0o700);
+      const programJsonData = readFileSync(programJsonPath);
+      const programJson = JSON.parse(programJsonData);
+      programJson.manifest = programJson.manifest.filter((config) => !config.custom);
+      writeFileSync(programJsonPath, JSON.stringify(programJson));
+      chmodSync(programJsonPath, mode);
+      Logger.debug('program.json cleaned!');
+    } catch (error) {
+      Logger.debug('Failed to clean program.json!');
+    }
   }
 }
 
 function cleanNonDefaultVirtualBackgrounds() {
+  if (!existsSync(virtualBackgroundDir)) return;
   Logger.debug('Removing non-default virtual backgrounds...');
 
   readdirSync(virtualBackgroundDir, { withFileTypes: true })

--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -4,6 +4,7 @@ import Langmap from 'langmap';
 import fs from 'fs';
 import Users from '/imports/api/users';
 import './settings';
+import './customVirtualBackground';
 import { lookup as lookupUserAgent } from 'useragent';
 import { check } from 'meteor/check';
 import Logger from './logger';


### PR DESCRIPTION
### What does this PR do?

This PR makes virtual background image/thumbnail easier to customize.

- Allows the operator to copy and paste the image/thumbnail into a familiar directory.
- Allows to add a new virtual background without rebuilding.
- Limits the number of custom virtual backgrounds to 10.
- Works in both dev and production mode.

**How it works?**

1. To have your own custom virtual backgrounds, just copy and paste the background images into `/var/www/bigbluebutton/client/images/virtual-backgrounds` and the thumbnails into `/var/www/bigbluebutton/client/images/virtual-backgrounds/thumbnails`. It is mandatory that the image and its thumbnail have the same name.
2. For the changes to take effect, restart the HTML5 client.
3. If the previous directories don't exist, you can create them, or you can specify your own virtual background directory by setting the `BBB_HTML5_CUSTOM_VIRTUAL_BACKGROUNDS` environment variable. In that case, create a `thumbnails` folder within that directory.
4. To remove a custom virtual background, just delete its image from `/var/www/bigbluebutton/client/images/virtual-backgrounds` or from the directory specified with `BBB_HTML5_CUSTOM_VIRTUAL_BACKGROUNDS` and restart the client.
5. Optionally, you can customize the tooltip text for the virtual background by adding an "**app.video.virtualBackground._basename_**": "**Tooltip Text**" in the locale files (/usr/share/meteor/bundle/programs/web.browser/app/locales) of the languages of your choice (where _basename_ is the virtual background's filename without extension). Otherwise, the tooltip will fall back to numbering ([13797](https://github.com/bigbluebutton/bigbluebutton/pull/13797#event-5773373763)).

### Closes Issue(s)

Closes #12937