### PR TITLE
fix(whiteboard): annotations duplication in websocket/collection

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendWhiteboardAnnotationPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendWhiteboardAnnotationPubMsgHdlr.scala
@@ -10,8 +10,8 @@ trait SendWhiteboardAnnotationsPubMsgHdlr extends RightsManagementTrait {
 
   def handle(msg: SendWhiteboardAnnotationsPubMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
 
-    def broadcastEvent(msg: SendWhiteboardAnnotationsPubMsg, whiteboardId: String, annotations: Array[AnnotationVO]): Unit = {
-      val routing = Routing.addMsgToHtml5InstanceIdRouting(liveMeeting.props.meetingProp.intId, liveMeeting.props.systemProps.html5InstanceId.toString)
+    def broadcastEvent(msg: SendWhiteboardAnnotationsPubMsg, whiteboardId: String, annotations: Array[AnnotationVO], html5InstanceId: String): Unit = {
+      val routing = Routing.addMsgToHtml5InstanceIdRouting(liveMeeting.props.meetingProp.intId, html5InstanceId)
       val envelope = BbbCoreEnvelope(SendWhiteboardAnnotationsEvtMsg.NAME, routing)
       val header = BbbClientMsgHeader(SendWhiteboardAnnotationsEvtMsg.NAME, liveMeeting.props.meetingProp.intId, msg.header.userId)
 
@@ -53,7 +53,7 @@ trait SendWhiteboardAnnotationsPubMsgHdlr extends RightsManagementTrait {
       }
       println("============= Printed Sanitized annotations  ============")
       val annotations = sendWhiteboardAnnotations(msg.body.whiteboardId, msg.header.userId, msg.body.annotations, liveMeeting)
-      broadcastEvent(msg, msg.body.whiteboardId, annotations)
+      broadcastEvent(msg, msg.body.whiteboardId, annotations, msg.body.html5InstanceId)
     } else {
       //val meetingId = liveMeeting.props.meetingProp.intId
       //val reason = "No permission to send a whiteboard annotation."

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WhiteboardMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WhiteboardMsgs.scala
@@ -53,7 +53,7 @@ case class SendCursorPositionPubMsgBody(whiteboardId: String, xPercent: Double, 
 
 object SendWhiteboardAnnotationsPubMsg { val NAME = "SendWhiteboardAnnotationsPubMsg" }
 case class SendWhiteboardAnnotationsPubMsg(header: BbbClientMsgHeader, body: SendWhiteboardAnnotationsPubMsgBody) extends StandardMsg
-case class SendWhiteboardAnnotationsPubMsgBody(whiteboardId: String, annotations: Array[AnnotationVO])
+case class SendWhiteboardAnnotationsPubMsgBody(whiteboardId: String, annotations: Array[AnnotationVO], html5InstanceId: String)
 
 object DeleteWhiteboardAnnotationsPubMsg { val NAME = "DeleteWhiteboardAnnotationsPubMsg" }
 case class DeleteWhiteboardAnnotationsPubMsg(header: BbbClientMsgHeader, body: DeleteWhiteboardAnnotationsPubMsgBody) extends StandardMsg

--- a/bigbluebutton-html5/imports/api/annotations/server/methods/sendAnnotationHelper.js
+++ b/bigbluebutton-html5/imports/api/annotations/server/methods/sendAnnotationHelper.js
@@ -21,6 +21,7 @@ export default function sendAnnotationHelper(annotations, meetingId, requesterUs
       const payload = {
         whiteboardId,
         annotations: whiteboardAnnotations,
+        html5InstanceId: parseInt(process.env.INSTANCE_ID, 10) || 1,
       };
   
       RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);

--- a/bigbluebutton-html5/imports/startup/server/redis.js
+++ b/bigbluebutton-html5/imports/startup/server/redis.js
@@ -270,6 +270,12 @@ class RedisPubSub {
         }
       }
 
+      if (eventName === 'SendWhiteboardAnnotationsEvtMsg') {
+        // we need the instanceId in the handler to avoid calling the same upsert on the
+        // Annotations collection multiple times
+        parsedMessage.core.body.myInstanceId = this.instanceId;
+      }
+
       if (!this.meetingsQueues[meetingIdFromMessageCoreHeader]) {
         Logger.warn(`Frontend meeting queue had not been initialized   ${message}`, { eventName, meetingIdFromMessageCoreHeader });
         this.meetingsQueues[NO_MEETING_ID].add({

--- a/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
@@ -123,22 +123,6 @@ export default withTracker(() => {
     oldRole = currentUser?.role;
   }
 
-  const annotationsHandler = Meteor.subscribe('annotations', {
-    onReady: () => {
-      const activeTextShapeId = AnnotationsTextService.activeTextShapeId();
-      AnnotationsLocal.remove({ id: { $ne: `${activeTextShapeId}-fake` } });
-      Annotations.find({ id: { $ne: activeTextShapeId } }, { reactive: false }).forEach((a) => {
-        try {
-          AnnotationsLocal.insert(a);
-        } catch (e) {
-          // TODO
-        }
-      });
-      annotationsHandler.stop();
-    },
-    ...subscriptionErrorHandler,
-  });
-
   subscriptionsHandlers = subscriptionsHandlers.filter(obj => obj);
   const ready = subscriptionsHandlers.every(handler => handler.ready());
   let groupChatMessageHandler = {};
@@ -166,6 +150,21 @@ export default withTracker(() => {
   let usersPersistentDataHandler = {};
   if (ready) {
     usersPersistentDataHandler = Meteor.subscribe('users-persistent-data');
+    const annotationsHandler = Meteor.subscribe('annotations', {
+      onReady: () => {
+        const activeTextShapeId = AnnotationsTextService.activeTextShapeId();
+        AnnotationsLocal.remove({ id: { $ne: `${activeTextShapeId}-fake` } });
+        Annotations.find({ id: { $ne: activeTextShapeId } }, { reactive: false }).forEach((a) => {
+          try {
+            AnnotationsLocal.insert(a);
+          } catch (e) {
+            // TODO
+          }
+        });
+        annotationsHandler.stop();
+      },
+      ...subscriptionErrorHandler,
+    });
   }
 
   return {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fix 2 bugs that occurs with annotations in the meteor/mongodb collection:

-  [af1c7fe7fc9212bab90b31cfc57626b4c2fd80b2](https://github.com/bigbluebutton/bigbluebutton/commit/af1c7fe7fc9212bab90b31cfc57626b4c2fd80b2): The subscription to annotations sometimes could be ready and stopped before the component fully loads, allowing it to be subscribed again (and then receiving all the annotations via websocket two times).
   - Moved the subscription to occur only after the base ones. (this don't dependes on the number of backends/frontends)

- [d770a7df8c591159c57b7caee042dfe8b9769494](https://github.com/bigbluebutton/bigbluebutton/commit/d770a7df8c591159c57b7caee042dfe8b9769494): We were calling upsert in the Annotations collection for the same annotation in all frontend instances, this could lead to the same annotation being inserted multiple times with different IDs due to concurrency.
  - Added the html5InstanceId of the original request to the redis message so we can use it to only call upsert in one instance.

### Motivation
Discovered while investigating reports by [Pablo](https://groups.google.com/g/bigbluebutton-dev/c/gy6KmK-41mY/m/RHJmTzvmBQAJ), where he observed that users joining late were receiving a lot  more annotations than what was drawn. Big thanks to him for the great insights.

### More

I also tried to remove the server Annotations collection entirely to only use the streamer, but that led to other non-wanted behaviours like when late-joiners asked for akka for the annotations, all the other users were receiving the updates again, so we would need a deeper rework to do that.

Also affects older versions (2.5, 2.4), will need to backport.
