### PR TITLE
fix(config): Reload nginx configuration before BBB start

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -113,7 +113,6 @@ jobs:
             cat bbb-install.sh | sed "s|> /etc/apt/sources.list.d/bigbluebutton.list||g" | bash -s -- -v focal-26-dev -s bbb-ci.test -d /certs/
             bbb-conf --salt bbbci
             echo "NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/bbb-dev/bbb-dev-ca.crt" >> /usr/share/meteor/bundle/bbb-html5-with-roles.conf
-            systemctl reload nginx
             bbb-conf --restart
             '
       - name: Install test dependencies

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -368,6 +368,9 @@ start_bigbluebutton () {
         fi
     fi
 
+    echo "Reloading NginX configuration"
+    systemctl reload nginx
+
     echo "Starting BigBlueButton"
 
     if systemctl list-units --full -all | grep -q $TOMCAT_USER.service; then
@@ -1676,7 +1679,7 @@ String BigBlueButtonURL = \"$BBB_WEB_URL/bigbluebutton/\";
     sudo xmlstarlet edit --inplace --update 'configuration/settings//param[@name="password"]/@value' --value $ESL_PASSWORD /opt/freeswitch/etc/freeswitch/autoload_configs/event_socket.conf.xml
 
 
-    echo "Restarting the BigBlueButton $BIGBLUEBUTTON_RELEASE ..."
+    echo "Restarting BigBlueButton $BIGBLUEBUTTON_RELEASE ..."
     stop_bigbluebutton
     start_bigbluebutton
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Reloads nginx configuration before BBB start
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none


### Motivation
I have had to reload the configuration on all new installations the last few attemps. I see the same error on automated tests too and it seems to get resolved with reloading the configuration.
<!-- What inspired you to submit this pull request? -->

```
# Potential problems described below
curl: (7) Failed to connect to droplet-4180.bbb-server.com port 443: Connection refused
.curl: (7) Failed to connect to droplet-4180.bbb-server.com port 443: Connection refused
.curl: (7) Failed to connect to droplet-4180.bbb-server.com port 443: Connection refused
....
.curl: (7) Failed to connect to droplet-4180.bbb-server.com port 443: Connection refused

```


