### PR TITLE
Testsuite console log

### DIFF
--- a/bigbluebutton-tests/playwright/README.md
+++ b/bigbluebutton-tests/playwright/README.md
@@ -28,9 +28,9 @@ $ npm test
 
 You can also run a single test suite and limit the execution to only one browser:
 ```bash
-$ npx playwright test chat --browser=firefox
+$ npx playwright test chat --project=firefox
 or
-$ npm test chat -- --browser=firefox
+$ npm test chat -- --project=firefox
 ```
 #### Additional commands
 

--- a/bigbluebutton-tests/playwright/README.md
+++ b/bigbluebutton-tests/playwright/README.md
@@ -28,9 +28,9 @@ $ npm test
 
 You can also run a single test suite and limit the execution to only one browser:
 ```bash
-$ npx playwright test chat --project=firefox
+$ npx playwright test chat --browser=firefox
 or
-$ npm test chat -- --project=firefox
+$ npm test chat -- --browser=firefox
 ```
 #### Additional commands
 
@@ -49,3 +49,18 @@ You can also use this also through the test tree, adding the test suite / group 
 ```bash
 $ npm run test:filter "notifications chat"
 ```
+
+You can print the browser console log to standard output by setting the environment variable `CONSOLE`:
+```
+$ CONSOLE= npm test chat -- --project=firefox
+```
+
+`CONSOLE` can be blank (as in the example), or can be a comma-separated list of the following options:
+
+| Option | Meaning |
+| ------ | ------- |
+| color  | (or "colour") colorize the output |
+| label  | label each line with the BigBlueButton user |
+| norefs | remove JavaScript reference URLs |
+| nots   | remove timestamps |
+| nocl   | remove "clientLogger:" strings |

--- a/bigbluebutton-tests/playwright/core/page.js
+++ b/bigbluebutton-tests/playwright/core/page.js
@@ -24,17 +24,17 @@ function formatWithCss(CONSOLE_options, ...args) {
   // See https://console.spec.whatwg.org/ sections 2.2.1 and 2.3.4
 
   let split_arg0 = args[0].split("%");
-  for (var i=1, j=1; i<split_arg0.length; i++, j++) {
+  for (let i=1, j=1; i<split_arg0.length; i++, j++) {
     if (split_arg0[i].startsWith('c')) {
       split_arg0[i] = 's' + split_arg0[i].substr(1);
       const styles = args[j].split(';');
       args[j] = '';
-      for (var style of styles) {
-	style = style.trim();
-	if (style.startsWith('color:') && CONSOLE_options.colorize) {
-	  const color = style.substr(6).trim().toLowerCase();
+      for (const style of styles) {
+	const stdStyle = style.trim().toLowerCase();
+	if (stdStyle.startsWith('color:') && CONSOLE_options.colorize) {
+	  const color = stdStyle.substr(6).trim();
 	  args[j] = chalk.keyword(color)._styler.open;
-	} else if (style.startsWith('font-size:') && CONSOLE_options.drop_references) {
+	} else if (stdStyle.startsWith('font-size:') && CONSOLE_options.drop_references) {
           // For Chrome, we "drop references" by discarding everything after a font size change
 	  split_arg0.length = i;
 	  args.length = j;
@@ -43,7 +43,7 @@ function formatWithCss(CONSOLE_options, ...args) {
     } else if (split_arg0[i] == "") {
       // format is "%%", so don't do special processing for
       // split_arg0[i+1], and only increment i, not j
-      i ++;
+      i ++;  // NOSONAR
     }
   }
   args[0] = split_arg0.join('%');

--- a/bigbluebutton-tests/playwright/package-lock.json
+++ b/bigbluebutton-tests/playwright/package-lock.json
@@ -7,6 +7,7 @@
       "dependencies": {
         "@playwright/test": "^1.19.2",
         "axios": "^0.26.1",
+        "chalk": "^4.1.2",
         "dotenv": "^16.0.0",
         "playwright": "^1.19.2",
         "sha1": "^1.1.1",
@@ -33,12 +34,41 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.40.tgz",
       "integrity": "sha512-UXdBxNGqTMtm7hCwh9HtncFVLrXoqA3oJW30j6XWp5BH/wu3mVeaxo7cq5benFdBw34HB3XDT2TRPI7rXZ+mDg=="
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/axios": {
       "version": "0.26.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
       "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
       "dependencies": {
         "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/charenc": {
@@ -48,6 +78,22 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/crypt": {
       "version": "0.0.2",
@@ -82,6 +128,14 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/playwright": {
@@ -127,6 +181,17 @@
         "node": "*"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
@@ -163,6 +228,14 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.40.tgz",
       "integrity": "sha512-UXdBxNGqTMtm7hCwh9HtncFVLrXoqA3oJW30j6XWp5BH/wu3mVeaxo7cq5benFdBw34HB3XDT2TRPI7rXZ+mDg=="
     },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
     "axios": {
       "version": "0.26.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
@@ -171,10 +244,32 @@
         "follow-redirects": "^1.14.8"
       }
     },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
     "charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "crypt": {
       "version": "0.0.2",
@@ -190,6 +285,11 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
       "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "playwright": {
       "version": "1.22.2",
@@ -216,6 +316,14 @@
       "requires": {
         "charenc": ">= 0.0.1",
         "crypt": ">= 0.0.1"
+      }
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "requires": {
+        "has-flag": "^4.0.0"
       }
     },
     "xml2js": {

--- a/bigbluebutton-tests/playwright/package.json
+++ b/bigbluebutton-tests/playwright/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@playwright/test": "^1.19.2",
     "axios": "^0.26.1",
+    "chalk": "^4.1.2",
     "dotenv": "^16.0.0",
     "playwright": "^1.19.2",
     "sha1": "^1.1.1",


### PR DESCRIPTION
Allows testsuite users to print browser console logs to playwright's standard output.

#### From the updated README:

You can print the browser console log to standard output by setting the environment variable `CONSOLE`:
```
$ CONSOLE= npm test chat -- --project=firefox
```

`CONSOLE` can be blank (as in the example), or can be a comma-separated list of the following options:

| Option | Meaning |
| ------ | ------- |
| color  | (or "colour") colorize the output |
| label  | label each line with the BigBlueButton user |
| norefs | remove JavaScript reference URLs |
| nots   | remove timestamps |
| nocl   | remove "clientLogger:" strings |

