### PR TITLE
fix: "Autoswaplayout: true" doesn't work as expected

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -154,6 +154,7 @@ class App extends Component {
       settingsLayout,
       isRTL,
       hidePresentation,
+      autoSwapLayout,
     } = this.props;
     const { browserName } = browserInfo;
     const { osName } = deviceInfo;
@@ -167,7 +168,7 @@ class App extends Component {
 
     layoutContextDispatch({
       type: ACTIONS.SET_PRESENTATION_IS_OPEN,
-      value: !hidePresentation,
+      value: !(autoSwapLayout || hidePresentation),
     });
 
     Modal.setAppElement('#app');

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -231,6 +231,7 @@ export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) 
       Meteor.settings.public.presentation.restoreOnUpdate,
     ),
     hidePresentation: getFromUserSettings('bbb_hide_presentation', LAYOUT_CONFIG.hidePresentation),
+    autoSwapLayout: getFromUserSettings('bbb_auto_swap_layout', LAYOUT_CONFIG.autoSwapLayout),
     hideActionsBar: getFromUserSettings('bbb_hide_actions_bar', false),
     isModalOpen: !!getModal(),
   };


### PR DESCRIPTION
### What does this PR do?

Prevents an issue where cameras could appear at the wrong position on meeting start if `autoSwapLayout` is set to true.

### Closes Issue(s)
Closes #14766