### PR TITLE
refactor(presentation): extra hint upload limit

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -20,6 +20,9 @@ const { isMobile } = deviceInfo;
 
 const propTypes = {
   intl: PropTypes.object.isRequired,
+  fileUploadConstraintsHint: PropTypes.bool.isRequired,
+  fileSizeMax: PropTypes.number.isRequired,
+  filePagesMax: PropTypes.number.isRequired,
   handleSave: PropTypes.func.isRequired,
   dispatchTogglePresentationDownloadable: PropTypes.func.isRequired,
   fileValidMimeTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -87,6 +90,10 @@ const intlMessages = defineMessages({
   fileToUpload: {
     id: 'app.presentationUploder.fileToUpload',
     description: 'message used in the file selected for upload',
+  },
+  extraHint: {
+    id: 'app.presentationUploder.extraHint',
+    description: 'message used to indicate upload file max sizes',
   },
   rejectedError: {
     id: 'app.presentationUploder.rejectedError',
@@ -635,6 +642,25 @@ class PresentationUploader extends Component {
     );
   }
 
+  renderExtraHint() {
+    const {
+      intl,
+      fileSizeMax,
+      filePagesMax,
+    } = this.props;
+
+    const options = {
+      0: fileSizeMax/1000000,
+      1: filePagesMax,
+    };
+
+    return (
+      <div className={styles.extraHint}>
+        {intl.formatMessage(intlMessages.extraHint, options)}
+      </div>
+    );
+  }
+
   renderPresentationList() {
     const { presentations } = this.state;
     const { intl } = this.props;
@@ -997,7 +1023,10 @@ class PresentationUploader extends Component {
 
   render() {
     const {
-      isOpen, isPresenter, intl,
+      isOpen,
+      isPresenter,
+      intl,
+      fileUploadConstraintsHint,
     } = this.props;
     if (!isPresenter) return null;
     const { presentations, disableActions } = this.state;
@@ -1038,6 +1067,7 @@ class PresentationUploader extends Component {
 
           <div className={styles.modalHint}>
             {`${intl.formatMessage(intlMessages.message)}`}
+            {fileUploadConstraintsHint ? this.renderExtraHint() : null}
           </div>
           {this.renderPresentationList()}
           {isMobile ? this.renderPicDropzone() : null}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/container.jsx
@@ -28,6 +28,9 @@ export default withTracker(() => {
 
   return {
     presentations: currentPresentations,
+    fileUploadConstraintsHint: PRESENTATION_CONFIG.fileUploadConstraintsHint,
+    fileSizeMax: PRESENTATION_CONFIG.mirroredFromBBBCore.uploadSizeMax,
+    filePagesMax: PRESENTATION_CONFIG.mirroredFromBBBCore.uploadPagesMax,
     fileValidMimeTypes: PRESENTATION_CONFIG.uploadValidMimeTypes,
     allowDownloadable: PRESENTATION_CONFIG.allowDownloadable,
     handleSave: (presentations) => Service.persistPresentationChanges(

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.scss
@@ -404,6 +404,11 @@
   width: var(--fileLineWidth);
 } 
 
+.extraHint {
+  margin-top: 1rem;
+  font-weight: bold;
+}
+
 .statusIcon {
   margin-left: auto;
   [dir="rtl"] & {

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -600,6 +600,11 @@ public:
     restoreOnUpdate: false
     oldMinimizeButton: false
     uploadEndpoint: '/bigbluebutton/presentation/upload'
+    fileUploadConstraintsHint: false
+    # mirroredFromBBBCore are values controlled in bbb-web properties file. We include a copy here for notification purposes
+    mirroredFromBBBCore:
+      uploadSizeMax: 30000000
+      uploadPagesMax: 200
     uploadValidMimeTypes:
       - extension: .pdf
         mime: application/pdf

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -192,6 +192,7 @@
     "app.presentation.placeholder": "Waiting for a presentation to be uploaded",
     "app.presentationUploder.title": "Presentation",
     "app.presentationUploder.message": "As a presenter you have the ability to upload any office document or PDF file.  We recommend PDF file for best results. Please ensure that a presentation is selected using the circle checkbox on the right hand side.",
+    "app.presentationUploder.extraHint": "IMPORTANT: each file may not exceed {0} MB and {1} pages.",
     "app.presentationUploder.uploadLabel": "Upload",
     "app.presentationUploder.confirmLabel": "Confirm",
     "app.presentationUploder.confirmDesc": "Save your changes and start the presentation",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Adds a text hint about the accepted presentation file size limit on the presentation upload modal.

<!-- A brief description of each change being made with this pull request. -->

![presentation_hint](https://user-images.githubusercontent.com/32987232/150350698-6afbe524-7b4c-400e-a74d-150977b9d869.png)

### Motivation

Currently, the user is informed about the presentation size limit only when a uploading error occurs.
Therefore, this is intended to inform users about the presentation size limit before they attempt to upload a file.

<!-- What inspired you to submit this pull request? -->
