### PR TITLE
fix: presentation does not appear if user joins shortly after meeting start

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -158,6 +158,8 @@ class Presentation extends PureComponent {
       intl,
     } = this.props;
 
+    const { presentationWidth, presentationHeight } = this.state;
+
     const {
       numCameras: prevNumCameras,
       presentationBounds: prevPresentationBounds,
@@ -235,7 +237,8 @@ class Presentation extends PureComponent {
         }
       }
 
-      if (presentationBounds !== prevPresentationBounds) this.onResize();
+      if ((presentationBounds !== prevPresentationBounds) ||
+        (!presentationWidth && !presentationHeight)) this.onResize();
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

Prevents an issue with the presentation where it fails to set slides size on initial load if the user joins shortly after meeting creation.

It happened because `getInitialPresentationSizes` was triggered only on component mount (when slides information might not be available).