### PR TITLE
fix: add missing custom virtual background param

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -354,13 +354,13 @@ class VideoPreview extends Component {
   };
 
   // Resolves into true if the background switch is successful, false otherwise
-  handleVirtualBgSelected(type, name) {
+  handleVirtualBgSelected(type, name, customParams) {
     const { sharedDevices } = this.props;
     const { webcamDeviceId } = this.state;
     const shared = sharedDevices.includes(webcamDeviceId);
 
     if (type !== EFFECT_TYPES.NONE_TYPE) {
-      return this.startVirtualBackground(this.currentVideoStream, type, name).then((switched) => {
+      return this.startVirtualBackground(this.currentVideoStream, type, name, customParams).then((switched) => {
         // If it's not shared we don't have to update here because
         // it will be updated in the handleStartSharing method.
         if (switched && shared) this.updateVirtualBackgroundInfo();


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Adds missing paramater that contains custom virtual background data. Otherwise, we can't initialize custom backgrounds and an exception is thrown.

![2022-08-25_09-01](https://user-images.githubusercontent.com/62393923/186659020-2fe94cae-6e69-4132-acd6-9403dbf9c083.png)

It was left out in https://github.com/bigbluebutton/bigbluebutton/pull/15566.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes none