### PR TITLE
fix(guest-wait): Add missing locale meetingForciblyEnded

### DIFF
--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -604,6 +604,7 @@
     "app.guest.seatWait": "Guest waiting for a seat in the meeting.",
     "app.guest.allow": "Guest approved and redirecting to meeting.",
     "app.guest.guestInvalid": "Guest user is invalid",
+    "app.guest.meetingForciblyEnded": "You can not join a meeting that has already been forcibly ended",
     "app.userList.guest.waitingUsers": "Waiting Users",
     "app.userList.guest.waitingUsersTitle": "User Management",
     "app.userList.guest.optionTitle": "Review Pending Users",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -604,7 +604,7 @@
     "app.guest.seatWait": "Guest waiting for a seat in the meeting.",
     "app.guest.allow": "Guest approved and redirecting to meeting.",
     "app.guest.guestInvalid": "Guest user is invalid",
-    "app.guest.meetingForciblyEnded": "You can not join a meeting that has already been forcibly ended",
+    "app.guest.meetingForciblyEnded": "You cannot join a meeting that has already been forcibly ended",
     "app.userList.guest.waitingUsers": "Waiting Users",
     "app.userList.guest.waitingUsersTitle": "User Management",
     "app.userList.guest.optionTitle": "Review Pending Users",


### PR DESCRIPTION
### What does this PR do?

Add a locale for when the guest user reach the status of  `meetingForciblyEnded`, that means the guest user was in guest while a meeting has been ended

### Closes Issue(s)
Closes  #14366

### More

How I reproduced:

- Change locale to DE
- Join a meeting as moderator
- Make sure guest police is `ask moderator`
- Join with a guest user 
- end the meeting trough settings dropdown

