### PR TITLE
fix: Screenshare is not displayed to new users, if autoSwapLayout=true

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -155,6 +155,8 @@ class App extends Component {
       isRTL,
       hidePresentation,
       autoSwapLayout,
+      shouldShowScreenshare,
+      shouldShowExternalVideo,
     } = this.props;
     const { browserName } = browserInfo;
     const { osName } = deviceInfo;
@@ -166,9 +168,12 @@ class App extends Component {
       value: isRTL,
     });
 
+    const presentationOpen = !(autoSwapLayout || hidePresentation)
+      || shouldShowExternalVideo || shouldShowScreenshare;
+
     layoutContextDispatch({
       type: ACTIONS.SET_PRESENTATION_IS_OPEN,
-      value: !(autoSwapLayout || hidePresentation),
+      value: presentationOpen,
     });
 
     Modal.setAppElement('#app');


### PR DESCRIPTION
### What does this PR do?

Fix swap layout screenshare regression caused by #14771.

### Closes Issue(s)
Closes #14689