### PR TITLE
Add tooltips to user names in userlist

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-name/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/user-name/component.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages } from 'react-intl';
 import Icon from '/imports/ui/components/icon/component';
+import TooltipContainer from '/imports/ui/components/tooltip/container';
 import _ from 'lodash';
 import { styles } from './styles';
 
@@ -121,10 +122,12 @@ const UserName = (props) => {
       aria-expanded={isActionsOpen}
     >
       <span aria-hidden className={styles.userNameMain}>
-        <span>
-          {user.name}
-          &nbsp;
-        </span>
+        <TooltipContainer title={user.name}>
+          <span>
+            {user.name}
+            &nbsp;
+          </span>
+        </TooltipContainer>
         <i>{(isMe(user.userId)) ? `(${intl.formatMessage(messages.you)})` : ''}</i>
       </span>
       {


### PR DESCRIPTION
### What does this PR do?

Adds tooltips to user names in userlist, displaying the entire name on mouse hover.

#### Example:
<img width="250" alt="Screen Shot 2022-02-18 at 15 26 43" src="https://user-images.githubusercontent.com/3728706/154712519-885f5954-08fd-4c92-be2f-0142697d5aa2.png">

### Closes Issue(s)
Closes #14402