### PR TITLE
test suite: fix race condition on webcam connecting (2.5)

### DIFF
--- a/bigbluebutton-tests/playwright/core/page.js
+++ b/bigbluebutton-tests/playwright/core/page.js
@@ -87,9 +87,9 @@ class Page {
       await this.waitForSelector(e.videoPreview, videoPreviewTimeout);
       await this.waitAndClick(e.startSharingWebcam);
     }
-    await this.waitForSelector(e.webcamConnecting);
     await this.waitForSelector(e.webcamContainer, VIDEO_LOADING_WAIT_TIME);
     await this.waitForSelector(e.leaveVideo, VIDEO_LOADING_WAIT_TIME);
+    await this.wasRemoved(e.webcamConnecting);
   }
 
   getLocator(selector) {


### PR DESCRIPTION
Don't check for a transient "connecting" message, check instead that it's been removed.

