### PR TITLE
fix(audio): prevent uncaught rejections in the experimental audio bridge startup; [+]

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/FullAudioBridge.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/FullAudioBridge.js
@@ -1,7 +1,7 @@
 import BaseAudioBridge from './base';
 import Auth from '/imports/ui/services/auth';
 import logger from '/imports/startup/client/logger';
-import FullAudioBroker from '/imports/ui/services/bbb-webrtc-sfu/fullaudio-broker';
+import AudioBroker from '/imports/ui/services/bbb-webrtc-sfu/audio-broker';
 import loadAndPlayMediaStream from '/imports/ui/services/bbb-webrtc-sfu/load-play';
 import {
   fetchWebRTCMappedStunTurnServers,
@@ -128,6 +128,10 @@ export default class FullAudioBridge extends BaseAudioBridge {
     return null;
   }
 
+  get role() {
+    return this.broker?.role;
+  }
+
   async setInputStream(stream) {
     try {
       if (this.broker == null) return null;
@@ -137,11 +141,12 @@ export default class FullAudioBridge extends BaseAudioBridge {
       return stream;
     } catch (error) {
       logger.warn({
-        logCode: 'fullaudio_setinputstream_error',
+        logCode: 'sfuaudio_setinputstream_error',
         extraInfo: {
           errorCode: error.code,
           errorMessage: error.message,
           bridgeName: this.bridgeName,
+          role: this.role,
         },
       }, 'Failed to set input stream (mic)');
       return null;
@@ -191,13 +196,14 @@ export default class FullAudioBridge extends BaseAudioBridge {
     ).catch((error) => {
       // Error handling is a no-op because it will be "handled" in handleBrokerFailure
       logger.debug({
-        logCode: 'fullaudio_reconnect_failed',
+        logCode: 'sfuaudio_reconnect_failed',
         extraInfo: {
           errorMessage: error.errorMessage,
           reconnecting: this.reconnecting,
           bridge: this.bridgeName,
+          role: this.role,
         },
-      }, 'Fullaudio reconnect failed');
+      }, 'SFU audio reconnect failed');
     });
   }
 
@@ -208,30 +214,31 @@ export default class FullAudioBridge extends BaseAudioBridge {
 
       if (this.broker.started && !this.reconnecting) {
         logger.error({
-          logCode: 'fullaudio_error_try_to_reconnect',
+          logCode: 'sfuaudio_error_try_to_reconnect',
           extraInfo: {
             errorMessage,
             errorCode,
             errorCause,
             bridge: this.bridgeName,
+            role: this.role,
           },
-        }, 'Fullaudio failed, try to reconnect');
+        }, 'SFU audio failed, try to reconnect');
         this.reconnect();
         return resolve();
       }
-
       // Already tried reconnecting once OR the user handn't succesfully
       // connected firsthand. Just finish the session and reject with error
       logger.error({
-        logCode: 'fullaudio_error',
+        logCode: 'sfuaudio_error',
         extraInfo: {
           errorMessage,
           errorCode,
           errorCause,
           reconnecting: this.reconnecting,
           bridge: this.bridgeName,
+          role: this.role,
         },
-      }, 'Fullaudio failed');
+      }, 'SFU audio failed');
       this.clearReconnectionTimeout();
       this.broker.stop();
       this.callback({
@@ -265,9 +272,13 @@ export default class FullAudioBridge extends BaseAudioBridge {
       // This will be handled in audio-manager.
       if (error.name === 'NotAllowedError') {
         logger.error({
-          logCode: 'fullaudio_error_autoplay',
-          extraInfo: { errorName: error.name, bridge: this.bridgeName },
-        }, 'Fullaudio media play failed due to autoplay error');
+          logCode: 'sfuaudio_error_autoplay',
+          extraInfo: {
+            errorName: error.name,
+            bridge: this.bridgeName,
+            role: this.role,
+          },
+        }, 'SFU audio media play failed due to autoplay error');
         this.dispatchAutoplayHandlingEvent(mediaElement);
       } else {
         const normalizedError = {
@@ -310,7 +321,6 @@ export default class FullAudioBridge extends BaseAudioBridge {
       const { isListenOnly, extension, inputStream } = options;
       this.inEchoTest = !!extension;
       this.isListenOnly = isListenOnly;
-
       const callerIdName = [
         `${this.userId}_${getAudioSessionNumber()}`,
         'bbbID',
@@ -327,7 +337,7 @@ export default class FullAudioBridge extends BaseAudioBridge {
         stream: (inputStream && inputStream.active) ? inputStream : undefined,
       };
 
-      this.broker = new FullAudioBroker(
+      this.broker = new AudioBroker(
         Auth.authenticateURL(SFU_URL),
         isListenOnly ? RECV_ROLE : SENDRECV_ROLE,
         brokerOptions,
@@ -339,23 +349,24 @@ export default class FullAudioBridge extends BaseAudioBridge {
 
       return initBrokerEventsPromise;
     } catch (error) {
-      logger.warn({ logCode: 'fullaudio_bridge_broker_init_fail' },
+      logger.warn({ logCode: 'sfuaudio_bridge_broker_init_fail' },
         'Problem when initializing SFU broker for fullaudio bridge');
       throw error;
     }
   }
 
   async joinAudio(options, callback) {
+    this.callback = callback;
+
     try {
-      this.callback = callback;
       this.iceServers = await fetchWebRTCMappedStunTurnServers(this.sessionToken);
     } catch (error) {
-      logger.error({ logCode: 'fullaudio_stun-turn_fetch_failed' },
+      logger.error({ logCode: 'sfuaudio_stun-turn_fetch_failed' },
         'SFU audio bridge failed to fetch STUN/TURN info, using default servers');
       this.iceServers = getMappedFallbackStun();
-    } finally {
-      await this._startBroker(options);
     }
+
+    return this._startBroker(options);
   }
 
   sendDtmf(tones) {
@@ -383,11 +394,12 @@ export default class FullAudioBridge extends BaseAudioBridge {
       return updatedStream;
     } catch (error) {
       logger.warn({
-        logCode: 'fullaudio_livechangeinputdevice_error',
+        logCode: 'sfuaudio_livechangeinputdevice_error',
         extraInfo: {
           errorCode: error.code,
           errorMessage: error.message,
           bridgeName: this.bridgeName,
+          role: this.role,
         },
       }, 'Failed to change input device (mic)');
       return null;
@@ -412,11 +424,12 @@ export default class FullAudioBridge extends BaseAudioBridge {
       }
     } catch (error) {
       logger.error({
-        logCode: 'fullaudio_audio_constraint_error',
+        logCode: 'sfuaudio_audio_constraint_error',
         extraInfo: {
           errorCode: error.code,
           errorMessage: error.message,
           bridgeName: this.bridgeName,
+          role: this.role,
         },
       }, 'Failed to update audio constraint');
     }

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/audio-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/audio-broker.js
@@ -5,9 +5,9 @@ const ON_ICE_CANDIDATE_MSG = 'iceCandidate';
 const SUBSCRIBER_ANSWER = 'subscriberAnswer';
 const DTMF = 'dtmf';
 
-const SFU_COMPONENT_NAME = 'fullaudio';
+const SFU_COMPONENT_NAME = 'audio';
 
-class FullAudioBroker extends BaseBroker {
+class AudioBroker extends BaseBroker {
   constructor(
     wsUrl,
     role,
@@ -157,7 +157,7 @@ class FullAudioBroker extends BaseBroker {
         sfuComponent: this.sfuComponent,
         started: this.started,
       },
-    }, 'Listen only failed in SFU');
+    }, 'Audio failed in SFU');
     this.onerror(error);
   }
 
@@ -207,7 +207,7 @@ class FullAudioBroker extends BaseBroker {
           errorMessage: error.name || error.message || 'Unknown error',
           sfuComponent: this.sfuComponent,
         },
-      }, 'Listen only offer generation failed');
+      }, 'Audio offer generation failed');
       // 1305: "PEER_NEGOTIATION_FAILED",
       this.onerror(error);
     }
@@ -237,4 +237,4 @@ class FullAudioBroker extends BaseBroker {
   }
 }
 
-export default FullAudioBroker;
+export default AudioBroker;

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/audio-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/audio-broker.js
@@ -59,7 +59,7 @@ class AudioBroker extends BaseBroker {
     return Promise.resolve();
   }
 
-  joinAudio() {
+  _join() {
     return new Promise((resolve, reject) => {
       const options = {
         audioStream: this.stream,
@@ -111,9 +111,9 @@ class AudioBroker extends BaseBroker {
     });
   }
 
-  listen() {
+  joinAudio() {
     return this.openWSConnection()
-      .then(this.joinAudio.bind(this));
+      .then(this._join.bind(this));
   }
 
   onWSMessage(message) {

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/fullaudio-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/fullaudio-broker.js
@@ -74,8 +74,8 @@ class FullAudioBroker extends BaseBroker {
       };
 
       const WebRTCPeer = (this.role === 'sendrecv')
-        ? kurentoUtils.WebRtcPeer.WebRtcPeerSendrecv
-        : kurentoUtils.WebRtcPeer.WebRtcPeerRecvonly;
+        ? window.kurentoUtils.WebRtcPeer.WebRtcPeerSendrecv
+        : window.kurentoUtils.WebRtcPeer.WebRtcPeerRecvonly;
 
       this.webRtcPeer = WebRTCPeer(options, (error) => {
         if (error) {
@@ -116,7 +116,7 @@ class FullAudioBroker extends BaseBroker {
       .then(this.joinAudio.bind(this));
   }
 
-  onWSMessage (message) {
+  onWSMessage(message) {
     const parsedMessage = JSON.parse(message.data);
 
     switch (parsedMessage.id) {
@@ -139,12 +139,12 @@ class FullAudioBroker extends BaseBroker {
       default:
         logger.debug({
           logCode: `${this.logCodePrefix}_invalid_req`,
-          extraInfo: { messageId: parsedMessage.id || 'Unknown', sfuComponent: this.sfuComponent }
-        }, `Discarded invalid SFU message`);
+          extraInfo: { messageId: parsedMessage.id || 'Unknown', sfuComponent: this.sfuComponent },
+        }, 'Discarded invalid SFU message');
     }
   }
 
-  handleSFUError (sfuResponse) {
+  handleSFUError(sfuResponse) {
     const { code, reason, role } = sfuResponse;
     const error = BaseBroker.assembleError(code, reason);
 
@@ -157,11 +157,11 @@ class FullAudioBroker extends BaseBroker {
         sfuComponent: this.sfuComponent,
         started: this.started,
       },
-    }, `Listen only failed in SFU`);
+    }, 'Listen only failed in SFU');
     this.onerror(error);
   }
 
-  sendLocalDescription (localDescription) {
+  sendLocalDescription(localDescription) {
     const message = {
       id: SUBSCRIBER_ANSWER,
       type: this.sfuComponent,
@@ -172,7 +172,7 @@ class FullAudioBroker extends BaseBroker {
     this.sendMessage(message);
   }
 
-  onRemoteDescriptionReceived (sfuResponse) {
+  onRemoteDescriptionReceived(sfuResponse) {
     if (this.offering) {
       return this.processAnswer(sfuResponse);
     }
@@ -180,7 +180,7 @@ class FullAudioBroker extends BaseBroker {
     return this.processOffer(sfuResponse);
   }
 
-  sendStartReq (offer) {
+  sendStartReq(offer) {
     const message = {
       id: 'start',
       type: this.sfuComponent,
@@ -194,28 +194,28 @@ class FullAudioBroker extends BaseBroker {
     logger.debug({
       logCode: `${this.logCodePrefix}_offer_generated`,
       extraInfo: { sfuComponent: this.sfuComponent, role: this.role },
-    }, `SFU audio offer generated`);
+    }, 'SFU audio offer generated');
 
     this.sendMessage(message);
   }
 
-  onOfferGenerated (error, sdpOffer) {
+  onOfferGenerated(error, sdpOffer) {
     if (error) {
       logger.error({
         logCode: `${this.logCodePrefix}_offer_failure`,
         extraInfo: {
           errorMessage: error.name || error.message || 'Unknown error',
-          sfuComponent: this.sfuComponent
+          sfuComponent: this.sfuComponent,
         },
-      }, `Listen only offer generation failed`);
+      }, 'Listen only offer generation failed');
       // 1305: "PEER_NEGOTIATION_FAILED",
-      return this.onerror(error);
+      this.onerror(error);
     }
 
     this.sendStartReq(sdpOffer);
   }
 
-  dtmf (tones) {
+  dtmf(tones) {
     const message = {
       id: DTMF,
       type: this.sfuComponent,
@@ -225,7 +225,7 @@ class FullAudioBroker extends BaseBroker {
     this.sendMessage(message);
   }
 
-  onIceCandidate (candidate, role) {
+  onIceCandidate(candidate, role) {
     const message = {
       id: ON_ICE_CANDIDATE_MSG,
       role,


### PR DESCRIPTION
### What does this PR do?

- [refactor(audio): address linter warnings in fullaudio-broker.js](https://github.com/bigbluebutton/bigbluebutton/pull/14865/commits/2eaf96ae9530bf0db919ed52c75cbd737fb303d5)
- [refactor(audio): generic use of sfu audio broker to cover mic and listen only](https://github.com/bigbluebutton/bigbluebutton/pull/14865/commits/1e80d050b7a1348c46fb188b9c82acda7e2635fc)
  * Renames fullaudio-broker.js to audio-broker.js
  * Transform all logCode prefixes to `sfu_audio`
  * Add `role` to all log extraInfos
  * Review leftover, out-of-place references to keywords `listen`, `\clistenonly`, `fullaudio`
- [fix(audio): prevent uncaught rejections in the experimental audio bridge](https://github.com/bigbluebutton/bigbluebutton/pull/14865/commits/6fd6a52d47e372edc154aba1013624066e9d98bd)
  * #14639
### Closes Issue(s)

Partially addresses #14639 

### Motivation

- #14639
- Groundwork to remove the kurento.js listen only bridge in spite of the new fullaudio one
  * Server component was unified recently, so the client code can be unified as well
