### PR TITLE
Fix bbb libreoffice dockerfile

### DIFF
--- a/bbb-libreoffice/docker/Dockerfile
+++ b/bbb-libreoffice/docker/Dockerfile
@@ -3,9 +3,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
 RUN apt update && apt -y install locales-all fontconfig libxt6 libxrender1
-RUN apt update && apt -y install -t \
-  bullseye-backports \
-  libreoffice \
+RUN apt update && apt -y install libreoffice \
   && rm -f \
   /usr/share/java/ant-apache-log4j-1.10.9.jar \
   /usr/share/java/log4j-1.2-1.2.17.jar /usr/share/java/log4j-1.2.jar \

--- a/bigbluebutton-config/bin/apply-lib.sh
+++ b/bigbluebutton-config/bin/apply-lib.sh
@@ -30,15 +30,19 @@ fi
 
 BBB_WEB_ETC_CONFIG=/etc/bigbluebutton/bbb-web.properties
 
+# We'll create a newline file to ensure bigbluebutton.properties ends with a newline
+tmpfile=$(mktemp /tmp/carriage-return.XXXXXX)
+echo "\n" > $tmpfile
+
 PROTOCOL=http
 if [ -f $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties ]; then
-  SERVER_URL=$(cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties $BBB_WEB_ETC_CONFIG | grep -v '#' | sed -n '/^bigbluebutton.web.serverURL/{s/.*\///;p}' | tail -n 1)
-  if cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties $BBB_WEB_ETC_CONFIG | grep -v '#' | grep ^bigbluebutton.web.serverURL | tail -n 1 | grep -q https; then
+  SERVER_URL=$(cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties $tmpfile $BBB_WEB_ETC_CONFIG | grep -v '#' | sed -n '/^bigbluebutton.web.serverURL/{s/.*\///;p}' | tail -n 1)
+  if cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties $tmpfile $BBB_WEB_ETC_CONFIG | grep -v '#' | grep ^bigbluebutton.web.serverURL | tail -n 1 | grep -q https; then
     PROTOCOL=https
   fi
 fi
 
-HOST=$(cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties $BBB_WEB_ETC_CONFIG | grep -v '#' | sed -n '/^bigbluebutton.web.serverURL/{s/.*\///;p}' | tail -n 1)
+HOST=$(cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties $tmpfile $BBB_WEB_ETC_CONFIG | grep -v '#' | sed -n '/^bigbluebutton.web.serverURL/{s/.*\///;p}' | tail -n 1)
 
 HTML5_CONFIG=/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml
 BBB_WEB_CONFIG=$SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties


### PR DESCRIPTION
### What does this PR do?

The build for `bbb-soffice` docker file started to fail.  After a bit of testing, found it installs with removing `-t bullseye-backports` from Dockerfile.

### Closes Issue(s)
Closes #15703

### More

While this appears to get the install working again, more testing is needed.
