### PR TITLE
fix: ghost button focus shadow

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/button/styles.js
@@ -415,7 +415,7 @@ const ButtonSpan = styled.span`
       color: ${btnDefaultBg};
       background-color: ${btnDefaultColor};
       background-clip: padding-box;
-      box-shadow: 0 0 0 ${borderSizeLarge} ${btnDefaultBg};
+      box-shadow: 0 0 0 ${borderSizeLarge} ${btnDefaultBg} !important;
     }
 
     &:hover,


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

Fixes a small bug introduced in https://github.com/bigbluebutton/bigbluebutton/pull/15044/commits/2a09629698136f725cbbd95bddfff145b53dee8b that messes up focus shadow of a few buttons.

**Before**
_Normal / Focus_
![btn-normal](https://user-images.githubusercontent.com/62393923/170576302-c4a2c5b8-d382-417b-8a01-ed58209743ed.png) ![btn-focus-before](https://user-images.githubusercontent.com/62393923/170576424-b33499a6-5ed7-4708-b663-33b405f5a254.png)

**After**
_Normal / Focus_
![btn-normal](https://user-images.githubusercontent.com/62393923/170576302-c4a2c5b8-d382-417b-8a01-ed58209743ed.png) ![btn-focus-after](https://user-images.githubusercontent.com/62393923/170576576-de02eef7-3af0-443a-8c37-f0630d950fad.png)


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
None


### Motivation

n/a

### More

n/a