### PR TITLE
feat(theme): add dark mode

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -38,6 +38,7 @@ import SidebarNavigationContainer from '../sidebar-navigation/container';
 import SidebarContentContainer from '../sidebar-content/container';
 import { makeCall } from '/imports/ui/services/api';
 import ConnectionStatusService from '/imports/ui/components/connection-status/service';
+import DarkReader from 'darkreader';
 import Settings from '/imports/ui/services/settings';
 import LayoutService from '/imports/ui/components/layout/service';
 import { registerTitleView } from '/imports/utils/dom-utils';
@@ -113,6 +114,7 @@ const propTypes = {
   actionsbar: PropTypes.element,
   captions: PropTypes.element,
   locale: PropTypes.string,
+  darkTheme: PropTypes.bool.isRequired,
 };
 
 const defaultProps = {
@@ -235,6 +237,8 @@ class App extends Component {
       layoutContextDispatch,
       mountRandomUserModal,
     } = this.props;
+
+    this.renderDarkMode();
 
     if (meetingLayout !== prevProps.meetingLayout) {
       layoutContextDispatch({
@@ -364,6 +368,7 @@ class App extends Component {
 
     return (
       <Styled.ActionsBar
+        id="ActionsBar"
         role="region"
         aria-label={intl.formatMessage(intlMessages.actionsBarLabel)}
         aria-hidden={this.shouldAriaHide()}
@@ -406,6 +411,17 @@ class App extends Component {
         meetingId={User.meetingId}
       />
     ) : null);
+  }
+
+  renderDarkMode() {
+    const { darkTheme } = this.props;
+
+    return darkTheme
+      ? DarkReader.enable(
+        { brightness: 100, contrast: 90 },
+        { invert: [Styled.DtfInvert], ignoreInlineStyle: [Styled.DtfCss] },
+      )
+      : DarkReader.disable();
   }
 
   render() {

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -214,6 +214,7 @@ export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) 
     pushLayoutToEveryone: selectedLayout?.includes('Push'),
     audioAlertEnabled: AppSettings.chatAudioAlerts,
     pushAlertEnabled: AppSettings.chatPushAlerts,
+    darkTheme: AppSettings.darkTheme,
     shouldShowScreenshare,
     shouldShowPresentation: !shouldShowScreenshare && !shouldShowExternalVideo,
     shouldShowExternalVideo,

--- a/bigbluebutton-html5/imports/ui/components/app/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { barsPadding } from '/imports/ui/stylesheets/styled-components/general';
 import { FlexColumn } from '/imports/ui/stylesheets/styled-components/placeholders';
+import { colorBackground } from '/imports/ui/stylesheets/styled-components/palette';
 
 const CaptionsWrapper = styled.div`
   height: auto;
@@ -12,14 +13,43 @@ const CaptionsWrapper = styled.div`
 const ActionsBar = styled.section`
   flex: 1;
   padding: ${barsPadding};
+  background-color: ${colorBackground};
   position: relative;
   order: 3;
 `;
 
 const Layout = styled(FlexColumn)``;
 
+const DtfInvert = `
+  body {
+    background-color: var(--darkreader-neutral-background) !important;
+  }
+  header[id="Navbar"] {
+    background-color: var(--darkreader-neutral-background) !important;
+  }
+  section[id="ActionsBar"] {
+    background-color: var(--darkreader-neutral-background) !important;
+  }
+  select {
+    border: 0.1rem solid #FFFFFF !important;
+  }
+  select[data-test="skipSlide"] {
+    border: unset !important;
+  }
+  div[data-test="presentationContainer"] {
+    background-color: var(--darkreader-neutral-background) !important;
+  }
+  #connectionBars > div
+`;
+
+const DtfCss = `
+  [id="colorPicker"]
+`;
+
 export default {
   CaptionsWrapper,
   ActionsBar,
   Layout,
+  DtfInvert,
+  DtfCss,
 };

--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/styles.js
@@ -40,7 +40,7 @@ const Messages = styled.div`
 
 const SystemMessageChatItem = styled(MessageChatItem)`
   ${({ border }) => border && `
-    background: ${systemMessageBackgroundColor};
+    background-color: ${systemMessageBackgroundColor};
     border: 1px solid ${systemMessageBorderColor};
     border-radius: ${borderRadius};
     font-weight: ${btnFontWeight};
@@ -194,7 +194,7 @@ const PollMessageChatItem = styled(MessageChatItem)`
   color: ${colorText};
   word-wrap: break-word;
 
-  background: ${systemMessageBackgroundColor};
+  background-color: ${systemMessageBackgroundColor};
   border: solid 1px ${colorGrayLighter};
   border-radius: ${borderRadius};
   padding: ${chatPollMarginSm};

--- a/bigbluebutton-html5/imports/ui/components/connection-status/icon/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/icon/component.jsx
@@ -18,7 +18,7 @@ const STATS = {
 
 const Icon = ({ level, grayscale }) => (
   <>
-    <Styled.SignalBars level={level} grayscale={grayscale}>
+    <Styled.SignalBars id="connectionBars" level={level} grayscale={grayscale}>
       <Styled.FirstBar />
       <Styled.SecondBar active={STATS[level].bars >= 2} />
       <Styled.ThirdBar active={STATS[level].bars >= 3} />

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -188,6 +188,7 @@ class NavBar extends Component {
 
     return (
       <Styled.Navbar
+        id="Navbar"
         style={
           main === 'new'
             ? {

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/styles.js
@@ -5,6 +5,7 @@ import {
   colorWhite,
   colorDanger,
   colorGrayDark,
+  colorBackground,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import { fontSizeBase } from '/imports/ui/stylesheets/styled-components/typography';
 import { phoneLandscape } from '/imports/ui/stylesheets/styled-components/breakpoints';
@@ -16,6 +17,7 @@ const Navbar = styled.header`
   flex-direction: column;
   text-align: center;
   font-size: 1.5rem;
+  background-color: ${colorBackground};
   padding: ${barsPadding} ${barsPadding} 0 ${barsPadding};
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/component.jsx
@@ -85,6 +85,7 @@ const propTypes = {
     guestWaitingAudioAlerts: PropTypes.bool,
     guestWaitingPushAlerts: PropTypes.bool,
     paginationEnabled: PropTypes.bool,
+    darkTheme: PropTypes.bool,
     fallbackLocale: PropTypes.string,
     fontSize: PropTypes.string,
     locale: PropTypes.string,

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -30,6 +30,10 @@ const intlMessages = defineMessages({
     id: 'app.submenu.application.audioFilterLabel',
     description: 'audio filters label',
   },
+  darkThemeLabel: {
+    id: 'app.submenu.application.darkThemeLabel',
+    description: 'dark mode label',
+  },
   fontSizeControlLabel: {
     id: 'app.submenu.application.fontSizeControlLabel',
     description: 'label for font size ontrol',
@@ -364,6 +368,38 @@ class ApplicationMenu extends BaseMenu {
     );
   }
 
+  renderDarkThemeToggle() {
+    const { intl, showToggleLabel, displaySettingsStatus } = this.props;
+    const { settings } = this.state;
+
+    const isDarkThemeEnabled = Meteor.settings.public.app.darkTheme.enabled;
+    if (!isDarkThemeEnabled) return null;
+
+    return (
+      <Styled.Row>
+        <Styled.Col aria-hidden="true">
+          <Styled.FormElement>
+            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+            <Styled.Label>
+              {intl.formatMessage(intlMessages.darkThemeLabel)}
+            </Styled.Label>
+          </Styled.FormElement>
+        </Styled.Col>
+        <Styled.Col>
+          <Styled.FormElementRight>
+            {displaySettingsStatus(settings.darkTheme)}
+            <Toggle
+              icons={false}
+              defaultChecked={settings.darkTheme}
+              onChange={() => this.handleToggle('darkTheme')}
+              showToggleLabel={showToggleLabel}
+            />
+          </Styled.FormElementRight>
+        </Styled.Col>
+      </Styled.Row>
+    );
+  }
+
   render() {
     const {
       allLocales, intl, showToggleLabel, displaySettingsStatus,
@@ -420,6 +456,7 @@ class ApplicationMenu extends BaseMenu {
 
           {this.renderAudioFilters()}
           {this.renderPaginationToggle()}
+          {this.renderDarkThemeToggle()}
 
           <Styled.Row>
             <Styled.Col>

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/component.jsx
@@ -735,7 +735,7 @@ class WhiteboardToolbar extends Component {
 
     return (
       <Styled.CustomSvgIcon>
-        <rect x="25%" y="25%" width="50%" height="50%" stroke="black" strokeWidth="1" fill={colorSelected.value}>
+        <rect x="25%" y="25%" width="50%" height="50%" stroke="black" strokeWidth="1" fill={colorSelected.value} id="colorPicker">
           <animate
             ref={(ref) => { this.colorListIconColor = ref; }}
             attributeName="fill"

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-submenu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-submenu/component.jsx
@@ -89,7 +89,7 @@ class ToolbarSubmenu extends Component {
     if (type === 'color') {
       return (
         <Styled.CustomSvgIcon>
-          <rect x="20%" y="20%" width="60%" height="60%" fill={obj.value} />
+          <rect x="20%" y="20%" width="60%" height="60%" fill={obj.value} id="colorPicker"/>
         </Styled.CustomSvgIcon>
       );
     } if (type === 'thickness') {

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -39,6 +39,7 @@
     "bowser": "^2.11.0",
     "browser-bunyan": "^1.6.3",
     "classnames": "^2.2.6",
+    "darkreader": "^4.9.46",
     "eventemitter2": "~5.0.1",
     "fastdom": "^1.0.10",
     "fibers": "^4.0.2",

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -48,6 +48,8 @@ public:
     learningDashboardBase: '/learning-analytics-dashboard'
     # Use https URL of CSS file. Example: https://docs.bigbluebutton.org/admin/customize.html#examples
     customStyleUrl: null
+    darkTheme:
+      enabled: true
     askForFeedbackOnLogout: false
     # the default logoutUrl matches window.location.origin i.e. bigbluebutton.org for demo.bigbluebutton.org
     # in some cases we want only custom logoutUrl to be used when provided on meeting create. Default value: true
@@ -124,6 +126,7 @@ public:
         guestWaitingAudioAlerts: true
         guestWaitingPushAlerts: true
         paginationEnabled: true
+        darkTheme: false
         pushLayoutToEveryone: false
         # fallbackLocale: if the locale the client is loaded in does not have a
         # translation a string, it will use the translation from the locale

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -385,6 +385,7 @@
     "app.submenu.application.applicationSectionTitle": "Application",
     "app.submenu.application.animationsLabel": "Animations",
     "app.submenu.application.audioFilterLabel": "Audio Filters for Microphone",
+    "app.submenu.application.darkThemeLabel": "Dark mode",
     "app.submenu.application.fontSizeControlLabel": "Font size",
     "app.submenu.application.increaseFontBtnLabel": "Increase application font size",
     "app.submenu.application.decreaseFontBtnLabel": "Decrease application font size",


### PR DESCRIPTION
### What does this PR do?
Add a new package for [dark mode](https://github.com/darkreader/darkreader).
Add a new toggle button to enable/disable dark theme in settings modal.
Dark theme can be disable via settings.yml


### Screenshots
https://user-images.githubusercontent.com/42683590/162489084-3cda38eb-7b21-45b2-9aa9-9a0d3b73f194.mp4


### Closes Issue(s)
- Closes https://github.com/bigbluebutton/bigbluebutton/issues/11218

### More
- [ ] Whiteboard may have problems with palette colors, it would be very interesting to review this point after the implementation of the new whiteboard. 
- [ ] Need to validate multiple custom styles.