### PR TITLE
fix: Closed caption button with style bug

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/captions-list-item/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/captions-list-item/styles.js
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 
-import Styled from '/imports/ui/components/user-list/styles';
+import StyledContent from '/imports/ui/components/user-list/user-list-content/styles';
 
-const ListItem = styled(Styled.ListItem)``;
+const ListItem = styled(StyledContent.ListItem)``;
 
 export default {
   ListItem,


### PR DESCRIPTION
### What does this PR do?

Adjusts closed captions button icon styles.

#### before
![captions-before](https://user-images.githubusercontent.com/3728706/162270179-d8938c5c-74a2-4823-8eeb-4af2a1ac065f.png)

#### after
![captions-after](https://user-images.githubusercontent.com/3728706/162270153-6119a7d3-3e5d-4dcb-b662-e506f4affa6f.png)


### Closes Issue(s)
Closes #14745