### PR TITLE
feat: Support to disable Virtual backgrounds via disabledFeatures

### DIFF
--- a/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
+++ b/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
@@ -44,7 +44,6 @@ trait AppsTestFixtures {
   val allowModsToEjectCameras = false
   val authenticatedGuest = false
   val meetingLayout = ""
-  val virtualBackgroundsEnabled = false
 
   val metadata: collection.immutable.Map[String, String] = Map("foo" -> "bar", "bar" -> "baz", "baz" -> "foo")
   val breakoutProps = BreakoutProps(parentId = parentMeetingId, sequence = sequence, freeJoin = false, breakoutRooms = Vector())
@@ -64,7 +63,7 @@ trait AppsTestFixtures {
   val usersProp = UsersProp(maxUsers = maxUsers, webcamsOnlyForModerator = webcamsOnlyForModerator,
     userCameraCap = userCameraCap,
     guestPolicy = guestPolicy, allowModsToUnmuteUsers = allowModsToUnmuteUsers, allowModsToEjectCameras = allowModsToEjectCameras,
-    authenticatedGuest = authenticatedGuest, meetingLayout = meetingLayout, virtualBackgroundsEnabled = virtualBackgroundsEnabled)
+    authenticatedGuest = authenticatedGuest, meetingLayout = meetingLayout)
   val metadataProp = new MetadataProp(metadata)
 
   val defaultProps = DefaultProps(meetingProp, breakoutProps, durationProps, password, recordProp, welcomeProp, voiceProp,

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
@@ -35,15 +35,14 @@ case class WelcomeProp(welcomeMsgTemplate: String, welcomeMsg: String, modOnlyMe
 case class VoiceProp(telVoice: String, voiceConf: String, dialNumber: String, muteOnStart: Boolean)
 
 case class UsersProp(
-    maxUsers:                   Int,
-    webcamsOnlyForModerator:    Boolean,
-    userCameraCap:              Int,
-    guestPolicy:                String,
-    meetingLayout:              String,
-    allowModsToUnmuteUsers:     Boolean,
-    allowModsToEjectCameras:    Boolean,
-    authenticatedGuest:         Boolean,
-    virtualBackgroundsDisabled: Boolean
+    maxUsers:                Int,
+    webcamsOnlyForModerator: Boolean,
+    userCameraCap:           Int,
+    guestPolicy:             String,
+    meetingLayout:           String,
+    allowModsToUnmuteUsers:  Boolean,
+    allowModsToEjectCameras: Boolean,
+    authenticatedGuest:      Boolean
 )
 
 case class MetadataProp(metadata: collection.immutable.Map[String, String])

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -417,7 +417,7 @@ public class MeetingService implements MessageListener {
             m.getUserActivitySignResponseDelayInMinutes(), m.getEndWhenNoModerator(), m.getEndWhenNoModeratorDelayInMinutes(),
             m.getMuteOnStart(), m.getAllowModsToUnmuteUsers(), m.getAllowModsToEjectCameras(), m.getMeetingKeepEvents(),
             m.breakoutRoomsParams, m.lockSettingsParams, m.getHtml5InstanceId(),
-            m.getGroups(), m.getVirtualBackgroundsDisabled(), m.getDisabledFeatures());
+            m.getGroups(), m.getDisabledFeatures());
   }
 
   private String formatPrettyDate(Long timestamp) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -473,12 +473,6 @@ public class ParamsProcessorUtil {
             }
         }
 
-        // Check if VirtualBackgrounds is disabled
-        boolean virtualBackgroundsDisabled = false;
-        if (!StringUtils.isEmpty(params.get(ApiParams.VIRTUAL_BACKGROUNDS_DISABLED))) {
-            virtualBackgroundsDisabled = Boolean.valueOf(params.get(ApiParams.VIRTUAL_BACKGROUNDS_DISABLED));
-        }
-
         // Check Disabled Features
         ArrayList<String> listOfDisabledFeatures=new ArrayList(Arrays.asList(defaultDisabledFeatures.split(",")));
         if (!StringUtils.isEmpty(params.get(ApiParams.DISABLED_FEATURES))) {
@@ -488,6 +482,15 @@ public class ParamsProcessorUtil {
         listOfDisabledFeatures.removeAll(Arrays.asList("", null));
         listOfDisabledFeatures.replaceAll(String::trim);
         listOfDisabledFeatures = new ArrayList<>(new HashSet<>(listOfDisabledFeatures));
+
+        // Check if VirtualBackgrounds is disabled
+        if (!StringUtils.isEmpty(params.get(ApiParams.VIRTUAL_BACKGROUNDS_DISABLED))) {
+            boolean virtualBackgroundsDisabled = Boolean.valueOf(params.get(ApiParams.VIRTUAL_BACKGROUNDS_DISABLED));
+            if(virtualBackgroundsDisabled == true && !listOfDisabledFeatures.contains("virtualBackgrounds")) {
+                log.warn("[DEPRECATION] use disabledFeatures=virtualBackgrounds instead of virtualBackgroundsDisabled=true");
+                listOfDisabledFeatures.add("virtualBackgrounds");
+            }
+        }
 
         boolean learningDashboardEn = learningDashboardEnabled;
         if (!StringUtils.isEmpty(params.get(ApiParams.LEARNING_DASHBOARD_ENABLED))) {
@@ -660,7 +663,6 @@ public class ParamsProcessorUtil {
                 .withLearningDashboardCleanupDelayInMinutes(learningDashboardCleanupMins)
                 .withLearningDashboardAccessToken(learningDashboardAccessToken)
                 .withGroups(groups)
-                .withVirtualBackgroundsDisabled(virtualBackgroundsDisabled)
                 .withDisabledFeatures(listOfDisabledFeatures)
                 .build();
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -53,7 +53,6 @@ public class Meeting {
 	private String viewerPass;
 	private int learningDashboardCleanupDelayInMinutes;
 	private String learningDashboardAccessToken;
-	private Boolean virtualBackgroundsDisabled;
 	private ArrayList<String> disabledFeatures;
 	private String welcomeMsgTemplate;
 	private String welcomeMsg;
@@ -118,7 +117,6 @@ public class Meeting {
         intMeetingId = builder.internalId;
         viewerPass = builder.viewerPass;
         moderatorPass = builder.moderatorPass;
-		virtualBackgroundsDisabled = builder.virtualBackgroundsDisabled;
 		disabledFeatures = builder.disabledFeatures;
 		learningDashboardCleanupDelayInMinutes = builder.learningDashboardCleanupDelayInMinutes;
 		learningDashboardAccessToken = builder.learningDashboardAccessToken;
@@ -360,10 +358,6 @@ public class Meeting {
 
 	public String getLearningDashboardAccessToken() {
 		return learningDashboardAccessToken;
-	}
-
-	public Boolean getVirtualBackgroundsDisabled() {
-		return virtualBackgroundsDisabled;
 	}
 
 	public ArrayList<String> getDisabledFeatures() {
@@ -793,7 +787,6 @@ public class Meeting {
     	private String viewerPass;
     	private int learningDashboardCleanupDelayInMinutes;
     	private String learningDashboardAccessToken;
-		private Boolean virtualBackgroundsDisabled;
 		private ArrayList<String> disabledFeatures;
     	private int duration;
     	private String webVoice;
@@ -906,11 +899,6 @@ public class Meeting {
 	    	this.learningDashboardAccessToken = t;
 	    	return this;
 	    }
-
-		public Builder withVirtualBackgroundsDisabled(Boolean d) {
-			this.virtualBackgroundsDisabled = d;
-			return this;
-		}
 
 		public Builder withDisabledFeatures(ArrayList<String> list) {
 			this.disabledFeatures = list;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
@@ -41,7 +41,6 @@ public interface IBbbWebApiGWApp {
                      LockSettingsParams lockSettingsParams,
                      Integer html5InstanceId,
                      ArrayList<Group> groups,
-                     Boolean virtualBackgroundsDisabled,
                      ArrayList<String> disabledFeatures);
 
   void registerUser(String meetingID, String internalUserId, String fullname, String role,

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -146,7 +146,6 @@ class BbbWebApiGWApp(
                     lockSettingsParams:                     LockSettingsParams,
                     html5InstanceId:                        java.lang.Integer,
                     groups:                                 java.util.ArrayList[Group],
-                    virtualBackgroundsDisabled:             java.lang.Boolean,
                     disabledFeatures:                       java.util.ArrayList[String]): Unit = {
 
     val disabledFeaturesAsVector: Vector[String] = disabledFeatures.asScala.toVector
@@ -192,7 +191,7 @@ class BbbWebApiGWApp(
       userCameraCap = userCameraCap.intValue(),
       guestPolicy = guestPolicy, meetingLayout = meetingLayout, allowModsToUnmuteUsers = allowModsToUnmuteUsers.booleanValue(),
       allowModsToEjectCameras = allowModsToEjectCameras.booleanValue(),
-      authenticatedGuest = authenticatedGuest.booleanValue(), virtualBackgroundsDisabled = virtualBackgroundsDisabled.booleanValue())
+      authenticatedGuest = authenticatedGuest.booleanValue())
     val metadataProp = MetadataProp(mapAsScalaMap(metadata).toMap)
 
     val lockSettingsProps = LockSettingsProps(

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -65,7 +65,6 @@ export default function addMeeting(meeting) {
       allowModsToUnmuteUsers: Boolean,
       allowModsToEjectCameras: Boolean,
       meetingLayout: String,
-      virtualBackgroundsDisabled: Boolean,
     },
     durationProps: {
       createdTime: Number,

--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -17,10 +17,10 @@ import {
   EFFECT_TYPES,
   SHOW_THUMBNAILS,
   setSessionVirtualBackgroundInfo,
-  isVirtualBackgroundEnabled,
   getSessionVirtualBackgroundInfo,
-} from '/imports/ui/services/virtual-background/service'
+} from '/imports/ui/services/virtual-background/service';
 import Settings from '/imports/ui/services/settings';
+import { isVirtualBackgroundsEnabled } from '/imports/ui/services/features';
 
 const VIEW_STATES = {
   finding: 'finding',
@@ -633,7 +633,7 @@ class VideoPreview extends Component {
             </>
           )
         }
-        {isVirtualBackgroundEnabled() && this.renderVirtualBgSelector()}
+        {isVirtualBackgroundsEnabled() && this.renderVirtualBgSelector()}
       </Styled.Col>
     );
   }

--- a/bigbluebutton-html5/imports/ui/services/features/index.js
+++ b/bigbluebutton-html5/imports/ui/services/features/index.js
@@ -47,3 +47,7 @@ export function isBreakoutRoomsEnabled() {
 export function isLayoutsEnabled() {
   return getDisabledFeatures().indexOf('layouts') === -1;
 }
+
+export function isVirtualBackgroundsEnabled() {
+  return getDisabledFeatures().indexOf('virtualBackgrounds') === -1;
+}

--- a/bigbluebutton-html5/imports/ui/services/virtual-background/service.js
+++ b/bigbluebutton-html5/imports/ui/services/virtual-background/service.js
@@ -85,17 +85,6 @@ const getSessionVirtualBackgroundInfoWithDefault = (deviceId) => {
   };
 }
 
-const isVirtualBackgroundEnabled = () => {
-  const meeting = Meetings.findOne({ meetingId: Auth.meetingID },
-    { fields: { 'usersProp.virtualBackgroundsDisabled': 1 } });
-
-  if (meeting?.usersProp && meeting.usersProp.virtualBackgroundsDisabled === true) {
-    return false;
-  }
-
-  return VIRTUAL_BACKGROUND_ENABLED;
-}
-
 const isVirtualBackgroundSupported = () => {
   return !(deviceInfo.isIos || browserInfo.isSafari);
 }
@@ -117,7 +106,6 @@ export {
   setSessionVirtualBackgroundInfo,
   getSessionVirtualBackgroundInfo,
   getSessionVirtualBackgroundInfoWithDefault,
-  isVirtualBackgroundEnabled,
   isVirtualBackgroundSupported,
   createVirtualBackgroundStream,
   getVirtualBackgroundThumbnail,

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -412,7 +412,7 @@ endWhenNoModerator=false
 endWhenNoModeratorDelayInMinutes=1
 
 # List of features to disable (comma-separated)
-# Available options: breakoutRooms, captions, chat, externalVideos, layouts, learningDashboard, polls, screenshare, sharedNotes
+# Available options: breakoutRooms, captions, chat, externalVideos, layouts, learningDashboard, polls, screenshare, sharedNotes, virtualBackgrounds
 #disabledFeatures=
 
 # Allow endpoint with current BigBlueButton version


### PR DESCRIPTION
Moving on with the implementation of `disabledFeatures` param #14293.

- Add new feature to disableable list: `virtualBackgrounds`;
- Keep support for previous API param `virtualBackgroundsDisabled`, but log a [DEPRECATION] warning when this param is used.