### PR TITLE
build: bump bbb-webrtc-sfu to v2.6.11

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.6.10 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.6.11 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
Bump bbb-webrtc-sfu to [v2.6.11](https://github.com/bigbluebutton/bbb-webrtc-sfu/releases/tag/v2.6.11)
