### PR TITLE
build: allow building of multiple packages via one command

### DIFF
--- a/build/setup.sh
+++ b/build/setup.sh
@@ -1,10 +1,11 @@
 #!/bin/bash -ex
 
-PACKAGE_TO_BUILD="$1"
-if [ -z "$PACKAGE_TO_BUILD" ]; then
+IFS=' ' read -ra PACKAGES_TO_BUILD <<< "$@"
+if [ -z "$PACKAGES_TO_BUILD" ]; then
     set +x
-    echo "please provide a package name as first parameter, e.g."
+    echo "please provide one or many package names as a first parameter, e.g."
     echo "build/setup.sh bbb-freeswitch-core"
+    echo "build/setup.sh bbb-freeswitch-core bbb-config"
     exit 1
 fi
 
@@ -15,17 +16,19 @@ mkdir -p artifacts
 
 DOCKER_IMAGE=$(python3 -c 'import yaml; print(yaml.load(open("./.gitlab-ci.yml"), Loader=yaml.SafeLoader)["default"]["image"])')
 
-# -v "$CACHE_DIR/dev":/root/dev
-sudo docker run --rm \
+for PACKAGE_TO_BUILD in "${PACKAGES_TO_BUILD[@]}"; do
+    # -v "$CACHE_DIR/dev":/root/dev
+    sudo docker run --rm \
         -e "LOCAL_BUILD=1" \
         --mount type=bind,src="$PWD",dst=/mnt \
         --mount type=bind,src="${PWD}/artifacts,dst=/artifacts" \
         -t "$DOCKER_IMAGE" /mnt/build/setup-inside-docker.sh "$PACKAGE_TO_BUILD"
-        
-#        -v "$CACHE_DIR/$DISTRO/.gradle:/root/.gradle" \
-#        -v "$CACHE_DIR/$DISTRO/.grails:/root/.grails" \
-#        -v "$CACHE_DIR/$DISTRO/.ivy2:/root/.ivy2" \
-#        -v "$CACHE_DIR/$DISTRO/.m2:/root/.m2" \
-#        -v "$TMP/$TARGET:$TMP/$TARGET"  \
 
-find artifacts
+    #    -v "$CACHE_DIR/$DISTRO/.gradle:/root/.gradle" \
+    #    -v "$CACHE_DIR/$DISTRO/.grails:/root/.grails" \
+    #    -v "$CACHE_DIR/$DISTRO/.ivy2:/root/.ivy2" \
+    #    -v "$CACHE_DIR/$DISTRO/.m2:/root/.m2" \
+    #    -v "$TMP/$TARGET:$TMP/$TARGET"  \
+
+    find artifacts
+done


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Modifies the existing `build/setup.sh bbb-some-package` command to also accept a list of packages to build (useful when wanting to [re]build all packages outside of a pipeline)

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none


### Motivation
Instead of running

`./build/setup.sh bbb-config`
`./build/setup.sh bbb-html5`

to be able to run
`./build/setup.sh bbb-config bbb-html5` etc


<!-- What inspired you to submit this pull request? -->
