### PR TITLE
fix: Cannot change presentation download permission twice

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -301,12 +301,14 @@ class PresentationUploader extends Component {
         }
       });
 
-      this.setState({
-        presentations: Object.values({
-          ...presentations,
-          ...propPresentations,
-        }),
-      });
+      if (!_.isEqual(prevProps.presentations, propPresentations) || presentations.length === 0) {
+        this.setState({
+          presentations: Object.values({
+            ...presentations,
+            ...propPresentations,
+          }),
+        });
+      }
     }
 
     if (presentations.length > 0) {


### PR DESCRIPTION
### What does this PR do?

Prevents an issue where presentation download permission would fail to be removed.

### Closes Issue(s)
Closes #14440