### PR TITLE
recording: Fix incorrect seek offsets in video

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video.rb
@@ -552,7 +552,7 @@ module BigBlueButton
 
         ffmpeg_filter << ",trim=end=#{ms_to_s(duration)}"
 
-        ffmpeg_cmd = [*FFMPEG]
+        ffmpeg_cmd = [*FFMPEG, '-copyts']
         ffmpeg_inputs.each do |input|
           ffmpeg_cmd += ['-ss', ms_to_s(input[:seek]), '-i', input[:filename]]
         end


### PR DESCRIPTION
When converting from using the 'movie' source filter to using separate ffmpeg command line inputs, it wasn't taken into account that the 'movie' filter passes through timestamps from the source file, while the ffmpeg input adjusts timestamps so that '0' is the selected seek point.

The easiest fix is to add an option to the ffmpeg command to disable the timestamp adjustments.

Fixes #15644 (This needs to go into BigBlueButton 2.5 and 2.6)