### PR TITLE
fix: Webcams overlap speakerlist in Breakout Rooms

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -450,9 +450,9 @@ class CustomLayout extends Component {
       if (!isOpen) {
         cameraDockBounds.width = mediaAreaBounds.width;
         cameraDockBounds.maxWidth = mediaAreaBounds.width;
-        cameraDockBounds.height = mediaAreaBounds.height;
+        cameraDockBounds.height = mediaAreaBounds.height - bannerAreaHeight;
         cameraDockBounds.maxHeight = mediaAreaBounds.height;
-        cameraDockBounds.top = DEFAULT_VALUES.navBarHeight;
+        cameraDockBounds.top = DEFAULT_VALUES.navBarHeight + bannerAreaHeight;
         cameraDockBounds.left = !isRTL ? mediaAreaBounds.left : 0;
         cameraDockBounds.right = isRTL ? sidebarSize : null;
       } else {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -395,9 +395,9 @@ class PresentationFocusLayout extends Component {
       if (!isOpen) {
         cameraDockBounds.width = mediaAreaBounds.width;
         cameraDockBounds.maxWidth = mediaAreaBounds.width;
-        cameraDockBounds.height = mediaAreaBounds.height;
+        cameraDockBounds.height = mediaAreaBounds.height - this.bannerAreaHeight();
         cameraDockBounds.maxHeight = mediaAreaBounds.height;
-        cameraDockBounds.top = DEFAULT_VALUES.navBarHeight;
+        cameraDockBounds.top = DEFAULT_VALUES.navBarHeight + this.bannerAreaHeight();
         cameraDockBounds.left = !isRTL ? mediaAreaBounds.left : 0;
         cameraDockBounds.right = isRTL ? sidebarSize : null;
       } else {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -400,23 +400,26 @@ class VideoFocusLayout extends Component {
       if (!isOpen) {
         cameraDockBounds.width = mediaAreaBounds.width;
         cameraDockBounds.maxWidth = mediaAreaBounds.width;
-        cameraDockBounds.height = mediaAreaBounds.height;
+        cameraDockBounds.height = mediaAreaBounds.height - this.bannerAreaHeight();
         cameraDockBounds.maxHeight = mediaAreaBounds.height;
-        cameraDockBounds.top = DEFAULT_VALUES.navBarHeight;
+        cameraDockBounds.top = DEFAULT_VALUES.navBarHeight + this.bannerAreaHeight();
         cameraDockBounds.left = !isRTL ? mediaAreaBounds.left : 0;
         cameraDockBounds.right = isRTL ? sidebarSize : null;
       } else {
+        const mobileCameraHeight = mediaAreaBounds.height * 0.7 - this.bannerAreaHeight();
+        const cameraHeight = mediaAreaBounds.height - this.bannerAreaHeight();
+
         if (deviceType === DEVICE_TYPE.MOBILE) {
-          cameraDockBounds.minHeight = mediaAreaBounds.height * 0.7;
-          cameraDockBounds.height = mediaAreaBounds.height * 0.7;
-          cameraDockBounds.maxHeight = mediaAreaBounds.height * 0.7;
+          cameraDockBounds.minHeight = mobileCameraHeight;
+          cameraDockBounds.height = mobileCameraHeight;
+          cameraDockBounds.maxHeight = mobileCameraHeight;
         } else {
-          cameraDockBounds.minHeight = mediaAreaBounds.height;
-          cameraDockBounds.height = mediaAreaBounds.height;
-          cameraDockBounds.maxHeight = mediaAreaBounds.height;
+          cameraDockBounds.minHeight = cameraHeight;
+          cameraDockBounds.height = cameraHeight;
+          cameraDockBounds.maxHeight = cameraHeight;
         }
 
-        cameraDockBounds.top = DEFAULT_VALUES.navBarHeight;
+        cameraDockBounds.top = DEFAULT_VALUES.navBarHeight + this.bannerAreaHeight();
         cameraDockBounds.left = !isRTL ? mediaAreaBounds.left : null;
         cameraDockBounds.right = isRTL ? sidebarSize : null;
         cameraDockBounds.minWidth = mediaAreaBounds.width;


### PR DESCRIPTION
### What does this PR do?

Prevents webcam/speaker list overlap in breakout rooms and specific conditions:
- Custom layout + presentation minimized
- Focus on presentation layout + presentation minimized
- Focus on video layout

### Closes Issue(s)
Closes #13933