### PR TITLE
fix: undefined user prop crash in userlist

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
@@ -211,9 +211,9 @@ class UserListItem extends PureComponent {
   componentDidUpdate() {
     const { user, selectedUserId } = this.props;
     const { selected } = this.state;
-    if (selectedUserId === user.userId && !selected) {
+    if (selectedUserId === user?.userId && !selected) {
       this.setState({ selected: true });
-    } else if (selectedUserId !== user.userId && selected) {
+    } else if (selectedUserId !== user?.userId && selected) {
       this.setState({ selected: false });
     }
   }


### PR DESCRIPTION
### What does this PR do?

Prevents a "blue screen" crash in userlist, that could happen when users are still loading (and `user` prop is undefined).

![2022-04-18_13-45](https://user-images.githubusercontent.com/3728706/163853077-23b22127-10ae-4790-9a8d-a2f8536fdf1b.png)

