### PR TITLE
fix user removal in breakout

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectUserFromMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectUserFromMeetingCmdMsgHdlr.scala
@@ -51,7 +51,7 @@ trait EjectUserFromMeetingCmdMsgHdlr extends RightsManagementTrait {
               breakoutModel <- state.breakout
             } yield {
               breakoutModel.rooms.values.foreach { room =>
-                room.users.filter(u => u.id == ru.externId + "-" + room.sequence).foreach(user => {
+                room.users.filter(u => u.id == ru.id + "-" + room.sequence).foreach(user => {
                   eventBus.publish(BigBlueButtonEvent(room.id, EjectUserFromBreakoutInternalMsg(meetingId, room.id, user.id, ejectedBy, reason, EjectReasonCode.EJECT_USER, ban)))
                 })
               }


### PR DESCRIPTION
### What does this PR do?

Fixes user removal from breakout room when `userID` is previously set.

### Motivation

[@gustavotrott request in here](https://github.com/bigbluebutton/bigbluebutton/pull/15135#issuecomment-1149354113)

