### PR TITLE
fix: userlist throttle instead of debounce

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/components-data/users-context/service.js
+++ b/bigbluebutton-html5/imports/ui/components/components-data/users-context/service.js
@@ -1,8 +1,10 @@
-import { useState, useContext, useEffect } from 'react';
+import {
+  useState, useContext, useRef, useEffect,
+} from 'react';
 import { UsersContext } from '/imports/ui/components/components-data/users-context/context';
+import { throttle } from 'lodash';
 
-const USER_JOIN_UPDATE_TIMEOUT = 1000;
-let updateTimeout = null;
+const USER_JOIN_UPDATE_THROTTLE_TIME = 1000;
 
 export default function useContextUsers() {
   const usingUsersContext = useContext(UsersContext);
@@ -11,17 +13,15 @@ export default function useContextUsers() {
   const [users, setUsers] = useState(null);
   const [isReady, setIsReady] = useState(true);
 
+  const throttledSetUsers = useRef(throttle(() => {
+    setUsers(contextUsers);
+    setIsReady(true);
+  },
+  USER_JOIN_UPDATE_THROTTLE_TIME, { trailing: true }));
+
   useEffect(() => {
     setIsReady(false);
-
-    if (updateTimeout) {
-      clearTimeout(updateTimeout);
-    }
-
-    updateTimeout = setTimeout(() => {
-      setUsers(contextUsers);
-      setIsReady(true);
-    }, USER_JOIN_UPDATE_TIMEOUT);
+    throttledSetUsers.current();
   }, [contextUsers]);
 
   return {

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/container.jsx
@@ -22,9 +22,9 @@ const UserParticipantsContainer = (props) => {
   const { videoUsers, whiteboardUsers } = props;
   const { users: contextUsers, isReady } = useContextUsers();
 
-  const currentUser = contextUsers ? contextUsers[Auth.meetingID][Auth.userID] : null;
-  const usersArray = contextUsers ? Object.values(contextUsers[Auth.meetingID]) : null;
-  const users = contextUsers ? formatUsers(usersArray, videoUsers, whiteboardUsers) : [];
+  const currentUser = contextUsers && isReady ? contextUsers[Auth.meetingID][Auth.userID] : null;
+  const usersArray = contextUsers && isReady ? Object.values(contextUsers[Auth.meetingID]) : null;
+  const users = contextUsers && isReady ? formatUsers(usersArray, videoUsers, whiteboardUsers) : [];
 
   return (
     <UserParticipants {


### PR DESCRIPTION
### What does this PR do?

Removes debounce (added in #14445) and adds throttle to the userlist updates. 
It prevents an issue where the userlist update could be delayed forever if users keep joining/leaving.

**Before:** userlist is only updated if no user joined/left in the last second.
**After:** userlist is updated when a user joins/leaves unless there was an update within the last second.