### PR TITLE
Improve STUN checks in bbb-conf (2.4)

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -1282,19 +1282,34 @@ check_state() {
     if [ ! -z "$STUN" ]; then
       for i in $STUN; do
         STUN_SERVER="$(xmlstarlet sel -N x="http://www.springframework.org/schema/beans" -t -m "_:beans/_:bean[@id=\"$i\"]/_:constructor-arg[@index=\"0\"]" -v @value $TURN | sed 's/stun://g')"
-        if echo $STUN_SERVER | grep -q ':'; then
-          STUN_SERVER="$(echo $STUN_SERVER | sed 's/:.*//g') $(echo $STUN_SERVER | sed 's/.*://g')"
-        else
-          STUN_SERVER="$STUN_SERVER 3478"
-        fi
 
-        if which stunclient > /dev/null 2>&1; then
-          if stunclient --mode full --localport 30000 $STUN_SERVER | grep -q "fail\|Unable\ to\ resolve"; then
+	# stun is from the stun-client package, which is available on both bionic and focal
+	# stunclient is from the stuntman-client package, which is available on bionic but was removed from focal
+	if which stun > /dev/null 2>&1; then
+	  # stun return codes, from its client.cxx
+	  # low nibble: open (0), various STUN combinations (2-9), firewall (a), blocked (c), unknown (e), error (f)
+	  # high nibble: hairpin (1)
+	  stun $STUN_SERVER > /dev/null
+          if (( ($? & 0xf) > 9 )); then
             echo
             echo "#"
             echo "# Warning: Failed to verify STUN server at $STUN_SERVER with command"
             echo "#"
-            echo "#    stunclient --mode full --localport 30000 $STUN_SERVER"
+            echo "#    stun $STUN_SERVER"
+            echo "#"
+          fi
+        elif which stunclient > /dev/null 2>&1; then
+          if echo $STUN_SERVER | grep -q ':'; then
+            STUN_SERVER="$(echo $STUN_SERVER | sed 's/:.*//g') $(echo $STUN_SERVER | sed 's/.*://g')"
+          else
+            STUN_SERVER="$STUN_SERVER 3478"
+          fi
+          if stunclient $STUN_SERVER | grep -q "fail\|Unable\ to\ resolve"; then
+            echo
+            echo "#"
+            echo "# Warning: Failed to verify STUN server at $STUN_SERVER with command"
+            echo "#"
+            echo "#    stunclient $STUN_SERVER"
             echo "#"
           fi
         fi


### PR DESCRIPTION
This is PR #15850, backported to 2.4.

I left out a backport of PR #15904 (adding `stun-client` to the package dependencies), because 2.4 packaging already lists `stuntman-client` (the older STUN client) as a dependency, and PR #15850 will work with either `stuntman-client` or `stun-client` (the newer one).

Closes bbb-install issue [#565](https://github.com/bigbluebutton/bbb-install/issues/565)
