### PR TITLE
fix: Presentation sometimes starts minimized (2.4.6)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -232,6 +232,20 @@ class Presentation extends PureComponent {
       }
 
       if (presentationBounds !== prevPresentationBounds) this.onResize();
+    } else if (slidePosition) {
+      const { width: currWidth, height: currHeight } = slidePosition;
+
+      layoutContextDispatch({
+        type: ACTIONS.SET_PRESENTATION_CURRENT_SLIDE_SIZE,
+        value: {
+          width: currWidth,
+          height: currHeight,
+        },
+      });
+      layoutContextDispatch({
+        type: ACTIONS.SET_PRESENTATION_NUM_CURRENT_SLIDE,
+        value: currentSlide.num,
+      });
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

Prevents an issue with the presentation where it fails to set slides size on initial load if the user joins shortly after meeting creation (similar to #14743).
### Closes Issue(s)
Closes #14750