### PR TITLE
fix(webcam): unresponsive camera button on mobile

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
@@ -66,6 +66,7 @@ const JoinVideoButton = ({
   const exitVideo = () => hasVideoStream
     && !isMobile
     && (!VideoService.isMultipleCamerasEnabled() || shouldEnableWebcamSelectorButton);
+  const isMobileSharingCamera = hasVideoStream && isMobile;
 
   const handleOnClick = debounce(() => {
     if (!validIOSVersion()) {
@@ -74,6 +75,8 @@ const JoinVideoButton = ({
 
     if (exitVideo()) {
       VideoService.exitVideo();
+    } else if (isMobileSharingCamera) {
+      forceMountVideoPreview();
     } else {
       mountVideoPreview();
     }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Fixes #14084 by option 1.
Makes the camera button on mobile always open the video preview modal If the user is already sharing camera.
This allows mobile users to switch virtual backgrounds.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #14084
