### PR TITLE
improvement: virtual background selector thumbnail

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
@@ -203,9 +203,9 @@ const VirtualBgSelector = ({
             </div>
           </>
 
-          <>
+          <Styled.ThumbnailButtonWrapper isVisualEffects={isVisualEffects}>
             <Styled.ThumbnailButton
-              style={{ backgroundImage: `url('${getVirtualBackgroundThumbnail(BLUR_FILENAME)}')` }}
+              background={getVirtualBackgroundThumbnail(BLUR_FILENAME)}
               aria-label={intl.formatMessage(intlMessages.blurLabel)}
               label={intl.formatMessage(intlMessages.blurLabel)}
               aria-describedby={`vr-cam-btn-blur`}
@@ -220,7 +220,7 @@ const VirtualBgSelector = ({
             <div aria-hidden className="sr-only" id={`vr-cam-btn-blur`}>
               {intl.formatMessage(intlMessages.camBgAriaDesc, { 0: EFFECT_TYPES.BLUR_TYPE })}
             </div>
-          </>
+          </Styled.ThumbnailButtonWrapper>
 
           {IMAGE_NAMES.map((imageName, index) => {
             const label = intl.formatMessage(intlMessages[imageName.split('.').shift()], {
@@ -229,7 +229,10 @@ const VirtualBgSelector = ({
             });
 
             return (
-              <div key={`${imageName}-${index}`} style={{ position: 'relative' }}>
+              <Styled.ThumbnailButtonWrapper
+                key={`${imageName}-${index}`}
+                isVisualEffects={isVisualEffects}
+              >
                 <Styled.ThumbnailButton
                   id={`${imageName}-${index}`}
                   label={label}
@@ -243,16 +246,12 @@ const VirtualBgSelector = ({
                   onClick={() => _virtualBgSelected(EFFECT_TYPES.IMAGE_TYPE, imageName, index + 1)}
                   disabled={disabled}
                   isVisualEffects={isVisualEffects}
+                  background={getVirtualBackgroundThumbnail(imageName)}
                 />
-                <Styled.Thumbnail onClick={() => {
-                  const node = findDOMNode(inputElementsRef.current[index + 1]);
-                  node.focus();
-                  node.click();
-                }} aria-hidden src={getVirtualBackgroundThumbnail(imageName)} />
                 <div aria-hidden className="sr-only" id={`vr-cam-btn-${index}`}>
                   {intl.formatMessage(intlMessages.camBgAriaDesc, { 0: label })}
                 </div>
-              </div>
+              </Styled.ThumbnailButtonWrapper>
             )
           })}
 
@@ -265,7 +264,10 @@ const VirtualBgSelector = ({
               });
 
               return (
-                <Styled.ThumbnailButtonWrapper key={`${filename}-${index}`}>
+                <Styled.ThumbnailButtonWrapper
+                  key={`${filename}-${index}`}
+                  isVisualEffects={isVisualEffects}
+                >
                   <Styled.ThumbnailButton
                     id={`${filename}-${imageIndex}`}
                     label={label}
@@ -284,12 +286,8 @@ const VirtualBgSelector = ({
                     )}
                     disabled={disabled}
                     isVisualEffects={isVisualEffects}
+                    background={data}
                   />
-                  <Styled.Thumbnail onClick={() => {
-                    const node = findDOMNode(inputElementsRef.current[index + IMAGE_NAMES.length + 1]);
-                    node.focus();
-                    node.click();
-                  }} aria-hidden src={data} />
                   <Styled.ButtonWrapper>
                     <Styled.ButtonRemove
                       label={intl.formatMessage(intlMessages.removeLabel)}

--- a/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/styles.js
@@ -62,14 +62,7 @@ const ThumbnailButton = styled(Button)`
   z-index: 1;
   background-color: transparent;
   border: ${borderSizeSmall} solid ${userThumbnailBorder};
-  margin: 0 0.15em;
   flex-shrink: 0;
-
-  ${({ isVisualEffects }) => isVisualEffects && `
-    background-size: cover;
-    background-position: center;
-    margin: 0.15em;
-  `}
 
   & + img {
     border-radius: ${borderSizeLarge};
@@ -89,15 +82,16 @@ const ThumbnailButton = styled(Button)`
       filter: grayscale(1);
     }
   `}
-`;
 
-const Thumbnail = styled.img`
-  position: absolute;
-  cursor: pointer;
-  width: 47px;
-  height: 47px;
-  top: 0.063rem;
-  left: 0.188rem;
+  ${({ background }) => background && `
+    background-image: url(${background});
+    background-size: 46px 46px;
+    background-origin: padding-box;
+
+    &:active {
+      background-image: url(${background});
+    }
+  `}
 `;
 
 const Select = styled.select`
@@ -133,6 +127,11 @@ const Label = styled.label`
 
 const ThumbnailButtonWrapper = styled.div`
   position: relative;
+  margin: 0 0.15em;
+
+  ${({ isVisualEffects }) => isVisualEffects && `
+    margin: 0.15em;
+  `}
 `;
 
 const ButtonWrapper = styled.div`
@@ -156,7 +155,6 @@ export default {
   BgWrapper,
   BgNoneButton,
   ThumbnailButton,
-  Thumbnail,
   Select,
   Label,
   ThumbnailButtonWrapper,

--- a/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/styles.js
@@ -41,11 +41,11 @@ const BgNoneButton = styled(Button)`
   height: 48px;
   width: 48px;
   border: ${borderSizeSmall} solid ${userThumbnailBorder};
-  margin: 0 0.15em;
+  margin: 0 0.15rem;
   flex-shrink: 0;
 
   ${({ isVisualEffects }) => isVisualEffects && `
-    margin: 0.15em;
+    margin: 0.15rem;
   `}
 `;
 
@@ -127,10 +127,10 @@ const Label = styled.label`
 
 const ThumbnailButtonWrapper = styled.div`
   position: relative;
-  margin: 0 0.15em;
+  margin: 0 0.15rem;
 
   ${({ isVisualEffects }) => isVisualEffects && `
-    margin: 0.15em;
+    margin: 0.15rem;
   `}
 `;
 


### PR DESCRIPTION
### What does this PR do?

Improves styling of virtual background selector thumbnails. Fixes bad alignment of images within selector containers.

_Before_ (images are a bit off)
![before](https://user-images.githubusercontent.com/62393923/176767181-cb9abf4f-51fb-4f27-9ec7-ce5e365fdb07.png)

After
![after](https://user-images.githubusercontent.com/62393923/176769101-575db9ea-6904-4356-a900-23de7183095d.png)

### Closes Issue(s)

None

### Motivation

n/a

### More

n/a