### PR TITLE
fix(Shared notes): missing temporaryPresentationId parameter in upload

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notes/converter-button/service.js
+++ b/bigbluebutton-html5/imports/ui/components/notes/converter-button/service.js
@@ -3,35 +3,50 @@ import PresentationUploaderService from '/imports/ui/components/presentation/pre
 import PadsService from '/imports/ui/components/pads/service';
 import NotesService from '/imports/ui/components/notes/service';
 import { makeCall } from '/imports/ui/services/api';
+import _ from 'lodash';
+import { Random } from 'meteor/random';
 
 const PADS_CONFIG = Meteor.settings.public.pads;
 const PRESENTATION_CONFIG = Meteor.settings.public.presentation;
 
 async function convertAndUpload() {
   const params = PadsService.getParams();
-
   const padId = await PadsService.getPadId(NotesService.ID);
+  const extension = 'pdf';
 
-  const exportUrl = Auth.authenticateURL(`${PADS_CONFIG.url}/p/${padId}/export/pdf?${params}`);
-  const sharedNotesAsPdf = await fetch(exportUrl, { credentials: 'include' });
-  const data = await sharedNotesAsPdf.blob();
+  const exportUrl = Auth.authenticateURL(`${PADS_CONFIG.url}/p/${padId}/export/${extension}?${params}`);
+  const sharedNotesAsFile = await fetch(exportUrl, { credentials: 'include' });
 
-  const sharedNotesData = new File([data], 'SharedNotes.pdf', {
+  const data = await sharedNotesAsFile.blob();
+
+  let filename = 'Shared_Notes';
+  const presentations = PresentationUploaderService.getPresentations();
+  const duplicates = presentations.filter((pres) => pres.filename.startsWith(filename)).length;
+
+  if (duplicates !== 0) { filename = `${filename}(${duplicates})`; }
+
+  const podId = 'DEFAULT_PRESENTATION_POD';
+  const tmpPresId = _.uniqueId(Random.id(20));
+
+  const sharedNotesData = new File([data], `${filename}.${extension}`, {
     type: data.type,
   });
 
   const formData = new FormData();
 
-  formData.append('presentation_name', 'SharedNotes.pdf');
-  formData.append('Filename', 'SharedNotes.pdf');
   formData.append('conference', Auth.meetingID);
-  formData.append('room', Auth.meetingID);
-  formData.append('pod_id', 'DEFAULT_PRESENTATION_POD');
+  formData.append('pod_id', podId);
   formData.append('is_downloadable', false);
   formData.append('current', true);
   formData.append('fileUpload', sharedNotesData);
+  formData.append('temporaryPresentationId', tmpPresId);
 
-  const presentationUploadToken = await PresentationUploaderService.requestPresentationUploadToken('DEFAULT_PRESENTATION_POD', Auth.meetingID, 'SharedNotes.pdf');
+  const presentationUploadToken = await PresentationUploaderService.requestPresentationUploadToken(
+    tmpPresId,
+    podId,
+    Auth.meetingID,
+    filename,
+  );
 
   fetch(PRESENTATION_CONFIG.uploadEndpoint.replace('upload', `${presentationUploadToken}/upload`), {
     body: formData,


### PR DESCRIPTION
### What does this PR do?
Requesting a token for upload now requires a temporary presentation id (#14537), a change which was not yet reflected in the shared notes export. As a result, the "Move shared notes to whiteboard" button stopped functioning.

Additionally, if throughout a meeting an instructor chooses to repeatedly use this feature, the resulting file will now be appended with the corresponding version number instead of being the same every time:

![SharedNotes](https://user-images.githubusercontent.com/33319791/167222145-beabb7da-4e6a-4185-9b5c-bf43af2b6f44.png)

### Motivation
Make it easier for instructors to find the latest exported shared notes file.
Automatic upload of the shared notes stopped functioning.
