### PR TITLE
fix: fullscreen presentation shortcut in presenter toolbar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -710,6 +710,7 @@ class Presentation extends PureComponent {
         fitToWidthHandler={this.fitToWidthHandler}
         isFullscreen={fullscreenContext}
         fullscreenAction={ACTIONS.SET_FULLSCREEN_ELEMENT}
+        fullscreenRef={this.refPresentationContainer}
       />
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -158,8 +158,11 @@ class PresentationToolbar extends PureComponent {
       isFullscreen,
       layoutContextDispatch,
       fullscreenAction,
+      fullscreenRef,
+      handleToggleFullScreen,
     } = this.props;
 
+    handleToggleFullScreen(fullscreenRef);
     const newElement = isFullscreen ? '' : fullscreenElementId;
 
     layoutContextDispatch({

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -8,6 +8,7 @@ import PollService from '/imports/ui/components/poll/service';
 import { makeCall } from '/imports/ui/services/api';
 import PresentationToolbar from './component';
 import PresentationToolbarService from './service';
+import FullscreenService from '/imports/ui/components/fullscreen-button/service';
 
 const POLLING_ENABLED = Meteor.settings.public.poll.enabled;
 
@@ -17,12 +18,17 @@ const PresentationToolbarContainer = (props) => {
     layoutSwapped,
   } = props;
 
+  const handleToggleFullScreen = (ref) => FullscreenService.toggleFullScreen(ref);
+
   if (userIsPresenter && !layoutSwapped) {
     // Only show controls if user is presenter and layout isn't swapped
 
     return (
       <PresentationToolbar
         {...props}
+        {...{
+          handleToggleFullScreen,
+        }}
       />
     );
   }


### PR DESCRIPTION
### What does this PR do?

Restores "real" fullscreen feature to presenter toolbar shortcut (when **enter** is pressed).