### PR TITLE
fix: Users disappearing from the polling results when they vote

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -248,6 +248,10 @@ class Poll extends Component {
     }
   }
 
+  componentWillUnmount() {
+    Session.set('secretPoll', false);
+  }
+
   handleBackClick() {
     const { stopPoll } = this.props;
     this.setState({


### PR DESCRIPTION
### What does this PR do?

Prevents an issue where (after closing poll panel and opening it again) a presenter starts a regular (not anonymous) poll and is not able to see viewers answers in live-result.

### Closes Issue(s)
Closes #13841
