### PR TITLE
Add a message for when the guest isn't valid

### DIFF
--- a/akka-bbb-apps/.bsp/sbt.json
+++ b/akka-bbb-apps/.bsp/sbt.json
@@ -1,0 +1,1 @@
+{"name":"sbt","version":"1.5.2","bspVersion":"2.0.0-M5","languages":["scala"],"argv":["/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java","-Xms100m","-Xmx100m","-classpath","/home/dev/.local/share/JetBrains/IdeaIC2021.3/Scala/launcher/sbt-launch.jar","xsbt.boot.Boot","-bsp","--sbt-launch-jar=/home/dev/.local/share/JetBrains/IdeaIC2021.3/Scala/launcher/sbt-launch.jar"]}

--- a/akka-bbb-apps/.bsp/sbt.json
+++ b/akka-bbb-apps/.bsp/sbt.json
@@ -1,1 +1,0 @@
-{"name":"sbt","version":"1.5.2","bspVersion":"2.0.0-M5","languages":["scala"],"argv":["/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java","-Xms100m","-Xmx100m","-classpath","/home/dev/.local/share/JetBrains/IdeaIC2021.3/Scala/launcher/sbt-launch.jar","xsbt.boot.Boot","-bsp","--sbt-launch-jar=/home/dev/.local/share/JetBrains/IdeaIC2021.3/Scala/launcher/sbt-launch.jar"]}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -139,13 +139,13 @@ public class MeetingService implements MessageListener {
   public void registerUser(String meetingID, String internalUserId,
                            String fullname, String role, String externUserID,
                            String authToken, String avatarURL, Boolean guest,
-                           Boolean authed, String guestStatus, Boolean excludeFromDashboard) {
+                           Boolean authed, String guestStatus, Boolean excludeFromDashboard, Boolean leftGuestLobby) {
     handle(new RegisterUser(meetingID, internalUserId, fullname, role,
-      externUserID, authToken, avatarURL, guest, authed, guestStatus, excludeFromDashboard));
+      externUserID, authToken, avatarURL, guest, authed, guestStatus, excludeFromDashboard, leftGuestLobby));
 
     Meeting m = getMeeting(meetingID);
     if (m != null) {
-      RegisteredUser ruser = new RegisteredUser(authToken, internalUserId, guestStatus, excludeFromDashboard);
+      RegisteredUser ruser = new RegisteredUser(authToken, internalUserId, guestStatus, excludeFromDashboard, leftGuestLobby);
       m.userRegistered(ruser);
     }
   }
@@ -274,9 +274,7 @@ public class MeetingService implements MessageListener {
     for (AbstractMap.Entry<String, Meeting> entry : this.meetings.entrySet()) {
       Long now = System.currentTimeMillis();
       Meeting meeting = entry.getValue();
-
       ConcurrentMap<String, User> users = meeting.getUsersMap();
-
       for (AbstractMap.Entry<String, RegisteredUser> registeredUser : meeting.getRegisteredUsers().entrySet()) {
         String registeredUserID = registeredUser.getKey();
         RegisteredUser ru = registeredUser.getValue();
@@ -285,6 +283,7 @@ public class MeetingService implements MessageListener {
         if (elapsedTime >= 15000 && ru.getGuestStatus() == GuestPolicy.WAIT) {
           if (meeting.userUnregistered(registeredUserID) != null) {
             gw.guestWaitingLeft(meeting.getInternalId(), registeredUserID);
+            meeting.setLeftGuestLobby(registeredUserID, true);
           };
         }
       }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -194,7 +194,6 @@ public class Meeting {
 	}
 
 	public void setLeftGuestLobby(String userId, Boolean bool) {
-		System.out.println("colocando o usuario como invalido " + userId);
 		RegisteredUser ruser = registeredUsers.get(userId);
 		if (ruser != null) {
 			ruser.setLeftGuestLobby(bool);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -193,6 +193,23 @@ public class Meeting {
 		}
 	}
 
+	public void setLeftGuestLobby(String userId, Boolean bool) {
+		System.out.println("colocando o usuario como invalido " + userId);
+		RegisteredUser ruser = registeredUsers.get(userId);
+		if (ruser != null) {
+			ruser.setLeftGuestLobby(bool);
+		}
+	}
+
+	public Boolean didGuestUserLeaveGuestLobby(String userId) {
+		RegisteredUser ruser = registeredUsers.get(userId);
+
+		if (ruser != null) {
+			return ruser.getLeftGuestLobby();
+		}
+		return true;
+	}
+
 	public void setGuestStatusWithId(String userId, String guestStatus) {
     	User user = getUserById(userId);
     	if (user != null) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/RegisteredUser.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/RegisteredUser.java
@@ -5,7 +5,6 @@ public class RegisteredUser {
     public final String userId;
     public final Long registeredOn;
 
-
     private String guestStatus;
     private Boolean excludeFromDashboard;
     private Long guestWaitedOn;
@@ -31,7 +30,9 @@ public class RegisteredUser {
         return guestStatus;
     }
 
-    public Boolean getLeftGuestLobby() { return leftGuestLobby; }
+    public Boolean getLeftGuestLobby() {
+        return leftGuestLobby;
+    }
 
     public void setExcludeFromDashboard(Boolean excludeFromDashboard) {
         this.excludeFromDashboard = excludeFromDashboard;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/RegisteredUser.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/RegisteredUser.java
@@ -5,15 +5,18 @@ public class RegisteredUser {
     public final String userId;
     public final Long registeredOn;
 
+
     private String guestStatus;
     private Boolean excludeFromDashboard;
     private Long guestWaitedOn;
+    private Boolean leftGuestLobby;
 
-    public RegisteredUser(String authToken, String userId, String guestStatus, Boolean excludeFromDashboard) {
+    public RegisteredUser(String authToken, String userId, String guestStatus, Boolean excludeFromDashboard, Boolean leftGuestLobby) {
         this.authToken = authToken;
         this.userId = userId;
         this.guestStatus = guestStatus;
         this.excludeFromDashboard = excludeFromDashboard;
+        this.leftGuestLobby = leftGuestLobby;
 
         Long currentTimeMillis = System.currentTimeMillis();
         this.registeredOn = currentTimeMillis;
@@ -28,6 +31,8 @@ public class RegisteredUser {
         return guestStatus;
     }
 
+    public Boolean getLeftGuestLobby() { return leftGuestLobby; }
+
     public void setExcludeFromDashboard(Boolean excludeFromDashboard) {
         this.excludeFromDashboard = excludeFromDashboard;
     }
@@ -40,6 +45,9 @@ public class RegisteredUser {
         this.guestWaitedOn = System.currentTimeMillis();
     }
 
+    public void setLeftGuestLobby(boolean bool) {
+        this.leftGuestLobby = bool;
+    }
     public Long getGuestWaitedOn() {
         return this.guestWaitedOn;
     }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/UserSession.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/UserSession.java
@@ -45,6 +45,7 @@ public class UserSession {
   public String guestStatus = GuestPolicy.ALLOW;
   public String clientUrl = null;
   public Boolean excludeFromDashboard = false;
+  public Boolean leftGuestLobby = false;
 
   private AtomicInteger connections = new AtomicInteger(0);
   

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/RegisterUser.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/RegisterUser.java
@@ -14,10 +14,11 @@ public class RegisterUser implements IMessage {
 	public final Boolean authed;
 	public final String guestStatus;
 	public final Boolean excludeFromDashboard;
-	
+	public final Boolean leftGuestLobby;
+
 	public RegisterUser(String meetingID, String internalUserId, String fullname, String role, String externUserID,
 						String authToken, String avatarURL, Boolean guest,
-						Boolean authed, String guestStatus, Boolean excludeFromDashboard) {
+						Boolean authed, String guestStatus, Boolean excludeFromDashboard, Boolean leftGuestLobby) {
 		this.meetingID = meetingID;
 		this.internalUserId = internalUserId;
 		this.fullname = fullname;
@@ -29,5 +30,6 @@ public class RegisterUser implements IMessage {
 		this.authed = authed;
 		this.guestStatus = guestStatus;
 		this.excludeFromDashboard = excludeFromDashboard;
+		this.leftGuestLobby = leftGuestLobby;
 	}
 }

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -602,6 +602,7 @@
     "app.guest.guestDeny": "Guest denied of joining the meeting.",
     "app.guest.seatWait": "Guest waiting for a seat in the meeting.",
     "app.guest.allow": "Guest approved and redirecting to meeting.",
+    "app.guest.guestInvalid": "Guest user is invalid",
     "app.userList.guest.waitingUsers": "Waiting Users",
     "app.userList.guest.waitingUsersTitle": "User Management",
     "app.userList.guest.optionTitle": "Review Pending Users",

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -322,6 +322,7 @@ class ApiController {
     us.guestStatus = guestStatusVal
     us.logoutUrl = meeting.getLogoutUrl()
     us.defaultLayout = meeting.getMeetingLayout()
+    us.leftGuestLobby = false
 
     if (!StringUtils.isEmpty(params.defaultLayout)) {
       us.defaultLayout = params.defaultLayout;
@@ -366,7 +367,8 @@ class ApiController {
         us.guest,
         us.authed,
         guestStatusVal,
-        us.excludeFromDashboard
+        us.excludeFromDashboard,
+        us.leftGuestLobby
     )
 
     session.setMaxInactiveInterval(SESSION_TIMEOUT);
@@ -733,7 +735,6 @@ class ApiController {
             request.getParameterMap(),
             request.getQueryString()
     )
-
     if(!(validationResponse == null)) {
       msgKey = validationResponse.getKey()
       msgValue = validationResponse.getValue()
@@ -790,6 +791,14 @@ class ApiController {
         break
       default:
         break
+    }
+
+    if(meeting.didGuestUserLeaveGuestLobby(us.internalUserId)){
+      destURL = meeting.getLogoutUrl()
+      msgKey = "guestInvalid"
+      msgValue = "Invalid user"
+      status = GuestPolicy.DENY
+      redirectClient = false
     }
 
     if (redirectClient) {

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -846,7 +846,6 @@ class ApiController {
             request.getParameterMap(),
             request.getQueryString(),
     )
-
     if(!(validationResponse == null)) {
       respMessage = validationResponse.getValue()
       reject = true


### PR DESCRIPTION
### What does this PR do?

This PR adds a new field to registered user for when he leaves the lobby and use it to notify the user about a invalid request, it's meant for users who left the guest lobby and returned and users with connection issues

### Motivation
Before this PR the user isn't notified about the invalidation of the requests and keep trying to join the meeting, but the moderator isn't nofied about the new attempts. Now the user receives a notifications that his request is invalid
### How to test

- Join with a moderator
- Join with guest
- Close the tab in guest lobby
- Wait the guest disapear in the guest panel in moderator tab
- Re-open the tab with guest lobby