### PR TITLE
fix: fixes deployment of modified bigbluebutton-html5 code 

### DIFF
--- a/bigbluebutton-html5/deploy_to_usr_share.sh
+++ b/bigbluebutton-html5/deploy_to_usr_share.sh
@@ -40,7 +40,7 @@ echo "writing $DESTINATION_DIR/mongod_start_pre.sh"
 sudo cp $LOCAL_PACKAGING_DIR/mongod_start_pre.sh "$DESTINATION_DIR"/mongod_start_pre.sh
 
 echo "writing $DESTINATION_DIR/mongo-ramdisk.conf"
-sudo cp $LOCAL_PACKAGING_DIR/mongo-ramdisk.conf "$DESTINATION_DIR"/mongo-ramdisk.conf
+sudo cp $LOCAL_PACKAGING_DIR/bionic/mongo-ramdisk.conf "$DESTINATION_DIR"/mongo-ramdisk.conf
 
 echo "writing $DESTINATION_DIR/bbb-html5-with-roles.conf"
 sudo tee "$DESTINATION_DIR/bbb-html5-with-roles.conf" >/dev/null <<HERE


### PR DESCRIPTION
After running `bigbluebutton-html/deploy_to_usr_share.sh` in 2.4 branch my server was broken.

Investigating a while, I've noticed that the script was getting aborted because the wrong path of `mongo-ramdisk.conf`.

This PR fixes this problem.
