### PR TITLE
Fixed issue with checksum algorithms

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -66,6 +66,7 @@ public class ParamsProcessorUtil {
     private String apiVersion;
     private boolean serviceEnabled = false;
     private String securitySalt;
+    private String supportedChecksumAlgorithms;
     private String checksumHash;
     private int defaultMaxUsers = 20;
     private String defaultWelcomeMessage;
@@ -946,25 +947,37 @@ public class ParamsProcessorUtil {
 		log.info("CHECKSUM={} length={}", checksum, checksum.length());
 
 		String data = apiCall + queryString + securitySalt;
-        String cs;
 
-        checksumHash = checksumHash.toLowerCase();
-        switch(checksumHash) {
-            case "sha256":
-                cs = DigestUtils.sha256Hex(data);
-                log.info("SHA256 {}", cs);
+		int checksumLength = checksum.length();
+        String cs = null;
+
+        switch(checksumLength) {
+            case 40:
+                if(supportedChecksumAlgorithms.contains("sha1")) {
+                    cs = DigestUtils.sha1Hex(data);
+                    log.info("SHA1 {}", cs);
+                }
                 break;
-            case "sha384":
-                cs = DigestUtils.sha384Hex(data);
-                log.info("SHA384 {}", cs);
+            case 64:
+                if(supportedChecksumAlgorithms.contains("sha256")) {
+                    cs = DigestUtils.sha256Hex(data);
+                    log.info("SHA256 {}", cs);
+                }
                 break;
-            case "sha512":
-                cs = DigestUtils.sha512Hex(data);
-                log.info("SHA512 {}", cs);
+            case 96:
+                if(supportedChecksumAlgorithms.contains("sha384")) {
+                    cs = DigestUtils.sha384Hex(data);
+                    log.info("SHA384 {}", cs);
+                }
+                break;
+            case 128:
+                if(supportedChecksumAlgorithms.contains("sha512")) {
+                    cs = DigestUtils.sha512Hex(data);
+                    log.info("SHA512 {}", cs);
+                }
                 break;
             default:
-                cs = DigestUtils.sha1Hex(data);
-                log.info("SHA1 {}", cs);
+                log.info("No algorithm could be found that matches the provided checksum length");
         }
 
 		if (cs == null || !cs.equals(checksum)) {
@@ -1051,6 +1064,8 @@ public class ParamsProcessorUtil {
 	public void setSecuritySalt(String securitySalt) {
 		this.securitySalt = securitySalt;
 	}
+
+    public void setSupportedChecksumAlgorithms(String supportedChecksumAlgorithms) { this.supportedChecksumAlgorithms = supportedChecksumAlgorithms; }
 
 	public void setChecksumHash(String checksumHash) { this.checksumHash = checksumHash; }
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/GetChecksumValidator.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/GetChecksumValidator.java
@@ -20,7 +20,7 @@ public class GetChecksumValidator implements ConstraintValidator<GetChecksumCons
     @Override
     public boolean isValid(GetChecksum checksum, ConstraintValidatorContext context) {
         String securitySalt = ServiceUtils.getValidationService().getSecuritySalt();
-        String checksumHash = ServiceUtils.getValidationService().getChecksumHash().toLowerCase();
+        String supportedChecksumAlgorithms = ServiceUtils.getValidationService().getSupportedChecksumAlgorithms();
 
         if (securitySalt.isEmpty()) {
             log.warn("Security is disabled in this service. Make sure this is intentional.");
@@ -42,24 +42,37 @@ public class GetChecksumValidator implements ConstraintValidator<GetChecksumCons
         }
 
         String data = checksum.getApiCall() + queryStringWithoutChecksum + securitySalt;
-        String createdCheckSum;
 
-        switch(checksumHash) {
-            case "sha256":
-                createdCheckSum = DigestUtils.sha256Hex(data);
-                log.info("SHA256 {}", createdCheckSum);
+        int checksumLength = providedChecksum.length();
+        String createdCheckSum = null;
+
+        switch(checksumLength) {
+            case 40:
+                if(supportedChecksumAlgorithms.contains("sha1")) {
+                    createdCheckSum = DigestUtils.sha1Hex(data);
+                    log.info("SHA1 {}", createdCheckSum);
+                }
                 break;
-            case "sha384":
-                createdCheckSum = DigestUtils.sha384Hex(data);
-                log.info("SHA384 {}", createdCheckSum);
+            case 64:
+                if(supportedChecksumAlgorithms.contains("sha256")) {
+                    createdCheckSum = DigestUtils.sha256Hex(data);
+                    log.info("SHA256 {}", createdCheckSum);
+                }
                 break;
-            case "sha512":
-                createdCheckSum = DigestUtils.sha512Hex(data);
-                log.info("SHA512 {}", createdCheckSum);
+            case 96:
+                if(supportedChecksumAlgorithms.contains("sha384")) {
+                    createdCheckSum = DigestUtils.sha384Hex(data);
+                    log.info("SHA384 {}", createdCheckSum);
+                }
+                break;
+            case 128:
+                if(supportedChecksumAlgorithms.contains("sha512")) {
+                    createdCheckSum = DigestUtils.sha512Hex(data);
+                    log.info("SHA512 {}", createdCheckSum);
+                }
                 break;
             default:
-                createdCheckSum = DigestUtils.sha1Hex(data);
-                log.info("SHA1 {}", createdCheckSum);
+                log.info("No algorithm could be found that matches the provided checksum length");
         }
 
         if (createdCheckSum == null || !createdCheckSum.equals(providedChecksum)) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/ValidationService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/ValidationService.java
@@ -56,7 +56,7 @@ public class ValidationService {
     }
 
     private String securitySalt;
-    private String checksumHash;
+    private String supportedChecksumAlgorithms;
     private Boolean allowRequestsWithoutSession;
 
     private ValidatorFactory validatorFactory;
@@ -278,8 +278,8 @@ public class ValidationService {
     public void setSecuritySalt(String securitySalt) { this.securitySalt = securitySalt; }
     public String getSecuritySalt() { return securitySalt; }
 
-    public void setChecksumHash(String checksumHash) { this.checksumHash = checksumHash; }
-    public String getChecksumHash() { return checksumHash; }
+    public void setSupportedChecksumAlgorithms(String supportedChecksumAlgorithms) { this.supportedChecksumAlgorithms = supportedChecksumAlgorithms; }
+    public String getSupportedChecksumAlgorithms() { return supportedChecksumAlgorithms; }
 
     public void setAllowRequestsWithoutSession(Boolean allowRequestsWithoutSession) {
         this.allowRequestsWithoutSession = allowRequestsWithoutSession;

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -330,8 +330,9 @@ apiVersion=2.0
 # Salt which is used by 3rd-party apps to authenticate api calls
 securitySalt=330a8b08c3b4c61533e1d0c5ce1ac88f
 
-# List of supported hash algorithms for validating checksums
-supportedChecksumAlgorithms=sha1|sha256|sha384|sha512
+# List of supported hash algorithms for validating checksums (comma-separated)
+# Available options: sha1, sha256, sha384, sha512
+supportedChecksumAlgorithms=sha1,sha256,sha384,sha512
 
 
 # Directory where we drop the <meeting-id-recorded>.done file

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -333,8 +333,6 @@ securitySalt=330a8b08c3b4c61533e1d0c5ce1ac88f
 # List of supported hash algorithms for validating checksums
 supportedChecksumAlgorithms=sha1|sha256|sha384|sha512
 
-# Hash algorithm to be used to validate checksum
-checksumHash=sha256
 
 # Directory where we drop the <meeting-id-recorded>.done file
 recordStatusDir=/var/bigbluebutton/recording/status/recorded

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -330,6 +330,9 @@ apiVersion=2.0
 # Salt which is used by 3rd-party apps to authenticate api calls
 securitySalt=330a8b08c3b4c61533e1d0c5ce1ac88f
 
+# List of supported hash algorithms for validating checksums
+supportedChecksumAlgorithms=sha1|sha256|sha384|sha512
+
 # Hash algorithm to be used to validate checksum
 checksumHash=sha256
 

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -121,7 +121,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 
     <bean id="validationService" class="org.bigbluebutton.api.service.ValidationService">
         <property name="securitySalt" value="${securitySalt}"/>
-        <property name="checksumHash" value="${checksumHash}"/>
+        <property name="supportedChecksumAlgorithms" value="${supportedChecksumAlgorithms}"/>
         <property name="allowRequestsWithoutSession" value="${allowRequestsWithoutSession}"/>
     </bean>
 
@@ -134,7 +134,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="apiVersion" value="${apiVersion}"/>
         <property name="serviceEnabled" value="${serviceEnabled}"/>
         <property name="securitySalt" value="${securitySalt}"/>
-        <property name="checksumHash" value="${checksumHash}"/>
+        <property name="supportedChecksumAlgorithms" value="${supportedChecksumAlgorithms}"/>
         <property name="defaultMaxUsers" value="${defaultMaxUsers}"/>
         <property name="defaultWelcomeMessage" value="${defaultWelcomeMessage}"/>
         <property name="defaultWelcomeMessageFooter" value="${defaultWelcomeMessageFooter}"/>


### PR DESCRIPTION
### What does this PR do?

Fixes issues introduced in #15684 that made it so users who wished use to sha1 to validate checksums were required to make a configuration change in bigbluebutton.properties. This PR allows the following hash algorithms: SHA1, SHA256, SHA384, and SHA512, to be used without any additional configuration. Users who wish to reduce the number of available algorithms can edit the "supportedChecksumAlgorithms" property in the bugbluebutton.properties file to remove algorithms that are not needed.
