### PR TITLE
Add tooltip to raise hand notification

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/status-notifier/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/status-notifier/component.jsx
@@ -6,11 +6,16 @@ import Icon from '/imports/ui/components/common/icon/component';
 import { ENTER } from '/imports/utils/keyCodes';
 import Styled from './styles';
 import {Meteor} from "meteor/meteor";
+import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 
 const messages = defineMessages({
   lowerHandsLabel: {
     id: 'app.statusNotifier.lowerHands',
     description: 'text displayed to clear all raised hands',
+  },
+  lowerHandDescOneUser: {
+    id: 'app.statusNotifier.lowerHandDescOneUser',
+    description: 'text displayed to clear a single user raised hands',
   },
   raisedHandsTitle: {
     id: 'app.statusNotifier.raisedHandsTitle',
@@ -75,7 +80,7 @@ class StatusNotifier extends Component {
             autoClose: false,
             closeOnClick: false,
             closeButton: false,
-            className: "actionToast",
+            className: "raiseHandToast",
           });
         }
         break;
@@ -118,22 +123,25 @@ class StatusNotifier extends Component {
   }
 
   raisedHandAvatars() {
-    const { emojiUsers, clearUserStatus } = this.props;
+    const { emojiUsers, clearUserStatus, intl } = this.props;
     let users = emojiUsers;
     if (emojiUsers.length > MAX_AVATAR_COUNT) users = users.slice(0, MAX_AVATAR_COUNT);
 
     const avatars = users.map(u => (
-      <Styled.Avatar
-        role="button"
-        tabIndex={0}
-        style={{ backgroundColor: `${u.color}` }}
-        onClick={() => clearUserStatus(u.userId)}
-        onKeyDown={e => (e.keyCode === ENTER ? clearUserStatus(u.userId) : null)}
+      <TooltipContainer
         key={`statusToastAvatar-${u.userId}`}
-        data-test="avatarsWrapperAvatar"
-      >
-        {u.name.slice(0, 2)}
-      </Styled.Avatar>
+        title={intl.formatMessage(messages.lowerHandDescOneUser, { 0: u.name })}>
+        <Styled.Avatar
+          role="button"
+          tabIndex={0}
+          style={{ backgroundColor: `${u.color}` }}
+          onClick={() => clearUserStatus(u.userId)}
+          onKeyDown={e => (e.keyCode === ENTER ? clearUserStatus(u.userId) : null)}
+          data-test="avatarsWrapperAvatar"
+        >
+          {u.name.slice(0, 2)}
+        </Styled.Avatar>
+      </TooltipContainer>
     ));
 
     if (emojiUsers.length > MAX_AVATAR_COUNT) {

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/globalStyles.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/globalStyles.js
@@ -148,6 +148,15 @@ const GlobalStyle = createGlobalStyle`
       left: none !important;
     }
   }
+
+  .raiseHandToast {
+    background-color: ${colorWhite};
+    padding: 1rem;
+
+    i.close {
+      left: none !important;
+    }
+  }
 `;
 
 export default GlobalStyle;

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -414,6 +414,7 @@
     "app.settings.dataSavingTab.description": "To save your bandwidth adjust what's currently being displayed.",
     "app.settings.save-notification.label": "Settings have been saved",
     "app.statusNotifier.lowerHands": "Lower Hands",
+    "app.statusNotifier.lowerHandDescOneUser": "Lower {0}'s hand",
     "app.statusNotifier.raisedHandsTitle": "Raised Hands",
     "app.statusNotifier.raisedHandDesc": "{0} raised their hands",
     "app.statusNotifier.raisedHandDescOneUser": "{0} raised hand",


### PR DESCRIPTION
### What does this PR do?

- Adds tooltip to user avatar in raise hand notification
- Restores vertical padding in raise hand notification

#### before
<img width="310" alt="Screen Shot 2022-02-24 at 17 04 40" src="https://user-images.githubusercontent.com/3728706/155572225-fdd035fd-fa8d-4e7f-aa75-8f9846bda598.png">

#### after

<img width="307" alt="Screen Shot 2022-02-24 at 17 03 59" src="https://user-images.githubusercontent.com/3728706/155572224-d009c19a-ae51-4180-8689-7344ffa2fa73.png">
