### PR TITLE
Add param to disable Virtual Backgrounds in API /create

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -174,7 +174,7 @@ object Users2x {
       newUser
     }
   }
-  
+
   def hasPresenter(users: Users2x): Boolean = {
     findPresenter(users) match {
       case Some(p) => true

--- a/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
+++ b/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
@@ -42,6 +42,8 @@ trait AppsTestFixtures {
   val allowModsToUnmuteUsers = false
   val allowModsToEjectCameras = false
   val authenticatedGuest = false
+  val meetingLayout = ""
+  val virtualBackgroundsEnabled = false
 
   val red5DeskShareIPTestFixture = "127.0.0.1"
   val red5DeskShareAppTestFixtures = "red5App"
@@ -61,7 +63,8 @@ trait AppsTestFixtures {
     modOnlyMessage = modOnlyMessage)
   val voiceProp = VoiceProp(telVoice = voiceConfId, voiceConf = voiceConfId, dialNumber = dialNumber, muteOnStart = muteOnStart)
   val usersProp = UsersProp(maxUsers = maxUsers, webcamsOnlyForModerator = webcamsOnlyForModerator,
-    guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers, allowModsToEjectCameras = allowModsToEjectCameras, authenticatedGuest = authenticatedGuest)
+    guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers, allowModsToEjectCameras = allowModsToEjectCameras,
+    authenticatedGuest = authenticatedGuest, meetingLayout = meetingLayout, virtualBackgroundsEnabled = virtualBackgroundsEnabled)
   val metadataProp = new MetadataProp(metadata)
 
   val defaultProps = DefaultProps(meetingProp, breakoutProps, durationProps, password, recordProp, welcomeProp, voiceProp,

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
@@ -28,7 +28,16 @@ case class WelcomeProp(welcomeMsgTemplate: String, welcomeMsg: String, modOnlyMe
 
 case class VoiceProp(telVoice: String, voiceConf: String, dialNumber: String, muteOnStart: Boolean)
 
-case class UsersProp(maxUsers: Int, webcamsOnlyForModerator: Boolean, guestPolicy: String, meetingLayout: String, allowModsToUnmuteUsers: Boolean, allowModsToEjectCameras: Boolean, authenticatedGuest: Boolean)
+case class UsersProp(
+    maxUsers:                   Int,
+    webcamsOnlyForModerator:    Boolean,
+    guestPolicy:                String,
+    meetingLayout:              String,
+    allowModsToUnmuteUsers:     Boolean,
+    allowModsToEjectCameras:    Boolean,
+    authenticatedGuest:         Boolean,
+    virtualBackgroundsDisabled: Boolean
+)
 
 case class MetadataProp(metadata: collection.immutable.Map[String, String])
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -58,6 +58,7 @@ public class ApiParams {
     public static final String WEB_VOICE = "webVoice";
     public static final String LEARNING_DASHBOARD_ENABLED = "learningDashboardEnabled";
     public static final String LEARNING_DASHBOARD_CLEANUP_DELAY_IN_MINUTES = "learningDashboardCleanupDelayInMinutes";
+    public static final String VIRTUAL_BACKGROUNDS_DISABLED = "virtualBackgroundsDisabled";
     public static final String WEBCAMS_ONLY_FOR_MODERATOR = "webcamsOnlyForModerator";
     public static final String WELCOME = "welcome";
     public static final String HTML5_INSTANCE_ID = "html5InstanceId";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -418,7 +418,7 @@ public class MeetingService implements MessageListener {
             m.getUserActivitySignResponseDelayInMinutes(), m.getEndWhenNoModerator(), m.getEndWhenNoModeratorDelayInMinutes(),
             m.getMuteOnStart(), m.getAllowModsToUnmuteUsers(), m.getAllowModsToEjectCameras(), m.getMeetingKeepEvents(),
             m.breakoutRoomsParams,
-            m.lockSettingsParams, m.getHtml5InstanceId());
+            m.lockSettingsParams, m.getHtml5InstanceId(), m.getVirtualBackgroundsDisabled());
   }
 
   private String formatPrettyDate(Long timestamp) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -460,6 +460,14 @@ public class ParamsProcessorUtil {
             learningDashboardAccessToken = RandomStringUtils.randomAlphanumeric(12).toLowerCase();
         }
 
+
+        // Check if VirtualBackgrounds is disabled
+        boolean virtualBackgroundsDisabled = false;
+        if (!StringUtils.isEmpty(params.get(ApiParams.VIRTUAL_BACKGROUNDS_DISABLED))) {
+            virtualBackgroundsDisabled = Boolean.valueOf(params.get(ApiParams.VIRTUAL_BACKGROUNDS_DISABLED));
+        }
+
+
         boolean webcamsOnlyForMod = webcamsOnlyForModerator;
         if (!StringUtils.isEmpty(params.get(ApiParams.WEBCAMS_ONLY_FOR_MODERATOR))) {
             try {
@@ -560,6 +568,7 @@ public class ParamsProcessorUtil {
                 .withLearningDashboardEnabled(learningDashboardEn)
                 .withLearningDashboardCleanupDelayInMinutes(learningDashboardCleanupMins)
                 .withLearningDashboardAccessToken(learningDashboardAccessToken)
+                .withVirtualBackgroundsDisabled(virtualBackgroundsDisabled)
                 .build();
 
         if (!StringUtils.isEmpty(params.get(ApiParams.MODERATOR_ONLY_MESSAGE))) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -54,6 +54,7 @@ public class Meeting {
 	private Boolean learningDashboardEnabled;
 	private int learningDashboardCleanupDelayInMinutes;
 	private String learningDashboardAccessToken;
+	private Boolean virtualBackgroundsDisabled;
 	private String welcomeMsgTemplate;
 	private String welcomeMsg;
 	private String modOnlyMessage = "";
@@ -113,6 +114,7 @@ public class Meeting {
         viewerPass = builder.viewerPass;
         moderatorPass = builder.moderatorPass;
 		learningDashboardEnabled = builder.learningDashboardEnabled;
+		virtualBackgroundsDisabled = builder.virtualBackgroundsDisabled;
 		learningDashboardCleanupDelayInMinutes = builder.learningDashboardCleanupDelayInMinutes;
 		learningDashboardAccessToken = builder.learningDashboardAccessToken;
         maxUsers = builder.maxUsers;
@@ -343,6 +345,10 @@ public class Meeting {
 
 	public String getLearningDashboardAccessToken() {
 		return learningDashboardAccessToken;
+	}
+
+	public Boolean getVirtualBackgroundsDisabled() {
+		return virtualBackgroundsDisabled;
 	}
 
   public String getWelcomeMessageTemplate() {
@@ -744,6 +750,7 @@ public class Meeting {
     	private Boolean learningDashboardEnabled;
     	private int learningDashboardCleanupDelayInMinutes;
     	private String learningDashboardAccessToken;
+		private Boolean virtualBackgroundsDisabled;
     	private int duration;
     	private String webVoice;
     	private String telVoice;
@@ -848,6 +855,11 @@ public class Meeting {
 	    	this.learningDashboardAccessToken = t;
 	    	return this;
 	    }
+
+		public Builder withVirtualBackgroundsDisabled(Boolean d) {
+			this.virtualBackgroundsDisabled = d;
+			return this;
+		}
 
     	public Builder withWelcomeMessage(String w) {
     		welcomeMsg = w;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
@@ -34,7 +34,7 @@ public interface IBbbWebApiGWApp {
                      Boolean keepEvents,
                      BreakoutRoomsParams breakoutParams,
                      LockSettingsParams lockSettingsParams,
-                     Integer html5InstanceId);
+                     Integer html5InstanceId, Boolean virtualBackgroundsDisabled);
 
   void registerUser(String meetingID, String internalUserId, String fullname, String role,
                     String externUserID, String authToken, String avatarURL,

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -144,7 +144,8 @@ class BbbWebApiGWApp(
                     keepEvents:                             java.lang.Boolean,
                     breakoutParams:                         BreakoutRoomsParams,
                     lockSettingsParams:                     LockSettingsParams,
-                    html5InstanceId:                        java.lang.Integer): Unit = {
+                    html5InstanceId:                        java.lang.Integer,
+                    virtualBackgroundsDisabled:             java.lang.Boolean): Unit = {
 
     val meetingProp = MeetingProp(name = meetingName, extId = extMeetingId, intId = meetingId,
       isBreakout = isBreakout.booleanValue(), learningDashboardEnabled = learningDashboardEnabled.booleanValue())
@@ -180,7 +181,7 @@ class BbbWebApiGWApp(
     val usersProp = UsersProp(maxUsers = maxUsers.intValue(), webcamsOnlyForModerator = webcamsOnlyForModerator.booleanValue(),
       guestPolicy = guestPolicy, meetingLayout = meetingLayout, allowModsToUnmuteUsers = allowModsToUnmuteUsers.booleanValue(),
       allowModsToEjectCameras = allowModsToEjectCameras.booleanValue(),
-      authenticatedGuest = authenticatedGuest.booleanValue())
+      authenticatedGuest = authenticatedGuest.booleanValue(), virtualBackgroundsDisabled = virtualBackgroundsDisabled.booleanValue())
     val metadataProp = MetadataProp(mapAsScalaMap(metadata).toMap)
     val screenshareProps = ScreenshareProps(
       screenshareConf = voiceBridge + screenshareConfSuffix,

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -63,6 +63,7 @@ export default function addMeeting(meeting) {
       allowModsToUnmuteUsers: Boolean,
       allowModsToEjectCameras: Boolean,
       meetingLayout: String,
+      virtualBackgroundsDisabled: Boolean,
     },
     durationProps: {
       createdTime: Number,

--- a/bigbluebutton-html5/imports/ui/services/virtual-background/service.js
+++ b/bigbluebutton-html5/imports/ui/services/virtual-background/service.js
@@ -1,6 +1,8 @@
 import deviceInfo from '/imports/utils/deviceInfo';
 import browserInfo from '/imports/utils/browserInfo';
 import { createVirtualBackgroundService } from '/imports/ui/services/virtual-background';
+import Meetings from '/imports/api/meetings';
+import Auth from '/imports/ui/services/auth';
 
 const BLUR_FILENAME = 'blur.jpg';
 const EFFECT_TYPES = {
@@ -84,6 +86,13 @@ const getSessionVirtualBackgroundInfoWithDefault = (deviceId) => {
 }
 
 const isVirtualBackgroundEnabled = () => {
+  const meeting = Meetings.findOne({ meetingId: Auth.meetingID },
+    { fields: { 'usersProp.virtualBackgroundsDisabled': 1 } });
+
+  if (meeting?.usersProp && meeting.usersProp.virtualBackgroundsDisabled === true) {
+    return false;
+  }
+
   return VIRTUAL_BACKGROUND_ENABLED;
 }
 


### PR DESCRIPTION
This PR implements a new param called `virtualBackgroundsDisabled` to API.
_By default the value is false._

Options:
**true**: Virtual Backgrounds will be disabled for this meeting.
**false** or absent: Virtual Backgrounds will respect the configs set in `settings.yml`.

Closes #13964.

https://user-images.githubusercontent.com/5660191/149225027-a8ab67b9-7553-40bf-84ff-412d14c04f70.mp4


