### PR TITLE
fix: Do not display data saving toggles when features are disabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/component.jsx
@@ -105,7 +105,7 @@ class Settings extends Component {
     super(props);
 
     const {
-      dataSaving, application, selectedTab
+      dataSaving, application, selectedTab,
     } = props;
 
     this.state = {
@@ -117,7 +117,7 @@ class Settings extends Component {
         dataSaving: _.clone(dataSaving),
         application: _.clone(application),
       },
-      selectedTab: _.isFinite(selectedTab) && selectedTab >=0 && selectedTab <= 2
+      selectedTab: _.isFinite(selectedTab) && selectedTab >= 0 && selectedTab <= 2
         ? selectedTab
         : 0,
     };
@@ -167,6 +167,8 @@ class Settings extends Component {
       showToggleLabel,
       layoutContextDispatch,
       selectedLayout,
+      isScreenSharingEnabled,
+      isVideoEnabled,
     } = this.props;
 
     const {
@@ -174,6 +176,8 @@ class Settings extends Component {
       current,
       allLocales,
     } = this.state;
+
+    const isDataSavingTabEnabled = isScreenSharingEnabled || isVideoEnabled;
 
     return (
       <Styled.SettingsTabs
@@ -195,13 +199,17 @@ class Settings extends Component {
             <Styled.SettingsIcon iconName="alert" />
             <span id="notificationTab">{intl.formatMessage(intlMessages.notificationLabel)}</span>
           </Styled.SettingsTabSelector>
-          <Styled.SettingsTabSelector
-            aria-labelledby="dataSavingTab"
-            selectedClassName="is-selected"
-          >
-            <Styled.SettingsIcon iconName="network" />
-            <span id="dataSaving">{intl.formatMessage(intlMessages.dataSavingLabel)}</span>
-          </Styled.SettingsTabSelector>
+          {isDataSavingTabEnabled
+            ? (
+              <Styled.SettingsTabSelector
+                aria-labelledby="dataSavingTab"
+                selectedClassName="is-selected"
+              >
+                <Styled.SettingsIcon iconName="network" />
+                <span id="dataSaving">{intl.formatMessage(intlMessages.dataSavingLabel)}</span>
+              </Styled.SettingsTabSelector>
+            )
+            : null}
         </Styled.SettingsTabList>
         <Styled.SettingsTabPanel selectedClassName="is-selected">
           <Application
@@ -225,14 +233,20 @@ class Settings extends Component {
             {...{ isModerator }}
           />
         </Styled.SettingsTabPanel>
-        <Styled.SettingsTabPanel selectedClassName="is-selected">
-          <DataSaving
-            settings={current.dataSaving}
-            handleUpdateSettings={this.handleUpdateSettings}
-            showToggleLabel={showToggleLabel}
-            displaySettingsStatus={this.displaySettingsStatus}
-          />
-        </Styled.SettingsTabPanel>
+        {isDataSavingTabEnabled
+          ? (
+            <Styled.SettingsTabPanel selectedClassName="is-selected">
+              <DataSaving
+                settings={current.dataSaving}
+                handleUpdateSettings={this.handleUpdateSettings}
+                showToggleLabel={showToggleLabel}
+                displaySettingsStatus={this.displaySettingsStatus}
+                isScreenSharingEnabled={isScreenSharingEnabled}
+                isVideoEnabled={isVideoEnabled}
+              />
+            </Styled.SettingsTabPanel>
+          )
+          : null}
       </Styled.SettingsTabs>
     );
   }
@@ -252,7 +266,7 @@ class Settings extends Component {
         confirm={{
           callback: () => {
             this.updateSettings(current, intl.formatMessage(intlMessages.savedAlertLabel));
-            document.body.classList.remove(`lang-${saved.application.locale.split('-')[0]}`)
+            document.body.classList.remove(`lang-${saved.application.locale.split('-')[0]}`);
             document.body.classList.add(`lang-${current.application.locale.split('-')[0]}`);
             document.getElementsByTagName('html')[0].lang = current.application.locale;
             /* We need to use mountModal(null) here to prevent submenu state updates,

--- a/bigbluebutton-html5/imports/ui/components/settings/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/container.jsx
@@ -3,6 +3,7 @@ import { withTracker } from 'meteor/react-meteor-data';
 import SettingsService from '/imports/ui/services/settings';
 import Settings from './component';
 import { layoutDispatch } from '../layout/context';
+import { isScreenSharingEnabled } from '/imports/ui/services/features';
 
 import {
   getUserRoles,
@@ -27,4 +28,6 @@ export default withTracker((props) => ({
   isModerator: getUserRoles() === 'MODERATOR',
   showGuestNotification: showGuestNotification(),
   showToggleLabel: false,
+  isScreenSharingEnabled: isScreenSharingEnabled(),
+  isVideoEnabled: Meteor.settings.public.kurento.enableVideo,
 }))(SettingsContainer);

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/data-saving/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/data-saving/component.jsx
@@ -34,7 +34,13 @@ class DataSaving extends BaseMenu {
   }
 
   render() {
-    const { intl, showToggleLabel, displaySettingsStatus } = this.props;
+    const {
+      intl,
+      showToggleLabel,
+      displaySettingsStatus,
+      isScreenSharingEnabled,
+      isVideoEnabled,
+    } = this.props;
 
     const { viewParticipantsWebcams, viewScreenshare } = this.state.settings;
 
@@ -45,50 +51,58 @@ class DataSaving extends BaseMenu {
           <Styled.SubTitle>{intl.formatMessage(intlMessages.dataSavingDesc)}</Styled.SubTitle>
         </div>
         <Styled.Form>
-          <Styled.Row>
-            <Styled.Col aria-hidden="true">
-              <Styled.FormElement>
-                <Styled.Label>
-                  {intl.formatMessage(intlMessages.webcamLabel)}
-                </Styled.Label>
-              </Styled.FormElement>
-            </Styled.Col>
-            <Styled.Col>
-              <Styled.FormElementRight>
-                {displaySettingsStatus(viewParticipantsWebcams)}
-                <Toggle
-                  icons={false}
-                  defaultChecked={viewParticipantsWebcams}
-                  onChange={() => this.handleToggle('viewParticipantsWebcams')}
-                  ariaLabelledBy="webcamToggle"
-                  ariaLabel={intl.formatMessage(intlMessages.webcamLabel)}
-                  showToggleLabel={showToggleLabel}
-                />
-              </Styled.FormElementRight>
-            </Styled.Col>
-          </Styled.Row>
-          <Styled.Row>
-            <Styled.Col aria-hidden="true">
-              <Styled.FormElement>
-                <Styled.Label>
-                  {intl.formatMessage(intlMessages.screenShareLabel)}
-                </Styled.Label>
-              </Styled.FormElement>
-            </Styled.Col>
-            <Styled.Col>
-              <Styled.FormElementRight>
-                {displaySettingsStatus(viewScreenshare)}
-                <Toggle
-                  icons={false}
-                  defaultChecked={viewScreenshare}
-                  onChange={() => this.handleToggle('viewScreenshare')}
-                  ariaLabelledBy="screenShare"
-                  ariaLabel={intl.formatMessage(intlMessages.screenShareLabel)}
-                  showToggleLabel={showToggleLabel}
-                />
-              </Styled.FormElementRight>
-            </Styled.Col>
-          </Styled.Row>
+          {isVideoEnabled
+            ? (
+              <Styled.Row>
+                <Styled.Col aria-hidden="true">
+                  <Styled.FormElement>
+                    <Styled.Label>
+                      {intl.formatMessage(intlMessages.webcamLabel)}
+                    </Styled.Label>
+                  </Styled.FormElement>
+                </Styled.Col>
+                <Styled.Col>
+                  <Styled.FormElementRight>
+                    {displaySettingsStatus(viewParticipantsWebcams)}
+                    <Toggle
+                      icons={false}
+                      defaultChecked={viewParticipantsWebcams}
+                      onChange={() => this.handleToggle('viewParticipantsWebcams')}
+                      ariaLabelledBy="webcamToggle"
+                      ariaLabel={intl.formatMessage(intlMessages.webcamLabel)}
+                      showToggleLabel={showToggleLabel}
+                    />
+                  </Styled.FormElementRight>
+                </Styled.Col>
+              </Styled.Row>
+            )
+            : null}
+          {isScreenSharingEnabled
+            ? (
+              <Styled.Row>
+                <Styled.Col aria-hidden="true">
+                  <Styled.FormElement>
+                    <Styled.Label>
+                      {intl.formatMessage(intlMessages.screenShareLabel)}
+                    </Styled.Label>
+                  </Styled.FormElement>
+                </Styled.Col>
+                <Styled.Col>
+                  <Styled.FormElementRight>
+                    {displaySettingsStatus(viewScreenshare)}
+                    <Toggle
+                      icons={false}
+                      defaultChecked={viewScreenshare}
+                      onChange={() => this.handleToggle('viewScreenshare')}
+                      ariaLabelledBy="screenShare"
+                      ariaLabel={intl.formatMessage(intlMessages.screenShareLabel)}
+                      showToggleLabel={showToggleLabel}
+                    />
+                  </Styled.FormElementRight>
+                </Styled.Col>
+              </Styled.Row>
+            )
+            : null}
         </Styled.Form>
       </div>
     );


### PR DESCRIPTION
### What does this PR do?

Hides screensharing/webcam data saving toggle switches in settings menu when the features are disabled.
Hides Data Savings tab if both `enableScreensharing` and `enableVideo` are set to **false**.

### Closes Issue(s)
Closes #10813