### PR TITLE
chore: webrtc-sfu@v2.7.0-alpha.1 (full audio + mediasoup)

### DIFF
--- a/bbb-voice-conference/config/freeswitch/conf/dialplan/public/bbb_sfu.xml
+++ b/bbb-voice-conference/config/freeswitch/conf/dialplan/public/bbb_sfu.xml
@@ -1,0 +1,10 @@
+<include>
+    <extension name="bbb_webrtc_call" continue="true">
+      <condition field="${sip_user_agent}" expression="bbb-webrtc-sfu" break="on-false">
+        <action application="set" data="bbb_authorized=true"/>
+        <action application="set" data="rtp_manual_rtp_bugs=ACCEPT_ANY_PACKETS"/>
+        <action application="set" data="jb_use_timestamps=true"/>
+        <action application="transfer" data="${destination_number} XML default"/>
+      </condition>
+    </extension>
+</include>

--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.6.5 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.7.0-alpha.1 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

- chore: bump bbb-webrtc-sfu to v2.7.0-alpha.1 
  * Bidirectional media flows with single transport in mediasoup (#14020)
- feat: add new dialplan rule for bbb-webrtc-sfu calls

### Closes Issue(s)

Closes #14020

### More

Dialplan rationale in commit message details (3d1b2c8)