### PR TITLE
fix(virtualBG): snippet "blur" translation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
@@ -11,7 +11,6 @@ import {
   getVirtualBackgroundThumbnail,
   isVirtualBackgroundSupported,
 } from '/imports/ui/services/virtual-background/service';
-import { capitalizeFirstLetter } from '/imports/utils/string-utils';
 
 const propTypes = {
   intl: PropTypes.shape({
@@ -167,8 +166,8 @@ const VirtualBgSelector = ({
             <Button
               style={{ backgroundImage: `url('${getVirtualBackgroundThumbnail(BLUR_FILENAME)}')` }}
               className={thumbnailStyles.join(' ')}
-              aria-label={EFFECT_TYPES.BLUR_TYPE}
-              label={capitalizeFirstLetter(EFFECT_TYPES.BLUR_TYPE)}
+              aria-label={intl.formatMessage(intlMessages.blurLabel)}
+              label={intl.formatMessage(intlMessages.blurLabel))}
               aria-describedby={`vr-cam-btn-blur`}
               tabIndex={disabled ? -1 : 0}
               hideLabel


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

This small patch enables the translation of "blur" for the virtual background picture selection modal.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes a half of #14222


### Motivation

To have the same style (translation) with other thumbnails. 

### More

before:
![151478190-c4cf1fa0-599c-4b88-aa21-407cb2100efb](https://user-images.githubusercontent.com/45039819/151648664-2f46ecb1-ce3e-49b6-bf2d-72afb98c360b.jpg)

after:
![1 0](https://user-images.githubusercontent.com/45039819/151648620-1983e0df-1073-449b-9f7e-e3815724656b.jpeg)

