### PR TITLE
fix: cursor bug after camera is dropped in the same place

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
@@ -125,10 +125,11 @@ const WebcamComponent = ({
     setIsDragging(false);
     setDraggedAtLeastOneTime(false);
     document.body.style.overflow = 'auto';
-    const layout = document.getElementById('layout');
-    layout?.setAttribute("data-cam-position", e?.target?.id);
 
     if (Object.values(CAMERADOCK_POSITION).includes(e.target.id) && draggedAtLeastOneTime) {
+      const layout = document.getElementById('layout');
+      layout?.setAttribute("data-cam-position", e?.target?.id);
+
       layoutContextDispatch({
         type: ACTIONS.SET_CAMERA_DOCK_POSITION,
         value: e.target.id,


### PR DESCRIPTION
### What does this PR do?

Prevents a bug that may cause the whiteboard cursor to appear in the wrong position if it is dragged & dropped in the same position.


https://user-images.githubusercontent.com/3728706/192372239-b9ab5600-59ab-4ee9-96a7-5d919065b59a.mp4

