### PR TITLE
Fix #13994 - bigbluebutton cron job inadvertently deletes /var/bigbluebutton/learning-dashboard

### DIFF
--- a/bigbluebutton-config/cron.daily/bigbluebutton
+++ b/bigbluebutton-config/cron.daily/bigbluebutton
@@ -31,7 +31,7 @@ log_history=28
 #
 # Delete presentations older than N days
 #
-find /var/bigbluebutton/ -maxdepth 1 -type d -name "*-*" -mtime +$history -exec rm -rf '{}' +
+find /var/bigbluebutton/ -maxdepth 1 -type d -name "*-[0-9]*" -mtime +$history -exec rm -rf '{}' +
 
 #
 # Delete streams from Kurento and mediasoup older than N days


### PR DESCRIPTION
Fixes #13994 