### PR TITLE
build: use official ep_cursortrace

### DIFF
--- a/build/packages-template/bbb-etherpad/build.sh
+++ b/build/packages-template/bbb-etherpad/build.sh
@@ -32,9 +32,7 @@ git clone https://github.com/mconf/ep_redis_publisher.git
 npm pack ./ep_redis_publisher
 npm install ./ep_redis_publisher-*.tgz
 
-# npm install ep_cursortrace
-# using mconf's fork due to https://github.com/ether/ep_cursortrace/pull/25 not being accepted upstream
-npm install git+https://github.com/mconf/ep_cursortrace.git
+npm install ep_cursortrace
 npm install ep_disable_chat
 
 # For some reason installing from github using npm 7.5.2 gives


### PR DESCRIPTION
### What does this PR do?
Switches from mconf's `ep_cursortrace` back to the official `ep_cursortrace` Etherpad plugin
Effectively revering PR #13470

<!-- A brief description of each change being made with this pull request. -->
The difference was https://github.com/ether/ep_cursortrace/pull/25 which was closed
