### PR TITLE
build: enable websocket compression in front-end servers (2.5)

### DIFF
--- a/build/packages-template/bbb-html5/systemd_start_frontend.sh
+++ b/build/packages-template/bbb-html5/systemd_start_frontend.sh
@@ -50,7 +50,7 @@ export MONGO_OPLOG_URL=mongodb://127.0.1.1/local
 export MONGO_URL=mongodb://127.0.1.1/meteor
 export NODE_ENV=production
 export NODE_VERSION=node-v14.19.1-linux-x64
-export SERVER_WEBSOCKET_COMPRESSION=0
+export SERVER_WEBSOCKET_COMPRESSION='{"level":5, "maxWindowBits":13, "memLevel":7, "requestMaxWindowBits":13}'
 export BIND_IP=127.0.0.1
 PORT=$PORT /usr/share/$NODE_VERSION/bin/node --max-old-space-size=2048 --max_semi_space_size=128 main.js
 


### PR DESCRIPTION
### What does this PR do?

Backports #15779 changes to 2.5.

_Enables SERVER_WEBSOCKET_COMPRESSION in html5client front-end servers, reducing data size transferred via websocket._