### PR TITLE
fix(audio): better control audio state for main and breakout rooms

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -1041,11 +1041,11 @@ class SIPSession {
             + `${peer.signalingState}`);
 
             if (peer.signalingState === 'stable') {
-              const { sdp: remoteSdp } = this.currentSession
-                .sessionDescriptionHandler.peerConnection.remoteDescription;
+              if (!peer.remoteDescription || !peer.localDescription) return;
 
-              const { sdp: localSdp } = this.currentSession
-                .sessionDescriptionHandler.peerConnection.localDescription;
+              const { sdp: remoteSdp } = peer.remoteDescription;
+
+              const { sdp: localSdp } = peer.localDescription;
 
               logger.info({
                 logCode: 'sip_js_session_peer_has_sdp',

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -46,6 +46,8 @@ const propTypes = {
   formattedTelVoice: PropTypes.string.isRequired,
   autoplayBlocked: PropTypes.bool.isRequired,
   handleAllowAutoplay: PropTypes.func.isRequired,
+  setUserSelectedMicrophone: PropTypes.func.isRequired,
+  setUserSelectedListenOnly: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
@@ -297,6 +299,8 @@ class AudioModal extends Component {
     const {
       joinListenOnly,
       isConnecting,
+      setUserSelectedMicrophone,
+      setUserSelectedListenOnly,
     } = this.props;
 
     const {
@@ -308,6 +312,9 @@ class AudioModal extends Component {
     this.setState({
       disableActions: true,
     });
+
+    setUserSelectedListenOnly(true);
+    setUserSelectedMicrophone(false);
 
     return joinListenOnly().then(() => {
       this.setState({
@@ -326,6 +333,8 @@ class AudioModal extends Component {
     const {
       joinMicrophone,
       isConnecting,
+      setUserSelectedMicrophone,
+      setUserSelectedListenOnly,
     } = this.props;
 
     const {
@@ -338,6 +347,9 @@ class AudioModal extends Component {
       hasError: false,
       disableActions: true,
     });
+
+    setUserSelectedMicrophone(true);
+    setUserSelectedListenOnly(false);
 
     joinMicrophone().then(() => {
       this.setState({

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -15,6 +15,8 @@ import {
   closeModal,
   joinListenOnly,
   leaveEchoTest,
+  setUserSelectedMicrophone,
+  setUserSelectedListenOnly,
 } from './service';
 import Storage from '/imports/ui/services/storage/session';
 import Service from '../service';
@@ -98,5 +100,7 @@ export default lockContextContainer(withModalMounter(withTracker(({ userLocks })
     handleAllowAutoplay: () => Service.handleAllowAutoplay(),
     isRTL,
     AudioError,
+    setUserSelectedMicrophone,
+    setUserSelectedListenOnly,
   });
 })(AudioModalContainer)));

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/service.js
@@ -8,7 +8,6 @@ const CLIENT_DID_USER_SELECTED_LISTEN_ONLY_KEY = 'clientUserSelectedListenOnly';
 export const setUserSelectedMicrophone = (value) => (
   Storage.setItem(CLIENT_DID_USER_SELECTED_MICROPHONE_KEY, !!value)
 );
-
 export const setUserSelectedListenOnly = (value) => (
   Storage.setItem(CLIENT_DID_USER_SELECTED_LISTEN_ONLY_KEY, !!value)
 );
@@ -22,9 +21,6 @@ export const didUserSelectedListenOnly = () => (
 );
 
 export const joinMicrophone = (skipEchoTest = false) => {
-  Storage.setItem(CLIENT_DID_USER_SELECTED_MICROPHONE_KEY, true);
-  Storage.setItem(CLIENT_DID_USER_SELECTED_LISTEN_ONLY_KEY, false);
-
   const call = new Promise((resolve, reject) => {
     try {
       if (skipEchoTest && !Service.isConnected()) {
@@ -45,9 +41,6 @@ export const joinMicrophone = (skipEchoTest = false) => {
 };
 
 export const joinListenOnly = () => {
-  Storage.setItem(CLIENT_DID_USER_SELECTED_MICROPHONE_KEY, false);
-  Storage.setItem(CLIENT_DID_USER_SELECTED_LISTEN_ONLY_KEY, true);
-
   const call = new Promise((resolve) => {
     Service.joinListenOnly().then(() => {
       // Autoplay block wasn't triggered. Close the modal. If autoplay was
@@ -79,11 +72,27 @@ export const closeModal = () => {
   showModal(null);
 };
 
+/**
+ * Helper function that join (or not) user in audio. If user previously
+ * selected microphone, it will automatically join mic (without audio modal).
+ * If user previously selected listen only option in audio modal, then it will
+ * automatically join listen only.
+ * @returns a Promise for the audio joining process.
+ */
+export const joinAudioAutomatically = async () => {
+  if (Service.isConnected()) return Promise.resolve();
+
+  if (didUserSelectedMicrophone()) return joinMicrophone(true);
+
+  if (didUserSelectedListenOnly()) return joinListenOnly();
+
+  return Promise.resolve();
+};
+
 export default {
   joinMicrophone,
   closeModal,
   joinListenOnly,
   leaveEchoTest,
-  didUserSelectedMicrophone,
-  didUserSelectedListenOnly,
+  joinAudioAutomatically,
 };

--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -12,10 +12,7 @@ import getFromUserSettings from '/imports/ui/services/users-settings';
 import VideoPreviewContainer from '/imports/ui/components/video-preview/container';
 import lockContextContainer from '/imports/ui/components/lock-viewers/context/container';
 import {
-  joinMicrophone,
-  joinListenOnly,
-  didUserSelectedMicrophone,
-  didUserSelectedListenOnly,
+  joinAudioAutomatically,
 } from '/imports/ui/components/audio/audio-modal/service';
 
 import Service from './service';
@@ -80,54 +77,44 @@ class AudioContainer extends PureComponent {
   }
 
   componentDidMount() {
-    const { meetingIsBreakout } = this.props;
+    const {
+      meetingIsBreakout,
+      openVideoPreviewModal,
+    } = this.props;
 
     this.init().then(() => {
       if (meetingIsBreakout && !Service.isUsingAudio()) {
-        this.joinAudio();
+        joinAudioAutomatically();
+        return;
       }
+
+      Breakouts.find().observeChanges({
+        removed() {
+          // if the user joined a breakout room, the main room's audio was
+          // programmatically dropped to avoid interference. On breakout end,
+          // offer to rejoin main room audio only if the user is not in audio
+          // already
+          const enableVideo = getFromUserSettings('bbb_enable_video',
+            KURENTO_CONFIG.enableVideo);
+          const autoShareWebcam = getFromUserSettings('bbb_auto_share_webcam',
+            KURENTO_CONFIG.autoShareWebcam);
+
+          if (Service.isUsingAudio()) {
+            if (enableVideo && autoShareWebcam) {
+              openVideoPreviewModal();
+            }
+
+            return;
+          }
+
+          joinAudioAutomatically().then(() => {
+            if (enableVideo && autoShareWebcam) {
+              openVideoPreviewModal();
+            }
+          });
+        },
+      });
     });
-  }
-
-  componentDidUpdate(prevProps) {
-    if (this.userIsReturningFromBreakoutRoom(prevProps)) {
-      this.joinAudio();
-    }
-  }
-
-  /**
-   * Helper function to determine wheter user is returning from breakout room
-   * to main room.
-   * @param  {[Object} prevProps prevProps param from componentDidUpdate
-   * @return {boolean}           True if user is returning from breakout room
-   *                             to main room. False, otherwise.
-   */
-  userIsReturningFromBreakoutRoom(prevProps) {
-    const { hasBreakoutRooms } = this.props;
-    const { hasBreakoutRooms: hadBreakoutRooms } = prevProps;
-    return hadBreakoutRooms && !hasBreakoutRooms;
-  }
-
-  /**
-   * Helper function that join (or not) user in audio. If user previously
-   * selected microphone, it will automatically join mic (without audio modal).
-   * If user previously selected listen only option in audio modal, then it will
-   * automatically join listen only.
-   */
-  joinAudio() {
-    if (Service.isConnected()) return;
-
-    const {
-      userSelectedMicrophone,
-      userSelectedListenOnly,
-    } = this.props;
-
-    if (userSelectedMicrophone) {
-      joinMicrophone(true);
-      return;
-    }
-
-    if (userSelectedListenOnly) joinListenOnly();
   }
 
   render() {
@@ -168,10 +155,7 @@ export default lockContextContainer(withModalMounter(injectIntl(withTracker(({ m
   const autoShareWebcam = getFromUserSettings('bbb_auto_share_webcam', KURENTO_CONFIG.autoShareWebcam);
   const { userWebcam, userMic } = userLocks;
 
-  const userSelectedMicrophone = didUserSelectedMicrophone();
-  const userSelectedListenOnly = didUserSelectedListenOnly();
   const meetingIsBreakout = AppService.meetingIsBreakout();
-  const hasBreakoutRooms = AppService.getBreakoutRooms().length > 0;
   const openAudioModal = () => new Promise((resolve) => {
     mountModal(<AudioModalContainer resolve={resolve} />);
   });
@@ -190,33 +174,9 @@ export default lockContextContainer(withModalMounter(injectIntl(withTracker(({ m
     }
   }
 
-  Breakouts.find().observeChanges({
-    removed() {
-      // if the user joined a breakout room, the main room's audio was
-      // programmatically dropped to avoid interference. On breakout end,
-      // offer to rejoin main room audio only if the user is not in audio already
-      if (Service.isUsingAudio()
-        || userSelectedMicrophone
-        || userSelectedListenOnly) {
-        if (enableVideo && autoShareWebcam) {
-          openVideoPreviewModal();
-        }
-
-        return;
-      }
-      setTimeout(() => openAudioModal().then(() => {
-         if (enableVideo && autoShareWebcam) {
-           openVideoPreviewModal();
-          }
-        }), 0);
-    },
-  });
-
   return {
-    hasBreakoutRooms,
     meetingIsBreakout,
-    userSelectedMicrophone,
-    userSelectedListenOnly,
+    openVideoPreviewModal,
     init: async () => {
       await Service.init(messages, intl);
       const enableVideo = getFromUserSettings('bbb_enable_video', KURENTO_CONFIG.enableVideo);
@@ -230,10 +190,7 @@ export default lockContextContainer(withModalMounter(injectIntl(withTracker(({ m
       Session.set('audioModalIsOpen', true);
       if (enableVideo && autoShareWebcam) {
         openAudioModal().then(() => { openVideoPreviewModal(); didMountAutoJoin = true; });
-      } else if (!(
-        userSelectedMicrophone
-        && userSelectedListenOnly
-        && meetingIsBreakout)) {
+      } else if (!(meetingIsBreakout)) {
         openAudioModal();
         didMountAutoJoin = true;
       }
@@ -243,8 +200,6 @@ export default lockContextContainer(withModalMounter(injectIntl(withTracker(({ m
 })(AudioContainer))));
 
 AudioContainer.propTypes = {
-  hasBreakoutRooms: PropTypes.bool.isRequired,
   meetingIsBreakout: PropTypes.bool.isRequired,
-  userSelectedListenOnly: PropTypes.bool.isRequired,
-  userSelectedMicrophone: PropTypes.bool.isRequired,
+  openVideoPreviewModal: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
The breakout room state is now retrieve directly from Breakouts collection,
and not from the previou states: this fix a race condition where
the previous state had a dirty value, leading the main audio to reconnect
in the main room while the user was actually being transfered to the breakout
room. In this situation, user had microphone active in both main and breakout
rooms.

We now let the mic state to depends only on ICE/SIP states, instead of
waiting for FreeSWITCH confirmation. This also prevents another bug/rc where
the client didn't get updated depending on the focus state of the main/breakout
room and user gets stucked at "Establishing audio connection" modal.
This also speeds up the audio connection a bit.

Closes #13636