### PR TITLE
fix: Joining breakout rooms creates popup windows

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
@@ -77,6 +77,8 @@ const intlMessages = defineMessages({
   },
 });
 
+let prevBreakoutData = {};
+
 class BreakoutRoom extends PureComponent {
   static sortById(a, b) {
     if (a.userId > b.userId) {
@@ -143,7 +145,9 @@ class BreakoutRoom extends PureComponent {
       const breakoutUrlData = getBreakoutRoomUrl(requestedBreakoutId);
 
       if (!breakoutUrlData) return false;
-      if (breakoutUrlData.redirectToHtml5JoinURL !== '') {
+      if (breakoutUrlData.redirectToHtml5JoinURL !== ''
+        && breakoutUrlData.redirectToHtml5JoinURL !== prevBreakoutData.redirectToHtml5JoinURL) {
+        prevBreakoutData = breakoutUrlData;
         window.open(breakoutUrlData.redirectToHtml5JoinURL, '_blank');
         _.delay(() => this.setState({ generated: true, waiting: false }), 1000);
       }


### PR DESCRIPTION
### What does this PR do?

Prevents a case where the breakout panel component updates after the join button is clicked, resulting in multiple breakout windows opening at the same time.

### Closes Issue(s)
Closes #13889
