### PR TITLE
refactor: improve userlist performance

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/components-data/users-ready-context/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/users-ready-context/context.jsx
@@ -1,0 +1,58 @@
+import React, {
+  createContext,
+  useReducer,
+} from 'react';
+
+export const READY_ACTIONS = {
+  READY: 'ready',
+};
+
+export const UsersReadyContext = createContext();
+
+const reducer = (state, action) => {
+  switch (action.type) {
+    case READY_ACTIONS.READY: {
+      if (state.isReady === action.value.isReady) return state;
+
+      return {
+        ...state,
+        ...action.value,
+      };
+    }
+    default: {
+      throw new Error(`Unexpected action: ${JSON.stringify(action)}`);
+    }
+  }
+};
+
+export const UsersReadyContextProvider = (props) => {
+  const [usersReadyContextState, usersReadyContextDispatch] = useReducer(reducer, {});
+
+  const { isReady } = usersReadyContextState;
+
+  return (
+    <UsersReadyContext.Provider value={
+      {
+        ...props,
+        dispatch: usersReadyContextDispatch,
+        isReady,
+      }
+    }
+    >
+      {props.children}
+    </UsersReadyContext.Provider>
+  );
+};
+
+export const UsersReadyContextConsumer = Component => props => (
+  <UsersReadyContext.Consumer>
+    {contexts => <Component {...props} {...contexts} />}
+  </UsersReadyContext.Consumer>
+);
+
+export const withUsersReadyConsumer = Component => UsersReadyContextConsumer(Component);
+
+export default {
+  UsersReadyContextConsumer,
+  UsersReadyContextProvider,
+};

--- a/bigbluebutton-html5/imports/ui/components/context-providers/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/context-providers/component.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ChatContextProvider } from '/imports/ui/components/components-data/chat-context/context';
 import { UsersContextProvider } from '/imports/ui/components/components-data/users-context/context';
+import { UsersReadyContextProvider } from '/imports/ui/components/components-data/users-ready-context/context';
 import { GroupChatContextProvider } from '/imports/ui/components/components-data/group-chat-context/context';
 import { LayoutContextProvider } from '/imports/ui/components/layout/context';
 
@@ -8,6 +9,7 @@ const providersList = [
   ChatContextProvider,
   GroupChatContextProvider,
   UsersContextProvider,
+  UsersReadyContextProvider,
   LayoutContextProvider,
 ];
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl, defineMessages } from 'react-intl';
 import Styled from './styles';
 import UserParticipantsContainer from './user-participants/container';
 import UserMessagesContainer from './user-messages/container';
@@ -16,7 +17,41 @@ const propTypes = {
 const CHAT_ENABLED = Meteor.settings.public.chat.enabled;
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 
+const intlMessages = defineMessages({
+  usersTitle: {
+    id: 'app.userList.usersTitle',
+    description: 'Title for the Header',
+  },
+  loading: {
+    id: 'app.userList.loading',
+    description: 'Loading users message',
+  },
+});
+
 class UserContent extends PureComponent {
+  constructor() {
+    super();
+
+    this.renderEmptyUserlist = this.renderEmptyUserlist.bind(this);
+  }
+
+  renderEmptyUserlist() {
+    const { intl } = this.props;
+
+    return (
+      <Styled.UserListColumn data-test="userList">
+        <Styled.Container>
+          <Styled.SmallTitle>
+            {intl.formatMessage(intlMessages.usersTitle)}
+          </Styled.SmallTitle>
+        </Styled.Container>
+        <Styled.LoadingUsersText>
+          {intl.formatMessage(intlMessages.loading)}
+        </Styled.LoadingUsersText>
+      </Styled.UserListColumn>
+    );
+  }
+
   render() {
     const {
       currentUser,
@@ -24,6 +59,7 @@ class UserContent extends PureComponent {
       isWaitingRoomEnabled,
       isGuestLobbyMessageEnabled,
       compact,
+      isReady,
     } = this.props;
 
     const showWaitingRoom = (isGuestLobbyMessageEnabled && isWaitingRoomEnabled)
@@ -40,7 +76,7 @@ class UserContent extends PureComponent {
           ) : null}
         <UserPollsContainer isPresenter={currentUser.presenter} />
         <BreakoutRoomContainer />
-        <UserParticipantsContainer compact={compact}/>
+        { isReady ? <UserParticipantsContainer compact={compact} /> : this.renderEmptyUserlist() }
       </Styled.Content>
     );
   }
@@ -48,4 +84,4 @@ class UserContent extends PureComponent {
 
 UserContent.propTypes = propTypes;
 
-export default UserContent;
+export default injectIntl(UserContent);

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/container.jsx
@@ -3,25 +3,20 @@ import { withTracker } from 'meteor/react-meteor-data';
 import Auth from '/imports/ui/services/auth';
 import UserContent from './component';
 import GuestUsers from '/imports/api/guest-users';
-import { UsersContext } from '/imports/ui/components/components-data/users-context/context';
 import WaitingUsersService from '/imports/ui/components/waiting-users/service';
+import Users from '/imports/api/users';
+import { UsersReadyContext } from '/imports/ui/components/components-data/users-ready-context/context';
 
 const UserContentContainer = (props) => {
-  const usingUsersContext = useContext(UsersContext);
-  const { users } = usingUsersContext;
-  const currentUser = {
-    userId: Auth.userID,
-    presenter: users[Auth.meetingID][Auth.userID].presenter,
-    locked: users[Auth.meetingID][Auth.userID].locked,
-    role: users[Auth.meetingID][Auth.userID].role,
-  };
   const { isGuestLobbyMessageEnabled } = WaitingUsersService;
+  const usingUsersReadyContext = useContext(UsersReadyContext);
+  const { isReady } = usingUsersReadyContext;
 
   return (
     <UserContent
       {...{
         isGuestLobbyMessageEnabled,
-        currentUser,
+        isReady,
         ...props,
       }}
     />
@@ -34,5 +29,7 @@ export default withTracker(() => ({
     approved: false,
     denied: false,
   }).fetch(),
+  currentUser: Users.findOne({meetingId: Auth.meetingID, userId: Auth.userID},
+    { fields: { presenter: 1, locked: 1, role: 1, userId: 1 } }),
   isWaitingRoomEnabled: WaitingUsersService.isWaitingRoomEnabled(),
 }))(UserContentContainer);

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/styles.js
@@ -163,6 +163,19 @@ const Separator = styled.hr`
   border-top: 1px solid ${colorGrayLighter};
 `;
 
+const UserListColumn = styled(FlexColumn)`
+  min-height: 0;
+  flex-grow: 1;
+`;
+
+const SmallTitle = styled(Styled.SmallTitle)``;
+
+const LoadingUsersText = styled.div`
+  display: flex;
+  font-weight: bold;
+  justify-content: center;
+`;
+
 export default {
   Content,
   Container,
@@ -172,4 +185,7 @@ export default {
   UnreadMessages,
   UnreadMessagesText,
   Separator,
+  UserListColumn,
+  SmallTitle,
+  LoadingUsersText,
 };

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/styles.js
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 
-import { FlexColumn } from '/imports/ui/stylesheets/styled-components/placeholders';
 import Styled from '/imports/ui/components/user-list/styles';
 import StyledContent from '/imports/ui/components/user-list/user-list-content/styles';
 import {
@@ -16,10 +15,7 @@ const SmallTitle = styled(Styled.SmallTitle)``;
 
 const Separator = styled(StyledContent.Separator)``;
 
-const UserListColumn = styled(FlexColumn)`
-  min-height: 0;
-  flex-grow: 1;
-`;
+const UserListColumn = styled(StyledContent.UserListColumn)``;
 
 const VirtualizedScrollableList = styled(ScrollboxVertical)`
   background: linear-gradient(${userListBg} 30%, rgba(255,255,255,0)),

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -131,6 +131,7 @@
     "app.userList.userOptions.savedNames.title": "List of users in meeting {0} at {1}",
     "app.userList.userOptions.sortedFirstName.heading": "Sorted by first name:",
     "app.userList.userOptions.sortedLastName.heading": "Sorted by last name:",
+    "app.userList.loading": "Loading users...",
     "app.media.label": "Media",
     "app.media.autoplayAlertDesc": "Allow Access",
     "app.media.screenshare.start": "Screenshare has started",


### PR DESCRIPTION
### What does this PR do?

Adds an empty userlist component to be displayed when many users are joining at the same time, in order to reduce additional renders and decrease cpu/ram usage in the client.

#### Loading message:
<img width="239" alt="Screen Shot 2022-02-21 at 17 23 50" src="https://user-images.githubusercontent.com/3728706/155003287-60c618b1-d5a1-4676-b1ba-9bf3b325bbfc.png">
