### PR TITLE
chore: add user infos in custom HTTP headers to checkAuthorization's OK, forward them to SFU

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
@@ -39,6 +39,9 @@ class ConnectionController {
       response.contentType = 'plain/text'
 
       if (userSession != null && !isSessionTokenInvalid) {
+        response.addHeader("User-Id", userSession.internalUserId)
+        response.addHeader("Meeting-Id", userSession.meetingID)
+        response.addHeader("Voice-Bridge", userSession.voicebridge )
         response.setStatus(200)
         response.outputStream << 'authorized'
       } else {

--- a/build/packages-template/bbb-webrtc-sfu/webrtc-sfu.nginx
+++ b/build/packages-template/bbb-webrtc-sfu/webrtc-sfu.nginx
@@ -1,14 +1,21 @@
 location /bbb-webrtc-sfu {
+    auth_request /bigbluebutton/connection/checkAuthorization;
+    auth_request_set $auth_status $upstream_status;
+    # Extra variables are annotated by bbb-web as custom headers
+    auth_request_set $user_id $sent_http_user_id;
+    auth_request_set $meeting_id $sent_http_meeting_id;
+    auth_request_set $voice_bridge $sent_http_voice_bridge;
+
     proxy_pass http://127.0.0.1:3008;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";
+    # Following custom headers are used by bbb-webrtc-sfu
+    proxy_set_header User-Id $user_id;
+    proxy_set_header Meeting-Id $meeting_id;
+    proxy_set_header Voice-Bridge $voice_bridge;
     proxy_read_timeout 6h;
     proxy_send_timeout 6h;
     client_body_timeout 6h;
     send_timeout 6h;
-
-    auth_request /bigbluebutton/connection/checkAuthorization;
-    auth_request_set $auth_status $upstream_status;
 }
-


### PR DESCRIPTION
### What does this PR do?

- chore: add user infos in custom HTTP headers to checkAuthorization's OK response
  * Allows server-side endpoints to fetch userId, meetingId and voice bridge via req headers (annotated by bbb-web)
- chore: pipe user info from bbb-web checkAuth to webrtc-sfu
  * Forwards the aforementioned user infos to bbb-webrtc-sfu so we can use them there

### Closes Issue(s)

None