### PR TITLE
fix (bbb-web): Default presentation is always null

### DIFF
--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -371,7 +371,7 @@ beans.presentationService.testPresentationName=appkonference
 # Uploaded presentation file
 beans.presentationService.testUploadedPresentation=appkonference.txt
 # Default Uploaded presentation file
-# to disable default presentation set it as null or comment the line below
+# to disable default presentation set its value to null
 beans.presentationService.defaultUploadedPresentation=${bigbluebutton.web.serverURL}/default.pdf
 # Discard default presentation (default.pdf) when Pre-upload Slides are sent within the create call (default true)
 beans.presentationService.preUploadedPresentationOverrideDefault=true

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -203,7 +203,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="testRoomMock" value="${beans.presentationService.testRoomMock}"/>
         <property name="testPresentationName" value="${beans.presentationService.testPresentationName}"/>
         <property name="testUploadedPresentation" value="${beans.presentationService.testUploadedPresentation}"/>
-        <property name="defaultUploadedPresentation" value="${beans.presentationService.defaultUploadedPresentation:null}"/>
+        <property name="defaultUploadedPresentation" value="${beans.presentationService.defaultUploadedPresentation}"/>
         <property name="presentationBaseUrl" value="${presentationBaseURL}"/>
         <property name="preUploadedPresentationOverrideDefault" value="${beans.presentationService.preUploadedPresentationOverrideDefault}"/>
     </bean>


### PR DESCRIPTION
Since #15860 was merged, the default presentation is always absent!

This PR undo this behavior.