### PR TITLE
Revert "fix: show learning dashboard after session was ended in cluster proxy scenario"

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/learning-dashboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/learning-dashboard/service.js
@@ -42,7 +42,7 @@ const setLearningDashboardCookie = () => {
 const openLearningDashboardUrl = (lang) => {
   const APP = Meteor.settings.public.app;
   if (getLearningDashboardAccessToken() && setLearningDashboardCookie()) {
-    window.open(`${APP.learningDashboardBase}/?meeting=${Auth.meetingID}&lang=${lang}&report=${getLearningDashboardAccessToken()}`, '_blank');
+    window.open(`${APP.learningDashboardBase}/?meeting=${Auth.meetingID}&lang=${lang}`, '_blank');
   } else {
     window.open(`${APP.learningDashboardBase}/?meeting=${Auth.meetingID}&sessionToken=${Auth.sessionToken}&lang=${lang}`, '_blank');
   }


### PR DESCRIPTION
Reverts bigbluebutton/bigbluebutton#15822

This change goes against a security requirement `Avoid anonymous access to Learning Dashboard (remove token from URL params)`.
The access link used to contain the param `report`, but it was removed in #13084 (https://github.com/bigbluebutton/bigbluebutton/pull/13084/commits/ddb383cf0591859ac5c29dd5c187aaab0a9e9077) for security reasons.

The Dashboard keeps reading `report` param because there is an idea of a button "Share public link" for the future. But this should not be the default way to access the Dashboard.