### PR TITLE
Adding border inside shared notes for viewers

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/pads/content/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/pads/content/styles.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import {
   colorGray,
+  colorGrayLightest
 } from '/imports/ui/stylesheets/styled-components/palette';
 
 const Wrapper = styled.div`
@@ -42,6 +43,8 @@ top: 0;
 const Iframe = styled.iframe`
   border-width: 0;
   width: 100%;
+  border-top: 1px solid ${colorGrayLightest};
+  border-bottom: 1px solid ${colorGrayLightest};
 `;
 
 export default {


### PR DESCRIPTION
Before this PR there wasn't any border inside shared notes for the viewers when they were locked.

![borderNotWorking](https://user-images.githubusercontent.com/19312495/169875379-a1924f63-ec46-4734-9521-4713ad2acf9f.png)

Now, there is a border on the bottom and another one on the top.

![Screenshot from 2022-05-23 14-25-52](https://user-images.githubusercontent.com/19312495/169875467-582b977f-41b1-4f6e-8e27-546b8880ca72.png)

