### PR TITLE
fix(pads): add double quotes to APIKEY

### DIFF
--- a/build/packages-template/bbb-pads/after-install.sh
+++ b/build/packages-template/bbb-pads/after-install.sh
@@ -8,7 +8,7 @@ case "$1" in
 
     if [ -f /usr/share/etherpad-lite/APIKEY.txt ]; then
       API_KEY=$(cat /usr/share/etherpad-lite/APIKEY.txt)
-      sed -i "s/ETHERPAD_API_KEY/$API_KEY/g" $TARGET
+      sed -i "s/ETHERPAD_API_KEY/\"$API_KEY\"/g" $TARGET
 
       startService bbb-pads || echo "bbb-pads could not be registered or started"
     else


### PR DESCRIPTION
JSON file format requires double quoted string data. Add quotes when configuring
ETHERPAD_API_KEY at bbb-pads build scripts.