### PR TITLE
build: enable G722 by default

### DIFF
--- a/bbb-voice-conference/config/freeswitch/conf/autoload_configs/modules.conf.xml
+++ b/bbb-voice-conference/config/freeswitch/conf/autoload_configs/modules.conf.xml
@@ -19,6 +19,7 @@
     <load module="mod_dialplan_xml"/>
 
     <!-- Codec Interfaces -->
+    <load module="mod_spandsp"/>
     <load module="mod_opus"/>
     <load module="mod_opusfile"/>
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

modifies the list of loaded modules in FreeSWITCH to support G722 codec.

### Motivation

8 kHz audio sucks.

### More

same change as in #14520 but for BBB 2.5+ build system