### PR TITLE
fix: some presentation slides are not loaded after conversion

### DIFF
--- a/bigbluebutton-html5/imports/api/presentations/server/modifiers/addPresentation.js
+++ b/bigbluebutton-html5/imports/api/presentations/server/modifiers/addPresentation.js
@@ -10,7 +10,7 @@ const getSlideText = async (url) => {
   let content = '';
   try {
     const request = await axios(url);
-    content = request.data;
+    content = request.data.toString();
   } catch (error) {
     Logger.error(`No file found. ${error}`);
   }


### PR DESCRIPTION


<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Prevents a bug where some presentation slides are not loaded after conversion.

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #15209
