### PR TITLE
build: fix typo in docker-bbb-build image tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ stages:
 
 # define which docker image to use for builds
 default:
-  image: gitlab.senfcall.de:5050/senfcall-public/docker-bbb-build:v2022-02-08-bbb-2.5
+  image: gitlab.senfcall.de:5050/senfcall-public/docker-bbb-build:v2022-02-08-bbb-2-5
 
 # This stage uses git to find out since when each package has been unmodified.
 # it then checks an API endpoint on the package server to find out for which of


### PR DESCRIPTION
### What does this PR do?

I think it was meant to be `gitlab.senfcall.de:5050/senfcall-public/docker-bbb-build:v2022-02-08-bbb-2-5` (`-` instead of `.`). Ref.: https://gitlab.senfcall.de/senfcall-public/docker-bbb-build/container_registry/4

At least I couldn't get it working without changing this.

### Closes Issue(s)

None

### Motivation

n/a

### More

n/a
