### PR TITLE
Keep original order of poll answers in whiteboard annotation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
@@ -217,7 +217,7 @@ class PollDrawComponent extends Component {
     const { slideWidth, slideHeight, intl } = this.props;
 
     // group duplicated responses and keep track of the number of removed items
-    const reducedResult = result.reduce(caseInsensitiveReducer, []);
+    const reducedResult = result.reduce(caseInsensitiveReducer, []).sort((a, b) => a.id - b.id);
     const reducedResultRatio = reducedResult.length * 100 / result.length;
 
     // x1 and y1 - coordinates of the top left corner of the annotation


### PR DESCRIPTION
### What does this PR do?

Makes whiteboard annotation for poll results use the same order as chat/live-result.

### Closes Issue(s)
Closes #13280