### PR TITLE
Display Correct Zoom Value on Presentation Restore

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
@@ -309,10 +309,8 @@ class AudioSettings extends React.Component {
           <Styled.BackButton
             label={intl.formatMessage(intlMessages.backLabel)}
             size="md"
-            color="primary"
             onClick={handleBack}
             disabled={isConnecting}
-            ghost
           />
           <Button
             size="md"

--- a/bigbluebutton-html5/imports/ui/components/common/button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/button/styles.js
@@ -769,19 +769,31 @@ const Button = styled(BaseButton)`
   ${({ color }) => color === 'primary' && `
     color: ${btnPrimaryColor};
     background-color: ${btnPrimaryBg};
-    border: ${borderSizeLarge} solid transparent;
+    border: ${borderSizeLarge} solid transparent !important;
 
-    &:focus,
-    .buttonWrapper:focus:not([aria-disabled="true"]) & {
+    &:focus:not([aria-disabled="true"]){
       color: ${btnPrimaryColor};
       background-color: ${btnPrimaryBg};
       background-clip: padding-box;
-      box-shadow: 0 0 0 ${borderSize} ${btnPrimaryBg};
+      box-shadow: 0 0 0 ${borderSize} ${btnPrimaryBorder};
     }
 
-    &:hover,
-    .buttonWrapper:hover & {
+    &:hover{
+      filter: brightness(90%);
       color: ${btnPrimaryColor};
+      background-color: ${btnPrimaryHoverBg} !important;
+    }
+
+    &:active:focus{
+      filter: brightness(85%);
+      color: ${btnPrimaryColor};
+      background-color: ${btnPrimaryActiveBg};
+    }
+
+    &:active{
+      filter: brightness(85%);
+      color: ${btnPrimaryColor};
+      background-color: ${btnPrimaryActiveBg} !important;
     }
   `}
 

--- a/bigbluebutton-html5/imports/ui/components/common/modal/fullscreen/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/modal/fullscreen/styles.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import Styled from '../base/styles';
 import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints';
 import Button from '/imports/ui/components/common/button/component';
-import { borderSize, smPaddingX, borderRadius } from '/imports/ui/stylesheets/styled-components/general';
+import { borderSize, smPaddingX } from '/imports/ui/stylesheets/styled-components/general';
 import {
   lineHeightComputed,
   modalTitleFw,
@@ -10,9 +10,6 @@ import {
 import {
   colorGrayLightest,
   colorText,
-  colorWhite,
-  colorLink,
-  colorBlueLight,
 } from '/imports/ui/stylesheets/styled-components/palette';
 
 const FullscreenModal = styled(Styled.BaseModal)`
@@ -62,26 +59,10 @@ const Content = styled.div`
 
 const DismissButton = styled(Button)`
   flex: 0 1 48%;
-  border: 1px solid ${colorBlueLight};
-  border-radius: ${borderRadius};
-  color: ${colorBlueLight};
-
-  &:focus,
-  .buttonWrapper:focus:not([aria-disabled="true"]) & {
-    color: ${colorBlueLight};
-  }
-
-  &:hover,
-  .buttonWrapper:hover & {
-    color: ${colorBlueLight};
-  }
 `;
 
 const ConfirmButton = styled(Button)`
   flex: 0 1 48%;
-  color: ${colorWhite} !important;
-  background-color: ${colorLink} !important;
-  border-width: 1px;
 
   ${({ popout }) => popout === 'popout' && `
     & > i {

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/modal/component.jsx
@@ -131,6 +131,7 @@ class ExternalVideoModal extends Component {
             onClick={this.startWatchingHandler}
             disabled={startDisabled}
             data-test="startNewVideo"
+            color="primary"
           />
         </Styled.Content>
       </Styled.ExternalVideoModal>

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/modal/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/modal/styles.js
@@ -9,8 +9,6 @@ import {
   colorText,
   colorGrayLighter,
   colorGray,
-  colorWhite,
-  colorLink,
   colorBlueLight,
   colorPrimary,
 } from '/imports/ui/stylesheets/styled-components/palette';
@@ -120,8 +118,6 @@ const StartButton = styled(Button)`
   display: block;
   position: absolute;
   bottom: 20px;
-  color: ${colorWhite} !important;
-  background-color: ${colorLink} !important;
 `;
 
 export default {

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -74,6 +74,7 @@ class Presentation extends PureComponent {
       fitToWidth: false,
       isFullscreen: false,
       tldrawAPI: null,
+      isZoomed: false,
     };
 
     this.currentPresentationToastId = null;
@@ -88,6 +89,7 @@ class Presentation extends PureComponent {
     this.getPresentationSizesAvailable = this.getPresentationSizesAvailable.bind(this);
     this.handleResize = this.handleResize.bind(this);
     this.setTldrawAPI = this.setTldrawAPI.bind(this);
+    this.setIsZoomed = this.setIsZoomed.bind(this);
 
     this.onResize = () => setTimeout(this.handleResize.bind(this), 0);
     this.renderCurrentPresentationToast = this.renderCurrentPresentationToast.bind(this);
@@ -281,6 +283,12 @@ class Presentation extends PureComponent {
   setTldrawAPI(api) {
     this.setState({
       tldrawAPI: api,
+    })
+  }
+
+  setIsZoomed(isZoomed) {
+    this.setState({
+      isZoomed,
     })
   }
 
@@ -516,6 +524,7 @@ class Presentation extends PureComponent {
     const {
       zoom,
       fitToWidth,
+      isZoomed,
     } = this.state;
 
     if (!userIsPresenter && !multiUser) {
@@ -566,6 +575,8 @@ class Presentation extends PureComponent {
           physicalSlideHeight={physicalDimensions.height}
           zoom={zoom}
           zoomChanger={this.zoomChanger}
+          setIsZoomed={this.setIsZoomed}
+          isZoomed={isZoomed}
         />
       </PresentationOverlayContainer>
     );
@@ -739,6 +750,7 @@ class Presentation extends PureComponent {
           layoutContextDispatch,
           presentationIsOpen,
         }}
+        isZoomed={this.state.isZoomed}
         tldrawAPI={this.state.tldrawAPI}
         curPageId={this.state.tldrawAPI?.getPage()?.id}
         currentSlideNum={currentSlide.num}
@@ -946,6 +958,7 @@ class Presentation extends PureComponent {
             intl={intl}
             presentationBounds={presentationBounds}
             isViewersCursorLocked={isViewersCursorLocked}
+            setIsZoomed={this.setIsZoomed}
           />
           {isFullscreen && <PollingContainer />}
           {this.renderPresentationToolbar()}

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -713,6 +713,7 @@ class Presentation extends PureComponent {
       fullscreenContext,
       layoutContextDispatch,
       presentationIsOpen,
+      slidePosition,
     } = this.props;
     const { zoom, fitToWidth } = this.state;
 
@@ -732,6 +733,7 @@ class Presentation extends PureComponent {
           zoom,
           podId,
           currentSlide,
+          slidePosition,
           toolbarWidth,
           fullscreenElementId,
           layoutContextDispatch,

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -432,20 +432,8 @@ class Presentation extends PureComponent {
     };
   }
 
-  zoomChanger(incomingZoom) {
-    const {
-      zoom,
-    } = this.state;
-
-    let newZoom = incomingZoom;
-
-    if (newZoom <= HUNDRED_PERCENT) {
-      newZoom = HUNDRED_PERCENT;
-    } else if (incomingZoom >= MAX_PERCENT) {
-      newZoom = MAX_PERCENT;
-    }
-
-    if (newZoom !== zoom) this.setState({ zoom: newZoom });
+  zoomChanger(zoom) {
+    this.setState({ zoom });
   }
 
   fitToWidthHandler() {
@@ -959,6 +947,7 @@ class Presentation extends PureComponent {
             presentationBounds={presentationBounds}
             isViewersCursorLocked={isViewersCursorLocked}
             setIsZoomed={this.setIsZoomed}
+            zoomChanger={this.zoomChanger}
           />
           {isFullscreen && <PollingContainer />}
           {this.renderPresentationToolbar()}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -382,7 +382,7 @@ class PresentationToolbar extends PureComponent {
               <TooltipContainer>
                 <ZoomTool
                   slidePosition={slidePosition}
-                  zoomValue={tldrawAPI?.getPageState()?.camera?.zoom}
+                  zoomValue={zoom}
                   currentSlideNum={currentSlideNum}
                   change={this.change}
                   minBound={0.1}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -258,6 +258,7 @@ class PresentationToolbar extends PureComponent {
       toolbarWidth,
       multiUserSize,
       multiUser,
+      isZoomed,
     } = this.props;
 
     const { isMobile } = deviceInfo;
@@ -389,6 +390,7 @@ class PresentationToolbar extends PureComponent {
                   step={STEP}
                   isMeteorConnected={isMeteorConnected}
                   tldrawAPI={tldrawAPI}
+                  isZoomed={isZoomed}
                 />
               </TooltipContainer>
             ) : null}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -253,6 +253,8 @@ class PresentationToolbar extends PureComponent {
       parseCurrentSlideContent,
       startPoll,
       currentSlide,
+      slidePosition,
+      tldrawAPI,
       toolbarWidth,
       multiUserSize,
       multiUser,
@@ -378,16 +380,15 @@ class PresentationToolbar extends PureComponent {
             {!isMobile ? (
               <TooltipContainer>
                 <ZoomTool
-                  zoomValue={
-                    this.props?.tldrawAPI?.getPageState()?.camera?.zoom
-                  }
+                  slidePosition={slidePosition}
+                  zoomValue={tldrawAPI?.getPageState()?.camera?.zoom}
                   currentSlideNum={currentSlideNum}
                   change={this.change}
                   minBound={0.1}
                   maxBound={5}
                   step={STEP}
                   isMeteorConnected={isMeteorConnected}
-                  tldrawAPI={this.props?.tldrawAPI}
+                  tldrawAPI={tldrawAPI}
                 />
               </TooltipContainer>
             ) : null}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/zoom-tool/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/zoom-tool/component.jsx
@@ -58,9 +58,10 @@ class ZoomTool extends PureComponent {
     const isDifferent = zoomValue !== stateZoomValue;
     if (isDifferent) {
       this.onChanger(zoomValue);
-      if (tldrawAPI && zoomValue === 1 && tldrawAPI?.getPageState()?.camera?.zoom === 1) {
-        tldrawAPI?.zoomToFit();
-      }
+    }
+
+    if (tldrawAPI && zoomValue === 1 && tldrawAPI?.getPageState()?.camera?.zoom === 1) {
+      tldrawAPI?.zoomToFit();
     }
   }
 
@@ -153,6 +154,7 @@ class ZoomTool extends PureComponent {
       step,
       tldrawAPI,
       slidePosition,
+      isZoomed,
     } = this.props;
     const { stateZoomValue } = this.state;
 
@@ -186,7 +188,7 @@ class ZoomTool extends PureComponent {
               onClick={() => {
                 tldrawAPI.zoomTo(tldrawAPI?.getPageState()?.camera?.zoom - ZOOM_INCREMENT);
               }}
-              disabled={(zoomValue <= minBound) || !isMeteorConnected}
+              disabled={!isZoomed || !isMeteorConnected}
               hideLabel
             />
             <div id="zoomOutDescription" hidden>{intl.formatMessage(intlMessages.zoomOutDesc)}</div>
@@ -199,7 +201,7 @@ class ZoomTool extends PureComponent {
               aria-describedby="resetZoomDescription"
               disabled={(stateZoomValue === minBound) || !isMeteorConnected}
               color="default"
-              customIcon={`${parseInt(slidePosition?.zoom * 100)}%`}
+              customIcon={`${parseInt(tldrawAPI?.getPageState()?.camera?.zoom * 100)}%`}
               size="md"
               onClick={() => tldrawAPI?.zoomTo(1)}
               label={intl.formatMessage(intlMessages.resetZoomLabel)}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/zoom-tool/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/zoom-tool/component.jsx
@@ -53,10 +53,15 @@ class ZoomTool extends PureComponent {
   }
 
   componentDidUpdate() {
-    const { zoomValue } = this.props;
+    const { zoomValue, tldrawAPI } = this.props;
     const { stateZoomValue } = this.state;
     const isDifferent = zoomValue !== stateZoomValue;
-    if (isDifferent) this.onChanger(zoomValue);
+    if (isDifferent) {
+      this.onChanger(zoomValue);
+      if (tldrawAPI && zoomValue === 1 && tldrawAPI?.getPageState()?.camera?.zoom === 1) {
+        tldrawAPI?.zoomToFit();
+      }
+    }
   }
 
   onChanger(value) {

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/zoom-tool/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/zoom-tool/component.jsx
@@ -152,6 +152,7 @@ class ZoomTool extends PureComponent {
       isMeteorConnected,
       step,
       tldrawAPI,
+      slidePosition,
     } = this.props;
     const { stateZoomValue } = this.state;
 
@@ -198,7 +199,7 @@ class ZoomTool extends PureComponent {
               aria-describedby="resetZoomDescription"
               disabled={(stateZoomValue === minBound) || !isMeteorConnected}
               color="default"
-              customIcon={`${parseInt(this.props?.tldrawAPI?.getPageState()?.camera?.zoom * 100)}%`}
+              customIcon={`${parseInt(slidePosition?.zoom * 100)}%`}
               size="md"
               onClick={() => tldrawAPI?.zoomTo(1)}
               label={intl.formatMessage(intlMessages.resetZoomLabel)}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/zoom-tool/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/zoom-tool/component.jsx
@@ -57,11 +57,7 @@ class ZoomTool extends PureComponent {
     const { stateZoomValue } = this.state;
     const isDifferent = zoomValue !== stateZoomValue;
     if (isDifferent) {
-      this.onChanger(zoomValue);
-    }
-
-    if (tldrawAPI && zoomValue === 1 && tldrawAPI?.getPageState()?.camera?.zoom === 1) {
-      tldrawAPI?.zoomToFit();
+      this.onChanger(tldrawAPI?.getPageState()?.camera?.zoom);
     }
   }
 
@@ -169,7 +165,11 @@ class ZoomTool extends PureComponent {
     }
 
     const stateZoomPct = intl.formatNumber((stateZoomValue / 100), { style: 'percent' });
-
+    const tldrawZoomState = tldrawAPI?.getPageState()?.camera?.zoom;
+    let displayZoom = zoomValue < tldrawZoomState && tldrawZoomState !== 1 
+      ? tldrawZoomState : zoomValue;
+    if (zoomValue === 1) displayZoom = tldrawZoomState;
+    
     return (
       [
         (
@@ -201,7 +201,7 @@ class ZoomTool extends PureComponent {
               aria-describedby="resetZoomDescription"
               disabled={(stateZoomValue === minBound) || !isMeteorConnected}
               color="default"
-              customIcon={`${parseInt(tldrawAPI?.getPageState()?.camera?.zoom * 100)}%`}
+              customIcon={`${parseInt(displayZoom * 100)}%`}
               size="md"
               onClick={() => tldrawAPI?.zoomTo(1)}
               label={intl.formatMessage(intlMessages.resetZoomLabel)}

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -48,6 +48,7 @@ export default function Whiteboard(props) {
     presentationBounds,
     isViewersCursorLocked,
     setIsZoomed,
+    zoomChanger,
     isZoomed,
   } = props;
 
@@ -90,6 +91,7 @@ export default function Whiteboard(props) {
       point[1] = (presentationBounds.height - (slidePosition.height * zoom)) / 2 / zoom
     }
 
+    isPresenter && zoomChanger(zoom);
     return {point, zoom}
   }
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -47,6 +47,8 @@ export default function Whiteboard(props) {
     svgUri,
     presentationBounds,
     isViewersCursorLocked,
+    setIsZoomed,
+    isZoomed,
   } = props;
 
   const { pages, pageStates } = initDefaultPages(curPres?.pages.length || 1);
@@ -66,7 +68,6 @@ export default function Whiteboard(props) {
   const [selectedIds, setSelectedIds] = React.useState([]);
   const [tldrawAPI, setTLDrawAPI] = React.useState(null);
   const [cameraFitSlide, setCameraFitSlide] = React.useState({point: [0, 0], zoom: 0});
-  const [zoomedIn, setZoomedIn] = React.useState(false);
   const prevShapes = usePrevious(shapes);
   const prevSlidePosition = usePrevious(slidePosition);
   const prevPageId = usePrevious(curPageId);
@@ -176,7 +177,7 @@ export default function Whiteboard(props) {
     if (curPageId && slidePosition) {
       const camera = calculateCameraFitSlide();
       setCameraFitSlide(camera);
-      if (!zoomedIn) {
+      if (!isZoomed) {
         tldrawAPI?.setCamera(camera.point, camera.zoom);
       }
     }
@@ -188,7 +189,7 @@ export default function Whiteboard(props) {
       const previousPageZoom = tldrawAPI.getPageState()?.camera?.zoom;
       tldrawAPI.changePage(curPageId);
       //change zoom of the new page to follow the previous one
-      if (!zoomedIn && cameraFitSlide.zoom !== 0) {
+      if (!isZoomed && cameraFitSlide.zoom !== 0) {
         tldrawAPI?.setCamera(cameraFitSlide.point, cameraFitSlide.zoom, "zoomed");
       } else {
         previousPageZoom &&
@@ -203,10 +204,10 @@ export default function Whiteboard(props) {
     if (tldrawAPI && !isPresenter && curPageId && slidePosition) {
       if (slidePosition.zoom === 0 && slidePosition.xCamera === 0 && slidePosition.yCamera === 0) {
         tldrawAPI?.setCamera(cameraFitSlide.point, cameraFitSlide.zoom);
-        setZoomedIn(false);
+        setIsZoomed(false);
       } else {
         tldrawAPI?.setCamera([slidePosition.xCamera, slidePosition.yCamera], slidePosition.zoom);
-        setZoomedIn(true);
+        setIsZoomed(true);
       }
     }
   }, [curPageId, slidePosition]);
@@ -237,8 +238,8 @@ export default function Whiteboard(props) {
                 app.setCamera(cameraFitSlide.point, cameraFitSlide.zoom);
                 setCameraFitSlide(cameraFitSlide);
               } else {
-                app.setCamera([slidePosition.xCamera, slidePosition.yCamera], slidePosition.zoom)
-                setZoomedIn(true);
+                app.setCamera([slidePosition.xCamera, slidePosition.yCamera], slidePosition.zoom);
+                setIsZoomed(true);
               }
             }
           }}
@@ -361,21 +362,21 @@ export default function Whiteboard(props) {
               //don't allow zoom out more than fit
               if (camera.zoom <= cameraFitSlide.zoom) {
                 tldrawAPI?.setCamera(cameraFitSlide.point, cameraFitSlide.zoom);
-                setZoomedIn(false);
+                setIsZoomed(false);
                 zoomSlide(parseInt(curPageId), podId, 0, 0, 0);
               } else {
                 zoomSlide(parseInt(curPageId), podId, camera.zoom, camera.point[0], camera.point[1]);
-                setZoomedIn(true);
+                setIsZoomed(true);
               }
             }
             //don't allow non-presenters to pan&zoom
             if (slidePosition && reason && !isPresenter && (reason.includes("zoomed") || reason.includes("panned"))) {
               if (slidePosition.zoom === 0 && slidePosition.xCamera === 0 && slidePosition.yCamera === 0) {
                 tldrawAPI?.setCamera(cameraFitSlide.point, cameraFitSlide.zoom);
-                setZoomedIn(false);
+                setIsZoomed(false);
               } else {
                 tldrawAPI?.setCamera([slidePosition.xCamera, slidePosition.yCamera], slidePosition.zoom);
-                setZoomedIn(true);
+                setIsZoomed(true);
               }
             } 
           }}

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -14,7 +14,7 @@ const WhiteboardContainer = (props) => {
     return <Whiteboard {...{isPresenter, currentUser}} {...props} meetingId={Auth.meetingID} />
 };
 
-export default withTracker(({ whiteboardId, curPageId, intl }) => {
+export default withTracker(({ whiteboardId, curPageId, intl, zoomChanger }) => {
   const shapes = Service.getShapes(whiteboardId, curPageId, intl);
   const assets = Service.getAssets();
   const curPres = Service.getCurrentPres();
@@ -32,5 +32,6 @@ export default withTracker(({ whiteboardId, curPageId, intl }) => {
     removeShapes: Service.removeShapes,
     zoomSlide: PresentationToolbarService.zoomSlide,
     skipToSlide: PresentationToolbarService.skipToSlide,
+    zoomChanger: zoomChanger,
   };
 })(WhiteboardContainer);


### PR DESCRIPTION
### What does this PR do?
Fixes the zoom value displayed on the presentation toolbar being reset when the presentation component is unmounted / mounted.
![zoom-retention](https://user-images.githubusercontent.com/22058534/172366456-40b824a3-c0ed-4a83-a304-b98e1311330a.gif)

