### PR TITLE
(build) Clear cache before publish common-message and common-web

### DIFF
--- a/build/packages-template/bbb-apps-akka/build.sh
+++ b/build/packages-template/bbb-apps-akka/build.sh
@@ -15,6 +15,9 @@ find -name build.sbt -exec sed -i "s|\(.*org.bigbluebutton.*bbb-common-message[^
 
 export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
+#Clear cached .jar of common-message
+rm -rf akka-bbb-apps/lib_managed/jars/org.bigbluebutton/bbb-common-message_*
+
 cd bbb-common-message
 sbt publish
 sbt publishLocal

--- a/build/packages-template/bbb-web/build.sh
+++ b/build/packages-template/bbb-web/build.sh
@@ -41,6 +41,10 @@ sed -i 's/\r$//' bbb-common-web/project/Dependencies.scala
 sed -i 's|\(val bbbCommons = \)"[^"]*"$|\1"EPHEMERAL_VERSION"|g' bbb-common-web/project/Dependencies.scala
 sed -i "s/EPHEMERAL_VERSION/$EPHEMERAL_VERSION/g" bbb-common-web/project/Dependencies.scala
 
+#Clear cached .jar of common-message and common-web
+rm -rf bbb-common-web/lib_managed/jars/org.bigbluebutton/bbb-common-message_*
+rm -rf bigbluebutton-web/lib/bbb-*
+
 echo start building bbb-common-message
 cd bbb-common-message
 sbt publish


### PR DESCRIPTION
Copy to build scripts the same commands added on #14346.

It will force to remove all cached .jar before publish `common-message`  and `bbb-common-web` during the build.
