### PR TITLE
fix: Audio device selector icon wrong position in RTL layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/button/styles.scss
+++ b/bigbluebutton-html5/imports/ui/components/button/styles.scss
@@ -252,6 +252,13 @@
     font-size: 50%;
     margin-top: 40%;
     color: var(--btn-default-color);
+
+    [dir="rtl"] & {
+      left: unset;
+      margin-left: unset;
+      right: 0;
+      margin-right: 25%;
+    }
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

Adjusts audio button icon position in RTL languages.

### Closes Issue(s)
Closes #14864