### PR TITLE
feat: Add config option for HTML5 settings storage

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/settings/index.js
+++ b/bigbluebutton-html5/imports/ui/services/settings/index.js
@@ -1,6 +1,10 @@
-import Storage from '/imports/ui/services/storage/session';
+import {default as LocalStorage} from '/imports/ui/services/storage/local';
+import {default as SessionStorage} from '/imports/ui/services/storage/session';
+
 import _ from 'lodash';
 import { makeCall } from '/imports/ui/services/api';
+
+const APP_CONFIG = Meteor.settings.public.app;
 
 const SETTINGS = [
   'application',
@@ -55,6 +59,7 @@ class Settings {
   }
 
   loadChanged() {
+    const Storage = (APP_CONFIG.userSettingsStorage == 'local') ? LocalStorage : SessionStorage;
     const savedSettings = {};
 
     SETTINGS.forEach((s) => {
@@ -72,6 +77,7 @@ class Settings {
   }
 
   save(settings = CHANGED_SETTINGS) {
+    const Storage = (APP_CONFIG.userSettingsStorage == 'local') ? LocalStorage : SessionStorage;
     if (settings === CHANGED_SETTINGS) {
       Object.keys(this).forEach((k) => {
         const values = this[k].value;

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -110,6 +110,13 @@ public:
     enableNetworkStats: true
     # Enable the button to allow users to copy network stats to clipboard
     enableCopyNetworkStatsButton: true
+    # where should client settings be stored? if you run a single BBB server or
+    # a cluster with a reverse proxy in front of it, you may set this to 'local'
+    # See https://docs.bigbluebutton.org/admin/clusterproxy.html
+    # allowed values:
+    # 'session' -> settings are stored in browser sessionStorage
+    # 'local' -> settings are stored in browser localStorage
+    userSettingsStorage: session
     defaultSettings:
       application:
         animations: true


### PR DESCRIPTION
### What does this PR do?

It adds a config option to configure the HTML5 client settings storage. 
The default value is same behaviour as without this patch.

### Motivation

When BBB is run as a single node or in a scaleout setup with a cluster
proxy in front (see https://docs.bigbluebutton.org/admin/clusterproxy.html) it
is useful to store client settings in browser `localStorage` instead of
`sessionStorage`. If `localStorage` is configured then the client will keep seetings
like notifications for user joining, chat etc across meetings.

It is not advisable to set the setting to `local` in a setup of multiple BBB
nodes without a cluster proxy in front of it because this would lead to
unexpected behaviour at users. The browser would store settings for each server
and for users it would look like BBB is sometimes store the settings and
sometimes not.

It adds the new setting

```yaml
public:
  app:
    userSettingsStorage: (session|local)
```
