### PR TITLE
fix: Users not being ejected from breakout rooms (only from main room)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/InMessages.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/InMessages.scala
@@ -84,7 +84,7 @@ case class EndBreakoutRoomInternalMsg(parentId: String, breakoutId: String, reas
 case class ExtendBreakoutRoomTimeInternalMsg(parentId: String, breakoutId: String, extendTimeInMinutes: Int) extends InMessage
 
 /**
- * Sent by parent meeting to breakout room to extend time.
+ * Sent by parent meeting to breakout room to eject user.
  * @param parentId
  * @param breakoutId
  * @param extUserId

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/InMessages.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/InMessages.scala
@@ -83,6 +83,18 @@ case class EndBreakoutRoomInternalMsg(parentId: String, breakoutId: String, reas
  */
 case class ExtendBreakoutRoomTimeInternalMsg(parentId: String, breakoutId: String, extendTimeInMinutes: Int) extends InMessage
 
+/**
+ * Sent by parent meeting to breakout room to extend time.
+ * @param parentId
+ * @param breakoutId
+ * @param extUserId
+ * @param ejectedBy
+ * @param reason
+ * @param reasonCode
+ * @param ban
+ */
+case class EjectUserFromBreakoutInternalMsg(parentId: String, breakoutId: String, extUserId: String, ejectedBy: String, reason: String, reasonCode: String, ban: Boolean) extends InMessage
+
 // DeskShare
 case class DeskShareStartedRequest(conferenceName: String, callerId: String, callerIdName: String) extends InMessage
 case class DeskShareStoppedRequest(conferenceName: String, callerId: String, callerIdName: String) extends InMessage

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutApp2x.scala
@@ -16,6 +16,7 @@ trait BreakoutApp2x extends BreakoutRoomCreatedMsgHdlr
   with TransferUserToMeetingRequestHdlr
   with EndBreakoutRoomInternalMsgHdlr
   with ExtendBreakoutRoomTimeInternalMsgHdlr
+  with EjectUserFromBreakoutInternalMsgHdlr
   with BreakoutRoomEndedInternalMsgHdlr {
 
   this: MeetingActor =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EjectUserFromBreakoutInternalMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EjectUserFromBreakoutInternalMsgHdlr.scala
@@ -1,0 +1,37 @@
+package org.bigbluebutton.core.apps.breakout
+
+import org.bigbluebutton.core.api.EjectUserFromBreakoutInternalMsg
+import org.bigbluebutton.core.apps.users.UsersApp
+import org.bigbluebutton.core.models.{ RegisteredUsers }
+import org.bigbluebutton.core.running.{ LiveMeeting, MeetingActor, OutMsgRouter }
+import org.bigbluebutton.core2.message.senders.Sender
+
+trait EjectUserFromBreakoutInternalMsgHdlr {
+  this: MeetingActor =>
+
+  val liveMeeting: LiveMeeting
+
+  val outGW: OutMsgRouter
+
+  def handleEjectUserFromBreakoutInternalMsgHdlr(msg: EjectUserFromBreakoutInternalMsg) = {
+
+    for {
+      registeredUser <- RegisteredUsers.findAllWithExternUserId(msg.extUserId, liveMeeting.registeredUsers)
+    } yield {
+      UsersApp.ejectUserFromMeeting(
+        outGW,
+        liveMeeting,
+        registeredUser.id,
+        msg.ejectedBy,
+        msg.reason,
+        msg.reasonCode,
+        msg.ban
+      )
+      // send a system message to force disconnection
+      Sender.sendDisconnectClientSysMsg(msg.breakoutId, registeredUser.id, msg.ejectedBy, msg.reasonCode, outGW)
+
+      log.info("Eject user {} id={} in breakoutId {}", registeredUser.name, registeredUser.id, msg.breakoutId)
+    }
+
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -284,6 +284,7 @@ class MeetingActor(
     case msg: BreakoutRoomUsersUpdateInternalMsg => state = handleBreakoutRoomUsersUpdateInternalMsg(msg, state)
     case msg: EndBreakoutRoomInternalMsg         => handleEndBreakoutRoomInternalMsg(msg)
     case msg: ExtendBreakoutRoomTimeInternalMsg  => state = handleExtendBreakoutRoomTimeInternalMsgHdlr(msg, state)
+    case msg: EjectUserFromBreakoutInternalMsg   => handleEjectUserFromBreakoutInternalMsgHdlr(msg)
     case msg: BreakoutRoomEndedInternalMsg       => state = handleBreakoutRoomEndedInternalMsg(msg, state)
     case msg: SendBreakoutTimeRemainingInternalMsg =>
       handleSendBreakoutTimeRemainingInternalMsg(msg)
@@ -408,7 +409,7 @@ class MeetingActor(
 
       // Client requested to eject user
       case m: EjectUserFromMeetingCmdMsg =>
-        usersApp.handleEjectUserFromMeetingCmdMsg(m)
+        usersApp.handleEjectUserFromMeetingCmdMsg(m, state)
         updateUserLastActivity(m.body.ejectedBy)
 
       // Another part of system (e.g. bbb-apps) requested to eject user.


### PR DESCRIPTION
When a user is removed from the main room, he is not being removed from the breakout rooms as well.
This PR fix this problem.

![remove-from-breakout](https://user-images.githubusercontent.com/5660191/156945595-eb2681d3-cf94-413b-8697-0513e46c0aeb.gif)



Closes #14194