### PR TITLE
fix: set breakout name input as readonly when updating users

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -750,7 +750,7 @@ class BreakoutRoom extends PureComponent {
   }
 
   renderRoomsGrid() {
-    const { intl } = this.props;
+    const { intl, isUpdate } = this.props;
     const {
       leastOneUserIsValid,
       numberOfRooms,
@@ -814,6 +814,7 @@ class BreakoutRoom extends PureComponent {
                   onBlur={changeRoomName(value)}
                   aria-label={`${this.getRoomName(value)}`}
                   aria-describedby={this.getRoomName(value).length === 0 ? `room-error-${value}` : `room-input-${value}`}
+                  readOnly={isUpdate}
                 />
                 <div aria-hidden id={`room-input-${value}`} className="sr-only">
                   {intl.formatMessage(intlMessages.roomNameInputDesc)}

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.js
@@ -77,6 +77,10 @@ const BreakoutNameInput = styled.input`
     color: ${colorGray};
     opacity: 1;
   }
+
+  ${({ readOnly }) => readOnly && `
+    cursor: default;
+  `}
 `;
 
 const BreakoutBox = styled(ScrollboxVertical)`


### PR DESCRIPTION
### What does this PR do?

Sets room name inputs as read-only and removes "text" cursor when the moderator is managing breakout users (after breakout creation).

#### before
https://user-images.githubusercontent.com/3728706/189920692-266eed9f-b1a7-4355-abc2-a1a38085a3b0.mp4

#### after
https://user-images.githubusercontent.com/3728706/189920661-b640692c-ad22-4e6c-a372-3a56d2278084.mp4


### Motivation

Breakout room names can't be changed after creation, but displaying them as editable text fields might confuse users.


### Closes Issue(s)
Closes #15669