### PR TITLE
refactor: Dashboard support for users grouped by extId

### DIFF
--- a/bbb-learning-dashboard/src/App.js
+++ b/bbb-learning-dashboard/src/App.js
@@ -139,12 +139,17 @@ class App extends React.Component {
     }
 
     function totalOfActivity() {
-      const minTime = Object.values(activitiesJson.users || {}).reduce((prevVal, elem) => {
+      const usersTimes = Object.values(activitiesJson.users || {}).reduce((prev, user) => ([
+        ...prev,
+        ...Object.values(user.intIds),
+      ]), []);
+
+      const minTime = Object.values(usersTimes || {}).reduce((prevVal, elem) => {
         if (prevVal === 0 || elem.registeredOn < prevVal) return elem.registeredOn;
         return prevVal;
       }, 0);
 
-      const maxTime = Object.values(activitiesJson.users || {}).reduce((prevVal, elem) => {
+      const maxTime = Object.values(usersTimes || {}).reduce((prevVal, elem) => {
         if (elem.leftOn === 0) return (new Date()).getTime();
         if (elem.leftOn > prevVal) return elem.leftOn;
         return prevVal;
@@ -230,7 +235,7 @@ class App extends React.Component {
                   </span>
                 )
                 : null
-}
+            }
             <br />
             <span className="text-sm font-medium">{activitiesJson.name || ''}</span>
           </h1>
@@ -280,8 +285,11 @@ class App extends React.Component {
                   ? intl.formatMessage({ id: 'app.learningDashboard.indicators.usersOnline', defaultMessage: 'Active Users' })
                   : intl.formatMessage({ id: 'app.learningDashboard.indicators.usersTotal', defaultMessage: 'Total Number Of Users' })
               }
-              number={Object.values(activitiesJson.users || {})
-                .filter((u) => activitiesJson.endedOn > 0 || u.leftOn === 0).length}
+              number={Object
+                .values(activitiesJson.users || {})
+                .filter((u) => activitiesJson.endedOn > 0
+                  || Object.values(u.intIds)[Object.values(u.intIds).length - 1].leftOn === 0)
+                .length}
               cardClass="border-pink-500"
               iconClass="bg-pink-50 text-pink-500"
               onClick={() => {

--- a/bbb-learning-dashboard/src/components/StatusTable.jsx
+++ b/bbb-learning-dashboard/src/components/StatusTable.jsx
@@ -80,7 +80,7 @@ class StatusTable extends React.Component {
                     <td className="px-3.5 2xl:px-4 py-3 text-sm col-text-left">
                       { Object.values(user.intIds).map(({ registeredOn, leftOn }) => (
                         <>
-                          { registeredOn > period && registeredOn < period + spanMinutes ? (
+                          { registeredOn >= period && registeredOn < period + spanMinutes ? (
                             <span title={intl.formatDate(registeredOn, {
                               month: 'short',
                               day: 'numeric',
@@ -132,7 +132,7 @@ class StatusTable extends React.Component {
                                 ))
                             );
                           }()) }
-                          { leftOn > period && leftOn < period + spanMinutes ? (
+                          { leftOn >= period && leftOn < period + spanMinutes ? (
                             <span title={intl.formatDate(leftOn, {
                               month: 'short',
                               day: 'numeric',

--- a/bbb-learning-dashboard/src/components/StatusTable.jsx
+++ b/bbb-learning-dashboard/src/components/StatusTable.jsx
@@ -80,81 +80,83 @@ class StatusTable extends React.Component {
                     <td className="px-3.5 2xl:px-4 py-3 text-sm col-text-left">
                       { Object.values(user.intIds).map(({ registeredOn, leftOn }) => (
                         <>
-                          { registeredOn > period && registeredOn < period + spanMinutes
-                            ? (
-                              <span title={intl.formatDate(registeredOn, {
-                                month: 'short',
-                                day: 'numeric',
-                                hour: '2-digit',
-                                minute: '2-digit',
-                                second: '2-digit',
-                              })}
+                          { registeredOn > period && registeredOn < period + spanMinutes ? (
+                            <span title={intl.formatDate(registeredOn, {
+                              month: 'short',
+                              day: 'numeric',
+                              hour: '2-digit',
+                              minute: '2-digit',
+                              second: '2-digit',
+                            })}
+                            >
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                className="h-4 w-4 text-xs text-green-400"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
                               >
-                                <svg
-                                  xmlns="http://www.w3.org/2000/svg"
-                                  className="h-4 w-4 text-xs text-green-400"
-                                  fill="none"
-                                  viewBox="0 0 24 24"
-                                  stroke="currentColor"
-                                >
-                                  <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth="2"
-                                    d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1"
-                                  />
-                                </svg>
-                              </span>
-                            ) : null }
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth="2"
+                                  d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1"
+                                />
+                              </svg>
+                            </span>
+                          ) : null }
                           { (function getEmojis() {
-                            const userEmojisInPeriod = getUserEmojisSummary(user,
+                            const userEmojisInPeriod = getUserEmojisSummary(
+                              user,
                               null,
                               registeredOn > period && registeredOn < period + spanMinutes
                                 ? registeredOn : period,
                               leftOn > period && leftOn < period + spanMinutes
-                                ? leftOn : period + spanMinutes);
+                                ? leftOn : period + spanMinutes,
+                            );
 
-                            return Object
-                              .keys(userEmojisInPeriod)
-                              .map((emoji) => (
-                                <div className="text-sm text-gray-800">
-                                  <i className={`${emojiConfigs[emoji].icon} text-sm`} />
-                                  &nbsp;
-                                  { userEmojisInPeriod[emoji] }
-                                  &nbsp;
-                                  <FormattedMessage
-                                    id={emojiConfigs[emoji].intlId}
-                                    defaultMessage={emojiConfigs[emoji].defaultMessage}
-                                  />
-                                </div>
-                              ));
+                            return (
+                              Object
+                                .keys(userEmojisInPeriod)
+                                .map((emoji) => (
+                                  <div className="text-sm text-gray-800">
+                                    <i className={`${emojiConfigs[emoji].icon} text-sm`} />
+                                    &nbsp;
+                                    { userEmojisInPeriod[emoji] }
+                                    &nbsp;
+                                    <FormattedMessage
+                                      id={emojiConfigs[emoji].intlId}
+                                      defaultMessage={emojiConfigs[emoji].defaultMessage}
+                                    />
+                                  </div>
+                                ))
+                            );
                           }()) }
-                          { leftOn > period && leftOn < period + spanMinutes
-                            ? (
-                              <span title={intl.formatDate(leftOn, {
-                                month: 'short',
-                                day: 'numeric',
-                                hour: '2-digit',
-                                minute: '2-digit',
-                                second: '2-digit',
-                              })}
+                          { leftOn > period && leftOn < period + spanMinutes ? (
+                            <span title={intl.formatDate(leftOn, {
+                              month: 'short',
+                              day: 'numeric',
+                              hour: '2-digit',
+                              minute: '2-digit',
+                              second: '2-digit',
+                            })}
+                            >
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                className="h-4 w-4 text-red-400"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
                               >
-                                <svg
-                                  xmlns="http://www.w3.org/2000/svg"
-                                  className="h-4 w-4 text-red-400"
-                                  fill="none"
-                                  viewBox="0 0 24 24"
-                                  stroke="currentColor"
-                                >
-                                  <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth="2"
-                                    d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
-                                  />
-                                </svg>
-                              </span>
-                            ) : null }
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth="2"
+                                  d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
+                                />
+                              </svg>
+                            </span>
+                          ) : null }
                         </>
                       )) }
                     </td>

--- a/bbb-learning-dashboard/src/components/UsersTable.jsx
+++ b/bbb-learning-dashboard/src/components/UsersTable.jsx
@@ -83,7 +83,7 @@ class UsersTable extends React.Component {
 
     const usersEmojisSummary = {};
     Object.values(allUsers || {}).forEach((user) => {
-      usersEmojisSummary[user.intId] = getUserEmojisSummary(user, 'raiseHand');
+      usersEmojisSummary[user.extId] = getUserEmojisSummary(user, 'raiseHand');
     });
 
     function getOnlinePercentage(registeredOn, leftOn) {
@@ -97,7 +97,7 @@ class UsersTable extends React.Component {
 
     const usersActivityScore = {};
     Object.values(allUsers || {}).forEach((user) => {
-      usersActivityScore[user.intId] = getActivityScore(user);
+      usersActivityScore[user.extId] = getActivityScore(user);
     });
 
     return (
@@ -175,10 +175,10 @@ class UsersTable extends React.Component {
           { typeof allUsers === 'object' && Object.values(allUsers || {}).length > 0 ? (
             Object.values(allUsers || {})
               .sort((a, b) => {
-                if (tab === 'overview_activityscore' && usersActivityScore[a.intId] < usersActivityScore[b.intId]) {
+                if (tab === 'overview_activityscore' && usersActivityScore[a.extId] < usersActivityScore[b.extId]) {
                   return activityscoreOrder === 'desc' ? 1 : -1;
                 }
-                if (tab === 'overview_activityscore' && usersActivityScore[a.intId] > usersActivityScore[b.intId]) {
+                if (tab === 'overview_activityscore' && usersActivityScore[a.extId] > usersActivityScore[b.extId]) {
                   return activityscoreOrder === 'desc' ? -1 : 1;
                 }
                 if (a.isModerator === false && b.isModerator === true) return 1;
@@ -189,7 +189,7 @@ class UsersTable extends React.Component {
               })
               .map((user) => (
                 <tr key={user} className="text-gray-700">
-                  <td className="px-3.5 2xl:px-4 py-3 col-text-left text-sm">
+                  <td className="flex items-center px-3.5 2xl:px-4 py-3 col-text-left text-sm">
                     <div className="inline-block relative w-8 h-8 rounded-full">
                       {/* <img className="object-cover w-full h-full rounded-full" */}
                       {/*     src="" */}
@@ -205,32 +205,33 @@ class UsersTable extends React.Component {
                       <p className="font-semibold">
                         {user.name}
                       </p>
-                      <p className="text-xs text-gray-600 dark:text-gray-400">
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          className="h-4 w-4 inline"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth="2"
-                            d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1"
-                          />
-                        </svg>
-                        <FormattedDate
-                          value={user.registeredOn}
-                          month="short"
-                          day="numeric"
-                          hour="2-digit"
-                          minute="2-digit"
-                          second="2-digit"
-                        />
-                      </p>
-                      {
-                          user.leftOn > 0
+                      { Object.values(user.intIds || {}).map((intId, index) => (
+                        <>
+                          <p className="text-xs text-gray-600 dark:text-gray-400">
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              className="h-4 w-4 inline"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth="2"
+                                d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1"
+                              />
+                            </svg>
+                            <FormattedDate
+                              value={intId.registeredOn}
+                              month="short"
+                              day="numeric"
+                              hour="2-digit"
+                              minute="2-digit"
+                              second="2-digit"
+                            />
+                          </p>
+                          { intId.leftOn > 0
                             ? (
                               <p className="text-xs text-gray-600 dark:text-gray-400">
                                 <svg
@@ -249,7 +250,7 @@ class UsersTable extends React.Component {
                                 </svg>
 
                                 <FormattedDate
-                                  value={user.leftOn}
+                                  value={intId.leftOn}
                                   month="short"
                                   day="numeric"
                                   hour="2-digit"
@@ -258,8 +259,14 @@ class UsersTable extends React.Component {
                                 />
                               </p>
                             )
-                            : null
-                        }
+                            : null }
+                          { index === Object.values(user.intIds).length - 1
+                            ? null
+                            : (
+                              <hr className="my-1" />
+                            ) }
+                        </>
+                      )) }
                     </div>
                   </td>
                   <td className="px-3.5 2xl:px-4 py-3 text-sm text-center items-center">
@@ -278,23 +285,34 @@ class UsersTable extends React.Component {
                       />
                     </svg>
                     &nbsp;
-                    { tsToHHmmss(
-                      (user.leftOn > 0
-                        ? user.leftOn
-                        : (new Date()).getTime()) - user.registeredOn,
-                    ) }
+                    { tsToHHmmss(Object.values(user.intIds).reduce((prev, intId) => (
+                      prev + ((intId.leftOn > 0
+                        ? intId.leftOn
+                        : (new Date()).getTime()) - intId.registeredOn)
+                    ), 0)) }
                     <br />
-                    <div
-                      className="bg-gray-200 transition-colors duration-500 rounded-full overflow-hidden"
-                      title={`${getOnlinePercentage(user.registeredOn, user.leftOn).toString()}%`}
-                    >
-                      <div
-                        aria-label=" "
-                        className="bg-gradient-to-br from-green-100 to-green-600 transition-colors duration-900 h-1.5"
-                        style={{ width: `${getOnlinePercentage(user.registeredOn, user.leftOn).toString()}%` }}
-                        role="progressbar"
-                      />
-                    </div>
+                    {
+                      (function getPercentage() {
+                        const { intIds } = user;
+                        const percentage = Object.values(intIds || {}).reduce((prev, intId) => (
+                          prev + getOnlinePercentage(intId.registeredOn, intId.leftOn)
+                        ), 0);
+
+                        return (
+                          <div
+                            className="bg-gray-200 transition-colors duration-500 rounded-full overflow-hidden"
+                            title={`${percentage.toString()}%`}
+                          >
+                            <div
+                              aria-label=" "
+                              className="bg-gradient-to-br from-green-100 to-green-600 transition-colors duration-900 h-1.5"
+                              style={{ width: `${percentage.toString()}%` }}
+                              role="progressbar"
+                            />
+                          </div>
+                        );
+                      }())
+                    }
                   </td>
                   <td className="px-3.5 2xl:px-4 py-3 text-sm text-center">
                     { user.talk.totalTime > 0
@@ -367,11 +385,11 @@ class UsersTable extends React.Component {
                   </td>
                   <td className="px-3.5 2xl:px-4 py-3 text-sm col-text-left">
                     {
-                      Object.keys(usersEmojisSummary[user.intId] || {}).map((emoji) => (
+                      Object.keys(usersEmojisSummary[user.extId] || {}).map((emoji) => (
                         <div className="text-xs whitespace-nowrap">
                           <i className={`${emojiConfigs[emoji].icon} text-sm`} />
                           &nbsp;
-                          { usersEmojisSummary[user.intId][emoji] }
+                          { usersEmojisSummary[user.extId][emoji] }
                           &nbsp;
                           <FormattedMessage
                             id={emojiConfigs[emoji].intlId}
@@ -405,37 +423,37 @@ class UsersTable extends React.Component {
                       ) : null }
                   </td>
                   {
-                      !user.isModerator ? (
-                        <td className="px-3.5 2xl:px-4 py-3 text-sm text-center items">
-                          <svg viewBox="0 0 82 12" width="82" height="12" className="flex-none m-auto inline">
-                            <rect width="12" height="12" fill={usersActivityScore[user.intId] > 0 ? '#A7F3D0' : '#e4e4e7'} />
-                            <rect width="12" height="12" x="14" fill={usersActivityScore[user.intId] > 2 ? '#6EE7B7' : '#e4e4e7'} />
-                            <rect width="12" height="12" x="28" fill={usersActivityScore[user.intId] > 4 ? '#34D399' : '#e4e4e7'} />
-                            <rect width="12" height="12" x="42" fill={usersActivityScore[user.intId] > 6 ? '#10B981' : '#e4e4e7'} />
-                            <rect width="12" height="12" x="56" fill={usersActivityScore[user.intId] > 8 ? '#059669' : '#e4e4e7'} />
-                            <rect width="12" height="12" x="70" fill={usersActivityScore[user.intId] === 10 ? '#047857' : '#e4e4e7'} />
-                          </svg>
-                          &nbsp;
-                          <span className="text-xs bg-gray-200 rounded-full px-2">
-                            <FormattedNumber value={usersActivityScore[user.intId]} minimumFractionDigits="0" maximumFractionDigits="1" />
-                          </span>
-                        </td>
-                      ) : <td />
-                    }
+                    !user.isModerator ? (
+                      <td className="px-3.5 2xl:px-4 py-3 text-sm text-center items">
+                        <svg viewBox="0 0 82 12" width="82" height="12" className="flex-none m-auto inline">
+                          <rect width="12" height="12" fill={usersActivityScore[user.extId] > 0 ? '#A7F3D0' : '#e4e4e7'} />
+                          <rect width="12" height="12" x="14" fill={usersActivityScore[user.extId] > 2 ? '#6EE7B7' : '#e4e4e7'} />
+                          <rect width="12" height="12" x="28" fill={usersActivityScore[user.extId] > 4 ? '#34D399' : '#e4e4e7'} />
+                          <rect width="12" height="12" x="42" fill={usersActivityScore[user.extId] > 6 ? '#10B981' : '#e4e4e7'} />
+                          <rect width="12" height="12" x="56" fill={usersActivityScore[user.extId] > 8 ? '#059669' : '#e4e4e7'} />
+                          <rect width="12" height="12" x="70" fill={usersActivityScore[user.extId] === 10 ? '#047857' : '#e4e4e7'} />
+                        </svg>
+                        &nbsp;
+                        <span className="text-xs bg-gray-200 rounded-full px-2">
+                          <FormattedNumber value={usersActivityScore[user.extId]} minimumFractionDigits="0" maximumFractionDigits="1" />
+                        </span>
+                      </td>
+                    ) : <td />
+                  }
                   <td className="px-3.5 2xl:px-4 py-3 text-xs text-center">
                     {
-                                      user.leftOn > 0
-                                        ? (
-                                          <span className="px-2 py-1 font-semibold leading-tight text-red-700 bg-red-100 rounded-full">
-                                            <FormattedMessage id="app.learningDashboard.usersTable.userStatusOffline" defaultMessage="Offline" />
-                                          </span>
-                                        )
-                                        : (
-                                          <span className="px-2 py-1 font-semibold leading-tight text-green-700 bg-green-100 rounded-full">
-                                            <FormattedMessage id="app.learningDashboard.usersTable.userStatusOnline" defaultMessage="Online" />
-                                          </span>
-                                        )
-                                  }
+                      Object.values(user.intIds)[Object.values(user.intIds).length - 1].leftOn > 0
+                        ? (
+                          <span className="px-2 py-1 font-semibold leading-tight text-red-700 bg-red-100 rounded-full">
+                            <FormattedMessage id="app.learningDashboard.usersTable.userStatusOffline" defaultMessage="Offline" />
+                          </span>
+                        )
+                        : (
+                          <span className="px-2 py-1 font-semibold leading-tight text-green-700 bg-green-100 rounded-full">
+                            <FormattedMessage id="app.learningDashboard.usersTable.userStatusOnline" defaultMessage="Online" />
+                          </span>
+                        )
+                    }
                   </td>
                 </tr>
               ))

--- a/bbb-learning-dashboard/src/components/UsersTable.jsx
+++ b/bbb-learning-dashboard/src/components/UsersTable.jsx
@@ -83,7 +83,7 @@ class UsersTable extends React.Component {
 
     const usersEmojisSummary = {};
     Object.values(allUsers || {}).forEach((user) => {
-      usersEmojisSummary[user.extId] = getUserEmojisSummary(user, 'raiseHand');
+      usersEmojisSummary[user.userKey] = getUserEmojisSummary(user, 'raiseHand');
     });
 
     function getOnlinePercentage(registeredOn, leftOn) {
@@ -97,7 +97,7 @@ class UsersTable extends React.Component {
 
     const usersActivityScore = {};
     Object.values(allUsers || {}).forEach((user) => {
-      usersActivityScore[user.extId] = getActivityScore(user);
+      usersActivityScore[user.userKey] = getActivityScore(user);
     });
 
     return (
@@ -175,10 +175,10 @@ class UsersTable extends React.Component {
           { typeof allUsers === 'object' && Object.values(allUsers || {}).length > 0 ? (
             Object.values(allUsers || {})
               .sort((a, b) => {
-                if (tab === 'overview_activityscore' && usersActivityScore[a.extId] < usersActivityScore[b.extId]) {
+                if (tab === 'overview_activityscore' && usersActivityScore[a.userKey] < usersActivityScore[b.userKey]) {
                   return activityscoreOrder === 'desc' ? 1 : -1;
                 }
-                if (tab === 'overview_activityscore' && usersActivityScore[a.extId] > usersActivityScore[b.extId]) {
+                if (tab === 'overview_activityscore' && usersActivityScore[a.userKey] > usersActivityScore[b.userKey]) {
                   return activityscoreOrder === 'desc' ? -1 : 1;
                 }
                 if (a.isModerator === false && b.isModerator === true) return 1;
@@ -385,11 +385,11 @@ class UsersTable extends React.Component {
                   </td>
                   <td className="px-3.5 2xl:px-4 py-3 text-sm col-text-left">
                     {
-                      Object.keys(usersEmojisSummary[user.extId] || {}).map((emoji) => (
+                      Object.keys(usersEmojisSummary[user.userKey] || {}).map((emoji) => (
                         <div className="text-xs whitespace-nowrap">
                           <i className={`${emojiConfigs[emoji].icon} text-sm`} />
                           &nbsp;
-                          { usersEmojisSummary[user.extId][emoji] }
+                          { usersEmojisSummary[user.userKey][emoji] }
                           &nbsp;
                           <FormattedMessage
                             id={emojiConfigs[emoji].intlId}
@@ -426,16 +426,16 @@ class UsersTable extends React.Component {
                     !user.isModerator ? (
                       <td className="px-3.5 2xl:px-4 py-3 text-sm text-center items">
                         <svg viewBox="0 0 82 12" width="82" height="12" className="flex-none m-auto inline">
-                          <rect width="12" height="12" fill={usersActivityScore[user.extId] > 0 ? '#A7F3D0' : '#e4e4e7'} />
-                          <rect width="12" height="12" x="14" fill={usersActivityScore[user.extId] > 2 ? '#6EE7B7' : '#e4e4e7'} />
-                          <rect width="12" height="12" x="28" fill={usersActivityScore[user.extId] > 4 ? '#34D399' : '#e4e4e7'} />
-                          <rect width="12" height="12" x="42" fill={usersActivityScore[user.extId] > 6 ? '#10B981' : '#e4e4e7'} />
-                          <rect width="12" height="12" x="56" fill={usersActivityScore[user.extId] > 8 ? '#059669' : '#e4e4e7'} />
-                          <rect width="12" height="12" x="70" fill={usersActivityScore[user.extId] === 10 ? '#047857' : '#e4e4e7'} />
+                          <rect width="12" height="12" fill={usersActivityScore[user.userKey] > 0 ? '#A7F3D0' : '#e4e4e7'} />
+                          <rect width="12" height="12" x="14" fill={usersActivityScore[user.userKey] > 2 ? '#6EE7B7' : '#e4e4e7'} />
+                          <rect width="12" height="12" x="28" fill={usersActivityScore[user.userKey] > 4 ? '#34D399' : '#e4e4e7'} />
+                          <rect width="12" height="12" x="42" fill={usersActivityScore[user.userKey] > 6 ? '#10B981' : '#e4e4e7'} />
+                          <rect width="12" height="12" x="56" fill={usersActivityScore[user.userKey] > 8 ? '#059669' : '#e4e4e7'} />
+                          <rect width="12" height="12" x="70" fill={usersActivityScore[user.userKey] === 10 ? '#047857' : '#e4e4e7'} />
                         </svg>
                         &nbsp;
                         <span className="text-xs bg-gray-200 rounded-full px-2">
-                          <FormattedNumber value={usersActivityScore[user.extId]} minimumFractionDigits="0" maximumFractionDigits="1" />
+                          <FormattedNumber value={usersActivityScore[user.userKey]} minimumFractionDigits="0" maximumFractionDigits="1" />
                         </span>
                       </td>
                     ) : <td />


### PR DESCRIPTION
### What does this PR do?

This PR refactors the Learning Dashboard for supporting the grouping by `extId` rather than `intId`. Only one row per user will be displayed in the tables.

![Captura de tela de 2021-12-07 16-58-08](https://user-images.githubusercontent.com/62393923/145097775-35c8c3cb-9910-4aef-80cb-d51a10b701b7.png)

![Captura de tela de 2021-12-07 16-58-19](https://user-images.githubusercontent.com/62393923/145097809-f33f3cc8-6ba3-45a4-936e-0bdb97633286.png)

### Motivation

With #13826, the info will be stored using `extId` rather than `intId`. So, this PR adds the necessary Dashboard changes for matching that implementation.
