### PR TITLE
fix: Focus on text-field is lost if a viewer raises his hand

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -162,9 +162,10 @@ class Presentation extends PureComponent {
     const {
       numCameras: prevNumCameras,
       presentationBounds: prevPresentationBounds,
+      multiUser: prevMultiUser,
     } = prevProps;
 
-    if (!multiUser) {
+    if (prevMultiUser && !multiUser) {
       clearFakeAnnotations();
       clearCursors();
     }


### PR DESCRIPTION
### What does this PR do?

Adjusts cursors/annotations removal to only trigger once when multiUser is disabled, and not on every update.
This change prevents an issue where annotation is lost if another user raises hand.

### Closes Issue(s)
Closes #15238