### PR TITLE
fix: autoSwapLayout/restoreOnUpdate new presentation fails to show (2.5)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -73,6 +73,7 @@ class Presentation extends PureComponent {
       zoom: 100,
       fitToWidth: false,
       isFullscreen: false,
+      hadPresentation: false,
     };
 
     this.currentPresentationToastId = null;
@@ -158,8 +159,7 @@ class Presentation extends PureComponent {
       intl,
     } = this.props;
 
-    const { presentationWidth, presentationHeight } = this.state;
-
+    const { presentationWidth, presentationHeight, hadPresentation } = this.state;
     const {
       numCameras: prevNumCameras,
       presentationBounds: prevPresentationBounds,
@@ -210,6 +210,11 @@ class Presentation extends PureComponent {
           render: this.renderCurrentPresentationToast(),
         });
       }
+
+      if (layoutSwapped && restoreOnUpdate && currentSlide && hadPresentation) {
+        toggleSwapLayout(layoutContextDispatch);
+        this.setState({ hadPresentation: false });
+      }
     }
 
     if (prevProps?.slidePosition && slidePosition) {
@@ -253,6 +258,10 @@ class Presentation extends PureComponent {
         type: ACTIONS.SET_PRESENTATION_NUM_CURRENT_SLIDE,
         value: currentSlide.num,
       });
+    }
+
+    if (prevProps.currentSlide && !currentSlide) {
+      this.setState({ hadPresentation: true });
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

This is a (partial) port of PR #15109 from 2.4 to 2.5.

_Prevents a bug where the restoreOnUpdate feature (sometimes) fail if a large file is uploaded._
