### PR TITLE
packaging: Add dependencies on yq 3

### DIFF
--- a/build/packages-template/bbb-config/build.sh
+++ b/build/packages-template/bbb-config/build.sh
@@ -78,4 +78,5 @@ fpm -s dir -C ./staging -n $PACKAGE \
     --after-install after-install.sh \
     --description "BigBlueButton configuration utilities" \
     $DIRECTORIES \
-    $OPTS
+    $OPTS \
+    -d 'yq (>= 3)' -d 'yq (<< 4)'

--- a/build/packages-template/bbb-html5/build.sh
+++ b/build/packages-template/bbb-html5/build.sh
@@ -129,4 +129,5 @@ fpm -s dir -C ./staging -n $PACKAGE \
     --after-remove after-remove.sh \
     --description "The HTML5 components for BigBlueButton" \
     $DIRECTORIES \
-    $OPTS
+    $OPTS \
+    -d 'yq (>= 3)' -d 'yq (<< 4)'

--- a/build/packages-template/bbb-html5/opts-focal.sh
+++ b/build/packages-template/bbb-html5/opts-focal.sh
@@ -1,4 +1,3 @@
 . ./opts-global.sh
 
-# TODO - add yq
 OPTS="$OPTS -d bc,bbb-pads,bbb-webrtc-sfu,bbb-web,mongodb-org -t deb"

--- a/build/packages-template/bbb-playback-podcast/build.sh
+++ b/build/packages-template/bbb-playback-podcast/build.sh
@@ -42,6 +42,7 @@ fpm -s dir -C ./staging -n $PACKAGE \
     --after-install after-install.sh \
     --description "BigBluebutton playback in podcast" \
     $DIRECTORIES \
-    $OPTS
+    $OPTS \
+    -d 'yq (>= 3)' -d 'yq (<< 4)'
 
 

--- a/build/packages-template/bbb-playback-presentation/build.sh
+++ b/build/packages-template/bbb-playback-presentation/build.sh
@@ -42,6 +42,5 @@ fpm -s dir -C ./staging -n $PACKAGE \
     --after-install after-install.sh \
     --description "BigBluebutton playback of presentation" \
     $DIRECTORIES \
-    $OPTS
-
-
+    $OPTS \
+    -d 'yq (>= 3)' -d 'yq (<< 4)'

--- a/build/packages-template/bbb-playback-presentation/opts-focal.sh
+++ b/build/packages-template/bbb-playback-presentation/opts-focal.sh
@@ -1,4 +1,3 @@
 . ./opts-global.sh
 
-# TODO - add yq
 OPTS="$OPTS -t deb -d bbb-record-core"

--- a/build/packages-template/bbb-record-core/build.sh
+++ b/build/packages-template/bbb-record-core/build.sh
@@ -59,4 +59,5 @@ fpm -s dir -C ./staging -n $PACKAGE \
     --before-remove before-remove.sh    \
     --description "BigBlueButton record and playback" \
     $DIRECTORIES \
-    $OPTS
+    $OPTS \
+    -d 'yq (>= 3)' -d 'yq (<< 4)'

--- a/build/packages-template/bbb-record-core/opts-focal.sh
+++ b/build/packages-template/bbb-record-core/opts-focal.sh
@@ -1,4 +1,3 @@
 . ./opts-global.sh
 
-# TODO - add yq
 OPTS="$OPTS -t deb -d bbb-mkclean,ffmpeg,gir1.2-pango-1.0,libcurl4,libncurses5,libsystemd0,poppler-utils,python3,python3-attr,python3-cairo,python3-gi,python3-gi-cairo,python3-icu,python3-lxml,redis-server,rsync,ruby,ruby-bundler,zlib1g"

--- a/build/packages-template/bbb-webhooks/build.sh
+++ b/build/packages-template/bbb-webhooks/build.sh
@@ -45,4 +45,5 @@ fpm -s dir -C ./staging -n $PACKAGE                 \
     --before-remove before-remove.sh                \
     --description "BigBlueButton Webhooks"          \
     $DIRECTORIES                                    \
-    $OPTS
+    $OPTS                                           \
+    -d 'yq (>= 3)' -d 'yq (<< 4)'

--- a/build/packages-template/bbb-webhooks/opts-focal.sh
+++ b/build/packages-template/bbb-webhooks/opts-focal.sh
@@ -1,4 +1,3 @@
 . ./opts-global.sh
 
-# TODO - add yq
 OPTS="$OPTS -t deb -d nodejs,npm"

--- a/build/packages-template/bbb-webrtc-sfu/build.sh
+++ b/build/packages-template/bbb-webrtc-sfu/build.sh
@@ -63,4 +63,5 @@ fpm -s dir -C ./staging -n $PACKAGE                 \
     --before-remove before-remove.sh                \
     --description "BigBlueButton WebRTC SFU"        \
     $DIRECTORIES                                    \
-    $OPTS
+    $OPTS                                           \
+    -d 'yq (>= 3)' -d 'yq (<< 4)'

--- a/build/packages-template/bbb-webrtc-sfu/opts-focal.sh
+++ b/build/packages-template/bbb-webrtc-sfu/opts-focal.sh
@@ -1,4 +1,3 @@
 . ./opts-global.sh
 
-# TODO - add yq
 OPTS="$OPTS -t deb -d git-core,nginx,kurento-media-server,openh264-gst-plugins-bad-1.5,bbb-apps-akka,nodejs,npm,build-essential,xmlstarlet"


### PR DESCRIPTION
yq package is now provided in the [BigBlueButton support PPA](https://launchpad.net/~bigbluebutton/+archive/ubuntu/support/+packages) for BBB 2.5 on focal, so we can depend on the package now. Ensure the dependency is specific to avoid an incompatible yq version 4 from being installed.

The dependency can't be specified in the `opts-${dist}.sh` files because it contains some characters that would case escaping issues in the bash variables. This could potentially be fixed by changing the variables to be bash arrays instead of strings.