### PR TITLE
Fix: Default presentation allow null

### DIFF
--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -203,7 +203,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="testRoomMock" value="${beans.presentationService.testRoomMock}"/>
         <property name="testPresentationName" value="${beans.presentationService.testPresentationName}"/>
         <property name="testUploadedPresentation" value="${beans.presentationService.testUploadedPresentation}"/>
-        <property name="defaultUploadedPresentation" value="${beans.presentationService.defaultUploadedPresentation}"/>
+        <property name="defaultUploadedPresentation" value="${beans.presentationService.defaultUploadedPresentation:null}"/>
         <property name="presentationBaseUrl" value="${presentationBaseURL}"/>
         <property name="preUploadedPresentationOverrideDefault" value="${beans.presentationService.preUploadedPresentationOverrideDefault}"/>
     </bean>

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1412,9 +1412,8 @@ class ApiController {
     def presId
 
     if (presFilename == "" || filenameExt == "") {
-      log.debug("Upload failed. Invalid filename " + presOrigFilename)
-      uploadFailReasons.add("invalid_filename")
-      uploadFailed = true
+      log.debug("presentation is null by default")
+      return
     } else {
       String presentationDir = presentationService.getPresentationDir()
       presId = Util.generatePresentationId(presFilename)
@@ -1423,13 +1422,13 @@ class ApiController {
         def newFilename = Util.createNewFilename(presId, filenameExt)
         def newFilePath = uploadDir.absolutePath + File.separatorChar + newFilename
 
-        if (presDownloadService.savePresentation(meetingId, newFilePath, address)) {
-          pres = new File(newFilePath)
-        } else {
+        if(presDownloadService.savePresentation(meetingId, newFilePath, address)) pres = new File(newFilePath)
+        else {
           log.error("Failed to download presentation=[${address}], meeting=[${meetingId}], fileName=[${fileName}]")
           uploadFailReasons.add("failed_to_download_file")
-          uploadFailed = true
+           uploadFailed = true
         }
+
       } else {
         log.error("Null presentation directory meeting=[${meetingId}], presentationDir=[${presentationDir}], presId=[${presId}]")
         uploadFailReasons.add("null_presentation_dir")


### PR DESCRIPTION
### What does this PR do?

Allows default presentation to be null

### Motivation

In past it would cause ambiguous errors if presentation is null
