### PR TITLE
fix: In Firefox, "Start a private chat" is always with hover style (2.5)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
@@ -117,7 +117,10 @@ class BBBMenu extends React.Component {
         <div
           onClick={(e) => {
             e.persist();
-            this.opts.autoFocus = !(['mouse', 'touch'].includes(e.nativeEvent.pointerType));
+            const firefoxInputSource = !([1, 5].includes(e.nativeEvent.mozInputSource)); // 1 = mouse, 5 = touch (firefox only)
+            const chromeInputSource = !(['mouse', 'touch'].includes(e.nativeEvent.pointerType));
+
+            this.opts.autoFocus = firefoxInputSource && chromeInputSource;
             this.handleClick(e);
           }}
           onKeyPress={(e) => {


### PR DESCRIPTION
### What does this PR do?

Prevents a bug with the auto-focus feature (keyboard-only navigation) by adjusting menu click event so the correct value is obtained in Firefox.

### Closes Issue(s)
Closes #14669
