### PR TITLE
Fix: ensure services can't modify their code

### DIFF
--- a/build/packages-template/bbb-etherpad/after-install.sh
+++ b/build/packages-template/bbb-etherpad/after-install.sh
@@ -1,6 +1,12 @@
 #!/bin/bash -e
 
-chown -R etherpad:etherpad /usr/share/etherpad-lite
+chown etherpad:etherpad /usr/share/etherpad-lite/APIKEY.txt
+# minified assets
+chown -R etherpad:etherpad /usr/share/etherpad-lite/var
+# npm update wants to write this
+chown -R etherpad:etherpad /usr/share/etherpad-lite/.config
+# etherpad wants to write to this
+chown -R etherpad:etherpad /usr/share/etherpad-lite/node_modules
 chown root:root /usr/lib/systemd/system/etherpad.service
 
 SOURCE=/tmp/settings.json

--- a/build/packages-template/bbb-etherpad/opts-bionic.sh
+++ b/build/packages-template/bbb-etherpad/opts-bionic.sh
@@ -1,5 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -d yq,tidy -t deb --deb-user etherpad --deb-group etherpad --deb-use-file-permissions"
-# OPTS="$OPTS -d yq,redis-server,libreoffice,tidy -t deb --deb-user etherpad --deb-group etherpad --deb-use-file-permissions"
-
+OPTS="$OPTS -d yq,tidy -t deb"

--- a/build/packages-template/bbb-freeswitch-core/after-install.sh
+++ b/build/packages-template/bbb-freeswitch-core/after-install.sh
@@ -46,7 +46,9 @@ case "$1" in
 
 
     chown freeswitch:daemon /var/freeswitch/meetings
-    chown -R freeswitch:daemon /opt/freeswitch
+    chown -R freeswitch:daemon /opt/freeswitch/var
+    chown -R freeswitch:daemon /opt/freeswitch/etc
+    chmod -R g-rwx,o-rwx /opt/freeswitch/etc
   ;;
 
   abort-upgrade|abort-remove|abort-deconfigure)

--- a/build/packages-template/bbb-freeswitch-core/opts-bionic.sh
+++ b/build/packages-template/bbb-freeswitch-core/opts-bionic.sh
@@ -8,6 +8,5 @@
 # reprepro --priority optional -b /var/lib/jenkins/reprepro_dev/m22/bionic-2.3.0 includedeb bigbluebutton-bionic *
 
 
-#OPTS="$OPTS -t deb -d xmlstarlet,libfreetype6,libcurl3,libspeex1,libspeexdsp1,libopus0,libopusfile0,libopusenc0,libsndfile1,liblua5.2-0,libjbig0,libldns1,bbb-freeswitch-sounds --deb-user freeswitch --deb-group daemon --deb-use-file-permissions"
-OPTS="$OPTS -t deb -d xmlstarlet,libfreetype6,libcurl4,libspeex1,libspeexdsp1,libopus0,libsndfile1,libopusenc0,libopusfile0,liblua5.2-0,libjbig0,libldns2,bbb-freeswitch-sounds --deb-user freeswitch --deb-group daemon --deb-use-file-permissions"
+OPTS="$OPTS -t deb -d xmlstarlet,libfreetype6,libcurl4,libspeex1,libspeexdsp1,libopus0,libsndfile1,libopusenc0,libopusfile0,liblua5.2-0,libjbig0,libldns2,bbb-freeswitch-sounds"
 

--- a/build/packages-template/bbb-freeswitch-sounds/opts-bionic.sh
+++ b/build/packages-template/bbb-freeswitch-sounds/opts-bionic.sh
@@ -1,4 +1,4 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb --deb-user freeswitch --deb-group daemon --deb-use-file-permissions"
+OPTS="$OPTS -t deb"
 

--- a/build/packages-template/bbb-html5/after-install.sh
+++ b/build/packages-template/bbb-html5/after-install.sh
@@ -9,12 +9,6 @@ fi
 
 cd /usr/share/meteor
 
-# meteor code should be owned by root, config file by meteor user
-meteor_owner=$(stat -c %U:%G /usr/share/meteor)
-if [[ $meteor_owner != "root:root" ]] ; then
-    chown -R root:root /usr/share/meteor
-fi
-
 if [ -f $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties ]; then
   sed -i 's/^svgImagesRequired=.*/svgImagesRequired=true/' $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties
   if [ ! -f /.dockerenv ]; then

--- a/build/packages-template/bbb-html5/opts-bionic.sh
+++ b/build/packages-template/bbb-html5/opts-bionic.sh
@@ -1,4 +1,4 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -d bbb-webrtc-sfu,bc,yq,bbb-etherpad,bbb-web -t deb --deb-user meteor --deb-group meteor --deb-use-file-permissions"
+OPTS="$OPTS -d bbb-webrtc-sfu,bc,yq,bbb-etherpad,bbb-web -t deb"
 

--- a/build/packages-template/bbb-web/opts-bionic.sh
+++ b/build/packages-template/bbb-web/opts-bionic.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d zip,unzip,imagemagick,redis-server,xpdf-utils,bbb-libreoffice-docker,psmisc,fonts-crosextra-carlito,fonts-crosextra-caladea,fonts-noto,openjdk-8-jdk --deb-user bigbluebutton --deb-group bigbluebutton --deb-use-file-permissions"
+OPTS="$OPTS -t deb -d zip,unzip,imagemagick,redis-server,xpdf-utils,bbb-libreoffice-docker,psmisc,fonts-crosextra-carlito,fonts-crosextra-caladea,fonts-noto,openjdk-8-jdk"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

`fpm` was called with the dangerous `--deb-user`, `--deb-group` and `--deb-use-file-permissions` command line options. All files in packages should be owned by root.

The dangerous `fpm` options are still used in the `bbb-lti` package. I did not modify this because I don't use LTI and have no idea if something breaks if this is changed.

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)

Closes #11752
Closes #10831
