### PR TITLE
fix: remove audio/video first join info on meeting end

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
@@ -15,6 +15,7 @@ import Users from '/imports/api/users';
 import Meetings from '/imports/api/meetings';
 import AudioManager from '/imports/ui/services/audio-manager';
 import { meetingIsBreakout } from '/imports/ui/components/app/service';
+import Storage from '/imports/ui/services/storage/session';
 
 const intlMessage = defineMessages({
   410: {
@@ -156,6 +157,8 @@ class MeetingEnded extends PureComponent {
     this.getEndingMessage = this.getEndingMessage.bind(this);
 
     AudioManager.exitAudio();
+    Storage.removeItem('getEchoTest');
+    Storage.removeItem('isFirstJoin');
     Meteor.disconnect();
   }
 


### PR DESCRIPTION
### What does this PR do?

Removes "first join" information (from video preview and echo test) when a user leaves the meeting, preventing an issue where `getEchoTest` and `isFirstJoin` data could be preserved from a previous session.

### Closes Issue(s)
Closes #14132