### PR TITLE
fix: Dashboard doesn't update user demote

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
@@ -270,16 +270,14 @@ class LearningDashboardActor(
   }
 
   private def handleUserRoleChangedEvtMsg(msg: UserRoleChangedEvtMsg) {
-    if(msg.body.role == Roles.MODERATOR_ROLE) {
-      for {
-        meeting <- meetings.values.find(m => m.intId == msg.header.meetingId)
-        user <- findUserByIntId(meeting, msg.body.userId)
-      } yield {
-        val updatedUser = user.copy(isModerator = true)
-        val updatedMeeting = meeting.copy(users = meeting.users + (updatedUser.userKey -> updatedUser))
+    for {
+      meeting <- meetings.values.find(m => m.intId == msg.header.meetingId)
+      user <- findUserByIntId(meeting, msg.body.userId)
+    } yield {
+      val updatedUser = user.copy(isModerator = (msg.body.role == Roles.MODERATOR_ROLE))
+      val updatedMeeting = meeting.copy(users = meeting.users + (updatedUser.userKey -> updatedUser))
 
-        meetings += (updatedMeeting.intId -> updatedMeeting)
-      }
+      meetings += (updatedMeeting.intId -> updatedMeeting)
     }
   }
 


### PR DESCRIPTION
The initial idea was to show in Dashboard if the user had been Moderator at any moment.
But as @pedrobmarin explained, it could cause some confusing.

With this PR the Dashboard will always show the last role of the user.
![dashboard-demote](https://user-images.githubusercontent.com/5660191/155413812-5d019620-a692-42c2-9c66-13a9704cece4.gif)

Closes #14101