### PR TITLE
fix: forceCacheUpdate method

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
@@ -128,13 +128,15 @@ class TimeWindowList extends PureComponent {
     }
 
     const prevTimeWindowsLength = prevTimeWindowsValues.length;
+    const timeWindowsValuesLength = timeWindowsValues.length;
     const prevLastTimeWindow = prevTimeWindowsValues[prevTimeWindowsLength - 1];
     const lastTimeWindow = timeWindowsValues[prevTimeWindowsLength - 1];
 
     if ((lastTimeWindow
       && (prevLastTimeWindow?.content.length !== lastTimeWindow?.content.length))) {
       if (this.listRef) {
-        this.forceCacheUpdate();
+        this.cache.clear(timeWindowsValuesLength - 1);
+        this.listRef.recomputeRowHeights(timeWindowsValuesLength - 1);
       }
     }
 
@@ -182,12 +184,11 @@ class TimeWindowList extends PureComponent {
     }
   }
 
-  forceCacheUpdate() {
-    const { timeWindowsValues } = this.props;
-    const { length } = timeWindowsValues;
-
-    this.cache.clear(length - 1);
-    this.listRef.recomputeRowHeights(length - 1);
+  forceCacheUpdate(index) {
+    if (index >= 0) {
+      this.cache.clear(index);
+      this.listRef.recomputeRowHeights(index);
+    }
   }
 
   rowRender({
@@ -228,7 +229,8 @@ class TimeWindowList extends PureComponent {
             dispatch={dispatch}
             chatId={chatId}
             height={style.height}
-            forceCacheUpdate={() => this.forceCacheUpdate()}
+            index={index}
+            forceCacheUpdate={this.forceCacheUpdate}
           />
         </span>
       </CellMeasurer>

--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/component.jsx
@@ -58,11 +58,11 @@ const intlMessages = defineMessages({
 
 class TimeWindowChatItem extends PureComponent {
   componentDidUpdate(prevProps, prevState) {
-    const { height, forceCacheUpdate, systemMessage } = this.props;
+    const { height, forceCacheUpdate, systemMessage, index } = this.props;
     const elementHeight = this.itemRef ? this.itemRef.clientHeight : null;
 
     if (systemMessage && elementHeight && height !== 'auto' && elementHeight !== height) {
-      forceCacheUpdate();
+      forceCacheUpdate(index);
     }
 
     ChatLogger.debug('TimeWindowChatItem::componentDidUpdate::props', { ...this.props }, { ...prevProps });


### PR DESCRIPTION
### What does this PR do?

Prevents an issue with the _forceCacheUpdate_  method (added in #14023) where the wrong index could be recomputed, causing an infinite loop.