### PR TITLE
fix path

### DIFF
--- a/bigbluebutton-html5/deploy_to_usr_share.sh
+++ b/bigbluebutton-html5/deploy_to_usr_share.sh
@@ -6,11 +6,11 @@ UPPER_DESTINATION_DIR=/usr/share/meteor
 DESTINATION_DIR=$UPPER_DESTINATION_DIR/bundle
 
 SERVICE_FILES_DIR=/usr/lib/systemd/system
-LOCAL_PACKAGING_DIR=/home/bigbluebutton/dev/bigbluebutton/build/packages-template/bbb-html5
+LOCAL_PACKAGING_DIR=/home/ubuntu/dev/bigbluebutton/build/packages-template/bbb-html5
 
 if [ ! -d "$LOCAL_PACKAGING_DIR" ]; then
-  echo "Did not find LOCAL_PACKAGING_DIR=$LOCAL_PACKAGING_DIR"
-  exit
+    echo "Did not find LOCAL_PACKAGING_DIR=$LOCAL_PACKAGING_DIR"
+    exit
 fi
 
 sudo rm -rf "$UPPER_DESTINATION_DIR"
@@ -19,7 +19,7 @@ sudo chown -R meteor:meteor "$UPPER_DESTINATION_DIR"
 
 # the next 5 lines may be temporarily commented out if you are sure you are not tweaking the required node_modules after first use of the script. This will save a minute or two during the run of the script
 if [ -d "node_modules" ]; then
-   rm -r node_modules/
+    rm -r node_modules/
 fi
 meteor reset
 meteor npm ci --production


### PR DESCRIPTION
### What does this PR do?

This pull request fix `LOCAL_PACKAGING_DIR` in deploy_to_usr_share.sh because in ur main doc step two for create bigbluebutton dev we need to create a folder at `~/dev` path that mean /home/ubuntu/dev path not /home/bigbluebutton/dev path.
![BigBlueButton _ Development - Google Chrome 2022-02-24 at 4 31 59 PM](https://user-images.githubusercontent.com/48118282/155544203-201639df-01ce-4a00-aaf8-4f082a18f74c.jpeg)


### Motivation

Because I am using this project with my current company and I like it, I want to improve this issue so when other users wants to run this script will not face any issues.