### PR TITLE
build: set default epoch of 1 to bbb*akka components

### DIFF
--- a/build/packages-template/bbb-apps-akka/build.sh
+++ b/build/packages-template/bbb-apps-akka/build.sh
@@ -36,7 +36,7 @@ sed -i "s/^version .*/version := \"$VERSION\"/g" build.sbt
 if [[ -n $EPOCH && $EPOCH -gt 0 ]] ; then
     echo 'version in Debian := "'$EPOCH:$VERSION'"' >> build.sbt
 else
-    echo 'version in Debian := "'$VERSION-$BUILD'"' >> build.sbt
+    echo 'version in Debian := "'1:$VERSION-$BUILD'"' >> build.sbt
 fi
 sbt update
 sbt debian:packageBin

--- a/build/packages-template/bbb-fsesl-akka/build.sh
+++ b/build/packages-template/bbb-fsesl-akka/build.sh
@@ -51,7 +51,7 @@ sed -i "s/^version .*/version := \"$VERSION\"/g" build.sbt
 if [[ -n $EPOCH && $EPOCH -gt 0 ]] ; then
     echo 'version in Debian := "'$EPOCH:$VERSION'"' >> build.sbt
 else
-    echo 'version in Debian := "'$VERSION-$BUILD'"' >> build.sbt
+    echo 'version in Debian := "'1:$VERSION-$BUILD'"' >> build.sbt
 fi
 sbt debian:packageBin
 cp ./target/*.deb ..


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Sets epoch of `1` to `bbb-apps-akka` and `bbb-fsesl-akka`
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #14957


### Motivation
The epoch is not set only for these two packages, which leads to incorrect calculation of `--version`, see #14957

```
$ dpkg -l | grep bbb-
ii  bbb-apps-akka                        2.6-19                            all          BigBlueButton Apps (Akka)
ii  bbb-config                           1:2.6-15                          amd64        BigBlueButton configuration utilities
ii  bbb-etherpad                         1:2.6-4                           amd64        The EtherPad Lite components for BigBlueButton
ii  bbb-export-annotations               1:2.6-5                           amd64        BigBlueButton Export Annotations
ii  bbb-freeswitch-core                  2:2.6-5                           amd64        BigBlueButton build of FreeSWITCH
ii  bbb-freeswitch-sounds                1:2.6-1                           amd64        FreeSWITCH Sounds
ii  bbb-fsesl-akka                       2.6-11                            all          BigBlueButton FS-ESL (Akka)
ii  bbb-html5                            1:2.6-40                          amd64        The HTML5 components for BigBlueButton
ii  bbb-html5-nodejs                     1:2.6-1                           amd64        Include a specific NodeJS version for bbb-html5
ii  bbb-learning-dashboard               1:2.6-4                           amd64        BigBlueButton bbb-learning-dashboard
ii  bbb-libreoffice-docker               1:2.6-4                           amd64        BigBlueButton setup for LibreOffice running in docker
ii  bbb-mkclean                          1:2.6-2                           amd64        Clean and optimize Matroska and WebM files
ii  bbb-pads                             1:2.6-11                          amd64        BigBlueButton Pads
ii  bbb-playback                         1:2.6-5                           amd64        BigBlueButton playback
ii  bbb-playback-presentation            1:2.6-5                           amd64        BigBluebutton playback of presentation
ii  bbb-record-core                      1:2.6-8                           amd64        BigBlueButton record and playback
ii  bbb-web                              1:2.6-14                          amd64        BigBlueButton API
ii  bbb-webhooks                         1:2.6-6                           amd64        BigBlueButton Webhooks
ii  bbb-webrtc-sfu                       1:2.6-12                          amd64        BigBlueButton WebRTC SFU
```


<!-- What inspired you to submit this pull request? -->


