### PR TITLE
chore: disable candidate signaling by default

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -212,9 +212,9 @@ public:
     wsConnectionTimeout: 4000
     # Time in milis to wait for the browser to return a gUM call (used in video-preview)
     gUMTimeout: 20000
-    # Experiment(al). Controls whether ICE candidates should be signaled.
-    # Applies to webcams, listen only and screen sharing. True is "stable behavior".
-    signalCandidates: true
+    # Controls whether ICE candidates should be signaled to bbb-webrtc-sfu.
+    # Enable this if you want to use Kurento as the media server.
+    signalCandidates: false
     # Forces relay usage only on Firefox. Applies to listen only, webcams and screenshare.
     forceRelayOnFirefox: false
     cameraTimeouts:


### PR DESCRIPTION
### What does this PR do?

mediasoup is the default media server in v2.5, so we don't need ICE candidates 
to be signaled to bbb-webrtc-sfu (ICE-lite, ...). 

### Closes Issue(s)
 
n/a

### Motivation

Disabling it saves resources, both in the client and server.

### Additional information

The `signalCandidates` config should only be enabled if someone wishes to use
Kurento as the media server for some reason. I'll add that to the docs later.