### PR TITLE
Adding border inside shared notes for viewers

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/pads/content/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/pads/content/styles.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import {
   colorGray,
+  colorGrayLightest
 } from '/imports/ui/stylesheets/styled-components/palette';
 
 const Wrapper = styled.div`
@@ -42,6 +43,8 @@ top: 0;
 const Iframe = styled.iframe`
   border-width: 0;
   width: 100%;
+  border-top: 1px solid ${colorGrayLightest};
+  border-bottom: 1px solid ${colorGrayLightest};
 `;
 
 export default {


### PR DESCRIPTION
Before this PR there wasn't any border inside shared notes for the viewers when they were locked.
![borderNotWorking](https://user-images.githubusercontent.com/19312495/169891614-b0d47d17-6088-4fe9-9e4a-32cbc8b5c4ba.png)


Now, there is a border on the bottom and another one on the top
![Screenshot from 2022-05-23 14-25-52](https://user-images.githubusercontent.com/19312495/169891606-226aedb5-5064-4f4d-b3a6-ca4e63c19219.png)
.


Closes #15000