### PR TITLE
feat: add filterable identifier to FS channels originated from SFU

### DIFF
--- a/bbb-voice-conference/config/freeswitch/conf/dialplan/public/bbb_sfu.xml
+++ b/bbb-voice-conference/config/freeswitch/conf/dialplan/public/bbb_sfu.xml
@@ -1,6 +1,7 @@
 <include>
     <extension name="bbb_webrtc_call" continue="true">
       <condition field="${sip_user_agent}" expression="bbb-webrtc-sfu" break="on-false">
+        <action application="set" data="presence_data=from_bbb-webrtc-sfu"/>
         <action application="set" data="bbb_authorized=true"/>
         <action application="set" data="rtp_manual_rtp_bugs=ACCEPT_ANY_PACKETS"/>
         <action application="set" data="jb_use_timestamps=true"/>


### PR DESCRIPTION
### What does this PR do?

Use the presence_data field to annotate channels with a filterable
identifier that allows us to differentiate SIP.js channels from SFU
ones.

### Closes Issue(s)

None

### Motivation

Motivation: allow metrics exporters/instrumentations/etc to
generate comparison metrics (eg.: mediaStats, usage) between the default
bridge and the experimental one without having to do multiple or overly
verbose json_api or mod_command/fs_cli calls to filter channels out.

### More

n/a
