### PR TITLE
fix(recording): Override configuration properties applied to 2.4 (closes #15388)

### DIFF
--- a/record-and-playback/core/scripts/post_events/post_events_analytics_callback.rb
+++ b/record-and-playback/core/scripts/post_events/post_events_analytics_callback.rb
@@ -46,7 +46,7 @@ BigBlueButton.logger = logger
 
 options = {}
 OptionParser.new do |opts|
-  opts.banner = 'Usage: ruby post_events/post_events.rb -m <meeting_id>'
+  opts.banner = 'Usage: ruby post_events/post_events_analytics_callback.rb -m <meeting_id>'
 
   opts.on('-m', '--meeting-id MEETING_ID', 'meeting_id (required)') do |m|
     options[:meeting_id] = m
@@ -152,8 +152,20 @@ begin
   # analytics_callback_url = metadata.key?("analytics-callback-url") ? metadata["analytics-callback-url"].value : nil
   unless analytics_callback_url.nil?
     BigBlueButton.logger.info("Processing events for analytics...")
+    filepathOverride = "/etc/bigbluebutton/bbb-web.properties"
+    hasOverride = File.file?(filepathOverride)
 
     bbb_props = JavaProperties::Properties.new("/usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties")
+    
+    # If the file does exists: 
+    if (hasOverride)
+      bbbOverrideProps = JavaProperties::Properties.new(filepathOverride)
+      # Override the props
+      bbbOverrideProps.each do |key, prop|
+        bbb_props[key]=prop
+      end
+    end
+
     secret = bbb_props[:securitySalt]
     external_meeting_id = metadata.attributes['meetingId']&.content
 


### PR DESCRIPTION
Only applying the code currently available in 2.5+ to 2.4. For its inclusion if / when another release comes out.