### PR TITLE
fix: disable Tldraw autofocus

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -230,6 +230,9 @@ export default function Whiteboard(props) {
           // disable the ability to drag and drop files onto the whiteboard
           // until we handle saving of assets in akka.
           disableAssets={true}
+          // Disable automatic focus. Users were losing focus on shared notes
+          // and chat on presentation mount.
+          autofocus={false}
           onMount={(app) => {
             setTLDrawAPI(app);
             props.setTldrawAPI(app);


### PR DESCRIPTION
### What does this PR do?

Disables Tldraw autofocus on mount. That prevents the user from losing focus on shared notes, chat, etc when presentation is mounted.

### Closes Issue(s)
None
