### PR TITLE
build: export-annotations depend on cairosvg imagemagick ghostscript

### DIFF
--- a/build/packages-template/bbb-export-annotations/opts-focal.sh
+++ b/build/packages-template/bbb-export-annotations/opts-focal.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d nodejs,npm,bbb-apps-akka,bbb-web"
+OPTS="$OPTS -t deb -d nodejs,npm,bbb-apps-akka,bbb-web,cairosvg,ghostscript,imagemagick"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
This is a first cut in ensuring the dependencies from https://github.com/bigbluebutton/bigbluebutton/pull/14562 are present
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none


### Motivation
Without `cairosvg` the generated pdfs are blank...
`imagemagick` is already present on the system as dependency of bbb-web but I include it here to in case bbb-export-annotation outlives bbb-web.
`ghostscript` seems to already be present within Ubuntu but I see no harm in ensuring its presence.
<!-- What inspired you to submit this pull request? -->

### More
There is still work to do in this area based on https://github.com/bigbluebutton/bigbluebutton/pull/14562 :
- [ ] ImageMagick seems to have to be a specific version - ImageMagick-6.9.12
- [ ] fonts need to be included
This work should be coming in a subsequent PR