### PR TITLE
Let packaging scripts operate in a git worktree

### DIFF
--- a/build/setup-inside-docker.sh
+++ b/build/setup-inside-docker.sh
@@ -26,16 +26,9 @@ for dir in .gradle .grails .ivy2 .m2; do
     ln -s "${SOURCE}/cache/${dir}" "/root/${dir}"
 done
 
-if [ "$LOCAL_BUILD" != 1 ] ; then
-    GIT_REV="${CI_COMMIT_SHA:0:10}"
-else
-    GIT_REV=$(git rev-parse HEAD)
-    GIT_REV="local-build-${GIT_REV:0:10}"
-fi
 VERSION_NUMBER="$(cat "$SOURCE/bigbluebutton-config/bigbluebutton-release" | cut -d '=' -f2 | cut -d "-" -f1)"
 # this contains stuff like alpha4 etc
 VERSION_ADDON="$(cat "$SOURCE/bigbluebutton-config/bigbluebutton-release" | cut -d '=' -f2 | cut -d "-" -f2)"
-COMMIT_DATE="$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%dT%H%M%S')"
 BUILD_NUMBER=${BUILD_NUMBER:=1}
 EPOCH=${EPOCH:=2}
 


### PR DESCRIPTION


### What does this PR do?

Modfies the package build scripts to calculate GIT_REV and COMMIT_DATE outside the docker container and pass them in as environment variables, since we can't compute them inside the docker container if the source directory is a git worktree


<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)

Closes #14888

### Other issues

I'm not sure how this interacts with the CI environment, since I can't easily test it.  In particular, it moves a reference to CI_COMMIT_SHA from `setup-inside-docker.sh` to `setup.sh`.  Somebody who knows the CI system should check to make sure this doesn't break things.
