### PR TITLE
build: bump bbb-webrtc-sfu to v2.6.10

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.6.9 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.6.10 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

Bump bbb-webrtc-sfu to [v2.6.10](https://github.com/bigbluebutton/bbb-webrtc-sfu/releases/tag/v2.6.10)