### PR TITLE
feat(bbb-web): make HTTP session timeout configurable

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -78,6 +78,7 @@ public class ParamsProcessorUtil {
     private String defaultHTML5ClientUrl;
     private String defaultGuestWaitURL;
     private Boolean allowRequestsWithoutSession = false;
+    private Integer defaultHttpSessionTimeout = 14400;
     private Boolean useDefaultAvatar = false;
     private String defaultAvatarURL;
     private String defaultGuestPolicy;
@@ -819,6 +820,14 @@ public class ParamsProcessorUtil {
 	public Boolean getAllowRequestsWithoutSession() {
 		return allowRequestsWithoutSession;
 	}
+
+  public Integer getDefaultHttpSessionTimeout() {
+    return defaultHttpSessionTimeout;
+  }
+
+  public void setDefaultHttpSessionTimeout(Integer value) {
+    this.defaultHttpSessionTimeout = value;
+  }
 
 	public String getDefaultLogoutUrl() {
 		 if ((StringUtils.isEmpty(defaultLogoutUrl)) || "default".equalsIgnoreCase(defaultLogoutUrl)) {

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -313,6 +313,11 @@ defaultLogoURL=${bigbluebutton.web.serverURL}/images/logo.png
 # Allow requests without JSESSIONID to be handled (default = false)
 allowRequestsWithoutSession=false
 
+# Timeout (seconds) to invalidate inactive HTTP sessions.
+# Default: 4 hours.
+# For more info, refer to javax.servlet.http.HttpSession#setMaxInactiveInterval 's spec
+defaultHttpSessionTimeout=14400
+
 # The url for where the guest will poll if approved to join or not.
 defaultGuestWaitURL=${bigbluebutton.web.serverURL}/html5client/guestWait
 

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -150,6 +150,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="defaultLogoURL" value="${defaultLogoURL}"/>
         <property name="defaultGuestWaitURL" value="${defaultGuestWaitURL}"/>
         <property name="allowRequestsWithoutSession" value="${allowRequestsWithoutSession}"/>
+        <property name="defaultHttpSessionTimeout" value="${defaultHttpSessionTimeout}"/>
         <property name="defaultMeetingDuration" value="${defaultMeetingDuration}"/>
         <property name="disableRecordingDefault" value="${disableRecordingDefault}"/>
         <property name="autoStartRecording" value="${autoStartRecording}"/>

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -46,7 +46,6 @@ import org.json.JSONArray
 import javax.servlet.ServletRequest
 
 class ApiController {
-  private static final Integer SESSION_TIMEOUT = 14400  // 4 hours
   private static final String CONTROLLER_NAME = 'ApiController'
   protected static final String RESP_CODE_SUCCESS = 'SUCCESS'
   protected static final String RESP_CODE_FAILED = 'FAILED'
@@ -407,7 +406,7 @@ class ApiController {
         us.leftGuestLobby
     )
 
-    session.setMaxInactiveInterval(SESSION_TIMEOUT);
+    session.setMaxInactiveInterval(paramsProcessorUtil.getDefaultHttpSessionTimeout())
 
     //check if exists the param redirect
     boolean redirectClient = true;


### PR DESCRIPTION
### What does this PR do?

- [feat(bbb-web): make HTTP session timeout configurable](https://github.com/bigbluebutton/bigbluebutton/commit/0a796ef39d1e1c01913e82fd27f5ca59636c35c6)
  * This commit makes bbb-web's HTTP session timeout configurable, system-wide, via
    bigbluebutton.properties. Default timeout (4h) is preserved.

### Closes Issue(s)

None

### Motivation

Java/Grails' HTTP session inactivity timeout is hardcoded to 4 hours.
This gives less flexibility for long-lived sessions - ie in rare
scenarios where users stay connected for >= that amount of time without
any re-connections or intermediate calls to checkAuthorization.

Ideally, we should look into a more permanent solution to avoid
invalidating perfectly healthy user sessions. This commit fixes
nothing in that regard.