### PR TITLE
fix: welcome message overlap

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
@@ -55,6 +55,7 @@ class TimeWindowList extends PureComponent {
     this.userScrolledBack = false;
     this.handleScrollUpdate = _.debounce(this.handleScrollUpdate.bind(this), 150);
     this.rowRender = this.rowRender.bind(this);
+    this.forceCacheUpdate = this.forceCacheUpdate.bind(this);
     this.systemMessagesResized = {};
 
     this.state = {
@@ -127,15 +128,13 @@ class TimeWindowList extends PureComponent {
     }
 
     const prevTimeWindowsLength = prevTimeWindowsValues.length;
-    const timeWindowsValuesLength = timeWindowsValues.length;
     const prevLastTimeWindow = prevTimeWindowsValues[prevTimeWindowsLength - 1];
     const lastTimeWindow = timeWindowsValues[prevTimeWindowsLength - 1];
 
     if ((lastTimeWindow
       && (prevLastTimeWindow?.content.length !== lastTimeWindow?.content.length))) {
       if (this.listRef) {
-        this.cache.clear(timeWindowsValuesLength - 1);
-        this.listRef.recomputeRowHeights(timeWindowsValuesLength - 1);
+        this.forceCacheUpdate();
       }
     }
 
@@ -183,6 +182,14 @@ class TimeWindowList extends PureComponent {
     }
   }
 
+  forceCacheUpdate() {
+    const { timeWindowsValues } = this.props;
+    const { length } = timeWindowsValues;
+
+    this.cache.clear(length - 1);
+    this.listRef.recomputeRowHeights(length - 1);
+  }
+
   rowRender({
     index,
     parent,
@@ -220,6 +227,8 @@ class TimeWindowList extends PureComponent {
             scrollArea={scrollArea}
             dispatch={dispatch}
             chatId={chatId}
+            height={style.height}
+            forceCacheUpdate={() => this.forceCacheUpdate()}
           />
         </span>
       </CellMeasurer>

--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/component.jsx
@@ -58,6 +58,13 @@ const intlMessages = defineMessages({
 
 class TimeWindowChatItem extends PureComponent {
   componentDidUpdate(prevProps, prevState) {
+    const { height, forceCacheUpdate, systemMessage } = this.props;
+    const elementHeight = this.itemRef ? this.itemRef.clientHeight : null;
+
+    if (systemMessage && elementHeight && height !== 'auto' && elementHeight !== height) {
+      forceCacheUpdate();
+    }
+
     ChatLogger.debug('TimeWindowChatItem::componentDidUpdate::props', { ...this.props }, { ...prevProps });
     ChatLogger.debug('TimeWindowChatItem::componentDidUpdate::state', { ...this.state }, { ...prevState });
   }
@@ -86,7 +93,10 @@ class TimeWindowChatItem extends PureComponent {
     }
 
     return (
-      <div className={styles.item} key={`time-window-chat-item-${messageKey}`}>
+      <div
+        className={styles.item}
+        key={`time-window-chat-item-${messageKey}`}
+        ref={element => this.itemRef = element} >
         <div className={styles.messages}>
           {messages.map(message => (
             message.text !== ''


### PR DESCRIPTION
### What does this PR do?

Prevents a visual bug with the welcome message not being correctly displayed in specific conditions.

Tested in Firefox with a 1920x1080 23" monitor.

### Sample message 1:

```
وینک قلبی اتعذب فی هواک وینک قلبی العاشق ما ینساک لا جوابات یا ناسینی فیهم شوق و ود وشایلین سلامات کل یوم راح تجینی ترد لقلبی البسمه و للیل النجمات عندما یحب الرجل المرأة بصمت .. یخسر کل شیء حتى هی… وعندما تحب المرأة الرجل بصوت.. تخسر کل شیء حتى هو! ففی الحب الصمت جریمة الرجل والصوت جریمة المرأة…
اربك تكست هو اول موقع يسمح لزواره الكرام بتحويل الكتابة العربي الى كتابة مفهومة من قبل اغلب برامج التصميم مثل الفوتوشوب و الافترايفكتس و البريمير و الافد ميدا كومبوزر و السموك و برامج اخرى كثيرة
```

#### before
![Screen Shot 2022-01-07 at 11 40 05](https://user-images.githubusercontent.com/3728706/148559761-d388ee49-14b2-4f06-b434-3912f1c2aeef.png)

![Screen Shot 2022-01-07 at 11 32 00](https://user-images.githubusercontent.com/3728706/148559436-85776f38-8f98-422a-af5f-10ee546013e1.png)

#### after
![Screen Shot 2022-01-07 at 11 32 24](https://user-images.githubusercontent.com/3728706/148559439-92fc0f6d-b48e-42aa-a2f8-a4b79f4a1187.png)

### Sample message 2:

```
Willkommen zu "<b>%%CONFNAME%%</b>"<br><br>Eine kurze BigBlueButton-Einf&uuml;hrung in Form von Video-Tutorials findet sich unter: <a href="event:https://bigbluebutton.org/html5/">https://bigbluebutton.org/html5/</a>.<br><br>Nach M&ouml;glichkeit bitte ein Headset bzw. Kopfh&ouml;rer nutzen, um St&ouml;rger&auml;uche zu vermeiden.
<br>Um via Telefon teilzunehmen %%DIALNUM%% w&auml;hlen und folgende Konferenz-PIN eingeben: %%CONFNUM%% #<br><i>Hinweis: Mittels der Ziffer 0 k&ouml;nnen telefonisch zugeschaltete Personen selbst ihr Mikrofon ein- und ausschalten.</i><br><br><b>Weitere Steuerung bei telefonischer Teilnahme:</b><br><br>Mit 4 l&auml;sst sich das Mikrofon leiser stellen<br> Mit 5 l&auml;sst sich das Mikrofon auf Standard-Lautst&auml;rke stellen<br> Mit 6 l&auml;sst sich das Mikrofon lauter stellen<br><br>Mit * lassen sich sowohl Mikrofon als auch Lautsprecher ein- und ausschalten<br>Mit 0 l&auml;sst sich das Mikrofon ein- und ausschalten<br>
```

#### before

![Screen Shot 2022-01-07 at 11 40 33](https://user-images.githubusercontent.com/3728706/148559858-ce04d209-3dac-4e2d-98ac-ef3e1feb7336.png)

![Screen Shot 2022-01-07 at 11 30 25](https://user-images.githubusercontent.com/3728706/148559426-12ea1d92-6a89-4509-a7df-d03858215f6b.png)

#### after
![Screen Shot 2022-01-07 at 11 30 49](https://user-images.githubusercontent.com/3728706/148559433-63c5d319-00c2-462b-ad21-bd37f9750931.png)


### Closes Issue(s)
Closes #13160
Closes #12178
