### PR TITLE
fix: check virtual background type on change

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/virtual-background/index.js
+++ b/bigbluebutton-html5/imports/ui/services/virtual-background/index.js
@@ -240,16 +240,22 @@ class VirtualBackgroundService {
 
     changeBackgroundImage(parameters = null) {
         const virtualBackgroundImagePath = getVirtualBgImagePath();
-        let imagesrc = virtualBackgroundImagePath + '';
+        let name = '';
         let type = 'blur';
+        let isVirtualBackground = false;
         if (parameters != null && Object.keys(parameters).length > 0) {
-            imagesrc = parameters.name;
+            name = parameters.name;
             type = parameters.type;
-            this._options.virtualBackground.isVirtualBackground = parameters.isVirtualBackground;
+            isVirtualBackground = parameters.isVirtualBackground;
         }
-        this._virtualImage = document.createElement('img');
-        this._virtualImage.crossOrigin = 'anonymous';
-        this._virtualImage.src = virtualBackgroundImagePath + imagesrc;
+        this._options.virtualBackground.virtualSource = virtualBackgroundImagePath + name;
+        this._options.virtualBackground.backgroundType = type;
+        this._options.virtualBackground.isVirtualBackground = isVirtualBackground;
+        if (this._options.virtualBackground.backgroundType === 'image') {
+            this._virtualImage = document.createElement('img');
+            this._virtualImage.crossOrigin = 'anonymous';
+            this._virtualImage.src = virtualBackgroundImagePath + name;
+        }
     }
 
     /**


### PR DESCRIPTION
### What does this PR do?

Checks the type of virtual background on change. If it is **image**, go ahead and create a new image tag. If it's not (it's **Blur** effect), skip such step. That way, we avoid an undesirable request to `public/resources/images/virtual-backgrounds/Blur` (which doesn't even exist and doesn't need to).

Closes #15555