### PR TITLE
fix: Adjust property path for grails session.cookie.secure

### DIFF
--- a/bigbluebutton-web/grails-app/conf/application.yml
+++ b/bigbluebutton-web/grails-app/conf/application.yml
@@ -35,9 +35,10 @@ endpoints:
         enabled: true
 
 server:
-    session:
-        cookie:
-            secure: true
+    servlet:
+        session:
+            cookie:
+                secure: true
 
 ---
 grails:


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Looks like the path for `session.cookie` has changed and we have to tweak how we set property `secure`
Credit: @pedrobmarin 
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none


### More
Local testing worked fine


