### PR TITLE
feat(bbb-html5): add npm run script to lint a specific file/directory

### DIFF
--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -12,6 +12,7 @@
     "test-visual-regression": "export REGRESSION_TESTING=true;env $(cat ../bigbluebutton-tests/puppeteer/.env | xargs)  jest all.test.js --color --detectOpenHandles --forceExit",
     "test-visual-regression:recording": "export WITH_RECORD=true;export REGRESSION_TESTING=true;env $(cat ../bigbluebutton-tests/puppeteer/.env | xargs)  jest all.test.js --color --detectOpenHandles --forceExit",
     "lint": "eslint . --ext .jsx,.js",
+    "lint:file": "eslint",
     "preinstall": "npx npm-force-resolutions"
   },
   "meteor": {


### PR DESCRIPTION
### What does this PR do?

Adds the `lint:file` npm run script to lint a specific file/directory.
Usage: `npm run lint:file <path>`

### Closes Issue(s)

None

### Motivation

The lint-staged hook fixes/alters things. The `lint` run script runs eslint over the whole root directory.
I don't use either. I just want to _check_ linting offenses on a per-file/directory basis without having files messed with.

If there's already a way to do this with any of the existing scripts, ignore.
