### PR TITLE
fix(audio): clean up sfu broker, guarantee peer exists in getLocalStream

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/FullAudioBridge.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/FullAudioBridge.js
@@ -412,8 +412,9 @@ export default class FullAudioBridge extends BaseAudioBridge {
   exitAudio() {
     const mediaElement = document.getElementById(MEDIA_TAG);
 
-    this.broker.stop();
     this.clearReconnectionTimeout();
+    this.broker.stop();
+    this.broker = null;
 
     if (mediaElement && typeof mediaElement.pause === 'function') {
       mediaElement.pause();

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/fullaudio-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/fullaudio-broker.js
@@ -23,7 +23,7 @@ class FullAudioBroker extends BaseBroker {
   }
 
   getLocalStream() {
-    if (this.webRtcPeer.peerConnection) {
+    if (this.webRtcPeer && this.webRtcPeer.peerConnection) {
       return this.webRtcPeer.peerConnection.getLocalStreams()[0];
     }
 


### PR DESCRIPTION
### What does this PR do?

- Properly clean up SFU audio broker in its bridge when it's stopped
- Guarantee that the peer connection exists before trying to access SFU's audio broker local stream

### Closes Issue(s)

None

### Motivation

Re-connections could occasionally fail due to old brokers being erroneously carried over to new connections.

### More

n/a
