### PR TITLE
[fix] - fix debounce not working properly

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notes/converter-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/converter-button/component.jsx
@@ -1,17 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
 import { defineMessages, injectIntl } from 'react-intl';
 import Service from './service';
 import Styled from './styles';
 import { useState } from 'react';
 
 const DEBOUNCE_TIMEOUT = 15000;
-const DEBOUNCE_OPTIONS = {
-  leading: true,
-  trailing: false,
-  maxWait: DEBOUNCE_TIMEOUT,
-};
 
 const intlMessages = defineMessages({
   convertAndUploadLabel: {
@@ -36,10 +30,10 @@ const ConverterButtonComponent = ({
   ? (
     <Styled.ConvertAndUpload
       disabled={converterButtonDisabled}
-      onClick={_.debounce(() => {
+      onClick={() => {
         setConverterButtonDisabled(true);
         setTimeout(() => setConverterButtonDisabled(false), DEBOUNCE_TIMEOUT);
-        return Service.convertAndUpload()}, DEBOUNCE_TIMEOUT, DEBOUNCE_OPTIONS)}
+        return Service.convertAndUpload()}}
       label={intl.formatMessage(intlMessages.convertAndUploadLabel)}
       icon="upload"
     />

--- a/bigbluebutton-html5/imports/ui/components/notes/converter-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/converter-button/component.jsx
@@ -4,11 +4,13 @@ import _ from 'lodash';
 import { defineMessages, injectIntl } from 'react-intl';
 import Service from './service';
 import Styled from './styles';
+import { useState } from 'react';
 
 const DEBOUNCE_TIMEOUT = 15000;
 const DEBOUNCE_OPTIONS = {
   leading: true,
   trailing: false,
+  maxWait: DEBOUNCE_TIMEOUT,
 };
 
 const intlMessages = defineMessages({
@@ -28,15 +30,21 @@ const propTypes = {
 const ConverterButtonComponent = ({
   intl,
   amIPresenter,
-}) => (amIPresenter
+}) => {
+  [converterButtonDisabled, setConverterButtonDisabled] = useState(false);
+  return (amIPresenter
   ? (
     <Styled.ConvertAndUpload
-      onClick={_.debounce(() => Service.convertAndUpload(), DEBOUNCE_TIMEOUT, DEBOUNCE_OPTIONS)}
+      disabled={converterButtonDisabled}
+      onClick={_.debounce(() => {
+        setConverterButtonDisabled(true);
+        setTimeout(() => setConverterButtonDisabled(false), DEBOUNCE_TIMEOUT);
+        return Service.convertAndUpload()}, DEBOUNCE_TIMEOUT, DEBOUNCE_OPTIONS)}
       label={intl.formatMessage(intlMessages.convertAndUploadLabel)}
       icon="upload"
     />
   )
-  : null);
+  : null)};
 
 ConverterButtonComponent.propTypes = propTypes;
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -854,7 +854,7 @@ class Presentation extends PureComponent {
     const { downloadable } = currentPresentation;
 
     return (
-      <Styled.InnerToastWrapper>
+      <Styled.InnerToastWrapper data-test="currentPresentationToast">
         <Styled.ToastIcon>
           <Styled.IconWrapper>
             <Icon iconName="presentation" />


### PR DESCRIPTION
### What does this PR do?

It fixes the debounce feature that worked the wrong way (it restarted the timeout every time the user clicked the button `move notes to whiteboard`).

It also disables the button while this debouncing is activated, so now the user sees a block sign in place of the mouse indicator whenever they hover it, and the click event is forbidden during this period. 

### More

https://user-images.githubusercontent.com/69865537/194387726-445685d2-39aa-4486-a7f1-ff44fd332e76.mp4

Here is a demo - so when clicked once, the debounce is activated and it prevents the user to click again for some amount of time, which now is 15 s.
