### PR TITLE
fix(virtualBG): recover shrunken thumbnails on the modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/styles.scss
@@ -31,6 +31,7 @@
 .virtualBackgroundItem {
   outline: none;
   display: flex;
+  flex-shrink: 0;
   position: relative;
   justify-content: center;
   align-items: center;
@@ -71,4 +72,5 @@
   border-radius: var(--border-size-large);
   height: var(--thumbnail-btn-md);
   width: var(--thumbnail-btn-md);
+  flex-shrink: 0;
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

This small patch prevents the null and blur thumbnails from being shrunken in the virtual BG selection modal, when more than one custom BG picture is added.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes a half of #14222


### Motivation

For a cosmetic reason.

### More

Before:
![151478190-c4cf1fa0-599c-4b88-aa21-407cb2100efb](https://user-images.githubusercontent.com/45039819/151648805-fdab0c75-7bfc-494c-98b3-18121a68e163.jpg)

After:
![1 0](https://user-images.githubusercontent.com/45039819/151648810-57e3a35c-fc16-4406-8b86-0a00ddfc08e1.jpeg)

