### PR TITLE
fix: Different behaviour on userdata-bbb_listen_only_mode=false

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -178,6 +178,8 @@ class AudioModal extends Component {
       if (forceListenOnlyAttendee || audioLocked) return this.handleJoinListenOnly();
 
       if (joinFullAudioImmediately && !listenOnlyMode) return this.handleJoinMicrophone();
+
+      if (!listenOnlyMode) return this.handleGoToEchoTest();
     }
     return false;
   }


### PR DESCRIPTION
### What does this PR do?

Changes audio modal behavior when `userdata-bbb_listen_only_mode` is set to `false`.

#### before
When audio modal is mounted with listen only disabled, the microphone button is displayed and the user needs to click on it in order to start echo test.

#### after
When audio modal is mounted with listen only disabled, it will start echo test without the need of clicking microphone button (like it was in bbb 2.2).

### Closes Issue(s)
Closes #12681