### PR TITLE
fix: Adds 'current' as optional parameter of the internal upload endpoint

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/PresentationController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/PresentationController.groovy
@@ -109,6 +109,14 @@ class PresentationController {
 
     def isDownloadable = params.boolean('is_downloadable') //instead of params.is_downloadable
     def podId = params.pod_id
+
+    // Defaults current to false (optional upload parameter)
+    def current = false
+    
+    if (null != params.current) {
+      current = params.current.toBoolean()
+    }
+    
     log.debug "@Default presentation pod" + podId
 
     def uploadFailed = false
@@ -155,7 +163,7 @@ class PresentationController {
             presId,
             presFilename,
             presentationBaseUrl,
-            false /* default presentation */,
+            current,
             params.authzToken,
             uploadFailed,
             uploadFailReasons


### PR DESCRIPTION
### What does this PR do?
Adds `current` as an optional parameter when using the internal endpoint to upload files.

```javascript
...

  formData.append('is_downloadable', false);
  formData.append('current', true); // This will set the file attached below as the one to be displayed
  formData.append('fileUpload', file);

...
```
This avoids the need of waiting for the upload to finish, getting the generated ID of the latest presentation, and making a `setPresentation` call with the corresponding `presId` and `podId`.

### Motivation
For features such as PR #14585, users expect to see the shared notes being quickly uploaded and with as little manual intervention as possible.

The `insertDocument` API call already supports `current=true`, this PR adds the equivalent option internally.

### More
The attribute is entirely optional. Existing implementations using the upload endpoint will continue to default `current` as `false`.