### PR TITLE
feat: configurable DSCP marking for WebRTC media

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
@@ -30,6 +30,7 @@ const DEFAULT_FULLAUDIO_MEDIA_SERVER = MEDIA.audio.fullAudioMediaServer;
 const LISTEN_ONLY_OFFERING = MEDIA.listenOnlyOffering;
 const MEDIA_TAG = MEDIA.mediaTag.replace(/#/g, '');
 const RECONNECT_TIMEOUT_MS = MEDIA.listenOnlyCallTimeout || 15000;
+const { audio: NETWORK_PRIORITY } = MEDIA.networkPriorities || {};
 const SENDRECV_ROLE = 'sendrecv';
 const RECV_ROLE = 'recv';
 const BRIDGE_NAME = 'fullaudio';
@@ -316,6 +317,7 @@ export default class SFUAudioBridge extends BaseAudioBridge {
           offering: isListenOnly ? LISTEN_ONLY_OFFERING : true,
           signalCandidates: SIGNAL_CANDIDATES,
           traceLogs: TRACE_LOGS,
+          networkPriority: NETWORK_PRIORITY,
         };
 
         this.broker = new AudioBroker(

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -12,6 +12,7 @@ const SFU_URL = SFU_CONFIG.wsUrl;
 const OFFERING = SFU_CONFIG.screenshare.subscriberOffering;
 const SIGNAL_CANDIDATES = Meteor.settings.public.kurento.signalCandidates;
 const TRACE_LOGS = Meteor.settings.public.kurento.traceLogs;
+const { screenshare: NETWORK_PRIORITY } = Meteor.settings.public.media.networkPriorities || {};
 
 const BRIDGE_NAME = 'kurento'
 const SCREENSHARE_VIDEO_TAG = 'screenshareVideo';
@@ -307,6 +308,7 @@ export default class KurentoScreenshareBridge {
         signalCandidates: SIGNAL_CANDIDATES,
         forceRelay: shouldForceRelay(),
         traceLogs: TRACE_LOGS,
+        networkPriority: NETWORK_PRIORITY,
       };
 
       this.broker = new ScreenshareBroker(

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -27,6 +27,7 @@ import WebRtcPeer from '/imports/ui/services/webrtc-base/peer';
 // FIXME Remove hardcoded defaults 2.3.
 const WS_CONN_TIMEOUT = Meteor.settings.public.kurento.wsConnectionTimeout || 4000;
 
+const { webcam: NETWORK_PRIORITY } = Meteor.settings.public.media.networkPriorities || {};
 const {
   baseTimeout: CAMERA_SHARE_FAILED_WAIT_TIME = 15000,
   maxTimeout: MAX_CAMERA_SHARE_FAILED_WAIT_TIME = 60000,
@@ -616,6 +617,7 @@ class VideoProvider extends Component {
         iceTransportPolicy: shouldForceRelay() ? 'relay' : undefined,
       },
       trace: TRACE_LOGS,
+      networkPriorities: NETWORK_PRIORITY ? { video: NETWORK_PRIORITY } : undefined,
     };
 
     try {

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/audio-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/audio-broker.js
@@ -28,6 +28,7 @@ class AudioBroker extends BaseBroker {
     // stream,
     // signalCandidates
     // traceLogs
+    // networkPriority
     Object.assign(this, options);
   }
 
@@ -82,6 +83,7 @@ class AudioBroker extends BaseBroker {
             this.onIceCandidate(candidate, this.role);
           },
           trace: this.traceLogs,
+          networkPriorities: this.networkPriority ? { audio: this.networkPriority } : undefined,
         };
 
         const peerRole = this.role === 'sendrecv' ? this.role : 'recvonly';

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/screenshare-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/screenshare-broker.js
@@ -37,6 +37,7 @@ class ScreenshareBroker extends BaseBroker {
     // mediaServer,
     // signalCandidates,
     // traceLogs
+    // networkPriority
     Object.assign(this, options);
   }
 
@@ -187,6 +188,7 @@ class ScreenshareBroker extends BaseBroker {
           videoStream: this.stream,
           configuration: this.populatePeerConfiguration(),
           trace: this.traceLogs,
+          networkPriorities: this.networkPriority ? { video: this.networkPriority } : undefined,
         };
         this.webRtcPeer = new WebRtcPeer('sendonly', options);
         this.webRtcPeer.iceQueue = [];

--- a/bigbluebutton-html5/imports/ui/services/webrtc-base/peer.js
+++ b/bigbluebutton-html5/imports/ui/services/webrtc-base/peer.js
@@ -19,6 +19,12 @@ export default class WebRtcPeer extends EventEmitter2 {
     this.configuration = this.options.configuration;
     this.onicecandidate = this.options.onicecandidate;
     this.oncandidategatheringdone = this.options.oncandidategatheringdone;
+    // this.networkPriorities: <{
+    //  audio: <'very-low' | 'low' | 'medium' | 'high' | undefined>
+    //  video: <'very-low' | 'low' | 'medium' | 'high' | undefined>
+    // } | undefined >
+    this.networkPriorities = this.options.networkPriorities;
+
     this.candidateGatheringDone = false;
 
     this._outboundCandidateQueue = [];
@@ -39,6 +45,40 @@ export default class WebRtcPeer extends EventEmitter2 {
     if (typeof this.options.mediaStreamFactory === 'function') {
       this.mediaStreamFactory = this.options.mediaStreamFactory.bind(this);
     }
+  }
+
+  _processEncodingOptions() {
+    this.peerConnection?.getSenders().forEach((sender) => {
+      const { track } = sender;
+      if (track) {
+        // TODO: this is not ideal and a bit anti-spec. The correct thing to do
+        // would be to set this in the transceiver creation via sendEncodings in
+        // addTransceiver, but FF doesn't support that. So we should split this
+        // between Chromium/WebKit (addTransceiver) and FF (this way) later - prlanzarin
+        const parameters = sender.getParameters();
+        // The encoder parameters might not be up yet; if that's the case,
+        // add a filler object so we can alter the parameters anyways
+        if (parameters.encodings == null || parameters.encodings.length === 0) {
+          parameters.encodings = [{}];
+        }
+
+        parameters.encodings.forEach((encoding) => {
+          // networkPriority
+          if (this.networkPriorities && this.networkPriorities[track.kind]) {
+            // eslint-disable-next-line no-param-reassign
+            encoding.networkPriority = this.networkPriorities[track.kind];
+          }
+
+          // Add further custom encoding parameters here
+        });
+
+        try {
+          sender.setParameters(parameters);
+        } catch (error) {
+          this.logger.error('BBB::WebRtcPeer::_processEncodingOptions - setParameters failed', error);
+        }
+      }
+    });
   }
 
   _flushInboundCandidateQueue() {
@@ -282,6 +322,7 @@ export default class WebRtcPeer extends EventEmitter2 {
         return this.peerConnection.setLocalDescription(offer);
       })
       .then(() => {
+        this._processEncodingOptions();
         const localDescription = this.getLocalSessionDescriptor();
         this.logger.debug('BBB::WebRtcPeer::generateOffer - local description set', localDescription);
         return localDescription.sdp;

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -621,6 +621,13 @@ public:
       useRtcLoopbackInChromium: true
     # showVolumeMeter: shows an energy bar for microphones in the AudioSettings view
     showVolumeMeter: true
+    # networkPriorities: DSCP markings for each media type. Chromium only, applies
+    # to sender flows. See https://datatracker.ietf.org/doc/html/rfc8837#section-5
+    # for further info.
+    #networkPriorities:
+    #  audio: high
+    #  webcam: medium
+    #  screenshare: medium
   stats:
     enabled: true
     interval: 10000


### PR DESCRIPTION
### What does this PR do?

- [feat: configurable DSCP marking for WebRTC media](https://github.com/bigbluebutton/bigbluebutton/commit/0e162f1cda54a00cb67fde38cc7d8b348fe75fcd)
  * See the public.app.media.networkPriorities configuration in
settings.yml. 
  * Audio, camera and screenshare priorities can be controlled
separately. 
  * For further info on the possible values, see:
    - https://www.w3.org/TR/webrtc-priority/
    - https://datatracker.ietf.org/doc/html/rfc8837#section-5

### Closes Issue(s)

None

### Motivation

 RTCRTPSender exposes DSCP marking via `networkPriority` in the encodings
configuration dictionaries. That should allow us to control QoS priorities for 
different media streams, eg audio with higher network priority than video. 

The only browser that implements that right now is Chromium.
Disabled by default until we can make sure there isn't any significant drawback to this.

### More

n/a
