### PR TITLE
fix: add config to disable emoji sort on click

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
@@ -69,7 +69,7 @@ const messages = defineMessages({
 
 const CHAT_CONFIG = Meteor.settings.public.chat;
 const AUTO_CONVERT_EMOJI = Meteor.settings.public.chat.autoConvertEmoji;
-const ENABLE_EMOJI_PICKER = Meteor.settings.public.chat.enableEmojiPicker;
+const ENABLE_EMOJI_PICKER = Meteor.settings.public.chat.emojiPicker.enable;
 
 class MessageForm extends PureComponent {
   constructor(props) {

--- a/bigbluebutton-html5/imports/ui/components/emoji-picker/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/emoji-picker/component.jsx
@@ -5,6 +5,7 @@ import { Picker } from 'emoji-mart';
 import 'emoji-mart/css/emoji-mart.css';
 
 const DISABLE_EMOJIS = Meteor.settings.public.chat.disableEmojis;
+const FREQUENT_SORT_ON_CLICK = Meteor.settings.public.chat.emojiPicker.frequentEmojiSortOnClick;
 
 const propTypes = {
   intl: PropTypes.shape({
@@ -66,7 +67,7 @@ const EmojiPicker = (props) => {
     <Picker
       emoji=""
       onSelect={(emojiObject, event) => onEmojiSelect(emojiObject, event)}
-      enableFrequentEmojiSort
+      enableFrequentEmojiSort={FREQUENT_SORT_ON_CLICK}
       native
       title=""
       emojiSize={24}

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -512,7 +512,9 @@ public:
       enabled: true
     moderatorChatEmphasized: true
     autoConvertEmoji: true
-    enableEmojiPicker: false
+    emojiPicker:
+      enable: false
+      frequentEmojiSortOnClick: false
     # e.g.: disableEmojis: ['1F595','1F922']
     disableEmojis: []
   notes:

--- a/bigbluebutton-tests/playwright/core/settings.js
+++ b/bigbluebutton-tests/playwright/core/settings.js
@@ -21,7 +21,7 @@ async function generateSettingsData(page) {
       chatEnabled: settingsData.chat.enabled,
       publicChatOptionsEnabled: settingsData.chat.enableSaveAndCopyPublicChat,
       maxMessageLength: settingsData.chat.max_message_length,
-      emojiPickerEnabled: settingsData.chat.enableEmojiPicker,
+      emojiPickerEnabled: settingsData.chat.emojiPicker.enable,
       autoConvertEmojiEnabled: settingsData.chat.autoConvertEmoji,
       // Polling
       pollEnabled: settingsData.poll.enabled,


### PR DESCRIPTION
### What does this PR do?

Adds config in `Settings.yml` to disable frequent emoji sort on emoji click.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #15712
