### PR TITLE
fix: bbb-demo, ship empty bbb_api_conf.jsp, populate in --setip

### DIFF
--- a/bbb-api-demo/src/main/webapp/bbb_api_conf.jsp
+++ b/bbb-api-demo/src/main/webapp/bbb_api_conf.jsp
@@ -1,0 +1,1 @@
+<%-- Placeholder file for bbb-demo configuration properties --%>

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -1419,12 +1419,6 @@ if [ $CHECK ]; then
     echo "                        ws-binding: $(xmlstarlet sel -t -m 'profile/settings/param[@name="ws-binding"]' -v @value $FREESWITCH_EXTERNAL)"
     echo "                       wss-binding: $(xmlstarlet sel -t -m 'profile/settings/param[@name="wss-binding"]' -v @value $FREESWITCH_EXTERNAL)"
 
-    if [ -f ${SERVLET_DIR}/demo/bbb_api_conf.jsp ]; then
-        BBB_WEB_URL=$(cat ${SERVLET_DIR}//WEB-INF/classes/bigbluebutton.properties | grep -v '#' | sed -n '/^bigbluebutton.web.serverURL/{s/.*\///;p}')
-        echo
-        echo "${SERVLET_DIR}/demo/bbb_api_conf.jsp (API demos)"
-        echo "                               url: $BBB_WEB_URL"
-    fi
 
 #     if [ -f ${LTI_DIR}/WEB-INF/classes/lti-config.properties ]; then
 #          LTI_URL=$(cat ${LTI_DIR}/WEB-INF/classes/lti-config.properties | grep -v '#' | sed -n '/^bigbluebuttonURL/{s/.*http[s]:\/\///;s/\/.*//;p}' | tr -d '\015')
@@ -1673,12 +1667,20 @@ if [ -n "$HOST" ]; then
     # Update api demos
     #
     if [ -f ${TOMCAT_DIR}/webapps/demo/bbb_api_conf.jsp ]; then
-        echo "Assigning $HOST for api demos in ${TOMCAT_DIR}/webapps/demo/bbb_api_conf.jsp"
-        $SUDO sed -i "s/BigBlueButtonURL = \"http[s]*:\/\/\([^\"\/]*\)\([\"\/]\)/BigBlueButtonURL = \"$PROTOCOL:\/\/$HOST\2/g" \
-                ${TOMCAT_DIR}/webapps/demo/bbb_api_conf.jsp
+      echo "there is bbb-demo installed"
+      BBB_WEB_URL=$(get_bbb_web_config_value bigbluebutton.web.serverURL)
+      SECRET=$(get_bbb_web_config_value securitySalt)
+
+      echo "Assigning $BBB_WEB_URL for api demos in ${TOMCAT_DIR}/webapps/demo/bbb_api_conf.jsp"
+      $SUDO echo -n "<%" > ${TOMCAT_DIR}/webapps/demo/bbb_api_conf.jsp
+      $SUDO echo "!
+// This is the security salt that must match the value set in the BigBlueButton server
+String salt = \"$SECRET\";
+
+// This is the URL for the BigBlueButton server
+String BigBlueButtonURL = \"$BBB_WEB_URL/bigbluebutton/\";
+%>" >> ${TOMCAT_DIR}/webapps/demo/bbb_api_conf.jsp
     fi
-
-
 
     if [ -f ${LTI_DIR}/WEB-INF/classes/lti-config.properties ]; then
         echo "Assigning $HOST for LTI integration in ${LTI_DIR}/WEB-INF/classes/lti-config.properties"

--- a/build/packages-template/bbb-demo/after-remove.sh
+++ b/build/packages-template/bbb-demo/after-remove.sh
@@ -2,5 +2,6 @@
 
 if [ "$1" = "remove" ]; then
 	rm -f /var/lib/$TOMCAT_SERVICE/webapps/demo.war
+	rm -rf /var/lib/$TOMCAT_SERVICE/webapps/demo
 fi
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
- includes an [almost] empty file `bbb_api_conf.jsp`, a placeholder so that bbb-demo can be installed
- includes code in `bbb-conf --setip` to populate the current SALT and URL in `bbb_api_conf.jsp`
- ensure `demo/` unpacked directory is fully gone on removal of `bbb-demo`

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #14533
Closes #12520


### Motivation
Currently we can't install `bbb-demo` because we're missing `bbb_api_conf.jsp` and it is required in
` <%@ include file="bbb_api_conf.jsp"%> ` in bbb-demo

<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->
* It is now mandatory to run `bbb-conf --setip yourserver.com` after an upgrade or clean install so that bbb-demo can get its `bbb_api_conf.jsp` file updated. Note that `bbb-demo` is an optional package
