### PR TITLE
Fix: toast background styles

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/toast/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/toast/component.jsx
@@ -31,7 +31,7 @@ const Toast = ({
 }) => (
   <Styled.ToastContainer small={small} data-test="toastContainer">
     <Styled.Toast type={type}>
-      <Styled.ToastIcon small={small}>
+      <Styled.ToastIcon className="toastIcon" small={small}>
         <Icon iconName={icon || defaultIcons[type]} />
       </Styled.ToastIcon>
       <Styled.ToastMessage data-test="toastSmallMsg">

--- a/bigbluebutton-html5/imports/ui/components/common/toast/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/toast/styles.js
@@ -142,35 +142,35 @@ const Toast = styled.div`
   display: flex;
 
   ${({ type }) => type === 'default' && `
-    & > i {
+    & .toastIcon {
       color: ${toastDefaultColor};
       background-color: ${toastDefaultBg};
     }
   `}
 
   ${({ type }) => type === 'error' && `
-    & > i {
+    & .toastIcon {
       color: ${toastErrorColor};
       background-color: ${toastErrorBg};
     }
   `}
 
   ${({ type }) => type === 'info' && `
-    & > i {
+    & .toastIcon {
       color: ${toastInfoColor};
       background-color: ${toastInfoBg};
     }
   `}
 
   ${({ type }) => type === 'success' && `
-    & > i {
+    & .toastIcon {
       color: ${toastSuccessColor};
       background-color: ${toastSuccessBg};
     }
   `}
 
   ${({ type }) => type === 'warning' && `
-    & > i {
+    & .toastIcon {
       color: ${toastWarningColor};
       background-color: ${toastWarningBg};
     }


### PR DESCRIPTION
### What does this PR do?

Restores missing toast styles.

#### before

<img width="301" alt="Screen Shot 2022-02-25 at 20 29 59" src="https://user-images.githubusercontent.com/3728706/155798249-473946d8-0b71-4c46-b1ee-d1d9475a8f28.png">

#### after

<img width="319" alt="Screen Shot 2022-02-25 at 20 28 10" src="https://user-images.githubusercontent.com/3728706/155798242-fb450c8a-cdec-46b9-8c78-27c3d8b45d8d.png">
