### PR TITLE
style: Adding revised styles for our external links

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/styles.js
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import {
   colorWhite,
   colorGrayDark,
+  colorPrimary
 } from '/imports/ui/stylesheets/styled-components/palette';
 import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints';
 import Button from '/imports/ui/components/common/button/component';
@@ -24,6 +25,35 @@ const Chat = styled.div`
   justify-content: space-around;
   overflow: hidden;
   height: 100%;
+
+  a {
+    color: ${colorPrimary};
+    text-decoration: none;
+
+    &:focus {
+      color: ${colorPrimary};
+      text-decoration: underline;
+    }
+    &:hover {
+      filter: brightness(90%);
+      text-decoration: underline;
+    }
+    &:active {
+      filter: brightness(85%);
+      text-decoration: underline;
+    }
+    &:hover:focus{
+      filter: brightness(90%);
+      text-decoration: underline;
+    }
+    &:focus:active {
+      filter: brightness(85%);
+      text-decoration: underline;
+    }
+  }
+  u {
+    text-decoration-line: none;
+  }
 
   ${({ isChrome }) => isChrome && `
     transform: translateZ(0);

--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/component.jsx
@@ -152,7 +152,6 @@ class TimeWindowChatItem extends PureComponent {
     } = this.props;
 
     const dateTime = new Date(timestamp);
-    const regEx = /<a[^>]+>/i;
     ChatLogger.debug('TimeWindowChatItem::renderMessageItem', this.props);
     const defaultAvatarString = name?.toLowerCase().slice(0, 2) || "  ";
     const emphasizedText = messageFromModerator && CHAT_EMPHASIZE_TEXT && chatId === CHAT_PUBLIC_ID;
@@ -188,7 +187,6 @@ class TimeWindowChatItem extends PureComponent {
             <Styled.Messages>
               {messages.map(message => (
                 <Styled.ChatItem
-                  hasLink={regEx.test(message.text)}
                   emphasizedMessage={emphasizedText}
                   key={message.id}
                   text={message.text}

--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/styles.js
@@ -173,12 +173,6 @@ const ChatItem = styled(MessageChatItem)`
   color: ${colorText};
   word-wrap: break-word;
 
-  ${({ hasLink }) => hasLink && `
-    & > a {
-      color: ${colorPrimary};
-    }
-  `}
-
   ${({ emphasizedMessage }) => emphasizedMessage && `
     font-weight: bold;
   `}


### PR DESCRIPTION
Before this PR the external links hadn't any styles, like hover, focus, or pressed.
![externalNot](https://user-images.githubusercontent.com/19312495/170533141-196a8998-d3e4-4bd7-82c1-ff7742e9176a.png)

![styles](https://user-images.githubusercontent.com/19312495/170533355-d4ce2d53-86b0-4531-a967-84c44eca2ead.png)
So, I changed the styles according to this png above.

And Now, the external links has those styles, hover, focus, pressed, focus/hover, and focus/pressed. 



![Screenshot from 2022-05-26 15-32-13](https://user-images.githubusercontent.com/19312495/170553697-3f581068-4b16-44f7-9a18-7ea734c9c68e.png)

Closes #7716