### PR TITLE
fix: prevent users from being able to send more than one typed poll answer (2.3)

### DIFF
--- a/bigbluebutton-html5/imports/api/polls/server/methods/publishTypedVote.js
+++ b/bigbluebutton-html5/imports/api/polls/server/methods/publishTypedVote.js
@@ -18,6 +18,21 @@ export default function publishTypedVote(id, pollAnswer) {
     check(pollAnswer, String);
     check(id, String);
 
+    const allowedToVote = Polls.findOne({
+      id,
+      users: { $in: [requesterUserId] },
+      meetingId,
+    }, {
+      fields: {
+        users: 1,
+      },
+    });
+
+    if (!allowedToVote) {
+      Logger.info(`Poll User={${requesterUserId}} has already voted in PollId={${id}}`);
+      return null;
+    }
+
     const activePoll = Polls.findOne({ meetingId, id }, {
       fields: {
         answers: 1,


### PR DESCRIPTION
### What does this PR do?

This is a port of PR #13757 from 2.4 to 2.3.

_Adds a check before publishing typed poll vote, the same way it is done in other polls._