### PR TITLE
build: enable G722 by default

### DIFF
--- a/build/packages-template/bbb-freeswitch-core/build.sh
+++ b/build/packages-template/bbb-freeswitch-core/build.sh
@@ -136,6 +136,8 @@ cp -r /opt/freeswitch staging/opt
 
 	rm -rf $CONFDIR/*
 	cp -r config/freeswitch/conf/* $CONFDIR
+    # enable spandsp module by default for G722 codec
+    sed -i '/<!-- Codec Interfaces -->/a\    <load module="mod_spandsp"/>' $CONFDIR/autoload_configs/modules.conf.xml
 
 	pushd $DESTDIR/opt/freeswitch
 	ln -s ./etc/freeswitch conf


### PR DESCRIPTION
currently it is enabled in the config but the module is not loaded.

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

modifies the list of loaded modules in FreeSWITCH to support G722 codec.

### Motivation

8 kHz audio sucks.

### More

will provide a patch for 2.5 as well, in 2.5 the config is taken from `bbb-voice-conference/config/freeswitch/conf/autoload_configs/modules.conf.xml` instead of freeswitch repo.
