### PR TITLE
Fix rap-enqueue.rb to load gems with bundler

### DIFF
--- a/record-and-playback/core/scripts/rap-enqueue.rb
+++ b/record-and-playback/core/scripts/rap-enqueue.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 # Copyright © 2021 BigBlueButton Inc. and by respective authors.
@@ -18,10 +18,14 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with BigBlueButton.  If not, see <http://www.gnu.org/licenses/>.
 
+require 'rubygems'
+
+ENV['BUNDLE_GEMFILE'] = File.join(__dir__, '../Gemfile')
+require 'bundler/setup'
+
 require_relative '../lib/recordandplayback'
 
 require 'recordandplayback/workers'
-require 'rubygems'
 require 'yaml'
 require 'resque'
 


### PR DESCRIPTION
In BBB 2.5, we switched the recording system to use bundled gems
included privately in the recording package, rather than installed
system-wide. The rap-enqueue.rb script needs to be updated to load the
bundler gems.

According to bundler devs, setting the BUNDLE_GEMFILE environement
variable is the supported way to tell bundler where to find it
(otherwise bundler will search starting at the current working directory,
which in the case of rap-enqueue.rb is probably nowhere near the
Gemfile).

Use a relative path from the directory where the script is located so it
can be run both when installed and from a development environment.

Switch the script interpreter to use /usr/bin/env to load ruby from the
path. Doesn't make a difference in the installed package, but it makes
testing on development systems with multiple ruby environments easier.

Fixes #15085