### PR TITLE
refactor: remove unused imports/variables

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -10,12 +10,9 @@ import Settings from '/imports/ui/services/settings';
 import logger from '/imports/startup/client/logger';
 import Users from '/imports/api/users';
 import { Session } from 'meteor/session';
-import { FormattedMessage } from 'react-intl';
 import { Meteor } from 'meteor/meteor';
 import Meetings from '/imports/api/meetings';
 import AppService from '/imports/ui/components/app/service';
-import AudioService from '/imports/ui/components/audio/service';
-import { notify } from '/imports/ui/services/notification';
 import deviceInfo from '/imports/utils/deviceInfo';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import { layoutSelectInput, layoutDispatch } from '../../ui/components/layout/context';
@@ -94,10 +91,6 @@ class Base extends Component {
     });
 
     MediaService.setSwapLayout(layoutContextDispatch);
-
-    const {
-      userID: localUserId,
-    } = Auth;
 
     if (animations) HTML.classList.add('animationsEnabled');
     if (!animations) HTML.classList.add('animationsDisabled');

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import _ from 'lodash';
-import Button from '/imports/ui/components/common/button/component';
 import { Session } from 'meteor/session';
 import logger from '/imports/startup/client/logger';
 import Styled from './styles';

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/styles.js
@@ -1,6 +1,5 @@
 import styled, { css, keyframes } from 'styled-components';
 import {
-  systemMessageBorderColor,
   mdPaddingX,
   borderSize,
   listItemBgHover, borderSizeSmall,


### PR DESCRIPTION
### What does this PR do?

Removes unused imports and exports reported by [lgtm alerts](https://lgtm.com/projects/g/bigbluebutton/bigbluebutton/alerts)

### Motivation

*Unused local variables make code hard to read and understand. Any computation used to initialize an unused variable is wasted, which may lead to performance problems.*

*Similarly, unused imports and unused functions or classes can be confusing. They may even be a symptom of a bug caused, for example, by an incomplete refactoring.* (https://lgtm.com/rules/1780092/)
