### PR TITLE
fix: preloaded fonts being requested again

### DIFF
--- a/bigbluebutton-html5/client/stylesheets/fonts.css
+++ b/bigbluebutton-html5/client/stylesheets/fonts.css
@@ -4,7 +4,7 @@
   font-style: normal;
   font-weight: 300;
   src: local('Source Sans Pro Light'), local('SourceSansPro-Light'),
-       url('fonts/SourceSansPro/SourceSansPro-Light.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-Light.woff?v=VERSION') format('woff');
   unicode-range: U+0102-0103, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -13,7 +13,7 @@
   font-style: normal;
   font-weight: 300;
   src: local('Source Sans Pro Light'), local('SourceSansPro-Light'),
-      url('fonts/SourceSansPro/SourceSansPro-Light.woff') format('woff');
+      url('fonts/SourceSansPro/SourceSansPro-Light.woff?v=VERSION') format('woff');
   unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -22,7 +22,7 @@
   font-style: normal;
   font-weight: 300;
   src: local('Source Sans Pro Light'), local('SourceSansPro-Light'),
-       url('fonts/SourceSansPro/SourceSansPro-Light.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-Light.woff?v=VERSION') format('woff');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
 }
 /* vietnamese */
@@ -31,7 +31,7 @@
   font-style: normal;
   font-weight: 400;
   src: local('Source Sans Pro'), local('SourceSansPro-Regular'),
-      url('fonts/SourceSansPro/SourceSansPro-Regular.woff') format('woff');
+      url('fonts/SourceSansPro/SourceSansPro-Regular.woff?v=VERSION') format('woff');
   unicode-range: U+0102-0103, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -40,7 +40,7 @@
   font-style: normal;
   font-weight: 400;
   src: local('Source Sans Pro'), local('SourceSansPro-Regular'),
-       url('fonts/SourceSansPro/SourceSansPro-Regular.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-Regular.woff?v=VERSION') format('woff');
   unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -49,7 +49,7 @@
   font-style: normal;
   font-weight: 400;
   src: local('Source Sans Pro'), local('SourceSansPro-Regular'),
-       url('fonts/SourceSansPro/SourceSansPro-Regular.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-Regular.woff?v=VERSION') format('woff');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
 }
 /* vietnamese */
@@ -58,7 +58,7 @@
   font-style: normal;
   font-weight: 600;
   src: local('Source Sans Pro Semibold'), local('SourceSansPro-Semibold'),
-       url('fonts/SourceSansPro/SourceSansPro-Semibold.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-Semibold.woff?v=VERSION') format('woff');
   unicode-range: U+0102-0103, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -67,7 +67,7 @@
   font-style: normal;
   font-weight: 600;
   src: local('Source Sans Pro Semibold'), local('SourceSansPro-Semibold'),
-       url('fonts/SourceSansPro/SourceSansPro-Semibold.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-Semibold.woff?v=VERSION') format('woff');
   unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -76,7 +76,7 @@
   font-style: normal;
   font-weight: 600;
   src: local('Source Sans Pro Semibold'), local('SourceSansPro-Semibold'),
-       url('fonts/SourceSansPro/SourceSansPro-Semibold.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-Semibold.woff?v=VERSION') format('woff');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
 }
 /* vietnamese */
@@ -85,7 +85,7 @@
   font-style: normal;
   font-weight: 700;
   src: local('Source Sans Pro Bold'), local('SourceSansPro-Bold'),
-       url('fonts/SourceSansPro/SourceSansPro-Bold.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-Bold.woff?v=VERSION') format('woff');
   unicode-range: U+0102-0103, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -94,7 +94,7 @@
   font-style: normal;
   font-weight: 700;
   src: local('Source Sans Pro Bold'), local('SourceSansPro-Bold'),
-       url('fonts/SourceSansPro/SourceSansPro-Bold.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-Bold.woff?v=VERSION') format('woff');
   unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -103,7 +103,7 @@
   font-style: normal;
   font-weight: 700;
   src: local('Source Sans Pro Bold'), local('SourceSansPro-Bold'),
-       url('fonts/SourceSansPro/SourceSansPro-Bold.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-Bold.woff?v=VERSION') format('woff');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
 }
 /* vietnamese */
@@ -112,7 +112,7 @@
   font-style: italic;
   font-weight: 300;
   src: local('Source Sans Pro Light Italic'), local('SourceSansPro-LightIt'),
-       url('fonts/SourceSansPro/SourceSansPro-LightItalic.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-LightItalic.woff?v=VERSION') format('woff');
   unicode-range: U+0102-0103, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -121,7 +121,7 @@
   font-style: italic;
   font-weight: 300;
   src: local('Source Sans Pro Light Italic'), local('SourceSansPro-LightIt'),
-       url('fonts/SourceSansPro/SourceSansPro-LightItalic.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-LightItalic.woff?v=VERSION') format('woff');
   unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -130,7 +130,7 @@
   font-style: italic;
   font-weight: 300;
   src: local('Source Sans Pro Light Italic'), local('SourceSansPro-LightIt'),
-       url('fonts/SourceSansPro/SourceSansPro-LightItalic.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-LightItalic.woff?v=VERSION') format('woff');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
 }
 /* vietnamese */
@@ -139,7 +139,7 @@
   font-style: italic;
   font-weight: 400;
   src: local('Source Sans Pro Italic'), local('SourceSansPro-It'),
-       url('fonts/SourceSansPro/SourceSansPro-Italic.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-Italic.woff?v=VERSION') format('woff');
   unicode-range: U+0102-0103, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -148,7 +148,7 @@
   font-style: italic;
   font-weight: 400;
   src: local('Source Sans Pro Italic'), local('SourceSansPro-It'),
-       url('fonts/SourceSansPro/SourceSansPro-Italic.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-Italic.woff?v=VERSION') format('woff');
   unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -157,7 +157,7 @@
   font-style: italic;
   font-weight: 400;
   src: local('Source Sans Pro Italic'), local('SourceSansPro-It'),
-       url('fonts/SourceSansPro/SourceSansPro-Italic.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-Italic.woff?v=VERSION') format('woff');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
 }
 /* vietnamese */
@@ -166,7 +166,7 @@
   font-style: italic;
   font-weight: 600;
   src: local('Source Sans Pro Semibold Italic'), local('SourceSansPro-SemiboldIt'),
-       url('fonts/SourceSansPro/SourceSansPro-SemiboldItalic.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-SemiboldItalic.woff?v=VERSION') format('woff');
   unicode-range: U+0102-0103, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -175,7 +175,7 @@
   font-style: italic;
   font-weight: 600;
   src: local('Source Sans Pro Semibold Italic'), local('SourceSansPro-SemiboldIt'),
-       url('fonts/SourceSansPro/SourceSansPro-SemiboldItalic.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-SemiboldItalic.woff?v=VERSION') format('woff');
   unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -184,7 +184,7 @@
   font-style: italic;
   font-weight: 600;
   src: local('Source Sans Pro Semibold Italic'), local('SourceSansPro-SemiboldIt'),
-       url('fonts/SourceSansPro/SourceSansPro-SemiboldItalic.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-SemiboldItalic.woff?v=VERSION') format('woff');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
 }
 /* vietnamese */
@@ -193,7 +193,7 @@
   font-style: italic;
   font-weight: 700;
   src: local('Source Sans Pro Bold Italic'), local('SourceSansPro-BoldIt'),
-       url('fonts/SourceSansPro/SourceSansPro-BoldItalic.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-BoldItalic.woff?v=VERSION') format('woff');
   unicode-range: U+0102-0103, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
@@ -202,7 +202,7 @@
   font-style: italic;
   font-weight: 700;
   src: local('Source Sans Pro Bold Italic'), local('SourceSansPro-BoldIt'),
-       url('fonts/SourceSansPro/SourceSansPro-BoldItalic.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-BoldItalic.woff?v=VERSION') format('woff');
   unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -211,6 +211,6 @@
   font-style: italic;
   font-weight: 700;
   src: local('Source Sans Pro Bold Italic'), local('SourceSansPro-BoldIt'),
-       url('fonts/SourceSansPro/SourceSansPro-BoldItalic.woff') format('woff');
+       url('fonts/SourceSansPro/SourceSansPro-BoldItalic.woff?v=VERSION') format('woff');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
 }

--- a/build/packages-template/bbb-html5/build.sh
+++ b/build/packages-template/bbb-html5/build.sh
@@ -18,7 +18,7 @@ rm -rf staging
 
 # New format
 if [ -f private/config/settings.yml ]; then
-  sed -i "s/HTML5_CLIENT_VERSION/$(($BUILD))/" private/config/settings.yml
+  sed -i "s/HTML5_CLIENT_VERSION/$(($BUILD))/g" private/config/settings.yml
 fi
 
 mkdir -p staging/usr/share/bigbluebutton/nginx

--- a/build/packages-template/bbb-html5/build.sh
+++ b/build/packages-template/bbb-html5/build.sh
@@ -104,7 +104,7 @@ if [ -f staging/usr/share/meteor/bundle/programs/web.browser/head.html ]; then
   sed -i "s/VERSION/$(($BUILD))/" staging/usr/share/meteor/bundle/programs/web.browser/head.html
 fi
 
-find staging/usr/share/meteor/bundle/programs/web.browser -name '*.css' -exec sed -i "s/VERSION/$(($BUILD))/" '{}' \;
+find staging/usr/share/meteor/bundle/programs/web.browser -name '*.css' -exec sed -i "s/VERSION/$(($BUILD))/g" '{}' \;
 
 # Compress CSS, Javascript and tensorflow WASM binaries used for virtual backgrounds. Keep the
 # uncompressed versions as well so it works with mismatched nginx location blocks

--- a/build/packages-template/bbb-html5/build.sh
+++ b/build/packages-template/bbb-html5/build.sh
@@ -7,6 +7,7 @@ PACKAGE=$(echo $TARGET | cut -d'_' -f1)
 VERSION=$(echo $TARGET | cut -d'_' -f2)
 DISTRO=$(echo $TARGET | cut -d'_' -f3)
 TAG=$(echo $TARGET | cut -d'_' -f4)
+BUILD=$1
 
 #
 # Clean up directories
@@ -17,7 +18,7 @@ rm -rf staging
 
 # New format
 if [ -f private/config/settings.yml ]; then
-  sed -i "s/HTML5_CLIENT_VERSION/$(($1))/" private/config/settings.yml
+  sed -i "s/HTML5_CLIENT_VERSION/$(($BUILD))/" private/config/settings.yml
 fi
 
 mkdir -p staging/usr/share/bigbluebutton/nginx
@@ -98,9 +99,12 @@ fi
 
 cp node-v14.19.1-linux-x64.tar.gz staging/usr/share
 
+# replace v=VERSION with build number in head and css files
 if [ -f staging/usr/share/meteor/bundle/programs/web.browser/head.html ]; then
   sed -i "s/VERSION/$(($BUILD))/" staging/usr/share/meteor/bundle/programs/web.browser/head.html
 fi
+
+find staging/usr/share/meteor/bundle/programs/web.browser -name '*.css' -exec sed -i "s/VERSION/$(($BUILD))/" '{}' \;
 
 # Compress CSS, Javascript and tensorflow WASM binaries used for virtual backgrounds. Keep the
 # uncompressed versions as well so it works with mismatched nginx location blocks


### PR DESCRIPTION
### What does this PR do?

- adjusts build script, so `v=VERSION` is replaced by the correct build number.
- appends version number to font urls in fonts.css file, preventing the following warning from appearing in browser console: 

_The resource <URL> was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally_