### PR TITLE
test suite: add API tests for getMeetings/getMeetingInfo

### DIFF
--- a/bigbluebutton-tests/playwright/api/api.js
+++ b/bigbluebutton-tests/playwright/api/api.js
@@ -4,8 +4,16 @@ const { expect } = require("@playwright/test");
 
 const Page = require('../core/page');
 const parameters = require('../core/parameters');
-const { createMeeting, getMeetings, getMeetingInfo } = require('../core/helpers');
+const { apiCall, createMeeting } = require('../core/helpers');
 const e = require('../core/elements');
+
+function getMeetings() {
+  return apiCall('getMeetings', {});
+}
+
+function getMeetingInfo(meetingID) {
+  return apiCall('getMeetingInfo', {meetingID: meetingID});
+}
 
 class API {
 

--- a/bigbluebutton-tests/playwright/api/api.js
+++ b/bigbluebutton-tests/playwright/api/api.js
@@ -28,16 +28,10 @@ class API {
       modPage.init(true, false, { meetingId, fullName: 'Moderator' }),
       userPage.init(false, false, { meetingId, fullName: 'Attendee' }),
     ]);
-    await modPage.waitForSelector(e.audioModal);
-    await userPage.waitForSelector(e.audioModal);
-
-    await modPage.waitAndClick(e.microphoneButton);
-    await userPage.waitAndClick(e.microphoneButton);
-    await modPage.waitAndClick(e.echoYesButton, modPage.settings.listenOnlyCallTimeout);
-    await userPage.waitAndClick(e.echoYesButton, userPage.settings.listenOnlyCallTimeout);
-
-    await modPage.hasElement(e.leaveAudio);
-    await userPage.hasElement(e.leaveAudio);
+    await Promise.all([
+      modPage.joinMicrophone(),
+      userPage.joinMicrophone()
+    ]);
 
     /* hasJoinedVoice: ['true'] is not part of these expectedUser patterns because it isn't consistently true
      * in the API's returned data structures.  Is there something we can await on the browser page that
@@ -63,7 +57,6 @@ class API {
 
     /* check that this meeting is in the server's list of all meetings */
     const response = await getMeetings();
-    // console.log(util.inspect(response, false, null));
     expect(response.response.returncode).toEqual(['SUCCESS']);
     expect(response.response.meetings[0].meeting).toContainEqual(expect.objectContaining(expectedMeeting));
 
@@ -79,16 +72,10 @@ class API {
       modPage.init(true, false, { meetingId, fullName: 'Moderator' }),
       userPage.init(false, false, { meetingId, fullName: 'Attendee' }),
     ]);
-    await modPage.waitForSelector(e.audioModal);
-    await userPage.waitForSelector(e.audioModal);
-
-    await modPage.waitAndClick(e.microphoneButton);
-    await userPage.waitAndClick(e.microphoneButton);
-    await modPage.waitAndClick(e.echoYesButton, modPage.settings.listenOnlyCallTimeout);
-    await userPage.waitAndClick(e.echoYesButton, userPage.settings.listenOnlyCallTimeout);
-
-    await modPage.hasElement(e.leaveAudio);
-    await userPage.hasElement(e.leaveAudio);
+    await Promise.all([
+      modPage.joinMicrophone(),
+      userPage.joinMicrophone()
+    ]);
 
     /* hasJoinedVoice: ['true'] is not part of these expectedUser patterns because it isn't consistently true
      * in the API's returned data structures.  Is there something we can await on the browser page that
@@ -114,13 +101,11 @@ class API {
 
     /* check that we can retrieve this meeting by its meetingId */
     const response2 = await getMeetingInfo(meetingId);
-    // console.log(util.inspect(response2, false, null));
     expect(response2.response.returncode).toEqual(['SUCCESS']);
     expect(response2.response).toMatchObject(expectedMeeting);
 
     /* check that we can retrieve this meeting by its internal meeting ID */
     const response3 = await getMeetingInfo(response2.response.internalMeetingID[0]);
-    // console.log(util.inspect(response3, false, null));
     expect(response3.response.returncode).toEqual(['SUCCESS']);
     expect(response3.response).toMatchObject(expectedMeeting);
 

--- a/bigbluebutton-tests/playwright/api/api.js
+++ b/bigbluebutton-tests/playwright/api/api.js
@@ -1,0 +1,87 @@
+// const util = require('node:util');
+
+const { expect } = require("@playwright/test");
+
+const Page = require('../core/page');
+const parameters = require('../core/parameters');
+const { createMeeting, getMeetings, getMeetingInfo } = require('../core/helpers');
+const e = require('../core/elements');
+
+class API {
+
+  constructor(browser, context, page) {
+    this.modPage = new Page(browser, page);
+    this.browser = browser;
+    this.context = context;
+    this.userPages = [];
+  }
+
+  async getNewPageTab() {
+    return this.browser.newPage();
+  }
+
+  async getMeetingInfo() {
+    const meetingId = await createMeeting(parameters);
+    const modPage = new Page(this.browser, await this.getNewPageTab());
+    const userPage = new Page(this.browser, await this.getNewPageTab());
+    await Promise.all([
+      modPage.init(true, false, { meetingId, fullName: 'Moderator' }),
+      userPage.init(false, false, { meetingId, fullName: 'Attendee' }),
+    ]);
+    await modPage.waitForSelector(e.audioModal);
+    await userPage.waitForSelector(e.audioModal);
+
+    await modPage.waitAndClick(e.microphoneButton);
+    await userPage.waitAndClick(e.microphoneButton);
+    await modPage.waitAndClick(e.echoYesButton, modPage.settings.listenOnlyCallTimeout);
+    await userPage.waitAndClick(e.echoYesButton, userPage.settings.listenOnlyCallTimeout);
+
+    await modPage.hasElement(e.leaveAudio);
+    await userPage.hasElement(e.leaveAudio);
+
+    /* hasJoinedVoice: ['true'] is not part of these expectedUser patterns because it isn't consistently true
+     * in the API's returned data structures.  Is there something we can await on the browser page that
+     * should ensure that the API will report hasJoinedVoice?
+     */
+
+    const expectedUsers = [expect.objectContaining({fullName: ['Moderator'],
+						    role: ['MODERATOR'],
+						    isPresenter: ['true'],
+						   }),
+			   expect.objectContaining({fullName: ['Attendee'],
+						    role: ['VIEWER'],
+						    isPresenter: ['false'],
+						   })
+			  ];
+    const expectedMeeting = {meetingName : [meetingId],
+			     running : ['true'],
+			     participantCount : ['2'],
+			     moderatorCount : ['1'],
+			     isBreakout: ['false'],
+			     attendees: [{ attendee: expect.arrayContaining(expectedUsers) }]
+			    };
+
+    /* check that this meeting is in the server's list of all meetings */
+    const response = await getMeetings();
+    // console.log(util.inspect(response, false, null));
+    expect(response.response.returncode).toEqual(['SUCCESS']);
+    expect(response.response.meetings[0].meeting).toContainEqual(expect.objectContaining(expectedMeeting));
+
+    /* check that we can retrieve this meeting by its meetingId */
+    const response2 = await getMeetingInfo(meetingId);
+    // console.log(util.inspect(response2, false, null));
+    expect(response2.response.returncode).toEqual(['SUCCESS']);
+    expect(response2.response).toMatchObject(expectedMeeting);
+
+    /* check that we can retrieve this meeting by its internal meeting ID */
+    const response3 = await getMeetingInfo(response2.response.internalMeetingID[0]);
+    // console.log(util.inspect(response3, false, null));
+    expect(response3.response.returncode).toEqual(['SUCCESS']);
+    expect(response3.response).toMatchObject(expectedMeeting);
+
+    await modPage.page.close();
+    await userPage.page.close();
+  }
+}
+
+exports.API = API;

--- a/bigbluebutton-tests/playwright/api/api.spec.js
+++ b/bigbluebutton-tests/playwright/api/api.spec.js
@@ -1,0 +1,11 @@
+const { test } = require('@playwright/test');
+const { API } = require('./api.js');
+
+test.describe.parallel('API', () => {
+
+  test('getMeetings / getMeetingInfo', async ({ browser, context, page }) => {
+    const api = new API(browser, context, page);
+    await api.getMeetingInfo();
+  });
+
+});

--- a/bigbluebutton-tests/playwright/api/api.spec.js
+++ b/bigbluebutton-tests/playwright/api/api.spec.js
@@ -3,9 +3,14 @@ const { API } = require('./api.js');
 
 test.describe.parallel('API', () => {
 
-  test('getMeetings / getMeetingInfo', async ({ browser, context, page }) => {
+  test('getMeetings', async ({ browser, context, page }) => {
     const api = new API(browser, context, page);
-    await api.getMeetingInfo();
+    await api.testGetMeetings();
+  });
+
+  test('getMeetingInfo', async ({ browser, context, page }) => {
+    const api = new API(browser, context, page);
+    await api.testGetMeetingInfo();
   });
 
 });

--- a/bigbluebutton-tests/playwright/core/helpers.js
+++ b/bigbluebutton-tests/playwright/core/helpers.js
@@ -28,14 +28,6 @@ function apiCall(name, callParams) {
   return axios.get(url, { adapter: http }).then(response => xml2js.parseStringPromise(response.data));
 }
 
-function getMeetings() {
-  return apiCall('getMeetings', {});
-}
-
-function getMeetingInfo(meetingID) {
-  return apiCall('getMeetingInfo', {meetingID: meetingID});
-}
-
 function createMeetingUrl(params, customParameter) {
   const meetingID = `random-${getRandomInt(1000000, 10000000).toString()}`;
   const mp = params.moderatorPW;
@@ -79,8 +71,6 @@ function sleep(time) {
 exports.getRandomInt = getRandomInt;
 exports.apiCallUrl = apiCallUrl;
 exports.apiCall = apiCall;
-exports.getMeetings = getMeetings;
-exports.getMeetingInfo = getMeetingInfo;
 exports.createMeetingUrl = createMeetingUrl;
 exports.createMeetingPromise = createMeetingPromise;
 exports.createMeeting = createMeeting;

--- a/bigbluebutton-tests/playwright/core/helpers.js
+++ b/bigbluebutton-tests/playwright/core/helpers.js
@@ -2,6 +2,9 @@ require('dotenv').config();
 const sha1 = require('sha1');
 const path = require('path');
 const axios = require('axios');
+const xml2js = require('xml2js');
+
+const parameters = require('./parameters');
 
 const httpPath = path.join(path.dirname(require.resolve('axios')), 'lib/adapters/http');
 const http = require(httpPath);
@@ -10,6 +13,22 @@ function getRandomInt(min, max) {
   min = Math.ceil(min);
   max = Math.floor(max);
   return Math.floor(Math.random() * (max - min)) + min;
+}
+
+async function apiCall(name, callParams) {
+  const query = new URLSearchParams(callParams).toString();
+  const apicall = `${name}${query}${parameters.secret}`;
+  const checksum = sha1(apicall);
+  const url = `${parameters.server}/${name}?${query}&checksum=${checksum}`;
+  return axios.get(url, { adapter: http }).then(response => xml2js.parseStringPromise(response.data));
+}
+
+async function getMeetings() {
+  return apiCall('getMeetings', {});
+}
+
+async function getMeetingInfo(meetingID) {
+  return apiCall('getMeetingInfo', {meetingID: meetingID});
 }
 
 async function createMeeting(params, customParameter) {
@@ -43,6 +62,9 @@ function sleep(time) {
 }
 
 exports.getRandomInt = getRandomInt;
+exports.apiCall = apiCall;
+exports.getMeetings = getMeetings;
+exports.getMeetingInfo = getMeetingInfo;
 exports.createMeeting = createMeeting;
 exports.getJoinURL = getJoinURL;
 exports.sleep = sleep;

--- a/bigbluebutton-tests/playwright/core/helpers.js
+++ b/bigbluebutton-tests/playwright/core/helpers.js
@@ -52,7 +52,7 @@ function createMeetingPromise(params, customParameter) {
 async function createMeeting(params, customParameter) {
   const promise = createMeetingPromise(params, customParameter);
   const response = await promise;
-  expect(response.data.response.returncode).toEqual('SUCCESS');
+  expect(response.status).toEqual(200);
   const xmlresponse = await xml2js.parseStringPromise(response.data);
   return xmlresponse.response.meetingID[0];
 }

--- a/bigbluebutton-tests/playwright/core/helpers.js
+++ b/bigbluebutton-tests/playwright/core/helpers.js
@@ -4,6 +4,8 @@ const path = require('path');
 const axios = require('axios');
 const xml2js = require('xml2js');
 
+const { expect } = require("@playwright/test");
+
 const parameters = require('./parameters');
 
 const httpPath = path.join(path.dirname(require.resolve('axios')), 'lib/adapters/http');
@@ -49,8 +51,10 @@ function createMeetingPromise(params, customParameter) {
 
 async function createMeeting(params, customParameter) {
   const promise = createMeetingPromise(params, customParameter);
-  const response = await promise.then(response => xml2js.parseStringPromise(response.data));
-  return response.response.meetingID[0];
+  const response = await promise;
+  expect(response.data.response.returncode).toEqual('SUCCESS');
+  const xmlresponse = await xml2js.parseStringPromise(response.data);
+  return xmlresponse.response.meetingID[0];
 }
 
 function getJoinURL(meetingID, params, moderator, customParameter) {

--- a/bigbluebutton-tests/playwright/core/helpers.js
+++ b/bigbluebutton-tests/playwright/core/helpers.js
@@ -15,23 +15,28 @@ function getRandomInt(min, max) {
   return Math.floor(Math.random() * (max - min)) + min;
 }
 
-async function apiCall(name, callParams) {
+function apiCallUrl(name, callParams) {
   const query = new URLSearchParams(callParams).toString();
   const apicall = `${name}${query}${parameters.secret}`;
   const checksum = sha1(apicall);
   const url = `${parameters.server}/${name}?${query}&checksum=${checksum}`;
+  return url;
+}
+
+function apiCall(name, callParams) {
+  const url = apiCallUrl(name, callParams);
   return axios.get(url, { adapter: http }).then(response => xml2js.parseStringPromise(response.data));
 }
 
-async function getMeetings() {
+function getMeetings() {
   return apiCall('getMeetings', {});
 }
 
-async function getMeetingInfo(meetingID) {
+function getMeetingInfo(meetingID) {
   return apiCall('getMeetingInfo', {meetingID: meetingID});
 }
 
-async function createMeeting(params, customParameter) {
+function createMeetingUrl(params, customParameter) {
   const meetingID = `random-${getRandomInt(1000000, 10000000).toString()}`;
   const mp = params.moderatorPW;
   const ap = params.attendeePW;
@@ -42,8 +47,18 @@ async function createMeeting(params, customParameter) {
   const apicall = `create${query}${params.secret}`;
   const checksum = sha1(apicall);
   const url = `${params.server}/create?${query}&checksum=${checksum}`;
-  await axios.get(url, { adapter: http });
-  return meetingID;
+  return url;
+}
+
+function createMeetingPromise(params, customParameter) {
+  const url = createMeetingUrl(params, customParameter);
+  return axios.get(url, { adapter: http });
+}
+
+async function createMeeting(params, customParameter) {
+  const promise = createMeetingPromise(params, customParameter);
+  const response = await promise.then(response => xml2js.parseStringPromise(response.data));
+  return response.response.meetingID[0];
 }
 
 function getJoinURL(meetingID, params, moderator, customParameter) {
@@ -62,9 +77,12 @@ function sleep(time) {
 }
 
 exports.getRandomInt = getRandomInt;
+exports.apiCallUrl = apiCallUrl;
 exports.apiCall = apiCall;
 exports.getMeetings = getMeetings;
 exports.getMeetingInfo = getMeetingInfo;
+exports.createMeetingUrl = createMeetingUrl;
+exports.createMeetingPromise = createMeetingPromise;
 exports.createMeeting = createMeeting;
 exports.getJoinURL = getJoinURL;
 exports.sleep = sleep;

--- a/bigbluebutton-tests/playwright/package-lock.json
+++ b/bigbluebutton-tests/playwright/package-lock.json
@@ -9,7 +9,8 @@
         "axios": "^0.26.1",
         "dotenv": "^16.0.0",
         "playwright": "^1.19.2",
-        "sha1": "^1.1.1"
+        "sha1": "^1.1.1",
+        "xml2js": "^0.4.23"
       }
     },
     "node_modules/@playwright/test": {
@@ -109,6 +110,11 @@
         "node": ">=14"
       }
     },
+    "node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "node_modules/sha1": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz",
@@ -119,6 +125,26 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "engines": {
+        "node": ">=4.0"
       }
     }
   },
@@ -178,6 +204,11 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.22.2.tgz",
       "integrity": "sha512-w/hc/Ld0RM4pmsNeE6aL/fPNWw8BWit2tg+TfqJ3+p59c6s3B6C8mXvXrIPmfQEobkcFDc+4KirNzOQ+uBSP1Q=="
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "sha1": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz",
@@ -186,6 +217,20 @@
         "charenc": ">= 0.0.1",
         "crypt": ">= 0.0.1"
       }
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     }
   }
 }

--- a/bigbluebutton-tests/playwright/package.json
+++ b/bigbluebutton-tests/playwright/package.json
@@ -9,9 +9,10 @@
   },
   "dependencies": {
     "@playwright/test": "^1.19.2",
-    "playwright": "^1.19.2",
     "axios": "^0.26.1",
     "dotenv": "^16.0.0",
-    "sha1": "^1.1.1"
+    "playwright": "^1.19.2",
+    "sha1": "^1.1.1",
+    "xml2js": "^0.4.23"
   }
 }


### PR DESCRIPTION
This tests the bug fixed in PR #15652

Creates a new `api` directory `bigbluebutton-tests/playwright` intended for API tests.  Currently only `getMeetings` and `getMeetingInfo` are tested explicitly, though `create` and `join` are also tested because they're used throughout the test suite.

This also creates a new package requirement (xml2js) for the playwright test suite and adds a new helper function to make an API call and obtain its parsed XML response as a JavaScript object.
