### PR TITLE
fix(layout): Fix propagation bugs and allow moderators to set the pushLayout flag

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/BroadcastPushLayoutMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/BroadcastPushLayoutMsgHdlr.scala
@@ -1,0 +1,41 @@
+package org.bigbluebutton.core.apps.layout
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.models.{ Layouts }
+import org.bigbluebutton.core.running.OutMsgRouter
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
+
+trait BroadcastPushLayoutMsgHdlr extends RightsManagementTrait {
+  this: LayoutApp2x =>
+
+  val outGW: OutMsgRouter
+
+  def handleBroadcastPushLayoutMsg(msg: BroadcastPushLayoutMsg): Unit = {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val reason = "No permission to broadcast pushLayout to meeting."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)
+    } else {
+
+      Layouts.setPushLayout(liveMeeting.layouts, msg.body.pushLayout)
+      Layouts.setRequestedBy(liveMeeting.layouts, msg.header.userId)
+
+      sendBroadcastPushLayoutEvtMsg(msg.header.userId)
+    }
+  }
+
+  def sendBroadcastPushLayoutEvtMsg(fromUserId: String): Unit = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, fromUserId)
+    val envelope = BbbCoreEnvelope(BroadcastPushLayoutEvtMsg.NAME, routing)
+    val header = BbbClientMsgHeader(BroadcastPushLayoutEvtMsg.NAME, liveMeeting.props.meetingProp.intId, fromUserId)
+
+    val body = BroadcastPushLayoutEvtMsgBody(
+      Layouts.getPushLayout(liveMeeting.layouts),
+      Layouts.getLayoutSetter(liveMeeting.layouts),
+    )
+    val event = BroadcastPushLayoutEvtMsg(header, body)
+    val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+
+    outGW.send(msgEvent)
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/LayoutApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/LayoutApp2x.scala
@@ -5,6 +5,7 @@ import org.bigbluebutton.core.running.MeetingActor
 
 trait LayoutApp2x
   extends BroadcastLayoutMsgHdlr
+  with BroadcastPushLayoutMsgHdlr
   with GetCurrentLayoutReqMsgHdlr {
 
   this: MeetingActor =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -239,6 +239,8 @@ class ReceivedJsonMsgHandlerActor(
         routeGenericMsg[GetCurrentLayoutReqMsg](envelope, jsonNode)
       case BroadcastLayoutMsg.NAME =>
         routeGenericMsg[BroadcastLayoutMsg](envelope, jsonNode)
+      case BroadcastPushLayoutMsg.NAME =>
+        routeGenericMsg[BroadcastPushLayoutMsg](envelope, jsonNode)
 
       case UserLeaveReqMsg.NAME =>
         routeGenericMsg[UserLeaveReqMsg](envelope, jsonNode)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -471,6 +471,7 @@ class MeetingActor(
       // Layout
       case m: GetCurrentLayoutReqMsg  => handleGetCurrentLayoutReqMsg(m)
       case m: BroadcastLayoutMsg      => handleBroadcastLayoutMsg(m)
+      case m: BroadcastPushLayoutMsg  => handleBroadcastPushLayoutMsg(m)
 
       // Pads
       case m: PadCreateGroupReqMsg    => padsApp2x.handle(m, liveMeeting, msgBus)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/LayoutMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/LayoutMsgs.scala
@@ -9,6 +9,10 @@ object BroadcastLayoutMsg { val NAME = "BroadcastLayoutMsg" }
 case class BroadcastLayoutMsg(header: BbbClientMsgHeader, body: BroadcastLayoutMsgBody) extends StandardMsg
 case class BroadcastLayoutMsgBody(layout: String, pushLayout: Boolean, presentationIsOpen: Boolean, isResizing: Boolean, cameraPosition: String, focusedCamera: String, presentationVideoRate: Double)
 
+object BroadcastPushLayoutMsg { val NAME = "BroadcastPushLayoutMsg" }
+case class BroadcastPushLayoutMsg(header: BbbClientMsgHeader, body: BroadcastPushLayoutMsgBody) extends StandardMsg
+case class BroadcastPushLayoutMsgBody(pushLayout: Boolean)
+
 // Out messages
 object GetCurrentLayoutRespMsg { val NAME = "GetCurrentLayoutRespMsg" }
 case class GetCurrentLayoutRespMsg(header: BbbClientMsgHeader, body: GetCurrentLayoutRespMsgBody) extends BbbCoreMsg
@@ -17,3 +21,7 @@ case class GetCurrentLayoutRespMsgBody(layout: String, locked: Boolean, setByUse
 object BroadcastLayoutEvtMsg { val NAME = "BroadcastLayoutEvtMsg" }
 case class BroadcastLayoutEvtMsg(header: BbbClientMsgHeader, body: BroadcastLayoutEvtMsgBody) extends BbbCoreMsg
 case class BroadcastLayoutEvtMsgBody(layout: String, pushLayout: Boolean, presentationIsOpen: Boolean, isResizing: Boolean, cameraPosition: String, focusedCamera: String, presentationVideoRate: Double, locked: Boolean, setByUserId: String)
+
+object BroadcastPushLayoutEvtMsg { val NAME = "BroadcastPushLayoutEvtMsg" }
+case class BroadcastPushLayoutEvtMsg(header: BbbClientMsgHeader, body: BroadcastPushLayoutEvtMsgBody) extends BbbCoreMsg
+case class BroadcastPushLayoutEvtMsgBody(pushLayout: Boolean, setByUserId: String)

--- a/bigbluebutton-html5/imports/api/meetings/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/eventHandlers.js
@@ -16,6 +16,7 @@ import handleBroadcastLayout from './handlers/broadcastLayout';
 import handleNotifyAllInMeetingEvtMsg from './handlers/handleNotifyAllInMeetingEvtMsg';
 import handleNotifyUserInMeeting from './handlers/handleNotifyUserInMeeting';
 import handleNotifyRoleInMeeting from './handlers/handleNotifyRoleInMeeting';
+import handleBroadcastPushLayout from './handlers/broadcastPushLayout';
 
 RedisPubSub.on('MeetingCreatedEvtMsg', handleMeetingCreation);
 RedisPubSub.on('SyncGetMeetingInfoRespMsg', handleGetAllMeetings);
@@ -35,3 +36,4 @@ RedisPubSub.on('BroadcastLayoutEvtMsg', handleBroadcastLayout);
 RedisPubSub.on('NotifyAllInMeetingEvtMsg', handleNotifyAllInMeetingEvtMsg);
 RedisPubSub.on('NotifyUserInMeetingEvtMsg', handleNotifyUserInMeeting);
 RedisPubSub.on('NotifyRoleInMeetingEvtMsg', handleNotifyRoleInMeeting);
+RedisPubSub.on('BroadcastPushLayoutEvtMsg', handleBroadcastPushLayout);

--- a/bigbluebutton-html5/imports/api/meetings/server/handlers/broadcastPushLayout.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/handlers/broadcastPushLayout.js
@@ -1,0 +1,7 @@
+import setPushLayout from '../modifiers/setPushLayout';
+
+export default function broadcastPushLayout({ body }, meetingId) {
+  const { pushLayout, setByUserId } = body;
+
+  setPushLayout(meetingId, pushLayout, setByUserId);
+}

--- a/bigbluebutton-html5/imports/api/meetings/server/methods.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/methods.js
@@ -6,6 +6,7 @@ import toggleLockSettings from './methods/toggleLockSettings';
 import toggleWebcamsOnlyForModerator from './methods/toggleWebcamsOnlyForModerator';
 import clearRandomlySelectedUser from './methods/clearRandomlySelectedUser';
 import changeLayout from './methods/changeLayout';
+import setPushLayout from './methods/setPushLayout';
 
 Meteor.methods({
   endMeeting,
@@ -15,4 +16,5 @@ Meteor.methods({
   toggleWebcamsOnlyForModerator,
   clearRandomlySelectedUser,
   changeLayout,
+  setPushLayout,
 });

--- a/bigbluebutton-html5/imports/api/meetings/server/methods/setPushLayout.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/methods/setPushLayout.js
@@ -1,0 +1,25 @@
+import Logger from '/imports/startup/server/logger';
+import RedisPubSub from '/imports/startup/server/redis';
+import { extractCredentials } from '/imports/api/common/server/helpers';
+import { check } from 'meteor/check';
+
+export default function setPushLayout(payload) {
+  const REDIS_CONFIG = Meteor.settings.private.redis;
+  const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
+  const EVENT_NAME = 'BroadcastPushLayoutMsg';
+
+  try {
+    const { meetingId, requesterUserId } = extractCredentials(this.userId);
+
+    check(meetingId, String);
+    check(requesterUserId, String);
+
+    check(payload, {
+      pushLayout: Boolean,
+    });
+
+    RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);
+  } catch (err) {
+    Logger.error(`Exception while invoking method push layout ${err.stack}`);
+  }
+}

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/setPushLayout.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/setPushLayout.js
@@ -1,0 +1,29 @@
+import Logger from '/imports/startup/server/logger';
+import { LayoutMeetings } from '/imports/api/meetings';
+import { check } from 'meteor/check';
+
+export default function setPushLayout(meetingId, pushLayout, requesterUserId) {
+  try {
+    check(meetingId, String);
+    check(requesterUserId, String);
+
+    const selector = {
+      meetingId,
+    };
+
+    // TODO: create a exclusive collection for layout changes
+    const modifier = {
+      $set: {
+        pushLayout,
+      },
+    };
+
+    const numberAffected = LayoutMeetings.update(selector, modifier);
+
+    if (numberAffected) {
+      Logger.info(`MeetingLayout pushLayout changed to ${pushLayout} for meeting=${meetingId} requested by user=${requesterUserId}`);
+    }
+  } catch (err) {
+    Logger.error(`Exception while invoking method setPushLayout ${err.stack}`);
+  }
+}

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -25,6 +25,7 @@ const propTypes = {
   stopExternalVideoShare: PropTypes.func.isRequired,
   isMobile: PropTypes.bool.isRequired,
   setMeetingLayout: PropTypes.func.isRequired,
+  setPushLayout: PropTypes.func.isRequired,
   showPushLayout: PropTypes.bool.isRequired,
 };
 
@@ -138,6 +139,7 @@ class ActionsDropdown extends PureComponent {
       layoutContextDispatch,
       hidePresentation,
       setMeetingLayout,
+      setPushLayout,
       showPushLayout,
     } = this.props;
 
@@ -217,12 +219,12 @@ class ActionsDropdown extends PureComponent {
       })
     }
 
-    if (amIPresenter && showPushLayout) {
+    if ((amIPresenter || amIModerator) && showPushLayout) {
       actions.push({
         icon: 'send',
         label: intl.formatMessage(intlMessages.propagateLayoutLabel),
         key: 'propagate layout',
-        onClick: setMeetingLayout,
+        onClick: amIPresenter ? setMeetingLayout : setPushLayout,
       });
     }
 

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -129,6 +129,7 @@ class ActionsDropdown extends PureComponent {
     const {
       intl,
       amIPresenter,
+      amIModerator,
       allowExternalVideo,
       handleTakePresenter,
       isSharingVideo,

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -36,6 +36,7 @@ class ActionsBar extends PureComponent {
       actionsBarStyle,
       setMeetingLayout,
       showPushLayout,
+      setPushLayout,
     } = this.props;
 
     return (
@@ -59,6 +60,7 @@ class ActionsBar extends PureComponent {
             stopExternalVideoShare,
             isMeteorConnected,
             setMeetingLayout,
+            setPushLayout,
             presentationIsOpen,
             showPushLayout,
           }}

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -311,35 +311,7 @@ class App extends Component {
 
     this.renderDarkMode();
 
-    if (meetingLayout !== prevProps.meetingLayout
-      || meetingLayoutUpdatedAt !== prevProps.meetingLayoutUpdatedAt) {
-
-      let contextLayout = meetingLayout;
-      if (isMobile()) {
-        contextLayout = meetingLayout === 'custom' ? 'smart' : meetingLayout;
-      }
-
-      layoutContextDispatch({
-        type: ACTIONS.SET_LAYOUT_TYPE,
-        value: contextLayout,
-      });
-
-      Settings.application.selectedLayout = contextLayout;
-      Settings.save();
-    }
-
-    if (selectedLayout !== prevProps.selectedLayout) {
-      layoutContextDispatch({
-        type: ACTIONS.SET_LAYOUT_TYPE,
-        value: selectedLayout,
-      });
-
-      Settings.application.selectedLayout = selectedLayout;
-      Settings.save();
-    }
-
-    if (meetingLayout !== prevProps.meetingLayout
-      || meetingLayoutUpdatedAt !== prevProps.meetingLayoutUpdatedAt) {
+    if (meetingLayout !== prevProps.meetingLayout) {
 
       let contextLayout = meetingLayout;
       if (isMobile()) {
@@ -357,6 +329,7 @@ class App extends Component {
 
     if (pushLayoutMeeting !== prevProps.pushLayoutMeeting) {
       Settings.application.pushLayout = pushLayoutMeeting;
+      Settings.save();
     }
 
     if (meetingLayout === "custom" && !isPresenter) {
@@ -420,14 +393,14 @@ class App extends Component {
     }
 
     const layoutChanged = presentationIsOpen !== prevProps.presentationIsOpen
+      || selectedLayout !== prevProps.selectedLayout
       || cameraIsResizing !== prevProps.cameraIsResizing
       || cameraPosition !== prevProps.cameraPosition
       || focusedCamera !== prevProps.focusedCamera
       || !equalDouble(presentationVideoRate, prevProps.presentationVideoRate);
 
-    if ((pushLayout && selectedLayout === 'custom' && layoutChanged) // change layout sizes / states
-      || (!pushLayout && prevProps.pushLayout) // special case where we set pushLayout to false in all viewers
-      || (pushLayout && !prevProps.pushLayout && selectedLayout === 'custom') // push layout once after presenter presses the button
+    if ((pushLayout && layoutChanged) // change layout sizes / states
+      || (pushLayout !== prevProps.pushLayout) // push layout once after presenter toggles / special case where we set pushLayout to false in all viewers
     ) {
       if (isPresenter) {
         setMeetingLayout();

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -293,6 +293,7 @@ class App extends Component {
       cameraHeight,
       cameraIsResizing,
       isPresenter,
+      isModerator,
       layoutPresOpen,
       layoutIsResizing,
       layoutCamPosition,
@@ -304,6 +305,7 @@ class App extends Component {
       pushLayoutMeeting,
       layoutContextDispatch,
       mountRandomUserModal,
+      setPushLayout,
       setMeetingLayout,
     } = this.props;
 
@@ -423,11 +425,15 @@ class App extends Component {
       || focusedCamera !== prevProps.focusedCamera
       || !equalDouble(presentationVideoRate, prevProps.presentationVideoRate);
 
-    if (isPresenter && ((pushLayout && selectedLayout === 'custom' && layoutChanged) // change layout sizes / states
+    if ((pushLayout && selectedLayout === 'custom' && layoutChanged) // change layout sizes / states
       || (!pushLayout && prevProps.pushLayout) // special case where we set pushLayout to false in all viewers
-      || (pushLayout && !prevProps.pushLayout && selectedLayout === 'custom')) // push layout once after presenter presses the button
+      || (pushLayout && !prevProps.pushLayout && selectedLayout === 'custom') // push layout once after presenter presses the button
     ) {
-      setMeetingLayout();
+      if (isPresenter) {
+        setMeetingLayout();
+      } else if (isModerator) {
+        setPushLayout();
+      }
     }
 
     if (mountRandomUserModal) mountModal(<RandomUserSelectContainer />);
@@ -529,6 +535,7 @@ class App extends Component {
       intl,
       actionsBarStyle,
       hideActionsBar,
+      setPushLayout,
       setMeetingLayout,
       presentationIsOpen,
       selectedLayout,
@@ -556,6 +563,7 @@ class App extends Component {
         }
       >
         <ActionsBarContainer
+          setPushLayout={setPushLayout}
           setMeetingLayout={setMeetingLayout}
           showPushLayout={showPushLayoutButton && selectedLayout === 'custom'}
           presentationIsOpen={presentationIsOpen}

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -22,6 +22,8 @@ import {
   layoutDispatch,
 } from '../layout/context';
 
+const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
+
 import {
   getFontSize,
   getBreakoutRooms,
@@ -112,6 +114,12 @@ const AppContainer = (props) => {
   && randomlySelectedUser.length > 0
   && !isModalOpen;
 
+  const setPushLayout = () => {
+    LayoutService.setMeetingLayout({
+      pushLayout,
+    });
+  }
+
   const setMeetingLayout = () => {
     const { isResizing } = cameraDockInput;
     LayoutService.setMeetingLayout({
@@ -132,6 +140,7 @@ const AppContainer = (props) => {
           actionsBarStyle,
           captionsStyle,
           currentUserId,
+          setPushLayout,
           setMeetingLayout,
           meetingLayout,
           selectedLayout,
@@ -190,7 +199,7 @@ export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) 
     {
       fields:
       {
-        approved: 1, emoji: 1, userId: 1, presenter: 1,
+        approved: 1, emoji: 1, userId: 1, presenter: 1, role: 1,
       },
     },
   );
@@ -249,6 +258,7 @@ export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) 
     randomlySelectedUser,
     currentUserId: currentUser?.userId,
     isPresenter,
+    isModerator: currentUser.role === ROLE_MODERATOR,
     meetingLayout: layout,
     meetingLayoutUpdatedAt: layoutUpdatedAt,
     presentationIsOpen,

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -115,9 +115,7 @@ const AppContainer = (props) => {
   && !isModalOpen;
 
   const setPushLayout = () => {
-    LayoutService.setMeetingLayout({
-      pushLayout,
-    });
+    LayoutService.setPushLayout(pushLayout);
   }
 
   const setMeetingLayout = () => {

--- a/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
@@ -98,7 +98,7 @@ const LayoutModalComponent = (props) => {
       return null;
     }
 
-    if (isKeepPushingLayoutEnabled && selectedLayout === 'custom') {
+    if (isKeepPushingLayoutEnabled) {
       return (
         <Styled.PushContainer>
           <Styled.LabelPushLayout>

--- a/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
@@ -14,6 +14,7 @@ const LayoutModalComponent = (props) => {
   const {
     intl,
     closeModal,
+    isModerator,
     isPresenter,
     showToggleLabel,
     application,
@@ -93,7 +94,7 @@ const LayoutModalComponent = (props) => {
   };
 
   const renderPushLayoutsOptions = () => {
-    if (!isPresenter) {
+    if (!isPresenter && !isModerator) {
       return null;
     }
 

--- a/bigbluebutton-html5/imports/ui/components/layout/modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/modal/container.jsx
@@ -11,10 +11,11 @@ import {
 
 const LayoutModalContainer = (props) => <LayoutModalComponent {...props} />;
 
-export default withModalMounter(withTracker(({ mountModal }) => ({
+export default withModalMounter(withTracker(({ mountModal, amIModerator }) => ({
   closeModal: () => mountModal(null),
   application: SettingsService.application,
   updateSettings,
   isPresenter: isPresenter(),
+  isModerator: amIModerator,
   showToggleLabel: false,
 }))(LayoutModalContainer));

--- a/bigbluebutton-html5/imports/ui/components/layout/service.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/service.js
@@ -1,10 +1,14 @@
 import { makeCall } from '/imports/ui/services/api';
 
-const setMeetingLayout = (options) => {
+const setPushLayout = (pushLayout) => {
+  makeCall('setPushLayout', { pushLayout });
+};
 
+const setMeetingLayout = (options) => {
   makeCall('changeLayout', options)
 };
 
 export default {
+  setPushLayout,
   setMeetingLayout,
 };


### PR DESCRIPTION
* Allows moderator to set the pushLayout flag for the meeting (it will still follow the presenter layout, but moderator can set it on/off)
* Correctly pushes the layout once pushLayout flag is set from flase -> true
* Allow the pushing of layoutType again