### PR TITLE
Automatic upload of the shared notes as a presentation

### DIFF
--- a/akka-bbb-apps/project/Dependencies.scala
+++ b/akka-bbb-apps/project/Dependencies.scala
@@ -20,6 +20,7 @@ object Dependencies {
     val logback = "1.2.3"
     val quicklens = "1.4.11"
     val spray = "1.3.4"
+    val scalaj = "2.4.2"
 
     // Apache Commons
     val lang = "3.9"
@@ -56,6 +57,8 @@ object Dependencies {
 
     val bbbCommons = "org.bigbluebutton" % "bbb-common-message_2.12" % Versions.bbbCommons excludeAll (
       ExclusionRule(organization = "org.red5"))
+
+    val scalaj = "org.scalaj" %% "scalaj-http" % Versions.scalaj
   }
 
   object Test {
@@ -88,5 +91,6 @@ object Dependencies {
     Compile.apacheLang,
     Compile.akkaHttp,
     Compile.akkaHttpSprayJson,
-    Compile.bbbCommons) ++ testing
+    Compile.bbbCommons,
+    Compile.scalaj) ++ testing
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
@@ -7,7 +7,7 @@ trait SystemConfiguration {
   val config = ConfigFactory.load()
 
   lazy val bbbWebHost = Try(config.getString("services.bbbWebHost")).getOrElse("localhost")
-  lazy val bbbWebPort = Try(config.getInt("services.bbbWebPort")).getOrElse(8888)
+  lazy val bbbWebPort = Try(config.getInt("services.bbbWebPort")).getOrElse(8090)
   lazy val bbbWebAPI = Try(config.getString("services.bbbWebAPI")).getOrElse("localhost")
   lazy val bbbWebSharedSecret = Try(config.getString("services.sharedSecret")).getOrElse("changeme")
   lazy val bbbWebModeratorPassword = Try(config.getString("services.moderatorPassword")).getOrElse("changeme")

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -267,6 +267,10 @@ class ReceivedJsonMsgHandlerActor(
       case AssignPresenterReqMsg.NAME =>
         routeGenericMsg[AssignPresenterReqMsg](envelope, jsonNode)
 
+      // Shared notes
+      case ConvertAndUploadSharedNotesReqMsg.NAME =>
+        routeGenericMsg[ConvertAndUploadSharedNotesReqMsg](envelope, jsonNode)
+
       // Presentation Pods
       case CreateNewPresentationPodPubMsg.NAME =>
         routeGenericMsg[CreateNewPresentationPodPubMsg](envelope, jsonNode)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
@@ -128,6 +128,7 @@ class AnalyticsActor(val includeChat: Boolean) extends Actor with ActorLogging {
       case m: PresentationPageCountErrorEvtMsg => logMessage(msg)
       case m: PresentationUploadedFileTooLargeErrorSysPubMsg => logMessage(msg)
       case m: PresentationUploadedFileTooLargeErrorEvtMsg => logMessage(msg)
+      // case m: ConvertAndUploadSharedNotesReqMsg => logMessage(msg)
 
       // Group Chats
       case m: SendGroupChatMessageMsg => logChatMessage(msg)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PresentationMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PresentationMsgs.scala
@@ -5,6 +5,9 @@ import org.bigbluebutton.common2.domain.PresentationVO
 // ------------ client to akka-apps ------------
 
 // ------------ client to akka-apps ------------
+object ConvertAndUploadSharedNotesReqMsg { val NAME = "ConvertAndUploadSharedNotesReqMsg" }
+case class ConvertAndUploadSharedNotesReqMsg(header: BbbClientMsgHeader, body: ConvertAndUploadSharedNotesReqMsgBody) extends StandardMsg
+case class ConvertAndUploadSharedNotesReqMsgBody(sharedNotesData: String)
 
 // ------------ bbb-common-web to akka-apps ------------
 object PreuploadedPresentationsSysPubMsg { val NAME = "PreuploadedPresentationsSysPubMsg" }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/bus/ReceivedJsonMsgHdlrActor.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/bus/ReceivedJsonMsgHdlrActor.scala
@@ -108,6 +108,8 @@ class ReceivedJsonMsgHdlrActor(val msgFromAkkaAppsEventBus: MsgFromAkkaAppsEvent
         route[RecordingStatusChangedEvtMsg](envelope, jsonNode)
       case LearningDashboardEvtMsg.NAME =>
         route[LearningDashboardEvtMsg](envelope, jsonNode)
+      case ConvertAndUploadSharedNotesReqMsg.NAME =>
+        route[ConvertAndUploadSharedNotesReqMsg](envelope, jsonNode)
 
       case _ =>
       //log.debug("************ Cannot route envelope name " + envelope.name)

--- a/bigbluebutton-html5/imports/api/common/server/etherpad.js
+++ b/bigbluebutton-html5/imports/api/common/server/etherpad.js
@@ -5,7 +5,9 @@ import createNote from '/imports/api/note/server/methods/createNote';
 import createCaptions from '/imports/api/captions/server/methods/createCaptions';
 
 const ETHERPAD = Meteor.settings.private.etherpad;
+
 const BASE_URL = `http://${ETHERPAD.host}:${ETHERPAD.port}/api/${ETHERPAD.version}`;
+const EXPORT_URL = `http://${ETHERPAD.host}:${ETHERPAD.port}/p`
 const HASH_SIZE = 36;
 
 const createPadURL = padId => `${BASE_URL}/createPad?apikey=${ETHERPAD.apikey}&padID=${padId}`;
@@ -13,6 +15,10 @@ const createPadURL = padId => `${BASE_URL}/createPad?apikey=${ETHERPAD.apikey}&p
 const getReadOnlyIdURL = padId => `${BASE_URL}/getReadOnlyID?apikey=${ETHERPAD.apikey}&padID=${padId}`;
 
 const appendTextURL = (padId, text) => `${BASE_URL}/appendText?apikey=${ETHERPAD.apikey}&padID=${padId}&text=${encodeURIComponent(text)}`;
+
+const getNotePdf = (padId) => `${EXPORT_URL}/${padId}/export/pdf`;
+
+const getNoteText = (padId) => axios.get(`${EXPORT_URL}/${padId}/export/txt`, { responseType: 'json' } );
 
 const checkTokenURL = () => `${BASE_URL}/checkToken?apikey=${ETHERPAD.apikey}`;
 
@@ -48,6 +54,8 @@ export {
   createPadURL,
   getReadOnlyIdURL,
   appendTextURL,
+  getNotePdf,
+  getNoteText,
   initPads,
   withInstaceId,
 }

--- a/bigbluebutton-html5/imports/api/note/server/methods.js
+++ b/bigbluebutton-html5/imports/api/note/server/methods.js
@@ -1,6 +1,8 @@
 import { Meteor } from 'meteor/meteor';
 import getNoteId from './methods/getNoteId';
+import getPadContents from './methods/getPadContents';
 
 Meteor.methods({
   getNoteId,
+  getPadContents,
 });

--- a/bigbluebutton-html5/imports/api/note/server/methods/getPadContents.js
+++ b/bigbluebutton-html5/imports/api/note/server/methods/getPadContents.js
@@ -1,0 +1,77 @@
+import RedisPubSub from '/imports/startup/server/redis';
+import Note from '/imports/api/note';
+import Users from '/imports/api/users';
+import Meetings from '/imports/api/meetings';
+import Logger from '/imports/startup/server/logger';
+import { extractCredentials } from '/imports/api/common/server/helpers';
+import { getNoteText, getNotePdf } from '/imports/api/common/server/etherpad';
+
+const ROLE_VIEWER = Meteor.settings.public.user.role_viewer;
+
+const hasNoteAccess = (meetingId, userId) => {
+  const user = Users.findOne(
+    { meetingId, userId },
+    {
+      fields: {
+        role: 1,
+        locked: 1,
+      },
+    }
+  );
+
+  if (!user) return false;
+
+  if (user.role === ROLE_VIEWER && user.locked) {
+    const meeting = Meetings.findOne(
+      { meetingId },
+      { fields: { 'lockSettingsProps.disableNote': 1 } }
+    );
+
+    if (!meeting) return false;
+
+    const { lockSettingsProps } = meeting;
+    if (lockSettingsProps) {
+      if (lockSettingsProps.disableNote) return false;
+    } else {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+export default function getPadContents() {
+  const REDIS_CONFIG = Meteor.settings.private.redis;
+  const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
+  const EVENT_NAME = 'ConvertAndUploadSharedNotesReqMsg';
+  
+  try {
+    const { meetingId, requesterUserId } = extractCredentials(this.userId);
+
+    const note = Note.findOne(
+      { meetingId },
+      {
+        fields: {
+          noteId: 1,
+          readOnlyNoteId: 1,
+        },
+      }
+    );
+
+    if (note) {
+      if (hasNoteAccess(meetingId, requesterUserId)) {
+        const sharedNotesData = getNotePdf(note.noteId)
+        const payload = {
+          sharedNotesData,
+        }
+
+        return RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);
+      }
+    }
+
+    return null;
+
+  } catch (err) {
+      Logger.error(`Exception while invoking method getPdf ${err.stack}`);
+  }
+}

--- a/bigbluebutton-html5/imports/ui/components/note/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/note/container.jsx
@@ -1,16 +1,25 @@
-import React from 'react';
+import React,  { useContext } from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import Note from './component';
 import NoteService from './service';
 import { layoutSelectInput, layoutDispatch } from '../layout/context';
+import { UsersContext } from '/imports/ui/components/components-data/users-context/context';
+import Auth from '/imports/ui/services/auth';
+
+const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 
 const NoteContainer = ({ children, ...props }) => {
   const cameraDock = layoutSelectInput((i) => i.cameraDock);
   const { isResizing } = cameraDock;
   const layoutContextDispatch = layoutDispatch();
 
+  const usingUsersContext = useContext(UsersContext);
+  const { users } = usingUsersContext;
+  const currentUser = users[Auth.meetingID][Auth.userID];
+  const amIModerator = currentUser.role === ROLE_MODERATOR;
+
   return (
-    <Note {...{ layoutContextDispatch, isResizing, ...props }}>
+    <Note {...{ amIModerator, layoutContextDispatch, isResizing, ...props }}>
       {children}
     </Note>
   );

--- a/bigbluebutton-html5/imports/ui/components/note/service.js
+++ b/bigbluebutton-html5/imports/ui/components/note/service.js
@@ -49,6 +49,7 @@ const isLocked = () => {
 };
 
 const getNoteId = () => makeCall('getNoteId');
+const getPadContents = () => makeCall('getPadContents')
 
 const buildNoteURL = (noteId) => {
   if (noteId) {
@@ -116,6 +117,7 @@ const toggleNotePanel = (sidebarContentPanel, layoutContextDispatch) => {
 
 export default {
   getNoteId,
+  getPadContents,
   buildNoteURL,
   toggleNotePanel,
   isLocked,

--- a/bigbluebutton-html5/imports/ui/components/note/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/note/styles.js
@@ -87,6 +87,38 @@ const HideButton = styled(Button)`
   }
 `;
 
+const ConvertAndUpload = styled(Button)`
+  position: relative;
+  background-color: ${colorWhite};
+  display: block;
+  margin: ${borderSizeLarge};
+  margin-bottom: ${borderSize};
+  padding-left: 0;
+  padding-right: inherit;
+
+  [dir="rtl"] & {
+    padding-left: inherit;
+    padding-right: 0;
+  }
+
+  & > i {
+    color: ${colorGrayDark};
+    font-size: smaller;
+
+    [dir="rtl"] & {
+      -webkit-transform: scale(-1, 1);
+      -moz-transform: scale(-1, 1);
+      -ms-transform: scale(-1, 1);
+      -o-transform: scale(-1, 1);
+      transform: scale(-1, 1);
+    }
+  }
+
+  &:hover {
+    background-color: ${colorWhite};
+  }
+`;
+
 const Hint = styled.span`
   visibility: hidden;
   position: absolute;
@@ -124,6 +156,7 @@ export default {
   Header,
   Title,
   HideButton,
+  ConvertAndUpload,
   Hint,
   IFrame,
 };

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -2123,6 +2123,14 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "etherpad-lite-client": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/etherpad-lite-client/-/etherpad-lite-client-0.9.0.tgz",
+      "integrity": "sha512-ZThh4LXX1B3nyoxpbtd5K+hp3o09f8fM2Mwwjw5AHZSjERd/NZXllCmyOwUFQ+2VDYYF3k6RgQ4RPs73cuvFjg==",
+      "requires": {
+        "underscore": "1.3.x"
+      }
+    },
     "eventemitter2": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
@@ -5929,6 +5937,11 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "underscore": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.3.3.tgz",
+      "integrity": "sha1-R6xTaD2vgyv6lS4XdEF9pHgXrkI="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -38,6 +38,7 @@
     "browser-bunyan": "^1.6.3",
     "classnames": "^2.2.6",
     "crypto-js": "^4.0.0",
+    "etherpad-lite-client": "^0.9.0",
     "eventemitter2": "~5.0.1",
     "fastdom": "^1.0.10",
     "fibers": "^4.0.2",

--- a/bigbluebutton-html5/public/locales/de.json
+++ b/bigbluebutton-html5/public/locales/de.json
@@ -55,6 +55,8 @@
     "app.textInput.sendLabel": "Absenden",
     "app.title.defaultViewLabel": "Standardpräsentation",
     "app.note.title": "Geteilte Notizen",
+    "app.note.convertAndUpload": "Geteilte Notizen im Präsentations-Bereich laden",
+    "app.note.uploadSharedNotes": "Geteilte Notizen werden hochgeladen...",
     "app.note.label": "Notiz",
     "app.note.hideNoteLabel": "Notiz verbergen",
     "app.note.tipLabel": "Drücken Sie Esc, um die Editorwerkzeugliste auszuwählen",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -55,6 +55,8 @@
     "app.textInput.sendLabel": "Send",
     "app.title.defaultViewLabel": "Default presentation view",
     "app.note.title": "Shared Notes",
+    "app.note.convertAndUpload": "Move notes to whiteboard",
+    "app.note.uploadSharedNotes": "Uploading shared notes...",
     "app.note.label": "Note",
     "app.note.hideNoteLabel": "Hide note",
     "app.note.tipLabel": "Press Esc to focus editor toolbar",

--- a/bigbluebutton-html5/public/locales/pt_BR.json
+++ b/bigbluebutton-html5/public/locales/pt_BR.json
@@ -52,6 +52,8 @@
     "app.captions.pad.speechRecognitionStop": "O reconhecimento de voz parou devido à incompatibilidade do navegador ou algum tempo de silêncio",
     "app.textInput.sendLabel": "Enviar",
     "app.note.title": "Notas compartilhadas",
+    "app.note.convertAndUpload": "Adicionar notas compartilhadas como apresentação",
+    "app.note.uploadSharedNotes": "Carregando notas compartilhadas...",
     "app.note.label": "Nota",
     "app.note.hideNoteLabel": "Ocultar nota",
     "app.note.tipLabel": "Pressione Esc para focar na barra de ferramentas do editor",

--- a/bigbluebutton-html5/public/locales/zh_CN.json
+++ b/bigbluebutton-html5/public/locales/zh_CN.json
@@ -52,6 +52,8 @@
     "app.textInput.sendLabel": "发送",
     "app.title.defaultViewLabel": "默认演讲视图",
     "app.note.title": "分享笔记",
+    "app.note.convertAndUpload": "上传共享笔记",
+    "app.note.uploadSharedNotes": "共享笔记上传中...",
     "app.note.label": "笔记",
     "app.note.hideNoteLabel": "隐藏笔记面板",
     "app.note.tipLabel": "按Esc键定位到编辑器工具栏",

--- a/bigbluebutton-html5/public/locales/zh_TW.json
+++ b/bigbluebutton-html5/public/locales/zh_TW.json
@@ -52,6 +52,8 @@
     "app.captions.pad.speechRecognitionStop": "由於瀏覽器不相容或一段時間的靜音，語音辨識停止",
     "app.textInput.sendLabel": "送出",
     "app.note.title": "共享筆記",
+    "app.note.convertAndUpload": "上傳共享筆記",
+    "app.note.uploadSharedNotes": "共享筆記上傳中...",
     "app.note.label": "筆記",
     "app.note.hideNoteLabel": "隱藏筆記",
     "app.note.tipLabel": "按下 Esc 鍵以聚焦到編輯器工具列",

--- a/labs/vertx-akka/src/main/scala/org/bigbluebutton/client/meeting/AllowedMessageNames.scala
+++ b/labs/vertx-akka/src/main/scala/org/bigbluebutton/client/meeting/AllowedMessageNames.scala
@@ -62,6 +62,9 @@ object AllowedMessageNames {
     RemovePresentationPodPubMsg.NAME,
     SetPresenterInPodReqMsg.NAME,
 
+    // Shared Notes messages
+    ConvertAndUploadSharedNotesReqMsg.NAME
+
     // Whiteboard Messages
     ModifyWhiteboardAccessPubMsg.NAME,
     UndoWhiteboardPubMsg.NAME,


### PR DESCRIPTION
### What does this PR do?
Gives instructor the ability to convert the shared notes as a PDF file, which is then automatically uploaded into the main room.

https://user-images.githubusercontent.com/33319791/152700535-fd6d1f9b-0f15-448f-a9dc-4ba84814351a.mov

### Motivation
Developed for the Open Source Lab at TUM.

### More
It looks like my development branch fell behind the changes made after the introduction of the new `bbb-pads` module.
Therefore, while applying those changes, I'm submitting this PR as a prototype to showcase the architecture I had in mind for this feature, acting as a proof of concept.

- Implements Scalaj as a dependency.
- Sets `bbbWebPort` to 8090 instead of 8888 in the `MeetingActor`.
