### PR TITLE
build: drop net-tools from bbb-freeswitch-core

### DIFF
--- a/build/packages-template/bbb-freeswitch-core/opts-focal.sh
+++ b/build/packages-template/bbb-freeswitch-core/opts-focal.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d xmlstarlet,libfreetype6,libcurl4,libspeex1,libspeexdsp1,libopus0,libsndfile1,libopusenc0,libopusfile0,liblua5.2-0,libjbig0,libldns2,bbb-freeswitch-sounds,net-tools"
+OPTS="$OPTS -t deb -d xmlstarlet,libfreetype6,libcurl4,libspeex1,libspeexdsp1,libopus0,libsndfile1,libopusenc0,libopusfile0,liblua5.2-0,libjbig0,libldns2,bbb-freeswitch-sounds"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Drops the dependency `net-tools` introduced in #14677
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation
@ffdixon made adjustments in #14677 to close #14670 but also re-introduced `net-tools` as a dependency (which was removed a few days earlier, see https://github.com/bigbluebutton/bigbluebutton/issues/14670#issuecomment-1083147298)

<!-- What inspired you to submit this pull request? -->

### More
Related to #14670
