### PR TITLE
fix: necessity of clicking twice for downloading presentation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/time-window-chat-item/component.jsx
@@ -312,7 +312,10 @@ class TimeWindowChatItem extends PureComponent {
     const dateTime = new Date(timestamp);
 
     return messages ? (
-      <Styled.Item key={_.uniqueId('message-presentation-item-')}>
+      <Styled.Item
+        key={_.uniqueId('message-presentation-item-')}
+        onMouseDown={(e) => { e.stopPropagation(); }}
+      >
         <Styled.PresentationWrapper ref={(ref) => { this.item = ref; }}>
           <Styled.AvatarWrapper>
             <UserAvatar color="#0F70D7">


### PR DESCRIPTION
### What does this PR do?

Stops the propagation of the click so we prevent a re-render.

### Closes Issue(s)

Closes #15854
