### PR TITLE
feat: Implements param lockSettingsHideViewersCursor (Backend only)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadCreateGroupReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadCreateGroupReqMsgHdlr.scala
@@ -22,9 +22,9 @@ trait PadCreateGroupReqMsgHdlr {
     }
 
     val padEnabled = msg.body.model match {
-      case "notes" => !liveMeeting.props.meetingProp.disabledFeatures.contains("sharedNotes")
+      case "notes"    => !liveMeeting.props.meetingProp.disabledFeatures.contains("sharedNotes")
       case "captions" => !liveMeeting.props.meetingProp.disabledFeatures.contains("captions")
-      case _ => false
+      case _          => false
     }
 
     if (padEnabled && !Pads.hasGroup(liveMeeting.pads, msg.body.externalId)) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
@@ -29,7 +29,8 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
         hideUserList = msg.body.hideUserList,
         lockedLayout = msg.body.lockedLayout,
         lockOnJoin = msg.body.lockOnJoin,
-        lockOnJoinConfigurable = msg.body.lockOnJoinConfigurable
+        lockOnJoinConfigurable = msg.body.lockOnJoinConfigurable,
+        hideViewersCursor = msg.body.hideViewersCursor
       )
 
       if (!MeetingStatus2x.permissionsEqual(liveMeeting.status, settings) || !MeetingStatus2x.permisionsInitialized(liveMeeting.status)) {
@@ -67,6 +68,7 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
           lockedLayout = settings.lockedLayout,
           lockOnJoin = settings.lockOnJoin,
           lockOnJoinConfigurable = settings.lockOnJoinConfigurable,
+          hideViewersCursor = settings.hideViewersCursor,
           msg.body.setBy
         )
         val header = BbbClientMsgHeader(

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetLockSettingsReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetLockSettingsReqMsgHdlr.scala
@@ -24,7 +24,8 @@ trait GetLockSettingsReqMsgHdlr {
       hideUserList = settings.hideUserList,
       lockedLayout = settings.lockedLayout,
       lockOnJoin = settings.lockOnJoin,
-      lockOnJoinConfigurable = settings.lockOnJoinConfigurable
+      lockOnJoinConfigurable = settings.lockOnJoinConfigurable,
+      hideViewersCursor = settings.hideViewersCursor
     )
     val header = BbbClientMsgHeader(GetLockSettingsRespMsg.NAME, meetingId, requestedBy)
     val event = GetLockSettingsRespMsg(header, body)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -297,7 +297,8 @@ class MeetingActor(
       hideUserList = lockSettingsProp.hideUserList,
       lockedLayout = lockSettingsProp.lockedLayout,
       lockOnJoin = lockSettingsProp.lockOnJoin,
-      lockOnJoinConfigurable = lockSettingsProp.lockOnJoinConfigurable
+      lockOnJoinConfigurable = lockSettingsProp.lockOnJoinConfigurable,
+      hideViewersCursor = lockSettingsProp.hideViewersCursor
     )
 
     MeetingStatus2x.initializePermissions(liveMeeting.status)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/MeetingStatus2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/MeetingStatus2x.scala
@@ -13,7 +13,8 @@ case class Permissions(
     hideUserList:           Boolean = false,
     lockedLayout:           Boolean = false,
     lockOnJoin:             Boolean = true,
-    lockOnJoinConfigurable: Boolean = false
+    lockOnJoinConfigurable: Boolean = false,
+    hideViewersCursor:      Boolean = false
 )
 
 case class MeetingExtensionProp(maxExtensions: Int = 2, numExtensions: Int = 0, extendByMinutes: Int = 20,

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
@@ -59,7 +59,8 @@ case class LockSettingsProps(
     hideUserList:           Boolean,
     lockedLayout:           Boolean,
     lockOnJoin:             Boolean,
-    lockOnJoinConfigurable: Boolean
+    lockOnJoinConfigurable: Boolean,
+    hideViewersCursor:      Boolean
 )
 
 case class SystemProps(

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
@@ -253,7 +253,7 @@ case class ChangeLockSettingsInMeetingCmdMsg(
 ) extends StandardMsg
 case class ChangeLockSettingsInMeetingCmdMsgBody(disableCam: Boolean, disableMic: Boolean, disablePrivChat: Boolean,
                                                  disablePubChat: Boolean, disableNotes: Boolean, hideUserList: Boolean, lockedLayout: Boolean, lockOnJoin: Boolean,
-                                                 lockOnJoinConfigurable: Boolean, setBy: String)
+                                                 lockOnJoinConfigurable: Boolean, hideViewersCursor: Boolean, setBy: String)
 
 object LockSettingsInMeetingChangedEvtMsg { val NAME = "LockSettingsInMeetingChangedEvtMsg" }
 case class LockSettingsInMeetingChangedEvtMsg(
@@ -262,7 +262,7 @@ case class LockSettingsInMeetingChangedEvtMsg(
 ) extends BbbCoreMsg
 case class LockSettingsInMeetingChangedEvtMsgBody(disableCam: Boolean, disableMic: Boolean, disablePrivChat: Boolean,
                                                   disablePubChat: Boolean, disableNotes: Boolean, hideUserList: Boolean, lockedLayout: Boolean, lockOnJoin: Boolean,
-                                                  lockOnJoinConfigurable: Boolean, setBy: String)
+                                                  lockOnJoinConfigurable: Boolean, hideViewersCursor: Boolean, setBy: String)
 
 /**
  * Sent by client to query the lock settings.
@@ -278,7 +278,7 @@ object GetLockSettingsRespMsg { val NAME = "GetLockSettingsRespMsg" }
 case class GetLockSettingsRespMsg(header: BbbClientMsgHeader, body: GetLockSettingsRespMsgBody) extends BbbCoreMsg
 case class GetLockSettingsRespMsgBody(disableCam: Boolean, disableMic: Boolean, disablePrivChat: Boolean,
                                       disablePubChat: Boolean, disableNotes: Boolean, hideUserList: Boolean, lockedLayout: Boolean, lockOnJoin: Boolean,
-                                      lockOnJoinConfigurable: Boolean)
+                                      lockOnJoinConfigurable: Boolean, hideViewersCursor: Boolean)
 
 object LockSettingsNotInitializedRespMsg { val NAME = "LockSettingsNotInitializedRespMsg" }
 case class LockSettingsNotInitializedRespMsg(header: BbbClientMsgHeader, body: LockSettingsNotInitializedRespMsgBody) extends BbbCoreMsg

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -83,6 +83,7 @@ public class ApiParams {
     public static final String LOCK_SETTINGS_LOCKED_LAYOUT = "lockSettingsLockedLayout";
     public static final String LOCK_SETTINGS_LOCK_ON_JOIN = "lockSettingsLockOnJoin";
     public static final String LOCK_SETTINGS_LOCK_ON_JOIN_CONFIGURABLE = "lockSettingsLockOnJoinConfigurable";
+    public static final String LOCK_SETTINGS_HIDE_VIEWERS_CURSOR = "lockSettingsHideViewersCursor";
 
     // New param passed on create call to callback when meeting ends.
     // This is a duplicate of the endCallbackUrl meta param as we want this

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -113,6 +113,7 @@ public class ParamsProcessorUtil {
 		private boolean defaultLockSettingsLockedLayout;
 		private boolean defaultLockSettingsLockOnJoin;
 		private boolean defaultLockSettingsLockOnJoinConfigurable;
+		private boolean defaultLockSettingsHideViewersCursor;
 
     private Long maxPresentationFileUpload = 30000000L; // 30MB
 
@@ -335,6 +336,12 @@ public class ParamsProcessorUtil {
 				lockSettingsLockOnJoinConfigurable = Boolean.parseBoolean(lockSettingsLockOnJoinConfigurableParam);
 			}
 
+			Boolean lockSettingsHideViewersCursor = defaultLockSettingsHideViewersCursor;
+			String lockSettingsHideViewersCursorParam = params.get(ApiParams.LOCK_SETTINGS_HIDE_VIEWERS_CURSOR);
+			if (!StringUtils.isEmpty(lockSettingsHideViewersCursorParam)) {
+                lockSettingsHideViewersCursor = Boolean.parseBoolean(lockSettingsHideViewersCursorParam);
+			}
+
 			return new LockSettingsParams(lockSettingsDisableCam,
 							lockSettingsDisableMic,
 							lockSettingsDisablePrivateChat,
@@ -343,7 +350,8 @@ public class ParamsProcessorUtil {
 							lockSettingsHideUserList,
 							lockSettingsLockedLayout,
 							lockSettingsLockOnJoin,
-							lockSettingsLockOnJoinConfigurable);
+							lockSettingsLockOnJoinConfigurable,
+                            lockSettingsHideViewersCursor);
 		}
 
     private ArrayList<Group> processGroupsParams(Map<String, String> params) {
@@ -1296,6 +1304,10 @@ public class ParamsProcessorUtil {
 
 	public void setLockSettingsLockOnJoinConfigurable(Boolean lockSettingsLockOnJoinConfigurable) {
 		this.defaultLockSettingsLockOnJoinConfigurable = lockSettingsLockOnJoinConfigurable;
+	}
+
+	public void setLockSettingsHideViewersCursor(Boolean lockSettingsHideViewersCursor) {
+		this.defaultLockSettingsHideViewersCursor = lockSettingsHideViewersCursor;
 	}
 
 	public void setAllowDuplicateExtUserid(Boolean allow) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/LockSettingsParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/LockSettingsParams.java
@@ -10,6 +10,7 @@ public class LockSettingsParams {
 	public final Boolean lockedLayout;
 	public final Boolean lockOnJoin;
 	public final Boolean lockOnJoinConfigurable;
+	public final Boolean hideViewersCursor;
 
 	public LockSettingsParams(Boolean disableCam,
 					Boolean disableMic,
@@ -19,7 +20,8 @@ public class LockSettingsParams {
 					Boolean hideUserList,
 					Boolean lockedLayout,
 					Boolean lockOnJoin,
-					Boolean lockOnJoinConfigurable) {
+					Boolean lockOnJoinConfigurable,
+					Boolean hideViewersCursor) {
 		this.disableCam = disableCam;
 		this.disableMic = disableMic;
 		this.disablePrivateChat = disablePrivateChat;
@@ -29,5 +31,6 @@ public class LockSettingsParams {
 		this.lockedLayout = lockedLayout;
 		this.lockOnJoin = lockOnJoin;
 		this.lockOnJoinConfigurable = lockOnJoinConfigurable;
+		this.hideViewersCursor = hideViewersCursor;
 	}
 }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -123,8 +123,8 @@ class BbbWebApiGWApp(
                     autoStartRecording:      java.lang.Boolean,
                     allowStartStopRecording: java.lang.Boolean, webcamsOnlyForModerator: java.lang.Boolean,
                     meetingCameraCap: java.lang.Integer,
-                    userCameraCap: java.lang.Integer,
-                    moderatorPass: String, viewerPass: String, learningDashboardAccessToken: String,
+                    userCameraCap:    java.lang.Integer,
+                    moderatorPass:    String, viewerPass: String, learningDashboardAccessToken: String,
                     createTime: java.lang.Long, createDate: String, isBreakout: java.lang.Boolean,
                     sequence: java.lang.Integer,
                     freeJoin: java.lang.Boolean,
@@ -204,7 +204,8 @@ class BbbWebApiGWApp(
       hideUserList = lockSettingsParams.hideUserList.booleanValue(),
       lockedLayout = lockSettingsParams.lockedLayout.booleanValue(),
       lockOnJoin = lockSettingsParams.lockOnJoin.booleanValue(),
-      lockOnJoinConfigurable = lockSettingsParams.lockOnJoinConfigurable.booleanValue()
+      lockOnJoinConfigurable = lockSettingsParams.lockOnJoinConfigurable.booleanValue(),
+      hideViewersCursor = lockSettingsParams.hideViewersCursor.booleanValue()
     )
 
     val systemProps = SystemProps(

--- a/bigbluebutton-html5/imports/api/meetings/server/methods/toggleLockSettings.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/methods/toggleLockSettings.js
@@ -24,6 +24,7 @@ export default function toggleLockSettings(lockSettingsProps) {
       lockedLayout: Boolean,
       lockOnJoin: Boolean,
       lockOnJoinConfigurable: Boolean,
+      hideViewersCursor: Boolean,
       setBy: Match.Maybe(String),
     });
 
@@ -37,6 +38,7 @@ export default function toggleLockSettings(lockSettingsProps) {
       lockedLayout,
       lockOnJoin,
       lockOnJoinConfigurable,
+      hideViewersCursor,
     } = lockSettingsProps;
 
     const payload = {
@@ -49,6 +51,7 @@ export default function toggleLockSettings(lockSettingsProps) {
       lockedLayout,
       lockOnJoin,
       lockOnJoinConfigurable,
+      hideViewersCursor,
       setBy: requesterUserId,
     };
 

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -112,6 +112,7 @@ export default function addMeeting(meeting) {
       lockOnJoin: Boolean,
       lockOnJoinConfigurable: Boolean,
       lockedLayout: Boolean,
+      hideViewersCursor: Boolean,
     },
     systemProps: {
       html5InstanceId: Number,

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/changeLockSettings.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/changeLockSettings.js
@@ -14,6 +14,7 @@ export default function changeLockSettings(meetingId, payload) {
     lockedLayout: Boolean,
     lockOnJoin: Boolean,
     lockOnJoinConfigurable: Boolean,
+    hideViewersCursor: Boolean,
     setBy: Match.Maybe(String),
   });
 
@@ -27,6 +28,7 @@ export default function changeLockSettings(meetingId, payload) {
     lockedLayout,
     lockOnJoin,
     lockOnJoinConfigurable,
+    hideViewersCursor,
     setBy,
   } = payload;
 
@@ -46,6 +48,7 @@ export default function changeLockSettings(meetingId, payload) {
         lockedLayout,
         lockOnJoin,
         lockOnJoinConfigurable,
+        hideViewersCursor,
         setBy,
       },
     },

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/context/context.js
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/context/context.js
@@ -12,6 +12,7 @@ export function LockStruct() {
       lockOnJoin: true,
       lockOnJoinConfigurable: false,
       lockedLayout: false,
+      hideViewersCursor: false,
     },
     userLocks: {
       userWebcam: false,

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -397,6 +397,7 @@ lockSettingsHideUserList=false
 lockSettingsLockedLayout=false
 lockSettingsLockOnJoin=true
 lockSettingsLockOnJoinConfigurable=false
+lockSettingsHideViewersCursor=false
 
 allowDuplicateExtUserid=true
 

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -171,7 +171,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="muteOnStart" value="${muteOnStart}"/>
         <property name="allowModsToUnmuteUsers" value="${allowModsToUnmuteUsers}"/>
         <property name="allowModsToEjectCameras" value="${allowModsToEjectCameras}"/>
-        <property name="breakoutRoomsEnabled" value="${breakoutRoomsEnabled}"/>
+        <property name="breakoutRoomsEnabled" value="${breakoutRoomsEnabled:true}"/>
         <property name="breakoutRoomsRecord" value="${breakoutRoomsRecord}"/>
         <property name="breakoutRoomsPrivateChatEnabled" value="${breakoutRoomsPrivateChatEnabled}"/>
         <property name="lockSettingsDisableCam" value="${lockSettingsDisableCam}"/>
@@ -183,6 +183,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="lockSettingsLockedLayout" value="${lockSettingsLockedLayout}"/>
         <property name="lockSettingsLockOnJoin" value="${lockSettingsLockOnJoin}"/>
         <property name="lockSettingsLockOnJoinConfigurable" value="${lockSettingsLockOnJoinConfigurable}"/>
+        <property name="lockSettingsHideViewersCursor" value="${lockSettingsHideViewersCursor}"/>
         <property name="allowDuplicateExtUserid" value="${allowDuplicateExtUserid}"/>
         <property name="endWhenNoModerator" value="${endWhenNoModerator}"/>
         <property name="endWhenNoModeratorDelayInMinutes" value="${endWhenNoModeratorDelayInMinutes}"/>


### PR DESCRIPTION
Backend portion of #14636

Implements `lockSettingsHideViewersCursor` param in API /create.

And in `bigbluebutton.properties`:
![image](https://user-images.githubusercontent.com/5660191/159340360-a32f444e-83e3-483c-b330-322d08818f44.png)

Let `hideViewersCursor` available for html5 in `lockSettingsProps`:
![image](https://user-images.githubusercontent.com/5660191/159340260-414f8c06-2a8f-44d3-8217-304c34844a2e.png)
