### PR TITLE
fix: close sidebar panel for non-presenters

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -235,13 +235,13 @@ class Poll extends Component {
   }
 
   componentDidUpdate() {
-    const { amIPresenter, layoutContextDispatch } = this.props;
+    const { amIPresenter, layoutContextDispatch, sidebarContentPanel } = this.props;
 
     if (Session.equals('resetPollPanel', true)) {
       this.handleBackClick();
     }
 
-    if (!amIPresenter) {
+    if (!amIPresenter && sidebarContentPanel === PANELS.POLL) {
       layoutContextDispatch({
         type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
         value: false,

--- a/bigbluebutton-html5/imports/ui/components/poll/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/container.jsx
@@ -8,13 +8,15 @@ import { Session } from 'meteor/session';
 import Service from './service';
 import Auth from '/imports/ui/services/auth';
 import { UsersContext } from '../components-data/users-context/context';
-import { layoutDispatch } from '../layout/context';
+import { layoutDispatch, layoutSelectInput } from '../layout/context';
 
 const CHAT_CONFIG = Meteor.settings.public.chat;
 const PUBLIC_CHAT_KEY = CHAT_CONFIG.public_id;
 
 const PollContainer = ({ ...props }) => {
   const layoutContextDispatch = layoutDispatch();
+  const sidebarContent = layoutSelectInput((i) => i.sidebarContent);
+  const { sidebarContentPanel } = sidebarContent;
 
   const usingUsersContext = useContext(UsersContext);
   const { users } = usingUsersContext;
@@ -28,7 +30,7 @@ const PollContainer = ({ ...props }) => {
 
   return (
     <Poll
-      {...{ layoutContextDispatch, ...props }}
+      {...{ layoutContextDispatch, sidebarContentPanel, ...props }}
       usernames={usernames}
       amIPresenter={amIPresenter}
     />


### PR DESCRIPTION
### What does this PR do?

Prevents an issue where the sidebar content panel would close for non-presenters when userlist updates.

### Closes Issue(s)
Closes #13963