### PR TITLE
fix(presentation) - Refactored `temporaryPresId` format to accept german umlauts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -302,12 +302,23 @@ class PresentationUploader extends Component {
         }
       });
 
-      this.setState({
-        presentations: Object.values({
-          ...presentations,
-          ...propPresentations,
-        }),
+      const presState = Object.values({
+        ...propPresentations,
+        ...presentations,
       });
+      const presStateMapped = presState.map((presentation) => {
+        propPresentations.forEach((propPres) => {
+          if (propPres.id == presentation.id){
+            presentation.isCurrent = propPres.isCurrent;
+          }
+        })
+        return presentation;
+      })
+
+      this.setState({
+        presentations: presStateMapped,
+      })
+      
     }
 
     if (presentations.length > 0) {

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/service.js
@@ -5,6 +5,7 @@ import Poll from '/imports/api/polls/';
 import { makeCall } from '/imports/ui/services/api';
 import logger from '/imports/startup/client/logger';
 import _ from 'lodash';
+import { Random } from 'meteor/random'
 
 const CONVERSION_TIMEOUT = 300000;
 const TOKEN_TIMEOUT = 5000;
@@ -153,7 +154,6 @@ const requestPresentationUploadToken = (
 });
 
 const uploadAndConvertPresentation = (
-  tmpPresId,
   file,
   downloadable,
   podId,
@@ -163,9 +163,9 @@ const uploadAndConvertPresentation = (
   onProgress,
   onConversion,
 ) => {
+  const tmpPresId = _.uniqueId(Random.id(20))
+
   const data = new FormData();
-  data.append('presentation_name', file.name);
-  data.append('Filename', file.name);
   data.append('fileUpload', file);
   data.append('conference', meetingId);
   data.append('room', meetingId);
@@ -207,7 +207,7 @@ const uploadAndConvertPresentations = (
   podId,
   uploadEndpoint,
 ) => Promise.all(presentationsToUpload.map((p) => uploadAndConvertPresentation(
-  p.id, p.file, p.isDownloadable, podId, meetingId, uploadEndpoint,
+  p.file, p.isDownloadable, podId, meetingId, uploadEndpoint,
   p.onUpload, p.onProgress, p.onConversion,
 )));
 


### PR DESCRIPTION
### What does this PR do?

It fixes the bug of crashing the `presentation-uploader` component when a presentation is sent with `filename` having german umlauts.

The fix is a refactor of the `temporaryPresId` format to not rely on UTF-8 encoding when sending the multipart/form-data content-type in `futch` method. Therefore it won't be wrongly decoded in the back-end and end up not being validated in the front-end.

### Closes Issue(s)

Closes #14749
