### PR TITLE
fix(layout): hide/show media in videoFocus

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -477,6 +477,11 @@ class VideoFocusLayout extends Component {
       mediaBounds.top = sidebarContentHeight + this.bannerAreaHeight();
       mediaBounds.width = sidebarContentWidth;
       mediaBounds.zIndex = 1;
+    } else if (!input.presentation.isOpen) {
+      mediaBounds.width = 0;
+      mediaBounds.height = 0;
+      mediaBounds.top = 0;
+      mediaBounds.left = 0;
     } else {
       mediaBounds.height = mediaAreaBounds.height;
       mediaBounds.width = mediaAreaBounds.width;


### PR DESCRIPTION
### What does this PR do?

Fix an error that the hide/show button does not work when there is external
video/screenshare and the layout is "videoFocus".

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/14100
