### PR TITLE
Modify maxParticipant calculation 2.4

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -939,6 +939,13 @@ public class MeetingService implements MessageListener {
       User user = new User(message.userId, message.externalUserId,
         message.name, message.role, message.avatarURL, message.guest, message.guestStatus,
               message.clientType);
+
+      if(m.getMaxUsers() > 0 && m.getUsers().size() >= m.getMaxUsers()) {
+        m.removeEnteredUser(user.getInternalUserId());
+        gw.ejectDuplicateUser(message.meetingId, user.getInternalUserId(), user.getFullname(), user.getExternalUserId());
+        return;
+      }
+
       m.userJoined(user);
       m.setGuestStatusWithId(user.getInternalUserId(), message.guestStatus);
       UserSession userSession = getUserSessionWithUserId(user.getInternalUserId());

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/GuestPolicyValidator.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/GuestPolicyValidator.java
@@ -24,7 +24,7 @@ public class GuestPolicyValidator implements ConstraintValidator<GuestPolicyCons
         MeetingService meetingService = ServiceUtils.getMeetingService();
         UserSession userSession = meetingService.getUserSessionWithAuthToken(sessionToken);
 
-        if(userSession == null || userSession.guestStatus.equals(GuestPolicy.DENY)) {
+        if(userSession == null || !userSession.guestStatus.equals(GuestPolicy.ALLOW)) {
             return false;
         }
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/MaxParticipantsValidator.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/MaxParticipantsValidator.java
@@ -41,7 +41,7 @@ public class MaxParticipantsValidator implements ConstraintValidator<MaxParticip
         int joinedUsers = meeting.getUsers().size();
         int enteredUsers = meeting.getEnteredUsers().size();
 
-        boolean reachedMax = (joinedUsers + enteredUsers) >= maxParticipants;
+        boolean reachedMax = joinedUsers >= maxParticipants;
         if(enabled && !rejoin && !reenter && reachedMax) {
             return false;
         }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/MaxParticipantsValidator.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/MaxParticipantsValidator.java
@@ -39,7 +39,6 @@ public class MaxParticipantsValidator implements ConstraintValidator<MaxParticip
         boolean rejoin = meeting.getUserById(userSession.internalUserId) != null;
         boolean reenter = meeting.getEnteredUserById(userSession.internalUserId) != null;
         int joinedUsers = meeting.getUsers().size();
-        int enteredUsers = meeting.getEnteredUsers().size();
 
         boolean reachedMax = joinedUsers >= maxParticipants;
         if(enabled && !rejoin && !reenter && reachedMax) {

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -903,6 +903,7 @@ class ApiController {
           reject = true
           respMessage = "The maximum number of participants allowed for this meeting has been reached."
         } else {
+          log.info("User ${us.internalUserId} has entered")
           meeting.userEntered(us.internalUserId)
         }
       }
@@ -1540,7 +1541,11 @@ class ApiController {
     // Users that are entering the meeting
     int enteredUsers = meeting.getEnteredUsers().size()
 
-    Boolean reachedMax = (joinedUsers + enteredUsers) >= maxParticipants;
+    log.info("Joined users - ${joinedUsers}")
+    log.info("Entered users - ${enteredUsers}")
+
+    Boolean reachedMax = joinedUsers >= maxParticipants;
+
     if (enabled && !rejoin && !reenter && reachedMax) {
       return true;
     }


### PR DESCRIPTION
### What does this PR do?

What does this PR do?
Modifies the maxParticipants calculation to only count joined users. A new maxParticipants check is done when a user moves from being entered to joined and the user is ejected if this check fails.
