### PR TITLE
build: Use $1 if no EPOCH in akka-apps version

### DIFF
--- a/build/packages-template/bbb-apps-akka/build.sh
+++ b/build/packages-template/bbb-apps-akka/build.sh
@@ -5,6 +5,7 @@ TARGET=`basename $(pwd)`
 
 PACKAGE=$(echo $TARGET | cut -d'_' -f1)
 DISTRO=$(echo $TARGET | cut -d'_' -f3)
+BUILD=$1
 
 ##
 
@@ -34,6 +35,8 @@ sed -i "s/^version .*/version := \"$VERSION\"/g" build.sbt
 # set epoch if its greater than 0
 if [[ -n $EPOCH && $EPOCH -gt 0 ]] ; then
     echo 'version in Debian := "'$EPOCH:$VERSION'"' >> build.sbt
+else
+    echo 'version in Debian := "'$VERSION-$BUILD'"' >> build.sbt
 fi
 sbt update
 sbt debian:packageBin

--- a/build/packages-template/bbb-fsesl-akka/build.sh
+++ b/build/packages-template/bbb-fsesl-akka/build.sh
@@ -5,6 +5,7 @@ TARGET=`basename $(pwd)`
 
 PACKAGE=$(echo $TARGET | cut -d'_' -f1)
 DISTRO=$(echo $TARGET | cut -d'_' -f3)
+BUILD=$1
 
 ##
 
@@ -48,6 +49,8 @@ echo '#JAVA_OPTS="-Dconfig.file=/usr/share/bbb-fsesl-akka/conf/application.conf 
 sed -i "s/^version .*/version := \"$VERSION\"/g" build.sbt
 if [[ -n $EPOCH && $EPOCH -gt 0 ]] ; then
     echo 'version in Debian := "'$EPOCH:$VERSION'"' >> build.sbt
+else
+    echo 'version in Debian := "'$VERSION-$BUILD'"' >> build.sbt
 fi
 sbt debian:packageBin
 cp ./target/*.deb ..


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
In this PR I use the passed value ($1) as a build number and append it to the version at build time.

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #14407 


### Motivation
We were not setting the version of `bbb-apps-akka` and `bbb-fsesl-akka` packages, so each new build was reusing only the release portion `2.5`. This also meant that newer builds of these packages were not replacing the old ones (same version).
See #14407 
<!-- What inspired you to submit this pull request? -->

### More

