### PR TITLE
Adjust dropdown menu position

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -262,7 +262,7 @@ class ActionsDropdown extends PureComponent {
       return null;
     }
     const { isMobile } = deviceInfo;
-    const customStyles = { top: '-4rem' };
+    const customStyles = { top: '-3rem' };
 
     return (
       <BBBMenu

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -281,7 +281,7 @@ class SettingsDropdown extends PureComponent {
     } = this.props;
 
     const { isMobile } = deviceInfo;
-    const customStyles = { top: '4rem' };
+    const customStyles = { top: '3rem' };
 
     return (
       <BBBMenu


### PR DESCRIPTION
### What does this PR do?

Reduces space between dropdown and button (settings and actions dropdown).

#### before
<img width="231" alt="Screen Shot 2022-02-22 at 20 39 38" src="https://user-images.githubusercontent.com/3728706/155215480-33e34b40-cb68-4d2a-adb8-6d5bc03570e2.png">
<img width="191" alt="Screen Shot 2022-02-22 at 20 39 32" src="https://user-images.githubusercontent.com/3728706/155215476-14872a0b-cfbc-4f49-8ffb-6174672c66bf.png">

#### after
<img width="235" alt="Screen Shot 2022-02-22 at 20 35 30" src="https://user-images.githubusercontent.com/3728706/155215326-d7b938a5-0c28-4e3e-8945-b7ba39bc303a.png">
<img width="198" alt="Screen Shot 2022-02-22 at 20 35 36" src="https://user-images.githubusercontent.com/3728706/155215336-83b003a5-d531-4078-bc2d-2258c694ba7a.png">