### PR TITLE
fix: external video is not displayed to new users - smart layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
@@ -21,6 +21,8 @@ const LayoutEngine = ({ layoutType }) => {
   const actionbarInput = layoutSelectInput((i) => i.actionBar);
   const sidebarNavigationInput = layoutSelectInput((i) => i.sidebarNavigation);
   const sidebarContentInput = layoutSelectInput((i) => i.sidebarContent);
+  const externalVideoInput = layoutSelectInput((i) => i.externalVideo);
+  const screenShareInput = layoutSelectInput((i) => i.screenShare);
 
   const fullscreen = layoutSelect((i) => i.fullscreen);
   const isRTL = layoutSelect((i) => i.isRTL);
@@ -46,6 +48,8 @@ const LayoutEngine = ({ layoutType }) => {
   const baseCameraDockBounds = (mediaAreaBounds, sidebarSize) => {
     const { isOpen, currentSlide } = presentationInput;
     const { num: currentSlideNumber } = currentSlide;
+    const { hasExternalVideo } = externalVideoInput;
+    const { hasScreenShare } = screenShareInput;
 
     const cameraDockBounds = {};
 
@@ -58,7 +62,7 @@ const LayoutEngine = ({ layoutType }) => {
 
     const isSmartLayout = (layoutType === LAYOUT_TYPE.SMART_LAYOUT);
 
-    if (!isOpen || (isSmartLayout && currentSlideNumber === 0)) {
+    if (!isOpen || (isSmartLayout && currentSlideNumber === 0 && !hasExternalVideo && !hasScreenShare)) {
       cameraDockBounds.width = mediaAreaBounds.width;
       cameraDockBounds.maxWidth = mediaAreaBounds.width;
       cameraDockBounds.height = mediaAreaBounds.height - bannerAreaHeight();

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -119,6 +119,12 @@ const SmartLayout = (props) => {
           cameraDock: {
             numCameras: cameraDockInput.numCameras,
           },
+          externalVideo: {
+            hasExternalVideo: externalVideoInput.hasExternalVideo,
+          },
+          screenShare: {
+            hasScreenShare: screenShareInput.hasScreenShare,
+          }
         }, INITIAL_INPUT_STATE),
       });
     }
@@ -226,7 +232,7 @@ const SmartLayout = (props) => {
     const { element: fullscreenElement } = fullscreen;
     const { num: currentSlideNumber } = currentSlide;
 
-    if (!isOpen || currentSlideNumber === 0) {
+    if (!isOpen || (currentSlideNumber === 0 && !hasExternalVideo && !hasScreenShare)) {
       mediaBounds.width = 0;
       mediaBounds.height = 0;
       mediaBounds.top = 0;


### PR DESCRIPTION
### What does this PR do?

Prevents an issue where external video / screenshare does not appear to a user that joins after video is shared.

### Closes Issue(s)
Closes #14617