### PR TITLE
fix: serve compressed Javascript and CSS

### DIFF
--- a/build/packages-template/bbb-html5/bionic/bbb-html5.nginx
+++ b/build/packages-template/bbb-html5/bionic/bbb-html5.nginx
@@ -35,6 +35,7 @@ location /html5client/wasm {
 }
 
 location /html5client {
+  gzip_static on;
   alias /usr/share/meteor/bundle/programs/web.browser;
   try_files $uri @html5client;
 }

--- a/build/packages-template/bbb-html5/build.sh
+++ b/build/packages-template/bbb-html5/build.sh
@@ -102,15 +102,11 @@ if [ -f staging/usr/share/meteor/bundle/programs/web.browser/head.html ]; then
   sed -i "s/VERSION/$(($BUILD))/" staging/usr/share/meteor/bundle/programs/web.browser/head.html
 fi
 
-# Compress tensorflow WASM binaries used for virtual backgrounds. Keep the
+# Compress CSS, Javascript andtensorflow WASM binaries used for virtual backgrounds. Keep the
 # uncompressed versions as well so it works with mismatched nginx location blocks
-if [ -f staging/usr/share/meteor/bundle/programs/web.browser/app/wasm/tflite-simd.wasm ]; then
-  gzip -k -f -9 staging/usr/share/meteor/bundle/programs/web.browser/app/wasm/tflite-simd.wasm
-fi
-
-if [ -f staging/usr/share/meteor/bundle/programs/web.browser/app/wasm/tflite.wasm ]; then
-  gzip -k -f -9 staging/usr/share/meteor/bundle/programs/web.browser/app/wasm/tflite.wasm
-fi
+find staging/usr/share/meteor/bundle/programs/web.browser -name '*.js' -exec gzip -k -f -9 '{}' \;
+find staging/usr/share/meteor/bundle/programs/web.browser -name '*.css' -exec gzip -k -f -9 '{}' \;
+find staging/usr/share/meteor/bundle/programs/web.browser -name '*.wasm' -exec gzip -k -f -9 '{}' \;
 
 mkdir -p staging/etc/nginx/sites-available
 cp bigbluebutton.nginx staging/etc/nginx/sites-available/bigbluebutton


### PR DESCRIPTION
The BBB html5 client is huge and can be compressed easliy. As nginx
already services the static files, it can also handle service gzipped
files.

### What does this PR do?

Ship compressed files with the package.

### Motivation

When benchmarking my cluster proxy setup, I let many clients join in a short time frame. I noticed that client loading needed a lot of bandwidth, much more than for example video traffic. So I started investigating...

If we had a more recent Ubuntu and nginx, we could also serve brotli compressed files which reduces the size of the Javascript from 3.6 MB to around 600k instead of 900k with gzip.

### More

@antobinary you might want to adapt this to the scripts building the official packages.