### PR TITLE
fix(webcams): missing allowModsToEjectCameras in resources.xml

### DIFF
--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -170,6 +170,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="clientLogoutTimerInMinutes" value="${clientLogoutTimerInMinutes}"/>
         <property name="muteOnStart" value="${muteOnStart}"/>
         <property name="allowModsToUnmuteUsers" value="${allowModsToUnmuteUsers}"/>
+        <property name="allowModsToEjectCameras" value="${allowModsToEjectCameras}"/>
         <property name="breakoutRoomsEnabled" value="${breakoutRoomsEnabled}"/>
         <property name="breakoutRoomsRecord" value="${breakoutRoomsRecord}"/>
         <property name="breakoutRoomsPrivateChatEnabled" value="${breakoutRoomsPrivateChatEnabled}"/>


### PR DESCRIPTION
### What does this PR do?

Setting wasn't being picked up by bbb-web/bigbluebutton.properties.
Only worked as a `create` parameter.
Forgot about that one in #13915.

### Closes Issue(s)

None
