### PR TITLE
[2.3] fix(webcams): viewer accounting, improved perm. checks in akka-apps, [...]

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/Boot.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/Boot.scala
@@ -70,7 +70,9 @@ object Boot extends App with SystemConfiguration {
   val redisMessageHandlerActor = system.actorOf(ReceivedJsonMsgHandlerActor.props(bbbMsgBus, incomingJsonMessageBus))
   incomingJsonMessageBus.subscribe(redisMessageHandlerActor, toAkkaAppsJsonChannel)
 
-  val channelsToSubscribe = Seq(toAkkaAppsRedisChannel, fromVoiceConfRedisChannel)
+  val channelsToSubscribe = Seq(
+    toAkkaAppsRedisChannel, fromVoiceConfRedisChannel, fromSfuRedisChannel,
+  )
 
   val redisSubscriberActor = system.actorOf(
     AppsRedisSubscriberActor.props(

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
@@ -1,9 +1,18 @@
 package org.bigbluebutton
 
 import org.bigbluebutton.common2.msgs.{ BbbCommonEnvCoreMsg, BbbCoreEnvelope, BbbCoreHeaderWithMeetingId, MessageTypes, MuteUserInVoiceConfSysMsg, MuteUserInVoiceConfSysMsgBody, Routing }
-import org.bigbluebutton.core.models.{ Roles, Users2x, VoiceUserState, VoiceUsers }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.{ MeetingStatus2x }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
+import org.bigbluebutton.core.models.{
+  Roles,
+  Users2x,
+  UserState,
+  VoiceUserState,
+  VoiceUsers,
+  Webcams,
+  WebcamStream
+}
 
 object LockSettingsUtil {
 
@@ -63,6 +72,100 @@ object LockSettingsUtil {
       if (vu.listenOnly && !vu.muted) {
         muteUserInVoiceConf(liveMeeting, outGW, vu, true)
       }
+    }
+  }
+
+  private def requestBroadcastedCamEjection(
+      meetingId: String, userId: String, streamId: String, outGW: OutMsgRouter
+  ): Unit = {
+    val event = MsgBuilder.buildCamBroadcastStopSysMsg(
+      meetingId, userId, streamId
+    )
+    outGW.send(event)
+  }
+
+  def isCameraBroadcastLocked(user: UserState, liveMeeting: LiveMeeting): Boolean = {
+    val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
+
+    user.role == Roles.VIEWER_ROLE && user.locked && permissions.disableCam
+  }
+
+  def isCameraSubscribeLocked(
+      user: UserState, stream: WebcamStream, liveMeeting: LiveMeeting
+  ): Boolean = {
+    var locked = false
+    val publisherUserId: String = stream.stream.userId
+
+    for {
+      publisher <- Users2x.findWithIntId(liveMeeting.users2x, publisherUserId)
+    } yield {
+      if (MeetingStatus2x.webcamsOnlyForModeratorEnabled(liveMeeting.status)
+        && publisher.role != Roles.MODERATOR_ROLE
+        && user.role == Roles.VIEWER_ROLE
+        && user.locked) {
+        locked = true
+      }
+    }
+
+    locked
+  }
+
+  private def requestCamSubscriptionEjection(
+      meetingId: String, userId: String, streamId: String, outGW: OutMsgRouter
+  ): Unit = {
+    val event = MsgBuilder.buildCamStreamUnsubscribeSysMsg(
+      meetingId, userId, streamId
+    )
+    outGW.send(event)
+  }
+
+  private def enforceSeeOtherViewersForUser(
+      user: UserState, liveMeeting: LiveMeeting, outGW: OutMsgRouter
+  ): Unit = {
+    if (MeetingStatus2x.webcamsOnlyForModeratorEnabled(liveMeeting.status)) {
+      Webcams.findAll(liveMeeting.webcams) foreach { webcam =>
+        val streamId = webcam.stream.id
+        val userId = user.intId
+
+        if (isCameraSubscribeLocked(user, webcam, liveMeeting)
+          && Webcams.isViewingWebcam(liveMeeting.webcams, user.intId, webcam.stream.id)) {
+          requestCamSubscriptionEjection(
+            liveMeeting.props.meetingProp.intId,
+            userId,
+            streamId,
+            outGW
+          )
+        }
+      }
+    }
+  }
+
+  private def enforceDisableCamForUser(
+      user: UserState, liveMeeting: LiveMeeting, outGW: OutMsgRouter
+  ): Unit = {
+    if (isCameraBroadcastLocked(user, liveMeeting)) {
+      val broadcastedWebcams = Webcams.findWebcamsForUser(liveMeeting.webcams, user.intId)
+      broadcastedWebcams foreach { webcam =>
+        requestBroadcastedCamEjection(
+          liveMeeting.props.meetingProp.intId,
+          user.intId,
+          webcam.stream.id,
+          outGW
+        )
+      }
+    }
+  }
+
+  def enforceCamLockSettingsForUser(
+      user: UserState, liveMeeting: LiveMeeting, outGW: OutMsgRouter
+  ): Unit = {
+    enforceDisableCamForUser(user, liveMeeting, outGW)
+    enforceSeeOtherViewersForUser(user, liveMeeting, outGW)
+  }
+
+  def enforceCamLockSettingsForAllUsers(liveMeeting: LiveMeeting, outGW: OutMsgRouter): Unit = {
+    Users2x.findLockedViewers(liveMeeting.users2x).foreach { user =>
+      enforceCamLockSettingsForUser(user, liveMeeting, outGW)
     }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
@@ -63,6 +63,9 @@ trait SystemConfiguration {
   lazy val toVoiceConfRedisChannel = Try(config.getString("redis.toVoiceConfRedisChannel")).getOrElse("to-voice-conf-redis-channel")
   lazy val fromVoiceConfRedisChannel = Try(config.getString("redis.fromVoiceConfRedisChannel")).getOrElse("from-voice-conf-redis-channel")
 
+  lazy val toSfuRedisChannel = Try(config.getString("redis.toSfuRedisChannel")).getOrElse("to-sfu-redis-channel")
+  lazy val fromSfuRedisChannel = Try(config.getString("redis.fromSfuRedisChannel")).getOrElse("from-sfu-redis-channel")
+
   lazy val fromAkkaAppsWbRedisChannel = Try(config.getString("redis.fromAkkaAppsWbRedisChannel")).getOrElse("from-akka-apps-wb-redis-channel")
   lazy val fromAkkaAppsChatRedisChannel = Try(config.getString("redis.fromAkkaAppsChatRedisChannel")).getOrElse("from-akka-apps-chat-redis-channel")
   lazy val fromAkkaAppsPresRedisChannel = Try(config.getString("redis.fromAkkaAppsPresRedisChannel")).getOrElse("from-akka-apps-pres-redis-channel")

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
@@ -44,6 +44,10 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
           LockSettingsUtil.enforceLockSettingsForAllVoiceUsers(liveMeeting, outGW)
         }
 
+        if (!oldPermissions.disableCam && settings.disableCam) {
+          LockSettingsUtil.enforceCamLockSettingsForAllUsers(liveMeeting, outGW)
+        }
+
         val routing = Routing.addMsgToClientRouting(
           MessageTypes.BROADCAST_TO_MEETING,
           props.meetingProp.intId,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
@@ -1,9 +1,10 @@
 package org.bigbluebutton.core.apps.users
 
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.models.{ RegisteredUsers, Roles, Users2x }
+import org.bigbluebutton.core.models.{ RegisteredUsers, Roles, Users2x, UserState }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
+import org.bigbluebutton.LockSettingsUtil
 
 trait ChangeUserRoleCmdMsgHdlr extends RightsManagementTrait {
   this: UsersApp =>
@@ -36,9 +37,14 @@ trait ChangeUserRoleCmdMsgHdlr extends RightsManagementTrait {
             msg.body.changedBy, Roles.MODERATOR_ROLE)
           outGW.send(event)
         } else if (msg.body.role == Roles.VIEWER_ROLE) {
-          Users2x.changeRole(liveMeeting.users2x, uvo, msg.body.role)
+          val newUvo: UserState = Users2x.changeRole(liveMeeting.users2x, uvo, msg.body.role)
           val event = buildUserRoleChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.userId,
             msg.body.changedBy, Roles.VIEWER_ROLE)
+
+          if (newUvo.locked) {
+            LockSettingsUtil.enforceCamLockSettingsForAllUsers(liveMeeting, outGW)
+          }
+
           outGW.send(event)
         }
       }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetCamBroadcastPermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetCamBroadcastPermissionReqMsgHdlr.scala
@@ -4,6 +4,7 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core.models.Users2x
 import org.bigbluebutton.core2.message.senders.MsgBuilder
+import org.bigbluebutton.LockSettingsUtil
 
 trait GetCamBroadcastPermissionReqMsgHdlr {
   this: MeetingActor =>
@@ -11,13 +12,17 @@ trait GetCamBroadcastPermissionReqMsgHdlr {
   val outGW: OutMsgRouter
 
   def handleGetCamBroadcastPermissionReqMsg(msg: GetCamBroadcastPermissionReqMsg) {
+    var camBroadcastLocked: Boolean = false
     var allowed = false
 
     for {
       user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
     } yield {
+      camBroadcastLocked = LockSettingsUtil.isCameraBroadcastLocked(user, liveMeeting)
+
       if (!user.userLeftFlag.left
-        && liveMeeting.props.meetingProp.intId == msg.body.meetingId) {
+        && liveMeeting.props.meetingProp.intId == msg.body.meetingId
+        && (applyPermissionCheck && !camBroadcastLocked)) {
         allowed = true
       }
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LockUserInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LockUserInMeetingCmdMsgHdlr.scala
@@ -35,6 +35,8 @@ trait LockUserInMeetingCmdMsgHdlr extends RightsManagementTrait {
           VoiceUsers.findWithIntId(liveMeeting.voiceUsers, uvo.intId).foreach { vu =>
             LockSettingsUtil.enforceLockSettingsForVoiceUser(vu, liveMeeting, outGW)
           }
+
+          LockSettingsUtil.enforceCamLockSettingsForUser(uvo, liveMeeting, outGW)
         }
 
         log.info("Lock user.  meetingId=" + props.meetingProp.intId + " userId=" + uvo.intId + " locked=" + uvo.locked)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UpdateWebcamsOnlyForModeratorCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UpdateWebcamsOnlyForModeratorCmdMsgHdlr.scala
@@ -4,6 +4,7 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
+import org.bigbluebutton.LockSettingsUtil
 
 trait UpdateWebcamsOnlyForModeratorCmdMsgHdlr extends RightsManagementTrait {
   this: UsersApp =>
@@ -18,14 +19,15 @@ trait UpdateWebcamsOnlyForModeratorCmdMsgHdlr extends RightsManagementTrait {
       val reason = "No permission to change lock settings"
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)
     } else {
-      log.info("Change webcams only for moderator status. meetingId=" + liveMeeting.props.meetingProp.intId + " webcamsOnlyForModeratorrecording=" + msg.body.webcamsOnlyForModerator)
       if (MeetingStatus2x.webcamsOnlyForModeratorEnabled(liveMeeting.status) != msg.body.webcamsOnlyForModerator) {
+        log.info("Change webcams only for moderator status. meetingId=" + liveMeeting.props.meetingProp.intId + " webcamsOnlyForModeratorrecording=" + msg.body.webcamsOnlyForModerator)
         MeetingStatus2x.setWebcamsOnlyForModerator(liveMeeting.status, msg.body.webcamsOnlyForModerator)
-
+        LockSettingsUtil.enforceCamLockSettingsForAllUsers(liveMeeting, outGW)
         val event = buildWebcamsOnlyForModeratorChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.setBy, msg.body.webcamsOnlyForModerator)
         outGW.send(event)
       }
     }
+
     def buildWebcamsOnlyForModeratorChangedEvtMsg(meetingId: String, userId: String, webcamsOnlyForModerator: Boolean): BbbCommonEnvCoreMsg = {
       val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
       val envelope = BbbCoreEnvelope(WebcamsOnlyForModeratorChangedEvtMsg.NAME, routing)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserBroadcastCamStartMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserBroadcastCamStartMsgHdlr.scala
@@ -3,6 +3,9 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.{ MediaStream, WebcamStream, Webcams }
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
+import org.bigbluebutton.core.models.Users2x
+import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.LockSettingsUtil
 
 trait UserBroadcastCamStartMsgHdlr {
   this: MeetingActor =>
@@ -10,6 +13,7 @@ trait UserBroadcastCamStartMsgHdlr {
   val outGW: OutMsgRouter
 
   def handleUserBroadcastCamStartMsg(msg: UserBroadcastCamStartMsg): Unit = {
+    var allowed: Boolean = false
 
     def broadcastEvent(msg: UserBroadcastCamStartMsg): Unit = {
       val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, props.meetingProp.intId, msg.header.userId)
@@ -22,13 +26,32 @@ trait UserBroadcastCamStartMsgHdlr {
       outGW.send(msgEvent)
     }
 
-    val stream = new MediaStream(msg.body.stream, msg.body.stream, msg.header.userId, Map.empty, Set.empty)
-    val webcamStream = new WebcamStream(msg.body.stream, stream)
-
     for {
-      uvo <- Webcams.addWebcamBroadcastStream(liveMeeting.webcams, webcamStream)
+      user <- Users2x.findWithIntId(liveMeeting.users2x, msg.header.userId)
     } yield {
-      broadcastEvent(msg)
+      val meetingId = props.meetingProp.intId
+      val camBroadcastLocked = LockSettingsUtil.isCameraBroadcastLocked(user, liveMeeting)
+
+      if (!user.userLeftFlag.left
+        && meetingId == msg.header.meetingId
+        && msg.body.stream.startsWith(msg.header.userId)
+        && (applyPermissionCheck && !camBroadcastLocked)) {
+        allowed = true
+      }
+
+      if (!allowed) {
+        val reason = "No permission to share camera."
+        PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)
+      } else {
+        val stream = new MediaStream(msg.body.stream, msg.body.stream, msg.header.userId, Map.empty, Set.empty)
+        val webcamStream = new WebcamStream(msg.body.stream, stream)
+
+        for {
+          uvo <- Webcams.addWebcamBroadcastStream(liveMeeting.webcams, webcamStream)
+        } yield {
+          broadcastEvent(msg)
+        }
+      }
     }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
@@ -98,6 +98,18 @@ object UsersApp {
     outGW.send(ejectFromVoiceEvent)
   }
 
+  def sendEjectUserFromSfuSysMsg(
+    outGW: OutMsgRouter,
+    meetingId: String,
+    userId: String
+  ): Unit = {
+    val event = MsgBuilder.buildEjectUserFromSfuSysMsg(
+      meetingId,
+      userId,
+    )
+    outGW.send(event)
+  }
+
   def ejectUserFromMeeting(outGW: OutMsgRouter, liveMeeting: LiveMeeting,
                            userId: String, ejectedBy: String, reason: String,
                            reasonCode: String, ban: Boolean): Unit = {
@@ -110,6 +122,7 @@ object UsersApp {
     } yield {
       sendUserEjectedMessageToClient(outGW, meetingId, userId, ejectedBy, reason, reasonCode)
       sendUserLeftMeetingToAllClients(outGW, meetingId, userId)
+      sendEjectUserFromSfuSysMsg(outGW, meetingId, userId)
       if (user.presenter) {
         automaticallyAssignPresenter(outGW, liveMeeting)
       }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -79,6 +79,10 @@ object Users2x {
     users.toVector.filter(u => u.role == Roles.VIEWER_ROLE)
   }
 
+  def findLockedViewers(users: Users2x): Vector[UserState] = {
+    users.toVector.filter(u => u.role == Roles.VIEWER_ROLE && u.locked)
+  }
+
   def updateLastUserActivity(users: Users2x, u: UserState): UserState = {
     val newUserState = modify(u)(_.lastActivityTime).setTo(System.currentTimeMillis())
     users.save(newUserState)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -137,6 +137,12 @@ class ReceivedJsonMsgHandlerActor(
         routeGenericMsg[GetCamBroadcastPermissionReqMsg](envelope, jsonNode)
       case GetCamSubscribePermissionReqMsg.NAME =>
         routeGenericMsg[GetCamSubscribePermissionReqMsg](envelope, jsonNode)
+      case CamStreamSubscribedInSfuEvtMsg.NAME =>
+        routeGenericMsg[CamStreamSubscribedInSfuEvtMsg](envelope, jsonNode)
+      case CamStreamUnsubscribedInSfuEvtMsg.NAME =>
+        routeGenericMsg[CamStreamUnsubscribedInSfuEvtMsg](envelope, jsonNode)
+      case CamBroadcastStoppedInSfuEvtMsg.NAME =>
+        routeGenericMsg[CamBroadcastStoppedInSfuEvtMsg](envelope, jsonNode)
 
       // Voice
       case RecordingStartedVoiceConfEvtMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -80,6 +80,9 @@ class MeetingActor(
   with GetScreenSubscribePermissionReqMsgHdlr
   with GetCamBroadcastPermissionReqMsgHdlr
   with GetCamSubscribePermissionReqMsgHdlr
+  with CamStreamSubscribedInSfuEvtMsgHdlr
+  with CamStreamUnsubscribedInSfuEvtMsgHdlr
+  with CamBroadcastStoppedInSfuEvtMsgHdlr
 
   with EjectUserFromVoiceCmdMsgHdlr
   with EndMeetingSysCmdMsgHdlr
@@ -339,27 +342,31 @@ class MeetingActor(
   private def handleMessageThatAffectsInactivity(msg: BbbCommonEnvCoreMsg): Unit = {
 
     msg.core match {
-      case m: EndMeetingSysCmdMsg                 => handleEndMeeting(m, state)
+      case m: EndMeetingSysCmdMsg     => handleEndMeeting(m, state)
 
       // Users
-      case m: ValidateAuthTokenReqMsg             => state = usersApp.handleValidateAuthTokenReqMsg(m, state)
-      case m: UserJoinMeetingReqMsg               =>
+      case m: ValidateAuthTokenReqMsg => state = usersApp.handleValidateAuthTokenReqMsg(m, state)
+      case m: UserJoinMeetingReqMsg =>
         state = handleUserJoinMeetingReqMsg(m, state)
         updateModeratorsPresence()
       case m: UserJoinMeetingAfterReconnectReqMsg =>
         state = handleUserJoinMeetingAfterReconnectReqMsg(m, state)
         updateModeratorsPresence()
-      case m: UserLeaveReqMsg                     =>
+      case m: UserLeaveReqMsg =>
         state = handleUserLeaveReqMsg(m, state)
         updateModeratorsPresence()
-      case m: UserBroadcastCamStartMsg            => handleUserBroadcastCamStartMsg(m)
-      case m: UserBroadcastCamStopMsg             => handleUserBroadcastCamStopMsg(m)
-      case m: GetCamBroadcastPermissionReqMsg     => handleGetCamBroadcastPermissionReqMsg(m)
-      case m: GetCamSubscribePermissionReqMsg     => handleGetCamSubscribePermissionReqMsg(m)
+      case m: UserBroadcastCamStartMsg         => handleUserBroadcastCamStartMsg(m)
+      case m: UserBroadcastCamStopMsg          => handleUserBroadcastCamStopMsg(m)
+      case m: GetCamBroadcastPermissionReqMsg  => handleGetCamBroadcastPermissionReqMsg(m)
+      case m: GetCamSubscribePermissionReqMsg  => handleGetCamSubscribePermissionReqMsg(m)
+      case m: CamStreamSubscribedInSfuEvtMsg   => handleCamStreamSubscribedInSfuEvtMsg(m)
+      case m: CamStreamUnsubscribedInSfuEvtMsg => handleCamStreamUnsubscribedInSfuEvtMsg(m)
+      case m: CamStreamUnsubscribedInSfuEvtMsg => handleCamStreamUnsubscribedInSfuEvtMsg(m)
+      case m: CamBroadcastStoppedInSfuEvtMsg   => handleCamBroadcastStoppedInSfuEvtMsg(m)
 
-      case m: UserJoinedVoiceConfEvtMsg           => handleUserJoinedVoiceConfEvtMsg(m)
-      case m: LogoutAndEndMeetingCmdMsg           => usersApp.handleLogoutAndEndMeetingCmdMsg(m, state)
-      case m: SetRecordingStatusCmdMsg            =>
+      case m: UserJoinedVoiceConfEvtMsg        => handleUserJoinedVoiceConfEvtMsg(m)
+      case m: LogoutAndEndMeetingCmdMsg        => usersApp.handleLogoutAndEndMeetingCmdMsg(m, state)
+      case m: SetRecordingStatusCmdMsg =>
         state = usersApp.handleSetRecordingStatusCmdMsg(m, state)
         updateUserLastActivity(m.body.setBy)
       case m: RecordAndClearPreviousMarkersCmdMsg =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/FromAkkaAppsMsgSenderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/FromAkkaAppsMsgSenderActor.scala
@@ -64,6 +64,14 @@ class FromAkkaAppsMsgSenderActor(msgSender: MessageSender)
       case GetUsersStatusToVoiceConfSysMsg.NAME =>
         msgSender.send(toVoiceConfRedisChannel, json)
 
+      // Sent to SFU
+      case EjectUserFromSfuSysMsg.NAME =>
+        msgSender.send(toSfuRedisChannel, json)
+      case CamBroadcastStopSysMsg.NAME =>
+        msgSender.send(toSfuRedisChannel, json)
+      case CamStreamUnsubscribeSysMsg.NAME =>
+        msgSender.send(toSfuRedisChannel, json)
+
       //==================================================================
       // Send chat, presentation, and whiteboard in different channels so as not to
       // flood other applications (e.g. bbb-web) with unnecessary messages

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/streams/CamBroadcastStoppedInSfuEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/streams/CamBroadcastStoppedInSfuEvtMsgHdlr.scala
@@ -1,0 +1,36 @@
+package org.bigbluebutton.core.apps.users
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.models.Webcams
+import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
+import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core2.message.senders.MsgBuilder
+
+trait CamBroadcastStoppedInSfuEvtMsgHdlr {
+  this: MeetingActor =>
+
+  val outGW: OutMsgRouter
+
+  def handleCamBroadcastStoppedInSfuEvtMsg(msg: CamBroadcastStoppedInSfuEvtMsg): Unit = {
+    for {
+      publisherStream <- Webcams.findWithStreamId(liveMeeting.webcams, msg.body.streamId)
+    } yield {
+      if (publisherStream.stream.userId != msg.header.userId
+        || !msg.body.streamId.startsWith(msg.header.userId)) {
+        val reason = "User does not own camera stream"
+        PermissionCheck.ejectUserForFailedPermission(
+          props.meetingProp.intId, msg.header.userId, reason, outGW, liveMeeting
+        )
+      } else {
+        for {
+          _ <- Webcams.removeWebcamBroadcastStream(liveMeeting.webcams, msg.body.streamId)
+        } yield {
+          val event = MsgBuilder.buildUserBroadcastCamStoppedEvtMsg(
+            props.meetingProp.intId, msg.header.userId, msg.body.streamId
+          )
+          outGW.send(event)
+        }
+      }
+    }
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/streams/CamStreamSubscribedInSfuEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/streams/CamStreamSubscribedInSfuEvtMsgHdlr.scala
@@ -1,0 +1,50 @@
+package org.bigbluebutton.core2.message.handlers
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
+import org.bigbluebutton.core.models.{ Users2x }
+import org.bigbluebutton.core.models.Webcams.{ findWithStreamId, addViewer }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
+import org.bigbluebutton.LockSettingsUtil
+
+trait CamStreamSubscribedInSfuEvtMsgHdlr {
+  this: MeetingActor =>
+
+  val outGW: OutMsgRouter
+
+  def isAllowedToSubscribeToCam(userId: String, streamId: String): Boolean = {
+    var allowed = false
+
+    for {
+      user <- Users2x.findWithIntId(liveMeeting.users2x, userId)
+      stream <- findWithStreamId(liveMeeting.webcams, streamId)
+    } yield {
+      val camSubscribeLocked = LockSettingsUtil.isCameraSubscribeLocked(user, stream, liveMeeting)
+      if (!user.userLeftFlag.left
+        && (applyPermissionCheck && !camSubscribeLocked)) {
+        allowed = true
+      }
+    }
+
+    allowed
+  }
+
+  def handleCamStreamSubscribedInSfuEvtMsg(msg: CamStreamSubscribedInSfuEvtMsg) {
+    // Subscriber's user ID
+    val userId = msg.header.userId
+    // Publisher's stream ID
+    val streamId = msg.body.streamId
+    val allowed = isAllowedToSubscribeToCam(userId, streamId)
+
+    if (allowed) {
+      addViewer(liveMeeting.webcams, streamId, userId)
+    } else {
+      val event = MsgBuilder.buildCamStreamUnsubscribeSysMsg(
+        liveMeeting.props.meetingProp.intId,
+        userId,
+        streamId
+      )
+      outGW.send(event)
+    }
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/streams/CamStreamUnsubscribedInSfuEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/streams/CamStreamUnsubscribedInSfuEvtMsgHdlr.scala
@@ -1,0 +1,20 @@
+package org.bigbluebutton.core2.message.handlers
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
+import org.bigbluebutton.core.models.Webcams.{ removeViewer }
+
+trait CamStreamUnsubscribedInSfuEvtMsgHdlr {
+  this: MeetingActor =>
+
+  val outGW: OutMsgRouter
+
+  def handleCamStreamUnsubscribedInSfuEvtMsg(msg: CamStreamUnsubscribedInSfuEvtMsg) {
+    // Subscriber's user ID
+    val userId = msg.header.userId
+    // Publisher's stream ID
+    val streamId = msg.body.streamId
+
+    removeViewer(liveMeeting.webcams, streamId, userId)
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -504,4 +504,55 @@ object MsgBuilder {
 
     BbbCommonEnvCoreMsg(envelope, event)
   }
+
+  def buildEjectUserFromSfuSysMsg(
+      meetingId: String,
+      userId:    String
+  ): BbbCommonEnvCoreMsg = {
+    val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
+    val envelope = BbbCoreEnvelope(EjectUserFromSfuSysMsg.NAME, routing)
+    val body = EjectUserFromSfuSysMsgBody(userId)
+    val header = BbbCoreHeaderWithMeetingId(EjectUserFromSfuSysMsg.NAME, meetingId)
+    val event = EjectUserFromSfuSysMsg(header, body)
+
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
+
+  def buildCamBroadcastStopSysMsg(
+      meetingId: String,
+      userId:    String,
+      streamId:  String
+  ): BbbCommonEnvCoreMsg = {
+    val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
+    val envelope = BbbCoreEnvelope(CamBroadcastStopSysMsg.NAME, routing)
+    val body = CamBroadcastStopSysMsgBody(meetingId, userId, streamId)
+    val header = BbbCoreBaseHeader(CamBroadcastStopSysMsg.NAME)
+    val event = CamBroadcastStopSysMsg(header, body)
+
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
+
+  def buildCamStreamUnsubscribeSysMsg(
+      meetingId: String, userId: String, streamId: String
+  ): BbbCommonEnvCoreMsg = {
+    val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
+    val envelope = BbbCoreEnvelope(CamStreamUnsubscribeSysMsg.NAME, routing)
+    val body = CamStreamUnsubscribeSysMsgBody(meetingId, userId, streamId)
+    val header = BbbCoreBaseHeader(CamStreamUnsubscribeSysMsg.NAME)
+    val event = CamStreamUnsubscribeSysMsg(header, body)
+
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
+
+  def buildUserBroadcastCamStoppedEvtMsg(
+      meetingId: String, userId: String, streamId: String
+  ): BbbCommonEnvCoreMsg = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
+    val envelope = BbbCoreEnvelope(UserBroadcastCamStoppedEvtMsg.NAME, routing)
+    val header = BbbClientMsgHeader(UserBroadcastCamStoppedEvtMsg.NAME, meetingId, userId)
+    val body = UserBroadcastCamStoppedEvtMsgBody(userId, streamId)
+    val event = UserBroadcastCamStoppedEvtMsg(header, body)
+
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
 }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WebcamsMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WebcamsMsgs.scala
@@ -1,5 +1,6 @@
 package org.bigbluebutton.common2.msgs
 
+// Broadcasting messages
 object UserBroadcastCamStartedEvtMsg { val NAME = "UserBroadcastCamStartedEvtMsg" }
 case class UserBroadcastCamStartedEvtMsg(
     header: BbbClientMsgHeader,
@@ -105,4 +106,80 @@ case class GetCamSubscribePermissionRespMsgBody(
     streamId:     String,
     sfuSessionId: String,
     allowed:      Boolean
+)
+
+/**
+ * Sent to bbb-webrtc-sfu to eject all media streams from #userId
+ */
+object EjectUserFromSfuSysMsg { val NAME = "EjectUserFromSfuSysMsg" }
+case class EjectUserFromSfuSysMsg(
+    header: BbbCoreHeaderWithMeetingId,
+    body:   EjectUserFromSfuSysMsgBody
+) extends BbbCoreMsg
+case class EjectUserFromSfuSysMsgBody(userId: String)
+
+/**
+ * Sent to bbb-webrtc-sfu to tear down broadcaster stream #streamId
+ */
+object CamBroadcastStopSysMsg { val NAME = "CamBroadcastStopSysMsg" }
+case class CamBroadcastStopSysMsg(
+    header: BbbCoreBaseHeader,
+    body:   CamBroadcastStopSysMsgBody
+) extends BbbCoreMsg
+case class CamBroadcastStopSysMsgBody(
+    meetingId: String,
+    userId:    String,
+    streamId:  String
+)
+
+/**
+ * Sent from bbb-webrtc-sfu to indicate that #userId unsubscribed from #streamId
+ */
+object CamBroadcastStoppedInSfuEvtMsg { val NAME = "CamBroadcastStoppedInSfuEvtMsg" }
+case class CamBroadcastStoppedInSfuEvtMsg(
+    header: BbbClientMsgHeader,
+    body:   CamBroadcastStoppedInSfuEvtMsgBody
+) extends StandardMsg
+case class CamBroadcastStoppedInSfuEvtMsgBody(streamId: String)
+
+/**
+ * Sent to bbb-webrtc-sfu to detach #userId's subscribers from #streamId
+ */
+object CamStreamUnsubscribeSysMsg { val NAME = "CamStreamUnsubscribeSysMsg" }
+case class CamStreamUnsubscribeSysMsg(
+    header: BbbCoreBaseHeader,
+    body:   CamStreamUnsubscribeSysMsgBody
+) extends BbbCoreMsg
+case class CamStreamUnsubscribeSysMsgBody(
+    meetingId: String,
+    userId:    String,
+    streamId:  String
+)
+
+/**
+ * Sent from bbb-webrtc-sfu to indicate that #userId unsubscribed from #streamId
+ */
+object CamStreamUnsubscribedInSfuEvtMsg { val NAME = "CamStreamUnsubscribedInSfuEvtMsg" }
+case class CamStreamUnsubscribedInSfuEvtMsg(
+    header: BbbClientMsgHeader,
+    body:   CamStreamUnsubscribedInSfuEvtMsgBody
+) extends StandardMsg
+case class CamStreamUnsubscribedInSfuEvtMsgBody(
+    streamId:           String, // Publisher's internal stream ID
+    subscriberStreamId: String,
+    sfuSessionId:       String // Subscriber's SFU session ID
+)
+
+/**
+ * Sent from bbb-webrtc-sfu to indicate that #userId subscribed to #streamId
+ */
+object CamStreamSubscribedInSfuEvtMsg { val NAME = "CamStreamSubscribedInSfuEvtMsg" }
+case class CamStreamSubscribedInSfuEvtMsg(
+    header: BbbClientMsgHeader,
+    body:   CamStreamSubscribedInSfuEvtMsgBody
+) extends StandardMsg
+case class CamStreamSubscribedInSfuEvtMsgBody(
+    streamId:           String, // Publisher's internal stream ID
+    subscriberStreamId: String,
+    sfuSessionId:       String // Subscriber's SFU session ID
 )


### PR DESCRIPTION


### What does this PR do?

Backports #13790 into 2.3.

>   - Improve permission checks by making them lock-settings aware
>   - Account for camera viewers in akka-apps. They should now be
>     present in the analytics endpoint
>   - Further integrate akka-apps and webrtc-sfu so their states remain
>     consistent. We'd also like to be able to slowly dehydrate some
>     of the logic that today resides in webrtc-sfu and move it to
>     akka-apps and this is a first step.
>   - Add additional broadcasted stream ID checks (ownership and streamID
>     format)

### Closes Issue(s)

None

### Motivation

This also implies a minor version bump in the bbb-webrtc-sfu version BBB 2.3 uses.
The target is now bbb-webrtc-sfu v2.6.x (up from v2.5.x), making it on par with BBB 2.4.