### PR TITLE
Fix recording slide and thumbnail orientation issue with JPEG Exif

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ThumbnailCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ThumbnailCreatorImp.java
@@ -80,7 +80,7 @@ public class ThumbnailCreatorImp implements ThumbnailCreator {
 
     if (SupportedFileTypes.isImageFile(pres.getFileType())) {
       dest = thumbsDir.getAbsolutePath() + File.separatorChar + "thumb-" + page + ".png";
-      COMMAND = IMAGEMAGICK_DIR + File.separatorChar + "convert -thumbnail 150x150 "  + source + " " + dest;
+      COMMAND = IMAGEMAGICK_DIR + File.separatorChar + "convert -auto-orient -thumbnail 150x150 "  + source + " " + dest;
     } else {
       dest = thumbsDir.getAbsolutePath() + File.separatorChar + TEMP_THUMB_NAME + "-" + page; // the "-x.png" is appended automagically
       COMMAND = "pdftocairo -png -scale-to 150 " + source + " " + dest;

--- a/record-and-playback/core/lib/recordandplayback/generators/presentation.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/presentation.rb
@@ -88,7 +88,7 @@ module BigBlueButton
       # the larger of height, width in the resize parameter.
       scale = resize.split('x').map(&:to_i).max
       BigBlueButton.logger.info("Task: Converting image to .png")
-      command = "convert #{image} -resize #{scale}x#{scale} -background white -flatten #{png_image}"
+      command = "convert #{image} -resize #{scale}x#{scale} -background white -auto-orient -flatten #{png_image}"
       status = BigBlueButton.execute(command, false)
       if !status.success? or !File.exist?(png_image)
         # If image conversion failed, generate a blank white image


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Fixes an issue in the recordings where slides and thumbnails are sometimes shown with incorrect orientation.

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #13351
-->
Closes #13351

### Motivation
The JPEG portrait photo below was taken with an iPhone X and uploaded into a recorded BBB meeting:

![Screenshot 2022-04-27 at 17 08 39](https://user-images.githubusercontent.com/33319791/165562155-ed441ad5-4158-46d4-889c-d1daa965af95.png)

During playback, both the thumbnail and slide are flipped:
![Screenshot 2022-04-27 at 17 10 30](https://user-images.githubusercontent.com/33319791/165562372-eb680020-d30d-4058-b481-3b04a22dc2b6.png)

### More
All this PR does is to add `-auto-orient` when ImageMagick is called. Tested on BigBlueButton Server 2.5.0-alpha.6 (166).
