### PR TITLE
chore: Add jsconfig for bigbluebutton-html5/

### DIFF
--- a/bigbluebutton-html5/jsconfig.json
+++ b/bigbluebutton-html5/jsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": { "/*": ["*"] }
+    }
+}


### PR DESCRIPTION
### What does this PR do?

As the BBB uses absolute imports in some cases it makes it more difficult to track the file and open it, making the developer spend a lot of time looking for the file in the file explorer and not being able to use auto complete tools, adding the jsconfig file makes it easier for some code editors understand the root path of imports and make development more agile 

### Motivation
Improve DX in bbb-html5 


With jsconfig:

https://user-images.githubusercontent.com/15806883/154966334-f0dccdaa-415c-4ab1-9ac5-a402d8611846.mp4

without jsconfig:


https://user-images.githubusercontent.com/15806883/154966457-41d0d739-42a9-437b-858f-e2f324a580dc.mp4



