### PR TITLE
fix(recording): bump bbb_version to 2.6.0 in events.xml

### DIFF
--- a/record-and-playback/core/scripts/bigbluebutton.yml
+++ b/record-and-playback/core/scripts/bigbluebutton.yml
@@ -1,4 +1,4 @@
-bbb_version: '2.1.0'
+bbb_version: '2.6.0'
 raw_audio_src: /var/freeswitch/meetings
 kurento_video_src: /var/kurento/recordings
 kurento_screenshare_src: /var/kurento/screenshare

--- a/record-and-playback/presentation/scripts/process/presentation.rb
+++ b/record-and-playback/presentation/scripts/process/presentation.rb
@@ -144,6 +144,7 @@ unless FileTest.directory?(target_dir)
     metadata_file.close
     BigBlueButton.logger.info('Created an updated metadata.xml with start_time and end_time')
 
+    version_atleast_2_6_0 = BigBlueButton::Events.bbb_version_compare(@doc, 2, 6, 0)
     # Start processing raw files
     presentation_text = {}
     presentations.each do |pres|
@@ -176,7 +177,7 @@ unless FileTest.directory?(target_dir)
           1.upto(num_pages) do |page|
             BigBlueButton::Presentation.extract_png_page_from_pdf(
               page, pres_pdf, "#{target_pres_dir}/slide-#{page}.png", '1600x1600'
-            )
+            ) if !version_atleast_2_6_0
             next unless File.exist?("#{pres_dir}/textfiles/slide-#{page}.txt")
             t = File.read("#{pres_dir}/textfiles/slide-#{page}.txt", encoding: 'UTF-8')
             text["slide-#{page}"] = t.encode('UTF-8', invalid: :replace)
@@ -187,13 +188,13 @@ unless FileTest.directory?(target_dir)
       else
         BigBlueButton::Presentation.convert_image_to_png(
           images[0], "#{target_pres_dir}/slide-1.png", '1600x1600'
-        )
+        ) if !version_atleast_2_6_0
       end
 
       # Copy thumbnails from raw files
       FileUtils.cp_r("#{pres_dir}/thumbnails", "#{target_pres_dir}/thumbnails") if File.exist?("#{pres_dir}/thumbnails")
-      tldraw = BigBlueButton::Events.check_for_tldraw_events(@doc);
-      if (tldraw)
+      if version_atleast_2_6_0
+        # Copy svgs from raw files (needed for Tldraw)
         FileUtils.cp_r("#{pres_dir}/svgs", "#{target_pres_dir}/svgs") if File.exist?("#{pres_dir}/svgs")
       end
     end

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -891,7 +891,7 @@ def process_presentation(package_dir)
   panzooms = []
   cursors = []
   shapes = {}
-  tldraw = BigBlueButton::Events.check_for_tldraw_events(@doc)
+  tldraw = @version_atleast_2_6_0
   tldraw_shapes = {}
 
   # Iterate through the events.xml and store the events, building the
@@ -1387,6 +1387,9 @@ begin
         )
         @version_atleast_2_0_0 = BigBlueButton::Events.bbb_version_compare(
           @doc, 2, 0, 0
+        )
+        @version_atleast_2_6_0 = BigBlueButton::Events.bbb_version_compare(
+          @doc, 2, 6, 0
         )
         BigBlueButton.logger.info('Creating metadata.xml')
 


### PR DESCRIPTION


<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

- Update the version to 2.6.0 to ease the detection of old/new whiteboard events
- Fix recording cursor when there is no pan/zoom and annotations in tldraw
- Don't generate slides pngs for 2.6.0, they are not used anymore in playback (svgs instead).

