### PR TITLE
fix(Dashboard): wrap header on small screens

### DIFF
--- a/bbb-learning-dashboard/src/App.css
+++ b/bbb-learning-dashboard/src/App.css
@@ -11,3 +11,12 @@
 [dir="rtl"] .col-text-right {
   text-align: left;
 }
+
+@media (max-width: 640px) {
+  .col-text-right {
+    text-align: left;
+  }
+  [dir="rtl"] .col-text-right {
+    text-align: right;
+  }
+}

--- a/bbb-learning-dashboard/src/App.js
+++ b/bbb-learning-dashboard/src/App.js
@@ -313,7 +313,7 @@ class App extends React.Component {
 
     return (
       <div className="mx-10">
-        <div className="flex items-start justify-between pb-3">
+        <div className="flex flex-col sm:flex-row items-start justify-between pb-3">
           <h1 className="mt-3 text-2xl font-semibold whitespace-nowrap inline-block">
             <FormattedMessage id="app.learningDashboard.dashboardTitle" defaultMessage="Learning Dashboard" />
             {


### PR DESCRIPTION
Before
![before](https://user-images.githubusercontent.com/62393923/178523170-144c790d-b01a-4a96-ba4f-e360f3c193d1.png)

After
![after](https://user-images.githubusercontent.com/62393923/178523197-fdb750c6-6ec5-43d3-ae09-ef12b54d2367.png)

Closes #15312