### PR TITLE
fix: warning "disabledFeatures have no value"

### DIFF
--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -419,7 +419,7 @@ endWhenNoModeratorDelayInMinutes=1
 
 # List of features to disable (comma-separated)
 # Available options: screenshare
-disabledFeatures=
+#disabledFeatures=
 
 # Allow endpoint with current BigBlueButton version
 allowRevealOfBBBVersion=false


### PR DESCRIPTION
Since `disabledFeatures` was added to `bigbluebutton.properties` with null value:
![image](https://user-images.githubusercontent.com/5660191/156371614-5c0cabea-9631-4ac8-8428-0be8e81a7625.png)

`bbb-conf --check` is showing this warning
![image](https://user-images.githubusercontent.com/5660191/156371586-a709a529-65db-4089-8471-900c7b024e6f.png)

This PR let this line commented by default in order to avoid this warning.