### PR TITLE
fix: light button warning

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/button/component.jsx
@@ -11,7 +11,7 @@ const SIZES = [
 ];
 
 const COLORS = [
-  'default', 'primary', 'danger', 'warning', 'success', 'dark', 'offline', 'muted', 'secondary',
+  'default', 'primary', 'danger', 'warning', 'success', 'dark', 'light', 'offline', 'muted', 'secondary',
 ];
 
 const propTypes = {


### PR DESCRIPTION
### What does this PR do?

Adds `light` as a valid button color.

![2022-08-29_09-34](https://user-images.githubusercontent.com/3728706/187203087-b14859b4-d96f-468d-8342-bd990cde998d.png)
