### PR TITLE
Add a different background color for contents that are being displayed under the side panel

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -3,7 +3,12 @@ import { throttle, defaultsDeep } from 'lodash';
 import { LayoutContextFunc } from '/imports/ui/components/layout/context';
 import DEFAULT_VALUES from '/imports/ui/components/layout/defaultValues';
 import { INITIAL_INPUT_STATE } from '/imports/ui/components/layout/initState';
-import { DEVICE_TYPE, ACTIONS, PANELS } from '/imports/ui/components/layout/enums';
+import {
+  DEVICE_TYPE,
+  ACTIONS,
+  PANELS,
+  CAMERADOCK_POSITION,
+} from '/imports/ui/components/layout/enums';
 
 const windowWidth = () => window.document.documentElement.clientWidth;
 const windowHeight = () => window.document.documentElement.clientHeight;
@@ -616,6 +621,7 @@ class PresentationFocusLayout extends Component {
       type: ACTIONS.SET_CAMERA_DOCK_OUTPUT,
       value: {
         display: input.cameraDock.numCameras > 0,
+        position: CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM,
         minWidth: cameraDockBounds.minWidth,
         width: cameraDockBounds.width,
         maxWidth: cameraDockBounds.maxWidth,

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -864,6 +864,9 @@ class Presentation extends PureComponent {
           width: presentationBounds.width,
           height: presentationBounds.height,
           zIndex: fullscreenContext ? presentationBounds.zIndex : undefined,
+          background: layoutType === LAYOUT_TYPE.VIDEO_FOCUS && numCameras > 0 && !fullscreenContext
+            ? 'var(--color-content-background)'
+            : null,
         }}
       >
         {isFullscreen && <PollingContainer />}

--- a/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
@@ -256,6 +256,7 @@ const WebcamComponent = ({
               width: isDragging ? cameraSize.width : cameraDock.width,
               height: isDragging ? cameraSize.height : cameraDock.height,
               opacity: isDragging ? 0.5 : undefined,
+              background: isCameraSidebar ? 'var(--color-content-background)' : null,
             }}
           >
             <VideoProviderContainer


### PR DESCRIPTION
### What does this PR do?

Adds a different background-color (`--color-content-background`, the same color used in screenshare) for presentation/cameras when positioned in sidebar-content.

### Closes Issue(s)
Closes #14153
