### PR TITLE
Fix Menu Item Descriptions Not Being Announced

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
@@ -4,7 +4,6 @@ import { defineMessages, injectIntl } from "react-intl";
 
 import Menu from "@material-ui/core/Menu";
 import { Divider } from "@material-ui/core";
-
 import Icon from "/imports/ui/components/common/icon/component";
 import { SMALL_VIEWPORT_BREAKPOINT } from '/imports/ui/components/layout/enums';
 
@@ -65,7 +64,7 @@ class BBBMenu extends React.Component {
     const { actions, selectedEmoji } = this.props;
 
     return actions?.map(a => {
-      const { dataTest, label, onClick, key, disabled } = a;
+      const { dataTest, label, onClick, key, disabled, description } = a;
 
       const emojiSelected = key?.toLowerCase()?.includes(selectedEmoji?.toLowerCase());
 
@@ -101,7 +100,8 @@ class BBBMenu extends React.Component {
           }}>
           <Styled.MenuItemWrapper>
             {a.icon ? <Icon iconName={a.icon} key="icon" /> : null}
-            <Styled.Option>{label}</Styled.Option>
+            <Styled.Option aria-describedby={`${key}-option-desc`}>{label}</Styled.Option>
+            {description && <div className="sr-only" id={`${key}-option-desc`}>{description}</div>}
             {a.iconRight ? <Styled.IconRight iconName={a.iconRight} key="iconRight" /> : null}
           </Styled.MenuItemWrapper>
         </Styled.BBBMenuItem>,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -124,6 +124,10 @@ const intlMessages = defineMessages({
     id: 'app.userList.userOptions.sortedLastName.heading',
     description: '',
   },
+  newTab: {
+    id: 'app.modal.newTab',
+    description: 'label used in aria description',
+  }
 });
 
 class UserOptions extends PureComponent {
@@ -310,7 +314,7 @@ class UserOptions extends PureComponent {
             icon: 'multi_whiteboard',
             iconRight: 'popout_window',
             label: intl.formatMessage(intlMessages.learningDashboardLabel),
-            description: intl.formatMessage(intlMessages.learningDashboardDesc),
+            description: `${intl.formatMessage(intlMessages.learningDashboardDesc)} ${intl.formatMessage(intlMessages.newTab)}`,
             key: this.learningDashboardId,
             onClick: () => { openLearningDashboardUrl(locale); },
             dividerTop: true,

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -835,7 +835,7 @@
     "app.connection-status.next": "Next page",
     "app.connection-status.prev": "Previous page",
     "app.learning-dashboard.label": "Learning Analytics Dashboard",
-    "app.learning-dashboard.description": "Open dashboard with users activities",
+    "app.learning-dashboard.description": "Dashboard with users activities",
     "app.learning-dashboard.clickHereToOpen": "Open Learning Analytics Dashboard",
     "app.recording.startTitle": "Start recording",
     "app.recording.stopTitle": "Pause recording",


### PR DESCRIPTION
### What does this PR do?
Fix menu item descriptions not being announced by screen reader.
Update description for learning analytics dashboard item.

announcement before:
`Learning Analytics Dashboard  9 of 9`

announcement  after:
`Learning Analytics Dashboard Dashboard with users activities (opens new tab)  9 of 9`

### Motivation
Potential violation: The learning analytics dashboard menu item will open a new window or tab. The option fails to announce to screen reader users that the control opens a new window/tab.
![image](https://user-images.githubusercontent.com/22058534/194373912-3d5bf2c4-e327-4378-8ff7-7ab3e48ecac4.png)
