### PR TITLE
fix: Any webcam start/stop steals focus from typing

### DIFF
--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -5187,12 +5187,12 @@
       }
     },
     "react-draggable": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-3.3.2.tgz",
-      "integrity": "sha512-oaz8a6enjbPtx5qb0oDWxtDNuybOylvto1QLydsXgKmwT7e3GXC2eMVDwEMIUYJIFqVG72XpOv673UuuAq6LhA==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.5.tgz",
+      "integrity": "sha512-OMHzJdyJbYTZo4uQE393fHcqqPYsEtkjfMgvCHr6rejT+Ezn4OZbNyGH50vv+SunC1RMvwOTSWkEODQLzw1M9g==",
       "requires": {
-        "classnames": "^2.2.5",
-        "prop-types": "^15.6.0"
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1"
       }
     },
     "react-dropzone": {

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -60,7 +60,7 @@
     "react-autosize-textarea": "^5.0.1",
     "react-color": "^2.19.3",
     "react-dom": "^16.14.0",
-    "react-draggable": "^3.3.2",
+    "react-draggable": "^4.4.5",
     "react-dropzone": "^7.0.1",
     "react-intl": "^3.12.1",
     "react-loading-skeleton": "^3.0.3",


### PR DESCRIPTION
### What does this PR do?

Updates react-draggable to fix an issue where focus on text input is partially lost on camera sharing start/stop.

### Closes Issue(s)
Closes #15422

### More

More details about the bug: https://github.com/react-grid-layout/react-draggable/issues/315