### PR TITLE
fix (2.6): enhancements over disconnection situation (delay to remove and show ejected reason)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -45,8 +45,9 @@ const intlMessages = defineMessages({
   },
 });
 
-const endMeeting = (code) => {
+const endMeeting = (code, ejectedReason) => {
   Session.set('codeError', code);
+  Session.set('errorMessageDescription', ejectedReason);
   Session.set('isMeetingEnded', true);
 };
 
@@ -189,8 +190,8 @@ const currentUserEmoji = (currentUser) => (currentUser
 
 export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) => {
   Users.find({ userId: Auth.userID, meetingId: Auth.meetingID }).observe({
-    removed() {
-      endMeeting('403');
+    removed(userData) {
+      endMeeting(403, userData.ejectedReason || null);
     },
   });
 

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -191,8 +191,14 @@ const currentUserEmoji = (currentUser) => (currentUser
 export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) => {
   Users.find({ userId: Auth.userID, meetingId: Auth.meetingID }).observe({
     removed(userData) {
-      endMeeting(403, userData.ejectedReason || null);
-    },
+      //wait 3secs (before endMeeting), client will try to authenticate again
+      setTimeout(() => {
+        const queryCurrentUser = Users.find({ userId: Auth.userID, meetingId: Auth.meetingID });
+        if (queryCurrentUser.count() === 0) {
+          endMeeting(403, userData.ejectedReason || null);
+        }
+      }, 3000);
+    }
   });
 
   const currentUser = Users.findOne(

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -191,14 +191,15 @@ const currentUserEmoji = (currentUser) => (currentUser
 export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) => {
   Users.find({ userId: Auth.userID, meetingId: Auth.meetingID }).observe({
     removed(userData) {
-      //wait 3secs (before endMeeting), client will try to authenticate again
+      // wait 3secs (before endMeeting), client will try to authenticate again
+      const delayForReconnection = userData.ejected ? 0 : 3000;
       setTimeout(() => {
         const queryCurrentUser = Users.find({ userId: Auth.userID, meetingId: Auth.meetingID });
         if (queryCurrentUser.count() === 0) {
           endMeeting(403, userData.ejectedReason || null);
         }
-      }, 3000);
-    }
+      }, delayForReconnection);
+    },
   });
 
   const currentUser = Users.findOne(

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -266,7 +266,7 @@ export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) 
     randomlySelectedUser,
     currentUserId: currentUser?.userId,
     isPresenter,
-    isModerator: currentUser.role === ROLE_MODERATOR,
+    isModerator: currentUser?.role === ROLE_MODERATOR,
     meetingLayout: layout,
     meetingLayoutUpdatedAt: layoutUpdatedAt,
     presentationIsOpen,

--- a/bigbluebutton-html5/imports/ui/components/error-screen/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/error-screen/component.jsx
@@ -46,6 +46,15 @@ const intlMessages = defineMessages({
   user_inactivity_eject_reason: {
     id: 'app.meeting.logout.userInactivityEjectReason',
   },
+  user_requested_eject_reason: {
+    id: 'app.meeting.logout.ejectedFromMeeting',
+  },
+  duplicate_user_in_meeting_eject_reason: {
+    id: 'app.meeting.logout.duplicateUserEjectReason',
+  },
+  not_enough_permission_eject_reason: {
+    id: 'app.meeting.logout.permissionEjectReason',
+  },
 });
 
 const propTypes = {
@@ -93,7 +102,9 @@ class ErrorScreen extends PureComponent {
           {formatedMessage}
         </Styled.Message>
         {
-          !errorMessageDescription || (
+          !errorMessageDescription
+          || formatedMessage === errorMessageDescription
+          || (
             <Styled.SessionMessage>
               {errorMessageDescription}
             </Styled.SessionMessage>

--- a/bigbluebutton-html5/imports/ui/components/error-screen/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/error-screen/component.jsx
@@ -43,6 +43,9 @@ const intlMessages = defineMessages({
   joined_another_window_reason: {
     id: 'app.error.joinedAnotherWindow',
   },
+  user_inactivity_eject_reason: {
+    id: 'app.meeting.logout.userInactivityEjectReason',
+  },
 });
 
 const propTypes = {

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
@@ -179,7 +179,7 @@ class MeetingEnded extends PureComponent {
   }
 
   getEndingMessage() {
-    const { intl, code, endedReason } = this.props;
+    const { intl, code, ejectedReason, endedReason } = this.props;
 
     if (endedReason && endedReason === 'ENDED_DUE_TO_NO_MODERATOR') {
       return this.endWhenNoModeratorMinutes === 1
@@ -189,6 +189,10 @@ class MeetingEnded extends PureComponent {
 
     if (this.meetingEndedBy) {
       return intl.formatMessage(intlMessage.messageEndedByUser, { 0: this.meetingEndedBy });
+    }
+
+    if (intlMessage[ejectedReason]) {
+      return intl.formatMessage(intlMessage[ejectedReason]);
     }
 
     if (intlMessage[code]) {


### PR DESCRIPTION
### Problem 1:
When the user is ejected due to inactivity, a generic error is being showed.
And there is a random behavior where sometimes the user see the first print and sometimes the second.
![ejected-before](https://user-images.githubusercontent.com/5660191/185201294-68048ddf-6539-4ac3-8693-95e2c7367d97.png)
![error403-before](https://user-images.githubusercontent.com/5660191/185201329-3d2e35b7-f890-4bd7-b8ff-8f2a275e7888.png)

This PR will show the properly reason why he was removed:
![error-ejected](https://user-images.githubusercontent.com/5660191/185201396-8f214733-d92c-4de2-9720-ec545927c043.png)

### Problem 2:
When the user has problem with disconnection. When the connection is re-established he can't join to the meeting again!
He is immediately removed once he connects to the server!

https://user-images.githubusercontent.com/5660191/185202180-51e6ef30-3677-4bb9-8299-b2e29c21d32b.mp4

With this PR this situation will be avoided once the user will have 3 seconds to try to re-establish the connection before being removed from the meeting:

https://user-images.githubusercontent.com/5660191/185202404-13081143-afe4-419c-b5ba-87f66b1c0b82.mp4

-----
- Problem 1 details:

1. When user is ejected by the system, he is updated with the following props:
```{ejected: true, ejectedReason: 'user_inactivity_eject_reason'}```
It would take the user to the `meeting-ended` screen.

2. But the user is also REMOVED from the `Users` collection.
And it makes the user identify that he was removed and take the user to the `error-screen` with `403` code.

Sometimes the first option is faster, and sometimes the second one is faster.
It will stop happening once the second option will have a delay of 3 seconds where client can identify the `ejected:true` and show the right screen `meeting-ended`.

Moreover: Now the `meeting-ended` will check if there is an error msg for the `ejectedReason` that the user received! And show the reason message in this cases!

----

- Problem 2 details:
When the user loses connection with the server, he firstly is updated with the `userLeftFlag`. And after 10 seconds he is removed from the `Users` collection.

Once the user can establish a connection with the server again, he would try authenticate again.
But at the same time he received the updated `Users` collection and check that he is not in the list anymore! And immediately call the function `endMeeting()` without having time to try to authenticate (and join meeting) again!

With this PR there will be a delay of 3 seconds before call the `endMeeting()` and the user is able to rejoin the meeting during this time and avoid the "You were removed" error.

---




A refactor of this part in order to avoid this random behavior is welcome! Let's prioritize it for BBB 2.7 release!

PS: A thorough test/review will be appreciated. Once this part is sensitive and this change can possibly trigger some side effect.
Once the observer that call `endMeeting()` immediately when user is removed was introduced a long time ago (2.3-alpha-3) and remain working until now.. https://github.com/bigbluebutton/bigbluebutton/pull/10369
![image](https://user-images.githubusercontent.com/5660191/185206042-eb724cdc-facf-415b-a06f-7c23373383e5.png)



Closes #15527