### PR TITLE
Audio modal polishing

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/styles.js
@@ -8,6 +8,7 @@ import {
 } from '/imports/ui/stylesheets/styled-components/palette';
 import {
   mdPaddingY,
+  btnSpacing,
 } from '/imports/ui/stylesheets/styled-components/general';
 import { lineHeightComputed } from '/imports/ui/stylesheets/styled-components/typography';
 
@@ -48,6 +49,8 @@ const AudioModalButton = styled(Button)`
     color: black;
     font-size: 1rem;
     font-weight: 600;
+    margin-top: ${btnSpacing};
+    line-height: 1.5;
   }
 `;
 
@@ -115,6 +118,7 @@ const Title = styled.h2`
   font-size: 1.3rem;
   color: ${colorGrayDark};
   white-space: normal;
+  margin: 0;
 
   @media ${smallOnly} {
     font-size: 1rem;


### PR DESCRIPTION
### What does this PR do?

Adjusts audio modal buttons position:
- reduces spacing between title and buttons
- increases spacing between content and modal bottom
- increases spacing between button icon and buttons label

#### before
![audio-modal-before](https://user-images.githubusercontent.com/3728706/171931349-7fb746a9-777f-418e-9404-a3294a40973d.png)

#### after
![audio-modal-after](https://user-images.githubusercontent.com/3728706/171932611-78bb1a7d-16e2-4c58-97d6-678974131bb9.png)
