### PR TITLE
fix(webcam): unresponsive webcam selector button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -217,6 +217,7 @@ class VideoPreview extends Component {
   componentDidMount() {
     const {
       webcamDeviceId,
+      forceOpen,
     } = this.props;
 
     this._isMounted = true;
@@ -225,7 +226,7 @@ class VideoPreview extends Component {
       navigator.mediaDevices.enumerateDevices().then((devices) => {
         VideoService.updateNumberOfDevices(devices);
         // Video preview skip is activated, short circuit via a simpler procedure
-        if (PreviewService.getSkipVideoPreview()) return this.skipVideoPreview();
+        if (PreviewService.getSkipVideoPreview() && !forceOpen) return this.skipVideoPreview();
         // Late enumerateDevices resolution, stop.
         if (!this._isMounted) return;
 
@@ -717,6 +718,7 @@ class VideoPreview extends Component {
       intl,
       sharedDevices,
       hasVideoStream,
+      forceOpen,
     } = this.props;
 
     const {
@@ -725,7 +727,9 @@ class VideoPreview extends Component {
       deviceError,
       previewError,
     } = this.state;
-    const shouldDisableButtons = PreviewService.getSkipVideoPreview() && !(deviceError || previewError);
+    const shouldDisableButtons = PreviewService.getSkipVideoPreview()
+    && !forceOpen
+    && !(deviceError || previewError);
 
     const shared = sharedDevices.includes(webcamDeviceId);
 
@@ -785,6 +789,7 @@ class VideoPreview extends Component {
     const {
       intl,
       isCamLocked,
+      forceOpen,
     } = this.props;
 
     if (isCamLocked === true) {
@@ -792,7 +797,7 @@ class VideoPreview extends Component {
       return null;
     }
 
-    if (PreviewService.getSkipVideoPreview()) {
+    if (PreviewService.getSkipVideoPreview() && !forceOpen) {
       return null;
     }
 
@@ -801,7 +806,9 @@ class VideoPreview extends Component {
       previewError,
     } = this.state;
 
-    const allowCloseModal = !!(deviceError || previewError) || !PreviewService.getSkipVideoPreview();
+    const allowCloseModal = !!(deviceError || previewError)
+    || !PreviewService.getSkipVideoPreview()
+    || forceOpen;
 
     return (
       <Modal

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
@@ -49,6 +49,7 @@ const propTypes = {
   intl: PropTypes.object.isRequired,
   hasVideoStream: PropTypes.bool.isRequired,
   mountVideoPreview: PropTypes.func.isRequired,
+  forceMountVideoPreview: PropTypes.func.isRequired,
 };
 
 const JoinVideoButton = ({
@@ -56,6 +57,7 @@ const JoinVideoButton = ({
   hasVideoStream,
   disableReason,
   mountVideoPreview,
+  forceMountVideoPreview,
 }) => {
   const { isMobile } = deviceInfo;
   const shouldEnableWebcamSelectorButton = ENABLE_WEBCAM_SELECTOR_BUTTON
@@ -79,7 +81,7 @@ const JoinVideoButton = ({
 
   const handleOpenAdvancedOptions = (e) => {
     e.stopPropagation();
-    mountVideoPreview();
+    forceMountVideoPreview();
   };
 
   let label = exitVideo()

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/container.jsx
@@ -15,11 +15,12 @@ const JoinVideoOptionsContainer = (props) => {
     ...restProps
   } = props;
 
-  const mountVideoPreview = () => { mountModal(<VideoPreviewContainer />); };
+  const mountVideoPreview = () => { mountModal(<VideoPreviewContainer forceOpen={false} />); };
+  const forceMountVideoPreview = () => { mountModal(<VideoPreviewContainer forceOpen />); };
 
   return (
     <JoinVideoButton {...{
-      mountVideoPreview, hasVideoStream, disableReason, ...restProps,
+      mountVideoPreview, forceMountVideoPreview, hasVideoStream, disableReason, ...restProps,
     }}
     />
   );


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Forces the video preview modal opening when triggered by the webcam selector button regardless of skip video preview userdata. This fixes webcam selector button with no action when skip video preview is set(`usedata-bbb_skip_video_preview=true`).

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #14073
