### PR TITLE
feat(screenshare): picture-in-picture

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/pip-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/pip-button/component.jsx
@@ -63,31 +63,7 @@ const PictureInPictureButtonComponent = ({
       right={isIphone}
     >
       <Styled.PipButton
-        customIcon={(
-          isInPictureInPictureMode
-            ? (
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                width="24"
-                height="24"
-              >
-                <path fill="none" d="M0 0h24v24H0z" />
-                <path d="M21 3a1 1 0 0 1 1 1v7h-2V5H4v14h6v2H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h18zm0 10a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1h-8a1 1 0 0 1-1-1v-6a1 1 0 0 1 1-1h8zm-9.5-6L9.457 9.043l2.25 2.25-1.414 1.414-2.25-2.25L6 12.5V7h5.5z" fill="rgba(255,255,255,1)" />
-              </svg>
-            )
-            : (
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                width="24"
-                height="24"
-              >
-                <path fill="none" d="M0 0h24v24H0z" />
-                <path d="M21 3a1 1 0 0 1 1 1v7h-2V5H4v14h6v2H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h18zm0 10a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1h-8a1 1 0 0 1-1-1v-6a1 1 0 0 1 1-1h8zM6.707 6.293l2.25 2.25L11 6.5V12H5.5l2.043-2.043-2.25-2.25 1.414-1.414z" fill="rgba(255,255,255,1)" />
-              </svg>
-            )
-        )}
+        icon={isInPictureInPictureMode ? 'video_off' : 'video'}
         color={color || 'default'}
         size="sm"
         onClick={() => handleClick()}

--- a/bigbluebutton-html5/imports/ui/components/pip-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/pip-button/component.jsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { defineMessages, injectIntl } from 'react-intl';
+import PropTypes from 'prop-types';
+import Styled from './styles';
+
+const intlMessages = defineMessages({
+  pictureInPictureButton: {
+    id: 'app.pictureInPictureButton.label',
+    description: 'Picture-in-Picture label',
+  },
+  pictureInPictureUndoButton: {
+    id: 'app.pictureInPictureUndoButton.label',
+    description: 'Undo Picture-in-Picture label',
+  },
+});
+
+const propTypes = {
+  intl: PropTypes.shape({
+    formatMessage: PropTypes.func.isRequired,
+  }).isRequired,
+  isIphone: PropTypes.bool,
+  dark: PropTypes.bool,
+  bottom: PropTypes.bool,
+  className: PropTypes.string,
+  color: PropTypes.string,
+  isInPictureInPictureMode: PropTypes.bool.isRequired,
+  togglePictureInPictureMode: PropTypes.func.isRequired,
+};
+
+const defaultProps = {
+  isIphone: false,
+  dark: false,
+  bottom: false,
+  className: '',
+  color: 'default',
+};
+
+const PictureInPictureButtonComponent = ({
+  intl,
+  dark,
+  color,
+  bottom,
+  isIphone,
+  className,
+  togglePictureInPictureMode,
+  isInPictureInPictureMode,
+}) => {
+  const formattedLabel = (isInPictureInPicture) => (isInPictureInPicture
+    ? intl.formatMessage(intlMessages.pictureInPictureUndoButton)
+    : intl.formatMessage(intlMessages.pictureInPictureButton)
+  );
+
+  const handleClick = () => {
+    togglePictureInPictureMode();
+  };
+
+  return (
+    <Styled.Wrapper
+      dark={dark}
+      light={!dark}
+      bottom={bottom}
+      top={!bottom}
+      right={isIphone}
+    >
+      <Styled.PipButton
+        customIcon={(
+          isInPictureInPictureMode
+            ? (
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                width="24"
+                height="24"
+              >
+                <path fill="none" d="M0 0h24v24H0z" />
+                <path d="M21 3a1 1 0 0 1 1 1v7h-2V5H4v14h6v2H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h18zm0 10a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1h-8a1 1 0 0 1-1-1v-6a1 1 0 0 1 1-1h8zm-9.5-6L9.457 9.043l2.25 2.25-1.414 1.414-2.25-2.25L6 12.5V7h5.5z" fill="rgba(255,255,255,1)" />
+              </svg>
+            )
+            : (
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                width="24"
+                height="24"
+              >
+                <path fill="none" d="M0 0h24v24H0z" />
+                <path d="M21 3a1 1 0 0 1 1 1v7h-2V5H4v14h6v2H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h18zm0 10a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1h-8a1 1 0 0 1-1-1v-6a1 1 0 0 1 1-1h8zM6.707 6.293l2.25 2.25L11 6.5V12H5.5l2.043-2.043-2.25-2.25 1.414-1.414z" fill="rgba(255,255,255,1)" />
+              </svg>
+            )
+        )}
+        color={color || 'default'}
+        size="sm"
+        onClick={() => handleClick()}
+        label={formattedLabel(isInPictureInPictureMode)}
+        hideLabel
+        className={className}
+        data-test="screensharePictureInPictureModeButton"
+      />
+    </Styled.Wrapper>
+  );
+};
+
+PictureInPictureButtonComponent.propTypes = propTypes;
+PictureInPictureButtonComponent.defaultProps = defaultProps;
+
+export default injectIntl(PictureInPictureButtonComponent);

--- a/bigbluebutton-html5/imports/ui/components/pip-button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/pip-button/container.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import PictureInPictureButtonComponent from './component';
+import browserInfo from '/imports/utils/browserInfo';
+import logger from '/imports/startup/client/logger';
+
+const PictureInPictureButtonContainer = (props) => <PictureInPictureButtonComponent {...props} />;
+
+export default (props) => {
+  const { videoTag } = props;
+  const {
+    isValidSafariForPictureInPicture,
+    isAnotherValidBrowserForPictureInPicture,
+  } = browserInfo;
+
+  const [isInPictureInPictureMode, setIsPictureInPictureMode] = useState(false);
+
+  if (!(isValidSafariForPictureInPicture || isAnotherValidBrowserForPictureInPicture)) return null;
+  if (!(document.pictureInPictureEnabled && videoTag)) return null;
+
+  videoTag.addEventListener('enterpictureinpicture', () => setIsPictureInPictureMode(true));
+  videoTag.addEventListener('leavepictureinpicture', () => setIsPictureInPictureMode(false));
+
+  function togglePictureInPictureMode() {
+    if (document.pictureInPictureElement && isInPictureInPictureMode) {
+      setTimeout(() => {
+        document.exitPictureInPicture()
+          .then(() => setIsPictureInPictureMode(false))
+          .catch((e) => logger.warn({
+            logCode: 'picture_in_picture_action_failed',
+            extraInfo: { errorMessage: e.message, errorCode: e.code },
+          }, 'Could not exit picture-in-picture'));
+      }, 0);
+    } else {
+      setTimeout(() => {
+        videoTag.requestPictureInPicture()
+          .then(() => setIsPictureInPictureMode(true))
+          .catch((e) => logger.warn({
+            logCode: 'picture_in_picture_action_failed',
+            extraInfo: { errorMessage: e.message, errorCode: e.code },
+          }, 'Could not start picture-in-picture'));
+      }, 0);
+    }
+  }
+
+  if (isValidSafariForPictureInPicture) {
+    videoTag.autoPictureInPicture = true;
+  }
+
+  const isIphone = !!(navigator.userAgent.match(/iPhone/i));
+
+  return (
+    <PictureInPictureButtonContainer
+      {...props}
+      {...{
+        isIphone,
+        togglePictureInPictureMode,
+        isInPictureInPictureMode,
+      }}
+    />
+  );
+};

--- a/bigbluebutton-html5/imports/ui/components/pip-button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/pip-button/styles.js
@@ -1,0 +1,67 @@
+import styled from 'styled-components';
+import Button from '/imports/ui/components/common/button/component';
+
+const PipButton = styled(Button)`
+  display: flex;
+  padding: 5px;
+  &,
+  &:active,
+  &:hover,
+  &:focus {
+    border: none !important;
+    background-color: var(--color-transparent) !important;
+    svg {
+      border: none !important;
+      background-color: var(--color-transparent) !important;
+    }
+  }
+  svg {
+    width: 1rem;
+    height: 1rem;
+  }
+`;
+
+const Wrapper = styled.div`
+  position: absolute;
+  right: 2rem;
+  left: auto;
+  background-color: var(--color-transparent);
+  cursor: pointer;
+  border: 0;
+  z-index: 2;
+  margin: 2px;
+  [dir="rtl"] & {
+    right: auto;
+    left: 2rem;
+  }
+  ${({ dark }) => dark && `
+    background-color: rgba(0, 0, 0, .3);
+    & .button path:nth-child(2) {
+      fill: var(--color-white);
+    }
+  `}
+  ${({ light }) => light && `
+    background-color: var(--color-transparent);
+    & .button path:nth-child(2) {
+      fill: var(--color-black);
+    }
+  `}
+  ${({ bottom }) => bottom && `
+    bottom: 0;
+  `}
+  ${({ top }) => top && `
+    top: 0;
+  `}
+  ${({ right }) => right && `
+    right: 0;
+    [dir="rtl"] & {
+      right: auto;
+      left: 0;
+    }
+  `}
+`;
+
+export default {
+  PipButton,
+  Wrapper,
+};

--- a/bigbluebutton-html5/imports/ui/components/pip-button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/pip-button/styles.js
@@ -1,23 +1,30 @@
 import styled from 'styled-components';
 import Button from '/imports/ui/components/common/button/component';
+import {
+  colorWhite,
+  colorBlack,
+  colorTransparent,
+} from '/imports/ui/stylesheets/styled-components/palette';
 
 const PipButton = styled(Button)`
   display: flex;
   padding: 5px;
+
   &,
   &:active,
   &:hover,
   &:focus {
     border: none !important;
-    background-color: var(--color-transparent) !important;
-    svg {
+    background-color: ${colorTransparent} !important;
+
+    i {
       border: none !important;
-      background-color: var(--color-transparent) !important;
+      background-color: ${colorTransparent} !important;
     }
   }
-  svg {
-    width: 1rem;
-    height: 1rem;
+
+  i {
+    font-size: 1rem;
   }
 `;
 
@@ -25,33 +32,39 @@ const Wrapper = styled.div`
   position: absolute;
   right: 2rem;
   left: auto;
-  background-color: var(--color-transparent);
+  background-color: ${colorTransparent};
   cursor: pointer;
   border: 0;
   z-index: 2;
   margin: 2px;
+
   [dir="rtl"] & {
     right: auto;
     left: 2rem;
   }
+
   ${({ dark }) => dark && `
     background-color: rgba(0, 0, 0, .3);
-    & .button path:nth-child(2) {
-      fill: var(--color-white);
+    i {
+      color: ${colorWhite};
     }
   `}
+
   ${({ light }) => light && `
-    background-color: var(--color-transparent);
-    & .button path:nth-child(2) {
-      fill: var(--color-black);
+    background-color: ${colorTransparent};
+    i {
+      color: ${colorBlack};
     }
   `}
+
   ${({ bottom }) => bottom && `
     bottom: 0;
   `}
+
   ${({ top }) => top && `
     top: 0;
   `}
+
   ${({ right }) => right && `
     right: 0;
     [dir="rtl"] & {

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -30,6 +30,7 @@ import {
 import { ACTIONS } from '/imports/ui/components/layout/enums';
 import Settings from '/imports/ui/services/settings';
 import deviceInfo from '/imports/utils/deviceInfo';
+import PictureInPictureButtonContainer from '../pip-button/container';
 
 const intlMessages = defineMessages({
   screenShareLabel: {
@@ -345,6 +346,15 @@ class ScreenshareComponent extends React.Component {
     );
   }
 
+  renderPictureInPictureButton() {
+    return (
+      <PictureInPictureButtonContainer
+        videoTag={this.videoTag}
+        dark
+      />
+    );
+  }
+
   renderAutoplayOverlay() {
     const { intl } = this.props;
 
@@ -486,6 +496,7 @@ class ScreenshareComponent extends React.Component {
         id="screenshareContainer"
       >
         {loaded && this.renderFullscreenButton()}
+        {loaded && this.renderPictureInPictureButton()}
         {this.renderVideo(true)}
         {loaded && enableVolumeControl && this.renderVolumeSlider() }
 

--- a/bigbluebutton-html5/imports/utils/browserInfo.js
+++ b/bigbluebutton-html5/imports/utils/browserInfo.js
@@ -18,6 +18,27 @@ const isValidSafariVersion = Bowser.getParser(userAgent).satisfies({
 
 const isTabletApp =  !!(userAgent.match(/BigBlueButton-Tablet/i));
 
+const isValidSafariForPictureInPicture = Bowser
+  .getParser(window.navigator.userAgent)
+  .satisfies({
+    desktop: {
+      safari: '>=13.1',
+    },
+    mobile: {
+      safari: '>=13.4',
+    },
+  });
+
+const isAnotherValidBrowserForPictureInPicture = Bowser
+  .getParser(window.navigator.userAgent)
+  .satisfies({
+    desktop: {
+      chrome: '>=69',
+      edge: '>=79',
+      opera: '>=56',
+    },
+  });
+
 const browserInfo = {
   isChrome,
   isSafari,
@@ -27,7 +48,9 @@ const browserInfo = {
   browserName,
   versionNumber,
   isValidSafariVersion,
-  isTabletApp
+  isTabletApp,
+  isValidSafariForPictureInPicture,
+  isAnotherValidBrowserForPictureInPicture,
 };
 
 export default browserInfo;

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1025,6 +1025,8 @@
     "app.video.dropZoneLabel": "Drop here",
     "app.fullscreenButton.label": "Make {0} fullscreen",
     "app.fullscreenUndoButton.label": "Undo {0} fullscreen",
+    "app.pictureInPictureButton.label": "Turn Picture-in-Picture on",
+    "app.pictureInPictureUndoButton.label": "Turn Picture-in-Picture off",
     "app.switchButton.expandLabel": "Expand screenshare video",
     "app.switchButton.shrinkLabel": "Shrink screenshare video",
     "app.sfu.mediaServerConnectionError2000": "Unable to connect to media server (error 2000)",


### PR DESCRIPTION
### What does this PR do?

This PR implements Picture-in-Picture mode for the screenshare.

Most of the desktop browsers supports picture-in-picture, all but Internet Explorer and Firefox. On mobile, only Safari supports it.

**Supported browsers:**

Desktop:
- Chrome (>=69)
- Edge (>=79)
- Opera (>=56)
- Safari (>=13.1)

Mobile:
- Safari (>=13.4)

### Motivation

Picture-inPicture can improve the productivity of the users. You can see the screen sharing of the presenter while performing any other tasks.

### Presenter:

![Captura de tela de 2021-12-02 11-36-17](https://user-images.githubusercontent.com/62393923/144444589-688ba095-c1c5-42d0-b761-887fe1eeec61.png)

### Other Participants:

![Captura de tela de 2021-12-02 11-31-56](https://user-images.githubusercontent.com/62393923/144444729-dfa3870a-0921-42d6-b0b1-df45a7a697b0.png)

![Captura de tela de 2021-12-02 11-32-05](https://user-images.githubusercontent.com/62393923/144444752-af165572-f4b1-4b86-a812-a0522df6f137.png)

![Captura de tela de 2021-12-02 11-32-15](https://user-images.githubusercontent.com/62393923/144444773-2e094ba1-6dfc-400d-bc16-e12d1bedc33d.png)

![Captura de tela de 2021-12-02 11-32-24](https://user-images.githubusercontent.com/62393923/144444786-df3922fa-fb43-4b5a-b96e-40e5373574d8.png)