### PR TITLE
build: ensure redis is up redis-server.service.d/overrride.conf

### DIFF
--- a/build/packages-template/bbb-config/before-install.sh
+++ b/build/packages-template/bbb-config/before-install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+case "$1" in
+    install|upgrade|1|2)
+
+        # We want to ensure Redis is fully started before it signals it is ready to rely on
+        mkdir -p /etc/systemd/system/redis-server.service.d
+        cat <<HERE > /etc/systemd/system/redis-server.service.d/overrride.conf
+[Service]
+ExecStartPost=/usr/bin/timeout 30 sh -c 'while ! ss -H -t -l -n sport = :6379 | grep -q "^LISTEN.*:6379"; do sleep 1; done'
+HERE
+    ;;
+
+    abort-upgrade)
+    ;;
+
+    *)
+        echo "## preinst called with unknown argument \`$1'" >&2
+    ;;
+esac

--- a/build/packages-template/bbb-config/build.sh
+++ b/build/packages-template/bbb-config/build.sh
@@ -60,6 +60,7 @@ cp bigbluebutton.target staging/lib/systemd/system/
 fpm -s dir -C ./staging -n $PACKAGE \
     --version $VERSION --epoch $EPOCH \
     --after-install after-install.sh \
+    --before-install before-install.sh \
     --description "BigBlueButton configuration utilities" \
     $DIRECTORIES \
     $OPTS \


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Introduces a wait time in Redis' start procedure to ensure it is up, running and listening before other BBB components start. See #15342

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #15342


### Motivation
After #14616 was introduced we were seeing #15342 
@danimo came up with this solution. I am including it in the packaging.
<!-- What inspired you to submit this pull request? -->

### More

Credits: @danimo 
