### PR TITLE
Fix Moved to Back Shapes Lost Forever

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -128,7 +128,7 @@ export default function Whiteboard(props) {
 
       next.pages[curPageId].shapes["slide-background-shape"] = {
         assetId: `slide-background-asset-${curPageId}`,
-        childIndex: 0.5,
+        childIndex: -1,
         id: "slide-background-shape",
         name: "Image",
         type: TDShapeType.Image,


### PR DESCRIPTION
### What does this PR do?
Ensures shapes can't be sent behind the background slide image.

### Closes Issue(s)

Closes #15836 
