### PR TITLE
test: Don't wait for screenshareConnecting

### DIFF
--- a/bigbluebutton-tests/playwright/screenshare/util.js
+++ b/bigbluebutton-tests/playwright/screenshare/util.js
@@ -3,12 +3,10 @@ const { VIDEO_LOADING_WAIT_TIME } = require('../core/constants');
 
 async function startScreenshare(test) {
   await test.waitAndClick(e.startScreenSharing);
-  await test.waitForSelector(e.screenshareConnecting);
   await test.waitForSelector(e.screenShareVideo, VIDEO_LOADING_WAIT_TIME);
 }
 
 async function getScreenShareBreakoutContainer(test) {
-  await test.waitForSelector(e.screenshareConnecting, VIDEO_LOADING_WAIT_TIME);
   await test.hasElement(e.screenShareVideo, VIDEO_LOADING_WAIT_TIME);
 }
 


### PR DESCRIPTION
Waiting for `e.screenshareConnecting` creates a race condition if the
screen share connects quickly, before the test waits for the
screenshareConnecting message.
