### PR TITLE
Fix etherpad session authentication to work in cluster setups

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/pads/service.js
+++ b/bigbluebutton-html5/imports/ui/components/pads/service.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import Pads, { PadsUpdates } from '/imports/api/pads';
+import Pads, { PadsSessions, PadsUpdates } from '/imports/api/pads';
 import { makeCall } from '/imports/ui/services/api';
 import Auth from '/imports/ui/services/auth';
 import Settings from '/imports/ui/services/settings';
@@ -47,9 +47,13 @@ const throttledCreateSession = _.throttle(createSession, THROTTLE_TIMEOUT, {
 
 const buildPadURL = (padId) => {
   if (padId) {
-    const params = getParams();
-    const url = Auth.authenticateURL(`${PADS_CONFIG.url}/p/${padId}?${params}`);
-    return url;
+    const padsSessions = PadsSessions.findOne({});
+    if (padsSessions && padsSessions.sessions) {
+      const params = getParams();
+      const sessionIds = padsSessions.sessions.map(session => Object.values(session)).join(',');
+      const url = Auth.authenticateURL(`${PADS_CONFIG.url}/auth_session?padName=${padId}&sessionID=${sessionIds}&${params}`);
+      return url;
+    }
   }
 
   return null;

--- a/build/packages-template/bbb-etherpad/build.sh
+++ b/build/packages-template/bbb-etherpad/build.sh
@@ -49,6 +49,7 @@ npm install ./ep_redis_publisher-*.tgz
 
 npm install ep_cursortrace
 npm install ep_disable_chat
+npm install --no-save --legacy-peer-deps ep_auth_session
 
 mkdir -p staging/usr/share/etherpad-lite
 

--- a/build/packages-template/bbb-etherpad/notes.nginx
+++ b/build/packages-template/bbb-etherpad/notes.nginx
@@ -22,6 +22,16 @@ location /pad/p/ {
     auth_request_set $auth_status $upstream_status;
 }
 
+location /pad/auth_session {
+    rewrite /pad/auth_session(.*) /auth_session$1 break;
+    proxy_pass http://127.0.0.1:9001/;
+    proxy_pass_header Server;
+    proxy_set_header Host $host;
+    proxy_buffering off;
+    auth_request /bigbluebutton/connection/checkAuthorization;
+    auth_request_set $auth_status $upstream_status;
+}
+
 location /pad {
     rewrite /pad/(.*) /$1 break;
     rewrite ^/pad$ /pad/ permanent;


### PR DESCRIPTION


<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fix shared notes and closed captions to work in a cluster proxy setup

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)

None

### Motivation

I use a cluster proxy setup as described in https://docs.bigbluebutton.org/admin/clusterproxy.html 
Etherpad did not work with BBB 2.5 in this configuration.

### More

Etherpad uses the sessionID cookie for authorization. In cluster setups the
host part of the URI which serves the html5 frontend is different from
the hostname part of the URI which serves etherpad. Therefore the
bbb-html5 client can't set a cookie for etherpad which contains the
etherpad sessionID.

This patch uses the `ep_auth_session` etherpad plugin which takes the
`sessionID` as query parameter, sets the cookie in the browser and
redirects the iframe to the pad URI.

I tested shared notes, shared notes in a breakout session and closed captions. 
Is there anything else that I could test?
