### PR TITLE
Add server side notification

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/UpdateBreakoutRoomsTimeMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/UpdateBreakoutRoomsTimeMsgHdlr.scala
@@ -6,6 +6,7 @@ import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.BigBlueButtonEvent
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
+import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
 import org.bigbluebutton.core.util.TimeUtil
 
 trait UpdateBreakoutRoomsTimeMsgHdlr extends RightsManagementTrait {
@@ -52,6 +53,14 @@ trait UpdateBreakoutRoomsTimeMsgHdlr extends RightsManagementTrait {
         } else {
           breakoutModel.rooms.values.foreach { room =>
             eventBus.publish(BigBlueButtonEvent(room.id, UpdateBreakoutRoomTimeInternalMsg(props.breakoutProps.parentId, room.id, newDurationInSeconds)))
+            val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+              room.id,
+              "success",
+              "about",
+              "app.chat.breakoutDurationUpdated",
+              Vector(s"${msg.body.timeInMinutes}")
+            )
+            outGW.send(notifyEvent)
           }
           log.debug("Updating {} minutes for breakout rooms time in meeting {}", msg.body.timeInMinutes, props.meetingProp.intId)
           breakoutModel.setTime(newDurationInSeconds)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -1,7 +1,7 @@
 package org.bigbluebutton.core2.message.senders
 
 import org.bigbluebutton.common2.domain.DefaultProps
-import org.bigbluebutton.common2.msgs.{ BbbCommonEnvCoreMsg, BbbCoreEnvelope, BbbCoreHeaderWithMeetingId, MessageTypes, Routing, ValidateConnAuthTokenSysRespMsg, ValidateConnAuthTokenSysRespMsgBody, _ }
+import org.bigbluebutton.common2.msgs.{ BbbCommonEnvCoreMsg, BbbCoreEnvelope, BbbCoreHeaderWithMeetingId, MessageTypes, Routing, ValidateConnAuthTokenSysRespMsg, ValidateConnAuthTokenSysRespMsgBody, NotifyAllInMeetingEvtMsg, NotifyAllInMeetingEvtMsgBody, _ }
 import org.bigbluebutton.core.models.GuestWaiting
 
 object MsgBuilder {
@@ -612,6 +612,22 @@ object MsgBuilder {
     val header = BbbClientMsgHeader(UserBroadcastCamStoppedEvtMsg.NAME, meetingId, userId)
     val body = UserBroadcastCamStoppedEvtMsgBody(userId, streamId)
     val event = UserBroadcastCamStoppedEvtMsg(header, body)
+
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
+
+  def buildNotifyAllInMeetingEvtMsg(
+      meetingId:        String,
+      notificationType: String,
+      icon:             String,
+      messageId:        String,
+      messageValues:    Vector[String]
+  ): BbbCommonEnvCoreMsg = {
+    val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
+    val envelope = BbbCoreEnvelope(NotifyAllInMeetingEvtMsg.NAME, routing)
+    val header = BbbClientMsgHeader(NotifyAllInMeetingEvtMsg.NAME, meetingId, "not-used")
+    val body = NotifyAllInMeetingEvtMsgBody(meetingId, notificationType, icon, messageId, messageValues)
+    val event = NotifyAllInMeetingEvtMsg(header, body)
 
     BbbCommonEnvCoreMsg(envelope, event)
   }

--- a/akka-bbb-apps/src/universal/conf/application.conf
+++ b/akka-bbb-apps/src/universal/conf/application.conf
@@ -43,8 +43,8 @@ expire {
 }
 
 services {
-  bbbWebAPI = "https://192.168.23.33/bigbluebutton/api"
-  sharedSecret = "changeme"
+  bbbWebAPI = "https://tainan.bbbvm.imdt.com.br/bigbluebutton/api"
+  sharedSecret = "Ajsjl1g45QXQ2BdnIaK0p5ERAIceMfMUFaS230TH4"
 }
 
 red5 {

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/SystemMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/SystemMsgs.scala
@@ -94,6 +94,30 @@ case class MeetingEndingEvtMsg(
 case class MeetingEndingEvtMsgBody(meetingId: String, reason: String)
 
 /**
+ * Sent from akka-apps to clients to inform them of notifications
+ */
+object NotifyAllInMeetingEvtMsg { val NAME = "NotifyAllInMeetingEvtMsg" }
+case class NotifyAllInMeetingEvtMsg(
+    header: BbbClientMsgHeader,
+    body:   NotifyAllInMeetingEvtMsgBody
+) extends BbbCoreMsg
+case class NotifyAllInMeetingEvtMsgBody(meetingId: String, notificationType: String, icon: String, messageId: String, messageValues: Vector[String])
+
+object NotifyUserInMeetingEvtMsg { val NAME = "NotifyUserInMeetingEvtMsg" }
+case class NotifyUserInMeetingEvtMsg(
+    header: BbbClientMsgHeader,
+    body:   NotifyUserInMeetingEvtMsgBody
+) extends BbbCoreMsg
+case class NotifyUserInMeetingEvtMsgBody(userId: String, meetingId: String, notificationType: String, icon: String, messageId: String, messageValues: Vector[String])
+
+object NotifyRoleInMeetingEvtMsg { val NAME = "NotifyRoleInMeetingEvtMsg" }
+case class NotifyRoleInMeetingEvtMsg(
+    header: BbbClientMsgHeader,
+    body:   NotifyRoleInMeetingEvtMsgBody
+) extends BbbCoreMsg
+case class NotifyRoleInMeetingEvtMsgBody(role: String, meetingId: String, notificationType: String, icon: String, messageId: String, messageValues: Vector[String])
+
+/**
  * Sent to bbb-web
  */
 object MeetingDestroyedEvtMsg { val NAME = "MeetingDestroyedEvtMsg" }

--- a/bigbluebutton-html5/client/collection-mirror-initializer.js
+++ b/bigbluebutton-html5/client/collection-mirror-initializer.js
@@ -21,7 +21,7 @@ import Annotations from '/imports/api/annotations';
 import Breakouts from '/imports/api/breakouts';
 import BreakoutsHistory from '/imports/api/breakouts-history';
 import guestUsers from '/imports/api/guest-users';
-import Meetings, { RecordMeetings, ExternalVideoMeetings, MeetingTimeRemaining } from '/imports/api/meetings';
+import Meetings, { RecordMeetings, ExternalVideoMeetings, MeetingTimeRemaining, Notifications } from '/imports/api/meetings';
 import { UsersTyping } from '/imports/api/group-chat-msg';
 import Users, { CurrentUser } from '/imports/api/users';
 import { Slides, SlidePositions } from '/imports/api/slides';
@@ -59,6 +59,7 @@ export const localBreakoutsHistorySync = new AbstractCollection(BreakoutsHistory
 export const localGuestUsersSync = new AbstractCollection(guestUsers, guestUsers);
 export const localMeetingsSync = new AbstractCollection(Meetings, Meetings);
 export const localUsersSync = new AbstractCollection(Users, Users);
+export const localNotificationsSync = new AbstractCollection(Notifications, Notifications);
 
 const collectionMirrorInitializer = () => {
   localCurrentPollSync.setupListeners();
@@ -93,6 +94,7 @@ const collectionMirrorInitializer = () => {
   localGuestUsersSync.setupListeners();
   localMeetingsSync.setupListeners();
   localUsersSync.setupListeners();
+  localNotificationsSync.setupListeners();
 };
 
 export default collectionMirrorInitializer;

--- a/bigbluebutton-html5/imports/api/meetings/index.js
+++ b/bigbluebutton-html5/imports/api/meetings/index.js
@@ -8,6 +8,7 @@ const Meetings = new Mongo.Collection('meetings', collectionOptions);
 const RecordMeetings = new Mongo.Collection('record-meetings', collectionOptions);
 const ExternalVideoMeetings = new Mongo.Collection('external-video-meetings', collectionOptions);
 const MeetingTimeRemaining = new Mongo.Collection('meeting-time-remaining', collectionOptions);
+const Notifications = new Mongo.Collection('notifications', collectionOptions);
 
 if (Meteor.isServer) {
   // types of queries for the meetings:
@@ -23,5 +24,6 @@ export {
   RecordMeetings,
   ExternalVideoMeetings,
   MeetingTimeRemaining,
+  Notifications,
 };
 export default Meetings;

--- a/bigbluebutton-html5/imports/api/meetings/notificationEmitter.js
+++ b/bigbluebutton-html5/imports/api/meetings/notificationEmitter.js
@@ -1,0 +1,3 @@
+import EventEmitter from 'events';
+
+export default new EventEmitter();

--- a/bigbluebutton-html5/imports/api/meetings/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/eventHandlers.js
@@ -13,6 +13,9 @@ import handleTimeRemainingUpdate from './handlers/timeRemainingUpdate';
 import handleChangeWebcamOnlyModerator from './handlers/webcamOnlyModerator';
 import handleSelectRandomViewer from './handlers/selectRandomViewer';
 import handleBroadcastLayout from './handlers/broadcastLayout';
+import handleNotifyAllInMeetingEvtMsg from './handlers/handleNotifyAllInMeetingEvtMsg';
+import handleNotifyUserInMeeting from './handlers/handleNotifyUserInMeeting';
+import handleNotifyRoleInMeeting from './handlers/handleNotifyRoleInMeeting';
 
 RedisPubSub.on('MeetingCreatedEvtMsg', handleMeetingCreation);
 RedisPubSub.on('SyncGetMeetingInfoRespMsg', handleGetAllMeetings);
@@ -29,3 +32,6 @@ RedisPubSub.on('GuestLobbyMessageChangedEvtMsg', handleGuestLobbyMessageChanged)
 RedisPubSub.on('MeetingTimeRemainingUpdateEvtMsg', handleTimeRemainingUpdate);
 RedisPubSub.on('SelectRandomViewerRespMsg', handleSelectRandomViewer);
 RedisPubSub.on('BroadcastLayoutEvtMsg', handleBroadcastLayout);
+RedisPubSub.on('NotifyAllInMeetingEvtMsg', handleNotifyAllInMeetingEvtMsg);
+RedisPubSub.on('NotifyUserInMeetingEvtMsg', handleNotifyUserInMeeting);
+RedisPubSub.on('NotifyRoleInMeetingEvtMsg', handleNotifyRoleInMeeting);

--- a/bigbluebutton-html5/imports/api/meetings/server/handlers/handleNotifyAllInMeetingEvtMsg.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/handlers/handleNotifyAllInMeetingEvtMsg.js
@@ -1,0 +1,13 @@
+import { check } from 'meteor/check';
+import emitNotification from '/imports/api/meetings/server/modifiers/emitNotification';
+
+export default function handleNotifyAllInMeeting({ body }) {
+  check(body, {
+    meetingId: String,
+    notificationType: String,
+    icon: String,
+    messageId: String,
+    messageValues: Array,
+  });
+  return emitNotification(body, 'notifyAllInMeeting');
+}

--- a/bigbluebutton-html5/imports/api/meetings/server/handlers/handleNotifyRoleInMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/handlers/handleNotifyRoleInMeeting.js
@@ -1,0 +1,14 @@
+import { check } from 'meteor/check';
+import emitNotification from '/imports/api/meetings/server/modifiers/emitNotification';
+
+export default function handleNotifyRoleInMeeting({ body }) {
+  check(body, {
+    role: String,
+    meetingId: String,
+    notificationType: String,
+    icon: String,
+    messageId: String,
+    messageValues: Array,
+  });
+  return emitNotification(body, 'NotifyRoleInMeeting');
+}

--- a/bigbluebutton-html5/imports/api/meetings/server/handlers/handleNotifyUserInMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/handlers/handleNotifyUserInMeeting.js
@@ -1,0 +1,14 @@
+import { check } from 'meteor/check';
+import emitNotification from '/imports/api/meetings/server/modifiers/emitNotification';
+
+export default function handleNotifyUserInMeeting({ body }) {
+  check(body, {
+    userId: String,
+    meetingId: String,
+    notificationType: String,
+    icon: String,
+    messageId: String,
+    messageValues: Array,
+  });
+  return emitNotification(body, 'NotifyUserInMeeting');
+}

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/emitNotification.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/emitNotification.js
@@ -1,0 +1,10 @@
+import notificationEmitter from '../../notificationEmitter';
+
+export default function emitNotification(body, type) {
+  if (!process.env.BBB_HTML5_ROLE || (process.env.BBB_HTML5_ROLE === 'frontend')) {
+    notificationEmitter.emit('notification', {
+      type,
+      ...body,
+    });
+  }
+}

--- a/bigbluebutton-html5/imports/api/meetings/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/publishers.js
@@ -8,6 +8,7 @@ import Users from '/imports/api/users';
 import Logger from '/imports/startup/server/logger';
 import { publicationSafeGuard } from '/imports/api/common/server/helpers';
 import AuthTokenValidation, { ValidationStates } from '/imports/api/auth-token-validation';
+import notificationEmitter from '../notificationEmitter';
 
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 
@@ -132,3 +133,37 @@ function timeRemainingPublish(...args) {
 }
 
 Meteor.publish('meeting-time-remaining', timeRemainingPublish);
+
+function notifications() {
+  const tokenValidation = AuthTokenValidation.findOne({ connectionId: this.connection.id });
+  if (tokenValidation || tokenValidation.validationStatus === ValidationStates.VALIDATED) {
+    notificationEmitter.on('notification', (notification) => {
+      const { meetingId, userId } = tokenValidation;
+      switch (notification.type) {
+        case 'notifyAllInMeeting':
+          if (notification.meetingId === meetingId) this.added('notifications', Math.random() * 500, notification);
+          break;
+        case 'NotifyUserInMeeting':
+          if (notification.userId === userId) this.added('notifications', Math.random() * 500, notification);
+          break;
+        case 'NotifyRoleInMeeting': {
+          const user = Users.findOne({ userId, meetingId }, { fields: { role: 1, userId: 1 } });
+          if (notification.role === user.role) this.added('notifications', Math.random() * 500, notification);
+          break;
+        }
+        default: Logger.warn(`wrong type: ${notification.type} userId: ${userId}`);
+      }
+    });
+
+    this.ready();
+  } else {
+    Logger.warn(`Publishing notification was requested by unauth connection ${this.connection.id}`);
+  }
+}
+
+function notificationsPublish(...args) {
+  const boundNotifications = notifications.bind(this);
+  return boundNotifications(...args);
+}
+
+Meteor.publish('notifications', notificationsPublish);

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -44,6 +44,7 @@ import ConnectionStatusService from '/imports/ui/components/connection-status/se
 import Settings from '/imports/ui/services/settings';
 import LayoutService from '/imports/ui/components/layout/service';
 import { registerTitleView } from '/imports/utils/dom-utils';
+import Notifications from '../notifications/container';
 import GlobalStyles from '/imports/ui/stylesheets/styled-components/globalStyles';
 
 const MOBILE_MEDIA = 'only screen and (max-width: 40em)';
@@ -457,6 +458,7 @@ class App extends Component {
 
     return (
       <>
+        <Notifications />
         <LayoutEngine layoutType={layoutType} />
         <GlobalStyles />
         <Styled.Layout

--- a/bigbluebutton-html5/imports/ui/components/notifications/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications/container.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import { Notifications as NotificationsCollection } from '/imports/api/meetings';
+import { notify } from '/imports/ui/services/notification';
+import { withTracker } from 'meteor/react-meteor-data';
+
+export default withTracker(() => {
+  NotificationsCollection.find({}).observe({
+    added: (obj) => {
+      notify(
+        <FormattedMessage
+          id={obj.messageId}
+          values={obj.messageValues}
+          description="Notification for when the recording starts"
+        />,
+        obj.notificationType,
+        obj.icon,
+      );
+    },
+  });
+  return {};
+})(() => null);

--- a/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
@@ -27,7 +27,7 @@ const SUBSCRIPTIONS = [
   'presentation-pods', 'users-settings', 'guestUser', 'users-infos', 'meeting-time-remaining',
   'local-settings', 'users-typing', 'record-meetings', 'video-streams',
   'connection-status', 'voice-call-states', 'external-video-meetings', 'breakouts', 'breakouts-history',
-  'pads', 'pads-sessions', 'pads-updates',
+  'pads', 'pads-sessions', 'pads-updates', 'notifications',
 ];
 
 const EVENT_NAME = 'bbb-group-chat-messages-subscription-has-stoppped';

--- a/bigbluebutton-html5/imports/ui/services/LiveDataEventBroker/LiveDataEventBroker.js
+++ b/bigbluebutton-html5/imports/ui/services/LiveDataEventBroker/LiveDataEventBroker.js
@@ -21,7 +21,7 @@ class CollectionEventsBroker {
       const index = CollectionEventsBroker.getKey({ collection, msg: event });
       const TheresCallback = this.callbacks[index];
       if (TheresCallback) {
-        throw new Error('There is already an associated callback for this event');
+        throw new Error(`There is already an associated callback for this event ${index}`);
       }
       this.callbacks[index] = callback;
       return true;


### PR DESCRIPTION
### What does this PR do?

Implements a way to send notifications from akka, adding three new messages:

- NotifyAllInMeeting - It'll notify all users of a meeting
- NotifyUserInMeeting - Notify a single user in a meeting
- NotifyRoleInMeeting - Notify all users of s specific role in a meeting

With this PR we can make the implementation of notifications easy and remove the load of processing notifications on client side

### Closes Issue(s)
Closes # #14493
