### PR TITLE
fix(audio): use correct media server in listen only via fullaudio bridge

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/FullAudioBridge.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/FullAudioBridge.js
@@ -407,7 +407,8 @@ export default class FullAudioBridge extends BaseAudioBridge {
         );
         this.setInputStream(stream);
       } else {
-        this.inputStream.getAudioTracks().forEach((track) => track.applyConstraints(matchConstraints));
+        this.inputStream.getAudioTracks()
+          .forEach((track) => track.applyConstraints(matchConstraints));
       }
     } catch (error) {
       logger.error({


### PR DESCRIPTION
### What does this PR do?

The experimental audio bridge didn't make a distinction between the configured media server adapters for microphone and listen only, always defaulting to the one used in microphones. This PR fixes that behavior. 
It also includes a minor linter warning fix and removes an unnecessary (and undefined) `this.voiceBridge` reference in the callerId assembly.

### Closes Issue(s)

None

### Motivation

n/a

### More

n/a