### PR TITLE
Update Menu Ids to Remove Duplicates

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -318,7 +318,7 @@ class ActionsDropdown extends PureComponent {
         }
         actions={children}
         opts={{
-          id: "default-dropdown-menu",
+          id: "actions-dropdown-menu",
           keepMounted: true,
           transitionDuration: 0,
           elevation: 3,

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/component.jsx
@@ -428,7 +428,7 @@ class InputStreamLiveSelector extends Component {
           )}
           actions={dropdownListComplete}
           opts={{
-            id: 'default-dropdown-menu',
+            id: 'audio-selector-dropdown-menu',
             keepMounted: true,
             transitionDuration: 0,
             elevation: 3,

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-dropdown/component.jsx
@@ -102,7 +102,7 @@ class BreakoutDropdown extends PureComponent {
             />
           }
           opts={{
-            id: "default-dropdown-menu",
+            id: "breakoutroom-dropdown-menu",
             keepMounted: true,
             transitionDuration: 0,
             elevation: 3,

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-dropdown/component.jsx
@@ -144,7 +144,7 @@ class ChatDropdown extends PureComponent {
             />                    
           }
           opts={{
-            id: 'default-dropdown-menu',
+            id: 'chat-options-dropdown-menu',
             keepMounted: true,
             transitionDuration: 0,
             elevation: 3,

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -333,7 +333,7 @@ class SettingsDropdown extends PureComponent {
         )}
         actions={this.renderMenuItems()}
         opts={{
-          id: "default-dropdown-menu",
+          id: "app-settings-dropdown-menu",
           keepMounted: true,
           transitionDuration: 0,
           elevation: 3,

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -278,7 +278,7 @@ const PresentationMenu = (props) => {
           </TooltipContainer>
         }
         opts={{
-          id: "default-dropdown-menu",
+          id: "presentation-dropdown-menu",
           keepMounted: true,
           transitionDuration: 0,
           elevation: 3,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -341,7 +341,7 @@ class UserOptions extends PureComponent {
         )}
         actions={this.renderMenuItems()}
         opts={{
-          id: "default-dropdown-menu",
+          id: "user-options-dropdown-menu",
           keepMounted: true,
           transitionDuration: 0,
           elevation: 3,

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.jsx
@@ -148,7 +148,7 @@ const UserActions = (props) => {
             )}
             actions={getAvailableActions()}
             opts={{
-              id: 'default-dropdown-menu',
+              id: `webcam-${user?.userId}-dropdown-menu`,
               keepMounted: true,
               transitionDuration: 0,
               elevation: 3,


### PR DESCRIPTION
### What does this PR do?
Provides unique ids for menu component.

### Motivation
Multiple elements exist with the same id of `default-dropdown-menu` which creates problem with a11y.