### PR TITLE
build(etherpad): forbid userName argument

### DIFF
--- a/build/packages-template/bbb-etherpad/notes.nginx
+++ b/build/packages-template/bbb-etherpad/notes.nginx
@@ -1,5 +1,10 @@
 # https://github.com/ether/etherpad-lite/wiki/How-to-put-Etherpad-Lite-behind-a-reverse-Proxy
 location /pad/p/ {
+    # Avoid setting the user name from the embedded URL
+    if ($arg_userName) {
+        return 401;
+    }
+
     rewrite /pad/p/(.*) /p/$1 break;
     rewrite ^/pad/p$ /pad/p/ permanent;
     proxy_pass http://127.0.0.1:9001/p;


### PR DESCRIPTION
### What does this PR do?

Use nginx rules to block an access attempt that contains the userName argument.

### Motivation

Since bbb-pads user's name is set internally by akka-apps and bbb-pads internal
credentials exchange. Yet, Etherpad's embedded URL params still work and the user
could use it to ovewrite.

### More

Kudos @fcecagno for the **arg** suggestion.