### PR TITLE
fix(webcams): bad reference to enableWebcamSelectorButton config

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
@@ -10,7 +10,7 @@ import { validIOSVersion } from '/imports/ui/components/app/service';
 import deviceInfo from '/imports/utils/deviceInfo';
 import { debounce } from 'lodash';
 
-const ENABLE_WEBCAM_SELECTOR_BUTTON = Meteor.settings.public.app;
+const ENABLE_WEBCAM_SELECTOR_BUTTON = Meteor.settings.public.app.enableWebcamSelectorButton;
 
 const intlMessages = defineMessages({
   joinVideo: {


### PR DESCRIPTION
### What does this PR do?

Properly reference the `enableWebcamSelectorButton` config.
I missed this in https://github.com/bigbluebutton/bigbluebutton/pull/13818

### Closes Issue(s)

None

### Motivation

There's no big deal in this since the default is true and the borked config evaluation also evaluates to true, so default works as expect.
This restores the expected behavior where setting `false` would disable the webcam options selector.
