### PR TITLE
Add stun-client package dependency to bbb-config

### DIFF
--- a/build/packages-template/bbb-config/opts-focal.sh
+++ b/build/packages-template/bbb-config/opts-focal.sh
@@ -1,4 +1,4 @@
 . ./opts-global.sh
 
 AKKA_APPS="bbb-fsesl-akka,bbb-apps-akka"
-OPTS="$OPTS -t deb -d netcat-openbsd,bbb-html5,bbb-playback-presentation,bbb-playback,bbb-freeswitch-core,$AKKA_APPS"
+OPTS="$OPTS -t deb -d netcat-openbsd,stun-client,bbb-html5,bbb-playback-presentation,bbb-playback,bbb-freeswitch-core,$AKKA_APPS"


### PR DESCRIPTION
This is a followup to PR #15850, ensuring that a STUN client will be installed, so that `bbb-conf` will run STUN checks

Closes bbb-install issue [#565](https://github.com/bigbluebutton/bbb-install/issues/565)
