### PR TITLE
fix: screenshare position regression

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/styles.js
@@ -20,7 +20,7 @@ const MainText = styled.h1`
 `;
 
 const ScreenshareVideo = styled.video`
-  ${({ unhealthy }) => unhealthy && `
+  ${({ unhealthyStream }) => unhealthyStream && `
     filter: grayscale(50%) opacity(50%);
   `}
 `;
@@ -32,6 +32,9 @@ const ScreenshareContainer = styled.div`
   height: 100%;
 
   ${({ switched }) => !switched && `
+    display: flex;
+    align-items: center;
+    justify-content: center;
     flex-direction: column;
   `}
 `;


### PR DESCRIPTION
### What does this PR do?

Restores missing styles for screenshare (presenter view)

#### regression
<img width="734" alt="Screen Shot 2022-01-26 at 13 56 24" src="https://user-images.githubusercontent.com/3728706/151209849-67db2a02-7ba9-4f14-b65c-f9d3bf0a23e1.png">

#### fixed
<img width="520" alt="Screen Shot 2022-01-26 at 13 53 57" src="https://user-images.githubusercontent.com/3728706/151209845-89c86654-da18-47d6-a4f0-495a113652a6.png">
