### PR TITLE
refactor(recording): Refactored record-and-playback's deploy script to work properly

### DIFF
--- a/record-and-playback/deploy.sh
+++ b/record-and-playback/deploy.sh
@@ -24,7 +24,9 @@ sudo rm -rf /usr/local/bigbluebutton/core/lib
 sudo cp -r core/lib /usr/local/bigbluebutton/core/
 sudo rm -rf /usr/local/bigbluebutton/core/scripts
 sudo cp -r core/scripts /usr/local/bigbluebutton/core/
-sudo rm -rf /var/bigbluebutton/playback/*
+sudo rm -rf /var/bigbluebutton/playback/presentation/0.81/
+sudo rm -rf /var/bigbluebutton/playback/presentation/0.9.0/
+sudo rm -rf /var/bigbluebutton/playback/presentation/2.0/
 
 function deploy_format() {
 	local formats=$1
@@ -95,10 +97,10 @@ if [ ! -d "$REC_STATUS_SANITY_DIR" ]; then
   sudo mkdir -p $REC_STATUS_SANITY_DIR
 fi
 
-sudo mv /usr/local/bigbluebutton/core/scripts/*.nginx /etc/bigbluebutton/nginx/
-sudo service nginx reload
+#sudo mv /usr/local/bigbluebutton/core/scripts/*.nginx /etc/bigbluebutton/nginx/
+#sudo service nginx reload
 sudo chown -R bigbluebutton:bigbluebutton /var/bigbluebutton/ /var/log/bigbluebutton/
-sudo chown -R red5:red5 /var/bigbluebutton/screenshare/
+#sudo chown -R red5:red5 /var/bigbluebutton/screenshare/
 
 #cd /usr/local/bigbluebutton/core/
 #sudo bundle install

--- a/record-and-playback/deploy.sh
+++ b/record-and-playback/deploy.sh
@@ -97,10 +97,4 @@ if [ ! -d "$REC_STATUS_SANITY_DIR" ]; then
   sudo mkdir -p $REC_STATUS_SANITY_DIR
 fi
 
-#sudo mv /usr/local/bigbluebutton/core/scripts/*.nginx /etc/bigbluebutton/nginx/
-#sudo service nginx reload
 sudo chown -R bigbluebutton:bigbluebutton /var/bigbluebutton/ /var/log/bigbluebutton/
-#sudo chown -R red5:red5 /var/bigbluebutton/screenshare/
-
-#cd /usr/local/bigbluebutton/core/
-#sudo bundle install


### PR DESCRIPTION
### What does this PR do?

While working on issue 13547, the one related to the differentiation of user's roles in the recording chat, I faced a building problem as I am going to describe it as follows:

As playback of 2.3 stays in another repository now, any changes in ruby scripts of the process or publish phase caused the removal of all folders inside `/var/bigbluebutton/playback/presentation/` including the 2.3 folder which is responsible to display the recording in the browser. As a result, playback stopped working.

So, this PR simply change the removal of all the folders inside `/var/bigbluebutton/playback/presentation/` directory and instead, it only removes the 3 directories that this script will re-deploy: `0.81`, `0.9.0` and `2.0`. The other change in the deploy file simply take care of the nginx not to reload.

One more thing that worth a comment is that `record-and-playback` repository has no longer control of the playback phase, this feature is now controlled by https://github.com/bigbluebutton/bbb-playback.
