### PR TITLE
[2.5] chore(bbb-html5): enable camera pin/screenshare volume control by default

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -225,7 +225,7 @@ public:
       maxTimeout: 60000
     screenshare:
       # Whether volume control should be allowed if screen sharing has audio
-      enableVolumeControl: false
+      enableVolumeControl: true
       # Experimental. True is the canonical behavior. Flip to false to reverse
       # the negotiation flow for subscribers.
       subscriberOffering: false
@@ -332,7 +332,7 @@ public:
     enableScreensharing: true
     enableVideo: true
     enableVideoMenu: true
-    enableVideoPin: false
+    enableVideoPin: true
     enableListenOnly: true
     # Experimental. Server wide configuration to choose which bbb-webrtc-sfu
     # media server adapter should be used for listen only.


### PR DESCRIPTION
### What does this PR do?

Enable camera pin and screenshare volume control features by default.

They were added in v2.4.x as hidden/false-by-default features since they were late to the party,
but they should be enabled by default in v2.5.

### Closes Issue(s)

None