### PR TITLE
add zero padding for date string in user-list export file

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -662,8 +662,8 @@ export const getUserNamesLink = (docTitle, fnSortedLabel, lnSortedLabel) => {
   const meeting = Meetings.findOne({ meetingId: Auth.meetingID },
     { fields: { 'meetingProp.name': 1 } });
   const date = new Date();
-  const time = `${date.getHours()}-${date.getMinutes()}`;
-  const dateString = `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}_${time}`;
+  const time = `${('0'+date.getHours()).slice(-2)}-${('0'+date.getMinutes()).slice(-2)}`;
+  const dateString = `${date.getFullYear()}-${('0'+(date.getMonth() + 1)).slice(-2)}-${('0'+date.getDate()).slice(-2)}_${time}`;
   link.setAttribute('download', `bbb-${meeting.meetingProp.name}[users-list]_${dateString}.txt`);
   link.setAttribute(
     'href',


### PR DESCRIPTION
### What does this PR do?
The date string used in exported user lists would previously not use 0 padding, i.e. dates could be formatted to:
```
2022-3-29_9-2
```
referring to `2022-03-29 09:02`. 

### Motivation
Dates and especially minutes are less natural to read without zero padding, and filenames don't sort well when downloaded and stored without zero padding. 
