### PR TITLE
feat: Support to disable shared notes and captions via disabledFeatures

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadCreateGroupReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadCreateGroupReqMsgHdlr.scala
@@ -21,7 +21,15 @@ trait PadCreateGroupReqMsgHdlr {
       bus.outGW.send(msgEvent)
     }
 
-    if (!Pads.hasGroup(liveMeeting.pads, msg.body.externalId)) {
+    val padEnabled = {
+      if (msg.body.externalId == "notes" && liveMeeting.props.meetingProp.disabledFeatures.contains("sharedNotes")) {
+        false
+      } else {
+        true
+      }
+    }
+
+    if (padEnabled && !Pads.hasGroup(liveMeeting.pads, msg.body.externalId)) {
       Pads.addGroup(liveMeeting.pads, msg.body.externalId, msg.body.model, msg.body.name, msg.header.userId)
       broadcastEvent(msg.body.externalId, msg.body.model)
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadCreateGroupReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadCreateGroupReqMsgHdlr.scala
@@ -21,14 +21,10 @@ trait PadCreateGroupReqMsgHdlr {
       bus.outGW.send(msgEvent)
     }
 
-    val padEnabled = {
-      if (msg.body.model == "notes" && liveMeeting.props.meetingProp.disabledFeatures.contains("sharedNotes")) {
-        false
-      } else if (msg.body.model == "captions" && liveMeeting.props.meetingProp.disabledFeatures.contains("captions")) {
-        false
-      } else {
-        true
-      }
+    val padEnabled = msg.body.model match {
+      case "notes" => !liveMeeting.props.meetingProp.disabledFeatures.contains("sharedNotes")
+      case "captions" => !liveMeeting.props.meetingProp.disabledFeatures.contains("captions")
+      case _ => false
     }
 
     if (padEnabled && !Pads.hasGroup(liveMeeting.pads, msg.body.externalId)) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadCreateGroupReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadCreateGroupReqMsgHdlr.scala
@@ -22,7 +22,9 @@ trait PadCreateGroupReqMsgHdlr {
     }
 
     val padEnabled = {
-      if (msg.body.externalId == "notes" && liveMeeting.props.meetingProp.disabledFeatures.contains("sharedNotes")) {
+      if (msg.body.model == "notes" && liveMeeting.props.meetingProp.disabledFeatures.contains("sharedNotes")) {
+        false
+      } else if (msg.body.model == "captions" && liveMeeting.props.meetingProp.disabledFeatures.contains("captions")) {
         false
       } else {
         true

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadCreateSessionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadCreateSessionReqMsgHdlr.scala
@@ -1,7 +1,6 @@
 package org.bigbluebutton.core.apps.pads
 
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.apps.PermissionCheck
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.models.Pads
 import org.bigbluebutton.core.running.LiveMeeting
@@ -22,11 +21,7 @@ trait PadCreateSessionReqMsgHdlr {
       bus.outGW.send(msgEvent)
     }
 
-    if (liveMeeting.props.meetingProp.disabledFeatures.contains("sharedNotes")) {
-      val meetingId = liveMeeting.props.meetingProp.intId
-      val reason = "Shared Notes disabled for this meeting."
-      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
-    } else if (Pads.hasAccess(liveMeeting, msg.body.externalId, msg.header.userId)) {
+    if (Pads.hasAccess(liveMeeting, msg.body.externalId, msg.header.userId)) {
       Pads.getGroup(liveMeeting.pads, msg.body.externalId) match {
         case Some(group) => broadcastEvent(group.groupId, msg.header.userId)
         case _           =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadCreateSessionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadCreateSessionReqMsgHdlr.scala
@@ -1,6 +1,7 @@
 package org.bigbluebutton.core.apps.pads
 
 import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.apps.PermissionCheck
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.models.Pads
 import org.bigbluebutton.core.running.LiveMeeting
@@ -21,7 +22,11 @@ trait PadCreateSessionReqMsgHdlr {
       bus.outGW.send(msgEvent)
     }
 
-    if (Pads.hasAccess(liveMeeting, msg.body.externalId, msg.header.userId)) {
+    if (liveMeeting.props.meetingProp.disabledFeatures.contains("sharedNotes")) {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val reason = "Shared Notes disabled for this meeting."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
+    } else if (Pads.hasAccess(liveMeeting, msg.body.externalId, msg.header.userId)) {
       Pads.getGroup(liveMeeting.pads, msg.body.externalId) match {
         case Some(group) => broadcastEvent(group.groupId, msg.header.userId)
         case _           =>

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -215,7 +215,9 @@ export default function addMeeting(meeting) {
       if (newMeeting.meetingProp.disabledFeatures.indexOf('sharedNotes') === -1) {
         initPads(meetingId);
       }
-      initCaptions(meetingId);
+      if (newMeeting.meetingProp.disabledFeatures.indexOf('captions') === -1) {
+        initCaptions(meetingId);
+      }
     } else if (numberAffected) {
       Logger.info(`Upserted meeting id=${meetingId}`);
     }

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -212,7 +212,9 @@ export default function addMeeting(meeting) {
 
     if (insertedId) {
       Logger.info(`Added meeting id=${meetingId}`);
-      initPads(meetingId);
+      if (newMeeting.meetingProp.disabledFeatures.indexOf('sharedNotes') === -1) {
+        initPads(meetingId);
+      }
       initCaptions(meetingId);
     } else if (numberAffected) {
       Logger.info(`Upserted meeting id=${meetingId}`);

--- a/bigbluebutton-html5/imports/ui/components/captions/service.js
+++ b/bigbluebutton-html5/imports/ui/components/captions/service.js
@@ -6,6 +6,7 @@ import SpeechService from '/imports/ui/components/captions/speech/service';
 import { makeCall } from '/imports/ui/services/api';
 import { Meteor } from 'meteor/meteor';
 import { Session } from 'meteor/session';
+import { isCaptionsEnabled } from '/imports/ui/services/features';
 
 const CAPTIONS_CONFIG = Meteor.settings.public.captions;
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
@@ -128,8 +129,6 @@ const getCaptionsData = () => {
 const setCaptionsActive = (locale) => Session.set('captionsActive', locale);
 
 const amICaptionsOwner = (ownerId) => ownerId === Auth.userID;
-
-const isCaptionsEnabled = () => CAPTIONS_CONFIG.enabled;
 
 const isCaptionsAvailable = () => {
   if (isCaptionsEnabled()) {

--- a/bigbluebutton-html5/imports/ui/components/notes/service.js
+++ b/bigbluebutton-html5/imports/ui/components/notes/service.js
@@ -4,6 +4,7 @@ import PadsService from '/imports/ui/components/pads/service';
 import Auth from '/imports/ui/services/auth';
 import { Session } from 'meteor/session';
 import { ACTIONS, PANELS } from '/imports/ui/components/layout/enums';
+import { isSharedNotesEnabled } from '/imports/ui/services/features';
 
 const NOTES_CONFIG = Meteor.settings.public.notes;
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
@@ -58,7 +59,7 @@ const hasUnreadNotes = (sidebarContentPanel) => {
   return rev !== 0 && rev > lastRev;
 };
 
-const isEnabled = () => NOTES_CONFIG.enabled;
+const isEnabled = () => isSharedNotesEnabled();
 
 const toggleNotesPanel = (sidebarContentPanel, layoutContextDispatch) => {
   layoutContextDispatch({

--- a/bigbluebutton-html5/imports/ui/services/features/index.js
+++ b/bigbluebutton-html5/imports/ui/services/features/index.js
@@ -35,3 +35,7 @@ export function isChatEnabled() {
 export function isSharedNotesEnabled() {
   return getDisabledFeatures().indexOf('sharedNotes') === -1 && Meteor.settings.public.notes.enabled;
 }
+
+export function isCaptionsEnabled() {
+  return getDisabledFeatures().indexOf('captions') === -1 && Meteor.settings.public.captions.enabled;
+}

--- a/bigbluebutton-html5/imports/ui/services/features/index.js
+++ b/bigbluebutton-html5/imports/ui/services/features/index.js
@@ -31,3 +31,7 @@ export function isExternalVideoEnabled() {
 export function isChatEnabled() {
   return getDisabledFeatures().indexOf('chat') === -1 && Meteor.settings.public.chat.enabled;
 }
+
+export function isSharedNotesEnabled() {
+  return getDisabledFeatures().indexOf('sharedNotes') === -1 && Meteor.settings.public.notes.enabled;
+}

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -409,7 +409,7 @@ endWhenNoModerator=false
 endWhenNoModeratorDelayInMinutes=1
 
 # List of features to disable (comma-separated)
-# Available options: chat, externalVideos, learningDashboard, polls, screenshare, sharedNotes
+# Available options: captions, chat, externalVideos, learningDashboard, polls, screenshare, sharedNotes
 #disabledFeatures=
 
 # Allow endpoint with current BigBlueButton version

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -409,7 +409,7 @@ endWhenNoModerator=false
 endWhenNoModeratorDelayInMinutes=1
 
 # List of features to disable (comma-separated)
-# Available options: chat, externalVideos, learningDashboard, polls, screenshare
+# Available options: chat, externalVideos, learningDashboard, polls, screenshare, sharedNotes
 #disabledFeatures=
 
 # Allow endpoint with current BigBlueButton version


### PR DESCRIPTION
Moving on with the implementation of `disabledFeatures` param #14293.

Add new features to disableable list: `sharedNotes` and `captions`.