### PR TITLE
[2.3] fix(screenshare): add state sync, akka-apps|webrtc-sfu broadcast stop sys msg

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
@@ -8,7 +8,8 @@ class ScreenshareApp2x(implicit val context: ActorContext)
   with ScreenshareStoppedVoiceConfEvtMsgHdlr
   with GetScreenshareStatusReqMsgHdlr
   with ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr
-  with ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr {
+  with ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr
+  with SyncGetScreenshareInfoRespMsgHdlr {
 
   val log = Logging(context.system, getClass)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
@@ -2,6 +2,40 @@ package org.bigbluebutton.core.apps.screenshare
 
 import akka.actor.ActorContext
 import akka.event.Logging
+import org.bigbluebutton.core.apps.ScreenshareModel
+import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
+
+
+object ScreenshareApp2x {
+  def requestBroadcastStop(outGW: OutMsgRouter, liveMeeting: LiveMeeting): Unit = {
+    if (ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel)) {
+      val event = MsgBuilder.buildScreenBroadcastStopSysMsg(
+        liveMeeting.props.meetingProp.intId,
+        ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel),
+      )
+
+      outGW.send(event)
+    }
+  }
+
+  def broadcastStopped(outGW: OutMsgRouter, liveMeeting: LiveMeeting): Unit = {
+    if (ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel)) {
+      ScreenshareModel.resetDesktopSharingParams(liveMeeting.screenshareModel)
+
+      val event = MsgBuilder.buildStopScreenshareRtmpBroadcastEvtMsg(
+        liveMeeting.props.meetingProp.intId,
+        ScreenshareModel.getVoiceConf(liveMeeting.screenshareModel),
+        ScreenshareModel.getScreenshareConf(liveMeeting.screenshareModel),
+        ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel),
+        ScreenshareModel.getScreenshareVideoWidth(liveMeeting.screenshareModel),
+        ScreenshareModel.getScreenshareVideoHeight(liveMeeting.screenshareModel),
+        ScreenshareModel.getTimestamp(liveMeeting.screenshareModel)
+      )
+      outGW.send(event)
+    }
+  }
+}
 
 class ScreenshareApp2x(implicit val context: ActorContext)
   extends ScreenshareStartedVoiceConfEvtMsgHdlr

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
@@ -12,6 +12,7 @@ object ScreenshareApp2x {
     if (ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel)) {
       val event = MsgBuilder.buildScreenBroadcastStopSysMsg(
         liveMeeting.props.meetingProp.intId,
+        ScreenshareModel.getVoiceConf(liveMeeting.screenshareModel),
         ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel),
       )
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr.scala
@@ -4,48 +4,16 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.ScreenshareModel
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.running.LiveMeeting
+import org.bigbluebutton.core.apps.screenshare.ScreenshareApp2x.{ broadcastStopped }
 
 trait ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr {
   this: ScreenshareApp2x =>
 
   def handle(msg: ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
-
-    def broadcastEvent(voiceConf: String, screenshareConf: String,
-                       stream: String, vidWidth: Int, vidHeight: Int,
-                       timestamp: String): BbbCommonEnvCoreMsg = {
-
-      val routing = Routing.addMsgToClientRouting(
-        MessageTypes.BROADCAST_TO_MEETING,
-        liveMeeting.props.meetingProp.intId, "not-used"
-      )
-      val envelope = BbbCoreEnvelope(ScreenshareRtmpBroadcastStoppedEvtMsg.NAME, routing)
-      val header = BbbClientMsgHeader(
-        ScreenshareRtmpBroadcastStoppedEvtMsg.NAME,
-        liveMeeting.props.meetingProp.intId, "not-used"
-      )
-
-      val body = ScreenshareRtmpBroadcastStoppedEvtMsgBody(voiceConf, screenshareConf,
-        stream, vidWidth, vidHeight, timestamp)
-      val event = ScreenshareRtmpBroadcastStoppedEvtMsg(header, body)
-      BbbCommonEnvCoreMsg(envelope, event)
-    }
-
     log.info("handleScreenshareRTMPBroadcastStoppedRequest: isBroadcastingRTMP=" +
       ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel) + " URL:" +
       ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel))
 
-    // only valid if currently broadcasting
-    if (ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel)) {
-      log.info("STOP broadcast ALLOWED when isBroadcastingRTMP=true")
-      ScreenshareModel.broadcastingRTMPStopped(liveMeeting.screenshareModel)
-
-      // notify viewers that RTMP broadcast stopped
-      val msgEvent = broadcastEvent(msg.body.voiceConf, msg.body.screenshareConf, msg.body.stream,
-        msg.body.vidWidth, msg.body.vidHeight, msg.body.timestamp)
-      bus.outGW.send(msgEvent)
-    } else {
-      log.info("STOP broadcast NOT ALLOWED when isBroadcastingRTMP=false")
-    }
+    broadcastStopped(bus.outGW, liveMeeting)
   }
-
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/SyncGetScreenshareInfoRespMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/SyncGetScreenshareInfoRespMsgHdlr.scala
@@ -1,0 +1,37 @@
+package org.bigbluebutton.core.apps.screenshare
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.apps.ScreenshareModel
+import org.bigbluebutton.core.bus.MessageBus
+import org.bigbluebutton.core.running.LiveMeeting
+
+trait SyncGetScreenshareInfoRespMsgHdlr {
+  this: ScreenshareApp2x =>
+
+  def handleSyncGetScreenshareInfoRespMsg(liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
+    val routing = Routing.addMsgToHtml5InstanceIdRouting(
+      liveMeeting.props.meetingProp.intId,
+      liveMeeting.props.systemProps.html5InstanceId.toString
+    )
+    val envelope = BbbCoreEnvelope(SyncGetScreenshareInfoRespMsg.NAME, routing)
+    val header = BbbClientMsgHeader(
+      SyncGetScreenshareInfoRespMsg.NAME,
+      liveMeeting.props.meetingProp.intId,
+      "nodeJSapp"
+    )
+    val body = SyncGetScreenshareInfoRespMsgBody(
+      ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel),
+      ScreenshareModel.getVoiceConf(liveMeeting.screenshareModel),
+      ScreenshareModel.getScreenshareConf(liveMeeting.screenshareModel),
+      ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel),
+      ScreenshareModel.getScreenshareVideoWidth(liveMeeting.screenshareModel),
+      ScreenshareModel.getScreenshareVideoHeight(liveMeeting.screenshareModel),
+      ScreenshareModel.getTimestamp(liveMeeting.screenshareModel),
+      ScreenshareModel.getHasAudio(liveMeeting.screenshareModel)
+    )
+    val event = SyncGetScreenshareInfoRespMsg(header, body)
+    val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+
+    bus.outGW.send(msgEvent)
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AssignPresenterReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AssignPresenterReqMsgHdlr.scala
@@ -6,6 +6,7 @@ import org.bigbluebutton.core.models.{ PresentationPod, UserState, Users2x }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.domain.MeetingState2x
+import org.bigbluebutton.core.apps.screenshare.ScreenshareApp2x.{ requestBroadcastStop }
 
 trait AssignPresenterReqMsgHdlr extends RightsManagementTrait {
   this: UsersApp =>
@@ -69,6 +70,11 @@ object AssignPresenterActionHandler extends RightsManagementTrait {
       } yield {
         Users2x.makeNotPresenter(liveMeeting.users2x, oldPres.intId)
         broadcastOldPresenterChange(oldPres)
+        if (oldPres.intId != newPresenterId) {
+          // Request a screen broadcast stop (goes to SFU, comes back through
+          // ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg)
+          requestBroadcastStop(outGW, liveMeeting)
+        }
       }
 
       for {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -576,7 +576,8 @@ class MeetingActor(
     // sync all lock settings
     handleSyncGetLockSettingsMsg(state, liveMeeting, msgBus)
 
-    // TODO send all screen sharing info
+    // send all screen sharing info
+    screenshareApp2x.handleSyncGetScreenshareInfoRespMsg(liveMeeting, msgBus)
   }
 
   def handleGetAllMeetingsReqMsg(msg: GetAllMeetingsReqMsg): Unit = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -555,4 +555,32 @@ object MsgBuilder {
 
     BbbCommonEnvCoreMsg(envelope, event)
   }
+
+  def buildStopScreenshareRtmpBroadcastEvtMsg(
+      meetingId: String,
+      voiceConf: String, screenshareConf: String,
+      stream: String, vidWidth: Int, vidHeight: Int,
+      timestamp: String
+  ): BbbCommonEnvCoreMsg = {
+
+    val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, "not-used")
+    val envelope = BbbCoreEnvelope(ScreenshareRtmpBroadcastStoppedEvtMsg.NAME, routing)
+    val header = BbbClientMsgHeader(ScreenshareRtmpBroadcastStoppedEvtMsg.NAME, meetingId, "not-used")
+    val body = ScreenshareRtmpBroadcastStoppedEvtMsgBody(voiceConf, screenshareConf, stream, vidWidth, vidHeight, timestamp)
+    val event = ScreenshareRtmpBroadcastStoppedEvtMsg(header, body)
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
+
+  def buildScreenBroadcastStopSysMsg(
+      meetingId: String,
+      streamId:  String
+  ): BbbCommonEnvCoreMsg = {
+    val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
+    val envelope = BbbCoreEnvelope(ScreenBroadcastStopSysMsg.NAME, routing)
+    val body = ScreenBroadcastStopSysMsgBody(meetingId, streamId)
+    val header = BbbCoreBaseHeader(ScreenBroadcastStopSysMsg.NAME)
+    val event = ScreenBroadcastStopSysMsg(header, body)
+
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -573,11 +573,12 @@ object MsgBuilder {
 
   def buildScreenBroadcastStopSysMsg(
       meetingId: String,
+      voiceConf: String,
       streamId:  String
   ): BbbCommonEnvCoreMsg = {
     val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
     val envelope = BbbCoreEnvelope(ScreenBroadcastStopSysMsg.NAME, routing)
-    val body = ScreenBroadcastStopSysMsgBody(meetingId, streamId)
+    val body = ScreenBroadcastStopSysMsgBody(meetingId, voiceConf, streamId)
     val header = BbbCoreBaseHeader(ScreenBroadcastStopSysMsg.NAME)
     val event = ScreenBroadcastStopSysMsg(header, body)
 

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
@@ -40,6 +40,25 @@ case class ScreenshareRtmpBroadcastStartedEvtMsgBody(voiceConf: String, screensh
                                                      timestamp: String, hasAudio: Boolean)
 
 /**
+ * Sync screenshare state with bbb-html5
+ */
+object SyncGetScreenshareInfoRespMsg { val NAME = "SyncGetScreenshareInfoRespMsg" }
+case class SyncGetScreenshareInfoRespMsg(
+    header: BbbClientMsgHeader,
+    body:   SyncGetScreenshareInfoRespMsgBody
+) extends BbbCoreMsg
+case class SyncGetScreenshareInfoRespMsgBody(
+    isBroadcasting:  Boolean,
+    voiceConf:       String,
+    screenshareConf: String,
+    stream:          String,
+    vidWidth:        Int,
+    vidHeight:       Int,
+    timestamp:       String,
+    hasAudio:        Boolean
+)
+
+/**
  * Send by FS that RTMP stream has stopped.
  */
 object ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg { val NAME = "ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg" }
@@ -166,6 +185,7 @@ case class GetScreenSubscribePermissionRespMsgBody(
     sfuSessionId: String,
     allowed:      Boolean
 )
+
 /**
  * Sent to FS to eject all users from the voice conference.
  */

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
@@ -187,6 +187,19 @@ case class GetScreenSubscribePermissionRespMsgBody(
 )
 
 /**
+ * Sent to bbb-webrtc-sfu to tear down screen stream #streamId
+ */
+object ScreenBroadcastStopSysMsg { val NAME = "ScreenBroadcastStopSysMsg" }
+case class ScreenBroadcastStopSysMsg(
+    header: BbbCoreBaseHeader,
+    body:   ScreenBroadcastStopSysMsgBody
+) extends BbbCoreMsg
+case class ScreenBroadcastStopSysMsgBody(
+    meetingId: String,
+    streamId:  String
+)
+
+/**
  * Sent to FS to eject all users from the voice conference.
  */
 object EjectAllFromVoiceConfMsg { val NAME = "EjectAllFromVoiceConfMsg" }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
@@ -196,6 +196,7 @@ case class ScreenBroadcastStopSysMsg(
 ) extends BbbCoreMsg
 case class ScreenBroadcastStopSysMsgBody(
     meetingId: String,
+    voiceConf: String,
     streamId:  String
 )
 

--- a/bigbluebutton-html5/imports/api/screenshare/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/screenshare/server/eventHandlers.js
@@ -1,6 +1,8 @@
 import RedisPubSub from '/imports/startup/server/redis';
 import handleScreenshareStarted from './handlers/screenshareStarted';
 import handleScreenshareStopped from './handlers/screenshareStopped';
+import handleScreenshareSync from './handlers/screenshareSync';
 
 RedisPubSub.on('ScreenshareRtmpBroadcastStartedEvtMsg', handleScreenshareStarted);
 RedisPubSub.on('ScreenshareRtmpBroadcastStoppedEvtMsg', handleScreenshareStopped);
+RedisPubSub.on('SyncGetScreenshareInfoRespMsg', handleScreenshareSync);

--- a/bigbluebutton-html5/imports/api/screenshare/server/handlers/screenshareSync.js
+++ b/bigbluebutton-html5/imports/api/screenshare/server/handlers/screenshareSync.js
@@ -1,0 +1,19 @@
+import { check } from 'meteor/check';
+import addScreenshare from '../modifiers/addScreenshare';
+import clearScreenshare from '../modifiers/clearScreenshare';
+
+export default function handleScreenshareSync({ body }, meetingId) {
+  check(meetingId, String);
+  check(body, Object);
+
+  const { isBroadcasting, screenshareConf } = body;
+
+  check(screenshareConf, String);
+  check(isBroadcasting, Boolean);
+
+  if (!isBroadcasting) {
+    return clearScreenshare(meetingId, screenshareConf);
+  }
+
+  return addScreenshare(meetingId, body);
+}


### PR DESCRIPTION
### What does this PR do?

Backport of #14076 and #14091 to 2.3 (from 2.4)

Newly added: 
  - refactor(screenshare): add voiceConf to ScreenshareBroadcastStopSysMsg
    * Just to make it easier to guarantee idempotence in webrtc-sfu while we dont get rid of voiceConf usage. Will lift to v2.4.

### Closes Issue(s)

None

### Additional info

- Intentionally left some mismatched parts out of the backport (the server-side ejection on external video start).