### PR TITLE
fix(bbb-web) broken Asian filename for pre-uploaded presentation (fix on bbb-web)

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1307,7 +1307,13 @@ class ApiController {
     log.debug("ApiController#downloadAndProcessDocument(${address}, ${meetingId}, ${fileName})");
     String presOrigFilename;
     if (StringUtils.isEmpty(fileName)) {
-      presOrigFilename = URLDecoder.decode(address.tokenize("/")[-1]);
+      try {
+        presOrigFilename = URLDecoder.decode(address.tokenize("/")[-1], "UTF-8");
+      } catch (UnsupportedEncodingException e) {
+        log.error "Couldn't decode the uploaded file name.", e
+        invalid("fileNameError", "Cannot decode the uploaded file name")
+        return;
+      }
     } else {
       presOrigFilename = fileName;
     }

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1307,7 +1307,7 @@ class ApiController {
     log.debug("ApiController#downloadAndProcessDocument(${address}, ${meetingId}, ${fileName})");
     String presOrigFilename;
     if (StringUtils.isEmpty(fileName)) {
-      presOrigFilename = address.tokenize("/")[-1];
+      presOrigFilename = URLDecoder.decode(address.tokenize("/")[-1]);
     } else {
       presOrigFilename = fileName;
     }


### PR DESCRIPTION
### What does this PR do?

This is an improved version of #14127, which can be closed.
Fixes a bug, in which a filename by Asian letters is not decoded when pre-uploaded from Greenlight. 

I tested this PR and confirmed working on 2.4.x. 
By mistake, I submitted this against "develop" branch. Let me know if I have to resubmit it against 2.4.x

### More

It can be fixed also in Greenlight, but BBB should have this fail-safe fix to make the API robust.
Below are the screenshots explaining the bug:

![1 0](https://user-images.githubusercontent.com/45039819/149954399-05066ca2-091f-4db1-a004-74852a89d4f9.jpeg)
This is when the presentation is pre-uploaded from GL.

![2 1](https://user-images.githubusercontent.com/45039819/149954442-34943d35-610e-4ee8-b22b-e897eac2359e.jpeg)
Here, the file above is pre-uploaded from GL, and the one below is a newly uploaded one from HTML5 client. The latter is displayed correctly.
