### PR TITLE
fix: prevent chat-context crash on missing data

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
@@ -96,7 +96,7 @@ const Adapter = () => {
   /* needed to prevent an issue with dupĺicated messages when user role is changed
   more info: https://github.com/bigbluebutton/bigbluebutton/issues/11842 */
   useEffect(() => {
-    if (users[Auth.meetingID]) {
+    if (users[Auth.meetingID] && users[Auth.meetingID][Auth.userID]) {
       if (currentUserData?.role !== users[Auth.meetingID][Auth.userID].role) {
         prevUserData = currentUserData;
       }


### PR DESCRIPTION
### What does this PR do?

Adds additional check to chat-context adapter to prevent a crash when user data is not present.