### PR TITLE
fix(waiting users): text box outline

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
@@ -174,6 +174,7 @@
 
 .lobbyMessage {
   border-bottom: 1px solid var(--color-gray-lightest);
+  margin: 2px 2px 0 2px;
 
   p {
     background-color: var(--color-off-white);


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

- Adds a subtle margin around the _text box_ in order to prevent focus outline from overflowing.

Before:
![Captura de tela de 2022-01-19 13-43-09](https://user-images.githubusercontent.com/62393923/150176734-1f5e06a8-d1b2-4e13-8212-e19876da91e5.png)

After:
![Captura de tela de 2022-01-19 13-43-53](https://user-images.githubusercontent.com/62393923/150176769-fcd3a7fa-eb30-49bd-a08a-9eca4f2a40dd.png)


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #13955 