### PR TITLE
fix: breakout remaining time label

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-remaining-time/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-remaining-time/container.jsx
@@ -61,11 +61,14 @@ class breakoutRemainingTimeContainer extends React.Component {
       return null;
     }
     if (bold) {
+      const words = message.split(' ');
+      const time = words.pop();
+      const text = words.join(' ');
       return (
         <BreakoutRemainingTimeComponent>
-          <Text>{message.split(' ')[0]}</Text>
+          <Text>{text}</Text>
           <br />
-          <Time>{message.split(' ')[1]}</Time>
+          <Time>{time}</Time>
         </BreakoutRemainingTimeComponent>
       );
     }


### PR DESCRIPTION
Fixes the breakout rooms remaining time label in languages whose translation for the word "Duration" is more than one word.

_For example, Persian (Farsi)_
![2022-07-20_12-26](https://user-images.githubusercontent.com/62393923/180021851-60a086a3-7f46-438b-b9dc-d141d34469cc.png)

Closes #15397