### PR TITLE
Adjust jitterbuffer settings in FreeSWITCH to improve audio

### DIFF
--- a/bbb-voice-conference/config/freeswitch/conf/dialplan/default/bbb_conference.xml
+++ b/bbb-voice-conference/config/freeswitch/conf/dialplan/default/bbb_conference.xml
@@ -3,7 +3,7 @@
       <condition field="${bbb_authorized}" expression="true" break="on-false"/>
       <condition field="${sip_via_protocol}" expression="^wss?$"/>
       <condition field="destination_number" expression="^(\d{5,11})$">
-        <action application="jitterbuffer" data="60:120"/>
+        <action application="jitterbuffer" data="120"/>
         <action application="answer"/>
         <action application="conference" data="$1@cdquality"/>
       </condition>
@@ -11,7 +11,7 @@
     <extension name="bbb_conferences">
       <condition field="${bbb_authorized}" expression="true" break="on-false"/>
       <condition field="destination_number" expression="^(\d{5,11})$">
-        <action application="jitterbuffer" data="60:120"/>
+        <action application="jitterbuffer" data="120"/>
         <action application="answer"/>
         <action application="conference" data="$1@cdquality"/>
       </condition>

--- a/bbb-voice-conference/config/freeswitch/conf/dialplan/default/bbb_echo_to_conference.xml
+++ b/bbb-voice-conference/config/freeswitch/conf/dialplan/default/bbb_echo_to_conference.xml
@@ -2,7 +2,7 @@
   <extension name="ECHO_TO_CONFERENCE">
     <condition field="${bbb_from_echo}" expression="true" break="on-false"/>
     <condition field="destination_number" expression="^(ECHO_TO_CONFERENCE)$">
-      <action application="jitterbuffer" data="60:120"/>
+      <action application="jitterbuffer" data="120"/>
       <action application="answer"/>
       <action application="conference" data="${vbridge}@cdquality"/>
     </condition>


### PR DESCRIPTION

### What does this PR do?

Adjust jitterbuffer settings based on feedback from SignalWire (the folks behind FreeSWITCH).

### Motivation

We are always looking for ways to improve the audio in BigBlueButton.  We reached out to SignalWire, the developers of FreeSWITCH, and asked them to look over the default audio settings.  They suggested this change to improve the audio.

See also 

 https://groups.google.com/g/bigbluebutton-setup/c/5F2z24avZvk/m/vBeCrq_LAAAJ

