### PR TITLE
fix: Screenshare is not displayed to new users, if autoSwapLayout=true

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -23,6 +23,7 @@ import { LayoutContextFunc } from '../../ui/components/layout/context';
 import VideoService from '/imports/ui/components/video-provider/service';
 import DebugWindow from '/imports/ui/components/debug-window/component';
 import { ACTIONS, PANELS } from '../../ui/components/layout/enums';
+import MediaService from '/imports/ui/components/media/service';
 
 const CHAT_CONFIG = Meteor.settings.public.chat;
 const CHAT_ENABLED = CHAT_CONFIG.enabled;
@@ -94,6 +95,8 @@ class Base extends Component {
       type: ACTIONS.SET_NUM_CAMERAS,
       value: usersVideo.length,
     });
+
+    MediaService.setSwapLayout(layoutContextDispatch);
 
     const {
       userID: localUserId,

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -20,7 +20,6 @@ import BannerBarContainer from '/imports/ui/components/banner-bar/container';
 import WaitingNotifierContainer from '/imports/ui/components/waiting-users/alert/container';
 import LockNotifier from '/imports/ui/components/lock-viewers/notify/container';
 import StatusNotifier from '/imports/ui/components/status-notifier/container';
-import MediaService from '/imports/ui/components/media/service';
 import ManyWebcamsNotifier from '/imports/ui/components/video-provider/many-users-notify/container';
 import UploaderContainer from '/imports/ui/components/presentation/presentation-uploader/container';
 import RandomUserSelectContainer from '/imports/ui/components/modal/random-user/container';
@@ -171,7 +170,6 @@ class App extends Component {
       value: !hidePresentation,
     });
 
-    MediaService.setSwapLayout(layoutContextDispatch);
     Modal.setAppElement('#app');
 
     const fontSize = isMobile() ? MOBILE_FONT_SIZE : DESKTOP_FONT_SIZE;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -120,6 +120,12 @@ class SmartLayout extends Component {
           cameraDock: {
             numCameras: input.cameraDock.numCameras,
           },
+          externalVideo: {
+            hasExternalVideo: input.externalVideo.hasExternalVideo,
+          },
+          screenShare: {
+            hasScreenShare: input.screenShare.hasScreenShare,
+          },
         }, INITIAL_INPUT_STATE),
       });
     }
@@ -343,9 +349,13 @@ class SmartLayout extends Component {
     const {
       input, fullscreen, isRTL, deviceType,
     } = layoutContextState;
-    const { presentation } = input;
-    const { isOpen } = presentation;
+    const { presentation, externalVideo, screenShare } = input;
+    const { isOpen, currentSlide } = presentation;
     const { camerasMargin, presentationToolbarMinWidth } = DEFAULT_VALUES;
+
+    const { num: currentSlideNumber } = currentSlide;
+    const { hasExternalVideo } = externalVideo;
+    const { hasScreenShare } = screenShare;
 
     const cameraDockBounds = {};
     cameraDockBounds.isCameraHorizontal = false;
@@ -360,7 +370,7 @@ class SmartLayout extends Component {
       cameraDockBounds.right = isRTL ? sidebarSize : null;
       cameraDockBounds.zIndex = 1;
 
-      if (!isOpen) {
+      if (!isOpen || (currentSlideNumber === 0 && !hasExternalVideo && !hasScreenShare)) {
         cameraDockBounds.width = mediaAreaBounds.width;
         cameraDockBounds.maxWidth = mediaAreaBounds.width;
         cameraDockBounds.height = mediaAreaBounds.height;
@@ -447,13 +457,14 @@ class SmartLayout extends Component {
       input, fullscreen, isRTL, deviceType,
     } = layoutContextState;
     const { presentation, externalVideo, screenShare } = input;
-    const { isOpen } = presentation;
+    const { isOpen, currentSlide } = presentation;
+    const { num: currentSlideNumber } = currentSlide;
     const { hasExternalVideo } = externalVideo;
     const { hasScreenShare } = screenShare;
     const mediaBounds = {};
     const { element: fullscreenElement } = fullscreen;
 
-    if (!isOpen) {
+    if (!isOpen || (currentSlideNumber === 0 && !hasExternalVideo && !hasScreenShare)) {
       mediaBounds.width = 0;
       mediaBounds.height = 0;
       mediaBounds.top = 0;


### PR DESCRIPTION
### What does this PR do?

Backport of #14620 for 2.4 + fix to a condition where setSwapLayout happens only after other components are mounted.

_Prevents an issue where external video / screenshare does not appear to a user that joins after video is shared._

### Closes Issue(s)
Closes #14689