### PR TITLE
fix: whiteboard access avatar icon in RTL mode

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-avatar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-avatar/styles.js
@@ -179,7 +179,7 @@ const Avatar = styled.div`
   ${({ whiteboardAccess }) => whiteboardAccess && `
     &:before {
       content: "\\00a0\\e925\\00a0";
-      padding: ${mdPaddingY};
+      padding: ${mdPaddingY} !important;
       border-radius: 50% !important;
       opacity: 1;
       top: ${userIndicatorsOffset};
@@ -193,6 +193,7 @@ const Avatar = styled.div`
         left: auto;
         right: ${userIndicatorsOffset};
         letter-spacing: -.33rem;
+        transform: scale(-1, 1);
       }
     }
   `}


### PR DESCRIPTION
Before
![2022-07-22_10-17](https://user-images.githubusercontent.com/62393923/180447485-9c1bf813-6781-408b-a10b-b2efbf5b835c.png)

After
![2022-07-22_10-13](https://user-images.githubusercontent.com/62393923/180447535-897a7416-dae2-483d-9887-9bd69c7ef679.png)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes none, but related to https://github.com/bigbluebutton/bigbluebutton/issues/15168#issuecomment-1186213746.