### PR TITLE
fix(whiteboard): text annotations stuck as fake and re-adds right click to cancel

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -27,7 +27,7 @@ const clearPreview = (annotation) => {
 
 const clearFakeAnnotations = () => {
   UnsentAnnotations.remove({});
-  Annotations.remove({ id: /-fake/g, annotationType: { $ne: 'text' } });
+  Annotations.remove({ id: /-fake/g });
 }
 
 function handleAddedLiveSyncPreviewAnnotation({

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -41,50 +41,10 @@ function handleAddedLiveSyncPreviewAnnotation({
     return;
   }
 
-  const fakeAnnotation = Annotations.findOne({ id: `${annotation.id}-fake` });
-  let fakePoints;
-
-  if (fakeAnnotation) {
-    fakePoints = fakeAnnotation.annotationInfo.points;
-    const { points: lastPoints } = annotation.annotationInfo;
-
-    if (annotation.annotationType !== 'pencil') {
-      Annotations.update(fakeAnnotation._id, {
-        $set: {
-          position: annotation.position,
-          'annotationInfo.color': isEqual(fakePoints, lastPoints) || annotation.status === DRAW_END
-            ? annotation.annotationInfo.color : fakeAnnotation.annotationInfo.color,
-        },
-        $inc: { version: 1 }, // TODO: Remove all this version stuff
-      });
-      return;
-    }
+  if (annotation.status === DRAW_END) {
+    Annotations.remove({ id: `${annotation.id}-fake` });
+    Annotations.upsert(query.selector, query.modifier);
   }
-
-  Annotations.upsert(query.selector, query.modifier, (err) => {
-    if (err) {
-      logger.error({
-        logCode: 'whiteboard_annotation_upsert_error',
-        extraInfo: { error: err },
-      }, 'Error on adding an annotation');
-      return;
-    }
-
-    // Remove fake annotation for pencil on draw end
-    if (annotation.status === DRAW_END) {
-      Annotations.remove({ id: `${annotation.id}-fake` });
-      return;
-    }
-
-    if (annotation.status === DRAW_START) {
-      Annotations.update(fakeAnnotation._id, {
-        $set: {
-          position: annotation.position - 1,
-        },
-        $inc: { version: 1 }, // TODO: Remove all this version stuff
-      });
-    }
-  });
 }
 
 function handleAddedAnnotation({

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/component.jsx
@@ -238,6 +238,8 @@ export default class WhiteboardOverlay extends Component {
       setTextShapeActiveId,
       contextMenuHandler,
       clearPreview,
+      addAnnotationToDiscardedList,
+      undoAnnotation,
       updateCursor,
     } = this.props;
 
@@ -255,6 +257,8 @@ export default class WhiteboardOverlay extends Component {
       setTextShapeActiveId,
       contextMenuHandler,
       clearPreview,
+      addAnnotationToDiscardedList,
+      undoAnnotation,
     };
 
     return (
@@ -319,4 +323,6 @@ WhiteboardOverlay.propTypes = {
   setTextShapeActiveId: PropTypes.func.isRequired,
   // Defines a handler to publish cursor position to the server
   updateCursor: PropTypes.func.isRequired,
+  addAnnotationToDiscardedList: PropTypes.func.isRequired,
+  undoAnnotation: PropTypes.func.isRequired,
 };

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/container.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import PropTypes from 'prop-types';
 import WhiteboardOverlayService from './service';
+import WhiteboardToolbarService from '../whiteboard-toolbar/service';
 import WhiteboardOverlay from './component';
 
 const WhiteboardOverlayContainer = (props) => {
@@ -15,10 +16,12 @@ const WhiteboardOverlayContainer = (props) => {
 };
 
 export default withTracker(() => ({
+  undoAnnotation: WhiteboardToolbarService.undoAnnotation,
   clearPreview: WhiteboardOverlayService.clearPreview,
   contextMenuHandler: WhiteboardOverlayService.contextMenuHandler,
   sendAnnotation: WhiteboardOverlayService.sendAnnotation,
   sendLiveSyncPreviewAnnotation: WhiteboardOverlayService.sendLiveSyncPreviewAnnotation,
+  addAnnotationToDiscardedList: WhiteboardOverlayService.addAnnotationToDiscardedList,
   setTextShapeActiveId: WhiteboardOverlayService.setTextShapeActiveId,
   resetTextShapeSession: WhiteboardOverlayService.resetTextShapeSession,
   drawSettings: WhiteboardOverlayService.getWhiteboardToolbarValues(),

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/service.js
@@ -1,6 +1,6 @@
 import Storage from '/imports/ui/services/storage/session';
 import Auth from '/imports/ui/services/auth';
-import { sendAnnotation, sendLiveSyncPreviewAnnotation, clearPreview } from '/imports/ui/components/whiteboard/service';
+import { sendAnnotation, sendLiveSyncPreviewAnnotation, clearPreview, addAnnotationToDiscardedList } from '/imports/ui/components/whiteboard/service';
 import { publishCursorUpdate } from '/imports/ui/components/cursor/service';
 
 const DRAW_SETTINGS = 'drawSettings';
@@ -55,6 +55,7 @@ const updateCursor = (payload) => {
 };
 
 export default {
+  addAnnotationToDiscardedList,
   sendAnnotation,
   sendLiveSyncPreviewAnnotation,
   getWhiteboardToolbarValues,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/text-draw-listener/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/whiteboard-overlay/text-draw-listener/component.jsx
@@ -218,11 +218,12 @@ export default class TextDrawListener extends Component {
       }
 
     // second case is when a user finished writing the text and publishes the final result
-    } else if (isRightClick) {
-      this.discardAnnotation();
     } else {
       // publishing the final shape and resetting the state
       this.sendLastMessage();
+      if (isRightClick) {
+        this.discardAnnotation();
+      }
     }
   }
 
@@ -485,15 +486,18 @@ export default class TextDrawListener extends Component {
   discardAnnotation() {
     const {
       actions,
+      whiteboardId,
     } = this.props;
 
     const {
       getCurrentShapeId,
-      clearPreview,
+      undoAnnotation,
+      addAnnotationToDiscardedList,
     } = actions;
 
     this.resetState();
-    clearPreview(getCurrentShapeId());
+    undoAnnotation(whiteboardId);
+    addAnnotationToDiscardedList(getCurrentShapeId());
   }
 
   render() {
@@ -598,5 +602,7 @@ TextDrawListener.propTypes = {
     resetTextShapeSession: PropTypes.func.isRequired,
     // Defines a function that sets a session value for the current active text shape
     setTextShapeActiveId: PropTypes.func.isRequired,
+    undoAnnotation: PropTypes.func.isRequired,
+    addAnnotationToDiscardedList: PropTypes.func.isRequired,
   }).isRequired,
 };


### PR DESCRIPTION
### What does this PR do?
First, this PR reverts https://github.com/bigbluebutton/bigbluebutton/commit/74c4c1c4ccc8f183704121a5747c769a3802bd15 because it causes fake annotations from the text tool not to be removed. Since the text tool is the only one that generates fake annotations(because it is the only one that is live synced), the function to clear fake annotations is directly intended to clear them.
Also this PR fixes 2 issues that are extremelly related:
- **text annotations being stuck as fake**
  Cleans up and modifies the added annotation handler to suit only for text annotation. As soon as the `DRAW_END` message is sent, the local fake annotations are removed and replaced by the complete/not fake annotation.
- **right click to cancel annotation not working**
  Re-adds cancelling text annotation on right click. To achieve this, some mechanisms that were previously used to handle live synced annotations were rescued. So this partially reverts https://github.com/bigbluebutton/bigbluebutton/commit/40b18b0662b0d11ce109a1ffb703a4057de99840.

### Closes Issue(s)
Closes #15595
Closes #15458