### PR TITLE
fix: Blue screen when using fill poll values option

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -343,9 +343,11 @@ class Poll extends Component {
         diff -= 1;
       }
     } else {
+      let index = optList.length-1;
       while (diff < 0) {
-        this.handleRemoveOption();
+        this.handleRemoveOption(index);
         diff += 1;
+        index -=1;
       }
     }
   }


### PR DESCRIPTION
### What does this PR do?

Prevents a "blue screen" error when the fill poll values feature is used, by adding the required `index` parameter to the `handleRemoveOption` method. 

### Closes Issue(s)
Closes #14866