### PR TITLE
Upload presentations and still have default.pdf

### DIFF
--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -363,8 +363,7 @@ beans.presentationService.testPresentationName=appkonference
 beans.presentationService.testUploadedPresentation=appkonference.txt
 # Default Uploaded presentation file
 beans.presentationService.defaultUploadedPresentation=${bigbluebutton.web.serverURL}/default.pdf
-# Decides weather to send the default.pdf document along with the other presentations in create endpoint (false)
-# or not (true / default)
+# Discard default presentation (default.pdf) when Pre-upload Slides are sent within the create call (default true)
 beans.presentationService.preUploadedPresentationOverrideDefault=true
 
 presentationBaseURL=${bigbluebutton.web.serverURL}/bigbluebutton/presentation

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -350,10 +350,6 @@ serviceEnabled = true
 testVoiceBridge=99999
 testConferenceMock=conference-mock-default
 
-# Decides weather to send the default.pdf document along with the other presentations in create endpoint (false)
-# or not (true / default)
-preUploadedPresentationOverrideDefault=true
-
 #------------------------------------------------------
 # These properties are used to test the conversion process.
 # Conference name folder in ${presentationDir} (see above)
@@ -367,8 +363,9 @@ beans.presentationService.testPresentationName=appkonference
 beans.presentationService.testUploadedPresentation=appkonference.txt
 # Default Uploaded presentation file
 beans.presentationService.defaultUploadedPresentation=${bigbluebutton.web.serverURL}/default.pdf
-# Send default.pdf presentation along the others
-beans.presentationService.preUploadedPresentationOverrideDefault=${preUploadedPresentationOverrideDefault}
+# Decides weather to send the default.pdf document along with the other presentations in create endpoint (false)
+# or not (true / default)
+beans.presentationService.preUploadedPresentationOverrideDefault=true
 
 presentationBaseURL=${bigbluebutton.web.serverURL}/bigbluebutton/presentation
 

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -350,6 +350,10 @@ serviceEnabled = true
 testVoiceBridge=99999
 testConferenceMock=conference-mock-default
 
+# Decides weather to send the default.pdf document along with the other presentations in create endpoint (false)
+# or not (true / default)
+preUploadedPresentationOverrideDefault=true
+
 #------------------------------------------------------
 # These properties are used to test the conversion process.
 # Conference name folder in ${presentationDir} (see above)
@@ -363,6 +367,8 @@ beans.presentationService.testPresentationName=appkonference
 beans.presentationService.testUploadedPresentation=appkonference.txt
 # Default Uploaded presentation file
 beans.presentationService.defaultUploadedPresentation=${bigbluebutton.web.serverURL}/default.pdf
+# Send default.pdf presentation along the others
+beans.presentationService.preUploadedPresentationOverrideDefault=${preUploadedPresentationOverrideDefault}
 
 presentationBaseURL=${bigbluebutton.web.serverURL}/bigbluebutton/presentation
 

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1315,9 +1315,15 @@ class ApiController {
       key, value -> params[key] = sanitizeInput(value)
     }
 
+    Boolean preUploadedPresentationOverrideDefault=true
+    if (!isFromInsertAPI) {
+      String[] po = request.getParameterMap().get("preUploadedPresentationOverrideDefault")
+      if (po == null) preUploadedPresentationOverrideDefault = presentationService.preUploadedPresentationOverrideDefault.toBoolean()
+      else preUploadedPresentationOverrideDefault = po[0].toBoolean()
+    }
+
     String requestBody = request.inputStream == null ? null : request.inputStream.text;
     requestBody = StringUtils.isEmpty(requestBody) ? null : requestBody;
-    Boolean preUploadedPresentationOverrideDefault = presentationService.preUploadedPresentationOverrideDefault.toBoolean()
     Boolean isDefaultPresentationCurrent = false;
 
     if (requestBody == null) {
@@ -1389,7 +1395,8 @@ class ApiController {
         }
       }
     }
-    if (!preUploadedPresentationOverrideDefault || requestBody == null){
+    Boolean uploadDefault = !preUploadedPresentationOverrideDefault || requestBody == null;
+    if (uploadDefault){
       downloadAndProcessDocument(presentationService.defaultUploadedPresentation, conf.getInternalId(), isDefaultPresentationCurrent /* default presentation */, '', false, true);
     }
   }

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1349,6 +1349,7 @@ class ApiController {
               break
             }
           }
+          isDefaultPresentationCurrent=!hasCurrent
           Boolean foundCurrent = !hasCurrent;
           int lastIndex = module.children().size() - 1
           module.children().eachWithIndex { document, index ->

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1317,13 +1317,15 @@ class ApiController {
 
     String requestBody = request.inputStream == null ? null : request.inputStream.text;
     requestBody = StringUtils.isEmpty(requestBody) ? null : requestBody;
+    Boolean preUploadedPresentationOverrideDefault = presentationService.preUploadedPresentationOverrideDefault.toBoolean()
+    Boolean isDefaultPresentationCurrent = false;
 
     if (requestBody == null) {
       if (isFromInsertAPI){
         log.warn("Insert Document API called without a payload - ignoring")
         return;
       }
-      downloadAndProcessDocument(presentationService.defaultUploadedPresentation, conf.getInternalId(), true /* default presentation */, '', false, true);
+      isDefaultPresentationCurrent = true
     } else {
       def xml = new XmlSlurper().parseText(requestBody);
       xml.children().each { module ->
@@ -1386,6 +1388,9 @@ class ApiController {
           }
         }
       }
+    }
+    if (!preUploadedPresentationOverrideDefault || requestBody == null){
+      downloadAndProcessDocument(presentationService.defaultUploadedPresentation, conf.getInternalId(), isDefaultPresentationCurrent /* default presentation */, '', false, true);
     }
   }
 

--- a/bigbluebutton-web/grails-app/services/org/bigbluebutton/web/services/PresentationService.groovy
+++ b/bigbluebutton-web/grails-app/services/org/bigbluebutton/web/services/PresentationService.groovy
@@ -34,6 +34,7 @@ class PresentationService {
 	def testUploadedPresentation
 	def defaultUploadedPresentation
 	def presentationBaseUrl
+	def preUploadedPresentationOverrideDefault
 
 	def deletePresentation = {conf, room, filename ->
 		def directory = new File(roomDirectory(conf, room).absolutePath + File.separatorChar + filename)


### PR DESCRIPTION
### What does this PR do?

It changes the flow to preupload some documents: now with the parameter `preUploadedPresentationOverrideDefault=false`, it is possible to have the documents preuploaded along with the `default.pdf` too. 

### Closes Issue(s)

Closes #14828 
