### PR TITLE
(fix) - Show errors in root

### DIFF
--- a/bigbluebutton-config/assets/index.html
+++ b/bigbluebutton-config/assets/index.html
@@ -5,10 +5,53 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>BigBlueButton</title>
+    <style>
+        .error-div {
+            background-color: #f2dede;
+            padding: 15px;
+            border-radius: 10px;
+            border-color: #ebccd1;
+        }
+        .error-div-title {
+            font-size: 25px;
+        }
+        .error-message {
+            color: #a94442;
+            font-size: 15px;
+            margin-top: 2px 0 0 0;
+        }
+    </style>
 </head>
 <body style="margin:0">
     <div style="display: flex; height: 100vh; margin: 0; flex-direction: column; align-items: center; justify-content: center;">
-        <h1>Welcome to BigBlueButton!</h1>
+        <h1 id="welcome-message">Welcome to BigBlueButton!</h1>
     </div>
 </body>
+<script>
+    const ERRORS_QUERY_LABLE = "errors"
+    const queryString = decodeURI(window.location.search).slice(1);
+    const positionError = queryString.indexOf(ERRORS_QUERY_LABLE);
+    let jsonString;
+    if (positionError !== -1) {
+        jsonString = JSON.parse(queryString.slice(positionError + ERRORS_QUERY_LABLE.length + 1));
+        const welcomeMessage = document.querySelector('#welcome-message');
+        const errorContainer = document.createElement('div');
+        errorContainer.classList.add("error-div");
+        welcomeMessage.before(errorContainer);
+
+        for (i in jsonString) {
+            const newError = document.createElement('p')
+            newError.classList.add("error-message");
+            newError.innerHTML = "<b>Error</b>: " + jsonString[i].message;
+            errorContainer.appendChild(newError);
+        }
+
+        welcomeMessage.remove();
+
+        const bigBlueButton = document.createElement('h1');
+        bigBlueButton.innerHTML = "BigBlueButton";
+        errorContainer.before(bigBlueButton);
+    }
+    
+</script>
 </html>


### PR DESCRIPTION
### What does this PR do?

It adds the logic to show errors when necessary by reading the URL query params and display them in a certain way

### Motivation

BBB-demo had this feature, which was nice as it explains to the user why and what has happened. But since we don't have bbb-demo anymore, the new static content that goes in the root can be responsible for that.

### More

![image](https://user-images.githubusercontent.com/69865537/186673064-9e121b0a-3528-4f62-8ba6-af7bfdc14445.png)

This first picture shows what would happen if we had more the one error to display.

![image](https://user-images.githubusercontent.com/69865537/186673444-7e24c353-ddf9-47b4-a3cc-dafd4eec2ead.png)

For just one error.

![image](https://user-images.githubusercontent.com/69865537/186673604-bd523523-7505-4890-93cc-4e1bd4aef35c.png)

And for no errors, it would maintain the same as it was before.