### PR TITLE
fix: some presentation slides are not loaded after conversion (2.5)

### DIFF
--- a/bigbluebutton-html5/imports/api/presentations/server/modifiers/addPresentation.js
+++ b/bigbluebutton-html5/imports/api/presentations/server/modifiers/addPresentation.js
@@ -10,7 +10,7 @@ const getSlideText = async (url) => {
   let content = '';
   try {
     const request = await axios(url);
-    content = request.data;
+    content = request.data.toString();
   } catch (error) {
     Logger.error(`No file found. ${error}`);
   }


### PR DESCRIPTION
### What does this PR do?

This is a port of PR #15215 from develop branch to 2.5.

_Prevents a bug where some presentation slides are not loaded after conversion._