### PR TITLE
Breakout rooms: have multiple "remaining time" notifications

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-remaining-time/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-remaining-time/container.jsx
@@ -104,6 +104,7 @@ export default injectNotify(injectIntl(withTracker(({
   messageDuration,
   timeEndedMessage,
   fromBreakoutPanel,
+  displayAlerts,
 }) => {
   const data = {};
   if (breakoutRoom) {
@@ -130,7 +131,7 @@ export default injectNotify(injectIntl(withTracker(({
       const time = getTimeRemaining();
       const alertsInSeconds = REMAINING_TIME_ALERT_THRESHOLD_ARRAY.map((item) => item * 60);
 
-      if (alertsInSeconds.includes(time) && time !== lastAlertTime) {
+      if (alertsInSeconds.includes(time) && time !== lastAlertTime && displayAlerts) {
         const timeInMinutes = time / 60;
         const msg = { id: `${intlMessages.alertBreakoutEndsUnderMinutes.id}${timeInMinutes === 1 ? 'Singular' : 'Plural'}` };
         const alertMessage = intl.formatMessage(msg, { 0: timeInMinutes })

--- a/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
@@ -180,6 +180,7 @@ export default injectIntl(withTracker(({ intl }) => {
           breakoutRoom={currentBreakout}
           messageDuration={intlMessages.breakoutTimeRemaining}
           timeEndedMessage={intlMessages.breakoutWillClose}
+          displayAlerts={true}
         />
       );
     }
@@ -200,6 +201,7 @@ export default injectIntl(withTracker(({ intl }) => {
           breakoutRoom={meetingTimeRemaining}
           messageDuration={intlMessages.meetingTimeRemaining}
           timeEndedMessage={intlMessages.meetingWillClose}
+          displayAlerts={true}
         />
       );
     }

--- a/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
@@ -26,7 +26,6 @@ const STATUS_WAITING = 'waiting';
 const METEOR_SETTINGS_APP = Meteor.settings.public.app;
 
 const REMAINING_TIME_THRESHOLD = METEOR_SETTINGS_APP.remainingTimeThreshold;
-const REMAINING_TIME_ALERT_THRESHOLD = METEOR_SETTINGS_APP.remainingTimeAlertThreshold;
 
 const intlMessages = defineMessages({
   failedMessage: {
@@ -172,8 +171,6 @@ export default injectIntl(withTracker(({ intl }) => {
   const meetingId = Auth.meetingID;
   const breakouts = breakoutService.getBreakouts();
 
-  let msg = { id: `${intlMessages.alertBreakoutEndsUnderMinutes.id}${REMAINING_TIME_ALERT_THRESHOLD === 1 ? 'Singular' : 'Plural'}` };
-
   if (breakouts.length > 0) {
     const currentBreakout = breakouts.find((b) => b.breakoutId === meetingId);
 
@@ -183,10 +180,6 @@ export default injectIntl(withTracker(({ intl }) => {
           breakoutRoom={currentBreakout}
           messageDuration={intlMessages.breakoutTimeRemaining}
           timeEndedMessage={intlMessages.breakoutWillClose}
-          alertMessage={
-            intl.formatMessage(msg, { 0: REMAINING_TIME_ALERT_THRESHOLD })
-          }
-          alertUnderMinutes={REMAINING_TIME_ALERT_THRESHOLD}
         />
       );
     }
@@ -201,18 +194,12 @@ export default injectIntl(withTracker(({ intl }) => {
     const { isBreakout } = Meeting.meetingProp;
     const underThirtyMin = timeRemaining && timeRemaining <= (REMAINING_TIME_THRESHOLD * 60);
 
-    msg = { id: `${intlMessages.alertMeetingEndsUnderMinutes.id}${REMAINING_TIME_ALERT_THRESHOLD === 1 ? 'Singular' : 'Plural'}` };
-
     if (underThirtyMin && !isBreakout) {
       data.message = (
         <BreakoutRemainingTime
           breakoutRoom={meetingTimeRemaining}
           messageDuration={intlMessages.meetingTimeRemaining}
           timeEndedMessage={intlMessages.meetingWillClose}
-          alertMessage={
-            intl.formatMessage(msg, { 0: REMAINING_TIME_ALERT_THRESHOLD })
-          }
-          alertUnderMinutes={REMAINING_TIME_ALERT_THRESHOLD}
         />
       );
     }

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -77,7 +77,7 @@ public:
       threshold: -50
       duration: 4000
     remainingTimeThreshold: 30
-    remainingTimeAlertThreshold: 1
+    remainingTimeAlertThresholdArray: [1,5]
     enableDebugWindow: true
     # Warning: increasing the limit of breakout rooms per meeting
     # can generate excessive overhead to the server. We recommend


### PR DESCRIPTION
### What does this PR do?

Modifies `remainingTimeAlertThreshold` structure, so it receives an array (it is also renamed to `remainingTimeAlertThresholdArray`). 
An alert is displayed in the breakout rooms when breakout remaining time reaches any of the informed values (default: 1 and 5 minutes).

### Closes Issue(s)
Closes #14909