### PR TITLE
fix(recording): Add PDF cropbox parameter to thumbnails and slides for playback

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ThumbnailCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ThumbnailCreatorImp.java
@@ -83,7 +83,7 @@ public class ThumbnailCreatorImp implements ThumbnailCreator {
       COMMAND = IMAGEMAGICK_DIR + File.separatorChar + "convert -thumbnail 150x150 "  + source + " " + dest;
     } else {
       dest = thumbsDir.getAbsolutePath() + File.separatorChar + TEMP_THUMB_NAME + "-" + page; // the "-x.png" is appended automagically
-      COMMAND = "pdftocairo -png -scale-to 150 " + source + " " + dest;
+      COMMAND = "pdftocairo -png -scale-to 150 -cropbox " + source + " " + dest;
     }
 
     //System.out.println(COMMAND);

--- a/record-and-playback/core/lib/recordandplayback/generators/presentation.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/presentation.rb
@@ -51,7 +51,7 @@ module BigBlueButton
       temp_out = "#{File.dirname(png_out)}/temp-#{File.basename(png_out, '.png')}"
       status = BigBlueButton.execute(
         [
-          'pdftocairo', '-png', '-f', page_num.to_s, '-l', page_num.to_s, '-scale-to', scale.to_s, '-singlefile',
+          'pdftocairo', '-png', '-f', page_num.to_s, '-l', page_num.to_s, '-scale-to', scale.to_s, '-singlefile', '-cropbox',
           pdf_presentation, temp_out,
         ],
         false


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Fixes how thumbnails and slides are displayed in recordings when the presentation slide was cropped.

### Steps to reproduce
1. Crop a PDF slide using a tool like Apple's Preview
2. Upload cropped PDF to meeting

![Meeting Client](https://user-images.githubusercontent.com/33319791/177599260-11220680-3315-41dc-b369-5d85eab52fbe.png)


4. Record meeting, add anotations
5. Playback shows uncropped thumbnails and slides, with incorrect annotation positioning

**Expected result:**
![Meeting Fixed](https://user-images.githubusercontent.com/33319791/177599256-ac3980e7-72dc-48c9-b693-77905a3f9c58.png)

**Actual result:** (recreated)
![Meeting broken](https://user-images.githubusercontent.com/33319791/177599237-f396eceb-6718-4894-939b-3291cbb41314.png)

### More
As Tldraw recordings use the SVG slides that were shown in the meeting, that should not be an issue there. But the thumbnails likely still have to be changed in 2.6.

Tested on 2.5 but issue also present in 2.4.
