### PR TITLE
fix: re-subscribe to current poll when presenter changes

### DIFF
--- a/bigbluebutton-html5/imports/api/polls/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/polls/server/publishers.js
@@ -12,8 +12,10 @@ Meteor.server.setPublicationStrategy('polls', DDPServer.publicationStrategies.NO
 
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 
-function currentPoll(secretPoll) {
+function currentPoll(secretPoll, amIPresenter) {
   check(secretPoll, Boolean);
+  check(amIPresenter, Boolean);
+
   const tokenValidation = AuthTokenValidation.findOne({
     connectionId: this.connection.id,
   });

--- a/bigbluebutton-html5/imports/api/polls/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/polls/server/publishers.js
@@ -12,10 +12,8 @@ Meteor.server.setPublicationStrategy('polls', DDPServer.publicationStrategies.NO
 
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 
-function currentPoll(secretPoll, amIPresenter) {
+function currentPoll(secretPoll) {
   check(secretPoll, Boolean);
-  check(amIPresenter, Boolean);
-
   const tokenValidation = AuthTokenValidation.findOne({
     connectionId: this.connection.id,
   });

--- a/bigbluebutton-html5/imports/ui/components/poll/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/container.jsx
@@ -22,6 +22,9 @@ const PollContainer = ({ ...props }) => {
   const { users } = usingUsersContext;
   const amIPresenter = users[Auth.meetingID][Auth.userID].presenter;
 
+  const isPollSecret = Session.get('secretPoll') || false;
+  Meteor.subscribe('current-poll', isPollSecret, amIPresenter);
+
   const usernames = {};
 
   Object.values(users[Auth.meetingID]).forEach((user) => {
@@ -38,9 +41,6 @@ const PollContainer = ({ ...props }) => {
 };
 
 export default withTracker(() => {
-  const isPollSecret = Session.get('secretPoll') || false;
-  Meteor.subscribe('current-poll', isPollSecret);
-
   const currentPresentation = Presentations.findOne({
     current: true,
   }, { fields: { podId: 1 } }) || {};


### PR DESCRIPTION
### What does this PR do?

Prevents a bug where the current poll would not be published if the meeting presenter changes.