### PR TITLE
build: Added auto restart of bbb-html5-backend and frontend on failure

### DIFF
--- a/build/packages-template/bbb-html5/bionic/bbb-html5-backend@.service
+++ b/build/packages-template/bbb-html5/bionic/bbb-html5-backend@.service
@@ -3,6 +3,9 @@ Description=BigBlueButton HTML5 service, backend instance %i
 Requires=bbb-html5.service
 Before=bbb-html5.service
 BindsTo=bbb-html5.service
+StartLimitBurst=4
+StartLimitInterval=70sec
+StartLimitAction=exit
 
 [Service]
 PermissionsStartOnly=true
@@ -14,6 +17,7 @@ WorkingDirectory=/usr/share/meteor/bundle
 StandardOutput=syslog
 StandardError=syslog
 TimeoutStartSec=10
+Restart=on-failure
 RestartSec=10
 User=meteor
 Group=meteor

--- a/build/packages-template/bbb-html5/bionic/bbb-html5-frontend@.service
+++ b/build/packages-template/bbb-html5/bionic/bbb-html5-frontend@.service
@@ -3,6 +3,9 @@ Description=BigBlueButton HTML5 service, frontend instance %i
 Requires=bbb-html5.service
 Before=bbb-html5.service
 BindsTo=bbb-html5.service
+StartLimitBurst=4
+StartLimitInterval=70sec
+StartLimitAction=exit
 
 [Service]
 PermissionsStartOnly=true
@@ -14,6 +17,7 @@ WorkingDirectory=/usr/share/meteor/bundle
 StandardOutput=syslog
 StandardError=syslog
 TimeoutStartSec=10
+Restart=on-failure
 RestartSec=10
 User=meteor
 Group=meteor


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Restarts a failing bbb-html5* sevice (check the constraints) to restore the capacity of a server.
In BBB 2.3 we encountered a number of bbb-html5* crashes (OOM, etc) which were inconvenient, especially the bbb-html5-backend ones.

Credits to @zhem0004 . Cherrypicking the original PR was a bit messy though, so I included the changes in 1 commit.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
Backport of #13527
This change is also included in the packaging for BBB 2.4 as of BBB 2.4.1, so including this PR in the open source build scripts   keeps the sync.

<!-- What inspired you to submit this pull request? -->

