### PR TITLE
refactor: remove unused imports/variables

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -20,7 +20,6 @@ import VideoService from '/imports/ui/components/video-provider/service';
 import DebugWindow from '/imports/ui/components/debug-window/component';
 import { ACTIONS, PANELS } from '../../ui/components/layout/enums';
 import { isChatEnabled } from '/imports/ui/services/features';
-import MediaService from '/imports/ui/components/media/service';
 
 const CHAT_CONFIG = Meteor.settings.public.chat;
 const PUBLIC_CHAT_ID = CHAT_CONFIG.public_id;

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -160,12 +160,8 @@ class App extends Component {
       layoutContextDispatch,
       meetingLayout,
       settingsLayout,
-      focusedCamera,
-      presentationVideoRate,
       cameraWidth,
       cameraHeight,
-      cameraPosition,
-      presentationIsOpen,
       layoutPresOpen,
       layoutCamPosition,
       layoutFocusedCam,
@@ -617,7 +613,6 @@ class App extends Component {
       shouldShowExternalVideo,
       isPresenter,
       selectedLayout,
-      meetingLayout,
       presentationIsOpen,
     } = this.props;
 

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -5,7 +5,6 @@ import LocalesDropdown from '/imports/ui/components/common/locales-dropdown/comp
 import { defineMessages, injectIntl } from 'react-intl';
 import BaseMenu from '../base/component';
 import Styled from './styles';
-import SettingsService from '/imports/ui/components/settings/service';
 import VideoService from '/imports/ui/components/video-provider/service';
 import { ACTIONS } from '/imports/ui/components/layout/enums';
 import Settings from '/imports/ui/services/settings';


### PR DESCRIPTION
### What does this PR do?

Removes unused imports and exports reported by [lgtm alerts](https://lgtm.com/projects/g/bigbluebutton/bigbluebutton/alerts)

### Motivation

*Unused local variables make code hard to read and understand. Any computation used to initialize an unused variable is wasted, which may lead to performance problems.*

*Similarly, unused imports and unused functions or classes can be confusing. They may even be a symptom of a bug caused, for example, by an incomplete refactoring.* (https://lgtm.com/rules/1780092/)
