### PR TITLE
test: Playwright- fixes for the locales test

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -287,6 +287,7 @@ class SettingsDropdown extends PureComponent {
           <Button
             label={intl.formatMessage(intlMessages.optionsLabel)}
             icon="more"
+            data-test="optionsButton"
             ghost
             circle
             hideLabel

--- a/bigbluebutton-tests/playwright/core/elements.js
+++ b/bigbluebutton-tests/playwright/core/elements.js
@@ -2,6 +2,7 @@
 exports.actions = 'button[aria-label="Actions"]';
 exports.pollMenuButton = 'div[data-test="pollMenuButton"]';
 exports.options = 'button[aria-label="Options"]';
+exports.optionsButton = 'button[data-test="optionsButton"]';
 exports.settings = 'li[data-test="settings"]';
 exports.modalConfirmButton = 'button[data-test="modalConfirmButton"]';
 exports.screenshareConnecting = 'div[data-test="screenshareConnecting"]';

--- a/bigbluebutton-tests/playwright/playwright.config.js
+++ b/bigbluebutton-tests/playwright/playwright.config.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 
 const config = {
   workers: 1,
+  timeout: 3 * 60 * 1000,
   use: {
     headless: true,
   },

--- a/bigbluebutton-tests/playwright/settings/language.js
+++ b/bigbluebutton-tests/playwright/settings/language.js
@@ -8,13 +8,15 @@ class Language extends Page {
   }
 
   async test(locale) {
-    await openSettings(this.page);
-    await this.page.waitForSelector('#langSelector');
-    const langDropdown = await this.page.$('#langSelector');
-    const langOptions = await langDropdown.$$('option');
-    await langDropdown.selectOption({ value: locale });
-    await this.page.click(e.modalConfirmButton);
-    await openSettings(this.page);
+    for(let locale of e.locales) {
+      console.log(`Testing ${locale} locale`);
+      await openSettings(this.page);
+      await this.page.waitForSelector('#langSelector');
+      const langDropdown = await this.page.$('#langSelector');
+      const langOptions = await langDropdown.$$('option');
+      await langDropdown.selectOption({ value: locale });
+      await this.page.click(e.modalConfirmButton);
+    }
   }
 }
 

--- a/bigbluebutton-tests/playwright/settings/settings.spec.js
+++ b/bigbluebutton-tests/playwright/settings/settings.spec.js
@@ -1,14 +1,10 @@
 const { test } = require('@playwright/test');
 const { Language } = require('./language');
-const e = require('../core/elements');
 
 test.describe.parallel('Settings test suite', () => {
-  for(let locale of e.locales) {
-    test.skip(`Test ${locale} locale`, async ({ browser, page }) => {
-      console.log(browser);
+    test(`Test locales`, async ({ browser, page }) => {
       const language = new Language(browser, page);
       await language.init(true, true);
-      await language.test(locale);
+      await language.test();
     });
-  }
 });

--- a/bigbluebutton-tests/playwright/settings/util.js
+++ b/bigbluebutton-tests/playwright/settings/util.js
@@ -1,8 +1,8 @@
 const e = require('../core/elements');
 
 async function openSettings(page) {
-  await page.waitForSelector(e.options);
-  await page.click(e.options);
+  await page.waitForSelector(e.optionsButton);
+  await page.click(e.optionsButton);
   await page.waitForSelector(e.settings);
   await page.click(e.settings);
 }


### PR DESCRIPTION
### What does this PR do?

This PR improves the locales test: it does all the actions within one browser session, instead of creating a new session for each locale.
- looping through the locales within one browser session
- using `data-test` instead of `aria-label` for selecting the options button in the navbar (`aria-label` changes its value when language changes, so it can't be used for the locales test)
- increasing the timeout for Playwright tests to 3 minutes (the default value isn't enough for looping through all locales).