### PR TITLE
fix(audio): review in/out device management and switching

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/base.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/base.js
@@ -4,15 +4,13 @@ import CallStateOptions from '/imports/api/voice-call-states/utils/callStates';
 import logger from '/imports/startup/client/logger';
 import Auth from '/imports/ui/services/auth';
 import {
-  DEFAULT_INPUT_DEVICE_ID,
-  reloadAudioElement
+  getAudioConstraints,
 } from '/imports/api/audio/client/bridge/service';
 
 const MEDIA = Meteor.settings.public.media;
 const BASE_BRIDGE_NAME = 'base';
 const CALL_TRANSFER_TIMEOUT = MEDIA.callTransferTimeout;
 const TRANSFER_TONE = '1';
-const MEDIA_TAG = MEDIA.mediaTag;
 
 export default class BaseAudioBridge {
   constructor(userData) {
@@ -55,60 +53,82 @@ export default class BaseAudioBridge {
     console.error('The Bridge must implement changeInputDevice');
   }
 
+  setInputStream() {
+    console.error('The Bridge must implement setInputStream');
+  }
+
   sendDtmf() {
     console.error('The Bridge must implement sendDtmf');
   }
 
-  setDefaultInputDevice() {
-    this.inputDeviceId = DEFAULT_INPUT_DEVICE_ID;
+  set inputDeviceId (deviceId) {
+    this._inputDeviceId = deviceId;
   }
 
-  async changeInputDeviceId(inputDeviceId) {
-    if (!inputDeviceId) {
-      throw new Error();
-    }
+  get inputDeviceId () {
+    return this._inputDeviceId;
 
-    this.inputDeviceId = inputDeviceId;
-    return inputDeviceId;
   }
 
-  async changeOutputDevice(value, isLive) {
-    const audioElement = document.querySelector(MEDIA_TAG);
+  /**
+   * Change the input device with the given deviceId, without renegotiating
+   * peer.
+   * A new MediaStream object is created for the given deviceId. This object
+   * is returned by the resolved promise.
+   * @param  {String}  deviceId The id of the device to be set as input
+   * @return {Promise}          A promise that is resolved with the MediaStream
+   *                            object after changing the input device.
+   */
+  async liveChangeInputDevice(deviceId) {
+    let newStream;
+    let backupStream;
 
-    if (audioElement.setSinkId) {
-      try {
-        if (!isLive) {
-          audioElement.srcObject = null;
-        }
+    try {
+      const constraints = {
+        audio: getAudioConstraints({ deviceId }),
+      };
 
-        await audioElement.setSinkId(value);
-        reloadAudioElement(audioElement);
-        logger.debug({
-          logCode: 'audio_reload_audio_element',
-          extraInfo: {
-            bridgeName: this.bridgeName,
-            deviceId: value,
-            isLive,
-          },
-        }, 'Audio element reloaded after changing output device');
-
-        this.outputDeviceId = value;
-      } catch (error) {
-        logger.error({
-          logCode: 'audio_changeoutputdevice_error',
-          extraInfo: {
-            bridgeName: this.bridgeName,
-            deviceId: value,
-            isLive,
-            errorName: error.name,
-            errorMessage: error.message,
-          },
-        }, `Change output device failed: ${error.name}`);
-        throw new Error(this.baseErrorCodes.MEDIA_ERROR);
+      // Backup stream (current one) in case the switch fails
+      if (this.inputStream && this.inputStream.active) {
+        backupStream = this.inputStream ? this.inputStream.clone() : null;
+        this.inputStream.getAudioTracks().forEach((track) => track.stop());
       }
-    }
 
-    return this.outputDeviceId;
+      newStream = await navigator.mediaDevices.getUserMedia(constraints);
+      await this.setInputStream(newStream);
+      this.inputDeviceId = deviceId;
+      backupStream.getAudioTracks().forEach((track) => track.stop());
+      backupStream = null;
+
+      return newStream;
+    } catch (error) {
+      // Device change failed. Clean up the tentative new stream to avoid lingering
+      // stuff, then try to rollback to the previous input stream.
+      if (newStream && typeof newStream.getAudioTracks === 'function') {
+        newStream.getAudioTracks().forEach((t) => t.stop());
+        newStream = null;
+      }
+
+      // Rollback to backup stream
+      if (backupStream && backupStream.active) {
+        this.setInputStream(backupStream).catch((rollbackError) => {
+          logger.error({
+            logCode: 'audio_changeinputdevice_rollback_failure',
+            extraInfo: {
+              bridgeName: this.bridgeName,
+              deviceId,
+              errorName: rollbackError.name,
+              errorMessage: rollbackError.message,
+            },
+          }, 'Microphone device change rollback failed - the device may become silent');
+
+          backupStream.getAudioTracks().forEach((track) => track.stop());
+          backupStream = null;
+        });
+      }
+
+      throw error;
+    }
   }
 
   trackTransferState(transferCallback) {

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/base.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/base.js
@@ -97,8 +97,10 @@ export default class BaseAudioBridge {
       newStream = await navigator.mediaDevices.getUserMedia(constraints);
       await this.setInputStream(newStream);
       this.inputDeviceId = deviceId;
-      backupStream.getAudioTracks().forEach((track) => track.stop());
-      backupStream = null;
+      if (backupStream && backupStream.active) {
+        backupStream.getAudioTracks().forEach((track) => track.stop());
+        backupStream = null;
+      }
 
       return newStream;
     } catch (error) {

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
@@ -1,5 +1,6 @@
 import Settings from '/imports/ui/services/settings';
 import logger from '/imports/startup/client/logger';
+import Storage from '/imports/ui/services/storage/session';
 
 const AUDIO_SESSION_NUM_KEY = 'AudioSessionNumber';
 const DEFAULT_INPUT_DEVICE_ID = '';
@@ -8,6 +9,7 @@ const INPUT_DEVICE_ID_KEY = 'audioInputDeviceId';
 const OUTPUT_DEVICE_ID_KEY = 'audioOutputDeviceId';
 const AUDIO_MICROPHONE_CONSTRAINTS = Meteor.settings.public.app.defaultSettings
   .application.microphoneConstraints;
+const MEDIA_TAG = Meteor.settings.public.media.mediaTag;
 
 const getAudioSessionNumber = () => {
   let currItem = parseInt(sessionStorage.getItem(AUDIO_SESSION_NUM_KEY), 10);
@@ -30,6 +32,16 @@ const reloadAudioElement = (audioElement) => {
 
   return false;
 };
+
+const getCurrentAudioSinkId = () => {
+  const audioElement = document.querySelector(MEDIA_TAG);
+  return audioElement?.sinkId || DEFAULT_OUTPUT_DEVICE_ID;
+};
+
+const getStoredAudioInputDeviceId = () => Storage.getItem(INPUT_DEVICE_ID_KEY);
+const getStoredAudioOutputDeviceId = () => Storage.getItem(OUTPUT_DEVICE_ID_KEY);
+const storeAudioInputDeviceId = (deviceId) => Storage.setItem(INPUT_DEVICE_ID_KEY, deviceId);
+const storeAudioOutputDeviceId = (deviceId) => Storage.setItem(OUTPUT_DEVICE_ID_KEY, deviceId);
 
 /**
  * Filter constraints set in audioDeviceConstraints, based on
@@ -89,4 +101,9 @@ export {
   reloadAudioElement,
   filterSupportedConstraints,
   getAudioConstraints,
+  getCurrentAudioSinkId,
+  getStoredAudioInputDeviceId,
+  storeAudioInputDeviceId,
+  getStoredAudioOutputDeviceId,
+  storeAudioOutputDeviceId,
 };

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
@@ -8,13 +8,8 @@ import {
   getMappedFallbackStun,
 } from '/imports/utils/fetchStunTurnServers';
 import getFromMeetingSettings from '/imports/ui/services/meeting-settings';
-import Storage from '/imports/ui/services/storage/session';
 import browserInfo from '/imports/utils/browserInfo';
 import {
-  DEFAULT_INPUT_DEVICE_ID,
-  DEFAULT_OUTPUT_DEVICE_ID,
-  INPUT_DEVICE_ID_KEY,
-  OUTPUT_DEVICE_ID_KEY,
   getAudioSessionNumber,
   getAudioConstraints,
   filterSupportedConstraints,
@@ -76,51 +71,11 @@ export default class SFUAudioBridge extends BaseAudioBridge {
     this.userId = userData.userId;
     this.name = userData.username;
     this.sessionToken = userData.sessionToken;
-    this.media = {
-      inputDevice: {},
-    };
     this.broker = null;
     this.reconnecting = false;
     this.iceServers = [];
     this.inEchoTest = false;
     this.bridgeName = BRIDGE_NAME;
-  }
-
-  get inputDeviceId() {
-    const sessionInputDeviceId = Storage.getItem(INPUT_DEVICE_ID_KEY);
-
-    if (sessionInputDeviceId) {
-      return sessionInputDeviceId;
-    }
-
-    if (this.media.inputDeviceId) {
-      return this.media.inputDeviceId;
-    }
-
-    return DEFAULT_INPUT_DEVICE_ID;
-  }
-
-  set inputDeviceId(deviceId) {
-    Storage.setItem(INPUT_DEVICE_ID_KEY, deviceId);
-    this.media.inputDeviceId = deviceId;
-  }
-
-  get outputDeviceId() {
-    const sessionOutputDeviceId = Storage.getItem(OUTPUT_DEVICE_ID_KEY);
-    if (sessionOutputDeviceId) {
-      return sessionOutputDeviceId;
-    }
-
-    if (this.media.outputDeviceId) {
-      return this.media.outputDeviceId;
-    }
-
-    return DEFAULT_OUTPUT_DEVICE_ID;
-  }
-
-  set outputDeviceId(deviceId) {
-    Storage.setItem(OUTPUT_DEVICE_ID_KEY, deviceId);
-    this.media.outputDeviceId = deviceId;
   }
 
   get inputStream() {
@@ -135,25 +90,10 @@ export default class SFUAudioBridge extends BaseAudioBridge {
     return this.broker?.role;
   }
 
-  async setInputStream(stream) {
-    try {
-      if (this.broker == null) return null;
+  setInputStream(stream) {
+    if (this.broker == null) return null;
 
-      await this.broker.setLocalStream(stream);
-
-      return stream;
-    } catch (error) {
-      logger.warn({
-        logCode: 'sfuaudio_setinputstream_error',
-        extraInfo: {
-          errorCode: error.code,
-          errorMessage: error.message,
-          bridgeName: this.bridgeName,
-          role: this.role,
-        },
-      }, 'Failed to set input stream (mic)');
-      return null;
-    }
+    return this.broker.setLocalStream(stream);
   }
 
   getPeerConnection() {
@@ -368,32 +308,6 @@ export default class SFUAudioBridge extends BaseAudioBridge {
     return this.trackTransferState(onTransferSuccess);
   }
 
-  async liveChangeInputDevice(deviceId) {
-    try {
-      const constraints = {
-        audio: getAudioConstraints({ deviceId }),
-      };
-
-      this.inputStream.getAudioTracks().forEach((t) => t.stop());
-      const updatedStream = await navigator.mediaDevices.getUserMedia(constraints);
-      await this.setInputStream(updatedStream);
-      this.inputDeviceId = deviceId;
-
-      return updatedStream;
-    } catch (error) {
-      logger.warn({
-        logCode: 'sfuaudio_livechangeinputdevice_error',
-        extraInfo: {
-          errorCode: error.code,
-          errorMessage: error.message,
-          bridgeName: this.bridgeName,
-          role: this.role,
-        },
-      }, 'Failed to change input device (mic)');
-      return null;
-    }
-  }
-
   async updateAudioConstraints(constraints) {
     try {
       if (typeof constraints !== 'object') return;
@@ -405,7 +319,7 @@ export default class SFUAudioBridge extends BaseAudioBridge {
         const stream = await navigator.mediaDevices.getUserMedia(
           { audio: matchConstraints },
         );
-        this.setInputStream(stream);
+        await this.setInputStream(stream);
       } else {
         this.inputStream.getAudioTracks()
           .forEach((track) => track.applyConstraints(matchConstraints));

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -17,15 +17,12 @@ import { Tracker } from 'meteor/tracker';
 import VoiceCallStates from '/imports/api/voice-call-states';
 import CallStateOptions from '/imports/api/voice-call-states/utils/callStates';
 import Auth from '/imports/ui/services/auth';
-import Storage from '/imports/ui/services/storage/session';
 import browserInfo from '/imports/utils/browserInfo';
 import {
   getCurrentAudioSessionNumber,
   getAudioSessionNumber,
   getAudioConstraints,
   filterSupportedConstraints,
-  DEFAULT_OUTPUT_DEVICE_ID,
-  OUTPUT_DEVICE_ID_KEY,
 } from '/imports/api/audio/client/bridge/service';
 
 const MEDIA = Meteor.settings.public.media;

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -24,8 +24,8 @@ import {
   getAudioSessionNumber,
   getAudioConstraints,
   filterSupportedConstraints,
-  DEFAULT_INPUT_DEVICE_ID,
   DEFAULT_OUTPUT_DEVICE_ID,
+  OUTPUT_DEVICE_ID_KEY,
 } from '/imports/api/audio/client/bridge/service';
 
 const MEDIA = Meteor.settings.public.media;
@@ -48,8 +48,6 @@ const TRACE_SIP = MEDIA.traceSip || false;
 const SDP_SEMANTICS = MEDIA.sdpSemantics;
 const FORCE_RELAY = MEDIA.forceRelay;
 
-const INPUT_DEVICE_ID_KEY = 'audioInputDeviceId';
-const OUTPUT_DEVICE_ID_KEY = 'audioOutputDeviceId';
 const UA_SERVER_VERSION = Meteor.settings.public.app.bbbServerVersion;
 const UA_CLIENT_VERSION = Meteor.settings.public.app.html5ClientBuild;
 
@@ -108,61 +106,10 @@ class SIPSession {
    * @return {Promise}            A Promise that is resolved with the
    *                              MediaStream object that was set.
    */
-  async setInputStream(stream) {
-    try {
-      if (!this.currentSession
-        || !this.currentSession.sessionDescriptionHandler
-      ) return null;
+  setInputStream(stream) {
+    if (!this.currentSession?.sessionDescriptionHandler) return null;
 
-      await this.currentSession.sessionDescriptionHandler
-        .setLocalMediaStream(stream);
-
-      return stream;
-    } catch (error) {
-      logger.warn({
-        logCode: 'sip_js_setinputstream_error',
-        extraInfo: {
-          errorCode: error.code,
-          errorMessage: error.message,
-          callerIdName: this.user.callerIdName,
-        },
-      }, 'Failed to set input stream (mic)');
-      return null;
-    }
-  }
-
-  /**
-   * Change the input device with the given deviceId, without renegotiating
-   * peer.
-   * A new MediaStream object is created for the given deviceId. This object
-   * is returned by the resolved promise.
-   * @param  {String}  deviceId The id of the device to be set as input
-   * @return {Promise}          A promise that is resolved with the MediaStream
-   *                            object after changing the input device.
-   */
-  async liveChangeInputDevice(deviceId) {
-    try {
-      this.inputDeviceId = deviceId;
-
-      const constraints = {
-        audio: getAudioConstraints({ deviceId: this.inputDeviceId }),
-      };
-
-      this.inputStream.getAudioTracks().forEach((t) => t.stop());
-
-      return await navigator.mediaDevices.getUserMedia(constraints)
-        .then(this.setInputStream.bind(this));
-    } catch (error) {
-      logger.warn({
-        logCode: 'sip_js_livechangeinputdevice_error',
-        extraInfo: {
-          errorCode: error.code,
-          errorMessage: error.message,
-          callerIdName: this.user.callerIdName,
-        },
-      }, 'Failed to change input device (mic)');
-      return null;
-    }
+    return this.currentSession.sessionDescriptionHandler.setLocalMediaStream(stream);
   }
 
   get inputDeviceId() {
@@ -1214,10 +1161,6 @@ export default class SIPBridge extends BaseAudioBridge {
       name: username,
     };
 
-    this.media = {
-      inputDevice: {},
-    };
-
     this.protocol = window.document.location.protocol;
     if (MEDIA['sip_ws_host'] != null && MEDIA['sip_ws_host'] != '') {
       this.hostname = MEDIA.sip_ws_host;
@@ -1235,59 +1178,6 @@ export default class SIPBridge extends BaseAudioBridge {
 
     // No easy way to expose the client logger to sip.js code so we need to attach it globally
     window.clientLogger = logger;
-  }
-
-  get inputDeviceId() {
-    const sessionInputDeviceId = Storage.getItem(INPUT_DEVICE_ID_KEY);
-
-    if (sessionInputDeviceId) {
-      return sessionInputDeviceId;
-    }
-
-    if (this.media.inputDeviceId) {
-      return this.media.inputDeviceId;
-    }
-
-    if (this.activeSession) {
-      return this.activeSession.inputDeviceId;
-    }
-
-    return DEFAULT_INPUT_DEVICE_ID;
-  }
-
-  set inputDeviceId(deviceId) {
-    Storage.setItem(INPUT_DEVICE_ID_KEY, deviceId);
-    this.media.inputDeviceId = deviceId;
-
-    if (this.activeSession) {
-      this.activeSession.inputDeviceId = deviceId;
-    }
-  }
-
-  get outputDeviceId() {
-    const sessionOutputDeviceId = Storage.getItem(OUTPUT_DEVICE_ID_KEY);
-    if (sessionOutputDeviceId) {
-      return sessionOutputDeviceId;
-    }
-
-    if (this.media.outputDeviceId) {
-      return this.media.outputDeviceId;
-    }
-
-    if (this.activeSession) {
-      return this.activeSession.outputDeviceId;
-    }
-
-    return DEFAULT_OUTPUT_DEVICE_ID;
-  }
-
-  set outputDeviceId(deviceId) {
-    Storage.setItem(OUTPUT_DEVICE_ID_KEY, deviceId);
-    this.media.outputDeviceId = deviceId;
-
-    if (this.activeSession) {
-      this.activeSession.outputDeviceId = deviceId;
-    }
   }
 
   get inputStream() {
@@ -1355,7 +1245,6 @@ export default class SIPBridge extends BaseAudioBridge {
               inputStream,
             }, callback)
               .then((value) => {
-                this.changeOutputDevice(outputDeviceId, true);
                 resolve(value);
               }).catch((reason) => {
                 reject(reason);
@@ -1376,7 +1265,6 @@ export default class SIPBridge extends BaseAudioBridge {
         inputStream,
       }, callback)
         .then((value) => {
-          this.changeOutputDevice(outputDeviceId, true);
           resolve(value);
         }).catch((reason) => {
           reject(reason);
@@ -1414,9 +1302,8 @@ export default class SIPBridge extends BaseAudioBridge {
     return this.activeSession.exitAudio();
   }
 
-  liveChangeInputDevice(deviceId) {
-    this.inputDeviceId = deviceId;
-    return this.activeSession.liveChangeInputDevice(deviceId);
+  setInputStream(stream) {
+    return this.activeSession.setInputStream(stream);
   }
 
   async updateAudioConstraints(constraints) {

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/component.jsx
@@ -48,6 +48,10 @@ const intlMessages = defineMessages({
     id: 'app.actionsBar.unmuteLabel',
     description: 'Unmute audio button label',
   },
+  deviceChangeFailed: {
+    id: 'app.audioNotification.deviceChangeFailed',
+    description: 'Device change failed',
+  },
 });
 
 const propTypes = {
@@ -67,6 +71,7 @@ const propTypes = {
   muted: PropTypes.bool.isRequired,
   disable: PropTypes.bool.isRequired,
   talking: PropTypes.bool,
+  notify: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
@@ -113,12 +118,20 @@ class InputStreamLiveSelector extends Component {
   onDeviceListClick(deviceId, deviceKind, callback) {
     if (!deviceId) return;
 
+    const { intl, notify } = this.props;
+
     if (deviceKind === AUDIO_INPUT) {
-      this.setState({ selectedInputDeviceId: deviceId });
-      callback(deviceId);
+      callback(deviceId).then(() => {
+        this.setState({ selectedInputDeviceId: deviceId });
+      }).catch((error) => {
+        notify(intl.formatMessage(intlMessages.deviceChangeFailed), true);
+      });
     } else {
-      this.setState({ selectedOutputDeviceId: deviceId });
-      callback(deviceId, true);
+      callback(deviceId, true).then(() => {
+        this.setState({ selectedOutputDeviceId: deviceId });
+      }).catch((error) => {
+        notify(intl.formatMessage(intlMessages.deviceChangeFailed), true);
+      });
     }
   }
 
@@ -166,8 +179,11 @@ class InputStreamLiveSelector extends Component {
         meetingId: Auth.meetingID,
       },
     }, 'Current input device was removed. Fallback to default device');
-    this.setState({ selectedInputDeviceId: fallbackDevice.deviceId });
-    liveChangeInputDevice(fallbackDevice.deviceId);
+    liveChangeInputDevice(fallbackDevice.deviceId).then(() => {
+      this.setState({ selectedInputDeviceId: fallbackDevice.deviceId });
+    }).catch((error) => {
+      notify(intl.formatMessage(intlMessages.deviceChangeFailed), true);
+    });
   }
 
   fallbackOutputDevice(fallbackDevice) {
@@ -184,8 +200,11 @@ class InputStreamLiveSelector extends Component {
         meetingId: Auth.meetingID,
       },
     }, 'Current output device was removed. Fallback to default device');
-    this.setState({ selectedOutputDeviceId: fallbackDevice.deviceId });
-    liveChangeOutputDevice(fallbackDevice.deviceId, true);
+    liveChangeOutputDevice(fallbackDevice.deviceId, true).then(() => {
+      this.setState({ selectedOutputDeviceId: fallbackDevice.deviceId });
+    }).catch((error) => {
+      notify(intl.formatMessage(intlMessages.deviceChangeFailed), true);
+    });
   }
 
   updateRemovedDevices(audioInputDevices, audioOutputDevices) {

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/container.jsx
@@ -18,5 +18,6 @@ export default withTracker(({ handleLeaveAudio }) => ({
   currentOutputDeviceId: Service.outputDeviceId(),
   liveChangeInputDevice: Service.liveChangeInputDevice,
   liveChangeOutputDevice: Service.changeOutputDevice,
+  notify: Service.notify,
   handleLeaveAudio,
 }))(InputStreamLiveSelectorContainer);

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -47,6 +47,7 @@ const propTypes = {
   changeInputStream: PropTypes.func.isRequired,
   localEchoEnabled: PropTypes.bool.isRequired,
   showVolumeMeter: PropTypes.bool.isRequired,
+  notify: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
@@ -512,6 +513,7 @@ class AudioModal extends Component {
       changeOutputDevice,
       localEchoEnabled,
       showVolumeMeter,
+      notify,
     } = this.props;
 
     const confirmationCallback = !localEchoEnabled
@@ -542,6 +544,7 @@ class AudioModal extends Component {
         withVolumeMeter={showVolumeMeter}
         withEcho={localEchoEnabled}
         produceStreams={localEchoEnabled || showVolumeMeter}
+        notify={notify}
       />
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -96,6 +96,7 @@ export default lockContextContainer(withModalMounter(withTracker(({ userLocks })
     isIE: isIe,
     autoplayBlocked: Service.autoplayBlocked(),
     handleAllowAutoplay: () => Service.handleAllowAutoplay(),
+    notify: Service.notify,
     isRTL,
     AudioError,
   });

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
@@ -155,12 +155,19 @@ class AudioSettings extends React.Component {
       // In this case, the volume meter or local echo test.
       if (produceStreams) {
         this.generateInputStream(deviceId).then((stream) => {
+          // Extract the deviceId again from the stream to guarantee consistency
+          // between stream DID vs chosen DID. That's necessary in scenarios where,
+          // eg, there's no default/pre-set deviceId ('') and the browser's
+          // default device has been altered by the user (browser default != system's
+          // default).
+          const extractedDeviceId = MediaStreamUtils.extractDeviceIdFromStream(stream, 'audio');
+          if (extractedDeviceId && extractedDeviceId !== deviceId) changeInputDevice(extractedDeviceId);
+
+          // Component unmounted after gUM resolution -> skip echo rendering
           if (!this._isMounted) return;
 
           this.setState({
-            // We extract the deviceId again from the stream to guarantee consistency
-            // between stream vs chosen device
-            inputDeviceId: MediaStreamUtils.extractDeviceIdFromStream(stream, 'audio'),
+            inputDeviceId: extractedDeviceId,
             stream,
             producingStreams: false,
           });

--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -111,9 +111,7 @@ export default {
   changeInputDevice: (inputDeviceId) => AudioManager.changeInputDevice(inputDeviceId),
   changeInputStream: (newInputStream) => { AudioManager.inputStream = newInputStream; },
   liveChangeInputDevice: (inputDeviceId) => AudioManager.liveChangeInputDevice(inputDeviceId),
-  changeOutputDevice: (outputDeviceId, isLive) => {
-    AudioManager.changeOutputDevice(outputDeviceId, isLive);
-  },
+  changeOutputDevice: (outputDeviceId, isLive) => AudioManager.changeOutputDevice(outputDeviceId, isLive),
   isConnected: () => AudioManager.isConnected,
   isTalking: () => AudioManager.isTalking,
   isHangingUp: () => AudioManager.isHangingUp,
@@ -144,4 +142,5 @@ export default {
   localEchoEnabled: LOCAL_ECHO_TEST_ENABLED,
   localEchoInitHearingState: LOCAL_ECHO_INIT_HEARING_STATE,
   showVolumeMeter: SHOW_VOLUME_METER,
+  notify: (message, error, icon) => { AudioManager.notify(message, error, icon); },
 };

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -16,10 +16,17 @@ import getFromMeetingSettings from '/imports/ui/services/meeting-settings';
 import {
   DEFAULT_INPUT_DEVICE_ID,
   DEFAULT_OUTPUT_DEVICE_ID,
+  reloadAudioElement,
+  getCurrentAudioSinkId,
+  getStoredAudioInputDeviceId,
+  storeAudioInputDeviceId,
+  getStoredAudioOutputDeviceId,
+  storeAudioOutputDeviceId,
 } from '/imports/api/audio/client/bridge/service';
 
 const STATS = Meteor.settings.public.stats;
 const MEDIA = Meteor.settings.public.media;
+const MEDIA_TAG = MEDIA.mediaTag;
 const ECHO_TEST_NUMBER = MEDIA.echoTestNumber;
 const MAX_LISTEN_ONLY_RETRIES = 1;
 const LISTEN_ONLY_CALL_TIMEOUT_MS = MEDIA.listenOnlyCallTimeout || 25000;
@@ -85,8 +92,71 @@ class AudioManager {
 
     this._inputStream = null;
     this._inputStreamTracker = new Tracker.Dependency();
+    this._inputDeviceId = {
+      value: getStoredAudioInputDeviceId() || DEFAULT_INPUT_DEVICE_ID,
+      tracker: new Tracker.Dependency(),
+    };
+    this._outputDeviceId = {
+      value: DEFAULT_OUTPUT_DEVICE_ID,
+      tracker: new Tracker.Dependency(),
+    };
 
     this.BREAKOUT_AUDIO_TRANSFER_STATES = BREAKOUT_AUDIO_TRANSFER_STATES;
+    this._applyCachedOutputDeviceId();
+  }
+
+  _applyCachedOutputDeviceId() {
+    const cachedId = getStoredAudioOutputDeviceId();
+
+    if (typeof cachedId === 'string') {
+      this.changeOutputDevice(cachedId, false).then(() => {
+        this.outputDeviceId = cachedId;
+      }).catch((error) => {
+        logger.warn({
+          logCode: 'audiomanager_output_device_storage_failed',
+          extraInfo: {
+            deviceId: cachedId,
+            errorMessage: error.message,
+          },
+        }, `Failed to apply output audio device from storage: ${error.message}`);
+      });
+    }
+  }
+
+  set inputDeviceId(value) {
+    if (this._inputDeviceId.value !== value) {
+      this._inputDeviceId.value = value;
+      this._inputDeviceId.tracker.changed();
+    }
+
+    if (this.fullAudioBridge) {
+      this.fullAudioBridge.inputDeviceId = this._inputDeviceId.value;
+    }
+  }
+
+  get inputDeviceId() {
+    this._inputDeviceId.tracker.depend();
+    return this._inputDeviceId.value;
+  }
+
+  set outputDeviceId(value) {
+    if (this._outputDeviceId.value !== value) {
+      this._outputDeviceId.value = value;
+      this._outputDeviceId.tracker.changed();
+    }
+
+    if (this.fullAudioBridge) {
+      this.fullAudioBridge.outputDeviceId = this._outputDeviceId.value;
+    }
+
+    if (this.listenOnlyBridge) {
+      this.listenOnlyBridge.outputDeviceId = this._outputDeviceId.value;
+    }
+  }
+
+  get outputDeviceId() {
+    this._outputDeviceId.tracker.depend();
+    return this._outputDeviceId.value;
   }
 
   async init(userData, audioEventHandler) {
@@ -138,6 +208,10 @@ class AudioManager {
 
     this.fullAudioBridge = new FullAudioBridge(userData);
     this.listenOnlyBridge = new ListenOnlyBridge(userData);
+    // Initialize device IDs in configured bridges
+    this.fullAudioBridge.inputDeviceId = this.inputDeviceId;
+    this.fullAudioBridge.outputDeviceId = this.outputDeviceId;
+    this.listenOnlyBridge.outputDeviceId = this.outputDeviceId;
   }
 
   setAudioMessages(messages, intl) {
@@ -407,7 +481,6 @@ class AudioManager {
     if (this.inputStream) {
       this.inputStream.getTracks().forEach((track) => track.stop());
       this.inputStream = null;
-      this.inputDevice = { id: 'default' };
     }
 
     window.removeEventListener('audioPlayFailed', this.handlePlayElementFailed);
@@ -485,6 +558,13 @@ class AudioManager {
       });
     }
     Session.set('audioModalIsOpen', false);
+
+    // Enforce correct output device on audio join
+    this.changeOutputDevice(this.outputDeviceId, true);
+    // Audio joined successfully - add device IDs to session storage so they
+    // can be re-used on refreshes/other sessions
+    storeAudioInputDeviceId(this.inputDeviceId);
+    storeAudioOutputDeviceId(this.outputDeviceId);
   }
 
   onTransferStart() {
@@ -502,7 +582,6 @@ class AudioManager {
     if (this.inputStream) {
       this.inputStream.getTracks().forEach((track) => track.stop());
       this.inputStream = null;
-      this.inputDevice = { id: 'default' };
     }
 
     if (!this.error && !this.isEchoTest) {
@@ -602,75 +681,30 @@ class AudioManager {
     );
   }
 
-  setDefaultInputDevice() {
-    return this.changeInputDevice();
-  }
-
-  setDefaultOutputDevice() {
-    return this.changeOutputDevice('default');
-  }
-
   changeInputDevice(deviceId) {
-    if (!deviceId) {
-      return Promise.resolve();
-    }
+    if (typeof deviceId !== 'string') throw new TypeError('Invalid inputDeviceId');
 
-    const currentDeviceId = this.inputDevice?.id ?? 'none';
+    if (deviceId === this.inputDeviceId) return this.inputDeviceId;
 
-    const handleChangeInputDeviceSuccess = (inputDeviceId) => {
-      logger.debug({
-        logCode: 'audiomanager_input_device_change',
-        extraInfo: {
-          deviceId: currentDeviceId,
-          newDeviceId: inputDeviceId,
-        },
-      }, `Microphone input device changed: from ${currentDeviceId} to ${deviceId}`);
+    const currentDeviceId = this.inputDeviceId ?? 'none';
+    this.inputDeviceId = deviceId;
+    logger.debug({
+      logCode: 'audiomanager_input_device_change',
+      extraInfo: {
+        deviceId: currentDeviceId,
+        newDeviceId: deviceId,
+      },
+    }, `Microphone input device changed: from ${currentDeviceId} to ${deviceId}`);
 
-      this.inputDevice.id = inputDeviceId;
-
-      return Promise.resolve(inputDeviceId);
-    };
-
-    const handleChangeInputDeviceError = (error) => {
-      logger.error({
-        logCode: 'audiomanager_error_getting_device',
-        extraInfo: {
-          errorName: error.name,
-          errorMessage: error.message,
-          deviceId: currentDeviceId,
-          newDeviceId: deviceId,
-        },
-      }, `Error getting microphone - {${error.name}: ${error.message}}`);
-
-      const { MIC_ERROR } = AudioErrors;
-      const disabledSysSetting = error.message.includes(
-        'Permission denied by system'
-      );
-      const isMac = navigator.platform.indexOf('Mac') !== -1;
-
-      let code = MIC_ERROR.NO_PERMISSION;
-      if (isMac && disabledSysSetting) code = MIC_ERROR.MAC_OS_BLOCK;
-
-      return Promise.reject({
-        type: 'MEDIA_ERROR',
-        message: this.messages.error.MEDIA_ERROR,
-        code,
-      });
-    };
-
-    return this.bridge
-      .changeInputDeviceId(deviceId)
-      .then(handleChangeInputDeviceSuccess)
-      .catch(handleChangeInputDeviceError);
+    return this.inputDeviceId;
   }
 
   liveChangeInputDevice(deviceId) {
+    const currentDeviceId = this.inputDeviceId ?? 'none';
     // we force stream to be null, so MutedAlert will deallocate it and
     // a new one will be created for the new stream
     this.inputStream = null;
-    this.bridge.liveChangeInputDevice(deviceId).then((stream) => {
-      const currentDeviceId = this.inputDevice?.id ?? 'none';
-
+    return this.bridge.liveChangeInputDevice(deviceId).then((stream) => {
       logger.debug({
         logCode: 'audiomanager_input_live_device_change',
         extraInfo: {
@@ -679,41 +713,75 @@ class AudioManager {
         },
       }, `Microphone input device (live) changed: from ${currentDeviceId} to ${deviceId}`);
       this.setSenderTrackEnabled(!this.isMuted);
+      this.inputDeviceId = deviceId;
+      // Live input device change - add device ID to session storage so it
+      // can be re-used on refreshes/other sessions
+      storeAudioInputDeviceId(deviceId);
       this.inputStream = stream;
-    });
-  }
-
-  changeOutputDevice(deviceId, isLive) {
-    const targetDeviceId = deviceId || DEFAULT_OUTPUT_DEVICE_ID;
-    const currentDeviceId = this.bridge.outputDeviceId ?? 'none';
-
-    return this.bridge.changeOutputDevice(targetDeviceId, isLive).then((outputDeviceId) => {
-      logger.debug({
-        logCode: 'audiomanager_output_device_change',
-        extraInfo: {
-          deviceId: currentDeviceId,
-          newDeviceId: outputDeviceId,
-        },
-      }, `Audio output device changed: from ${currentDeviceId || 'default'} to ${outputDeviceId || 'default'}`);
-      return outputDeviceId;
     }).catch((error) => {
       logger.error({
-        logCode: 'audiomanager_output_device_change_failure',
+        logCode: 'audiomanager_input_live_device_change_failure',
         extraInfo: {
           errorName: error.name,
           errorMessage: error.message,
           deviceId: currentDeviceId,
-          newDeviceId: targetDeviceId,
+          newDeviceId: deviceId,
         },
-      }, `Error changing output device - {${error.name}: ${error.message}}`);
+      }, `Input device live change failed - {${error.name}: ${error.message}}`);
 
       throw error;
     });
   }
 
-  set inputDevice(value) {
-    this._inputDevice.value = value;
-    this._inputDevice.tracker.changed();
+  async changeOutputDevice(deviceId, isLive) {
+    const targetDeviceId = deviceId;
+    const currentDeviceId = this.outputDeviceId ?? getCurrentAudioSinkId();
+    const audioElement = document.querySelector(MEDIA_TAG);
+    const sinkIdSupported = audioElement && typeof audioElement.setSinkId === 'function';
+
+    if (typeof deviceId === 'string' && sinkIdSupported && currentDeviceId !== targetDeviceId) {
+      try {
+        if (!isLive) audioElement.srcObject = null;
+
+        await audioElement.setSinkId(deviceId);
+        reloadAudioElement(audioElement);
+        logger.debug({
+          logCode: 'audiomanager_output_device_change',
+          extraInfo: {
+            deviceId: currentDeviceId,
+            newDeviceId: deviceId,
+          },
+        }, `Audio output device changed: from ${currentDeviceId || 'default'} to ${deviceId || 'default'}`);
+        this.outputDeviceId = deviceId;
+
+        // Live output device change - add device ID to session storage so it
+        // can be re-used on refreshes/other sessions
+        if (isLive) storeAudioOutputDeviceId(deviceId);
+
+        return this.outputDeviceId;
+      } catch (error) {
+        logger.error({
+          logCode: 'audiomanager_output_device_change_failure',
+          extraInfo: {
+            errorName: error.name,
+            errorMessage: error.message,
+            deviceId: currentDeviceId,
+            newDeviceId: targetDeviceId,
+          },
+        }, `Error changing output device - {${error.name}: ${error.message}}`);
+
+        // Rollback/enforce current sinkId (if possible)
+        if (sinkIdSupported) {
+          this.outputDeviceId = getCurrentAudioSinkId();
+        } else {
+          this.outputDeviceId = currentDeviceId;
+        }
+
+        throw error;
+      }
+    }
+
+    return this.outputDeviceId;
   }
 
   get inputStream() {
@@ -734,22 +802,6 @@ class AudioManager {
     }
 
     this._inputStream = stream;
-  }
-
-  get inputDevice() {
-    return this._inputDevice;
-  }
-
-  get inputDeviceId() {
-    return this.bridge && this.bridge.inputDeviceId
-      ? this.bridge.inputDeviceId
-      : DEFAULT_INPUT_DEVICE_ID;
-  }
-
-  get outputDeviceId() {
-    return this.bridge && this.bridge.outputDeviceId
-      ? this.bridge.outputDeviceId
-      : DEFAULT_OUTPUT_DEVICE_ID;
   }
 
   /**

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -537,6 +537,7 @@
     "app.audioNotification.audioFailedError1012": "Connection closed (ICE error 1012)",
     "app.audioNotification.audioFailedMessage": "Your audio connection failed to connect",
     "app.audioNotification.mediaFailedMessage": "getUserMicMedia failed as only secure origins are allowed",
+    "app.audioNotification.deviceChangeFailed": "Audio device change failed. Check if the chosen device is properly set up and available",
     "app.audioNotification.closeLabel": "Close",
     "app.audioNotificaion.reconnectingAsListenOnly": "Microphone has been locked for viewers, you are being connected as listen only",
     "app.breakoutJoinConfirmation.title": "Join breakout room",


### PR DESCRIPTION
### What does this PR do?

There's no rollback procedure in case a device switch fails right now,
nor does the code entrypoints that call the switching procedures wait
for resolution or failure before marking the new device as chosen. That
may cause inconsistent states in a couple of ways:
  - No rollback: switch fails, audio is still on but no actual
    microphone input is being transmitted
  - Not waiting for resolutions: inconsistent chosen devices on failures
Device switching errors are also not surfaced to the end user

This commit:
  - Adds device rollback and proper resolution/failure response
    awaits to try and make the state a bit more consistent.
  - Centralizes the input device switching code to be reused between
    different bridges
  - Centralizes device ID state management in audio-manager to try and
    mantain them a bit more consistent across the board
  - Surface device switching failures to the end user
  - Guarantee device IDs are set to the session storage on all
    appropriate scenarios

### Closes Issue(s)

Closes #

### Motivation

<!-- What inspired you to submit this pull request? -->