### PR TITLE
feat: Emoji Status Control in Raise Hand Button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import CaptionsButtonContainer from '/imports/ui/components/captions/button/container';
-import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
 import deviceInfo from '/imports/utils/deviceInfo';
 import Styled from './styles';
 import ActionsDropdown from './actions-dropdown/container';
@@ -9,7 +8,7 @@ import ScreenshareButtonContainer from '/imports/ui/components/actions-bar/scree
 import AudioControlsContainer from '../audio/audio-controls/container';
 import JoinVideoOptionsContainer from '../video-provider/video-button/container';
 import PresentationOptionsContainer from './presentation-options/component';
-import Button from '/imports/ui/components/common/button/component';
+import RaiseHandDropdownContainer from './raise-hand/container';
 
 class ActionsBar extends PureComponent {
   render() {
@@ -29,12 +28,10 @@ class ActionsBar extends PureComponent {
       isPollingEnabled,
       isSelectRandomUserEnabled,
       isRaiseHandButtonEnabled,
-      isPresentationDisabled,
       isThereCurrentPresentation,
       allowExternalVideo,
       setEmojiStatus,
       currentUser,
-      shortcuts,
       layoutContextDispatch,
       actionsBarStyle,
       setMeetingLayout,
@@ -103,36 +100,18 @@ class ActionsBar extends PureComponent {
           />
           {isRaiseHandButtonEnabled
             ? (
-              <Button
-                icon="hand"
-                label={intl.formatMessage({
-                  id: `app.actionsBar.emojiMenu.${
-                    currentUser.emoji === 'raiseHand'
-                      ? 'lowerHandLabel'
-                      : 'raiseHandLabel'
-                  }`,
-                })}
-                accessKey={shortcuts.raisehand}
-                color={currentUser.emoji === 'raiseHand' ? 'primary' : 'default'}
-                data-test={currentUser.emoji === 'raiseHand' ? 'lowerHandLabel' : 'raiseHandLabel'}
-                ghost={currentUser.emoji !== 'raiseHand'}
-                emoji={currentUser.emoji}
-                hideLabel
-                circle
-                size="lg"
-                onClick={() => {
-                  setEmojiStatus(
-                    currentUser.userId,
-                    currentUser.emoji === 'raiseHand' ? 'none' : 'raiseHand',
-                  );
-                }}
+              <RaiseHandDropdownContainer {...{
+                setEmojiStatus,
+                currentUser,
+                intl,
+              }
+              }
               />
-            )
-            : null}
+            ) : null}
         </Styled.Right>
       </Styled.ActionsBar>
     );
   }
 }
 
-export default withShortcutHelper(ActionsBar, ['raiseHand']);
+export default ActionsBar;

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand/component.jsx
@@ -1,0 +1,121 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { defineMessages } from 'react-intl';
+import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
+import BBBMenu from '/imports/ui/components/common/menu/component';
+import Button from '/imports/ui/components/common/button/component';
+import Styled from './styles';
+
+const propTypes = {
+  intl: PropTypes.shape({
+    formatMessage: PropTypes.func.isRequired,
+  }).isRequired,
+  shortcuts: PropTypes.string,
+};
+
+const defaultProps = {
+  shortcuts: '',
+};
+
+const intlMessages = defineMessages({
+  statusTriggerLabel: {
+    id: 'app.actionsBar.emojiMenu.statusTriggerLabel',
+    description: 'label for option to show emoji menu',
+  },
+});
+
+class RaiseHandDropdown extends PureComponent {
+  getAvailableActions() {
+    const {
+      userId,
+      getEmojiList,
+      setEmojiStatus,
+      intl,
+    } = this.props;
+
+    const actions = [];
+    const statuses = Object.keys(getEmojiList);
+
+    statuses.forEach((s) => {
+      actions.push({
+        key: s,
+        label: intl.formatMessage({ id: `app.actionsBar.emojiMenu.${s}Label` }),
+        onClick: () => {
+          setEmojiStatus(userId, s);
+        },
+        icon: getEmojiList[s],
+      });
+    });
+    return actions;
+  }
+
+  renderRaiseHandButton() {
+    const {
+      intl,
+      setEmojiStatus,
+      currentUser,
+      shortcuts,
+    } = this.props;
+
+    return (
+      <Button
+        icon="hand"
+        label={intl.formatMessage({
+          id: `app.actionsBar.emojiMenu.${
+            currentUser.emoji === 'raiseHand'
+              ? 'lowerHandLabel'
+              : 'raiseHandLabel'
+          }`,
+        })}
+        accessKey={shortcuts.raisehand}
+        color={currentUser.emoji === 'raiseHand' ? 'primary' : 'default'}
+        data-test={currentUser.emoji === 'raiseHand' ? 'lowerHandLabel' : 'raiseHandLabel'}
+        ghost={currentUser.emoji !== 'raiseHand'}
+        emoji={currentUser.emoji}
+        hideLabel
+        circle
+        size="lg"
+        onClick={(e) => {
+          e.stopPropagation();
+          setEmojiStatus(
+            currentUser.userId,
+            currentUser.emoji === 'raiseHand' ? 'none' : 'raiseHand',
+          );
+        }}
+      />
+    );
+  }
+
+  render() {
+    const {
+      intl,
+    } = this.props;
+
+    const actions = this.getAvailableActions();
+
+    return (
+      <Styled.OffsetBottom>
+        {this.renderRaiseHandButton()}
+        <BBBMenu
+          trigger={(
+            <>
+              <Styled.HideDropdownButton
+                emoji="device_list_selector"
+                label={intl.formatMessage(intlMessages.statusTriggerLabel)}
+                hideLabel
+                tabIndex={0}
+                rotate
+              />
+            </>
+            )}
+          actions={actions}
+        />
+      </Styled.OffsetBottom>
+    );
+  }
+}
+
+RaiseHandDropdown.propTypes = propTypes;
+RaiseHandDropdown.defaultProps = defaultProps;
+
+export default withShortcutHelper(RaiseHandDropdown, ['raiseHand']);

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand/container.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { withTracker } from 'meteor/react-meteor-data';
+import RaiseHandDropdown from './component';
+import UserListService from '/imports/ui/components/user-list/service';
+
+const RaiseHandDropdownContainer = (props) => (
+  <RaiseHandDropdown {...props} />
+);
+
+export default withTracker(() => ({
+  isDropdownOpen: Session.get('dropdownOpen'),
+  getEmojiList: UserListService.getEmojiList(),
+}))(RaiseHandDropdownContainer);

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand/styles.js
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+import ButtonEmoji from '/imports/ui/components/common/button/button-emoji/ButtonEmoji';
+
+const HideDropdownButton = styled(ButtonEmoji)`
+  span {
+    i {
+      width: 0px !important;
+      bottom: 1px;
+    }
+  }
+`;
+
+const OffsetBottom = styled.div`
+  position: relative;
+`;
+
+export default {
+  HideDropdownButton,
+  OffsetBottom,
+};


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
This PR adds a dropdown menu, which allows a user to change their emoji status, to the raise hand button. 
<!-- A brief description of each change being made with this pull request. -->


### Motivation
In some lectures professors like to use the status for getting a general overview over the students opinions. This is more comfortable than starting a poll. The menu to change the status was pretty hidden. This PR makes it easier to access it.
<!-- What inspired you to submit this pull request? -->

