### PR TITLE
refactor(user): do not timeout registered users

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
@@ -19,8 +19,6 @@ trait SystemConfiguration {
   lazy val expireLastUserLeft = Try(config.getInt("expire.lastUserLeft")).getOrElse(60) // 1 minute
   lazy val expireNeverJoined = Try(config.getInt("expire.neverJoined")).getOrElse(5 * 60) // 5 minutes
 
-  lazy val maxRegUserToJoinTime = Try(config.getInt("expire.maxRegUserToJoin")).getOrElse(5 * 60) // 5 minutes
-
   lazy val analyticsChannel = Try(config.getString("eventBus.analyticsChannel")).getOrElse("analytics-channel")
   lazy val meetingManagerChannel = Try(config.getString("eventBus.meetingManagerChannel")).getOrElse("MeetingManagerChannel")
   lazy val outMessageChannel = Try(config.getString("eventBus.outMessageChannel")).getOrElse("OutgoingMessageChannel")

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
@@ -21,7 +21,6 @@ object RegisteredUsers {
       0,
       false,
       false,
-      false,
       loggedOut,
     )
   }
@@ -40,10 +39,6 @@ object RegisteredUsers {
 
   def findAllWithExternUserId(id: String, users: RegisteredUsers): Vector[RegisteredUser] = {
     users.toVector.filter(ru => id == ru.externId)
-  }
-
-  def findUsersNotJoined(users: RegisteredUsers): Vector[RegisteredUser] = {
-    users.toVector.filter(u => u.joined == false && u.markAsJoinTimedOut == false)
   }
 
   def getRegisteredUserWithToken(token: String, userId: String, regUsers: RegisteredUsers): Option[RegisteredUser] = {
@@ -135,12 +130,6 @@ object RegisteredUsers {
     u
   }
 
-  def markAsUserFailedToJoin(users: RegisteredUsers, user: RegisteredUser): RegisteredUser = {
-    val u = user.copy(markAsJoinTimedOut = true)
-    users.save(u)
-    u
-  }
-
   def setUserLoggedOutFlag(users: RegisteredUsers, user: RegisteredUser): RegisteredUser = {
     val u = user.copy(loggedOut = true)
     users.save(u)
@@ -182,7 +171,6 @@ case class RegisteredUser(
     registeredOn:             Long,
     lastAuthTokenValidatedOn: Long,
     joined:                   Boolean,
-    markAsJoinTimedOut:       Boolean,
     banned:                   Boolean,
     loggedOut:                Boolean
 )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -751,7 +751,6 @@ class MeetingActor(
     setRecordingChapterBreak()
 
     processUserInactivityAudit()
-    flagRegisteredUsersWhoHasNotJoined()
     checkIfNeedToEndMeetingWhenNoAuthedUsers(liveMeeting)
     checkIfNeedToEndMeetingWhenNoModerators(liveMeeting)
   }
@@ -966,22 +965,6 @@ class MeetingActor(
         )
 
         Sender.sendDisconnectClientSysMsg(liveMeeting.props.meetingProp.intId, u.intId, SystemUser.ID, EjectReasonCode.USER_INACTIVITY, outGW)
-      }
-    }
-  }
-
-  def flagRegisteredUsersWhoHasNotJoined(): Unit = {
-    val users = RegisteredUsers.findUsersNotJoined(liveMeeting.registeredUsers)
-    users foreach { u =>
-      val now = System.currentTimeMillis()
-      if (now - u.registeredOn > TimeUtil.secondsToMillis(maxRegUserToJoinTime)) {
-        RegisteredUsers.markAsUserFailedToJoin(liveMeeting.registeredUsers, u)
-        val event = MsgBuilder.buildRegisteredUserJoinTimeoutMsg(
-          liveMeeting.props.meetingProp.intId,
-          u.id,
-          u.name
-        )
-        outGW.send(event)
       }
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
@@ -40,7 +40,6 @@ class AnalyticsActor(val includeChat: Boolean) extends Actor with ActorLogging {
       case m: GetRunningMeetingsReqMsg                       => logMessage(msg)
 
       case m: RegisterUserReqMsg                             => logMessage(msg)
-      case m: RegisteredUserJoinTimeoutMsg                   => logMessage(msg)
       case m: UserRegisteredRespMsg                          => logMessage(msg)
       case m: DisconnectAllClientsSysMsg                     => logMessage(msg)
       case m: DisconnectClientSysMsg                         => logMessage(msg)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -424,15 +424,6 @@ object MsgBuilder {
     BbbCommonEnvCoreMsg(envelope, event)
   }
 
-  def buildRegisteredUserJoinTimeoutMsg(meetingId: String, userId: String, name: String): BbbCommonEnvCoreMsg = {
-    val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
-    val envelope = BbbCoreEnvelope(RegisteredUserJoinTimeoutMsg.NAME, routing)
-    val header = BbbCoreHeaderWithMeetingId(RegisteredUserJoinTimeoutMsg.NAME, meetingId)
-    val body = RegisteredUserJoinTimeoutMsgBody(meetingId, userId, name)
-    val event = RegisteredUserJoinTimeoutMsg(header, body)
-    BbbCommonEnvCoreMsg(envelope, event)
-  }
-
   def buildGetScreenSubscribePermissionRespMsg(
       meetingId:    String,
       voiceConf:    String,

--- a/akka-bbb-apps/src/universal/conf/application.conf
+++ b/akka-bbb-apps/src/universal/conf/application.conf
@@ -39,7 +39,6 @@ expire {
   # time in seconds
   lastUserLeft = 60
   neverJoined = 300
-  maxRegUserToJoin = 300
 }
 
 services {

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
@@ -25,13 +25,6 @@ case class UserRegisteredRespMsg(
 case class UserRegisteredRespMsgBody(meetingId: String, userId: String, name: String,
                                      role: String, excludeFromDashboard: Boolean, registeredOn: Long)
 
-object RegisteredUserJoinTimeoutMsg { val NAME = "RegisteredUserJoinTimeoutMsg" }
-case class RegisteredUserJoinTimeoutMsg(
-    header: BbbCoreHeaderWithMeetingId,
-    body:   RegisteredUserJoinTimeoutMsgBody
-) extends BbbCoreMsg
-case class RegisteredUserJoinTimeoutMsgBody(meetingId: String, userId: String, name: String)
-
 object ValidateAuthTokenReqMsg {
   val NAME = "ValidateAuthTokenReqMsg"
 


### PR DESCRIPTION
### What does this PR do?

Avoid removing registered users on join timeout.

### Motivation

This registered users cleanup routine should be deprecated since guest users
do not have a join timeout anymore.

### More

Follows https://github.com/bigbluebutton/bigbluebutton/pull/14131
