### PR TITLE
fix: broadcast push alert crash in breakouts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/service.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/service.js
@@ -81,8 +81,8 @@ const mapGroupMessage = (message) => {
     const mappedSender = {
       avatar: sender?.avatar,
       color: message.color,
-      isModerator: sender?.role === ROLE_MODERATOR,
-      name: sender.name,
+      isModerator: message.senderRole === ROLE_MODERATOR,
+      name: message.senderName,
       isOnline: !!sender,
     };
 


### PR DESCRIPTION
### What does this PR do?

Fix for a crash that happens if a moderator sends a broadcast message to breakouts and the breakout user has push alerts enabled.

### Closes Issue(s)
Closes #15709