### PR TITLE
fix: adjust captions icon position

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/captions/button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/captions/button/styles.js
@@ -9,6 +9,9 @@ const ClosedCaptionToggleButton = styled(Button)`
       background-color: transparent !important;
       border-color: ${colorWhite} !important;
     }
+    i {
+      margin-top: .4rem;
+    }
   `}
 `;
 


### PR DESCRIPTION
### What does this PR do?

Adjusts captions button icon position.

#### before
![2022-08-02_17-34](https://user-images.githubusercontent.com/3728706/182468363-67a83ae4-7331-453b-b7fa-e94401da3733.png)

#### after
![2022-08-02_17-33](https://user-images.githubusercontent.com/3728706/182468371-dd55d583-f34f-4927-8b05-686a209d2c6e.png)
