### PR TITLE
chore: Add .bsp directory to .gitignore

### DIFF
--- a/akka-bbb-apps/.gitignore
+++ b/akka-bbb-apps/.gitignore
@@ -49,3 +49,4 @@ lib_managed/
 bin/
 src/main/resources/
 .bsp/
+

--- a/akka-bbb-apps/.gitignore
+++ b/akka-bbb-apps/.gitignore
@@ -48,4 +48,4 @@ lib_managed/
 .cache
 bin/
 src/main/resources/
-
+.bsp/

--- a/bbb-common-message/.gitignore
+++ b/bbb-common-message/.gitignore
@@ -54,3 +54,4 @@ lib_managed/
 .cache
 bin/
 .bsp/
+

--- a/bbb-common-message/.gitignore
+++ b/bbb-common-message/.gitignore
@@ -53,4 +53,4 @@ akka-patterns-store/
 lib_managed/
 .cache
 bin/
-
+.bsp/

--- a/bbb-common-web/.gitignore
+++ b/bbb-common-web/.gitignore
@@ -54,3 +54,4 @@ lib_managed/
 .cache
 bin/
 .bsp/
+

--- a/bbb-common-web/.gitignore
+++ b/bbb-common-web/.gitignore
@@ -53,4 +53,4 @@ akka-patterns-store/
 lib_managed/
 .cache
 bin/
-
+.bsp/


### PR DESCRIPTION
Since sbt 1.4.0 on every bootstrap sbt will create `.bsp/sbt.json` file that is environment specific.

Reference: https://contributors.scala-lang.org/t/build-server-protocol-in-sbt/4234