### PR TITLE
fix(config): correct path for bbb-pads.service

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -482,7 +482,7 @@ display_bigbluebutton_status () {
         units="$units bbb-lti"
     fi
 
-    if [ -f /lib/systemd/system/bbb-pads.service ]; then
+    if [ -f /usr/lib/systemd/system/bbb-pads.service ]; then
         units="$units bbb-pads"
     fi
 


### PR DESCRIPTION
Corrected the path for bbb-pads so we can see it when running `bbb-conf --status`

After:

`bbb-pads ——————————————► [✔ - active]`