### PR TITLE
fix: API crashes when a big number is set for learningDashboardCleanupDelayInMinutes

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
@@ -58,6 +58,14 @@ public class LearningDashboardService {
     }
 
     public void removeJsonDataFile(String meetingId, int cleanUpDelayMinutes) {
+
+        //Avoid big cleanUpDelayMinutes numbers once Java can't handle with it
+        int maxMinutesAllowed = Integer.MAX_VALUE / 60000;
+        if(cleanUpDelayMinutes > maxMinutesAllowed) {
+            log.warn("Learning Dashboard availability time reduced from {} to {} minutes for meeting {}.", cleanUpDelayMinutes, maxMinutesAllowed ,meetingId);
+            cleanUpDelayMinutes = maxMinutesAllowed;
+        }
+
         //Delay `cleanUpDelayMinutes` then moderators can open the Dashboard before files has been removed
         new java.util.Timer().schedule(
                 new java.util.TimerTask() {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.util.Calendar;
 
 public class LearningDashboardService {
     private static Logger log = LoggerFactory.getLogger(LearningDashboardService.class);
@@ -59,12 +60,8 @@ public class LearningDashboardService {
 
     public void removeJsonDataFile(String meetingId, int cleanUpDelayMinutes) {
 
-        //Avoid big cleanUpDelayMinutes numbers once Java can't handle with it
-        int maxMinutesAllowed = Integer.MAX_VALUE / 60000;
-        if(cleanUpDelayMinutes > maxMinutesAllowed) {
-            log.warn("Learning Dashboard availability time reduced from {} to {} minutes for meeting {}.", cleanUpDelayMinutes, maxMinutesAllowed ,meetingId);
-            cleanUpDelayMinutes = maxMinutesAllowed;
-        }
+        Calendar cleanUpDelayCalendar = Calendar.getInstance();
+        cleanUpDelayCalendar.add(Calendar.MINUTE, cleanUpDelayMinutes);
 
         //Delay `cleanUpDelayMinutes` then moderators can open the Dashboard before files has been removed
         new java.util.Timer().schedule(
@@ -75,8 +72,7 @@ public class LearningDashboardService {
                         LearningDashboardService.deleteDirectory(ldMeetingFilesDir);
                         log.info("Learning Dashboard files removed for meeting {}.",meetingId);
                     }
-                },
-                (cleanUpDelayMinutes * 60) * 1000
+                }, cleanUpDelayCalendar.getTime()
         );
     }
 


### PR DESCRIPTION
Closes #13692.

Bbb-web was crashing when receiving big numbers for `learningDashboardCleanupDelayInMinutes`.
Once it was being converted to milliseconds and it was becoming higher then Java limit (`Integer.MAX_VALUE`).

Now Bbb-web uses `Date` instead of `int` as parameter for `schedule` and so it supports numbers like `252000` perfectly.