### PR TITLE
refactor (bbb-soffice): Switch parent image to amazoncorretto:17-alpine

### DIFF
--- a/bbb-libreoffice/docker/Dockerfile
+++ b/bbb-libreoffice/docker/Dockerfile
@@ -1,13 +1,3 @@
-FROM openjdk:17-slim-bullseye
-ENV DEBIAN_FRONTEND noninteractive
+FROM amazoncorretto:17-alpine
 
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
-RUN apt update && apt -y install locales-all fontconfig libxt6 libxrender1
-RUN apt update && apt -y install libreoffice \
-  && rm -f \
-  /usr/share/java/ant-apache-log4j-1.10.9.jar \
-  /usr/share/java/log4j-1.2-1.2.17.jar /usr/share/java/log4j-1.2.jar \
-  /usr/share/maven-repo/log4j/log4j/1.2.17/log4j-1.2.17.jar \
-  /usr/share/maven-repo/log4j/log4j/1.2.x/log4j-1.2.x.jar \
-  /usr/share/maven-repo/org/apache/ant/ant-apache-log4j/1.10.9/ant-apache-log4j-1.10.9.jar
-
+RUN apk add fontconfig libreoffice


### PR DESCRIPTION
As reported in https://hub.docker.com/_/openjdk, the current parent image `openjdk` is deprecated!
![image](https://user-images.githubusercontent.com/5660191/192779624-d453ae7a-58f1-428c-8917-281f51fb1be6.png)

This PR will switch the parent docker image to `amazoncorretto`.

It will bring some pros:
- It will use less disk space
- It brings a more recent version of Libreoffice


  | Before | After
-- | -- | --
OS | Debian 11 (bullseye) | Alpine Linux v3.15
LibreOffice | 7.0.4.2 00 | 7.2.2.2
Jdk | 17.0.2 2022-01-18 | 17.0.4.1 2022-08-12 LTS
Bbb-soffice image size | 2.48GB | 877MB
Parent Image | openjdk | amazoncorretto
Parent Image size | 408MB | 333MB

