### PR TITLE
refactor(prom-html5) More prometheus metrics

### DIFF
--- a/bigbluebutton-html5/imports/api/connection-status/server/methods/voidConnection.js
+++ b/bigbluebutton-html5/imports/api/connection-status/server/methods/voidConnection.js
@@ -1,4 +1,9 @@
+import { PrometheusAgent, METRIC_NAMES } from '/imports/startup/server/prom-metrics/index.js'
+
 // Round-trip time helper
-export default function voidConnection() {
+export default function voidConnection(previousRtt) {
+  if (previousRtt) {
+    PrometheusAgent.observe(METRIC_NAMES.METEOR_RTT, previousRtt/1000);
+  }
   return 0;
 }

--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -144,7 +144,8 @@ Meteor.startup(() => {
   Meteor.onMessage(event => {
     const { method } = event;
     if (method) {
-      PrometheusAgent.increment(METRIC_NAMES.METEOR_METHODS, { methodName: method });
+      const methodName = method.includes('stream-cursor') ? 'stream-cursor' : method;
+      PrometheusAgent.increment(METRIC_NAMES.METEOR_METHODS, { methodName });
     }
   });
 

--- a/bigbluebutton-html5/imports/startup/server/logger.js
+++ b/bigbluebutton-html5/imports/startup/server/logger.js
@@ -1,5 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { createLogger, format, transports } from 'winston';
+import WinstonPromTransport from './prom-metrics/winstonPromTransport';
 
 const LOG_CONFIG = Meteor?.settings?.private?.serverLog || {};
 const { level } = LOG_CONFIG;
@@ -19,6 +20,10 @@ const Logger = createLogger({
       colorize: true,
       handleExceptions: true,
       level,
+    }),
+    // export error logs to prometheus
+    new WinstonPromTransport({
+      level: 'error',
     }),
   ],
 });

--- a/bigbluebutton-html5/imports/startup/server/prom-metrics/metrics.js
+++ b/bigbluebutton-html5/imports/startup/server/prom-metrics/metrics.js
@@ -8,6 +8,7 @@ const METRICS_PREFIX = 'html5_'
 const METRIC_NAMES = {
   METEOR_METHODS: 'meteorMethods',
   METEOR_ERRORS_TOTAL: 'meteorErrorsTotal',
+  METEOR_RTT: 'meteorRtt',
   REDIS_MESSAGE_QUEUE: 'redisMessageQueue',
   REDIS_PAYLOAD_SIZE: 'redisPayloadSize',
   REDIS_PROCESSING_TIME: 'redisProcessingTime'
@@ -27,6 +28,13 @@ const buildMetrics = () => {
         name: `${METRICS_PREFIX}meteor_errors_total`,
         help: 'Total number of errors logs in meteor',
         labelNames: ['errorMessage', 'role', 'instanceId'],
+      }),
+
+      [METRIC_NAMES.METEOR_RTT]: new Histogram({
+        name: `${METRICS_PREFIX}meteor_rtt_seconds`,
+        help: 'Round-trip time of meteor client-server connections in seconds',
+        buckets: [0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1, 1.5, 2, 2.5, 5],
+        labelNames: ['role', 'instanceId'],
       }),
 
       [METRIC_NAMES.REDIS_MESSAGE_QUEUE]: new Gauge({

--- a/bigbluebutton-html5/imports/startup/server/prom-metrics/metrics.js
+++ b/bigbluebutton-html5/imports/startup/server/prom-metrics/metrics.js
@@ -1,34 +1,52 @@
 const {
   Counter,
+  Gauge,
+  Histogram
 } = require('prom-client');
 
 const METRICS_PREFIX = 'html5_'
 const METRIC_NAMES = {
   METEOR_METHODS: 'meteorMethods',
+  METEOR_ERRORS_TOTAL: 'meteorErrorsTotal',
+  REDIS_MESSAGE_QUEUE: 'redisMessageQueue',
+  REDIS_PAYLOAD_SIZE: 'redisPayloadSize',
+  REDIS_PROCESSING_TIME: 'redisProcessingTime'
 }
-
-const buildFrontendMetrics = () => {
-  return {
-    [METRIC_NAMES.METEOR_METHODS]: new Counter({
-      name: `${METRICS_PREFIX}meteor_methods`,
-      help: 'Total number of meteor methods processed in html5',
-      labelNames: ['methodName', 'role', 'instanceId'],
-    }),
-  }
-}
-
-const buildBackendMetrics = () => {
-  // TODO add relevant backend metrics
-  return {}
-}  
 
 let METRICS;
 const buildMetrics = () => {
   if (METRICS == null) {
-    const isFrontend = (!process.env.BBB_HTML5_ROLE || process.env.BBB_HTML5_ROLE === 'frontend');
-    const isBackend = (!process.env.BBB_HTML5_ROLE || process.env.BBB_HTML5_ROLE === 'backend');
-    if (isFrontend) METRICS = buildFrontendMetrics();
-    if (isBackend) METRICS = { ...METRICS, ...buildBackendMetrics()} 
+    METRICS = {
+      [METRIC_NAMES.METEOR_METHODS]: new Counter({
+        name: `${METRICS_PREFIX}meteor_methods`,
+        help: 'Total number of meteor methods processed in html5',
+        labelNames: ['methodName', 'role', 'instanceId'],
+      }),
+
+      [METRIC_NAMES.METEOR_ERRORS_TOTAL]: new Counter({
+        name: `${METRICS_PREFIX}meteor_errors_total`,
+        help: 'Total number of errors logs in meteor',
+        labelNames: ['errorMessage', 'role', 'instanceId'],
+      }),
+
+      [METRIC_NAMES.REDIS_MESSAGE_QUEUE]: new Gauge({
+        name: `${METRICS_PREFIX}redis_message_queue`,
+        help: 'Message queue size in redis',
+        labelNames: ['meetingId', 'role', 'instanceId'],
+      }),
+
+      [METRIC_NAMES.REDIS_PAYLOAD_SIZE]: new Histogram({
+        name: `${METRICS_PREFIX}redis_payload_size`,
+        help: 'Redis events payload size',
+        labelNames: ['eventName', 'role', 'instanceId'],
+      }),
+
+      [METRIC_NAMES.REDIS_PROCESSING_TIME]: new Histogram({
+        name: `${METRICS_PREFIX}redis_processing_time`,
+        help: 'Redis events processing time in milliseconds',
+        labelNames: ['eventName', 'role', 'instanceId'],
+      }),
+    }
   }
 
   return METRICS;

--- a/bigbluebutton-html5/imports/startup/server/prom-metrics/promAgent.js
+++ b/bigbluebutton-html5/imports/startup/server/prom-metrics/promAgent.js
@@ -81,6 +81,16 @@ class PrometheusScrapeAgent {
       metric.set(labelsObject, value)
     }
   }
+
+  observe(metricName, value, labelsObject) {
+    if (!this.started) return;
+
+    const metric = this.metrics[metricName];
+    if (metric) {
+      labelsObject = { ...labelsObject, ...this.roleAndInstanceLabels };
+      metric.observe(labelsObject, value)
+    }
+  }
 }
 
 export default PrometheusScrapeAgent;

--- a/bigbluebutton-html5/imports/startup/server/prom-metrics/winstonPromTransport.js
+++ b/bigbluebutton-html5/imports/startup/server/prom-metrics/winstonPromTransport.js
@@ -1,0 +1,19 @@
+const Transport = require('winston-transport');
+import { PrometheusAgent, METRIC_NAMES } from './index.js'
+
+module.exports = class WinstonPromTransport extends Transport {
+  constructor(opts) {
+    super(opts);
+    
+  }
+
+  log(info, callback) {
+    setImmediate(() => {
+      this.emit('logged', info);
+    });
+
+    PrometheusAgent.increment(METRIC_NAMES.METEOR_ERRORS_TOTAL, { errorMessage: info.message });
+
+    callback();
+  }
+};

--- a/bigbluebutton-html5/imports/ui/components/connection-status/service.js
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/service.js
@@ -29,6 +29,7 @@ const intlMessages = defineMessages({
 });
 
 let stats = -1;
+let lastRtt = null;
 const statsDep = new Tracker.Dependency();
 
 let statsTimeout = null;
@@ -111,11 +112,12 @@ const addConnectionStatus = (level, type, value) => {
 
 const fetchRoundTripTime = () => {
   const t0 = Date.now();
-  makeCall('voidConnection').then(() => {
+  makeCall('voidConnection', lastRtt).then(() => {
     const tf = Date.now();
     const rtt = tf - t0;
     const event = new CustomEvent('socketstats', { detail: { rtt } });
     window.dispatchEvent(event);
+    lastRtt = rtt;
   });
 };
 

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -833,3 +833,5 @@ private:
     path: '/metrics'
     # Whether default metrics for Node.js processes should be exported
     collectDefaultMetrics: false
+    # Whether redis metrics should be exported
+    collectRedisMetrics: false


### PR DESCRIPTION
### What does this PR do?

- Added bbb-html5 prometheus metrics:

```
# HELP html5_meteor_rtt_seconds Round-trip time of meteor client-server connections in seconds
# TYPE html5_meteor_rtt_seconds histogram

# HELP html5_meteor_errors_total Total number of errors logs in meteor
# TYPE html5_meteor_errors_total counter

# HELP html5_redis_message_queue Message queue size in redis
# TYPE html5_redis_message_queue gauge

# HELP html5_redis_payload_size Redis events payload size
# TYPE html5_redis_payload_size histogram

# HELP html5_redis_processing_time Redis events processing time in milliseconds
# TYPE html5_redis_processing_time histogram
```
- New config in settings.yml:
`settings.private.prometheus.collectRedisMetrics, disabled by default`

- Fix stream-cursor event to not include the meeting-id in the event name.

### Motivation
Adds some new relevant metrics to help monitoring meteor.
