### PR TITLE
fix(bbb-html5): serve compressed version of /compatibility files

### DIFF
--- a/build/packages-template/bbb-html5/bbb-html5.nginx
+++ b/build/packages-template/bbb-html5/bbb-html5.nginx
@@ -11,6 +11,7 @@ location /html5client/locales {
 }
 
 location /html5client/compatibility {
+  gzip_static on;
   alias /usr/share/meteor/bundle/programs/web.browser/app/compatibility;
 }
 


### PR DESCRIPTION
### What does this PR do?

- [fix(bbb-html5): serve compressed version of /compatibility files](https://github.com/bigbluebutton/bigbluebutton/commit/83ddc621a8902be36289ae932c48ae29661f7c48)
  * This commit serves the previously compressed files instead (thus
  reducing initial transfer size by ~1 MB).

### Closes Issue(s)

None

### Motivation

/compatibility files are compressed on build, but gzip_static on isn't set on their
nginx route == original files are being served, uncompressed.

### More

Someone should look into whether serving compressed version of the rest
of assets makes sense - it probably does.
Still pending: fonts, locales, svgs, everything under resources, ...
