### PR TITLE
Implements a progress bar on external video for viewers.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
@@ -77,6 +77,8 @@ class VideoPlayer extends Component {
       volume: 1,
       playbackRate: 1,
       key: 0,
+      played:0,
+      loaded:0,
     };
 
     this.hideVolume = {
@@ -299,11 +301,15 @@ class VideoPlayer extends Component {
     }
   }
 
-  handleOnProgress() {
+  handleOnProgress(data) {
     const { mutedByEchoTest } = this.state;
 
     const volume = this.getCurrentVolume();
     const muted = this.getMuted();
+
+    const { played, loaded } = data;
+
+    this.setState({played, loaded});
 
     if (!mutedByEchoTest) {
       this.setState({ volume, muted });
@@ -547,7 +553,7 @@ class VideoPlayer extends Component {
 
     const {
       playing, playbackRate, mutedByEchoTest, autoPlayBlocked,
-      volume, muted, key, showHoverToolBar,
+      volume, muted, key, showHoverToolBar, played, loaded
     } = this.state;
 
     // This looks weird, but I need to get this nested player
@@ -615,6 +621,20 @@ class VideoPlayer extends Component {
           {
             !isPresenter
               ? [
+                (
+                  <div className={styles.progressBar}>
+                    <div 
+                      className={styles.loaded}
+                      style={{ width: loaded * 100 + '%' }}
+                      >
+                      <div
+                        className={styles.played}
+                        style={{ width: played * 100 / loaded + '%'}}
+                      >
+                      </div>
+                    </div>
+                  </div>
+                ),
                 (
                   <div className={hoverToolbarStyle} key="hover-toolbar-external-video">
                     <VolumeSlider

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/styles.scss
@@ -69,3 +69,28 @@
   text-align: center;
   pointer-events: none;
 }
+
+.progressBar {
+  display: none;
+
+  :hover > & {
+    display: block;
+  }
+
+  height: 5px;
+  width: 100%;
+
+  background-color: transparent;   
+}
+
+.loaded {
+  height: 100%;
+
+  background-color: gray;
+}
+
+.played {
+  height: 100%;
+ 
+  background-color: #DF2721;
+}


### PR DESCRIPTION
The viewer can't see if the shared video is ending or in the middle.
![IMG-20220317-WA0009(1)](https://user-images.githubusercontent.com/19312495/158865684-bb0ef6f4-d482-4ab2-849f-223c2bc9c8e1.jpg)


This PR adds a progress bar for the viewers, so they can follow the progress of the video.
![IMG-20220317-WA0008(1)](https://user-images.githubusercontent.com/19312495/158865943-726d2880-32c5-4707-ae98-cb0aacf8cd3b.jpg)

