### PR TITLE
Notifications rework - akka-apps

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/ShowPollResultReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/ShowPollResultReqMsgHdlr.scala
@@ -7,6 +7,7 @@ import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models.Polls
 import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
+import org.bigbluebutton.core2.message.senders.{ MsgBuilder }
 
 trait ShowPollResultReqMsgHdlr extends RightsManagementTrait {
   this: PollApp2x =>
@@ -23,6 +24,16 @@ trait ShowPollResultReqMsgHdlr extends RightsManagementTrait {
       val event = PollShowResultEvtMsg(header, body)
       val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
       bus.outGW.send(msgEvent)
+
+      val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+        liveMeeting.props.meetingProp.intId,
+        "info",
+        "polling",
+        "app.whiteboard.annotations.poll",
+        "Message displayed when a poll is published",
+        Vector()
+      )
+      bus.outGW.send(notifyEvent)
 
       // SendWhiteboardAnnotationPubMsg
       val annotationRouting = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, msg.header.userId)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
@@ -7,6 +7,7 @@ import org.bigbluebutton.core.running.OutMsgRouter
 import org.bigbluebutton.core.running.MeetingActor
 import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core2.Permissions
+import org.bigbluebutton.core2.message.senders.{ MsgBuilder }
 
 trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
@@ -40,13 +41,153 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
 
         MeetingStatus2x.setPermissions(liveMeeting.status, settings)
 
-        if (!oldPermissions.disableMic && settings.disableMic) {
-          // Apply lock settings when disableMic from false to true.
-          LockSettingsUtil.enforceLockSettingsForAllVoiceUsers(liveMeeting, outGW)
+        if (oldPermissions.disableCam != settings.disableCam) {
+          if (settings.disableCam) {
+            val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+              liveMeeting.props.meetingProp.intId,
+              "info",
+              "lock",
+              "app.userList.userOptions.disableCam",
+              "Label to disable cam notification",
+              Vector()
+            )
+            outGW.send(notifyEvent)
+
+            LockSettingsUtil.enforceCamLockSettingsForAllUsers(liveMeeting, outGW)
+          } else {
+            val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+              liveMeeting.props.meetingProp.intId,
+              "info",
+              "lock",
+              "app.userList.userOptions.enableCam",
+              "Label to enable cam notification",
+              Vector()
+            )
+            outGW.send(notifyEvent)
+          }
         }
 
-        if (!oldPermissions.disableCam && settings.disableCam) {
-          LockSettingsUtil.enforceCamLockSettingsForAllUsers(liveMeeting, outGW)
+        if (oldPermissions.disableMic != settings.disableMic) {
+          if (settings.disableMic) {
+            val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+              liveMeeting.props.meetingProp.intId,
+              "info",
+              "lock",
+              "app.userList.userOptions.disableMic",
+              "Label to disable mic notification",
+              Vector()
+            )
+            outGW.send(notifyEvent)
+
+            // Apply lock settings when disableMic from false to true.
+            LockSettingsUtil.enforceLockSettingsForAllVoiceUsers(liveMeeting, outGW)
+          } else {
+            val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+              liveMeeting.props.meetingProp.intId,
+              "info",
+              "lock",
+              "app.userList.userOptions.enableMic",
+              "Label to enable mic notification",
+              Vector()
+            )
+            outGW.send(notifyEvent)
+          }
+        }
+
+        if (oldPermissions.disablePrivChat != settings.disablePrivChat) {
+          if (settings.disablePrivChat) {
+            val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+              liveMeeting.props.meetingProp.intId,
+              "info",
+              "lock",
+              "app.userList.userOptions.disablePrivChat",
+              "Label to disable private chat notification",
+              Vector()
+            )
+            outGW.send(notifyEvent)
+          } else {
+            val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+              liveMeeting.props.meetingProp.intId,
+              "info",
+              "lock",
+              "app.userList.userOptions.enablePrivChat",
+              "Label to enable private chat notification",
+              Vector()
+            )
+            outGW.send(notifyEvent)
+          }
+        }
+
+        if (oldPermissions.disablePubChat != settings.disablePubChat) {
+          if (settings.disablePubChat) {
+            val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+              liveMeeting.props.meetingProp.intId,
+              "info",
+              "lock",
+              "app.userList.userOptions.disablePubChat",
+              "Label to disable public chat notification",
+              Vector()
+            )
+            outGW.send(notifyEvent)
+          } else {
+            val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+              liveMeeting.props.meetingProp.intId,
+              "info",
+              "lock",
+              "app.userList.userOptions.enablePubChat",
+              "Label to enable public chat notification",
+              Vector()
+            )
+            outGW.send(notifyEvent)
+          }
+        }
+
+        if (oldPermissions.disableNotes != settings.disableNotes) {
+          if (settings.disableNotes) {
+            val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+              liveMeeting.props.meetingProp.intId,
+              "info",
+              "lock",
+              "app.userList.userOptions.disableNotes",
+              "Label to disable shared notes notification",
+              Vector()
+            )
+            outGW.send(notifyEvent)
+          } else {
+            val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+              liveMeeting.props.meetingProp.intId,
+              "info",
+              "lock",
+              "app.userList.userOptions.enableNotes",
+              "Label to enable shared notes notification",
+              Vector()
+            )
+            outGW.send(notifyEvent)
+          }
+        }
+
+        if (oldPermissions.hideUserList != settings.hideUserList) {
+          if (settings.hideUserList) {
+            val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+              liveMeeting.props.meetingProp.intId,
+              "info",
+              "lock",
+              "app.userList.userOptions.hideUserList",
+              "Label to disable user list notification",
+              Vector()
+            )
+            outGW.send(notifyEvent)
+          } else {
+            val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+              liveMeeting.props.meetingProp.intId,
+              "info",
+              "lock",
+              "app.userList.userOptions.showUserList",
+              "Label to enable user list notification",
+              Vector()
+            )
+            outGW.send(notifyEvent)
+          }
         }
 
         val routing = Routing.addMsgToClientRouting(

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RegisterUserReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RegisterUserReqMsgHdlr.scala
@@ -60,6 +60,16 @@ trait RegisterUserReqMsgHdlr {
         val guest = GuestWaiting(regUser.id, regUser.name, regUser.role, regUser.guest, regUser.avatarURL, regUser.authed, regUser.registeredOn)
         addGuestToWaitingForApproval(guest, liveMeeting.guestsWaiting)
         notifyModeratorsOfGuestWaiting(Vector(guest), liveMeeting.users2x, liveMeeting.props.meetingProp.intId)
+        val notifyEvent = MsgBuilder.buildNotifyRoleInMeetingEvtMsg(
+          "MODERATOR",
+          liveMeeting.props.meetingProp.intId,
+          "info",
+          "user",
+          "app.userList.guest.pendingGuestAlert",
+          "Notification that a new guest user joined the session",
+          Vector(s"${regUser.name}")
+        )
+        outGW.send(notifyEvent)
       case GuestStatus.DENY =>
         val g = GuestApprovedVO(regUser.id, GuestStatus.DENY)
         UsersApp.approveOrRejectGuest(liveMeeting, outGW, g, SystemUser.ID)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/SetRecordingStatusCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/SetRecordingStatusCmdMsgHdlr.scala
@@ -8,6 +8,7 @@ import org.bigbluebutton.core.util.TimeUtil
 import org.bigbluebutton.core.bus.BigBlueButtonEvent
 import org.bigbluebutton.core.api.SendRecordingTimerInternalMsg
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
+import org.bigbluebutton.core2.message.senders.{ MsgBuilder }
 
 trait SetRecordingStatusCmdMsgHdlr extends RightsManagementTrait {
   this: UsersApp =>
@@ -37,8 +38,28 @@ trait SetRecordingStatusCmdMsgHdlr extends RightsManagementTrait {
       if (liveMeeting.props.recordProp.allowStartStopRecording &&
         MeetingStatus2x.isRecording(liveMeeting.status) != msg.body.recording) {
         if (msg.body.recording) {
+          val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+            liveMeeting.props.meetingProp.intId,
+            "success",
+            "record",
+            "app.notification.recordingStart",
+            "Notification for when the recording starts",
+            Vector()
+          )
+          outGW.send(notifyEvent)
+
           MeetingStatus2x.recordingStarted(liveMeeting.status)
         } else {
+          val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+            liveMeeting.props.meetingProp.intId,
+            "error",
+            "record",
+            "app.notification.recordingPaused",
+            "Notification for when the recording stops",
+            Vector()
+          )
+          outGW.send(notifyEvent)
+
           MeetingStatus2x.recordingStopped(liveMeeting.status)
         }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/UpdateWebcamsOnlyForModeratorCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/UpdateWebcamsOnlyForModeratorCmdMsgHdlr.scala
@@ -4,6 +4,7 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.PermissionCheck
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.running.LiveMeeting
+import org.bigbluebutton.core2.message.senders.{ MsgBuilder }
 
 trait UpdateWebcamsOnlyForModeratorCmdMsgHdlr {
   this: WebcamApp2x =>
@@ -48,6 +49,29 @@ trait UpdateWebcamsOnlyForModeratorCmdMsgHdlr {
       ) match {
           case Some(value) => {
             log.info(s"Change webcams only for moderator status. meetingId=${meetingId} value=${value}")
+
+            if (value) {
+              val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+                meetingId,
+                "info",
+                "lock",
+                "app.userList.userOptions.webcamsOnlyForModerator",
+                "Label to disable all webcams except for the moderators cam",
+                Vector()
+              )
+              bus.outGW.send(notifyEvent)
+            } else {
+              val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+                meetingId,
+                "info",
+                "lock",
+                "app.userList.userOptions.enableOnlyModeratorWebcam",
+                "Label to enable all webcams except for the moderators cam",
+                Vector()
+              )
+              bus.outGW.send(notifyEvent)
+            }
+
             broadcastEvent(meetingId, msg.body.setBy, value)
           }
           case _ =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -72,6 +72,17 @@ trait HandlerHelpers extends SystemConfiguration {
 
             val event = UserJoinedMeetingEvtMsgBuilder.build(liveMeeting.props.meetingProp.intId, newUser)
             outGW.send(event)
+
+            val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+              liveMeeting.props.meetingProp.intId,
+              "info",
+              "user",
+              "app.notification.userJoinPushAlert",
+              "Notification for a user joins the meeting",
+              Vector(s"${newUser.name}")
+            )
+            outGW.send(notifyEvent)
+
             val newState = startRecordingIfAutoStart2x(outGW, liveMeeting, state)
             if (!Users2x.hasPresenter(liveMeeting.users2x)) {
               // println(s"userJoinMeeting will trigger an automaticallyAssignPresenter for user=${newUser}")

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -859,6 +859,16 @@ class MeetingActor(
         val userLeftMeetingEvent = MsgBuilder.buildUserLeftMeetingEvtMsg(liveMeeting.props.meetingProp.intId, u.intId)
         outGW.send(userLeftMeetingEvent)
 
+        val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+          liveMeeting.props.meetingProp.intId,
+          "info",
+          "user",
+          "app.notification.userLeavePushAlert",
+          "Notification for a user leaves the meeting",
+          Vector(s"${u.name}")
+        )
+        outGW.send(notifyEvent)
+
         if (u.presenter) {
           log.info("removeUsersWithExpiredUserLeftFlag will cause an automaticallyAssignPresenter because user={} left", u)
           UsersApp.automaticallyAssignPresenter(outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/MuteAllExceptPresentersCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/MuteAllExceptPresentersCmdMsgHdlr.scala
@@ -5,6 +5,7 @@ import org.bigbluebutton.core.models.{ UserState, Users2x, VoiceUserState, Voice
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
+import org.bigbluebutton.core2.message.senders.{ MsgBuilder }
 
 trait MuteAllExceptPresentersCmdMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
@@ -19,8 +20,28 @@ trait MuteAllExceptPresentersCmdMsgHdlr extends RightsManagementTrait {
     } else {
       if (msg.body.mute != MeetingStatus2x.isMeetingMuted(liveMeeting.status)) {
         if (msg.body.mute) {
+          val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+            liveMeeting.props.meetingProp.intId,
+            "info",
+            "mute",
+            "app.toast.meetingMuteOnViewers.label",
+            "Message used when viewers of a meeting have been muted",
+            Vector()
+          )
+          outGW.send(notifyEvent)
+
           MeetingStatus2x.muteMeeting(liveMeeting.status)
         } else {
+          val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+            liveMeeting.props.meetingProp.intId,
+            "info",
+            "unmute",
+            "app.toast.meetingMuteOff.label",
+            "Message used when meeting has been unmuted",
+            Vector()
+          )
+          outGW.send(notifyEvent)
+
           MeetingStatus2x.unmuteMeeting(liveMeeting.status)
         }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/MuteMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/MuteMeetingCmdMsgHdlr.scala
@@ -5,6 +5,7 @@ import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.models.{ VoiceUserState, VoiceUsers }
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core2.MeetingStatus2x
+import org.bigbluebutton.core2.message.senders.{ MsgBuilder }
 
 trait MuteMeetingCmdMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
@@ -44,8 +45,28 @@ trait MuteMeetingCmdMsgHdlr extends RightsManagementTrait {
 
       if (msg.body.mute != MeetingStatus2x.isMeetingMuted(liveMeeting.status)) {
         if (msg.body.mute) {
+          val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+            liveMeeting.props.meetingProp.intId,
+            "info",
+            "mute",
+            "app.toast.meetingMuteOn.label",
+            "Message used when meeting has been muted",
+            Vector()
+          )
+          outGW.send(notifyEvent)
+
           MeetingStatus2x.muteMeeting(liveMeeting.status)
         } else {
+          val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+            liveMeeting.props.meetingProp.intId,
+            "info",
+            "unmute",
+            "app.toast.meetingMuteOff.label",
+            "Message used when meeting has been unmuted",
+            Vector()
+          )
+          outGW.send(notifyEvent)
+
           MeetingStatus2x.unmuteMeeting(liveMeeting.status)
         }
 

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -651,6 +651,7 @@
     "app.toast.clearedEmoji.label": "Emoji status cleared",
     "app.toast.setEmoji.label": "Emoji status set to {0}",
     "app.toast.meetingMuteOn.label": "All users have been muted",
+    "app.toast.meetingMuteOnViewers.label": "All viewers have been muted",
     "app.toast.meetingMuteOff.label": "Meeting mute turned off",
     "app.toast.setEmoji.raiseHand": "You have raised your hand",
     "app.toast.setEmoji.lowerHand": "Your hand has been lowered",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -635,7 +635,7 @@
     "app.userList.guest.pendingUsers": "{0} Pending Users",
     "app.userList.guest.noPendingUsers": "Currently no pending users...",
     "app.userList.guest.pendingGuestUsers": "{0} Pending Guest Users",
-    "app.userList.guest.pendingGuestAlert": "Has joined the session and is waiting for your approval.",
+    "app.userList.guest.pendingGuestAlert": "{0} has joined the session and is waiting for your approval.",
     "app.userList.guest.rememberChoice": "Remember choice",
     "app.userList.guest.emptyMessage": "There is currently no message",
     "app.userList.guest.inputPlaceholder": "Message to the guests' lobby",


### PR DESCRIPTION
### What does this PR do?
Adds the following notifications to akka-apps:

- start recording
- stop recording
- meeting muted
- meeting unmuted
- poll published
- user promoted
- user demoted
- lock settings notifications
- guest user join
- user join
- user leave

### Closes Issue(s)
part of https://github.com/bigbluebutton/bigbluebutton/issues/14725