### PR TITLE
refactor: reduce timeout intervals for webrtc-sfu and FS WebSocket proxies

### DIFF
--- a/build/packages-template/bbb-html5/sip.nginx
+++ b/build/packages-template/bbb-html5/sip.nginx
@@ -3,10 +3,10 @@ location /ws {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
-        proxy_read_timeout 6h;
-        proxy_send_timeout 6h;
-        client_body_timeout 6h;
-        send_timeout 6h;
+        proxy_read_timeout 120s;
+        proxy_send_timeout 120s;
+        client_body_timeout 120s;
+        send_timeout 120s;
 
 	auth_request /bigbluebutton/connection/checkAuthorization;
 	auth_request_set $auth_status $upstream_status;

--- a/build/packages-template/bbb-webrtc-sfu/webrtc-sfu.nginx
+++ b/build/packages-template/bbb-webrtc-sfu/webrtc-sfu.nginx
@@ -14,8 +14,8 @@ location /bbb-webrtc-sfu {
     proxy_set_header User-Id $user_id;
     proxy_set_header Meeting-Id $meeting_id;
     proxy_set_header Voice-Bridge $voice_bridge;
-    proxy_read_timeout 6h;
-    proxy_send_timeout 6h;
-    client_body_timeout 6h;
-    send_timeout 6h;
+    proxy_read_timeout 60s;
+    proxy_send_timeout 60s;
+    client_body_timeout 60s;
+    send_timeout 60s;
 }


### PR DESCRIPTION
### What does this PR do?

This PR reduces the timeout intervals for bbb-webrtc-sfu and FS's WebSocket proxies in nginx to more sane values (60s and 120s, respectively).
The heartbeat routine in bbb-webrtc-sfu runs every 20s. The heartbeat routine in SIP.js/FS runs every 30(+10)s. The new timeouts are those values multiplied by 3.

### Closes Issue(s)

None.

### Motivation

Reducing those timeouts allow resources (WebSockets) to be cleaned up faster when their terminations are ungraceful.
Moreover: the old 6h values seem far too large and I can't recall nor find any good justification for them to be that way. If anyone can, feel free to voice their concerns in this PR.