### PR TITLE
Update SR New Message Notification 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -15,6 +15,7 @@ import ConnectionStatusService from '/imports/ui/components/connection-status/se
 import SettingsDropdownContainer from './settings-dropdown/container';
 import browserInfo from '/imports/utils/browserInfo';
 import deviceInfo from '/imports/utils/deviceInfo';
+import {alertScreenReader} from '/imports/utils/dom-utils';
 import { PANELS, ACTIONS } from '../layout/enums';
 
 const intlMessages = defineMessages({
@@ -29,6 +30,10 @@ const intlMessages = defineMessages({
   newMessages: {
     id: 'app.navBar.toggleUserList.newMessages',
     description: 'label for toggleUserList btn when showing red notification',
+  },
+  newMsgAria: {
+    id: 'app.navBar.toggleUserList.newMsgAria',
+    description: 'label for new message screen reader alert',
   },
 });
 
@@ -47,6 +52,10 @@ const defaultProps = {
 class NavBar extends Component {
   constructor(props) {
     super(props);
+
+    this.state = {
+        acs: props.activeChats,
+    }
 
     this.handleToggleUserList = this.handleToggleUserList.bind(this);
   }
@@ -77,6 +86,12 @@ class NavBar extends Component {
           this.handleToggleUserList();
         }
       });
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (JSON.stringify(prevProps.activeChats) !== JSON.stringify(this.props.activeChats)) {
+      this.setState({ acs: this.props.activeChats})
     }
   }
 
@@ -132,6 +147,9 @@ class NavBar extends Component {
       hasUnreadMessages,
       hasUnreadNotes,
       // isExpanded,
+      activeChats,
+      chat,
+      isPublicChat,
       intl,
       shortcuts: TOGGLE_USERLIST_AK,
       mountModal,
@@ -142,6 +160,15 @@ class NavBar extends Component {
       sidebarNavigation,
     } = this.props;
 
+  //   const localizedChatName = isPublicChat(chat)
+  //   ? intl.formatMessage(intlMessages.publicChat)
+  //   : chat.name;
+
+  // const arialabel = `${localizedChatName} ${
+  //   counter > 1
+  //     ? intl.formatMessage(intlMessages.unreadPlural, { 0: counter })
+  //     : intl.formatMessage(intlMessages.unreadSingular)}`;
+
     const hasNotification = hasUnreadMessages || hasUnreadNotes;
     const toggleBtnClasses = {};
     toggleBtnClasses[styles.btn] = true;
@@ -151,6 +178,14 @@ class NavBar extends Component {
     ariaLabel += hasNotification ? (` ${intl.formatMessage(intlMessages.newMessages)}`) : '';
 
     const isExpanded = sidebarNavigation.isOpen;
+
+    const { acs } = this.state;
+
+    activeChats.map((c, i) => {
+      if (c?.unreadCounter > 0 && c?.unreadCounter !== acs[i]?.unreadCounter) {
+        alertScreenReader(`${intl.formatMessage(intlMessages.newMsgAria, { 0: c.name })}`)
+      }
+    });
 
     return (
       <header

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -15,6 +15,7 @@ import ConnectionStatusService from '/imports/ui/components/connection-status/se
 import SettingsDropdownContainer from './settings-dropdown/container';
 import browserInfo from '/imports/utils/browserInfo';
 import deviceInfo from '/imports/utils/deviceInfo';
+import _ from "lodash";
 import {alertScreenReader} from '/imports/utils/dom-utils';
 import { PANELS, ACTIONS } from '../layout/enums';
 
@@ -90,7 +91,7 @@ class NavBar extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (JSON.stringify(prevProps.activeChats) !== JSON.stringify(this.props.activeChats)) {
+    if (!_.isEqual(prevProps.activeChats, this.props.activeChats)) {
       this.setState({ acs: this.props.activeChats})
     }
   }

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -148,8 +148,6 @@ class NavBar extends Component {
       hasUnreadNotes,
       // isExpanded,
       activeChats,
-      chat,
-      isPublicChat,
       intl,
       shortcuts: TOGGLE_USERLIST_AK,
       mountModal,

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -160,15 +160,6 @@ class NavBar extends Component {
       sidebarNavigation,
     } = this.props;
 
-  //   const localizedChatName = isPublicChat(chat)
-  //   ? intl.formatMessage(intlMessages.publicChat)
-  //   : chat.name;
-
-  // const arialabel = `${localizedChatName} ${
-  //   counter > 1
-  //     ? intl.formatMessage(intlMessages.unreadPlural, { 0: counter })
-  //     : intl.formatMessage(intlMessages.unreadSingular)}`;
-
     const hasNotification = hasUnreadMessages || hasUnreadNotes;
     const toggleBtnClasses = {};
     toggleBtnClasses[styles.btn] = true;

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/container.jsx
@@ -9,6 +9,7 @@ import { ChatContext } from '/imports/ui/components/components-data/chat-context
 import { GroupChatContext } from '/imports/ui/components/components-data/group-chat-context/context';
 import { UsersContext } from '/imports/ui/components/components-data/users-context/context';
 import NoteService from '/imports/ui/components/note/service';
+import UserlsitService from '/imports/ui/components/user-list/service';
 import Service from './service';
 import NavBar from './component';
 import LayoutContext from '../layout/context';
@@ -36,6 +37,7 @@ const NavBarContainer = ({ children, ...props }) => {
   const { chats: groupChatsMessages } = usingChatContext;
   const { users } = usingUsersContext;
   const { groupChat: groupChats } = usingGroupChatContext;
+  const activeChats = UserlsitService.getActiveChats({ groupChatsMessages, groupChats, users:users[Auth.meetingID] });
   const { ...rest } = props;
   const {
     input, output,
@@ -70,6 +72,7 @@ const NavBarContainer = ({ children, ...props }) => {
         sidebarContent,
         layoutContextDispatch,
         isExpanded,
+        activeChats,
         ...rest,
       }}
       style={{ ...navBar }}

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -333,6 +333,7 @@
     "app.navBar.userListToggleBtnLabel": "User list toggle",
     "app.navBar.toggleUserList.ariaLabel": "Users and messages toggle",
     "app.navBar.toggleUserList.newMessages": "with new message notification",
+    "app.navBar.toggleUserList.newMsgAria": "New message from {0}",
     "app.navBar.recording": "This session is being recorded",
     "app.navBar.recording.on": "Recording",
     "app.navBar.recording.off": "Not recording",


### PR DESCRIPTION
### What does this PR do?
Previously these notifications would not be available unless the user list was open. This PR updates the screen reader alert for new messages so that they are announced even when the list is closed.

![SR_chat_msgs_closed](https://user-images.githubusercontent.com/22058534/147573687-44ca2d4d-ec23-472c-82fc-ed2462ea968e.gif)

Related to #10942
