### PR TITLE
fix: Removing presentation is broken

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -286,6 +286,16 @@ class PresentationUploader extends Component {
         }
       });
       return presentation;
+    }).filter((presentation) => {
+      const currentPropPres = propPresentations.find((pres) => pres.id === presentation.id);
+
+      if (!currentPropPres) return false;
+
+      presentation.conversion = currentPropPres.conversion;
+      presentation.isDownloadable = currentPropPres.isDownloadable;
+      presentation.isRemovable = currentPropPres.isRemovable;
+
+      return true;
     });
 
     if (shouldUpdateState) {


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where removed presentations would still appear in the presentation upload modal. 

### Closes Issue(s)
Closes #15503