### PR TITLE
fix: Unable to expand the sidebar content by pulling on webcam part when close to whiteboard

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/styles.js
@@ -125,6 +125,7 @@ const PresentationContainer = styled.div`
   left: 0;
   right: 0;
   bottom: 0;
+  z-index: 0;
 `;
 
 const Presentation = styled.div`


### PR DESCRIPTION
### What does this PR do?

Prevents an issue where sidebar can't be resized (from webcam area) when webcam is below the chat.

### Closes Issue(s)
Closes #15718