### PR TITLE
fix: wrong locales keys on FallbackView

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/fallback-errors/fallback-view/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/fallback-errors/fallback-view/component.jsx
@@ -6,15 +6,15 @@ import { styles } from './styles';
 
 const intlMessages = defineMessages({
   title: {
-    id: 'app.error.fallback.view.title',
+    id: 'app.error.fallback.presentation.title',
     description: 'title for presentation when fallback is showed',
   },
   description: {
-    id: 'app.error.fallback.view.description',
+    id: 'app.error.fallback.presentation.description',
     description: 'description for presentation when fallback is showed',
   },
   reloadButton: {
-    id: 'app.error.fallback.view.reloadButton',
+    id: 'app.error.fallback.presentation.reloadButton',
     description: 'Button label when fallback is showed',
   },
 });


### PR DESCRIPTION
### What does this PR do?

`FallbackView` component was referencing wrong locale keys.
I supposed it meant these: https://github.com/bigbluebutton/bigbluebutton/blob/9e371dc0414a1337979267bc84d05545906218b2/bigbluebutton-html5/public/locales/en.json#L586-L588

The ones currently being used are undefined.

### Closes Issue(s)

None
