### PR TITLE
fix(etherpad): avoid icons overlapping

### DIFF
--- a/build/packages-template/bbb-etherpad/settings.json
+++ b/build/packages-template/bbb-etherpad/settings.json
@@ -576,9 +576,10 @@
   "toolbar": {
     "left": [
       ["bold", "italic", "underline", "strikethrough"],
-      ["orderedlist", "unorderedlist", "undo", "redo"]
+      ["orderedlist", "unorderedlist", "undo", "redo"],
+      ["importexport"]
     ],
-    "right": [["importexport"]]
+    "right": [[]]
   },
 
   /*


### PR DESCRIPTION
### What does this PR do?

Inside narrow panels, Etherpad's toolbar icons overlap themselves.
This PR changes the etherpad config in order to avoid this scenario.

### Before
https://user-images.githubusercontent.com/42683590/157463940-6f4ba30e-f7b7-4bdb-9e3d-832a86f4fcfa.mp4


### After
https://user-images.githubusercontent.com/42683590/157463962-98088ce9-02c9-4fc0-87b2-6cfb323038f6.mp4
