### PR TITLE
refactor(audio): remove duplicated loadBridges method definition

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -143,47 +143,6 @@ class AudioManager {
     }
   }
 
-  /**
-   * Load audio bridges modules to be used the manager.
-   *
-   * Bridges can be configured in settings.yml file.
-   * @param {Object} userData The Object representing user data to be passed to
-   *                      the bridge.
-   */
-  async loadBridges(userData) {
-    let FullAudioBridge = SIPBridge;
-    let ListenOnlyBridge = KurentoBridge;
-
-    if (MEDIA.audio) {
-      const { bridges, defaultFullAudioBridge, defaultListenOnlyBridge } =
-        MEDIA.audio;
-
-      this.bridges = {};
-
-      await Promise.all(
-        Object.values(bridges).map(async (bridge) => {
-          // eslint-disable-next-line import/no-dynamic-require, global-require
-          this.bridges[bridge.name] = (
-            (await import(DEFAULT_AUDIO_BRIDGES_PATH + bridge.path)) || {}
-          ).default;
-        })
-      );
-
-      if (defaultFullAudioBridge && this.bridges[defaultFullAudioBridge]) {
-        FullAudioBridge = this.bridges[defaultFullAudioBridge];
-      }
-
-      if (defaultListenOnlyBridge && this.bridges[defaultListenOnlyBridge]) {
-        ListenOnlyBridge = this.bridges[defaultListenOnlyBridge];
-      }
-    }
-
-    this.bridge = new FullAudioBridge(userData);
-    if (this.useKurento) {
-      this.listenOnlyBridge = new ListenOnlyBridge(userData);
-    }
-  }
-
   setAudioMessages(messages, intl) {
     this.messages = messages;
     this.intl = intl;


### PR DESCRIPTION
### What does this PR do?

Seems to have been introduced by a partial merge commit (v2.4 -> v2.5)

There were a bunch of style changes introduced by that partial commit as well; I kept those changes to avoid introducing further conflicts between v2.4-2.5...

Also: the duplicated definition was a stale one and it was overriding the fresh definition.

### Closes Issue(s)

n/a

### Motivation

n/a

### More

n/a
