### PR TITLE
build: Automatically set bbbServerVersion in settings.yml

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -28,7 +28,7 @@ public:
     #
     clientTitle: BigBlueButton
     appName: BigBlueButton HTML5 Client
-    bbbServerVersion: 2.5
+    bbbServerVersion: HTML5_FULL_BBB_VERSION
     displayBbbServerVersion: false
     copyright: '©2022 BigBlueButton Inc.'
     html5ClientBuild: HTML5_CLIENT_VERSION

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -29,7 +29,7 @@ public:
     clientTitle: BigBlueButton
     appName: BigBlueButton HTML5 Client
     bbbServerVersion: HTML5_FULL_BBB_VERSION
-    displayBbbServerVersion: false
+    displayBbbServerVersion: true
     copyright: '©2022 BigBlueButton Inc.'
     html5ClientBuild: HTML5_CLIENT_VERSION
     helpLink: https://bigbluebutton.org/html5/

--- a/build/packages-template/bbb-html5/after-install.sh
+++ b/build/packages-template/bbb-html5/after-install.sh
@@ -58,6 +58,17 @@ if [ ! -f /.dockerenv ]; then
   systemctl daemon-reload
 fi
 
+# set full BBB version in settings.yml so it can be displayed in the client
+BBB_RELEASE_FILE=/etc/bigbluebutton/bigbluebutton-release
+BBB_HTML5_SETTINGS_FILE=/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml
+if [[ -f $BBB_RELEASE_FILE ]] ; then
+  BBB_FULL_VERSION=$(cat $BBB_RELEASE_FILE | sed -n '/^BIGBLUEBUTTON_RELEASE/{s/.*=//;p}' )
+  echo "setting BBB_FULL_VERSION=$BBB_FULL_VERSION in $BBB_HTML5_SETTINGS_FILE "
+  if [[ -f $BBB_HTML5_SETTINGS_FILE ]] ; then
+    sed -i "s/HTML5_FULL_BBB_VERSION/$BBB_FULL_VERSION/g" $BBB_HTML5_SETTINGS_FILE
+  fi
+fi
+
 # Remove old overrides 
 if [ -f /etc/systemd/system/mongod.service.d/override-mongo.conf ] \
   || [ -f /etc/systemd/system/mongod.service.d/override.conf ] \


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
On package `bbb-html5` installation we try to set the value for `bbbServerVersion` to what the component `bbb-config` contains -- a reliable source of full BBB version.
Together with https://github.com/bigbluebutton/bigbluebutton/pull/14281 this PR closes  #10443
<!-- A brief description of each change being made with this pull request. -->

I also enable by default `displayBbbServerVersion`
### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #10443


### Motivation
See #10443 and #10451
<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->

