### PR TITLE
build: bump bbb-webrtc-sfu to v2.7.0-alpha.4 (mediasoup is default)

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.7.0-alpha.2 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.7.0-alpha.4 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

Bump bbb-webrtc-sfu to v2.7.0-alpha.4.
This makes mediasoup the default media server for everything except recordings

### Closes Issue(s)

n/a
