### PR TITLE
(fix) - Fixed error logs in recordings about etherpad

### DIFF
--- a/record-and-playback/core/scripts/archive/archive.rb
+++ b/record-and-playback/core/scripts/archive/archive.rb
@@ -54,7 +54,10 @@ def archive_notes(meeting_id, notes_endpoint, notes_formats, raw_archive_dir)
   FileUtils.mkdir_p(notes_dir)
 
   tmp_note = "#{notes_dir}/tmp_note.txt"
-  BigBlueButton.try_download("#{notes_endpoint}/#{CGI.escape notes_id}/export/txt", tmp_note)
+  base_path_notes = CGI.escape notes_id
+  if base_path_notes != "undefined"
+    BigBlueButton.try_download("#{notes_endpoint}/#{base_path_notes}/export/txt", tmp_note)
+  end
   if File.exist? tmp_note
     # If the notes are empty, do not archive them
     blank = false


### PR DESCRIPTION
### What does this PR do?

It  ensures that the etherpad endpoint is available, if so, it proceeds with the request and the logic, if that's not the case, it doesn't request the endpoint, and there is no Error log.

### Closes Issue(s)

Closes #15160

