### PR TITLE
fix: "restoreOnUpdate=true" conflicts with "Focus on presentation"

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -167,9 +167,9 @@ class Presentation extends PureComponent {
     }
 
     if (
-      currentSlide?.num != null &&
-      prevProps?.currentSlide?.num != null &&
-      currentSlide?.num !== prevProps.currentSlide?.num
+      currentSlide?.num != null
+      && prevProps?.currentSlide?.num != null
+      && currentSlide?.num !== prevProps.currentSlide?.num
     ) {
       politeSRAlert(intl.formatMessage(intlMessages.slideContentChanged, { 0: currentSlide.num }));
     }
@@ -815,6 +815,7 @@ class Presentation extends PureComponent {
       layoutType,
       numCameras,
       currentPresentation,
+      layoutSwapped,
     } = this.props;
 
     const {
@@ -879,6 +880,7 @@ class Presentation extends PureComponent {
           right: presentationBounds.right,
           width: presentationBounds.width,
           height: presentationBounds.height,
+          display: layoutSwapped ? 'none' : 'flex',
           zIndex: fullscreenContext ? presentationBounds.zIndex : undefined,
           background: layoutType === LAYOUT_TYPE.VIDEO_FOCUS && numCameras > 0 && !fullscreenContext
             ? 'var(--color-content-background)'


### PR DESCRIPTION
### What does this PR do?

Prevents an issue where camera pagination does not work when:
- presentation is minimized 
- restoreOnUpdate is set to true
- layout "focus on presentation" is active 

### Closes Issue(s)
Closes #14168
