### PR TITLE
fix(whiteboard): don't hide presenter's cursor

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/cursor/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/cursor/container.jsx
@@ -26,11 +26,12 @@ class CursorContainer extends Component {
 
 
 export default withTracker((params) => {
-  const { cursorId, whiteboardId } = params;
+  const { cursorId, whiteboardId, presenter } = params;
 
   const cursor = CursorService.getCurrentCursor(cursorId);
+  const hasPermission = presenter || WhiteboardService.hasMultiUserAccess(whiteboardId, cursor.userId);
 
-  if (cursor && WhiteboardService.hasMultiUserAccess(whiteboardId, cursor.userId)) {
+  if (cursor && hasPermission) {
     const { xPercent: cursorX, yPercent: cursorY, userName } = cursor;
     const isRTL = document.documentElement.getAttribute('dir') === 'rtl';
     return {


### PR DESCRIPTION
Fix presenter cursor not showing when multiUser is off.


