### PR TITLE
build and config: drop references to tomcat6 or 7

### DIFF
--- a/bbb-api-demo/README
+++ b/bbb-api-demo/README
@@ -4,11 +4,8 @@ gradle resolveDeps
 
 gradle build
 
-sudo rm -rf /var/lib/tomcat7/webapps/demo*
+sudo rm -rf /var/lib/tomcat8/webapps/demo*
 
-sudo cp build/libs/demo.war /var/lib/tomcat7/webapps/
+sudo cp build/libs/demo.war /var/lib/tomcat8/webapps/
 
-sudo systemctl restart tomcat7
-
-
-
+sudo systemctl restart tomcat8

--- a/bbb-lti/README.rst
+++ b/bbb-lti/README.rst
@@ -38,11 +38,11 @@ Deployment
 =============
 Place the war file into the tomcat webapps directory and restart tomcat
         
-    sudo cp target/lti-0.2.war /var/lib/tomcat6/webapps/lti.war
+    sudo cp target/lti-0.2.war /var/lib/tomcat8/webapps/lti.war
        
 Configure the properties
         
-    sudo vi /var/lib/tomcat6/webapps/lti/WEB-INF/classes/lti.properties
+    sudo vi /var/lib/tomcat8/webapps/lti/WEB-INF/classes/lti.properties
 
 Edit the URL and Salt of the BigBlueButton server you are going to connect to (NOTE: Remove any trailing slashes from the URL!)
     
@@ -58,7 +58,7 @@ Edit the LTI basic information
     
 Restart tomcat
         
-    sudo service tomcat6 restart
+    sudo service tomcat8 restart
         
 When running on the BigBlueButton server, create the map to this new application on nginx
     

--- a/bigbluebutton-config/bin/apply-lib.sh
+++ b/bigbluebutton-config/bin/apply-lib.sh
@@ -19,8 +19,6 @@ fi
 
 if [ -f /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties ]; then
   SERVLET_DIR=/usr/share/bbb-web
-else
-  SERVLET_DIR=/var/lib/tomcat7/webapps/bigbluebutton
 fi
 
 BBB_WEB_ETC_CONFIG=/etc/bigbluebutton/bbb-web.properties

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -108,9 +108,6 @@ else
     if [ "$DISTRIB_CODENAME" == "bionic" ]; then
       TOMCAT_USER=tomcat8
     fi
-    if [ "$DISTRIB_CODENAME" == "xenial" ]; then
-      TOMCAT_USER=tomcat7
-    fi
     TOMCAT_DIR=/var/lib/$TOMCAT_USER
     SERVLET_LOGS=$TOMCAT_DIR/logs
     REDIS_SERVICE=redis-server
@@ -126,8 +123,6 @@ LTI_DIR=/usr/share/bbb-lti
 
 if [ -f /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties ]; then
     SERVLET_DIR=/usr/share/bbb-web
-else
-    SERVLET_DIR=/var/lib/tomcat7/webapps/bigbluebutton
 fi
 
 

--- a/bigbluebutton-config/cron.daily/bigbluebutton
+++ b/bigbluebutton-config/cron.daily/bigbluebutton
@@ -62,7 +62,6 @@ find /var/freeswitch/meetings/ -name "*.opus" -mtime +$history -delete
 # Delete old/rotated log files
 #
 find /opt/freeswitch/var/log/freeswitch -type f -mtime +$log_history -delete
-[[ -d /var/log/tomcat7 ]] && find /var/log/tomcat7 -type f -mtime +$log_history -delete
 find /var/log/bigbluebutton -type f -mtime +$log_history -delete
 find /var/log/bbb-webrtc-sfu -type f -mtime +$log_history -delete
 find /var/log/kurento-media-server -name "*.pid*.log" -type f -mtime +$log_history -delete

--- a/build/deb-helper.sh
+++ b/build/deb-helper.sh
@@ -252,8 +252,6 @@ if [ -f /etc/redhat-release ]; then
 else
   if grep -q bionic /etc/lsb-release; then
     TOMCAT_SERVICE=tomcat8
-  else
-    TOMCAT_SERVICE=tomcat7
   fi
 fi
 

--- a/build/packages-template/bbb-lti/after-remove.sh
+++ b/build/packages-template/bbb-lti/after-remove.sh
@@ -1,5 +1,1 @@
 #!/bin/bash -e
-
-#if [ "$1" = "remove" ]; then
-#	rm -f /var/lib/tomcat7/webapps/lti.war
-#fi

--- a/build/packages-template/bbb-playback-podcast/opts-trusty.sh
+++ b/build/packages-template/bbb-playback-podcast/opts-trusty.sh
@@ -1,4 +1,4 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d tomcat7 -d bbb-record-core"
+OPTS="$OPTS -t deb -d tomcat8 -d bbb-record-core"
 

--- a/build/packages-template/bbb-playback-presentation/opts-trusty.sh
+++ b/build/packages-template/bbb-playback-presentation/opts-trusty.sh
@@ -1,4 +1,4 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d tomcat7 -d bbb-record-core"
+OPTS="$OPTS -t deb -d tomcat8 -d bbb-record-core"
 

--- a/build/packages-template/bbb-web/before-install.sh
+++ b/build/packages-template/bbb-web/before-install.sh
@@ -4,15 +4,8 @@ case "$1" in
     install|upgrade|1|2)
         
         rm -f /tmp/bigbluebutton.properties
-        if [ -f /var/lib/tomcat7/webapps/bigbluebutton/WEB-INF/classes/bigbluebutton.properties ]; then
-          mv -f /var/lib/tomcat7/webapps/bigbluebutton/WEB-INF/classes/bigbluebutton.properties /tmp
-          # Disable as not yet supported in HTML5 client
-          sed -i 's/^defaultGuestPolicy=.*/defaultGuestPolicy=ALWAYS_ACCEPT/' /tmp/bigbluebutton.properties
-          rm /var/lib/tomcat7/webapps/bigbluebutton.war
-        else  
-          if [ -f $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties ]; then
-            cp $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties /tmp
-          fi
+        if [ -f $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties ]; then
+          cp $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties /tmp
         fi
 
         if [ -f $SERVLET_DIR/WEB-INF/classes/spring/turn-stun-servers.xml ]; then

--- a/build/packages-template/bbb-web/build.sh
+++ b/build/packages-template/bbb-web/build.sh
@@ -90,10 +90,6 @@ rm bigbluebutton-0.10.0.war
 popd
 pwd
 
-#mv target/bigbluebutton-0.9.0.war       staging/var/tmp/bigbluebutton.war
-#mkdir -p staging/usr/share/tomcat7/bin
-#cp setenv.sh staging/usr/share/tomcat7/bin
-
 # Copy this as simply 'web' and we'll make a symbolic link later in the .postinst script
 mkdir -p "$STAGING"/etc/bigbluebutton/nginx
 cp bbb-web.nginx "$STAGING"/etc/bigbluebutton/nginx/web

--- a/build/packages-template/bbb-web/opts-trusty.sh
+++ b/build/packages-template/bbb-web/opts-trusty.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d tomcat7,zip,unzip,imagemagick,redis-server,xpdf-utils,bbb-libreoffice,bbb-swftools"
+OPTS="$OPTS -t deb -d tomcat8,zip,unzip,imagemagick,redis-server,xpdf-utils,bbb-libreoffice,bbb-swftools"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Drops any references to tomcat6 or tomcat7 leftover from previous BBB versions
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation
On BBB 2.4 and 2.5 we only install/use tomcat8. Preparing for easier/cleaner upgrade of tomcat.
<!-- What inspired you to submit this pull request? -->

### More
Part of a series of cleanup changes
