### PR TITLE
add an "advanced" button to API demos

### DIFF
--- a/bbb-api-demo/src/main/webapp/bbb_api.jsp
+++ b/bbb-api-demo/src/main/webapp/bbb_api.jsp
@@ -170,7 +170,7 @@ public String getJoinURL(String username, String meetingID, String record, Strin
     String isHTML5Client = "false";
     String isModerator = "true";
 
-    return getJoinURLExtended(username, meetingID, record, welcome, metadata, xml, isHTML5Client, isModerator);
+    return getJoinURLExtended(username, meetingID, record, welcome, metadata, xml, isHTML5Client, isModerator, null, null);
 }
 
 
@@ -192,7 +192,7 @@ public String getJoinURL(String username, String meetingID, String record, Strin
 //
 //  Note this meeting will use username for meetingID
 
-public String getJoinURLExtended(String username, String meetingID, String record, String welcome, Map<String, String> metadata, String xml, String isHTML5Client, String isModerator) {
+public String getJoinURLExtended(String username, String meetingID, String record, String welcome, Map<String, String> metadata, String xml, String isHTML5Client, String isModerator, String extraCreateParameters, String extraJoinParameters) {
 
 	String base_url_create = BigBlueButtonURL + "api/create?";
 	String base_url_join = BigBlueButtonURL + "api/join?";
@@ -228,6 +228,9 @@ public String getJoinURLExtended(String username, String meetingID, String recor
 		+ "&attendeePW=ap&moderatorPW=mp"
 		+ "&isBreakoutRoom=false"
 		+ "&record=" + record + getMetaData( metadata );
+	if ((extraCreateParameters != null) && !extraCreateParameters.equals("")) {
+		create_parameters += "&" + extraCreateParameters;
+	}
 
 
 	String password = "mp"; // Attempt to join as moderator by default
@@ -259,6 +262,11 @@ public String getJoinURLExtended(String username, String meetingID, String recor
 
 		+ "&joinViaHtml5=" + isHTML5Client
 	 	+ "&password=" + password;
+
+		if ((extraJoinParameters != null) && !extraJoinParameters.equals("")) {
+			join_parameters += "&" + extraJoinParameters;
+		}
+
 
 		return base_url_join + join_parameters + "&checksum="
 			+ checksum("join" + join_parameters + salt);

--- a/bbb-api-demo/src/main/webapp/demoHTML5.jsp
+++ b/bbb-api-demo/src/main/webapp/demoHTML5.jsp
@@ -103,7 +103,7 @@ if (request.getParameterMap().isEmpty()) {
 		isModerator = Boolean.parseBoolean(request.getParameter("isModerator"));
 	}
 
-	String joinURL = getJoinURLExtended(username, meetingname, isRecorded.toString(), null, null, null, isHTML5.toString(), isModerator.toString());
+	String joinURL = getJoinURLExtended(username, meetingname, isRecorded.toString(), null, null, null, isHTML5.toString(), isModerator.toString(), request.getParameter("createParameters"), request.getParameter("joinParameters"));
 
 	if (joinURL.startsWith("http://") || joinURL.startsWith("https://")) {
 %>

--- a/bbb-api-demo/src/main/webapp/demoHTML5Video.jsp
+++ b/bbb-api-demo/src/main/webapp/demoHTML5Video.jsp
@@ -85,7 +85,7 @@ if (request.getParameterMap().isEmpty()) {
 	Boolean isHTML5 = new Boolean(true);
 	Boolean isRecorded = new Boolean(true);
 
-	String joinURL = getJoinURLExtended(username, meetingname, isRecorded.toString(), null, metadata, null, isHTML5.toString(), isModerator.toString());
+	String joinURL = getJoinURLExtended(username, meetingname, isRecorded.toString(), null, metadata, null, isHTML5.toString(), isModerator.toString(), null, null);
 
 	if (joinURL.startsWith("http://") || joinURL.startsWith("https://")) {
 %>

--- a/bbb-api-demo/src/main/webapp/demoNative.jsp
+++ b/bbb-api-demo/src/main/webapp/demoNative.jsp
@@ -103,7 +103,7 @@ if (request.getParameterMap().isEmpty()) {
 		isModerator = Boolean.parseBoolean(request.getParameter("isModerator"));
 	}
 
-	String joinURL = getJoinURLExtended(username, meetingname, isRecorded.toString(), null, null, null, isHTML5.toString(), isModerator.toString());
+	String joinURL = getJoinURLExtended(username, meetingname, isRecorded.toString(), null, null, null, isHTML5.toString(), isModerator.toString(), null, null);
 
 	if (joinURL.startsWith("https://")) {
 		joinURL = joinURL.replaceAll("https://", "bbbnative://join//");

--- a/bigbluebutton-config/web/index.html
+++ b/bigbluebutton-config/web/index.html
@@ -53,13 +53,28 @@
 
             <form name="form1" method="GET" onsubmit="return checkform(this);" action="/demo/demoHTML5.jsp">
               <input type="text" id="username" required="" name="username" placeholder="Enter Your Name" size="29" class="field input-default" autofocus>
+	      <input type="hidden" id="createParameters" name="createParameters" placeholder="Enter create parameters" size="29" class="field input-default">
+	      <input type="hidden" id="joinParameters" name="joinParameters" placeholder="Enter join parameters" size="29" class="field input-default">
               <input type="submit" value="Join" class="submit_btn button success large"><br>
               <input type="hidden" name="isModerator" value="true">
               <input type="hidden" name="action" value="create">
             </form>
 
+	    <script>
+	      function toggleAdvanced() {
+		  if (document.getElementById("createParameters").getAttribute("type") == "hidden") {
+		      document.getElementById("createParameters").setAttribute("type", "text");
+		      document.getElementById("joinParameters").setAttribute("type", "text");
+		  } else {
+		      document.getElementById("createParameters").setAttribute("type", "hidden");
+		      document.getElementById("joinParameters").setAttribute("type", "hidden");
+		  }
+	      }
+	    </script>
+
           <a class="watch" href="https://www.youtube.com/watch?v=uYYnryIM0Uw;feature=youtu.be" class="pull-right">Viewer Overview</a> - 
-          <a class="watch" href="https://www.youtube.com/watch?v=Q2tG2SS4gXA&feature=youtu.be" class="pull-right">Moderator Overview</a>
+          <a class="watch" href="https://www.youtube.com/watch?v=Q2tG2SS4gXA&feature=youtu.be" class="pull-right">Moderator Overview</a> -
+	  <a class="watch" href="#" onclick="toggleAdvanced();return false;" class="pull-right">Advanced</a>
 
           </div>
         </div>


### PR DESCRIPTION
This PR adds an "advanced" button to the main web page for the API demos that when clicked exposes fields to set create and join parameters, like this:

![image](https://user-images.githubusercontent.com/5731463/174647281-14e362a1-a49e-432e-918d-5eb0cbe3a04a.png)

It's useful for testing.

I haven't done anything to escape URI characters, so you need to do your own quoting of special characters.  Inserting an unquoted "&" will allow you to specify multiple options.

Any reason not to allow demo users to specify these parameters?