### PR TITLE
fix: Incorrect position of the microphone icon in the webcam box in RTL - BBB v2.4.5

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.scss
@@ -230,6 +230,11 @@
   &::before {
     font-size: var(--audio-indicator-fs);
   }
+
+  [dir="rtl"] & {
+    right: auto;
+    left: 7px;
+  }
 }
 
 .muted {


### PR DESCRIPTION
### What does this PR do?

Adjusts video list icons position in RTL.

### Closes Issue(s)
Closes #14790