### PR TITLE
docs: set 2.5 as the recommended version, discontinue 2.3

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,13 +6,14 @@ We actively support BigBlueButton through the community forums and through secur
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 2.0.x (or earlier)  | :x:                |
-| 2.2.x   | :x:  |
-| 2.3.x   | :white_check_mark: |
+| 2.3.x (or earlier)  | :x:    |
+| 2.4.x   | :white_check_mark: |
+| 2.5.x   | :white_check_mark: |
+| 2.6.x   | :x: |
 
-We have released 2.3 to the community and all our support efforts are now transitioned to 2.3.  Also, BigBlueButton 2.2 is running on Ubuntu 16.04 which is now end of life.
+We have released 2.5 to the community and are going to support both 2.4 and 2.5 together for the coming months (while we're actively developing the next release).  Also, BigBlueButton 2.3 is now end of life.
 
-As such, we highly recommend that all administrators deploy 2.3 going forward as it is built upon Ubuntu 18.04.  You'll find [many improvements](/2.3/new.html) in this newer version.
+As such, we recommend that all administrators deploy 2.5 going forward.  You'll find [many improvements](https://docs.bigbluebutton.org/2.5/new.html) in this newer version.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Backport of https://github.com/bigbluebutton/bigbluebutton/pull/15187