### PR TITLE
refactor: Switch user_action logs from debug to info

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
@@ -286,7 +286,7 @@ class BreakoutRoom extends PureComponent {
           status: AudioManager.BREAKOUT_AUDIO_TRANSFER_STATES.RETURNING,
         });
         this.returnBackToMeeeting(breakoutId);
-        return logger.debug({
+        return logger.info({
           logCode: 'breakoutroom_return_main_audio',
           extraInfo: { logType: 'user_action' },
         }, 'Returning to main audio (breakout room audio closed)');
@@ -297,7 +297,7 @@ class BreakoutRoom extends PureComponent {
           status: AudioManager.BREAKOUT_AUDIO_TRANSFER_STATES.CONNECTED,
         });
         this.transferUserToBreakoutRoom(breakoutId);
-        return logger.debug({
+        return logger.info({
           logCode: 'breakoutroom_join_audio_from_main_room',
           extraInfo: { logType: 'user_action' },
         }, 'joining breakout room audio (main room audio closed)');
@@ -321,7 +321,7 @@ class BreakoutRoom extends PureComponent {
                   // leave main room's audio,
                   // and stops video and screenshare when joining a breakout room
                   exitAudio();
-                  logger.debug({
+                  logger.info({
                     logCode: 'breakoutroom_join',
                     extraInfo: { logType: 'user_action' },
                   }, 'joining breakout room closed audio in the main room');


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Switches breakout room related user_action logs from debug to info.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
These log keywords come in handy when debugging whether a student intentionally did an action X or the system (or moderator?) did it instead. I am switching them to .info as they are occasionally needed on production systems for debugging but debug level is not really a recommended production log level.

Requested by @ritzalam 
<!-- What inspired you to submit this pull request? -->

### More
The rest of the `user_action` logs I find are all `info` level

