### PR TITLE
Bug fix: support recordings with no fill attribute

### DIFF
--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -610,7 +610,8 @@ def events_parse_shape(shapes, event, current_presentation, current_slide, times
   end
   if  shape[:type] == 'rectangle' or
       shape[:type] == 'ellipse' or shape[:type] == 'triangle'
-    fill = event.at_xpath('fill').text
+    fill = event.at_xpath('fill')
+    fill = fill.nil? ? "false" : fill.text
     shape[:fill] = fill =~ /true/ ? true : false
   end
   if shape[:type] == 'rectangle'


### PR DESCRIPTION
### What does this PR do?
Adds a fallback for the fill property for older BBB versions where the fill property is missing in `events.xml`.

<!-- A brief description of each change being made with this pull request. -->
### Motivation
This script is failing for older recordings with no fill attribute. In that case,`event.at_xpath('fill')` is `nil`, failing once `.text` on `nil` is called.

### More
Discussion with @hiroshisuga in:
https://github.com/bigbluebutton/bigbluebutton/pull/10737#issuecomment-991685610

Originally planned to include it in #13836, but since it's a small change it can be added/reviewed now.
