### PR TITLE
Fix: Removing phone users always bans them

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/SelectRandomViewerReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/SelectRandomViewerReqMsgHdlr.scala
@@ -50,7 +50,7 @@ trait SelectRandomViewerReqMsgHdlr extends RightsManagementTrait {
           Users2x.setUserExempted(liveMeeting.users2x, pickedUser, true)
         }
       }
-      
+
       val userIds = users.map { case (v) => v.intId }
       broadcastEvent(msg, userIds, pickedUser)
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -174,7 +174,7 @@ object Users2x {
       newUser
     }
   }
-  
+
   def hasPresenter(users: Users2x): Boolean = {
     findPresenter(users) match {
       case Some(p) => true

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/EjectUserFromVoiceCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/EjectUserFromVoiceCmdMsgHdlr.scala
@@ -22,10 +22,16 @@ trait EjectUserFromVoiceCmdMsgHdlr extends RightsManagementTrait {
       for {
         u <- VoiceUsers.findWithIntId(liveMeeting.voiceUsers, msg.body.userId)
       } yield {
-        log.info("Ejecting user from voice.  meetingId=" + props.meetingProp.intId + " userId=" + u.intId)
-        VoiceUsers.ban(liveMeeting.voiceUsers, u)
-        val event = MsgBuilder.buildEjectUserFromVoiceConfSysMsg(props.meetingProp.intId, props.voiceProp.voiceConf, u.voiceUserId)
-        outGW.send(event)
+        if (msg.body.banUser) {
+          log.info("Ejecting and banning user from voice.  meetingId=" + props.meetingProp.intId + " userId=" + u.intId)
+          VoiceUsers.ban(liveMeeting.voiceUsers, u)
+          val event = MsgBuilder.buildEjectUserFromVoiceConfSysMsg(props.meetingProp.intId, props.voiceProp.voiceConf, u.voiceUserId)
+          outGW.send(event)
+        } else {
+          log.info("Ejecting user from voice.  meetingId=" + props.meetingProp.intId + " userId=" + u.intId)
+          val event = MsgBuilder.buildEjectUserFromVoiceConfSysMsg(props.meetingProp.intId, props.voiceProp.voiceConf, u.voiceUserId)
+          outGW.send(event)
+        }
       }
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/EjectUserFromVoiceCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/EjectUserFromVoiceCmdMsgHdlr.scala
@@ -22,15 +22,11 @@ trait EjectUserFromVoiceCmdMsgHdlr extends RightsManagementTrait {
       for {
         u <- VoiceUsers.findWithIntId(liveMeeting.voiceUsers, msg.body.userId)
       } yield {
+        log.info("Ejecting user from voice.  meetingId=" + props.meetingProp.intId + " userId=" + u.intId + " ban=" + msg.body.banUser)
+        val event = MsgBuilder.buildEjectUserFromVoiceConfSysMsg(props.meetingProp.intId, props.voiceProp.voiceConf, u.voiceUserId)
+        outGW.send(event)
         if (msg.body.banUser) {
-          log.info("Ejecting and banning user from voice.  meetingId=" + props.meetingProp.intId + " userId=" + u.intId)
           VoiceUsers.ban(liveMeeting.voiceUsers, u)
-          val event = MsgBuilder.buildEjectUserFromVoiceConfSysMsg(props.meetingProp.intId, props.voiceProp.voiceConf, u.voiceUserId)
-          outGW.send(event)
-        } else {
-          log.info("Ejecting user from voice.  meetingId=" + props.meetingProp.intId + " userId=" + u.intId)
-          val event = MsgBuilder.buildEjectUserFromVoiceConfSysMsg(props.meetingProp.intId, props.voiceProp.voiceConf, u.voiceUserId)
-          outGW.send(event)
         }
       }
     }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
@@ -184,7 +184,7 @@ case class EjectUserFromVoiceCmdMsg(
     header: BbbClientMsgHeader,
     body:   EjectUserFromVoiceCmdMsgBody
 ) extends StandardMsg
-case class EjectUserFromVoiceCmdMsgBody(userId: String, ejectedBy: String)
+case class EjectUserFromVoiceCmdMsgBody(userId: String, ejectedBy: String, banUser: Boolean)
 
 /**
  * Sent by client to mute all users except presenters in the voice conference.

--- a/bigbluebutton-html5/imports/api/voice-users/server/methods/ejectUserFromVoice.js
+++ b/bigbluebutton-html5/imports/api/voice-users/server/methods/ejectUserFromVoice.js
@@ -4,7 +4,7 @@ import RedisPubSub from '/imports/startup/server/redis';
 import { extractCredentials } from '/imports/api/common/server/helpers';
 import Logger from '/imports/startup/server/logger';
 
-export default function ejectUserFromVoice(userId) {
+export default function ejectUserFromVoice(userId, banUser) {
   try {
     const REDIS_CONFIG = Meteor.settings.private.redis;
     const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
@@ -15,10 +15,12 @@ export default function ejectUserFromVoice(userId) {
     check(meetingId, String);
     check(requesterUserId, String);
     check(userId, String);
+    check(banUser, Boolean);
 
     const payload = {
       userId,
       ejectedBy: requesterUserId,
+      banUser,
     };
 
     RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -30,9 +30,9 @@ const STARTED_CHAT_LIST_KEY = 'startedChatList';
 
 const CUSTOM_LOGO_URL_KEY = 'CustomLogoUrl';
 
-export const setCustomLogoUrl = path => Storage.setItem(CUSTOM_LOGO_URL_KEY, path);
+export const setCustomLogoUrl = (path) => Storage.setItem(CUSTOM_LOGO_URL_KEY, path);
 
-export const setModeratorOnlyMessage = msg => Storage.setItem('ModeratorOnlyMessage', msg);
+export const setModeratorOnlyMessage = (msg) => Storage.setItem('ModeratorOnlyMessage', msg);
 
 const getCustomLogoUrl = () => Storage.getItem(CUSTOM_LOGO_URL_KEY);
 
@@ -304,7 +304,7 @@ const isMeetingLocked = (id) => {
   let isLocked = false;
 
   if (meeting.lockSettingsProps !== undefined) {
-    const {lockSettingsProps:lockSettings, usersProp} = meeting;
+    const { lockSettingsProps: lockSettings, usersProp } = meeting;
 
     if (lockSettings.disableCam
       || lockSettings.disableMic
@@ -447,7 +447,7 @@ const assignPresenter = (userId) => { makeCall('assignPresenter', userId); };
 
 const removeUser = (userId, banUser) => {
   if (isVoiceOnlyUser(userId)) {
-    makeCall('ejectUserFromVoice', userId);
+    makeCall('ejectUserFromVoice', userId, banUser);
   } else {
     makeCall('removeUser', userId, banUser);
   }


### PR DESCRIPTION
Closes #14002
<h3>What does this PR do?</h3>
Fixes the issue where users have been getting banned from the meeting after being removed, while connected via phone call

<h3>Motivation</h3>
Previously: If moderator removed a user connected via phone-call - user would get banned regardless of the moderator's choice

Currently: Moderator can choose whether the user will be able to reconnect after getting banned.