### PR TITLE
fix(menu): update previous open dropdown on user list reordering

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
@@ -33,6 +33,15 @@ class BBBMenu extends React.Component {
     this.handleClose = this.handleClose.bind(this);
   }
 
+  componentDidUpdate() {
+    const { anchorEl } = this.state;
+    if (this.props.open === false && anchorEl) {
+      this.setState({ anchorEl: null });
+    } else if (this.props.open === true && !anchorEl) {
+      this.setState({ anchorEl: this.anchorElRef });
+    }
+  }
+
   handleClick(event) {
     this.setState({ anchorEl: event.currentTarget });
   };
@@ -126,6 +135,7 @@ class BBBMenu extends React.Component {
             this.handleClick(e);
           }}
           accessKey={this.props?.accessKey}
+          ref={(ref) => this.anchorElRef = ref}
         >
           {trigger}
         </div>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
@@ -81,6 +81,8 @@ class UserParticipants extends Component {
         this.handleClickSelectedUser,
       );
     }
+
+    window.addEventListener('beforeunload', () => Session.set('dropdownOpenUserId', null));
   }
 
   shouldComponentUpdate(nextProps) {

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
@@ -208,6 +208,16 @@ class UserListItem extends PureComponent {
     this.seperator = _.uniqueId('action-separator-');
   }
 
+  componentDidUpdate() {
+    const { user, selectedUserId } = this.props;
+    const { selected } = this.state;
+    if (selectedUserId === user.userId && !selected) {
+      this.setState({ selected: true });
+    } else if (selectedUserId !== user.userId && selected) {
+      this.setState({ selected: false });
+    }
+  }
+
   handleScroll() {
     this.setState({
       isActionsOpen: false,
@@ -646,6 +656,7 @@ class UserListItem extends PureComponent {
       userLastBreakout,
       isMe,
       isRTL,
+      selectedUserId,
     } = this.props;
 
     const {
@@ -814,7 +825,7 @@ class UserListItem extends PureComponent {
               isActionsOpen={isActionsOpen}
               selected={selected === true}
               tabIndex={-1}
-              onClick={() => this.setState({ selected: true })}
+              onClick={() => this.setState({ selected: true }, () => Session.set('dropdownOpenUserId', user.userId))}
               onKeyPress={() => { }}
               role="button"
             >
@@ -824,7 +835,8 @@ class UserListItem extends PureComponent {
         }
         actions={actions}
         selectedEmoji={user.emoji}
-        onCloseCallback={() => this.setState({ selected: false, showNestedOptions: false })}
+        onCloseCallback={() => this.setState({ selected: false }, () => Session.set('dropdownOpenUserId', null))}
+        open={selectedUserId === user.userId}
       />
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/container.jsx
@@ -56,5 +56,6 @@ export default withTracker(({ user }) => {
     getEmojiList: UserListService.getEmojiList(),
     getEmoji: UserListService.getEmoji(),
     usersProp: UserListService.getUsersProp(),
+    selectedUserId: Session.get('dropdownOpenUserId'),
   };
 })(UserListItemContainer);


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

_Updates previous open dropdown (if open) on user list reordering. This prevents users from clicking on user actions with wrong data._

Before reordering:
![Screenshot from 2022-03-31 14-12-57](https://user-images.githubusercontent.com/62393923/161113411-df4c5917-8113-4995-94f1-a13440cdbe48.png)

After reordering:
![Screenshot from 2022-03-31 14-13-18](https://user-images.githubusercontent.com/62393923/161113518-6f81fc19-ba21-476c-9d01-1be1de014f56.png)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #14659 