### PR TITLE
increase sidebar-content max width value

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/defaultValues.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/defaultValues.js
@@ -41,7 +41,7 @@ const DEFAULT_VALUES = {
   sidebarNavTabOrder: 1,
   sidebarNavPanel: PANELS.USERLIST,
 
-  sidebarContentMaxWidth: 350,
+  sidebarContentMaxWidth: 800,
   sidebarContentMinWidth: 150,
   sidebarContentMinHeight: 200,
   sidebarContentHeight: '100%',


### PR DESCRIPTION
### What does this PR do?

Increases 2.4 sidebar-content max-width value to match 2.3 shared-notes max-width (800px).

### Closes Issue(s)
Closes #13760