### PR TITLE
build: use FIFO scheduler in bbb-webrtc-sfu

### DIFF
--- a/build/packages-template/bbb-html5/bbb-html5-backend@.service
+++ b/build/packages-template/bbb-html5/bbb-html5-backend@.service
@@ -22,7 +22,7 @@ RestartSec=10
 User=meteor
 Group=meteor
 CPUSchedulingPolicy=fifo
-Nice=19
+Nice=18
 
 [Install]
 WantedBy=bbb-html5.service

--- a/build/packages-template/bbb-html5/bbb-html5-frontend@.service
+++ b/build/packages-template/bbb-html5/bbb-html5-frontend@.service
@@ -22,7 +22,7 @@ RestartSec=10
 User=meteor
 Group=meteor
 CPUSchedulingPolicy=fifo
-Nice=19
+Nice=18
 
 [Install]
 WantedBy=bbb-html5.service

--- a/build/packages-template/bbb-webrtc-sfu/bbb-webrtc-sfu.service
+++ b/build/packages-template/bbb-webrtc-sfu/bbb-webrtc-sfu.service
@@ -13,6 +13,8 @@ User=bigbluebutton
 Group=bigbluebutton
 Environment=NODE_ENV=production
 Environment=NODE_CONFIG_DIR=/etc/bigbluebutton/bbb-webrtc-sfu/:/usr/local/bigbluebutton/bbb-webrtc-sfu/config/
+CPUSchedulingPolicy=fifo
+Nice=19
 
 [Install]
 WantedBy=multi-user.target bigbluebutton.target


### PR DESCRIPTION
### What does this PR do?

- [build: use FIFO scheduler in bbb-webrtc-sfu](https://github.com/bigbluebutton/bigbluebutton/commit/ef7b1fb3e5d59a32266aea67d471ea0e5f499b3a)
  * This commit puts bbb-webrtc-sfu in the FIFO scheduling policy (same as
    bbb-html5). Also bumps bbb-html5 nice level up to 18 and sets SFU to
    nice 19 (so bbb-html5 has some advantage when push comes to shove).

### Closes Issue(s)

Closes #

### Motivation

bbb-webrtc-sfu (and mediasoup) are running in the CFS scheduler which
means it has to compete with (much) lower priority tasks like
presentation conversion, recording processing, [...]
Since it encompasses an RTC application which also handles audio, it
should be _at least_ on the same scheduling policy as FS/bbb-html5 - and
that should be safer now with mediasoup which has a lower footprint
(and generates lower CPU noise overall).

This can be improved further by using per-process priorities in SFU.
Ideally we'd want mediasoup audio workers and mcs-core to be the same
priority as FS (so higher than bbb-html5), but the rest of them
(video/screen workers) to be the same or lower than bbb-html5. 
For future reference:
  - https://github.com/bigbluebutton/bbb-webrtc-sfu/commit/3e245122dfa155ecb77b536eeadac1e4607cee
  - https://github.com/bigbluebutton/bbb-webrtc-sfu/commit/66d443d2047fe4fd9872404904b91e0fab4e6948
