### PR TITLE
fix: Any webcam start/stop steals focus from typing

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
@@ -79,6 +79,7 @@ class MessageForm extends PureComponent {
     this.setMessageHint = this.setMessageHint.bind(this);
     this.handleUserTyping = _.throttle(this.handleUserTyping.bind(this), 2000, { trailing: false });
     this.typingIndicator = CHAT_CONFIG.typingIndicator.enabled;
+    this.forceFocus = _.throttle(this.forceFocus.bind(this), 2000, { trailing: false });
   }
 
   componentDidMount() {
@@ -174,6 +175,8 @@ class MessageForm extends PureComponent {
   }
 
   handleMessageKeyDown(e) {
+    this.forceFocus();
+
     // TODO Prevent send message pressing enter on mobile and/or virtual keyboard
     if (e.keyCode === 13 && !e.shiftKey) {
       e.preventDefault();
@@ -191,6 +194,13 @@ class MessageForm extends PureComponent {
     const { startUserTyping, chatId } = this.props;
     if (error || !this.typingIndicator) return;
     startUserTyping(chatId);
+  }
+
+  forceFocus() {
+    if (this.textarea) {
+      this.textarea.blur();
+      this.textarea.focus();
+    }
   }
 
   handleMessageChange(e) {


### PR DESCRIPTION
### What does this PR do?

Restores focus to chat input if the focus is lost when a user starts/stops webcam sharing.

### Closes Issue(s)
Closes #15422

### More
When a user starts or stops sharing webcam, the message form input (if focused) enters a state where `onChange` events are not triggered (but `onKeyDown` are). This PR restores it to the "real" focused state by forcing blur/focus on the element when onKeyDown event is triggered. 

As @JoVictorNunes [mentioned](https://github.com/bigbluebutton/bigbluebutton/issues/15422#issuecomment-1198204310), the bug only happens in Chrome browser.