### PR TITLE
improvement: text selection in chat

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/styles.js
@@ -146,6 +146,7 @@ const Offline = styled.span`
   font-size: 90%;
   line-height: 1;
   align-self: center;
+  user-select: none;
 `;
 
 const Time = styled.time`

--- a/bigbluebutton-html5/imports/ui/components/user-avatar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-avatar/styles.js
@@ -100,6 +100,7 @@ const Avatar = styled.div`
   text-align: center;
   font-size: .85rem;
   border: 2px solid transparent;
+  user-select: none;
 
   ${({ animations }) => animations && `
     transition: .3s ease-in-out;


### PR DESCRIPTION
### What does this PR do?

Prevents avatar text and _offline_ label from being selected when selecting text in chat.

Closes #15746 