### PR TITLE
refactor: swap netstat with ss

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -912,7 +912,7 @@ check_state() {
         RUNNING_APPS="${RUNNING_APPS} Nginx"
     fi
 
-    if ! netstat -ant | grep '8090' > /dev/null; then
+    if ! ss -ant | grep '8090' > /dev/null; then
         print_header
         NOT_RUNNING_APPS="${NOT_RUNNING_APPS} ${TOMCAT_USER} or grails"
     else
@@ -1025,7 +1025,7 @@ check_state() {
     # Check if the user is running their own bbb-web
     #
     if grep -q 8888 /usr/share/bigbluebutton/nginx/web.nginx; then
-        if ! netstat -ant | grep '8888' > /dev/null; then
+        if ! ss -ant | grep '8888' > /dev/null; then
             echo "# Warning: There is no application server listening to port 8888."
             echo
         fi
@@ -1257,7 +1257,7 @@ check_state() {
       echo "#"
     fi
 
-    FREESWITCH_SIP=$(netstat -anlt | grep :5066 | grep -v tcp6 | grep LISTEN | sed 's/ [ ]*/ /g' | cut -d' ' -f4 | sed 's/:5066//g')
+    FREESWITCH_SIP=$(ss -anlt | grep :5066 | grep -v tcp6 | grep LISTEN | sed 's/ [ ]*/ /g' | cut -d' ' -f4 | sed 's/:5066//g')
     KURENTO_SIP=$(echo "$KURENTO_CONFIG" | yq r - freeswitch.sip_ip)
     
     if [ ! -z "$FREESWITCH_SIP" ]; then
@@ -1845,11 +1845,11 @@ if [ $CLEAN ]; then
 fi
 
 if [ $NETWORK ]; then
-    netstat -ant | egrep ":80|:443\ " | egrep -v ":::|0.0.0.0" > /tmp/t_net
+    ss -ant | egrep ":80|:443\ " | egrep -v ":::|0.0.0.0" > /tmp/t_net
     REMOTE=$(cat /tmp/t_net | cut -c 45-68 | cut -d ":" -f1 | sort | uniq)
 
     if [ "$REMOTE" != "" ]; then
-        echo -e "netstat\t\t\t80\t443"
+        echo -e "ss\t\t\t80\t443"
         for IP in $REMOTE ; do
             PORT_80=$(cat /tmp/t_net | grep :80 | cut -c 45-68 | cut -d ":" -f1 | grep $IP | wc -l )
             PORT_443=$(cat /tmp/t_net | grep :443 | cut -c 45-68 | cut -d ":" -f1 | grep $IP | wc -l )

--- a/bigbluebutton-html5/deploy_to_usr_share.sh
+++ b/bigbluebutton-html5/deploy_to_usr_share.sh
@@ -79,7 +79,7 @@ sudo systemctl daemon-reload
 
 echo 'before stopping bbb-html5:'
 ps -ef | grep node-
-sudo netstat -netlp | grep -i node
+sudo ss -netlp | grep -i node
 echo 'before stopping bbb-html5:'
 echo '_____________'
 
@@ -88,7 +88,7 @@ sudo systemctl stop bbb-html5
 sleep 5s
 echo 'after stopping bbb-html5:'
 ps -ef | grep node-
-sudo netstat -netlp | grep -i node
+sudo ss -netlp | grep -i node
 echo 'after stopping bbb-html5:'
 echo '_____________'
 
@@ -97,6 +97,6 @@ sudo systemctl start bbb-html5
 sleep 10s
 echo 'after:...'
 ps -ef | grep node-
-sudo netstat -netlp | grep -i node
+sudo ss -netlp | grep -i node
 echo 'after:'
 echo '_____________'

--- a/bigbluebutton-web/run-dev.sh
+++ b/bigbluebutton-web/run-dev.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-IS_BBB_WEB_RUNNING=`netstat -an | grep LISTEN | grep 8090 > /dev/null && echo 1 || echo 0`
+IS_BBB_WEB_RUNNING=`ss -an | grep LISTEN | grep 8090 > /dev/null && echo 1 || echo 0`
 
 if [ "$IS_BBB_WEB_RUNNING" = "1" ]; then
 	echo "bbb-web is running, exiting"

--- a/bigbluebutton-web/run.sh
+++ b/bigbluebutton-web/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-IS_BBB_WEB_RUNNING=`netstat -an | grep LISTEN | grep 8090 > /dev/null && echo 1 || echo 0`
+IS_BBB_WEB_RUNNING=`ss -an | grep LISTEN | grep 8090 > /dev/null && echo 1 || echo 0`
 
 if [ "$IS_BBB_WEB_RUNNING" = "1" ]; then
 	echo "bbb-web is running, exiting"

--- a/build/packages-template/bbb-html5/run_mongo.sh
+++ b/build/packages-template/bbb-html5/run_mongo.sh
@@ -15,7 +15,7 @@ nohup mongod --config ./mongo-ramdisk.conf --oplogSize 8 --replSet rs0 --noauth 
 MONGO_OK=0
 
 while [ "$MONGO_OK" = "0" ]; do
-    MONGO_OK=`netstat -lan | grep 127.0.1.1 | grep 27017 &> /dev/null && echo 1 || echo 0`
+    MONGO_OK=`ss -lan | grep 127.0.1.1 | grep 27017 &> /dev/null && echo 1 || echo 0`
     sleep 1;
 done;
 

--- a/build/packages-template/bbb-html5/systemd_start.sh
+++ b/build/packages-template/bbb-html5/systemd_start.sh
@@ -9,7 +9,7 @@ echo "Starting mongoDB"
 MONGO_OK=0
 
 while [ "$MONGO_OK" = "0" ]; do
-    MONGO_OK=$(netstat -lan | grep 127.0.1.1 | grep 27017 &> /dev/null && echo 1 || echo 0)
+    MONGO_OK=$(ss -lan | grep 127.0.1.1 | grep 27017 &> /dev/null && echo 1 || echo 0)
     sleep 1;
 done;
 

--- a/build/packages-template/bbb-html5/systemd_start_frontend.sh
+++ b/build/packages-template/bbb-html5/systemd_start_frontend.sh
@@ -9,7 +9,7 @@ echo "Starting mongoDB"
 MONGO_OK=0
 
 while [ "$MONGO_OK" = "0" ]; do
-    MONGO_OK=$(netstat -lan | grep 127.0.1.1 | grep 27017 &> /dev/null && echo 1 || echo 0)
+    MONGO_OK=$(ss -lan | grep 127.0.1.1 | grep 27017 &> /dev/null && echo 1 || echo 0)
     sleep 1;
 done;
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Swaps `netstat` usage with `ss`, following @danimo's https://github.com/bigbluebutton/bigbluebutton/pull/14647
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
On a clean install I encountered `/usr/share/meteor/bundle/systemd_start_[frontend.sh](http://frontend.sh/): line 12: netstat: command not found`
and
`/usr/bin/bbb-conf: line 915: netstat: command not found`
<!-- What inspired you to submit this pull request? -->

### More
Made changes suggested by @danimo so if this works, all credit goes to @danimo :)
