### PR TITLE
fix(webcam): brightness not working when changing quality profile

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -313,28 +313,6 @@ class VideoPreview extends Component {
                 viewState: VIEW_STATES.found,
               });
               this.displayPreview();
-
-              if (CAMERA_BRIGHTNESS_AVAILABLE) {
-                const setBrightnessInfo = () => {
-                  const stream = this.currentVideoStream || {};
-                  const service = stream.virtualBgService || {};
-                  const { brightness = 100, wholeImageBrightness = false } = service;
-                  this.setState({ brightness, wholeImageBrightness });
-                };
-
-                if (!this.currentVideoStream.virtualBgService) {
-                  this.startVirtualBackground(
-                    this.currentVideoStream,
-                    EFFECT_TYPES.NONE_TYPE
-                  ).then((switched) => {
-                    if (switched) {
-                      setBrightnessInfo();
-                    }
-                  });
-                } else {
-                  setBrightnessInfo();
-                }
-              }
             });
         } else {
           // There were no webcams coming from enumerateDevices. Throw an error.
@@ -375,6 +353,30 @@ class VideoPreview extends Component {
     this.terminateCameraStream(this.currentVideoStream, webcamDeviceId);
     this.cleanupStreamAndVideo();
     this._isMounted = false;
+  }
+
+  startCameraBrightness() {
+    if (CAMERA_BRIGHTNESS_AVAILABLE) {
+      const setBrightnessInfo = () => {
+        const stream = this.currentVideoStream || {};
+        const service = stream.virtualBgService || {};
+        const { brightness = 100, wholeImageBrightness = false } = service;
+        this.setState({ brightness, wholeImageBrightness });
+      };
+
+      if (!this.currentVideoStream.virtualBgService) {
+        this.startVirtualBackground(
+          this.currentVideoStream,
+          EFFECT_TYPES.NONE_TYPE,
+        ).then((switched) => {
+          if (switched) {
+            setBrightnessInfo();
+          }
+        });
+      } else {
+        setBrightnessInfo();
+      }
+    }
   }
 
   handleSelectWebcam(event) {
@@ -637,6 +639,7 @@ class VideoPreview extends Component {
       if (!this._isMounted) return this.terminateCameraStream(bbbVideoStream, deviceId);
 
       this.currentVideoStream = bbbVideoStream;
+      this.startCameraBrightness();
       this.setState({
         isStartSharingDisabled: false,
       });


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Correctly starts webcam brightness whenever the user changes camera device or camera quality profile.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #15834