### PR TITLE
fix(webcams): fix client crash on camera user ejection

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/container.jsx
@@ -34,7 +34,7 @@ export default withTracker((props) => {
     voiceUser: VoiceUsers.findOne({ intId: userId },
       { fields: { muted: 1, listenOnly: 1, talking: 1 } }),
     user: Users.findOne({ intId: userId },
-      { fields: { pin: 1, role: 1, userId: 1 } }),
+      { fields: { pin: 1, userId: 1 } }),
   };
 })(VideoListItemContainer);
 


### PR DESCRIPTION
### What does this PR do?

 - Fix a client crash on camera user ejections (the old user collection data is nullish drill)
 - Added extra proptypes validation to video-list-item
 - Made sure to add extra ?. checks to voiceUsers in video-list-item as well because... who knows? 
 - Removed unused user role prop from video-list-item

### Closes Issue(s)

None (although this can be considered a regression of #13835)
