### PR TITLE
Implements a progress-bar on mobile inside the external video for the viewers.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
@@ -579,6 +579,7 @@ class VideoPlayer extends Component {
           width,
           pointerEvents: isResizing ? 'none' : 'inherit',
           display: isMinimized && 'none',
+          background: 'black',
         }}
       >
         <div
@@ -622,20 +623,6 @@ class VideoPlayer extends Component {
             !isPresenter
               ? [
                 (
-                  <div className={styles.progressBar}>
-                    <div 
-                      className={styles.loaded}
-                      style={{ width: loaded * 100 + '%' }}
-                      >
-                      <div
-                        className={styles.played}
-                        style={{ width: played * 100 / loaded + '%'}}
-                      >
-                      </div>
-                    </div>
-                  </div>
-                ),
-                (
                   <div className={hoverToolbarStyle} key="hover-toolbar-external-video">
                     <VolumeSlider
                       hideVolume={this.hideVolume[playerName]}
@@ -650,6 +637,19 @@ class VideoPlayer extends Component {
                       label={intl.formatMessage(intlMessages.refreshLabel)}
                     />
                     {this.renderFullscreenButton()}
+
+                    <div className={styles.progressBar}>
+                      <div 
+                        className={styles.loaded}
+                        style={{ width: loaded * 100 + '%' }}
+                      >
+                        <div
+                          className={styles.played}
+                          style={{ width: played * 100 / loaded + '%'}}
+                        >
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 ),
                 (deviceInfo.isMobile && playing) && (

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
@@ -579,7 +579,7 @@ class VideoPlayer extends Component {
           width,
           pointerEvents: isResizing ? 'none' : 'inherit',
           display: isMinimized && 'none',
-          background: 'black',
+          background: 'var(--color-black)',
         }}
       >
         <div

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
@@ -646,8 +646,7 @@ class VideoPlayer extends Component {
                         <div
                           className={styles.played}
                           style={{ width: played * 100 / loaded + '%'}}
-                        >
-                        </div>
+                        />
                       </div>
                     </div>
                   </div>

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/styles.scss
@@ -71,12 +71,8 @@
 }
 
 .progressBar {
-  display: none;
-
-  :hover > & {
-    display: block;
-  }
-
+  position: absolute;
+  bottom: 0;
   height: 5px;
   width: 100%;
 

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/volume-slider/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/volume-slider/styles.scss
@@ -17,8 +17,8 @@
 .slider {
   @extend %baseIndicator;
   display: flex;
-  position: relative;
-  bottom: 3.5em;
+  position: absolute;
+  bottom: 2.5em;
   left: 1em;
   padding: 0.25rem 0.5rem;
   min-width: 200px;


### PR DESCRIPTION
1 - The viewer can't see the progress bar on their phones.

![Peek 08-04-2022 15-58](https://user-images.githubusercontent.com/19312495/162506288-1b121829-111d-44fc-b174-558044828d0a.gif)


2 - Now, the viewer can see the progress bar when hovering the video area.

![mobileProgressBar](https://user-images.githubusercontent.com/19312495/162503997-9b4f8b7a-7b1b-4c9f-b494-00c981751d4c.gif)

