### PR TITLE
build(fsesl-akka): build deps in sequence to allow for ci use

### DIFF
--- a/build/packages-template/bbb-fsesl-akka/build.sh
+++ b/build/packages-template/bbb-fsesl-akka/build.sh
@@ -22,18 +22,19 @@ build_common_messages () {
     cd bbb-common-message
     sbt publish
     sbt publishLocal
+    cd ..
 }
 
 build_fsesl_client () {
     cd bbb-fsesl-client
     sbt publish
     sbt publishLocal
+    cd ..
 }
 
-# build these two in parallel
-build_common_messages &
-build_fsesl_client &
-wait
+build_common_messages
+build_fsesl_client
+
 
 cd akka-bbb-fsesl
 sed -i 's/\r$//' project/Dependencies.scala


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Switches the building of akka-fsesl dependencies `bbb-common-message` and `bbb-fsesl-client` to build in sequence, not in parallel.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation
In GitHub Actions we sometimes see the action hit an error

```
[error] sbt.librarymanagement.ResolveException: Error downloading org.bigbluebutton:bbb-fsesl-client:0.0.1652198455-SNAPSHOT
```
I am not 100% sure if this is the cause, but given the small size of the two dependencies, I think it's not an issue do build them in sequence.

<!-- What inspired you to submit this pull request? -->

