### PR TITLE
fix(chat): `undefined` property access

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
@@ -97,7 +97,7 @@ const Adapter = () => {
   more info: https://github.com/bigbluebutton/bigbluebutton/issues/11842 */
   useEffect(() => {
     if (users[Auth.meetingID]) {
-      if (currentUserData?.role !== users[Auth.meetingID][Auth.userID].role) {
+      if (currentUserData?.role !== users[Auth.meetingID][Auth.userID]?.role) {
         prevUserData = currentUserData;
       }
       currentUserData = users[Auth.meetingID][Auth.userID];


### PR DESCRIPTION
### What does this PR do?

Avoids crashing when `users[Auth.meetingID][Auth.userID]` is `undefined`.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #15359