### PR TITLE
fix: html5 client loads outdated language file from browser cache after update

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/intl.jsx
+++ b/bigbluebutton-html5/imports/startup/client/intl.jsx
@@ -16,6 +16,7 @@ const propTypes = {
 };
 
 const DEFAULT_LANGUAGE = Meteor.settings.public.app.defaultSettings.application.fallbackLocale;
+const CLIENT_VERSION = Meteor.settings.public.app.html5ClientBuild;
 
 const RTL_LANGUAGES = ['ar', 'dv', 'fa', 'he'];
 const LARGE_FONT_LANGUAGES = ['te', 'km'];
@@ -73,7 +74,7 @@ class IntlStartup extends Component {
         })
         .then(({ normalizedLocale, regionDefaultLocale }) => {
           const fetchFallbackMessages = new Promise((resolve, reject) => {
-            fetch(`${localesPath}/${DEFAULT_LANGUAGE}.json`)
+            fetch(`${localesPath}/${DEFAULT_LANGUAGE}.json?v=${CLIENT_VERSION}`)
               .then((response) => {
                 if (!response.ok) {
                   return reject();
@@ -86,7 +87,7 @@ class IntlStartup extends Component {
             if (!regionDefaultLocale) {
               return resolve(false);
             }
-            fetch(`${localesPath}/${regionDefaultLocale}.json`)
+            fetch(`${localesPath}/${regionDefaultLocale}.json?v=${CLIENT_VERSION}`)
               .then((response) => {
                 if (!response.ok) {
                   return resolve(false);
@@ -104,7 +105,7 @@ class IntlStartup extends Component {
             if (!normalizedLocale || normalizedLocale === DEFAULT_LANGUAGE || normalizedLocale === regionDefaultLocale) {
               return resolve(false);
             }
-            fetch(`${localesPath}/${normalizedLocale}.json`)
+            fetch(`${localesPath}/${normalizedLocale}.json?v=${CLIENT_VERSION}`)
               .then((response) => {
                 if (!response.ok) {
                   return resolve(false);

--- a/bigbluebutton-html5/imports/ui/components/legacy/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/legacy/component.jsx
@@ -71,6 +71,7 @@ const FALLBACK = 'fallback';
 const READY = 'ready';
 const supportedBrowsers = ['Chrome', 'Firefox', 'Safari', 'Opera', 'Microsoft Edge', 'Yandex Browser'];
 const DEFAULT_LANGUAGE = Meteor.settings.public.app.defaultSettings.application.fallbackLocale;
+const CLIENT_VERSION = Meteor.settings.public.app.html5ClientBuild;
 
 export default class Legacy extends Component {
   constructor(props) {
@@ -93,7 +94,7 @@ export default class Legacy extends Component {
         return response.json();
       })
       .then(({ normalizedLocale, regionDefaultLocale }) => {
-        fetch(`${localesPath}/${DEFAULT_LANGUAGE}.json`)
+        fetch(`${localesPath}/${DEFAULT_LANGUAGE}.json?v=${CLIENT_VERSION}`)
           .then((response) => {
             if (!response.ok) {
               return Promise.reject();
@@ -102,7 +103,7 @@ export default class Legacy extends Component {
           })
           .then((messages) => {
             if (regionDefaultLocale !== '') {
-              fetch(`${localesPath}/${regionDefaultLocale}.json`)
+              fetch(`${localesPath}/${regionDefaultLocale}.json?v=${CLIENT_VERSION}`)
                 .then((response) => {
                   if (!response.ok) {
                     return Promise.resolve();
@@ -116,7 +117,7 @@ export default class Legacy extends Component {
             }
 
             if (normalizedLocale && normalizedLocale !== DEFAULT_LANGUAGE && normalizedLocale !== regionDefaultLocale) {
-              fetch(`${localesPath}/${normalizedLocale}.json`)
+              fetch(`${localesPath}/${normalizedLocale}.json?v=${CLIENT_VERSION}`)
                 .then((response) => {
                   if (!response.ok) {
                     return Promise.reject();


### PR DESCRIPTION
### What does this PR do?

Appends build string to locales requests, preventing an issue where an old translation file would stay in browser cache after BBB version update.

### Closes Issue(s)
Closes #13984