### PR TITLE
build: bbb-etherpad set npm to 6.14.11

### DIFF
--- a/build/packages-template/bbb-etherpad/build.sh
+++ b/build/packages-template/bbb-etherpad/build.sh
@@ -18,6 +18,13 @@ rm -rf staging
 
 set +e
 
+# as of March 12, 2022, circa BigBlueButton 2.5-alpha4, we set npm by default to 8.5.0
+# however, it seems bbb-etherpad has troubles building with npm as high.
+# Setting npm to 6.14.11 which was used successfully for building in BigBlueButton 2.4.x
+npm -v
+npm i -g npm@6.14.11
+npm -v
+
 ls -l node_modules/
 ls -l node_modules/ep_etherpad-lite
 ls -l src/


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Sets npm to 6.14.11 for building of `bbb-etherpad`. Worked muuuch better locally than using npm 8.5.0. I was able to run bbb-etherpad built locally with this set of scripts.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
Continuation from #14583
<!-- What inspired you to submit this pull request? -->

### More

