### PR TITLE
fix: In Android Screen share and Share external video not showing to newly joined

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -155,6 +155,14 @@ const CustomLayout = (props) => {
           cameraDock: {
             numCameras: cameraDockInput.numCameras,
           },
+          externalVideo: {
+            hasExternalVideo: input.externalVideo.hasExternalVideo,
+          },
+          screenShare: {
+            hasScreenShare: input.screenShare.hasScreenShare,
+            width: input.screenShare.width,
+            height: input.screenShare.height,
+          },
         }, INITIAL_INPUT_STATE),
       });
     } else {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -131,6 +131,14 @@ const PresentationFocusLayout = (props) => {
           cameraDock: {
             numCameras: cameraDockInput.numCameras,
           },
+          externalVideo: {
+            hasExternalVideo: input.externalVideo.hasExternalVideo,
+          },
+          screenShare: {
+            hasScreenShare: input.screenShare.hasScreenShare,
+            width: input.screenShare.width,
+            height: input.screenShare.height,
+          },
         }, INITIAL_INPUT_STATE),
       });
     }

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -91,6 +91,14 @@ const SmartLayout = (props) => {
           cameraDock: {
             numCameras: cameraDockInput.numCameras,
           },
+          externalVideo: {
+            hasExternalVideo: externalVideoInput.hasExternalVideo,
+          },
+          screenShare: {
+            hasScreenShare: screenShareInput.hasScreenShare,
+            width: screenShareInput.width,
+            height: screenShareInput.height,
+          },
         }, INITIAL_INPUT_STATE),
       });
     } else {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -97,6 +97,14 @@ const VideoFocusLayout = (props) => {
             cameraDock: {
               numCameras: cameraDockInput.numCameras,
             },
+            externalVideo: {
+              hasExternalVideo: input.externalVideo.hasExternalVideo,
+            },
+            screenShare: {
+              hasScreenShare: input.screenShare.hasScreenShare,
+              width: input.screenShare.width,
+              height: input.screenShare.height,
+            },
           },
           INITIAL_INPUT_STATE,
         ),


### PR DESCRIPTION
### What does this PR do?

Sets initial values for external video/screnshare for mobile devices.

### Closes Issue(s)
Closes #15453