### PR TITLE
Layout Selection Modal A11y Updates

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
@@ -76,6 +76,10 @@ const LayoutModalComponent = (props) => {
       id: 'app.layout.modal.layoutSingular',
       description: 'label for singular layout',
     },
+    layoutBtnDesc: {
+      id: 'app.layout.modal.layoutBtnDesc',
+      description: 'label for singular layout',
+    },
   });
 
   const handleSwitchLayout = (e) => {
@@ -126,12 +130,18 @@ const LayoutModalComponent = (props) => {
       {Object.values(LAYOUT_TYPE)
         .map((layout) => (
           <Styled.ButtonLayoutContainer key={layout}>
-            <Styled.LabelLayoutNames>{intl.formatMessage(intlMessages[`${layout}Layout`])}</Styled.LabelLayoutNames>
+            <Styled.LabelLayoutNames aria-hidden>{intl.formatMessage(intlMessages[`${layout}Layout`])}</Styled.LabelLayoutNames>
             <Styled.LayoutBtn
               label=""
-              customIcon={<Styled.IconSvg src={`${LAYOUTS_PATH}${layout}.svg`} alt={`${layout} ${intl.formatMessage(intlMessages.layoutSingular)}`} />}
+              customIcon={(
+                <Styled.IconSvg
+                  src={`${LAYOUTS_PATH}${layout}.svg`}
+                  alt={`${layout} ${intl.formatMessage(intlMessages.layoutSingular)}`}
+                />
+                )}
               onClick={() => handleSwitchLayout(layout)}
               active={(layout === selectedLayout).toString()}
+              aria-describedby="layout-btn-desc"
             />
           </Styled.ButtonLayoutContainer>
         ))}
@@ -171,6 +181,7 @@ const LayoutModalComponent = (props) => {
           onClick={handleCloseModal}
         />
       </Styled.ButtonBottomContainer>
+      <div style={{ display: 'none' }} id="layout-btn-desc">{intl.formatMessage(intlMessages.layoutBtnDesc)}</div>
     </Styled.LayoutModal>
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
@@ -72,6 +72,10 @@ const LayoutModalComponent = (props) => {
       id: 'app.layout.style.videoFocus',
       description: 'label for videoFocus layout style',
     },
+    layoutSingular: {
+      id: 'app.layout.modal.layoutSingular',
+      description: 'label for singular layout',
+    },
   });
 
   const handleSwitchLayout = (e) => {
@@ -125,7 +129,7 @@ const LayoutModalComponent = (props) => {
             <Styled.LabelLayoutNames>{intl.formatMessage(intlMessages[`${layout}Layout`])}</Styled.LabelLayoutNames>
             <Styled.LayoutBtn
               label=""
-              customIcon={<Styled.IconSvg src={`${LAYOUTS_PATH}${layout}.svg`} alt={`${LAYOUTS_PATH}${layout}Layout`} />}
+              customIcon={<Styled.IconSvg src={`${LAYOUTS_PATH}${layout}.svg`} alt={`${layout} ${intl.formatMessage(intlMessages.layoutSingular)}`} />}
               onClick={() => handleSwitchLayout(layout)}
               active={(layout === selectedLayout).toString()}
             />
@@ -159,7 +163,7 @@ const LayoutModalComponent = (props) => {
         <Styled.BottomButton
           label={intl.formatMessage(intlMessages.cancel)}
           onClick={closeModal}
-          color='secondary'
+          color="secondary"
         />
         <Button
           color="primary"

--- a/bigbluebutton-html5/imports/ui/components/layout/modal/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/modal/styles.js
@@ -80,6 +80,12 @@ const LayoutBtn = styled(Button)`
     border-radius: 10px;
     width: fit-content;
   }
+
+  &:focus,
+  &:hover {
+    border: ${colorPrimary} solid 6px;
+    border-radius: 5px;
+  }
   
   ${({ active }) => (active === 'true') && `
     border: ${colorPrimary} solid 6px;

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -53,6 +53,11 @@ const intlMessages = defineMessages({
     description: 'Snapshot of current slide label',
     defaultMessage: 'Snapshot of current slide',
   },
+  whiteboardLabel: {
+    id: "app.shortcut-help.whiteboard",
+    description: 'used for aria whiteboard options button label',
+    defaultMessage: 'Whiteboard',
+  }
 });
 
 const propTypes = {
@@ -267,7 +272,7 @@ const PresentationMenu = (props) => {
           <TooltipContainer title={intl.formatMessage(intlMessages.optionsLabel)}>
             <Styled.DropdownButton
               state={isDropdownOpen ? 'open' : 'closed'}
-              aria-label={intl.formatMessage(intlMessages.optionsLabel)}
+              aria-label={`${intl.formatMessage(intlMessages.whiteboardLabel)} ${intl.formatMessage(intlMessages.optionsLabel)}`}
               data-test="whiteboardOptionsButton"
               onClick={() => {
                 setIsDropdownOpen((isOpen) => !isOpen)

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1078,6 +1078,7 @@
     "app.layout.modal.keepPushingLayoutLabel": "Keep pushing to everyone",
     "app.layout.modal.pushLayoutLabel": "Push to everyone",
     "app.layout.modal.layoutToastLabel": "Layout settings changed",
+    "app.layout.modal.layoutSingular": "Layout",
     "app.layout.style.custom": "Custom",
     "app.layout.style.smart": "Smart layout",
     "app.layout.style.presentationFocus": "Focus on presentation",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1079,6 +1079,7 @@
     "app.layout.modal.pushLayoutLabel": "Push to everyone",
     "app.layout.modal.layoutToastLabel": "Layout settings changed",
     "app.layout.modal.layoutSingular": "Layout",
+    "app.layout.modal.layoutBtnDesc": "Sets layout as selected option",
     "app.layout.style.custom": "Custom",
     "app.layout.style.smart": "Smart layout",
     "app.layout.style.presentationFocus": "Focus on presentation",


### PR DESCRIPTION
### What does this PR do?

- Remove paths from layout button aria labels.
- Add hover and focus states to layout buttons.
- Add aria descriptions to  layout buttons.
- Hide duplicate button label from screen reader.

also 
- Update whiteboard options button label with more context.

### Motivation

These are A11y improvements for 2.6 

