### PR TITLE
[2.3] chore: add legacy checkAuthorization endpoint

### DIFF
--- a/bigbluebutton-web/bbb-web.nginx
+++ b/bigbluebutton-web/bbb-web.nginx
@@ -91,6 +91,14 @@
 			proxy_set_header         X-Original-URI $request_uri;
 		}
 
+		location = /bigbluebutton/connection/legacyCheckAuthorization {
+			internal;
+			proxy_pass               http://127.0.0.1:8090;
+			proxy_pass_request_body  off;
+			proxy_set_header         Content-Length "";
+			proxy_set_header         X-Original-URI $request_uri;
+		}
+
 		location = /bigbluebutton/connection/validatePad {
 			internal;
 			proxy_pass               http://127.0.0.1:8090;

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
@@ -53,6 +53,26 @@ class ConnectionController {
     }
   }
 
+  def legacyCheckAuthorization = {
+    try {
+      def uri = request.getHeader("x-original-uri")
+      def sessionToken = ParamsUtil.getSessionToken(uri)
+      UserSession userSession = meetingService.getUserSessionWithAuthToken(sessionToken)
+
+      response.addHeader("Cache-Control", "no-cache")
+      response.contentType = 'plain/text'
+      if (userSession != null) {
+        response.setStatus(200)
+        response.outputStream << 'authorized'
+      } else {
+        response.setStatus(401)
+        response.outputStream << 'unauthorized'
+      }
+    } catch (IOException e) {
+      log.error("Error while authenticating connection.\n" + e.getMessage())
+    }
+  }
+
   def validatePad = {
     try {
       String uri = request.getHeader("x-original-uri")


### PR DESCRIPTION
For the sake of backwards compatibility
Backport of #13941 to 2.3.