### PR TITLE
Increase create breakout room users list height

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.js
@@ -22,8 +22,7 @@ import {
 
 const BoxContainer = styled.div`
   display: grid;
-  grid-template-columns: repeat(3, minmax(4rem, 16rem));
-  grid-template-rows: repeat(auto-fill, minmax(4rem, 8rem));
+  grid-template-columns: repeat(3, 1fr);
   grid-gap: 1.6rem 1rem;
   box-sizing: border-box;
   padding-bottom: 1rem;
@@ -38,6 +37,13 @@ const Alert = styled.div`
       color: ${colorDanger};
     }
   `}
+
+  grid-row: span 3;
+
+  & > div {
+    height: 25.2rem;
+    max-height: 25.2rem;
+  }
 `;
 
 const FreeJoinLabel = styled.label`
@@ -71,8 +77,7 @@ const BreakoutNameInput = styled.input`
 
 const BreakoutBox = styled(ScrollboxVertical)`
   width: 100%;
-  height: 80%;
-  min-height: 4rem;
+  min-height: 6rem;
   max-height: 8rem;
   border: 1px solid ${colorGrayLighter};
   border-radius: ${borderRadius}; 


### PR DESCRIPTION
### What does this PR do?

Makes every room box the same size and increases "not assigned" box height (3 times the height of room boxes).

#### before
<img width="599" alt="Screen Shot 2022-02-11 at 14 16 55" src="https://user-images.githubusercontent.com/3728706/153607655-f83de565-edfb-4cd4-9f59-848cd2601b2f.png">

#### after
<img width="605" alt="Screen Shot 2022-02-11 at 14 13 58" src="https://user-images.githubusercontent.com/3728706/153607631-20b055d5-9a59-4d64-84bd-f76f415e75f9.png">

### Closes Issue(s)
Closes #13123