### PR TITLE
fix(style): custom style in screenshare container

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/styles.scss
@@ -29,6 +29,7 @@
 
 .screenshareContainer {
   position: relative;
+  background-color: var(--color-content-background);
   width: 100%;
   height: 100%;
 }


### PR DESCRIPTION
### What does this PR do?
Custom color isn't applied in the screenshare container. This PR fixes it.

### Before
![image](https://user-images.githubusercontent.com/42683590/147969254-99a4de0f-bb08-48cb-b95b-762314644d37.png)

### After
![image](https://user-images.githubusercontent.com/42683590/147969206-6e73add2-cba9-4460-b4ef-10c6eddf2f6e.png)

