### PR TITLE
[issue-13547] - Diferentiate the user's roles

### DIFF
--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1071,7 +1071,8 @@ def processChatMessages(events, bbb_props)
           direction: 'down',
           name: chat[:sender],
           message: chat[:message],
-          target: 'chat'
+          target: 'chat',
+          emphasised: chat[:emphasised]
         }
         chattimeline[:out] = (chat[:out] / 1000.0).round(1) unless chat[:out].nil?
         xml.chattimeline(**chattimeline)


### PR DESCRIPTION
### What does this PR do?

This code resolves the issue #13547. It basically calculates the period in which each user was moderator (if that is the case), and with this information, it checks every message in the chat to see if it falls into any of the periods calculated before, that being true, this message receives an emphasis tag that is propagated on to the xml chat file.

In the client side, it interprets the emphasis tag inside the xml item and display the message in bold to differentiate the moderators' messages from the viewers' messages.

PS.: This is a work in progress, but I already did the part described in the first paragraph.

### Closes Issue:

Closes issue #13547