### PR TITLE
(refactor) bbb-web - Undo disabledFeatures=none in bigbluebutton.properties

### DIFF
--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -417,7 +417,7 @@ endWhenNoModeratorDelayInMinutes=1
 # List of features to disable (comma-separated)
 # Available options: breakoutRooms, captions, chat, externalVideos, layouts, learningDashboard, polls, screenshare,
 # sharedNotes, virtualBackgrounds, downloadPresentationWithAnnotations, importPresentationWithAnnotationsFromBreakoutRooms
-disabledFeatures=none
+#disabledFeatures=
 
 # Notify users that recording is on
 notifyRecordingIsOn=false


### PR DESCRIPTION
### Motivation

[This line](https://github.com/bigbluebutton/bigbluebutton/blob/fe6a300ef3086d77d18c2c2282c257228f04eef9/bigbluebutton-web/grails-app/conf/bigbluebutton.properties#L420) was commented as default before #15467.
