### PR TITLE
fix: change log level from 'error' to 'warn'

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/authenticated-handler/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/authenticated-handler/component.jsx
@@ -41,7 +41,9 @@ class AuthenticatedHandler extends Component {
     AuthenticatedHandler.addReconnectObservable();
 
     const setReason = (reason) => {
-      logger.error({
+      const log = reason.error === 403 ? 'warn' : 'error';
+      
+      logger[log]({
         logCode: 'authenticatedhandlercomponent_setreason',
         extraInfo: { reason },
       }, 'Encountered error while trying to authenticate');

--- a/bigbluebutton-html5/imports/ui/components/error-screen/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/error-screen/component.jsx
@@ -56,9 +56,10 @@ const defaultProps = {
 class ErrorScreen extends PureComponent {
   componentDidMount() {
     const { code } = this.props;
+    const log = code === 403 ? 'warn' : 'error';
     AudioManager.exitAudio();
     Meteor.disconnect();
-    logger.error({ logCode: 'startup_client_usercouldnotlogin_error' }, `User could not log in HTML5, hit ${code}`);
+    logger[log]({ logCode: 'startup_client_usercouldnotlogin_error' }, `User could not log in HTML5, hit ${code}`);
   }
 
   render() {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

If a user tries to rejoin the meeting after being removed, some logs will be logged with the level of 'error'. This PR changes the level to 'warn'.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #13944


### Motivation

Those logs don't seem to be 'errors'. So, They don't need to be treated as such.