### PR TITLE
fix(chat): remove empty area after message list

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/styles.scss
@@ -39,12 +39,6 @@
     margin: 0 0 0 auto;
     padding: 0 0 0 var(--md-padding-x);
   }
-
-  &:after {
-    content: "";
-    display: block;
-    height: var(--md-padding-x);
-  }
 }
 
 .unreadButton {


### PR DESCRIPTION
this fixes autoscroll not goint all the way to end of the scrollbar

Essentially reverts [#4802](https://github.com/bigbluebutton/bigbluebutton/pull/4802), the problem does not happen anymore on firefox.

![image](https://user-images.githubusercontent.com/2726293/148442545-ffb42a12-07fa-4b1b-a6de-c518a3a6deb0.png)

