### PR TITLE
record-and-playback: Don't seek past end of video input

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video.rb
@@ -486,6 +486,18 @@ module BigBlueButton
 
             pad_name = "#{layout_area[:name]}_x#{tile_x}_y#{tile_y}"
 
+            tile_x += 1
+            if tile_x >= tiles_h
+              tile_x = 0
+              tile_y += 1
+            end
+
+            # Only create the video input if the seekpoint is before the end of the file
+            if seek >= this_videoinfo[:duration]
+              ffmpeg_filter << "color=c=white:s=#{tile_width}x#{tile_height}:r=#{layout[:framerate]}[#{pad_name}];"
+              next
+            end
+
             # Apply the video start time offset to seek to the correct point.
             # Only actually apply the offset if we're already seeking so we
             # don't start seeking in a file where we've overridden the seek
@@ -518,12 +530,6 @@ module BigBlueButton
             ffmpeg_filter << "color=c=white:s=#{tile_width}x#{tile_height}:r=#{layout[:framerate]}"
             ffmpeg_filter << "[#{pad_name}_pad];"
             ffmpeg_filter << "[#{pad_name}_movie][#{pad_name}_pad]concat=n=2:v=1:a=0[#{pad_name}];"
-
-            tile_x += 1
-            if tile_x >= tiles_h
-              tile_x = 0
-              tile_y += 1
-            end
           end
 
           # Create the video rows


### PR DESCRIPTION
In some cases with incomplete/partially corrupt files, the input video file can be shorter than the displayed time. If there is a badly timed cut, this can result in a seek being generated to a point where ffmpeg is unable to start at.

Add a detection for this situation, and replace with a blank video.

Fixes errors that look like this:
```
[Parsed_movie_13 @ 0x5569fb8fe4c0] /srv/bn-rs/work/recording/raw/XXX/deskshare/YYY.webm: could not seek to position 2477000
[AVFilterGraph @ 0x5569fb892a00] Error initializing filter 'movie' with args '/var/bigbluebutton/recording/raw/XXX/deskshare/YYY.webm:sp=2.477'
```