### PR TITLE
improvement: add internationalization singleton

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/intl.jsx
+++ b/bigbluebutton-html5/imports/startup/client/intl.jsx
@@ -8,6 +8,7 @@ import getFromUserSettings from '/imports/ui/services/users-settings';
 import _ from 'lodash';
 import { Session } from 'meteor/session';
 import Logger from '/imports/startup/client/logger';
+import Intl from '/imports/ui/services/locale';
 
 const propTypes = {
   locale: PropTypes.string,
@@ -65,6 +66,7 @@ class IntlStartup extends Component {
     const url = `./locale?locale=${locale}&init=${init}`;
     const localesPath = 'locales';
 
+    Intl.fetching = true;
     this.setState({ fetching: true }, () => {
       fetch(url)
         .then((response) => {
@@ -136,6 +138,7 @@ class IntlStartup extends Component {
               }
 
               const dasherizedLocale = normalizedLocale.replace('_', '-');
+              Intl.setLocale(dasherizedLocale, mergedMessages);
               this.setState({ messages: mergedMessages, fetching: false, normalizedLocale: dasherizedLocale }, () => {
                 Settings.application.locale = dasherizedLocale;
                 if (RTL_LANGUAGES.includes(dasherizedLocale.substring(0, 2))) {

--- a/bigbluebutton-html5/imports/ui/components/settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/component.jsx
@@ -267,7 +267,7 @@ class Settings extends Component {
         title={intl.formatMessage(intlMessages.SettingsLabel)}
         confirm={{
           callback: () => {
-            this.updateSettings(current, intl.formatMessage(intlMessages.savedAlertLabel));
+            this.updateSettings(current, intlMessages.savedAlertLabel);
             document.body.classList.remove(`lang-${saved.application.locale.split('-')[0]}`);
             document.body.classList.add(`lang-${current.application.locale.split('-')[0]}`);
             document.getElementsByTagName('html')[0].lang = current.application.locale;

--- a/bigbluebutton-html5/imports/ui/components/settings/service.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/service.js
@@ -3,6 +3,7 @@ import Auth from '/imports/ui/services/auth';
 import Settings from '/imports/ui/services/settings';
 import {notify} from '/imports/ui/services/notification';
 import GuestService from '/imports/ui/components/waiting-users/service';
+import Intl from '/imports/ui/services/locale';
 
 const getUserRoles = () => {
   const user = Users.findOne({
@@ -30,18 +31,20 @@ const showGuestNotification = () => {
 
 const isKeepPushingLayoutEnabled = () => Meteor.settings.public.layout.showPushLayoutToggle;
 
-const updateSettings = (obj, msg) => {
+const updateSettings = (obj, msgDescriptor) => {
   Object.keys(obj).forEach(k => (Settings[k] = obj[k]));
   Settings.save();
 
-  if (msg) {
+  if (msgDescriptor) {
     // prevents React state update on unmounted component
     setTimeout(() => {
-      notify(
-        msg,
-        'info',
-        'settings',
-      );
+      Intl.formatMessage(msgDescriptor).then((txt) => {
+        notify(
+          txt,
+          'info',
+          'settings',
+        );
+      });
     }, 0);
   }
 };

--- a/bigbluebutton-html5/imports/ui/services/locale/index.js
+++ b/bigbluebutton-html5/imports/ui/services/locale/index.js
@@ -1,0 +1,68 @@
+import { createIntl } from 'react-intl';
+
+/**
+ * Use this if you need any translation outside of React lifecyle.
+ */
+class BBBIntl {
+  _intl = {
+    tracker: new Tracker.Dependency(),
+    value: undefined,
+  };
+
+  _fetching = {
+    tracker: new Tracker.Dependency(),
+    value: true,
+  };
+
+  setLocale(locale, messages) {
+    this.intl = createIntl({
+      locale,
+      messages,
+    });
+
+    this.fetching = false;
+  }
+
+  set fetching(value) {
+    this._fetching.value = value;
+    this._fetching.tracker.changed();
+  }
+
+  get fetching() {
+    this._fetching.tracker.depend();
+    return this._fetching.value;
+  }
+
+  set intl(value) {
+    this._intl.value = value;
+    this._intl.tracker.changed();
+  }
+
+  get intl() {
+    this._intl.tracker.depend();
+    return this._intl.value;
+  }
+
+  formatMessage(descriptor, values, options) {
+    return new Promise((resolve, reject) => {
+      try {
+        if (!this.fetching && this.intl) {
+          resolve(this.intl.formatMessage(descriptor, values, options));
+        } else {
+          Tracker.autorun((c) => {
+            const { fetching, intl } = this;
+
+            if (fetching || !intl) return;
+
+            resolve(this.intl.formatMessage(descriptor, values, options));
+            c.stop();
+          });
+        }
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
+}
+
+export default new BBBIntl();

--- a/bigbluebutton-html5/imports/ui/services/locale/index.js
+++ b/bigbluebutton-html5/imports/ui/services/locale/index.js
@@ -1,5 +1,7 @@
 import { createIntl } from 'react-intl';
 
+const FALLBACK_ON_EMPTY_STRING = Meteor.settings.public.app.fallbackOnEmptyLocaleString;
+
 /**
  * Use this if you need any translation outside of React lifecyle.
  */
@@ -14,10 +16,15 @@ class BBBIntl {
     value: true,
   };
 
+  constructor({ fallback }) {
+    this._fallback = fallback;
+  }
+
   setLocale(locale, messages) {
     this.intl = createIntl({
       locale,
       messages,
+      fallbackOnEmptyString: this._fallback,
     });
 
     this.fetching = false;
@@ -65,4 +72,4 @@ class BBBIntl {
   }
 }
 
-export default new BBBIntl();
+export default new BBBIntl({ fallback: FALLBACK_ON_EMPTY_STRING });


### PR DESCRIPTION
### What does this PR do?

Adds internationalization singleton object in order to translate messages outside of React lifecycle.

### Closes Issue(s)

Closes #15713

### Motivation

We needed a transparent way of translating text outside of React lifecycle/components.
