### PR TITLE
Removes parameters usage in the group-chat-messages and authtoken-validation publishers

### DIFF
--- a/bigbluebutton-html5/imports/api/auth-token-validation/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/auth-token-validation/server/publishers.js
@@ -1,11 +1,33 @@
 import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+import _ from 'lodash';
 import AuthTokenValidation from '/imports/api/auth-token-validation';
+import { extractCredentials } from '/imports/api/common/server/helpers';
 import Logger from '/imports/startup/server/logger';
 
-function authTokenValidation({ meetingId, userId }) {
+async function authTokenValidation({ meetingId, userId }) {
+  check(meetingId, String);
+  check(userId, String);
+
+  const credentials = await new Promise((resp)=> {
+    const tempSettimeout = () => {
+      setTimeout(() => {
+        const cred = extractCredentials(this.userId);
+        const objIsEmpty = _.isEmpty(cred);
+        if (objIsEmpty) {
+          return tempSettimeout();
+        }
+        return resp(cred);
+      }, 200);
+    };
+    tempSettimeout();
+  });
+
+  const { meetingId: mId, requesterUserId } = credentials;
+
   const selector = {
-    meetingId,
-    userId,
+    meetingId: mId,
+    userId: requesterUserId,
   };
 
   Logger.debug(`Publishing auth-token-validation for ${meetingId} ${userId}`);

--- a/bigbluebutton-html5/imports/api/polls/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/polls/server/publishers.js
@@ -1,4 +1,5 @@
 import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
 import Logger from '/imports/startup/server/logger';
 import Users from '/imports/api/users';
 import Polls from '/imports/api/polls';
@@ -9,6 +10,7 @@ import AuthTokenValidation, {
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 
 function currentPoll(secretPoll) {
+  check(secretPoll, Boolean);
   const tokenValidation = AuthTokenValidation.findOne({
     connectionId: this.connection.id,
   });

--- a/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
@@ -104,7 +104,7 @@ export default withTracker(() => {
   let groupChatMessageHandler = {};
 
   if (CHAT_ENABLED && ready) {
-    const chats = GroupChat.find({
+    const chatsCount = GroupChat.find({
       $or: [
         {
           meetingId,
@@ -113,15 +113,13 @@ export default withTracker(() => {
         },
         { meetingId, users: { $all: [requesterUserId] } },
       ],
-    }).fetch();
-
-    const chatIds = chats.map(chat => chat.chatId);
+    }).count();
 
     const subHandler = {
       ...subscriptionErrorHandler,
     };
 
-    groupChatMessageHandler = Meteor.subscribe('group-chat-msg', chatIds, subHandler);
+    groupChatMessageHandler = Meteor.subscribe('group-chat-msg', chatsCount, subHandler);
   }
 
   // TODO: Refactor all the late subscribers


### PR DESCRIPTION
### What does this PR do?
This PR moves the data necessary for publishers to be get internally and use the parameters only to maintain publisher reactivity to data changes

List of all publishers with parameters:
- breakouts - publisher already use data from internal source the parameter is used to reactivitty
- guestUsers - publisher already use data from internal source the parameter is used to reactivitty
- meetings - publisher already use data from internal source the parameter is used to reactivitty
- users - publisher already use data from internal source the parameter is used to reactivitty

- currentPoll - added check, the value is used as the second parameter in a comparison, there is no way to override the system option
- presentationUploadToken - It already checks the parameters and uses the fields userId and meetingId to make sure the user is subscribing to a token it has access

