### PR TITLE
fix: send notification messages to appropriate redis channel

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/FromAkkaAppsMsgSenderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/FromAkkaAppsMsgSenderActor.scala
@@ -156,6 +156,15 @@ class FromAkkaAppsMsgSenderActor(msgSender: MessageSender)
       case UpdateExternalVideoEvtMsg.NAME =>
         msgSender.send("from-akka-apps-frontend-redis-channel", json)
 
+      case NotifyAllInMeetingEvtMsg.NAME =>
+        msgSender.send("from-akka-apps-frontend-redis-channel", json)
+
+      case NotifyUserInMeetingEvtMsg.NAME =>
+        msgSender.send("from-akka-apps-frontend-redis-channel", json)
+
+      case NotifyRoleInMeetingEvtMsg.NAME =>
+        msgSender.send("from-akka-apps-frontend-redis-channel", json)
+
       case _ =>
         msgSender.send(fromAkkaAppsRedisChannel, json)
     }


### PR DESCRIPTION
### What does this PR do?

- Sends back-end notifications (from akka) to the appropriate _Redis_ channel, as they are handled by _bbb-html5 frontend_ instances.

https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-html5/imports/api/meetings/server/modifiers/emitNotification.js#L4

Closes #15463