### PR TITLE
feat(chat): Auto convert text to emoji

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
@@ -203,7 +203,7 @@ class MessageForm extends PureComponent {
     let message = null;
     let error = null;
 
-    if (AUTO_CONVERT_EMOJI === true) {
+    if (AUTO_CONVERT_EMOJI) {
       message = checkText(e.target.value);
     } else {
       message = e.target.value;

--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
+import { checkText } from 'smile2emoji';
 import deviceInfo from '/imports/utils/deviceInfo';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
@@ -61,6 +62,7 @@ const messages = defineMessages({
 });
 
 const CHAT_CONFIG = Meteor.settings.public.chat;
+const AUTO_CONVERT_EMOJI = Meteor.settings.public.chat.autoConvertEmoji;
 
 class MessageForm extends PureComponent {
   constructor(props) {
@@ -198,8 +200,14 @@ class MessageForm extends PureComponent {
       maxMessageLength,
     } = this.props;
 
-    const message = e.target.value;
+    let message = null;
     let error = null;
+
+    if (AUTO_CONVERT_EMOJI === true) {
+      message = checkText(e.target.value);
+    } else {
+      message = e.target.value;
+    }
 
     if (message.length > maxMessageLength) {
       error = intl.formatMessage(

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -5679,6 +5679,11 @@
         }
       }
     },
+    "smile2emoji": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/smile2emoji/-/smile2emoji-2.8.0.tgz",
+      "integrity": "sha512-TDdBc3lFKNodwgRN33GhjzaqAfRHjorFCJu57L6gdaF9Y6iIxKeVhzY2GW6EFNUL5YedC+Cp86rydnit7LZvNg=="
+    },
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -78,6 +78,7 @@
     "sanitize-html": "2.3.3",
     "scheduler": "^0.20.2",
     "sdp-transform": "2.7.0",
+    "smile2emoji": "^2.8.0",
     "string-hash": "~1.1.3",
     "styled-components": "^5.3.3",
     "tippy.js": "^5.1.3",

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -470,6 +470,7 @@ public:
     typingIndicator:
       enabled: true
     moderatorChatEmphasized: true
+    autoConvertEmoji: true
   notes:
     enabled: true
     id: notes


### PR DESCRIPTION
Before this PR, if the user typed a smiley face it would stay the same way.
![emojiNotWorking](https://user-images.githubusercontent.com/19312495/167653387-ce3abee9-a44f-410e-bcef-805b6850a9b4.gif)

Now, if the user types a smiley face, it will convert to an emoji.
![emoji](https://user-images.githubusercontent.com/19312495/167653353-ce5cc7ec-badb-471d-9555-a73bad1ff7e0.gif)

To disable this functionality, set autoConvertEmoji to false inside the settings file.
