### PR TITLE
fix: URL display in chat push notification

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/alert/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/alert/component.jsx
@@ -125,7 +125,7 @@ const ChatAlert = (props) => {
             { autoClose: 3000 },
             <div>
               <div style={{ fontWeight: 700 }}>{chatsTracker[key].lastSender}</div>
-              <div>{chatsTracker[key].content}</div>
+              <div dangerouslySetInnerHTML={{ __html: chatsTracker[key].content }} />
             </div>,
             true,
           );


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

Uses `dangerouslySetInnerHTML` for injecting HTML so that links will be evaluated properly.

![Captura de tela de 2022-02-16 11-02-16](https://user-images.githubusercontent.com/62393923/154282658-2c29258b-d394-4a78-a51b-27952a989ad2.png)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #14374

### More
The sanitizing part is done here: https://github.com/JoVictorNunes/bigbluebutton/blob/6fe2b69dc784b018dddb25f6e2667131542b6589/bigbluebutton-html5/imports/api/group-chat-msg/server/methods/sendGroupChatMsg.js#L15-L29

So, the message content is already sanitized on the browser, which prevents security issues like XSS attack.