### PR TITLE
[2.3] fix(webcams): add stream ID to broadcast check, better lock setting enforcement

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
@@ -41,9 +41,7 @@ trait ChangeUserRoleCmdMsgHdlr extends RightsManagementTrait {
           val event = buildUserRoleChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.userId,
             msg.body.changedBy, Roles.VIEWER_ROLE)
 
-          if (newUvo.locked) {
-            LockSettingsUtil.enforceCamLockSettingsForAllUsers(liveMeeting, outGW)
-          }
+          LockSettingsUtil.enforceCamLockSettingsForAllUsers(liveMeeting, outGW)
 
           outGW.send(event)
         }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetCamBroadcastPermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetCamBroadcastPermissionReqMsgHdlr.scala
@@ -22,6 +22,7 @@ trait GetCamBroadcastPermissionReqMsgHdlr {
 
       if (!user.userLeftFlag.left
         && liveMeeting.props.meetingProp.intId == msg.body.meetingId
+        && msg.body.streamId.startsWith(msg.header.userId)
         && (applyPermissionCheck && !camBroadcastLocked)) {
         allowed = true
       }
@@ -30,6 +31,7 @@ trait GetCamBroadcastPermissionReqMsgHdlr {
     val event = MsgBuilder.buildGetCamBroadcastPermissionRespMsg(
       liveMeeting.props.meetingProp.intId,
       msg.body.userId,
+      msg.body.streamId,
       msg.body.sfuSessionId,
       allowed
     )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -460,6 +460,7 @@ object MsgBuilder {
   def buildGetCamBroadcastPermissionRespMsg(
       meetingId:    String,
       userId:       String,
+      streamId:     String,
       sfuSessionId: String,
       allowed:      Boolean
   ): BbbCommonEnvCoreMsg = {
@@ -470,6 +471,7 @@ object MsgBuilder {
     val body = GetCamBroadcastPermissionRespMsgBody(
       meetingId,
       userId,
+      streamId,
       sfuSessionId,
       allowed
     )

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WebcamsMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WebcamsMsgs.scala
@@ -61,6 +61,7 @@ case class GetCamBroadcastPermissionReqMsg(
 case class GetCamBroadcastPermissionReqMsgBody(
     meetingId:    String,
     userId:       String,
+    streamId:     String,
     sfuSessionId: String
 )
 
@@ -74,6 +75,7 @@ case class GetCamBroadcastPermissionRespMsg(
 case class GetCamBroadcastPermissionRespMsgBody(
     meetingId:    String,
     userId:       String,
+    streamId:     String,
     sfuSessionId: String,
     allowed:      Boolean
 )


### PR DESCRIPTION
Backport of https://github.com/bigbluebutton/bigbluebutton/pull/14269 into v2.3

> ### What does this PR do?
> 
> - Add streamId to broadcast permission checks
>   * Guarantees better enforcement of stream ownership
> - Always run camera lock settings enforcement on user demotion
>   * Checking for the user locked state before running the procedure is not entirely
> correct since some lock settings should always be applied. An example of this
> the See other viewers lock which must be enforced on demotion regardless of
> whether the demoted user is locked or not.
> 
> ### Closes Issue(s)
> 
> n/a
> 
> 
> ### Motivation
> 
> n/a
> 
> ### More
> 
> Works with webrtc-sfu@v2.6.9
