### PR TITLE
Checksum Hash Algorithm Updates

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -66,6 +66,7 @@ public class ParamsProcessorUtil {
     private String apiVersion;
     private boolean serviceEnabled = false;
     private String securitySalt;
+    private String checksumHash;
     private int defaultMaxUsers = 20;
     private String defaultWelcomeMessage;
     private String defaultWelcomeMessageFooter;
@@ -945,11 +946,26 @@ public class ParamsProcessorUtil {
 		log.info("CHECKSUM={} length={}", checksum, checksum.length());
 
 		String data = apiCall + queryString + securitySalt;
-		String cs = DigestUtils.sha1Hex(data);
-		if (checksum.length() == 64) {
-			cs = DigestUtils.sha256Hex(data);
-			log.info("SHA256 {}", cs);
-		}
+        String cs;
+
+        checksumHash = checksumHash.toLowerCase();
+        switch(checksumHash) {
+            case "sha256":
+                cs = DigestUtils.sha256Hex(data);
+                log.info("SHA256 {}", cs);
+            case "sha384":
+                cs = DigestUtils.sha384Hex(data);
+                log.info("SHA384 {}", cs);
+                break;
+            case "sha512":
+                cs = DigestUtils.sha512Hex(data);
+                log.info("SHA512 {}", cs);
+                break;
+            default:
+                cs = DigestUtils.sha1Hex(data);
+                log.info("SHA1 {}", cs);
+        }
+
 		if (cs == null || !cs.equals(checksum)) {
 			log.info("query string after checksum removed: [{}]", queryString);
 			log.info("checksumError: query string checksum failed. our: [{}], client: [{}]", cs, checksum);
@@ -1034,6 +1050,8 @@ public class ParamsProcessorUtil {
 	public void setSecuritySalt(String securitySalt) {
 		this.securitySalt = securitySalt;
 	}
+
+	public void setChecksumHash(String checksumHash) { this.checksumHash = checksumHash; }
 
 	public void setDefaultMaxUsers(int defaultMaxUsers) {
 		this.defaultMaxUsers = defaultMaxUsers;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/ValidationService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/ValidationService.java
@@ -56,6 +56,7 @@ public class ValidationService {
     }
 
     private String securitySalt;
+    private String checksumHash;
     private Boolean allowRequestsWithoutSession;
 
     private ValidatorFactory validatorFactory;
@@ -276,6 +277,9 @@ public class ValidationService {
 
     public void setSecuritySalt(String securitySalt) { this.securitySalt = securitySalt; }
     public String getSecuritySalt() { return securitySalt; }
+
+    public void setChecksumHash(String checksumHash) { this.checksumHash = checksumHash; }
+    public String getChecksumHash() { return checksumHash; }
 
     public void setAllowRequestsWithoutSession(Boolean allowRequestsWithoutSession) {
         this.allowRequestsWithoutSession = allowRequestsWithoutSession;

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -322,6 +322,8 @@ apiVersion=2.0
 # Salt which is used by 3rd-party apps to authenticate api calls
 securitySalt=330a8b08c3b4c61533e1d0c5ce1ac88f
 
+# Hash algorithm to be used to validate checksum
+checksumHash=sha256
 
 # Directory where we drop the <meeting-id-recorded>.done file
 recordStatusDir=/var/bigbluebutton/recording/status/recorded

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -121,6 +121,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
     <bean id="validationService" class="org.bigbluebutton.api.service.ValidationService">
         <property name="securitySalt" value="${securitySalt}"/>
+        <property name="checksumHash" value="${checksumHash}"/>
         <property name="allowRequestsWithoutSession" value="${allowRequestsWithoutSession}"/>
     </bean>
 
@@ -133,6 +134,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="apiVersion" value="${apiVersion}"/>
         <property name="serviceEnabled" value="${serviceEnabled}"/>
         <property name="securitySalt" value="${securitySalt}"/>
+        <property name="checksumHash" value="${checksumHash}"/>
         <property name="defaultMaxUsers" value="${defaultMaxUsers}"/>
         <property name="defaultWelcomeMessage" value="${defaultWelcomeMessage}"/>
         <property name="defaultWelcomeMessageFooter" value="${defaultWelcomeMessageFooter}"/>


### PR DESCRIPTION
### What does this PR do?

Adds support for SHA384 and SHA512 checksums. A new property, checksumHash, has been added to the bigbluebutton properties file which allows a user to set what hash algorithm should be used to validate checksums. If no algorithm is defined it defaults to using SHA1.
