### PR TITLE
fix: body background gets overwritten by .layout--Z2pPMwf

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.scss
@@ -19,7 +19,6 @@
 
 .layout {
   @extend %flex-column;
-  background-color: #06172a;
 }
 
 .navbar {

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -864,7 +864,6 @@ class Presentation extends PureComponent {
           width: presentationBounds.width,
           height: presentationBounds.height,
           zIndex: fullscreenContext ? presentationBounds.zIndex : undefined,
-          backgroundColor: '#06172A',
         }}
       >
         {isFullscreen && <PollingContainer />}


### PR DESCRIPTION
### What does this PR do?

Prevents an issue where custom styles will fail to overwrite body background because of hardcoded styles.

### Closes Issue(s)
Closes #14079