### PR TITLE
fix(breakout invitation): pick users from state instead of props

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -470,6 +470,7 @@ class BreakoutRoom extends PureComponent {
       .filter((user) => !stateUsersId.includes(user.userId))
       .map((user) => ({
         userId: user.userId,
+        extId: user.extId,
         userName: user.name,
         isModerator: user.role === ROLE_MODERATOR,
         room: 0,
@@ -611,7 +612,8 @@ class BreakoutRoom extends PureComponent {
   }
 
   populateWithLastBreakouts(lastBreakouts) {
-    const { getBreakoutUserWasIn, users, intl } = this.props;
+    const { getBreakoutUserWasIn, intl } = this.props;
+    const { users } = this.state;
 
     const changedNames = [];
     lastBreakouts.forEach((breakout) => {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

_Picks users from state instead of props when populating with last breakouts._

The state holds users who haven't joined a breakout, whereas props holds all users. Since we want to move only users not joined when populating with last breakouts, we must pick users from state.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #14740