### PR TITLE
refactor: remove unused imports/variables

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
 import deviceInfo from '/imports/utils/deviceInfo';
-import getFromUserSettings from '/imports/ui/services/users-settings';
 import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
 import InputStreamLiveSelectorContainer from './input-stream-live-selector/container';
 import MutedAlert from '/imports/ui/components/muted-alert/component';

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
@@ -265,7 +265,6 @@ class BreakoutRoom extends PureComponent {
       breakoutId: _stateBreakoutId,
       requestedBreakoutId,
       waiting,
-      generated,
     } = this.state;
 
     const {

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/styles.js
@@ -1,11 +1,6 @@
 import styled from 'styled-components';
 import Icon from '../icon/component';
-import {
-  barsPadding,
-  lgPaddingY,
-  mdPaddingX,
-  borderSize,
-} from '/imports/ui/stylesheets/styled-components/general';
+import { barsPadding, borderSize } from '/imports/ui/stylesheets/styled-components/general';
 import {
   colorWhite,
   colorDanger,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/text/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/text/component.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import RenderInBrowser from 'react-render-in-browser';
 import { getFormattedColor, denormalizeCoord } from '../helpers';
 
 const DRAW_END = Meteor.settings.public.whiteboard.annotations.status.end;
@@ -144,7 +143,6 @@ export default class TextDrawComponent extends Component {
   }
 
   renderViewerTextShape(results) {
-    const { annotation } = this.props;
     const styles = TextDrawComponent.getViewerStyles(results);
 
     return (


### PR DESCRIPTION
### What does this PR do?

Removes unused imports and exports reported by [lgtm alerts](https://lgtm.com/projects/g/bigbluebutton/bigbluebutton/alerts)

### Motivation

*Unused local variables make code hard to read and understand. Any computation used to initialize an unused variable is wasted, which may lead to performance problems.*

*Similarly, unused imports and unused functions or classes can be confusing. They may even be a symptom of a bug caused, for example, by an incomplete refactoring.* (https://lgtm.com/rules/1780092/)
