### PR TITLE
build: Enable bbb-rap-resque-worker and bbb-rap-starter on install

### DIFF
--- a/build/packages-template/bbb-record-core/after-install.sh
+++ b/build/packages-template/bbb-record-core/after-install.sh
@@ -83,6 +83,9 @@ case "$1" in
     else
       echo "Error: FreeSWITCH not installed"
     fi
+
+    systemctl enable bbb-rap-resque-worker.service
+    systemctl enable bbb-rap-starter.service
   ;;
   
   *)

--- a/build/packages-template/bbb-record-core/after-install.sh
+++ b/build/packages-template/bbb-record-core/after-install.sh
@@ -86,6 +86,7 @@ case "$1" in
 
     systemctl enable bbb-rap-resque-worker.service
     systemctl enable bbb-rap-starter.service
+    systemctl enable bbb-rap-caption-inbox.service
   ;;
   
   *)


### PR DESCRIPTION

### What does this PR do?

Enable servies `bbb-rap-resque-worker.service` and `bbb-rap-starter.service` so recordings will process after server reboots.


### Closes Issue(s)
Closes #15138 

