### PR TITLE
fix: adjust chat area size

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/styles.js
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 import {
   smPaddingX,
-  smPaddingY,
   mdPaddingX,
   mdPaddingY,
 } from '/imports/ui/stylesheets/styled-components/general';
@@ -26,10 +25,9 @@ const MessageListWrapper = styled.div`
   overflow-y: auto;
   padding-left: ${smPaddingX};
   margin-left: calc(-1 * ${mdPaddingX});
-  padding-right: ${smPaddingY};
+  padding-right: ${smPaddingX};
   margin-right: calc(-1 * ${mdPaddingY});
   padding-bottom: ${mdPaddingX};
-  margin-bottom: calc(-1 * ${mdPaddingX});
   z-index: 2;
   [dir="rtl"] & {
     padding-right: ${mdPaddingX};


### PR DESCRIPTION
### What does this PR do?

Adjusts chat area padding/margin.

#### before
![chat-styles-before](https://user-images.githubusercontent.com/3728706/160618940-50cbdea4-85fd-4abd-bc6c-b713c59eecf5.png)

#### after
![chat-styles-after](https://user-images.githubusercontent.com/3728706/160618932-282bddeb-673e-4015-913d-a01daab430bc.png)


### Closes Issue(s)
Closes #7579