### PR TITLE
fix(export-presentation): Fix slides export for cluster setup

### DIFF
--- a/bbb-export-annotations/config/index.js
+++ b/bbb-export-annotations/config/index.js
@@ -1,3 +1,13 @@
+let _ = require('lodash');
+let fs = require('fs');
 const settings = require('./settings');
+const LOCAL_SETTINGS_FILE_PATH = '/etc/bigbluebutton/bbb-export-annotations.json';
+
 const config = settings;
+
+if (fs.existsSync(LOCAL_SETTINGS_FILE_PATH)) {
+  const local_config = JSON.parse(fs.readFileSync(LOCAL_SETTINGS_FILE_PATH));
+  _.mergeWith(config, local_config, (a, b) => (_.isArray(b) ? b : undefined));
+}
+
 module.exports = config;

--- a/bbb-export-annotations/config/settings.json
+++ b/bbb-export-annotations/config/settings.json
@@ -28,6 +28,7 @@
       "msgName": "NewPresAnnFileAvailableMsg"
     },
     "bbbWebAPI": "http://127.0.0.1:8090",
+    "bbbWebPublicAPI": "/bigbluebutton/",
     "bbbPadsAPI": "http://127.0.0.1:9002",
     "redis": {
       "host": "127.0.0.1",

--- a/bbb-export-annotations/package.json
+++ b/bbb-export-annotations/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "axios": "^0.26.0",
     "form-data": "^4.0.0",
+    "lodash": "^4.17.21",
     "perfect-freehand": "^1.0.16",
     "probe-image-size": "^7.2.3",
     "redis": "^4.0.3",

--- a/bbb-export-annotations/workers/notifier.js
+++ b/bbb-export-annotations/workers/notifier.js
@@ -28,7 +28,7 @@ async function notifyMeetingActor() {
   await client.connect();
   client.on('error', (err) => logger.info('Redis Client Error', err));
 
-  const link = path.join(`${path.sep}bigbluebutton`, 'presentation',
+  const link = config.bbbWebPublicAPI + path.join('presentation',
       exportJob.parentMeetingId, exportJob.parentMeetingId,
       exportJob.presId, 'pdf', jobId, filename);
 


### PR DESCRIPTION


<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

In cluster proxy setup as described in https://docs.bigbluebutton.org/admin/clusterproxy.html you cannot assume that the BBB Web API URL is at the same domain as the html5 client. Therefore operators need to adjust the URL where presentation download is available.

This patch adds the ability to override the config provided by the package and adds a setting for the BBB Web API public URI. As the `bbb-export-annotations.service` constructs the URI for downloading the annotations, it has to know the public API URI

### Related Issue(s)

Belongs to #14484