### PR TITLE
improvement: share audio and video setup among different sessions

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
@@ -1,6 +1,6 @@
 import Settings from '/imports/ui/services/settings';
 import logger from '/imports/startup/client/logger';
-import Storage from '/imports/ui/services/storage/session';
+import Storage from '/imports/ui/services/storage/local';
 
 const AUDIO_SESSION_NUM_KEY = 'AudioSessionNumber';
 const DEFAULT_INPUT_DEVICE_ID = '';

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
@@ -1,6 +1,6 @@
 import Settings from '/imports/ui/services/settings';
 import logger from '/imports/startup/client/logger';
-import Storage from '/imports/ui/services/storage/local';
+import BBBStorage from '/imports/ui/services/storage';
 
 const AUDIO_SESSION_NUM_KEY = 'AudioSessionNumber';
 const DEFAULT_INPUT_DEVICE_ID = '';
@@ -38,10 +38,10 @@ const getCurrentAudioSinkId = () => {
   return audioElement?.sinkId || DEFAULT_OUTPUT_DEVICE_ID;
 };
 
-const getStoredAudioInputDeviceId = () => Storage.getItem(INPUT_DEVICE_ID_KEY);
-const getStoredAudioOutputDeviceId = () => Storage.getItem(OUTPUT_DEVICE_ID_KEY);
-const storeAudioInputDeviceId = (deviceId) => Storage.setItem(INPUT_DEVICE_ID_KEY, deviceId);
-const storeAudioOutputDeviceId = (deviceId) => Storage.setItem(OUTPUT_DEVICE_ID_KEY, deviceId);
+const getStoredAudioInputDeviceId = () => BBBStorage.getItem(INPUT_DEVICE_ID_KEY);
+const getStoredAudioOutputDeviceId = () => BBBStorage.getItem(OUTPUT_DEVICE_ID_KEY);
+const storeAudioInputDeviceId = (deviceId) => BBBStorage.setItem(INPUT_DEVICE_ID_KEY, deviceId);
+const storeAudioOutputDeviceId = (deviceId) => BBBStorage.setItem(OUTPUT_DEVICE_ID_KEY, deviceId);
 
 /**
  * Filter constraints set in audioDeviceConstraints, based on

--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -466,9 +466,18 @@ class VideoPreview extends Component {
   }
 
   handleStartSharing() {
-    const { resolve, startSharing } = this.props;
-    const { webcamDeviceId, brightness } = this.state;
-    // Only streams that will be shared should be stored in the service.  // If the store call returns false, we're duplicating stuff. So clean this one
+    const {
+      resolve,
+      startSharing,
+    } = this.props;
+    const {
+      webcamDeviceId,
+      selectedProfile,
+      brightness,
+    } = this.state;
+
+    // Only streams that will be shared should be stored in the service.
+    // If the store call returns false, we're duplicating stuff. So clean this one
     // up because it's an impostor.
     if(!PreviewService.storeStream(webcamDeviceId, this.currentVideoStream)) {
       this.currentVideoStream.stop();
@@ -484,6 +493,8 @@ class VideoPreview extends Component {
 
     this.updateVirtualBackgroundInfo();
     this.cleanupStreamAndVideo();
+    PreviewService.changeProfile(selectedProfile);
+    PreviewService.changeWebcam(webcamDeviceId);
     startSharing(webcamDeviceId);
     if (resolve) resolve();
   }
@@ -607,7 +618,6 @@ class VideoPreview extends Component {
     }
 
     this.setState({ webcamDeviceId: actualDeviceId, });
-    PreviewService.changeWebcam(actualDeviceId);
   }
 
   getInitialCameraStream(deviceId) {
@@ -627,7 +637,6 @@ class VideoPreview extends Component {
       previewError: undefined,
     });
 
-    PreviewService.changeProfile(profile.id);
     this.terminateCameraStream(this.currentVideoStream, webcamDeviceId);
     this.cleanupStreamAndVideo();
 

--- a/bigbluebutton-html5/imports/ui/components/video-preview/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/service.js
@@ -1,4 +1,5 @@
 import Storage from '/imports/ui/services/storage/session';
+import LocalStorage from '/imports/ui/services/storage/local';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
 import VideoService from '/imports/ui/components/video-provider/service';
@@ -15,7 +16,8 @@ const CAMERA_PROFILES = Meteor.settings.public.kurento.cameraProfiles || [];
 const PREVIEW_CAMERA_PROFILES = CAMERA_PROFILES.filter(p => !p.hidden);
 
 const getDefaultProfile = () => {
-  return CAMERA_PROFILES.find(profile => profile.id === VideoService.getUserParameterProfile())
+  return CAMERA_PROFILES.find(profile => profile.id === LocalStorage.getItem('WebcamProfileId'))
+    || CAMERA_PROFILES.find(profile => profile.id === VideoService.getUserParameterProfile())
     || CAMERA_PROFILES.find(profile => profile.default)
     || CAMERA_PROFILES[0];
 }
@@ -221,11 +223,11 @@ export default {
   CAMERA_PROFILES,
   promiseTimeout,
   changeWebcam: (deviceId) => {
-    Session.set('WebcamDeviceId', deviceId);
+    LocalStorage.setItem('WebcamDeviceId', deviceId);
   },
-  webcamDeviceId: () => Session.get('WebcamDeviceId'),
+  webcamDeviceId: () => LocalStorage.getItem('WebcamDeviceId'),
   changeProfile: (profileId) => {
-    Session.set('WebcamProfileId', profileId);
+    LocalStorage.setItem('WebcamProfileId', profileId);
   },
   getSkipVideoPreview,
   storeStream,

--- a/bigbluebutton-html5/imports/ui/components/video-preview/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/service.js
@@ -1,5 +1,5 @@
 import Storage from '/imports/ui/services/storage/session';
-import LocalStorage from '/imports/ui/services/storage/local';
+import BBBStorage from '/imports/ui/services/storage';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
 import VideoService from '/imports/ui/components/video-provider/service';
@@ -16,7 +16,7 @@ const CAMERA_PROFILES = Meteor.settings.public.kurento.cameraProfiles || [];
 const PREVIEW_CAMERA_PROFILES = CAMERA_PROFILES.filter(p => !p.hidden);
 
 const getDefaultProfile = () => {
-  return CAMERA_PROFILES.find(profile => profile.id === LocalStorage.getItem('WebcamProfileId'))
+  return CAMERA_PROFILES.find(profile => profile.id === BBBStorage.getItem('WebcamProfileId'))
     || CAMERA_PROFILES.find(profile => profile.id === VideoService.getUserParameterProfile())
     || CAMERA_PROFILES.find(profile => profile.default)
     || CAMERA_PROFILES[0];
@@ -223,11 +223,11 @@ export default {
   CAMERA_PROFILES,
   promiseTimeout,
   changeWebcam: (deviceId) => {
-    LocalStorage.setItem('WebcamDeviceId', deviceId);
+    BBBStorage.setItem('WebcamDeviceId', deviceId);
   },
-  webcamDeviceId: () => LocalStorage.getItem('WebcamDeviceId'),
+  webcamDeviceId: () => Storage.getItem('WebcamDeviceId'),
   changeProfile: (profileId) => {
-    LocalStorage.setItem('WebcamProfileId', profileId);
+    BBBStorage.setItem('WebcamProfileId', profileId);
   },
   getSkipVideoPreview,
   storeStream,

--- a/bigbluebutton-html5/imports/ui/components/video-preview/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/service.js
@@ -225,7 +225,7 @@ export default {
   changeWebcam: (deviceId) => {
     BBBStorage.setItem('WebcamDeviceId', deviceId);
   },
-  webcamDeviceId: () => Storage.getItem('WebcamDeviceId'),
+  webcamDeviceId: () => BBBStorage.getItem('WebcamDeviceId'),
   changeProfile: (profileId) => {
     BBBStorage.setItem('WebcamProfileId', profileId);
   },

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -14,6 +14,7 @@ import browserInfo from '/imports/utils/browserInfo';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import VideoPreviewService from '../video-preview/service';
 import Storage from '/imports/ui/services/storage/session';
+import LocalStorage from '/imports/ui/services/storage/local';
 import logger from '/imports/startup/client/logger';
 import _ from 'lodash';
 import {
@@ -688,11 +689,11 @@ class VideoService {
   }
 
   getCameraProfile() {
-    const profileId = Session.get('WebcamProfileId') || '';
+    const profileId = LocalStorage.getItem('WebcamProfileId') || '';
     const cameraProfile = CAMERA_PROFILES.find(profile => profile.id === profileId)
       || CAMERA_PROFILES.find(profile => profile.default)
       || CAMERA_PROFILES[0];
-    const deviceId = Session.get('WebcamDeviceId');
+    const deviceId = LocalStorage.getItem('WebcamDeviceId');
     if (deviceId) {
       cameraProfile.constraints = cameraProfile.constraints || {};
       cameraProfile.constraints.deviceId = { exact: deviceId };

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -756,7 +756,7 @@ class VideoService {
     if (this.userParameterProfile === null) {
       this.userParameterProfile = getFromUserSettings(
         'bbb_preferred_camera_profile',
-        (CAMERA_PROFILES.filter(i => i.default) || {}).id,
+        (CAMERA_PROFILES.find(i => i.default) || {}).id || null,
       );
     }
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -14,7 +14,7 @@ import browserInfo from '/imports/utils/browserInfo';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import VideoPreviewService from '../video-preview/service';
 import Storage from '/imports/ui/services/storage/session';
-import LocalStorage from '/imports/ui/services/storage/local';
+import BBBStorage from '/imports/ui/services/storage';
 import logger from '/imports/startup/client/logger';
 import _ from 'lodash';
 import {
@@ -689,11 +689,11 @@ class VideoService {
   }
 
   getCameraProfile() {
-    const profileId = LocalStorage.getItem('WebcamProfileId') || '';
+    const profileId = BBBStorage.getItem('WebcamProfileId') || '';
     const cameraProfile = CAMERA_PROFILES.find(profile => profile.id === profileId)
       || CAMERA_PROFILES.find(profile => profile.default)
       || CAMERA_PROFILES[0];
-    const deviceId = LocalStorage.getItem('WebcamDeviceId');
+    const deviceId = BBBStorage.getItem('WebcamDeviceId');
     if (deviceId) {
       cameraProfile.constraints = cameraProfile.constraints || {};
       cameraProfile.constraints.deviceId = { exact: deviceId };

--- a/bigbluebutton-html5/imports/ui/services/settings/index.js
+++ b/bigbluebutton-html5/imports/ui/services/settings/index.js
@@ -1,6 +1,10 @@
-import Storage from '/imports/ui/services/storage/session';
+import {default as LocalStorage} from '/imports/ui/services/storage/local';
+import {default as SessionStorage} from '/imports/ui/services/storage/session';
+
 import _ from 'lodash';
 import { makeCall } from '/imports/ui/services/api';
+
+const APP_CONFIG = Meteor.settings.public.app;
 
 const SETTINGS = [
   'application',
@@ -55,6 +59,7 @@ class Settings {
   }
 
   loadChanged() {
+    const Storage = (APP_CONFIG.userSettingsStorage == 'local') ? LocalStorage : SessionStorage;
     const savedSettings = {};
 
     SETTINGS.forEach((s) => {
@@ -72,6 +77,7 @@ class Settings {
   }
 
   save(settings = CHANGED_SETTINGS) {
+    const Storage = (APP_CONFIG.userSettingsStorage == 'local') ? LocalStorage : SessionStorage;
     if (settings === CHANGED_SETTINGS) {
       Object.keys(this).forEach((k) => {
         const values = this[k].value;

--- a/bigbluebutton-html5/imports/ui/services/storage/index.js
+++ b/bigbluebutton-html5/imports/ui/services/storage/index.js
@@ -1,7 +1,8 @@
 import Local from './local';
 import Session from './session';
 
-export default {
-  Local,
-  Session,
-};
+const APP_CONFIG = Meteor.settings.public.app;
+
+const BBBStorage = APP_CONFIG.userSettingsStorage === 'local' ? Local : Session;
+
+export default BBBStorage;

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -144,6 +144,13 @@ public:
     enableNetworkStats: true
     # Enable the button to allow users to copy network stats to clipboard
     enableCopyNetworkStatsButton: true
+    # where should client settings be stored? if you run a single BBB server or
+    # a cluster with a reverse proxy in front of it, you may set this to 'local'
+    # See https://docs.bigbluebutton.org/admin/clusterproxy.html
+    # allowed values:
+    # 'session' -> settings are stored in browser sessionStorage
+    # 'local' -> settings are stored in browser localStorage
+    userSettingsStorage: session
     defaultSettings:
       application:
         animations: true


### PR DESCRIPTION
### What does this PR do?

Persists, on `localStorage`, audio and video setup that the user last selected in order to share it among different sessions.

It uses a new config option as described in https://github.com/bigbluebutton/bigbluebutton/pull/15413 to define which storage BBB will use to store the settings: `localStorage` or `sessionStorage`.

if `userSettingsStorage: session`: the last used devices won't be persisted across meetings. In short, it will work as-is currently.

if `userSettingsStorage: local`: the last used devices will be persisted across meetings. When entering a new meeting, the stored devices will be automatically selected when opening either audio or video modals.

### Closes Issue(s)

Closes none


### Motivation

Every time users join a session they need to set up their preferred audio and video devices (which don't change often). Storing that information on `localStorage` will allow to share them among sessions.

### More

This PR is also a port of https://github.com/bigbluebutton/bigbluebutton/pull/15413 (by @schrd) to 2.6. Thanks @schrd!