### PR TITLE
Presentation publishing script improvements

### DIFF
--- a/record-and-playback/core/scripts/README
+++ b/record-and-playback/core/scripts/README
@@ -34,7 +34,7 @@ playback_host: 10.0.3.203
    which recording to process.
 
 4. Before running the scripts, we have to make sure our scripts have the PATHs setup correctly.
-   Edit presentation/scripts/process/presentation.rb and uncomment the DEVELOPMENT PATH while
+   Edit presentation/scripts/process/presentation.rb, presentation/scripts/publish/presentation.rb, presentation/scripts/presentation.yml and uncomment the DEVELOPMENT PATH while
    commenting the PRODUCTION PATH. We need to do this so the script will be able to find the
    core library.
 

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 # Set encoding to utf-8
 # encoding: UTF-8
 
@@ -210,12 +210,7 @@ end
 
 def svg_render_shape_line(g, slide, shape)
   g['shape'] = "line#{shape[:shape_unique_id]}"
-  g['style'] = "stroke:##{shape[:color]};stroke-width:#{shape_thickness(slide, shape)};visibility:hidden;fill:none"
-  g['style'] += if @version_atleast_2_0_0
-                  ';stroke-linecap:butt'
-                else
-                  ';stroke-linecap:round'
-                end
+  g['style'] = "stroke:##{shape[:color]};stroke-width:#{shape_thickness(slide, shape)};visibility:hidden;fill:none#{@version_atleast_2_0_0 ? ";stroke-linecap:butt" : ";stroke-linecap:round"}"
 
   doc = g.document
   data_points = shape[:data_points]
@@ -233,12 +228,7 @@ end
 
 def svg_render_shape_rect(g, slide, shape)
   g['shape'] = "rect#{shape[:shape_unique_id]}"
-  g['style'] = stroke_attributes(slide, shape)
-  g['style'] += if @version_atleast_2_0_0
-                  ';stroke-linejoin:miter'
-                else
-                  ';stroke-linejoin:round'
-                end
+  g['style'] = "#{stroke_attributes(slide, shape)}#{@version_atleast_2_0_0 ? ";stroke-linejoin:miter" : ";stroke-linejoin:round"}"
 
   doc = g.document
   data_points = shape[:data_points]
@@ -268,12 +258,7 @@ end
 
 def svg_render_shape_triangle(g, slide, shape)
   g['shape'] = "triangle#{shape[:shape_unique_id]}"
-  g['style'] = stroke_attributes(slide, shape)
-  g['style'] += if @version_atleast_2_0_0
-                  ';stroke-linejoin:miter;stroke-miterlimit:8'
-                else
-                  ';stroke-linejoin:round'
-                end
+  g['style'] = "#{stroke_attributes(slide, shape)}#{@version_atleast_2_0_0 ? ";stroke-linejoin:miter;stroke-miterlimit:8" : ";stroke-linejoin:round"}"
 
   doc = g.document
   data_points = shape[:data_points]
@@ -326,11 +311,11 @@ def svg_render_shape_ellipse(g, slide, shape)
   # path element's elliptical arc code renders r_x or r_y
   # degenerate cases as line segments, so we can use that.
   path = "M#{x1} #{hy}"
-  path += "A#{width_r} #{height_r} 0 0 1 #{hx} #{y1}"
-  path += "A#{width_r} #{height_r} 0 0 1 #{x2} #{hy}"
-  path += "A#{width_r} #{height_r} 0 0 1 #{hx} #{y2}"
-  path += "A#{width_r} #{height_r} 0 0 1 #{x1} #{hy}"
-  path += 'Z'
+  path << "A#{width_r} #{height_r} 0 0 1 #{hx} #{y1}"
+  path << "A#{width_r} #{height_r} 0 0 1 #{x2} #{hy}"
+  path << "A#{width_r} #{height_r} 0 0 1 #{hx} #{y2}"
+  path << "A#{width_r} #{height_r} 0 0 1 #{x1} #{hy}"
+  path << 'Z'
 
   svg_path = doc.create_element('path', d: path)
   g << svg_path

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -210,7 +210,7 @@ end
 
 def svg_render_shape_line(g, slide, shape)
   g['shape'] = "line#{shape[:shape_unique_id]}"
-  g['style'] = "stroke:##{shape[:color]};stroke-width:#{shape_thickness(slide, shape)};visibility:hidden;fill:none#{@version_atleast_2_0_0 ? ";stroke-linecap:butt" : ";stroke-linecap:round"}"
+  g['style'] = "stroke:##{shape[:color]};stroke-width:#{shape_thickness(slide, shape)};visibility:hidden;fill:none#{@version_atleast_2_0_0 ? ';stroke-linecap:butt' : ';stroke-linecap:round'}"
 
   doc = g.document
   data_points = shape[:data_points]
@@ -228,7 +228,7 @@ end
 
 def svg_render_shape_rect(g, slide, shape)
   g['shape'] = "rect#{shape[:shape_unique_id]}"
-  g['style'] = "#{stroke_attributes(slide, shape)}#{@version_atleast_2_0_0 ? ";stroke-linejoin:miter" : ";stroke-linejoin:round"}"
+  g['style'] = "#{stroke_attributes(slide, shape)}#{@version_atleast_2_0_0 ? ';stroke-linejoin:miter' : ';stroke-linejoin:round'}"
 
   doc = g.document
   data_points = shape[:data_points]
@@ -258,7 +258,7 @@ end
 
 def svg_render_shape_triangle(g, slide, shape)
   g['shape'] = "triangle#{shape[:shape_unique_id]}"
-  g['style'] = "#{stroke_attributes(slide, shape)}#{@version_atleast_2_0_0 ? ";stroke-linejoin:miter;stroke-miterlimit:8" : ";stroke-linejoin:round"}"
+  g['style'] = "#{stroke_attributes(slide, shape)}#{@version_atleast_2_0_0 ? ';stroke-linejoin:miter;stroke-miterlimit:8' : ';stroke-linejoin:round'}"
 
   doc = g.document
   data_points = shape[:data_points]
@@ -1104,7 +1104,7 @@ def get_poll_type(events, published_poll_event)
   published_poll_id = get_poll_id(published_poll_event)
 
   type = ''
-  events.xpath("//event[@eventname='PollStartedRecordEvent']").each do |event|
+  events.xpath("recording/event[@eventname='PollStartedRecordEvent']").each do |event|
     poll_id = get_poll_id(event)
 
     if poll_id.eql?(published_poll_id)
@@ -1121,7 +1121,7 @@ def process_poll_events(events, package_dir)
 
   published_polls = []
   @rec_events.each do |re|
-    events.xpath("//event[@eventname='PollPublishedRecordEvent']").each do |event|
+    events.xpath("recording/event[@eventname='PollPublishedRecordEvent']").each do |event|
       next unless (event[:timestamp].to_i >= re[:start_timestamp]) && (event[:timestamp].to_i <= re[:stop_timestamp])
       published_polls << {
         timestamp: (translate_timestamp(event[:timestamp]) / 1000).to_i,
@@ -1278,8 +1278,8 @@ begin
 
         # presentation_url = "/slides/" + @meeting_id + "/presentation"
 
-        @meeting_start = @doc.xpath('//event')[0][:timestamp]
-        @meeting_end = @doc.xpath('//event').last[:timestamp]
+        @meeting_start = BigBlueButton::Events.first_event_timestamp(@doc)
+        @meeting_end = BigBlueButton::Events.last_event_timestamp(@doc)
 
         @version_atleast_0_9_0 = BigBlueButton::Events.bbb_version_compare(
           @doc, 0, 9, 0
@@ -1309,7 +1309,7 @@ begin
         published = recording.at_xpath('published')
         published.content = 'true'
         ## Remove empty playback
-        metadata.search('//recording/playback').each(&:remove)
+        metadata.search('recording/playback').each(&:remove)
         ## Add the actual playback
         presentation = BigBlueButton::Presentation.get_presentation_for_preview(@process_dir.to_s)
         Nokogiri::XML::Builder.with(metadata.at('recording')) do |xml|

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Set encoding to utf-8
 # encoding: UTF-8
 
@@ -21,7 +22,13 @@
 
 performance_start = Time.now
 
-require File.expand_path('../../../lib/recordandplayback', __FILE__)
+# For DEVELOPMENT
+# Allows us to run the script manually
+require File.expand_path('../../../../core/lib/recordandplayback', __FILE__)
+
+# For PRODUCTION
+# require File.expand_path('../../../lib/recordandplayback', __FILE__)
+
 require 'rubygems'
 require 'trollop'
 require 'yaml'
@@ -31,7 +38,7 @@ require 'json'
 
 # This script lives in scripts/archive/steps while properties.yaml lives in scripts/
 bbb_props = BigBlueButton.read_props
-$presentation_props = YAML::load(File.read('presentation.yml'))
+$presentation_props = YAML.safe_load(File.read('presentation.yml'))
 
 # There's a couple of places where stuff is mysteriously divided or multiplied
 # by 2. This is just here to call out how spooky that is.
@@ -41,11 +48,11 @@ def scaleToDeskshareVideo(width, height)
   deskshare_video_height = $presentation_props['deskshare_output_height'].to_f
   deskshare_video_width = $presentation_props['deskshare_output_height'].to_f
 
-  scale = [deskshare_video_width/width, deskshare_video_height/height]
+  scale = [deskshare_video_width / width, deskshare_video_height / height]
   video_width = width * scale.min
   video_height = height * scale.min
 
-  return video_width.floor, video_height.floor
+  [video_width.floor, video_height.floor]
 end
 
 def getDeskshareVideoDimension(deskshare_stream_name)
@@ -60,7 +67,7 @@ def getDeskshareVideoDimension(deskshare_stream_name)
     BigBlueButton.logger.error("Could not find deskshare video: #{deskshare_video_filename}")
   end
 
-  return video_width, video_height
+  [video_width, video_height]
 end
 
 #
@@ -86,7 +93,7 @@ end
 #
 def translateTimestamp(timestamp)
   new_timestamp = translateTimestamp_helper(timestamp.to_f).to_f
-#	BigBlueButton.logger.info("Translating #{timestamp}, old value=#{timestamp.to_f-$meeting_start.to_f}, new value=#{new_timestamp}")
+  #	BigBlueButton.logger.info("Translating #{timestamp}, old value=#{timestamp.to_f-$meeting_start.to_f}, new value=#{new_timestamp}")
   new_timestamp
 end
 
@@ -99,30 +106,32 @@ def translateTimestamp_helper(timestamp)
     if timestamp <= event[:start_timestamp]
       return event[:start_timestamp] - event[:offset]
     # if the timestamp is during the recording period, it is just translated to the new one using the offset
-    elsif timestamp > event[:start_timestamp] and timestamp <= event[:stop_timestamp]
+    elsif (timestamp > event[:start_timestamp]) && (timestamp <= event[:stop_timestamp])
       return timestamp - event[:offset]
     end
   end
   # if the timestamp comes after the last stop recording event, then the timestamp is translated to the last stop recording event timestamp
-  return timestamp - $rec_events.last()[:offset] + $rec_events.last()[:duration]
+  timestamp - $rec_events.last[:offset] + $rec_events.last[:duration]
 end
 
 def color_to_hex(color)
   color = color.to_i.to_s(16)
-  return '0'*(6-color.length) + color
+  '0' * (6 - color.length) + color
 end
 
 def shape_scale_width(slide, x)
-  return (x / 100.0 * slide[:width]).round(5)
+  (x / 100.0 * slide[:width]).round(5)
 end
+
 def shape_scale_height(slide, y)
-  return (y / 100.0 * slide[:height]).round(5)
+  (y / 100.0 * slide[:height]).round(5)
 end
+
 def shape_thickness(slide, shape)
   if !shape[:thickness_percent].nil?
-    return shape_scale_width(slide, shape[:thickness_percent])
+    shape_scale_width(slide, shape[:thickness_percent])
   else
-    return shape[:thickness]
+    shape[:thickness]
   end
 end
 
@@ -140,9 +149,9 @@ def svg_render_shape_pencil(g, slide, shape)
     BigBlueButton.logger.info("Pencil #{shape[:shape_unique_id]}: Drawing single point")
     g['style'] = "stroke:none;fill:##{shape[:color]};visibility:hidden"
     circle = doc.create_element('circle',
-            cx: shape_scale_width(slide, shape[:data_points][0]),
-            cy: shape_scale_height(slide, shape[:data_points][1]),
-            r: (shape_thickness(slide, shape) / 2.0).round(5))
+                                cx: shape_scale_width(slide, shape[:data_points][0]),
+                                cy: shape_scale_height(slide, shape[:data_points][1]),
+                                r: (shape_thickness(slide, shape) / 2.0).round(5))
     g << circle
   else
     path = []
@@ -184,7 +193,7 @@ def svg_render_shape_pencil(g, slide, shape)
       y = shape_scale_height(slide, data_points.next)
       path << "M#{x} #{y}"
       begin
-        while true
+        loop do
           x = shape_scale_width(slide, data_points.next)
           y = shape_scale_height(slide, data_points.next)
           path << "L#{x} #{y}"
@@ -194,7 +203,7 @@ def svg_render_shape_pencil(g, slide, shape)
     end
 
     path = path.join('')
-    g['style'] = "stroke:##{shape[:color]};stroke-linecap:round;stroke-linejoin:round;stroke-width:#{shape_thickness(slide,shape)};visibility:hidden;fill:none"
+    g['style'] = "stroke:##{shape[:color]};stroke-linecap:round;stroke-linejoin:round;stroke-width:#{shape_thickness(slide, shape)};visibility:hidden;fill:none"
     svg_path = doc.create_element('path', d: path)
     g << svg_path
   end
@@ -202,31 +211,31 @@ end
 
 def svg_render_shape_line(g, slide, shape)
   g['shape'] = "line#{shape[:shape_unique_id]}"
-  g['style'] = "stroke:##{shape[:color]};stroke-width:#{shape_thickness(slide,shape)};visibility:hidden;fill:none"
-  if $version_atleast_2_0_0
-    g['style'] += ";stroke-linecap:butt"
-  else
-    g['style'] += ";stroke-linecap:round"
-  end
+  g['style'] = "stroke:##{shape[:color]};stroke-width:#{shape_thickness(slide, shape)};visibility:hidden;fill:none"
+  g['style'] += if $version_atleast_2_0_0
+                  ';stroke-linecap:butt'
+                else
+                  ';stroke-linecap:round'
+                end
 
   doc = g.document
   data_points = shape[:data_points]
   line = doc.create_element('line',
-          x1: shape_scale_width(slide, data_points[0]),
-          y1: shape_scale_height(slide, data_points[1]),
-          x2: shape_scale_width(slide, data_points[2]),
-          y2: shape_scale_height(slide, data_points[3]))
+                            x1: shape_scale_width(slide, data_points[0]),
+                            y1: shape_scale_height(slide, data_points[1]),
+                            x2: shape_scale_width(slide, data_points[2]),
+                            y2: shape_scale_height(slide, data_points[3]))
   g << line
 end
 
 def svg_render_shape_rect(g, slide, shape)
   g['shape'] = "rect#{shape[:shape_unique_id]}"
-  g['style'] = "stroke:##{shape[:color]};stroke-width:#{shape_thickness(slide,shape)};visibility:hidden;fill:#{shape[:fill] ? '#'+shape[:color] : 'none'}"
-  if $version_atleast_2_0_0
-    g['style'] += ";stroke-linejoin:miter"
-  else
-    g['style'] += ";stroke-linejoin:round"
-  end
+  g['style'] = "stroke:##{shape[:color]};stroke-width:#{shape_thickness(slide, shape)};visibility:hidden;fill:#{shape[:fill] ? '#' + shape[:color] : 'none'}"
+  g['style'] += if $version_atleast_2_0_0
+                  ';stroke-linejoin:miter'
+                else
+                  ';stroke-linejoin:round'
+                end
 
   doc = g.document
   data_points = shape[:data_points]
@@ -250,18 +259,18 @@ def svg_render_shape_rect(g, slide, shape)
   end
 
   path = doc.create_element('path',
-          d: "M#{x1} #{y1}L#{x2} #{y1}L#{x2} #{y2}L#{x1} #{y2}Z")
+                            d: "M#{x1} #{y1}L#{x2} #{y1}L#{x2} #{y2}L#{x1} #{y2}Z")
   g << path
 end
 
 def svg_render_shape_triangle(g, slide, shape)
   g['shape'] = "triangle#{shape[:shape_unique_id]}"
-  g['style'] = "stroke:##{shape[:color]};stroke-width:#{shape_thickness(slide,shape)};visibility:hidden;fill:#{shape[:fill] ? '#'+shape[:color] : 'none'}"
-  if $version_atleast_2_0_0
-    g['style'] += ";stroke-linejoin:miter;stroke-miterlimit:8"
-  else
-    g['style'] += ";stroke-linejoin:round"
-  end
+  g['style'] = "stroke:##{shape[:color]};stroke-width:#{shape_thickness(slide, shape)};visibility:hidden;fill:#{shape[:fill] ? '#' + shape[:color] : 'none'}"
+  g['style'] += if $version_atleast_2_0_0
+                  ';stroke-linejoin:miter;stroke-miterlimit:8'
+                else
+                  ';stroke-linejoin:round'
+                end
 
   doc = g.document
   data_points = shape[:data_points]
@@ -273,13 +282,13 @@ def svg_render_shape_triangle(g, slide, shape)
   px = ((x1 + x2) / 2.0).round(5)
 
   path = doc.create_element('path',
-          d: "M#{px} #{y1}L#{x2} #{y2}L#{x1} #{y2}Z")
+                            d: "M#{px} #{y1}L#{x2} #{y2}L#{x1} #{y2}Z")
   g << path
 end
 
 def svg_render_shape_ellipse(g, slide, shape)
   g['shape'] = "ellipse#{shape[:shape_unique_id]}"
-  g['style'] = "stroke:##{shape[:color]};stroke-width:#{shape_thickness(slide,shape)};visibility:hidden;fill:#{shape[:fill] ? '#'+shape[:color] : 'none'}"
+  g['style'] = "stroke:##{shape[:color]};stroke-width:#{shape_thickness(slide, shape)};visibility:hidden;fill:#{shape[:fill] ? '#' + shape[:color] : 'none'}"
 
   doc = g.document
   data_points = shape[:data_points]
@@ -318,7 +327,7 @@ def svg_render_shape_ellipse(g, slide, shape)
   path += "A#{width_r} #{height_r} 0 0 1 #{x2} #{hy}"
   path += "A#{width_r} #{height_r} 0 0 1 #{hx} #{y2}"
   path += "A#{width_r} #{height_r} 0 0 1 #{x1} #{hy}"
-  path += "Z"
+  path += 'Z'
 
   svg_path = doc.create_element('path', d: path)
   g << svg_path
@@ -340,13 +349,11 @@ def svg_render_shape_text(g, slide, shape)
 
   switch = doc.create_element('switch')
   fo = doc.create_element('foreignObject',
-          width: width, height: height, x: x, y: y)
+                          width: width, height: height, x: x, y: y)
   p = doc.create_element('p',
-          xmlns: 'http://www.w3.org/1999/xhtml', style: 'margin:0;padding:0')
+                         xmlns: 'http://www.w3.org/1999/xhtml', style: 'margin:0;padding:0')
   shape[:text].each_line.with_index do |line, index|
-    if index > 0
-      p << doc.create_element('br')
-    end
+    p << doc.create_element('br') if index > 0
     p << doc.create_text_node(line.chomp)
   end
   fo << p
@@ -376,13 +383,13 @@ def svg_render_shape_poll(g, slide, shape)
   # Save the poll json to a temp file
   IO.write(json_file, result)
   # Render the poll svg
-  ret = BigBlueButton.exec_ret('utils/gen_poll_svg', '-i', json_file, '-w', "#{width.round}", '-h', "#{height.round}", '-n', "#{num_responders}", '-o', svg_file)
-  raise "Failed to generate poll svg" if ret != 0
+  ret = BigBlueButton.exec_ret('utils/gen_poll_svg', '-i', json_file, '-w', width.round.to_s, '-h', height.round.to_s, '-n', num_responders.to_s, '-o', svg_file)
+  raise 'Failed to generate poll svg' if ret != 0
 
   # Poll image
   g << doc.create_element('image',
-          'xlink:href' => "presentation/#{presentation}/poll_result#{poll_id}.svg",
-          width: width, height: height, x: x, y: y)
+                          'xlink:href' => "presentation/#{presentation}/poll_result#{poll_id}.svg",
+                          width: width, height: height, x: x, y: y)
 end
 
 def svg_render_shape(canvas, slide, shape, image_id)
@@ -391,8 +398,8 @@ def svg_render_shape(canvas, slide, shape, image_id)
     return
   end
 
-  if shape[:in] >= slide[:out] or
-      (!shape[:out].nil? and shape[:out] <= slide[:in])
+  if (shape[:in] >= slide[:out]) ||
+     (!shape[:out].nil? && (shape[:out] <= slide[:in]))
     BigBlueButton.logger.info("Draw #{shape[:shape_id]} Shape #{shape[:shape_unique_id]} is not visible during image time span")
     return
   end
@@ -401,8 +408,8 @@ def svg_render_shape(canvas, slide, shape, image_id)
 
   doc = canvas.document
   g = doc.create_element('g',
-          id: "image#{image_id}-draw#{shape[:shape_id]}", class: 'shape',
-          timestamp: shape[:in], undo: (shape[:undo].nil? ? -1 : shape[:undo]))
+                         id: "image#{image_id}-draw#{shape[:shape_id]}", class: 'shape',
+                         timestamp: shape[:in], undo: (shape[:undo].nil? ? -1 : shape[:undo]))
 
   case shape[:type]
   when 'pencil'
@@ -425,9 +432,7 @@ def svg_render_shape(canvas, slide, shape, image_id)
 
   g[:shape] = "image#{image_id}-#{g[:shape]}"
 
-  if g.element_children.length > 0
-    canvas << g
-  end
+  canvas << g unless g.element_children.empty?
 end
 
 $svg_image_id = 1
@@ -442,35 +447,32 @@ def svg_render_image(svg, slide, shapes)
 
   BigBlueButton.logger.info("Image #{image_id}: Presentation #{slide[:presentation]} Slide #{slide[:slide]} Deskshare #{slide[:deskshare]} from #{slide[:in]} to #{slide[:out]}")
 
-
   doc = svg.document
   image = doc.create_element('image',
-          id: "image#{image_id}", class: 'slide',
-          in: slide[:in], out: slide[:out],
-          'xlink:href' => slide[:src],
-          width: slide[:width], height: slide[:height], x: 0, y: 0,
-          style: 'visibility:hidden')
-  image['text'] = slide[:text] if !slide[:text].nil?
+                             id: "image#{image_id}", class: 'slide',
+                             in: slide[:in], out: slide[:out],
+                             'xlink:href' => slide[:src],
+                             width: slide[:width], height: slide[:height], x: 0, y: 0,
+                             style: 'visibility:hidden')
+  image['text'] = slide[:text] unless slide[:text].nil?
   svg << image
 
-  if slide[:deskshare] or
-      shapes[slide[:presentation]].nil? or
-      shapes[slide[:presentation]][slide[:slide]].nil?
+  if slide[:deskshare] ||
+     shapes[slide[:presentation]].nil? ||
+     shapes[slide[:presentation]][slide[:slide]].nil?
     return
   end
   shapes = shapes[slide[:presentation]][slide[:slide]]
 
   canvas = doc.create_element('g',
-          class: 'canvas', id: "canvas#{image_id}",
-          image: "image#{image_id}", display: 'none')
+                              class: 'canvas', id: "canvas#{image_id}",
+                              image: "image#{image_id}", display: 'none')
 
   shapes.each do |shape|
     svg_render_shape(canvas, slide, shape, image_id)
   end
 
-  if canvas.element_children.length > 0
-    svg << canvas
-  end
+  svg << canvas unless canvas.element_children.empty?
 end
 
 def panzoom_viewbox(panzoom)
@@ -486,12 +488,12 @@ def panzoom_viewbox(panzoom)
   w = shape_scale_width(panzoom, panzoom[:width_ratio])
   h = shape_scale_height(panzoom, panzoom[:height_ratio])
 
-  return [x, y, w, h]
+  [x, y, w, h]
 end
 
 def panzooms_emit_event(rec, panzoom)
   if panzoom[:in] == panzoom[:out]
-    BigBlueButton.logger.info("Panzoom: not emitting, duration rounds to 0")
+    BigBlueButton.logger.info('Panzoom: not emitting, duration rounds to 0')
     return
   end
 
@@ -511,7 +513,7 @@ end
 
 def cursors_emit_event(rec, cursor)
   if cursor[:in] == cursor[:out]
-    BigBlueButton.logger.info("Cursor: not emitting, duration rounds to 0")
+    BigBlueButton.logger.info('Cursor: not emitting, duration rounds to 0')
     return
   end
 
@@ -527,7 +529,7 @@ def cursors_emit_event(rec, cursor)
            (panzoom[:width_ratio] / 100.0)).round(5)
       y = (((cursor[:y] / 100.0) + (panzoom[:y_offset] * $magic_mystery_number / 100.0)) /
            (panzoom[:height_ratio] / 100.0)).round(5)
-      if x < 0 or x > 1 or y < 0 or y > 1
+      if (x < 0) || (x > 1) || (y < 0) || (y > 1)
         x = -1.0
         y = -1.0
       end
@@ -557,16 +559,16 @@ def events_parse_shape(shapes, event, current_presentation, current_slide, times
   # for old BBB where this info isn't in the shape messages
   presentation = event.at_xpath('presentation')
   slide = event.at_xpath('pageNumber')
-  if presentation.nil?
-    presentation = current_presentation
-  else
-    presentation = presentation.text
-  end
+  presentation = if presentation.nil?
+                   current_presentation
+                 else
+                   presentation.text
+                 end
   if slide.nil?
     slide = current_slide
   else
     slide = slide.text.to_i
-    slide -=1 unless $version_atleast_0_9_0
+    slide -= 1 unless $version_atleast_0_9_0
   end
 
   # Set up the shapes data structures if needed
@@ -581,21 +583,21 @@ def events_parse_shape(shapes, event, current_presentation, current_slide, times
   # Common properties
   shape[:in] = timestamp
   shape[:type] = event.at_xpath('type').text
-  shape[:data_points] = event.at_xpath('dataPoints').text.split(',').map { |p| p.to_f }
+  shape[:data_points] = event.at_xpath('dataPoints').text.split(',').map(&:to_f)
   # These can be missing in old BBB versions, there are fallbacks
   user_id = event.at_xpath('userId')
-  shape[:user_id] = user_id.text if !user_id.nil?
+  shape[:user_id] = user_id.text unless user_id.nil?
   shape_id = event.at_xpath('id')
-  shape[:id] = shape_id.text if !shape_id.nil?
+  shape[:id] = shape_id.text unless shape_id.nil?
   status = event.at_xpath('status')
-  shape[:status] = status.text if !status.nil?
+  shape[:status] = status.text unless status.nil?
   shape[:shape_id] = $svg_shape_id
   $svg_shape_id += 1
 
   # Some shape-specific properties
-  if shape[:type] == 'pencil' or shape[:type] == 'rectangle' or
-      shape[:type] == 'ellipse' or shape[:type] == 'triangle' or
-      shape[:type] == 'line'
+  if (shape[:type] == 'pencil') || (shape[:type] == 'rectangle') ||
+     (shape[:type] == 'ellipse') || (shape[:type] == 'triangle') ||
+     (shape[:type] == 'line')
     shape[:color] = color_to_hex(event.at_xpath('color').text)
     thickness = event.at_xpath('thickness')
     unless thickness
@@ -608,28 +610,24 @@ def events_parse_shape(shapes, event, current_presentation, current_slide, times
       shape[:thickness] = thickness.text.to_i
     end
   end
-  if  shape[:type] == 'rectangle' or
-      shape[:type] == 'ellipse' or shape[:type] == 'triangle'
-    fill = event.at_xpath('fill').text
-    shape[:fill] = fill =~ /true/ ? true : false
+  if  (shape[:type] == 'rectangle') ||
+      (shape[:type] == 'ellipse') || (shape[:type] == 'triangle')
+    # TODO: uncomment this
+    # fill = event.at_xpath('fill').text
+    # shape[:fill] = fill =~ /true/ ? true : false
+    shape[:fill] = false
   end
   if shape[:type] == 'rectangle'
     square = event.at_xpath('square')
-    if !square.nil?
-      shape[:square] = (square.text == 'true')
-    end
+    shape[:square] = (square.text == 'true') unless square.nil?
   end
   if shape[:type] == 'ellipse'
     circle = event.at_xpath('circle')
-    if !circle.nil?
-      shape[:circle] = (circle.text == 'true')
-    end
+    shape[:circle] = (circle.text == 'true') unless circle.nil?
   end
   if shape[:type] == 'pencil'
     commands = event.at_xpath('commands')
-    if !commands.nil?
-      shape[:commands] = commands.text.split(',').map { |c| c.to_i }
-    end
+    shape[:commands] = commands.text.split(',').map(&:to_i) unless commands.nil?
   end
   if shape[:type] == 'poll_result'
     shape[:num_responders] = event.at_xpath('num_responders').text.to_i
@@ -650,25 +648,25 @@ def events_parse_shape(shapes, event, current_presentation, current_slide, times
 
     shape[:font_color] = color_to_hex(event.at_xpath('fontColor').text)
     text = event.at_xpath('text')
-    if !text.nil?
-      shape[:text] = text.text
-    else
-      shape[:text] = ''
-    end
+    shape[:text] = if !text.nil?
+                     text.text
+                   else
+                     ''
+                   end
   end
 
   # Find the previous shape, for updates
   prev_shape = nil
   if !shape[:id].nil?
     # If we have a shape ID, look up the previous shape by ID
-    prev_shape = shapes.find_all {|s| s[:id] == shape[:id] }.last
+    prev_shape = shapes.find_all { |s| s[:id] == shape[:id] }.last
   else
     # No shape ID, so do heuristic matching. If the previous shape had the
     # same type and same first two data points, update it.
     last_shape = shapes.last
-    if last_shape[:type] == shape[:type] and
-        last_shape[:data_points][0] == shape[:data_points][0] and
-        last_shape[:data_points][1] == shape[:data_points][1]
+    if (last_shape[:type] == shape[:type]) &&
+       (last_shape[:data_points][0] == shape[:data_points][0]) &&
+       (last_shape[:data_points][1] == shape[:data_points][1])
       prev_shape = last_shape
     end
   end
@@ -676,7 +674,7 @@ def events_parse_shape(shapes, event, current_presentation, current_slide, times
     prev_shape[:out] = timestamp
     shape[:shape_unique_id] = prev_shape[:shape_unique_id]
 
-    if shape[:type] == 'pencil' and shape[:status] == 'DRAW_UPDATE'
+    if (shape[:type] == 'pencil') && (shape[:status] == 'DRAW_UPDATE')
       # BigBlueButton 2.0 quirk - 'DRAW_UPDATE' events on pencil tool only
       # include newly added points, rather than the full list.
       shape[:data_points] = prev_shape[:data_points] + shape[:data_points]
@@ -695,22 +693,20 @@ def events_parse_undo(shapes, event, current_presentation, current_slide, timest
   # for old BBB where this info isn't in the undo messages
   presentation = event.at_xpath('presentation')
   slide = event.at_xpath('pageNumber')
-  if presentation.nil?
-    presentation = current_presentation
-  else
-    presentation = presentation.text
-  end
+  presentation = if presentation.nil?
+                   current_presentation
+                 else
+                   presentation.text
+                 end
   if slide.nil?
     slide = current_slide
   else
     slide = slide.text.to_i
-    slide -=1 unless $version_atleast_0_9_0
+    slide -= 1 unless $version_atleast_0_9_0
   end
   # Newer undo messages have the shape id, making this a lot easier
   shape_id = event.at_xpath('shapeId')
-  if !shape_id.nil?
-    shape_id = shape_id.text
-  end
+  shape_id = shape_id.text unless shape_id.nil?
 
   # Set up the shapes data structures if needed
   shapes[presentation] = {} if shapes[presentation].nil?
@@ -724,11 +720,8 @@ def events_parse_undo(shapes, event, current_presentation, current_slide, timest
     # all the shapes with that id.
     BigBlueButton.logger.info("Undo: removing shape with ID #{shape_id} at #{timestamp}")
     shapes.each do |shape|
-      if shape[:id] == shape_id
-        if shape[:undo].nil? or shape[:undo] > timestamp
-          shape[:undo] = timestamp
-        end
-      end
+      next unless shape[:id] == shape_id
+      shape[:undo] = timestamp if shape[:undo].nil? || (shape[:undo] > timestamp)
     end
   else
     # The undo command removes the most recently added shape that has not
@@ -740,14 +733,11 @@ def events_parse_undo(shapes, event, current_presentation, current_slide, timest
       # of the same shape. Use that to determine which shapes to apply undo
       # times to.
       shapes.each do |shape|
-        if shape[:shape_unique_id] == undo_shape[:shape_unique_id]
-          if shape[:undo].nil? or shape[:undo] > timestamp
-            shape[:undo] = timestamp
-          end
-        end
+        next unless shape[:shape_unique_id] == undo_shape[:shape_unique_id]
+        shape[:undo] = timestamp if shape[:undo].nil? || (shape[:undo] > timestamp)
       end
     else
-      BigBlueButton.logger.info("Undo: no applicable shapes found")
+      BigBlueButton.logger.info('Undo: no applicable shapes found')
     end
   end
 end
@@ -757,30 +747,28 @@ def events_parse_clear(shapes, event, current_presentation, current_slide, times
   # for old BBB where this info isn't in the clear messages
   presentation = event.at_xpath('presentation')
   slide = event.at_xpath('pageNumber')
-  if presentation.nil?
-    presentation = current_presentation
-  else
-    presentation = presentation.text
-  end
+  presentation = if presentation.nil?
+                   current_presentation
+                 else
+                   presentation.text
+                 end
   if slide.nil?
     slide = current_slide
   else
     slide = slide.text.to_i
-    slide -=1 unless $version_atleast_0_9_0
+    slide -= 1 unless $version_atleast_0_9_0
   end
 
   # BigBlueButton 2.0 per-user clear features
   full_clear = event.at_xpath('fullClear')
-  if !full_clear.nil?
-    full_clear = (full_clear.text == 'true')
-  else
-    # Default to full clear on older versions
-    full_clear = true
-  end
+  full_clear = if !full_clear.nil?
+                 (full_clear.text == 'true')
+               else
+                 # Default to full clear on older versions
+                 true
+               end
   user_id = event.at_xpath('userId')
-  if !user_id.nil?
-    user_id = user_id.text
-  end
+  user_id = user_id.text unless user_id.nil?
 
   # Set up the shapes data structures if needed
   shapes[presentation] = {} if shapes[presentation].nil?
@@ -790,16 +778,14 @@ def events_parse_clear(shapes, event, current_presentation, current_slide, times
   shapes = shapes[presentation][slide]
 
   if full_clear
-    BigBlueButton.logger.info("Clear: removing all shapes")
+    BigBlueButton.logger.info('Clear: removing all shapes')
   else
     BigBlueButton.logger.info("Clear: removing shapes for User #{user_id}")
   end
 
   shapes.each do |shape|
-    if full_clear or user_id == shape[:user_id]
-      if shape[:undo].nil? or shape[:undo] > timestamp
-        shape[:undo] = timestamp
-      end
+    if full_clear || (user_id == shape[:user_id])
+      shape[:undo] = timestamp if shape[:undo].nil? || (shape[:undo] > timestamp)
     end
   end
 end
@@ -835,24 +821,24 @@ end
 # Create the shapes.svg, cursors.xml, and panzooms.xml files used for
 # rendering the presentation area
 def processPresentation(package_dir)
-  shapes_doc = Nokogiri::XML::Document.new()
+  shapes_doc = Nokogiri::XML::Document.new
   shapes_doc.create_internal_subset('svg', '-//W3C//DTD SVG 1.1//EN',
-                             'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd')
+                                    'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd')
   svg = shapes_doc.root = shapes_doc.create_element('svg',
-          id: 'svgfile',
-          style: 'position:absolute;height:600px;width:800px',
-          xmlns: 'http://www.w3.org/2000/svg',
-          'xmlns:xlink' => 'http://www.w3.org/1999/xlink',
-          version: '1.1',
-          viewBox: '0 0 800 600')
+                                                    id: 'svgfile',
+                                                    style: 'position:absolute;height:600px;width:800px',
+                                                    xmlns: 'http://www.w3.org/2000/svg',
+                                                    'xmlns:xlink' => 'http://www.w3.org/1999/xlink',
+                                                    version: '1.1',
+                                                    viewBox: '0 0 800 600')
 
-  panzooms_doc = Nokogiri::XML::Document.new()
+  panzooms_doc = Nokogiri::XML::Document.new
   panzooms_rec = panzooms_doc.root = panzooms_doc.create_element('recording',
-          id: 'panzoom_events')
+                                                                 id: 'panzoom_events')
 
-  cursors_doc = Nokogiri::XML::Document.new()
+  cursors_doc = Nokogiri::XML::Document.new
   cursors_rec = cursors_doc.root = cursors_doc.create_element('recording',
-          id: 'cursor_events')
+                                                              id: 'cursor_events')
 
   # Current presentation/slide state
   current_presentation_slide = {}
@@ -883,7 +869,7 @@ def processPresentation(package_dir)
   events_xml.xpath('/recording/event').each do |event|
     eventname = event['eventname']
     last_timestamp = timestamp =
-      (translateTimestamp(event['timestamp']) / 1000.0).round(1)
+                       (translateTimestamp(event['timestamp']) / 1000.0).round(1)
 
     # Make sure to add initial entries to the slide & panzoom lists
     slide_changed = slides.empty?
@@ -910,21 +896,21 @@ def processPresentation(package_dir)
       current_height_ratio = event.at_xpath('heightRatio').text.to_f
       panzoom_changed = true
 
-    elsif  $presentation_props['include_deskshare'] and (eventname == 'DeskshareStartedEvent' or eventname == 'StartWebRTCDesktopShareEvent')
+    elsif $presentation_props['include_deskshare'] && ((eventname == 'DeskshareStartedEvent') || (eventname == 'StartWebRTCDesktopShareEvent'))
       deskshare = true
       slide_changed = true
 
-    elsif $presentation_props['include_deskshare'] and (eventname == 'DeskshareStoppedEvent' or eventname == 'StopWebRTCDesktopShareEvent')
+    elsif $presentation_props['include_deskshare'] && ((eventname == 'DeskshareStoppedEvent') || (eventname == 'StopWebRTCDesktopShareEvent'))
       deskshare = false
       slide_changed = true
 
-    elsif eventname == 'AddShapeEvent' or eventname == 'ModifyTextEvent'
+    elsif (eventname == 'AddShapeEvent') || (eventname == 'ModifyTextEvent')
       events_parse_shape(shapes, event, current_presentation, current_slide, timestamp)
 
-    elsif eventname == 'UndoShapeEvent' or eventname == 'UndoAnnotationEvent'
+    elsif (eventname == 'UndoShapeEvent') || (eventname == 'UndoAnnotationEvent')
       events_parse_undo(shapes, event, current_presentation, current_slide, timestamp)
 
-    elsif eventname == 'ClearPageEvent' or eventname == 'ClearWhiteboardEvent'
+    elsif (eventname == 'ClearPageEvent') || (eventname == 'ClearWhiteboardEvent')
       events_parse_clear(shapes, event, current_presentation, current_slide, timestamp)
 
     elsif eventname == 'AssignPresenterEvent'
@@ -943,7 +929,7 @@ def processPresentation(package_dir)
     elsif eventname == 'WhiteboardCursorMoveEvent'
       user_id = event.at_xpath('userId')
       # Only draw cursor for current presentor. TODO multi-cursor support
-      if user_id.nil? or user_id.text == presenter
+      if user_id.nil? || (user_id.text == presenter)
         cursor_x = event.at_xpath('xOffset').text.to_f
         cursor_y = event.at_xpath('yOffset').text.to_f
         cursor_visible = true
@@ -954,14 +940,14 @@ def processPresentation(package_dir)
     # Perform slide finalization
     if slide_changed
       slide = slides.last
-      if !slide.nil? and
-          slide[:presentation] == current_presentation and
-          slide[:slide] == current_slide and
-          slide[:deskshare] == deskshare
+      if !slide.nil? &&
+         (slide[:presentation] == current_presentation) &&
+         (slide[:slide] == current_slide) &&
+         (slide[:deskshare] == deskshare)
         BigBlueButton.logger.info('Presentation/Slide: skipping, no changes')
         slide_changed = false
       else
-        if !slide.nil?
+        unless slide.nil?
           slide[:out] = timestamp
           svg_render_image(svg, slide, shapes)
         end
@@ -982,18 +968,18 @@ def processPresentation(package_dir)
     if panzoom_changed
       slide = slides.last
       panzoom = panzooms.last
-      if !panzoom.nil? and
-          panzoom[:x_offset] == current_x_offset and
-          panzoom[:y_offset] == current_y_offset and
-          panzoom[:width_ratio] == current_width_ratio and
-          panzoom[:height_ratio] == current_height_ratio and
-          panzoom[:width] == slide[:width] and
-          panzoom[:height] == slide[:height] and
-          panzoom[:deskshare] == deskshare
+      if !panzoom.nil? &&
+         (panzoom[:x_offset] == current_x_offset) &&
+         (panzoom[:y_offset] == current_y_offset) &&
+         (panzoom[:width_ratio] == current_width_ratio) &&
+         (panzoom[:height_ratio] == current_height_ratio) &&
+         (panzoom[:width] == slide[:width]) &&
+         (panzoom[:height] == slide[:height]) &&
+         (panzoom[:deskshare] == deskshare)
         BigBlueButton.logger.info('Panzoom: skipping, no changes')
         panzoom_changed = false
       else
-        if !panzoom.nil?
+        unless panzoom.nil?
           panzoom[:out] = timestamp
           panzooms_emit_event(panzooms_rec, panzoom)
         end
@@ -1006,41 +992,40 @@ def processPresentation(package_dir)
           width: slide[:width],
           height: slide[:height],
           in: timestamp,
-          deskshare: deskshare,
+          deskshare: deskshare
         }
         panzooms << panzoom
       end
     end
 
     # Perform cursor finalization
-    if cursor_changed or panzoom_changed
-      unless cursor_x >= 0 and cursor_x <= 100 and
-          cursor_y >= 0 and cursor_y <= 100
-        cursor_visible = false
-      end
+    next unless cursor_changed || panzoom_changed
+    unless (cursor_x >= 0) && (cursor_x <= 100) &&
+           cursor_y >= 0 && (cursor_y <= 100)
+      cursor_visible = false
+    end
 
-      panzoom = panzooms.last
-      cursor = cursors.last
-      if !cursor.nil? and
-          ((!cursor[:visible] and !cursor_visible) or
-           (cursor[:x] == cursor_x and cursor[:y] == cursor_y)) and
-          !panzoom_changed
-        BigBlueButton.logger.info('Cursor: skipping, no changes')
-      else
-        if !cursor.nil?
-          cursor[:out] = timestamp
-          cursors_emit_event(cursors_rec, cursor)
-        end
-        BigBlueButton.logger.info("Cursor: visible #{cursor_visible}, #{cursor_x} #{cursor_y} (#{panzoom[:width]}x#{panzoom[:height]})")
-        cursor = {
-          visible: cursor_visible,
-          x: cursor_x,
-          y: cursor_y,
-          panzoom: panzoom,
-          in: timestamp,
-        }
-        cursors << cursor
+    panzoom = panzooms.last
+    cursor = cursors.last
+    if !cursor.nil? &&
+       ((!cursor[:visible] && !cursor_visible) ||
+        ((cursor[:x] == cursor_x) && (cursor[:y] == cursor_y))) &&
+       !panzoom_changed
+      BigBlueButton.logger.info('Cursor: skipping, no changes')
+    else
+      unless cursor.nil?
+        cursor[:out] = timestamp
+        cursors_emit_event(cursors_rec, cursor)
       end
+      BigBlueButton.logger.info("Cursor: visible #{cursor_visible}, #{cursor_x} #{cursor_y} (#{panzoom[:width]}x#{panzoom[:height]})")
+      cursor = {
+        visible: cursor_visible,
+        x: cursor_x,
+        y: cursor_y,
+        panzoom: panzoom,
+        in: timestamp
+      }
+      cursors << cursor
     end
   end
 
@@ -1062,10 +1047,10 @@ def processPresentation(package_dir)
 end
 
 def processChatMessages(events, bbb_props)
-  BigBlueButton.logger.info("Processing chat events")
+  BigBlueButton.logger.info('Processing chat events')
   # Create slides.xml and chat.
   Nokogiri::XML::Builder.new do |xml|
-    xml.popcorn {
+    xml.popcorn do
       BigBlueButton::Events.get_chat_events(events, $meeting_start.to_i, $meeting_end.to_i, bbb_props).each do |chat|
         chattimeline = {
           in: (chat[:in] / 1000.0).round(1),
@@ -1077,12 +1062,12 @@ def processChatMessages(events, bbb_props)
         chattimeline[:out] = (chat[:out] / 1000.0).round(1) unless chat[:out].nil?
         xml.chattimeline(**chattimeline)
       end
-    }
+    end
   end
 end
 
 def processDeskshareEvents(events)
-  BigBlueButton.logger.info("Processing deskshare events")
+  BigBlueButton.logger.info('Processing deskshare events')
   deskshare_matched_events = BigBlueButton::Events.get_matched_start_and_stop_deskshare_events(events)
 
   $deskshare_xml = Nokogiri::XML::Builder.new do |xml|
@@ -1091,64 +1076,53 @@ def processDeskshareEvents(events)
       deskshare_matched_events.each do |event|
         start_timestamp = (translateTimestamp(event[:start_timestamp].to_f) / 1000).round(1)
         stop_timestamp = (translateTimestamp(event[:stop_timestamp].to_f) / 1000).round(1)
-        if (start_timestamp != stop_timestamp)
-          video_info = BigBlueButton::EDL::Video.video_info("#{$deskshare_dir}/#{event[:stream]}")
-          if !video_info[:video]
-            BigBlueButton.logger.warn("#{event[:stream]} is not a valid video file, skipping...")
-            next
-          end
-          video_width, video_height = getDeskshareVideoDimension(event[:stream])
-          $xml.event(:start_timestamp => start_timestamp,
-                     :stop_timestamp => stop_timestamp,
-                     :video_width => video_width,
-                     :video_height => video_height)
+        next unless start_timestamp != stop_timestamp
+        video_info = BigBlueButton::EDL::Video.video_info("#{$deskshare_dir}/#{event[:stream]}")
+        unless video_info[:video]
+          BigBlueButton.logger.warn("#{event[:stream]} is not a valid video file, skipping...")
+          next
         end
+        video_width, video_height = getDeskshareVideoDimension(event[:stream])
+        $xml.event(start_timestamp: start_timestamp,
+                   stop_timestamp: stop_timestamp,
+                   video_width: video_width,
+                   video_height: video_height)
       end
     end
   end
 end
 
 def getPollQuestion(event)
-  question = ""
-  if not event.at_xpath("question").nil?
-    question = event.at_xpath("question").text
-  end
+  question = ''
+  question = event.at_xpath('question').text unless event.at_xpath('question').nil?
 
   question
 end
 
 def getPollAnswers(event)
   answers = []
-  if not event.at_xpath("answers").nil?
-    answers = JSON.load(event.at_xpath("answers").content)
-  end
+  answers = JSON.load(event.at_xpath('answers').content) unless event.at_xpath('answers').nil?
 
   answers
 end
 
 def getPollRespondents(event)
   respondents = 0
-  if not event.at_xpath("numRespondents").nil?
-    respondents = event.at_xpath("numRespondents").text.to_i
-  end
+  respondents = event.at_xpath('numRespondents').text.to_i unless event.at_xpath('numRespondents').nil?
 
   respondents
 end
 
 def getPollResponders(event)
   responders = 0
-  if not event.at_xpath("numResponders").nil?
-    responders = event.at_xpath("numResponders").text.to_i
-  end
+  responders = event.at_xpath('numResponders').text.to_i unless event.at_xpath('numResponders').nil?
 
   responders
 end
 
 def getPollId(event)
-  id = ""
-  if not event.at_xpath("pollId").nil?
-    id = event.at_xpath("pollId").text
-  end
+  id = ''
+  id = event.at_xpath('pollId').text unless event.at_xpath('pollId').nil?
 
   id
 end
@@ -1156,12 +1130,12 @@ end
 def getPollType(events, published_poll_event)
   published_poll_id = getPollId(published_poll_event)
 
-  type = ""
+  type = ''
   events.xpath("//event[@eventname='PollStartedRecordEvent']").each do |event|
     poll_id = getPollId(event)
 
     if poll_id.eql?(published_poll_id)
-      type = event.at_xpath("type").text
+      type = event.at_xpath('type').text
       break
     end
   end
@@ -1170,58 +1144,57 @@ def getPollType(events, published_poll_event)
 end
 
 def processPollEvents(events, package_dir)
-  BigBlueButton.logger.info("Processing poll events")
+  BigBlueButton.logger.info('Processing poll events')
 
   published_polls = []
   $rec_events.each do |re|
     events.xpath("//event[@eventname='PollPublishedRecordEvent']").each do |event|
-      if (event[:timestamp].to_i >= re[:start_timestamp] and event[:timestamp].to_i <= re[:stop_timestamp])
-        published_polls << {
-          :timestamp => (translateTimestamp(event[:timestamp]) / 1000).to_i,
-          :type => getPollType(events, event),
-          :question => getPollQuestion(event),
-          :answers => getPollAnswers(event),
-          :respondents => getPollRespondents(event),
-          :responders => getPollResponders(event)
-        }
-      end
+      next unless (event[:timestamp].to_i >= re[:start_timestamp]) && (event[:timestamp].to_i <= re[:stop_timestamp])
+      published_polls << {
+        timestamp: (translateTimestamp(event[:timestamp]) / 1000).to_i,
+        type: getPollType(events, event),
+        question: getPollQuestion(event),
+        answers: getPollAnswers(event),
+        respondents: getPollRespondents(event),
+        responders: getPollResponders(event)
+      }
     end
   end
 
-  if not published_polls.empty?
-    File.open("#{package_dir}/polls.json", "w") do |f|
+  unless published_polls.empty?
+    File.open("#{package_dir}/polls.json", 'w') do |f|
       f.puts(published_polls.to_json)
     end
   end
 end
 
-def processExternalVideoEvents(events, package_dir)
-  BigBlueButton.logger.info("Processing external video events")
+def processExternalVideoEvents(_events, package_dir)
+  BigBlueButton.logger.info('Processing external video events')
 
   # Retrieve external video events
   external_video_events = BigBlueButton::Events.match_start_and_stop_external_video_events(
-    BigBlueButton::Events.get_start_and_stop_external_video_events(@doc))
+    BigBlueButton::Events.get_start_and_stop_external_video_events(@doc)
+  )
 
   external_videos = []
   $rec_events.each do |re|
     external_video_events.each do |event|
-      #BigBlueButton.logger.info("Processing rec event #{re} and external video event #{event}")
+      # BigBlueButton.logger.info("Processing rec event #{re} and external video event #{event}")
       timestamp = (translateTimestamp(event[:start_timestamp]) / 1000).to_i
       # do not add same external_video twice
-      if (external_videos.find {|ev| ev[:timestamp] == timestamp}.nil?)
-        if ((event[:start_timestamp] >= re[:start_timestamp] and event[:start_timestamp] <= re[:stop_timestamp]) ||
-           (event[:start_timestamp] < re[:start_timestamp] and event[:stop_timestamp] >= re[:start_timestamp]))
-          external_videos << {
-            :timestamp => timestamp,
-            :external_video_url => event[:external_video_url]
-          }
-        end
+      next unless external_videos.find { |ev| ev[:timestamp] == timestamp }.nil?
+      if ((event[:start_timestamp] >= re[:start_timestamp]) && (event[:start_timestamp] <= re[:stop_timestamp])) ||
+         ((event[:start_timestamp] < re[:start_timestamp]) && (event[:stop_timestamp] >= re[:start_timestamp]))
+        external_videos << {
+          timestamp: timestamp,
+          external_video_url: event[:external_video_url]
+        }
       end
     end
   end
 
-  if not external_videos.empty?
-    File.open("#{package_dir}/external_videos.json", "w") do |f|
+  unless external_videos.empty?
+    File.open("#{package_dir}/external_videos.json", 'w') do |f|
       f.puts(external_videos.to_json)
     end
   end
@@ -1232,8 +1205,8 @@ $panzooms_xml_filename = 'panzooms.xml'
 $cursor_xml_filename = 'cursor.xml'
 $deskshare_xml_filename = 'deskshare.xml'
 
-opts = Trollop::options do
-  opt :meeting_id, "Meeting id to archive", :default => '58f4a6b3-cd07-444d-8564-59116cb53974', :type => String
+opts = Trollop.options do
+  opt :meeting_id, 'Meeting id to archive', default: '58f4a6b3-cd07-444d-8564-59116cb53974', type: String
 end
 
 $meeting_id = opts[:meeting_id]
@@ -1246,42 +1219,40 @@ puts $meeting_id
 puts $playback
 
 begin
-
-  if ($playback == "presentation")
+  if $playback == 'presentation'
 
     log_dir = bbb_props['log_dir']
 
-    logger = Logger.new("#{log_dir}/presentation/publish-#{$meeting_id}.log", 'daily' )
+    logger = Logger.new("#{log_dir}/presentation/publish-#{$meeting_id}.log", 'daily')
     BigBlueButton.logger = logger
 
-    BigBlueButton.logger.info("Setting recording dir")
+    BigBlueButton.logger.info('Setting recording dir')
     recording_dir = bbb_props['recording_dir']
-    BigBlueButton.logger.info("Setting process dir")
+    BigBlueButton.logger.info('Setting process dir')
     $process_dir = "#{recording_dir}/process/presentation/#{$meeting_id}"
-    BigBlueButton.logger.info("setting publish dir")
+    BigBlueButton.logger.info('setting publish dir')
     publish_dir = $presentation_props['publish_dir']
-    BigBlueButton.logger.info("setting playback url info")
+    BigBlueButton.logger.info('setting playback url info')
     playback_protocol = bbb_props['playback_protocol']
     playback_host = bbb_props['playback_host']
-    BigBlueButton.logger.info("setting target dir")
+    BigBlueButton.logger.info('setting target dir')
     target_dir = "#{recording_dir}/publish/presentation/#{$meeting_id}"
     $deskshare_dir = "#{recording_dir}/raw/#{$meeting_id}/deskshare"
 
-    if not FileTest.directory?(target_dir)
-      BigBlueButton.logger.info("Making dir target_dir")
+    if !FileTest.directory?(target_dir)
+      BigBlueButton.logger.info('Making dir target_dir')
       FileUtils.mkdir_p target_dir
 
       package_dir = "#{target_dir}/#{$meeting_id}"
-      BigBlueButton.logger.info("Making dir package_dir")
+      BigBlueButton.logger.info('Making dir package_dir')
       FileUtils.mkdir_p package_dir
 
       begin
-
         video_formats = $presentation_props['video_formats']
 
         video_files = Dir.glob("#{$process_dir}/webcams.{#{video_formats.join(',')}}")
-        if ! video_files.empty?
-          BigBlueButton.logger.info("Making video dir")
+        if !video_files.empty?
+          BigBlueButton.logger.info('Making video dir')
           video_dir = "#{package_dir}/video"
           FileUtils.mkdir_p video_dir
           video_files.each do |video_file|
@@ -1291,17 +1262,17 @@ begin
           end
         else
           audio_dir = "#{package_dir}/audio"
-          BigBlueButton.logger.info("Making audio dir")
+          BigBlueButton.logger.info('Making audio dir')
           FileUtils.mkdir_p audio_dir
           BigBlueButton.logger.info("Made audio dir - copying: #{$process_dir}/audio.webm to -> #{audio_dir}")
           FileUtils.cp("#{$process_dir}/audio.webm", audio_dir)
           BigBlueButton.logger.info("Copied audio.webm file - copying: #{$process_dir}/audio.ogg to -> #{audio_dir}")
           FileUtils.cp("#{$process_dir}/audio.ogg", audio_dir)
-          BigBlueButton.logger.info("Copied audio.ogg file")
+          BigBlueButton.logger.info('Copied audio.ogg file')
         end
 
         if File.exist?("#{$process_dir}/captions.json")
-          BigBlueButton.logger.info("Copying caption files")
+          BigBlueButton.logger.info('Copying caption files')
           FileUtils.cp("#{$process_dir}/captions.json", package_dir)
           Dir.glob("#{$process_dir}/caption_*.vtt").each do |caption|
             BigBlueButton.logger.debug(caption)
@@ -1310,8 +1281,8 @@ begin
         end
 
         video_files = Dir.glob("#{$process_dir}/deskshare.{#{video_formats.join(',')}}")
-        if ! video_files.empty?
-          BigBlueButton.logger.info("Making deskshare dir")
+        if !video_files.empty?
+          BigBlueButton.logger.info('Making deskshare dir')
           deskshare_dir = "#{package_dir}/deskshare"
           FileUtils.mkdir_p deskshare_dir
           video_files.each do |video_file|
@@ -1327,9 +1298,7 @@ begin
           FileUtils.cp("#{$process_dir}/presentation_text.json", package_dir)
         end
 
-        if File.exist?("#{$process_dir}/notes/notes.html")
-          FileUtils.cp("#{$process_dir}/notes/notes.html", package_dir)
-        end
+        FileUtils.cp("#{$process_dir}/notes/notes.html", package_dir) if File.exist?("#{$process_dir}/notes/notes.html")
 
         processing_time = File.read("#{$process_dir}/processing_time")
 
@@ -1337,20 +1306,23 @@ begin
 
         # Retrieve record events and calculate total recording duration.
         $rec_events = BigBlueButton::Events.match_start_and_stop_rec_events(
-          BigBlueButton::Events.get_start_and_stop_rec_events(@doc))
+          BigBlueButton::Events.get_start_and_stop_rec_events(@doc)
+        )
 
         recording_time = BigBlueButton::Events.get_recording_length(@doc)
 
         # presentation_url = "/slides/" + $meeting_id + "/presentation"
 
-        $meeting_start = @doc.xpath("//event")[0][:timestamp]
-        $meeting_end = @doc.xpath("//event").last()[:timestamp]
+        $meeting_start = @doc.xpath('//event')[0][:timestamp]
+        $meeting_end = @doc.xpath('//event').last[:timestamp]
 
         $version_atleast_0_9_0 = BigBlueButton::Events.bbb_version_compare(
-                        @doc, 0, 9, 0)
+          @doc, 0, 9, 0
+        )
         $version_atleast_2_0_0 = BigBlueButton::Events.bbb_version_compare(
-                        @doc, 2, 0, 0)
-        BigBlueButton.logger.info("Creating metadata.xml")
+          @doc, 2, 0, 0
+        )
+        BigBlueButton.logger.info('Creating metadata.xml')
 
         # Get the real-time start and end timestamp
         match = /.*-(\d+)$/.match($meeting_id)
@@ -1360,54 +1332,52 @@ begin
         #### INSTEAD OF CREATING THE WHOLE metadata.xml FILE AGAIN, ONLY ADD <playback>
         # Copy metadata.xml from process_dir
         FileUtils.cp("#{$process_dir}/metadata.xml", package_dir)
-        BigBlueButton.logger.info("Copied metadata.xml file")
+        BigBlueButton.logger.info('Copied metadata.xml file')
 
         # Update state and add playback to metadata.xml
         ## Load metadata.xml
         metadata = Nokogiri::XML(File.read("#{package_dir}/metadata.xml"))
         ## Update state
         recording = metadata.root
-        state = recording.at_xpath("state")
-        state.content = "published"
-        published = recording.at_xpath("published")
-        published.content = "true"
+        state = recording.at_xpath('state')
+        state.content = 'published'
+        published = recording.at_xpath('published')
+        published.content = 'true'
         ## Remove empty playback
-        metadata.search('//recording/playback').each do |playback|
-          playback.remove
-        end
+        metadata.search('//recording/playback').each(&:remove)
         ## Add the actual playback
-        presentation = BigBlueButton::Presentation.get_presentation_for_preview("#{$process_dir}")
+        presentation = BigBlueButton::Presentation.get_presentation_for_preview($process_dir.to_s)
         metadata_with_playback = Nokogiri::XML::Builder.with(metadata.at('recording')) do |xml|
-            xml.playback {
-              xml.format("presentation")
-              xml.link("#{playback_protocol}://#{playback_host}/playback/presentation/2.3/#{$meeting_id}")
-              xml.processing_time("#{processing_time}")
-              xml.duration("#{recording_time}")
-              unless presentation.empty?
-                xml.extensions {
-                  xml.preview {
-                    xml.images {
-                      presentation[:slides].each do |key,val|
-                        attributes = {:width => "176", :height => "136", :alt => (val[:alt] != nil)? "#{val[:alt]}": ""}
-                        xml.image(attributes){ xml.text("#{playback_protocol}://#{playback_host}/presentation/#{$meeting_id}/presentation/#{presentation[:id]}/thumbnails/thumb-#{key}.png") }
-                      end
-                    }
-                  }
-                }
+          xml.playback do
+            xml.format('presentation')
+            xml.link("#{playback_protocol}://#{playback_host}/playback/presentation/2.3/#{$meeting_id}")
+            xml.processing_time(processing_time.to_s)
+            xml.duration(recording_time.to_s)
+            unless presentation.empty?
+              xml.extensions do
+                xml.preview do
+                  xml.images do
+                    presentation[:slides].each do |key, val|
+                      attributes = { width: '176', height: '136', alt: !val[:alt].nil? ? (val[:alt]).to_s : '' }
+                      xml.image(attributes) { xml.text("#{playback_protocol}://#{playback_host}/presentation/#{$meeting_id}/presentation/#{presentation[:id]}/thumbnails/thumb-#{key}.png") }
+                    end
+                  end
+                end
               end
-            }
+            end
+          end
         end
         ## Write the new metadata.xml
-        metadata_file = File.new("#{package_dir}/metadata.xml","w")
-        metadata = Nokogiri::XML(metadata.to_xml) { |x| x.noblanks }
+        metadata_file = File.new("#{package_dir}/metadata.xml", 'w')
+        metadata = Nokogiri::XML(metadata.to_xml, &:noblanks)
         metadata_file.write(metadata.root)
         metadata_file.close
-        BigBlueButton.logger.info("Added playback to metadata.xml")
+        BigBlueButton.logger.info('Added playback to metadata.xml')
 
-        #Create slides.xml
-        BigBlueButton.logger.info("Generating xml for slides and chat")
+        # Create slides.xml
+        BigBlueButton.logger.info('Generating xml for slides and chat')
 
-        calculateRecordEventsOffset()
+        calculateRecordEventsOffset
 
         # Write slides.xml to file
         slides_doc = processChatMessages(@doc, bbb_props)
@@ -1424,15 +1394,13 @@ begin
         # Write deskshare.xml to file
         File.open("#{package_dir}/#{$deskshare_xml_filename}", 'w') { |f| f.puts $deskshare_xml.to_xml }
 
-        BigBlueButton.logger.info("Copying files to package dir")
+        BigBlueButton.logger.info('Copying files to package dir')
         FileUtils.cp_r("#{$process_dir}/presentation", package_dir)
-        BigBlueButton.logger.info("Copied files to package dir")
+        BigBlueButton.logger.info('Copied files to package dir')
 
-        BigBlueButton.logger.info("Publishing slides")
+        BigBlueButton.logger.info('Publishing slides')
         # Now publish this recording files by copying them into the publish folder.
-        if not FileTest.directory?(publish_dir)
-          FileUtils.mkdir_p publish_dir
-        end
+        FileUtils.mkdir_p publish_dir unless FileTest.directory?(publish_dir)
 
         # Get raw size of presentation files
         raw_dir = "#{recording_dir}/raw/#{$meeting_id}"
@@ -1441,21 +1409,22 @@ begin
         BigBlueButton.add_playback_size_to_metadata(package_dir)
 
         FileUtils.cp_r(package_dir, publish_dir) # Copy all the files.
-        BigBlueButton.logger.info("Finished publishing script presentation.rb successfully.")
+        BigBlueButton.logger.info('Finished publishing script presentation.rb successfully.')
 
-        BigBlueButton.logger.info("Removing processed files.")
-        FileUtils.rm_r(Dir.glob("#{$process_dir}/*"))
+        # TODO: remove comments
+        # BigBlueButton.logger.info("Removing processed files.")
+        # FileUtils.rm_r(Dir.glob("#{$process_dir}/*"))
 
-        BigBlueButton.logger.info("Removing published files.")
+        BigBlueButton.logger.info('Removing published files.')
         FileUtils.rm_r(Dir.glob("#{target_dir}/*"))
-        rescue  Exception => e
-          BigBlueButton.logger.error(e.message)
-          e.backtrace.each do |traceline|
+      rescue Exception => e
+        BigBlueButton.logger.error(e.message)
+        e.backtrace.each do |traceline|
           BigBlueButton.logger.error(traceline)
         end
         exit 1
       end
-      publish_done = File.new("#{recording_dir}/status/published/#{$meeting_id}-presentation.done", "w")
+      publish_done = File.new("#{recording_dir}/status/published/#{$meeting_id}-presentation.done", 'w')
       publish_done.write("Published #{$meeting_id}")
       publish_done.close
 
@@ -1463,14 +1432,12 @@ begin
       BigBlueButton.logger.info("#{target_dir} is already there")
     end
   end
-
-
 rescue Exception => e
   BigBlueButton.logger.error(e.message)
   e.backtrace.each do |traceline|
     BigBlueButton.logger.error(traceline)
   end
-  publish_done = File.new("#{recording_dir}/status/published/#{$meeting_id}-presentation.fail", "w")
+  publish_done = File.new("#{recording_dir}/status/published/#{$meeting_id}-presentation.fail", 'w')
   publish_done.write("Failed Publishing #{$meeting_id}")
   publish_done.close
 

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -174,7 +174,7 @@ def svg_render_shape_pencil(g, slide, shape)
           cy1 = shape_scale_height(slide, data_points.next)
           x = shape_scale_width(slide, data_points.next)
           y = shape_scale_height(slide, data_points.next)
-          path.push("Q#{cx1} #{cy2},#{x} #{y}")
+          path.push("Q#{cx1} #{cy1},#{x} #{y}")
         when 4 # C_CURVE_TO
           cx1 = shape_scale_width(slide, data_points.next)
           cy1 = shape_scale_height(slide, data_points.next)


### PR DESCRIPTION
### What does this PR do?
Improves the performance, readability and security of the presentation recording publishing script.

+ Update README instructions to setup development environment
+ Adds comment to run script manually
+ Uses Ruby's style guide
+ Refactors identical code
+ Linting
+ Performance gains

### Motivation
Developed for TU Munich's Open Source Lab course.

### Metrics / Benchmarks
Speed improvement: tbd
Rubocop: 487 offenses down to 5
Fasterer: tbd

Flay score (structural similarities): 907 -> 390 (lower is better)
Flog score (difficulty to test): 58.5 -> 50.4 flog/method (lower is better)

### More
I think the previously unassigned variable `cy1` in Q_CURVE_TO was meant to take the place of `cy2`, but this needs to be checked since it's a potentially breaking change

### TODOs
- [ ] Improve `events_parse_shape` speed
- [ ] Improve `events_parse_undo` speed
- [ ] Benchmark performance gain