### PR TITLE
fix(video): improvements to dynamic camera profiles

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -30,7 +30,11 @@ const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 const ROLE_VIEWER = Meteor.settings.public.user.role_viewer;
 const MIRROR_WEBCAM = Meteor.settings.public.app.mirrorOwnWebcam;
 const PIN_WEBCAM = Meteor.settings.public.kurento.enableVideoPin;
-const CAMERA_QUALITY_THRESHOLDS = Meteor.settings.public.kurento.cameraQualityThresholds.thresholds || [];
+const {
+  thresholds: CAMERA_QUALITY_THRESHOLDS = [],
+  applyConstraints: CAMERA_QUALITY_THR_CONSTRAINTS = false,
+  debounceTime: CAMERA_QUALITY_THR_DEBOUNCE = 2500,
+} = Meteor.settings.public.kurento.cameraQualityThresholds;
 const {
   paginationToggleEnabled: PAGINATION_TOGGLE_ENABLED,
   pageChangeDebounceTime: PAGE_CHANGE_DEBOUNCE_TIME,
@@ -825,59 +829,58 @@ class VideoService {
       return {
         ...constraints,
         width: trackSettings.width,
-        height: trackSettings.height
+        height: trackSettings.height,
       };
-    } else {
-      return constraints;
     }
+
+    return constraints;
   }
 
   applyCameraProfile (peer, profileId) {
-    const profile = CAMERA_PROFILES.find(targetProfile => targetProfile.id === profileId);
+    const profile = CAMERA_PROFILES.find((targetProfile) => targetProfile.id === profileId);
 
-    if (!profile) {
-      logger.warn({
-        logCode: 'video_provider_noprofile',
-        extraInfo: { profileId },
-      }, `Apply failed: no camera profile found.`);
-      return;
-    }
-
-    // Profile is currently applied or it's better than the original user's profile,
-    // skip
-    if (peer.currentProfileId === profileId
+    // When this should be skipped:
+    // 1 - Badly defined profile
+    // 2 - Badly defined peer (ie {})
+    // 3 - The target profile is already applied
+    // 4 - The targetr profile is better than the original profile
+    if (!profile
+      || peer == null
+      || peer.peerConnection == null
+      || peer.currentProfileId === profileId
       || this.isProfileBetter(profileId, peer.originalProfileId)) {
       return;
     }
 
     const { bitrate, constraints } = profile;
 
-    if (bitrate) {
-      this.applyBitrate(peer, bitrate);
-    }
+    if (bitrate) this.applyBitrate(peer, bitrate);
 
-    if (constraints && typeof constraints === 'object') {
-      peer.peerConnection.getSenders().forEach(sender => {
+    if (CAMERA_QUALITY_THR_CONSTRAINTS
+      && constraints
+      && typeof constraints === 'object'
+    ) {
+      peer.peerConnection.getSenders().forEach((sender) => {
         const { track } = sender;
-        if (track && track.kind === 'video' && typeof track.applyConstraints  === 'function') {
-          let normalizedVideoConstraints = this.reapplyResolutionIfNeeded(track, constraints);
+        if (track && track.kind === 'video' && typeof track.applyConstraints === 'function') {
+          const normalizedVideoConstraints = this.reapplyResolutionIfNeeded(track, constraints);
           track.applyConstraints(normalizedVideoConstraints)
-            .then(() => {
-              logger.info({
-                logCode: 'video_provider_profile_applied',
-                extraInfo: { profileId },
-              }, `New camera profile applied: ${profileId}`);
-              peer.currentProfileId = profileId;
-            })
-            .catch(error => {
+            .catch((error) => {
               logger.warn({
-                logCode: 'video_provider_profile_apply_failed',
+                logCode: 'video_provider_constraintchange_failed',
                 extraInfo: { errorName: error.name, errorCode: error.code },
               }, 'Error applying camera profile');
             });
         }
       });
     }
+
+    logger.info({
+      logCode: 'video_provider_profile_applied',
+      extraInfo: { profileId },
+    }, `New camera profile applied: ${profileId}`);
+
+    peer.currentProfileId = profileId;
   }
 
   getThreshold (numberOfPublishers) {
@@ -998,7 +1001,11 @@ export default {
   onBeforeUnload: () => videoService.onBeforeUnload(),
   notify: message => notify(message, 'error', 'video'),
   updateNumberOfDevices: devices => videoService.updateNumberOfDevices(devices),
-  applyCameraProfile: (peer, newProfile) => videoService.applyCameraProfile(peer, newProfile),
+  applyCameraProfile: _.debounce(
+    videoService.applyCameraProfile.bind(videoService),
+    CAMERA_QUALITY_THR_DEBOUNCE,
+    { leading: false, trailing: true },
+  ),
   getThreshold: (numberOfPublishers) => videoService.getThreshold(numberOfPublishers),
   isPaginationEnabled: () => videoService.isPaginationEnabled(),
   getNumberOfPages: () => videoService.getNumberOfPages(),

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -363,6 +363,8 @@ public:
     #            that will be applied to all cameras when threshold is hit
     cameraQualityThresholds:
       enabled: true
+      applyConstraints: false
+      debounceTime: 2500
       thresholds:
         - threshold: 8
           profile: low-u8

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -321,6 +321,7 @@ public:
         bitrate: 500
         constraints:
           width: 1280
+          height: 720
           frameRate: 15
       - id: hd
         name: High definition
@@ -328,6 +329,7 @@ public:
         bitrate: 800
         constraints:
           width: 1280
+          height: 720
           frameRate: 30
     enableScreensharing: true
     enableVideo: true

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -363,7 +363,11 @@ public:
     #            that will be applied to all cameras when threshold is hit
     cameraQualityThresholds:
       enabled: true
+      # applyConstraints: whether profile constraints should be applied on profile changes
       applyConstraints: false
+      # privilegedStreams: whether cameras should revert to their original profile on
+      # certain actions (eg floor changes, pin)
+      privilegedStreams: true
       debounceTime: 2500
       thresholds:
         - threshold: 8

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -275,38 +275,26 @@ public:
         name: low-u30
         bitrate: 30
         hidden: true
-        constraints:
-          frameRate: 3
       - id: low-u25
         name: low-u25
         bitrate: 40
         hidden: true
-        constraints:
-          frameRate: 3
       - id: low-u20
         name: low-u20
         bitrate: 50
         hidden: true
-        constraints:
-          frameRate: 5
       - id: low-u15
         name: low-u15
         bitrate: 70
         hidden: true
-        constraints:
-          frameRate: 8
       - id: low-u12
         name: low-u12
         bitrate: 90
         hidden: true
-        constraints:
-          frameRate: 10
       - id: low-u8
         name: low-u8
         bitrate: 100
         hidden: true
-        constraints:
-          frameRate: 10
       - id: low
         name: Low
         default: false


### PR DESCRIPTION
### What does this PR do?

- Backports https://github.com/bigbluebutton/bigbluebutton/pull/14513 from 2.5
- fix(video): add debounce and option to exclude constraints from dynamic camera profiles
  * Tries to mitigate too-rapidly-switching camera profiles causing video freezes due to encoder resets. 
  * Excluding constraints might not help a lot since the thing that actually restarts the encoder is the bitrate change, but they're not really important in the context of dynamic profiles. We can't get rid of bitrate changes, though, since it's what does the actual quality constraining.
  * The camera profile change debounce timer is 2.5s by default (which is the same timer used for floor changes).
- Fixed an issue with camera profile changes backfiring due to badly defined peers
- feat(video): add flag to disable quality change exemptions (floor, pin)
  * Still on by default
- refactor(video): remove frameRate constraints from quality control profiles
  * Rationale: the important thing here is bitrate. Disabling constraints should have no meaningful on 1) client-side bw 2) client-side cpu 3) server-side bw/cpu - while it will also guarantee seemingly smoother streams

### Closes Issue(s)

Closes #14580

### More

I noticed the first encoder reset/profile change is the one that actually makes the camera stutter more noticeably. Subsequent switches aren't really noticeable. I might revisit this very soon to see if I can make the initial constraint application dynamic - after getUserMedia _and_ before sending the offer to the server. That might conceal the problem in #14580 for good.
