### PR TITLE
Add new custom gems 

### DIFF
--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -193,7 +193,6 @@ add_gems() {
       cat $FILE_TO_ADD_GEMS >> /usr/local/bigbluebutton/core/Gemfile
       pushd /usr/local/bigbluebutton/core
          bundle config unset --local deployment
-         # rm Gemfile.lock
          bundle install
          # Remove unneeded files to reduce package size
          bundle clean
@@ -232,6 +231,7 @@ usage() {
    echo "   --tointernal <external meetingId>  get the internal meeting ids for the given external meetingId"
    echo "   --toexternal <internal meetingId>  get the external meeting id for the given internal meetingId"
    echo "   --republish <internal meetingID>   republish the recording for meetingID. (Only for Matterhorn Integration)"
+   echo "   --addcustomgems                    rebuild and install new custom gems (if /etc/bigbluebutton/recording/GemsToAdd is set with the new gems)"
    #echo "   --rearchive [meetingId]            rearchive the recording (created before a restart)"
    echo
 }

--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -185,6 +185,26 @@ check_path_owner_group() {
    fi
 }
 
+add_gems() {
+   echo "Checking for adding gems file..."
+   FILENAME_OF_GEMS="GemsToAdd"
+   FILE_TO_ADD_GEMS="/etc/bigbluebutton/recording/$FILENAME_OF_GEMS"
+   if [ -f "$FILE_TO_ADD_GEMS" ]; then
+      cat $FILE_TO_ADD_GEMS >> /usr/local/bigbluebutton/core/Gemfile
+      pushd /usr/local/bigbluebutton/core
+         bundle config unset --local deployment
+         # rm Gemfile.lock
+         bundle install
+         # Remove unneeded files to reduce package size
+         bundle clean
+         bundle config set --local deployment true
+      popd
+      mv $FILE_TO_ADD_GEMS "$FILE_TO_ADD_GEMS-used"
+   else
+      echo "No file to add gems, please insert one first"
+   fi
+}
+
 usage() {
    echo "BigBlueButton Recording Diagnostic Utility (BigBlueButton Version $BIGBLUEBUTTON_RELEASE)"
    echo
@@ -362,6 +382,13 @@ while [ $# -gt 0 ]; do
          shift
       fi
       TOINTERNAL=1
+      shift
+      continue
+   fi
+
+   if [ "$1" = "-addcustomgems" ] || [ "$1" = "--addcustomgems" ]; then
+      need_root
+      ADD_CUSTOM_GEMS=1
       shift
       continue
    fi
@@ -962,4 +989,8 @@ if [ $DEBUG ]; then
    fi
 
    exit 0
+fi
+
+if [ $ADD_CUSTOM_GEMS ]; then
+   add_gems
 fi


### PR DESCRIPTION
### What does this PR do?

This PR makes it possible to add new custom gems to the recording and post scripts.

### Motivation

As discussed, some users need to use other dependencies not previously installed, such as rest-client for the `post_event` scripts.

### More

In order to use/test this feature: 
 - Create a folder `/etc/bigbluebutton/recording` (all overridings will be there);
 - Create a GemsToAdd file and insert your custom dependencies such as if it was in common `Gemfile` (versions and all).
 - Make sure the new bbb-record script is placed correctly:
   - You can replace the old bbb-record to the new one in `/bin/bbb-record`;
 - Run the command `bbb-record --addcustomgems` to build those dependencies;

#### From now on, the scripts that follows are used to test the feature:

Place the following content in `/etc/bigbluebutton/recording` as `/etc/bigbluebutton/recording/GemsToAdd`

```bash
gem 'unicode-emoji', '~> 1.0', '>= 1.0.3'
gem 'rest-client'
```

The following ruby script must be placed in `/usr/local/bigbluebutton/core/scripts/post_events` as `sample_analytics_sender.rb`.

```ruby
#!/usr/bin/env ruby
# frozen_string_literal: true

require '../../core/lib/recordandplayback'
#require 'rubygems'
#require 'bundler/setup'
require 'optimist'
require 'yaml'
require 'fileutils'
require 'bbbevents'
require 'json'
require 'uri'
require 'logger'
require 'rest-client'
require 'redis'
require "unicode/emoji"

opts = Optimist.options do
  opt :meeting_id, 'Meeting id to archive', type: String
end

meeting_id = opts[:meeting_id]

logger = Logger.new("/var/log/bigbluebutton/sender-events-#{meeting_id}.log", 'daily')
BigBlueButton.logger = logger
BigBlueButton.logger.info("Publishing #{meeting_id} using multipart upload")
string = "String which contains all kinds of emoji:

- Singleton Emoji: 😴
- Textual singleton Emoji with Emoji variation: ▶️
- Emoji with skin tone modifier: 🛌🏽
- Sub-Region flag: 🏴󠁧󠁢󠁳󠁣󠁴󠁿
- Keycap sequence: 2️⃣
- Sequence using ZWJ (zero width joiner): 🤾🏽<200d>♀️

"
BigBlueButton.logger.info(string.scan(Unicode::Emoji::REGEX).inspect)
```
- Make sure that `defaultKeepEvents=true` is set in `/usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties`, if not, set it and reload bbb-web;
- Record anything;
- When finished, as the `post_event` script can tell us, there will be some logs in `/var/log/bigbluebutton/sender-events-<meeting-ID>.log`