### PR TITLE
fix(webcam): intermittent client crashes when sharing camera (2.5)

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/FullAudioBridge.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/FullAudioBridge.js
@@ -413,8 +413,11 @@ export default class FullAudioBridge extends BaseAudioBridge {
     const mediaElement = document.getElementById(MEDIA_TAG);
 
     this.clearReconnectionTimeout();
-    this.broker.stop();
-    this.broker = null;
+
+    if (this.broker) {
+      this.broker.stop();
+      this.broker = null;
+    }
 
     if (mediaElement && typeof mediaElement.pause === 'function') {
       mediaElement.pause();

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/kurento.js
@@ -297,7 +297,7 @@ export default class KurentoAudioBridge extends BaseAudioBridge {
   exitAudio() {
     const mediaElement = document.getElementById(MEDIA_TAG);
 
-    this.broker.stop();
+    if (this.broker) this.broker.stop();
     this.clearReconnectionTimeout();
 
     if (mediaElement && typeof mediaElement.pause === 'function') {

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -1375,6 +1375,8 @@ export default class SIPBridge extends BaseAudioBridge {
   }
 
   exitAudio() {
+    if (this.activeSession == null) return Promise.resolve();
+
     return this.activeSession.exitAudio();
   }
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -529,6 +529,7 @@ class VideoProvider extends Component {
         const handlePubPeerCreation = (error) => {
           try {
             const peer = this.webRtcPeers[stream];
+            peer.bbbVideoStream = bbbVideoStream;
             peer.stream = stream;
             peer.started = false;
             peer.attached = false;
@@ -542,15 +543,15 @@ class VideoProvider extends Component {
 
             // Store the media stream if necessary. The scenario here is one where
             // there is no preloaded stream stored.
-            if (bbbVideoStream == null) {
+            if (peer.bbbVideoStream == null) {
               bbbVideoStream = new BBBVideoStream(peer.getLocalStream());
               VideoPreviewService.storeStream(
                 MediaStreamUtils.extractVideoDeviceId(bbbVideoStream.mediaStream),
                 bbbVideoStream
               );
+              peer.bbbVideoStream = bbbVideoStream;
             }
 
-            peer.bbbVideoStream = bbbVideoStream;
             bbbVideoStream.on('streamSwapped', ({ newStream }) => {
               if (newStream && newStream instanceof MediaStream) {
                 this.replacePCVideoTracks(stream, newStream);
@@ -921,6 +922,11 @@ class VideoProvider extends Component {
       peer.attached = true;
 
       if (isLocal) {
+        if (peer.bbbVideoStream == null) {
+          this.handleVirtualBgError(new TypeError('Undefined media stream'));
+          return;
+        }
+
         const deviceId = MediaStreamUtils.extractVideoDeviceId(peer.bbbVideoStream.mediaStream);
         const { type, name } = getSessionVirtualBackgroundInfo(deviceId);
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -962,7 +962,7 @@ class VideoProvider extends Component {
       },
     }, `Failed to restore virtual background after reentering the room: ${error.message}`);
 
-    notify(intl.formatMessage(intlMessages.virtualBgGenericError), 'error', 'video');
+    notify(intl.formatMessage(intlClientErrors.virtualBgGenericError), 'error', 'video');
   }
 
   createVideoTag(stream, video) {


### PR DESCRIPTION
### What does this PR do?

- [fix(webcam): client intermittently crashes when sharing camera](https://github.com/bigbluebutton/bigbluebutton/commit/f74c7d4d0ad0e937e647748de6250230c0bd55b0) 
  * Under some specific scenarios, the virtual background restore code might
kick in _before_ the preloaded MediaStream is actually assigned to the
peer instance. That causes a crash because the peer attachment code
(where the vbg restore is triggered) tries to access the device ID of
said MediaStream - and it is undefined in the first place because it was
only being set in after the initial offer is generated which is an async
procedure.
- [fix(webcam): client crash due to undefined intl var](https://github.com/bigbluebutton/bigbluebutton/commit/32734586fbae5ad2e088399d67f2907383eb04f5)
- [fix(audio): check for session availability on exitAudio](https://github.com/bigbluebutton/bigbluebutton/commit/031bedf3cae8a025ec5283e8576140a062e4adcf) 
  * Mostly benign, but exitAudio/forceExitAudio was throwing an unhandled
error when called on sessions with no active audio because the
underlying bridge methods did not check whether there was an active
session to stop beforehand.

### Closes Issue(s)

None

### Motivation

Weird stuff I'm stumbling upon while migrating to v2.5.x.

