### PR TITLE
Fix Screen Reader Not Entering Actions Menu in FF (via Shortcut)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -282,7 +282,6 @@ class ActionsDropdown extends PureComponent {
         }
         actions={children}
         opts={{
-          disablePortal: true,
           id: "default-dropdown-menu",
           keepMounted: true,
           transitionDuration: 0,


### PR DESCRIPTION
### What does this PR do?

Remove `disablePortal` option from menu. 

### Closes Issue(s)
Closes #13820 
