### PR TITLE
test: lockShareWebcam

### DIFF
--- a/bigbluebutton-tests/playwright/core/page.js
+++ b/bigbluebutton-tests/playwright/core/page.js
@@ -139,8 +139,18 @@ class Page {
     await expect(locator).toBeHidden({ timeout });
   }
 
+  async wasNthElementRemoved(selector, count, timeout = ELEMENT_WAIT_TIME) {
+    const locator = this.getLocator(':nth-match(' + selector + ',' + count + ')');
+    await expect(locator).toBeHidden({ timeout });
+  }
+
   async hasElement(selector, timeout = ELEMENT_WAIT_TIME) {
     const locator = this.getLocator(selector);
+    await expect(locator).toBeVisible({ timeout });
+  }
+
+  async hasNElements(selector, count, timeout = ELEMENT_WAIT_TIME) {
+    const locator = this.getLocator(':nth-match(' + selector + ',' + count + ')');
     await expect(locator).toBeVisible({ timeout });
   }
 

--- a/bigbluebutton-tests/playwright/user/lockViewers.js
+++ b/bigbluebutton-tests/playwright/user/lockViewers.js
@@ -14,15 +14,20 @@ class LockViewers extends MultiUsers {
 
   async lockShareWebcam() {
     await this.modPage.shareWebcam();
+    await this.modPage.hasElement(e.webcamVideoItem);
     await this.userPage.hasElement(e.webcamVideoItem);
     await this.userPage2.hasElement(e.webcamVideoItem);
     await this.userPage.shareWebcam();
+    await this.modPage.hasNElements(e.webcamVideoItem, 2);
+    await this.userPage.hasNElements(e.webcamVideoItem, 2);
+    await this.userPage2.hasNElements(e.webcamVideoItem, 2);
     await openLockViewers(this.modPage);
     await this.modPage.waitAndClickElement(e.lockShareWebcam);
     await this.modPage.waitAndClick(e.applyLockSettings);
     // await waitAndClearNotification(this.modPage); // notification check is unstable
-    const videoContainerLockedCount = await this.userPage2.getSelectorCount(e.webcamVideoItem);
-    expect(videoContainerLockedCount).toBe(1);
+    await this.modPage.wasNthElementRemoved(e.webcamVideoItem, 2);
+    await this.userPage.wasNthElementRemoved(e.webcamVideoItem, 2);
+    await this.userPage2.wasNthElementRemoved(e.webcamVideoItem, 2);
 
     await this.userPage2.waitForSelector(e.dropdownWebcamButton);
     await this.userPage2.hasText(e.dropdownWebcamButton, this.modPage.username);


### PR DESCRIPTION
This fixes a test that was failing against a stock 2.4.7 BBB server.

There was a race condition in `lockShareWebcam` where the test locked attendees sharing webcams, there was an attendee webcam already shared, and the test expected it to have vanished without waiting for it to vanish.

I added two new helper functions, `hasNElements` and `wasNthElementRemoved`, and used them to test for the appearance and disappearance of the second webcam.  I also made the test check for the webcams on all user pages, including the user that shared the webcame, which it didn't do before.

Now github is telling me that it can't automatically merge this PR.  I'm guessing that's because I created it from v2.4.x-release, which seemed to me the most sensible thing to do, since I'm testing against the 2.4.7 release.  Maybe that wasn't the best idea.