### PR TITLE
chore: Enable drag and drop polls by default

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -433,7 +433,7 @@ public:
   poll:
     enabled: true
     maxCustom: 5
-    allowDragAndDropFile: false
+    allowDragAndDropFile: true
     maxTypedAnswerLength: 45
     chatMessage: true
   captions:


### PR DESCRIPTION
### What does this PR do?

Enables [drag & drop file poll feature](https://github.com/bigbluebutton/bigbluebutton/pull/11559) by default.