### PR TITLE
fix: Disconnected users omitted from connection history

### DIFF
--- a/bigbluebutton-html5/imports/api/connection-status/server/modifiers/updateConnectionStatus.js
+++ b/bigbluebutton-html5/imports/api/connection-status/server/modifiers/updateConnectionStatus.js
@@ -1,6 +1,7 @@
 import ConnectionStatus from '/imports/api/connection-status';
 import Logger from '/imports/startup/server/logger';
 import { check } from 'meteor/check';
+import changeHasConnectionStatus from '/imports/api/users-persistent-data/server/modifiers/changeHasConnectionStatus';
 
 export default function updateConnectionStatus(meetingId, userId, level) {
   check(meetingId, String);
@@ -24,6 +25,7 @@ export default function updateConnectionStatus(meetingId, userId, level) {
     const { numberAffected } = ConnectionStatus.upsert(selector, modifier);
 
     if (numberAffected) {
+      changeHasConnectionStatus(true, userId, meetingId);
       Logger.verbose(`Updated connection status meetingId=${meetingId} userId=${userId} level=${level}`);
     }
   } catch (err) {

--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addGroupChatMsg.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addGroupChatMsg.js
@@ -2,7 +2,7 @@ import { Match, check } from 'meteor/check';
 import Logger from '/imports/startup/server/logger';
 import { GroupChatMsg } from '/imports/api/group-chat-msg';
 import { BREAK_LINE } from '/imports/utils/lineEndings';
-import changeHasMessages from '/imports/api/users/server/modifiers/changeHasMessages';
+import changeHasMessages from '/imports/api/users-persistent-data/server/modifiers/changeHasMessages';
 
 export function parseMessage(message) {
   let parsedMessage = message || '';

--- a/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/changeHasConnectionStatus.js
+++ b/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/changeHasConnectionStatus.js
@@ -1,7 +1,7 @@
 import Logger from '/imports/startup/server/logger';
 import UsersPersistentData from '/imports/api/users-persistent-data';
 
-export default function changeHasMessages(hasMessages, userId, meetingId) {
+export default function changeHasConnectionStatus(hasConnectionStatus, userId, meetingId) {
   const selector = {
     meetingId,
     userId,
@@ -9,7 +9,7 @@ export default function changeHasMessages(hasMessages, userId, meetingId) {
 
   const modifier = {
     $set: {
-      'shouldPersist.hasMessages': hasMessages,
+      'shouldPersist.hasConnectionStatus': hasConnectionStatus,
     },
   };
 
@@ -17,9 +17,9 @@ export default function changeHasMessages(hasMessages, userId, meetingId) {
     const numberAffected = UsersPersistentData.update(selector, modifier);
 
     if (numberAffected) {
-      Logger.info(`Changed hasMessages=${hasMessages} id=${userId} meeting=${meetingId}`);
+      Logger.info(`Changed hasConnectionStatus=${hasConnectionStatus} id=${userId} meeting=${meetingId}`);
     }
   } catch (err) {
-    Logger.error(`Change hasMessages error: ${err}`);
+    Logger.error(`Change hasConnectionStatus error: ${err}`);
   }
 }

--- a/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/changeHasMessages.js
+++ b/bigbluebutton-html5/imports/api/users-persistent-data/server/modifiers/changeHasMessages.js
@@ -1,5 +1,5 @@
 import Logger from '/imports/startup/server/logger';
-import Users from '/imports/api/users';
+import UsersPersistentData from '/imports/api/users-persistent-data';
 
 export default function changeHasMessages(hasMessages, userId, meetingId) {
   const selector = {
@@ -14,7 +14,7 @@ export default function changeHasMessages(hasMessages, userId, meetingId) {
   };
 
   try {
-    const numberAffected = Users.update(selector, modifier);
+    const numberAffected = UsersPersistentData.update(selector, modifier);
 
     if (numberAffected) {
       Logger.info(`Changed hasMessages=${hasMessages} id=${userId} meeting=${meetingId}`);

--- a/bigbluebutton-html5/imports/api/users-persistent-data/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/users-persistent-data/server/publishers.js
@@ -27,7 +27,7 @@ function usersPersistentData() {
       meetingId,
       $or: [
         {
-          hasMessages: true,
+          'shouldPersist.hasMessages': true,
         },
         {
           loggedOut: false,

--- a/bigbluebutton-html5/imports/api/users-persistent-data/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/users-persistent-data/server/publishers.js
@@ -2,6 +2,9 @@ import UsersPersistentData from '/imports/api/users-persistent-data';
 import { Meteor } from 'meteor/meteor';
 import { extractCredentials } from '/imports/api/common/server/helpers';
 import { check } from 'meteor/check';
+import Users from '/imports/api/users';
+
+const ROLE_VIEWER = Meteor.settings.public.user.role_viewer;
 
 function usersPersistentData() {
   if (!this.userId) {
@@ -16,6 +19,23 @@ function usersPersistentData() {
     meetingId,
   };
 
+  const User = Users.findOne({ userId: requesterUserId, meetingId }, { fields: { role: 1 } });
+  if (!!User && User.role === ROLE_VIEWER) {
+    // viewers are allowed to see other users' data if:
+    // user is logged in or user sent a message in chat
+    const viewerSelector = {
+      meetingId,
+      $or: [
+        {
+          hasMessages: true,
+        },
+        {
+          loggedOut: false,
+        },
+      ],
+    };
+    return UsersPersistentData.find(viewerSelector);
+  }
   return UsersPersistentData.find(selector);
 }
 

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
@@ -5,7 +5,6 @@ import Logger from '/imports/startup/server/logger';
 import setloggedOutStatus from '/imports/api/users-persistent-data/server/modifiers/setloggedOutStatus';
 import clearUserInfoForRequester from '/imports/api/users-infos/server/modifiers/clearUserInfoForRequester';
 import ClientConnections from '/imports/startup/server/ClientConnections';
-import UsersPersistentData from '/imports/api/users-persistent-data';
 import VoiceUsers from '/imports/api/voice-users/';
 
 const clearAllSessions = (sessionUserId) => {
@@ -37,12 +36,7 @@ export default function removeUser(meetingId, userId) {
 
       clearUserInfoForRequester(meetingId, userId);
 
-      const currentUser = Users.findOne({ userId, meetingId });
-      const hasMessages = currentUser?.hasMessages;
   
-      if (!hasMessages) {
-        UsersPersistentData.remove(selector);
-      }
       Users.remove(selector);
       VoiceUsers.remove({ intId: userId, meetingId });
     }

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
@@ -5,6 +5,7 @@ import Logger from '/imports/startup/server/logger';
 import setloggedOutStatus from '/imports/api/users-persistent-data/server/modifiers/setloggedOutStatus';
 import clearUserInfoForRequester from '/imports/api/users-infos/server/modifiers/clearUserInfoForRequester';
 import ClientConnections from '/imports/startup/server/ClientConnections';
+import UsersPersistentData from '/imports/api/users-persistent-data';
 import VoiceUsers from '/imports/api/voice-users/';
 
 const clearAllSessions = (sessionUserId) => {
@@ -36,7 +37,13 @@ export default function removeUser(meetingId, userId) {
 
       clearUserInfoForRequester(meetingId, userId);
 
-  
+      const currentUser = UsersPersistentData.findOne({ userId, meetingId });
+      const hasMessages = currentUser?.shouldPersist?.hasMessages;
+      const hasConnectionStatus = currentUser?.shouldPersist?.hasConnectionStatus;
+
+      if (!hasMessages && !hasConnectionStatus) {
+        UsersPersistentData.remove(selector);
+      }
       Users.remove(selector);
       VoiceUsers.remove({ intId: userId, meetingId });
     }


### PR DESCRIPTION
### What does this PR do?

Makes the following changes, which makes disconnected users data available to moderators:
- move hasMessages from Users collection to shouldPersist.hasMessages in UsersPersistentData collection;
- add shouldPersist.hasConnectionStatus to UsersPersistentData collection;
- only remove data if both `shouldPersist.hasMessages` and `shouldPersist.hasConnectionStatus` are false;
- filter data on UsersPersistentData publisher based on user role (connection status of offline users is only available to moderators).

#### before
User data is removed on leave unless the user sends a message in chat.

#### after
Logged out users data remains available to moderators even if the user did not send any message in chat, and available do viewers if the user sends a message in chat.

### Closes Issue(s)
Closes #14099