### PR TITLE
change dropdown menu max-width value

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/menu/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/menu/styles.scss
@@ -57,7 +57,7 @@
     border-radius: var(--border-radius);
     border: 0;
     z-index: 9999;
-    max-width: 16rem;
+    max-width: 22rem;
   } 
 }
 


### PR DESCRIPTION
### What does this PR do?

Changes max-width value for dropdown menus, allowing the new Learning Dashboard name (Learning Analytics Dashboard) to fit in one line.

Does not have a related issue, suggested by @ffdixon [in a comment](https://github.com/bigbluebutton/bigbluebutton/pull/14027#issuecomment-1008305955)

#### before
![Screen Shot 2022-01-10 at 16 08 55](https://user-images.githubusercontent.com/3728706/148824845-c0dde8bf-9614-40f1-bc10-6d9f3f39db49.png)

#### after
![Screen Shot 2022-01-10 at 16 08 40](https://user-images.githubusercontent.com/3728706/148824839-cdfecb65-5acf-4e53-8f8e-64e29747d786.png)
