### PR TITLE
fix: Poll question on slide not visible when Chrome's dark mode flag is enabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
@@ -26,6 +26,16 @@ class PollDrawComponent extends Component {
   constructor(props) {
     super(props);
 
+    // Check whether Chrome's 'Auto Dark Mode' is enabled
+    // See: https://developer.chrome.com/blog/auto-dark-theme/#detecting-auto-dark-theme
+    const detection = document.createElement('div');
+    detection.style.display = 'none';
+    detection.style.backgroundColor = 'canvas';
+    detection.style.colorScheme = 'light';
+    document.body.appendChild(detection);
+    const isChromeAutoDarkModeEnabled = getComputedStyle(detection).backgroundColor !== 'rgb(255, 255, 255)';
+    document.body.removeChild(detection);
+
     this.state = {
       // We did it because it was calculated in the componentWillMount
       calculated: false,
@@ -71,6 +81,8 @@ class PollDrawComponent extends Component {
       fontSizeDirection: 1,
 
       reducedResult: [],
+
+      isChromeAutoDarkModeEnabled,
     };
 
     this.pollInitialCalculation = this.pollInitialCalculation.bind(this);
@@ -354,6 +366,7 @@ class PollDrawComponent extends Component {
       thickness,
       calculated,
       reducedResult,
+      isChromeAutoDarkModeEnabled,
     } = this.state;
     if (!calculated) return null;
 
@@ -425,7 +438,7 @@ class PollDrawComponent extends Component {
       let color;
       if (barWidth < maxDigitWidth + 8) {
         xNumVotes = xNumVotesMovedRight;
-        color = '#333333';
+        color = isChromeAutoDarkModeEnabled ? '#888888' : '#333333';
       } else {
         xNumVotes = xNumVotesDefault;
         color = 'white';
@@ -478,7 +491,7 @@ class PollDrawComponent extends Component {
           y={innerRect.y}
           width={innerRect.width}
           height={innerRect.height}
-          stroke="#333333"
+          stroke={isChromeAutoDarkModeEnabled ? '#888888' : '#333333'}
           fill={backgroundColor}
           strokeWidth={thickness}
         />
@@ -488,10 +501,11 @@ class PollDrawComponent extends Component {
             y={line.keyColumn.yLeft}
             dy={maxLineHeight / 2}
             key={`${line.key}_key`}
-            fill="#333333"
+            fill={isChromeAutoDarkModeEnabled ? '#888888' : '#333333'}
             fontFamily="Arial"
             fontSize={calcFontSize}
             textAnchor={isRTL ? 'end' : 'start'}
+            autoDarkMode={isChromeAutoDarkModeEnabled}
           >
             {line.keyColumn.keyString}
           </Styled.OutlineText>
@@ -503,15 +517,15 @@ class PollDrawComponent extends Component {
             y={line.barColumn.yBar}
             width={line.barColumn.barWidth}
             height={line.barColumn.barHeight}
-            stroke="#333333"
-            fill="#333333"
+            stroke={isChromeAutoDarkModeEnabled ? '#888888' : '#333333'}
+            fill={isChromeAutoDarkModeEnabled ? '#888888' : '#333333'}
             strokeWidth={thickness - 1}
           />
         ))}
         <text
           x={innerRect.x}
           y={innerRect.y}
-          fill="#333333"
+          fill={isChromeAutoDarkModeEnabled ? '#888888' : '#333333'}
           fontFamily="Arial"
           fontSize={calcFontSize}
           textAnchor={isRTL ? 'start' : 'end'}
@@ -522,6 +536,7 @@ class PollDrawComponent extends Component {
               y={line.percentColumn.yRight}
               dy={maxLineHeight / 2}
               key={`${line.key}_percent`}
+              autoDarkMode={isChromeAutoDarkModeEnabled}
             >
               {line.percentColumn.percentString}
             </Styled.OutlineTSpan>
@@ -530,7 +545,7 @@ class PollDrawComponent extends Component {
         <text
           x={innerRect.x}
           y={innerRect.y}
-          fill="#333333"
+          fill={isChromeAutoDarkModeEnabled ? '#888888' : '#333333'}
           fontFamily="Arial"
           fontSize={calcFontSize}
           textAnchor={isRTL ? 'end' : 'start'}

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/component.jsx
@@ -8,6 +8,7 @@ import {
   getSwapLayout,
   shouldEnableSwapLayout,
 } from '/imports/ui/components/media/service';
+import browserInfo from '/imports/utils/browserInfo';
 
 const intlMessages = defineMessages({
   pollResultAria: {
@@ -25,16 +26,6 @@ const MAX_DISPLAYED_CHARS = 15;
 class PollDrawComponent extends Component {
   constructor(props) {
     super(props);
-
-    // Check whether Chrome's 'Auto Dark Mode' is enabled
-    // See: https://developer.chrome.com/blog/auto-dark-theme/#detecting-auto-dark-theme
-    const detection = document.createElement('div');
-    detection.style.display = 'none';
-    detection.style.backgroundColor = 'canvas';
-    detection.style.colorScheme = 'light';
-    document.body.appendChild(detection);
-    const isChromeAutoDarkModeEnabled = getComputedStyle(detection).backgroundColor !== 'rgb(255, 255, 255)';
-    document.body.removeChild(detection);
 
     this.state = {
       // We did it because it was calculated in the componentWillMount
@@ -82,7 +73,7 @@ class PollDrawComponent extends Component {
 
       reducedResult: [],
 
-      isChromeAutoDarkModeEnabled,
+      isChromeAutoDarkModeEnabled: browserInfo.isChromeAutoDarkModeEnabled(),
     };
 
     this.pollInitialCalculation = this.pollInitialCalculation.bind(this);

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/annotations/poll/styles.js
@@ -5,11 +5,19 @@ import { pollAnnotationGray } from '/imports/ui/stylesheets/styled-components/pa
 const OutlineText = styled.text`
   stroke: ${pollAnnotationGray};
   stroke-width: .5;
+
+  ${(autoDarkMode) => autoDarkMode && `
+    stroke: #888888;
+  `}
 `;
 
 const OutlineTSpan = styled.tspan`
   stroke: ${pollAnnotationGray};
   stroke-width: .5;
+
+  ${(autoDarkMode) => autoDarkMode && `
+    stroke: #888888;
+  `}
 `;
 
 export default {

--- a/bigbluebutton-html5/imports/utils/browserInfo.js
+++ b/bigbluebutton-html5/imports/utils/browserInfo.js
@@ -15,6 +15,19 @@ const isValidSafariVersion = Bowser.getParser(window.navigator.userAgent).satisf
   safari: '>12',
 });
 
+// Check whether Chrome's 'Auto Dark Mode' is enabled
+// See: https://developer.chrome.com/blog/auto-dark-theme/#detecting-auto-dark-theme
+const isChromeAutoDarkModeEnabled = () => {
+  const detection = document.createElement('div');
+  detection.style.display = 'none';
+  detection.style.backgroundColor = 'canvas';
+  detection.style.colorScheme = 'light';
+  document.body.appendChild(detection);
+  const isChromeAutoDarkModeEnabled = getComputedStyle(detection).backgroundColor !== 'rgb(255, 255, 255)';
+  document.body.removeChild(detection);
+  return isChromeAutoDarkModeEnabled;
+};
+
 const browserInfo = {
   isChrome,
   isSafari,
@@ -24,6 +37,7 @@ const browserInfo = {
   browserName,
   versionNumber,
   isValidSafariVersion,
+  isChromeAutoDarkModeEnabled,
 };
 
 export default browserInfo;


### PR DESCRIPTION
### What does this PR do?

Fixes poll annotation color when Chrome's dark mode flag is enabled.

**Before**
![before](https://user-images.githubusercontent.com/62393923/182206137-050900fe-f224-44fa-9c61-1672d6fe0365.png)

**After**
![after](https://user-images.githubusercontent.com/62393923/182206170-b3114754-07c5-4d18-98b5-b70fccd9c985.png)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #13444