### PR TITLE
fix(video): webcam video username dropdown

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -126,13 +126,9 @@
 
 .info {
   position: absolute;
-  display: flex;
-  bottom: 5px;
-  left: 5px;
+  bottom: 1px;
+  left: 7px;
   right: 5px;
-  justify-content: space-between;
-  align-items: center;
-  height: 1.25rem;
   z-index: 2;
 }
 
@@ -164,6 +160,7 @@
 .userName {
   @extend %text-elipsis;
   position: relative;
+  max-width: 75%;
   // Keep the background with 0.5 opacity, but leave the text with 1
   background-color: rgba(0, 0, 0, 0.5);
   border-radius: 1px;
@@ -220,6 +217,9 @@
 .muted,
 .voice {
   display: inline-block;
+  position: absolute;
+  right: 7px;
+  bottom: 6px;
   width: var(--audio-indicator-width);
   height: var(--audio-indicator-width);
   min-width: var(--audio-indicator-width);


### PR DESCRIPTION
### What does this PR do?
Fix a problem that username in video container isn't wrapped if it's too long.
Fix a problem that can cause the audio indicator to disappear.
Fix some problems with the overflow property.
Refactor in css for the talking indicator be more centralized


### Closes Issue(s)
Closes: https://github.com/bigbluebutton/bigbluebutton/issues/13839