### PR TITLE
refactor: rename external upload parameters

### DIFF
--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
@@ -9,16 +9,16 @@ case class DurationProps(duration: Int, createdTime: Long, createdDate: String,
                          endWhenNoModerator:                     Boolean, endWhenNoModeratorDelayInMinutes: Int)
 
 case class MeetingProp(
-    name:                       String,
-    extId:                      String,
-    intId:                      String,
-    meetingCameraCap:           Int,
-    maxPinnedCameras:           Int,
-    isBreakout:                 Boolean,
-    disabledFeatures:           Vector[String],
-    notifyRecordingIsOn:        Boolean,
-    uploadExternalDescription:  String,
-    uploadExternalUrl:          String,
+    name:                                   String,
+    extId:                                  String,
+    intId:                                  String,
+    meetingCameraCap:                       Int,
+    maxPinnedCameras:                       Int,
+    isBreakout:                             Boolean,
+    disabledFeatures:                       Vector[String],
+    notifyRecordingIsOn:                    Boolean,
+    presentationUploadExternalDescription:  String,
+    presentationUploadExternalUrl:          String,
 )
 
 case class BreakoutProps(

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -73,8 +73,8 @@ public class ApiParams {
     public static final String DISABLED_FEATURES = "disabledFeatures";
     public static final String NOTIFY_RECORDING_IS_ON = "notifyRecordingIsOn";
 
-    public static final String UPLOAD_EXTERNAL_DESCRIPTION = "uploadExternalDescription";
-    public static final String UPLOAD_EXTERNAL_URL = "uploadExternalUrl";
+    public static final String PRESENTATION_UPLOAD_EXTERNAL_DESCRIPTION = "presentationUploadExternalDescription";
+    public static final String PRESENTATION_UPLOAD_EXTERNAL_URL = "presentationUploadExternalUrl";
 
     public static final String BREAKOUT_ROOMS_ENABLED = "breakoutRoomsEnabled";
     public static final String BREAKOUT_ROOMS_RECORD = "breakoutRoomsRecord";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -422,7 +422,7 @@ public class MeetingService implements MessageListener {
             m.getMuteOnStart(), m.getAllowModsToUnmuteUsers(), m.getAllowModsToEjectCameras(), m.getMeetingKeepEvents(),
             m.breakoutRoomsParams, m.lockSettingsParams, m.getHtml5InstanceId(),
             m.getGroups(), m.getDisabledFeatures(), m.getNotifyRecordingIsOn(),
-            m.getUploadExternalDescription(), m.getUploadExternalUrl());
+            m.getPresentationUploadExternalDescription(), m.getPresentationUploadExternalUrl());
   }
 
   private String formatPrettyDate(Long timestamp) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -101,8 +101,8 @@ public class ParamsProcessorUtil {
     private boolean defaultKeepEvents = false;
     private Boolean useDefaultLogo;
     private String defaultLogoURL;
-    private String defaultUploadExternalDescription = "";
-    private String defaultUploadExternalUrl = "";
+    private String defaultPresentationUploadExternalDescription = "";
+    private String defaultPresentationUploadExternalUrl = "";
 
 		private boolean defaultBreakoutRoomsEnabled = true;
 		private boolean defaultBreakoutRoomsRecord;
@@ -620,14 +620,14 @@ public class ParamsProcessorUtil {
         	guestPolicy = params.get(ApiParams.GUEST_POLICY);
 		    }
 
-        String uploadExternalDescription = defaultUploadExternalDescription;
-        if (!StringUtils.isEmpty(params.get(ApiParams.UPLOAD_EXTERNAL_DESCRIPTION))) {
-            uploadExternalDescription = params.get(ApiParams.UPLOAD_EXTERNAL_DESCRIPTION);
+        String presentationUploadExternalDescription = defaultPresentationUploadExternalDescription;
+        if (!StringUtils.isEmpty(params.get(ApiParams.PRESENTATION_UPLOAD_EXTERNAL_DESCRIPTION))) {
+            presentationUploadExternalDescription = params.get(ApiParams.PRESENTATION_UPLOAD_EXTERNAL_DESCRIPTION);
         }
 
-        String uploadExternalUrl = defaultUploadExternalUrl;
-        if (!StringUtils.isEmpty(params.get(ApiParams.UPLOAD_EXTERNAL_URL))) {
-            uploadExternalUrl = params.get(ApiParams.UPLOAD_EXTERNAL_URL);
+        String presentationUploadExternalUrl = defaultPresentationUploadExternalUrl;
+        if (!StringUtils.isEmpty(params.get(ApiParams.PRESENTATION_UPLOAD_EXTERNAL_URL))) {
+            presentationUploadExternalUrl = params.get(ApiParams.PRESENTATION_UPLOAD_EXTERNAL_URL);
         }
 
         String meetingLayout = defaultMeetingLayout;
@@ -713,8 +713,8 @@ public class ParamsProcessorUtil {
                 .withGroups(groups)
                 .withDisabledFeatures(listOfDisabledFeatures)
                 .withNotifyRecordingIsOn(notifyRecordingIsOn)
-                .withUploadExternalDescription(uploadExternalDescription)
-                .withUploadExternalUrl(uploadExternalUrl)
+                .withPresentationUploadExternalDescription(presentationUploadExternalDescription)
+                .withPresentationUploadExternalUrl(presentationUploadExternalUrl)
                 .build();
 
         if (!StringUtils.isEmpty(params.get(ApiParams.MODERATOR_ONLY_MESSAGE))) {
@@ -1383,12 +1383,12 @@ public class ParamsProcessorUtil {
       this.defaultNotifyRecordingIsOn = notifyRecordingIsOn;
   }
 
-  public void setUploadExternalDescription(String uploadExternalDescription) {
-    this.defaultUploadExternalDescription = uploadExternalDescription;
+  public void setPresentationUploadExternalDescription(String presentationUploadExternalDescription) {
+    this.defaultPresentationUploadExternalDescription = presentationUploadExternalDescription;
   }
 
-  public void setUploadExternalUrl(String uploadExternalUrl) {
-    this.defaultUploadExternalUrl = uploadExternalUrl;
+  public void setPresentationUploadExternalUrl(String presentationUploadExternalUrl) {
+    this.defaultPresentationUploadExternalUrl = presentationUploadExternalUrl;
   }
 
   public void setBbbVersion(String version) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -95,8 +95,8 @@ public class Meeting {
 	private Boolean allowRequestsWithoutSession = false;
 	private Boolean allowModsToEjectCameras = false;
 	private Boolean meetingKeepEvents;
-	private String uploadExternalDescription;
-	private String uploadExternalUrl;
+	private String presentationUploadExternalDescription;
+	private String presentationUploadExternalUrl;
 
 	private Integer meetingExpireIfNoUserJoinedInMinutes = 5;
 	private Integer meetingExpireWhenLastUserLeftInMinutes = 1;
@@ -121,8 +121,8 @@ public class Meeting {
         intMeetingId = builder.internalId;
 		disabledFeatures = builder.disabledFeatures;
 		notifyRecordingIsOn = builder.notifyRecordingIsOn;
-		uploadExternalDescription = builder.uploadExternalDescription;
-		uploadExternalUrl = builder.uploadExternalUrl;
+		presentationUploadExternalDescription = builder.presentationUploadExternalDescription;
+		presentationUploadExternalUrl = builder.presentationUploadExternalUrl;
 		if (builder.viewerPass == null){
 			viewerPass = "";
 		} else {
@@ -384,11 +384,11 @@ public class Meeting {
 		return notifyRecordingIsOn;
 	}
 
-	public String getUploadExternalDescription() {
-		return uploadExternalDescription;
+	public String getPresentationUploadExternalDescription() {
+		return presentationUploadExternalDescription;
 	}
-	public String getUploadExternalUrl() {
-		return uploadExternalUrl;
+	public String getPresentationUploadExternalUrl() {
+		return presentationUploadExternalUrl;
 	}
 
   public String getWelcomeMessageTemplate() {
@@ -821,8 +821,8 @@ public class Meeting {
     	private String learningDashboardAccessToken;
 		private ArrayList<String> disabledFeatures;
 		private Boolean notifyRecordingIsOn;
-		private String uploadExternalDescription;
-		private String uploadExternalUrl;
+		private String presentationUploadExternalDescription;
+		private String presentationUploadExternalUrl;
     	private int duration;
     	private String webVoice;
     	private String telVoice;
@@ -950,13 +950,13 @@ public class Meeting {
 	    	return this;
 	    }
 
-    	public Builder withUploadExternalDescription(String d) {
-	    	this.uploadExternalDescription = d;
+    	public Builder withPresentationUploadExternalDescription(String d) {
+	    	this.presentationUploadExternalDescription = d;
 	    	return this;
 	    }
 
-			public Builder withUploadExternalUrl(String u) {
-	    	this.uploadExternalUrl = u;
+			public Builder withPresentationUploadExternalUrl(String u) {
+	    	this.presentationUploadExternalUrl = u;
 	    	return this;
 	    }
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/converters/messages/CreateMeetingMessage.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/converters/messages/CreateMeetingMessage.java
@@ -25,8 +25,8 @@ public class CreateMeetingMessage {
 	public final String learningDashboardAccessToken;
 	public final ArrayList<String> disabledFeatures;
 	public final Boolean notifyRecordingIsOn;
-	public final String uploadExternalDescription;
-	public final String uploadExternalUrl;
+	public final String presentationUploadExternalDescription;
+	public final String presentationUploadExternalUrl;
 	public final Long createTime;
 	public final String createDate;
 	public final Map<String, String> metadata;
@@ -38,8 +38,8 @@ public class CreateMeetingMessage {
 						String viewerPass, String learningDashboardAccessToken,
 						ArrayList<String> disabledFeatures,
 						Boolean notifyRecordingIsOn,
-						String uploadExternalDescription,
-						String uploadExternalUrl,
+						String presentationUploadExternalDescription,
+						String presentationUploadExternalUrl,
 						Long createTime, String createDate, Map<String, String> metadata) {
 		this.id = id;
 		this.externalId = externalId;
@@ -58,8 +58,8 @@ public class CreateMeetingMessage {
 		this.learningDashboardAccessToken = learningDashboardAccessToken;
 		this.disabledFeatures = disabledFeatures;
 		this.notifyRecordingIsOn = notifyRecordingIsOn;
-		this.uploadExternalDescription = uploadExternalDescription;
-		this.uploadExternalUrl = uploadExternalUrl;
+		this.presentationUploadExternalDescription = presentationUploadExternalDescription;
+		this.presentationUploadExternalUrl = presentationUploadExternalUrl;
 		this.createTime = createTime;
 		this.createDate = createDate;
 		this.metadata = metadata;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
@@ -44,8 +44,8 @@ public interface IBbbWebApiGWApp {
                      ArrayList<Group> groups,
                      ArrayList<String> disabledFeatures,
                      Boolean notifyRecordingIsOn,
-                     String uploadExternalDescription,
-                     String uploadExternalUrl);
+                     String presentationUploadExternalDescription,
+                     String presentationUploadExternalUrl);
 
   void registerUser(String meetingID, String internalUserId, String fullname, String role,
                     String externUserID, String authToken, String avatarURL,

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -149,8 +149,8 @@ class BbbWebApiGWApp(
                     groups:                                 java.util.ArrayList[Group],
                     disabledFeatures:                       java.util.ArrayList[String],
                     notifyRecordingIsOn:                    java.lang.Boolean,
-                    uploadExternalDescription:              String,
-                    uploadExternalUrl:                      String): Unit = {
+                    presentationUploadExternalDescription:  String,
+                    presentationUploadExternalUrl:          String): Unit = {
 
     val disabledFeaturesAsVector: Vector[String] = disabledFeatures.asScala.toVector
 
@@ -163,8 +163,8 @@ class BbbWebApiGWApp(
       isBreakout = isBreakout.booleanValue(),
       disabledFeaturesAsVector,
       notifyRecordingIsOn,
-      uploadExternalDescription,
-      uploadExternalUrl
+      presentationUploadExternalDescription,
+      presentationUploadExternalUrl
     )
 
     val durationProps = DurationProps(

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -84,8 +84,8 @@ export default function addMeeting(meeting) {
       name: String,
       disabledFeatures: Array,
       notifyRecordingIsOn: Boolean,
-      uploadExternalDescription: String,
-      uploadExternalUrl: String,
+      presentationUploadExternalDescription: String,
+      presentationUploadExternalUrl: String,
     },
     usersProp: {
       webcamsOnlyForModerator: Boolean,

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -1185,9 +1185,9 @@ class PresentationUploader extends Component {
   renderExternalUpload() {
     const { externalUploadData, intl } = this.props;
 
-    const { uploadExternalDescription, uploadExternalUrl } = externalUploadData;
+    const { presentationUploadExternalDescription, presentationUploadExternalUrl } = externalUploadData;
 
-    if (!uploadExternalDescription || !uploadExternalUrl) return null;
+    if (!presentationUploadExternalDescription || !presentationUploadExternalUrl) return null;
 
     return (
       <Styled.ExternalUpload>
@@ -1196,11 +1196,11 @@ class PresentationUploader extends Component {
             {intl.formatMessage(intlMessages.externalUploadTitle)}
           </Styled.ExternalUploadTitle>
 
-          <p>{uploadExternalDescription}</p>
+          <p>{presentationUploadExternalDescription}</p>
         </div>
         <Styled.ExternalUploadButton
           color="default"
-          onClick={() => window.open(`${uploadExternalUrl}`)}
+          onClick={() => window.open(`${presentationUploadExternalUrl}`)}
           label={intl.formatMessage(intlMessages.externalUploadLabel)}
           aria-describedby={intl.formatMessage(intlMessages.externalUploadLabel)}
         />        

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/service.js
@@ -276,17 +276,17 @@ const getExternalUploadData = () => {
     { meetingId: Auth.meetingID },
     {
       fields: {
-        'meetingProp.uploadExternalDescription': 1,
-        'meetingProp.uploadExternalUrl': 1
+        'meetingProp.presentationUploadExternalDescription': 1,
+        'meetingProp.presentationUploadExternalUrl': 1
       },
     },
   );
 
-  const { uploadExternalDescription, uploadExternalUrl } = meetingProp;
+  const { presentationUploadExternalDescription, presentationUploadExternalUrl } = meetingProp;
 
   return {
-    uploadExternalDescription,
-    uploadExternalUrl,
+    presentationUploadExternalDescription,
+    presentationUploadExternalUrl,
   }
 };
 


### PR DESCRIPTION
### What does this PR do?

Renames `uploadExternalUrl` and `uploadExternalDescription` parameters to `presentationUploadExternalUrl` and `presentationUploadExternalDescription`

### Motivation

It might not be clear that the parameters are related to presentation.

### More

https://github.com/bigbluebutton/bigbluebutton/pull/15251