### PR TITLE
build: do not remove /usr/share/bigbluebutton/nginx/web on upgrade

### DIFF
--- a/build/packages-template/bbb-web/after-remove.sh
+++ b/build/packages-template/bbb-web/after-remove.sh
@@ -1,4 +1,3 @@
 #!/bin/bash -e
 
 rm -f /usr/share/bigbluebutton/nginx/bbb-web.nginx
-rm -f /usr/share/bigbluebutton/nginx/web


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
No longer deletes `/usr/share/bigbluebutton/nginx/web` on bbb-web` upgrade (the file was not replaced)
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none


### Motivation
After `bbb-web` rebuild, we were missing `/usr/share/bigbluebutton/nginx/web` which is needed for a link to web.nginx
<!-- What inspired you to submit this pull request? -->

### More
This is a follow up from overzealous https://github.com/bigbluebutton/bigbluebutton/pull/14600
<!-- Anything else we should know when reviewing? -->

