### PR TITLE
build(bbb-webrtc-sfu): v2.8.7

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.8.6 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.8.7 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

- [build(bbb-webrtc-sfu): v2.8.7](https://github.com/bigbluebutton/bigbluebutton/commit/09bec2daf9ef90fb12e1d25972d9050f05df3c7b)
  * See https://github.com/bigbluebutton/bbb-webrtc-sfu/releases/tag/v2.8.7
    - Switch away from the forked repo back to npm/upstream
    - This includes massive memory usage improvements in mediasoup

### Closes Issue(s)

None

### Motivation

n/æ

### More

n/æ