### PR TITLE
Rename snapshot button label

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -49,8 +49,8 @@ const intlMessages = defineMessages({
   },
   snapshotLabel: {
     id: 'app.presentation.options.snapshot',
-    description: 'Snapshot of current presentation label',
-    defaultMessage: 'Snapshot of current presentation',
+    description: 'Snapshot of current slide label',
+    defaultMessage: 'Snapshot of current slide',
   },
 });
 

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -173,7 +173,7 @@
     "app.presentation.options.fullscreen": "Fullscreen",
     "app.presentation.options.exitFullscreen": "Exit Fullscreen",
     "app.presentation.options.minimize": "Minimize",
-    "app.presentation.options.snapshot": "Snapshot of current presentation",
+    "app.presentation.options.snapshot": "Snapshot of current slide",
     "app.presentation.options.downloading": "Downloading...",
     "app.presentation.options.downloaded": "Current presentation was downloaded",
     "app.presentation.options.downloadFailed": "Could not download current presentation",


### PR DESCRIPTION
### What does this PR do?

Changes the text of snapshot button in order to better describe the feature (the snapshot file is for the current slide only).

#### before
![2022-06-08_15-26](https://user-images.githubusercontent.com/3728706/172689927-cd1bf5ca-30d1-4be6-ae95-6d963af32b25.png)

#### after
![2022-06-08_15-27](https://user-images.githubusercontent.com/3728706/172690184-740e4a88-bf75-43b4-9a19-3cd2f680e48a.png)
