### PR TITLE
Remove eject message usage and use user left message instead

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
@@ -83,9 +83,9 @@ object UsersApp {
   }
 
   def sendUserLeftMeetingToAllClients(outGW: OutMsgRouter, meetingId: String,
-                                      userId: String): Unit = {
+                                      userId: String, eject: Boolean = false, ejectedBy: String = "", banUser: Boolean = false, reason: String = "",  reasonCode: String = ""): Unit = {
     // send a user left event for the clients to update
-    val userLeftMeetingEvent = MsgBuilder.buildUserLeftMeetingEvtMsg(meetingId, userId)
+    val userLeftMeetingEvent = MsgBuilder.buildUserLeftMeetingEvtMsg(meetingId, userId, eject, ejectedBy, banUser, reason, reasonCode)
     outGW.send(userLeftMeetingEvent)
   }
 
@@ -124,8 +124,8 @@ object UsersApp {
     for {
       user <- Users2x.ejectFromMeeting(liveMeeting.users2x, userId)
     } yield {
-      sendUserEjectedMessageToClient(outGW, meetingId, userId, ejectedBy, reason, reasonCode)
-      sendUserLeftMeetingToAllClients(outGW, meetingId, userId)
+//      sendUserEjectedMessageToClient(outGW, meetingId, userId, ejectedBy, reason, reasonCode)
+      sendUserLeftMeetingToAllClients(outGW, meetingId, userId, true, ejectedBy, ban,reason, reasonCode)
       sendEjectUserFromSfuSysMsg(outGW, meetingId, userId)
       if (user.presenter) {
         // println(s"ejectUserFromMeeting will cause a automaticallyAssignPresenter for user=${user}")

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -296,11 +296,11 @@ object MsgBuilder {
     BbbCommonEnvCoreMsg(envelope, event)
   }
 
-  def buildUserLeftMeetingEvtMsg(meetingId: String, userId: String): BbbCommonEnvCoreMsg = {
+  def buildUserLeftMeetingEvtMsg(meetingId: String, userId: String, eject: Boolean = false, ejectedBy: String = "", banUser: Boolean = false, reason: String = "", reasonCode: String = ""): BbbCommonEnvCoreMsg = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
     val envelope = BbbCoreEnvelope(UserLeftMeetingEvtMsg.NAME, routing)
     val header = BbbClientMsgHeader(UserLeftMeetingEvtMsg.NAME, meetingId, userId)
-    val body = UserLeftMeetingEvtMsgBody(userId)
+    val body = UserLeftMeetingEvtMsgBody(userId, eject, ejectedBy, banUser, reason, reasonCode)
     val event = UserLeftMeetingEvtMsg(header, body)
 
     BbbCommonEnvCoreMsg(envelope, event)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/UserLeftMeetingEvtMsgSender.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/UserLeftMeetingEvtMsgSender.scala
@@ -4,11 +4,11 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.UserState
 
 object UserLeftMeetingEvtMsgSender {
-  def build(meetingId: String, user: UserState): BbbCommonEnvCoreMsg = {
+  def build(meetingId: String, user: UserState, eject: Boolean = false, ejectedBy: String = "", banUser: Boolean = false, reason: String = "", reasonCode: String = ""): BbbCommonEnvCoreMsg = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, user.intId)
     val envelope = BbbCoreEnvelope(UserLeftMeetingEvtMsg.NAME, routing)
 
-    val body = UserLeftMeetingEvtMsgBody(intId = user.intId)
+    val body = UserLeftMeetingEvtMsgBody(intId = user.intId, eject, ejectedBy, banUser, reason, reasonCode)
     val event = UserLeftMeetingEvtMsg(meetingId, user.intId, body)
 
     BbbCommonEnvCoreMsg(envelope, event)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
@@ -75,7 +75,7 @@ case class UserLeftMeetingEvtMsg(
     header: BbbClientMsgHeader,
     body:   UserLeftMeetingEvtMsgBody
 ) extends BbbCoreMsg
-case class UserLeftMeetingEvtMsgBody(intId: String)
+case class UserLeftMeetingEvtMsgBody(intId: String, eject: Boolean, ejectedBy: String, banUser: Boolean, reason: String, reasonCode: String)
 
 object UserJoinedMeetingEvtMsg {
   val NAME = "UserJoinedMeetingEvtMsg"

--- a/bigbluebutton-html5/imports/api/users/server/handlers/removeUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/removeUser.js
@@ -8,5 +8,5 @@ export default function handleRemoveUser({ body }, meetingId) {
   check(meetingId, String);
   check(intId, String);
 
-  return removeUser(meetingId, intId);
+  return removeUser(body, meetingId);
 }

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
@@ -6,6 +6,7 @@ import setloggedOutStatus from '/imports/api/users-persistent-data/server/modifi
 import clearUserInfoForRequester from '/imports/api/users-infos/server/modifiers/clearUserInfoForRequester';
 import ClientConnections from '/imports/startup/server/ClientConnections';
 import UsersPersistentData from '/imports/api/users-persistent-data';
+import userEjected from './userEjected';
 import VoiceUsers from '/imports/api/voice-users/';
 
 const clearAllSessions = (sessionUserId) => {
@@ -19,7 +20,8 @@ const clearAllSessions = (sessionUserId) => {
   }
 };
 
-export default function removeUser(meetingId, userId) {
+export default function removeUser(body, meetingId) {
+  const { intId: userId, reasonCode } = body;
   check(meetingId, String);
   check(userId, String);
 
@@ -31,6 +33,10 @@ export default function removeUser(meetingId, userId) {
         meetingId,
         userId,
       };
+
+      if (body.eject) {
+        userEjected(meetingId, userId, reasonCode);
+      }
 
       setloggedOutStatus(userId, meetingId, true);
       VideoStreams.remove({ meetingId, userId });


### PR DESCRIPTION
### What does this PR do?

Remove the eject message usage and replaces it with the remove message adding new field to remove messages, the preference for the user message is because it's more flexible then the eject message and it could contain the eject message too, The idea is make easy for meteor deliver the right state of the user when an user is removed.

### Closes Issue(s)
Closes #12080


### Motivation

Make Meteor handle only one event when user is removed 
