### PR TITLE
fix: Dashboard breaks with user using big name

### DIFF
--- a/bbb-learning-dashboard/src/components/PollsTable.jsx
+++ b/bbb-learning-dashboard/src/components/PollsTable.jsx
@@ -55,7 +55,7 @@ class PollsTable extends React.Component {
                       </div>
                       &nbsp;&nbsp;
                       <div>
-                        <p className="font-semibold">{user.name}</p>
+                        <p className="font-semibold truncate xl:max-w-sm max-w-xs">{user.name}</p>
                       </div>
                     </div>
                   </td>

--- a/bbb-learning-dashboard/src/components/StatusTable.jsx
+++ b/bbb-learning-dashboard/src/components/StatusTable.jsx
@@ -72,7 +72,7 @@ class StatusTable extends React.Component {
                       </div>
                       &nbsp;&nbsp;
                       <div>
-                        <p className="font-semibold">{user.name}</p>
+                        <p className="font-semibold truncate xl:max-w-sm max-w-xs">{user.name}</p>
                       </div>
                     </div>
                   </td>

--- a/bbb-learning-dashboard/src/components/UsersTable.jsx
+++ b/bbb-learning-dashboard/src/components/UsersTable.jsx
@@ -202,7 +202,7 @@ class UsersTable extends React.Component {
                     </div>
                     &nbsp;&nbsp;&nbsp;
                     <div className="inline-block">
-                      <p className="font-semibold">
+                      <p className="font-semibold truncate xl:max-w-sm max-w-xs">
                         {user.name}
                       </p>
                       { Object.values(user.intIds || {}).map((intId, index) => (


### PR DESCRIPTION
This PR will truncate big names in Dashboard.

#### Before:
![ghazi-name-problem](https://user-images.githubusercontent.com/5660191/146198553-0699f405-d283-42cb-b777-7d8e720f176a.png)
---
#### After:
![ghazi-name-problem-fix](https://user-images.githubusercontent.com/5660191/146198562-089536bd-bd5d-44de-93e8-4167f5d1d79b.png)

