### PR TITLE
build(bbb-pads): bump v1.0.2

### DIFF
--- a/bbb-pads.placeholder.sh
+++ b/bbb-pads.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v1.0.1 --depth 1 https://github.com/bigbluebutton/bbb-pads bbb-pads
+git clone --branch v1.0.2 --depth 1 https://github.com/bigbluebutton/bbb-pads bbb-pads


### PR DESCRIPTION
### What does this PR do?

Bumps bbb-pads build version to the latest

### Closes Issue(s)

None

### Motivation

bbb-pads' release v1.0.2 mitigates an issue on BigBlueButton server's start routine that was causing a false APIKEY mismatch error at bbb-pads.