### PR TITLE
fix(webcam): initial webcam direction

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -67,7 +67,7 @@ class VideoListItem extends Component {
       videoIsReady: false,
       isFullscreen: false,
       isStreamHealthy: false,
-      isMirrored: false,
+      isMirrored: VideoService.mirrorOwnWebcam(),
     };
 
     this.mirrorOwnWebcam = VideoService.mirrorOwnWebcam(props.userId);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -67,7 +67,7 @@ class VideoListItem extends Component {
       videoIsReady: false,
       isFullscreen: false,
       isStreamHealthy: false,
-      isMirrored: VideoService.mirrorOwnWebcam(),
+      isMirrored: VideoService.mirrorOwnWebcam(props.userId),
     };
 
     this.mirrorOwnWebcam = VideoService.mirrorOwnWebcam(props.userId);


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

- Enforces `mirrorOwnWebcam` value on video dock, not only on video preview.
- Currently the webcam always starts unmirrored on video dock.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #14130 

