### PR TITLE
feat(webcam): add a way to re-open video preview without multiple cameras

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/styles.scss
@@ -59,6 +59,7 @@
 }
 
 .offsetBottom {
+  position: relative
   :global(.MuiPaper-root) {
     top: auto !important;
     bottom: 4rem !important;

--- a/bigbluebutton-html5/imports/ui/components/button/button-emoji/ButtonEmoji.jsx
+++ b/bigbluebutton-html5/imports/ui/components/button/button-emoji/ButtonEmoji.jsx
@@ -42,6 +42,7 @@ const ButtonEmoji = (props) => {
   const {
     hideLabel,
     className,
+    hidden,
     ...newProps
   } = props;
 
@@ -61,6 +62,10 @@ const ButtonEmoji = (props) => {
 
   return (
     <span>
+      <div
+        className={styles.emojiButtonSpace}
+        hidden={hidden}
+      />
       <TooltipContainer title={label}>
         <button
           type="button"

--- a/bigbluebutton-html5/imports/ui/components/button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/button/styles.scss
@@ -231,7 +231,7 @@
   border-radius: 50%;
   width: 1em;
   height: 1em;
-  right: -1px;
+  right: -.2em;
   bottom: 0;
   background-color: var(--btn-default-bg);
   overflow: hidden;
@@ -261,8 +261,8 @@
   height: 1.4em;
   width: 1.4em;
   background-color: var(--color-background);
-  right: -4px;
-  bottom: -3px;
+  right: -.4em;
+  bottom: -.2em;
   border-radius: 50%;
 }
 

--- a/bigbluebutton-html5/imports/ui/components/button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/button/styles.scss
@@ -248,7 +248,6 @@
     top: 0;
     height: 60%;
     left: 0;
-    width: 75%;
     margin-left: 25%;
     font-size: 50%;
     margin-top: 40%;

--- a/bigbluebutton-html5/imports/ui/components/button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/button/styles.scss
@@ -256,6 +256,16 @@
   }
 }
 
+.emojiButtonSpace {
+  position: absolute;
+  height: 1.4em;
+  width: 1.4em;
+  background-color: var(--color-background);
+  right: -4px;
+  bottom: -3px;
+  border-radius: 50%;
+}
+
 /* Colors
  * ==========
  */

--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -83,10 +83,6 @@ const intlMessages = defineMessages({
     id: 'app.videoPreview.quality.hd',
     description: 'High definition option label',
   },
-  cancelLabel: {
-    id: 'app.videoPreview.cancelLabel',
-    description: 'Cancel button label',
-  },
   startSharingLabel: {
     id: 'app.videoPreview.startSharingLabel',
     description: 'Start sharing button label',
@@ -772,11 +768,6 @@ class VideoPreview extends Component {
             : null
           }
           <div className={styles.actions}>
-            <Button
-              label={intl.formatMessage(intlMessages.cancelLabel)}
-              onClick={this.handleProceed}
-              disabled={shouldDisableButtons}
-            />
             <Button
               data-test="startSharingWebcam"
               color={shared ? 'danger' : 'primary'}

--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -758,7 +758,7 @@ class VideoPreview extends Component {
         {this.renderContent()}
 
         <div className={styles.footer}>
-          {hasVideoStream
+          {hasVideoStream && VideoService.isMultipleCamerasEnabled()
             ? (
               <div className={styles.extraActions}>
                 <Button

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
@@ -7,7 +7,10 @@ import VideoService from '../service';
 import { defineMessages, injectIntl } from 'react-intl';
 import { styles } from './styles';
 import { validIOSVersion } from '/imports/ui/components/app/service';
+import deviceInfo from '/imports/utils/deviceInfo';
 import { debounce } from 'lodash';
+
+const ENABLE_WEBCAM_SELECTOR_BUTTON = Meteor.settings.public.app;
 
 const intlMessages = defineMessages({
   joinVideo: {
@@ -54,9 +57,12 @@ const JoinVideoButton = ({
   disableReason,
   mountVideoPreview,
 }) => {
-  const { enableWebcamSelectorButton } = Meteor.settings.public.app;
+  const { isMobile } = deviceInfo;
+  const shouldEnableWebcamSelectorButton = ENABLE_WEBCAM_SELECTOR_BUTTON
+    && !isMobile;
   const exitVideo = () => hasVideoStream
-    && (!VideoService.isMultipleCamerasEnabled() || enableWebcamSelectorButton);
+    && !isMobile
+    && (!VideoService.isMultipleCamerasEnabled() || shouldEnableWebcamSelectorButton);
 
   const handleOnClick = debounce(() => {
     if (!validIOSVersion()) {
@@ -80,10 +86,9 @@ const JoinVideoButton = ({
     : intl.formatMessage(intlMessages.joinVideo);
 
   if (disableReason) label = intl.formatMessage(intlMessages[disableReason]);
-  const shouldEnableEmojiButton = enableWebcamSelectorButton;
 
   const renderEmojiButton = () => (
-    shouldEnableEmojiButton
+    shouldEnableWebcamSelectorButton
       && (<ButtonEmoji
         onClick={handleOpenAdvancedOptions}
         emoji="device_list_selector"

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
@@ -54,8 +54,9 @@ const JoinVideoButton = ({
   disableReason,
   mountVideoPreview,
 }) => {
-  const exitVideo = () => hasVideoStream && !VideoService.isMultipleCamerasEnabled();
   const { enableWebcamSelectorButton } = Meteor.settings.public.app;
+  const exitVideo = () => hasVideoStream
+    && (!VideoService.isMultipleCamerasEnabled() || enableWebcamSelectorButton);
 
   const handleOnClick = debounce(() => {
     if (!validIOSVersion()) {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
@@ -89,31 +89,34 @@ const JoinVideoButton = ({
 
   const renderEmojiButton = () => (
     shouldEnableWebcamSelectorButton
-      && (<ButtonEmoji
+      && (
+      <ButtonEmoji
         onClick={handleOpenAdvancedOptions}
         emoji="device_list_selector"
         hidden={!hasVideoStream}
+        hideLabel
         label={intl.formatMessage(intlMessages.advancedVideo)}
       />
       )
   );
 
   return (
-    <Button
-      label={label}
-      data-test={hasVideoStream ? 'leaveVideo' : 'joinVideo'}
-      className={cx(hasVideoStream || styles.btn)}
-      onClick={handleOnClick}
-      hideLabel
-      color={hasVideoStream ? 'primary' : 'default'}
-      icon={hasVideoStream ? 'video' : 'video_off'}
-      ghost={!hasVideoStream}
-      size="lg"
-      circle
-      disabled={!!disableReason}
-    >
+    <div className={styles.offsetBottom}>
+      <Button
+        label={label}
+        data-test={hasVideoStream ? 'leaveVideo' : 'joinVideo'}
+        className={cx(hasVideoStream || styles.btn)}
+        onClick={handleOnClick}
+        hideLabel
+        color={hasVideoStream ? 'primary' : 'default'}
+        icon={hasVideoStream ? 'video' : 'video_off'}
+        ghost={!hasVideoStream}
+        size="lg"
+        circle
+        disabled={!!disableReason}
+      />
       {renderEmojiButton()}
-    </Button>
+    </div>
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
@@ -55,7 +55,7 @@ const JoinVideoButton = ({
   mountVideoPreview,
 }) => {
   const exitVideo = () => hasVideoStream && !VideoService.isMultipleCamerasEnabled();
-  const { enableWebcamEmojiButton } = Meteor.settings.public.app;
+  const { enableWebcamSelectorButton } = Meteor.settings.public.app;
 
   const handleOnClick = debounce(() => {
     if (!validIOSVersion()) {
@@ -79,7 +79,7 @@ const JoinVideoButton = ({
     : intl.formatMessage(intlMessages.joinVideo);
 
   if (disableReason) label = intl.formatMessage(intlMessages[disableReason]);
-  const shouldEnableEmojiButton = enableWebcamEmojiButton;
+  const shouldEnableEmojiButton = enableWebcamSelectorButton;
 
   const renderEmojiButton = () => (
     shouldEnableEmojiButton

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
@@ -59,6 +59,7 @@ const JoinVideoButton = ({
 }) => {
   const { isMobile } = deviceInfo;
   const shouldEnableWebcamSelectorButton = ENABLE_WEBCAM_SELECTOR_BUTTON
+    && hasVideoStream
     && !isMobile;
   const exitVideo = () => hasVideoStream
     && !isMobile
@@ -93,7 +94,6 @@ const JoinVideoButton = ({
       <ButtonEmoji
         onClick={handleOpenAdvancedOptions}
         emoji="device_list_selector"
-        hidden={!hasVideoStream}
         hideLabel
         label={intl.formatMessage(intlMessages.advancedVideo)}
       />

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
@@ -2,6 +2,7 @@ import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Button from '/imports/ui/components/button/component';
+import ButtonEmoji from '/imports/ui/components/button/button-emoji/ButtonEmoji';
 import VideoService from '../service';
 import { defineMessages, injectIntl } from 'react-intl';
 import { styles } from './styles';
@@ -16,6 +17,10 @@ const intlMessages = defineMessages({
   leaveVideo: {
     id: 'app.video.leaveVideo',
     description: 'Leave video button label',
+  },
+  advancedVideo: {
+    id: 'app.video.advancedVideo',
+    description: 'Open advanced video label',
   },
   videoLocked: {
     id: 'app.video.videoLocked',
@@ -50,6 +55,7 @@ const JoinVideoButton = ({
   mountVideoPreview,
 }) => {
   const exitVideo = () => hasVideoStream && !VideoService.isMultipleCamerasEnabled();
+  const { enableWebcamEmojiButton } = Meteor.settings.public.app;
 
   const handleOnClick = debounce(() => {
     if (!validIOSVersion()) {
@@ -63,11 +69,28 @@ const JoinVideoButton = ({
     }
   }, JOIN_VIDEO_DELAY_MILLISECONDS);
 
+  const handleOpenAdvancedOptions = (e) => {
+    e.stopPropagation();
+    mountVideoPreview();
+  };
+
   let label = exitVideo()
     ? intl.formatMessage(intlMessages.leaveVideo)
     : intl.formatMessage(intlMessages.joinVideo);
 
   if (disableReason) label = intl.formatMessage(intlMessages[disableReason]);
+  const shouldEnableEmojiButton = enableWebcamEmojiButton;
+
+  const renderEmojiButton = () => (
+    shouldEnableEmojiButton
+      && (<ButtonEmoji
+        onClick={handleOpenAdvancedOptions}
+        emoji="device_list_selector"
+        hidden={!hasVideoStream}
+        label={intl.formatMessage(intlMessages.advancedVideo)}
+      />
+      )
+  );
 
   return (
     <Button
@@ -82,7 +105,9 @@ const JoinVideoButton = ({
       size="lg"
       circle
       disabled={!!disableReason}
-    />
+    >
+      {renderEmojiButton()}
+    </Button>
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/styles.scss
@@ -20,6 +20,13 @@
   }
 }
 
+.offsetBottom {
+  :global(.MuiPaper-root) {
+    top: auto !important;
+    bottom: 4rem !important;
+  }
+}
+
 .item {
   display: flex;
   justify-content: flex-start;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/styles.scss
@@ -30,3 +30,7 @@
     flex-direction: row;
   }
 }
+
+.button {
+  position: relative;
+}

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -46,6 +46,7 @@ public:
     enableGuestLobbyMessage: true
     enableLimitOfViewersInWebcam: false
     enableMultipleCameras: true
+    enableWebcamEmojiButton: false
     enableTalkingIndicator: true
     mirrorOwnWebcam: false
     viewersInWebcam: 8

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -46,7 +46,10 @@ public:
     enableGuestLobbyMessage: true
     enableLimitOfViewersInWebcam: false
     enableMultipleCameras: true
-    enableWebcamEmojiButton: false
+    # Allow users to open webcam video modal/preview when video is already
+    # active. This also allows to change virtual backgrounds without
+    # restarting webcam.
+    enableWebcamSelectorButton: true
     enableTalkingIndicator: true
     mirrorOwnWebcam: false
     viewersInWebcam: 8

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -718,6 +718,7 @@
     "app.video.joinVideo": "Share webcam",
     "app.video.connecting": "Webcam sharing is starting ...",
     "app.video.leaveVideo": "Stop sharing webcam",
+    "app.video.advancedVideo": "Open advanced settings",
     "app.video.iceCandidateError": "Error on adding ICE candidate",
     "app.video.iceConnectionStateError": "Connection failure (ICE error 1107)",
     "app.video.permissionError": "Error on sharing webcam.  Please check permissions",


### PR DESCRIPTION
### What does this PR do?

- Add an "advanced options" selector button to the webcam button
  * Opens video-preview modal on click;
  * Goal is to allow swapping of virtual background effects on the fly (underlying mechanisms were there, UI was missing);
  * UI is the same as audio's device selector, behavior slightly different;
  * Mobile endpoints: there's no selector button. The new behavior is: clicking the webcam button _always_ opens the video-preview modal. The selector is too tiny to be usable in mobile endpoints, so trade-offs.
  * Multiple cameras: clicking the webcam button with multiple cameras shared will now _unshare all of them_. The old behavior of opening the video-preview modal is achievable by clicking the selector button.
- Add a margin to audio device selector/webcam selector button
  * Make the separation between the selector and actual media buttons a bit more visible
- Remove video-preview's `Cancel` button
  * Field trial of this approach indicated that end users found the `Cancel` button confusing in association with the virtual background's behavior of _always_ applying changes
  * Cancel didn't really mean cancellation. The only action it was responsible for was _closing the modal_, since actions were always applied on their own (sharing camera, applying virtual BGs) and not by the modal itself. And there are already two ways of closing the video-preview modal: clicking outside it's boundaries and the obvious `X` button.


### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/12836

### Additional info

A bunch of people were involved in this.
