### PR TITLE
Updates font-weight for the Cyrillic alphabet work properly.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/styles.js
@@ -56,7 +56,7 @@ const Center = styled.div`
 `;
 
 const PresentationTitle = styled.h1`
-  font-weight: 200;
+  font-weight: 400;
   color: ${colorWhite};
   font-size: ${fontSizeBase};
   margin: 0;


### PR DESCRIPTION
### What does this PR do?

Before this PR the room name font wasn't working as expected, because the Cyrillic alphabet hasn't some font-weights on Source Sans Pro font. In this case, the font-weight had a value of 200.

![Captura de tela de 2022-05-05 13-54-28](https://user-images.githubusercontent.com/19312495/166974176-ca360883-4749-4259-9953-fa18bf237647.png)

Now, I changed the font-weight to 400, to show the correct font with the Cyrillic alphabet.

![Captura de tela de 2022-05-05 13-43-10](https://user-images.githubusercontent.com/19312495/166974393-60df5fd2-1cdb-4b0e-aab8-925275a8b5ff.png)

### Closes Issue(s)

Closes #9190 
