### PR TITLE
style: increase dropdown menu padding

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
@@ -70,10 +70,10 @@ class BBBMenu extends React.Component {
       const emojiSelected = key?.toLowerCase()?.includes(selectedEmoji?.toLowerCase());
 
       let customStyles = {
-        paddingLeft: '4px',
-        paddingRight: '4px',
-        paddingTop: '8px',
-        paddingBottom: '8px',
+        paddingLeft: '8px',
+        paddingRight: '8px',
+        paddingTop: '12px',
+        paddingBottom: '12px',
         marginLeft: '0px',
         marginRight: '0px',
       };


### PR DESCRIPTION
### What does this PR do?

Adds more spacing around menu items in order to achieve a result that is more similar to what we had before #15048, but without white borders around the menu items.

#### before
![before](https://user-images.githubusercontent.com/3728706/169845987-765780af-eafe-45b6-a88b-6f8492ef34cb.png)

#### after
![2022-05-23_11-37](https://user-images.githubusercontent.com/3728706/169845837-d6f75153-8c7c-4e53-86cc-b0d19696d824.png)

### Motivation

Suggested by @ffdixon in https://github.com/bigbluebutton/bigbluebutton/pull/15048#issuecomment-1134729749