### PR TITLE
fix: remove extra parentheses from virtual background label

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
@@ -167,7 +167,7 @@ const VirtualBgSelector = ({
               style={{ backgroundImage: `url('${getVirtualBackgroundThumbnail(BLUR_FILENAME)}')` }}
               className={thumbnailStyles.join(' ')}
               aria-label={intl.formatMessage(intlMessages.blurLabel)}
-              label={intl.formatMessage(intlMessages.blurLabel))}
+              label={intl.formatMessage(intlMessages.blurLabel)}
               aria-describedby={`vr-cam-btn-blur`}
               tabIndex={disabled ? -1 : 0}
               hideLabel


### PR DESCRIPTION
### What does this PR do?

Removes extra parentheses from virtual background blur label (client was crashing during startup process because of this).

<img width="1400" alt="Screen Shot 2022-02-01 at 12 33 35" src="https://user-images.githubusercontent.com/3728706/151970570-c946cba5-213a-481a-839a-3b21ba9aa837.png">
