### PR TITLE
fix: Banner in meeting conflicts with layout calculation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -425,14 +425,14 @@ class PresentationFocusLayout extends Component {
               (windowHeight() - DEFAULT_VALUES.cameraDockMinHeight),
             );
           }
-          cameraDockBounds.top = windowHeight() - cameraDockHeight;
+          cameraDockBounds.top = windowHeight() - cameraDockHeight + this.bannerAreaHeight();
           cameraDockBounds.left = !isRTL ? sidebarNavWidth : 0;
           cameraDockBounds.right = isRTL ? sidebarNavWidth : 0;
           cameraDockBounds.minWidth = sidebarContentWidth;
           cameraDockBounds.width = sidebarContentWidth;
           cameraDockBounds.maxWidth = sidebarContentWidth;
           cameraDockBounds.minHeight = DEFAULT_VALUES.cameraDockMinHeight;
-          cameraDockBounds.height = cameraDockHeight;
+          cameraDockBounds.height = cameraDockHeight - this.bannerAreaHeight();
           cameraDockBounds.maxHeight = windowHeight() - sidebarContentHeight;
           cameraDockBounds.zIndex = 1;
         }

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -468,10 +468,10 @@ class VideoFocusLayout extends Component {
       mediaBounds.top = mediaAreaBounds.top + cameraDockBounds.height;
       mediaBounds.width = mediaAreaBounds.width;
     } else if (input.cameraDock.numCameras > 0) {
-      mediaBounds.height = windowHeight() - sidebarContentHeight;
+      mediaBounds.height = windowHeight() - sidebarContentHeight - this.bannerAreaHeight();
       mediaBounds.left = !isRTL ? sidebarNavWidth : 0;
       mediaBounds.right = isRTL ? sidebarNavWidth : 0;
-      mediaBounds.top = sidebarContentHeight;
+      mediaBounds.top = sidebarContentHeight + this.bannerAreaHeight();
       mediaBounds.width = sidebarContentWidth;
       mediaBounds.zIndex = 1;
     } else {


### PR DESCRIPTION
### What does this PR do?

Adjusts sidebar media size/position in focus on video and focus on presentation layouts when a banner is being displayed.

### Closes Issue(s)
Closes #13805