### PR TITLE
fix(recording): Fix typo in presentation scripts

### DIFF
--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -39,7 +39,7 @@ filepathPresOverride = "/etc/bigbluebutton/recording/presentation.yml"
 hasOverride = File.file?(filepathPresOverride)
 if (hasOverride)
   presOverrideProps = YAML::load(File.open(filepathPresOverride))
-  $presentation_props = $presentation_props.merge(presOverrideProps)
+  @presentation_props = @presentation_props.merge(presOverrideProps)
 end
 
 # There's a couple of places where stuff is mysteriously divided or multiplied


### PR DESCRIPTION
### What does this PR do?

It fixes a typo in presentation script that was generating nil errors.

### Closes Issue(s)

Closes #15439

