### PR TITLE
feat: add user name to checkAuthorization response, [...]

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/GetMicrophonePermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/GetMicrophonePermissionReqMsgHdlr.scala
@@ -38,7 +38,8 @@ trait GetMicrophonePermissionReqMsgHdlr {
       liveMeeting,
       msg.body.meetingId,
       msg.body.userId,
-      msg.body.voiceConf
+      msg.body.voiceConf,
+      msg.body.callerIdNum
     )
 
     broadcastEvent(

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceHdlrHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceHdlrHelpers.scala
@@ -1,7 +1,7 @@
 package org.bigbluebutton.core.apps.voice
 
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.models.{ Users2x }
+import org.bigbluebutton.core.models.{ Users2x, VoiceUsers }
 import org.bigbluebutton.core.running.{ LiveMeeting }
 import org.bigbluebutton.LockSettingsUtil
 import org.bigbluebutton.SystemConfiguration
@@ -27,7 +27,8 @@ object VoiceHdlrHelpers extends SystemConfiguration {
       liveMeeting: LiveMeeting,
       meetingId:   String,
       userId:      String,
-      voiceConf:   String
+      voiceConf:   String,
+      callerIdNum: String
   ): Boolean = {
     Users2x.findWithIntId(liveMeeting.users2x, userId) match {
       case Some(user) => {
@@ -35,8 +36,13 @@ object VoiceHdlrHelpers extends SystemConfiguration {
           user,
           liveMeeting
         )
+        val isCallerBanned = VoiceUsers.isCallerBanned(
+          callerIdNum,
+          liveMeeting.voiceUsers
+        )
 
         (applyPermissionCheck &&
+          !isCallerBanned &&
           !microphoneSharingLocked &&
           liveMeeting.props.meetingProp.intId == meetingId &&
           liveMeeting.props.voiceProp.voiceConf == voiceConf)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
@@ -564,6 +564,9 @@ case class GetGlobalAudioPermissionRespMsgBody(
 
 /* Sent by bbb-webrtc-sfu to ask permission for a new microphone/full audio
  * connection
+ *   - callerIdNum: the session's callerId as assembled by the requester
+ *   - sfuSessionId: the UUID for this request's session in bbb-webrtc-sfu.
+ *     Used for response matching.
  */
 object GetMicrophonePermissionReqMsg { val NAME = "GetMicrophonePermissionReqMsg" }
 case class GetMicrophonePermissionReqMsg(
@@ -574,9 +577,15 @@ case class GetMicrophonePermissionReqMsgBody(
     meetingId:    String,
     voiceConf:    String,
     userId:       String,
+    callerIdNum:  String,
     sfuSessionId: String
 )
 
+/* Sent to bbb-webrtc-sfu as a response to GetMicrophonePermissionReqMsg
+ *   - sfuSessionId: the UUID for this request's session in bbb-webrtc-sfu.
+ *     Used for response matching.
+ *   - allowed: whether session creation should be allowed.
+ */
 object GetMicrophonePermissionRespMsg { val NAME = "GetMicrophonePermissionRespMsg" }
 case class GetMicrophonePermissionRespMsg(
     header: BbbClientMsgHeader,

--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.9.0-alpha.2 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.9.0-alpha.3 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
@@ -28,7 +28,6 @@ const MEDIA = Meteor.settings.public.media;
 const DEFAULT_FULLAUDIO_MEDIA_SERVER = MEDIA.audio.fullAudioMediaServer;
 const LISTEN_ONLY_OFFERING = MEDIA.listenOnlyOffering;
 const MEDIA_TAG = MEDIA.mediaTag.replace(/#/g, '');
-const GLOBAL_AUDIO_PREFIX = 'GLOBAL_AUDIO_';
 const RECONNECT_TIMEOUT_MS = MEDIA.listenOnlyCallTimeout || 15000;
 const SENDRECV_ROLE = 'sendrecv';
 const RECV_ROLE = 'recv';
@@ -304,14 +303,9 @@ export default class SFUAudioBridge extends BaseAudioBridge {
         const { isListenOnly, extension, inputStream } = options;
         this.inEchoTest = !!extension;
         this.isListenOnly = isListenOnly;
-        const callerIdName = [
-          `${this.userId}_${getAudioSessionNumber()}`,
-          'bbbID',
-          isListenOnly ? `${GLOBAL_AUDIO_PREFIX}` : this.name,
-        ].join('-').replace(/"/g, "'");
 
         const brokerOptions = {
-          caleeName: callerIdName,
+          clientSessionNumber: getAudioSessionNumber(),
           extension,
           iceServers: this.iceServers,
           mediaServer: getMediaServerAdapter(isListenOnly),
@@ -431,8 +425,7 @@ export default class SFUAudioBridge extends BaseAudioBridge {
         fetchWebRTCMappedStunTurnServers(this.sessionToken)
           .then((iceServers) => {
             const options = {
-              userName: this.name,
-              caleeName: `${GLOBAL_AUDIO_PREFIX}${this.voiceBridge}`,
+              clientSessionNumber: getAudioSessionNumber(),
               iceServers,
               offering: LISTEN_ONLY_OFFERING,
             };

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/audio-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/audio-broker.js
@@ -18,7 +18,7 @@ class AudioBroker extends BaseBroker {
     this.offering = true;
 
     // Optional parameters are:
-    // caleeName,
+    // clientSessionNumber
     // iceServers,
     // offering,
     // mediaServer,
@@ -192,7 +192,7 @@ class AudioBroker extends BaseBroker {
       id: 'start',
       type: this.sfuComponent,
       role: this.role,
-      caleeName: this.caleeName,
+      clientSessionNumber: this.clientSessionNumber,
       sdpOffer: offer,
       mediaServer: this.mediaServer,
       extension: this.extension,

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
@@ -42,6 +42,7 @@ class ConnectionController {
         response.addHeader("User-Id", userSession.internalUserId)
         response.addHeader("Meeting-Id", userSession.meetingID)
         response.addHeader("Voice-Bridge", userSession.voicebridge )
+        response.addHeader("User-Name", userSession.fullname)
         response.setStatus(200)
         response.outputStream << 'authorized'
       } else {

--- a/build/packages-template/bbb-webrtc-sfu/webrtc-sfu.nginx
+++ b/build/packages-template/bbb-webrtc-sfu/webrtc-sfu.nginx
@@ -5,6 +5,7 @@ location /bbb-webrtc-sfu {
     auth_request_set $user_id $sent_http_user_id;
     auth_request_set $meeting_id $sent_http_meeting_id;
     auth_request_set $voice_bridge $sent_http_voice_bridge;
+    auth_request_set $user_name $sent_http_user_name;
 
     proxy_pass http://127.0.0.1:3008;
     proxy_http_version 1.1;
@@ -14,6 +15,8 @@ location /bbb-webrtc-sfu {
     proxy_set_header User-Id $user_id;
     proxy_set_header Meeting-Id $meeting_id;
     proxy_set_header Voice-Bridge $voice_bridge;
+    proxy_set_header User-Name $user_name;
+
     proxy_read_timeout 60s;
     proxy_send_timeout 60s;
     client_body_timeout 60s;


### PR DESCRIPTION
### What does this PR do?

- [feat: add user name to checkAuthorization response](https://github.com/bigbluebutton/bigbluebutton/commit/6225042148558da73fffeb8317c6e62a0838a6b7)
  - Audio's callerId depends on the user name and there isn't
    an "on-demand" way of fetching that field internally, making callerId
    assembly with trusted attributes impossible in bbb-webrtc-sfu.
  - Alternatives I've considered but discarded:
    - a new akka-apps req-resp pair for fetching the user name (+overhead)
    - a new akka-apps req-resp pair for generating the callerId (+overhead)
    - piggybacking on GetMicrophonePermissionReq/Resp to generate the
      callerId (same overhead, but mixing responsabilities)
- [refactor(audio): remove caller ID from fullaudio bridge start request](https://github.com/bigbluebutton/bigbluebutton/commit/602238b84ef8b0b59c3743acf49c5f2b50f61be1)
  - The callerId is assembled server-side as of bbb-webrtc-sfu
  v2.9.0-alpha.3 based on the work done in commit 62250421485
- [fix: add ban status to SFU audio permission check](https://github.com/bigbluebutton/bigbluebutton/commit/eeed5ce20811015a34dbfafe4f47f3b2c18c9a20)
  - This adds the same `UserJoinedVoice*` ban check to the pre-flight 
  permission probe so that calls are rejected earlier.
- [build(bbb-webrtc-sfu): v2.9.0-alpha.3](https://github.com/bigbluebutton/bigbluebutton/commit/2b204b3e83440c1318e7ea047d3e08a0811b3022)
  * See https://github.com/bigbluebutton/bbb-webrtc-sfu/releases/tag/v2.9.0-alpha.3
  
### Closes Issue(s)

None

### Motivation

Follow up to #15233 

### More

n/a