### PR TITLE
Fix: Improve typing input behavior of poll option text fields

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -197,7 +197,7 @@ const FILE_DRAG_AND_DROP_ENABLED = POLL_SETTINGS.allowDragAndDropFile;
 
 const validateInput = (i) => {
   let _input = i;
-  if (/^\s/.test(_input)) _input = '';
+  while (/^\s/.test(_input)) _input = _input.substring(1);
   return _input;
 };
 
@@ -280,9 +280,18 @@ class Poll extends Component {
     const { pollTypes } = this.props;
     const list = [...optList];
     const validatedVal = validateInput(e.target.value).replace(/\s{2,}/g, ' ');
+    const charsRemovedCount = e.target.value.length - validatedVal.length;
     const clearError = validatedVal.length > 0 && type !== pollTypes.Response;
+    const input = e.target;
+    const caretStart = e.target.selectionStart;
+    const caretEnd = e.target.selectionEnd;
     list[index] = { val: validatedVal };
-    this.setState({ optList: list, error: clearError ? null : error });
+    this.setState({ optList: list, error: clearError ? null : error },
+      () => {
+        input.focus();
+        input.selectionStart = caretStart - charsRemovedCount;
+        input.selectionEnd = caretEnd - charsRemovedCount;
+      });
   }
 
   handleTextareaChange(e) {


### PR DESCRIPTION
### What does this PR do?
Fixes strange typing behavior in poll option text fields

### Closes Issue(s)
Closes #14098

### Motivation
Find a bug, fix it

### More
The intention of the existing part of code probably(!) was to
1) avoid multiple whitespaces
2) avoid leading whitespaces

The problem of the current implementation is that this is already done while the user is typing and not when submitting the poll which leads to the problematic behavior described in #14098.

Now improved:
- You still can't enter multiple whitespaces
- You can't insert whitespaces at the beginning
- Hitting a whitespace at the beginning when already having some text will now not remove the text, but just ignore the whitespace input
- Even if you copy and paste text into the input field, leading and doubled whitespaces will be properly removed (before that PR pasting wouldn't have worked if the string contained leading whitespaces, for example)
- It's still possible to have one trailing whitespace (IMHO not problematic, that's just like it is right now, I don't see an easy way to prevent that anyway)

Additional thoughts: This still is a somehow atypical behavior of a text input field. Another possibility would be to remove the whitespaces only when sending the poll and avoid influencing the typing of the user at all (maybe keep the rule that you can't start with spaces). Let me know, if you have an opinion on this. I can rewrite this, no problem.

Additional tests are welcome as there might be some edge cases I've missed.

This probably should be ported to 2.5 as well. Don't have a server to test, but probably the same bug exists in current `develop` branch.