### PR TITLE
fix: Adding notification to waiting users list

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
@@ -9,6 +9,7 @@ import { PANELS, ACTIONS } from '../layout/enums';
 import Settings from '/imports/ui/services/settings';
 import browserInfo from '/imports/utils/browserInfo';
 import Header from '/imports/ui/components/common/control-header/component';
+import { notify } from '/imports/ui/services/notification';
 
 const intlMessages = defineMessages({
   waitingUsersTitle: {
@@ -252,10 +253,19 @@ const WaitingUsers = (props) => {
     setRememberChoice(checked);
   };
 
-  const changePolicy = (shouldExecutePolicy, policyRule, cb) => () => {
+  const changePolicy = (shouldExecutePolicy, policyRule, cb) => () => {   
     if (shouldExecutePolicy) {
       changeGuestPolicy(policyRule);
     }
+
+    if (policyRule === 'ALWAYS_ACCEPT_AUTH') {
+      notify("Action applied to waiting users: " + intl.formatMessage(intlMessages.allowAllAuthenticated).toUpperCase(), 'success');
+    }else if (policyRule === 'ALWAYS_ACCEPT') {
+      notify("Action applied to waiting users: " + intl.formatMessage(intlMessages.allowEveryone).toUpperCase(), 'success');
+    }else if(policyRule === 'ALWAYS_DENY') {
+      notify("Action applied to waiting users: " + intl.formatMessage(intlMessages.denyEveryone).toUpperCase(), 'success');
+    }
+
     closePanel();
     return cb();
   };

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
@@ -80,6 +80,10 @@ const intlMessages = defineMessages({
     id: 'app.userList.guest.denyLabel',
     description: 'Deny guest button label',
   },
+  feedbackMessage: {
+    id: 'app.userList.guest.feedbackMessage',
+    description: 'Feedback message moderator action',
+  },
 });
 
 const ALLOW_STATUS = 'ALLOW';
@@ -253,20 +257,15 @@ const WaitingUsers = (props) => {
     setRememberChoice(checked);
   };
 
-  const changePolicy = (shouldExecutePolicy, policyRule, cb) => () => {   
+  const changePolicy = (shouldExecutePolicy, policyRule, cb, message) => () => {   
     if (shouldExecutePolicy) {
       changeGuestPolicy(policyRule);
     }
 
-    if (policyRule === 'ALWAYS_ACCEPT_AUTH') {
-      notify("Action applied to waiting users: " + intl.formatMessage(intlMessages.allowAllAuthenticated).toUpperCase(), 'success');
-    }else if (policyRule === 'ALWAYS_ACCEPT') {
-      notify("Action applied to waiting users: " + intl.formatMessage(intlMessages.allowEveryone).toUpperCase(), 'success');
-    }else if(policyRule === 'ALWAYS_DENY') {
-      notify("Action applied to waiting users: " + intl.formatMessage(intlMessages.denyEveryone).toUpperCase(), 'success');
-    }
-
     closePanel();
+    
+    notify(intl.formatMessage(intlMessages.feedbackMessage) + message.toUpperCase(), 'success');
+    
     return cb();
   };
 
@@ -276,7 +275,7 @@ const WaitingUsers = (props) => {
       color={color}
       label={message}
       size="lg"
-      onClick={changePolicy(rememberChoice, policy, action)}
+      onClick={changePolicy(rememberChoice, policy, action, message)}
     />
   );
 

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -643,6 +643,7 @@
     "app.userList.guest.privateMessageLabel": "Message",
     "app.userList.guest.acceptLabel": "Accept",
     "app.userList.guest.denyLabel": "Deny",
+    "app.userList.guest.feedbackMessage": "Action applied: ",
     "app.user-info.title": "Directory Lookup",
     "app.toast.breakoutRoomEnded": "The breakout room ended.  Please rejoin in the audio.",
     "app.toast.chat.public": "New Public Chat message",


### PR DESCRIPTION
### What does this PR do?

Implements a notification to the action chosen by the moderator inside the waiting user's list.
![nots](https://user-images.githubusercontent.com/19312495/180273153-2034e034-1518-4cd2-8506-91aa7e7bbbc6.gif)


### Closes Issue(s)

Closes #15127