### PR TITLE
fix(webcam): prevent camera freeze due to _renderMask exceptions

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/virtual-background/index.js
+++ b/bigbluebutton-html5/imports/ui/services/virtual-background/index.js
@@ -15,6 +15,7 @@ import {
   MODELS,
   getVirtualBgImagePath,
 } from '/imports/ui/services/virtual-background/service'
+import logger from '/imports/startup/client/logger';
 
 const blurValue = '25px';
 
@@ -195,9 +196,23 @@ class VirtualBackgroundService {
      * @returns {void}
      */
     _renderMask() {
-        this.resizeSource();
-        this.runInference();
-        this.runPostProcessing();
+        try {
+            this.resizeSource();
+            this.runInference();
+            this.runPostProcessing();
+        } catch (error) {
+            // TODO This is a high frequency log so that's why it's debug level.
+            // Should be reviewed later when the actual problem with runPostProcessing
+            // throwing on stalled pages/iframes - prlanzarin Jun 30 2022
+            logger.debug({
+                logCode: 'virtualbg_renderMask_failure',
+                extraInfo: {
+                    errorMessage: error.message,
+                    errorCode: error.code,
+                    errorName: error.name,
+                },
+            }, `Virtual background renderMask failed: ${error.message || error.name}`);
+        }
 
         this._maskFrameTimerWorker.postMessage({
             id: SET_TIMEOUT,


### PR DESCRIPTION
### What does this PR do?

- [fix(webcam): prevent camera freeze due to _renderMask exceptions](https://github.com/bigbluebutton/bigbluebutton/commit/0c7c628f7a245a589975b348a5fa618ad7fe860f)
  * Address the issue with a try-catch and a log for debugability (it's high
    frequency, hence why not error level). We should probably remove the log
    entirely once we figure out why the post-processing method is failing.

### Closes Issue(s)

None

### Motivation

Under some scenarios, cameras are freezing when the virtual background
code is running due to runPostProcessing(_renderMask) throwing
NS_ERROR_FAILURE - mainly on Firefox - consequently preventing
subsequent TimerWorker ticks from being scheduled.
Cases where I've seen that happen are:
  - conferences running under an iframe where the iframe is briefly
    stalled for some reason

### More

n/a