### PR TITLE
fix(screenshare): add state sync between bbb-html5 and akka-apps

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
@@ -8,7 +8,8 @@ class ScreenshareApp2x(implicit val context: ActorContext)
   with ScreenshareStoppedVoiceConfEvtMsgHdlr
   with GetScreenshareStatusReqMsgHdlr
   with ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr
-  with ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr {
+  with ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr
+  with SyncGetScreenshareInfoRespMsgHdlr {
 
   val log = Logging(context.system, getClass)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/SyncGetScreenshareInfoRespMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/SyncGetScreenshareInfoRespMsgHdlr.scala
@@ -1,0 +1,37 @@
+package org.bigbluebutton.core.apps.screenshare
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.apps.ScreenshareModel
+import org.bigbluebutton.core.bus.MessageBus
+import org.bigbluebutton.core.running.LiveMeeting
+
+trait SyncGetScreenshareInfoRespMsgHdlr {
+  this: ScreenshareApp2x =>
+
+  def handleSyncGetScreenshareInfoRespMsg(liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
+    val routing = Routing.addMsgToHtml5InstanceIdRouting(
+      liveMeeting.props.meetingProp.intId,
+      liveMeeting.props.systemProps.html5InstanceId.toString
+    )
+    val envelope = BbbCoreEnvelope(SyncGetScreenshareInfoRespMsg.NAME, routing)
+    val header = BbbClientMsgHeader(
+      SyncGetScreenshareInfoRespMsg.NAME,
+      liveMeeting.props.meetingProp.intId,
+      "nodeJSapp"
+    )
+    val body = SyncGetScreenshareInfoRespMsgBody(
+      ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel),
+      ScreenshareModel.getVoiceConf(liveMeeting.screenshareModel),
+      ScreenshareModel.getScreenshareConf(liveMeeting.screenshareModel),
+      ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel),
+      ScreenshareModel.getScreenshareVideoWidth(liveMeeting.screenshareModel),
+      ScreenshareModel.getScreenshareVideoHeight(liveMeeting.screenshareModel),
+      ScreenshareModel.getTimestamp(liveMeeting.screenshareModel),
+      ScreenshareModel.getHasAudio(liveMeeting.screenshareModel)
+    )
+    val event = SyncGetScreenshareInfoRespMsg(header, body)
+    val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+
+    bus.outGW.send(msgEvent)
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -693,7 +693,8 @@ class MeetingActor(
     // sync all lock settings
     handleSyncGetLockSettingsMsg(state, liveMeeting, msgBus)
 
-    // TODO send all screen sharing info
+    // send all screen sharing info
+    screenshareApp2x.handleSyncGetScreenshareInfoRespMsg(liveMeeting, msgBus)
   }
 
   def handleGetAllMeetingsReqMsg(msg: GetAllMeetingsReqMsg): Unit = {

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
@@ -40,6 +40,25 @@ case class ScreenshareRtmpBroadcastStartedEvtMsgBody(voiceConf: String, screensh
                                                      timestamp: String, hasAudio: Boolean)
 
 /**
+ * Sync screenshare state with bbb-html5
+ */
+object SyncGetScreenshareInfoRespMsg { val NAME = "SyncGetScreenshareInfoRespMsg" }
+case class SyncGetScreenshareInfoRespMsg(
+    header: BbbClientMsgHeader,
+    body:   SyncGetScreenshareInfoRespMsgBody
+) extends BbbCoreMsg
+case class SyncGetScreenshareInfoRespMsgBody(
+    isBroadcasting:  Boolean,
+    voiceConf:       String,
+    screenshareConf: String,
+    stream:          String,
+    vidWidth:        Int,
+    vidHeight:       Int,
+    timestamp:       String,
+    hasAudio:        Boolean
+)
+
+/**
  * Send by FS that RTMP stream has stopped.
  */
 object ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg { val NAME = "ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg" }
@@ -166,6 +185,7 @@ case class GetScreenSubscribePermissionRespMsgBody(
     sfuSessionId: String,
     allowed:      Boolean
 )
+
 /**
  * Sent to FS to eject all users from the voice conference.
  */

--- a/bigbluebutton-html5/imports/api/screenshare/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/screenshare/server/eventHandlers.js
@@ -1,6 +1,8 @@
 import RedisPubSub from '/imports/startup/server/redis';
 import handleScreenshareStarted from './handlers/screenshareStarted';
 import handleScreenshareStopped from './handlers/screenshareStopped';
+import handleScreenshareSync from './handlers/screenshareSync';
 
 RedisPubSub.on('ScreenshareRtmpBroadcastStartedEvtMsg', handleScreenshareStarted);
 RedisPubSub.on('ScreenshareRtmpBroadcastStoppedEvtMsg', handleScreenshareStopped);
+RedisPubSub.on('SyncGetScreenshareInfoRespMsg', handleScreenshareSync);

--- a/bigbluebutton-html5/imports/api/screenshare/server/handlers/screenshareSync.js
+++ b/bigbluebutton-html5/imports/api/screenshare/server/handlers/screenshareSync.js
@@ -1,0 +1,19 @@
+import { check } from 'meteor/check';
+import addScreenshare from '../modifiers/addScreenshare';
+import clearScreenshare from '../modifiers/clearScreenshare';
+
+export default function handleScreenshareSync({ body }, meetingId) {
+  check(meetingId, String);
+  check(body, Object);
+
+  const { isBroadcasting, screenshareConf } = body;
+
+  check(screenshareConf, String);
+  check(isBroadcasting, Boolean);
+
+  if (!isBroadcasting) {
+    return clearScreenshare(meetingId, screenshareConf);
+  }
+
+  return addScreenshare(meetingId, body);
+}


### PR DESCRIPTION

### What does this PR do?

Addresses a _TODO_ 5 years in the making.

Partially fixes https://github.com/bigbluebutton/bigbluebutton/issues/14072 which is two different issues in itself.
This targets:
```
Second way to reproduce:
4b. restart bbb-html5* services (sudo systemctl restart bbb-html5*) or technically just the backend the meeting is on
The meeting should recover (depending on the .service including #13527) but nobody will be able to take control of the presentation area because akka-apps(?) has on record that screenshare is 
```

A fix for the presenter disconnection (which is kind of _unclear_ on how to reproduce since not all disconnections cause that to happen) will land in a separate PR.

### Closes Issue(s)

Partially addresses https://github.com/bigbluebutton/bigbluebutton/issues/14072

### Motivation

Noitavitom
