### PR TITLE
fix(user-avatar): avatar image covered

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-avatar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-avatar/styles.js
@@ -65,8 +65,11 @@ const Talking = styled.div`
   right: 0;
   bottom: 0;
   left: 0;
-  background-color: currentColor;
   border-radius: inherit;
+
+  ${({ talking }) => talking && css`
+    background-color: currentColor;
+  `}
 
   ${({ talking, animations }) => talking && animations && css`
     animation: ${pulse} 1s infinite ease-in;


### PR DESCRIPTION
### What does this PR do?
Fixes an issue that when the user joins with a custom avatar, the talking
indicator div ends up covering the avatar image.

### Screenshots
Before
![image](https://user-images.githubusercontent.com/42683590/167189969-a2a6fb29-cad6-4dad-842c-8552120f51a0.png)
After
![image](https://user-images.githubusercontent.com/42683590/167190862-73af3590-dd70-4d23-9452-e734a197cd6e.png)

