### PR TITLE
test suite: add Firefox tests to CI (2.5)

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -132,7 +132,7 @@ jobs:
           ACTIONS_RUNNER_DEBUG: true
           BBB_URL: https://bbb-ci.test/bigbluebutton/api
           BBB_SECRET: bbbci
-        run: npm run test-ci
+        run: npm run test-chromium-ci
       - name: Run Firefox tests
         working-directory: ./bigbluebutton-tests/playwright
         if: ${{ contains(github.event.pull_request.labels.*.name, 'test Firefox')

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -133,6 +133,21 @@ jobs:
           BBB_URL: https://bbb-ci.test/bigbluebutton/api
           BBB_SECRET: bbbci
         run: npm run test-ci
+      - name: Run Firefox tests
+        working-directory: ./bigbluebutton-tests/playwright
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'test Firefox')
+                || contains(github.event.pull_request.labels.*.name, 'Test Firefox') }}
+        env:
+          NODE_EXTRA_CA_CERTS: /usr/local/share/ca-certificates/bbb-dev/bbb-dev-ca.crt
+          ACTIONS_RUNNER_DEBUG: true
+          BBB_URL: https://bbb-ci.test/bigbluebutton/api
+          BBB_SECRET: bbbci
+        # patch playwright's firefox so that it uses the system's root certificate authority
+        run: |
+          sh -c '
+          find $HOME/.cache/ms-playwright -name libnssckbi.so -exec rm {} \; -exec ln -s /usr/lib/x86_64-linux-gnu/pkcs11/p11-kit-trust.so {} \;
+          npm run test-firefox-ci
+          '
       - if: always()
         uses: actions/upload-artifact@v3
         with:

--- a/bigbluebutton-tests/playwright/notifications/notifications.spec.js
+++ b/bigbluebutton-tests/playwright/notifications/notifications.spec.js
@@ -55,7 +55,9 @@ test.describe.parallel('Notifications', () => {
       await presenterNotifications.fileUploaderNotification();
     });
 
-    test('Screenshare notification', async ({ browser, context, page }) => {
+    test('Screenshare notification', async ({ browser, browserName, context, page }) => {
+      test.skip(browserName === 'firefox' && process.env.DISPLAY === undefined,
+                "Screenshare tests not able in Firefox browser without desktop");
       const presenterNotifications = new PresenterNotifications(browser, context);
       await presenterNotifications.initModPage(page);
       await presenterNotifications.screenshareToast();

--- a/bigbluebutton-tests/playwright/package.json
+++ b/bigbluebutton-tests/playwright/package.json
@@ -4,7 +4,8 @@
     "test:filter": "npx playwright test -g",
     "test:headed": "npx playwright test --headed",
     "test:debug": "npx playwright test --debug -g",
-    "test-ci": "export CI='true' && npx playwright test --project=chromium --grep @ci"
+    "test-ci": "export CI='true' && npx playwright test --project=chromium --grep @ci",
+    "test-firefox-ci": "export CI='true' && npx playwright test --project=firefox --grep @ci"
   },
   "dependencies": {
     "@playwright/test": "^1.19.2",

--- a/bigbluebutton-tests/playwright/package.json
+++ b/bigbluebutton-tests/playwright/package.json
@@ -4,7 +4,7 @@
     "test:filter": "npx playwright test -g",
     "test:headed": "npx playwright test --headed",
     "test:debug": "npx playwright test --debug -g",
-    "test-ci": "export CI='true' && npx playwright test --project=chromium --grep @ci",
+    "test-chromium-ci": "export CI='true' && npx playwright test --project=chromium --grep @ci",
     "test-firefox-ci": "export CI='true' && npx playwright test --project=firefox --grep @ci"
   },
   "dependencies": {

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.spec.js
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.spec.js
@@ -2,7 +2,9 @@ const { test, devices } = require('@playwright/test');
 const { ScreenShare } = require('./screenshare');
 
 test.describe.parallel('Screenshare', () => {
-  test('Share screen @ci', async ({ browser, page }) => {
+  test('Share screen @ci', async ({ browser, browserName, page }) => {
+    test.skip(browserName === 'firefox' && process.env.DISPLAY === undefined,
+              "Screenshare tests not able in Firefox browser without desktop");
     const screenshare = new ScreenShare(browser, page);
     await screenshare.init(true, true);
     await screenshare.startSharing();


### PR DESCRIPTION
Configure github to run Firefox tests on PRs with the "test Firefox" (or "Test Firefox") label

Also add conditions to the screen share tests so they're not attempted on Firefox without a DISPLAY variable set, because Firefox can't find a screen to share in that case
