### PR TITLE
feat(video): add user camera cap control

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetCamBroadcastPermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetCamBroadcastPermissionReqMsgHdlr.scala
@@ -2,9 +2,7 @@ package org.bigbluebutton.core2.message.handlers
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
-import org.bigbluebutton.core.models.Users2x
 import org.bigbluebutton.core2.message.senders.MsgBuilder
-import org.bigbluebutton.LockSettingsUtil
 
 trait GetCamBroadcastPermissionReqMsgHdlr {
   this: MeetingActor =>
@@ -12,21 +10,12 @@ trait GetCamBroadcastPermissionReqMsgHdlr {
   val outGW: OutMsgRouter
 
   def handleGetCamBroadcastPermissionReqMsg(msg: GetCamBroadcastPermissionReqMsg) {
-    var camBroadcastLocked: Boolean = false
-    var allowed = false
-
-    for {
-      user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
-    } yield {
-      camBroadcastLocked = LockSettingsUtil.isCameraBroadcastLocked(user, liveMeeting)
-
-      if (!user.userLeftFlag.left
-        && liveMeeting.props.meetingProp.intId == msg.body.meetingId
-        && msg.body.streamId.startsWith(msg.header.userId)
-        && (applyPermissionCheck && !camBroadcastLocked)) {
-        allowed = true
-      }
-    }
+    val allowed = CameraHdlrHelpers.isCameraBroadcastAllowed(
+      liveMeeting,
+      msg.body.meetingId,
+      msg.body.userId,
+      msg.body.streamId
+    )
 
     val event = MsgBuilder.buildGetCamBroadcastPermissionRespMsg(
       liveMeeting.props.meetingProp.intId,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/CameraHdlrHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/CameraHdlrHelpers.scala
@@ -1,0 +1,62 @@
+package org.bigbluebutton.core2.message.handlers
+
+import org.bigbluebutton.SystemConfiguration
+import org.bigbluebutton.core.running.{ LiveMeeting }
+import org.bigbluebutton.core.models.{ Users2x, Webcams, WebcamStream }
+import org.bigbluebutton.LockSettingsUtil
+
+object CameraHdlrHelpers extends SystemConfiguration {
+  def isCameraBroadcastAllowed(
+      liveMeeting: LiveMeeting,
+      meetingId:   String,
+      userId:      String,
+      streamId:    String
+  ): Boolean = {
+    Users2x.findWithIntId(liveMeeting.users2x, userId) match {
+      case Some(user) => {
+        val camBroadcastLocked = LockSettingsUtil.isCameraBroadcastLocked(user, liveMeeting)
+        val camCapReached = hasReachedCameraCap(liveMeeting, userId)
+
+        (applyPermissionCheck &&
+          !camBroadcastLocked &&
+          !camCapReached &&
+          !user.userLeftFlag.left &&
+          streamId.startsWith(user.intId) &&
+          liveMeeting.props.meetingProp.intId == meetingId)
+      }
+      case _ => false
+    }
+  }
+
+  def isCameraSubscribeAllowed(
+      liveMeeting: LiveMeeting,
+      meetingId:   String,
+      userId:      String,
+      stream:      WebcamStream
+  ): Boolean = {
+    Users2x.findWithIntId(liveMeeting.users2x, userId) match {
+      case Some(user) => {
+        val camSubscribeLocked = LockSettingsUtil.isCameraSubscribeLocked(user, stream, liveMeeting)
+
+        (applyPermissionCheck &&
+          !camSubscribeLocked &&
+          !user.userLeftFlag.left &&
+          liveMeeting.props.meetingProp.intId == meetingId)
+      }
+      case _ => false
+    }
+  }
+
+  def hasReachedCameraCap(
+      liveMeeting: LiveMeeting,
+      userId:      String
+  ): Boolean = {
+    val cameras = Webcams.findWebcamsForUser(liveMeeting.webcams, userId).length
+
+    liveMeeting.props.usersProp.userCameraCap match {
+      case 0                => false // disabled
+      case x if x > cameras => false
+      case _                => true
+    }
+  }
+}

--- a/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
+++ b/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
@@ -27,6 +27,7 @@ trait AppsTestFixtures {
   val keepEvents = false
   val allowStartStopRecording = false
   val webcamsOnlyForModerator = false;
+  val userCameraCap = 0
   val moderatorPassword = "modpass"
   val viewerPassword = "viewpass"
   val learningDashboardAccessToken = "ldToken"
@@ -63,6 +64,7 @@ trait AppsTestFixtures {
     modOnlyMessage = modOnlyMessage)
   val voiceProp = VoiceProp(telVoice = voiceConfId, voiceConf = voiceConfId, dialNumber = dialNumber, muteOnStart = muteOnStart)
   val usersProp = UsersProp(maxUsers = maxUsers, webcamsOnlyForModerator = webcamsOnlyForModerator,
+    userCameraCap = userCameraCap,
     guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers, allowModsToEjectCameras = allowModsToEjectCameras,
     authenticatedGuest = authenticatedGuest, meetingLayout = meetingLayout, virtualBackgroundsEnabled = virtualBackgroundsEnabled)
   val metadataProp = new MetadataProp(metadata)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
@@ -31,6 +31,7 @@ case class VoiceProp(telVoice: String, voiceConf: String, dialNumber: String, mu
 case class UsersProp(
     maxUsers:                   Int,
     webcamsOnlyForModerator:    Boolean,
+    userCameraCap:              Int,
     guestPolicy:                String,
     meetingLayout:              String,
     allowModsToUnmuteUsers:     Boolean,

--- a/bbb-common-message/src/test/scala/org/bigbluebutton/common2/TestFixtures.scala
+++ b/bbb-common-message/src/test/scala/org/bigbluebutton/common2/TestFixtures.scala
@@ -23,6 +23,7 @@ trait TestFixtures {
   val autoStartRecording = false
   val allowStartStopRecording = false
   val webcamsOnlyForModerator = false
+  val userCameraCap = 0
   val moderatorPassword = "modpass"
   val viewerPassword = "viewpass"
   val learningDashboardAccessToken = "ldToken"
@@ -56,6 +57,7 @@ trait TestFixtures {
     modOnlyMessage = modOnlyMessage)
   val voiceProp = VoiceProp(telVoice = voiceConfId, voiceConf = voiceConfId, dialNumber = dialNumber, muteOnStart = muteOnStart)
   val usersProp = UsersProp(maxUsers = maxUsers, webcamsOnlyForModerator = webcamsOnlyForModerator,
+    userCameraCap = userCameraCap,
     guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers, allowModsToEjectCameras = allowModsToEjectCameras, authenticatedGuest = authenticatedGuest)
   val metadataProp = new MetadataProp(metadata)
   val screenshareProps = ScreenshareProps(screenshareConf = "FixMe!", red5ScreenshareIp = "fixMe!",

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -61,6 +61,7 @@ public class ApiParams {
     public static final String LEARNING_DASHBOARD_CLEANUP_DELAY_IN_MINUTES = "learningDashboardCleanupDelayInMinutes";
     public static final String VIRTUAL_BACKGROUNDS_DISABLED = "virtualBackgroundsDisabled";
     public static final String WEBCAMS_ONLY_FOR_MODERATOR = "webcamsOnlyForModerator";
+    public static final String USER_CAMERA_CAP = "userCameraCap";
     public static final String WELCOME = "welcome";
     public static final String HTML5_INSTANCE_ID = "html5InstanceId";
     public static final String ROLE = "role";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -405,6 +405,7 @@ public class MeetingService implements MessageListener {
     logData.put("duration", m.getDuration());
     logData.put("isBreakout", m.isBreakout());
     logData.put("webcamsOnlyForModerator", m.getWebcamsOnlyForModerator());
+    logData.put("userCameraCap", m.getUserCameraCap());
     logData.put("record", m.isRecord());
     logData.put("logCode", "create_meeting");
     logData.put("description", "Create meeting.");
@@ -419,7 +420,7 @@ public class MeetingService implements MessageListener {
 
     gw.createMeeting(m.getInternalId(), m.getExternalId(), m.getParentMeetingId(), m.getName(), m.isRecord(),
             m.getTelVoice(), m.getDuration(), m.getAutoStartRecording(), m.getAllowStartStopRecording(),
-            m.getWebcamsOnlyForModerator(), m.getModeratorPassword(), m.getViewerPassword(),
+            m.getWebcamsOnlyForModerator(), m.getUserCameraCap(), m.getModeratorPassword(), m.getViewerPassword(),
             m.getLearningDashboardEnabled(), m.getLearningDashboardAccessToken(), m.getCreateTime(),
             formatPrettyDate(m.getCreateTime()), m.isBreakout(), m.getSequence(), m.isFreeJoin(), m.getMetadata(),
             m.getGuestPolicy(), m.getAuthenticatedGuest(), m.getMeetingLayout(), m.getWelcomeMessageTemplate(), m.getWelcomeMessage(), m.getModeratorOnlyMessage(),

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -85,6 +85,7 @@ public class ParamsProcessorUtil {
     private boolean learningDashboardEnabled;
     private int learningDashboardCleanupDelayInMinutes;
     private boolean webcamsOnlyForModerator;
+    private Integer defaultUserCameraCap = 0;
     private boolean defaultMuteOnStart = false;
     private boolean defaultAllowModsToUnmuteUsers = false;
     private boolean defaultAllowModsToEjectCameras = false;
@@ -480,6 +481,16 @@ public class ParamsProcessorUtil {
             }
         }
 
+        Integer userCameraCap = defaultUserCameraCap;
+        if (!StringUtils.isEmpty(params.get(ApiParams.USER_CAMERA_CAP))) {
+            try {
+                Integer userCameraCapParam = Integer.parseInt(params.get(ApiParams.USER_CAMERA_CAP));
+                if (userCameraCapParam >= 0) userCameraCap = userCameraCapParam;
+            } catch (NumberFormatException e) {
+                log.warn("Invalid param [userCameraCap] for meeting=[{}]", internalMeetingId);
+            }
+        }
+
         boolean endWhenNoModerator = defaultEndWhenNoModerator;
         if (!StringUtils.isEmpty(params.get(ApiParams.END_WHEN_NO_MODERATOR))) {
           try {
@@ -555,6 +566,7 @@ public class ParamsProcessorUtil {
                 .withAutoStartRecording(autoStartRec)
                 .withAllowStartStopRecording(allowStartStoptRec)
                 .withWebcamsOnlyForModerator(webcamsOnlyForMod)
+                .withUserCameraCap(userCameraCap)
                 .withMetadata(meetingInfo)
                 .withWelcomeMessageTemplate(welcomeMessageTemplate)
                 .withWelcomeMessage(welcomeMessage).isBreakout(isBreakout)
@@ -1005,6 +1017,10 @@ public class ParamsProcessorUtil {
 
     public void setWebcamsOnlyForModerator(boolean webcamsOnlyForModerator) {
         this.webcamsOnlyForModerator = webcamsOnlyForModerator;
+    }
+
+    public void setDefaultUserCameraCap(Integer userCameraCap) {
+        this.defaultUserCameraCap = userCameraCap;
     }
 
 	public void setUseDefaultAvatar(Boolean value) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -68,6 +68,7 @@ public class Meeting {
 	private boolean allowStartStopRecording = false;
 	private boolean haveRecordingMarks = false;
 	private boolean webcamsOnlyForModerator = false;
+	private Integer userCameraCap = 0;
 	private String dialNumber;
 	private String defaultAvatarURL;
 	private String guestPolicy = GuestPolicy.ASK_MODERATOR;
@@ -128,6 +129,7 @@ public class Meeting {
         autoStartRecording = builder.autoStartRecording;
         allowStartStopRecording = builder.allowStartStopRecording;
         webcamsOnlyForModerator = builder.webcamsOnlyForModerator;
+        userCameraCap = builder.userCameraCap;
         duration = builder.duration;
         webVoice = builder.webVoice;
         telVoice = builder.telVoice;
@@ -495,6 +497,10 @@ public class Meeting {
         return webcamsOnlyForModerator;
     }
 
+    public Integer getUserCameraCap() {
+        return userCameraCap;
+    }
+
 	public boolean hasUserJoined() {
 		return userHasJoined;
 	}
@@ -771,6 +777,7 @@ public class Meeting {
     	private boolean autoStartRecording;
         private boolean allowStartStopRecording;
         private boolean webcamsOnlyForModerator;
+        private Integer userCameraCap;
     	private String moderatorPass;
     	private String viewerPass;
     	private Boolean learningDashboardEnabled;
@@ -840,6 +847,11 @@ public class Meeting {
 
         public Builder withWebcamsOnlyForModerator(boolean only) {
             this.webcamsOnlyForModerator = only;
+            return this;
+        }
+
+        public Builder withUserCameraCap(Integer cap) {
+            this.userCameraCap = cap;
             return this;
         }
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/converters/messages/CreateMeetingMessage.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/converters/messages/CreateMeetingMessage.java
@@ -15,6 +15,7 @@ public class CreateMeetingMessage {
 	public boolean autoStartRecording;
 	public boolean allowStartStopRecording;
 	public boolean webcamsOnlyForModerator;
+	public final Integer userCameraCap;
 	public final String moderatorPass;
 	public final String viewerPass;
 	public final String learningDashboardAccessToken;
@@ -26,7 +27,7 @@ public class CreateMeetingMessage {
 	public CreateMeetingMessage(String id, String externalId, String name, Boolean record, 
 						String voiceBridge, Long duration, 
 						Boolean autoStartRecording, Boolean allowStartStopRecording,
-						Boolean webcamsOnlyForModerator, String moderatorPass,
+						Boolean webcamsOnlyForModerator, Integer userCameraCap, String moderatorPass,
 						String viewerPass, String learningDashboardAccessToken, Boolean learningDashboardEnabled,
 						Long createTime, String createDate, Map<String, String> metadata) {
 		this.id = id;
@@ -38,6 +39,7 @@ public class CreateMeetingMessage {
 		this.autoStartRecording = autoStartRecording;
 		this.allowStartStopRecording = allowStartStopRecording;
 		this.webcamsOnlyForModerator = webcamsOnlyForModerator;
+		this.userCameraCap = userCameraCap;
 		this.moderatorPass = moderatorPass;
 		this.viewerPass = viewerPass;
 		this.learningDashboardAccessToken = learningDashboardAccessToken;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/pub/IPublisherService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/pub/IPublisherService.java
@@ -12,6 +12,7 @@ public interface IPublisherService {
                        String parentMeetingID, String meetingName, Boolean recorded,
                        String voiceBridge, Integer duration, Boolean autoStartRecording,
                        Boolean allowStartStopRecording, Boolean webcamsOnlyForModerator,
+                       Integer userCameraCap,
                        String moderatorPass, String viewerPass, Long createTime,
                        String createDate, Boolean isBreakout, Integer sequence,
                        Boolean freeJoin, Map<String, String> metadata, String guestPolicy);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
@@ -17,6 +17,7 @@ public interface IBbbWebApiGWApp {
                      String parentMeetingID, String meetingName, Boolean recorded,
                      String voiceBridge, Integer duration, Boolean autoStartRecording,
                      Boolean allowStartStopRecording, Boolean webcamsOnlyForModerator,
+                     Integer userCameraCap,
                      String moderatorPass, String viewerPass, Boolean learningDashboardEnabled, String learningDashboardAccessToken, Long createTime,
                      String createDate, Boolean isBreakout, Integer sequence, Boolean freejoin, Map<String, String> metadata,
                      String guestPolicy, Boolean authenticatedGuest, String meetingLayout, String welcomeMsgTemplate, String welcomeMsg, String modOnlyMessage,

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/domain/UsersProp2.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/domain/UsersProp2.java
@@ -9,6 +9,7 @@ public class UsersProp2 {
     public final boolean authenticatedGuest;
     public final boolean userHasJoined;
     public final boolean webcamsOnlyForModerator;
+    public final int userCameraCap;
     public final int maxUsers;
     public final Map<String, String> userCustomData;
     public final Map<String, User2> users;
@@ -16,6 +17,7 @@ public class UsersProp2 {
 
     public UsersProp2(int maxUsers,
                       boolean webcamsOnlyForModerator,
+                      int userCameraCap,
                       String guestPolicy,
                       String meetingLayout,
                       boolean authenticatedGuest,
@@ -25,6 +27,7 @@ public class UsersProp2 {
                       Map<String, Long> registeredUsers) {
         this.maxUsers = maxUsers;
         this.webcamsOnlyForModerator = webcamsOnlyForModerator;
+        this.userCameraCap = userCameraCap;
         this.guestPolicy = guestPolicy;
         this.meetingLayout = meetingLayout;
         this.authenticatedGuest = authenticatedGuest;

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -124,6 +124,7 @@ class BbbWebApiGWApp(
                     recorded: java.lang.Boolean, voiceBridge: String, duration: java.lang.Integer,
                     autoStartRecording:      java.lang.Boolean,
                     allowStartStopRecording: java.lang.Boolean, webcamsOnlyForModerator: java.lang.Boolean,
+                    userCameraCap: java.lang.Integer,
                     moderatorPass: String, viewerPass: String, learningDashboardEnabled: java.lang.Boolean, learningDashboardAccessToken: String,
                     createTime: java.lang.Long, createDate: String, isBreakout: java.lang.Boolean,
                     sequence: java.lang.Integer,
@@ -179,6 +180,7 @@ class BbbWebApiGWApp(
       modOnlyMessage = modOnlyMessage)
     val voiceProp = VoiceProp(telVoice = voiceBridge, voiceConf = voiceBridge, dialNumber = dialNumber, muteOnStart = muteOnStart.booleanValue())
     val usersProp = UsersProp(maxUsers = maxUsers.intValue(), webcamsOnlyForModerator = webcamsOnlyForModerator.booleanValue(),
+      userCameraCap = userCameraCap.intValue(),
       guestPolicy = guestPolicy, meetingLayout = meetingLayout, allowModsToUnmuteUsers = allowModsToUnmuteUsers.booleanValue(),
       allowModsToEjectCameras = allowModsToEjectCameras.booleanValue(),
       authenticatedGuest = authenticatedGuest.booleanValue(), virtualBackgroundsDisabled = virtualBackgroundsDisabled.booleanValue())

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -57,6 +57,7 @@ export default function addMeeting(meeting) {
     },
     usersProp: {
       webcamsOnlyForModerator: Boolean,
+      userCameraCap: Number,
       guestPolicy: String,
       authenticatedGuest: Boolean,
       maxUsers: Number,

--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -35,6 +35,7 @@ const propTypes = {
   startSharing: PropTypes.func.isRequired,
   stopSharing: PropTypes.func.isRequired,
   resolve: PropTypes.func,
+  camCapReached: PropTypes.bool,
   hasVideoStream: PropTypes.bool.isRequired,
   webcamDeviceId: PropTypes.string,
   sharedDevices: PropTypes.arrayOf(PropTypes.string),
@@ -42,6 +43,7 @@ const propTypes = {
 
 const defaultProps = {
   resolve: null,
+  camCapReached: true,
   webcamDeviceId: null,
   sharedDevices: [],
 };
@@ -170,6 +172,10 @@ const intlMessages = defineMessages({
   genericError: {
     id: 'app.video.genericError',
     description: 'error message for when the webcam sharing fails with unknown error',
+  },
+  camCapReached: {
+    id: 'app.video.camCapReached',
+    description: 'message for when the camera cap has been reached',
   },
   virtualBgGenericError: {
     id: 'app.video.virtualBackground.genericError',
@@ -719,6 +725,7 @@ class VideoPreview extends Component {
       sharedDevices,
       hasVideoStream,
       forceOpen,
+      camCapReached,
     } = this.props;
 
     const {
@@ -772,13 +779,17 @@ class VideoPreview extends Component {
             : null
           }
           <div className={styles.actions}>
-            <Button
-              data-test="startSharingWebcam"
-              color={shared ? 'danger' : 'primary'}
-              label={intl.formatMessage(shared ? intlMessages.stopSharingLabel : intlMessages.startSharingLabel)}
-              onClick={shared ? this.handleStopSharing : this.handleStartSharing}
-              disabled={isStartSharingDisabled || isStartSharingDisabled === null || shouldDisableButtons}
-            />
+            {!shared && camCapReached ? (
+              <span>{intl.formatMessage(intlMessages.camCapReached)}</span>
+            ) : (
+              <Button
+                data-test="startSharingWebcam"
+                color={shared ? 'danger' : 'primary'}
+                label={intl.formatMessage(shared ? intlMessages.stopSharingLabel : intlMessages.startSharingLabel)}
+                onClick={shared ? this.handleStopSharing : this.handleStartSharing}
+                disabled={isStartSharingDisabled || isStartSharingDisabled === null || shouldDisableButtons}
+              />
+            )}
           </div>
         </div>
       </>

--- a/bigbluebutton-html5/imports/ui/components/video-preview/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/container.jsx
@@ -23,6 +23,7 @@ export default withModalMounter(withTracker(({ mountModal }) => ({
   },
   sharedDevices: VideoService.getSharedDevices(),
   isCamLocked: VideoService.isUserLocked(),
+  camCapReached: VideoService.hasCapReached(),
   closeModal: () => mountModal(null),
   webcamDeviceId: Service.webcamDeviceId(),
   hasVideoStream: VideoService.hasVideoStream(),

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -571,6 +571,31 @@ class VideoService {
     return false;
   }
 
+  hasCapReached() {
+    const meeting = Meetings.findOne(
+      { meetingId: Auth.meetingID },
+      {
+        fields: {
+          'usersProp.userCameraCap': 1,
+        },
+      },
+    );
+
+    if (!meeting?.usersProp) return true;
+
+    const localStreams = this.getLocalVideoStreamsCount();
+
+    return localStreams >= meeting.usersProp.userCameraCap;
+  }
+
+  getLocalVideoStreamsCount() {
+    const localStreams = VideoStreams.find(
+      { userId: Auth.userID }
+    ).count();
+
+    return localStreams;
+  }
+
   getInfo() {
     const m = Meetings.findOne({ meetingId: Auth.meetingID },
       { fields: { 'voiceProp.voiceConf': 1 } });
@@ -963,6 +988,7 @@ export default {
   getUserParameterProfile: () => videoService.getUserParameterProfile(),
   isMultipleCamerasEnabled: () => videoService.isMultipleCamerasEnabled(),
   mirrorOwnWebcam: userId => videoService.mirrorOwnWebcam(userId),
+  hasCapReached: () => videoService.hasCapReached(),
   onBeforeUnload: () => videoService.onBeforeUnload(),
   notify: message => notify(message, 'error', 'video'),
   updateNumberOfDevices: devices => videoService.updateNumberOfDevices(devices),

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -766,6 +766,7 @@
     "app.video.virtualBackground.background": "Background",
     "app.video.virtualBackground.genericError": "Failed to apply camera effect. Try again.",
     "app.video.virtualBackground.camBgAriaDesc": "Sets webcam virtual background to {0}",
+    "app.video.camCapReached": "You cannot share more cameras",
     "app.video.dropZoneLabel": "Drop here",
     "app.fullscreenButton.label": "Make {0} fullscreen",
     "app.fullscreenUndoButton.label": "Undo {0} fullscreen",

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -255,6 +255,11 @@ learningDashboardCleanupDelayInMinutes=2
 # Allow webcams streaming reception only to and from moderators
 webcamsOnlyForModerator=false
 
+# Per user camera share limit
+# if 0, there's no limit
+# Default 3
+userCameraCap=3
+
 # Mute the meeting on start
 muteOnStart=false
 

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -157,6 +157,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="learningDashboardEnabled" value="${learningDashboardEnabled}"/>
         <property name="learningDashboardCleanupDelayInMinutes" value="${learningDashboardCleanupDelayInMinutes}"/>
         <property name="webcamsOnlyForModerator" value="${webcamsOnlyForModerator}"/>
+        <property name="defaultUserCameraCap" value="${userCameraCap}"/>
         <property name="useDefaultAvatar" value="${useDefaultAvatar}"/>
         <property name="defaultAvatarURL" value="${defaultAvatarURL}"/>
         <property name="defaultGuestPolicy" value="${defaultGuestPolicy}"/>


### PR DESCRIPTION
### What does this PR do?

Include `userCameraCap` API param on create and enforce both server and
client to control the number of simultaneous webcams an user can share.

Default set to 3.

### Closes Issue(s)

None

### Motivation

Reinforce server's stability and improve system's dynamic configuration.