### PR TITLE
refactor(audio): log VoiceUser cleanup on User remove and centralize it

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
+++ b/bigbluebutton-html5/imports/api/users/server/modifiers/removeUser.js
@@ -7,7 +7,7 @@ import clearUserInfoForRequester from '/imports/api/users-infos/server/modifiers
 import ClientConnections from '/imports/startup/server/ClientConnections';
 import UsersPersistentData from '/imports/api/users-persistent-data';
 import userEjected from '/imports/api/users/server/modifiers/userEjected';
-import VoiceUsers from '/imports/api/voice-users/';
+import clearVoiceUser from '/imports/api/voice-users/server/modifiers/clearVoiceUser';
 
 const disconnectUser = (meetingId, userId) => {
   const sessionUserId = `${meetingId}--${userId}`;
@@ -54,8 +54,9 @@ export default function removeUser(body, meetingId) {
       if (!hasMessages && !hasConnectionStatus) {
         UsersPersistentData.remove(selector);
       }
+
       Users.remove(selector);
-      VoiceUsers.remove({ intId: userId, meetingId });
+      clearVoiceUser(meetingId, userId);
     }
 
     if (!process.env.BBB_HTML5_ROLE || process.env.BBB_HTML5_ROLE === 'frontend') {

--- a/bigbluebutton-html5/imports/api/voice-users/server/modifiers/clearVoiceUser.js
+++ b/bigbluebutton-html5/imports/api/voice-users/server/modifiers/clearVoiceUser.js
@@ -1,0 +1,20 @@
+import Logger from '/imports/startup/server/logger';
+import VoiceUsers from '/imports/api/voice-users';
+
+export default function clearVoiceUser(meetingId, intId) {
+  try {
+    check(meetingId, String);
+    check(intId, String);
+
+    const numberAffected = VoiceUsers.remove({ meetingId, intId });
+
+    if (numberAffected) {
+      Logger.info(`Remove voiceUser=${intId} meeting=${meetingId} (clear)`);
+    }
+
+    return numberAffected;
+  } catch (error) {
+    Logger.error(`Error on clearing voiceUser=${intId} meeting=${meetingId}. ${error}`);
+    return 0;
+  }
+}


### PR DESCRIPTION
### What does this PR do?

- [refactor(audio): log VoiceUser cleanup on User remove and centralize it](https://github.com/bigbluebutton/bigbluebutton/commit/6331e869b9db5df85b1ea7e644ef87011254d858)
  * This commit centralizes that cleanup in a new clearVoiceUser modifier in
  voice-user as well as logs when it works.

### Closes Issue(s)

None

### Motivation

There's a VoiceUser cleanup procedure bound to the User's cleanup
routine in Meteor's server-side. That cleanup is _silent_ and does not
use a dedicated modifier from voice-user et al, which is not
straightforward and might waste a few minutes of understanding what's
happening when debugging audio collections.

### More

n/a