### PR TITLE
fix: remove obsolete systemd overrides

### DIFF
--- a/build/packages-template/bbb-config/build.sh
+++ b/build/packages-template/bbb-config/build.sh
@@ -44,30 +44,6 @@ cp cron.daily/* staging/etc/cron.daily
 mkdir -p staging/etc/cron.hourly
 cp cron.hourly/bbb-resync-freeswitch staging/etc/cron.hourly
 
-# Overrides 
-
-mkdir -p staging/etc/systemd/system/bbb-apps-akka.service.d
-cat > staging/etc/systemd/system/bbb-apps-akka.service.d/override.conf <<HERE
-[Unit]
-Wants=redis-server.service
-After=redis-server.service
-HERE
-
-mkdir -p staging/etc/systemd/system/bbb-fsesl-akka.service.d
-cat > staging/etc/systemd/system/bbb-fsesl-akka.service.d/override.conf <<HERE
-[Unit]
-Wants=redis-server.service
-After=redis-server.service
-HERE
-
-
-mkdir -p staging/etc/systemd/system/bbb-transcode-akka.service.d
-cat > staging/etc/systemd/system/bbb-transcode-akka.service.d/override.conf <<HERE
-[Unit]
-Wants=redis-server.service
-After=redis-server.service
-HERE
-
 
 . ./opts-$DISTRO.sh
 


### PR DESCRIPTION
### What does this PR do?

The redis dependency for `bbb-apps-akka` and `bbb-fsesl-akka` has
already beed added to the unit files in commit b6777ed9cbed26adf8b06e295c17866d3427c1ec so
the override is no longer neccesary.

### Closes Issue(s)
Closes #15192
