### PR TITLE
fix: show learning dashboard after session was ended in cluster proxy scenario

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/learning-dashboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/learning-dashboard/service.js
@@ -42,7 +42,7 @@ const setLearningDashboardCookie = () => {
 const openLearningDashboardUrl = (lang) => {
   const APP = Meteor.settings.public.app;
   if (getLearningDashboardAccessToken() && setLearningDashboardCookie()) {
-    window.open(`${APP.learningDashboardBase}/?meeting=${Auth.meetingID}&lang=${lang}`, '_blank');
+    window.open(`${APP.learningDashboardBase}/?meeting=${Auth.meetingID}&lang=${lang}&report=${getLearningDashboardAccessToken()}`, '_blank');
   } else {
     window.open(`${APP.learningDashboardBase}/?meeting=${Auth.meetingID}&sessionToken=${Auth.sessionToken}&lang=${lang}`, '_blank');
   }


### PR DESCRIPTION
### What does this PR do?

Appends the `report` parameter when the session is no longer valid, instead of relying on the value being present as a cookie.

Closes: #15821