### PR TITLE
use findMeetingFromMeetingID in API calls

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -31,6 +31,7 @@ import org.bigbluebutton.api.domain.GuestPolicy
 import org.bigbluebutton.api.domain.Meeting
 import org.bigbluebutton.api.domain.UserSession
 import org.bigbluebutton.api.service.ValidationService
+import org.bigbluebutton.api.service.ServiceUtils
 import org.bigbluebutton.api.util.ParamsUtil
 import org.bigbluebutton.api.util.ResponseBuilder
 import org.bigbluebutton.presentation.PresentationUrlDownloadService
@@ -229,16 +230,9 @@ class ApiController {
 
     String fullName = ParamsUtil.stripControlChars(params.fullName)
 
-    String externalMeetingId = params.meetingID
-
     String attPW = params.password
 
-    // Everything is good so far. Translate the external meeting id to an internal meeting id. If
-    // we can't find the meeting, complain.
-    String internalMeetingId = paramsProcessorUtil.convertToInternalMeetingId(externalMeetingId);
-
-    log.info("Retrieving meeting ${internalMeetingId}")
-    Meeting meeting = meetingService.getMeeting(internalMeetingId);
+    Meeting meeting = ServiceUtils.findMeetingFromMeetingID(params.meetingID);
 
     // the createTime mismatch with meeting's createTime, complain
     // In the future, the createTime param will be required
@@ -511,13 +505,7 @@ class ApiController {
       return
     }
 
-    String externalMeetingId = params.meetingID
-
-    // Everything is good so far. Translate the external meeting id to an internal meeting id. If
-    // we can't find the meeting, complain.
-    String internalMeetingId = paramsProcessorUtil.convertToInternalMeetingId(externalMeetingId);
-    log.info("Retrieving meeting ${internalMeetingId}")
-    Meeting meeting = meetingService.getMeeting(internalMeetingId);
+    Meeting meeting = ServiceUtils.findMeetingFromMeetingID(params.meetingID);
     boolean isRunning = meeting != null && meeting.isRunning();
 
     response.addHeader("Cache-Control", "no-cache")
@@ -548,10 +536,7 @@ class ApiController {
       return
     }
 
-    String externalMeetingId = params.meetingID
-    String internalMeetingId = paramsProcessorUtil.convertToInternalMeetingId(externalMeetingId)
-    log.info("Retrieving meeting ${internalMeetingId}")
-    Meeting meeting = meetingService.getMeeting(internalMeetingId)
+    Meeting meeting = ServiceUtils.findMeetingFromMeetingID(params.meetingID);
 
     Map<String, Object> logData = new HashMap<String, Object>();
     logData.put("meetingid", meeting.getInternalId());
@@ -595,10 +580,7 @@ class ApiController {
       return
     }
 
-    String externalMeetingId = params.meetingID
-    String internalMeetingId = paramsProcessorUtil.convertToInternalMeetingId(externalMeetingId);
-    log.info("Retrieving meeting ${internalMeetingId}")
-    Meeting meeting = meetingService.getMeeting(internalMeetingId);
+    Meeting meeting = ServiceUtils.findMeetingFromMeetingID(params.meetingID);
 
     withFormat {
       xml {
@@ -721,9 +703,7 @@ class ApiController {
     }
 
 
-    // Translate the external meeting id into an internal meeting id.
-    String internalMeetingId = paramsProcessorUtil.convertToInternalMeetingId(params.meetingID);
-    Meeting meeting = meetingService.getMeeting(internalMeetingId);
+    Meeting meeting = ServiceUtils.findMeetingFromMeetingID(params.meetingID);
 
     String pollXML = params.pollXML
 
@@ -1167,10 +1147,7 @@ class ApiController {
       return
     }
 
-    String externalMeetingId = params.meetingID
-    String internalMeetingId = paramsProcessorUtil.convertToInternalMeetingId(externalMeetingId)
-    log.info("Retrieving meeting ${internalMeetingId}")
-    Meeting meeting = meetingService.getMeeting(internalMeetingId)
+    Meeting meeting = ServiceUtils.findMeetingFromMeetingID(params.meetingID);
 
     if (meeting != null){
       uploadDocuments(meeting, true);


### PR DESCRIPTION
When matching user-supplied meeting IDs in API calls, use `ServiceUtils.findMeetingFromMeetingID` instead of `meetingService.getMeeting`, in order to handle either external or internal meeting IDs

Prior to this PR, passing an internal meeting ID to `getMeetingInfo` (and probably other API calls) would trigger a 500 Internal Server Error in response.

Since the authentication API returns the internal meeting ID in response to a `checkAuthorization` call, it is important for the client-facing API to handle this case.
