### PR TITLE
fix: user not removed from users context on leave

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/components-data/users-context/adapter.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/users-context/adapter.jsx
@@ -1,6 +1,5 @@
 import { useContext, useEffect } from 'react';
-import { CurrentUser } from '/imports/api/users';
-import Users from '/imports/api/users';
+import Users, { CurrentUser } from '/imports/api/users';
 import UsersPersistentData from '/imports/api/users-persistent-data';
 import { UsersContext, ACTIONS } from './context';
 import ChatLogger from '/imports/ui/components/chat/chat-logger/ChatLogger';
@@ -30,7 +29,15 @@ const Adapter = () => {
           },
         });
       },
-      removed: () => {},
+      removed: (obj) => {
+        ChatLogger.debug('usersAdapter::observe::removed', obj);
+        dispatch({
+          type: ACTIONS.REMOVED,
+          value: {
+            user: obj,
+          },
+        });
+      },
     });
   }, []);
 


### PR DESCRIPTION
### What does this PR do?

Prevents an issue where the userlist is not updated for viewers when a user leaves (only happens if a user leaves by closing the browser tab).

### Closes Issue(s)
Closes #15069