### PR TITLE
feat(whiteboard): poll result, zoom fit slide +

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/PresentationPods.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/PresentationPods.scala
@@ -26,7 +26,7 @@ case class PresentationPage(
     current:     Boolean             = false,
     xCamera:     Double              = 0,
     yCamera:     Double              = 0,
-    zoom:        Double              = 1D,
+    zoom:        Double              = 0D,
 )
 
 object PresentationInPod {

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -857,6 +857,7 @@ class Presentation extends PureComponent {
       currentPresentation,
       layoutSwapped,
       podId,
+      intl,
     } = this.props;
 
     const {
@@ -939,6 +940,8 @@ class Presentation extends PureComponent {
             setTldrawAPI={this.setTldrawAPI}
             curPageId={currentSlide?.num.toString()}
             svgUri={currentSlide?.svgUri}
+            intl={intl}
+            presentationBounds={presentationBounds}
           />
           {isFullscreen && <PollingContainer />}
           {this.renderPresentationToolbar()}

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -14,8 +14,8 @@ const WhiteboardContainer = (props) => {
     return <Whiteboard {...{isPresenter, currentUser}} {...props} meetingId={Auth.meetingID} />
 };
 
-export default withTracker(({ whiteboardId }) => {
-  const shapes = Service.getShapes(whiteboardId);
+export default withTracker(({ whiteboardId, curPageId, intl }) => {
+  const shapes = Service.getShapes(whiteboardId, curPageId, intl);
   const assets = Service.getAssets();
   const curPres = Service.getCurrentPres();
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -306,7 +306,7 @@ const changeCurrentSlide = (s) => {
   makeCall("changeCurrentSlide", s);
 }
 
-const getShapes = (whiteboardId) => {
+const getShapes = (whiteboardId, curPageId, intl) => {
   const annotations =  Annotations.find(
     {
       whiteboardId,
@@ -319,6 +319,30 @@ const getShapes = (whiteboardId) => {
   let result = {};
 
   annotations.forEach((annotation) => {
+    if (annotation.annotationInfo.questionType) {
+      // poll result, convert it to text and create tldraw shape
+      const pollResult = PollService.getPollResultString(annotation.annotationInfo, intl)
+        .split('<br/>').join('\n').replace( /(<([^>]+)>)/ig, '');
+      annotation.annotationInfo = {
+        childIndex: 2,
+        id: annotation.annotationInfo.id,
+        name: `poll-result-${annotation.annotationInfo.id}`,
+        type: "text",
+        text: pollResult,
+        parentId: `${curPageId}`,
+        point: [0, 0],
+        rotation: 0,
+        style: {
+          isFilled: false,
+          size: "medium",
+          scale: 1,
+          color: "black",
+          textAlign: "start",
+          font: "script",
+          dash: "draw"
+        },
+      }
+    }
     annotation.annotationInfo.userId = annotation.userId;
     result[annotation.annotationInfo.id] = annotation.annotationInfo;
   });


### PR DESCRIPTION


<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

- Poll result as text shape in the lower right-hand
- Include all tldraw shape bounds as size in akka
- Default/initital zoom will be centered in the slide and maximize the size according to the presentation area
- Also limited the max zoom out to be the one that fits the slide, to be similar as we had before

Also fixes some small bugs whem using MoveToPage function.

Preview:

https://user-images.githubusercontent.com/2726293/171282297-8c6a395a-7d4d-4e3c-943c-cfdc49a8a6b1.mp4




