### PR TITLE
refactor: simplify groups json format

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -373,10 +373,8 @@ public class ParamsProcessorUtil {
 
                             Vector<String> groupUsers = new Vector<>();
                             if(groupJsonObj.has("roster") && groupJsonObj.get("roster").isJsonArray()) {
-                                for (JsonElement jsonElementUser : groupJsonObj.get("roster").getAsJsonArray()) {
-                                    if(jsonElementUser.isJsonObject() && jsonElementUser.getAsJsonObject().has("id")) {
-                                        groupUsers.add(jsonElementUser.getAsJsonObject().get("id").getAsString());
-                                    }
+                                for (JsonElement userExtId : groupJsonObj.get("roster").getAsJsonArray()) {
+                                    groupUsers.add(userExtId.getAsString());
                                 }
                             }
                             groups.add(new Group(groupId,groupName,groupUsers));


### PR DESCRIPTION
Refactor of parameter `groups` introduced in #13678.

As suggested in https://github.com/bigbluebutton/bigbluebutton/issues/13628#issuecomment-1060913533.
There is no need to make each user of the `roster` to be an object with only `id` property.
So this PR convert this property to an array of Strings instead of array of Objects.

Before:
```js
{ roster: [{id:123},{id:234},{id:345}] }
```

After:
```js
{ roster: [123,234,345] }
```