### PR TITLE
fix: typing indicator names position (2.5)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/typing-indicator/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/typing-indicator/styles.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { colorDanger, colorGrayDark } from '/imports/ui/stylesheets/styled-components/palette';
 import { borderSize } from '/imports/ui/stylesheets/styled-components/general';
-import { fontSizeSmaller, fontSizeMD, fontSizeBase } from '/imports/ui/stylesheets/styled-components/typography';
+import { fontSizeSmaller, fontSizeBase } from '/imports/ui/stylesheets/styled-components/typography';
 
 const SingleTyper = styled.span`
   overflow: hidden;
@@ -29,7 +29,6 @@ const TypingIndicator = styled.span`
     display: block;
     margin-right: 0.05rem;
     margin-left: 0.05rem;
-    line-height: ${fontSizeMD};
   }
 
   text-align: left;


### PR DESCRIPTION
### What does this PR do?

#### before

<img width="280" alt="Screen Shot 2021-12-08 at 08 31 24" src="https://user-images.githubusercontent.com/3728706/145201709-34ac3f89-e772-42d5-8836-64d52b63d810.png">

#### after
<img width="274" alt="Screen Shot 2021-12-08 at 08 30 51" src="https://user-images.githubusercontent.com/3728706/145201705-66212ad4-71e8-4a34-b2ba-44a23e83180b.png">
