### PR TITLE
refactor: Decrease time allowed for reconnection

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -50,7 +50,7 @@ object Users2x {
   def findAllExpiredUserLeftFlags(users: Users2x, meetingExpireWhenLastUserLeftInMs: Long): Vector[UserState] = {
     if (meetingExpireWhenLastUserLeftInMs > 0) {
       users.toVector filter (u => u.userLeftFlag.left && u.userLeftFlag.leftOn != 0 &&
-        System.currentTimeMillis() - u.userLeftFlag.leftOn > 30000)
+        System.currentTimeMillis() - u.userLeftFlag.leftOn > 10000)
     } else {
       // When meetingExpireWhenLastUserLeftInMs is set zero we need to
       // remove user right away to end the meeting as soon as possible.


### PR DESCRIPTION
We are receiving feedback that due to this 30s period that the user remains in the room, if a user exits a breakout room, that  user won't be able to re-join it until 30s elapses.
More investigation is needed but given that this 30s value is somewhat large, I'm [temporarily] reducing it to 10s. Related #13531

Related to https://github.com/bigbluebutton/bigbluebutton/issues/13832 but the full solution is deeper than this. We should open an issue about the internal plan from @TiagoJacobs and @Tainan404 

Requested by @ffdixon 
Will be further investigated likely by @Tainan404 