### PR TITLE
fix(presentation): new message for presentation item status

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -99,6 +99,10 @@ const intlMessages = defineMessages({
     id: 'app.presentationUploder.rejectedError',
     description: 'some files rejected, please check the file mime types',
   },
+  badConnectionError: {
+    id: 'app.presentationUploder.connectionClosedError',
+    description: 'message indicating that the connection was closed',
+  },
   uploadProcess: {
     id: 'app.presentationUploder.upload.progress',
     description: 'message that indicates the percentage of the upload',
@@ -982,6 +986,11 @@ class PresentationUploader extends Component {
     if (item.upload.done && item.upload.error) {
       if (item.conversion.status === 'FILE_TOO_LARGE') {
         constraint['0'] = ((item.conversion.maxFileSize) / 1000 / 1000).toFixed(2);
+      }
+
+      if (item.upload.progress < 100) {
+        const errorMessage = intlMessages.badConnectionError;
+        return intl.formatMessage(errorMessage);
       }
 
       const errorMessage = intlMessages[item.upload.status] || intlMessages.genericError;

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -207,7 +207,7 @@
     "app.presentationUploder.fileToUpload": "To be uploaded ...",
     "app.presentationUploder.currentBadge": "Current",
     "app.presentationUploder.rejectedError": "The selected file(s) have been rejected. Please check the file type(s).",
-    "app.presentationUploder.connectionClosedError": "Oops, bad connection to the server. Try again.",
+    "app.presentationUploder.connectionClosedError": "Interrupted by poor connectivity. Please try again.",
     "app.presentationUploder.upload.progress": "Uploading ({0}%)",
     "app.presentationUploder.upload.413": "File is too large, exceeded the maximum of {0} MB",
     "app.presentationUploder.genericError": "Oops, Something went wrong ...",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -207,6 +207,7 @@
     "app.presentationUploder.fileToUpload": "To be uploaded ...",
     "app.presentationUploder.currentBadge": "Current",
     "app.presentationUploder.rejectedError": "The selected file(s) have been rejected. Please check the file type(s).",
+    "app.presentationUploder.connectionClosedError": "Oops, bad connection to the server. Try again.",
     "app.presentationUploder.upload.progress": "Uploading ({0}%)",
     "app.presentationUploder.upload.413": "File is too large, exceeded the maximum of {0} MB",
     "app.presentationUploder.genericError": "Oops, Something went wrong ...",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

In some cases when uploading a large presentation file, for some unknown reason a `net::ERR_CONNECTION_CLOSED` exception will be raised.

![Captura de tela de 2022-02-21 15-07-28](https://user-images.githubusercontent.com/62393923/155007491-db84c56b-e6fd-4340-83ec-1a4274117d9e.png)

That impedes the upload progress of reaching `100`. Then, a generic error message is showed:

![screenshot](https://user-images.githubusercontent.com/290351/153985745-1e22185e-2df6-473d-9cb7-9a689dca8e8f.png)

This PR adds a more descriptive error message for that case:

![Captura de tela de 2022-02-21 15-16-25](https://user-images.githubusercontent.com/62393923/155008422-265136cd-3380-4e27-b9a9-f0011fde4a81.png)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #14362