### PR TITLE
refactor: Upgrade Libreoffice docker from java 11 to java 17

### DIFF
--- a/bbb-libreoffice/docker/Dockerfile
+++ b/bbb-libreoffice/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-bullseye
+FROM openjdk:17-slim-bullseye
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list


### PR DESCRIPTION
Upgrade the Java version of Libreoffice container to `openjdk:17-slim-bullseye`, once this is the next LTS version since current `openjdk:11-jre-bullseye`.
![image](https://user-images.githubusercontent.com/5660191/186426028-b6f9c947-d8dc-408f-b6dd-fbce5387f15e.png)

The Libreoffice conversions is working fine with this upgrade!