### PR TITLE
Use node installed from package sources for HTML5 client

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/HTML5LoadBalancingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/HTML5LoadBalancingService.java
@@ -47,8 +47,8 @@ public class HTML5LoadBalancingService {
 
     // Find nodejs processes associated with processing meeting events
     // $ ps -u meteor -o pcpu,cmd= | grep NODEJS_BACKEND_INSTANCE_ID
-    // 1.1 /usr/share/node-v12.16.1-linux-x64/bin/node --max-old-space-size=2048 --max_semi_space_size=128 main.js NODEJS_BACKEND_INSTANCE_ID=1
-    // 1.0 /usr/share/node-v12.16.1-linux-x64/bin/node --max-old-space-size=2048 --max_semi_space_size=128 main.js NODEJS_BACKEND_INSTANCE_ID=2
+    // 1.1 /usr/bin/node --max-old-space-size=2048 --max_semi_space_size=128 main.js NODEJS_BACKEND_INSTANCE_ID=1
+    // 1.0 /usr/bin/node --max-old-space-size=2048 --max_semi_space_size=128 main.js NODEJS_BACKEND_INSTANCE_ID=2
     public void scanHTML5processes() {
         try {
             this.list = new ArrayList<HTML5ProcessLine>();

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/HTML5ProcessLine.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/HTML5ProcessLine.java
@@ -27,8 +27,8 @@ public class HTML5ProcessLine {
 
     public HTML5ProcessLine(String input) {
         // $ ps -u meteor -o pcpu,cmd= | grep NODEJS_BACKEND_INSTANCE_ID
-        // 1.1 /usr/share/node-v12.16.1-linux-x64/bin/node --max-old-space-size=2048 --max_semi_space_size=128 main.js NODEJS_BACKEND_INSTANCE_ID=1
-        // 1.0 /usr/share/node-v12.16.1-linux-x64/bin/node --max-old-space-size=2048 --max_semi_space_size=128 main.js NODEJS_BACKEND_INSTANCE_ID=2
+        // 1.1 /usr/bin/node --max-old-space-size=2048 --max_semi_space_size=128 main.js NODEJS_BACKEND_INSTANCE_ID=1
+        // 1.0 /usr/bin/node --max-old-space-size=2048 --max_semi_space_size=128 main.js NODEJS_BACKEND_INSTANCE_ID=2
 
         String[] a = input.trim().split(" ");
         this.percentageCPU = Double.parseDouble(a[0]);

--- a/build/packages-template/bbb-html5/after-install.sh
+++ b/build/packages-template/bbb-html5/after-install.sh
@@ -82,24 +82,6 @@ if [ -f /etc/systemd/system/mongod.service.d/override-mongo.conf ] \
   systemctl daemon-reload
 fi
 
-# Setup specific version of node
-
-
-source /etc/lsb-release
-
-if [ "$DISTRIB_RELEASE" == "18.04" ]; then
-  node_version="14.18.1"
-  if [[ ! -d /usr/share/node-v${node_version}-linux-x64 ]]; then
-    cd /usr/share
-    tar xfz "node-v${node_version}-linux-x64.tar.gz"
-  fi
-  node_owner=$(stat -c %U:%G "/usr/share/node-v${node_version}-linux-x64")
-  if [[ $node_owner != root:root ]] ; then
-    chown -R root:root "/usr/share/node-v${node_version}-linux-x64"
-  fi
-fi
-
-
 # Enable Listen Only support in FreeSWITCH
 
 if [ -f /opt/freeswitch/etc/freeswitch/sip_profiles/external.xml ]; then

--- a/build/packages-template/bbb-html5/bionic/systemd_start.sh
+++ b/build/packages-template/bbb-html5/bionic/systemd_start.sh
@@ -49,8 +49,7 @@ fi
 export MONGO_OPLOG_URL=mongodb://127.0.1.1/local
 export MONGO_URL=mongodb://127.0.1.1/meteor
 export NODE_ENV=production
-export NODE_VERSION=node-v14.18.1-linux-x64
 export SERVER_WEBSOCKET_COMPRESSION=0
 export BIND_IP=127.0.0.1
-PORT=$PORT /usr/share/$NODE_VERSION/bin/node --max-old-space-size=2048 --max_semi_space_size=128 main.js NODEJS_BACKEND_INSTANCE_ID=$INSTANCE_ID
+PORT=$PORT /usr/bin/node --max-old-space-size=2048 --max_semi_space_size=128 main.js NODEJS_BACKEND_INSTANCE_ID=$INSTANCE_ID
 

--- a/build/packages-template/bbb-html5/bionic/systemd_start_frontend.sh
+++ b/build/packages-template/bbb-html5/bionic/systemd_start_frontend.sh
@@ -49,8 +49,7 @@ fi
 export MONGO_OPLOG_URL=mongodb://127.0.1.1/local
 export MONGO_URL=mongodb://127.0.1.1/meteor
 export NODE_ENV=production
-export NODE_VERSION=node-v14.18.1-linux-x64
 export SERVER_WEBSOCKET_COMPRESSION=0
 export BIND_IP=127.0.0.1
-PORT=$PORT /usr/share/$NODE_VERSION/bin/node --max-old-space-size=2048 --max_semi_space_size=128 main.js
+PORT=$PORT /usr/bin/node --max-old-space-size=2048 --max_semi_space_size=128 main.js
 

--- a/build/packages-template/bbb-html5/build.sh
+++ b/build/packages-template/bbb-html5/build.sh
@@ -92,12 +92,6 @@ cp $DISTRO/bbb-html5-frontend@.service staging/usr/lib/systemd/system
 
 mkdir -p staging/usr/share
 
-if [ ! -f node-v14.18.1-linux-x64.tar.gz ]; then
-  wget https://nodejs.org/dist/v14.18.1/node-v14.18.1-linux-x64.tar.gz
-fi
-
-cp node-v14.18.1-linux-x64.tar.gz staging/usr/share
-
 if [ -f staging/usr/share/meteor/bundle/programs/web.browser/head.html ]; then
   sed -i "s/VERSION/$(($BUILD))/" staging/usr/share/meteor/bundle/programs/web.browser/head.html
 fi


### PR DESCRIPTION
### What does this PR do?

Currently the packaging scripts for HTML5 client downloads and installs a specific node version (`v14.18.1` at this time, already two patch releases behind).

### Closes Issue(s)
Closes #14162

### Motivation

Security hardening

### More

Note that `bbb-install` needs to be updated such that `node 14` is installed from official repositories instead of `node 12`. Also note that this will result in `bbb-webrtc-sfu` running with `node 14` as well.