### PR TITLE
build: FreeSWITCH dependencies installed in Dockerfile instead

### DIFF
--- a/build/packages-template/bbb-freeswitch-core/build.sh
+++ b/build/packages-template/bbb-freeswitch-core/build.sh
@@ -24,22 +24,6 @@ mkdir -p $DESTDIR
 cp modules.conf $BUILDDIR/freeswitch
 cd $BUILDDIR/freeswitch
 
-#
-# Need to figure out how to build with mod_av
-if [ $DISTRO == "centos7" ] || [ $DISTRO == "amzn2" ]; then
-  sed -i 's/applications\/mod_av/#applications\/mod_av/g' modules.conf
-else
-  apt-get update
-  apt-get install -y software-properties-common
-  add-apt-repository -y ppa:bigbluebutton/support
-fi
-
-if [ "$DISTRO" == "bionic" ]; then
-  add-apt-repository ppa:bigbluebutton/support -y
-  apt-get update
-  apt-get install -y libopusfile-dev opus-tools libopusenc-dev
-fi
-
 pushd .
 
 # sofia-sip start
@@ -68,18 +52,6 @@ git checkout e59ca8fb8b1591e626e6a12fdc60a2ebe83435ed
 make -j $(nproc)
 make install
 
-if [ $DISTRO == "centos7" ] || [ $DISTRO == "amzn2" ]; then
-  export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
-  yum install -y opusfile-devel
-
-  git clone https://github.com/xiph/libopusenc.git
-  cd libopusenc/
-  git checkout dc6ab59ac41a96c5bf262056ea09fa5e2f776fe6
-  ./autogen.sh
-  ./configure
-  make -j $(nproc)
-  make install
-fi
 popd
 # spandsp end
 
@@ -161,7 +133,6 @@ HERE
     popd
   fi
 
-
   mkdir -p $DESTDIR/usr/local/bin
 	cp fs_clibbb $DESTDIR/usr/local/bin
 	chmod +x $DESTDIR/usr/local/bin/fs_clibbb
@@ -177,4 +148,3 @@ fpm -s dir -C $DESTDIR -n $PACKAGE \
     --description "BigBlueButton build of FreeSWITCH" \
     $DIRECTORIES                            \
     $OPTS
-


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Drops opus related packages which are installed at build time for `bbb-freeswitch-core` which are already present, installed via Dockerfile
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # None


### Motivation
Packages `libopusfile-dev`,  `opus-tools`,  `libopusenc-dev` and `software-properties-common` are part of Dockerfile already -- https://gitlab.senfcall.de/senfcall-public/docker-bbb-build/-/blob/v2022-02-08-bbb-2.5/Dockerfile
And so is the PPA `ppa:bigbluebutton/support`
<!-- What inspired you to submit this pull request? -->

### More

Part of a series of cleanup changes