### PR TITLE
fix: omit unused props in talking-indicator, input stream selector and EmojiButton

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/component.jsx
@@ -296,7 +296,7 @@ class InputStreamLiveSelector extends Component {
         size="lg"
         circle
         accessKey={shortcuts.togglemute}
-        talking={talking || undefined}
+        $talking={talking || undefined}
         animations={animations}
         data-test="toggleMicrophoneButton"
       />

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/styles.js
@@ -40,15 +40,15 @@ const MuteToggleButton = styled(Button)`
     }
   `}
 
-  ${({ talking }) => talking && `
+  ${({ $talking }) => $talking && `
     border-radius: 50%;
   `}
-    
-  ${({ talking, animations }) => talking && animations && css`
+
+  ${({ $talking, animations }) => $talking && animations && css`
     animation: ${pulse} 1s infinite ease-in;
   `}
 
-  ${({ talking, animations }) => talking && !animations && css`
+  ${({ $talking, animations }) => $talking && !animations && css`
     & span {
       content: '';
       outline: none !important;

--- a/bigbluebutton-html5/imports/ui/components/common/icon/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/icon/component.jsx
@@ -21,7 +21,7 @@ const Icon = ({
   <i
     className={cx(className, [prependIconName, iconName].join(''))}
     // ToastContainer from react-toastify passes a useless closeToast prop here
-    {..._.omit(props, ['closeToast', 'animations'])}
+    {..._.omit(props, ['closeToast', 'animations', 'rotate'])}
   />
 );
 

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/component.jsx
@@ -66,9 +66,9 @@ class TalkingIndicator extends PureComponent {
 
       return (
         <Styled.TalkingIndicatorButton
-          spoke={!talking}
-          muted={muted}
-          isViewer={!amIModerator}
+          $spoke={!talking || undefined}
+          $muted={muted}
+          $isViewer={!amIModerator || undefined}
           key={_.uniqueId(`${callerName}-`)}
           onClick={() => this.handleMuteUser(id)}
           label={callerName}
@@ -109,9 +109,9 @@ class TalkingIndicator extends PureComponent {
 
       return (
         <Styled.TalkingIndicatorButton
-          spoke={nobodyTalking}
-          muted={false}
-          isViewer={false}
+          $spoke={nobodyTalking}
+          $muted={false}
+          $isViewer={false}
           key={_.uniqueId('_has__More_')}
           onClick={() => {}} // maybe add a dropdown to show the rest of the users
           label="..."

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/styles.js
@@ -45,7 +45,7 @@ const TalkingIndicatorButton = styled(Button)`
   @media ${phoneLandscape} {
     height: 1rem;
   }
-  
+
   i,
   span {
     position: relative;
@@ -92,7 +92,7 @@ const TalkingIndicatorButton = styled(Button)`
     opacity: 1;
   }
 
-  ${({ spoke }) => spoke && `
+  ${({ $spoke }) => $spoke && `
     opacity: ${spokeOpacity};
 
     [dir="rtl"]  & {
@@ -100,15 +100,15 @@ const TalkingIndicatorButton = styled(Button)`
     }
   `}
 
-  ${({ muted }) => muted && `
+  ${({ $muted }) => $muted && `
     cursor: default;
-  
+
     i {
       background-color: ${colorDanger};
     }
   `}
 
-  ${({ isViewer }) => isViewer && `
+  ${({ $isViewer }) => $isViewer && `
     cursor: default;
   `}
 `;


### PR DESCRIPTION
### What does this PR do?

- Make the talking, spoke, muted and isViewer props transient
  (styled-components) - which means they won't reach the DOM (as
  expected since they're for styling purposes only)
- Omit the EmojiButton `rotate` prop in the Icon component itself
  * Made that instead of transient because might be useful to migrate
    the rotate code to the Icon component?

### Closes Issue(s)

None that I know of

### Motivation

The talking-indicator, emoji-button and input-live-stream-selector
components are passing props downstream that weren't omitted or handled
by inherited components (Button, Icon). That causes a handful of error
logs to be spammed in the console of dev environments, eg
`Warning: Received `true` for a non-boolean attribute` et al, which is gets in
the way of actual debugging.

### More

n/a
