### PR TITLE
chore: package-lock changes for html-to-image lib

### DIFF
--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -2487,6 +2487,11 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
+    "html-to-image": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.9.0.tgz",
+      "integrity": "sha512-9gaDCIYg62Ek07F2pBk76AHgYZ2gxq2YALU7rK3gNCqXuhu6cWzsOQqM7qGbjZiOzxGzrU1deDqZpAod2NEwbA=="
+    },
     "htmlparser2": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

Adds package-lock changes after install html-to-image as dependency.

Changes missing from https://github.com/bigbluebutton/bigbluebutton/pull/14406