### PR TITLE
refactor: Container name out of the form fixed

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { styles } from './styles';
 import UserParticipantsContainer from './user-participants/container';
-import UserMessages from './user-messages/container';
+import UserMessagesContainer from './user-messages/container';
 import UserNotesContainer from './user-notes/container';
 import UserCaptionsContainer from './user-captions/container';
 import WaitingUsers from './waiting-users/component';
@@ -58,7 +58,7 @@ class UserContent extends PureComponent {
       >
         {CHAT_ENABLED
           ? (
-            <UserMessages
+            <UserMessagesContainer
               {...{
                 isPublicChat,
                 compact,


### PR DESCRIPTION


### What does this PR do?
The component name were out of the form, then i changed from 'UserMessage' to 'UserMessageContainer'


### Motivation

Keep the name in the norm 
