### PR TITLE
fix: show mute/unmute button, if a user is unlocked

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
@@ -424,6 +424,7 @@ class UserListItem extends PureComponent {
       },
       {
         allowed: allowedToUnmuteAudio
+          && !user.locked
           && !userLocks.userMic
           && isMeteorConnected
           && !meetingIsBreakout


### PR DESCRIPTION

### What does this PR do?

show mute/unmute button, if a user is unlocked