### PR TITLE
fix(pads): read-only content style

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/pads/content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/pads/content/component.jsx
@@ -6,7 +6,10 @@ const PadContent = ({
 }) => (
   <Styled.Wrapper>
     <Styled.Content>
-      <div dangerouslySetInnerHTML={{ __html: content }} />
+      <div
+        dangerouslySetInnerHTML={{ __html: content }}
+        style={{ width: '100%' }}
+      />
     </Styled.Content>
   </Styled.Wrapper>
 );


### PR DESCRIPTION
### What does this PR do?

Set width to the inner div that will receive the pad's HTML content.

### Closes Issue(s)

Closes #14758