### PR TITLE
fix: Etherpad cutting off text

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/pads/content/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/pads/content/styles.js
@@ -20,12 +20,13 @@ box-sizing: border-box;
 display: block;
 overflow-x: hidden;
 overflow-wrap: break-word;
-word-break: break-all;
 overflow-y: auto;
 padding-top: 1rem;
 position: absolute;
-width: 100%;
+right: 0;
+left:0;
 top: 0;
+white-space: normal;
 
 
 [dir="ltr"] & {

--- a/bigbluebutton-html5/imports/ui/components/pads/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/pads/styles.js
@@ -35,10 +35,12 @@ const Pad = styled.div`
 
 const IFrame = styled.iframe`
   width: 100%;
-  height: 100%;
+  height: auto;
   overflow: hidden;
   border-style: none;
   border-bottom: 1px solid ${colorGrayLightest};
+
+  padding-bottom: 5px;
 `;
 
 export default {


### PR DESCRIPTION
Before this  PR the etherpad iframe was cutting off the last line at the end of the document.
![lk](https://user-images.githubusercontent.com/19312495/172917065-1e2457a3-08af-4f9d-b15f-292a4ffa3d58.png)



Now, the etherpad isn't cutting the text and it works correctly.
![Screenshot from 2022-06-07 10-57-45](https://user-images.githubusercontent.com/19312495/172916941-ae359eba-cbf3-4153-a068-0893b3504c81.png)

Closes #12286