### PR TITLE
fix: makes restoreOnUpdate work for moderators

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -147,7 +147,6 @@ class Presentation extends PureComponent {
       layoutSwapped,
       currentSlide,
       publishedPoll,
-      isViewer,
       toggleSwapLayout,
       restoreOnUpdate,
       layoutContextDispatch,
@@ -221,7 +220,7 @@ class Presentation extends PureComponent {
         });
       }
 
-      if (layoutSwapped && restoreOnUpdate && isViewer && currentSlide) {
+      if (layoutSwapped && restoreOnUpdate && !userIsPresenter && currentSlide) {
         const slideChanged = currentSlide.id !== prevProps.currentSlide.id;
         const positionChanged = slidePosition
           .viewBoxHeight !== prevProps.slidePosition.viewBoxHeight

--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -5,7 +5,6 @@ import MediaService, {
   shouldEnableSwapLayout,
 } from '/imports/ui/components/media/service';
 import { notify } from '/imports/ui/services/notification';
-import { Session } from 'meteor/session';
 import PresentationService from './service';
 import { Slides } from '/imports/api/slides';
 import Presentation from '/imports/ui/components/presentation/component';
@@ -17,8 +16,6 @@ import getFromUserSettings from '/imports/ui/services/users-settings';
 import LayoutContext from '../layout/context';
 import WhiteboardService from '/imports/ui/components/whiteboard/service';
 import { DEVICE_TYPE } from '../layout/enums';
-
-const ROLE_VIEWER = Meteor.settings.public.user.role_viewer;
 
 const PresentationContainer = ({ presentationPodIds, mountPresentation, ...props }) => {
   const fullscreenElementId = 'Presentation';
@@ -48,7 +45,6 @@ const PresentationContainer = ({ presentationPodIds, mountPresentation, ...props
         layoutContextDispatch,
         numCameras,
         ...props,
-        isViewer: currentUser.role === ROLE_VIEWER,
         userIsPresenter: userIsPresenter && !layoutSwapped,
         presentationBounds: presentation,
         layoutType,


### PR DESCRIPTION
### What does this PR do?

Makes restoreOnUpdate feature work with all users that are not presenters, instead of all users that are viewers.

### Closes Issue(s)
Closes #14215