### PR TITLE
refactor(video-list-item): hookify and reorganize component

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -958,7 +958,7 @@ class VideoProvider extends Component {
     const peer = this.webRtcPeers[stream];
     this.videoTags[stream] = video;
 
-    if (peer && !peer.attached) {
+    if (peer && !peer.attached && peer.stream === stream) {
       this.attachVideoStream(stream);
     }
   }

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -1,90 +1,69 @@
-import React, { Component } from 'react';
-import { defineMessages, injectIntl } from 'react-intl';
-import browserInfo from '/imports/utils/browserInfo';
-import { Meteor } from 'meteor/meteor';
+import React, { useEffect, useRef, useState } from 'react';
+import { injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
-import BBBMenu from '/imports/ui/components/common/menu/component';
-import FullscreenService from '/imports/ui/components/common/fullscreen-button/service';
-import FullscreenButtonContainer from '/imports/ui/components/common/fullscreen-button/container';
-import Styled from './styles';
-import VideoService from '../../service';
+import ViewActions from '/imports/ui/components/video-provider/video-list/video-list-item/view-actions/component';
+import UserActions from '/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component';
+import UserStatus from '/imports/ui/components/video-provider/video-list/video-list-item/user-status/component';
+import PinArea from '/imports/ui/components/video-provider/video-list/video-list-item/pin-area/component';
 import {
   isStreamStateUnhealthy,
   subscribeToStreamStateChange,
   unsubscribeFromStreamStateChange,
 } from '/imports/ui/services/bbb-webrtc-sfu/stream-state-service';
-import { ACTIONS } from '/imports/ui/components/layout/enums';
 import Settings from '/imports/ui/services/settings';
+import Styled from './styles';
 
-const ALLOW_FULLSCREEN = Meteor.settings.public.app.allowFullscreen;
-const { isSafari } = browserInfo;
-const FULLSCREEN_CHANGE_EVENT = isSafari ? 'webkitfullscreenchange' : 'fullscreenchange';
+const VideoListItem = (props) => {
+  const {
+    name, voiceUser, isFullscreenContext, layoutContextDispatch, user, onHandleVideoFocus,
+    cameraId, numOfStreams, focused, onVideoItemMount, onVideoItemUnmount,
+  } = props;
 
-const intlMessages = defineMessages({
-  focusLabel: {
-    id: 'app.videoDock.webcamFocusLabel',
-  },
-  focusDesc: {
-    id: 'app.videoDock.webcamFocusDesc',
-  },
-  unfocusLabel: {
-    id: 'app.videoDock.webcamUnfocusLabel',
-  },
-  unfocusDesc: {
-    id: 'app.videoDock.webcamUnfocusDesc',
-  },
-  pinLabel: {
-    id: 'app.videoDock.webcamPinLabel',
-  },
-  pinDesc: {
-    id: 'app.videoDock.webcamPinDesc',
-  },
-  unpinLabel: {
-    id: 'app.videoDock.webcamUnpinLabel',
-  },
-  unpinLabelDisabled: {
-    id: 'app.videoDock.webcamUnpinLabelDisabled',
-  },
-  unpinDesc: {
-    id: 'app.videoDock.webcamUnpinDesc',
-  },
-  mirrorLabel: {
-    id: 'app.videoDock.webcamMirrorLabel',
-  },
-  mirrorDesc: {
-    id: 'app.videoDock.webcamMirrorDesc',
-  },
-});
+  const [videoIsReady, setVideoIsReady] = useState(false);
+  const [isStreamHealthy, setIsStreamHealthy] = useState(false);
+  const [isMirrored, setIsMirrored] = useState(false);
 
-class VideoListItem extends Component {
-  constructor(props) {
-    super(props);
-    this.videoTag = null;
+  const videoTag = useRef();
+  const videoContainer = useRef();
 
-    this.state = {
-      videoIsReady: false,
-      isFullscreen: false,
-      isStreamHealthy: false,
-      isMirrored: VideoService.mirrorOwnWebcam(props.userId),
+  const shouldRenderReconnect = !isStreamHealthy && videoIsReady;
+  const { animations } = Settings.application;
+  const talking = voiceUser?.talking;
+
+  const onStreamStateChange = (e) => {
+    const { streamState } = e.detail;
+    const newHealthState = !isStreamStateUnhealthy(streamState);
+    e.stopPropagation();
+
+    if (newHealthState !== isStreamHealthy) {
+      setIsStreamHealthy(newHealthState);
+    }
+  };
+
+  const handleSetVideoIsReady = () => {
+    setVideoIsReady(true);
+    window.dispatchEvent(new Event('resize'));
+
+    /* used when re-sharing cameras after leaving a breakout room.
+    it is needed in cases where the user has more than one active camera
+    so we only share the second camera after the first
+    has finished loading (can't share more than one at the same time) */
+    Session.set('canConnect', true);
+  };
+
+  // component did mount
+  useEffect(() => {
+    onVideoItemMount(videoTag.current);
+    subscribeToStreamStateChange(cameraId, onStreamStateChange);
+    videoTag.current.addEventListener('loadeddata', handleSetVideoIsReady);
+
+    return () => {
+      videoTag.current.removeEventListener('loadeddata', handleSetVideoIsReady);
     };
+  }, []);
 
-    this.mirrorOwnWebcam = VideoService.mirrorOwnWebcam(props.userId);
-
-    this.setVideoIsReady = this.setVideoIsReady.bind(this);
-    this.onFullscreenChange = this.onFullscreenChange.bind(this);
-    this.onStreamStateChange = this.onStreamStateChange.bind(this);
-  }
-
-  componentDidMount() {
-    const { onVideoItemMount, cameraId } = this.props;
-
-    onVideoItemMount(this.videoTag);
-    this.videoTag.addEventListener('loadeddata', this.setVideoIsReady);
-    this.videoContainer.addEventListener(FULLSCREEN_CHANGE_EVENT, this.onFullscreenChange);
-    subscribeToStreamStateChange(cameraId, this.onStreamStateChange);
-  }
-
-  componentDidUpdate() {
+  // component will mount
+  useEffect(() => {
     const playElement = (elem) => {
       if (elem.paused) {
         elem.play().catch((error) => {
@@ -100,268 +79,88 @@ class VideoListItem extends Component {
     // This is here to prevent the videos from freezing when they're
     // moved around the dom by react, e.g., when  changing the user status
     // see https://bugs.chromium.org/p/chromium/issues/detail?id=382879
-    if (this.videoTag) {
-      playElement(this.videoTag);
+    if (videoIsReady) {
+      playElement(videoTag.current);
     }
-  }
+  }, [videoIsReady]);
 
-  componentWillUnmount() {
-    const {
-      cameraId,
-      onVideoItemUnmount,
-      isFullscreenContext,
-      layoutContextDispatch,
-    } = this.props;
-
-    this.videoTag.removeEventListener('loadeddata', this.setVideoIsReady);
-    this.videoContainer.removeEventListener(FULLSCREEN_CHANGE_EVENT, this.onFullscreenChange);
-    unsubscribeFromStreamStateChange(cameraId, this.onStreamStateChange);
+  // component will unmount
+  useEffect(() => () => {
+    unsubscribeFromStreamStateChange(cameraId, onStreamStateChange);
     onVideoItemUnmount(cameraId);
+  }, []);
 
-    if (isFullscreenContext) {
-      layoutContextDispatch({
-        type: ACTIONS.SET_FULLSCREEN_ELEMENT,
-        value: {
-          element: '',
-          group: '',
-        },
-      });
-    }
-  }
-
-  onStreamStateChange(e) {
-    const { streamState } = e.detail;
-    const { isStreamHealthy } = this.state;
-
-    const newHealthState = !isStreamStateUnhealthy(streamState);
-    e.stopPropagation();
-
-    if (newHealthState !== isStreamHealthy) {
-      this.setState({ isStreamHealthy: newHealthState });
-    }
-  }
-
-  onFullscreenChange() {
-    const { isFullscreen } = this.state;
-    const serviceIsFullscreen = FullscreenService.isFullScreen(this.videoContainer);
-
-    if (isFullscreen !== serviceIsFullscreen) {
-      this.setState({ isFullscreen: serviceIsFullscreen });
-    }
-  }
-
-  setVideoIsReady() {
-    const { videoIsReady } = this.state;
-    if (!videoIsReady) this.setState({ videoIsReady: true });
-    window.dispatchEvent(new Event('resize'));
-
-    /* used when re-sharing cameras after leaving a breakout room.
-    it is needed in cases where the user has more than one active camera
-    so we only share the second camera after the first
-    has finished loading (can't share more than one at the same time) */
-    Session.set('canConnect', true);
-  }
-
-  getAvailableActions() {
-    const {
-      intl,
-      cameraId,
-      numOfStreams,
-      onHandleVideoFocus,
-      user,
-      focused,
-    } = this.props;
-
-    const pinned = user?.pin;
-    const userId = user?.userId;
-
-    const isPinnedIntlKey = !pinned ? 'pin' : 'unpin';
-    const isFocusedIntlKey = !focused ? 'focus' : 'unfocus';
-
-    const menuItems = [{
-      key: `${cameraId}-mirror`,
-      label: intl.formatMessage(intlMessages.mirrorLabel),
-      description: intl.formatMessage(intlMessages.mirrorDesc),
-      onClick: () => this.mirrorCamera(cameraId),
-    }];
-
-    if (numOfStreams > 2) {
-      menuItems.push({
-        key: `${cameraId}-focus`,
-        label: intl.formatMessage(intlMessages[`${isFocusedIntlKey}Label`]),
-        description: intl.formatMessage(intlMessages[`${isFocusedIntlKey}Desc`]),
-        onClick: () => onHandleVideoFocus(cameraId),
-      });
-    }
-
-    if (VideoService.isVideoPinEnabledForCurrentUser()) {
-      menuItems.push({
-        key: `${cameraId}-pin`,
-        label: intl.formatMessage(intlMessages[`${isPinnedIntlKey}Label`]),
-        description: intl.formatMessage(intlMessages[`${isPinnedIntlKey}Desc`]),
-        onClick: () => VideoService.toggleVideoPin(userId, pinned),
-      });
-    }
-
-    return menuItems;
-  }
-
-  mirrorCamera() {
-    const { isMirrored } = this.state;
-    this.setState({ isMirrored: !isMirrored });
-  }
-
-  renderFullscreenButton() {
-    const { name, cameraId } = this.props;
-    const { isFullscreen } = this.state;
-
-    if (!ALLOW_FULLSCREEN) return null;
-
-    return (
-      <FullscreenButtonContainer
-        data-test="webcamsFullscreenButton"
-        fullscreenRef={this.videoContainer}
-        elementName={name}
-        elementId={cameraId}
-        elementGroup="webcams"
-        isFullscreen={isFullscreen}
-        dark
-      />
-    );
-  }
-
-  renderPinButton() {
-    const { user, intl } = this.props;
-    const pinned = user?.pin;
-    const userId = user?.userId;
-    const shouldRenderPinButton = pinned && userId;
-    const videoPinActionAvailable = VideoService.isVideoPinEnabledForCurrentUser();
-
-    if (!shouldRenderPinButton) return null;
-
-    return (
-      <Styled.PinButtonWrapper>
-        <Styled.PinButton
-          color="default"
-          icon={!pinned ? 'pin-video_on' : 'pin-video_off'}
-          size="sm"
-          onClick={() => VideoService.toggleVideoPin(userId, true)}
-          label={videoPinActionAvailable
-            ? intl.formatMessage(intlMessages.unpinLabel)
-            : intl.formatMessage(intlMessages.unpinLabelDisabled)}
-          hideLabel
-          disabled={!videoPinActionAvailable}
-          data-test="pinVideoButton"
-        />
-      </Styled.PinButtonWrapper>
-    );
-  }
-
-  render() {
-    const {
-      videoIsReady,
-      isStreamHealthy,
-      isMirrored,
-    } = this.state;
-    const {
-      name,
-      user,
-      voiceUser,
-      numOfStreams,
-      isFullscreenContext,
-    } = this.props;
-    const availableActions = this.getAvailableActions();
-    const enableVideoMenu = Meteor.settings.public.kurento.enableVideoMenu || false;
-    const shouldRenderReconnect = !isStreamHealthy && videoIsReady;
-
-    const { isFirefox } = browserInfo;
-    const { animations } = Settings.application;
-    const talking = voiceUser?.talking;
-    const listenOnly = voiceUser?.listenOnly;
-    const muted = voiceUser?.muted;
-    const voiceUserJoined = voiceUser?.joined;
-    
-    return (
-      <Styled.Content
-        talking={talking}
-        fullscreen={isFullscreenContext}
-        data-test={talking ? 'webcamItemTalkingUser' : 'webcamItem'}
-        animations={animations}
-      >
-        {
-          !videoIsReady
-          && (
-            <Styled.WebcamConnecting
-              data-test="webcamConnecting"
-              talking={talking}
-              animations={animations}
-            >
-              <Styled.LoadingText>{name}</Styled.LoadingText>
-            </Styled.WebcamConnecting>
-          )
-
-        }
-
-        {
-          shouldRenderReconnect
-          && <Styled.Reconnecting />
-        }
-
-        <Styled.VideoContainer ref={(ref) => { this.videoContainer = ref; }}>
-          <Styled.Video
-            muted
-            data-test={this.mirrorOwnWebcam ? 'mirroredVideoContainer' : 'videoContainer'}
-            mirrored={isMirrored}
-            unhealthyStream={shouldRenderReconnect}
-            ref={(ref) => { this.videoTag = ref; }}
-            autoPlay
-            playsInline
-          />
-          {videoIsReady && this.renderFullscreenButton()}
-          {videoIsReady && this.renderPinButton()}
-        </Styled.VideoContainer>
-        {videoIsReady
-          && (
-            <Styled.Info>
-              {enableVideoMenu && availableActions.length >= 1
-                ? (
-                  <BBBMenu
-                    trigger={<Styled.DropdownTrigger tabIndex={0} data-test="dropdownWebcamButton">{name}</Styled.DropdownTrigger>}
-                    actions={this.getAvailableActions()}
-                    opts={{
-                      id: "default-dropdown-menu",
-                      keepMounted: true,
-                      transitionDuration: 0,
-                      elevation: 3,
-                      getContentAnchorEl: null,
-                      fullwidth: "true",
-                      anchorOrigin: { vertical: 'bottom', horizontal: 'left' },
-                      transformorigin: { vertical: 'bottom', horizontal: 'left' },
-                    }}
+  return (
+    <Styled.Content
+      ref={videoContainer}
+      talking={talking}
+      fullscreen={isFullscreenContext}
+      data-test={talking ? 'webcamItemTalkingUser' : 'webcamItem'}
+      animations={animations}
+    >
+      {
+          videoIsReady
+            ? (
+              <>
+                <Styled.TopBar>
+                  <PinArea
+                    user={user}
                   />
-                )
-                : (
-                  <Styled.Dropdown isFirefox={isFirefox}>
-                    <Styled.UserName noMenu={numOfStreams < 3}>
-                      {name}
-                    </Styled.UserName>
-                  </Styled.Dropdown>
-                )}
-              {muted && !listenOnly ? <Styled.Muted iconName="unmute_filled" /> : null}
-              {listenOnly ? <Styled.Voice iconName="listen" /> : null}
-              {voiceUserJoined && !muted ? <Styled.Voice iconName="unmute" /> : null}
-            </Styled.Info>
-          )}
-      </Styled.Content>
-    );
-  }
-}
+                  <ViewActions
+                    videoContainer={videoContainer}
+                    name={name}
+                    cameraId={cameraId}
+                    isFullscreenContext={isFullscreenContext}
+                    layoutContextDispatch={layoutContextDispatch}
+                  />
+                </Styled.TopBar>
+                <Styled.BottomBar>
+                  <UserActions
+                    name={name}
+                    user={user}
+                    cameraId={cameraId}
+                    numOfStreams={numOfStreams}
+                    onHandleVideoFocus={onHandleVideoFocus}
+                    focused={focused}
+                    onHandleMirror={() => setIsMirrored((value) => !value)}
+                  />
+                  <UserStatus
+                    voiceUser={voiceUser}
+                  />
+                </Styled.BottomBar>
+              </>
+            )
+            : (
+              <Styled.WebcamConnecting
+                data-test="webcamConnecting"
+                talking={talking}
+                animations={animations}
+              >
+                <Styled.LoadingText>{name}</Styled.LoadingText>
+              </Styled.WebcamConnecting>
+            )
+        }
+
+      <Styled.VideoContainer>
+        <Styled.Video
+          muted
+          mirrored={isMirrored}
+          unhealthyStream={shouldRenderReconnect}
+          ref={videoTag}
+          autoPlay
+          playsInline
+        />
+      </Styled.VideoContainer>
+
+      {shouldRenderReconnect && <Styled.Reconnecting />}
+    </Styled.Content>
+  );
+};
 
 export default injectIntl(VideoListItem);
 
 VideoListItem.defaultProps = {
   numOfStreams: 0,
-  user: null,
 };
 
 VideoListItem.propTypes = {
@@ -372,11 +171,15 @@ VideoListItem.propTypes = {
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
   onHandleVideoFocus: PropTypes.func.isRequired,
+  onVideoItemMount: PropTypes.func.isRequired,
+  onVideoItemUnmount: PropTypes.func.isRequired,
+  isFullscreenContext: PropTypes.bool.isRequired,
+  layoutContextDispatch: PropTypes.func.isRequired,
   user: PropTypes.shape({
     pin: PropTypes.bool.isRequired,
     userId: PropTypes.string.isRequired,
   }).isRequired,
-  voiceUser:  PropTypes.shape({
+  voiceUser: PropTypes.shape({
     muted: PropTypes.bool.isRequired,
     listenOnly: PropTypes.bool.isRequired,
     talking: PropTypes.bool.isRequired,

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/container.jsx
@@ -34,7 +34,11 @@ export default withTracker((props) => {
     voiceUser: VoiceUsers.findOne({ intId: userId },
       { fields: { muted: 1, listenOnly: 1, talking: 1 } }),
     user: Users.findOne({ intId: userId },
-      { fields: { pin: 1, userId: 1 } }),
+      {
+        fields: {
+          pin: 1, userId: 1, name: 1,
+        },
+      }),
   };
 })(VideoListItemContainer);
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/pin-area/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/pin-area/component.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+import VideoService from '/imports/ui/components/video-provider/service';
+import Styled from './styles';
+
+const intlMessages = defineMessages({
+  unpinLabel: {
+    id: 'app.videoDock.webcamUnpinLabel',
+  },
+  unpinLabelDisabled: {
+    id: 'app.videoDock.webcamUnpinLabelDisabled',
+  },
+});
+
+const PinArea = (props) => {
+  const intl = useIntl();
+
+  const { user } = props;
+  const pinned = user?.pin;
+  const userId = user?.userId;
+  const shouldRenderPinButton = pinned && userId;
+  const videoPinActionAvailable = VideoService.isVideoPinEnabledForCurrentUser();
+
+  if (!shouldRenderPinButton) return <Styled.PinButtonWrapper />;
+
+  return (
+    <Styled.PinButtonWrapper>
+      <Styled.PinButton
+        color="default"
+        icon={!pinned ? 'pin-video_on' : 'pin-video_off'}
+        size="sm"
+        onClick={() => VideoService.toggleVideoPin(userId, true)}
+        label={videoPinActionAvailable
+          ? intl.formatMessage(intlMessages.unpinLabel)
+          : intl.formatMessage(intlMessages.unpinLabelDisabled)}
+        hideLabel
+        disabled={!videoPinActionAvailable}
+        data-test="pinVideoButton"
+      />
+    </Styled.PinButtonWrapper>
+  );
+};
+
+export default PinArea;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/pin-area/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/pin-area/styles.js
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+import Button from '/imports/ui/components/common/button/component';
+import { colorTransparent, colorWhite } from '/imports/ui/stylesheets/styled-components/palette';
+
+const PinButton = styled(Button)`
+  padding: 5px;
+  &,
+  &:active,
+  &:hover,
+  &:focus {
+    background-color: ${colorTransparent} !important;
+    border: none !important;
+
+    & > i {
+      border: none !important;
+      color: ${colorWhite};
+      font-size: 1rem;
+      background-color: ${colorTransparent} !important;
+    }
+  }
+`;
+
+const PinButtonWrapper = styled.div`
+  background-color: rgba(0,0,0,.3);
+  cursor: pointer;
+  border: 0;
+  margin: 2px;
+  height: fit-content;
+
+  [dir="rtl"] & {
+    right: auto;
+    left :0;
+  }
+
+  [class*="presentationZoomControls"] & {
+    position: relative !important;
+  }
+`;
+
+export default {
+  PinButtonWrapper,
+  PinButton,
+};

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/styles.js
@@ -1,21 +1,10 @@
 import styled from 'styled-components';
-import Icon from '/imports/ui/components/common/icon/component';
-import Button from '/imports/ui/components/common/button/component';
 import {
   colorPrimary,
   colorBlack,
   colorWhite,
-  colorOffWhite,
-  colorDanger,
-  colorSuccess,
-  colorTransparent,
 } from '/imports/ui/stylesheets/styled-components/palette';
-import { TextElipsis, DivElipsis } from '/imports/ui/stylesheets/styled-components/placeholders';
-import { landscape, mediumUp } from '/imports/ui/stylesheets/styled-components/breakpoints';
-import {
-  audioIndicatorWidth,
-  audioIndicatorFs,
-} from '/imports/ui/stylesheets/styled-components/general';
+import { TextElipsis } from '/imports/ui/stylesheets/styled-components/placeholders';
 
 const Content = styled.div`
   position: relative;
@@ -161,149 +150,24 @@ const Video = styled.video`
   `}
 `;
 
-const Info = styled.div`
+const TopBar = styled.div`
   position: absolute;
-  bottom: 1px;
-  left: 7px;
-  right: 5px;
-  z-index: 2;
-`;
-
-const Dropdown = styled.div`
   display: flex;
-  outline: none !important;
-  width: 70%;
-
-  @media ${mediumUp} {
-    >[aria-expanded] {
-      padding: .25rem;
-    }
-  }
-
-  @media ${landscape} {
-    button {
-      width: calc(100vw - 4rem);
-      margin-left: 1rem;
-    }
-  }
-
-  ${({ isFirefox }) => isFirefox && `
-    max-width: 100%;
-  `}
-`;
-
-const UserName = styled(TextElipsis)`
-  position: relative;
-  max-width: 75%;
-  // Keep the background with 0.5 opacity, but leave the text with 1
-  background-color: rgba(0, 0, 0, 0.5);
-  border-radius: 1px;
-  color: ${colorOffWhite};
-  padding: 0 1rem 0 .5rem !important;
-  font-size: 80%;
-
-  ${({ noMenu }) => noMenu && `
-    padding: 0 .5rem 0 .5rem !important;
-  `}
-`;
-
-const Muted = styled(Icon)`
-  display: inline-block;
-  position: absolute;
-  right: 7px;
-  bottom: 6px;
-  width: ${audioIndicatorWidth};
-  height: ${audioIndicatorWidth};
-  min-width: ${audioIndicatorWidth};
-  min-height: ${audioIndicatorWidth};
-  color: ${colorWhite};
-  border-radius: 50%;
-
-  &::before {
-    font-size: ${audioIndicatorFs};
-  }
-
-  background-color: ${colorDanger};
-`;
-
-const Voice = styled(Icon)`
-  display: inline-block;
-  position: absolute;
-  right: 7px;
-  bottom: 6px;
-  width: ${audioIndicatorWidth};
-  height: ${audioIndicatorWidth};
-  min-width: ${audioIndicatorWidth};
-  min-height: ${audioIndicatorWidth};
-  color: ${colorWhite};
-  border-radius: 50%;
-
-  &::before {
-    font-size: ${audioIndicatorFs};
-  }
-
-  background-color: ${colorSuccess};
-`;
-
-const DropdownTrigger = styled(DivElipsis)`
-  position: relative;
-  max-width: 75%;
-  // Keep the background with 0.5 opacity, but leave the text with 1
-  background-color: rgba(0, 0, 0, 0.5);
-  border-radius: 1px;
-  color: ${colorOffWhite};
-  padding: 0 1rem 0 .5rem !important;
-  font-size: 80%;
-
-  cursor: pointer;
-
-  &::after {
-    content: "\\203a";
-    position: absolute;
-    transform: rotate(90deg);
-    top: 45%;
-    width: 0;
-    line-height: 0;
-    right: .45rem;
-  }
-`;
-
-const PinButtonWrapper = styled.div`
-  position: absolute;
+  width: 100%;
+  z-index: 1;
   top: 0;
-  left: auto;
-  background-color: rgba(0,0,0,.3);
-  cursor: pointer;
-  border: 0;
-  z-index: 2;
-  margin: 2px;
-
-  [dir="rtl"] & {
-    right: auto;
-    left :0;
-  }
-
-  [class*="presentationZoomControls"] & {
-    position: relative !important;
-  }
+  padding: 5px;
+  justify-content: space-between;
 `;
 
-const PinButton = styled(Button)`
-  padding: 5px;
-  &,
-  &:active,
-  &:hover,
-  &:focus {
-    background-color: ${colorTransparent} !important;
-    border: none !important;
-
-    & > i {
-      border: none !important;
-      color: ${colorWhite};
-      font-size: 1rem;
-      background-color: ${colorTransparent} !important;
-    }
-  }
+const BottomBar = styled.div`
+  position: absolute;
+  display: flex;
+  width: 100%;
+  z-index: 1;
+  bottom: 0;
+  padding: 1px 7px;
+  justify-content: space-between;
 `;
 
 export default {
@@ -313,12 +177,6 @@ export default {
   Reconnecting,
   VideoContainer,
   Video,
-  Info,
-  Dropdown,
-  UserName,
-  Muted,
-  Voice,
-  DropdownTrigger,
-  PinButtonWrapper,
-  PinButton,
+  TopBar,
+  BottomBar,
 };

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.jsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+import browserInfo from '/imports/utils/browserInfo';
+import VideoService from '/imports/ui/components/video-provider/service';
+import BBBMenu from '/imports/ui/components/common/menu/component';
+import PropTypes from 'prop-types';
+import Styled from './styles';
+
+const intlMessages = defineMessages({
+  focusLabel: {
+    id: 'app.videoDock.webcamFocusLabel',
+  },
+  focusDesc: {
+    id: 'app.videoDock.webcamFocusDesc',
+  },
+  unfocusLabel: {
+    id: 'app.videoDock.webcamUnfocusLabel',
+  },
+  unfocusDesc: {
+    id: 'app.videoDock.webcamUnfocusDesc',
+  },
+  pinLabel: {
+    id: 'app.videoDock.webcamPinLabel',
+  },
+  unpinLabel: {
+    id: 'app.videoDock.webcamUnpinLabel',
+  },
+  pinDesc: {
+    id: 'app.videoDock.webcamPinDesc',
+  },
+  unpinDesc: {
+    id: 'app.videoDock.webcamUnpinDesc',
+  },
+  mirrorLabel: {
+    id: 'app.videoDock.webcamMirrorLabel',
+  },
+  mirrorDesc: {
+    id: 'app.videoDock.webcamMirrorDesc',
+  },
+});
+
+const UserActions = (props) => {
+  const {
+    name, cameraId, numOfStreams, onHandleVideoFocus, user, focused, onHandleMirror,
+  } = props;
+
+  const intl = useIntl();
+  const enableVideoMenu = Meteor.settings.public.kurento.enableVideoMenu || false;
+  const { isFirefox } = browserInfo;
+
+  const getAvailableActions = () => {
+    const pinned = user?.pin;
+    const userId = user?.userId;
+    const isPinnedIntlKey = !pinned ? 'pin' : 'unpin';
+    const isFocusedIntlKey = !focused ? 'focus' : 'unfocus';
+
+    const menuItems = [{
+      key: `${cameraId}-mirror`,
+      label: intl.formatMessage(intlMessages.mirrorLabel),
+      description: intl.formatMessage(intlMessages.mirrorDesc),
+      onClick: () => onHandleMirror(),
+    }];
+
+    if (numOfStreams > 2) {
+      menuItems.push({
+        key: `${cameraId}-focus`,
+        label: intl.formatMessage(intlMessages[`${isFocusedIntlKey}Label`]),
+        description: intl.formatMessage(intlMessages[`${isFocusedIntlKey}Desc`]),
+        onClick: () => onHandleVideoFocus(cameraId),
+      });
+    }
+
+    if (VideoService.isVideoPinEnabledForCurrentUser()) {
+      menuItems.push({
+        key: `${cameraId}-pin`,
+        label: intl.formatMessage(intlMessages[`${isPinnedIntlKey}Label`]),
+        description: intl.formatMessage(intlMessages[`${isPinnedIntlKey}Desc`]),
+        onClick: () => VideoService.toggleVideoPin(userId, pinned),
+      });
+    }
+
+    return menuItems;
+  };
+
+  return (
+    <Styled.MenuWrapper>
+      {enableVideoMenu && getAvailableActions().length >= 1
+        ? (
+          <BBBMenu
+            trigger={(
+              <Styled.DropdownTrigger
+                tabIndex={0}
+                data-test="dropdownWebcamButton"
+              >
+                {name}
+              </Styled.DropdownTrigger>
+            )}
+            actions={getAvailableActions()}
+            opts={{
+              id: 'default-dropdown-menu',
+              keepMounted: true,
+              transitionDuration: 0,
+              elevation: 3,
+              getContentAnchorEl: null,
+              fullwidth: 'true',
+              anchorOrigin: { vertical: 'bottom', horizontal: 'left' },
+              transformorigin: { vertical: 'bottom', horizontal: 'left' },
+            }}
+          />
+        )
+        : (
+          <Styled.Dropdown isFirefox={isFirefox}>
+            <Styled.UserName noMenu={numOfStreams < 3}>
+              {name}
+            </Styled.UserName>
+          </Styled.Dropdown>
+        )}
+    </Styled.MenuWrapper>
+  );
+};
+
+export default UserActions;
+
+UserActions.defaultProps = {
+  focused: false,
+};
+
+UserActions.propTypes = {
+  name: PropTypes.string.isRequired,
+  cameraId: PropTypes.string.isRequired,
+  numOfStreams: PropTypes.number.isRequired,
+  onHandleVideoFocus: PropTypes.func.isRequired,
+  user: PropTypes.shape({
+    pin: PropTypes.bool.isRequired,
+    userId: PropTypes.string.isRequired,
+  }).isRequired,
+  focused: PropTypes.bool,
+  onHandleMirror: PropTypes.func.isRequired,
+};

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/styles.js
@@ -1,0 +1,78 @@
+import styled from 'styled-components';
+import { colorOffWhite } from '/imports/ui/stylesheets/styled-components/palette';
+import { TextElipsis, DivElipsis } from '/imports/ui/stylesheets/styled-components/placeholders';
+import { landscape, mediumUp } from '/imports/ui/stylesheets/styled-components/breakpoints';
+
+const DropdownTrigger = styled(DivElipsis)`
+  position: relative;
+  // Keep the background with 0.5 opacity, but leave the text with 1
+  background-color: rgba(0, 0, 0, 0.5);
+  border-radius: 1px;
+  color: ${colorOffWhite};
+  padding: 0 1rem 0 .5rem !important;
+  font-size: 80%;
+  cursor: pointer;
+  white-space: nowrap;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &::after {
+    content: "\\203a";
+    position: absolute;
+    transform: rotate(90deg);
+    top: 45%;
+    width: 0;
+    line-height: 0;
+    right: .45rem;
+  }
+`;
+
+const UserName = styled(TextElipsis)`
+  position: relative;
+  max-width: 75%;
+  // Keep the background with 0.5 opacity, but leave the text with 1
+  background-color: rgba(0, 0, 0, 0.5);
+  border-radius: 1px;
+  color: ${colorOffWhite};
+  padding: 0 1rem 0 .5rem !important;
+  font-size: 80%;
+
+  ${({ noMenu }) => noMenu && `
+    padding: 0 .5rem 0 .5rem !important;
+  `}
+`;
+
+const Dropdown = styled.div`
+  display: flex;
+  outline: none !important;
+  width: 70%;
+
+  @media ${mediumUp} {
+    >[aria-expanded] {
+      padding: .25rem;
+    }
+  }
+
+  @media ${landscape} {
+    button {
+      width: calc(100vw - 4rem);
+      margin-left: 1rem;
+    }
+  }
+
+  ${({ isFirefox }) => isFirefox && `
+    max-width: 100%;
+  `}
+`;
+
+const MenuWrapper = styled.div`
+  max-width: 75%;
+`;
+
+export default {
+  DropdownTrigger,
+  UserName,
+  Dropdown,
+  MenuWrapper,
+};

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-status/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-status/component.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Styled from './styles';
+
+const UserStatus = (props) => {
+  const { voiceUser } = props;
+
+  const listenOnly = voiceUser?.listenOnly;
+  const muted = voiceUser?.muted;
+  const voiceUserJoined = voiceUser?.joined;
+
+  return (
+    <>
+      {(muted && !listenOnly) && <Styled.Muted iconName="unmute_filled" />}
+      {listenOnly && <Styled.Voice iconName="listen" /> }
+      {(voiceUserJoined && !muted) && <Styled.Voice iconName="unmute" />}
+    </>
+  );
+};
+
+export default UserStatus;
+
+UserStatus.defaultProps = {
+};
+
+UserStatus.propTypes = {
+  voiceUser: PropTypes.shape({
+    listenOnly: PropTypes.bool.isRequired,
+    muted: PropTypes.bool.isRequired,
+    joined: PropTypes.bool,
+  }).isRequired,
+};

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-status/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-status/styles.js
@@ -1,0 +1,39 @@
+import styled from 'styled-components';
+import Icon from '/imports/ui/components/common/icon/component';
+import { audioIndicatorFs, audioIndicatorWidth } from '/imports/ui/stylesheets/styled-components/general';
+import { colorDanger, colorSuccess, colorWhite } from '/imports/ui/stylesheets/styled-components/palette';
+
+const Voice = styled(Icon)`
+  width: ${audioIndicatorWidth};
+  height: ${audioIndicatorWidth};
+  min-width: ${audioIndicatorWidth};
+  min-height: ${audioIndicatorWidth};
+  color: ${colorWhite};
+  border-radius: 50%;
+
+  &::before {
+    font-size: ${audioIndicatorFs};
+  }
+
+  background-color: ${colorSuccess};
+`;
+
+const Muted = styled(Icon)`
+  width: ${audioIndicatorWidth};
+  height: ${audioIndicatorWidth};
+  min-width: ${audioIndicatorWidth};
+  min-height: ${audioIndicatorWidth};
+  color: ${colorWhite};
+  border-radius: 50%;
+
+  &::before {
+    font-size: ${audioIndicatorFs};
+  }
+
+  background-color: ${colorDanger};
+`;
+
+export default {
+  Voice,
+  Muted,
+};

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/view-actions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/view-actions/component.jsx
@@ -1,0 +1,55 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { ACTIONS } from '/imports/ui/components/layout/enums';
+import FullscreenButtonContainer from '/imports/ui/components/common/fullscreen-button/container';
+import Styled from './styles';
+
+const ViewActions = (props) => {
+  const {
+    name, cameraId, videoContainer, isFullscreenContext, layoutContextDispatch,
+  } = props;
+
+  const ALLOW_FULLSCREEN = Meteor.settings.public.app.allowFullscreen;
+
+  useEffect(() => () => {
+    // exit fullscreen when component is unmounted
+    if (isFullscreenContext) {
+      layoutContextDispatch({
+        type: ACTIONS.SET_FULLSCREEN_ELEMENT,
+        value: {
+          element: '',
+          group: '',
+        },
+      });
+    }
+  }, []);
+
+  if (!ALLOW_FULLSCREEN) return null;
+
+  return (
+    <Styled.FullscreenWrapper>
+      <FullscreenButtonContainer
+        data-test="webcamsFullscreenButton"
+        fullscreenRef={videoContainer.current}
+        elementName={name}
+        elementId={cameraId}
+        elementGroup="webcams"
+        isFullscreen={isFullscreenContext}
+        dark
+      />
+    </Styled.FullscreenWrapper>
+  );
+};
+
+export default ViewActions;
+
+ViewActions.propTypes = {
+  name: PropTypes.string.isRequired,
+  cameraId: PropTypes.string.isRequired,
+  videoContainer: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]).isRequired,
+  isFullscreenContext: PropTypes.bool.isRequired,
+  layoutContextDispatch: PropTypes.func.isRequired,
+};

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/view-actions/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/view-actions/styles.js
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+const FullscreenWrapper = styled.div`
+  position: relative;
+`;
+
+export default {
+  FullscreenWrapper,
+};


### PR DESCRIPTION
### What does this PR do?
- This PR is directly linked to the third item in this issue https://github.com/bigbluebutton/bigbluebutton/issues/12954
- Provides a solution by refactoring the `UI code (video list rendering, video container rendering, BBB UI state tracking, ...)`

With this new approach proposed by this PR, the main component (video-list-item) was divided into 4 other components, where each of them has its own responsibility.

- **Video List Item:** responsible only for the video. It acts as the parent of the smaller components:
  - **View Actions:** top right corner area. It has fullscreen controls and other visualization-related buttons.
  - **Pin Area:** top left corner area. It has the icon to unpin the user.
  - **User Actions:** bottom left corner area. It has the user dropdown and the logic involved in them. Focus trigger, Mirror trigger, Pin trigger.
  - **User Status:** bottom right corner area. Has microphone status icons: Listen Only, Muted
 
 <p align=center>
<img src=https://user-images.githubusercontent.com/42683590/159970954-37a7d200-3cbd-46ed-8ff9-18be2d289b69.png width=50%/>
</p>

![image](https://user-images.githubusercontent.com/42683590/159971346-fd45fc98-e007-45a6-a9b9-8ad1cf201b3f.png)

