### PR TITLE
fix: Force update of common-message and common-web libs

### DIFF
--- a/akka-bbb-apps/run-dev.sh
+++ b/akka-bbb-apps/run-dev.sh
@@ -2,4 +2,4 @@
 
 rm -rf src/main/resources
 cp -R src/universal/conf src/main/resources
-exec sbt run
+exec sbt update run

--- a/bbb-common-message/deploy.sh
+++ b/bbb-common-message/deploy.sh
@@ -1,10 +1,4 @@
 #!/bin/bash
 
-#Clear cached .jar from bbb-common-web, akka-bbb-apps and bigbluebutton-web
-scriptDir=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
-rm -rf $scriptDir/../bbb-common-web/lib_managed/jars/org.bigbluebutton/bbb-common-message_*
-rm -rf $scriptDir/../akka-bbb-apps/lib_managed/jars/org.bigbluebutton/bbb-common-message_*
-rm -rf $scriptDir/../bigbluebutton-web/lib/bbb-*
-
 #Publish new common-message .jar
 sbt clean publish publishLocal

--- a/bbb-common-web/deploy.sh
+++ b/bbb-common-web/deploy.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
 
-#Clear cached .jar from bigbluebutton-web
-scriptDir=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
-rm -rf  $scriptDir/../bigbluebutton-web/lib/bbb-common-web*
-
 #Publish new bbb-common-web .jar
-sbt clean publish publishLocal
+sbt clean update publish publishLocal

--- a/build/packages-template/bbb-apps-akka/build.sh
+++ b/build/packages-template/bbb-apps-akka/build.sh
@@ -15,9 +15,6 @@ find -name build.sbt -exec sed -i "s|\(.*org.bigbluebutton.*bbb-common-message[^
 
 export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
-#Clear cached .jar of common-message
-rm -rf akka-bbb-apps/lib_managed/jars/org.bigbluebutton/bbb-common-message_*
-
 cd bbb-common-message
 sbt publish
 sbt publishLocal
@@ -38,6 +35,7 @@ sed -i "s/^version .*/version := \"$VERSION\"/g" build.sbt
 if [[ -n $EPOCH && $EPOCH -gt 0 ]] ; then
     echo 'version in Debian := "'$EPOCH:$VERSION'"' >> build.sbt
 fi
+sbt update
 sbt debian:packageBin
 cp ./target/*.deb ..
 

--- a/build/packages-template/bbb-web/build.sh
+++ b/build/packages-template/bbb-web/build.sh
@@ -41,10 +41,6 @@ sed -i 's/\r$//' bbb-common-web/project/Dependencies.scala
 sed -i 's|\(val bbbCommons = \)"[^"]*"$|\1"EPHEMERAL_VERSION"|g' bbb-common-web/project/Dependencies.scala
 sed -i "s/EPHEMERAL_VERSION/$EPHEMERAL_VERSION/g" bbb-common-web/project/Dependencies.scala
 
-#Clear cached .jar of common-message and common-web
-rm -rf bbb-common-web/lib_managed/jars/org.bigbluebutton/bbb-common-message_*
-rm -rf bigbluebutton-web/lib/bbb-*
-
 echo start building bbb-common-message
 cd bbb-common-message
 sbt publish
@@ -54,6 +50,7 @@ echo end building bbb-common-message
 
 # New project directory containing parts of bbb-web
 cd bbb-common-web
+sbt update
 sbt publish
 sbt publishLocal
 cd ..


### PR DESCRIPTION
Instead of removing the old .jars, there is a better way to force the projects to retrieve the last version of external libraries.
It is using `sbt update` command.


![image](https://user-images.githubusercontent.com/5660191/154497907-9794c8fa-2b5e-4fc0-8912-fdab694fdd9e.png)

https://www.scala-sbt.org/1.x/docs/Command-Line-Reference.html

This PR reverts the previous "clear cache" approach sent in #14346 and #14377.
And include the command `sbt update` before run/compile Akka, Common-web and Bbb-web.