### PR TITLE
fix(screenshare): decrease autoplay-overlay z-index

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/media/autoplay-overlay/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/media/autoplay-overlay/styles.scss
@@ -24,6 +24,6 @@
   font-size: var(--font-size-large);
   border-radius: 5px;
   position: absolute;
-  z-index: 9999;
+  z-index: 999;
   text-align: center;
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

Prevents the _autoplay overlay_ from overlapping the _echo test modal_.

**Before:**
![Captura de tela de 2022-02-09 15-33-53](https://user-images.githubusercontent.com/62393923/153268514-fe1ad214-6f7e-47de-92db-824644e0c7cb.png)

**After:**
![Captura de tela de 2022-02-09 15-28-03](https://user-images.githubusercontent.com/62393923/153268547-f5f86198-76c6-4b47-b449-4fa7c578efd6.png)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #14298