### PR TITLE
feat(webcams): exclude voice floor holder from camera quality limiter

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/stream-sorting.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/stream-sorting.js
@@ -75,7 +75,10 @@ export const sortLocalPresenterAlphabetical = (s1, s2) => {
 //     1.1.: the sorting function has the same behaviour as a regular .sort callback
 //   2 - add an entry to SORTING_METHODS, the key being the name to be used
 //   in settings.yml and the value object like the aforementioned
-const MANDATORY_DATA_TYPES = { userId: 1, stream: 1, name: 1, deviceId: 1, };
+const MANDATORY_DATA_TYPES = {
+  userId: 1, stream: 1, name: 1, deviceId: 1, floor: 1,
+};
+
 const SORTING_METHODS = Object.freeze({
   // Default
   LOCAL_ALPHABETICAL: {
@@ -120,5 +123,6 @@ export const sortVideoStreams = (streams, mode) => {
     stream: videoStream.stream,
     userId: videoStream.userId,
     name: videoStream.name,
+    floor: videoStream.floor,
   }));
 };


### PR DESCRIPTION
### What does this PR do?

Excludes voice floor holder from camera quality limiter.

### Closes Issue(s)

I don't think it's a good idea to preserve camera profiles by user role (presenter, moderator et al). Voice activity (and user pins in the future) should be enough. So:

Closes #11764

### Motivation

cameraQualityThresholds does not discriminate cameras by their relevance, meaning everybody gets slammed down to 2 FPS if configured to do so. That should be the case for almost everyone except those who should have a spotlight in the meeting. In this case, active talkers.
