### PR TITLE
fix(layout): don't show `navbar`/`actions-bar` before layout has been calculated

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
@@ -29,6 +29,8 @@ const ActionsBarContainer = (props) => {
 
   const amIPresenter = users[Auth.meetingID][Auth.userID].presenter;
 
+  if (actionsBarStyle.display === false) return null;
+
   return (
     <ActionsBar {
       ...{

--- a/bigbluebutton-html5/imports/ui/components/layout/initState.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/initState.js
@@ -99,7 +99,7 @@ export const INITIAL_INPUT_STATE = {
 
 export const INITIAL_OUTPUT_STATE = {
   navBar: {
-    display: true,
+    display: false,
     width: 0,
     height: 0,
     top: 0,
@@ -108,7 +108,7 @@ export const INITIAL_OUTPUT_STATE = {
     zIndex: 1,
   },
   actionBar: {
-    display: true,
+    display: false,
     width: 0,
     height: 0,
     top: 0,

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/container.jsx
@@ -57,7 +57,7 @@ const NavBarContainer = ({ children, ...props }) => {
 
   const hideNavBar = getFromUserSettings('bbb_hide_nav_bar', false);
 
-  if (hideNavBar) return null;
+  if (hideNavBar || navBar.display === false) return null;
 
   return (
     <NavBar


### PR DESCRIPTION
### What does this PR do?

Shows both `navbar` and `actions-bar` only after the layout has been calculated.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #15341


### Motivation

Just setting properties like `width`, `min-width`, `min-height` is not enough to hide the navbar and actions-bar. Still, the content will overflow and both navbar and actions-bar will be visible for a brief moment if the layout calculation takes too long.
