### PR TITLE
test: fixes for 2.4 Playwright tests

### DIFF
--- a/bigbluebutton-tests/playwright/breakout/join.js
+++ b/bigbluebutton-tests/playwright/breakout/join.js
@@ -22,8 +22,8 @@ class Join extends Create {
     const breakoutUserPage = await this.userPage.getLastTargetPage(this.context);
     await breakoutUserPage.bringToFront();
 
-    await breakoutUserPage.hasElement(e.presentationPlaceholder);
     if (!shouldJoinAudio) await breakoutUserPage.closeAudioModal();
+    await breakoutUserPage.waitForSelector(e.presentationTitle);
     return breakoutUserPage;
   }
 
@@ -33,7 +33,7 @@ class Join extends Create {
     const parsedSettings = await this.userPage.getSettingsYaml();
     const videoPreviewTimeout = parseInt(parsedSettings.public.kurento.gUMTimeout);
     await breakoutPage.shareWebcam(videoPreviewTimeout);
-    await breakoutPage.hasElement(e.presentationPlaceholder);
+    await breakoutPage.waitForSelector(e.presentationTitle);
   }
 
   async joinAndShareScreen() {

--- a/bigbluebutton-tests/playwright/core/elements.js
+++ b/bigbluebutton-tests/playwright/core/elements.js
@@ -201,7 +201,6 @@ exports.firstUser = 'div[data-test="userListItemCurrent"]';
 exports.multiWhiteboardTool = 'span[data-test="multiWhiteboardTool"]';
 exports.manageUsers = 'button[data-test="manageUsers"]';
 exports.presenterClassName = 'presenter--';
-exports.anyUser = 'div[data-test="userListItem"]';
 exports.userListToggleBtn = 'button[data-test="toggleUserList"]';
 exports.mobileUser = 'span[data-test="mobileUser"]';
 exports.connectionStatusBtn = 'button[data-test="connectionStatusButton"]';

--- a/bigbluebutton-tests/playwright/customparameters/customparameters.js
+++ b/bigbluebutton-tests/playwright/customparameters/customparameters.js
@@ -142,8 +142,8 @@ class CustomParameters extends MultiUsers {
     const zoomOutCase = await util.zoomOut(this.modPage);
     await expect(zoomOutCase).toBeTruthy();
     await util.poll(this.modPage, this.userPage);
-    await util.previousSlide(this.modPage);
     await util.nextSlide(this.modPage);
+    await util.previousSlide(this.modPage);
     await util.annotation(this.modPage);
     await this.userPage.checkElement(e.restorePresentation);
   }

--- a/bigbluebutton-tests/playwright/notifications/notifications.spec.js
+++ b/bigbluebutton-tests/playwright/notifications/notifications.spec.js
@@ -55,7 +55,7 @@ test.describe.parallel('Notifications', () => {
       await presenterNotifications.publishPollResults();
     });
 
-    test('Presentation upload notification', async ({ browser, context, page }) => {
+    test.fixme('Presentation upload notification', async ({ browser, context, page }) => { // this test is unstable, there's an apparent timing issue around the visibility of smallToastMsg
       const presenterNotifications = new PresenterNotifications(browser, context);
       await presenterNotifications.initPages(page);
       await presenterNotifications.fileUploaderNotification();

--- a/bigbluebutton-tests/playwright/virtualizedlist/virtualize.js
+++ b/bigbluebutton-tests/playwright/virtualizedlist/virtualize.js
@@ -13,7 +13,7 @@ class VirtualizeList {
   // Join BigBlueButton meeting
   async init() {
     await this.page1.init(true, true, { fullName: 'BroadCaster1' });
-    await this.page1.waitForSelector(e.anyUser);
+    await this.page1.waitForSelector(e.firstUser);
     for (let i = 1; i <= parseInt(USER_LIST_VLIST_BOTS_LISTENING); i++) {
       const newPage = await this.browser.newPage();
       const viewerPage = new Page(this.browser, newPage);
@@ -26,7 +26,7 @@ class VirtualizeList {
   }
 
   async test() {
-    const USER_LIST_VLIST_VISIBLE_USERS = await this.page1.getSelectorCount(e.anyUser);
+    const USER_LIST_VLIST_VISIBLE_USERS = await this.page1.getSelectorCount(e.userListItem);
     const totalNumberOfUsersMongo = await this.page1.page.evaluate(() => {
       const collection = require('/imports/api/users/index.js');
       return collection.default._collection.find().count();


### PR DESCRIPTION
### What does this PR do?

This PR introduces some minor fixes for 2.4 Playwright tests in the following areas:
- breakout rooms (updated presentation-related selector)
- user list (fix for the following scenario: when there's one user in the meeting, there's no user list element selectable by `div[data-test="userListItem"]`, so that means `userListItemCurrent` needs to be used)
- minor cleanup for the selector of users in the user list (`elements.js)
- custom parameters (change the order of switching between slides to make sure slides navigation buttons are enabled)
- notifications (presentation upload notification test seems to be unstable due to timing issue, so it is moved to `fixme` category).