### PR TITLE
fix(FS): Allow patch with different whitespace

### DIFF
--- a/build/packages-template/bbb-freeswitch-core/build.sh
+++ b/build/packages-template/bbb-freeswitch-core/build.sh
@@ -106,7 +106,7 @@ ldconfig
 cd $BUILDDIR/freeswitch
 
 patch -p0 < $BUILDDIR/floor.patch
-patch -p0 < $BUILDDIR/audio.patch       # Provisional patch for https://github.com/signalwire/freeswitch/pull/1531
+patch -p0 --ignore-whitespace < $BUILDDIR/audio.patch       # Provisional patch for https://github.com/signalwire/freeswitch/pull/1531
 
 ./bootstrap.sh 
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Allows the patch `audio.patch` to be applied despite the difference in whitespace (spaces vs tabs, etc) so the patch can be included prior to compiling
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
When I tried this locally it failed to apply the patch
<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->

