### PR TITLE
Enable sidebar resize in media area of 'focus on' layouts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
@@ -123,6 +123,10 @@ const SidebarContent = (props) => {
         width,
         height,
       }}
+      handleStyles={{
+        left: { height: '100vh' },
+        right: { height: '100vh' },
+      }}
     >
       {sidebarContentPanel === PANELS.CHAT
       && (


### PR DESCRIPTION
### What does this PR do?

Makes resizing possible in media part of sidebar in "focus on" layouts.


https://user-images.githubusercontent.com/3728706/162790845-b012b09e-77a2-4e2d-8d0b-fddcdad525db.mp4



### Closes Issue(s)
Closes #14762