### PR TITLE
Fix: only show breakout room in user list when user is in breakout room

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
@@ -653,6 +653,7 @@ class UserListItem extends PureComponent {
       user,
       intl,
       isThisMeetingLocked,
+      userInBreakout,
       userLastBreakout,
       isMe,
       isRTL,
@@ -746,7 +747,7 @@ class UserListItem extends PureComponent {
       if (LABEL.guest) userNameSub.push(intl.formatMessage(messages.guest));
     }
 
-    if (userLastBreakout) {
+    if (userInBreakout && userLastBreakout) {
       userNameSub.push(
         <span key={_.uniqueId('breakout-')}>
           <Icon iconName="rooms" />


### PR DESCRIPTION


### What does this PR do?

The user list in the main room showed user being in breakout rooms who
already left a breakout room. It adds a check if the user is still in a breakout room or not.

### Closes Issue(s)
Closes #14982
