### PR TITLE
fix(layout): set external-video/screen share initial states on all layouts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -183,6 +183,12 @@ const CustomLayout = (props) => {
           cameraDock: {
             numCameras: cameraDockInput.numCameras,
           },
+          externalVideo: {
+            hasExternalVideo: input.externalVideo.hasExternalVideo,
+          },
+          screenShare: {
+            hasScreenShare: input.screenShare.hasScreenShare,
+          },
         }, INITIAL_INPUT_STATE),
       });
     }

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -95,6 +95,12 @@ const PresentationFocusLayout = (props) => {
           cameraDock: {
             numCameras: cameraDockInput.numCameras,
           },
+          externalVideo: {
+            hasExternalVideo: input.externalVideo.hasExternalVideo,
+          },
+          screenShare: {
+            hasScreenShare: input.screenShare.hasScreenShare,
+          },
         }, INITIAL_INPUT_STATE),
       });
     } else {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -128,6 +128,12 @@ const VideoFocusLayout = (props) => {
             cameraDock: {
               numCameras: cameraDockInput.numCameras,
             },
+            externalVideo: {
+              hasExternalVideo: input.externalVideo.hasExternalVideo,
+            },
+            screenShare: {
+              hasScreenShare: input.screenShare.hasScreenShare,
+            },
           },
           INITIAL_INPUT_STATE,
         ),


### PR DESCRIPTION
### What does this PR do?

- [fix(layout): set external-video/screen share initial states on all layouts](https://github.com/bigbluebutton/bigbluebutton/commit/8f77f4cd1f12ff5f1460253f028c659b81adba22)
  * This commit guarantees those features are taken into account when
  populating initial input states for Focus On*/Custom layouts.

### Closes Issue(s)

None

### Motivation

Only smart layout takes screen sharing/external video states in account
when populating its initial state. The others don't, and that causes
some weird issues when switching back-and-forth between layout types due
to their input states becoming inconsistent - ie having an active screen
sharing and transitioning from Smart to a buggy layout would mark screen sharing
as false and pollute its state for subsequent layouts. 

A practical example of this issue: smart layout isn't "idempotent"
after switching between custom and smart a couple of times even
if all elements in the UI remained with the same sizes.

### More

n/a
