### PR TITLE
fix(connection status modal): network status icon

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/status-helper/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/status-helper/component.jsx
@@ -69,8 +69,8 @@ class ConnectionStatusIcon extends PureComponent {
         <Styled.Label>
           {intl.formatMessage(intlMessages.label)}
         </Styled.Label>
-        {level === 'critical' || level === 'danger'
-          && (
+        {(level === 'critical' || level === 'danger')
+          ? (
             <div>
               <Styled.Settings
                 onClick={this.openAdjustSettings.bind(this)}
@@ -79,6 +79,9 @@ class ConnectionStatusIcon extends PureComponent {
                 {intl.formatMessage(intlMessages.settings)}
               </Styled.Settings>
             </div>
+          )
+          : (
+            <div>&nbsp;</div>
           )
         }
       </Fragment>

--- a/bigbluebutton-html5/imports/ui/components/connection-status/status-helper/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/status-helper/styles.js
@@ -10,10 +10,10 @@ const StatusIconWrapper = styled.div`
   border-radius: 50%;
   padding: 1.5rem;
 
-  ${(color) => {
+  ${({ color }) => {
     let bgColor = colorSuccess;
-    backgroundColor = color === 'warning' ? colorWarning : bgColor;
-    backgroundColor = color === 'danger' ? colorDanger : bgColor;
+    bgColor = color === 'warning' ? colorWarning : bgColor;
+    bgColor = color === 'danger' ? colorDanger : bgColor;
     return `background-color: ${bgColor};`
   }}
 `;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fixes color inconsistency of the network status icon in the connection status modal. Fixes the "Adjust Your Settings" option as well.

_Before_
![2022-06-09_13-16](https://user-images.githubusercontent.com/62393923/172895313-35880143-ad87-4cc0-99de-6573881a8361.png)


_After_
![2022-06-09_13-08](https://user-images.githubusercontent.com/62393923/172894840-c9635654-6451-4ca7-858a-a7b4ac3222af.png)


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #15133


### Motivation

n/a

### More

n/a