### PR TITLE
feat(webcams): add option to allow moderators to close another user's webcams

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -143,6 +143,8 @@ class ReceivedJsonMsgHandlerActor(
         routeGenericMsg[CamStreamUnsubscribedInSfuEvtMsg](envelope, jsonNode)
       case CamBroadcastStoppedInSfuEvtMsg.NAME =>
         routeGenericMsg[CamBroadcastStoppedInSfuEvtMsg](envelope, jsonNode)
+      case EjectUserCamerasCmdMsg.NAME =>
+        routeGenericMsg[EjectUserCamerasCmdMsg](envelope, jsonNode)
 
       // Voice
       case RecordingStartedVoiceConfEvtMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -88,6 +88,7 @@ class MeetingActor(
   with CamStreamSubscribedInSfuEvtMsgHdlr
   with CamStreamUnsubscribedInSfuEvtMsgHdlr
   with CamBroadcastStoppedInSfuEvtMsgHdlr
+  with EjectUserCamerasCmdMsgHdlr
 
   with EjectUserFromVoiceCmdMsgHdlr
   with EndMeetingSysCmdMsgHdlr
@@ -388,6 +389,7 @@ class MeetingActor(
       case m: CamStreamSubscribedInSfuEvtMsg   => handleCamStreamSubscribedInSfuEvtMsg(m)
       case m: CamStreamUnsubscribedInSfuEvtMsg => handleCamStreamUnsubscribedInSfuEvtMsg(m)
       case m: CamBroadcastStoppedInSfuEvtMsg   => handleCamBroadcastStoppedInSfuEvtMsg(m)
+      case m: EjectUserCamerasCmdMsg           => handleEjectUserCamerasCmdMsg(m)
 
       case m: UserJoinedVoiceConfEvtMsg        => handleUserJoinedVoiceConfEvtMsg(m)
       case m: LogoutAndEndMeetingCmdMsg        => usersApp.handleLogoutAndEndMeetingCmdMsg(m, state)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/streams/EjectUserCamerasCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/streams/EjectUserCamerasCmdMsgHdlr.scala
@@ -1,0 +1,50 @@
+package org.bigbluebutton.core2.message.handlers
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.models.Webcams
+import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
+import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core2.message.senders.MsgBuilder
+
+trait EjectUserCamerasCmdMsgHdlr {
+  this: MeetingActor =>
+
+  val outGW: OutMsgRouter
+
+  def handleEjectUserCamerasCmdMsg(msg: EjectUserCamerasCmdMsg): Unit = {
+    val requesterUserId = msg.header.userId
+    val meetingId = liveMeeting.props.meetingProp.intId
+    val userToEject = msg.body.userId
+    val ejectionDisabled = !liveMeeting.props.usersProp.allowModsToEjectCameras
+    val isBreakout = liveMeeting.props.meetingProp.isBreakout
+    val badPermission = permissionFailed(
+      PermissionCheck.MOD_LEVEL,
+      PermissionCheck.VIEWER_LEVEL,
+      liveMeeting.users2x,
+      requesterUserId
+    )
+
+    if (ejectionDisabled || isBreakout || badPermission) {
+      val reason = "No permission to eject cameras from user."
+      PermissionCheck.ejectUserForFailedPermission(
+        meetingId,
+        requesterUserId,
+        reason,
+        outGW,
+        liveMeeting
+      )
+    } else {
+      log.info("Ejecting user cameras.  meetingId=" + meetingId
+        + " userId=" + userToEject
+        + " requesterUserId=" + requesterUserId)
+      val broadcastedWebcams = Webcams.findWebcamsForUser(liveMeeting.webcams, userToEject)
+      broadcastedWebcams foreach { webcam =>
+        // Goes to SFU and comes back through CamBroadcastStoppedInSfuEvtMsg
+        val event = MsgBuilder.buildCamBroadcastStopSysMsg(
+          meetingId, userToEject, webcam.stream.id
+        )
+        outGW.send(event)
+      }
+    }
+  }
+}

--- a/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
+++ b/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
@@ -40,6 +40,7 @@ trait AppsTestFixtures {
   val maxUsers = 25
   val guestPolicy = "ALWAYS_ASK"
   val allowModsToUnmuteUsers = false
+  val allowModsToEjectCameras = false
   val authenticatedGuest = false
 
   val red5DeskShareIPTestFixture = "127.0.0.1"
@@ -60,7 +61,7 @@ trait AppsTestFixtures {
     modOnlyMessage = modOnlyMessage)
   val voiceProp = VoiceProp(telVoice = voiceConfId, voiceConf = voiceConfId, dialNumber = dialNumber, muteOnStart = muteOnStart)
   val usersProp = UsersProp(maxUsers = maxUsers, webcamsOnlyForModerator = webcamsOnlyForModerator,
-    guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers, authenticatedGuest = authenticatedGuest)
+    guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers, allowModsToEjectCameras = allowModsToEjectCameras, authenticatedGuest = authenticatedGuest)
   val metadataProp = new MetadataProp(metadata)
 
   val defaultProps = DefaultProps(meetingProp, breakoutProps, durationProps, password, recordProp, welcomeProp, voiceProp,

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
@@ -28,7 +28,7 @@ case class WelcomeProp(welcomeMsgTemplate: String, welcomeMsg: String, modOnlyMe
 
 case class VoiceProp(telVoice: String, voiceConf: String, dialNumber: String, muteOnStart: Boolean)
 
-case class UsersProp(maxUsers: Int, webcamsOnlyForModerator: Boolean, guestPolicy: String, meetingLayout: String, allowModsToUnmuteUsers: Boolean, authenticatedGuest: Boolean)
+case class UsersProp(maxUsers: Int, webcamsOnlyForModerator: Boolean, guestPolicy: String, meetingLayout: String, allowModsToUnmuteUsers: Boolean, allowModsToEjectCameras: Boolean, authenticatedGuest: Boolean)
 
 case class MetadataProp(metadata: collection.immutable.Map[String, String])
 

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WebcamsMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WebcamsMsgs.scala
@@ -119,6 +119,16 @@ case class EjectUserFromSfuSysMsg(
 case class EjectUserFromSfuSysMsgBody(userId: String)
 
 /**
+ * Sent by the client to eject all cameras from user #userId
+ */
+object EjectUserCamerasCmdMsg { val NAME = "EjectUserCamerasCmdMsg" }
+case class EjectUserCamerasCmdMsg(
+    header: BbbClientMsgHeader,
+    body:   EjectUserCamerasCmdMsgBody
+) extends StandardMsg
+case class EjectUserCamerasCmdMsgBody(userId: String)
+
+/**
  * Sent to bbb-webrtc-sfu to tear down broadcaster stream #streamId
  */
 object CamBroadcastStopSysMsg { val NAME = "CamBroadcastStopSysMsg" }

--- a/bbb-common-message/src/test/scala/org/bigbluebutton/common2/TestFixtures.scala
+++ b/bbb-common-message/src/test/scala/org/bigbluebutton/common2/TestFixtures.scala
@@ -36,6 +36,7 @@ trait TestFixtures {
   val maxUsers = 25
   val muteOnStart = false
   val allowModsToUnmuteUsers = false
+  val allowModsToEjectCameras = false
   val keepEvents = false
   val guestPolicy = "ALWAYS_ASK"
   val authenticatedGuest = false
@@ -55,7 +56,7 @@ trait TestFixtures {
     modOnlyMessage = modOnlyMessage)
   val voiceProp = VoiceProp(telVoice = voiceConfId, voiceConf = voiceConfId, dialNumber = dialNumber, muteOnStart = muteOnStart)
   val usersProp = UsersProp(maxUsers = maxUsers, webcamsOnlyForModerator = webcamsOnlyForModerator,
-    guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers, authenticatedGuest = authenticatedGuest)
+    guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers, allowModsToEjectCameras = allowModsToEjectCameras, authenticatedGuest = authenticatedGuest)
   val metadataProp = new MetadataProp(metadata)
   val screenshareProps = ScreenshareProps(screenshareConf = "FixMe!", red5ScreenshareIp = "fixMe!",
     red5ScreenshareApp = "fixMe!")

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -46,6 +46,7 @@ public class ApiParams {
     public static final String MUTE_ON_START = "muteOnStart";
     public static final String MEETING_KEEP_EVENTS = "meetingKeepEvents";
     public static final String ALLOW_MODS_TO_UNMUTE_USERS = "allowModsToUnmuteUsers";
+    public static final String ALLOW_MODS_TO_EJECT_CAMERAS = "allowModsToEjectCameras";
     public static final String NAME = "name";
     public static final String PARENT_MEETING_ID = "parentMeetingID";
     public static final String PASSWORD = "password";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -416,7 +416,7 @@ public class MeetingService implements MessageListener {
             m.getMeetingExpireIfNoUserJoinedInMinutes(), m.getmeetingExpireWhenLastUserLeftInMinutes(),
             m.getUserInactivityInspectTimerInMinutes(), m.getUserInactivityThresholdInMinutes(),
             m.getUserActivitySignResponseDelayInMinutes(), m.getEndWhenNoModerator(), m.getEndWhenNoModeratorDelayInMinutes(),
-            m.getMuteOnStart(), m.getAllowModsToUnmuteUsers(), m.getMeetingKeepEvents(),
+            m.getMuteOnStart(), m.getAllowModsToUnmuteUsers(), m.getAllowModsToEjectCameras(), m.getMeetingKeepEvents(),
             m.breakoutRoomsParams,
             m.lockSettingsParams, m.getHtml5InstanceId());
   }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -87,6 +87,7 @@ public class ParamsProcessorUtil {
     private boolean webcamsOnlyForModerator;
     private boolean defaultMuteOnStart = false;
     private boolean defaultAllowModsToUnmuteUsers = false;
+    private boolean defaultAllowModsToEjectCameras = false;
     private boolean defaultKeepEvents = false;
     private Boolean useDefaultLogo;
     private String defaultLogoURL;
@@ -623,6 +624,12 @@ public class ParamsProcessorUtil {
         }
         meeting.setAllowModsToUnmuteUsers(allowModsToUnmuteUsers);
 
+    Boolean allowModsToEjectCameras = defaultAllowModsToEjectCameras;
+    if (!StringUtils.isEmpty(params.get(ApiParams.ALLOW_MODS_TO_EJECT_CAMERAS))) {
+      allowModsToEjectCameras = Boolean.parseBoolean(params.get(ApiParams.ALLOW_MODS_TO_EJECT_CAMERAS));
+    }
+    meeting.setAllowModsToEjectCameras(allowModsToEjectCameras);
+
         return meeting;
     }
 
@@ -1073,6 +1080,14 @@ public class ParamsProcessorUtil {
 	public Boolean getAllowModsToUnmuteUsers() {
 		return defaultAllowModsToUnmuteUsers;
 	}
+
+  public void setAllowModsToEjectCameras(Boolean value) {
+    defaultAllowModsToEjectCameras = value;
+  }
+
+  public Boolean getAllowModsToEjectCameras() {
+    return defaultAllowModsToEjectCameras;
+  }
 
 	public List<String> decodeIds(String encodeid) {
 		ArrayList<String> ids=new ArrayList<>();

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -86,6 +86,7 @@ public class Meeting {
 	private String customCopyright = "";
 	private Boolean muteOnStart = false;
 	private Boolean allowModsToUnmuteUsers = false;
+	private Boolean allowModsToEjectCameras = false;
 	private Boolean meetingKeepEvents;
 
 	private Integer meetingExpireIfNoUserJoinedInMinutes = 5;
@@ -513,6 +514,14 @@ public class Meeting {
 	public Boolean getAllowModsToUnmuteUsers() {
 		return allowModsToUnmuteUsers;
 	}
+
+  public void setAllowModsToEjectCameras(Boolean value) {
+    allowModsToEjectCameras = value;
+  }
+
+  public Boolean getAllowModsToEjectCameras() {
+    return allowModsToEjectCameras;
+  }
 
 	public void userJoined(User user) {
 		User u = getUserById(user.getInternalUserId());

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
@@ -30,6 +30,7 @@ public interface IBbbWebApiGWApp {
                      Integer endWhenNoModeratorDelayInMinutes,
                      Boolean muteOnStart,
                      Boolean allowModsToUnmuteUsers,
+                     Boolean allowModsToEjectCameras,
                      Boolean keepEvents,
                      BreakoutRoomsParams breakoutParams,
                      LockSettingsParams lockSettingsParams,

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -140,6 +140,7 @@ class BbbWebApiGWApp(
                     endWhenNoModeratorDelayInMinutes:       java.lang.Integer,
                     muteOnStart:                            java.lang.Boolean,
                     allowModsToUnmuteUsers:                 java.lang.Boolean,
+                    allowModsToEjectCameras:                java.lang.Boolean,
                     keepEvents:                             java.lang.Boolean,
                     breakoutParams:                         BreakoutRoomsParams,
                     lockSettingsParams:                     LockSettingsParams,
@@ -177,7 +178,9 @@ class BbbWebApiGWApp(
       modOnlyMessage = modOnlyMessage)
     val voiceProp = VoiceProp(telVoice = voiceBridge, voiceConf = voiceBridge, dialNumber = dialNumber, muteOnStart = muteOnStart.booleanValue())
     val usersProp = UsersProp(maxUsers = maxUsers.intValue(), webcamsOnlyForModerator = webcamsOnlyForModerator.booleanValue(),
-      guestPolicy = guestPolicy, meetingLayout = meetingLayout, allowModsToUnmuteUsers = allowModsToUnmuteUsers.booleanValue(), authenticatedGuest = authenticatedGuest.booleanValue())
+      guestPolicy = guestPolicy, meetingLayout = meetingLayout, allowModsToUnmuteUsers = allowModsToUnmuteUsers.booleanValue(),
+      allowModsToEjectCameras = allowModsToEjectCameras.booleanValue(),
+      authenticatedGuest = authenticatedGuest.booleanValue())
     val metadataProp = MetadataProp(mapAsScalaMap(metadata).toMap)
     val screenshareProps = ScreenshareProps(
       screenshareConf = voiceBridge + screenshareConfSuffix,

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -61,6 +61,7 @@ export default function addMeeting(meeting) {
       authenticatedGuest: Boolean,
       maxUsers: Number,
       allowModsToUnmuteUsers: Boolean,
+      allowModsToEjectCameras: Boolean,
       meetingLayout: String,
     },
     durationProps: {

--- a/bigbluebutton-html5/imports/api/video-streams/server/methods.js
+++ b/bigbluebutton-html5/imports/api/video-streams/server/methods.js
@@ -1,8 +1,10 @@
 import { Meteor } from 'meteor/meteor';
 import userShareWebcam from './methods/userShareWebcam';
 import userUnshareWebcam from './methods/userUnshareWebcam';
+import ejectUserCameras from './methods/ejectUserCameras';
 
 Meteor.methods({
   userShareWebcam,
   userUnshareWebcam,
+  ejectUserCameras,
 });

--- a/bigbluebutton-html5/imports/api/video-streams/server/methods/ejectUserCameras.js
+++ b/bigbluebutton-html5/imports/api/video-streams/server/methods/ejectUserCameras.js
@@ -1,0 +1,28 @@
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+import Logger from '/imports/startup/server/logger';
+import RedisPubSub from '/imports/startup/server/redis';
+import { extractCredentials } from '/imports/api/common/server/helpers';
+
+export default function ejectUserCameras(userId) {
+  try {
+    const REDIS_CONFIG = Meteor.settings.private.redis;
+    const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
+    const EVENT_NAME = 'EjectUserCamerasCmdMsg';
+    const { meetingId, requesterUserId } = extractCredentials(this.userId);
+
+    check(meetingId, String);
+    check(requesterUserId, String);
+    check(userId, String);
+
+    Logger.info(`Requesting ejection of cameras: userToEject=${userId} requesterUserId=${requesterUserId}`);
+
+    const payload = {
+      userId,
+    };
+
+    RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);
+  } catch (err) {
+    Logger.error(`Exception while invoking method ejectUserCameras ${err.stack}`);
+  }
+}

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -325,6 +325,7 @@ const getUsersProp = () => {
     {
       fields: {
         'usersProp.allowModsToUnmuteUsers': 1,
+        'usersProp.allowModsToEjectCameras': 1,
         'usersProp.authenticatedGuest': 1,
       },
     },
@@ -334,6 +335,7 @@ const getUsersProp = () => {
 
   return {
     allowModsToUnmuteUsers: false,
+    allowModsToEjectCameras: false,
     authenticatedGuest: false,
   };
 };
@@ -405,6 +407,10 @@ const getAvailableActions = (
   const allowedToChangeWhiteboardAccess = amIPresenter
     && !amISubjectUser;
 
+  const allowedToEjectCameras = amIModerator
+    && !amISubjectUser
+    && usersProp.allowModsToEjectCameras;
+
   return {
     allowedToChatPrivately,
     allowedToMuteAudio,
@@ -417,6 +423,7 @@ const getAvailableActions = (
     allowedToChangeStatus,
     allowedToChangeUserLockStatus,
     allowedToChangeWhiteboardAccess,
+    allowedToEjectCameras,
   };
 };
 
@@ -455,6 +462,10 @@ const toggleVoice = (userId) => {
       extraInfo: { logType: 'moderator_action', userId },
     }, 'moderator muted user microphone');
   }
+};
+
+const ejectUserCameras = (userId) => {
+  makeCall('ejectUserCameras', userId);
 };
 
 const getEmoji = () => {
@@ -670,4 +681,5 @@ export default {
   getUsersProp,
   getUserCount,
   sortUsersByCurrent,
+  ejectUserCameras,
 };

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
@@ -52,6 +52,7 @@ class UserListItem extends PureComponent {
       raiseHandPushAlert,
       layoutContextDispatch,
       isRTL,
+      ejectUserCameras,
     } = this.props;
 
     const contents = (
@@ -90,6 +91,7 @@ class UserListItem extends PureComponent {
           raiseHandPushAlert,
           layoutContextDispatch,
           isRTL,
+          ejectUserCameras,
         }}
       />
     );

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/container.jsx
@@ -33,6 +33,7 @@ export default withTracker(({ user }) => {
     removeUser: UserListService.removeUser,
     toggleUserLock: UserListService.toggleUserLock,
     changeRole: UserListService.changeRole,
+    ejectUserCameras: UserListService.ejectUserCameras,
     assignPresenter: UserListService.assignPresenter,
     getAvailableActions: UserListService.getAvailableActions,
     normalizeEmojiName: UserListService.normalizeEmojiName,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-dropdown/component.jsx
@@ -69,6 +69,10 @@ const messages = defineMessages({
     id: 'app.userList.menu.removeWhiteboardAccess.label',
     description: 'label to remove user whiteboard access',
   },
+  ejectUserCamerasLabel: {
+    id: 'app.userList.menu.ejectUserCameras.label',
+    description: 'label to eject user cameras',
+  },
   RemoveUserLabel: {
     id: 'app.userList.menu.removeUser.label',
     description: 'Forcefully remove this user from the meeting',
@@ -231,6 +235,7 @@ class UserDropdown extends PureComponent {
       removeUser,
       toggleVoice,
       changeRole,
+      ejectUserCameras,
       lockSettingsProps,
       hasPrivateChatBetweenUsers,
       toggleUserLock,
@@ -266,6 +271,7 @@ class UserDropdown extends PureComponent {
       allowedToChangeStatus,
       allowedToChangeUserLockStatus,
       allowedToChangeWhiteboardAccess,
+      allowedToEjectCameras,
     } = actionPermissions;
 
     const { disablePrivateChat } = lockSettingsProps;
@@ -480,6 +486,22 @@ class UserDropdown extends PureComponent {
           this.handleClose();
         },
         icon: 'circle_close',
+      });
+    }
+
+    if (allowedToEjectCameras
+      && user.isSharingWebcam
+      && isMeteorConnected
+      && !meetingIsBreakout
+    ) {
+      actions.push({
+        key: 'ejectUserCameras',
+        label: intl.formatMessage(messages.ejectUserCamerasLabel),
+        onClick: () => {
+          this.onActionsHide(ejectUserCameras(user.userId));
+          this.handleClose();
+        },
+        icon: 'video_off',
       });
     }
 

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -90,6 +90,7 @@
     "app.userList.menu.unmuteUserAudio.label": "Unmute user",
     "app.userList.menu.giveWhiteboardAccess.label" : "Give whiteboard access",
     "app.userList.menu.removeWhiteboardAccess.label": "Remove whiteboard access",
+    "app.userList.menu.ejectUserCameras.label": "Close cameras",
     "app.userList.userAriaLabel": "{0} {1} {2}  Status {3}",
     "app.userList.menu.promoteUser.label": "Promote to moderator",
     "app.userList.menu.demoteUser.label": "Demote to viewer",

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -262,6 +262,10 @@ muteOnStart=false
 # Gives moderators permisson to unmute other users
 allowModsToUnmuteUsers=false
 
+# Eject user webcams
+# Gives moderators permisson to close other users' webcams
+allowModsToEjectCameras=false
+
 # Saves meeting events even if the meeting is not recorded
 defaultKeepEvents=false
 


### PR DESCRIPTION
### What does this PR do?

- Includes a new create param/bbb-web conf called `allowModsToEjectCameras`
  * False by default, controls the availability of this feature

### Closes Issue(s)

There's an issue out there. I'll edit this description with it later.

### Additional information

- The button is located in the user-list's user options dropdown (alongside microphone mute et al)
- Closes _all_ webcams shared by the target user
- Disabled in breakout rooms
