### PR TITLE
fix(camera): prevent dock position change on click

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
@@ -23,6 +23,7 @@ const WebcamComponent = ({
   const [isFullscreen, setIsFullScreen] = useState(false);
   const [resizeStart, setResizeStart] = useState({ width: 0, height: 0 });
   const [cameraMaxWidth, setCameraMaxWidth] = useState(0);
+  const [draggedAtLeastOneTime, setDraggedAtLeastOneTime] = useState(false);
 
   const lastSize = Storage.getItem('webcamSize') || { width: 0, height: 0 };
   const { width: lastWidth, height: lastHeight } = lastSize;
@@ -140,9 +141,10 @@ const WebcamComponent = ({
 
   const handleWebcamDragStop = (e) => {
     setIsDragging(false);
+    setDraggedAtLeastOneTime(false);
     document.body.style.overflow = 'auto';
 
-    if (Object.values(CAMERADOCK_POSITION).includes(e.target.id)) {
+    if (Object.values(CAMERADOCK_POSITION).includes(e.target.id) && draggedAtLeastOneTime) {
       layoutContextDispatch({
         type: ACTIONS.SET_CAMERA_DOCK_POSITION,
         value: e.target.id,
@@ -181,6 +183,11 @@ const WebcamComponent = ({
           handle="video"
           bounds="html"
           onStart={handleWebcamDragStart}
+          onDrag={() => {
+            if (!draggedAtLeastOneTime) {
+              setDraggedAtLeastOneTime(true);
+            }
+          }}
           onStop={handleWebcamDragStop}
           onMouseDown={
             cameraDock.isDraggable ? (e) => e.preventDefault() : undefined


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

Prevents camera dock from changing position (custom layout) when no dragging operation is fired. That prevents it from changing when the user clicks on both the camera dock and a drop area at the same time. The idea of that PR is to allow position change only if the user performs at least one dragging operation.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #15036