### PR TITLE
fix: remove userLeftFlag from audio, camera and screen sharing auth checks

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
@@ -75,6 +75,12 @@ object LockSettingsUtil {
     }
   }
 
+  def isMicrophoneSharingLocked(user: UserState, liveMeeting: LiveMeeting): Boolean = {
+    val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
+
+    user.role == Roles.VIEWER_ROLE && user.locked && permissions.disableMic
+  }
+
   def isCameraBroadcastLocked(user: UserState, liveMeeting: LiveMeeting): Boolean = {
     val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenBroadcastPermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenBroadcastPermissionReqMsgHdlr.scala
@@ -25,8 +25,7 @@ trait GetScreenBroadcastPermissionReqMsgHdlr {
         val meetingId = liveMeeting.props.meetingProp.intId
         val reason = "No permission to share the screen."
         PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)
-      } else if (!user.userLeftFlag.left
-        && liveMeeting.props.meetingProp.intId == msg.body.meetingId
+      } else if (liveMeeting.props.meetingProp.intId == msg.body.meetingId
         && liveMeeting.props.voiceProp.voiceConf == msg.body.voiceConf) {
         allowed = true
       }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenSubscribePermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenSubscribePermissionReqMsgHdlr.scala
@@ -17,8 +17,7 @@ trait GetScreenSubscribePermissionReqMsgHdlr {
     for {
       user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
     } yield {
-      if (!user.userLeftFlag.left
-        && liveMeeting.props.meetingProp.intId == msg.body.meetingId
+      if (liveMeeting.props.meetingProp.intId == msg.body.meetingId
         && liveMeeting.props.voiceProp.voiceConf == msg.body.voiceConf
         && ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel) == msg.body.streamId) {
         allowed = true

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/GetGlobalAudioPermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/GetGlobalAudioPermissionReqMsgHdlr.scala
@@ -16,8 +16,7 @@ trait GetGlobalAudioPermissionReqMsgHdlr {
     for {
       user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
     } yield {
-      if (!user.userLeftFlag.left
-        && liveMeeting.props.meetingProp.intId == msg.body.meetingId
+      if (liveMeeting.props.meetingProp.intId == msg.body.meetingId
         && liveMeeting.props.voiceProp.voiceConf == msg.body.voiceConf) {
         allowed = true
       }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/GetMicrophonePermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/GetMicrophonePermissionReqMsgHdlr.scala
@@ -3,12 +3,13 @@ package org.bigbluebutton.core.apps.voice
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.running.{ LiveMeeting, MeetingActor, OutMsgRouter }
 
-trait GetGlobalAudioPermissionReqMsgHdlr {
+trait GetMicrophonePermissionReqMsgHdlr {
   this: MeetingActor =>
 
+  val liveMeeting: LiveMeeting
   val outGW: OutMsgRouter
 
-  def handleGetGlobalAudioPermissionReqMsg(msg: GetGlobalAudioPermissionReqMsg): Unit = {
+  def handleGetMicrophonePermissionReqMsg(msg: GetMicrophonePermissionReqMsg): Unit = {
 
     def broadcastEvent(
         meetingId:    String,
@@ -18,22 +19,22 @@ trait GetGlobalAudioPermissionReqMsgHdlr {
         allowed:      Boolean
     ): Unit = {
       val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, meetingId, userId)
-      val envelope = BbbCoreEnvelope(GetGlobalAudioPermissionRespMsg.NAME, routing)
-      val header = BbbClientMsgHeader(GetGlobalAudioPermissionRespMsg.NAME, meetingId, userId)
-      val body = GetGlobalAudioPermissionRespMsgBody(
+      val envelope = BbbCoreEnvelope(GetMicrophonePermissionRespMsg.NAME, routing)
+      val header = BbbClientMsgHeader(GetMicrophonePermissionRespMsg.NAME, meetingId, userId)
+      val body = GetMicrophonePermissionRespMsgBody(
         meetingId,
         voiceConf,
         userId,
         sfuSessionId,
         allowed
       )
-      val event = GetGlobalAudioPermissionRespMsg(header, body)
+      val event = GetMicrophonePermissionRespMsg(header, body)
       val eventMsg = BbbCommonEnvCoreMsg(envelope, event)
 
       outGW.send(eventMsg)
     }
 
-    val allowed = VoiceHdlrHelpers.isGlobalAudioSubscribeAllowed(
+    val allowed = VoiceHdlrHelpers.isMicrophoneSharingAllowed(
       liveMeeting,
       msg.body.meetingId,
       msg.body.userId,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceHdlrHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceHdlrHelpers.scala
@@ -1,0 +1,47 @@
+package org.bigbluebutton.core.apps.voice
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.models.{ Users2x }
+import org.bigbluebutton.core.running.{ LiveMeeting }
+import org.bigbluebutton.LockSettingsUtil
+import org.bigbluebutton.SystemConfiguration
+
+object VoiceHdlrHelpers extends SystemConfiguration {
+  def isGlobalAudioSubscribeAllowed(
+      liveMeeting: LiveMeeting,
+      meetingId:   String,
+      userId:      String,
+      voiceConf:   String
+  ): Boolean = {
+    Users2x.findWithIntId(liveMeeting.users2x, userId) match {
+      case Some(user) => (
+        applyPermissionCheck &&
+        liveMeeting.props.meetingProp.intId == meetingId &&
+        liveMeeting.props.voiceProp.voiceConf == voiceConf
+      )
+      case _ => false
+    }
+  }
+
+  def isMicrophoneSharingAllowed(
+      liveMeeting: LiveMeeting,
+      meetingId:   String,
+      userId:      String,
+      voiceConf:   String
+  ): Boolean = {
+    Users2x.findWithIntId(liveMeeting.users2x, userId) match {
+      case Some(user) => {
+        val microphoneSharingLocked = LockSettingsUtil.isMicrophoneSharingLocked(
+          user,
+          liveMeeting
+        )
+
+        (applyPermissionCheck &&
+          !microphoneSharingLocked &&
+          liveMeeting.props.meetingProp.intId == meetingId &&
+          liveMeeting.props.voiceProp.voiceConf == voiceConf)
+      }
+      case _ => false
+    }
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/CameraHdlrHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/CameraHdlrHelpers.scala
@@ -23,7 +23,6 @@ object CameraHdlrHelpers extends SystemConfiguration with RightsManagementTrait 
         (applyPermissionCheck &&
           !camBroadcastLocked &&
           !camCapReached &&
-          !user.userLeftFlag.left &&
           streamId.startsWith(user.intId) &&
           liveMeeting.props.meetingProp.intId == meetingId)
       }
@@ -43,7 +42,6 @@ object CameraHdlrHelpers extends SystemConfiguration with RightsManagementTrait 
 
         (applyPermissionCheck &&
           !camSubscribeLocked &&
-          !user.userLeftFlag.left &&
           liveMeeting.props.meetingProp.intId == meetingId)
       }
       case _ => false

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -215,6 +215,8 @@ class ReceivedJsonMsgHandlerActor(
         routeVoiceMsg[VoiceConfCallStateEvtMsg](envelope, jsonNode)
       case GetGlobalAudioPermissionReqMsg.NAME =>
         routeGenericMsg[GetGlobalAudioPermissionReqMsg](envelope, jsonNode)
+      case GetMicrophonePermissionReqMsg.NAME =>
+        routeGenericMsg[GetMicrophonePermissionReqMsg](envelope, jsonNode)
 
       // Breakout rooms
       case BreakoutRoomsListMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -80,6 +80,7 @@ class MeetingActor(
   with MuteMeetingCmdMsgHdlr
   with IsMeetingMutedReqMsgHdlr
   with GetGlobalAudioPermissionReqMsgHdlr
+  with GetMicrophonePermissionReqMsgHdlr
   with GetScreenBroadcastPermissionReqMsgHdlr
   with GetScreenSubscribePermissionReqMsgHdlr
 
@@ -467,6 +468,8 @@ class MeetingActor(
         handleUserStatusVoiceConfEvtMsg(m)
       case m: GetGlobalAudioPermissionReqMsg =>
         handleGetGlobalAudioPermissionReqMsg(m)
+      case m: GetMicrophonePermissionReqMsg =>
+        handleGetMicrophonePermissionReqMsg(m)
 
       // Layout
       case m: GetCurrentLayoutReqMsg  => handleGetCurrentLayoutReqMsg(m)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -461,23 +461,6 @@ object MsgBuilder {
     BbbCommonEnvCoreMsg(envelope, event)
   }
 
-  def buildGetGlobalAudioPermissionRespMsg(
-      meetingId:    String,
-      voiceConf:    String,
-      userId:       String,
-      sfuSessionId: String,
-      allowed:      Boolean
-  ): BbbCommonEnvCoreMsg = {
-    val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, meetingId, userId)
-    val envelope = BbbCoreEnvelope(GetGlobalAudioPermissionRespMsg.NAME, routing)
-    val header = BbbClientMsgHeader(GetGlobalAudioPermissionRespMsg.NAME, meetingId, userId)
-
-    val body = GetGlobalAudioPermissionRespMsgBody(meetingId, voiceConf, userId, sfuSessionId, allowed)
-    val event = GetGlobalAudioPermissionRespMsg(header, body)
-
-    BbbCommonEnvCoreMsg(envelope, event)
-  }
-
   def buildMeetingTimeRemainingUpdateEvtMsg(meetingId: String, timeLeftInSec: Long, timeUpdatedInMinutes: Int = 0): BbbCommonEnvCoreMsg = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, "not-used")
     val envelope = BbbCoreEnvelope(MeetingTimeRemainingUpdateEvtMsg.NAME, routing)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
@@ -561,3 +561,31 @@ case class GetGlobalAudioPermissionRespMsgBody(
     sfuSessionId: String,
     allowed:      Boolean
 )
+
+/* Sent by bbb-webrtc-sfu to ask permission for a new microphone/full audio
+ * connection
+ */
+object GetMicrophonePermissionReqMsg { val NAME = "GetMicrophonePermissionReqMsg" }
+case class GetMicrophonePermissionReqMsg(
+    header: BbbClientMsgHeader,
+    body:   GetMicrophonePermissionReqMsgBody
+) extends StandardMsg
+case class GetMicrophonePermissionReqMsgBody(
+    meetingId:    String,
+    voiceConf:    String,
+    userId:       String,
+    sfuSessionId: String
+)
+
+object GetMicrophonePermissionRespMsg { val NAME = "GetMicrophonePermissionRespMsg" }
+case class GetMicrophonePermissionRespMsg(
+    header: BbbClientMsgHeader,
+    body:   GetMicrophonePermissionRespMsgBody
+) extends StandardMsg
+case class GetMicrophonePermissionRespMsgBody(
+    meetingId:    String,
+    voiceConf:    String,
+    userId:       String,
+    sfuSessionId: String,
+    allowed:      Boolean
+)


### PR DESCRIPTION
### What does this PR do?

- fix: removes userLeftFlag from audio, camera and screen sharing auth 
checks for SFU-based components (a1988dbe769a530fcc0e081ca0de9db4ba92ea34, ebf378d11d5f60357b19a99639d2c47becacadc5, 706f322ac3c04a8ed25eeb0b8fea589f1bb8c946)
  * If the user is in akka-apps' user cache (which means they are still
   visible in the user list) and triggers a screenshare re-connect, the
   re-connect should be allowed to minimize outages.
  * If the user indeeds fails to be reconnected to the whole system, then
   the screen sharing sessions will be ejected when the user is
   completely ejected from the system.
  * The auth check still refuses connections when there's no user present in akka-apps at all
- [fix(audio): decouple SFU's mic auth RPCs from global audio](https://github.com/bigbluebutton/bigbluebutton/commit/d1d22dddc42655f04e0539f1f442a4c836fbffa1)
  * The SFU microphone module was using global audio authentication RPCs in
  akka-apps to determine whether a mic connection is valid.
  * Fixes an issue where SFU microphone connections wouldn't take lock
  settings in account in the permission checks.
  * In detail: decouple them by adding GetMicrophonePermissionReqMsg and
  RespMsg. Allows flexibility on which conditionals to use in both. IMO it
  is also better than renaming+adding a boolean to GetGlobalAudioPermission*
  due to the fact that it gets easier to guarantee backwards compatibility
  between SFU and BBB (ie SFU 2.9 keeps working on 2.4, 2.5).
  
### Closes Issue(s)

Closes #15233 

### Motivation

#15233 

### More

Depends on SFU v2.9.0-alpha.1 (tagged but not set to build yet)
