### PR TITLE
fix: Space bar does not switch to move tool

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -124,10 +124,12 @@ class PresentationToolbar extends PureComponent {
       podId,
     } = this.props;
     const requestedSlideNum = Number.parseInt(event.target.value, 10);
+
+    if (event) event.currentTarget.blur();
     skipToSlide(requestedSlideNum, podId);
   }
 
-  nextSlideHandler() {
+  nextSlideHandler(event) {
     const {
       nextSlide,
       currentSlideNum,
@@ -135,16 +137,18 @@ class PresentationToolbar extends PureComponent {
       podId,
     } = this.props;
 
+    if (event) event.currentTarget.blur();
     nextSlide(currentSlideNum, numberOfSlides, podId);
   }
 
-  previousSlideHandler() {
+  previousSlideHandler(event) {
     const {
       previousSlide,
       currentSlideNum,
       podId,
     } = this.props;
 
+    if (event) event.currentTarget.blur();
     previousSlide(currentSlideNum, podId);
   }
 


### PR DESCRIPTION
### What does this PR do?

Prevents an issue where focus is kept after clicking on previous/next/skip to slide on presentation toolbar.

### Closes Issue(s)
Closes #13675
