### PR TITLE
fix: remove empty object in logs (2.5)

### DIFF
--- a/bigbluebutton-html5/imports/startup/server/index.js
+++ b/bigbluebutton-html5/imports/startup/server/index.js
@@ -51,7 +51,7 @@ const serverHealth = () => {
     user: formatMemoryUsage(cpuData.user),
   }
 
-  Logger.info('Server health ', {memoryUsage, cpuUsage});
+  Logger.info('Server health', {memoryUsage, cpuUsage});
 };
 
 Meteor.startup(() => {

--- a/bigbluebutton-html5/imports/startup/server/logger.js
+++ b/bigbluebutton-html5/imports/startup/server/logger.js
@@ -10,9 +10,9 @@ const serverInfoFormat = format.printf(({ level, message, timestamp, ...metadata
   const role = process.env.BBB_HTML5_ROLE;
   const server = includeServerInfo && !Meteor?.isDevelopment ? `${role}-${instanceId} ` : "";
 
-  let msg = `${timestamp} ${server}[${level}] : ${message}`;
-  if (metadata) msg += JSON.stringify(metadata)
-  return msg
+  const msg = `${timestamp} ${server}[${level}] : ${message}`;
+  const meta = Object.keys(metadata).length ? JSON.stringify(metadata) : '';
+  return `${msg} ${meta}`;
 });
 
 const Logger = createLogger({


### PR DESCRIPTION
### What does this PR do?

Backports #15772 changes to 2.5.

_Removes empty object from logs that do not have additional data._