### PR TITLE
chore: set disableWebsocketFallback default value to true

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -241,7 +241,7 @@ public:
     # when the locale string is empty. If false, the empty
     # string will be returned.
     fallbackOnEmptyLocaleString: true
-    disableWebsocketFallback: false
+    disableWebsocketFallback: true
   externalVideoPlayer:
     enabled: true
   kurento:


### PR DESCRIPTION
### What does this PR do?

Sets `disableWebsocketFallback: true` by default in settings.yml (same as it was in 2.6 before the [2.5 PR with the settings](https://github.com/bigbluebutton/bigbluebutton/pull/15723) was merged into 2.6)