### PR TITLE
test suite: fix check for default presentation toast

### DIFF
--- a/bigbluebutton-tests/playwright/core/elements.js
+++ b/bigbluebutton-tests/playwright/core/elements.js
@@ -98,6 +98,7 @@ exports.etherpadEditable = 'body[id="innerdocbody"]';
 
 // Notifications
 exports.smallToastMsg = 'div[data-test="toastSmallMsg"]';
+exports.currentPresentationToast = 'div[data-test="toastSmallMsg"] > div';
 exports.notificationsTab = 'span[id="notificationTab"]';
 exports.chatPopupAlertsBtn = 'input[data-test="chatPopupAlertsBtn"]';
 exports.hasUnreadMessages = 'button[data-test="hasUnreadMessages"]';

--- a/bigbluebutton-tests/playwright/core/page.js
+++ b/bigbluebutton-tests/playwright/core/page.js
@@ -35,7 +35,7 @@ class Page {
     const joinUrl = helpers.getJoinURL(this.meetingId, this.initParameters, isModerator, customParameter);
     const response = await this.page.goto(joinUrl);
     await expect(response.ok()).toBeTruthy();
-    const hasErrorLabel = await this.page.evaluate(checkElement, [e.errorMessageLabel]);
+    const hasErrorLabel = await this.checkElement(e.errorMessageLabel);
     await expect(hasErrorLabel, 'Getting error when joining. Check if the BBB_URL and BBB_SECRET are set correctly').toBeFalsy();
     this.settings = await generateSettingsData(this.page);
     const { autoJoinAudioModal } = this.settings;

--- a/bigbluebutton-tests/playwright/core/util.js
+++ b/bigbluebutton-tests/playwright/core/util.js
@@ -2,6 +2,15 @@ const { expect } = require("@playwright/test");
 
 // Common
 function checkElement([element, index = 0]) {
+  /* Because this function is passed to a page.evaluate, it can only
+   * take a single argument; that's why we pass it an array.  It's so
+   * easy to pass it a string by mistake that we check to make sure
+   * the second argument is an integer and not a character from a
+   * destructured string.
+   */
+  if (typeof index != "number") {
+    throw Error("Assert failed: index not a number");
+  }
   return document.querySelectorAll(element)[index] !== undefined;
 }
 

--- a/bigbluebutton-tests/playwright/notifications/util.js
+++ b/bigbluebutton-tests/playwright/notifications/util.js
@@ -2,7 +2,6 @@ const { expect } = require('@playwright/test');
 const { ELEMENT_WAIT_LONGER_TIME } = require('../core/constants');
 const e = require('../core/elements');
 const { sleep } = require('../core/helpers');
-const { checkElement } = require('../core/util');
 
 async function enableChatPopup(test) {
   await test.waitAndClick(e.notificationsTab);
@@ -55,9 +54,9 @@ async function waitAndClearNotification(testPage) {
 }
 
 async function waitAndClearDefaultPresentationNotification(testPage) {
-  const hasPresentationUploaded = await testPage.page.evaluate(checkElement, e.whiteboard);
-  if (!hasPresentationUploaded) {
-    await testPage.waitForSelector(e.whiteboard, ELEMENT_WAIT_LONGER_TIME);
+  await testPage.waitForSelector(e.whiteboard,ELEMENT_WAIT_LONGER_TIME);
+  const hasCurrentPresentationToast = await testPage.checkElement(e.currentPresentationToast);
+  if (hasCurrentPresentationToast) {
     await waitAndClearNotification(testPage);
   }
 }


### PR DESCRIPTION
`checkElement` was being called from `waitAndClearDefaultPresentationNotification` in such a way that `svg[data-test="whiteboard"]` was being destructured in `checkElement` with `element` set to `s` and `index` set to `v`, instead of `element` being `svg[data-test="whiteboard"]` and `index` being `0`.  Therefore, this call to `checkElement` was always returning false.

Fixing that problem revealed a new one: `svg[data-test="whiteboard"]` is almost always present, even when a toast is being posted to indicate that the default presentation is being loaded.  Therefore, change `waitAndClearDefaultPresentationNotification` to check for the toast being present (and clearing it), rather than checking for the whiteboard being present.

I also added some code to `checkElement` to try and catch further errors of this kind, and made all the calls to `checkElement` consistent (i.e, call the method on the page, rather than calling `evaluate` on the page).
