### PR TITLE
fix: microphone design inside audio modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/styles.js
@@ -26,6 +26,7 @@ const AudioModalButton = styled(Button)`
 
   // Modifies the audio button icon colour
   & span:first-child {
+    display: inline-block;
     color: #1b3c4b;
     background-color: #f1f8ff;
     box-shadow: none;
@@ -46,6 +47,7 @@ const AudioModalButton = styled(Button)`
 
   // Modifies the button label text
   & span:last-child {
+    display: block;
     color: black;
     font-size: 1rem;
     font-weight: 600;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
This PR fixes the Microphone/Listen Only design inside the audio modal that was stretching when changing the Microphone/Listen Only label to a bigger sentence.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
#15211
