### PR TITLE
fix: apply presentation 'isCurrent' changes to local state

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -268,6 +268,31 @@ class PresentationUploader extends Component {
   componentDidUpdate(prevProps) {
     const { isOpen, presentations: propPresentations, intl } = this.props;
     const { presentations } = this.state;
+    const { presentations: prevPropPresentations } = prevProps;
+
+    let shouldUpdateState = isOpen && !prevProps.isOpen;
+    const presState = Object.values({
+      ...propPresentations,
+      ...presentations,
+    });
+    const presStateMapped = presState.map((presentation) => {
+      propPresentations.forEach((propPres) => {
+        if (propPres.id === presentation.id) {
+          const prevPropPres = prevPropPresentations.find((pres) => pres.id === propPres.id);
+          if (propPres.isCurrent !== prevPropPres?.isCurrent) {
+            presentation.isCurrent = propPres.isCurrent;
+            shouldUpdateState = true;
+          }
+        }
+      });
+      return presentation;
+    });
+
+    if (shouldUpdateState) {
+      this.setState({
+        presentations: presStateMapped,
+      });
+    }
 
     if (!isOpen && prevProps.isOpen) {
       unregisterTitleView();
@@ -300,24 +325,6 @@ class PresentationUploader extends Component {
           }
         }
       });
-
-      const presState = Object.values({
-        ...propPresentations,
-        ...presentations,
-      });
-      const presStateMapped = presState.map((presentation) => {
-        propPresentations.forEach((propPres) => {
-          if (propPres.id == presentation.id){
-            presentation.isCurrent = propPres.isCurrent;
-          }
-        })
-        return presentation;
-      })
-
-      this.setState({
-        presentations: presStateMapped,
-      })
-      
     }
 
     if (presentations.length > 0) {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Syncs presentation data `isCurrent` between props and local state.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #15272