### PR TITLE
feat(fullaudio): implement echo test, device change and audio filters (new bridge)

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/FullAudioBridge.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/FullAudioBridge.js
@@ -11,7 +11,6 @@ import getFromMeetingSettings from '/imports/ui/services/meeting-settings';
 import Storage from '/imports/ui/services/storage/session';
 import browserInfo from '/imports/utils/browserInfo';
 import {
-  DEFAULT_INPUT_DEVICE_ID,
   DEFAULT_OUTPUT_DEVICE_ID,
   INPUT_DEVICE_ID_KEY,
   OUTPUT_DEVICE_ID_KEY,
@@ -60,8 +59,6 @@ const getMediaServerAdapter = () => getFromMeetingSettings(
 export default class FullAudioBridge extends BaseAudioBridge {
   constructor(userData) {
     super();
-    this.internalMeetingID = userData.meetingId;
-    this.voiceBridge = userData.voiceBridge;
     this.userId = userData.userId;
     this.name = userData.username;
     this.sessionToken = userData.sessionToken;
@@ -310,7 +307,6 @@ export default class FullAudioBridge extends BaseAudioBridge {
       ].join('-').replace(/"/g, "'");
 
       const brokerOptions = {
-        userName: this.name,
         caleeName: callerIdName,
         extension,
         iceServers: this.iceServers,
@@ -321,9 +317,6 @@ export default class FullAudioBridge extends BaseAudioBridge {
 
       this.broker = new FullAudioBroker(
         Auth.authenticateURL(SFU_URL),
-        this.voiceBridge,
-        this.userId,
-        this.internalMeetingID,
         isListenOnly ? RECV_ROLE : SENDRECV_ROLE,
         brokerOptions,
       );

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/FullAudioBridge.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/FullAudioBridge.js
@@ -19,7 +19,7 @@ import {
   getAudioConstraints,
   filterSupportedConstraints,
 } from '/imports/api/audio/client/bridge/service';
-
+import { shouldForceRelay } from '/imports/ui/services/bbb-webrtc-sfu/utils';
 
 const SFU_URL = Meteor.settings.public.kurento.wsUrl;
 const MEDIA = Meteor.settings.public.media;
@@ -316,6 +316,7 @@ export default class FullAudioBridge extends BaseAudioBridge {
         iceServers: this.iceServers,
         mediaServer: getMediaServerAdapter(),
         constraints: getAudioConstraints({ deviceId: this.inputDeviceId }),
+        forceRelay: shouldForceRelay(),
       };
 
       this.broker = new FullAudioBroker(

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/base.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/base.js
@@ -1,3 +1,14 @@
+import { Tracker } from 'meteor/tracker';
+import VoiceCallStates from '/imports/api/voice-call-states';
+import CallStateOptions from '/imports/api/voice-call-states/utils/callStates';
+import logger from '/imports/startup/client/logger';
+import Auth from '/imports/ui/services/auth';
+
+const MEDIA = Meteor.settings.public.media;
+const BASE_BRIDGE_NAME = 'base';
+const CALL_TRANSFER_TIMEOUT = MEDIA.callTransferTimeout;
+const TRANSFER_TONE = '1';
+
 export default class BaseAudioBridge {
   constructor(userData) {
     this.userData = userData;
@@ -19,6 +30,8 @@ export default class BaseAudioBridge {
       reconnecting: 'reconnecting',
       autoplayBlocked: 'autoplayBlocked',
     };
+
+    this.bridgeName = BASE_BRIDGE_NAME;
   }
 
   getPeerConnection() {
@@ -39,5 +52,51 @@ export default class BaseAudioBridge {
 
   changeOutputDevice() {
     console.error('The Bridge must implement changeOutputDevice');
+  }
+
+  sendDtmf() {
+    console.error('The Bridge must implement sendDtmf');
+  }
+
+  trackTransferState(transferCallback) {
+    return new Promise((resolve, reject) => {
+      let trackerControl = null;
+
+      const timeout = setTimeout(() => {
+        trackerControl.stop();
+        logger.warn({ logCode: 'audio_transfer_timed_out' },
+          'Timeout on transferring from echo test to conference');
+        this.callback({
+          status: this.baseCallStates.failed,
+          error: 1008,
+          bridgeError: 'Timeout on call transfer',
+          bridge: this.bridgeName,
+        });
+
+        this.exitAudio();
+
+        reject(this.baseErrorCodes.REQUEST_TIMEOUT);
+      }, CALL_TRANSFER_TIMEOUT);
+
+      this.sendDtmf(TRANSFER_TONE);
+
+      Tracker.autorun((c) => {
+        trackerControl = c;
+        const selector = { meetingId: Auth.meetingID, userId: Auth.userID };
+        const query = VoiceCallStates.find(selector);
+
+        query.observeChanges({
+          changed: (id, fields) => {
+            if (fields.callState === CallStateOptions.IN_CONFERENCE) {
+              clearTimeout(timeout);
+              transferCallback();
+
+              c.stop();
+              resolve();
+            }
+          },
+        });
+      });
+    });
   }
 }

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
@@ -1,0 +1,92 @@
+import Settings from '/imports/ui/services/settings';
+import logger from '/imports/startup/client/logger';
+
+const AUDIO_SESSION_NUM_KEY = 'AudioSessionNumber';
+const DEFAULT_INPUT_DEVICE_ID = 'default';
+const DEFAULT_OUTPUT_DEVICE_ID = 'default';
+const INPUT_DEVICE_ID_KEY = 'audioInputDeviceId';
+const OUTPUT_DEVICE_ID_KEY = 'audioOutputDeviceId';
+const AUDIO_MICROPHONE_CONSTRAINTS = Meteor.settings.public.app.defaultSettings
+  .application.microphoneConstraints;
+
+const getAudioSessionNumber = () => {
+  let currItem = parseInt(sessionStorage.getItem(AUDIO_SESSION_NUM_KEY), 10);
+  if (!currItem) {
+    currItem = 0;
+  }
+
+  currItem += 1;
+  sessionStorage.setItem(AUDIO_SESSION_NUM_KEY, currItem);
+  return currItem;
+};
+
+const getCurrentAudioSessionNumber = () => sessionStorage.getItem(AUDIO_SESSION_NUM_KEY) || '0';
+
+const reloadAudioElement = (audioElement) => {
+  if (audioElement && (audioElement.readyState > 0)) {
+    audioElement.load();
+    return true;
+  }
+
+  return false;
+};
+
+/**
+ * Filter constraints set in audioDeviceConstraints, based on
+ * constants supported by browser. This avoids setting a constraint
+ * unsupported by browser. In currently safari version (13+), for example,
+ * setting an unsupported constraint crashes the audio.
+ * @param  {Object} audioDeviceConstraints Constraints to be set
+ * see: https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints
+ * @return {Object}                        A new Object of the same type as
+ * input, containing only the supported constraints.
+ */
+const filterSupportedConstraints = (audioDeviceConstraints) => {
+  try {
+    const matchConstraints = {};
+    const supportedConstraints = navigator
+      .mediaDevices.getSupportedConstraints() || {};
+    Object.entries(audioDeviceConstraints).forEach(
+      ([constraintName, constraintValue]) => {
+        if (supportedConstraints[constraintName]) {
+          matchConstraints[constraintName] = constraintValue;
+        }
+      },
+    );
+
+    return matchConstraints;
+  } catch (error) {
+    logger.error({
+      logCode: 'audio_unsupported_constraint_error',
+    }, 'Unsupported audio constraints');
+    return {};
+  }
+};
+
+const getAudioConstraints = ({ deviceId = '' }) => {
+  const userSettingsConstraints = Settings.application.microphoneConstraints;
+  const audioDeviceConstraints = userSettingsConstraints
+    || AUDIO_MICROPHONE_CONSTRAINTS || {};
+
+  const matchConstraints = filterSupportedConstraints(
+    audioDeviceConstraints,
+  );
+
+  if (deviceId) {
+    matchConstraints.deviceId = { exact: deviceId };
+  }
+
+  return matchConstraints;
+};
+
+export {
+  DEFAULT_INPUT_DEVICE_ID,
+  DEFAULT_OUTPUT_DEVICE_ID,
+  INPUT_DEVICE_ID_KEY,
+  OUTPUT_DEVICE_ID_KEY,
+  getAudioSessionNumber,
+  getCurrentAudioSessionNumber,
+  reloadAudioElement,
+  filterSupportedConstraints,
+  getAudioConstraints,
+};

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/fullaudio-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/fullaudio-broker.js
@@ -3,6 +3,7 @@ import BaseBroker from '/imports/ui/services/bbb-webrtc-sfu/sfu-base-broker';
 
 const ON_ICE_CANDIDATE_MSG = 'iceCandidate';
 const SUBSCRIBER_ANSWER = 'subscriberAnswer';
+const DTMF = 'dtmf';
 
 const SFU_COMPONENT_NAME = 'fullaudio';
 
@@ -22,7 +23,8 @@ class FullAudioBroker extends BaseBroker {
     this.role = role;
     this.offering = true;
 
-    // Optional parameters are: userName, caleeName, iceServers, offering, mediaServer
+    // Optional parameters are: userName, caleeName, iceServers, offering,
+    // mediaServer, extension
     Object.assign(this, options);
   }
 
@@ -43,8 +45,6 @@ class FullAudioBroker extends BaseBroker {
       const WebRTCPeer = (this.role === 'sendrecv')
         ? kurentoUtils.WebRtcPeer.WebRtcPeerSendrecv
         : kurentoUtils.WebRtcPeer.WebRtcPeerRecvonly;
-
-      window.kurento = kurentoUtils.WebRtcPeer;
 
       this.webRtcPeer = WebRTCPeer(options, (error) => {
         if (error) {
@@ -162,6 +162,7 @@ class FullAudioBroker extends BaseBroker {
       userName: this.userName,
       sdpOffer: offer,
       mediaServer: this.mediaServer,
+      extension: this.extension,
     };
 
     logger.debug({
@@ -186,6 +187,16 @@ class FullAudioBroker extends BaseBroker {
     }
 
     this.sendStartReq(sdpOffer);
+  }
+
+  dtmf (tones) {
+    const message = {
+      id: DTMF,
+      type: this.sfuComponent,
+      tones,
+    };
+
+    this.sendMessage(message);
   }
 
   onIceCandidate (candidate, role) {

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/fullaudio-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/fullaudio-broker.js
@@ -72,12 +72,11 @@ class FullAudioBroker extends BaseBroker {
           audio: this.constraints ? this.constraints : true,
           video: false,
         },
+        configuration: this.populatePeerConfiguration(),
         onicecandidate: (candidate) => {
           this.onIceCandidate(candidate, this.role);
         },
       };
-
-      this.addIceServers(options);
 
       const WebRTCPeer = (this.role === 'sendrecv')
         ? kurentoUtils.WebRtcPeer.WebRtcPeerSendrecv

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/fullaudio-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/fullaudio-broker.js
@@ -10,20 +10,14 @@ const SFU_COMPONENT_NAME = 'fullaudio';
 class FullAudioBroker extends BaseBroker {
   constructor(
     wsUrl,
-    voiceBridge,
-    userId,
-    internalMeetingId,
     role,
     options = {},
   ) {
     super(SFU_COMPONENT_NAME, wsUrl);
-    this.voiceBridge = voiceBridge;
-    this.userId = userId;
-    this.internalMeetingId = internalMeetingId;
     this.role = role;
     this.offering = true;
 
-    // Optional parameters are: userName, caleeName, iceServers, offering,
+    // Optional parameters are: caleeName, iceServers, offering,
     // mediaServer, extension, constraints
     Object.assign(this, options);
   }
@@ -171,7 +165,6 @@ class FullAudioBroker extends BaseBroker {
       id: SUBSCRIBER_ANSWER,
       type: this.sfuComponent,
       role: this.role,
-      voiceBridge: this.voiceBridge,
       sdpOffer: localDescription,
     };
 
@@ -191,11 +184,7 @@ class FullAudioBroker extends BaseBroker {
       id: 'start',
       type: this.sfuComponent,
       role: this.role,
-      internalMeetingId: this.internalMeetingId,
-      voiceBridge: this.voiceBridge,
       caleeName: this.caleeName,
-      userId: this.userId,
-      userName: this.userName,
       sdpOffer: offer,
       mediaServer: this.mediaServer,
       extension: this.extension,
@@ -240,7 +229,6 @@ class FullAudioBroker extends BaseBroker {
       id: ON_ICE_CANDIDATE_MSG,
       role,
       type: this.sfuComponent,
-      voiceBridge: this.voiceBridge,
       candidate,
     };
 


### PR DESCRIPTION
### What does this PR do?

- Implements echo test in the experimental full audio bridge
  * Includes a refactor to make the transfer tracking code re-usable across bridges
  * Transfer is done via server-side DTMF. Similar to the default bridge, but the DTMF signal point is in the server instead of in the client
- Implements input/output device changes in the experimental full audio bridges
  * Includes a refactor to make some of the input/output device code re-usable across bridges. More can be moved around in the future.
- Handles audio constraints/filter changes in the new bridge
- Handles the `forceRelayOnFirefox` and `forceRelay` flags
- Remove client RPC parameters that are fetched in the server (userId, meetingId, voiceBridge) + some unused ones (userName)

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/14191
Closes https://github.com/bigbluebutton/bigbluebutton/issues/14095 
Closes https://github.com/bigbluebutton/bigbluebutton/issues/14240 

### Motivation

https://github.com/bigbluebutton/bigbluebutton/issues/14191
https://github.com/bigbluebutton/bigbluebutton/issues/14095 
https://github.com/bigbluebutton/bigbluebutton/issues/14240 

### Pending

- [x] SFU v2.7-alpha tag needs to be integrated and built

### Known issues

- [ ] There might be a slight delay between echo test being flagged as "ready" and audio actually circling back to the client
  * To be addressed separately