### PR TITLE
(Optional) fix(screenshare): change toast notification text

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -153,10 +153,10 @@ class ScreenshareComponent extends React.Component {
     window.removeEventListener('screensharePlayFailed', this.handlePlayElementFailed);
     unsubscribeFromStreamStateChange('screenshare', this.onStreamStateChange);
 
-    if (!Settings.dataSaving.viewScreenshare) {
-      notify(intl.formatMessage(intlMessages.screenshareEndedDueToDataSaving), 'info', 'desktop');
-    } else {
+    if (Settings.dataSaving.viewScreenshare) {
       notify(intl.formatMessage(intlMessages.screenshareEnded), 'info', 'desktop');
+    } else {
+      notify(intl.formatMessage(intlMessages.screenshareEndedDueToDataSaving), 'info', 'desktop');
     }
 
     if (fullscreenContext) {

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -26,6 +26,7 @@ import {
 } from '/imports/ui/services/bbb-webrtc-sfu/stream-state-service';
 import { ACTIONS } from '/imports/ui/components/layout/enums';
 import deviceInfo from '/imports/utils/deviceInfo';
+import Settings from '/imports/ui/services/settings';
 
 const intlMessages = defineMessages({
   screenShareLabel: {
@@ -54,6 +55,10 @@ const intlMessages = defineMessages({
   screenshareEnded: {
     id: 'app.media.screenshare.end',
     description: 'toast to show when a screenshare has ended',
+  },
+  screenshareEndedDueToDataSaving: {
+    id: 'app.media.screenshare.endDueToDataSaving',
+    description: 'toast to show when a screenshare has ended by changing data savings option',
   },
 });
 
@@ -148,7 +153,11 @@ class ScreenshareComponent extends React.Component {
     window.removeEventListener('screensharePlayFailed', this.handlePlayElementFailed);
     unsubscribeFromStreamStateChange('screenshare', this.onStreamStateChange);
 
-    notify(intl.formatMessage(intlMessages.screenshareEnded), 'info', 'desktop');
+    if (!Settings.dataSaving.viewScreenshare) {
+      notify(intl.formatMessage(intlMessages.screenshareEndedDueToDataSaving), 'info', 'desktop');
+    } else {
+      notify(intl.formatMessage(intlMessages.screenshareEnded), 'info', 'desktop');
+    }
 
     if (fullscreenContext) {
       layoutContextDispatch({

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -135,6 +135,7 @@
     "app.media.autoplayAlertDesc": "Allow Access",
     "app.media.screenshare.start": "Screenshare has started",
     "app.media.screenshare.end": "Screenshare has ended",
+    "app.media.screenshare.endDueToDataSaving": "Screenshare stopped due to data savings",
     "app.media.screenshare.unavailable": "Screenshare Unavailable",
     "app.media.screenshare.notSupported": "Screensharing is not supported in this browser.",
     "app.media.screenshare.autoplayBlockedDesc": "We need your permission to show you the presenter's screen.",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

Changes toast notification text from "Screenshare has stopped" to "Screenshare has stopped due to data saving" whenever screenshare stops due to data savings.

![Captura de tela de 2022-02-07 14-30-42](https://user-images.githubusercontent.com/62393923/152841206-711b44fd-a238-4f74-b2f1-c62ee0fcd06d.png)
![Captura de tela de 2022-02-07 14-30-46](https://user-images.githubusercontent.com/62393923/152841216-8a1b25c1-d78a-4427-b388-f595fb38bada.png)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #14277