### PR TITLE
fix: Remove spurious FreeSWITCH dialplan bbb_sip.xml

### DIFF
--- a/bbb-voice-conference/config/freeswitch/conf/dialplan/public/bbb_sip.xml
+++ b/bbb-voice-conference/config/freeswitch/conf/dialplan/public/bbb_sip.xml
@@ -1,9 +1,0 @@
-<include>
-    <extension name="bbb_sp_call" continue="true">
-      <condition field="network_addr" expression="${domain}" break="on-false">
-        <action application="set" data="bbb_authorized=true"/>
-        <action application="transfer" data="${destination_number} XML default"/>
-      </condition>
-    </extension>
-</include>
-


### PR DESCRIPTION
### What does this PR do?

Removes spurious `bbb_sip.xml` dialplan from FreeSWITCH config.

### Motivation

The `bbb_sip.xml` dialplan is a remnant from the BBB red5 era. Nowadays calls are established exclusively via WebRTC socket (`ws` or `wss`).

Under specific circumstances the `bbb_sip.xml` dialplan will match WebRTC calls (supposed to be handled by `bbb_webrtc.xml`). If that happens, then `jb_use_timestamps` and `include_external_ip` channel vars will not be set in the affected channel (since they aren't set in `bbb_sip.xml`). I've observed this misbehavior on a node running behind a NAT where `nginx` was configured to connect to FreeSWITCH using an RFC1918 address (i.e. private IPv4).

Note: Channel vars of an ongoing call can be examined using `uuid_dump` command in the fs console.