### PR TITLE
FixGracePeriod

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
@@ -249,12 +249,15 @@ class WhiteboardModel extends SystemConfiguration {
 
   def getWhiteboardAccess(wbId: String): Array[String] = getWhiteboard(wbId).multiUser
 
+  def isNonEjectionGracePeriodOver(wbId: String, userId: String): Boolean = {
+    val wb = getWhiteboard(wbId)
+    val lastChange = System.currentTimeMillis() - wb.changedModeOn
+    !(wb.oldMultiUser.contains(userId) && lastChange < 5000)
+  }
+
   def hasWhiteboardAccess(wbId: String, userId: String): Boolean = {
     val wb = getWhiteboard(wbId)
-    wb.multiUser.contains(userId) || {
-      val lastChange = System.currentTimeMillis() - wb.changedModeOn
-      wb.oldMultiUser.contains(userId) && lastChange < 5000
-    }
+    wb.multiUser.contains(userId)
   }
 
   def getChangedModeOn(wbId: String): Long = getWhiteboard(wbId).changedModeOn

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ClearWhiteboardPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ClearWhiteboardPubMsgHdlr.scala
@@ -22,9 +22,11 @@ trait ClearWhiteboardPubMsgHdlr extends RightsManagementTrait {
     }
 
     if (filterWhiteboardMessage(msg.body.whiteboardId, msg.header.userId, liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
-      val meetingId = liveMeeting.props.meetingProp.intId
-      val reason = "No permission to clear the whiteboard."
-      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
+      if (isNonEjectionGracePeriodOver(msg.body.whiteboardId, msg.header.userId, liveMeeting)) {
+        val meetingId = liveMeeting.props.meetingProp.intId
+        val reason = "No permission to clear the whiteboard."
+        PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
+      }
     } else {
       for {
         fullClear <- clearWhiteboard(msg.body.whiteboardId, msg.header.userId, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ModifyWhiteboardAccessPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/ModifyWhiteboardAccessPubMsgHdlr.scala
@@ -21,10 +21,12 @@ trait ModifyWhiteboardAccessPubMsgHdlr extends RightsManagementTrait {
       bus.outGW.send(msgEvent)
     }
 
-    if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
-      val meetingId = liveMeeting.props.meetingProp.intId
-      val reason = "No permission to modify access to the whiteboard."
-      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
+    if (filterWhiteboardMessage(msg.body.whiteboardId, msg.header.userId, liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+      if (isNonEjectionGracePeriodOver(msg.body.whiteboardId, msg.header.userId, liveMeeting)) {
+        val meetingId = liveMeeting.props.meetingProp.intId
+        val reason = "No permission to modify access to the whiteboard."
+        PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
+      }
     } else {
       modifyWhiteboardAccess(msg.body.whiteboardId, msg.body.multiUser, liveMeeting)
       broadcastEvent(msg)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/UndoWhiteboardPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/UndoWhiteboardPubMsgHdlr.scala
@@ -22,9 +22,11 @@ trait UndoWhiteboardPubMsgHdlr extends RightsManagementTrait {
     }
 
     if (filterWhiteboardMessage(msg.body.whiteboardId, msg.header.userId, liveMeeting) && permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
-      val meetingId = liveMeeting.props.meetingProp.intId
-      val reason = "No permission to undo an annotation."
-      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
+      if (isNonEjectionGracePeriodOver(msg.body.whiteboardId, msg.header.userId, liveMeeting)) {
+        val meetingId = liveMeeting.props.meetingProp.intId
+        val reason = "No permission to undo an annotation."
+        PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
+      }
     } else {
       for {
         lastAnnotation <- undoWhiteboard(msg.body.whiteboardId, msg.header.userId, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/WhiteboardApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/WhiteboardApp2x.scala
@@ -78,4 +78,8 @@ class WhiteboardApp2x(implicit val context: ActorContext)
     // mode was changed. (ralam nov 22, 2017)
     !liveMeeting.wbModel.hasWhiteboardAccess(whiteboardId, userId)
   }
+
+  def isNonEjectionGracePeriodOver(wbId: String, userId: String, liveMeeting: LiveMeeting): Boolean = {
+    liveMeeting.wbModel.isNonEjectionGracePeriodOver(wbId, userId)
+  }
 }


### PR DESCRIPTION
<h3>What does this PR do?</h3>
<p>This PR changes the way grace period in permission check works. </p>
<p>Before: After permission is removed, permission checks would still pass for 5 seconds in case a message came late.</p>
<p>Now: Permission is removed immediately, but no one gets ejected for failed permission for 5 seconds</p>
