### PR TITLE
fix(audio): guarantee consistency of selected input devices in AudioSettings

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
@@ -124,7 +124,9 @@ class AudioSettings extends React.Component {
         if (!this._isMounted) return;
 
         this.setState({
-          inputDeviceId: deviceId,
+          // We extract the deviceId again from the stream to guarantee consistency
+          // between stream vs chosen device
+          inputDeviceId: MediaStreamUtils.extractDeviceIdFromStream(stream, 'audio'),
           stream,
           deviceSelectorsBlocked: false,
         });
@@ -248,7 +250,7 @@ class AudioSettings extends React.Component {
               {intl.formatMessage(intlMessages.micSourceLabel)}
               <Styled.DeviceSelectorSelect
                 id="inputDeviceSelector"
-                value={inputDeviceId}
+                deviceId={inputDeviceId}
                 kind="audioinput"
                 blocked={deviceSelectorsBlocked}
                 onChange={this.handleInputChange}
@@ -263,7 +265,7 @@ class AudioSettings extends React.Component {
               {intl.formatMessage(intlMessages.speakerSourceLabel)}
               <Styled.DeviceSelectorSelect
                 id="outputDeviceSelector"
-                value={outputDeviceId}
+                deviceId={outputDeviceId}
                 kind="audiooutput"
                 blocked={deviceSelectorsBlocked}
                 onChange={this.handleOutputChange}

--- a/bigbluebutton-html5/imports/ui/components/audio/device-selector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/device-selector/component.jsx
@@ -14,13 +14,13 @@ const propTypes = {
   kind: PropTypes.oneOf(['audioinput', 'audiooutput']),
   onChange: PropTypes.func.isRequired,
   blocked: PropTypes.bool,
-  value: PropTypes.string,
+  deviceId: PropTypes.string,
 };
 
 const defaultProps = {
   kind: 'audioinput',
   blocked: false,
-  value: undefined,
+  deviceId: '',
 };
 
 const intlMessages = defineMessages({
@@ -53,7 +53,6 @@ class DeviceSelector extends Component {
     this.handleSelectChange = this.handleSelectChange.bind(this);
 
     this.state = {
-      value: props.value,
       devices: [],
       options: [],
     };
@@ -96,10 +95,8 @@ class DeviceSelector extends Component {
     const { value } = event.target;
     const { onChange } = this.props;
     const { devices } = this.state;
-    this.setState({ value }, () => {
-      const selectedDevice = devices.find((d) => d.deviceId === value);
-      onChange(selectedDevice.deviceId, selectedDevice, event);
-    });
+    const selectedDevice = devices.find((d) => d.deviceId === value);
+    onChange(selectedDevice.deviceId, selectedDevice, event);
   }
 
   getFallbackLabel(index) {
@@ -127,10 +124,10 @@ class DeviceSelector extends Component {
 
   render() {
     const {
-      intl, kind, blocked, ...props
+      intl, kind, blocked, deviceId, ...props
     } = this.props;
 
-    const { options, value } = this.state;
+    const { options } = this.state;
     const { isSafari } = browserInfo;
 
     let notFoundOption;
@@ -148,7 +145,7 @@ class DeviceSelector extends Component {
     return (
       <select
         {...props}
-        value={value}
+        value={deviceId}
         onChange={this.handleSelectChange}
         disabled={!options.length}
       >


### PR DESCRIPTION
### What does this PR do?

The initial selected input device in AudioSettings could be the wrong one if
 1) gUM outputs an user-selected device rather than the default
 2) no previous device was selected for that domain and the enumeration
      list order caused the default not to be the first
  
The issue is tackled re-extracting the deviceId from an input stream if it
exists and making the DeviceSelector value follow what is defined in the client
(audio-manager) via a prop rather than splitting the selection value into an 
internal state.


### Closes Issue(s)

n/a


### Motivation

Related to https://github.com/bigbluebutton/bigbluebutton/pull/14736

### More

<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
