### PR TITLE
test: webcamContentCheck

### DIFF
--- a/bigbluebutton-tests/playwright/webcam/util.js
+++ b/bigbluebutton-tests/playwright/webcam/util.js
@@ -2,6 +2,10 @@ const e = require('../core/elements');
 const { sleep } = require('../core/helpers');
 const { LOOP_INTERVAL, ELEMENT_WAIT_LONGER_TIME } = require('../core/constants');
 
+// loop 5 times, every LOOP_INTERVAL milliseconds, and check that all
+// videos displayed are changing by comparing a hash of their
+// displayed contents
+
 async function webcamContentCheck(test) {
   await test.waitForSelector(e.webcamVideoItem);
   await test.wasRemoved(e.webcamConnecting, ELEMENT_WAIT_LONGER_TIME);
@@ -11,23 +15,44 @@ async function webcamContentCheck(test) {
     console.log(`loop ${i}`);
     const checkCameras = () => {
       const videos = document.querySelectorAll('video');
-      const lastVideoColor = document.lastVideoColor || {};
-      document.lastVideoColor = lastVideoColor;
+      const lastVideoHash = document.lastVideoHash || {};
+      document.lastVideoHash = lastVideoHash;
+
+      // If this code was running in the playwright test harness, we
+      // could just require('sha1'), but it's running in the test
+      // browser via test.page.evaluate, and I'm not sure how to get a
+      // node module (like sha1) into the test browser.  So I just
+      // found a nice hash function on the Internet.  -bwb
+
+      // public domain code from https://stackoverflow.com/a/52171480/1493790
+      // and/or https://github.com/bryc/code/blob/master/jshash/experimental/cyrb53.js
+
+      const cyrb53 = function(array, seed = 0) {
+          let h1 = 0xdeadbeef ^ seed, h2 = 0x41c6ce57 ^ seed;
+          for (let i = 0, ch; i < array.length; i++) {
+              ch = array[i];
+              h1 = Math.imul(h1 ^ ch, 2654435761);
+              h2 = Math.imul(h2 ^ ch, 1597334677);
+          }
+          h1 = Math.imul(h1 ^ (h1>>>16), 2246822507) ^ Math.imul(h2 ^ (h2>>>13), 3266489909);
+          h2 = Math.imul(h2 ^ (h2>>>16), 2246822507) ^ Math.imul(h1 ^ (h1>>>13), 3266489909);
+          return 4294967296 * (2097151 & h2) + (h1>>>0);
+      };
 
       for (let v = 0; v < videos.length; v++) {
         const video = videos[v];
         const canvas = document.createElement('canvas');
         const context = canvas.getContext('2d');
         context.drawImage(video, 0, 0, video.videoWidth, video.videoHeight);
-        const pixel = context.getImageData(0, 0, 1, 1).data;
-        const pixelString = new Array(pixel).join(' ').toString();
+        const pixel = context.getImageData(0, 0, video.videoWidth, video.videoHeight).data;
+        const pixelHash = cyrb53(pixel);
 
-        if (lastVideoColor[v]) {
-          if (lastVideoColor[v] == pixelString) {
+        if (lastVideoHash[v]) {
+          if (lastVideoHash[v] == pixelHash) {
             return false;
           }
         }
-        lastVideoColor[v] = pixelString;
+        lastVideoHash[v] = pixelHash;
       }
       return true;
     };


### PR DESCRIPTION
Check that webcam videos are changing by computing a hash of their entire contents, rather than checking a single pixel, which was producing false failures.

I cut-and-pasted a public domain hash function, slightly modified to work on arrays instead of hashes.  It's only a dozen lines of code, and I don't know a better way to get some kind of library module loaded into the test browser, as opposed to the test harness.

Default settings pause 1.2 seconds between each check, to give the video time to change, so even if the hash function slows things down slightly, it's unnoticeable.