### PR TITLE
feat(webcam): pin multiple cameras simultaneously

### DIFF
--- a/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
+++ b/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
@@ -28,6 +28,7 @@ trait AppsTestFixtures {
   val webcamsOnlyForModerator = false;
   val meetingCameraCap = 0
   val userCameraCap = 0
+  val maxPinnedCameras = 3
   val moderatorPassword = "modpass"
   val viewerPassword = "viewpass"
   val learningDashboardAccessToken = "ldToken"
@@ -50,6 +51,7 @@ trait AppsTestFixtures {
 
   val meetingProp = MeetingProp(name = meetingName, extId = externalMeetingId, intId = meetingId,
     meetingCameraCap = meetingCameraCap,
+    maxPinnedCameras = maxPinnedCameras,
     isBreakout = isBreakout.booleanValue())
   val durationProps = DurationProps(duration = durationInMinutes, createdTime = createTime, createdDate = createDate,
     meetingExpireIfNoUserJoinedInMinutes = meetingExpireIfNoUserJoinedInMinutes, meetingExpireWhenLastUserLeftInMinutes = meetingExpireWhenLastUserLeftInMinutes,

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
@@ -9,12 +9,14 @@ case class DurationProps(duration: Int, createdTime: Long, createdDate: String,
                          endWhenNoModerator:                     Boolean, endWhenNoModeratorDelayInMinutes: Int)
 
 case class MeetingProp(
-    name:             String,
-    extId:            String,
-    intId:            String,
-    meetingCameraCap: Int,
-    isBreakout:       Boolean,
-    disabledFeatures: Vector[String]
+    name:                 String,
+    extId:                String,
+    intId:                String,
+    meetingCameraCap:     Int,
+    maxPinnedCameras:     Int,
+    isBreakout:           Boolean,
+    disabledFeatures:     Vector[String],
+    notifyRecordingIsOn:  Boolean,
 )
 
 case class BreakoutProps(

--- a/bbb-common-message/src/test/scala/org/bigbluebutton/common2/TestFixtures.scala
+++ b/bbb-common-message/src/test/scala/org/bigbluebutton/common2/TestFixtures.scala
@@ -25,6 +25,7 @@ trait TestFixtures {
   val webcamsOnlyForModerator = false
   val meetingCameraCap = 0
   val userCameraCap = 0
+  val maxPinnedCameras = 3
   val moderatorPassword = "modpass"
   val viewerPassword = "viewpass"
   val learningDashboardAccessToken = "ldToken"
@@ -46,6 +47,7 @@ trait TestFixtures {
 
   val meetingProp = MeetingProp(name = meetingName, extId = externalMeetingId, intId = meetingId,
     meetingCameraCap = meetingCameraCap,
+    maxPinnedCameras = maxPinnedCameras,
     isBreakout = isBreakout.booleanValue())
   val breakoutProps = BreakoutProps(parentId = parentMeetingId, sequence = sequence, freeJoin = false, breakoutRooms = Vector())
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -63,6 +63,7 @@ public class ApiParams {
     public static final String WEBCAMS_ONLY_FOR_MODERATOR = "webcamsOnlyForModerator";
     public static final String MEETING_CAMERA_CAP = "meetingCameraCap";
     public static final String USER_CAMERA_CAP = "userCameraCap";
+    public static final String MAX_PINNED_CAMERAS = "maxPinnedCameras";
     public static final String MEETING_EXPIRE_IF_NO_USER_JOINED_IN_MINUTES = "meetingExpireIfNoUserJoinedInMinutes";
     public static final String MEETING_EXPIRE_WHEN_LAST_USER_LEFT_IN_MINUTES = "meetingExpireWhenLastUserLeftInMinutes";
     public static final String WELCOME = "welcome";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -393,6 +393,7 @@ public class MeetingService implements MessageListener {
     logData.put("webcamsOnlyForModerator", m.getWebcamsOnlyForModerator());
     logData.put("meetingCameraCap", m.getMeetingCameraCap());
     logData.put("userCameraCap", m.getUserCameraCap());
+    logData.put("maxPinnedCameras", m.getMaxPinnedCameras());
     logData.put("record", m.isRecord());
     logData.put("logCode", "create_meeting");
     logData.put("description", "Create meeting.");
@@ -407,7 +408,7 @@ public class MeetingService implements MessageListener {
 
     gw.createMeeting(m.getInternalId(), m.getExternalId(), m.getParentMeetingId(), m.getName(), m.isRecord(),
             m.getTelVoice(), m.getDuration(), m.getAutoStartRecording(), m.getAllowStartStopRecording(),
-            m.getWebcamsOnlyForModerator(), m.getMeetingCameraCap(), m.getUserCameraCap(), m.getModeratorPassword(), m.getViewerPassword(),
+            m.getWebcamsOnlyForModerator(), m.getMeetingCameraCap(), m.getUserCameraCap(), m.getMaxPinnedCameras(), m.getModeratorPassword(), m.getViewerPassword(),
             m.getLearningDashboardAccessToken(), m.getCreateTime(),
             formatPrettyDate(m.getCreateTime()), m.isBreakout(), m.getSequence(), m.isFreeJoin(), m.getMetadata(),
             m.getGuestPolicy(), m.getAuthenticatedGuest(), m.getMeetingLayout(), m.getWelcomeMessageTemplate(), m.getWelcomeMessage(), m.getModeratorOnlyMessage(),

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -92,6 +92,7 @@ public class ParamsProcessorUtil {
     private boolean webcamsOnlyForModerator;
     private Integer defaultMeetingCameraCap = 0;
     private Integer defaultUserCameraCap = 0;
+    private Integer defaultMaxPinnedCameras = 3;
     private boolean defaultMuteOnStart = false;
     private boolean defaultAllowModsToUnmuteUsers = false;
     private boolean defaultAllowModsToEjectCameras = false;
@@ -560,6 +561,16 @@ public class ParamsProcessorUtil {
             }
         }
 
+        Integer maxPinnedCameras = defaultMaxPinnedCameras;
+        if (!StringUtils.isEmpty(params.get(ApiParams.MAX_PINNED_CAMERAS))) {
+          try {
+            Integer maxPinnedCamerasParam = Integer.parseInt(params.get(ApiParams.MAX_PINNED_CAMERAS));
+            if (maxPinnedCamerasParam > 0) maxPinnedCameras = maxPinnedCamerasParam;
+          } catch (NumberFormatException e) {
+            log.warn("Invalid param [maxPinnedCameras] for meeting =[{}]", internalMeetingId);
+          }
+        }
+
         Integer meetingExpireIfNoUserJoinedInMinutes = defaultMeetingExpireIfNoUserJoinedInMinutes;
         if (!StringUtils.isEmpty(params.get(ApiParams.MEETING_EXPIRE_IF_NO_USER_JOINED_IN_MINUTES))) {
             try {
@@ -667,6 +678,7 @@ public class ParamsProcessorUtil {
                 .withWebcamsOnlyForModerator(webcamsOnlyForMod)
                 .withMeetingCameraCap(meetingCameraCap)
                 .withUserCameraCap(userCameraCap)
+                .withMaxPinnedCameras(maxPinnedCameras)
                 .withMetadata(meetingInfo)
                 .withWelcomeMessageTemplate(welcomeMessageTemplate)
                 .withWelcomeMessage(welcomeMessage).isBreakout(isBreakout)
@@ -1125,6 +1137,10 @@ public class ParamsProcessorUtil {
 
     public void setDefaultUserCameraCap(Integer userCameraCap) {
         this.defaultUserCameraCap = userCameraCap;
+    }
+
+    public void setDefaultMaxPinnedCameras(Integer maxPinnedCameras) {
+        this.defaultMaxPinnedCameras = maxPinnedCameras;
     }
 
 	public void setUseDefaultAvatar(Boolean value) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -69,6 +69,7 @@ public class Meeting {
 	private boolean webcamsOnlyForModerator = false;
 	private Integer meetingCameraCap = 0;
 	private Integer userCameraCap = 0;
+	private Integer maxPinnedCameras = 0;
 	private String dialNumber;
 	private String defaultAvatarURL;
 	private String guestPolicy = GuestPolicy.ASK_MODERATOR;
@@ -140,6 +141,7 @@ public class Meeting {
         webcamsOnlyForModerator = builder.webcamsOnlyForModerator;
         meetingCameraCap = builder.meetingCameraCap;
         userCameraCap = builder.userCameraCap;
+        maxPinnedCameras = builder.maxPinnedCameras;
         duration = builder.duration;
         webVoice = builder.webVoice;
         telVoice = builder.telVoice;
@@ -521,6 +523,10 @@ public class Meeting {
         return userCameraCap;
     }
 
+    public Integer getMaxPinnedCameras() {
+        return maxPinnedCameras;
+    }
+
 	public boolean hasUserJoined() {
 		return userHasJoined;
 	}
@@ -791,6 +797,7 @@ public class Meeting {
         private boolean webcamsOnlyForModerator;
         private Integer meetingCameraCap;
         private Integer userCameraCap;
+        private Integer maxPinnedCameras;
     	private String moderatorPass;
     	private String viewerPass;
     	private int learningDashboardCleanupDelayInMinutes;
@@ -870,6 +877,11 @@ public class Meeting {
 
         public Builder withUserCameraCap(Integer cap) {
             this.userCameraCap = cap;
+            return this;
+        }
+
+        public Builder withMaxPinnedCameras(Integer pins) {
+            this.maxPinnedCameras = pins;
             return this;
         }
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/converters/messages/CreateMeetingMessage.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/converters/messages/CreateMeetingMessage.java
@@ -19,6 +19,7 @@ public class CreateMeetingMessage {
 	public boolean webcamsOnlyForModerator;
 	public final Integer meetingCameraCap;
 	public final Integer userCameraCap;
+	public final Integer maxPinnedCameras;
 	public final String moderatorPass;
 	public final String viewerPass;
 	public final String learningDashboardAccessToken;
@@ -30,7 +31,7 @@ public class CreateMeetingMessage {
 	public CreateMeetingMessage(String id, String externalId, String name, Boolean record, 
 						String voiceBridge, Long duration, 
 						Boolean autoStartRecording, Boolean allowStartStopRecording,
-						Boolean webcamsOnlyForModerator, Integer meetingCameraCap, Integer userCameraCap, String moderatorPass,
+						Boolean webcamsOnlyForModerator, Integer meetingCameraCap, Integer userCameraCap, Integer maxPinnedCameras, String moderatorPass,
 						String viewerPass, String learningDashboardAccessToken,
 						ArrayList<String> disabledFeatures,
 						Long createTime, String createDate, Map<String, String> metadata) {
@@ -45,6 +46,7 @@ public class CreateMeetingMessage {
 		this.webcamsOnlyForModerator = webcamsOnlyForModerator;
 		this.meetingCameraCap = meetingCameraCap;
 		this.userCameraCap = userCameraCap;
+		this.maxPinnedCameras = maxPinnedCameras;
 		this.moderatorPass = moderatorPass;
 		this.viewerPass = viewerPass;
 		this.learningDashboardAccessToken = learningDashboardAccessToken;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
@@ -22,6 +22,7 @@ public interface IBbbWebApiGWApp {
                      Boolean allowStartStopRecording, Boolean webcamsOnlyForModerator,
                      Integer meetingCameraCap,
                      Integer userCameraCap,
+                     Integer maxPinnedCameras,
                      String moderatorPass, String viewerPass, String learningDashboardAccessToken, Long createTime,
                      String createDate, Boolean isBreakout, Integer sequence, Boolean freejoin, Map<String, String> metadata,
                      String guestPolicy, Boolean authenticatedGuest, String meetingLayout, String welcomeMsgTemplate, String welcomeMsg, String modOnlyMessage,

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/domain/MeetingProp2.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/domain/MeetingProp2.java
@@ -6,6 +6,7 @@ public class MeetingProp2 {
     public final String extId;
     public final String intId;
     public final int meetingCameraCap;
+    public final int maxPinnedCameras;
     public final String parentId;
     public final Integer sequence;
     public final Boolean isBreakout;
@@ -14,6 +15,7 @@ public class MeetingProp2 {
                         String extId,
                         String intId,
                         int meetingCameraCap,
+                        int maxPinnedCameras,
                         String parentId,
                         Integer sequence,
                         Boolean isBreakout) {
@@ -21,6 +23,7 @@ public class MeetingProp2 {
         this.extId = extId;
         this.intId = intId;
         this.meetingCameraCap = meetingCameraCap;
+        this.maxPinnedCameras = maxPinnedCameras;
         this.parentId = parentId;
         this.sequence = sequence;
         this.isBreakout = isBreakout;

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -124,6 +124,7 @@ class BbbWebApiGWApp(
                     allowStartStopRecording: java.lang.Boolean, webcamsOnlyForModerator: java.lang.Boolean,
                     meetingCameraCap: java.lang.Integer,
                     userCameraCap:    java.lang.Integer,
+                    maxPinnedCameras: java.lang.Integer,
                     moderatorPass:    String, viewerPass: String, learningDashboardAccessToken: String,
                     createTime: java.lang.Long, createDate: String, isBreakout: java.lang.Boolean,
                     sequence: java.lang.Integer,
@@ -155,6 +156,7 @@ class BbbWebApiGWApp(
       extId = extMeetingId,
       intId = meetingId,
       meetingCameraCap = meetingCameraCap.intValue(),
+      maxPinnedCameras = maxPinnedCameras.intValue(),
       isBreakout = isBreakout.booleanValue(),
       disabledFeaturesAsVector
     )

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -52,6 +52,7 @@ export default function addMeeting(meeting) {
       intId: String,
       extId: String,
       meetingCameraCap: Number,
+      maxPinnedCameras: Number,
       isBreakout: Boolean,
       name: String,
       disabledFeatures: Array,

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -259,6 +259,9 @@ meetingCameraCap=0
 # if 0, there's no limit
 userCameraCap=3
 
+# Maximum number of cameras pinned simultaneously
+maxPinnedCameras=3
+
 # Mute the meeting on start
 muteOnStart=false
 

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -156,6 +156,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="webcamsOnlyForModerator" value="${webcamsOnlyForModerator}"/>
         <property name="defaultMeetingCameraCap" value="${meetingCameraCap}"/>
         <property name="defaultUserCameraCap" value="${userCameraCap}"/>
+        <property name="defaultMaxPinnedCameras" value="${maxPinnedCameras}"/>
         <property name="useDefaultAvatar" value="${useDefaultAvatar}"/>
         <property name="defaultAvatarURL" value="${defaultAvatarURL}"/>
         <property name="defaultGuestPolicy" value="${defaultGuestPolicy}"/>


### PR DESCRIPTION
### What does this PR do?

Adds support for multiple camera pins.
The pinned cameras are stored in a FIFO-type queue
When a camera is pinned the oldest one is removed.
The queue size can be set via create parameter `maxPinnedCameras`, if not defaults to 3.

![pins](https://user-images.githubusercontent.com/32987232/163857656-d211fc0b-38c8-45bf-aa19-7bac7e4fbc0b.gif)

### Closes Issue(s)

Closes #14442
