### PR TITLE
fix: false positive when checking if bbb-web is running, run-dev.sh

### DIFF
--- a/bigbluebutton-web/run-dev.sh
+++ b/bigbluebutton-web/run-dev.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-IS_BBB_WEB_RUNNING=`ss -an | grep LISTEN | grep 8090 > /dev/null && echo 1 || echo 0`
+IS_BBB_WEB_RUNNING=`ss -lt | grep ":8090" > /dev/null && echo 1 || echo 0`
 
 if [ "$IS_BBB_WEB_RUNNING" = "1" ]; then
 	echo "bbb-web is running, exiting"


### PR DESCRIPTION
### What does this PR do?

- fix: false positive when checking if bbb-web is running, run-dev.sh
  * -a flag would list everything, including UNIX sockets, and then arbitrarily grep for 8090. That would lead to false positives.
  * Swap -an for -lt (only TCP sockets on LISTEN) so we can drop the extra LISTEN grep. 
  * Add an extra `:` to the port grep (avoid factoring things like tcp 18090)

### Closes Issue(s)

None

### Motivation

That thing is frequently tripping me up on dev env.

### More

n/a
