### PR TITLE
fix(polls): fix wrong typed poll results due to race condition

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/RespondToTypedPollReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/RespondToTypedPollReqMsgHdlr.scala
@@ -23,12 +23,12 @@ trait RespondToTypedPollReqMsgHdlr {
       bus.outGW.send(msgEvent)
     }
 
-    def broadcastUserRespondedToTypedPollRespMsg(msg: RespondToTypedPollReqMsg, pollId: String, answer: String, sendToId: String): Unit = {
+    def broadcastUserRespondedToTypedPollRespMsg(msg: RespondToTypedPollReqMsg, pollId: String, answerId: Int, sendToId: String): Unit = {
       val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, liveMeeting.props.meetingProp.intId, sendToId)
       val envelope = BbbCoreEnvelope(UserRespondedToTypedPollRespMsg.NAME, routing)
       val header = BbbClientMsgHeader(UserRespondedToTypedPollRespMsg.NAME, liveMeeting.props.meetingProp.intId, sendToId)
 
-      val body = UserRespondedToTypedPollRespMsgBody(pollId, msg.header.userId, answer)
+      val body = UserRespondedToTypedPollRespMsgBody(pollId, msg.header.userId, answerId)
       val event = UserRespondedToTypedPollRespMsg(header, body)
       val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
       bus.outGW.send(msgEvent)
@@ -43,7 +43,8 @@ trait RespondToTypedPollReqMsgHdlr {
       for {
         presenter <- Users2x.findPresenter(liveMeeting.users2x)
       } yield {
-        broadcastUserRespondedToTypedPollRespMsg(msg, pollId, msg.body.answer, presenter.intId)
+        val answerId = (updatedPoll.answers find (ans => ans.key == msg.body.answer)).get.id
+        broadcastUserRespondedToTypedPollRespMsg(msg, pollId, answerId, presenter.intId)
       }
     }
   }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PollsMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PollsMsgs.scala
@@ -44,7 +44,7 @@ case class UserRespondedToPollRespMsgBody(pollId: String, userId: String, answer
 
 object UserRespondedToTypedPollRespMsg { val NAME = "UserRespondedToTypedPollRespMsg" }
 case class UserRespondedToTypedPollRespMsg(header: BbbClientMsgHeader, body: UserRespondedToTypedPollRespMsgBody) extends BbbCoreMsg
-case class UserRespondedToTypedPollRespMsgBody(pollId: String, userId: String, answer: String)
+case class UserRespondedToTypedPollRespMsgBody(pollId: String, userId: String, answerId: Int)
 
 object ShowPollResultReqMsg { val NAME = "ShowPollResultReqMsg" }
 case class ShowPollResultReqMsg(header: BbbClientMsgHeader, body: ShowPollResultReqMsgBody) extends StandardMsg

--- a/bigbluebutton-html5/imports/api/polls/server/handlers/userTypedResponse.js
+++ b/bigbluebutton-html5/imports/api/polls/server/handlers/userTypedResponse.js
@@ -1,5 +1,4 @@
 import { check } from 'meteor/check';
-import Polls from '/imports/api/polls';
 import RedisPubSub from '/imports/startup/server/redis';
 
 export default function userTypedResponse({ header, body }) {
@@ -7,21 +6,13 @@ export default function userTypedResponse({ header, body }) {
   const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
   const EVENT_NAME = 'RespondToPollReqMsg';
 
-  const { pollId, userId, answer } = body;
+  const { pollId, userId, answerId } = body;
   const { meetingId } = header;
 
   check(pollId, String);
   check(meetingId, String);
   check(userId, String);
-  check(answer, String);
-
-  const poll = Polls.findOne({ meetingId, id: pollId });
-
-  let answerId = 0;
-  poll.answers.forEach((a) => {
-    const { id, key } = a;
-    if (key === answer) answerId = id;
-  });
+  check(answerId, Number);
 
   const payload = {
     requesterId: userId,


### PR DESCRIPTION
Sometimes a vote for a new answer text was being computed as a vote for the first option due to poll collection late update.

I changed the `UserRespondedToTypedPollRespMsg` message in akka to return the new answerId directly to avoid having to search it in html5.