### PR TITLE
fix(screenshare): guarantee local stream is cleaned up

### DIFF
--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -5,6 +5,7 @@ import ScreenshareBroker from '/imports/ui/services/bbb-webrtc-sfu/screenshare-b
 import { setSharingScreen, screenShareEndAlert } from '/imports/ui/components/screenshare/service';
 import { SCREENSHARING_ERRORS } from './errors';
 import { shouldForceRelay } from '/imports/ui/services/bbb-webrtc-sfu/utils';
+import MediaStreamUtils from '/imports/utils/media-stream-utils';
 
 const SFU_CONFIG = Meteor.settings.public.kurento;
 const SFU_URL = SFU_CONFIG.wsUrl;
@@ -356,7 +357,11 @@ export default class KurentoScreenshareBridge {
       mediaElement.srcObject = null;
     }
 
-    this.gdmStream = null;
+    if (this.gdmStream) {
+      MediaStreamUtils.stopMediaStreamTracks(this.gdmStream);
+      this.gdmStream = null;
+    }
+
     this.clearReconnectionTimeout();
   }
 }


### PR DESCRIPTION
### What does this PR do?

There could be a scenario where the local gDM stream wasn't cleaned up;
eg.: SFU is offline.

This commit guarantees all tracks from the local stream are stopped.

### Closes Issue(s)

None

### Motivation

.

### More

n/a