### PR TITLE
fix: whiteboard toolbar border-radius

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/styles.js
@@ -6,7 +6,7 @@ import {
   colorDanger,
   colorWhite,
   colorGrayDark,
-  colorGrayLighter,
+  toolbarButtonBorderColor,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import {
   toolbarButtonWidth,
@@ -16,6 +16,8 @@ import {
   smPaddingX,
   toolbarMargin,
   toolbarButtonBorderRadius,
+  toolbarItemOutlineOffset,
+  toolbarButtonBorder,
 } from '/imports/ui/stylesheets/styled-components/general';
 import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints';
 
@@ -87,11 +89,11 @@ const ToolbarWrapper = styled.div`
   pointer-events: all;
 
   .toolbarButtonWrapper > button {
-    outline-offset: -.19rem;
-    border-bottom: 1px solid ${colorGrayLighter};
+    outline-offset: ${toolbarItemOutlineOffset};
+    border-bottom: ${toolbarButtonBorder} solid ${toolbarButtonBorderColor};
   }
 
-  .toolbarButtonWrapper:first-child > button {
+  & > .toolbarButtonWrapper:first-child > button {
     border-top-left-radius: ${toolbarButtonBorderRadius};
     border-top-right-radius: ${toolbarButtonBorderRadius};
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-menu-item/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-toolbar/toolbar-menu-item/styles.js
@@ -3,8 +3,6 @@ import styled from 'styled-components';
 import {
   toolbarButtonWidth,
   toolbarButtonHeight,
-  toolbarItemOutlineOffset,
-  toolbarButtonBorder,
   toolbarButtonBorderRadius,
   toolbarItemTrianglePadding,
 } from '/imports/ui/stylesheets/styled-components/general';
@@ -24,22 +22,6 @@ const ButtonWrapper = styled.div`
   height: ${toolbarButtonHeight};
   min-height: ${toolbarButtonHeight};
   position: relative;
-
-  & > button {
-    outline-offset: ${toolbarItemOutlineOffset};
-    border-bottom: ${toolbarButtonBorder} solid ${toolbarButtonBorderColor};
-  }
-
-  &:first-child > button {
-    border-top-left-radius: ${toolbarButtonBorderRadius};
-    border-top-right-radius: ${toolbarButtonBorderRadius};
-  }
-
-  &:last-child > button {
-    border-bottom: 0;
-    border-bottom-left-radius: ${toolbarButtonBorderRadius};
-    border-bottom-right-radius: ${toolbarButtonBorderRadius};
-  }
 
   ${({ showCornerTriangle }) => showCornerTriangle && `
     &::before {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

Removes undesirable border-radius from multi-user whiteboard button.

![Screenshot from 2022-04-19 10-23-25](https://user-images.githubusercontent.com/62393923/164015302-5b8b4a56-1855-4a41-9737-12a4fa3c30c9.png)

![Screenshot from 2022-04-19 10-24-17](https://user-images.githubusercontent.com/62393923/164015312-b3e8e136-c160-4b96-af95-a60752dc7a58.png)