### PR TITLE
Keep original order of poll answers in whiteboard annotation (2.4)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
@@ -225,7 +225,7 @@ class PollDrawComponent extends Component {
     const { slideWidth, slideHeight, intl } = this.props;
 
     // group duplicated responses and keep track of the number of removed items
-    const reducedResult = result.reduce(caseInsensitiveReducer, []);
+    const reducedResult = result.reduce(caseInsensitiveReducer, []).sort((a, b) => a.id - b.id);
     const reducedResultRatio = reducedResult.length * 100 / result.length;
 
     // x1 and y1 - coordinates of the top left corner of the annotation


### PR DESCRIPTION
### What does this PR do?

This is a port of PR #13873 from 2.3 to 2.4.

_Makes whiteboard annotation for poll results use the same order as chat/live-result._
