### PR TITLE
fix(waiting-users): button cropped

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
@@ -288,16 +288,14 @@ const WaitingUsers = (props) => {
             </p>
           </div>
         ) : null}
-        <div>
-          <div>
-            <p className={styles.mainTitle}>{intl.formatMessage(intlMessages.optionTitle)}</p>
-            {
-              buttonsData.map((buttonData) => renderButton(
-                intl.formatMessage(buttonData.messageId),
-                buttonData,
-              ))
-            }
-          </div>
+        <div className={styles.moderatorActions}>
+          <p className={styles.mainTitle}>{intl.formatMessage(intlMessages.optionTitle)}</p>
+          {
+            buttonsData.map((buttonData) => renderButton(
+              intl.formatMessage(buttonData.messageId),
+              buttonData,
+            ))
+          }
 
           {allowRememberChoice ? (
             <div className={styles.rememberContainer}>

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/styles.scss
@@ -87,6 +87,12 @@
   margin: .3rem 0;
   font-weight: 400;
   font-size: var(--font-size-base);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.moderatorActions {
+  padding: 0 .2rem;
 }
 
 .mainTitle {


### PR DESCRIPTION
### What does this PR do?

Add a padding in order to avoid cropped "onFocus"
Add an overflow property in order to avoid horizontal scrollbar

Before:
![image](https://user-images.githubusercontent.com/42683590/158862660-21a55960-45a1-4222-996c-b505d3c01cdd.png)

After:
![image](https://user-images.githubusercontent.com/42683590/158862769-362ee5ba-5ab7-4618-87fd-923d196c7ba3.png)


### Closes Issue(s)
Closes https://github.com/bigbluebutton/bigbluebutton/issues/14619