### PR TITLE
check status of services for recording workers with `bbb-conf --status`

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -491,6 +491,18 @@ display_bigbluebutton_status () {
         units="$units bbb-pads"
     fi
 
+    if [ -f /usr/lib/systemd/system/bbb-rap-caption-inbox.service ]; then
+        units="$units bbb-rap-caption-inbox"
+    fi
+
+    if [ -f /lib/systemd/system/bbb-rap-resque-worker.service ]; then
+        units="$units bbb-rap-resque-worker"
+    fi
+
+    if [ -f /lib/systemd/system/bbb-rap-starter.service ]; then
+        units="$units bbb-rap-starter"
+    fi
+
     if systemctl list-units --full -all | grep -q $TOMCAT_USER.service; then
       TOMCAT_SERVICE=$TOMCAT_USER
     fi


### PR DESCRIPTION

### What does this PR do?

Add checks to `bbb-conf --status` to check the state of

- bbb-rap-caption-inbox
- bbb-rap-resque-worker
- bbb-rap-starter

This is to help warn the administrator if these services are not running.

### Motivation

See discussion https://groups.google.com/g/bigbluebutton-dev/c/KWWxS1rWjao/m/xVvcOkrmBgAJ.

Still need to determine why these scripts are not running on upgrade.
