### PR TITLE
refactor: Libreoffice - Force correct permissions for sudoers file

### DIFF
--- a/bbb-libreoffice/install-local.sh
+++ b/bbb-libreoffice/install-local.sh
@@ -48,6 +48,8 @@ FILE_SUDOERS_CHECK=`[ -f /etc/sudoers.d/zzz-bbb-docker-libreoffice ] && echo 1 |
 if [ "$FILE_SUDOERS_CHECK" = "0" ]; then
 	echo "Sudoers file doesn't exists, installing"
 	cp assets/zzz-bbb-docker-libreoffice /etc/sudoers.d/zzz-bbb-docker-libreoffice
+	chmod 0440 /etc/sudoers.d/zzz-bbb-docker-libreoffice
+	chown root:root /etc/sudoers.d/zzz-bbb-docker-libreoffice
 else
 	echo "Sudoers file already exists"
 fi;


### PR DESCRIPTION
Based on #13183.

On Libreoffice docker install script, it creates: `/etc/sudoers.d/zzz-bbb-docker-libreoffice`
This PR improve permissions forcing:
- Root as owner and group;
- Set file mod to (not world-writable) `0440`.