### PR TITLE
fix: Reduces Dashboard cookie lifetime

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -550,10 +550,10 @@ object MsgBuilder {
     BbbCommonEnvCoreMsg(envelope, event)
   }
 
-  def buildLearningDashboardEvtMsg(meetingId: String, activityJson: String): BbbCommonEnvCoreMsg = {
+  def buildLearningDashboardEvtMsg(meetingId: String, learningDashboardAccessToken: String, activityJson: String): BbbCommonEnvCoreMsg = {
     val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
     val envelope = BbbCoreEnvelope(LearningDashboardEvtMsg.NAME, routing)
-    val body = LearningDashboardEvtMsgBody(activityJson)
+    val body = LearningDashboardEvtMsgBody(learningDashboardAccessToken, activityJson)
     val header = BbbCoreHeaderWithMeetingId(LearningDashboardEvtMsg.NAME, meetingId)
     val event = LearningDashboardEvtMsg(header, body)
 

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/SystemMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/SystemMsgs.scala
@@ -232,4 +232,4 @@ case class LearningDashboardEvtMsg(
     header: BbbCoreHeaderWithMeetingId,
     body:   LearningDashboardEvtMsgBody
 ) extends BbbCoreMsg
-case class LearningDashboardEvtMsgBody(activityJson: String)
+case class LearningDashboardEvtMsgBody(learningDashboardAccessToken: String, activityJson: String)

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -963,10 +963,9 @@ public class MeetingService implements MessageListener {
   }
 
   public void processLearningDashboard(LearningDashboard message) {
+
     //Get all data from Json instead of getMeeting(message.meetingId), to process messages received even after meeting ended
     JsonObject activityJsonObject = new Gson().fromJson(message.activityJson, JsonObject.class).getAsJsonObject();
-    String learningDashboardAccessToken = activityJsonObject.get("learningDashboardAccessToken").getAsString();
-
     Map<String, Object> logData = new HashMap<String, Object>();
     logData.put("meetingId", activityJsonObject.get("intId").getAsString());
     logData.put("externalMeetingId", activityJsonObject.get("extId").getAsString());
@@ -979,7 +978,7 @@ public class MeetingService implements MessageListener {
 
     log.info(" --analytics-- data={}", logStr);
 
-    learningDashboardService.writeJsonDataFile(message.meetingId, learningDashboardAccessToken, message.activityJson);
+    learningDashboardService.writeJsonDataFile(message.meetingId, message.learningDashboardAccessToken, message.activityJson);
   }
 
   @Override

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/LearningDashboard.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/LearningDashboard.java
@@ -3,9 +3,11 @@ package org.bigbluebutton.api.messaging.messages;
 public class LearningDashboard implements IMessage {
     public final String meetingId;
     public final String activityJson;
+    public final String learningDashboardAccessToken;
 
-    public LearningDashboard(String meetingId, String activityJson) {
+    public LearningDashboard(String meetingId, String learningDashboardAccessToken, String activityJson) {
         this.meetingId = meetingId;
         this.activityJson = activityJson;
+        this.learningDashboardAccessToken = learningDashboardAccessToken;
     }
 }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
@@ -182,7 +182,7 @@ class OldMeetingMsgHdlrActor(val olgMsgGW: OldMessageReceivedGW)
   }
 
   def handleLearningDashboardEvtMsg(msg: LearningDashboardEvtMsg): Unit = {
-    olgMsgGW.handle(new LearningDashboard(msg.header.meetingId, msg.body.activityJson))
+    olgMsgGW.handle(new LearningDashboard(msg.header.meetingId, msg.body.learningDashboardAccessToken, msg.body.activityJson))
   }
 
 }

--- a/bbb-learning-dashboard/src/App.js
+++ b/bbb-learning-dashboard/src/App.js
@@ -48,18 +48,18 @@ class App extends React.Component {
     if (typeof params.report !== 'undefined') {
       learningDashboardAccessToken = params.report;
     } else {
-      const cookieName = `learningDashboardAccessToken-${params.meeting}`;
+      const cookieName = `ld-${params.meeting}`;
       const cDecoded = decodeURIComponent(document.cookie);
       const cArr = cDecoded.split('; ');
       cArr.forEach((val) => {
         if (val.indexOf(`${cookieName}=`) === 0) learningDashboardAccessToken = val.substring((`${cookieName}=`).length);
       });
 
-      // Extend AccessToken lifetime by 30d (in each access)
+      // Extend AccessToken lifetime by 7d (in each access)
       if (learningDashboardAccessToken !== '') {
         const cookieExpiresDate = new Date();
-        cookieExpiresDate.setTime(cookieExpiresDate.getTime() + (3600000 * 24 * 30));
-        document.cookie = `learningDashboardAccessToken-${meetingId}=${learningDashboardAccessToken}; expires=${cookieExpiresDate.toGMTString()}; path=/;SameSite=None;Secure`;
+        cookieExpiresDate.setTime(cookieExpiresDate.getTime() + (3600000 * 24 * 7));
+        document.cookie = `ld-${meetingId}=${learningDashboardAccessToken}; expires=${cookieExpiresDate.toGMTString()}; path=/;SameSite=None;Secure`;
       }
     }
 

--- a/bigbluebutton-html5/imports/ui/components/learning-dashboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/learning-dashboard/service.js
@@ -39,9 +39,9 @@ const getLearningDashboardAccessToken = () => ((
 const setLearningDashboardCookie = () => {
   const learningDashboardAccessToken = getLearningDashboardAccessToken();
   if (learningDashboardAccessToken !== null) {
-    const cookieExpiresDate = new Date();
-    cookieExpiresDate.setTime(cookieExpiresDate.getTime() + (3600000 * 24 * 30)); // keep cookie 30d
-    document.cookie = `learningDashboardAccessToken-${Auth.meetingID}=${getLearningDashboardAccessToken()}; expires=${cookieExpiresDate.toGMTString()}; path=/`;
+    const lifetime = new Date();
+    lifetime.setTime(lifetime.getTime() + (3600000)); // 1h (extends 7d when open Dashboard)
+    document.cookie = `ld-${Auth.meetingID}=${getLearningDashboardAccessToken()}; expires=${lifetime.toGMTString()}; path=/`;
     return true;
   }
   return false;


### PR DESCRIPTION
As reported by @prlanzarin, the Dashboard could possibly introduce a problem in BBB.
Every time a session is ended, Moderators receive a cookie with the `accessToken` to open the Dashboard.
Even when moderator doesn't want to open the Dashboard, the cookie is set. And after several meetings the cookies size limit would be exceeded and BBB would stop working.

E.g:
![dashboard-cookies](https://user-images.githubusercontent.com/5660191/145636222-bf595cae-5b49-4eeb-9162-537624c7abbe.png)

![image](https://user-images.githubusercontent.com/5660191/145636203-13db3424-f3d7-4cac-9aa4-441f30777913.png)
https://docs.microsoft.com/en-us/previous-versions/ms178194(v=vs.140)?redirectedfrom=MSDN
---
This PR propose some changes to reduce this probability:
- Set the default expire time to 1hour, instead of 30 days
- Case the Dashboard is opened, extends the cookie lifetime for more 7 days, instead of 30 days
- Reduce the name of the cookie replacing `learningDashboardAccessToken-*` by `ld-*`

- Plus: Remove the accessToken from the Json to avoid demoted users to copy the token before be demoted