### PR TITLE
refactor: Add Pan Button to Presentation Toolbar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -4,6 +4,7 @@ import WhiteboardOverlayContainer from '/imports/ui/components/whiteboard/whiteb
 import WhiteboardContainer from '/imports/ui/components/whiteboard/container';
 import WhiteboardToolbarContainer from '/imports/ui/components/whiteboard/whiteboard-toolbar/container';
 import { HUNDRED_PERCENT, MAX_PERCENT } from '/imports/utils/slideCalcUtils';
+import { SPACE } from '/imports/utils/keyCodes';
 import { defineMessages, injectIntl } from 'react-intl';
 import { toast } from 'react-toastify';
 import { Session } from 'meteor/session';
@@ -95,6 +96,7 @@ class Presentation extends PureComponent {
     this.renderPresentationMenu = this.renderPresentationMenu.bind(this);
     this.setIsZoomed = this.setIsZoomed.bind(this);
     this.setIsPanning = this.setIsPanning.bind(this);
+    this.handlePanShortcut = this.handlePanShortcut.bind(this);
 
     this.onResize = () => setTimeout(this.handleResize.bind(this), 0);
     this.renderCurrentPresentationToast = this.renderCurrentPresentationToast.bind(this);
@@ -126,8 +128,21 @@ class Presentation extends PureComponent {
     return stateChange;
   }
 
+  handlePanShortcut(e) {
+    if (e.keyCode === SPACE) {
+      switch(e.type) {
+        case 'keyup':
+          return this.state.isPanning && this.setIsPanning();
+        case 'keydown':
+          return !this.state.isPanning && this.setIsPanning(); 
+      }
+    }
+  }
+
   componentDidMount() {
     this.getInitialPresentationSizes();
+    this.refPresentationContainer.addEventListener('keydown', this.handlePanShortcut);
+    this.refPresentationContainer.addEventListener('keyup', this.handlePanShortcut);
     this.refPresentationContainer
       .addEventListener(FULLSCREEN_CHANGE_EVENT, this.onFullscreenChange);
     window.addEventListener('resize', this.onResize, false);
@@ -284,6 +299,8 @@ class Presentation extends PureComponent {
     window.removeEventListener('resize', this.onResize, false);
     this.refPresentationContainer
       .removeEventListener(FULLSCREEN_CHANGE_EVENT, this.onFullscreenChange);
+    this.refPresentationContainer.removeEventListener('keydown', this.handlePanShortcut);
+    this.refPresentationContainer.removeEventListener('keyup', this.handlePanShortcut);
 
     if (fullscreenContext) {
       layoutContextDispatch({

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -129,7 +129,8 @@ class Presentation extends PureComponent {
   }
 
   handlePanShortcut(e) {
-    if (e.keyCode === SPACE) {
+    const { userIsPresenter } = this.props;
+    if (e.keyCode === SPACE && userIsPresenter) {
       switch(e.type) {
         case 'keyup':
           return this.state.isPanning && this.setIsPanning();

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -77,6 +77,7 @@ class Presentation extends PureComponent {
       isFullscreen: false,
       tldrawAPI: null,
       isZoomed: false,
+      isPanning: false,
     };
 
     this.currentPresentationToastId = null;
@@ -93,6 +94,7 @@ class Presentation extends PureComponent {
     this.setTldrawAPI = this.setTldrawAPI.bind(this);
     this.renderPresentationMenu = this.renderPresentationMenu.bind(this);
     this.setIsZoomed = this.setIsZoomed.bind(this);
+    this.setIsPanning = this.setIsPanning.bind(this);
 
     this.onResize = () => setTimeout(this.handleResize.bind(this), 0);
     this.renderCurrentPresentationToast = this.renderCurrentPresentationToast.bind(this);
@@ -293,13 +295,19 @@ class Presentation extends PureComponent {
   setTldrawAPI(api) {
     this.setState({
       tldrawAPI: api,
-    })
+    });
   }
 
   setIsZoomed(isZoomed) {
     this.setState({
       isZoomed,
-    })
+    });
+  }
+
+  setIsPanning() {
+    this.setState({
+      isPanning: !this.state.isPanning,
+    });
   }
 
   handleResize() {
@@ -749,6 +757,8 @@ class Presentation extends PureComponent {
           layoutContextDispatch,
           presentationIsOpen,
         }}
+        setIsPanning={this.setIsPanning}
+        isPanning={this.state.isPanning}
         isZoomed={this.state.isZoomed}
         tldrawAPI={this.state.tldrawAPI}
         curPageId={this.state.tldrawAPI?.getPage()?.id}
@@ -985,6 +995,7 @@ class Presentation extends PureComponent {
             presentationHeight={presentationHeight}
             isViewersCursorLocked={isViewersCursorLocked}
             isZoomed={isZoomed}
+            isPanning={this.state.isPanning}
             setIsZoomed={this.setIsZoomed}
             zoomChanger={this.zoomChanger}
           />

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -170,7 +170,7 @@ class Presentation extends PureComponent {
       clearFakeAnnotations,
     } = this.props;
 
-    const { presentationWidth, presentationHeight } = this.state;
+    const { presentationWidth, presentationHeight, isZoomed, isPanning } = this.state;
     const {
       numCameras: prevNumCameras,
       presentationBounds: prevPresentationBounds,
@@ -270,6 +270,10 @@ class Presentation extends PureComponent {
         type: ACTIONS.SET_PRESENTATION_NUM_CURRENT_SLIDE,
         value: currentSlide.num,
       });
+    }
+
+    if (!isZoomed && isPanning || !userIsPresenter && prevProps.userIsPresenter) {
+      this.setIsPanning();
     }
   }
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -84,6 +84,10 @@ const intlMessages = defineMessages({
     id: 'app.whiteboard.toolbar.multiUserOff',
     description: 'Whiteboard toolbar turn multi-user off menu',
   },
+  pan: {
+    id: 'app.whiteboard.toolbar.tools.hand',
+    description: 'presentation toolbar pan label',
+  }
 });
 
 class PresentationToolbar extends PureComponent {
@@ -259,6 +263,8 @@ class PresentationToolbar extends PureComponent {
       multiUserSize,
       multiUser,
       isZoomed,
+      setIsPanning,
+      isPanning,
     } = this.props;
 
     const { isMobile } = deviceInfo;
@@ -397,6 +403,20 @@ class PresentationToolbar extends PureComponent {
                 />
               </TooltipContainer>
             ) : null}
+            <Styled.FitToWidthButton
+              role="button"
+              data-test="panButton"
+              aria-label={intl.formatMessage(intlMessages.pan)}
+              color="light"
+              disabled={!isZoomed}
+              icon="hand"
+              size="md"
+              circle
+              onClick={setIsPanning}
+              label={intl.formatMessage(intlMessages.pan)}
+              hideLabel
+              panning={isPanning}
+            />
             <Styled.FitToWidthButton
               role="button"
               data-test="fitToWidthButton"

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.js
@@ -204,6 +204,12 @@ const FitToWidthButton = styled(Button)`
     background-color: ${colorOffWhite};
     border: 0;
   }
+
+  ${({ panning }) => panning && `
+    > span {
+      background-color: #DCE4EC;
+    }
+  `}
 `;
 
 const MultiUserTool = styled.span`

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -524,6 +524,8 @@ export default function Whiteboard(props) {
         whiteboardId={whiteboardId}
         isViewersCursorLocked={isViewersCursorLocked}
         isMultiUserActive={isMultiUserActive}
+        isPanning={isPanning}
+
       >
         {hasWBAccess || isPresenter ? editableWB : readOnlyWB}
       </Cursors>

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -48,6 +48,7 @@ export default function Whiteboard(props) {
     isZoomed,
     isMultiUserActive,
     isRTL,
+    isPanning,
   } = props;
 
   const { pages, pageStates } = initDefaultPages(curPres?.pages.length || 1);
@@ -61,6 +62,7 @@ export default function Whiteboard(props) {
     assets: {},
   });
   const [tldrawAPI, setTLDrawAPI] = React.useState(null);
+  const [forcePanning, setForcePanning] = React.useState(false);
   const [cameraFitSlide, setCameraFitSlide] = React.useState({point: [0, 0], zoom: 0});
   const prevShapes = usePrevious(shapes);
 
@@ -217,7 +219,17 @@ export default function Whiteboard(props) {
       // removes image tool from the tldraw toolbar
       document.getElementById("TD-PrimaryTools-Image").style.display = 'none';
     }
+
+    if (tldrawAPI) {
+      tldrawAPI.isForcePanning = isPanning;
+    }
   });
+
+  React.useEffect(() => {
+    if (tldrawAPI) {
+      tldrawAPI.isForcePanning = isPanning;
+    }
+  }, [isPanning]);
 
   const onMount = (app) => {
     app.setSetting('language', document.getElementsByTagName('html')[0]?.lang || 'en');
@@ -297,7 +309,7 @@ export default function Whiteboard(props) {
 
   const editableWB = (
     <Tldraw
-      key={`wb-${document?.documentElement?.dir}-${document.getElementById('Navbar')?.style?.width}`}
+      key={`wb-${document?.documentElement?.dir}-${document.getElementById('Navbar')?.style?.width}-${forcePanning}`}
       document={doc}
       // disable the ability to drag and drop files onto the whiteboard
       // until we handle saving of assets in akka.

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
@@ -126,6 +126,7 @@ export default function Cursors(props) {
     hasMultiUserAccess,
     isMultiUserActive,
     application,
+    isPanning,
   } = props;
 
   const start = () => setActive(true);
@@ -260,10 +261,12 @@ export default function Cursors(props) {
   });
 
   const multiUserAccess = hasMultiUserAccess(whiteboardId, currentUser?.userId);
-
+  let cursorType = multiUserAccess || currentUser?.presenter ? "none" : "default";
+  if (isPanning) cursorType = 'grab';
+  
   return (
     <span ref={(r) => (cursorWrapper = r)}>
-      <div style={{ height: "100%", cursor: multiUserAccess || currentUser?.presenter ? "none" : "default" }}>
+      <div style={{ height: "100%", cursor: cursorType }}>
         {(active && multiUserAccess || (active && currentUser?.presenter)) && (
           <PositionLabel
             pos={pos}


### PR DESCRIPTION
### What does this PR do?
BBB's pan tool was removed from the whiteboard toolbar with the recent updates. This PR temporarily adds back a pan tool to the presentation toolbar.
![bbb-pan](https://user-images.githubusercontent.com/22058534/184557816-7208d800-0bd4-4e8d-8806-6a9a4fef4b19.gif)

### Closes
https://github.com/bigbluebutton/bigbluebutton/issues/15345

