### PR TITLE
Fix(build): add service dependency to redis for several services

### DIFF
--- a/build/packages-template/bbb-etherpad/etherpad.service
+++ b/build/packages-template/bbb-etherpad/etherpad.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Etherpad Server
 Wants=redis-server.service
-After=syslog.target network.target
+After=syslog.target network.target redis-server.service
 
 [Service]
 Type=simple

--- a/build/packages-template/bbb-html5/bbb-html5.service
+++ b/build/packages-template/bbb-html5/bbb-html5.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=BigBlueButton HTML5 service
-Wants=redis.service mongod.service disable-transparent-huge-pages.service bbb-pads.service
-After=redis.service mongod.service disable-transparent-huge-pages.service bbb-pads.service syslog.target network.target
+Wants=redis-server.service mongod.service disable-transparent-huge-pages.service bbb-pads.service
+After=redis-server.service mongod.service disable-transparent-huge-pages.service bbb-pads.service syslog.target network.target
 
 [Service]
 Type=oneshot

--- a/build/packages-template/bbb-pads/bbb-pads.service
+++ b/build/packages-template/bbb-pads/bbb-pads.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=BigBlueButton Pads
-Wants=redis.service etherpad.service
-After=syslog.target network.target
+Wants=redis-server.service etherpad.service
+After=syslog.target network.target redis-server.service etherpad.service
 
 [Service]
 WorkingDirectory=/usr/local/bigbluebutton/bbb-pads

--- a/build/packages-template/bbb-web/bbb-web.service
+++ b/build/packages-template/bbb-web/bbb-web.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=BigBlueButton Web Application
 Requires=network.target
-After=redis.service
+Wants=redis-server.service
+After=redis-server.service
 
 [Service]
 Type=simple

--- a/build/packages-template/bbb-webhooks/bbb-webhooks.service
+++ b/build/packages-template/bbb-webhooks/bbb-webhooks.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=BigBlueButton Webhooks
 Wants=redis-server.service
-After=syslog.target network.target
+After=syslog.target network.target redis-server.service
 
 [Service]
 WorkingDirectory=/usr/local/bigbluebutton/bbb-webhooks

--- a/build/packages-template/bbb-webrtc-sfu/bbb-webrtc-sfu.service
+++ b/build/packages-template/bbb-webrtc-sfu/bbb-webrtc-sfu.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=BigBlueButton WebRTC SFU
 Wants=redis-server.service
-After=syslog.target network.target freeswitch.service kurento-media-server.service
+After=syslog.target network.target freeswitch.service kurento-media-server.service redis-server.service
 
 [Service]
 WorkingDirectory=/usr/local/bigbluebutton/bbb-webrtc-sfu

--- a/record-and-playback/core/systemd/bbb-rap-resque-worker.service
+++ b/record-and-playback/core/systemd/bbb-rap-resque-worker.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=BigBlueButton resque worker for recordings
-Wants=redis.service
-After=redis.service
+Wants=redis-server.service
+After=redis-server.service
 
 [Service]
 Type=simple

--- a/record-and-playback/core/systemd/bbb-rap-starter.service
+++ b/record-and-playback/core/systemd/bbb-rap-starter.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=BigBlueButton recording processing starter
+Wants=redis-server.service
+After=redis-server.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
### What does this PR do?

* fix unit name: the unit name on Ubuntu is `redis-server.service`
* services which need a working redis require both After= and Wants=

### Closes Issue(s)

Closes #10989

### More

See the description for `After=` and `Wants=` in the `systemd.unit` man page.
