### PR TITLE
fix: allow video settings to open

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
@@ -90,7 +90,7 @@ const JoinVideoButton = ({
 
   const handleOpenAdvancedOptions = (e) => {
     e.stopPropagation();
-    mountVideoPreview(isMobileSharingCamera);
+    mountVideoPreview(isDesktopSharingCamera);
   };
 
   const getMessageFromStatus = () => {


### PR DESCRIPTION
### What does this PR do?

Allows _Webcam Settings_ modal to open when `userdata-bbb_skip_video_preview=true`, webcam is shared and device is desktop.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #15692