### PR TITLE
fix: Custom Parameter 'userdata-bbb_hide_presentation' keeps the "Minimize presentation" button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/media/service.js
+++ b/bigbluebutton-html5/imports/ui/components/media/service.js
@@ -51,7 +51,7 @@ const swapLayout = {
 const setSwapLayout = (layoutContextDispatch) => {
   const hidePresentation = getFromUserSettings('bbb_hide_presentation', LAYOUT_CONFIG.hidePresentation);
 
-  swapLayout.value = getFromUserSettings('bbb_auto_swap_layout', LAYOUT_CONFIG.autoSwapLayout);
+  swapLayout.value = getFromUserSettings('bbb_auto_swap_layout', LAYOUT_CONFIG.autoSwapLayout) || hidePresentation;
   swapLayout.tracker.changed();
 
   if (!hidePresentation) {
@@ -78,7 +78,7 @@ export const shouldEnableSwapLayout = () => {
     return true;
   }
   return !shouldShowScreenshare() && !shouldShowExternalVideo();
-}
+};
 
 export const getSwapLayout = () => {
   swapLayout.tracker.depend();


### PR DESCRIPTION
### What does this PR do?

Fix wrong initial state for minimize presentation button when the custom parameter `userdata-bbb_hide_presentation` is set to true.

### Closes Issue(s)
Closes #14446