### PR TITLE
Remove Grace Period for locked user in chat

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
@@ -39,12 +39,7 @@ trait SendGroupChatMessageMsgHdlr {
       }
     }
 
-    if (applyPermissionCheck && chatLocked) {
-      val meetingId = liveMeeting.props.meetingProp.intId
-      val reason = "No permission to send a message to this group chat."
-      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
-      state
-    } else {
+    if (!(applyPermissionCheck && chatLocked)) {
       def makeHeader(name: String, meetingId: String, userId: String): BbbClientMsgHeader = {
         BbbClientMsgHeader(name, meetingId, userId)
       }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
@@ -82,7 +82,7 @@ trait SendGroupChatMessageMsgHdlr {
         case Some(ns) => ns
         case None     => state
       }
-    }
+    } else { state }
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
@@ -39,10 +39,7 @@ trait SendGroupChatMessageMsgHdlr {
       }
     }
 
-    // Check if this message was sent while the lock settings was being changed.
-    val isDelayedMessage = System.currentTimeMillis() - MeetingStatus2x.getPermissionsChangedOn(liveMeeting.status) < 5000
-
-    if (applyPermissionCheck && chatLocked && !isDelayedMessage) {
+    if (applyPermissionCheck && chatLocked) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to send a message to this group chat."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)


### PR DESCRIPTION
### What does this PR do?

This PR removes the grace period for locked users and remove the behaviour of eject the locked users who sent chat messages (because there might be delayed messages sent between changing the lock setting) 
