### PR TITLE
Remove group chat unused info: name (2.5)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateDefaultPublicGroupChat.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateDefaultPublicGroupChat.scala
@@ -20,7 +20,7 @@ trait CreateDefaultPublicGroupChat {
       val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
       val envelope = BbbCoreEnvelope(GroupChatCreatedEvtMsg.NAME, routing)
       val header = BbbClientMsgHeader(GroupChatCreatedEvtMsg.NAME, meetingId, userId)
-      val body = GroupChatCreatedEvtMsgBody(correlationId, gc.id, gc.createdBy, gc.name, gc.access, gc.users, msgs)
+      val body = GroupChatCreatedEvtMsgBody(correlationId, gc.id, gc.createdBy, gc.access, gc.users, msgs)
       val event = GroupChatCreatedEvtMsg(header, body)
       BbbCommonEnvCoreMsg(envelope, event)
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateGroupChatReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateGroupChatReqMsgHdlr.scala
@@ -62,7 +62,7 @@ trait CreateGroupChatReqMsgHdlr extends SystemConfiguration {
           }
         }
 
-        val gc = GroupChatApp.createGroupChat(msg.body.name, msg.body.access, createdBy, users, msgs)
+        val gc = GroupChatApp.createGroupChat(msg.body.access, createdBy, users, msgs)
         sendMessages(msg, gc, liveMeeting, bus)
 
         val groupChats = state.groupChats.add(gc)
@@ -84,12 +84,12 @@ trait CreateGroupChatReqMsgHdlr extends SystemConfiguration {
       BbbCoreEnvelope(name, routing)
     }
 
-    def makeBody(chatId: String, name: String,
+    def makeBody(chatId: String,
                  access: String, correlationId: String,
                  createdBy: GroupChatUser, users: Vector[GroupChatUser],
                  msgs: Vector[GroupChatMsgToUser]): GroupChatCreatedEvtMsgBody = {
       GroupChatCreatedEvtMsgBody(correlationId, chatId, createdBy,
-        name, access, users, msgs)
+        access, users, msgs)
     }
 
     val meetingId = liveMeeting.props.meetingProp.intId
@@ -102,7 +102,7 @@ trait CreateGroupChatReqMsgHdlr extends SystemConfiguration {
         val envelope = makeEnvelope(MessageTypes.DIRECT, GroupChatCreatedEvtMsg.NAME, meetingId, userId)
         val header = makeHeader(GroupChatCreatedEvtMsg.NAME, meetingId, userId)
 
-        val body = makeBody(gc.id, gc.name, gc.access, correlationId, gc.createdBy, users, msgs)
+        val body = makeBody(gc.id, gc.access, correlationId, gc.createdBy, users, msgs)
         val event = GroupChatCreatedEvtMsg(header, body)
         val outEvent = BbbCommonEnvCoreMsg(envelope, event)
         bus.outGW.send(outEvent)
@@ -117,7 +117,7 @@ trait CreateGroupChatReqMsgHdlr extends SystemConfiguration {
         meetingId, userId)
       val header = makeHeader(GroupChatCreatedEvtMsg.NAME, meetingId, userId)
 
-      val body = makeBody(gc.id, gc.name, gc.access, correlationId, gc.createdBy, users, msgs)
+      val body = makeBody(gc.id, gc.access, correlationId, gc.createdBy, users, msgs)
       val event = GroupChatCreatedEvtMsg(header, body)
 
       val outEvent = BbbCommonEnvCoreMsg(envelope, event)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GetGroupChatsReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GetGroupChatsReqMsgHdlr.scala
@@ -27,8 +27,8 @@ trait GetGroupChatsReqMsgHdlr {
 
     val publicChats = state.groupChats.findAllPublicChats()
     val privateChats = state.groupChats.findAllPrivateChatsForUser(msg.header.userId)
-    val pubChats = publicChats map (pc => GroupChatInfo(pc.id, pc.name, pc.access, pc.createdBy, pc.users))
-    val privChats = privateChats map (pc => GroupChatInfo(pc.id, pc.name, pc.access, pc.createdBy, pc.users))
+    val pubChats = publicChats map (pc => GroupChatInfo(pc.id, pc.access, pc.createdBy, pc.users))
+    val privChats = privateChats map (pc => GroupChatInfo(pc.id, pc.access, pc.createdBy, pc.users))
 
     val allChats = pubChats ++ privChats
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChat.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChat.scala
@@ -51,8 +51,10 @@ object GroupChatApp {
 
   def createTestPublicGroupChat(state: MeetingState2x): MeetingState2x = {
     val createBy = GroupChatUser(SystemUser.ID)
-    val defaultPubGroupChat = GroupChatFactory.create("TEST_GROUP_CHAT", "TEST_GROUP_CHAT",
-      GroupChatAccess.PUBLIC, createBy, Vector.empty, Vector.empty)
+    val defaultPubGroupChat = GroupChatFactory.create(
+      "TEST_GROUP_CHAT",
+      GroupChatAccess.PUBLIC, createBy, Vector.empty, Vector.empty
+    )
     val groupChats = state.groupChats.add(defaultPubGroupChat)
     state.update(groupChats)
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChat.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChat.scala
@@ -9,10 +9,10 @@ object GroupChatApp {
 
   val MAIN_PUBLIC_CHAT = "MAIN-PUBLIC-GROUP-CHAT"
 
-  def createGroupChat(chatName: String, access: String, createBy: GroupChatUser,
+  def createGroupChat(access: String, createBy: GroupChatUser,
                       users: Vector[GroupChatUser], msgs: Vector[GroupChatMessage]): GroupChat = {
     val gcId = GroupChatFactory.genId()
-    GroupChatFactory.create(gcId, chatName, access, createBy, users, msgs)
+    GroupChatFactory.create(gcId, access, createBy, users, msgs)
   }
 
   def toGroupChatMessage(sender: GroupChatUser, msg: GroupChatMsgFromUser): GroupChatMessage = {
@@ -46,7 +46,7 @@ object GroupChatApp {
 
   def createDefaultPublicGroupChat(): GroupChat = {
     val createBy = GroupChatUser(SystemUser.ID)
-    GroupChatFactory.create(MAIN_PUBLIC_CHAT, MAIN_PUBLIC_CHAT, GroupChatAccess.PUBLIC, createBy, Vector.empty, Vector.empty)
+    GroupChatFactory.create(MAIN_PUBLIC_CHAT, GroupChatAccess.PUBLIC, createBy, Vector.empty, Vector.empty)
   }
 
   def createTestPublicGroupChat(state: MeetingState2x): MeetingState2x = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SyncGetGroupChatsInfoMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SyncGetGroupChatsInfoMsgHdlr.scala
@@ -41,7 +41,7 @@ trait SyncGetGroupChatsInfoMsgHdlr {
       val respMsg = buildSyncGetGroupChatMsgsRespMsg(msgs, pc.id)
       bus.outGW.send(respMsg)
 
-      GroupChatInfo(pc.id, pc.name, pc.access, pc.createdBy, pc.users)
+      GroupChatInfo(pc.id, pc.access, pc.createdBy, pc.users)
     })
 
     // publishing a message with the group chat info

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/GroupChats.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/GroupChats.scala
@@ -5,9 +5,9 @@ import org.bigbluebutton.core.util.RandomStringGenerator
 
 object GroupChatFactory {
   def genId(): String = System.currentTimeMillis() + "-" + RandomStringGenerator.randomAlphanumericString(8)
-  def create(id: String, name: String, access: String, createdBy: GroupChatUser,
+  def create(id: String, access: String, createdBy: GroupChatUser,
              users: Vector[GroupChatUser], msgs: Vector[GroupChatMessage]): GroupChat = {
-    new GroupChat(id, name, access, createdBy, users, msgs)
+    new GroupChat(id, access, createdBy, users, msgs)
   }
 
 }
@@ -23,7 +23,7 @@ case class GroupChats(chats: collection.immutable.Map[String, GroupChat]) {
   def getAllGroupChatsInMeeting(): Vector[GroupChat] = chats.values.toVector
 }
 
-case class GroupChat(id: String, name: String, access: String, createdBy: GroupChatUser,
+case class GroupChat(id: String, access: String, createdBy: GroupChatUser,
                      users: Vector[GroupChatUser],
                      msgs:  Vector[GroupChatMessage]) {
   def findMsgWithId(id: String): Option[GroupChatMessage] = msgs.find(m => m.id == id)

--- a/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/models/GroupsChatTests.scala
+++ b/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/models/GroupsChatTests.scala
@@ -7,10 +7,9 @@ class GroupsChatTests extends UnitSpec {
 
   "A GroupChat" should "be able to add and remove user" in {
     val gcId = "gc-id"
-    val chatName = "Public"
     val userId = "uid-1"
     val createBy = GroupChatUser("groupId")
-    val gc = GroupChatFactory.create(gcId, chatName, GroupChatAccess.PUBLIC, createBy, Vector.empty, Vector.empty)
+    val gc = GroupChatFactory.create(gcId, GroupChatAccess.PUBLIC, createBy, Vector.empty, Vector.empty)
     val user = GroupChatUser(userId)
     val gc2 = gc.add(user)
     assert(gc2.users.size == 1)
@@ -26,8 +25,7 @@ class GroupsChatTests extends UnitSpec {
   "A GroupChat" should "be able to add, update, and remove msg" in {
     val createBy = GroupChatUser("groupId")
     val gcId = "gc-id"
-    val chatName = "Public"
-    val gc = GroupChatFactory.create(gcId, chatName, GroupChatAccess.PUBLIC, createBy, Vector.empty, Vector.empty)
+    val gc = GroupChatFactory.create(gcId, GroupChatAccess.PUBLIC, createBy, Vector.empty, Vector.empty)
     val msgId1 = "msgid-1"
     val ts = System.currentTimeMillis()
     val hello = "Hello World!"

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
@@ -8,7 +8,7 @@ object GroupChatAccess {
 case class GroupChatUser(id: String, name: String = "", role: String = "VIEWER")
 case class GroupChatMsgFromUser(correlationId: String, sender: GroupChatUser, chatEmphasizedText: Boolean = false, message: String)
 case class GroupChatMsgToUser(id: String, timestamp: Long, correlationId: String, sender: GroupChatUser, chatEmphasizedText: Boolean = false, message: String)
-case class GroupChatInfo(id: String, name: String, access: String, createdBy: GroupChatUser, users: Vector[GroupChatUser])
+case class GroupChatInfo(id: String, access: String, createdBy: GroupChatUser, users: Vector[GroupChatUser])
 
 object OpenGroupChatWindowReqMsg { val NAME = "OpenGroupChatWindowReqMsg" }
 case class OpenGroupChatWindowReqMsg(header: BbbClientMsgHeader, body: OpenGroupChatWindowReqMsgBody) extends StandardMsg
@@ -36,14 +36,14 @@ case class GetGroupChatMsgsRespMsgBody(chatId: String, msgs: Vector[GroupChatMsg
 
 object CreateGroupChatReqMsg { val NAME = "CreateGroupChatReqMsg" }
 case class CreateGroupChatReqMsg(header: BbbClientMsgHeader, body: CreateGroupChatReqMsgBody) extends StandardMsg
-case class CreateGroupChatReqMsgBody(correlationId: String, name: String, access: String,
+case class CreateGroupChatReqMsgBody(correlationId: String, access: String,
                                      users: Vector[String], msg: Vector[GroupChatMsgFromUser])
 
 object GroupChatCreatedEvtMsg { val NAME = "GroupChatCreatedEvtMsg" }
 case class GroupChatCreatedEvtMsg(header: BbbClientMsgHeader, body: GroupChatCreatedEvtMsgBody) extends BbbCoreMsg
 case class GroupChatCreatedEvtMsgBody(correlationId: String, chatId: String, createdBy: GroupChatUser,
-                                      name: String, access: String,
-                                      users: Vector[GroupChatUser], msg: Vector[GroupChatMsgToUser])
+                                      access: String,
+                                      users:  Vector[GroupChatUser], msg: Vector[GroupChatMsgToUser])
 
 object DestroyGroupChatReqMsg { val NAME = "DestroyGroupChatReqMsg" }
 case class DestroyGroupChatReqMsg(header: BbbClientMsgHeader, body: DestroyGroupChatReqMsgBody) extends StandardMsg

--- a/bigbluebutton-html5/imports/api/group-chat/server/methods/createGroupChat.js
+++ b/bigbluebutton-html5/imports/api/group-chat/server/methods/createGroupChat.js
@@ -22,7 +22,6 @@ export default function createGroupChat(receiver) {
       msg: [],
       users: [receiver.userId],
       access: CHAT_ACCESS_PRIVATE,
-      name: receiver.name,
     };
 
     RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);

--- a/bigbluebutton-html5/imports/api/group-chat/server/modifiers/addGroupChat.js
+++ b/bigbluebutton-html5/imports/api/group-chat/server/modifiers/addGroupChat.js
@@ -9,7 +9,6 @@ export default function addGroupChat(meetingId, chat) {
     id: Match.Maybe(String),
     chatId: Match.Maybe(String),
     correlationId: Match.Maybe(String),
-    name: String,
     access: String,
     createdBy: Object,
     users: Array,
@@ -19,9 +18,8 @@ export default function addGroupChat(meetingId, chat) {
   const chatDocument = {
     meetingId,
     chatId: chat.chatId || chat.id,
-    name: chat.name,
     access: chat.access,
-    users: chat.users.map(u => u.id),
+    users: chat.users.map((u) => u.id),
     participants: chat.users,
     createdBy: chat.createdBy.id,
   };

--- a/bigbluebutton-html5/imports/api/group-chat/server/modifiers/addGroupChat.js
+++ b/bigbluebutton-html5/imports/api/group-chat/server/modifiers/addGroupChat.js
@@ -37,9 +37,9 @@ export default function addGroupChat(meetingId, chat) {
     const { insertedId } = GroupChat.upsert(selector, modifier);
 
     if (insertedId) {
-      Logger.info(`Added group-chat name=${chat.name} meetingId=${meetingId}`);
+      Logger.info(`Added group-chat chatId=${chatDocument.chatId} meetingId=${meetingId}`);
     } else {
-      Logger.info(`Upserted group-chat name=${chat.name} meetingId=${meetingId}`);
+      Logger.info(`Upserted group-chat chatId=${chatDocument.chatId} meetingId=${meetingId}`);
     }
   } catch (err) {
     Logger.error(`Adding group-chat to collection: ${err}`);


### PR DESCRIPTION
### What does this PR do?

This is a port of PR #14723 from 2.4 to 2.5.

_Removes unused group chat property "name" from bigbluebutton-html5 and akka-bbb-apps/bbb-common-message._