### PR TITLE
(fix) - Fixed isCurrent not being respected in insertDocument

### DIFF
--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -419,3 +419,6 @@ endWhenNoModeratorDelayInMinutes=1
 
 # Allow endpoint with current BigBlueButton version
 allowRevealOfBBBVersion=false
+
+# Allows the insertDocument to change the current presentation.
+allowInsertDocumentChangeCurrent=true

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -62,6 +62,7 @@ class ApiController {
   HTML5LoadBalancingService html5LoadBalancingService
   ResponseBuilder responseBuilder = initResponseBuilder()
   ValidationService validationService
+  Boolean allowInsertDocumentChangeCurrent = grailsApplication.config.getProperty("allowInsertDocumentChangeCurrent")
 
   def initResponseBuilder = {
     String protocol = this.getClass().getResource("").getProtocol();
@@ -1327,7 +1328,11 @@ class ApiController {
     requestBody = StringUtils.isEmpty(requestBody) ? null : requestBody;
     Boolean isDefaultPresentationCurrent = false;
     def listOfPresentation = []
+    def presentationListHasCurrent = false
 
+    // This part of the code is responsible for organize the presentations in a certain order
+    // It selects the one that has the current=true, and put it in the 0th place.
+    // Afterwards, the 0th presentation is going to be uploaded first, which spares processing time
     if (requestBody == null) {
       if (isFromInsertAPI){
         log.warn("Insert Document API called without a payload - ignoring")
@@ -1363,6 +1368,7 @@ class ApiController {
           }
         }
       }
+      presentationListHasCurrent = hasCurrent;
     }
 
     listOfPresentation.eachWithIndex { document, index ->
@@ -1382,10 +1388,16 @@ class ApiController {
         }
         // The array has already been processed to let the first be the current. (This way it is
         // ensured that only one document is current)
-        if (index == 0) {
+        if (index == 0 && isFromInsertAPI) {
+          if (presentationListHasCurrent) {
+            isCurrent = true
+          }
+        } else if (index == 0 && !isFromInsertAPI){
           isCurrent = true
         }
-        isCurrent = isCurrent && !isFromInsertAPI
+        if (isFromInsertAPI && allowInsertDocumentChangeCurrent != null) {
+          isCurrent = isCurrent && allowInsertDocumentChangeCurrent
+        }
         // Verifying whether the document is a base64 encoded or a url to download.
         if (!StringUtils.isEmpty(document.@url.toString())) {
           def fileName;


### PR DESCRIPTION
### What does this PR do?

It makes the `current` attribute from `insertDocument`'s payload to be respected.

### Closes Issue(s)

Closes #15565 

### More

The logic used in payload of not changing the current presentation if no document is set to be current is applied here, I also added a new property inside `bigbluebutton.properties` to either allow this changing of current presentation or not (previous behavior we are fixing with this PR).  
