### PR TITLE
fix: check whether there's a toast before dismissing

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/status-notifier/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/status-notifier/component.jsx
@@ -62,7 +62,9 @@ class StatusNotifier extends Component {
 
     switch (status) {
       case 'raiseHand':
-        if (emojiUsers.length === 0) return toast.dismiss(this.statusNotifierId);
+        if (emojiUsers.length === 0) {
+          return this.statusNotifierId ? toast.dismiss(this.statusNotifierId) : null;
+        }
 
         if (raiseHandAudioAlert && emojiUsers.length > prevProps.emojiUsers.length) {
           this.audio.play();


### PR DESCRIPTION
Avoids closing all active toasts.

Closes #14754