### PR TITLE
build: enable websocket compression in front-end servers

### DIFF
--- a/build/packages-template/bbb-html5/systemd_start_frontend.sh
+++ b/build/packages-template/bbb-html5/systemd_start_frontend.sh
@@ -49,7 +49,7 @@ fi
 export MONGO_OPLOG_URL=mongodb://127.0.1.1/local
 export MONGO_URL=mongodb://127.0.1.1/meteor
 export NODE_ENV=production
-export SERVER_WEBSOCKET_COMPRESSION=0
+export SERVER_WEBSOCKET_COMPRESSION='{"level":5, "maxWindowBits":13, "memLevel":7, "requestMaxWindowBits":13}'
 export BIND_IP=127.0.0.1
 PORT=$PORT /usr/lib/bbb-html5/node/bin/node --max-old-space-size=2048 --max_semi_space_size=128 main.js
 


### PR DESCRIPTION
### What does this PR do?

Enables `SERVER_WEBSOCKET_COMPRESSION` in html5client front-end servers, reducing data size transferred via websocket.

### More
From Pablo's report in [bigbluebutton-dev group](https://groups.google.com/g/bigbluebutton-dev/c/gy6KmK-41mY/m/RHJmTzvmBQAJ):

_Modern browsers are sending a header like this:_
_Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits_

_That tells the server that browser can handle compressed messages. But, as of now, BigBlueButton is ignoring that header._

_The first parameter "level" is recommended to be set between 4 and 6. All three options are good compression for little cpu being 6 the highest compression and 4 the most cpu. Other level of compressions are not suitable for this situation._

_I already have this in my 2.5.4 production server with level 4 and i have not seen any noticeable cpu impact. And i think, there should not be._

_After applying this fix i could save about 90% of the data size transferred via websocket in a long meeting._