### PR TITLE
fix: fullscreen instead of Exit Full Screen (presentation)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -728,7 +728,6 @@ class Presentation extends PureComponent {
       fullscreenElementId,
       layoutContextDispatch,
     } = this.props;
-    const { isFullscreen } = this.state;
 
     return (
       <PresentationMenu
@@ -736,7 +735,6 @@ class Presentation extends PureComponent {
         screenshotRef={this.getSvgRef()}
         elementName={intl.formatMessage(intlMessages.presentationLabel)}
         elementId={fullscreenElementId}
-        isFullscreen={isFullscreen}
         toggleSwapLayout={MediaService.toggleSwapLayout}
         layoutContextDispatch={layoutContextDispatch}
       />

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/container.jsx
@@ -10,6 +10,8 @@ const PresentationMenuContainer = (props) => {
   const fullscreen = layoutSelect((i) => i.fullscreen);
   const { element: currentElement, group: currentGroup } = fullscreen;
   const layoutContextDispatch = layoutDispatch();
+  const { elementId } = props;
+  const isFullscreen = currentElement === elementId;
 
   return (
     <PresentationMenu
@@ -17,6 +19,7 @@ const PresentationMenuContainer = (props) => {
       {...{
         currentElement,
         currentGroup,
+        isFullscreen,
         layoutContextDispatch,
       }}
     />
@@ -25,7 +28,6 @@ const PresentationMenuContainer = (props) => {
 
 export default withTracker((props) => {
   const handleToggleFullscreen = (ref) => FullscreenService.toggleFullScreen(ref);
-  const { isFullscreen } = props;
   const isIphone = !!(navigator.userAgent.match(/iPhone/i));
   const meetingId = Auth.meetingID;
   const meetingObject = Meetings.findOne({ meetingId }, { fields: { 'meetingProp.name': 1 } });
@@ -34,7 +36,6 @@ export default withTracker((props) => {
     ...props,
     handleToggleFullscreen,
     isIphone,
-    isFullscreen,
     isDropdownOpen: Session.get('dropdownOpen'),
     meetingName: meetingObject.meetingProp.name,
   };


### PR DESCRIPTION
### What does this PR do?

Adjusts isFullscreen value in presentation menu, so it displays the correct text when presentation is full-screen.

### Closes Issue(s)
Closes #14673