### PR TITLE
build: bump bbb-webrtc-sfu to v2.8.1

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.8.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.8.1 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

build: bump bbb-webrtc-sfu to [v2.8.1](https://github.com/bigbluebutton/bbb-webrtc-sfu/releases/tag/v2.8.1)

### Closes Issue(s)

n/a

### Motivation

n/a

### More

n/a
- [ ] Added/updated documentation
