### PR TITLE
fix(audio): check if broker exists before trying to stop

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
@@ -471,8 +471,11 @@ export default class SFUAudioBridge extends BaseAudioBridge {
     const mediaElement = document.getElementById(MEDIA_TAG);
 
     this.clearReconnectionTimeout();
-    this.broker.stop();
-    this.broker = null;
+
+    if (this.broker) {
+      this.broker.stop();
+      this.broker = null;
+    }
 
     if (mediaElement && typeof mediaElement.pause === 'function') {
       mediaElement.pause();


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): check if broker exists before trying to stop](https://github.com/bigbluebutton/bigbluebutton/commit/f026c397d9f147da453a9c8290b38cf8588d9f82)

### Closes Issue(s)

None - recently found via log analysis.

### Motivation

There are scenarios where the full audio broker (SFU) stop  procedure
may be called multiple times in a very short timestamp - eg a concurrent
stop + connection failure; a timeout in the transfer procedure + a
reconnect attempt, [...]. When that happens, calls to exitAudio may throw
errors if the broker was already released - and that's not the expected
behavior.

### More

n/a
