### PR TITLE
fix: prevent redirect after feedback of user

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
@@ -174,14 +174,8 @@ class MeetingEnded extends PureComponent {
   }
 
   confirmRedirect() {
-    const {
-      selected,
-    } = this.state;
-
-    if (selected <= 0) {
-      if (meetingIsBreakout()) window.close();
-      if (allowRedirectToLogoutURL()) logoutRouteHandler();
-    }
+    if (meetingIsBreakout()) window.close();
+    if (allowRedirectToLogoutURL()) logoutRouteHandler();
   }
 
   getEndingMessage() {
@@ -236,18 +230,9 @@ class MeetingEnded extends PureComponent {
       dispatched: true,
     });
 
-    if (allowRedirectToLogoutURL()) {
-      const FEEDBACK_WAIT_TIME = 500;
-      setTimeout(() => {
-        fetch(url, options)
-          .then(() => {
-            logoutRouteHandler();
-          })
-          .catch(() => {
-            logoutRouteHandler();
-          });
-      }, FEEDBACK_WAIT_TIME);
-    }
+    fetch(url, options).catch((e) => {
+      logger.warn(e);
+    });
   }
 
   renderNoFeedback() {
@@ -309,7 +294,6 @@ class MeetingEnded extends PureComponent {
     const { intl, code, ejectedReason } = this.props;
     const {
       selected,
-      dispatched,
     } = this.state;
 
     const noRating = selected <= 0;
@@ -347,17 +331,17 @@ class MeetingEnded extends PureComponent {
                 ) : null}
               </div>
             ) : null}
-            {noRating && allowRedirectToLogoutURL() ? (
+            {noRating ? (
               <Button
                 color="primary"
-                onClick={this.confirmRedirect}
+                onClick={() => this.setState({ dispatched: true })}
                 className={styles.button}
                 label={intl.formatMessage(intlMessage.buttonOkay)}
                 description={intl.formatMessage(intlMessage.confirmDesc)}
               />
             ) : null}
 
-            {!noRating && !dispatched ? (
+            {!noRating ? (
               <Button
                 color="primary"
                 onClick={this.sendFeedback}

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
@@ -230,7 +230,14 @@ class MeetingEnded extends PureComponent {
       dispatched: true,
     });
 
-    fetch(url, options).catch((e) => {
+    fetch(url, options).then(() => {
+      if (!(this.localUserRole.toLowerCase() === 'moderator')) {
+        const REDIRECT_WAIT_TIME = 5000;
+        setTimeout(() => {
+          logoutRouteHandler();
+        }, REDIRECT_WAIT_TIME);
+      }
+    }).catch((e) => {
       logger.warn({
         logCode: 'user_feedback_not_sent_error',
         extraInfo: {

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
@@ -231,7 +231,7 @@ class MeetingEnded extends PureComponent {
     });
 
     fetch(url, options).then(() => {
-      if (!(this.localUserRole.toLowerCase() === 'moderator')) {
+      if (this.localUserRole === 'VIEWER') {
         const REDIRECT_WAIT_TIME = 5000;
         setTimeout(() => {
           logoutRouteHandler();

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
@@ -231,7 +231,13 @@ class MeetingEnded extends PureComponent {
     });
 
     fetch(url, options).catch((e) => {
-      logger.warn(e);
+      logger.warn({
+        logCode: 'user_feedback_not_sent_error',
+        extraInfo: {
+          errorName: e.name,
+          errorMessage: e.message,
+        },
+      }, `Unable to send feedback: ${e.message}`);
     });
   }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

Currently, users are redirected to the logout url after they finish interacting with the feedback component (if enabled in _Settings.yml_ - `askForFeedbackOnLogout`), which skips the modal to open the Learning Dashboard.

This PR fixes that behavior. So, after the users finish interacting with the feedback component they will be "redirected" to the Learning Dashboard modal. Only after that they will be redirected to the logout url.

https://user-images.githubusercontent.com/62393923/157530039-704b089d-642b-4219-9350-e494f18d5b07.mp4

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #14416