### PR TITLE
build: drop ubuntu trusty (or xenial) files

### DIFF
--- a/build/packages-template/bbb-demo/opts-trusty.sh
+++ b/build/packages-template/bbb-demo/opts-trusty.sh
@@ -1,3 +1,0 @@
-. ./opts-global.sh
-
-OPTS="$OPTS -t deb"

--- a/build/packages-template/bbb-playback-podcast/opts-trusty.sh
+++ b/build/packages-template/bbb-playback-podcast/opts-trusty.sh
@@ -1,4 +1,0 @@
-. ./opts-global.sh
-
-OPTS="$OPTS -t deb -d tomcat8 -d bbb-record-core"
-

--- a/build/packages-template/bbb-playback-presentation/opts-trusty.sh
+++ b/build/packages-template/bbb-playback-presentation/opts-trusty.sh
@@ -1,4 +1,0 @@
-. ./opts-global.sh
-
-OPTS="$OPTS -t deb -d tomcat8 -d bbb-record-core"
-

--- a/build/packages-template/bbb-record-core/after-install.sh
+++ b/build/packages-template/bbb-record-core/after-install.sh
@@ -132,8 +132,4 @@ if dpkg -l | grep -q nginx; then
   reloadService nginx
 fi
 
-if ! grep -q xenial /etc/lsb-release; then
-  startService bbb-record-core.timer || echo "bbb-record-core could not be registered or started"
-fi
-
 systemctl daemon-reload

--- a/build/packages-template/bbb-record-core/opts-trusty.sh
+++ b/build/packages-template/bbb-record-core/opts-trusty.sh
@@ -1,4 +1,0 @@
-. ./opts-global.sh
-
-OPTS="$OPTS -t deb -d monit,vorbis-tools,sox,mencoder,ruby1.9.1-dev,libcurl4-openssl-dev,libxslt1-dev,libxml2-dev,build-essential,git,bbb-mkclean,libncurses5-dev,gnuplot,yq,libsystemd-dev"
-

--- a/build/packages-template/bbb-web/opts-trusty.sh
+++ b/build/packages-template/bbb-web/opts-trusty.sh
@@ -1,3 +1,0 @@
-. ./opts-global.sh
-
-OPTS="$OPTS -t deb -d tomcat8,zip,unzip,imagemagick,redis-server,xpdf-utils,bbb-libreoffice,bbb-swftools"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Drops obsolete ubuntu trusty (or xenial) files (currently on Ubuntu bionic)
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation
These are obsolete, we're on `bionic` now.
<!-- What inspired you to submit this pull request? -->

### More
Part of a series of cleanup changes
