### PR TITLE
fix: Change in bbb-conf to not rely on tomcat

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -1141,18 +1141,17 @@ check_state() {
     fi
 
     if bbb-conf --status | grep -q inactive; then
-        echo "entrou aqui no inactive"
 
         if bbb-conf --status | grep -q tomcat9; then
-            echo "# Warning: Tomcat9 is not started correctly"
+            echo "# Warning: $TOMCAT_SERVICE is not started correctly"
             echo "#"
-            echo "#   $(bbb-conf --status | grep inactive | grep tomcat9)"
+            echo "#   $(bbb-conf --status | grep inactive | grep $TOMCAT_SERVICE)"
             echo "#"
         fi
         if bbb-conf --status | grep inactive | grep -vq tomcat9; then
             echo "# Error: Detected some processes have not started correctly"
             echo "#"
-            echo "#   $(bbb-conf --status | grep inactive | grep -v tomcat9)"
+            echo "#   $(bbb-conf --status | grep inactive | grep -v $TOMCAT_SERVICE)"
             echo "#"
         fi
     fi

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -420,7 +420,15 @@ start_bigbluebutton () {
         TOMCAT_SERVICE=$TOMCAT_USER
     fi
 
-    systemctl start $TOMCAT_SERVICE nginx freeswitch $REDIS_SERVICE bbb-apps-akka bbb-fsesl-akka bbb-rap-resque-worker bbb-rap-starter.service bbb-rap-caption-inbox.service $HTML5 $WEBHOOKS $ETHERPAD $PADS $BBB_WEB $BBB_LTI
+    systemctl start $TOMCAT_SERVICE || {
+        echo
+        echo "# Warning: $TOMCAT_SERVICE could not be started. Please, check BBB-LTI or BBB-Demo."
+        echo "#     Run the command:"
+        echo "#       sudo journalctl -u $TOMCAT_SERVICE"
+        echo "#     To better understand the ERROR"
+    }
+
+    systemctl start nginx freeswitch $REDIS_SERVICE bbb-apps-akka bbb-fsesl-akka bbb-rap-resque-worker bbb-rap-starter.service bbb-rap-caption-inbox.service $HTML5 $WEBHOOKS $ETHERPAD $PADS $BBB_WEB $BBB_LTI
 
     if [ -f /usr/lib/systemd/system/bbb-html5.service ]; then
         systemctl start mongod
@@ -1133,10 +1141,20 @@ check_state() {
     fi
 
     if bbb-conf --status | grep -q inactive; then
-        echo "# Error: Detected some processes have not started correctly"
-        echo "#"
-        echo "#   $(bbb-conf --status | grep inactive)"
-        echo "#"
+        echo "entrou aqui no inactive"
+
+        if bbb-conf --status | grep -q tomcat9; then
+            echo "# Warning: Tomcat9 is not started correctly"
+            echo "#"
+            echo "#   $(bbb-conf --status | grep inactive | grep tomcat9)"
+            echo "#"
+        fi
+        if bbb-conf --status | grep inactive | grep -vq tomcat9; then
+            echo "# Error: Detected some processes have not started correctly"
+            echo "#"
+            echo "#   $(bbb-conf --status | grep inactive | grep -v tomcat9)"
+            echo "#"
+        fi
     fi
 
     if systemctl status freeswitch | grep -q SETSCHEDULER; then


### PR DESCRIPTION
### What does this PR do?

It doesn't let the `bbb-conf --restart` flow crash when tomcat is not available. It also doesn't log tomcat-related error, instead, it logs a warning.

### Closes Issue(s)

Closes #14852

### More

To test it, the reviewer could mock a situation where tomcat is blocked and can't be started. They could achieve it by doing: 

``` bash
sudo systemctl mask tomcat9
sudo systemctl start tomcat9 #just to make sure
```

Now replace the old bbb-conf script with the new one, by doing: 

``` bash 
#!/bin/bash

cd ../bigbluebutton-config/bin/

sudo rm /usr/bin/bbb-conf
sudo rm /usr/bin/bbb-record

sudo cp bbb-record /usr/bin/bbb-record
sudo cp bbb-conf /usr/bin/bbb-conf
```

Then try `sudo bbb-conf --restart` the expected output should contain: 

``` bash 
Starting BigBlueButton
Failed to start tomcat9.service: Unit tomcat9.service is masked.

# Warning: tomcat9 could not be started. Please, check BBB-LTI or BBB-Demo.
#     Run the command:
#       sudo journalctl -u tomcat9
#     To better understand the ERROR
```

To return the tomcat service, run `sudo systemctl unmask tomcat9`