### PR TITLE
fix(webcam): handle stream inactivation/gUM revocations

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/service.js
@@ -2,7 +2,7 @@ import Storage from '/imports/ui/services/storage/session';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
 import VideoService from '/imports/ui/components/video-provider/service';
-import { BBBVideoStream } from '/imports/ui/services/webrtc-base/bbb-video-stream';
+import BBBVideoStream from '/imports/ui/services/webrtc-base/bbb-video-stream';
 
 const GUM_TIMEOUT = Meteor.settings.public.kurento.gUMTimeout;
 // Unfiltered, includes hidden profiles

--- a/bigbluebutton-html5/imports/ui/components/video-preview/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/service.js
@@ -40,7 +40,7 @@ const storeStream = (deviceId, stream) => {
   VIDEO_STREAM_STORAGE.set(deviceId, stream);
 
   // Stream insurance: clean it up if it ends (see the events being listened to below)
-  stream.on('inactive', () => {
+  stream.once('inactive', () => {
     deleteStream(deviceId);
   });
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -13,7 +13,7 @@ import logger from '/imports/startup/client/logger';
 import { notifyStreamStateChange } from '/imports/ui/services/bbb-webrtc-sfu/stream-state-service';
 import VideoPreviewService from '../video-preview/service';
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
-import { BBBVideoStream } from '/imports/ui/services/webrtc-base/bbb-video-stream';
+import BBBVideoStream from '/imports/ui/services/webrtc-base/bbb-video-stream';
 import {
   EFFECT_TYPES,
   getSessionVirtualBackgroundInfo,

--- a/bigbluebutton-html5/imports/ui/services/webrtc-base/bbb-video-stream.js
+++ b/bigbluebutton-html5/imports/ui/services/webrtc-base/bbb-video-stream.js
@@ -2,12 +2,16 @@ import {
   EFFECT_TYPES,
   BLUR_FILENAME,
   createVirtualBackgroundStream,
-} from '/imports/ui/services/virtual-background/service'
+} from '/imports/ui/services/virtual-background/service';
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
 import { EventEmitter2 } from 'eventemitter2';
 
-export class BBBVideoStream extends EventEmitter2 {
-  static trackStreamTermination (stream, handler) {
+export default class BBBVideoStream extends EventEmitter2 {
+  static isVirtualBackground(type) {
+    return type === EFFECT_TYPES.IMAGE_TYPE;
+  }
+
+  static trackStreamTermination(stream, handler) {
     // Dirty, but effective way of checking whether the browser supports the 'inactive'
     // event. If the oninactive interface is null, it can be overridden === supported.
     // If undefined, it's not; so we fallback to the track 'ended' event.
@@ -39,7 +43,7 @@ export class BBBVideoStream extends EventEmitter2 {
     this._trackOriginalStreamTermination();
   }
 
-  set mediaStream (mediaStream) {
+  set mediaStream(mediaStream) {
     if (!this.mediaStream
       || mediaStream == null
       || mediaStream.id !== this.mediaStream.id) {
@@ -52,23 +56,19 @@ export class BBBVideoStream extends EventEmitter2 {
     }
   }
 
-  get mediaStream () {
+  get mediaStream() {
     return this._mediaStream;
   }
 
-  set virtualBgService (service) {
+  set virtualBgService(service) {
     this._virtualBgService = service;
   }
 
-  get virtualBgService () {
+  get virtualBgService() {
     return this._virtualBgService;
   }
 
-  isVirtualBackground (type) {
-    return type === EFFECT_TYPES.IMAGE_TYPE;
-  }
-
-  _trackOriginalStreamTermination () {
+  _trackOriginalStreamTermination() {
     const notify = () => {
       this.emit('inactive');
     };
@@ -76,12 +76,12 @@ export class BBBVideoStream extends EventEmitter2 {
     BBBVideoStream.trackStreamTermination(this.originalStream, notify);
   }
 
-  _changeVirtualBackground (type, name, customParams) {
+  _changeVirtualBackground(type, name, customParams) {
     try {
       this.virtualBgService.changeBackgroundImage({
         type,
         name,
-        isVirtualBackground: this.isVirtualBackground(type),
+        isVirtualBackground: BBBVideoStream.isVirtualBackground(type),
         customParams,
       });
       this.virtualBgType = type;
@@ -92,14 +92,13 @@ export class BBBVideoStream extends EventEmitter2 {
     }
   }
 
-
-  startVirtualBackground (type, name = '', customParams) {
+  startVirtualBackground(type, name = '', customParams) {
     if (this.virtualBgService) return this._changeVirtualBackground(type, name, customParams);
 
     return createVirtualBackgroundStream(
       type,
       name,
-      this.isVirtualBackground(type),
+      BBBVideoStream.isVirtualBackground(type),
       this.mediaStream,
       customParams,
     ).then(({ service, effect }) => {
@@ -112,7 +111,7 @@ export class BBBVideoStream extends EventEmitter2 {
     });
   }
 
-  stopVirtualBackground () {
+  stopVirtualBackground() {
     if (this.virtualBgService != null) {
       this.virtualBgService.stopEffect();
       this.virtualBgService = null;
@@ -124,7 +123,7 @@ export class BBBVideoStream extends EventEmitter2 {
     this.isVirtualBackgroundEnabled = false;
   }
 
-  stop () {
+  stop() {
     if (this.isVirtualBackgroundEnabled) {
       this.stopVirtualBackground();
     }

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -832,6 +832,7 @@
     "app.video.notReadableError": "Could not get webcam video. Please make sure another program is not using the webcam ",
     "app.video.timeoutError": "Browser did not respond in time.",
     "app.video.genericError": "An unknown error has occurred with the device ({0})",
+    "app.video.inactiveError": "Your webcam stopped unexpectedly. Please review your browser's permissions",
     "app.video.mediaTimedOutError": "Your webcam stream has been interrupted. Try sharing it again",
     "app.video.mediaFlowTimeout1020": "Media could not reach the server (error 1020)",
     "app.video.suggestWebcamLock": "Enforce lock setting to viewers webcams?",


### PR DESCRIPTION
### What does this PR do?

- [refactor(webcam): fix linter errors in BBBVideoStream](https://github.com/bigbluebutton/bigbluebutton/commit/e93440e15a098cf27a5bc1876f28439e67f53ed2)
  * It's a bit hard to work when everything is painted red in VIM
- [fix(webcam): handle stream inactivation/gUM revocations](https://github.com/bigbluebutton/bigbluebutton/commit/029c957b2290067b6f6f6eb86f05d79dd5d0dcc3)
  * Correctly stops the camera on unexpected stream inactivation
  * Surface that to the end user via a toast (provider) and/or error view (preview)
  * Includes a change to how video-provider's error notification works - extended onWebRTCError 
  to correctly include + notify more errors (by using error.message) and thus removed a trailing `notify`
  in the ICE connection state failure handler
  
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/15370


### Motivation

See https://github.com/bigbluebutton/bigbluebutton/issues/15370

### More

n/a