### PR TITLE
fix(screenshare): request ejection when presenter automatically changes

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
@@ -8,6 +8,7 @@ import org.bigbluebutton.core.bus.InternalEventBus
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
+import org.bigbluebutton.core.apps.screenshare.ScreenshareApp2x
 
 object UsersApp {
   def broadcastAddUserToPresenterGroup(meetingId: String, userId: String, requesterId: String,
@@ -56,6 +57,9 @@ object UsersApp {
   def automaticallyAssignPresenter(outGW: OutMsgRouter, liveMeeting: LiveMeeting): Unit = {
     // Stop external video if it's running
     ExternalVideoModel.stop(outGW, liveMeeting)
+    // Request a screen broadcast stop (goes to SFU, comes back through
+    // ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg)
+    ScreenshareApp2x.requestBroadcastStop(outGW, liveMeeting)
 
     val meetingId = liveMeeting.props.meetingProp.intId
     for {


### PR DESCRIPTION
### What does this PR do?

Fixes an edge case where screen ejections weren't being requested internally on
ungraceful presenter changes (presenter ejections, disconnections, ...; anything 
that wouldn't trigger presenter unassigned events).

### Closes Issue(s)

Partially addresses #14072 

### Motivation

#14072
