### PR TITLE
[2.5] fix: clear fake annotations on multi-user whiteboard off

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/cursor/service.js
+++ b/bigbluebutton-html5/imports/ui/components/cursor/service.js
@@ -5,6 +5,10 @@ import logger from '/imports/startup/client/logger';
 const Cursor = new Mongo.Collection(null);
 let cursorStreamListener = null;
 
+export const clearCursors = () => {
+  Cursor.remove({});
+};
+
 function updateCursor(userId, payload) {
   const selector = {
     userId,

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -156,6 +156,8 @@ class Presentation extends PureComponent {
       presentationBounds,
       numCameras,
       intl,
+      multiUser,
+      clearFakeAnnotations,
     } = this.props;
 
     const { presentationWidth, presentationHeight } = this.state;
@@ -164,6 +166,10 @@ class Presentation extends PureComponent {
       numCameras: prevNumCameras,
       presentationBounds: prevPresentationBounds,
     } = prevProps;
+
+    if (!multiUser) {
+      clearFakeAnnotations();
+    }
 
     if (numCameras !== prevNumCameras) {
       this.onResize();

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -25,6 +25,7 @@ import DEFAULT_VALUES from '../layout/defaultValues';
 import { colorContentBackground } from '/imports/ui/stylesheets/styled-components/palette';
 import browserInfo from '/imports/utils/browserInfo';
 import PresentationMenu from './presentation-menu/container';
+import { clearCursors } from '/imports/ui/components/cursor/service';
 
 const intlMessages = defineMessages({
   presentationLabel: {
@@ -169,6 +170,7 @@ class Presentation extends PureComponent {
 
     if (!multiUser) {
       clearFakeAnnotations();
+      clearCursors();
     }
 
     if (numCameras !== prevNumCameras) {

--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -138,5 +138,6 @@ export default withTracker(({ podId }) => {
       'bbb_force_restore_presentation_on_new_events',
       Meteor.settings.public.presentation.restoreOnUpdate,
     ),
+    clearFakeAnnotations: WhiteboardService.clearFakeAnnotations,
   };
 })(PresentationContainer);

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -25,7 +25,7 @@ const clearPreview = (annotation) => {
   UnsentAnnotations.remove({ id: annotation });
 };
 
-function clearFakeAnnotations() {
+const clearFakeAnnotations = () => {
   UnsentAnnotations.remove({});
   Annotations.remove({ id: /-fake/g });
 }
@@ -398,4 +398,5 @@ export {
   addIndividualAccess,
   removeGlobalAccess,
   removeIndividualAccess,
+  clearFakeAnnotations,
 };


### PR DESCRIPTION
Clears temporary annotation data when a user loses access to multi-user whiteboard.

Partially addresses #14948 