### PR TITLE
build: bump bbb-webrtc-sfu to v2.7.1

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.7.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.7.1 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
Bump bbb-webrtc-sfu to [v2.7.1](https://github.com/bigbluebutton/bbb-webrtc-sfu/releases/tag/v2.7.1)
