### PR TITLE
fix: raise hand notification icon position

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/status-notifier/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/status-notifier/styles.scss
@@ -1,8 +1,10 @@
 @import "/imports/ui/stylesheets/mixins/_indicators";
 @import "/imports/ui/stylesheets/variables/placeholders";
+@import "/imports/ui/stylesheets/variables/breakpoints";
 
 :root {
   --toast-margin: .5rem;
+  --toast-margin-mobile: .35rem;
   --avatar-side: 34px;
   --avatar-wrapper-offset: 14px;
   --avatar-inset: -7px;
@@ -100,10 +102,20 @@
     top: var(--toast-margin);
     left: var(--toast-margin);
     font-size: var(--font-size-xl);
-  
+
     [dir="rtl"] & {
       left: 0;
       right: 10px;
+    }
+
+    @include mq($small-only) {
+      top: var(--toast-margin-mobile);
+      left: var(--toast-margin-mobile);
+
+      [dir="rtl"] & {
+        left: 0;
+        right: var(--toast-margin);
+      }
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?

Adjusts the position of the raise hand notification icon in mobile devices.

#### before

<img width="334" alt="Screen Shot 2022-02-25 at 17 44 09" src="https://user-images.githubusercontent.com/3728706/155762473-88b7996d-347b-4e9b-b26b-16be523ad9d2.png">

#### after

<img width="335" alt="Screen Shot 2022-02-25 at 17 43 48" src="https://user-images.githubusercontent.com/3728706/155762470-bc948ca9-8f1f-4476-aff7-76fb56f5e83a.png">
