### PR TITLE
chore(audio): enable local echo test and volume meter by default

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -580,11 +580,11 @@ public:
     #   be used in Chromium browsers. Works around the fact that Chromium has no
     #   echo cancellation in non-rtc audio streams
     localEchoTest:
-      enabled: false
-      initialHearingState: false
-      useRtcLoopbackInChromium: false
+      enabled: true
+      initialHearingState: true
+      useRtcLoopbackInChromium: true
     # showVolumeMeter: shows an energy bar for microphones in the AudioSettings view
-    showVolumeMeter: false
+    showVolumeMeter: true
   stats:
     enabled: true
     interval: 10000


### PR DESCRIPTION
### What does this PR do?

Enables the feature set introduced in https://github.com/bigbluebutton/bigbluebutton/pull/14736 by default.

### Closes Issue(s)

n/a


### Motivation

Seen a couple of months of real testing by now, so it's stable even if it's not 100% UX/UI-ideal.

### More

n/a