### PR TITLE
fix(webcam): switching profiles in preview fails intermittently

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -383,15 +383,20 @@ class VideoPreview extends Component {
     });
   }
 
-  handleLocalStreamInactive() {
-    this.setState({
-      isStartSharingDisabled: true,
-    });
-    this.handlePreviewError(
-      'stream_inactive',
-      new Error('inactiveError'),
-      '- preview camera stream inactive',
-    );
+  handleLocalStreamInactive({ id }) {
+    // id === MediaStream.id
+    if (this.currentVideoStream
+      && typeof id === 'string'
+      && this.currentVideoStream?.mediaStream?.id === id) {
+      this.setState({
+        isStartSharingDisabled: true,
+      });
+      this.handlePreviewError(
+        'stream_inactive',
+        new Error('inactiveError'),
+        '- preview camera stream inactive',
+      );
+    }
   }
 
   updateVirtualBackgroundInfo = () => {
@@ -547,7 +552,7 @@ class VideoPreview extends Component {
     if (stream) {
       // Stream is being destroyed - remove gUM revocation handler to avoid false negatives
       stream.removeListener('inactive', this.handleLocalStreamInactive);
-      PreviewService.terminateCameraStream(this.currentVideoStream, deviceId);
+      PreviewService.terminateCameraStream(stream, deviceId);
     }
   }
 

--- a/bigbluebutton-html5/imports/ui/components/video-preview/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/service.js
@@ -3,8 +3,12 @@ import getFromUserSettings from '/imports/ui/services/users-settings';
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
 import VideoService from '/imports/ui/components/video-provider/service';
 import BBBVideoStream from '/imports/ui/services/webrtc-base/bbb-video-stream';
+import browserInfo from '/imports/utils/browserInfo';
 
 const GUM_TIMEOUT = Meteor.settings.public.kurento.gUMTimeout;
+// GUM retry + delay params (Chrome only for now)
+const GUM_MAX_RETRIES = 5;
+const GUM_RETRY_DELAY = 200;
 // Unfiltered, includes hidden profiles
 const CAMERA_PROFILES = Meteor.settings.public.kurento.cameraProfiles || [];
 // Filtered, without hidden profiles
@@ -134,7 +138,36 @@ const digestVideoDevices = (devices, priorityDevice) => {
     areLabelled,
     areIdentified,
   };
-}
+};
+
+const _retry = (foo, opts) => new Promise((resolve, reject) => {
+  const {
+    retries = 1,
+    delay = 0,
+    error: bubbledError,
+    errorRetryList = [],
+  } = opts;
+
+  if (!retries) return reject(bubbledError);
+
+  return foo().then(resolve).catch((_error) => {
+    if (errorRetryList.length > 0
+      && !errorRetryList.some((eName) => _error.name === eName)) {
+      reject(_error);
+      return;
+    }
+
+    const newOpts = {
+      ...opts,
+      retries: retries - 1,
+      error: _error,
+    };
+
+    setTimeout(() => {
+      _retry(foo, newOpts).then(resolve).catch(reject);
+    }, delay);
+  });
+});
 
 // Returns a promise that resolves an instance of BBBVideoStream or rejects an *Error
 const doGUM = (deviceId, profile) => {
@@ -153,13 +186,28 @@ const doGUM = (deviceId, profile) => {
   }
 
   const postProcessedgUM = (cts) => {
-    return navigator.mediaDevices.getUserMedia(cts).then((stream) => {
-      return (new BBBVideoStream(stream));
-    });
+    const ppGUM = () => navigator.mediaDevices.getUserMedia(cts)
+      .then((stream) => new BBBVideoStream(stream));
+
+    // Chrome/Edge sometimes bork gUM calls when switching camera
+    // profiles. This looks like a browser bug. Track release not
+    // being done synchronously -> quick subsequent gUM calls for the same
+    // device (profile switching) -> device becoming unavaible while previous
+    // tracks aren't finished - prlanzarin
+    if (browserInfo.isChrome || browserInfo.isEdge) {
+      const opts = {
+        retries: GUM_MAX_RETRIES,
+        errorRetryList: ['NotReadableError'],
+        delay: GUM_RETRY_DELAY,
+      };
+      return _retry(ppGUM, opts);
+    }
+
+    return ppGUM();
   };
 
   return promiseTimeout(GUM_TIMEOUT, postProcessedgUM(constraints));
-}
+};
 
 const terminateCameraStream = (bbbVideoStream, deviceId) => {
   // Cleanup current stream if it wasn't shared/stored


### PR DESCRIPTION
### What does this PR do?

- [fix(webcam): retry gUM on NotReadableError for Chrome/Edge](https://github.com/bigbluebutton/bigbluebutton/commit/5d04bcaf93af68eab7a90b75a626860ed41e65ef)
  * Chrome/Edge sometimes bork gUM calls when switching camera
profiles. This looks like a browser bug (issue TBD). Track release not
being done synchronously -> quick subsequent gUM calls for the same
device (profile switching) -> device becoming unavaible while previous
tracks aren't finished.
Since track stop is not "awaitable", this commit adds a retry procedure
that re-runs gUM up to 5 times (200 ms delay) only if error.name is
NotReadableError and browser is either Chrome or Edge.
- [fix(webcam): add MediaStream id to 'inactive' event handlers](https://github.com/bigbluebutton/bigbluebutton/commit/646db913676a4bca47d6e9b1b7168fabc0eb3858)
  * BBBVideoStream 'inactive' event currently does not send the
MediaStream id as the payload for handlers. This can cause theoretical
race conditions due to media stream mismatches in places where
'inactive' handling is done globally (eg video-preview).
This adds the MediaStream id to BBBVideoStream's 'inactive' event
and uses it in video-preview to avoid such race conditions.

### Closes Issue(s)

None