### PR TITLE
Add options polling audio

### DIFF
--- a/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
+++ b/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
@@ -37,6 +37,8 @@ const currentParameters = [
   'bbb_force_listen_only',
   'bbb_listen_only_mode',
   'bbb_skip_check_audio',
+  'bbb_enable_audio',
+  'bbb_enable_polling',
   'bbb_skip_check_audio_on_first_join',
   // BRANDING
   'bbb_display_branding_area',

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
@@ -63,7 +63,7 @@ export default withTracker(() => ({
   hasScreenshare: isVideoBroadcasting(),
   isCaptionsAvailable: CaptionsService.isCaptionsAvailable(),
   isMeteorConnected: Meteor.status().connected,
-  isPollingEnabled: POLLING_ENABLED,
+  isPollingEnabled: getFromUserSettings('bbb_enable_polling', POLLING_ENABLED),
   isPresentationDisabled: PRESENTATION_DISABLED,
   isSelectRandomUserEnabled: SELECT_RANDOM_USER_ENABLED,
   isRaiseHandButtonEnabled: RAISE_HAND_BUTTON_ENABLED,

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -22,6 +22,7 @@ import LockNotifier from '/imports/ui/components/lock-viewers/notify/container';
 import StatusNotifier from '/imports/ui/components/status-notifier/container';
 import MediaService from '/imports/ui/components/media/service';
 import ManyWebcamsNotifier from '/imports/ui/components/video-provider/many-users-notify/container';
+import getFromUserSettings from '/imports/ui/services/users-settings';
 import UploaderContainer from '/imports/ui/components/presentation/presentation-uploader/container';
 import RandomUserSelectContainer from '/imports/ui/components/modal/random-user/container';
 import NewWebcamContainer from '../webcam/container';
@@ -457,6 +458,7 @@ class App extends Component {
       shouldShowExternalVideo,
       isPresenter,
     } = this.props;
+    const enableAudio = getFromUserSettings('bbb_enable_audio', true);
 
     return (
       <>
@@ -487,7 +489,7 @@ class App extends Component {
           {this.renderCaptions()}
           <UploaderContainer />
           <BreakoutRoomInvitation />
-          <AudioContainer />
+          { enableAudio ? <AudioContainer /> : ''}
           <ToastContainer rtl />
           {(audioAlertEnabled || pushAlertEnabled)
             && (


### PR DESCRIPTION
### What does this PR do?

Add option userdata-bbb_enable_polling=true|false to enable or disable polling from api
Add option userdata-bbb_enable_audio=true|false to enable or disable audio from api

### Motivation

Conference without audio allows bigblugbutton to be used as only a blackboard in the classroom (no remote pupils).
Polling can be disabled if teachers don't want this feature.



