### PR TITLE
Add Screen Reader Notification When Moving Users to Rooms

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -620,6 +620,7 @@ class BreakoutRoom extends PureComponent {
   }
 
   changeUserRoom(userId, room) {
+    const { intl } = this.props;
     const { users, freeJoin } = this.state;
 
     const idxUser = users.findIndex((user) => user.userId === userId.replace('roomUserItem-', ''));

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -10,6 +10,7 @@ import { withModalMounter } from '/imports/ui/components/common/modal/service';
 import SortList from './sort-user-list/component';
 import Styled from './styles';
 import Icon from '/imports/ui/components/common/icon/component.jsx';
+import { addNewAlert } from '/imports/ui/components/screenreader-alert/service';
 import { importSharedNotesFromBreakoutRoomsEnabled } from '/imports/ui/services/features';
 
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
@@ -155,6 +156,10 @@ const intlMessages = defineMessages({
     id: 'app.createBreakoutRoom.roomNameInputDesc',
     description: 'aria description for room name change',
   },
+  movedUserLabel: {
+    id: 'app.createBreakoutRoom.movedUserLabel',
+    description: 'screen reader alert when users are moved to rooms',
+  }
 });
 
 const BREAKOUT_LIM = Meteor.settings.public.app.breakouts.breakoutRoomLimit;
@@ -317,6 +322,7 @@ class BreakoutRoom extends PureComponent {
       users.forEach((u, index) => {
         if (`roomUserItem-${u.userId}` === document.activeElement.id) {
           users[index].room = text.substr(text.length - 1).includes(')') ? 0 : parseInt(roomNumber, 10);
+          this.changeUserRoom(u.userId, users[index].room);
         }
       });
     }
@@ -619,12 +625,18 @@ class BreakoutRoom extends PureComponent {
     const idxUser = users.findIndex((user) => user.userId === userId.replace('roomUserItem-', ''));
 
     const usersCopy = [...users];
+    let userName = null;
 
-    if (idxUser >= 0) usersCopy[idxUser].room = room;
+    if (idxUser >= 0) {
+      usersCopy[idxUser].room = room;
+      userName = usersCopy[idxUser].userName;
+    };
 
     this.setState({
       users: usersCopy,
       leastOneUserIsValid: (this.getUserByRoom(0).length !== users.length || freeJoin),
+    }, () => {
+      addNewAlert(intl.formatMessage(intlMessages.movedUserLabel, { 0: userName, 1: room }))
     });
   }
 

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1045,6 +1045,7 @@
     "app.createBreakoutRoom.setTimeCancel": "Cancel",
     "app.createBreakoutRoom.setTimeHigherThanMeetingTimeError": "The breakout rooms duration can't exceed the meeting remaining time.",
     "app.createBreakoutRoom.roomNameInputDesc": "Updates breakout room name",
+    "app.createBreakoutRoom.movedUserLabel": "Assigned {0} to room {1}",
     "app.updateBreakoutRoom.modalDesc": "To update or invite a user, simply drag them into the desired room.",
     "app.updateBreakoutRoom.cancelLabel": "Cancel",
     "app.updateBreakoutRoom.title": "Update Breakout Rooms",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1045,7 +1045,7 @@
     "app.createBreakoutRoom.setTimeCancel": "Cancel",
     "app.createBreakoutRoom.setTimeHigherThanMeetingTimeError": "The breakout rooms duration can't exceed the meeting remaining time.",
     "app.createBreakoutRoom.roomNameInputDesc": "Updates breakout room name",
-    "app.createBreakoutRoom.movedUserLabel": "Assigned {0} to room {1}",
+    "app.createBreakoutRoom.movedUserLabel": "Moved {0} to room {1}",
     "app.updateBreakoutRoom.modalDesc": "To update or invite a user, simply drag them into the desired room.",
     "app.updateBreakoutRoom.cancelLabel": "Cancel",
     "app.updateBreakoutRoom.title": "Update Breakout Rooms",


### PR DESCRIPTION
### What does this PR do?
Adds a screen reader notification about the landing position of a selected user when assigning / moving to a breakout room.  
`Moved [userName] to room [roomNumber]`
### Motivation
When a moderator is assigning a user to a breakout room using a keyboard only: if they are also using a screen reader they are not provided with any feedback that the user has been successfully moved to a new breakout room.