### PR TITLE
Test suite: select YouTube iframe differently

### DIFF
--- a/bigbluebutton-tests/playwright/core/elements.js
+++ b/bigbluebutton-tests/playwright/core/elements.js
@@ -177,7 +177,8 @@ exports.videoPlayer = 'div[data-test="videoPlayer"]';
 exports.presentationTitle = 'h1[data-test="presentationTitle"]';
 // YouTube frame
 exports.youtubeLink = 'https://www.youtube.com/watch?v=Hso8yLzkqj8&ab_channel=BigBlueButton';
-exports.youtubeFrame = 'iframe[title^="YouTube"]';
+// The title we match for here is the title of the test video specified by youtubeLink
+exports.youtubeFrame = 'iframe[title~="GreenLight"]';
 exports.ytFrameTitle = 'a[class^="ytp-title-link"]';
 // Toasts
 exports.statingUploadPresentationToast = 'To be uploaded ...';


### PR DESCRIPTION
This PR selects YouTube iframes by looking for part of the video title in the iframe title, instead of looking for the prefix "YouTube"

My experience with the old way (matching on the prefix "YouTube") is that it only works for the moderator page, then fails for the user page.  (There are two pages in the test.  The moderator plays the video and we ensure that both moderator and user see it.)

By the time I inspect the playwright trace, the only thing I see in the iframe titles is the title of the video being played.  I'm wondering if there's a race condition here.  Maybe the iframe is initially titled "YouTube[something]" and once the video loads the title changes to the title of the video?
