### PR TITLE
build: set html5 client version on bbb-config update

### DIFF
--- a/build/packages-template/bbb-config/after-install.sh
+++ b/build/packages-template/bbb-config/after-install.sh
@@ -125,6 +125,17 @@ else
   sed -i 's/events {/worker_rlimit_nofile 10000;\n\nevents {/g' /etc/nginx/nginx.conf
 fi
 
+# set full BBB version in settings.yml so it can be displayed in the client
+BBB_RELEASE_FILE=/etc/bigbluebutton/bigbluebutton-release
+BBB_HTML5_SETTINGS_FILE=/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml
+if [[ -f $BBB_RELEASE_FILE ]] ; then
+  BBB_FULL_VERSION=$(cat $BBB_RELEASE_FILE | sed -n '/^BIGBLUEBUTTON_RELEASE/{s/.*=//;p}' )
+  echo "setting BBB_FULL_VERSION=$BBB_FULL_VERSION in $BBB_HTML5_SETTINGS_FILE "
+  if [[ -f $BBB_HTML5_SETTINGS_FILE ]] ; then
+    yq w -i $BBB_HTML5_SETTINGS_FILE public.app.bbbServerVersion $BBB_FULL_VERSION
+  fi
+fi
+
 # Fix permissions for logging
 chown bigbluebutton:bigbluebutton /var/log/bbb-fsesl-akka
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Handle a missed case on setting BBB's full version to be displayed within HTML5 client's About modal.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #14843


### Motivation
Follow up from https://github.com/bigbluebutton/bigbluebutton/pull/14393
The above PR does the job when bbb-html5 is updated on its own (within a release). But when there's an upgrade of BBB, for example from beta.2 to beta.3, bbb-html5 is upgraded first, it pulls the release string before bbb-config's upgrade sets it to beta.3.
This PR duplicates the set version code, so that this additional case is also handled.
bbb-html5's upgrade will set the (old) beta.2 in settings.yml
then
bbb-config's upgrade will set the (new) beta.3 in settings.yml
