### PR TITLE
build: bbb-etherpad add logs; comment out #14583

### DIFF
--- a/build/packages-template/bbb-etherpad/build.sh
+++ b/build/packages-template/bbb-etherpad/build.sh
@@ -17,7 +17,11 @@ rm -rf staging
 # package
 
 set +e
-rm -f node_modules/ep_etherpad-lite/package.json # Was preventing npm ci running, see https://github.com/ether/etherpad-lite/issues/4962#issuecomment-916642078
+
+ls -l node_modules/
+ls -l node_modules/ep_etherpad-lite
+ls -l src/
+# rm -f node_modules/ep_etherpad-lite/package.json # Was preventing npm ci running, see https://github.com/ether/etherpad-lite/issues/4962#issuecomment-916642078
 bin/installDeps.sh
 set -e
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
- Adding logs to see why I am missing package-lock.json in some instances of building bbb-etherpad
- commenting out the odd removal of package.json from #14583

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
Continuing with #14583 -- still encountering the issue of not being able to do the `bin/installDeps.sh` step of build.sh
<!-- What inspired you to submit this pull request? -->


