### PR TITLE
Fix: use grails configuration for CORS settings

### DIFF
--- a/bigbluebutton-web/bbb-web.nginx
+++ b/bigbluebutton-web/bbb-web.nginx
@@ -9,32 +9,16 @@
 
                     # Workaround IE refusal to set cookies in iframe
                     add_header P3P 'CP="No P3P policy available"';
-                    if ($bbb_loadbalancer_node) {
-                        add_header 'Access-Control-Allow-Origin' $bbb_loadbalancer_node always;
-                        add_header 'Access-Control-Allow-Credentials' 'true' always;
-                    }
 		}
 
 
 		location ~ "^\/bigbluebutton\/presentation\/(?<prestoken>[a-zA-Z0-9_-]+)/upload$" {
-			# Grails can't handle CORS OPTION preflight requests correctly -> lets do this in nginx
-			if ($request_method = 'OPTIONS') {
-				add_header 'Access-Control-Allow-Origin' $bbb_loadbalancer_node always;
-				add_header 'Access-Control-Allow-Credentials' 'true' always;
-				add_header 'Content-Type' 'text/plain; charset=utf-8';
-				add_header 'Content-Length' 0;
-				return 204;
-			}
 			proxy_pass         http://127.0.0.1:8090;
 			proxy_redirect     default;
 			proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
 
 			# Workaround IE refusal to set cookies in iframe
 			add_header P3P 'CP="No P3P policy available"';
-			if ($bbb_loadbalancer_node) {
-				add_header 'Access-Control-Allow-Origin' $bbb_loadbalancer_node always;
-				add_header 'Access-Control-Allow-Credentials' 'true' always;
-			}
 
 			# high limit for presentation as bbb-web will reject upload if larger than configured
 			client_max_body_size       1000m;
@@ -73,9 +57,6 @@
 			proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
 			# Workaround IE refusal to set cookies in iframe
 			add_header P3P 'CP="No P3P policy available"';
-			if ($bbb_loadbalancer_node) {
-				add_header 'Access-Control-Allow-Origin' $bbb_loadbalancer_node always;
-			}
 		}
 
 		location = /bigbluebutton/presentation/checkPresentation {
@@ -87,6 +68,7 @@
 			proxy_set_header        X-Original-URI $request_uri;
 			proxy_set_header	Content-Length "";
 			proxy_set_header	X-Original-Content-Length $http_content_length;
+			proxy_set_header	X-Original-Method $request_method;
 
 			# high limit for presentation as bbb-web will reject upload if larger than configured
 			client_max_body_size       1000m;
@@ -129,9 +111,6 @@
         location ~ "^/bigbluebutton\/textTrack\/(?<textTrackToken>[a-zA-Z0-9]+)\/(?<recordId>[a-zA-Z0-9_-]+)\/(?<textTrack>.+)$" {
             # Workaround IE refusal to set cookies in iframe
             add_header P3P 'CP="No P3P policy available"';
-            if ($bbb_loadbalancer_node) {
-                add_header 'Access-Control-Allow-Origin' $bbb_loadbalancer_node always;
-            }
 
             # Allow 30M uploaded presentation document.
             client_max_body_size       30m;

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/PresentationController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/PresentationController.groovy
@@ -48,8 +48,26 @@ class PresentationController {
       def originalContentLengthString = request.getHeader("x-original-content-length")
 
       def originalContentLength = 0
-      if (originalContentLengthString.isNumber()) {
+      // x-original-content-length may be missing (for example in CORS OPTION requests)
+      if (null != originalContentLengthString && originalContentLengthString.isNumber()) {
         originalContentLength = originalContentLengthString as int
+      }
+      if (request.getHeader("x-original-method") == 'OPTIONS') {
+        if (meetingService.authzTokenIsValid(presentationToken)) {
+          log.debug "OPTIONS SUCCESS \n"
+          response.setStatus(200)
+          response.addHeader("Cache-Control", "no-cache")
+          response.contentType = 'plain/text'
+          response.outputStream << 'upload-success';
+          return;
+        } else {
+          log.debug "OPTIONS FAIL\n"
+          response.setStatus(403)
+          response.addHeader("Cache-Control", "no-cache")
+          response.contentType = 'plain/text'
+          response.outputStream << 'upload-fail';
+          return;
+        }
       }
 
       if (null != presentationToken


### PR DESCRIPTION
### What does this PR do?

It removes quirks from bbb-web nginx config and uses grails config options to properly support CORS requests. CORS requests are only required if you run a cluster proxy setup as described in https://docs.bigbluebutton.org/admin/clusterproxy.html

### Closes Issue(s)

Closes #15436 


### Motivation

Grails can handle CORS on its own. It just has to be configured in
`/etc/bigbluebutton/bbb-web.properties`:

~~~
grails.cors.enabled=true
grails.cors.allowedOrigins=https://bbb-proxy.example.com
grails.cors.allowCredentials=true
~~~

This is a breaking change of the nginx config if (and only if) you run a
cluster setup as described in
https://docs.bigbluebutton.org/admin/clusterproxy.html

**If** you run such a setup, you **need** to change
`/etc/bigbluebutton/bbb-web.properties`. Otherwise users won't be able
to join meetings, upload slides etc.

The change in `PresentationController.groovy` fixes the handling of
`OPTIONS` requests in the `/bigbluebutton/presentation/checkPresentation`
handler.

<!-- What inspired you to submit this pull request? -->

### More

:warning: If you merge this into 2.5 operators must be warned that if they run a cluster proxy setup they must tweak their configuration
- [ ] documentation in https://docs.bigbluebutton.org/admin/clusterproxy.html has to be adjusted.
- [ ] if requiring config changes from operators is not acceptable in 2.5, the changes in `PresentationController.groovy` still fix a bug.

