### PR TITLE
build(fsesl-akka): build deps in sequence to allow for ci use

### DIFF
--- a/build/packages-template/bbb-fsesl-akka/build.sh
+++ b/build/packages-template/bbb-fsesl-akka/build.sh
@@ -22,18 +22,19 @@ build_common_messages () {
     cd bbb-common-message
     sbt publish
     sbt publishLocal
+    cd ..
 }
 
 build_fsesl_client () {
     cd bbb-fsesl-client
     sbt publish
     sbt publishLocal
+    cd ..
 }
 
-# build these two in parallel
-build_common_messages &
-build_fsesl_client &
-wait
+build_common_messages
+build_fsesl_client
+
 
 cd akka-bbb-fsesl
 sed -i 's/\r$//' project/Dependencies.scala


### PR DESCRIPTION
Backport of https://github.com/bigbluebutton/bigbluebutton/pull/14990 to 2.5 to resolve issues like https://github.com/bigbluebutton/bigbluebutton/runs/6660459033