### PR TITLE
Fix for #15387: Test if `$TOMCAT_SERVICE` is set

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -420,7 +420,7 @@ start_bigbluebutton () {
         TOMCAT_SERVICE=$TOMCAT_USER
     fi
 
-    systemctl start $TOMCAT_SERVICE || {
+    [ -z "$TOMCAT_SERVICE" ] || systemctl start $TOMCAT_SERVICE || {
         echo
         echo "# Warning: $TOMCAT_SERVICE could not be started. Please, check BBB-LTI or BBB-Demo."
         echo "#     Run the command:"


### PR DESCRIPTION
### What does this PR do?

This fix adds a test to see if `$TOMCAT_SERVICE` is set before calling systemctrl.

### Closes Issue(s)
Closes #15387

### Motivation

The problem exists since version 2.5.3 and has not been fixed until now.
