### PR TITLE
Changes the text of the 'Yes' button of the 'End meeting' dialog, ref…

### DIFF
--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -400,7 +400,7 @@
     "app.endMeeting.description": "This action will end the session for {0} active user(s). Are you sure you want to end this session?",
     "app.endMeeting.noUserDescription": "Are you sure you want to end this session?",
     "app.endMeeting.contentWarning": "Chat messages, shared notes, whiteboard content and shared documents for this session will no longer be directly accessible",
-    "app.endMeeting.yesLabel": "Yes",
+    "app.endMeeting.yesLabel": "End session for all users",
     "app.endMeeting.noLabel": "No",
     "app.about.title": "About",
     "app.about.version": "Client build:",


### PR DESCRIPTION
### What does this PR do?
Simply changing the text of the 'Yes' button of the 'End Meeting' dialog to 'End session for all users'.

### Closes Issue(s)
Closes #15892

### Motivation
Related to issue #15891 this PR should further prevent the premature or accidental ending of a meeting by making it a bit clearer what will happen if you click the red button.