### PR TITLE
fix: Keep the state of the presentation after sharing the screen

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -72,6 +72,7 @@ class ScreenshareComponent extends React.Component {
   constructor() {
     super();
     this.state = {
+      restoreOnUnmount: true,
       loaded: false,
       autoplayBlocked: false,
       isStreamHealthy: false,
@@ -112,7 +113,10 @@ class ScreenshareComponent extends React.Component {
 
     notify(intl.formatMessage(intlMessages.screenshareStarted), 'info', 'desktop');
 
-    if (getSwapLayout()) toggleSwapLayout(layoutContextDispatch);
+    if (getSwapLayout()) {
+      toggleSwapLayout(layoutContextDispatch)
+      this.setState({ restoreOnUnmount: false });
+    };
 
     if (hidePresentation) {
       layoutContextDispatch({
@@ -132,7 +136,14 @@ class ScreenshareComponent extends React.Component {
   }
 
   componentWillUnmount() {
-    const { intl, fullscreenContext, layoutContextDispatch, hidePresentation } = this.props;
+    const {
+      intl,
+      fullscreenContext,
+      layoutContextDispatch,
+      hidePresentation,
+      toggleSwapLayout,
+    } = this.props;
+    const { restoreOnUnmount } = this.state;
     screenshareHasEnded();
     window.removeEventListener('screensharePlayFailed', this.handlePlayElementFailed);
     unsubscribeFromStreamStateChange('screenshare', this.onStreamStateChange);
@@ -149,11 +160,12 @@ class ScreenshareComponent extends React.Component {
       });
     }
 
-    if (hidePresentation) {
+    if (hidePresentation || !restoreOnUnmount) {
       layoutContextDispatch({
         type: ACTIONS.SET_PRESENTATION_IS_OPEN,
         value: false,
       });
+      toggleSwapLayout(layoutContextDispatch);
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

Changes what happens when screenshare ends (like it was in bbb 2.2).

#### before
Presentation is restored after screenshare ends (even if it was hidden when screenshare started).

#### after
If the presentation is closed when screenshare starts, it will not be restored after screenshare ends.

### Closes Issue(s)
Closes #14069