### PR TITLE
[2.4] fix: clear fake annotations on multi-user whiteboard off

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/cursor/service.js
+++ b/bigbluebutton-html5/imports/ui/components/cursor/service.js
@@ -5,6 +5,10 @@ import logger from '/imports/startup/client/logger';
 const Cursor = new Mongo.Collection(null);
 let cursorStreamListener = null;
 
+export const clearCursors = () => {
+  Cursor.remove({});
+};
+
 function updateCursor(userId, payload) {
   const selector = {
     userId,

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -154,12 +154,18 @@ class Presentation extends PureComponent {
       presentationBounds,
       numCameras,
       intl,
+      multiUser,
+      clearFakeAnnotations,
     } = this.props;
 
     const {
       numCameras: prevNumCameras,
       presentationBounds: prevPresentationBounds,
     } = prevProps;
+
+    if (!multiUser) {
+      clearFakeAnnotations();
+    }
 
     if (numCameras !== prevNumCameras) {
       this.onResize();

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -24,6 +24,7 @@ import PollingContainer from '/imports/ui/components/polling/container';
 import { ACTIONS, LAYOUT_TYPE } from '../layout/enums';
 import DEFAULT_VALUES from '../layout/defaultValues';
 import browserInfo from '/imports/utils/browserInfo';
+import { clearCursors } from '/imports/ui/components/cursor/service';
 
 const intlMessages = defineMessages({
   presentationLabel: {
@@ -165,6 +166,7 @@ class Presentation extends PureComponent {
 
     if (!multiUser) {
       clearFakeAnnotations();
+      clearCursors();
     }
 
     if (numCameras !== prevNumCameras) {

--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -133,5 +133,6 @@ export default withTracker(({ podId }) => {
       'bbb_force_restore_presentation_on_new_events',
       Meteor.settings.public.presentation.restoreOnUpdate,
     ),
+    clearFakeAnnotations: WhiteboardService.clearFakeAnnotations,
   };
 })(PresentationContainer);

--- a/bigbluebutton-html5/imports/ui/components/presentation/cursor/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/cursor/container.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { withTracker } from 'meteor/react-meteor-data';
 import CursorService from './service';
 import Cursor from './component';
-
+import WhiteboardService from '/imports/ui/components/whiteboard/service';
 
 class CursorContainer extends Component {
 
@@ -26,11 +26,11 @@ class CursorContainer extends Component {
 
 
 export default withTracker((params) => {
-  const { cursorId } = params;
+  const { cursorId, whiteboardId } = params;
 
   const cursor = CursorService.getCurrentCursor(cursorId);
 
-  if (cursor) {
+  if (cursor && WhiteboardService.hasMultiUserAccess(whiteboardId, cursor.userId)) {
     const { xPercent: cursorX, yPercent: cursorY, userName } = cursor;
     const isRTL = document.documentElement.getAttribute('dir') === 'rtl';
     return {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -22,7 +22,7 @@ const clearPreview = (annotation) => {
   UnsentAnnotations.remove({ id: annotation });
 };
 
-function clearFakeAnnotations() {
+const clearFakeAnnotations = () => {
   UnsentAnnotations.remove({});
 }
 
@@ -299,4 +299,5 @@ export {
   addIndividualAccess,
   removeGlobalAccess,
   removeIndividualAccess,
+  clearFakeAnnotations,
 };


### PR DESCRIPTION
Clears temporary annotation data when a user loses access to multi-user whiteboard.

Closes #14948