### PR TITLE
(fix) - Resolve CORS problem for etherpad when having a proxy

### DIFF
--- a/build/packages-template/bbb-etherpad/notes.nginx
+++ b/build/packages-template/bbb-etherpad/notes.nginx
@@ -18,6 +18,11 @@ location /pad/p/ {
     proxy_set_header X-Forwarded-Proto $scheme; # for EP to set secure cookie flag when https is used
     proxy_http_version 1.1;
 
+    # add_header has no effect if value is null, details here: https://github.com/bigbluebutton/bigbluebutton/issues/15436#issue-1315627368
+    proxy_hide_header Access-Control-Allow-Origin;
+    add_header 'Access-Control-Allow-Origin' $bbb_loadbalancer_node always;
+    add_header 'Access-Control-Allow-Credentials' 'true' always;
+
     auth_request /bigbluebutton/connection/checkAuthorization;
     auth_request_set $auth_status $upstream_status;
 }


### PR DESCRIPTION
### What does this PR do?

It resolves CORS problem with etherpad when clicking `Move notes to whiteboard` button using reverse proxy. 

### Related to

This PR is related to #15436 and #15457. 

### More

When using a reverse proxy, if these changes are not applied, we hit a CORS problem by clicking the `Move notes to whiteboard` as showed ahead:

![image](https://user-images.githubusercontent.com/69865537/193051285-786be843-9e36-4ccd-893e-053c149e3aa7.png)

With this fix, the request works just fine!
![image](https://user-images.githubusercontent.com/69865537/193057818-9836a652-e1a9-48aa-b6e1-1a517853e3e0.png)
