### PR TITLE
fix(locale): add localization for `Manage users` label

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-dropdown/component.jsx
@@ -17,7 +17,6 @@ const intlMessages = defineMessages({
   manageUsers: {
     id: 'app.breakout.dropdown.manageUsers',
     description: 'Manage users label',
-    defaultMessage: 'Manage Users',
   },
   destroy: {
     id: 'app.breakout.dropdown.destroyAll',

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -554,6 +554,7 @@
     "app.breakout.dropdown.manageDuration": "Change duration",
     "app.breakout.dropdown.destroyAll": "End breakout rooms",
     "app.breakout.dropdown.options": "Breakout Options",
+    "app.breakout.dropdown.manageUsers": "Manage users",
     "app.calculatingBreakoutTimeRemaining": "Calculating remaining time ...",
     "app.audioModal.ariaTitle": "Join audio modal",
     "app.audioModal.microphoneLabel": "Microphone",


### PR DESCRIPTION
### What does this PR do?

Adds localization for the `Manage users` label, which is used in breakout dropdown.

### Closes Issue(s)

None