### PR TITLE
fix missing directory error for etherpad installation

### DIFF
--- a/build/packages-template/bbb-etherpad/after-install.sh
+++ b/build/packages-template/bbb-etherpad/after-install.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -e
 
+# avoid missing directories for fresh install
+mkdir -p /usr/share/etherpad-lite/.config
+mkdir -p /usr/share/etherpad-lite/node_modules
+
 chown etherpad:etherpad /usr/share/etherpad-lite/APIKEY.txt
 # minified assets
 chown -R etherpad:etherpad /usr/share/etherpad-lite/var


### PR DESCRIPTION
### What does this PR do?

Fixes installation crash of etherpad during fresh BBB installations. Bug was introduced in this commit: https://github.com/bigbluebutton/bigbluebutton/commit/5cce940346b8e49fc67b9d5a7e522fc5955c3ac7

### Closes Issue(s)

None

### Motivation

Our deployment failed.

### More
Nothing