### PR TITLE
Disable Background Slide Image Hover Highlight

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -234,6 +234,25 @@ export default function Whiteboard(props) {
             if (!hasWBAccess && !isPresenter) app.onPan = () => {};
             setTLDrawAPI(app);
             props.setTldrawAPI(app);
+            // disable pan for non presenter that doesn't have multi user access
+            if (!hasWBAccess && !isPresenter) app.onPan = () => {}; 
+            // disable hover highlight for background slide shape
+            app.setHoveredId = (id) => {
+              if (id.includes('slide-background')) return null;
+              app.patchState(
+                {
+                  document: {
+                    pageStates: {
+                      [app.getPage()?.id]: {
+                        hoveredId: id,
+                      },
+                    },
+                  },
+                },
+                `set_hovered_id`
+              );
+            };
+
             if (curPageId) {
               app.changePage(curPageId);
               if (slidePosition.zoom === 0) {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -231,27 +231,31 @@ export default function Whiteboard(props) {
           // until we handle saving of assets in akka.
           disableAssets={true}
           onMount={(app) => {
-            if (!hasWBAccess && !isPresenter) app.onPan = () => {};
             setTLDrawAPI(app);
             props.setTldrawAPI(app);
-            // disable pan for non presenter that doesn't have multi user access
-            if (!hasWBAccess && !isPresenter) app.onPan = () => {}; 
-            // disable hover highlight for background slide shape
-            app.setHoveredId = (id) => {
-              if (id.includes('slide-background')) return null;
-              app.patchState(
-                {
-                  document: {
-                    pageStates: {
-                      [app.getPage()?.id]: {
-                        hoveredId: id,
+            // disable for non presenter that doesn't have multi user access
+            if (!hasWBAccess && !isPresenter) {
+              app.onPan = () => {};
+              app.setSelectedIds = () => {};
+              app.setHoveredId = () => {};
+            } else {
+              // disable hover highlight for background slide shape
+              app.setHoveredId = (id) => {
+                if (id.includes('slide-background')) return null;
+                app.patchState(
+                  {
+                    document: {
+                      pageStates: {
+                        [app.getPage()?.id]: {
+                          hoveredId: id,
+                        },
                       },
                     },
                   },
-                },
-                `set_hovered_id`
-              );
-            };
+                  `set_hovered_id`
+                );
+              };
+            }
 
             if (curPageId) {
               app.changePage(curPageId);


### PR DESCRIPTION
### What does this PR do?
Disables the hover highlight on slide background image.
Also disables shape selection for non presenter (when multiuser is not enabled).