### PR TITLE
fix: In Firefox, "Start a private chat" is always with hover style (2.4)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/menu/component.jsx
@@ -105,7 +105,10 @@ class BBBMenu extends React.Component {
         <div
           onClick={(e) => {
             e.persist();
-            this.opts.autoFocus = !(['mouse', 'touch'].includes(e.nativeEvent.pointerType));
+            const firefoxInputSource = !([1, 5].includes(e.nativeEvent.mozInputSource)); // 1 = mouse, 5 = touch (firefox only)
+            const chromeInputSource = !(['mouse', 'touch'].includes(e.nativeEvent.pointerType));
+
+            this.opts.autoFocus = firefoxInputSource && chromeInputSource;
             this.handleClick(e);
           }}
           onKeyPress={(e) => {


### PR DESCRIPTION
### What does this PR do?

This is a backport of PR #14681 from 2.5 to 2.4.

_Prevents a bug with the auto-focus feature (keyboard-only navigation) by adjusting menu click event so the correct value is obtained in Firefox._