### PR TITLE
fix: add missing import in audio controls

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/styles.js
@@ -6,6 +6,7 @@ import {
   colorDanger,
   colorGrayDark,
   colorOffWhite,
+  colorWhite,
 } from '/imports/ui/stylesheets/styled-components/palette';
 
 const pulse = keyframes`


### PR DESCRIPTION
### What does this PR do?

Prevents a crash in the client when audio is muted.