### PR TITLE
fix(slide dimension) keep fitToWidth property on reloaded presentation

### DIFF
--- a/bigbluebutton-html5/imports/api/meetings/server/methods.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/methods.js
@@ -6,6 +6,7 @@ import toggleLockSettings from './methods/toggleLockSettings';
 import toggleWebcamsOnlyForModerator from './methods/toggleWebcamsOnlyForModerator';
 import clearRandomlySelectedUser from './methods/clearRandomlySelectedUser';
 import changeLayout from './methods/changeLayout';
+import setFitToWidth from './methods/setFitToWidth';
 
 Meteor.methods({
   endMeeting,
@@ -15,4 +16,5 @@ Meteor.methods({
   toggleWebcamsOnlyForModerator,
   clearRandomlySelectedUser,
   changeLayout,
+  setFitToWidth,
 });

--- a/bigbluebutton-html5/imports/api/meetings/server/methods/setFitToWidth.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/methods/setFitToWidth.js
@@ -1,0 +1,32 @@
+import Meetings from '/imports/api/meetings';
+import { extractCredentials } from '/imports/api/common/server/helpers';
+import { check } from 'meteor/check';
+import Logger from '/imports/startup/server/logger';
+
+export default function setFitToWidth(fitToWidth) {
+
+  try {
+    const { meetingId, requesterUserId } = extractCredentials(this.userId);
+
+    check(meetingId, String);
+    check(fitToWidth, Boolean);
+
+    const selector = {
+      meetingId,
+    };
+
+    const modifier = {
+      $set: {
+        fitToWidth,
+      }
+    }
+
+    const { insertedId } = Meetings.upsert(selector, modifier);
+    if (insertedId) {
+      Logger.info(`Set fitToWidth for meeting=${meetingId} by id=${requesterUserId}`);
+    }
+
+  } catch (err) {
+    Logger.error(`Exception while invoking method setFitToWidth ${err.stack}`);
+  }
+}

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -57,22 +57,25 @@ const { isSafari } = browserInfo;
 const FULLSCREEN_CHANGE_EVENT = isSafari ? 'webkitfullscreenchange' : 'fullscreenchange';
 
 class Presentation extends PureComponent {
-  constructor() {
+  constructor(props) {
     super();
+
+    const {
+      getFitToWidth,
+    } = props;
 
     this.state = {
       presentationWidth: 0,
       presentationHeight: 0,
       showSlide: false,
       zoom: 100,
-      fitToWidth: false,
+      fitToWidth: getFitToWidth(),
       isFullscreen: false,
     };
 
     this.currentPresentationToastId = null;
 
     this.getSvgRef = this.getSvgRef.bind(this);
-    this.setFitToWidth = this.setFitToWidth.bind(this);
     this.zoomChanger = this.zoomChanger.bind(this);
     this.updateLocalPosition = this.updateLocalPosition.bind(this);
     this.panAndZoomChanger = this.panAndZoomChanger.bind(this);
@@ -315,10 +318,6 @@ class Presentation extends PureComponent {
     }
   }
 
-  setFitToWidth(fitToWidth) {
-    this.setState({ fitToWidth });
-  }
-
   calculateSize(viewBoxDimensions) {
     const {
       presentationHeight,
@@ -396,6 +395,11 @@ class Presentation extends PureComponent {
     const {
       fitToWidth,
     } = this.state;
+
+    const {
+      setFitToWidth,
+    } = this.props;
+    setFitToWidth(!fitToWidth);
 
     this.setState({
       fitToWidth: !fitToWidth,

--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -128,6 +128,8 @@ export default withTracker(({ podId }) => {
     podId,
     layoutSwapped,
     toggleSwapLayout: MediaService.toggleSwapLayout,
+    setFitToWidth: PresentationService.setFitToWidth,
+    getFitToWidth: PresentationService.getFitToWidth,
     publishedPoll: Meetings.findOne({ meetingId: Auth.meetingID }, {
       fields: {
         publishedPoll: 1,

--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -1,11 +1,22 @@
 import PresentationPods from '/imports/api/presentation-pods';
 import Presentations from '/imports/api/presentations';
+import Meetings from '/imports/api/meetings';
 import { Slides, SlidePositions } from '/imports/api/slides';
 import Auth from '/imports/ui/services/auth';
 import PollService from '/imports/ui/components/poll/service';
+import { makeCall } from '/imports/ui/services/api';
 
 const POLL_SETTINGS = Meteor.settings.public.poll;
 const MAX_CUSTOM_FIELDS = POLL_SETTINGS.maxCustom;
+
+const setFitToWidth = (fitToWidth) => {
+  makeCall('setFitToWidth', fitToWidth);
+};
+
+const getFitToWidth = () => {
+  const meeting = Meetings.findOne({ meeringId: Auth.meetingId });
+  return(meeting.fitToWidth ? true : false);
+};
 
 const getCurrentPresentation = (podId) => Presentations.findOne({
   podId,
@@ -188,4 +199,6 @@ export default {
   currentSlidHasContent,
   parseCurrentSlideContent,
   getCurrentPresentation,
+  getFitToWidth,
+  setFitToWidth,
 };


### PR DESCRIPTION
### What does this PR do?

Keeps the fitToWidth property in a reloaded presentation (only) for the presenter, so that a portrait slide that is fit to the width can maintain its zoom rate and focal position even after [minimising slide]/[sharing screen]/[sharing external video]/[going out and in the room]/[switching presentations].

This is another implementation of #14178, which has been closed.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #14107, #14154


### Motivation

It has been uncomfortable that a portrait slide doesn't keep its focal point and the scaling due to the missing fitToWidth property after reloading a presentation.

### More

Before the change (at test24.bigbluebutton.org):
![before](https://user-images.githubusercontent.com/45039819/150641612-a6fb8145-c594-4f3a-9672-ad54e7166565.gif)

After the change:
![after](https://user-images.githubusercontent.com/45039819/150642021-3fe4a9e6-c0b2-4717-bff1-da1ba6be1259.gif)

#14178 adds the information to each slide, whereas this PR adds it to the meeting. This way we can solve the problem in a much simpler way. 

This PR adds the fitToWidth information to the mongoDB of the presenter. So if the presenter changes, the information will be reset as default (false).
