### PR TITLE
fix(webcam): user list pin icon

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-name/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-name/component.jsx
@@ -47,6 +47,7 @@ const messages = defineMessages({
 const propTypes = {
   user: PropTypes.shape({
     name: PropTypes.string.isRequired,
+    pin: PropTypes.bool.isRequired,
   }).isRequired,
   compact: PropTypes.bool.isRequired,
   intl: PropTypes.shape({
@@ -81,7 +82,9 @@ const UserName = (props) => {
   if (user.isSharingWebcam && LABEL.sharingWebcam) {
     userNameSub.push(
       <span key={_.uniqueId('video-')}>
-        <Icon iconName="video" />
+        { user.pin === true
+          ? <Icon iconName="pin-video_on" />
+          : <Icon iconName="video" /> }
         &nbsp;
         {intl.formatMessage(messages.sharingWebcam)}
       </span>,


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Replace the webcam icon in the user list for the pin icon when an user's pinned.
<!-- A brief description of each change being made with this pull request. -->

### Motivation
Make it clear in the user list that a user's webcam is pinned.
<!-- What inspired you to submit this pull request? -->

### More

![user-list_pin_icon](https://user-images.githubusercontent.com/32987232/148470998-dc8fc1e6-0613-49b8-881e-929b2f284874.gif)

