### PR TITLE
build: bump bbb-webrtc-sfu to v2.9.0-alpha.0

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.8.1 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.9.0-alpha.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

- build: bump bbb-webrtc-sfu to [v2.9.0-alpha.0](https://github.com/bigbluebutton/bbb-webrtc-sfu/releases/tag/v2.9.0-alpha.0)
