### PR TITLE
request breakout urls before join button click

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
@@ -103,6 +103,7 @@ class BreakoutRoom extends PureComponent {
     this.renderUserActions = this.renderUserActions.bind(this);
     this.returnBackToMeeeting = this.returnBackToMeeeting.bind(this);
     this.closePanel = this.closePanel.bind(this);
+    this.requestAllBreakoutURL = this.requestAllBreakoutURL.bind(this);
     this.state = {
       requestedBreakoutId: '',
       waiting: false,
@@ -117,6 +118,9 @@ class BreakoutRoom extends PureComponent {
 
   componentDidMount() {
     if (this.panel) this.panel.firstChild.focus();
+
+    const { breakoutRooms } = this.props;
+    this.requestAllBreakoutURL(breakoutRooms);
   }
 
   componentDidUpdate() {
@@ -138,6 +142,8 @@ class BreakoutRoom extends PureComponent {
     if (breakoutRooms.length === 0) {
       return this.closePanel();
     }
+
+    this.requestAllBreakoutURL(breakoutRooms);
 
     if (waiting && !generated) {
       const breakoutUrlData = getBreakoutRoomUrl(requestedBreakoutId);
@@ -199,6 +205,21 @@ class BreakoutRoom extends PureComponent {
     return intl.formatMessage(intlMessages.askToJoin);
   }
 
+  requestAllBreakoutURL(breakoutRooms) {
+    const {
+      getBreakoutRoomUrl,
+      requestJoinURL,
+    } = this.props;
+
+    breakoutRooms.forEach(room => {
+      const breakoutRoomUrlData = getBreakoutRoomUrl(room.breakoutId);
+
+      if(!breakoutRoomUrlData){
+        requestJoinURL(room.breakoutId);
+      }
+    });
+  }
+
   clearJoinedAudioOnly() {
     this.setState({ joinedAudioOnly: false });
   }
@@ -254,6 +275,7 @@ class BreakoutRoom extends PureComponent {
       exitAudio,
       setBreakoutAudioTransferStatus,
       getBreakoutAudioTransferStatus,
+      getBreakoutRoomUrl,
     } = this.props;
 
     const {
@@ -261,8 +283,9 @@ class BreakoutRoom extends PureComponent {
       breakoutId: _stateBreakoutId,
       requestedBreakoutId,
       waiting,
-      generated,
     } = this.state;
+
+    if (!getBreakoutRoomUrl(breakoutId)) return null;
 
     const {
       breakoutMeetingId: currentAudioTransferBreakoutId,


### PR DESCRIPTION
### What does this PR do?

Changes when breakout URL are requested, preventing an issue with browser popup blocker.

Breakout URLs are currently only requested when a user clicks the "join room" button, causing a delay between user action and the window.open (browsers might think the "open window" action is not related to the user click).

With the changes made in this PR, breakout room URLs will be requested as soon as the breakout panel is opened (and will only display the "join" button after the URL is available).


#### before
https://user-images.githubusercontent.com/3728706/145831494-40a4bc02-7b5b-4bf2-8c94-b13545ad91d1.mov

#### after 
https://user-images.githubusercontent.com/3728706/145831478-045d44b1-3a64-42d1-89f0-e953ab5912c7.mov



### Closes Issue(s)
Closes #13889