### PR TITLE
Update FreeSWITCH settings for improved audio

### DIFF
--- a/bbb-voice-conference/config/freeswitch/conf/autoload_configs/conference.conf.xml
+++ b/bbb-voice-conference/config/freeswitch/conf/autoload_configs/conference.conf.xml
@@ -39,7 +39,7 @@
       <!-- Domain (for presence) -->
       <param name="domain" value="$${domain}"/>
       <!-- Sample Rate-->
-      <param name="rate" value="8000"/>
+      <param name="rate" value="48000"/>
       <!-- Number of milliseconds per frame -->
       <param name="interval" value="20"/>
       <!-- Energy level required for audio to be sent to the other users -->
@@ -277,4 +277,3 @@
     </profile>
   </profiles>
 </configuration>
-

--- a/bbb-voice-conference/config/freeswitch/conf/autoload_configs/opus.conf.xml
+++ b/bbb-voice-conference/config/freeswitch/conf/autoload_configs/opus.conf.xml
@@ -1,12 +1,16 @@
 <configuration name="opus.conf">
-      <settings>
-        <param name="use-vbr" value="1"/>
-        <param name="use-dtx" value="0"/>
-	<param name="complexity" value="5"/>
-
-        <param name="packet-loss-percent" value="15"/>
-        <param name="keep-fec-enabled" value="1"/>
-        <param name="use-jb-lookahead" value="1"/>
-        <param name="advertise-useinbandfec" value="1"/>
-      </settings>
+   <settings>
+      <param name="use-vbr" value="1" />
+      <param name="use-dtx" value="0" />
+      <param name="complexity" value="10" />
+      <param name="packet-loss-percent" value="15" />
+      <param name="keep-fec-enabled" value="1" />
+      <param name="use-jb-lookahead" value="1" />
+      <param name="advertise-useinbandfec" value="1" />
+      <param name="maxaveragebitrate" value="64000" />
+      <param name="maxplaybackrate" value="48000" />
+      <param name="sprop-maxcapturerate" value="48000" />
+      <param name="adjust-bitrate" value="1" />
+      <param name="negotiate-bitrate" value="1" />
+   </settings>
 </configuration>

--- a/bbb-voice-conference/config/freeswitch/conf/dialplan/default/bbb_conference.xml
+++ b/bbb-voice-conference/config/freeswitch/conf/dialplan/default/bbb_conference.xml
@@ -1,19 +1,26 @@
 <include>
-    <extension name="bbb_conferences_ws">
-      <condition field="${bbb_authorized}" expression="true" break="on-false"/>
-      <condition field="${sip_via_protocol}" expression="^wss?$"/>
+   <extension name="bbb_conferences_ws">
+      <condition field="${bbb_authorized}" expression="true" break="on-false" />
+      <condition field="${sip_via_protocol}" expression="^wss?$" />
       <condition field="destination_number" expression="^(\d{5,11})$">
-        <action application="jitterbuffer" data="120"/>
-        <action application="answer"/>
-        <action application="conference" data="$1@cdquality"/>
+         <action application="set" data="jitterbuffer_msec=60:120:20" />
+         <action application="set" data="rtp_jitter_buffer_plc=true" />
+         <action application="set" data="rtp_jitter_buffer_during_bridge=true" />
+         <action application="set" data="suppress_cng=true" />
+         <action application="answer" />
+         <action application="conference" data="$1@cdquality" />
       </condition>
-    </extension>
-    <extension name="bbb_conferences">
-      <condition field="${bbb_authorized}" expression="true" break="on-false"/>
+   </extension>
+   <extension name="bbb_conferences">
+      <condition field="${bbb_authorized}" expression="true" break="on-false" />
       <condition field="destination_number" expression="^(\d{5,11})$">
-        <action application="jitterbuffer" data="120"/>
-        <action application="answer"/>
-        <action application="conference" data="$1@cdquality"/>
+         <action application="set" data="jitterbuffer_msec=60:120:20" />
+         <action application="set" data="rtp_jitter_buffer_plc=true" />
+         <action application="set" data="rtp_jitter_buffer_during_bridge=true" />
+         <action application="set" data="suppress_cng=true" />
+         <action application="answer" />
+         <action application="conference" data="$1@cdquality" />
       </condition>
-    </extension>
+   </extension>
 </include>
+

--- a/bbb-voice-conference/config/freeswitch/conf/dialplan/default/bbb_conference.xml
+++ b/bbb-voice-conference/config/freeswitch/conf/dialplan/default/bbb_conference.xml
@@ -3,7 +3,7 @@
       <condition field="${bbb_authorized}" expression="true" break="on-false" />
       <condition field="${sip_via_protocol}" expression="^wss?$" />
       <condition field="destination_number" expression="^(\d{5,11})$">
-         <action application="set" data="jitterbuffer_msec=60:120:20" />
+         <action application="set" data="jitterbuffer_msec=60:120" />
          <action application="set" data="rtp_jitter_buffer_plc=true" />
          <action application="set" data="rtp_jitter_buffer_during_bridge=true" />
          <action application="set" data="suppress_cng=true" />
@@ -14,7 +14,7 @@
    <extension name="bbb_conferences">
       <condition field="${bbb_authorized}" expression="true" break="on-false" />
       <condition field="destination_number" expression="^(\d{5,11})$">
-         <action application="set" data="jitterbuffer_msec=60:120:20" />
+         <action application="set" data="jitterbuffer_msec=60:120" />
          <action application="set" data="rtp_jitter_buffer_plc=true" />
          <action application="set" data="rtp_jitter_buffer_during_bridge=true" />
          <action application="set" data="suppress_cng=true" />

--- a/bbb-voice-conference/config/freeswitch/conf/dialplan/default/bbb_echo_to_conference.xml
+++ b/bbb-voice-conference/config/freeswitch/conf/dialplan/default/bbb_echo_to_conference.xml
@@ -2,9 +2,13 @@
   <extension name="ECHO_TO_CONFERENCE">
     <condition field="${bbb_from_echo}" expression="true" break="on-false"/>
     <condition field="destination_number" expression="^(ECHO_TO_CONFERENCE)$">
-      <action application="jitterbuffer" data="120"/>
+      <action application="set" data="jitterbuffer_msec=60:120:20" />
+      <action application="set" data="rtp_jitter_buffer_plc=true" />
+      <action application="set" data="rtp_jitter_buffer_during_bridge=true" />
+      <action application="set" data="suppress_cng=true" />
       <action application="answer"/>
       <action application="conference" data="${vbridge}@cdquality"/>
     </condition>
   </extension>
 </include>
+

--- a/bbb-voice-conference/config/freeswitch/conf/dialplan/default/bbb_echo_to_conference.xml
+++ b/bbb-voice-conference/config/freeswitch/conf/dialplan/default/bbb_echo_to_conference.xml
@@ -2,7 +2,7 @@
   <extension name="ECHO_TO_CONFERENCE">
     <condition field="${bbb_from_echo}" expression="true" break="on-false"/>
     <condition field="destination_number" expression="^(ECHO_TO_CONFERENCE)$">
-      <action application="set" data="jitterbuffer_msec=60:120:20" />
+      <action application="set" data="jitterbuffer_msec=60:120" />
       <action application="set" data="rtp_jitter_buffer_plc=true" />
       <action application="set" data="rtp_jitter_buffer_during_bridge=true" />
       <action application="set" data="suppress_cng=true" />


### PR DESCRIPTION
### Motivation

These are the update FreeSWITCH settings based on research by Ghazi Triki and feedback from members of the community.  See

  https://groups.google.com/g/bigbluebutton-setup/c/OJwurn8hfhM/m/pfS6kQg0BQAJ

### More

We want to thank the many members of the community that have been experimenting and sharing feedback on the FreeSWITCH audio settings.   

This change reverts the setting of the jitterbuffer in FreeSWITCH back to "60:120".  See    https://github.com/bigbluebutton/bigbluebutton/issues/15172.

In testing with Chrome, with the old settings, the outbound RTP data from the client was about 30 KBits/sec, and with the new settings the client sends about 60 KBits/sec, which also provides a better audio quality.

![image](https://user-images.githubusercontent.com/290351/193473667-89b261d6-3c2b-4dc7-8a87-773e46ad2e1d.png)

In contrast, I tested the above changes for a few hours with FireFox and couldn't get the outbound RTP stream above 8 KBits/sec.

In digging into the SDP, it seems in the SDP Answer from FreeSWITCH accepts two choices (109 and 101)

```
m=audio 21282 UDP/TLS/RTP/SAVPF 109 101   
...
a=rtpmap:109 opus/48000/2.  
a=rtpmap:101 telephone-event/8000.  
```

and for some reason FreeSWITCH drops down the bandwidth to 8000 KBits/sec, taken from the FreeSWITCH logs

```
2022-10-02 15:54:06.736549 97.30% [DEBUG] switch_core_media.c:5566 Set telephone-event payload to 101@8000
```
I think Roland at Fairkom found the same issue:  https://git.fairkom.net/hosting/fairteaching/-/issues/29


We'll make this change against 2.6.x and apply to 2.5.x shortly thereafter.

References
   https://freeswitch.org/confluence/display/FREESWITCH/FreeSWITCH+And+The+Opus+Audio+Codec

   
