### PR TITLE
fix: typing indicator names position (2.4)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/styles.scss
@@ -143,7 +143,6 @@
     display: block;
     margin-right: 0.05rem;
     margin-left: 0.05rem;
-    line-height: var(--font-size-md);
   }
 
   text-align: left;


### PR DESCRIPTION
### What does this PR do?

#### before

<img width="280" alt="Screen Shot 2021-12-08 at 08 31 24" src="https://user-images.githubusercontent.com/3728706/145201709-34ac3f89-e772-42d5-8836-64d52b63d810.png">

#### after
<img width="274" alt="Screen Shot 2021-12-08 at 08 30 51" src="https://user-images.githubusercontent.com/3728706/145201705-66212ad4-71e8-4a34-b2ba-44a23e83180b.png">
