### PR TITLE
fix(microphone): modal not showing errors

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -270,28 +270,7 @@ class AudioModal extends Component {
         disableActions: false,
       });
     }).catch((err) => {
-      const { type } = err;
-      switch (type) {
-        case 'MEDIA_ERROR':
-          this.setState({
-            content: 'help',
-            errCode: 0,
-            disableActions: false,
-          });
-          break;
-        case 'CONNECTION_ERROR':
-          this.setState({
-            errCode: 0,
-            disableActions: false,
-          });
-          break;
-        default:
-          this.setState({
-            errCode: 0,
-            disableActions: false,
-          });
-          break;
-      }
+      this.handleJoinMicrophoneError(err);
     });
   }
 
@@ -345,7 +324,29 @@ class AudioModal extends Component {
       this.setState({
         disableActions: false,
       });
-    }).catch(this.handleGoToAudioOptions);
+    }).catch((err) => {
+      this.handleJoinMicrophoneError(err);
+    });
+  }
+
+  handleJoinMicrophoneError(err) {
+    const { type } = err;
+    switch (type) {
+      case 'MEDIA_ERROR':
+        this.setState({
+          content: 'help',
+          errCode: 0,
+          disableActions: false,
+        });
+        break;
+      case 'CONNECTION_ERROR':
+      default:
+        this.setState({
+          errCode: 0,
+          disableActions: false,
+        });
+        break;
+    }
   }
 
   setContent(content) {


### PR DESCRIPTION
### What does this PR do?

Adds error handling to microphone join.

Before:
![before](https://user-images.githubusercontent.com/32987232/160472623-ed26a3ff-91fe-497a-984e-7f7e7d3a8c15.gif)

After:
![after](https://user-images.githubusercontent.com/32987232/160472640-c096dbb7-acdb-429a-b9ad-8bf018986b85.gif)


### Closes Issue(s)

Closes #6948
