### PR TITLE
Add breakout-room duration to sidebar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/breakout-room/component.jsx
@@ -4,16 +4,22 @@ import { defineMessages, injectIntl } from 'react-intl';
 import Icon from '/imports/ui/components/common/icon/component';
 import Styled from './styles';
 import { ACTIONS, PANELS } from '../../../layout/enums';
+import BreakoutRemainingTime from '/imports/ui/components/breakout-room/breakout-remaining-time/container';
 
 const intlMessages = defineMessages({
   breakoutTitle: {
     id: 'app.createBreakoutRoom.title',
     description: 'breakout title',
   },
+  breakoutTimeRemaining: {
+    id: 'app.createBreakoutRoom.duration',
+    description: 'Message that tells how much time is remaining for the breakout room',
+  },
 });
 
 const BreakoutRoomItem = ({
   hasBreakoutRoom,
+  breakoutRoom,
   sidebarContentPanel,
   layoutContextDispatch,
   intl,
@@ -50,7 +56,17 @@ const BreakoutRoomItem = ({
               onKeyPress={() => {}}
             >
               <Icon iconName="rooms" />
-              <span aria-hidden>{intl.formatMessage(intlMessages.breakoutTitle)}</span>
+              <div aria-hidden>
+                <Styled.BreakoutTitle>
+                  {intl.formatMessage(intlMessages.breakoutTitle)}
+                </Styled.BreakoutTitle>
+                <Styled.BreakoutDuration>
+                  <BreakoutRemainingTime
+                    messageDuration={intlMessages.breakoutTimeRemaining}
+                    breakoutRoom={breakoutRoom}
+                  />
+                </Styled.BreakoutDuration>
+              </div>
             </Styled.ListItem>
           </Styled.List>
         </Styled.ScrollableList>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/breakout-room/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/breakout-room/container.jsx
@@ -1,17 +1,35 @@
 import React from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
-import Service from '/imports/ui/components/user-list/service';
 import BreakoutRoomItem from './component';
 import { layoutSelectInput, layoutDispatch } from '../../../layout/context';
+import Breakouts from '/imports/api/breakouts';
+import Auth from '/imports/ui/services/auth';
 
-const BreakoutRoomContainer = ({ hasBreakoutRoom }) => {
+const BreakoutRoomContainer = ({ breakoutRoom }) => {
   const sidebarContent = layoutSelectInput((i) => i.sidebarContent);
   const { sidebarContentPanel } = sidebarContent;
   const layoutContextDispatch = layoutDispatch();
 
-  return <BreakoutRoomItem {...{ layoutContextDispatch, sidebarContentPanel, hasBreakoutRoom }} />;
+  const hasBreakoutRoom = !!breakoutRoom;
+
+  return (
+    <BreakoutRoomItem {...{
+      layoutContextDispatch,
+      sidebarContentPanel,
+      hasBreakoutRoom,
+      breakoutRoom,
+    }}
+    />
+  );
 };
 
-export default withTracker(() => ({
-  hasBreakoutRoom: Service.hasBreakoutRoom(),
-}))(BreakoutRoomContainer);
+export default withTracker(() => {
+  const breakoutRoom = Breakouts.findOne(
+    { parentMeetingId: Auth.meetingID },
+    { fields: { timeRemaining: 1 } },
+  );
+
+  return {
+    breakoutRoom,
+  };
+})(BreakoutRoomContainer);

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/breakout-room/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/breakout-room/styles.js
@@ -2,6 +2,8 @@ import styled from 'styled-components';
 
 import Styled from '/imports/ui/components/user-list/styles';
 import StyledContent from '/imports/ui/components/user-list/user-list-content/styles';
+import { colorGray } from '/imports/ui/stylesheets/styled-components/palette';
+import { fontSizeSmall } from '/imports/ui/stylesheets/styled-components/typography';
 
 const Messages = styled(Styled.Messages)``;
 
@@ -15,6 +17,21 @@ const List = styled(StyledContent.List)``;
 
 const ListItem = styled(StyledContent.ListItem)``;
 
+const BreakoutTitle = styled.div`
+  font-size: ${fontSizeSmall};
+`;
+
+const BreakoutDuration = styled.p`
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 200;
+  color: ${colorGray};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-style: italic;
+`;
+
 export default {
   Messages,
   Container,
@@ -22,4 +39,6 @@ export default {
   ScrollableList,
   List,
   ListItem,
+  BreakoutTitle,
+  BreakoutDuration,
 };


### PR DESCRIPTION
### What does this PR do?

Adds breakout duration to sidebar.

#### before
![Screen Shot 2022-03-07 at 16 34 03](https://user-images.githubusercontent.com/3728706/157076762-64b55f70-6ee1-41b8-a3cf-d63c9fdb01b1.png)

#### after
![Screen Shot 2022-03-07 at 16 33 34](https://user-images.githubusercontent.com/3728706/157076755-e8d089b9-51a4-4069-aab6-1e4798eea8f3.png)


### Closes Issue(s)
Partially resolves #9887