### PR TITLE
build: bump bbb-webrtc-sfu to v2.6.8

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
@@ -12,6 +12,7 @@ object ScreenshareApp2x {
     if (ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel)) {
       val event = MsgBuilder.buildScreenBroadcastStopSysMsg(
         liveMeeting.props.meetingProp.intId,
+        ScreenshareModel.getVoiceConf(liveMeeting.screenshareModel),
         ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel),
       )
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -613,11 +613,12 @@ object MsgBuilder {
 
   def buildScreenBroadcastStopSysMsg(
       meetingId: String,
+      voiceConf: String,
       streamId:  String
   ): BbbCommonEnvCoreMsg = {
     val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
     val envelope = BbbCoreEnvelope(ScreenBroadcastStopSysMsg.NAME, routing)
-    val body = ScreenBroadcastStopSysMsgBody(meetingId, streamId)
+    val body = ScreenBroadcastStopSysMsgBody(meetingId, voiceConf, streamId)
     val header = BbbCoreBaseHeader(ScreenBroadcastStopSysMsg.NAME)
     val event = ScreenBroadcastStopSysMsg(header, body)
 

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
@@ -196,6 +196,7 @@ case class ScreenBroadcastStopSysMsg(
 ) extends BbbCoreMsg
 case class ScreenBroadcastStopSysMsgBody(
     meetingId: String,
+    voiceConf: String,
     streamId:  String
 )
 

--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.6.5 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.6.8 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

- Bump bbb-webrtc-sfu to [v2.6.8](https://github.com/bigbluebutton/bbb-webrtc-sfu/releases/tag/v2.6.8)
- refactor(screenshare): add voiceConf to ScreenshareBroadcastStopSysMsg
  * Just to make it easier to guarantee idempotence in webrtc-sfu while we don't get rid of voiceConf usage

### Closes Issue(s)

n/a

### Motivation

n/a
