### PR TITLE
Remove guest attempts limit on guestWait endpoint

### DIFF
--- a/bigbluebutton-html5/private/static/guest-wait/guest-wait.html
+++ b/bigbluebutton-html5/private/static/guest-wait/guest-wait.html
@@ -247,7 +247,7 @@
                   return;
                 }
 
-                pollGuestStatus(sessionToken, 0, ATTEMPT_LIMIT, ATTEMPT_EVERY_MS);
+                pollGuestStatus(sessionToken, ATTEMPT_EVERY_MS);
               } catch (e) {
                 disableAnimation();
                 console.error(e);
@@ -277,15 +277,9 @@
       }, REDIRECT_TIMEOUT);
     };
 
-    function pollGuestStatus(token, attempt, limit, everyMs) {
+    function pollGuestStatus(token, everyMs) {
 
       setTimeout(function () {
-        if (attempt >= limit) {
-          disableAnimation();
-          updateMessage(_('app.guest.noModeratorResponse'));
-          return;
-        }
-
         fetchGuestWait(token)
           .then(async (resp) => await resp.json())
           .then((data) => {
@@ -314,7 +308,7 @@
 
             updateLobbyMessage(data.response.lobbyMessage);
 
-            return pollGuestStatus(token, attempt + 1, limit, everyMs);
+            return pollGuestStatus(token, everyMs);
           });
       }, everyMs);
     };


### PR DESCRIPTION
### What does this PR do?

This PR removes the limit of attempts the user can make for guestWait endpoint, basically the client is polling the server to receive the moderators' response about approval, currently there is a limit of attempts that the client can make, but when this limit is reached the user is removed and if he tries to reconnect the system doesn't notify the server about this new attempt and he is not joining the meeting, I basically removed the limit and now the user only timeout if he leaves the waiting screen and polling is stopped. more details in issue #12827

### Closes Issue(s)
Closes #12827 

