### PR TITLE
fix(webcam): properly flatten videoStream on meteor's webcam sync call

### DIFF
--- a/bigbluebutton-html5/imports/api/video-streams/server/modifiers/updatedVideoStream.js
+++ b/bigbluebutton-html5/imports/api/video-streams/server/modifiers/updatedVideoStream.js
@@ -1,6 +1,7 @@
 import { check } from 'meteor/check';
 import Logger from '/imports/startup/server/logger';
 import VideoStreams from '/imports/api/video-streams';
+import flat from 'flat';
 
 export default function updateVideoStream(meetingId, videoStream) {
   check(meetingId, String);
@@ -23,7 +24,7 @@ export default function updateVideoStream(meetingId, videoStream) {
 
   const modifier = {
     $set: Object.assign(
-      ...videoStream,
+      flat(videoStream),
     ),
   };
 


### PR DESCRIPTION
### What does this PR do?

- [fix(webcam): properly flatten videoStream on meteor sync call](https://github.com/bigbluebutton/bigbluebutton/commit/325eb036960f5b171c4c409e6e82a80a3baf46be)

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/15547

### Motivation

https://github.com/bigbluebutton/bigbluebutton/issues/15547