### PR TITLE
fix: push layout not working unless changed

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -314,7 +314,13 @@ class App extends Component {
 
     this.renderDarkMode();
 
-    if (meetingLayout !== prevProps.meetingLayout) {
+    const meetingLayoutDidChange = meetingLayout !== prevProps.meetingLayout;
+    const pushLayoutMeetingDidChange = pushLayoutMeeting !== prevProps.pushLayoutMeeting;
+    const shouldSwitchLayout = isPresenter
+      ? meetingLayoutDidChange
+      : (meetingLayoutDidChange || pushLayoutMeetingDidChange) && pushLayoutMeeting;
+
+    if (shouldSwitchLayout) {
 
       let contextLayout = meetingLayout;
       if (isMobile()) {
@@ -334,7 +340,7 @@ class App extends Component {
       });
     }
 
-    if (pushLayoutMeeting !== prevProps.pushLayoutMeeting) {
+    if (pushLayoutMeetingDidChange) {
       updateSettings({
         application: {
           ...Settings.application,

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -48,6 +48,7 @@ import Notifications from '../notifications/container';
 import GlobalStyles from '/imports/ui/stylesheets/styled-components/globalStyles';
 import MediaService from '/imports/ui/components/media/service';
 import ActionsBarContainer from '../actions-bar/container';
+import { updateSettings } from '/imports/ui/components/settings/service';
 
 const MOBILE_MEDIA = 'only screen and (max-width: 40em)';
 const APP_CONFIG = Meteor.settings.public.app;
@@ -325,13 +326,21 @@ class App extends Component {
         value: contextLayout,
       });
 
-      Settings.application.selectedLayout = contextLayout;
-      Settings.save();
+      updateSettings({
+        application: {
+          ...Settings.application,
+          selectedLayout: contextLayout,
+        },
+      });
     }
 
     if (pushLayoutMeeting !== prevProps.pushLayoutMeeting) {
-      Settings.application.pushLayout = pushLayoutMeeting;
-      Settings.save();
+      updateSettings({
+        application: {
+          ...Settings.application,
+          pushLayout: pushLayoutMeeting,
+        },
+      });
     }
 
     if (meetingLayout === "custom" && !isPresenter) {


### PR DESCRIPTION
### What does this PR do?

- https://github.com/bigbluebutton/bigbluebutton/commit/95077975882a8188d0041b785150c72ad516a9ed: Fixes the issue described in https://github.com/bigbluebutton/bigbluebutton/issues/15509.
- https://github.com/bigbluebutton/bigbluebutton/commit/f4fc11d53b1b456cfb7c920a20da6e372cf1cd24: Fixes the cases to switch between layouts (see an example below).

> Example:
> 
> 1. User A joins as moderator.
> 2. User B joins as viewer.
> 3. User A changes layout to, let's say, Focus on Video, turns Push Layout on and confirms it.
> 4. Layout is pushed to User B (correct!).
> 5. Now, User A changes layout to different one, turns Push Layout off and confirms it.
> 
> Expected behavior: Layout changes only for User A.
> 
> Actual behavior: Layout changes for User B as well.
> 
> Note: this must be tested on top of https://github.com/bigbluebutton/bigbluebutton/commit/95077975882a8188d0041b785150c72ad516a9ed.

Closes #15509 