### PR TITLE
fix: Talking indicator element not showing on mobile with content sidebar open

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/component.jsx
@@ -64,8 +64,6 @@ class TalkingIndicator extends PureComponent {
         [styles.talker]: true,
         [styles.spoke]: !talking,
         [styles.muted]: muted,
-        [styles.mobileHide]: sidebarNavigationIsOpen
-          && sidebarContentIsOpen,
         [styles.isViewer]: !amIModerator,
       };
 
@@ -114,9 +112,6 @@ class TalkingIndicator extends PureComponent {
       const style = {
         [styles.talker]: true,
         [styles.spoke]: nobodyTalking,
-        // [styles.muted]: false,
-        [styles.mobileHide]: sidebarNavigationIsOpen
-          && sidebarContentIsOpen,
       };
 
       const { moreThanMaxIndicatorsTalking, moreThanMaxIndicatorsWereTalking } = intlMessages;

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/styles.scss
@@ -127,12 +127,6 @@
   }
 }
 
-.mobileHide {
-  @include mq($small-only) {
-    visibility: hidden;
-  }
-}
-
 .isViewer {
   cursor: default;
 }


### PR DESCRIPTION
### What does this PR do?

Removes mobileHide styles from talking indicator, allowing the display of the talking indicator in mobile devices even when the sidebar content is open.

### Closes Issue(s)
Closes #14272