### PR TITLE
fix(layout): mobile external-video refresh icon

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
@@ -546,6 +546,7 @@ class VideoPlayer extends Component {
     const desktopHoverToolBarStyle = styles.hoverToolbar;
 
     const hoverToolbarStyle = this.isMobile ? mobileHoverToolBarStyle : desktopHoverToolBarStyle;
+    const isMinimized = width === 0 && height === 0;
 
     return (
       <span
@@ -557,6 +558,7 @@ class VideoPlayer extends Component {
           height,
           width,
           pointerEvents: isResizing ? 'none' : 'inherit',
+          display: isMinimized && 'none',
         }}
       >
         <div


### PR DESCRIPTION
### What does this PR do?

Fixes refresh icon misplaced on mobile when external-video is minimized.

#### Misplaced refresh icon:
![mobile](https://user-images.githubusercontent.com/32987232/145453648-4846dd79-d07b-4b94-ae7c-6da5bb80f3c2.gif)
