### PR TITLE
fix(screenshare): add akka-apps|webrtc-sfu broadcast stop sys msg

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/ScreenshareModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/ScreenshareModel.scala
@@ -91,24 +91,6 @@ object ScreenshareModel {
   def getHasAudio(status: ScreenshareModel): Boolean = {
     status.hasAudio
   }
-
-  def stop(outGW: OutMsgRouter, liveMeeting: LiveMeeting): Unit = {
-    if (isBroadcastingRTMP(liveMeeting.screenshareModel)) {
-      this.resetDesktopSharingParams(liveMeeting.screenshareModel)
-
-      val event = MsgBuilder.buildStopScreenshareRtmpBroadcastEvtMsg(
-        liveMeeting.props.meetingProp.intId,
-        getVoiceConf(liveMeeting.screenshareModel),
-        getScreenshareConf(liveMeeting.screenshareModel),
-        getRTMPBroadcastingUrl(liveMeeting.screenshareModel),
-        getScreenshareVideoWidth(liveMeeting.screenshareModel),
-        getScreenshareVideoHeight(liveMeeting.screenshareModel),
-        getTimestamp(liveMeeting.screenshareModel)
-      )
-      outGW.send(event)
-    }
-  }
-
 }
 
 class ScreenshareModel {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/externalvideo/StartExternalVideoPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/externalvideo/StartExternalVideoPubMsgHdlr.scala
@@ -1,9 +1,10 @@
 package org.bigbluebutton.core.apps.externalvideo
 
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.apps.{ ExternalVideoModel, PermissionCheck, RightsManagementTrait, ScreenshareModel }
+import org.bigbluebutton.core.apps.{ ExternalVideoModel, PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.running.LiveMeeting
+import org.bigbluebutton.core.apps.screenshare.ScreenshareApp2x.{ requestBroadcastStop }
 
 trait StartExternalVideoPubMsgHdlr extends RightsManagementTrait {
   this: ExternalVideoApp2x =>
@@ -29,8 +30,9 @@ trait StartExternalVideoPubMsgHdlr extends RightsManagementTrait {
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
     } else {
 
-      //Stop ScreenShare if it's running
-      ScreenshareModel.stop(bus.outGW, liveMeeting)
+      // Request a screen broadcast stop (goes to SFU, comes back through
+      // ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg)
+      requestBroadcastStop(bus.outGW, liveMeeting)
 
       ExternalVideoModel.setURL(liveMeeting.externalVideoModel, msg.body.externalVideoUrl)
       broadcastEvent(msg)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
@@ -2,6 +2,40 @@ package org.bigbluebutton.core.apps.screenshare
 
 import akka.actor.ActorContext
 import akka.event.Logging
+import org.bigbluebutton.core.apps.ScreenshareModel
+import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
+
+
+object ScreenshareApp2x {
+  def requestBroadcastStop(outGW: OutMsgRouter, liveMeeting: LiveMeeting): Unit = {
+    if (ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel)) {
+      val event = MsgBuilder.buildScreenBroadcastStopSysMsg(
+        liveMeeting.props.meetingProp.intId,
+        ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel),
+      )
+
+      outGW.send(event)
+    }
+  }
+
+  def broadcastStopped(outGW: OutMsgRouter, liveMeeting: LiveMeeting): Unit = {
+    if (ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel)) {
+      ScreenshareModel.resetDesktopSharingParams(liveMeeting.screenshareModel)
+
+      val event = MsgBuilder.buildStopScreenshareRtmpBroadcastEvtMsg(
+        liveMeeting.props.meetingProp.intId,
+        ScreenshareModel.getVoiceConf(liveMeeting.screenshareModel),
+        ScreenshareModel.getScreenshareConf(liveMeeting.screenshareModel),
+        ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel),
+        ScreenshareModel.getScreenshareVideoWidth(liveMeeting.screenshareModel),
+        ScreenshareModel.getScreenshareVideoHeight(liveMeeting.screenshareModel),
+        ScreenshareModel.getTimestamp(liveMeeting.screenshareModel)
+      )
+      outGW.send(event)
+    }
+  }
+}
 
 class ScreenshareApp2x(implicit val context: ActorContext)
   extends ScreenshareStartedVoiceConfEvtMsgHdlr

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr.scala
@@ -5,32 +5,16 @@ import org.bigbluebutton.core.apps.ScreenshareModel
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.core2.message.senders.MsgBuilder
+import org.bigbluebutton.core.apps.screenshare.ScreenshareApp2x.{ broadcastStopped }
 
 trait ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr {
   this: ScreenshareApp2x =>
 
   def handle(msg: ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
-
     log.info("handleScreenshareRTMPBroadcastStoppedRequest: isBroadcastingRTMP=" +
       ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel) + " URL:" +
       ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel))
 
-    // only valid if currently broadcasting
-    if (ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel)) {
-      log.info("STOP broadcast ALLOWED when isBroadcastingRTMP=true")
-      ScreenshareModel.broadcastingRTMPStopped(liveMeeting.screenshareModel)
-
-      // notify viewers that RTMP broadcast stopped
-      val msgEvent = MsgBuilder.buildStopScreenshareRtmpBroadcastEvtMsg(
-        liveMeeting.props.meetingProp.intId,
-        msg.body.voiceConf, msg.body.screenshareConf, msg.body.stream,
-        msg.body.vidWidth, msg.body.vidHeight, msg.body.timestamp
-      )
-
-      bus.outGW.send(msgEvent)
-    } else {
-      log.info("STOP broadcast NOT ALLOWED when isBroadcastingRTMP=false")
-    }
+    broadcastStopped(bus.outGW, liveMeeting)
   }
-
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AssignPresenterReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AssignPresenterReqMsgHdlr.scala
@@ -7,6 +7,7 @@ import org.bigbluebutton.core.models.{ PresentationPod, UserState, Users2x }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.domain.MeetingState2x
+import org.bigbluebutton.core.apps.screenshare.ScreenshareApp2x.{ requestBroadcastStop }
 
 trait AssignPresenterReqMsgHdlr extends RightsManagementTrait {
   this: UsersApp =>
@@ -72,6 +73,9 @@ object AssignPresenterActionHandler extends RightsManagementTrait {
         if (oldPres.intId != newPresenterId) {
           // Stop external video if it's running
           ExternalVideoModel.stop(outGW, liveMeeting)
+          // Request a screen broadcast stop (goes to SFU, comes back through
+          // ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg)
+          requestBroadcastStop(outGW, liveMeeting)
 
           Users2x.makeNotPresenter(liveMeeting.users2x, oldPres.intId)
           broadcastOldPresenterChange(oldPres)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -610,4 +610,17 @@ object MsgBuilder {
 
     BbbCommonEnvCoreMsg(envelope, event)
   }
+
+  def buildScreenBroadcastStopSysMsg(
+      meetingId: String,
+      streamId:  String
+  ): BbbCommonEnvCoreMsg = {
+    val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
+    val envelope = BbbCoreEnvelope(ScreenBroadcastStopSysMsg.NAME, routing)
+    val body = ScreenBroadcastStopSysMsgBody(meetingId, streamId)
+    val header = BbbCoreBaseHeader(ScreenBroadcastStopSysMsg.NAME)
+    val event = ScreenBroadcastStopSysMsg(header, body)
+
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
 }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
@@ -187,6 +187,19 @@ case class GetScreenSubscribePermissionRespMsgBody(
 )
 
 /**
+ * Sent to bbb-webrtc-sfu to tear down screen stream #streamId
+ */
+object ScreenBroadcastStopSysMsg { val NAME = "ScreenBroadcastStopSysMsg" }
+case class ScreenBroadcastStopSysMsg(
+    header: BbbCoreBaseHeader,
+    body:   ScreenBroadcastStopSysMsgBody
+) extends BbbCoreMsg
+case class ScreenBroadcastStopSysMsgBody(
+    meetingId: String,
+    streamId:  String
+)
+
+/**
  * Sent to FS to eject all users from the voice conference.
  */
 object EjectAllFromVoiceConfMsg { val NAME = "EjectAllFromVoiceConfMsg" }


### PR DESCRIPTION
### What does this PR do?

- Adds a server-side screen share broadcast ejection procedure between akka-apps and webrtc-sfu
  * akka-apps now requests an internal stream shutdown _before_ notifying a broadcast stop to the client
  * Current behavior is notify the client and then hope the stream closes
- akka-apps: change screen broadcast shutdown trigger on external video start to the new approach
- akka-apps: add a screen broadcast shutdown trigger when the presenter changes
- akka-apps: small refactor in `ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr`

### Closes Issue(s)

Partially addresses #14072 (hopefully)

### Motivation

#14072

### More

Needs https://github.com/bigbluebutton/bbb-webrtc-sfu/commit/b9238526ae71631e56f9e78a774ea21a2e1652d0 (still untagged) to be effective; development branch.