### PR TITLE
improvement: show a loader while loading custom backgrounds

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/loader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/loader/component.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Styled from './styles';
+import Settings from '/imports/ui/services/settings';
+
+const { animations } = Settings.application;
+
+const Loader = ({ size }) => (
+  <Styled.Spinner animations={animations} size={size}>
+    <Styled.Bounce1 animations={animations} />
+    <Styled.Bounce2 animations={animations} />
+    <div />
+  </Styled.Spinner>
+);
+
+export default Loader;

--- a/bigbluebutton-html5/imports/ui/components/common/loader/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/loader/styles.js
@@ -1,0 +1,69 @@
+import styled, { css, keyframes } from 'styled-components';
+import { colorBlack } from '/imports/ui/stylesheets/styled-components/palette';
+
+const skBouncedelay = keyframes`
+  0%,
+  80%,
+  100% {
+    transform: scale(0);
+  }
+  40% {
+    transform: scale(1.0);
+  }
+`;
+
+const Spinner = styled.div`
+  width: 100%;
+  text-align: center;
+  height: 22px;
+
+  & > div {
+    margin: 0 5px;
+    background-color: ${colorBlack};
+    border-radius: 100%;
+    display: inline-block;
+
+    ${({ animations }) => animations && css`
+      animation: ${skBouncedelay} 1.4s infinite ease-in-out both;
+    `}
+
+    ${({ size }) => {
+      switch (size) {
+        case 'md':
+          return (`
+            width: 14px;
+            height: 14px;
+          `);
+        case 'sm':
+          return (`
+            width: 10px;
+            height: 10px;
+          `);
+        case 'normal':
+        default:
+          return (`
+            width: 18px;
+            height: 18px;
+          `);
+      }
+    }}
+  }
+`;
+
+const Bounce1 = styled.div`
+  ${({ animations }) => animations && `
+    animation-delay: -0.32s !important;
+  `}
+`;
+
+const Bounce2 = styled.div`
+  ${({ animations }) => animations && `
+    animation-delay: -0.16s !important;
+  `}
+`;
+
+export default {
+  Spinner,
+  Bounce1,
+  Bounce2,
+};

--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -808,7 +808,7 @@ class VideoPreview extends Component {
             />)}
             </Styled.Actions>
           </Styled.Footer>
-        ) : null }
+        ) : <div aria-hidden={true} /> }
       </>
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
@@ -12,6 +12,7 @@ import {
 } from '/imports/ui/services/virtual-background/service';
 import { CustomVirtualBackgroundsContext } from './context';
 import VirtualBgService from '/imports/ui/components/video-preview/virtual-background/service';
+import Loader from '/imports/ui/components/common/loader/component'
 
 const propTypes = {
   intl: PropTypes.shape({
@@ -353,6 +354,14 @@ const VirtualBgSelector = ({
     if (showThumbnails) return renderThumbnailSelector();
     return renderDropdownSelector();
   };
+
+  if (!loaded && isVisualEffects) {
+    return (
+      <Styled.LoaderWrapper>
+        <Loader size="md" />
+      </Styled.LoaderWrapper>
+    );
+  }
 
   return (
     <>

--- a/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/styles.js
@@ -151,6 +151,14 @@ const ButtonRemove = styled(Button)`
 
 const BgCustomButton = styled(BgNoneButton)``;
 
+const LoaderWrapper = styled.div`
+  height: 15rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: calc(.4rem + 3px) 3px 3px;
+`;
+
 export default {
   VirtualBackgroundRowThumbnail,
   BgWrapper,
@@ -163,4 +171,5 @@ export default {
   ButtonWrapper,
   ButtonRemove,
   BgCustomButton,
+  LoaderWrapper,
 };


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Loading data from IndexedDB can take a while. The new feature introduced by https://github.com/bigbluebutton/bigbluebutton/pull/14794 loads/saves custom image data from/to IndexedDB. So, this PR adds a loader to be shown while image data is being loaded from IndexedDB. The thumbnails will only be shown after the images are loaded.

_Loading..._
![loading](https://user-images.githubusercontent.com/62393923/176921377-0bc6781e-40b9-43d2-bd30-1403b337ef52.png)

_Loaded_
![loaded](https://user-images.githubusercontent.com/62393923/176921581-a559d856-b6a4-43d7-8d58-c8df67a4d5f4.png)

### Closes Issue(s)

None

### Motivation

User feedback to indicate that custom backgrounds are being loaded.

### More

n/a
