### PR TITLE
[issue-15014] - Implemented 2 parameters for both bbb-conf and bbb-record

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -209,6 +209,22 @@ if [ -f $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties ]; then
     fi
 fi
 
+get_meetings_xml () {
+    api_method="getMeetings"
+    X=$( bbb-conf --secret | fgrep URL: )
+    api_url=${X##* }
+
+    Y=$( bbb-conf --secret | fgrep Secret: )
+    Secret=${Y##* }
+
+    string_for_checksum=$api_method$Secret
+    checksum=$( echo -n $string_for_checksum | sha1sum | cut -f 1 -d ' ' )
+
+    URL="${api_url}api/$api_method?checksum=$checksum"
+
+    echo $( curl -s "$URL" )
+}
+
 #
 # Determine IP so it works on multilingual installations
 #
@@ -496,6 +512,17 @@ fi
 
 # Parse the parameters
 while [ $# -gt 0 ]; do
+    if [ "$1" = "-list-running-meetings" -o "$1" = "--list-running-meetings" ]; then
+        need_root
+        if [ "$2" = "-human-readable" -o "$2" = "--human-readable" ]; then
+            HUMAN_READABLE=1
+            shift
+        fi
+        RUNNING_MEETINGS=1
+        shift
+        continue
+    fi
+
     if [ "$1" = "-stop" -o "$1" = "--stop" ]; then
         need_root
         stop_bigbluebutton
@@ -1510,6 +1537,23 @@ if [ $CHECK ]; then
      echo
 
      exit 0
+fi
+
+#
+# Return a list of the running meetings
+#
+if [ $RUNNING_MEETINGS ]; then
+    xml=$( get_meetings_xml )
+    has_any=$( echo $xml | grep "no meetings were found on this server" )
+    if [ "$has_any" == "" ]; then
+        if [ $HUMAN_READABLE ]; then
+            list_of_internalId=$( ruby /usr/local/bigbluebutton/core/lib/xml_parser.rb -x "$xml" --human-readable)
+        else
+            list_of_internalId=$( ruby /usr/local/bigbluebutton/core/lib/xml_parser.rb -x "$xml" )
+        fi
+        echo -e $list_of_internalId
+    fi
+    
 fi
 
 #

--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -142,17 +142,15 @@ is_meetingID_in_array() {
    list_meeting_id=$2
 
    if [ "$id_to_validate" = "" ]; then
-      retval=$([ 0 ])
-      return
+      return 0
    fi
    for meetingId in $list_meeting_id; do
       if [ "$id_to_validate" = "$meetingId" ]; then
-         retval=1
-         return
+         return 1
       fi
    done
 
-   retval=$([ 0 ])
+   return 0
 }
 
 usage() {
@@ -451,15 +449,11 @@ if [ $DELETEALL ]; then
 
       for meeting in $(ls /var/bigbluebutton | grep "^[0-9a-f]\{40\}-[[:digit:]]\{13\}$"); do
          is_meetingID_in_array "$meeting" "$list_running_meeting"
-         if [ ! $retval ]; then
-            echo "A meeting $meeting não está rodando"
-            # echo "deleting: $meeting"
-            # rm -rf /var/bigbluebutton/$meeting
-            # rm -rf /var/bigbluebutton/captions/$meeting
-
-         else
-
-            echo "A meeting $meeting está rodando"
+         retval=$? 
+         if [ $retval -eq 0 ]; then
+            echo "deleting: $meeting"
+            rm -rf /var/bigbluebutton/$meeting
+            rm -rf /var/bigbluebutton/captions/$meeting
          fi
       done
       

--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -107,6 +107,14 @@ mark_for_republish() {
    done
 }
 
+get_secret() {
+	for item in $(bbb-conf --salt | grep "Secret:"); do 
+      		if [ $item != "Secret:" ]; then
+            		echo $item
+      		fi
+	done
+}
+
 need_root() {
    if [ $EUID != 0 ]; then
       echo "Need to be root to run this option"
@@ -127,6 +135,24 @@ print_header() {
       echo "** Potential problems described below **"
       HEADER=1
    fi
+}
+
+is_meetingID_in_array() {
+   id_to_validate=$1
+   list_meeting_id=$2
+
+   if [ "$id_to_validate" = "" ]; then
+      retval=$([ 0 ])
+      return
+   fi
+   for meetingId in $list_meeting_id; do
+      if [ "$id_to_validate" = "$meetingId" ]; then
+         retval=1
+         return
+      fi
+   done
+
+   retval=$([ 0 ])
 }
 
 usage() {
@@ -233,10 +259,15 @@ while [ $# -gt 0 ]; do
 
    if [ "$1" = "-deleteall" -o "$1" = "--deleteall" ]; then
       need_root
+      if [ "$2" = "-only-recordings" -o "$2" = "--only-recordings" ]; then
+         ONLY_RECORDING=1
+         shift
+      fi
       DELETEALL=1
       shift
       continue
    fi
+
    if [ "$1" = "-check" -o "$1" = "--check" ]; then
       need_root
       CHECK=1
@@ -412,12 +443,34 @@ if [ $DELETEALL ]; then
    rm -f /var/bigbluebutton/screenshare/*.flv
    rm -f /var/freeswitch/meetings/*.wav
    rm -f /var/freeswitch/meetings/*.opus
+   
+   if [ $ONLY_RECORDING ]; then
+      list_running_meeting=$( sudo bbb-conf --list-running-meetings )
 
-   for meeting in $(ls /var/bigbluebutton | grep "^[0-9a-f]\{40\}-[[:digit:]]\{13\}$"); do
-      echo "deleting: $meeting"
-      rm -rf /var/bigbluebutton/$meeting
-      rm -rf /var/bigbluebutton/captions/$meeting
-   done
+      echo $list_running_meeting
+
+      for meeting in $(ls /var/bigbluebutton | grep "^[0-9a-f]\{40\}-[[:digit:]]\{13\}$"); do
+         is_meetingID_in_array "$meeting" "$list_running_meeting"
+         if [ ! $retval ]; then
+            echo "A meeting $meeting não está rodando"
+            # echo "deleting: $meeting"
+            # rm -rf /var/bigbluebutton/$meeting
+            # rm -rf /var/bigbluebutton/captions/$meeting
+
+         else
+
+            echo "A meeting $meeting está rodando"
+         fi
+      done
+      
+   else
+      for meeting in $(ls /var/bigbluebutton | grep "^[0-9a-f]\{40\}-[[:digit:]]\{13\}$"); do
+         echo "deleting: $meeting"
+         rm -rf /var/bigbluebutton/$meeting
+         rm -rf /var/bigbluebutton/captions/$meeting
+      done
+   fi
+
 fi
 
 if [ $LIST ]; then

--- a/record-and-playback/core/lib/xml_parser.rb
+++ b/record-and-playback/core/lib/xml_parser.rb
@@ -1,0 +1,50 @@
+# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+#
+# Copyright (c) 2017 BigBlueButton Inc. and by respective authors (see below).
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 3.0 of the License, or (at your option)
+# any later version.
+#
+# BigBlueButton is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+
+require 'optimist'
+require 'nokogiri'
+
+#### Start ####
+
+opts = Optimist::options do
+    opt :xml_string, "XML string", :type => :string
+    opt "human-readable", "Make the output humanly readable"
+end
+
+xml_string = opts[:xml_string]
+xml_object = Nokogiri::XML(xml_string)
+string_list_internalID = ""
+
+if opts["human-readable"]
+    string_list_internalID += "Internal meeting ID | Name | Start time | Moderator count | Viewer count | \\n"
+    string_list_internalID += "--------------------------------------------------------------------------\\n"
+    xml_object.xpath("//meeting").each_with_index do |item, index|
+        meetingId = item.xpath("//internalMeetingID")[index].text
+        meetingName = item.xpath("//meetingName")[index].text
+        startTime = item.xpath("//createDate")[index].text
+        moderatorCount = item.xpath("//moderatorCount")[index].text.to_i
+        viewerCount = item.xpath("//participantCount")[index].text.to_i - moderatorCount
+
+        string_list_internalID += meetingId + " | " + meetingName + " | " + startTime + " | " + moderatorCount.to_s + " | " + viewerCount.to_s + " |\\n"
+    end
+else
+    xml_object.xpath("//internalMeetingID").each do |item|
+        string_list_internalID += " " +  item.text
+    end 
+end
+
+puts string_list_internalID


### PR DESCRIPTION
### What does this PR do?

It implements 2 more options for both `bbb-record` and `bbb-conf`:

 * `bbb-conf --list-running-meetings (--human-readable)`
 * `bbb-record --deleteall --only-recordings`

The first returns a list of the running meetings, it can be at the format of just a list of meeting internal ID, or you can have more information on the running meetings passing the `--human-readable` as demonstrated below:

`bbb-conf --list-running-meetings --human-readable`
![image](https://user-images.githubusercontent.com/69865537/169148071-9befe974-28fa-4674-ac68-61f37e559ea1.png)

`bbb-conf --list-running-meetings`
![image](https://user-images.githubusercontent.com/69865537/169148242-18a44322-d01d-4783-b161-e9c3267eb9e7.png)

Those warnings about the deprecation can be resolved with an update of gems in the ruby (as far as I am concerned.)

And for `bbb-record --deleteall --only-recordings` it only deletes all not running meetings solving #14172.

### Closes Issue(s)

Closes #15014 

### More

For the reviewer: it is important to run also the `./record-and-playback/deploy` to insert the xml parser script from `record-and-playback`

Other than that, in order to run the newly added options, you can make a copy of both `/usr/bin/bbb-conf` and `/usr/bin/bbb-record` and then run:

```bash
#!/bin/bash
sudo rm /usr/bin/bbb-conf
sudo rm /usr/bin/bbb-record

sudo cp bbb-record /usr/bin/bbb-record
sudo cp bbb-conf /usr/bin/bbb-conf
```

 inside `bigbluebutton-config` directory