### PR TITLE
fix: specify height in high and hd camera profiles

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -322,6 +322,7 @@ public:
         bitrate: 500
         constraints:
           width: 1280
+          height: 720
           frameRate: 15
       - id: hd
         name: High definition
@@ -329,6 +330,7 @@ public:
         bitrate: 800
         constraints:
           width: 1280
+          height: 720
           frameRate: 30
     enableScreensharing: true
     enableVideo: true


### PR DESCRIPTION

### What does this PR do?

Set height to 720 in HD and High camera profiles.

### Closes Issue(s)

Closes #14476

### Motivation

Having only width set in HD/High profiles was causing certain devices to output webcam streams with non-standard ARs. Specifying height ups the chances that the stream's AR will be cohesive.

### More

Will backport to v2.4 once I'm sure this doesn't bring unexpected overconstraining issues (shouldn't).