### PR TITLE
Fix: bigbluebutton-html5 warnings

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -640,7 +640,7 @@ class App extends Component {
     return (
       <>
         <Notifications />
-        <LayoutEngine layoutType={selectedLayout} />
+        {selectedLayout ? <LayoutEngine layoutType={selectedLayout} /> : null}
         <GlobalStyles />
         <Styled.Layout
           id="layout"

--- a/bigbluebutton-html5/imports/ui/components/common/button/base/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/button/base/component.jsx
@@ -163,6 +163,7 @@ export default class ButtonBase extends React.Component {
       'full',
       'iconRight',
       'isVisualEffects',
+      'panning',
     ];
 
     return (

--- a/bigbluebutton-html5/imports/ui/components/common/control-header/left/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/control-header/left/component.jsx
@@ -12,7 +12,7 @@ class Left extends Component {
       <Styled.HideButton
         className="buttonWrapper"
         icon="left_arrow"
-        tabindex={0}
+        tabIndex={0}
         {...this.props}
       />
     );


### PR DESCRIPTION
### What does this PR do?

Fix the following warnings:
- Warning: Received false for a non-boolean attribute panning. (`ButtonBase` component)
- Warning: Invalid DOM property tabindex. Did you mean tabIndex? (control header `Left` component)
- Warning: Failed prop type: The prop layoutType is marked as required in LayoutEngine, but its value is undefined. (`LayoutEngine` being rendered too soon in `App` component)