### PR TITLE
Fix (bbb-web): checksumHash=sha256 not working

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -953,6 +953,7 @@ public class ParamsProcessorUtil {
             case "sha256":
                 cs = DigestUtils.sha256Hex(data);
                 log.info("SHA256 {}", cs);
+                break;
             case "sha384":
                 cs = DigestUtils.sha384Hex(data);
                 log.info("SHA384 {}", cs);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/GetChecksumValidator.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/GetChecksumValidator.java
@@ -48,6 +48,7 @@ public class GetChecksumValidator implements ConstraintValidator<GetChecksumCons
             case "sha256":
                 createdCheckSum = DigestUtils.sha256Hex(data);
                 log.info("SHA256 {}", createdCheckSum);
+                break;
             case "sha384":
                 createdCheckSum = DigestUtils.sha384Hex(data);
                 log.info("SHA384 {}", createdCheckSum);


### PR DESCRIPTION
Fix a bug introduced in #15684.

When the config `checksumHash=sha256` is set, bbb-web is using `sha384` instead.