### PR TITLE
Fix notes display order

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/pads/content/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/pads/content/styles.js
@@ -17,6 +17,7 @@ color: ${colorGray};
 bottom: 0;
 box-sizing: border-box;
 display: flex;
+flex-direction: column;
 overflow-x: hidden;
 overflow-wrap: break-word;
 word-break: break-all;


### PR DESCRIPTION
### What does this PR do?

After the last changes to the shared notes, the hyperlinks were displayed side by side, instead of display it in right way, This PR fixes it.

### More

<!-- Anything else we should know when reviewing? -->
Before:
![hl](https://user-images.githubusercontent.com/15806883/162829461-fd35b5b2-399c-49f1-9613-6443ae992c2a.png)

After:

![image](https://user-images.githubusercontent.com/15806883/162829638-c8971f66-3206-4bf7-ac30-08b81820ab6c.png)

