### PR TITLE
fix disable THP called too often

### DIFF
--- a/build/packages-template/bbb-html5/disable-transparent-huge-pages.service
+++ b/build/packages-template/bbb-html5/disable-transparent-huge-pages.service
@@ -1,10 +1,12 @@
 [Unit]
 Description=Disable Transparent Huge Pages
+ConditionPathIsDirectory=/sys/kernel/mm/transparent_hugepage
 
 [Service]
 Type=oneshot
 ExecStart=/bin/sh -c "/bin/echo "never" | tee /sys/kernel/mm/transparent_hugepage/enabled"
 ExecStart=/bin/sh -c "/bin/echo "never" | tee /sys/kernel/mm/transparent_hugepage/defrag"
+RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### What does this PR do?
This PR fixes the issue of disable-transparent-huge-pages.service being called too often by allowing services know that it has already been executed.

### Motivation
This service was wanted by multiple parts of bbb-html5, thus resulting in it executed several times, thus when several restarts were required, the number of calls would increase rapidly and cause
<b>disable-transparent-huge-pages.service: Failed with result 'start-limit-hit'</b>

### Closes Issues
Closes #12398
Closes #12566

### Note
This PR also implements an extra check for the directory presence, to ensure THP support before we disable it.
( ConditionPathIsDirectory=/sys/kernel/mm/transparent_hugepage )
This directory is important for this service, thus this check will help in future troubleshooting.

### More
credit for the solution ( RemainAfterExit=yes ) belongs to @kepstin