### PR TITLE
fix: bbb-conf --start to use bigbluebutton.target only

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -388,7 +388,7 @@ start_bigbluebutton () {
         }
     fi
 
-    systemctl start bigbluebutton.target nginx freeswitch $REDIS_SERVICE bbb-apps-akka bbb-fsesl-akka bbb-rap-resque-worker bbb-rap-starter.service bbb-rap-caption-inbox.service $HTML5 $WEBHOOKS $ETHERPAD $PADS $BBB_WEB $BBB_LTI
+    systemctl start bigbluebutton.target
 
     if [ -f /usr/lib/systemd/system/bbb-html5.service ]; then
         systemctl start mongod
@@ -898,14 +898,18 @@ check_state() {
 
     if ! ss -ant | grep '8090' > /dev/null; then
         print_header
-        NOT_RUNNING_APPS="${NOT_RUNNING_APPS} ${TOMCAT_USER} or grails"
+        if [ ! -z "$TOMCAT_SERVICE" ]; then
+            NOT_RUNNING_APPS="${NOT_RUNNING_APPS} ${TOMCAT_USER} or grails"
+        fi
     else
         if ps aux |  ps -aef | grep -v grep | grep grails | grep run-app > /dev/null; then
         print_header
         RUNNING_APPS="${RUNNING_APPS} Grails"
         echo "#   ${TOMCAT_USER}:      noticed you are running grails run-app instead of ${TOMCAT_USER}"
         else
-            RUNNING_APPS="${RUNNING_APPS} ${TOMCAT_USER}"
+            if [ ! -z "$TOMCAT_SERVICE" ]; then
+                RUNNING_APPS="${RUNNING_APPS} ${TOMCAT_USER}"
+            fi
         fi
     fi
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
* restores `bigbluebutton.target` as the one in control of what needs to be started/stopped with bbb-conf --start/stop
* one more tweak to the tomcat9 checks

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none


### Motivation
In https://github.com/bigbluebutton/bigbluebutton/pull/14616 we changed the start/stop command to utilize `bigbluebutton.target` However, likely during a merge from v2.5.x-release, we added a bunch more services to the command reducing its value.

The check for Tomcat is an addition to https://github.com/bigbluebutton/bigbluebutton/pull/15489 -- we were still listing tomcat9 as a non-running app
<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->
