### PR TITLE
?build: bbb-etherpad missing deps, hacky rm package.json

### DIFF
--- a/build/packages-template/bbb-etherpad/build.sh
+++ b/build/packages-template/bbb-etherpad/build.sh
@@ -17,17 +17,21 @@ rm -rf staging
 # package
 
 set +e
+rm -f node_modules/ep_etherpad-lite/package.json # Was preventing npm ci running, see https://github.com/ether/etherpad-lite/issues/4962#issuecomment-916642078
 bin/installDeps.sh
 set -e
 
+rm -rf ep_pad_ttl
 git clone https://github.com/mconf/ep_pad_ttl.git
 npm pack ./ep_pad_ttl
 npm install ./ep_pad_ttl-*.tgz
 
+rm -rf bbb-etherpad-plugin
 git clone https://github.com/alangecker/bbb-etherpad-plugin.git
 npm pack ./bbb-etherpad-plugin
 npm install ./ep_bigbluebutton_patches-*.tgz
 
+rm -rf ep_redis_publisher
 git clone https://github.com/mconf/ep_redis_publisher.git
 npm pack ./ep_redis_publisher
 npm install ./ep_redis_publisher-*.tgz


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
It does two things:
- adds a cleanup step before each clone, so that `build.sh` can be re-run without errors
- executes a removal of etherpad-lite's package.json ... because it did not have a matchingn package-lock.json... and based on https://github.com/ether/etherpad-lite/issues/4962#issuecomment-916642078 it seems removal of package.json helps resolve the issue.
**I am not super sure on how this is correct**. I am adding the word 'hacky' in the PR name and a `?` in the title.

Locally this removal helped. But to be fully sure I need to monitor it a bit when built and used on staging.

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none open


### Motivation
When building `bbb-etherpad` in the step `bin/installDeps.sh` we were not able to run `npm ci`. I am not sure what exactly caused this obstacle.

+ set +e
+ bin/installDeps.sh
Installing dependencies...
/var/tmp/bbb-etherpad_2.5_bionic_m25/node_modules/ep_etherpad-lite
total 28
-rw-r--r-- 1 1001 1001   66 Mar 11 17:22 README.md
drwxr-xr-x 1 1001 1001  794 Mar 11 17:22 bin
-rw-r--r-- 1 1001 1001 3057 Mar 11 17:22 ep.json
drwxr-xr-x 1 1001 1001  222 Mar 11 17:22 ep_align-main
-rw-r--r-- 1 1001 1001 5960 Mar 11 17:22 etherpad_icon.svg
drwxr-xr-x 1 1001 1001 1612 Mar 11 17:22 locales
drwxr-xr-x 1 1001 1001  156 Mar 11 17:22 node
-rw-r--r-- 1 1001 1001 6258 Mar 11 17:22 package.json
drwxr-xr-x 1 1001 1001   96 Mar 11 17:22 static
drwxr-xr-x 1 1001 1001  138 Mar 11 17:22 templates
drwxr-xr-x 1 1001 1001   84 Mar 11 17:22 tests
-rw-r--r-- 1 1001 1001 1131 Mar 11 17:22 web.config
npm ERR! The `npm ci` command can only install with an existing package-lock.json or
npm ERR! npm-shrinkwrap.json with lockfileVersion >= 1. Run an install with npm@5 or
npm ERR! later to generate a package-lock.json file, then try again.

+ set -e


<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
