### PR TITLE
fix: Menu is behind show hands popup

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/styles.scss
@@ -121,7 +121,7 @@
 }
 
 .dropdown{
-  z-index: 5;
+  z-index: 9999;
 }
 
 .hideDropdownButton {


### PR DESCRIPTION
### What does this PR do?

Changes settings dropdown z-index value so it appears in front of raised hands toast.

### Closes Issue(s)
Closes #13580