### PR TITLE
Improve STUN checks in bbb-conf

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -1291,19 +1291,34 @@ check_state() {
     if [ ! -z "$STUN" ]; then
       for i in $STUN; do
         STUN_SERVER="$(xmlstarlet sel -N x="http://www.springframework.org/schema/beans" -t -m "_:beans/_:bean[@id=\"$i\"]/_:constructor-arg[@index=\"0\"]" -v @value $TURN | sed 's/stun://g')"
-        if echo $STUN_SERVER | grep -q ':'; then
-          STUN_SERVER="$(echo $STUN_SERVER | sed 's/:.*//g') $(echo $STUN_SERVER | sed 's/.*://g')"
-        else
-          STUN_SERVER="$STUN_SERVER 3478"
-        fi
 
-        if which stunclient > /dev/null 2>&1; then
-          if stunclient --mode full --localport 30000 $STUN_SERVER | grep -q "fail\|Unable\ to\ resolve"; then
+	# stun is from the stun-client package, which is available on both bionic and focal
+	# stunclient is from the stuntman-client package, which is available on bionic but was removed from focal
+	if which stun > /dev/null 2>&1; then
+	  # stun return codes, from its client.cxx
+	  # low nibble: open (0), various STUN combinations (2-9), firewall (a), blocked (c), unknown (e), error (f)
+	  # high nibble: hairpin (1)
+	  stun $STUN_SERVER > /dev/null
+          if (( ($? & 0xf) > 9 )); then
             echo
             echo "#"
             echo "# Warning: Failed to verify STUN server at $STUN_SERVER with command"
             echo "#"
-            echo "#    stunclient --mode full --localport 30000 $STUN_SERVER"
+            echo "#    stun $STUN_SERVER"
+            echo "#"
+          fi
+        elif which stunclient > /dev/null 2>&1; then
+          if echo $STUN_SERVER | grep -q ':'; then
+            STUN_SERVER="$(echo $STUN_SERVER | sed 's/:.*//g') $(echo $STUN_SERVER | sed 's/.*://g')"
+          else
+            STUN_SERVER="$STUN_SERVER 3478"
+          fi
+          if stunclient $STUN_SERVER | grep -q "fail\|Unable\ to\ resolve"; then
+            echo
+            echo "#"
+            echo "# Warning: Failed to verify STUN server at $STUN_SERVER with command"
+            echo "#"
+            echo "#    stunclient $STUN_SERVER"
             echo "#"
           fi
         fi


### PR DESCRIPTION
### What does this PR do?

1. Change bbb-conf to use and prefer `stun` (available on focal) to check STUN servers, and only fallback on `stunclient` (only available on bionic) if `stun` is not installed on the system
2. Change how `stunclient` is called (drop the `--mode full`) to avoid nuisance complaints

### Closes Issue(s)

When ported to v2.4.x-release, will close bbb-install issue [#565](https://github.com/bigbluebutton/bbb-install/issues/565)

### Context

`bbb-conf` currently checks accessibility of STUN servers only if `stunclient` is installed, and furthermore runs the check with `--mode full`, which runs additional tests that often return errors.

Also, `stunclient`'s package (`stuntman`) is not installed by `bbb-install`, and has been removed from focal.

This PR will make `bbb-conf` run `stun` if it is present, fall back on `stunclient` if it is present, and if it runs `stunclient`, do so without the `--mode full` switch.

If we want these tests to be run consistently by `bbb-conf`, we'll also have to add something to `bbb-install` to make sure that `stun-client` (`stun`'s package) is installed.

