### PR TITLE
fix(screenshare): check packet flow to detect unhealthy streams earlier

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -9,14 +9,12 @@ import Auth from '/imports/ui/services/auth';
 import AudioService from '/imports/ui/components/audio/service';
 import { Meteor } from "meteor/meteor";
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
+import ConnectionStatusService from '/imports/ui/components/connection-status/service';
 
 const VOLUME_CONTROL_ENABLED = Meteor.settings.public.kurento.screenshare.enableVolumeControl;
 const SCREENSHARE_MEDIA_ELEMENT_NAME = 'screenshareVideo';
 
-/**
- * Screenshare status to be filtered in getStats()
- */
-const FILTER_SCREENSHARE_STATS = [
+const DEFAULT_SCREENSHARE_STATS_TYPES = [
   'outbound-rtp',
   'inbound-rtp',
 ];
@@ -152,33 +150,33 @@ const screenShareEndAlert = () => AudioService
 const dataSavingSetting = () => Settings.dataSaving.viewScreenshare;
 
 /**
-   * Get stats about all active screenshare peer.
-   * We filter the status based on FILTER_SCREENSHARE_STATS constant.
+   * Get stats about all active screenshare peers.
    *
    * For more information see:
-   * https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/getStats
-   * and
-   * https://developer.mozilla.org/en-US/docs/Web/API/RTCStatsReport
-   * @returns An Object containing the information about each active peer
-   *          (currently one, for screenshare). The returned format
-   *          follows the format returned by video's service getStats, which
-   *          considers more than one peer connection to be returned.
+   *  - https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/getStats
+   *  - https://developer.mozilla.org/en-US/docs/Web/API/RTCStatsReport
+
+   * @param {Array[String]} statsType - An array containing valid RTCStatsType
+   *                                    values to include in the return object
+   *
+   * @returns {Object} The information about each active screen sharing peer.
+   *          The returned format follows the format returned by video's service
+   *          getStats, which considers more than one peer connection to be returned.
    *          The format is given by:
    *          {
    *            peerIdString: RTCStatsReport
    *          }
    */
-const getStats = async () => {
+const getStats = async (statsTypes = DEFAULT_SCREENSHARE_STATS_TYPES) => {
+  const screenshareStats = {};
   const peer = KurentoBridge.getPeerConnection();
 
   if (!peer) return null;
 
   const peerStats = await peer.getStats();
 
-  const screenshareStats = {};
-
   peerStats.forEach((stat) => {
-    if (FILTER_SCREENSHARE_STATS.includes(stat.type)) {
+    if (statsTypes.includes(stat.type)) {
       screenshareStats[stat.type] = stat;
     }
   });
@@ -186,8 +184,21 @@ const getStats = async () => {
   return { screenshareStats };
 };
 
+// This method may throw errors
+const isMediaFlowing = (previousStats, currentStats) => {
+  const bpsData = ConnectionStatusService.calculateBitsPerSecond(
+    currentStats.screenshareStats,
+    previousStats.screenshareStats,
+  );
+  const bpsDataAggr = Object.values(bpsData)
+    .reduce((sum, partialBpsData = 0) => sum + parseFloat(partialBpsData), 0);
+
+  return bpsDataAggr > 0;
+};
+
 export {
   SCREENSHARE_MEDIA_ELEMENT_NAME,
+  isMediaFlowing,
   isVideoBroadcasting,
   screenshareHasEnded,
   screenshareHasStarted,


### PR DESCRIPTION
### What does this PR do?

Screen streams were only deemed unhealthy when the transport's ICE state
transitioned to failed. That was as good as nothing because the stream would
stay frozen with no visual UI feedback until it reconnected. Bad UX.

This commit mitigates that issue via two changes:
  - A stream is now deemed *potentially* unhealthy if the transport's
    state becomes disconnected
  - If a stream is deemed potentially unhealthy, a probe is started to 
    check whether there is media/packet flow (every 500ms).
    If there's no packet flow, the stream is flagged as unhealthy and
    UI feedback is rendered.
    
There also changes to make the "unhealthy" UI clearer: a grayscale is applied 
along with a clearer background. I believe that still can be improved further.
    
It's still not as good as it could be - relying on disconnected still
leaves a couple of seconds of silence to be dealt with. For that to be
addressed the prober would have to run nonstop, but that's for later.

### Closes Issue(s)

None


### Motivation

n/a

### More


Comparison:
- Currently (longer it takes for the dots to appear, the worse):

https://user-images.githubusercontent.com/4529051/167328357-0d61c57d-1835-4b27-b6e1-3d155e3ca85b.mp4

- This PR (longer it takes for the dots to appear, the worse):

https://user-images.githubusercontent.com/4529051/167328362-d7cda928-2d67-4b4d-ac79-1d7ff2434885.mp4



