### PR TITLE
fix(whiteboard): several zoom fixes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -177,22 +177,22 @@ export default function Whiteboard(props) {
 
   // when presentationSizes change, update tldraw camera
   React.useEffect(() => {
-    if (curPageId && slidePosition && tldrawAPI && presentationWidth !== 0 && presentationHeight !== 0) {
+    if (curPageId && slidePosition && tldrawAPI && presentationWidth > 0 && presentationHeight > 0) {
       if (prevFitToWidth !== null && fitToWidth !== prevFitToWidth) {
         const zoom = calculateZoom(slidePosition.width, slidePosition.height)
         tldrawAPI?.setCamera([0, 0], zoom);
         const viewedRegionH = SlideCalcUtil.calcViewedRegionHeight(tldrawAPI?.viewport.width, slidePosition.height);
+        setZoom(HUNDRED_PERCENT);
+        zoomChanger(HUNDRED_PERCENT);
         zoomSlide(parseInt(curPageId), podId, HUNDRED_PERCENT, viewedRegionH, 0, 0);
       } else {
         const currentAspectRatio =  Math.round((presentationWidth / presentationHeight) * 100) / 100;
         const previousAspectRatio = Math.round((slidePosition.viewBoxWidth / slidePosition.viewBoxHeight) * 100) / 100;
-        if (isMounting && currentAspectRatio !== previousAspectRatio) {
-          // wee need this to ensure tldraw updates the viewport size
-          // after re-mounting
+        if (fitToWidth && currentAspectRatio !== previousAspectRatio) {
+          // wee need this to ensure tldraw updates the viewport size after re-mounting
           setTimeout(() => {
             const zoom = calculateZoom(slidePosition.viewBoxWidth, slidePosition.viewBoxHeight);
             tldrawAPI.setCamera([slidePosition.x, slidePosition.y], zoom, 'zoomed');
-            setIsMounting(false);
           }, 50);
         } else {
           const zoom = calculateZoom(slidePosition.viewBoxWidth, slidePosition.viewBoxHeight);
@@ -201,6 +201,26 @@ export default function Whiteboard(props) {
       }
     }
   }, [presentationWidth, presentationHeight, curPageId, document?.documentElement?.dir]);
+
+  React.useEffect(() => {
+    if (presentationWidth > 0 && presentationHeight > 0) {
+      const cameraZoom = tldrawAPI?.getPageState()?.camera?.zoom;
+      const newzoom = calculateZoom(slidePosition.viewBoxWidth, slidePosition.viewBoxHeight);
+      if (cameraZoom && cameraZoom === 1) {
+          tldrawAPI?.setCamera([slidePosition.x, slidePosition.y], newzoom);
+      } else if (isMounting) {
+        if (!fitToWidth) {
+          setIsMounting(false);
+          // wee need this to ensure tldraw updates the viewport size after re-mounting
+          setTimeout(() => {
+            tldrawAPI?.setCamera([slidePosition.x, slidePosition.y], newzoom, 'zoomed');
+          }, 50);
+        } else {
+          tldrawAPI?.setCamera([slidePosition.x, slidePosition.y], newzoom);
+        }
+      }
+    }
+  }, [tldrawAPI?.getPageState()?.camera, presentationWidth, presentationHeight]);
 
   // change tldraw page when presentation page changes
   React.useEffect(() => {
@@ -226,13 +246,15 @@ export default function Whiteboard(props) {
     if (tldrawAPI && isPresenter && curPageId && slidePosition && zoom !== zoomValue) {
       const zoomFitSlide = calculateZoom(slidePosition.width, slidePosition.height);
       const zoomCamera = (zoomFitSlide * zoomValue) / HUNDRED_PERCENT;
-      tldrawAPI?.zoomTo(zoomCamera);
+      setTimeout(() => {
+        tldrawAPI?.zoomTo(zoomCamera);
+      }, 50);
     }
   }, [zoomValue]);
 
   // update zoom when presenter changes
   React.useEffect(() => {
-    if (tldrawAPI && isPresenter && curPageId && slidePosition) {
+    if (tldrawAPI && isPresenter && curPageId && slidePosition && !isMounting) {
       const currentAspectRatio =  Math.round((presentationWidth / presentationHeight) * 100) / 100;
       const previousAspectRatio = Math.round((slidePosition.viewBoxWidth / slidePosition.viewBoxHeight) * 100) / 100;
       if (previousAspectRatio !== currentAspectRatio && fitToWidth) {
@@ -240,9 +262,23 @@ export default function Whiteboard(props) {
         tldrawAPI?.setCamera([0, 0], zoom);
         const viewedRegionH = SlideCalcUtil.calcViewedRegionHeight(tldrawAPI?.viewport.width, slidePosition.height);
         zoomSlide(parseInt(curPageId), podId, HUNDRED_PERCENT, viewedRegionH, 0, 0);
+        setZoom(HUNDRED_PERCENT);
+        zoomChanger(HUNDRED_PERCENT);
       } else {
-        const zoom = calculateZoom(slidePosition.viewBoxWidth, slidePosition.viewBoxHeight)
-        tldrawAPI.setCamera([slidePosition.x, slidePosition.y], zoom, 'zoomed');
+        let viewedRegionW = SlideCalcUtil.calcViewedRegionWidth(tldrawAPI?.viewport.height, slidePosition.width);
+        let viewedRegionH = SlideCalcUtil.calcViewedRegionHeight(tldrawAPI?.viewport.width, slidePosition.height);
+        const camera = tldrawAPI?.getPageState()?.camera;
+        const zoomFitSlide = calculateZoom(slidePosition.width, slidePosition.height);
+        if (!fitToWidth && camera.zoom === zoomFitSlide) {
+          viewedRegionW = HUNDRED_PERCENT;
+          viewedRegionH = HUNDRED_PERCENT;
+        }
+        zoomSlide(parseInt(curPageId), podId, viewedRegionW, viewedRegionH, camera.point[0], camera.point[1]);
+        const zoomToolbar = Math.round((HUNDRED_PERCENT * camera.zoom) / zoomFitSlide * 100) / 100;
+        if (zoom !== zoomToolbar) {
+          setZoom(zoomToolbar);
+          zoomChanger(zoomToolbar);
+        }
       }
     }
   }, [isPresenter]);
@@ -336,15 +372,6 @@ export default function Whiteboard(props) {
 
     if (curPageId) {
       app.changePage(curPageId);
-      if (presentationWidth > 0 && presentationHeight > 0) {
-        const zoom = calculateZoom(slidePosition.viewBoxWidth, slidePosition.viewBoxHeight);
-        // wee need this to ensure tldraw updates the viewport size
-        // after re-mounting
-        setTimeout(() => {
-          app.setCamera([slidePosition.x, slidePosition.y], zoom, 'zoomed');
-          setIsMounting(false);
-        }, 50);
-      }
     }
   };
 


### PR DESCRIPTION
### What does this PR do?

Sometimes when whiteboard props change (mainly resizes), the tldraw component gets mounted again, resetting its camera, and was causing zoom to be applied incorrectly. I've added a useEffect to better react to when the camera resets and set to the corret zoom.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #15656 
Expept the undo stopping working (number 4), since the tldraw app gets mounted again, it loses it's history. We will probably have a way to have a local copy of the history/stack to avoid this
