### PR TITLE
Add Dropdown to Tab Order and Hover / Focus Styles

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.js
@@ -132,17 +132,19 @@ const SkipSlideSelect = styled.select`
   &:-moz-focusring {
     outline: none;
   }
-  
+
+  &:focus,
   &:hover {
     outline: transparent;
     outline-style: dotted;
     outline-width: ${borderSize};
+    background-color: #DCE4EC;
+    border-radius: 4px;
   }
 
   &:focus {
-    outline: transparent;
-    outline-width: ${borderSize};
     outline-style: solid;
+    box-shadow: 0 0 0 1px #cdd6e0 !important;
   }
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/zoom-tool/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/zoom-tool/styles.js
@@ -5,6 +5,7 @@ import {
 } from '/imports/ui/stylesheets/styled-components/palette';
 import {
   whiteboardToolbarMargin,
+  borderSize,
 } from '/imports/ui/stylesheets/styled-components/general';
 import Button from '/imports/ui/components/common/button/component';
 
@@ -22,11 +23,6 @@ const ResetZoomButton = styled(Button)`
   font-weight: 200;
   margin-left: ${whiteboardToolbarMargin};
   margin-right: ${whiteboardToolbarMargin};
-
-  &:hover {
-    opacity: .8;
-  }
-
   position: relative;
   color: ${toolbarButtonColor};
   background-color: ${colorOffWhite};
@@ -34,9 +30,22 @@ const ResetZoomButton = styled(Button)`
   box-shadow: none !important;
   border: 0;
 
+  &:focus,
+  &:hover {
+    outline: transparent;
+    outline-style: dotted;
+    outline-width: ${borderSize};
+    background-color: #DCE4EC;
+    border-radius: 4px;
+  }
+
+  &:hover {
+    opacity: .8;
+  }
+
   &:focus {
-    background-color: ${colorOffWhite};
-    border: 0;
+    outline-style: solid;
+    box-shadow: 0 0 0 1px #cdd6e0 !important;
   }
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
@@ -155,6 +155,7 @@ const JoinVideoButton = ({
             hideLabel
             label={intl.formatMessage(intlMessages.videoSettings)}
             rotate
+            tabIndex={0}
           />
         )}
         actions={actions}


### PR DESCRIPTION
### What does this PR do?
Adds video settings dropdown menu to the tab order.
Also adds hover and focus styles for reset zoom and skip slide elements.

### Motivation
Video settings dropdown was not accessible via keyboard.
Skip slide dropdown and reset zoom button have no styles for focus and hover states.