### PR TITLE
Fix User Options Mute Items Not Updating

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
@@ -195,6 +195,7 @@ class UserParticipants extends Component {
       clearAllEmojiStatus,
       currentUser,
       meetingIsBreakout,
+      isMeetingMuteOnStart,
     } = this.props;
     const { isOpen, scrollArea } = this.state;
 
@@ -214,6 +215,7 @@ class UserParticipants extends Component {
                       users,
                       clearAllEmojiStatus,
                       meetingIsBreakout,
+                      isMeetingMuteOnStart,
                     }}
                     />
                   ) : null

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/container.jsx
@@ -54,7 +54,15 @@ export default withTracker(() => {
   const currentMeeting = Meetings.findOne({ meetingId: Auth.meetingID },
     { fields: { lockSettingsProps: 1 } });
 
+  const isMeetingMuteOnStart = () => {
+    const { voiceProp } = Meetings.findOne({ meetingId: Auth.meetingID },
+      { fields: { 'voiceProp.muteOnStart': 1 } });
+    const { muteOnStart } = voiceProp;
+    return muteOnStart;
+  };
+  
   return ({
+    isMeetingMuteOnStart: isMeetingMuteOnStart(),
     meetingIsBreakout: meetingIsBreakout(),
     videoUsers: VideoService.getUsersIdFromVideoStreams(),
     whiteboardUsers,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -228,7 +228,7 @@ class UserOptions extends PureComponent {
         this.menuItems.push({
           key: this.muteAllId,
           label: intl.formatMessage(intlMessages[isMeetingMuted ? 'unmuteAllLabel' : 'muteAllLabel']),
-          // description: intl.formatMessage(intlMessages[isMeetingMuted ? 'unmuteAllDesc' : 'muteAllDesc']),
+          description: intl.formatMessage(intlMessages[isMeetingMuted ? 'unmuteAllDesc' : 'muteAllDesc']),
           onClick: toggleMuteAllUsers,
           icon: isMeetingMuted ? 'unmute' : 'mute',
         });
@@ -237,7 +237,7 @@ class UserOptions extends PureComponent {
           this.menuItems.push({
             key: this.muteId,
             label: intl.formatMessage(intlMessages.muteAllExceptPresenterLabel),
-            // description: intl.formatMessage(intlMessages.muteAllExceptPresenterDesc),
+            description: intl.formatMessage(intlMessages.muteAllExceptPresenterDesc),
             onClick: toggleMuteAllUsersExceptPresenter,
             icon: 'mute',
           });
@@ -246,7 +246,7 @@ class UserOptions extends PureComponent {
         this.menuItems.push({
           key: this.lockId,
           label: intl.formatMessage(intlMessages.lockViewersLabel),
-          // description: intl.formatMessage(intlMessages.lockViewersDesc),
+          description: intl.formatMessage(intlMessages.lockViewersDesc),
           onClick: () => mountModal(<LockViewersContainer />),
           icon: 'lock',
           dataTest: 'lockViewersButton',
@@ -257,7 +257,7 @@ class UserOptions extends PureComponent {
             key: this.guestPolicyId,
             icon: 'user',
             label: intl.formatMessage(intlMessages.guestPolicyLabel),
-            // description: intl.formatMessage(intlMessages.guestPolicyDesc),
+            description: intl.formatMessage(intlMessages.guestPolicyDesc),
             onClick: () => mountModal(<GuestPolicyContainer />),
             dataTest: 'guestPolicyLabel',
           });
@@ -278,7 +278,7 @@ class UserOptions extends PureComponent {
       this.menuItems.push({
         key: this.clearStatusId,
         label: intl.formatMessage(intlMessages.clearAllLabel),
-        // description: intl.formatMessage(intlMessages.clearAllDesc),
+        description: intl.formatMessage(intlMessages.clearAllDesc),
         onClick: toggleStatus,
         icon: 'clear_status',
         divider: true,
@@ -289,7 +289,7 @@ class UserOptions extends PureComponent {
           key: this.createBreakoutId,
           icon: 'rooms',
           label: intl.formatMessage(intlMessages.createBreakoutRoom),
-          // description: intl.formatMessage(intlMessages.createBreakoutRoomDesc),
+          description: intl.formatMessage(intlMessages.createBreakoutRoomDesc),
           onClick: this.onCreateBreakouts,
           dataTest: 'createBreakoutRooms',
         });
@@ -299,7 +299,7 @@ class UserOptions extends PureComponent {
         this.menuItems.push({
           icon: 'closed_caption',
           label: intl.formatMessage(intlMessages.captionsLabel),
-          // description: intl.formatMessage(intlMessages.captionsDesc),
+          description: intl.formatMessage(intlMessages.captionsDesc),
           key: this.captionsId,
           onClick: this.handleCaptionsClick,
         });

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/container.jsx
@@ -37,21 +37,15 @@ const UserOptionsContainer = withTracker((props) => {
     users,
     clearAllEmojiStatus,
     intl,
+    isMeetingMuteOnStart,
   } = props;
-
+  
   const toggleStatus = () => {
     clearAllEmojiStatus(users);
 
     notify(
       intl.formatMessage(intlMessages.clearStatusMessage), 'info', 'clear_status',
     );
-  };
-
-  const isMeetingMuteOnStart = () => {
-    const { voiceProp } = Meetings.findOne({ meetingId: Auth.meetingID },
-      { fields: { 'voiceProp.muteOnStart': 1 } });
-    const { muteOnStart } = voiceProp;
-    return muteOnStart;
   };
 
   const getMeetingName = () => {
@@ -66,7 +60,7 @@ const UserOptionsContainer = withTracker((props) => {
   return {
     toggleMuteAllUsers: () => {
       UserListService.muteAllUsers(Auth.userID);
-      if (isMeetingMuteOnStart()) {
+      if (isMeetingMuteOnStart) {
         return meetingMuteDisabledLog();
       }
       return logger.info({
@@ -76,7 +70,7 @@ const UserOptionsContainer = withTracker((props) => {
     },
     toggleMuteAllUsersExceptPresenter: () => {
       UserListService.muteAllExceptPresenter(Auth.userID);
-      if (isMeetingMuteOnStart()) {
+      if (isMeetingMuteOnStart) {
         return meetingMuteDisabledLog();
       }
       return logger.info({
@@ -85,7 +79,7 @@ const UserOptionsContainer = withTracker((props) => {
       }, 'moderator enabled meeting mute, all users muted except presenter');
     },
     toggleStatus,
-    isMeetingMuted: isMeetingMuteOnStart(),
+    isMeetingMuted: isMeetingMuteOnStart,
     amIModerator: ActionsBarService.amIModerator(),
     hasBreakoutRoom: UserListService.hasBreakoutRoom(),
     isBreakoutRecordable: ActionsBarService.isBreakoutRecordable(),


### PR DESCRIPTION
### What does this PR do?
Fixes the mute items not updating and restores the menu item descriptions.
![26-meeting-mute-toggle](https://user-images.githubusercontent.com/22058534/194423145-02cab9c8-50eb-40b9-9d47-7031da0ef41a.gif)

### Motivation
When all users have been muted, the control labels remain the same instead of changing to the unmute.
(Currently the labels only updates after closing / re-opening the user list)
![26-meeting-mute-toggle-no-change](https://user-images.githubusercontent.com/22058534/194423134-5a2da691-bf7e-4478-9173-ad99211010ed.gif)


