### PR TITLE
fix(cursor): hide cursor for others on mouse leave

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { _ } from "lodash";
-import logger from '/imports/startup/client/logger';
 const XS_OFFSET = 8;
 const SMALL_OFFSET = 18;
 const XL_OFFSET = 85;
@@ -134,18 +133,13 @@ export default function Cursors(props) {
   const start = () => setActive(true);
   
   const end = () => {
-    if(typeof whiteboardId == "String"){
+    if (whiteboardId) {
       publishCursorUpdate({
-        xPercent: 0,
-        yPercent: 0,
-        whiteboardId: whiteboardId,
+        xPercent: -1.0,
+        yPercent: -1.0,
+        whiteboardId,
       });
-    } else {
-      logger.info({
-        logCode: 'cursor_not_logged',
-        extraInfo: { whiteboardId: whiteboardId },
-      }, "cursor not sent since used when whiteboard not loaded, (whiteboardID = " + whiteboardId + ")");
-    }
+    };
     setActive(false);
   };
 
@@ -276,7 +270,7 @@ export default function Cursors(props) {
 
     !cursorWrapper.hasOwnProperty("touchmove") &&
       cursorWrapper?.addEventListener("touchmove", moved);
-  }, [cursorWrapper]);
+  }, [cursorWrapper, whiteboardId]);
 
   React.useEffect(() => {
     return () => {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { _ } from "lodash";
 const XS_OFFSET = 8;
 const SMALL_OFFSET = 18;
 const XL_OFFSET = 85;
@@ -141,7 +140,7 @@ export default function Cursors(props) {
       });
     };
     setActive(false);
-  };
+  }
 
   const moved = (event) => {
     const { type, x, y } = event;

--- a/bigbluebutton-tests/playwright/chat/privateChat.js
+++ b/bigbluebutton-tests/playwright/chat/privateChat.js
@@ -105,57 +105,6 @@ class PrivateChat extends MultiUsers {
     await this.modPage.hasText(e.privateChat, e.convertedEmojiMessage);
     await this.userPage.hasText(e.privateChat, e.convertedEmojiMessage);
   }
-  
-  // Emojis
-  async emojiSendPrivateChat() {
-    const { emojiPickerEnabled } = getSettings();
-    test.fail(!emojiPickerEnabled, 'Emoji Picker is disabled');
-
-    await openPrivateChat(this.modPage);
-    await this.modPage.waitForSelector(e.hidePrivateChat);
-    await sleep(500); // prevent a race condition when running on a deployed server
-    // modPage send message
-    await this.modPage.waitAndClick(e.emojiPickerButton);
-    await this.modPage.waitAndClick(e.emojiSent);
-    await this.modPage.waitAndClick(e.sendButton);
-    await this.userPage.waitUntilHaveCountSelector(e.chatButton, 2);
-    await this.userPage.waitAndClickElement(e.chatButton, 1);
-    await this.userPage.waitForSelector(e.hidePrivateChat);
-    // check sent messages 
-    await this.modPage.hasText(e.chatUserMessageText, e.frequentlyUsedEmoji);
-    await this.userPage.hasText(e.chatUserMessageText, e.frequentlyUsedEmoji);
-    // userPage send message
-    await this.userPage.waitAndClick(e.emojiPickerButton);
-    await this.userPage.waitAndClick(e.emojiSent);
-    await this.userPage.waitAndClick(e.sendButton);
-    // check sent messages 
-    await this.modPage.hasText(e.privateChat, e.frequentlyUsedEmoji);
-    await this.userPage.hasText(e.privateChat, e.frequentlyUsedEmoji);
-  }
-
-  async autoConvertEmojiSendPrivateChat() {
-    const { autoConvertEmojiEnabled } = getSettings();
-    test.fail(!autoConvertEmojiEnabled, 'Auto Convert Emoji is disabled');
-
-    await openPrivateChat(this.modPage);
-    await this.modPage.waitForSelector(e.hidePrivateChat);
-    await sleep(500); // prevent a race condition when running on a deployed server
-    // modPage send message
-    await this.modPage.type(e.chatBox, e.autoConvertEmojiMessage);
-    await this.modPage.waitAndClick(e.sendButton);
-    await this.userPage.waitUntilHaveCountSelector(e.chatButton, 2);
-    await this.userPage.waitAndClickElement(e.chatButton, 1);
-    await this.userPage.waitForSelector(e.hidePrivateChat);
-    // check sent messages 
-    await this.modPage.hasText(e.chatUserMessageText, e.convertedEmojiMessage);
-    await this.userPage.hasText(e.chatUserMessageText, e.convertedEmojiMessage);
-    // userPage send message
-    await this.userPage.type(e.chatBox, e.autoConvertEmojiMessage);
-    await this.userPage.waitAndClick(e.sendButton);
-    // check sent messages 
-    await this.modPage.hasText(e.privateChat, e.convertedEmojiMessage);
-    await this.userPage.hasText(e.privateChat, e.convertedEmojiMessage);
-  }
 }
 
 exports.PrivateChat = PrivateChat; 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

- Hide cursor for others when the mouse leave the whiteboard
- Set -1.0 as out of bound posistions so the cursor is also treated correctly in playback (otherwise it could be seen at the top left (0.0, 0.0)

### Motivation

[15690](https://github.com/bigbluebutton/bigbluebutton/pull/15690) introduced a bug where the out of bounds position were not being sent to akka.

