### PR TITLE
refactor(pads): unneeded redis subscription

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -790,7 +790,6 @@ private:
       - to-html5-redis-channel
       - from-akka-apps-[^f]*
       - from-third-party-redis-channel
-      - from-etherpad-redis-channel
     async:
       - from-akka-apps-wb-redis-channel
     ignored:


### PR DESCRIPTION
### What does this PR do?

Remove unneeded redis channel subscription from the html5 module

### Closes Issue(s)

None

### Motivation

Since bbb-pads the html client Etherpad redis' channel subscription isn't
needed anymore. All communication between Etherpad and BigBlueButton goes
through bbb-pads.