### PR TITLE
fix(audio): remove deprecated getLocalStreams usage

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/audio-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/audio-broker.js
@@ -30,8 +30,8 @@ class AudioBroker extends BaseBroker {
   }
 
   getLocalStream() {
-    if (this.webRtcPeer && this.webRtcPeer.peerConnection) {
-      return this.webRtcPeer.peerConnection.getLocalStreams()[0];
+    if (this.webRtcPeer && typeof this.webRtcPeer.getLocalStream === 'function') {
+      return this.webRtcPeer.getLocalStream();
     }
 
     return null;


### PR DESCRIPTION


### What does this PR do?

Use the built-in getLocalStream from the peer wrapper instead (which
relies on getSenders - the proper, spec-compliant way).

### Closes Issue(s)

None

### Motivation

Two different issues are addressed:
  - RTCPeerConnection.getLocalStreams is a pre-1.0 WebRTC spec which is
    deprecated and not recommended.
  - Fixed an issue where a switch from full audio to listen only could
  cause the latter to be rejected with an error 1004 in rare scenarios. Hard to
  reproduce, but identified via log processing that pointed down to 
  getLocalStreams usage on Safari.

### More

n/a
