### PR TITLE
fix: script to deploy html5 using wrong npm version

### DIFF
--- a/bigbluebutton-html5/deploy_to_usr_share.sh
+++ b/bigbluebutton-html5/deploy_to_usr_share.sh
@@ -33,7 +33,8 @@ echo 'stage3'
 
 
 cd "$DESTINATION_DIR"/programs/server/ || exit
-sudo npm i
+sudo chmod -R 777 .
+meteor npm i
 
 echo "deployed to $DESTINATION_DIR/programs/server\n\n\n"
 


### PR DESCRIPTION
When running the script `deploy_to_usr_share.sh`, it ends with the following error:
![node_version_problem](https://user-images.githubusercontent.com/5660191/191281647-c52168c4-8e42-4c92-8896-60700a5fcdd8.png)

As @ramonlsouza noticed, it happens because in the docker-dev, `npm` version is different from `meteor npm` version
![image](https://user-images.githubusercontent.com/5660191/191282956-6741708c-4552-47d1-8b22-095b6834f867.png)

In order to avoid this problem I made the script use the command `meteor npm i` (instead of `npm i`) and then use the same version that meteor used in the previous commands.