### PR TITLE
Change in current attribute for InsertDocument endpoint

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1315,6 +1315,8 @@ class ApiController {
               foundCurrent = isCurrent;
             }
 
+            isCurrent = isCurrent && !isFromInsertAPI
+
             // Verifying whether the document is a base64 encoded or a url to download.
             if (!StringUtils.isEmpty(document.@url.toString())) {
               def fileName;


### PR DESCRIPTION
### What does this PR do?

It changes the logic of altering the current document when sending a request via `InsertDocument` endpoint. It simply ignores the `current` attribute  sent in the payload (if any).

### Closes Issue(s)

Closes #14431


### More

As a context, it is important to comment that because of the recent decision of [refactoring the toast messages](https://github.com/bigbluebutton/bigbluebutton/issues/14493), this part was not tackled by this PR, since it would be redone soon.
