### PR TITLE
feat(audio): add sipjsAllowMdns option to control mDNS filtering in SIP.js

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -550,6 +550,9 @@ public:
     # showing to the user there's an audio error.
     audioReconnectionAttempts: 3
     sipjsHackViaWs: false
+    # sipjsAllowMdns: whether mDNS candidates should be allowed in local SDPs.
+    # Default is false since FreeSWITCH doesn't resolve mDNS by default.
+    sipjsAllowMdns: false
     # the fqdn of this host.
     # If you run a traditional setup of multiple nodes behind scalelite and the users see the hostnames of the
     # individual nodes, you can leave this at the default setting


### PR DESCRIPTION
### What does this PR do?

FreeSWITCH has mDNS resolution capabilities as of 1.10.7. Having the filtering
configurable in the client allows us to field trial whether we should keep that
on or off. The default is still to filter them out because FreeSWITCH does not
resolve mDNS candidates by default (ice_resolve_candidate in switch.conf.xml).

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/14908

### Motivation

https://groups.google.com/g/bigbluebutton-dev/c/1iSkpihoQwEr

The added bonus is that allowing mDNS candidates + resolution might reduce 
1004's.

### More

Documentation on how to enable mDNS resolution on FS is probably desirable 
once 2.6 docs are in place.
