### PR TITLE
refactor: remove host parameters in bbb-export-annotations config

### DIFF
--- a/bbb-export-annotations/config/settings.json
+++ b/bbb-export-annotations/config/settings.json
@@ -22,14 +22,9 @@
     "notifier": {
       "pod_id": "DEFAULT_PRESENTATION_POD",
       "is_downloadable": "false",
-      "msgName": "NewPresAnnFileAvailableMsg",
-      "protocol": "https",
-      "host": "localhost"
+      "msgName": "NewPresAnnFileAvailableMsg"
     },
-    "bbbWeb": {
-      "host": "127.0.0.1",
-      "port": 8090
-    },
+    "bbbWebAPI": "http://127.0.0.1:8090",
     "redis": {
       "host": "127.0.0.1",
       "port": 6379,

--- a/bbb-export-annotations/workers/collector.js
+++ b/bbb-export-annotations/workers/collector.js
@@ -2,7 +2,7 @@ const Logger = require('../lib/utils/logger');
 const config = require('../config');
 const fs = require('fs');
 const redis = require('redis');
-const {Worker, workerData, parentPort} = require('worker_threads');
+const {Worker, workerData} = require('worker_threads');
 const path = require('path');
 const cp = require('child_process');
 
@@ -100,5 +100,3 @@ const exportJob = JSON.parse(job);
 
   kickOffProcessWorker(exportJob.jobId);
 })();
-
-parentPort.postMessage({message: workerData});

--- a/bbb-export-annotations/workers/notifier.js
+++ b/bbb-export-annotations/workers/notifier.js
@@ -6,7 +6,7 @@ const redis = require('redis');
 const axios = require('axios').default;
 const path = require('path');
 
-const {workerData, parentPort} = require('worker_threads');
+const {workerData} = require('worker_threads');
 
 const [jobType, jobId, filename_with_extension] = workerData;
 
@@ -90,5 +90,3 @@ fs.rm(dropbox, {recursive: true}, (err) => {
     throw err;
   }
 });
-
-parentPort.postMessage({message: workerData});

--- a/bbb-export-annotations/workers/notifier.js
+++ b/bbb-export-annotations/workers/notifier.js
@@ -27,7 +27,11 @@ async function notifyMeetingActor() {
 
   await client.connect();
   client.on('error', (err) => logger.info('Redis Client Error', err));
-  const link = `${config.notifier.protocol}://${config.notifier.host}/bigbluebutton/presentation/${exportJob.parentMeetingId}/${exportJob.parentMeetingId}/${exportJob.presId}/pdf/${jobId}/${filename_with_extension}`;
+
+  const link = path.join(`${path.sep}bigbluebutton`, 'presentation',
+      exportJob.parentMeetingId, exportJob.parentMeetingId,
+      exportJob.presId, 'pdf', jobId, filename_with_extension);
+
   const notification = {
     envelope: {
       name: config.notifier.msgName,
@@ -57,7 +61,7 @@ async function notifyMeetingActor() {
 
 /** Upload PDF to a BBB room */
 async function upload() {
-  const callbackUrl = `http://${config.bbbWeb.host}:${config.bbbWeb.port}/bigbluebutton/presentation/${exportJob.presentationUploadToken}/upload`;
+  const callbackUrl = `${config.bbbWebAPI}/bigbluebutton/presentation/${exportJob.presentationUploadToken}/upload`;
   const formData = new FormData();
   const file = `${exportJob.presLocation}/pdfs/${jobId}/${filename_with_extension}`;
 

--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -3,7 +3,7 @@ const config = require('../config');
 const fs = require('fs');
 const {create} = require('xmlbuilder2', {encoding: 'utf-8'});
 const cp = require('child_process');
-const {Worker, workerData, parentPort} = require('worker_threads');
+const {Worker, workerData} = require('worker_threads');
 const path = require('path');
 const sanitize = require('sanitize-filename');
 const {getStroke, getStrokePoints} = require('perfect-freehand');
@@ -878,5 +878,3 @@ cp.spawnSync(config.shared.ghostscript, mergePDFs, {shell: false});
 logger.info(`Saved PDF at ${outputDir}/${jobId}/${filename_with_extension}`);
 
 kickOffNotifierWorker(exportJob.jobType, filename_with_extension);
-
-parentPort.postMessage({message: workerData});


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Suppresses the `protocol://hostname` in the public link generated for annotated PDF downloads since HTML links use the same parameters as the current page.

### Motivation
Reduce coupling by removing the need for packaging/after-install scripts to define the protocol, hostname, and port in annotated PDF exports.

### More
Removes unnecessary message being sent to parent worker before child exits.