### PR TITLE
build: bump bbb-webrtc-sfu to v2.8.2

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.8.1 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.8.2 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

- build: bump bbb-webrtc-sfu to [v2.8.2](https://github.com/bigbluebutton/bbb-webrtc-sfu/releases/tag/v2.8.2)

### More

**Full Changelog**: https://github.com/bigbluebutton/bbb-webrtc-sfu/compare/v2.8.1...v2.8.2

#### Fixes

- [fix(video): memory leak due to orphaned event handlers](https://github.com/bigbluebutton/bbb-webrtc-sfu/commit/dc34e6083cc8692a8c362c41cf8a12e2f4adc769)
  * Addressed a significant memory leak in one of the subprocesses - `VideoProcess.js`
- [fix(mediasoup): fix worker replacement routine](https://github.com/bigbluebutton/bbb-webrtc-sfu/commit/30b10f8d235bed0efe94967cbc78381da9bf6f76)
  * Guarantee the bare minimum is done in case a mediasoup-worker crashes:
    - Increment the Prometheus crash counter
    - Remove the crashed worker reference
    - Replace the crashed worker (in the correct worker pool)
- [fix(audio): properly normalize start errors](https://github.com/bigbluebutton/bbb-webrtc-sfu/commit/1e242faafc9dd65a120a5e62c6e99d948c52924e)
- [fix(mediasoup): handle missing producer on consumer creation](https://github.com/bigbluebutton/bbb-webrtc-sfu/commit/a1c086613b5724eca79b08e8ae125d541b5b27e8)
