### PR TITLE
fix(locale): Remove 'Import' as option from shared notes UI

### DIFF
--- a/build/packages-template/bbb-etherpad/settings.json
+++ b/build/packages-template/bbb-etherpad/settings.json
@@ -597,7 +597,40 @@
   "loglevel": "INFO",
 
   /* Override any strings found in locale directories */
-  "customLocaleStrings": {},
+  "customLocaleStrings": {
+    "de": {
+      "pad.importExport.import_export": "Export",
+      "pad.toolbar.import_export.title": "Export zu verschiedenen Dateiformaten"
+    },
+    "en-gb": {
+      "pad.importExport.import_export": "Export",
+      "pad.toolbar.import_export.title": "Export to different file formats"
+    },
+    "en": {
+      "pad.importExport.import_export": "Export",
+      "pad.toolbar.import_export.title": "Export to different file formats"
+    },
+    "es": {
+      "pad.importExport.import_export": "Exportar",
+      "pad.toolbar.import_export.title": "Exportar a diferentes formatos de archivos"
+    },
+    "fr": {
+      "pad.importExport.import_export": "Exporter",
+      "pad.toolbar.import_export.title": "Exporter vers un format de fichier différent"
+    },
+    "it": {
+      "pad.importExport.import_export": "Esportazione",
+      "pad.toolbar.import_export.title": "Esporta a diversi formati di file"
+    },
+    "pt-br": {
+      "pad.importExport.import_export": "Exportar",
+      "pad.toolbar.import_export.title": "Exportar para diferentes formatos de arquivo"
+    },
+    "pt": {
+      "pad.importExport.import_export": "Exportar",
+      "pad.toolbar.import_export.title": "Exportar para diferentes formatos de ficheiro"
+    }
+  },
 
   /* Disable Admin UI tests */
   "enableAdminUITests": false


### PR DESCRIPTION
### What does this PR do?
Removes "Import" from the text presented to users when hovering over or pressing the shared notes export button.

### Closes Issue(s)
Closes #15802
Closes #7054

### Motivation
"Import" was being presented as an option to users even though the notes are restricted to export only.

![Screenshot 2022-10-21 at 21 24 10](https://user-images.githubusercontent.com/33319791/197277129-33c8dffd-3052-416f-b53e-c82b24e66507.png)

### More
- Backporting this to 2.5 should be possible, but I did not try this.
- An alternative way to fix this is via Etherpad's `ep_bigbluebutton_patches` plugin, in which locales set there can override those in the main meeting. However, the API has a bug preventing this approach as I reported [here](https://github.com/ether/etherpad-lite/issues/5628). Once BBB starts using an Etherpad version with the fix, we can consider moving to individual language files instead of listing the locales in the JSON.
