### PR TITLE
fix: change StartLimitAction to none

### DIFF
--- a/build/packages-template/bbb-html5/bionic/bbb-html5-backend@.service
+++ b/build/packages-template/bbb-html5/bionic/bbb-html5-backend@.service
@@ -5,7 +5,7 @@ Before=bbb-html5.service
 BindsTo=bbb-html5.service
 StartLimitBurst=4
 StartLimitInterval=70sec
-StartLimitAction=exit
+StartLimitAction=none
 
 [Service]
 PermissionsStartOnly=true

--- a/build/packages-template/bbb-html5/bionic/bbb-html5-frontend@.service
+++ b/build/packages-template/bbb-html5/bionic/bbb-html5-frontend@.service
@@ -5,7 +5,7 @@ Before=bbb-html5.service
 BindsTo=bbb-html5.service
 StartLimitBurst=4
 StartLimitInterval=70sec
-StartLimitAction=exit
+StartLimitAction=none
 
 [Service]
 PermissionsStartOnly=true


### PR DESCRIPTION
### What does this PR do?

This PR sets stat limit action to none. Since in 2.5 "exit " is not recognised, this is a functionally similar replacement. 

### Closes Issue(s)
Closes #14338

### Motivation

Previously:
When action exit worked it used to exit the execution when the limit of restarts on failure was hit. 
However action exit is no longer being recognised, thus error below would be thrown
`Failed to parse failure action specifier, ignoring: exit`
Failure to exit could cause restarting infinitely

Currently:
In case of "none" it does not exit explicitly, but rather prevents start when StartLimit is reached.

For example id back-end reaches restart frequency limit error message bellow will be thrown and it will no longer restart automatically.
`Failed to start BigBlueButton HTML5 service, backend instance 1.`
