### PR TITLE
fix: Clear chat button is not working

### DIFF
--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/clearGroupChatMsg.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/clearGroupChatMsg.js
@@ -1,6 +1,6 @@
 import { GroupChatMsg } from '/imports/api/group-chat-msg';
 import Logger from '/imports/startup/server/logger';
-import addGroupChatMsg from '/imports/api/group-chat-msg/server/modifiers/addGroupChatMsg';
+import addSystemMsg from '/imports/api/group-chat-msg/server/modifiers/addSystemMsg';
 
 export default function clearGroupChatMsg(meetingId, chatId) {
   const CHAT_CONFIG = Meteor.settings.public.chat;
@@ -25,7 +25,7 @@ export default function clearGroupChatMsg(meetingId, chatId) {
           },
           message: CHAT_CLEAR_MESSAGE,
         };
-        addGroupChatMsg(meetingId, PUBLIC_GROUP_CHAT_ID, clearMsg);
+        addSystemMsg(meetingId, PUBLIC_GROUP_CHAT_ID, clearMsg);
       }
     } catch (err) {
       Logger.error(`Error on clearing GroupChat (${meetingId}, ${chatId}). ${err}`);


### PR DESCRIPTION
### What does this PR do?

Prevents an issue where the clear chat feature would not work.

Clear chat feature was not working because it was trying to call a method (`addGroupChatMsg`) that needs additional parameters.

### Closes Issue(s)
Closes #14655