### PR TITLE
fix(presentation): toast notification in RTL mode

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -625,7 +625,7 @@ class PresentationUploader extends Component {
         }}
       >
         <div className={styles.fileLine}>
-          <span className={styles.fileIcon}>
+          <span>
             <Icon iconName="file" />
           </span>
           <span className={styles.toastFileName}>

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.scss
@@ -8,9 +8,9 @@
   --statusInfoHeight: 8px;
   --toast-md-margin: .5rem;
   --iconLineHeight: 2.35rem;
-  --iconPadding-md: .65rem;
+  --iconPadding-md: .4rem;
   --fileLineWidth: 16.75rem;
-  --itemActionsWidth:  68px; // size of the 2 icons (check/trash)
+  --itemActionsWidth: 68px; // size of the 2 icons (check/trash)
   --uploadListHeight: 30vh;
   --modalInnerWidth: 40rem;
 }
@@ -48,9 +48,6 @@
   border-spacing: 0;
   border-collapse: collapse;
 
-  > thead {
-  }
-
   > tbody {
     text-align: left;
 
@@ -80,9 +77,6 @@
         font-weight: bold;
         color: var(--color-gray-dark);
       }
-
-      td {
-      }
     }
   }
 }
@@ -104,7 +98,7 @@
 }
 
 .notDownloadable {
-	  min-width: 48px;
+	min-width: 48px;
 }
 
 .tableItemIcon > i {
@@ -320,27 +314,16 @@
 
 .toastFileName,
 .fileName {
-    margin-left: var(--lg-padding-x);
-    top: var(--border-size-large);
-    height: 1rem;
-    width: auto;
-    position: relative;
-    text-align: left;
-    font-weight: var(--headings-font-weight);
+  margin-left: var(--md-padding-y);
+  height: 1rem;
+  width: auto;
+  text-align: left;
+  font-weight: var(--headings-font-weight);
 
-    [dir="rtl"] & {
-      margin-right: var(--lg-padding-x);
-      margin-left: 0;
-      text-align: right;
-    }
-}
-
-.fileIcon {
-  width: 1%;
-  padding-bottom: var(--iconPadding-md);
-  i {
-    position: relative;
-    top: var(--border-size-large);
+  [dir="rtl"] & {
+    margin-right: var(--md-padding-y);
+    margin-left: 0;
+    text-align: right;
   }
 }
 
@@ -362,13 +345,17 @@
 
 .loading,
 .done,
-.err{
+.err {
   position: relative;
   width: var(--statusIconSize);
   height: var(--statusIconSize);
   font-size: 117%;
-  bottom: var(--border-size);
   left: var(--statusInfoHeight);
+
+  [dir="rtl"] & {
+    left: unset;
+    right: var(--statusInfoHeight);
+  }
 }
 
 .uploadRow {
@@ -391,7 +378,7 @@
   bottom: var(--toast-md-margin);
   position: relative;
   left: var(--border-size-large);
-  
+
   [dir="rtl"] & {
     right: var(--border-size-large);
     left: 0;
@@ -401,6 +388,8 @@
 .fileLine {
   display: flex;
   flex-direction: row;
+  align-items: center;
+  padding-bottom: var(--iconPadding-md);
   width: var(--fileLineWidth);
 } 
 
@@ -410,15 +399,7 @@
 }
 
 .statusIcon {
-  margin-left: auto;
-  [dir="rtl"] & {
-    margin-right: auto;
-    margin-left: 0;
-  }
-
   i {
-    position: relative;
-    top: 1px;
     height: var(--statusIconSize);
     width: var(--statusIconSize);
   }
@@ -499,6 +480,11 @@
   padding-right: 1.5rem;
   box-sizing: content-box;
   background: none;
+
+  [dir="rtl"] & {
+    padding-right: 0;
+    padding-left: 1.5rem;
+  }
 }
 
 .toastWrapper {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

_Fixes an undesirable scrollbar on presentation upload toast notification in RTL mode._

**Then:**
![Captura de tela de 2022-02-11 14-32-12](https://user-images.githubusercontent.com/62393923/153666706-40bc49cb-9364-4439-b5ec-804e5bbbcbd4.png)

**Now:**
![Captura de tela de 2022-02-11 17-15-54](https://user-images.githubusercontent.com/62393923/153666758-d1ce5530-2782-4115-8310-52c520ad3663.png)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #12168 