### PR TITLE
fix(locale): add locale for audio settings speaker test label

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
@@ -36,6 +36,10 @@ const intlMessages = defineMessages({
     id: 'app.audio.audioSettings.speakerSourceLabel',
     description: 'Label for speaker source',
   },
+  testSpeakerLabel: {
+    id: 'app.audio.audioSettings.testSpeakerLabel',
+    description: 'Label for speaker source',
+  },
   streamVolumeLabel: {
     id: 'app.audio.audioSettings.microphoneStreamLabel',
     description: 'Label for stream volume',
@@ -136,9 +140,8 @@ class AudioSettings extends React.Component {
 
           <Styled.Row>
             <Styled.SpacedLeftCol>
-              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
               <Styled.LabelSmall htmlFor="audioTest">
-                Test your speaker volume
+                {intl.formatMessage(intlMessages.testSpeakerLabel)}
                 <AudioTestContainer id="audioTest" />
               </Styled.LabelSmall>
             </Styled.SpacedLeftCol>

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -545,6 +545,7 @@
     "app.audio.audioSettings.descriptionLabel": "Please note, a dialog will appear in your browser, requiring you to accept sharing your microphone.",
     "app.audio.audioSettings.microphoneSourceLabel": "Microphone source",
     "app.audio.audioSettings.speakerSourceLabel": "Speaker source",
+    "app.audio.audioSettings.testSpeakerLabel": "Test your speaker",
     "app.audio.audioSettings.microphoneStreamLabel": "Your audio stream volume",
     "app.audio.audioSettings.retryLabel": "Retry",
     "app.audio.listenOnly.backLabel": "Back",


### PR DESCRIPTION
### What does this PR do?

Adds a locale for the hardcoded `Test your speaker volume` string in the AudioSettings modal.

### Closes Issue(s)

None (I think)

### Motivation

n/a

### More
n/a
