### PR TITLE
fix: See other users in user list lock

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -311,6 +311,7 @@ const isMeetingLocked = (id) => {
       || lockSettings.disablePrivateChat
       || lockSettings.disablePublicChat
       || lockSettings.disableNote
+      || lockSettings.hideUserList
       || usersProp.webcamsOnlyForModerator) {
       isLocked = true;
     }


### PR DESCRIPTION
### What does this PR do?

Adds locked label and unlock option to userlist if **see other viewers in Users list** is the only active lock.

### Closes Issue(s)
Closes #13958
