### PR TITLE
(WIP) feat: pin/unpin shared notes on media area

### DIFF
--- a/bigbluebutton-html5/imports/api/pads/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/pads/server/eventHandlers.js
@@ -7,6 +7,7 @@ import padContent from './handlers/padContent';
 import padTail from './handlers/padTail';
 import sessionDeleted from './handlers/sessionDeleted';
 import captureSharedNotes from './handlers/captureSharedNotes';
+import padPinned from './handlers/padPinned';
 
 RedisPubSub.on('PadGroupCreatedRespMsg', groupCreated);
 RedisPubSub.on('PadCreatedRespMsg', padCreated);
@@ -16,3 +17,4 @@ RedisPubSub.on('PadContentEvtMsg', padContent);
 RedisPubSub.on('PadTailEvtMsg', padTail);
 RedisPubSub.on('PadSessionDeletedEvtMsg', sessionDeleted);
 RedisPubSub.on('CaptureSharedNotesReqEvtMsg', captureSharedNotes);
+RedisPubSub.on('PadPinnedEvtMsg', padPinned);

--- a/bigbluebutton-html5/imports/api/pads/server/handlers/padPinned.js
+++ b/bigbluebutton-html5/imports/api/pads/server/handlers/padPinned.js
@@ -1,0 +1,14 @@
+import pinPad from '/imports/api/pads/server/modifiers/pinPad';
+
+export default function padPinned({ header, body }) {
+  const {
+    meetingId,
+  } = header;
+
+  const {
+    externalId,
+    pinned,
+  } = body;
+
+  pinPad(meetingId, externalId, pinned);
+}

--- a/bigbluebutton-html5/imports/api/pads/server/methods.js
+++ b/bigbluebutton-html5/imports/api/pads/server/methods.js
@@ -2,9 +2,11 @@ import { Meteor } from 'meteor/meteor';
 import createGroup from './methods/createGroup';
 import createSession from './methods/createSession';
 import getPadId from './methods/getPadId';
+import pinPad from './methods/pinPad';
 
 Meteor.methods({
   createGroup,
   createSession,
   getPadId,
+  pinPad,
 });

--- a/bigbluebutton-html5/imports/api/pads/server/methods/pinPad.js
+++ b/bigbluebutton-html5/imports/api/pads/server/methods/pinPad.js
@@ -1,0 +1,32 @@
+import RedisPubSub from '/imports/startup/server/redis';
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+import { extractCredentials } from '/imports/api/common/server/helpers';
+import Logger from '/imports/startup/server/logger';
+import pinPadModifier from '../modifiers/pinPad';
+
+export default function pinPad(externalId, pinned) {
+  const REDIS_CONFIG = Meteor.settings.private.redis;
+  const CHANNEL = REDIS_CONFIG.channels.toAkkaApps;
+  const EVENT_NAME = 'PinPadReqMsg';
+
+  try {
+    const { meetingId, requesterUserId } = extractCredentials(this.userId);
+
+    check(meetingId, String);
+    check(requesterUserId, String);
+    check(externalId, String);
+    check(pinned, Boolean);
+
+    const payload = {
+      externalId,
+      pinned,
+    };
+
+    pinPadModifier(meetingId, externalId, pinned);
+
+    RedisPubSub.publishUserMessage(CHANNEL, EVENT_NAME, meetingId, requesterUserId, payload);
+  } catch (err) {
+    Logger.error(`Exception while invoking method pinPad ${err.stack}`);
+  }
+}

--- a/bigbluebutton-html5/imports/api/pads/server/modifiers/createPad.js
+++ b/bigbluebutton-html5/imports/api/pads/server/modifiers/createPad.js
@@ -16,6 +16,7 @@ export default function createPad(meetingId, externalId, padId) {
     const modifier = {
       $set: {
         padId,
+        pinned: false,
       },
     };
 

--- a/bigbluebutton-html5/imports/api/pads/server/modifiers/pinPad.js
+++ b/bigbluebutton-html5/imports/api/pads/server/modifiers/pinPad.js
@@ -1,0 +1,35 @@
+import { check } from 'meteor/check';
+import { default as Pads } from '/imports/api/pads';
+import Logger from '/imports/startup/server/logger';
+
+export default function pinPad(meetingId, externalId, pinned) {
+  try {
+    check(meetingId, String);
+    check(externalId, String);
+    check(pinned, Boolean);
+
+    if (pinned) {
+      Pads.update({ meetingId, pinned: true }, { $set: { pinned: false } });
+    }
+
+    const selector = {
+      meetingId,
+      externalId,
+    };
+
+    const modifier = {
+      $set: {
+        pinned,
+      },
+    };
+
+    const numberAffected = Pads.update(selector, modifier);
+
+    if (numberAffected) {
+      const prefix = pinned ? '' : 'un';
+      Logger.debug(`Pad ${prefix}pinned external=${externalId} meeting=${meetingId}`);
+    }
+  } catch (err) {
+    Logger.error(`Pinning pad: ${err}`);
+  }
+}

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -95,6 +95,14 @@ const intlMessages = defineMessages({
     id: 'app.actionsBar.actionsDropdown.layoutModal',
     description: 'Label for layouts selection button',
   },
+  pinNotes: {
+    id: 'app.actionsBar.actionsDropdown.pinNotes',
+    description: 'Label for pin shared notes button',
+  },
+  unpinNotes: {
+    id: 'app.actionsBar.actionsDropdown.unpinNotes',
+    description: 'Label for unpin shared notes button',
+  },
 });
 
 const handlePresentationClick = () => Session.set('showUploadPresentationView', true);
@@ -141,6 +149,9 @@ class ActionsDropdown extends PureComponent {
       setMeetingLayout,
       setPushLayout,
       showPushLayout,
+      toggleSharedNotes,
+      isSharedNotesPinned,
+      sidebarContent,
     } = this.props;
 
     const {
@@ -234,6 +245,19 @@ class ActionsDropdown extends PureComponent {
       key: 'layoutModal',
       onClick: () => mountModal(<LayoutModalContainer {...this.props} />),
     });
+
+    if (amIPresenter) {
+      actions.push({
+        icon: 'send',
+        label: isSharedNotesPinned
+          ? intl.formatMessage(intlMessages.unpinNotes)
+          : intl.formatMessage(intlMessages.pinNotes),
+        key: 'sharedNotes',
+        onClick: () => {
+          toggleSharedNotes();
+        },
+      });
+    }
 
     return actions;
   }

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/container.jsx
@@ -7,6 +7,7 @@ import ActionsDropdown from './component';
 import { layoutSelectInput, layoutDispatch, layoutSelect } from '../../layout/context';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import { SMALL_VIEWPORT_BREAKPOINT } from '../../layout/enums';
+import NotesService from '/imports/ui/components/notes/service';
 
 const ActionsDropdownContainer = (props) => {
   const sidebarContent = layoutSelectInput((i) => i.sidebarContent);
@@ -33,11 +34,14 @@ const LAYOUT_CONFIG = Meteor.settings.public.layout;
 
 export default withTracker(() => {
   const presentations = Presentations.find({ 'conversion.done': true }).fetch();
+  const isSharedNotesPinned = NotesService.isSharedNotesPinned();
   return ({
     presentations,
     isDropdownOpen: Session.get('dropdownOpen'),
     setPresentation: PresentationUploaderService.setPresentation,
     podIds: PresentationPodService.getPresentationPodIds(),
     hidePresentation: getFromUserSettings('bbb_hide_presentation', LAYOUT_CONFIG.hidePresentation),
+    isSharedNotesPinned,
+    toggleSharedNotes: () => NotesService.pinSharedNotes(!isSharedNotesPinned),
   });
 })(ActionsDropdownContainer);

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -47,6 +47,7 @@ import Notifications from '../notifications/container';
 import GlobalStyles from '/imports/ui/stylesheets/styled-components/globalStyles';
 import ActionsBarContainer from '../actions-bar/container';
 import PushLayoutEngine from '../layout/push-layout/pushLayoutEngine';
+import NotesContainer from '/imports/ui/components/notes/container';
 
 const MOBILE_MEDIA = 'only screen and (max-width: 40em)';
 const APP_CONFIG = Meteor.settings.public.app;
@@ -479,6 +480,7 @@ class App extends Component {
       shouldShowPresentation,
       shouldShowScreenshare,
       shouldShowExternalVideo,
+      shouldShowSharedNotes,
       isPresenter,
       selectedLayout,
       presentationIsOpen,
@@ -513,6 +515,7 @@ class App extends Component {
               ? <ExternalVideoContainer isLayoutSwapped={!presentationIsOpen} isPresenter={isPresenter} />
               : null
           }
+          {shouldShowSharedNotes ? <NotesContainer area="media" /> : null}
           {this.renderCaptions()}
           <AudioCaptionsSpeechContainer />
           {this.renderAudioCaptions()}

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -254,6 +254,7 @@ export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) 
   const AppSettings = Settings.application;
   const { selectedLayout, pushLayout } = AppSettings;
   const { viewScreenshare } = Settings.dataSaving;
+  const shouldShowSharedNotes = MediaService.shouldShowSharedNotes();
   const shouldShowExternalVideo = MediaService.shouldShowExternalVideo();
   const shouldShowScreenshare = MediaService.shouldShowScreenshare()
     && (viewScreenshare || currentUser?.presenter);
@@ -298,8 +299,9 @@ export default injectIntl(withModalMounter(withTracker(({ intl, baseControls }) 
     pushAlertEnabled: AppSettings.chatPushAlerts,
     darkTheme: AppSettings.darkTheme,
     shouldShowScreenshare,
-    shouldShowPresentation: !shouldShowScreenshare && !shouldShowExternalVideo,
+    shouldShowPresentation: !shouldShowScreenshare && !shouldShowExternalVideo && !shouldShowSharedNotes,
     shouldShowExternalVideo,
+    shouldShowSharedNotes,
     isLargeFont: Session.get('isLargeFont'),
     presentationRestoreOnUpdate: getFromUserSettings(
       'bbb_force_restore_presentation_on_new_events',

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/service.js
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/service.js
@@ -3,6 +3,7 @@ import Auth from '/imports/ui/services/auth';
 
 import { getStreamer } from '/imports/api/external-videos';
 import { makeCall } from '/imports/ui/services/api';
+import NotesService from '/imports/ui/components/notes/service';
 
 import ReactPlayer from 'react-player';
 
@@ -18,6 +19,9 @@ const startWatching = (url) => {
   if (Panopto.canPlay(url)) {
     externalVideoUrl = Panopto.getSocialUrl(url);
   }
+
+  // Close Shared Notes if open.
+  NotesService.pinSharedNotes(false);
 
   makeCall('startWatchingExternalVideo', externalVideoUrl);
 };

--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -1149,6 +1149,37 @@ const reducer = (state, action) => {
         },
       };
     }
+    case ACTIONS.SET_SHARED_NOTES_OUTPUT: {
+      const {
+        width,
+        height,
+        top,
+        left,
+        right,
+      } = action.value;
+      const { sharedNotes } = state.output;
+      if (sharedNotes.width === width
+        && sharedNotes.height === height
+        && sharedNotes.top === top
+        && sharedNotes.left === left
+        && sharedNotes.right === right) {
+        return state;
+      }
+      return {
+        ...state,
+        output: {
+          ...state.output,
+          sharedNotes: {
+            ...sharedNotes,
+            width,
+            height,
+            top,
+            left,
+            right,
+          },
+        },
+      };
+    }
     default: {
       throw new Error('Unexpected action');
     }

--- a/bigbluebutton-html5/imports/ui/components/layout/enums.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/enums.js
@@ -94,6 +94,8 @@ export const ACTIONS = {
   SET_HAS_EXTERNAL_VIDEO: 'setHasExternalVideo',
   SET_EXTERNAL_VIDEO_SIZE: 'setExternalVideoSize',
   SET_EXTERNAL_VIDEO_OUTPUT: 'setExternalVideoOutput',
+
+  SET_SHARED_NOTES_OUTPUT: 'setSharedNotesOutput',
 };
 
 export const PANELS = {

--- a/bigbluebutton-html5/imports/ui/components/layout/initState.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/initState.js
@@ -95,6 +95,13 @@ export const INITIAL_INPUT_STATE = {
     browserWidth: 0,
     browserHeight: 0,
   },
+  sharedNotes: {
+    isPinned: false,
+    width: 0,
+    height: 0,
+    browserWidth: 0,
+    browserHeight: 0,
+  },
 };
 
 export const INITIAL_OUTPUT_STATE = {
@@ -219,6 +226,15 @@ export const INITIAL_OUTPUT_STATE = {
     zIndex: 1,
   },
   externalVideo: {
+    display: false,
+    width: 0,
+    height: 0,
+    top: 0,
+    left: 0,
+    tabOrder: 0,
+    zIndex: 1,
+  },
+  sharedNotes: {
     display: false,
     width: 0,
     height: 0,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -683,6 +683,17 @@ const CustomLayout = (props) => {
         right: isRTL ? (mediaBounds.right + horizontalCameraDiff) : null,
       },
     });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SHARED_NOTES_OUTPUT,
+      value: {
+        width: mediaBounds.width,
+        height: mediaBounds.height,
+        top: mediaBounds.top,
+        left: mediaBounds.left,
+        right: isRTL ? (mediaBounds.right + horizontalCameraDiff) : null,
+      },
+    });
   };
 
   return null;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -470,6 +470,17 @@ const PresentationFocusLayout = (props) => {
         right: mediaBounds.right,
       },
     });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SHARED_NOTES_OUTPUT,
+      value: {
+        width: isOpen ? mediaBounds.width : 0,
+        height: isOpen ? mediaBounds.height : 0,
+        top: mediaBounds.top,
+        left: mediaBounds.left,
+        right: mediaBounds.right,
+      },
+    });
   };
 
   return null;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -536,6 +536,17 @@ const SmartLayout = (props) => {
         right: isRTL ? (mediaBounds.right + horizontalCameraDiff) : null,
       },
     });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SHARED_NOTES_OUTPUT,
+      value: {
+        width: mediaBounds.width,
+        height: mediaBounds.height,
+        top: mediaBounds.top,
+        left: mediaBounds.left,
+        right: isRTL ? (mediaBounds.right + horizontalCameraDiff) : null,
+      },
+    });
   };
 
   return null;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -491,6 +491,17 @@ const VideoFocusLayout = (props) => {
         right: isRTL ? mediaBounds.right : null,
       },
     });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SHARED_NOTES_OUTPUT,
+      value: {
+        width: mediaBounds.width,
+        height: mediaBounds.height,
+        top: mediaBounds.top,
+        left: mediaBounds.left,
+        right: isRTL ? mediaBounds.right : null,
+      },
+    });
   };
 
   return null;

--- a/bigbluebutton-html5/imports/ui/components/media/service.js
+++ b/bigbluebutton-html5/imports/ui/components/media/service.js
@@ -6,6 +6,7 @@ import getFromUserSettings from '/imports/ui/services/users-settings';
 import { isExternalVideoEnabled, isScreenSharingEnabled } from '/imports/ui/services/features';
 import { ACTIONS } from '../layout/enums';
 import UserService from '/imports/ui/components/user-list/service';
+import NotesService from '/imports/ui/components/notes/service';
 
 const LAYOUT_CONFIG = Meteor.settings.public.layout;
 const KURENTO_CONFIG = Meteor.settings.public.kurento;
@@ -34,6 +35,10 @@ function shouldShowExternalVideo() {
   return isExternalVideoEnabled() && getVideoUrl();
 }
 
+function shouldShowSharedNotes() {
+  return NotesService.isSharedNotesPinned();
+}
+
 function shouldShowOverlay() {
   return getFromUserSettings('bbb_enable_video', KURENTO_CONFIG.enableVideo);
 }
@@ -53,4 +58,5 @@ export default {
   shouldShowOverlay,
   isVideoBroadcasting,
   setPresentationIsOpen,
+  shouldShowSharedNotes,
 };

--- a/bigbluebutton-html5/imports/ui/components/notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.jsx
@@ -31,38 +31,72 @@ const propTypes = {
   layoutContextDispatch: PropTypes.func.isRequired,
 };
 
+const defaultProps = {
+  area: 'sidebarContent',
+};
+
 const Notes = ({
   hasPermission,
   intl,
   isRTL,
   layoutContextDispatch,
   isResizing,
+  area,
+  sidebarContent,
+  sharedNotesOutput,
 }) => {
   useEffect(() => () => Service.setLastRev(), []);
   const { isChrome } = browserInfo;
+  const isOnMediaArea = area === 'media';
+  const style = isOnMediaArea ? {
+    position: 'absolute',
+    ...sharedNotesOutput,
+  } : {};
+  const isHidden = isOnMediaArea && (style.width === 0 || style.height === 0);
+
+  if (isHidden) style.padding = 0;
+
+  useEffect(() => {
+    if (
+      isOnMediaArea
+      && sidebarContent.isOpen
+      && sidebarContent.sidebarContentPanel === PANELS.SHARED_NOTES
+    ) {
+      layoutContextDispatch({
+        type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+        value: false,
+      });
+      layoutContextDispatch({
+        type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+        value: PANELS.NONE,
+      });
+    }
+  }, []);
 
   return (
-    <Styled.Notes data-test="notes" isChrome={isChrome}>
-      <Header
-        leftButtonProps={{
-          onClick: () => {
-            layoutContextDispatch({
-              type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
-              value: false,
-            });
-            layoutContextDispatch({
-              type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
-              value: PANELS.NONE,
-            });
-          },
-          'data-test': 'hideNotesLabel',
-          'aria-label': intl.formatMessage(intlMessages.hide),
-          label: intl.formatMessage(intlMessages.title),
-        }}
-        customRightButton={
-          <ConverterButtonContainer />
-        }
-      />
+    <Styled.Notes data-test="notes" isChrome={isChrome} style={style}>
+      {!isOnMediaArea ? (
+        <Header
+          leftButtonProps={{
+            onClick: () => {
+              layoutContextDispatch({
+                type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+                value: false,
+              });
+              layoutContextDispatch({
+                type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+                value: PANELS.NONE,
+              });
+            },
+            'data-test': 'hideNotesLabel',
+            'aria-label': intl.formatMessage(intlMessages.hide),
+            label: intl.formatMessage(intlMessages.title),
+          }}
+          customRightButton={
+            <ConverterButtonContainer />
+          }
+        />
+      ): null}
       <PadContainer
         externalId={Service.ID}
         hasPermission={hasPermission}
@@ -74,5 +108,6 @@ const Notes = ({
 };
 
 Notes.propTypes = propTypes;
+Notes.defaultProps = defaultProps;
 
 export default injectWbResizeEvent(injectIntl(Notes));

--- a/bigbluebutton-html5/imports/ui/components/notes/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/container.jsx
@@ -2,14 +2,22 @@ import React from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import Notes from './component';
 import Service from './service';
-import { layoutSelectInput, layoutDispatch } from '../layout/context';
+import { layoutSelectInput, layoutDispatch, layoutSelectOutput } from '../layout/context';
 
 const Container = ({ ...props }) => {
   const cameraDock = layoutSelectInput((i) => i.cameraDock);
+  const sharedNotesOutput = layoutSelectOutput((i) => i.sharedNotes);
+  const sidebarContent = layoutSelectInput((i) => i.sidebarContent);
   const { isResizing } = cameraDock;
   const layoutContextDispatch = layoutDispatch();
 
-  return <Notes {...{ layoutContextDispatch, isResizing, ...props }} />;
+  return <Notes {...{
+    layoutContextDispatch,
+    isResizing,
+    sidebarContent,
+    sharedNotesOutput,
+    ...props
+  }} />;
 };
 
 export default withTracker(() => {

--- a/bigbluebutton-html5/imports/ui/components/notes/service.js
+++ b/bigbluebutton-html5/imports/ui/components/notes/service.js
@@ -75,6 +75,15 @@ const toggleNotesPanel = (sidebarContentPanel, layoutContextDispatch) => {
   });
 };
 
+const pinSharedNotes = (pinned) => {
+  PadsService.pinPad(NOTES_CONFIG.id, pinned);
+};
+
+const isSharedNotesPinned = () => {
+  const pinnedPad = PadsService.getPinnedPad();
+  return pinnedPad?.externalId === NOTES_CONFIG.id;
+};
+
 export default {
   ID: NOTES_CONFIG.id,
   toggleNotesPanel,
@@ -83,4 +92,6 @@ export default {
   setLastRev,
   getLastRev,
   hasUnreadNotes,
+  isSharedNotesPinned,
+  pinSharedNotes,
 };

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -11,6 +11,7 @@ import { Meteor } from "meteor/meteor";
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
 import ConnectionStatusService from '/imports/ui/components/connection-status/service';
 import browserInfo from '/imports/utils/browserInfo';
+import NotesService from '/imports/ui/components/notes/service';
 
 const VOLUME_CONTROL_ENABLED = Meteor.settings.public.kurento.screenshare.enableVolumeControl;
 const SCREENSHARE_MEDIA_ELEMENT_NAME = 'screenshareVideo';
@@ -175,6 +176,9 @@ const shareScreen = async (isPresenter, onFail) => {
       _handleStreamTermination();
       return;
     }
+
+    // Close Shared Notes if open.
+    NotesService.pinSharedNotes(false);
 
     setSharingScreen(true);
   } catch (error) {

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-notes/component.jsx
@@ -121,9 +121,9 @@ class UserNotes extends Component {
   }
 
   render() {
-    const { intl } = this.props;
+    const { intl, isPinned } = this.props;
 
-    if (!NotesService.isEnabled()) return null;
+    if (!NotesService.isEnabled() || isPinned) return null;
 
     return (
       <Styled.Messages>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-notes/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-notes/container.jsx
@@ -18,5 +18,6 @@ export default lockContextContainer(withTracker(({ userLocks }) => {
   return {
     rev: PadsService.getRev(NotesService.ID),
     disableNotes: shouldDisableNotes,
+    isPinned: NotesService.isSharedNotesPinned(),
   };
 })(UserNotesContainer));

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -421,6 +421,8 @@
     "app.actionsBar.actionsDropdown.minimizePresentationLabel": "Minimize presentation",
     "app.actionsBar.actionsDropdown.minimizePresentationDesc": "Button used to minimize presentation",
     "app.actionsBar.actionsDropdown.layoutModal": "Layout Settings Modal",
+    "app.actionsBar.actionsDropdown.pinNotes": "Pin Shared Notes",
+    "app.actionsBar.actionsDropdown.unpinNotes": "Unpin Shared Notes",
     "app.screenshare.screenShareLabel" : "Screen share",
     "app.submenu.application.applicationSectionTitle": "Application",
     "app.submenu.application.animationsLabel": "Animations",


### PR DESCRIPTION
### What does this PR do?

Adds a new option for showing the Shared Notes on media area.

![2022-10-24_10-14](https://user-images.githubusercontent.com/62393923/197534995-6d7e775c-fdcc-4163-bfab-af4508ea8391.png)

![2022-10-24_10-15](https://user-images.githubusercontent.com/62393923/197535011-2577e52d-03b4-4b72-b3ef-f19a1523d32e.png)

![2022-10-24_10-16](https://user-images.githubusercontent.com/62393923/197535024-aaa274f9-de4d-4df4-b3c2-6215871e220b.png)

![2022-10-24_10-18](https://user-images.githubusercontent.com/62393923/197535040-9549b81e-9a55-4a12-bf1b-71e1e10f9ccd.png)


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes none


### Motivation

1. We cannot use the chat and the shared notes at the same time.

### More

n/a