### PR TITLE
Fix links to documentation

### DIFF
--- a/bbb-common-message/README.md
+++ b/bbb-common-message/README.md
@@ -1,1 +1,1 @@
- see http://code.google.com/p/bigbluebutton/wiki/DevelopingBBB
+see https://docs.bigbluebutton.org/2.4/dev.html

--- a/bbb-common-web/README.md
+++ b/bbb-common-web/README.md
@@ -1,1 +1,1 @@
- see http://code.google.com/p/bigbluebutton/wiki/DevelopingBBB
+see https://docs.bigbluebutton.org/2.4/dev.html

--- a/bigbluebutton-web/INSTALL
+++ b/bigbluebutton-web/INSTALL
@@ -1,5 +1,5 @@
 Please read
-http://code.google.com/p/bigbluebutton/wiki/InstallingBigBlueButton
+https://docs.bigbluebutton.org/2.4/install.html
   
   
   

--- a/labs/stress-testing/bbb-test
+++ b/labs/stress-testing/bbb-test
@@ -4,7 +4,7 @@
 # Copyright (c) 2017-2019 by Dumalogiya (https://dumalogiya.ru)
 #
 # Documentation: 
-#   http://code.google.com/p/bigbluebutton/wiki/Testing
+#   https://code.google.com/archive/p/bigbluebutton/wikis/StressTesting.wiki
 #
 # This file is part of BigBlueButton - http://www.bigbluebutton.org
 #


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Some links, especially in `README.md` files, point to outdated documentation hosted on `code.google.com`. I have replaced them with their respective counterpart in `docs.bigbluebutton.org`.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes None


### Motivation

I wanted to look in the documentation and found myself on an outdated page.

### More

- [x] Added/updated documentation
