### PR TITLE
fix(audio): guarantee consistency of selected output devices in AudioSettings

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -112,9 +112,7 @@ export default {
   changeInputStream: (newInputStream) => { AudioManager.inputStream = newInputStream; },
   liveChangeInputDevice: (inputDeviceId) => AudioManager.liveChangeInputDevice(inputDeviceId),
   changeOutputDevice: (outputDeviceId, isLive) => {
-    if (AudioManager.outputDeviceId !== outputDeviceId) {
-      AudioManager.changeOutputDevice(outputDeviceId, isLive);
-    }
+    AudioManager.changeOutputDevice(outputDeviceId, isLive);
   },
   isConnected: () => AudioManager.isConnected,
   isTalking: () => AudioManager.isTalking,


### PR DESCRIPTION
### What does this PR do?

The initial selected output device in AudioSettings could be the wrong one if
the user's session had an output device ID already stored, but is joining on a
new session. That would cause the remote-media tag not to be updated with the
correct output device ID when it should (the service.js change)

The issue is tackled by guaranteeing the output device ID is set on all ends
when AudioSettings/AudioModal mounts.

### Closes Issue(s)

n/a

### Motivation

Related to https://github.com/bigbluebutton/bigbluebutton/pull/14736
Related to https://github.com/bigbluebutton/bigbluebutton/pull/14906

### More

n/a