### PR TITLE
refactor: html5 server log improvements

### DIFF
--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -34,12 +34,36 @@ process.on('uncaughtException', (err) => {
   process.exit(1);
 });
 
+const formatMemoryUsage = (data) => `${Math.round(data / 1024 / 1024 * 100) / 100} MB`
+
+const serverHealth = () => {
+  const memoryData = process.memoryUsage();
+  const memoryUsage = {
+    rss: formatMemoryUsage(memoryData.rss),
+    heapTotal: formatMemoryUsage(memoryData.heapTotal),
+    heapUsed: formatMemoryUsage(memoryData.heapUsed),
+    external: formatMemoryUsage(memoryData.external),
+  }
+
+  const cpuData = process.cpuUsage();
+  const cpuUsage = {
+    system: formatMemoryUsage(cpuData.system),
+    user: formatMemoryUsage(cpuData.user),
+  }
+
+  Logger.info('Server health', {memoryUsage, cpuUsage});
+};
+
 Meteor.startup(() => {
   const APP_CONFIG = Meteor.settings.public.app;
   const CDN_URL = APP_CONFIG.cdn;
   const instanceId = parseInt(process.env.INSTANCE_ID, 10) || 1;
 
   Logger.warn(`Started bbb-html5 process with instanceId=${instanceId}`);
+
+  Meteor.setInterval(() => {
+    serverHealth();
+  }, 30000);
 
   const { customHeartbeat } = APP_CONFIG;
 

--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -51,7 +51,7 @@ const serverHealth = () => {
     user: formatMemoryUsage(cpuData.user),
   }
 
-  Logger.info('Server health', {memoryUsage, cpuUsage});
+  Logger.info('Server health ', {memoryUsage, cpuUsage});
 };
 
 Meteor.startup(() => {
@@ -61,9 +61,15 @@ Meteor.startup(() => {
 
   Logger.warn(`Started bbb-html5 process with instanceId=${instanceId}`);
 
-  Meteor.setInterval(() => {
-    serverHealth();
-  }, 30000);
+  const LOG_CONFIG = Meteor.settings.private.serverLog;
+  const { healthChecker } = LOG_CONFIG;
+  const { enable: enableHealthCheck, intervalMs: healthCheckInterval } = healthChecker;
+
+  if (enableHealthCheck) {
+    Meteor.setInterval(() => {
+      serverHealth();
+    }, healthCheckInterval);
+  }
 
   const { customHeartbeat } = APP_CONFIG;
 

--- a/bigbluebutton-html5/imports/startup/server/logger.js
+++ b/bigbluebutton-html5/imports/startup/server/logger.js
@@ -3,15 +3,15 @@ import { createLogger, format, transports } from 'winston';
 import WinstonPromTransport from './prom-metrics/winstonPromTransport';
 
 const LOG_CONFIG = Meteor?.settings?.private?.serverLog || {};
-const { level } = LOG_CONFIG;
+const { level, includeServerInfo } = LOG_CONFIG;
 
-const serverInfoFormat = format.printf(({ level, message, timestamp, ...metadata}) => {
-  const instanceId = parseInt(process.env.INSTANCE_ID, 10);
+const serverInfoFormat = format.printf(({ level, message, timestamp, ...metadata }) => {
+  const instanceId = parseInt(process.env.INSTANCE_ID, 10) || 1;
   const role = process.env.BBB_HTML5_ROLE;
-  const server = Meteor?.isDevelopment ? 'development' : `${role}-${instanceId}`;
+  const server = includeServerInfo && !Meteor?.isDevelopment ? `${role}-${instanceId} ` : "";
 
-  let msg = `${timestamp} ${server} [${level}] : ${message}`;
-  if(metadata) msg += JSON.stringify(metadata)
+  let msg = `${timestamp} ${server}[${level}] : ${message}`;
+  if (metadata) msg += JSON.stringify(metadata)
   return msg
 });
 

--- a/bigbluebutton-html5/imports/startup/server/logger.js
+++ b/bigbluebutton-html5/imports/startup/server/logger.js
@@ -5,15 +5,13 @@ import WinstonPromTransport from './prom-metrics/winstonPromTransport';
 const LOG_CONFIG = Meteor?.settings?.private?.serverLog || {};
 const { level } = LOG_CONFIG;
 
-const serverInfoFormat = format.printf(({ level, message, ...metadata}) => {
+const serverInfoFormat = format.printf(({ level, message, timestamp, ...metadata}) => {
   const instanceId = parseInt(process.env.INSTANCE_ID, 10);
   const role = process.env.BBB_HTML5_ROLE;
-  const server = Meteor?.isDevelopment ? 'development' : `${role} ${instanceId}`;
+  const server = Meteor?.isDevelopment ? 'development' : `${role}-${instanceId}`;
 
-  let msg = `${server} [${level}] : ${message} `  
-  if(metadata) {
-	msg += JSON.stringify(metadata)
-  }
+  let msg = `${timestamp} ${server} [${level}] : ${message}`;
+  if(metadata) msg += JSON.stringify(metadata)
   return msg
 });
 
@@ -23,6 +21,7 @@ const Logger = createLogger({
     format.colorize({ level: true }),
     format.splat(),
     format.simple(),
+    format.timestamp(),
     serverInfoFormat,
   ),
   transports: [

--- a/bigbluebutton-html5/imports/startup/server/logger.js
+++ b/bigbluebutton-html5/imports/startup/server/logger.js
@@ -5,12 +5,25 @@ import WinstonPromTransport from './prom-metrics/winstonPromTransport';
 const LOG_CONFIG = Meteor?.settings?.private?.serverLog || {};
 const { level } = LOG_CONFIG;
 
+const serverInfoFormat = format.printf(({ level, message, ...metadata}) => {
+  const instanceId = parseInt(process.env.INSTANCE_ID, 10);
+  const role = process.env.BBB_HTML5_ROLE;
+  const server = Meteor?.isDevelopment ? 'development' : `${role} ${instanceId}`;
+
+  let msg = `${server} [${level}] : ${message} `  
+  if(metadata) {
+	msg += JSON.stringify(metadata)
+  }
+  return msg
+});
+
 const Logger = createLogger({
   level,
   format: format.combine(
     format.colorize({ level: true }),
     format.splat(),
     format.simple(),
+    serverInfoFormat,
   ),
   transports: [
     // console logging

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -798,6 +798,10 @@ private:
   serverLog:
     level: info
     streamerLog: false
+    includeServerInfo: true
+    healthChecker:
+      enable: true
+      intervalMs: 30000
   minBrowserVersions:
     - browser: chrome
       version: 72


### PR DESCRIPTION
### What does this PR do?
Makes the following changes so it becomes easier to monitor the health of the html5 servers:

- adds timestamp and information about server instance to server logs
- adds a new log message with cpu/memory usage for each server

#### Current
`info : Added presentation id=8ed482ae3f9e099142b9a939c663d0ee41e66cc9-1663336566249 meeting=197cc79b2223ce7871d7059d9b990a127aecd8df-1663336566196 {}`

#### After changes
`2022-09-16T13:56:13.306Z backend-1 [info] : Added presentation id=8ed482ae3f9e099142b9a939c663d0ee41e66cc9-1663336566249 meeting=197cc79b2223ce7871d7059d9b990a127aecd8df-1663336566196 {}`

#### server health log message
`2022-09-16T13:22:04.818Z frontend 1 [info] : Server health {"memoryUsage":{"rss":"111.24 MB","heapTotal":"59.7 MB","heapUsed":"55.67 MB","external":"23.42 MB"},"cpuUsage":{"system":"0.17 MB","user":"2.88 MB"}}`