### PR TITLE
fix: Drop old postMessage leftover

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -437,7 +437,6 @@ class AudioManager {
       this.inputDevice = { id: 'default' };
     }
 
-    window.parent.postMessage({ response: 'notInAudio' }, '*');
     window.removeEventListener('audioPlayFailed', this.handlePlayElementFailed);
 
     const bridge =


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Removed a single `postMessage` line which is not used.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation
Looks like it re-entered via https://github.com/bigbluebutton/bigbluebutton/pull/13821 after it was removed in https://github.com/bigbluebutton/bigbluebutton/pull/13778
<!-- What inspired you to submit this pull request? -->


