### PR TITLE
fix: add missing emoji-mart in html5 package-lock.json

### DIFF
--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -2288,6 +2288,15 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.117.tgz",
       "integrity": "sha512-ypZHxY+Sf/PXu7LVN+xoeanyisnJeSOy8Ki439L/oLueZb4c72FI45zXcK3gPpmTwyufh9m6NnbMLXnJh/0Fxg=="
     },
+    "emoji-mart": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-3.0.1.tgz",
+      "integrity": "sha512-sxpmMKxqLvcscu6mFn9ITHeZNkGzIvD0BSNFE/LJESPbCA8s1jM6bCDPjWbV31xHq7JXaxgpHxLB54RCbBZSlg==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "prop-types": "^15.6.0"
+      }
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Adds a missing block from package-lock.json
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
we could not build bbb-html5 package, 
<!-- What inspired you to submit this pull request? -->

### More

```
METEOR@2.7.1
+ meteor npm ci --production
[37;40mnpm[0m [0m[31;40mERR![0m[35m[0m cipm can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
[0m[37;40mnpm[0m [0m[31;40mERR![0m[35m[0m 
[0m[37;40mnpm[0m [0m[31;40mERR![0m[35m[0m 
[0m[37;40mnpm[0m [0m[31;40mERR![0m[35m[0m Missing: emoji-mart@^3.0.1
[0m[37;40mnpm[0m [0m[31;40mERR![0m[35m[0m 
[0m
[37;40mnpm[0m [0m[31;40mERR![0m[35m[0m A complete log of this run can be found in:
[0m[37;40mnpm[0m [0m[31;40mERR![0m[35m[0m     /root/.npm/_logs/2022-06-14T20_29_00_818Z-debug.log
[0mBuild step 'Execute shell' marked build as failure
Finished: FAILURE
```
