### PR TITLE
fix: restore missing variable

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -282,6 +282,7 @@ const PresentationFocusLayout = (props) => {
       sidebarContentWidth.width,
       sidebarContentHeight.height,
     );
+    const { isOpen } = presentationInput;
 
     layoutContextDispatch({
       type: ACTIONS.SET_NAVBAR_OUTPUT,


### PR DESCRIPTION
### What does this PR do?

Restores missing variable in presentation focus layout, removed when merging 2.4 into 2.5.