### PR TITLE
fix presentation download

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -21,7 +21,7 @@ const downloadPresentationUri = (podId) => {
   const presentationFileName = `${currentPresentation.id}.${currentPresentation.name.split('.').pop()}`;
 
   const APP = Meteor.settings.public.app;
-  const uri = `https://${APP.bbbWebBase}/presentation/download/`
+  const uri = `${APP.bbbWebBase}/presentation/download/`
     + `${currentPresentation.meetingId}/${currentPresentation.id}`
     + `?presFilename=${encodeURIComponent(presentationFileName)}`;
 


### PR DESCRIPTION


<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

This fixes the presentation download. The presentation download URL was constructed the wrong way. The default configuration doesn't need a protocol specified, and in a cluster setup the protocol is defined in the settings.
Unfortunately this slipped through in commit c46556e1f65bdfee874bec3c39ff765011ee01da
Sorry for that.


