### PR TITLE
style: increase dropdown menu padding

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
@@ -70,8 +70,8 @@ class BBBMenu extends React.Component {
       const emojiSelected = key?.toLowerCase()?.includes(selectedEmoji?.toLowerCase());
 
       let customStyles = {
-        paddingLeft: '8px',
-        paddingRight: '8px',
+        paddingLeft: '16px',
+        paddingRight: '16px',
         paddingTop: '12px',
         paddingBottom: '12px',
         marginLeft: '0px',


### PR DESCRIPTION
### What does this PR do?

Adds more spacing around menu items in order to achieve a result that is more similar to what we had before #15048, but without white borders around the menu items.

#### before
![before](https://user-images.githubusercontent.com/3728706/169845987-765780af-eafe-45b6-a88b-6f8492ef34cb.png)

#### after
![after](https://user-images.githubusercontent.com/3728706/169870904-dcd9c530-0cbb-48be-8ec7-a043feed2a26.png)

### Motivation

Suggested by @ffdixon in https://github.com/bigbluebutton/bigbluebutton/pull/15048#issuecomment-1134729749