### PR TITLE
test: 'Create quick poll - from the slide' improvement

### DIFF
--- a/bigbluebutton-tests/playwright/polling/poll.js
+++ b/bigbluebutton-tests/playwright/polling/poll.js
@@ -30,7 +30,8 @@ class Polling extends MultiUsers {
     await this.modPage.waitForSelector(e.whiteboard, ELEMENT_WAIT_LONGER_TIME);
     await utilPresentation.uploadSinglePresentation(this.modPage, e.questionSlideFileName);
 
-    await this.modPage.waitAndClick(e.quickPoll);
+    // The slide needs to be uploaded and converted, so wait a bit longer for this step
+    await this.modPage.waitAndClick(e.quickPoll, ELEMENT_WAIT_LONGER_TIME);
     await this.modPage.waitForSelector(e.pollMenuButton);
 
     await this.userPage.hasElement(e.pollingContainer);


### PR DESCRIPTION
wait a bit longer for a slide conversion that might fail a test if too slow
