### PR TITLE
fix: prevent user join from multiple tabs with same sessionToken

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/handlers/validateAuthToken.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/validateAuthToken.js
@@ -4,6 +4,7 @@ import Users from '/imports/api/users';
 import userJoin from './userJoin';
 import pendingAuthenticationsStore from '../store/pendingAuthentications';
 import createDummyUser from '../modifiers/createDummyUser';
+import updateUserConnectionId from '../modifiers/updateUserConnectionId';
 import ClientConnections from '/imports/startup/server/ClientConnections';
 
 import upsertValidationState from '/imports/api/auth-token-validation/server/modifiers/upsertValidationState';
@@ -81,6 +82,8 @@ export default function handleValidateAuthToken({ body }, meetingId) {
 
       if (!User) {
         createDummyUser(meetingId, userId, authToken);
+      }else{
+        updateUserConnectionId(meetingId, userId, methodInvocationObject.connection.id);
       }
 
       ClientConnections.add(sessionId, methodInvocationObject.connection);

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/updateUserConnectionId.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/updateUserConnectionId.js
@@ -1,0 +1,31 @@
+import { check } from 'meteor/check';
+import Logger from '/imports/startup/server/logger';
+import Users from '/imports/api/users';
+
+export default function updateUserConnectionId(meetingId, userId, connectionId) {
+  check(meetingId, String);
+  check(userId, String);
+  check(connectionId, String);
+
+  const selector = { meetingId, userId };
+
+  const modifier = {
+    $set: {
+      currentConnectionId: connectionId,
+    },
+  };
+
+  const User = Users.findOne(selector);
+
+  if (User) {
+    try {
+      const updated = Users.update(selector, modifier);
+
+      if (updated) {
+        Logger.info(`Updated connection user=${userId} connectionid=${connectionId} meeting=${meetingId}`);
+      }
+    } catch (err) {
+      Logger.error(`Updating user connection: ${err}`);
+    }
+  }
+}

--- a/bigbluebutton-html5/imports/api/users/server/modifiers/updateUserConnectionId.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/updateUserConnectionId.js
@@ -12,6 +12,7 @@ export default function updateUserConnectionId(meetingId, userId, connectionId) 
   const modifier = {
     $set: {
       currentConnectionId: connectionId,
+      connectionIdUpdateTime: new Date().getTime(),
     },
   };
 

--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -429,6 +429,7 @@ export default withTracker(() => {
     userId: 1,
     inactivityCheck: 1,
     responseDelay: 1,
+    currentConnectionId: 1,
   };
   const User = Users.findOne({ intId: credentials.requesterUserId }, { fields });
   const meeting = Meetings.findOne({ meetingId }, {
@@ -447,6 +448,13 @@ export default withTracker(() => {
   const ejected = User?.ejected;
   const ejectedReason = User?.ejectedReason;
   const meetingEndedReason = meeting?.meetingEndedReason;
+  const currentConnectionId = User?.currentConnectionId;
+  const { connectionID } = Auth;
+
+  if (currentConnectionId && currentConnectionId !== connectionID) {
+    Session.set('codeError', 403);
+    Session.set('errorMessageDescription', 'joined_another_window_reason')
+  }
 
   let userSubscriptionHandler;
 

--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -430,6 +430,7 @@ export default withTracker(() => {
     inactivityCheck: 1,
     responseDelay: 1,
     currentConnectionId: 1,
+    connectionIdUpdateTime: 1,
   };
   const User = Users.findOne({ intId: credentials.requesterUserId }, { fields });
   const meeting = Meetings.findOne({ meetingId }, {
@@ -449,9 +450,10 @@ export default withTracker(() => {
   const ejectedReason = User?.ejectedReason;
   const meetingEndedReason = meeting?.meetingEndedReason;
   const currentConnectionId = User?.currentConnectionId;
-  const { connectionID } = Auth;
+  const { connectionID, connectionAuthTime } = Auth;
+  const connectionIdUpdateTime = User?.connectionIdUpdateTime;
 
-  if (currentConnectionId && currentConnectionId !== connectionID) {
+  if (currentConnectionId && currentConnectionId !== connectionID && connectionIdUpdateTime > connectionAuthTime) {
     Session.set('codeError', 403);
     Session.set('errorMessageDescription', 'joined_another_window_reason')
   }

--- a/bigbluebutton-html5/imports/ui/components/error-screen/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/error-screen/component.jsx
@@ -40,6 +40,9 @@ const intlMessages = defineMessages({
   banned_user_rejoining_reason: {
     id: 'app.error.userBanned',
   },
+  joined_another_window_reason: {
+    id: 'app.error.joinedAnotherWindow',
+  },
 });
 
 const propTypes = {

--- a/bigbluebutton-html5/imports/ui/services/auth/index.js
+++ b/bigbluebutton-html5/imports/ui/services/auth/index.js
@@ -253,6 +253,7 @@ class Auth {
             initAnnotationsStreamListener();
             clearTimeout(validationTimeout);
             this.connectionID = authenticationTokenValidation.connectionId;
+            this.connectionAuthTime = new Date().getTime();
             Session.set('userWillAuth', false);
             setTimeout(() => resolve(true), 100);
             break;

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -603,6 +603,7 @@
     "app.error.500": "Ops, something went wrong",
     "app.error.userLoggedOut": "User has an invalid sessionToken due to log out",
     "app.error.ejectedUser": "User has an invalid sessionToken due to ejection",
+    "app.error.joinedAnotherWindow": "This session seems to be opened in another browser window.",
     "app.error.userBanned": "User has been banned",
     "app.error.leaveLabel": "Log in again",
     "app.error.fallback.presentation.title": "An error occurred",


### PR DESCRIPTION
### What does this PR do?

Displays an error message (in the old tab) when a user opens a new tab with the same sessionToken.

![another-window](https://user-images.githubusercontent.com/3728706/168375421-54fc25c7-a8e4-41bd-9761-d9c5fce4d96f.png)
