### PR TITLE
style: increase send to chat button font size

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.js
@@ -541,6 +541,7 @@ const DownloadButton = styled(Button)`
   color: ${colorBlueLight};
   cursor: pointer;
   display: inline-block;
+  font-size: 80%;
 
   &:hover {
     background-color: ${colorOffWhite} !important;


### PR DESCRIPTION
### What does this PR do?

Increases "send to chat" button font size, so it becomes easier to read (text looks "broken" in current size).

#### before
![before](https://user-images.githubusercontent.com/3728706/187935081-c4f5fb44-2866-45bb-b939-cef9bb541555.png)

#### after
![after](https://user-images.githubusercontent.com/3728706/187935053-c0f1f739-12e2-4796-a610-44dcf36406a4.png)
