### PR TITLE
fix: missing "chat has been cleared" message at chat export

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/service.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/service.js
@@ -19,7 +19,7 @@ const SYSTEM_CHAT_TYPE = CHAT_CONFIG.type_system;
 const PUBLIC_CHAT_ID = CHAT_CONFIG.public_id;
 const PUBLIC_GROUP_CHAT_ID = CHAT_CONFIG.public_group_id;
 
-const PUBLIC_CHAT_CLEAR = CHAT_CONFIG.chat_clear;
+const PUBLIC_CHAT_CLEAR = CHAT_CONFIG.system_messages_keys.chat_clear;
 const CHAT_POLL_RESULTS_MESSAGE = CHAT_CONFIG.system_messages_keys.chat_poll_result;
 
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
@@ -273,7 +273,7 @@ const exportChat = (timeWindowList, users, intl) => {
         : `${users[timeWindow.sender].name}: `;
       let messageText = '';
       if (message.text === PUBLIC_CHAT_CLEAR) {
-        message.text = intl.formatMessage(intlMessages.publicChatClear);
+        messageText = intl.formatMessage(intlMessages.publicChatClear);
       } else if (message.id.includes(CHAT_POLL_RESULTS_MESSAGE)) {
         userName = `${intl.formatMessage(intlMessages.pollResult)}:\n`;
         const { pollResultData } = timeWindow.extra;


### PR DESCRIPTION
Before this PR when the moderator cleared the public chat and then tried to save or copy instead of getting this specific message "The public chat history was cleared by a moderator" it was returning the message "PUBLIC_CHAT_CLEAR".
![Screenshot from 2022-06-01 09-40-55](https://user-images.githubusercontent.com/19312495/171410032-7fbc8fea-46d2-474b-8992-bb1a208de94d.png)
![Screenshot from 2022-06-01 09-41-22](https://user-images.githubusercontent.com/19312495/171410042-c2870262-d328-4890-b5bb-d2a61109e5c3.png)

Now, when the moderator does the same thing as described above the save and copy functionality is returning the specific message "The public chat history was cleared by a moderator" as it should be.
![Screenshot from 2022-06-01 09-46-49](https://user-images.githubusercontent.com/19312495/171410083-66a7093e-e575-4dd1-a018-5eb61fe5d198.png)
![Screenshot from 2022-06-01 09-57-19](https://user-images.githubusercontent.com/19312495/171410090-74f23801-1963-4fc7-8326-102f2e74dba1.png)

