### PR TITLE
fix: Recording indicator too subtle

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/component.jsx
@@ -242,6 +242,7 @@ class RecordingIndicator extends PureComponent {
                 aria-label={`${intl.formatMessage(recording
                   ? intlMessages.notificationRecordingStart
                   : intlMessages.notificationRecordingStop)}`}
+                  recording={recording}
               >
                 {recordingIndicatorIcon}
 

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/recording-indicator/styles.js
@@ -126,6 +126,13 @@ const RecordingIndicator = styled.div`
 
 const RecordingStatusViewOnly = styled.div`
   display: flex;
+
+  ${({ recording }) => recording && `
+    padding: 5px;
+    background-color: ${colorDanger};
+    border: ${borderSizeLarge} solid ${colorDanger};
+    border-radius: 10px;
+  `}
 `;
 
 export default {


### PR DESCRIPTION
### What does this PR do?

Adjusts recording indicator to be the same for viewers and moderators when the meeting is being recorded.

#### before
![record-before](https://user-images.githubusercontent.com/3728706/175655907-9dc4af18-d760-4d8b-a7de-d83be495ff2f.png)

#### after
![record-after](https://user-images.githubusercontent.com/3728706/175655913-e31d7b71-8680-474e-86a7-58e1d692f08e.png)

### Closes Issue(s)
Closes #15252