### PR TITLE
fix: mute + listen only icons in userlist

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-avatar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-avatar/styles.js
@@ -202,6 +202,23 @@ const Avatar = styled.div`
     }
   `}
 
+  ${({ voice }) => voice && `
+    &:after {
+      content: "\\00a0\\e931\\00a0";
+      background-color: ${colorSuccess};
+      top: 1.375rem;
+      left: 1.375rem;
+      right: auto;
+
+      [dir="rtl"] & {
+        left: auto;
+        right: 1.375rem;
+      }
+      opacity: 1;
+      width: 1.2rem;
+      height: 1.2rem;
+    }
+  `}
 
   ${({ muted }) => muted && `
     &:after {
@@ -216,24 +233,6 @@ const Avatar = styled.div`
   ${({ listenOnly }) => listenOnly && `
     &:after {
       content: "\\00a0\\e90c\\00a0";
-      opacity: 1;
-      width: 1.2rem;
-      height: 1.2rem;
-    }
-  `}
-
-  ${({ voice }) => voice && `
-    &:after {
-      content: "\\00a0\\e931\\00a0";
-      background-color: ${colorSuccess};
-      top: 1.375rem;
-      left: 1.375rem;
-      right: auto;
-
-      [dir="rtl"] & {
-        left: auto;
-        right: 1.375rem;
-      }
       opacity: 1;
       width: 1.2rem;
       height: 1.2rem;


### PR DESCRIPTION
### What does this PR do?

Fix for a bug that would display the wrong icon when user is muted or listen-only (the "voice" icon is displayed instead).