### PR TITLE
fix: button overflow in presentation toolbar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.js
@@ -30,6 +30,7 @@ const PresentationToolbarWrapper = styled.div`
   bottom: 0px;
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
+  padding: 2px;
 
   select {
     &:-moz-focusring {


### PR DESCRIPTION
### What does this PR do?

Adjust presentation toolbar so buttons don't overflow when in focused/active state

#### before
![button-before](https://user-images.githubusercontent.com/3728706/189739260-d427c433-fa03-4d5f-83ed-4a981a578ef5.png)

#### after
![button-after](https://user-images.githubusercontent.com/3728706/189739249-107392e7-a45f-4b78-9ed8-56471e6aa757.png)
