### PR TITLE
build: Update ehterpad-lite from 1.8.13 to 1.8.16

### DIFF
--- a/bbb-etherpad.placeholder.sh
+++ b/bbb-etherpad.placeholder.sh
@@ -1,2 +1,2 @@
-git clone --branch 1.8.13 --depth 1 https://github.com/ether/etherpad-lite bbb-etherpad
+git clone --branch 1.8.16 --depth 1 https://github.com/ether/etherpad-lite bbb-etherpad
 


### PR DESCRIPTION
Before - 1.8.13
Now 1.8.16
Link to etherpad-lite's releases
https://github.com/ether/etherpad-lite/releases

Local tests were fine. No visual differences from what I can tell.

Thanks @pedrobmarin and @alangecker 