### PR TITLE
[2.4] fix(storage): check for existing Tracker.Dependency() instance

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/storage/reactive.js
+++ b/bigbluebutton-html5/imports/ui/services/storage/reactive.js
@@ -67,6 +67,7 @@ export default class StorageTracker {
   removeItem(key) {
     const prefixedKey = this._prefixedKey(key);
     this._storage.removeItem(prefixedKey);
+    if (!this._trackers[prefixedKey]) return;
     this._trackers[prefixedKey].changed();
     delete this._trackers[prefixedKey];
   }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

_Checks if there is a Tracker.Dependency instance before calling `.changed()` and deleting the Tracker.Dependency instance._

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
_Closes #14267_ 


### Motivation

<!-- What inspired you to submit this pull request? -->

_There may be cases where there is no `Tracker.Dependency` because there is no previous calls to either `Storage.setItem` or `Storage.getItem` on the respective key._
