### PR TITLE
Fix (whiteboard): cursor has to travel the last mile

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/cursor/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/cursor/component.jsx
@@ -102,6 +102,20 @@ export default class Cursor extends Component {
     // we need to find the BBox of the text, so that we could set a proper border box arount it
   }
 
+  shouldComponentUpdate(nextProps) {
+    const { cursorX, cursorY, slideWidth, slideHeight } = this.props;
+    if (cursorX !== nextProps.cursorX || cursorY !== nextProps.cursorY) {
+      const cursorCoordinate = Cursor.getCursorCoordinates(
+        nextProps.cursorX,
+        nextProps.cursorY,
+        slideWidth,
+        slideHeight,
+      );
+      this.cursorCoordinate = cursorCoordinate;
+    }
+    return true;
+  }
+  
   componentDidUpdate(prevProps, prevState) {
     const {
       scaledSizes,
@@ -146,16 +160,6 @@ export default class Cursor extends Component {
             this.setState({
               scaledSizes: Cursor.getScaledSizes(this.props, this.state),
             });
-    }
-
-    if (cursorX !== prevProps.cursorX || cursorY !== prevProps.cursorY) {
-      const cursorCoordinate = Cursor.getCursorCoordinates(
-        cursorX,
-        cursorY,
-        slideWidth,
-        slideHeight,
-      );
-      this.cursorCoordinate = cursorCoordinate;
     }
   }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Let the whiteboard cursor travel the last mile so that the pointer reactivity gets much better (actually same as 2.2.x). 

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation

I saw many complaints about the whiteboard reactivity here and there since 2.3.x. I also felt it pretty uncomfortable time to time, without knowing what. 
I recently found out that one of the problems is obviously that the cursor position update happens in componentDidUpdate, so the cursor does not reflect the latest update.

### More

I moved it to shouldComponentUpdate, but probably it is not the right place to go. Please suggest if I am terribly wrong.

Here is the result. In these movie the cursor bears black (in fact it is an XOR background texture) colour, instead of the default red colour, but never mind.

Before the change:
![Animation1](https://user-images.githubusercontent.com/45039819/145151117-482c29a4-f094-4aae-af97-7ce8e315a5cb.gif)

After the change:
![Animation2](https://user-images.githubusercontent.com/45039819/145151127-260548c6-0436-4bcb-895c-7121dd086976.gif)


