### PR TITLE
build: recover bbb-lti packaging (now from own repo)

### DIFF
--- a/build/packages-template/bbb-lti/build.sh
+++ b/build/packages-template/bbb-lti/build.sh
@@ -21,18 +21,25 @@ done
 
 ##
 
+# After extracting out bbb-lti into its own repository there is an additional directory level
+if [ -d bbb-lti ]; then
+  cd bbb-lti/
+fi
+
 gradle clean
 gradle resolveDeps
 grails assemble
+
+cd ..
 
 mkdir -p staging/lib/systemd/system
 cp bbb-lti.service staging/lib/systemd/system
 
 mkdir -p staging/etc/bigbluebutton/nginx
-cp lti.nginx  staging/etc/bigbluebutton/nginx
+cp bbb-lti/lti.nginx  staging/etc/bigbluebutton/nginx
 
 mkdir -p staging/usr/share/bbb-lti
-cp build/libs/bbb-lti-0.5.war staging/usr/share/bbb-lti
+cp bbb-lti/build/libs/bbb-lti-0.5.war staging/usr/share/bbb-lti
 
 cd staging/usr/share/bbb-lti
 jar -xvf bbb-lti-0.5.war
@@ -41,12 +48,6 @@ cd ../../../..
 
 cp run-prod.sh staging/usr/share/bbb-lti
 chmod +x staging/usr/share/bbb-lti/run-prod.sh
-
-mkdir -p staging/etc/bigbluebutton/nginx
-cp lti.nginx  staging/etc/bigbluebutton/nginx
-
-mkdir -p staging/lib/systemd/system
-cp bbb-lti.service staging/lib/systemd/system
 
 ##
 

--- a/build/packages-template/bbb-lti/opts-bionic.sh
+++ b/build/packages-template/bbb-lti/opts-bionic.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d bbb-web --deb-user bigbluebutton --deb-group bigbluebutton --deb-use-file-permissions"
+OPTS="$OPTS -t deb -d bbb-web"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
- handles the extra level of `bbb-lti` directory introduced when I extracted bbb-lti into its own directory https://github.com/bigbluebutton/bigbluebutton/pull/14489 . The method I used focused on preserving the file git history. When I tried to `git mv` the files so we don't have `bbb-lti` inside `bbb-lti` it looked like we'd lose the history (everything was 1 commit old). In fact, I ended up re-creating the repository and repeating the extraction process and this time left bbb-lti/bbb/lti intact.
- Also drops the `fpm` flags about file ownership left out from #14110 Now that this can be built again, we'll know if anything's not working correctly
- Drops a few repeated commands for copying over .nginx and .service
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
`bbb-lti` package could not be built
<!-- What inspired you to submit this pull request? -->
