### PR TITLE
Adding dependabot to bigbluebutton-web

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gradle" # See documentation for possible values
+    directory: "bigbluebutton-web" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
### What does this PR do?
This PR prepares the config file for dependabot to be able to analyze dependencies of bigbluebtton-web

### Motivation
Dependabot is a useful too to keep track of dependencies
