### PR TITLE
fix: don't clear text fake annotations

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -27,7 +27,7 @@ const clearPreview = (annotation) => {
 
 const clearFakeAnnotations = () => {
   UnsentAnnotations.remove({});
-  Annotations.remove({ id: /-fake/g });
+  Annotations.remove({ id: /-fake/g, annotationType: { $ne: 'text' } });
 }
 
 function handleAddedLiveSyncPreviewAnnotation({


### PR DESCRIPTION
Since _text annotations_ are synced in 'real time', we shouldn't clean them up.

Closes #15458