### PR TITLE
fix: wrong poll results displayed in the chat when answers are grouped

### DIFF
--- a/bigbluebutton-html5/imports/api/polls/server/handlers/sendPollChatMsg.js
+++ b/bigbluebutton-html5/imports/api/polls/server/handlers/sendPollChatMsg.js
@@ -1,4 +1,5 @@
 import addSystemMsg from '../../../group-chat-msg/server/modifiers/addSystemMsg';
+import caseInsensitiveReducer from '/imports/utils/caseInsensitiveReducer';
 
 export default function sendPollChatMsg({ body }, meetingId) {
   const { poll } = body;
@@ -10,9 +11,14 @@ export default function sendPollChatMsg({ body }, meetingId) {
   const SYSTEM_CHAT_TYPE = CHAT_CONFIG.type_system;
 
   const pollResultData = poll;
+  const answers = pollResultData.answers.reduce(caseInsensitiveReducer, []);
+
   const extra = {
     type: 'poll',
-    pollResultData,
+    pollResultData: {
+      ...pollResultData,
+      answers,
+    },
   };
 
   const payload = {

--- a/bigbluebutton-html5/imports/ui/components/poll/service.js
+++ b/bigbluebutton-html5/imports/ui/components/poll/service.js
@@ -1,7 +1,6 @@
 import Auth from '/imports/ui/services/auth';
 import { CurrentPoll } from '/imports/api/polls';
 import { escapeHtml } from '/imports/utils/string-utils';
-import caseInsensitiveReducer from '/imports/utils/caseInsensitiveReducer';
 import { defineMessages } from 'react-intl';
 
 const POLL_AVATAR_COLOR = '#3B48A9';
@@ -89,7 +88,7 @@ const getPollResultsText = (isDefaultPoll, answers, numRespondents, intl) => {
   answers.map((item) => {
     responded += item.numVotes;
     return item;
-  }).reduce(caseInsensitiveReducer, []).forEach((item) => {
+  }).forEach((item) => {
     const numResponded = responded === numRespondents ? numRespondents : responded;
     const pct = Math.round((item.numVotes / numResponded) * 100);
     const pctBars = '|'.repeat((pct * MAX_POLL_RESULT_BARS) / 100);


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in poll publishing that could cause wrong results to be displayed in the chat, by moving the grouping of similar answers in poll results to sendPollChatMsg.