### PR TITLE
Fixed user not removed from the breakout when userID set

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectUserFromMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectUserFromMeetingCmdMsgHdlr.scala
@@ -51,7 +51,7 @@ trait EjectUserFromMeetingCmdMsgHdlr extends RightsManagementTrait {
               breakoutModel <- state.breakout
             } yield {
               breakoutModel.rooms.values.foreach { room =>
-                room.users.filter(u => u.id == ru.externId + "-" + room.sequence).foreach(user => {
+                room.users.filter(u => u.id == ru.id + "-" + room.sequence).foreach(user => {
                   eventBus.publish(BigBlueButtonEvent(room.id, EjectUserFromBreakoutInternalMsg(meetingId, room.id, user.id, ejectedBy, reason, EjectReasonCode.EJECT_USER, ban)))
                 })
               }


### PR DESCRIPTION
### What does this PR do?

Fixes the error of not removing a user from a breakout room with a previously set userID when being removed from the main meeting. 


### More:

To reproduce the error (using a `v2.4.x-release` server):

 - Create a meeting;
 - Enter with a moderator;
 - Then enter as a viewer, setting userID param,either via API Mate, or via the `join` request with a `userID=` URL parameter;
 - Create a breakout Room and assign the viewer to it;
 - Then, after the user has entered the room, remove they from the main meeting;
 - Note that the user continues in the breakout.

When using this branch, the expected behavior should be followed (the user is kicked out from both the breakout room and the main meeting).