### PR TITLE
[fix-PR-14628] - Include Return of the props in the read_props method.

### DIFF
--- a/record-and-playback/core/lib/recordandplayback.rb
+++ b/record-and-playback/core/lib/recordandplayback.rb
@@ -249,6 +249,7 @@ module BigBlueButton
       recOverrideProps = YAML::load(File.open(filepathRecOverride))
       @props = @props.merge(recOverrideProps)
     end
+    @props
   end
 
   def self.create_redis_publisher


### PR DESCRIPTION
### What does this PR do?

Includes a return statement in the read_props of `record-and-playback` method.