### PR TITLE
fix: Safari fullscreen issues (2.4)

### DIFF
--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -35,6 +35,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       background-color: #06172A;
     }
 
+    :-webkit-full-screen {
+      background-color: inherit;
+    }
+
     a {
       color: inherit;
     }

--- a/bigbluebutton-html5/imports/ui/components/fullscreen-button/service.js
+++ b/bigbluebutton-html5/imports/ui/components/fullscreen-button/service.js
@@ -30,7 +30,6 @@ function fullscreenRequest(element) {
     element.mozRequestFullScreen();
   } else if (element.webkitRequestFullscreen) {
     element.webkitRequestFullscreen();
-    element.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
   } else if (element.msRequestFullscreen) {
     element.msRequestFullscreen();
   } else {

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -11,6 +11,7 @@ import BBBMenu from '/imports/ui/components/menu/component';
 import ShortcutHelpComponent from '/imports/ui/components/shortcut-help/component';
 import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
 import FullscreenService from '../../fullscreen-button/service';
+import browserInfo from '/imports/utils/browserInfo';
 
 import { styles } from '../styles';
 
@@ -108,6 +109,8 @@ const defaultProps = {
 };
 
 const ALLOW_FULLSCREEN = Meteor.settings.public.app.allowFullscreen;
+const { isSafari } = browserInfo;
+const FULLSCREEN_CHANGE_EVENT = isSafari ? 'webkitfullscreenchange' : 'fullscreenchange';
 
 class SettingsDropdown extends PureComponent {
   constructor(props) {
@@ -125,11 +128,11 @@ class SettingsDropdown extends PureComponent {
   }
 
   componentDidMount() {
-    document.documentElement.addEventListener('fullscreenchange', this.onFullscreenChange);
+    document.documentElement.addEventListener(FULLSCREEN_CHANGE_EVENT, this.onFullscreenChange);
   }
 
   componentWillUnmount() {
-    document.documentElement.removeEventListener('fullscreenchange', this.onFullscreenChange);
+    document.documentElement.removeEventListener(FULLSCREEN_CHANGE_EVENT, this.onFullscreenChange);
   }
 
   onFullscreenChange() {

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -22,6 +22,7 @@ import Icon from '/imports/ui/components/icon/component';
 import PollingContainer from '/imports/ui/components/polling/container';
 import { ACTIONS, LAYOUT_TYPE } from '../layout/enums';
 import DEFAULT_VALUES from '../layout/defaultValues';
+import browserInfo from '/imports/utils/browserInfo';
 
 const intlMessages = defineMessages({
   presentationLabel: {
@@ -52,6 +53,8 @@ const intlMessages = defineMessages({
 
 const ALLOW_FULLSCREEN = Meteor.settings.public.app.allowFullscreen;
 const OLD_MINIMIZE_BUTTON_ENABLED = Meteor.settings.public.presentation.oldMinimizeButton;
+const { isSafari } = browserInfo;
+const FULLSCREEN_CHANGE_EVENT = isSafari ? 'webkitfullscreenchange' : 'fullscreenchange';
 
 class Presentation extends PureComponent {
   constructor() {
@@ -109,7 +112,7 @@ class Presentation extends PureComponent {
 
   componentDidMount() {
     this.getInitialPresentationSizes();
-    this.refPresentationContainer.addEventListener('fullscreenchange', this.onFullscreenChange);
+    this.refPresentationContainer.addEventListener(FULLSCREEN_CHANGE_EVENT, this.onFullscreenChange);
     window.addEventListener('resize', this.onResize, false);
 
     const {
@@ -222,7 +225,7 @@ class Presentation extends PureComponent {
     const { fullscreenContext, layoutContextDispatch } = this.props;
 
     window.removeEventListener('resize', this.onResize, false);
-    this.refPresentationContainer.removeEventListener('fullscreenchange', this.onFullscreenChange);
+    this.refPresentationContainer.removeEventListener(FULLSCREEN_CHANGE_EVENT, this.onFullscreenChange);
 
     if (fullscreenContext) {
       layoutContextDispatch({

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -17,6 +17,8 @@ import {
 import { ACTIONS } from '/imports/ui/components/layout/enums';
 
 const ALLOW_FULLSCREEN = Meteor.settings.public.app.allowFullscreen;
+const { isSafari } = browserInfo;
+const FULLSCREEN_CHANGE_EVENT = isSafari ? 'webkitfullscreenchange' : 'fullscreenchange';
 
 class VideoListItem extends Component {
   constructor(props) {
@@ -41,7 +43,7 @@ class VideoListItem extends Component {
 
     onVideoItemMount(this.videoTag);
     this.videoTag.addEventListener('loadeddata', this.setVideoIsReady);
-    this.videoContainer.addEventListener('fullscreenchange', this.onFullscreenChange);
+    this.videoContainer.addEventListener(FULLSCREEN_CHANGE_EVENT, this.onFullscreenChange);
     subscribeToStreamStateChange(cameraId, this.onStreamStateChange);
   }
 
@@ -75,7 +77,7 @@ class VideoListItem extends Component {
     } = this.props;
 
     this.videoTag.removeEventListener('loadeddata', this.setVideoIsReady);
-    this.videoContainer.removeEventListener('fullscreenchange', this.onFullscreenChange);
+    this.videoContainer.removeEventListener(FULLSCREEN_CHANGE_EVENT, this.onFullscreenChange);
     unsubscribeFromStreamStateChange(cameraId, this.onStreamStateChange);
     onVideoItemUnmount(cameraId);
 


### PR DESCRIPTION
### What does this PR do?

This is a port of PR #13487 from 2.3 to 2.4.

_Prevents the following bugs (all related to fullscreen on Safari browser):_
_- part of the screen becomes white when in fullscreen_
_- minimize presentation button appearing when the presentation is fullscreen_
_- presentation not using all available space when in fullscreen_