### PR TITLE
fix(external-video): Viewers can now mute/unmute their view of external video

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
@@ -387,7 +387,7 @@ class VideoPlayer extends Component {
     const { mutedByEchoTest, muted } = this.state;
     const intPlayer = this.player && this.player.getInternalPlayer();
 
-    return (intPlayer && intPlayer?.isMuted && intPlayer?.isMuted?.() && !mutedByEchoTest) || muted;
+    return (intPlayer && intPlayer.isMuted && intPlayer.isMuted?.() && !mutedByEchoTest) || muted;
   }
 
   autoPlayBlockDetected() {

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
@@ -384,10 +384,10 @@ class VideoPlayer extends Component {
   }
 
   getMuted() {
-    const { mutedByEchoTest } = this.state;
+    const { mutedByEchoTest, muted } = this.state;
     const intPlayer = this.player && this.player.getInternalPlayer();
 
-    return intPlayer && intPlayer.isMuted && intPlayer.isMuted() && !mutedByEchoTest;
+    return (intPlayer && intPlayer?.isMuted && intPlayer?.isMuted?.() && !mutedByEchoTest) || muted;
   }
 
   autoPlayBlockDetected() {


### PR DESCRIPTION
The viewer can't mute the volume. 
https://user-images.githubusercontent.com/19312495/160689998-3fdaa0f9-b9d9-4619-b009-ecd60c7be966.mp4

Now, the viewer can mute and unmute the volume with no problems.
https://user-images.githubusercontent.com/19312495/160690014-36a233eb-64f5-4d68-b06a-b43adc0e14d4.mp4


