### PR TITLE
fix: display presentation uploader limit errors

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -275,33 +275,36 @@ class PresentationUploader extends Component {
       ...propPresentations,
       ...presentations,
     });
-    const presStateMapped = presState.map((presentation) => {
-      propPresentations.forEach((propPres) => {
-        if (propPres.id === presentation.id) {
-          const prevPropPres = prevPropPresentations.find((pres) => pres.id === propPres.id);
-          if (propPres.isCurrent !== prevPropPres?.isCurrent) {
-            presentation.isCurrent = propPres.isCurrent;
-            shouldUpdateState = true;
-          }
-        }
-      });
-      return presentation;
-    }).filter((presentation) => {
+    const presStateFiltered = presState.filter((presentation) => {
       const currentPropPres = propPresentations.find((pres) => pres.id === presentation.id);
       const hasConversionError = presentation?.conversion?.error;
+      const finishedConversion = presentation?.conversion?.done || currentPropPres?.conversion?.done;
+      const hasTemporaryId = presentation.id.startsWith(presentation.filename);
 
-      if (hasConversionError) return true;
+      if (hasConversionError || (!finishedConversion && hasTemporaryId)) return true;
       if (!currentPropPres) return false;
 
       presentation.conversion = currentPropPres.conversion;
       presentation.isRemovable = currentPropPres.isRemovable;
 
       return true;
+    }).filter(presentation => {
+      const duplicated = presentations.find(
+        (pres) => pres.filename === presentation.filename
+          && pres.id !== presentation.id
+      );
+      if (duplicated
+        && duplicated.id.startsWith(presentation.filename)
+        && !presentation.id.startsWith(presentation.filename)
+        && presentation?.conversion?.done === duplicated?.conversion?.done) {
+          return false;
+      }
+      return true;
     });
 
     if (shouldUpdateState) {
       this.setState({
-        presentations: presStateMapped,
+        presentations: _.uniqBy(presStateFiltered, 'id')
       });
     }
 
@@ -730,7 +733,7 @@ class PresentationUploader extends Component {
             </tr>
           </thead>
           <tbody>
-            {presentationsSorted.map((item) => this.renderPresentationItem(item))}
+            {_.uniqBy(presentationsSorted, 'id').map((item) => this.renderPresentationItem(item))}
           </tbody>
         </Styled.Table>
       </Styled.FileList>

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -288,7 +288,9 @@ class PresentationUploader extends Component {
       return presentation;
     }).filter((presentation) => {
       const currentPropPres = propPresentations.find((pres) => pres.id === presentation.id);
+      const hasConversionError = presentation?.conversion?.error;
 
+      if (hasConversionError) return true;
       if (!currentPropPres) return false;
 
       presentation.conversion = currentPropPres.conversion;

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -289,8 +289,9 @@ class PresentationUploader extends Component {
     }).filter((presentation) => {
       const currentPropPres = propPresentations.find((pres) => pres.id === presentation.id);
       const hasConversionError = presentation?.conversion?.error;
+      const finishedConversion = presentation?.conversion?.done || currentPropPres?.conversion?.done;
 
-      if (hasConversionError) return true;
+      if (hasConversionError || !finishedConversion) return true;
       if (!currentPropPres) return false;
 
       presentation.conversion = currentPropPres.conversion;

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -277,12 +277,21 @@ class PresentationUploader extends Component {
     });
     const presStateFiltered = presState.filter((presentation) => {
       const currentPropPres = propPresentations.find((pres) => pres.id === presentation.id);
+      const prevPropPres = prevPropPresentations.find((pres) => pres.id === presentation.id);
       const hasConversionError = presentation?.conversion?.error;
       const finishedConversion = presentation?.conversion?.done || currentPropPres?.conversion?.done;
       const hasTemporaryId = presentation.id.startsWith(presentation.filename);
 
       if (hasConversionError || (!finishedConversion && hasTemporaryId)) return true;
       if (!currentPropPres) return false;
+
+      if(presentation?.conversion?.done !== finishedConversion) {
+        shouldUpdateState = true;
+      }
+
+      if (currentPropPres.isCurrent !== prevPropPres?.isCurrent) {
+        presentation.isCurrent = currentPropPres.isCurrent;
+      }
 
       presentation.conversion = currentPropPres.conversion;
       presentation.isRemovable = currentPropPres.isRemovable;

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -289,9 +289,8 @@ class PresentationUploader extends Component {
     }).filter((presentation) => {
       const currentPropPres = propPresentations.find((pres) => pres.id === presentation.id);
       const hasConversionError = presentation?.conversion?.error;
-      const finishedConversion = presentation?.conversion?.done || currentPropPres?.conversion?.done;
 
-      if (hasConversionError || !finishedConversion) return true;
+      if (hasConversionError) return true;
       if (!currentPropPres) return false;
 
       presentation.conversion = currentPropPres.conversion;

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -749,7 +749,7 @@ class PresentationUploader extends Component {
     let converted = 0;
 
     let presentationsSorted = presentations
-      .filter((p) => (p.upload.progress || p.conversion.status) && p.file)
+      .filter((p) => (p.upload.progress || p.upload.error || p.conversion.status) && p.file)
       .sort((a, b) => a.uploadTimestamp - b.uploadTimestamp)
       .sort((a, b) => a.conversion.done - b.conversion.done);
 
@@ -994,7 +994,7 @@ class PresentationUploader extends Component {
   }
 
   renderPresentationItemStatus(item) {
-    const { intl } = this.props;
+    const { intl, fileSizeMax } = this.props;
     if (!item.upload.done && item.upload.progress === 0) {
       return intl.formatMessage(intlMessages.fileToUpload);
     }
@@ -1008,13 +1008,13 @@ class PresentationUploader extends Component {
     const constraint = {};
 
     if (item.upload.done && item.upload.error) {
-      if (item.conversion.status === 'FILE_TOO_LARGE') {
-        constraint['0'] = ((item.conversion.maxFileSize) / 1000 / 1000).toFixed(2);
-      }
-
-      if (item.upload.progress < 100) {
-        const errorMessage = intlMessages.badConnectionError;
-        return intl.formatMessage(errorMessage);
+      if (item.conversion.status === 'FILE_TOO_LARGE' || item.upload.status === 413) {
+        constraint['0'] = (fileSizeMax / 1000 / 1000).toFixed(2);
+      } else {
+        if (item.upload.progress < 100) {
+          const errorMessage = intlMessages.badConnectionError;
+          return intl.formatMessage(errorMessage);
+        }
       }
 
       const errorMessage = intlMessages[item.upload.status] || intlMessages.genericError;

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/service.js
@@ -98,12 +98,6 @@ const observePresentationConversion = (
         }
       },
       changed: (newDoc) => {
-        if (newDoc.conversion.status === 'PAGE_COUNT_EXCEEDED') {
-          onConversion(newDoc.conversion);
-          c.stop();
-          clearTimeout(conversionTimeout);
-        }
-
         if (newDoc.temporaryPresentationId !== tmpPresId) return;
 
         onConversion(newDoc.conversion);

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/service.js
@@ -98,6 +98,12 @@ const observePresentationConversion = (
         }
       },
       changed: (newDoc) => {
+        if (newDoc.conversion.status === 'PAGE_COUNT_EXCEEDED') {
+          onConversion(newDoc.conversion);
+          c.stop();
+          clearTimeout(conversionTimeout);
+        }
+
         if (newDoc.temporaryPresentationId !== tmpPresId) return;
 
         onConversion(newDoc.conversion);


### PR DESCRIPTION
### What does this PR do?

Adjusts presentation uploader in order to correctly display errors when a presentation that exceeds file size or page limits is uploaded.

This PR was inspired by #15438 (thanks @MBM1607!), but includes other fixes to 2.5 presentation uploader issues.

### Closes Issue(s)

Closes #15543
Closes #15435