### PR TITLE
Option to hide waiting users icon when no pending users (2.5)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
@@ -15,6 +15,7 @@ const propTypes = {
 };
 
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
+const ALWAYS_SHOW_WAITING_ROOM = Meteor.settings.public.app.alwaysShowWaitingRoomUI;
 
 class UserContent extends PureComponent {
   render() {
@@ -26,7 +27,7 @@ class UserContent extends PureComponent {
       compact,
     } = this.props;
 
-    const showWaitingRoom = (isGuestLobbyMessageEnabled && isWaitingRoomEnabled)
+    const showWaitingRoom = (ALWAYS_SHOW_WAITING_ROOM && isWaitingRoomEnabled)
       || pendingUsers.length > 0;
 
     return (

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -55,6 +55,7 @@ public:
     allowUserLookup: false
     dynamicGuestPolicy: true
     enableGuestLobbyMessage: true
+    alwaysShowWaitingRoomUI: true
     enableLimitOfViewersInWebcam: false
     enableMultipleCameras: true
     # Allow users to open webcam video modal/preview when video is already


### PR DESCRIPTION
### What does this PR do?

Backports #15827 changes to 2.5.

_Introduces a new setting alwaysShowWaitingRoomUI which defaults to true and mantains current 'Waiting Users' UI behavior. If it's set to false the 'Waiting Users' UI element won't appear unless there is at least one guest user waiting to enter the meeting._