### PR TITLE
fix(layout): use actual screen share size when calculating smart layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -188,6 +188,8 @@ const CustomLayout = (props) => {
           },
           screenShare: {
             hasScreenShare: input.screenShare.hasScreenShare,
+            width: input.screenShare.width,
+            height: input.screenShare.height,
           },
         }, INITIAL_INPUT_STATE),
       });

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -100,6 +100,8 @@ const PresentationFocusLayout = (props) => {
           },
           screenShare: {
             hasScreenShare: input.screenShare.hasScreenShare,
+            width: input.screenShare.width,
+            height: input.screenShare.height,
           },
         }, INITIAL_INPUT_STATE),
       });

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -124,7 +124,9 @@ const SmartLayout = (props) => {
           },
           screenShare: {
             hasScreenShare: screenShareInput.hasScreenShare,
-          }
+            width: screenShareInput.width,
+            height: screenShareInput.height,
+          },
         }, INITIAL_INPUT_STATE),
       });
     }
@@ -224,7 +226,29 @@ const SmartLayout = (props) => {
     };
   };
 
-  const calculatesMediaBounds = (mediaAreaBounds, slideSize, sidebarSize) => {
+  const calculatesScreenShareSize = (mediaAreaBounds) => {
+    const { width = 0, height = 0 } = screenShareInput;
+
+    if (width === 0 && height === 0) return { width, height };
+
+    let screeShareWidth;
+    let screeShareHeight;
+
+    screeShareWidth = (width * mediaAreaBounds.height) / height;
+    screeShareHeight = mediaAreaBounds.height;
+
+    if (screeShareWidth > mediaAreaBounds.width) {
+      screeShareWidth = mediaAreaBounds.width;
+      screeShareHeight = (height * mediaAreaBounds.width) / width;
+    }
+
+    return {
+      width: screeShareWidth,
+      height: screeShareHeight,
+    };
+  }
+
+  const calculatesMediaBounds = (mediaAreaBounds, slideSize, sidebarSize, screenShareSize) => {
     const { isOpen, currentSlide } = presentationInput;
     const { hasExternalVideo } = externalVideoInput;
     const { hasScreenShare } = screenShareInput;
@@ -252,11 +276,13 @@ const SmartLayout = (props) => {
       return mediaBounds;
     }
 
+    const mediaContentSize = hasScreenShare ? screenShareSize : slideSize;
+
     if (cameraDockInput.numCameras > 0 && !cameraDockInput.isDragging) {
-      if (slideSize.width !== 0 && slideSize.height !== 0 && !hasExternalVideo && !hasScreenShare) {
-        if (slideSize.width < mediaAreaBounds.width && !isMobile) {
-          if (slideSize.width < (mediaAreaBounds.width * 0.8)) {
-            mediaBounds.width = slideSize.width;
+      if (mediaContentSize.width !== 0 && mediaContentSize.height !== 0 && !hasExternalVideo) {
+        if (mediaContentSize.width < mediaAreaBounds.width && !isMobile) {
+          if (mediaContentSize.width < (mediaAreaBounds.width * 0.8)) {
+            mediaBounds.width = mediaContentSize.width;
           } else {
             mediaBounds.width = mediaAreaBounds.width * 0.8;
           }
@@ -267,8 +293,8 @@ const SmartLayout = (props) => {
           mediaBounds.left = !isRTL ? sizeValue : null;
           mediaBounds.right = isRTL ? sidebarSize : null;
         } else {
-          if (slideSize.height < (mediaAreaBounds.height * 0.8)) {
-            mediaBounds.height = slideSize.height;
+          if (mediaContentSize.height < (mediaAreaBounds.height * 0.8)) {
+            mediaBounds.height = mediaContentSize.height;
           } else {
             mediaBounds.height = mediaAreaBounds.height * 0.8;
           }
@@ -325,8 +351,14 @@ const SmartLayout = (props) => {
     const navbarBounds = calculatesNavbarBounds(mediaAreaBounds);
     const actionbarBounds = calculatesActionbarBounds(mediaAreaBounds);
     const slideSize = calculatesSlideSize(mediaAreaBounds);
+    const screenShareSize = calculatesScreenShareSize(mediaAreaBounds);
     const sidebarSize = sidebarContentWidth.width + sidebarNavWidth.width;
-    const mediaBounds = calculatesMediaBounds(mediaAreaBounds, slideSize, sidebarSize);
+    const mediaBounds = calculatesMediaBounds(
+      mediaAreaBounds,
+      slideSize,
+      sidebarSize,
+      screenShareSize,
+    );
     const cameraDockBounds = calculatesCameraDockBounds(mediaAreaBounds, mediaBounds, sidebarSize);
     const horizontalCameraDiff = cameraDockBounds.isCameraHorizontal
       ? cameraDockBounds.width + (camerasMargin * 2)

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -133,6 +133,8 @@ const VideoFocusLayout = (props) => {
             },
             screenShare: {
               hasScreenShare: input.screenShare.hasScreenShare,
+              width: input.screenShare.width,
+              height: input.screenShare.height,
             },
           },
           INITIAL_INPUT_STATE,

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -16,6 +16,7 @@ import {
   screenshareHasEnded,
   screenshareHasStarted,
   getMediaElement,
+  getMediaElementDimensions,
   attachLocalPreviewStream,
   setVolume,
   getVolume,
@@ -67,6 +68,7 @@ const intlMessages = defineMessages({
 const ALLOW_FULLSCREEN = Meteor.settings.public.app.allowFullscreen;
 const MOBILE_HOVER_TIMEOUT = 5000;
 const MEDIA_FLOW_PROBE_INTERVAL = 500;
+const SCREEN_SIZE_DISPATCH_INTERVAL = 500;
 
 class ScreenshareComponent extends React.Component {
   static renderScreenshareContainerInside(mainText) {
@@ -89,6 +91,8 @@ class ScreenshareComponent extends React.Component {
     };
 
     this.onLoadedData = this.onLoadedData.bind(this);
+    this.onLoadedMetadata = this.onLoadedMetadata.bind(this);
+    this.onVideoResize = this.onVideoResize.bind(this);
     this.handleAllowAutoplay = this.handleAllowAutoplay.bind(this);
     this.handlePlayElementFailed = this.handlePlayElementFailed.bind(this);
     this.failedMediaElements = [];
@@ -96,6 +100,11 @@ class ScreenshareComponent extends React.Component {
     this.onSwitched = this.onSwitched.bind(this);
     this.handleOnVolumeChanged = this.handleOnVolumeChanged.bind(this);
     this.handleOnMuted = this.handleOnMuted.bind(this);
+    this.debouncedDispatchScreenShareSize = _.debounce(
+      this.dispatchScreenShareSize,
+      SCREEN_SIZE_DISPATCH_INTERVAL,
+      { leading: false, trailing: true },
+    );
 
     this.volume = getVolume();
     this.mobileHoverSetTimeout = null;
@@ -244,6 +253,44 @@ class ScreenshareComponent extends React.Component {
     }, MEDIA_FLOW_PROBE_INTERVAL);
   }
 
+  dispatchScreenShareSize() {
+    const {
+      layoutContextDispatch,
+    } = this.props;
+
+    const { width, height } = getMediaElementDimensions();
+    const value = {
+      width,
+      height,
+      browserWidth: window.innerWidth,
+      browserHeight: window.innerHeight,
+    }
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SCREEN_SHARE_SIZE,
+      value,
+    });
+  }
+
+  onVideoResize() {
+    // Debounced version of the dispatcher to pace things out - we don't want
+    // to hog the CPU just for resize recalculations...
+    this.debouncedDispatchScreenShareSize();
+  }
+
+  onLoadedMetadata() {
+    const element = getMediaElement();
+
+    // Track HTMLVideo's resize event to propagate stream size changes to the
+    // layout engine. See this.onVideoResize;
+    if (element && typeof element.onresize !== 'function') {
+      element.onresize = this.onVideoResize;
+    }
+
+    // Dispatch the initial stream size to the layout engine
+    this.dispatchScreenShareSize();
+  }
+
   onLoadedData() {
     this.setState({ loaded: true });
   }
@@ -385,6 +432,7 @@ class ScreenshareComponent extends React.Component {
           : { maxHeight: '25%', width: '25%', height: '25%' }}
         playsInline
         onLoadedData={this.onLoadedData}
+        onLoadedMetadata={this.onLoadedMetadata}
         ref={(ref) => {
           this.videoTag = ref;
         }}

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -114,6 +114,14 @@ const getMediaElement = () => {
   return document.getElementById(SCREENSHARE_MEDIA_ELEMENT_NAME);
 }
 
+const getMediaElementDimensions = () => {
+  const element = getMediaElement();
+  return {
+    width: element?.videoWidth ?? 0,
+    height: element?.videoHeight ?? 0,
+  };
+};
+
 const setVolume = (volume) => {
   KurentoBridge.setVolume(volume);
 };
@@ -255,6 +263,7 @@ export {
   isSharingScreen,
   setSharingScreen,
   getMediaElement,
+  getMediaElementDimensions,
   attachLocalPreviewStream,
   isGloballyBroadcasting,
   getStats,


### PR DESCRIPTION
### What does this PR do?

- [fix(layout): use actual screen share size when calculating smart layout](https://github.com/bigbluebutton/bigbluebutton/pull/15429/commits/b8811bafd410feb4460a902048e7e169d12a5836)

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/14691

### Motivation

Smart layout (et al) presumes screen sharing will always use 100%
width of the media area. That causes cameras to always be positioned on
top, which is not always the optimal position depending on the viewport
and stream aspect ratio/resolution - so space is wasted.

### More

This commit uses the actual screen sharing video size as provided by
HTMLVideo's videoWidth/videoHeight properties. The calculation uses the
same logic as the one used for presentation/slides, which should make it
a bit familiar.

There's also a handler for HTMLVideo's `resize` event for those browsers
that support it - which enables handling of variable-sized screen
sharing streams. That handler is debounced at 500 ms to prevent
excessive CPU use.

Extra testing is needed with the widest range possible of
browsers/environments and feature combinations. 

~Draft until I've verified fallback values (width 0/height 0);
they should behave as they currently do (100% width) - but I'm not sure it's doing that.
Important to prevent edge cases.~
