### PR TITLE
style: adjust breakout room assignment buttons

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.js
@@ -203,12 +203,9 @@ const AssignBtns = styled(Button)`
   color: ${colorPrimary};
   font-size: ${fontSizeSmall};
   white-space: nowrap;
-  margin: 0 auto 0 0;
+  margin: 3px auto;
   align-self: flex-end;
-
-  [dir="rtl"] & {
-    margin: 0 0 0 auto;
-  }
+  width: 100%;
 `;
 
 const CheckBoxesContainer = styled(FlexRow)`


### PR DESCRIPTION
### What does this PR do?

Adjust breakout room assignment buttons size and position.

#### before
![assign-buttons-before](https://user-images.githubusercontent.com/3728706/186429721-1669a081-c6ba-4cfd-b9a4-38723605096f.png)

#### after
![assign-buttons-after](https://user-images.githubusercontent.com/3728706/186432878-c225e1a6-bbd2-41a7-93ea-be4bccb88c92.png)
