### PR TITLE
(fix) Shared notes in recordings

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -78,9 +78,10 @@ module BigBlueButton
     end
 
     # Get the timestamp of the first event.
-    def self.first_event_timestamp(events)
+    def self.first_event_timestamp(events, isUtcType = false)
       first_event = events.at_xpath('/recording/event[position() = 1]')
-      first_event['timestamp'].to_i if first_event && first_event.key?('timestamp')
+      return first_event['timestamp'].to_i if first_event && first_event.key?('timestamp') && !isUtcType
+      return first_event.at_xpath('./timestampUTC')&.content.to_i if first_event && !first_event.at_xpath('timestampUTC').nil? && isUtcType
     end
 
     # Get the timestamp of the last event.

--- a/record-and-playback/core/scripts/bigbluebutton.yml
+++ b/record-and-playback/core/scripts/bigbluebutton.yml
@@ -64,6 +64,10 @@ captions_dir: /var/bigbluebutton/captions
 playback_host: 127.0.0.1
 playback_protocol: http
 
+# Utils
+script_utils_dir: /usr/local/bigbluebutton/core/scripts/utils
+diff_to_events_filename: extractEventsFromDiffs.js
+
 # For DEVELOPMENT
 # This allows us to run the scripts manually
 #scripts_dir: /home/ubuntu/dev/bigbluebutton/record-and-playback/core/scripts

--- a/record-and-playback/core/scripts/bigbluebutton.yml
+++ b/record-and-playback/core/scripts/bigbluebutton.yml
@@ -8,10 +8,9 @@ raw_deskshare_src: /var/bigbluebutton/deskshare
 raw_presentation_src: /var/bigbluebutton
 notes_endpoint: http://127.0.0.1:9002/p
 # Specify the notes formats we archive
-# txt, doc and odt are also supported
+# txt, doc, html, and odt are also supported
 notes_formats:
   - etherpad
-  - html
   - pdf
 redis_host: 127.0.0.1
 redis_port: 6379

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1432,9 +1432,6 @@ begin
         presentation_text = "#{@process_dir}/presentation_text.json"
         FileUtils.cp(presentation_text, package_dir) if File.exist?(presentation_text)
 
-        notes = "#{@process_dir}/notes/notes.html"
-        FileUtils.cp(notes, package_dir) if File.exist?(notes)
-
         processing_time = File.read("#{@process_dir}/processing_time")
 
         @doc = Nokogiri::XML(File.read("#{@process_dir}/events.xml"))

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -34,6 +34,9 @@ require 'json'
 
 # This script lives in scripts/archive/steps while properties.yaml lives in scripts/
 bbb_props = BigBlueButton.read_props
+utils_dir = bbb_props['script_utils_dir']
+diff_to_events_filename = bbb_props['diff_to_events_filename']
+@diff_to_events_dir = "#{utils_dir}/#{diff_to_events_filename}"
 @presentation_props = YAML.safe_load(File.read('presentation.yml'))
 filepathPresOverride = "/etc/bigbluebutton/recording/presentation.yml"
 hasOverride = File.file?(filepathPresOverride)
@@ -1117,6 +1120,93 @@ def process_chat_messages(events, bbb_props)
   xml
 end
 
+def process_json_events_for_notes(notes_event_dir, fileNameToRead, fileNameToWrite)
+  system("node", @diff_to_events_dir, notes_event_dir, fileNameToRead, fileNameToWrite)
+
+  tmp_json_notes_events = "#{notes_event_dir}/#{fileNameToWrite}"
+
+  if (File.exist?(tmp_json_notes_events))
+    
+    json_content = JSON.parse(File.open(tmp_json_notes_events).read)
+    return json_content
+  end
+  return nil
+end
+
+def process_notes_events(events, bbb_props, notes_event_dir, fileNameToRead, fileNameToWrite)
+  BigBlueButton.logger.info('Processing shared notes events')
+
+  if (File.exist?("#{notes_event_dir}/#{fileNameToRead}"))
+    BigBlueButton.logger.info("Found #{notes_event_dir}/#{fileNameToRead}, processing")
+    json_content = process_json_events_for_notes(notes_event_dir, fileNameToRead, fileNameToWrite)
+    if (!json_content.nil?)
+      # This timestamp UTC is important because etherpad events of changeSet  
+      # are stored relative to UTC timestamp.
+      initial_timestamp_UTC = BigBlueButton::Events.first_event_timestamp(events, utcType = true)
+      initial_timestamp = BigBlueButton::Events.first_event_timestamp(events)
+      start_time = @meeting_start - initial_timestamp
+      end_time =  @meeting_end - initial_timestamp
+
+      # This Offset variable is important to normalize the timestamp relative to the 
+      # recorded session (not the entire meeting itself). 
+      offset = start_time
+      last_stop_timestamp = start_time
+      xml_notes_events = Nokogiri::XML::Builder.new do |xml|
+        xml.root {
+          xml.events {
+            # meeting_start.to_i, @meeting_end.to_i
+            events_after_record = []
+            events.xpath('/recording/event').each do |event|
+              status_timestamp = event[:timestamp].to_i - initial_timestamp
+              case event[:eventname]
+              when "RecordStatusEvent"
+                status = event.at_xpath('./status')&.content == 'true'
+                # This is start record event, so we stash all notes events
+                # with timestamp greater than this.
+                if (status)
+                  offset += status_timestamp - last_stop_timestamp
+                  json_content.each_with_index do |json_event, index|
+                    timestamp = json_event["timestamp"] - initial_timestamp_UTC
+                    break if timestamp >= end_time
+                    if (timestamp >= status_timestamp)
+                      events_after_record = events_after_record.push({:index => index, :timestamp => timestamp})
+                    end
+                  end
+                # For this case, recording is stopped, so we need to check
+                # for note events that have timestamp lower than this one's,
+                # which will mean that it is within a recording interval.
+                else
+                  last_stop_timestamp = status_timestamp
+                  events_after_record.each do |event_recorded|
+                    timestamp = event_recorded[:timestamp]
+                    if (timestamp < status_timestamp)
+                      xml.event(:text => json_content[event_recorded[:index]]["text"], :timestamp => timestamp - offset)
+                    end 
+                    events_after_record = []
+                  end
+                end
+              # Same case as stop recording, once when ended, there is no
+              # other event.
+              when "EndAndKickAllEvent"
+                events_after_record.each do |event_recorded|
+                  timestamp = event_recorded[:timestamp]
+                  if (timestamp < status_timestamp)
+                    xml.event(:text => json_content[event_recorded[:index]]["text"], :timestamp => timestamp - offset)
+                  end 
+                  events_after_record = []
+                end
+              end
+            end 
+          }
+        }
+      end
+      return xml_notes_events.to_xml 
+    end
+  else
+  end
+  return nil
+end
+
 def process_deskshare_events(events)
   BigBlueButton.logger.info('Processing deskshare events')
   deskshare_matched_events = BigBlueButton::Events.get_matched_start_and_stop_deskshare_events(events)
@@ -1421,6 +1511,12 @@ begin
         # Write slides.xml to file
         slides_doc = process_chat_messages(@doc, bbb_props)
         File.open("#{package_dir}/slides_new.xml", 'w') { |f| f.puts slides_doc.target! }
+
+        # Write notes_events.xml to file
+        notes_events_doc = process_notes_events(@doc, bbb_props, "#{@process_dir}/notes", "notes.etherpad", "notes_events.json")
+        if (!notes_events_doc.nil?)
+          File.open("#{package_dir}/notes_events.xml", 'w') { |f| f.puts notes_events_doc }
+        end
 
         process_presentation(package_dir)
 

--- a/record-and-playback/presentation/scripts/utils/AttributeMap.js
+++ b/record-and-playback/presentation/scripts/utils/AttributeMap.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const attributes = require('./attributes');
+
+/**
+ * A `[key, value]` pair of strings describing a text attribute.
+ *
+ * @typedef {[string, string]} Attribute
+ */
+
+/**
+ * A concatenated sequence of zero or more attribute identifiers, each one represented by an
+ * asterisk followed by a base-36 encoded attribute number.
+ *
+ * Examples: '', '*0', '*3*j*z*1q'
+ *
+ * @typedef {string} AttributeString
+ */
+
+/**
+ * Convenience class to convert an Op's attribute string to/from a Map of key, value pairs.
+ */
+class AttributeMap extends Map {
+  /**
+   * Converts an attribute string into an AttributeMap.
+   *
+   * @param {AttributeString} str - The attribute string to convert into an AttributeMap.
+   * @param {AttributePool} pool - Attribute pool.
+   * @returns {AttributeMap}
+   */
+  static fromString(str, pool) {
+    return new AttributeMap(pool).updateFromString(str);
+  }
+
+  /**
+   * @param {AttributePool} pool - Attribute pool.
+   */
+  constructor(pool) {
+    super();
+    /** @public */
+    this.pool = pool;
+  }
+
+  /**
+   * @param {string} k - Attribute name.
+   * @param {string} v - Attribute value.
+   * @returns {AttributeMap} `this` (for chaining).
+   */
+  set(k, v) {
+    k = k == null ? '' : String(k);
+    v = v == null ? '' : String(v);
+    this.pool.putAttrib([k, v]);
+    return super.set(k, v);
+  }
+
+  toString() {
+    return attributes.attribsToString(attributes.sort([...this]), this.pool);
+  }
+
+  /**
+   * @param {Iterable<Attribute>} entries - [key, value] pairs to insert into this map.
+   * @param {boolean} [emptyValueIsDelete] - If true and an entry's value is the empty string, the
+   *     key is removed from this map (if present).
+   * @returns {AttributeMap} `this` (for chaining).
+   */
+  update(entries, emptyValueIsDelete = false) {
+    for (let [k, v] of entries) {
+      k = k == null ? '' : String(k);
+      v = v == null ? '' : String(v);
+      if (!v && emptyValueIsDelete) {
+        this.delete(k);
+      } else {
+        this.set(k, v);
+      }
+    }
+    return this;
+  }
+
+  /**
+   * @param {AttributeString} str - The attribute string identifying the attributes to insert into
+   *     this map.
+   * @param {boolean} [emptyValueIsDelete] - If true and an entry's value is the empty string, the
+   *     key is removed from this map (if present).
+   * @returns {AttributeMap} `this` (for chaining).
+   */
+  updateFromString(str, emptyValueIsDelete = false) {
+    return this.update(attributes.attribsFromString(str, this.pool), emptyValueIsDelete);
+  }
+}
+
+module.exports = AttributeMap;

--- a/record-and-playback/presentation/scripts/utils/AttributePool.js
+++ b/record-and-playback/presentation/scripts/utils/AttributePool.js
@@ -1,0 +1,239 @@
+'use strict';
+/**
+ * This code represents the Attribute Pool Object of the original Etherpad.
+ * 90% of the code is still like in the original Etherpad
+ * Look at https://github.com/ether/pad/blob/master/infrastructure/ace/www/easysync2.js
+ * You can find a explanation what a attribute pool is here:
+ * https://github.com/ether/etherpad-lite/blob/master/doc/easysync/easysync-notes.txt
+ */
+
+/*
+ * Copyright 2009 Google Inc., 2011 Peter 'Pita' Martischka (Primary Technology Ltd)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A `[key, value]` pair of strings describing a text attribute.
+ *
+ * @typedef {[string, string]} Attribute
+ */
+
+/**
+ * Maps an attribute's identifier to the attribute.
+ *
+ * @typedef {Object.<number, Attribute>} NumToAttrib
+ */
+
+/**
+ * An intermediate representation of the contents of an attribute pool, suitable for serialization
+ * via `JSON.stringify` and transmission to another user.
+ *
+ * @typedef {Object} Jsonable
+ * @property {NumToAttrib} numToAttrib - The pool's attributes and their identifiers.
+ * @property {number} nextNum - The attribute ID to assign to the next new attribute.
+ */
+
+/**
+ * Represents an attribute pool, which is a collection of attributes (pairs of key and value
+ * strings) along with their identifiers (non-negative integers).
+ *
+ * The attribute pool enables attribute interning: rather than including the key and value strings
+ * in changesets, changesets reference attributes by their identifiers.
+ *
+ * There is one attribute pool per pad, and it includes every current and historical attribute used
+ * in the pad.
+ */
+class AttributePool {
+  constructor() {
+    /**
+     * Maps an attribute identifier to the attribute's `[key, value]` string pair.
+     *
+     * TODO: Rename to `_numToAttrib` once all users have been migrated to call `getAttrib` instead
+     * of accessing this directly.
+     * @private
+     * TODO: Convert to an array.
+     * @type {NumToAttrib}
+     */
+    this.numToAttrib = {}; // e.g. {0: ['foo','bar']}
+
+    /**
+     * Maps the string representation of an attribute (`String([key, value])`) to its non-negative
+     * identifier.
+     *
+     * TODO: Rename to `_attribToNum` once all users have been migrated to use `putAttrib` instead
+     * of accessing this directly.
+     * @private
+     * TODO: Convert to a `Map` object.
+     * @type {Object.<string, number>}
+     */
+    this.attribToNum = {}; // e.g. {'foo,bar': 0}
+
+    /**
+     * The attribute ID to assign to the next new attribute.
+     *
+     * TODO: This property will not be necessary once `numToAttrib` is converted to an array (just
+     * push onto the array).
+     *
+     * @private
+     * @type {number}
+     */
+    this.nextNum = 0;
+  }
+
+  /**
+   * @returns {AttributePool} A deep copy of this attribute pool.
+   */
+  clone() {
+    const c = new AttributePool();
+    for (const [n, a] of Object.entries(this.numToAttrib)) c.numToAttrib[n] = [a[0], a[1]];
+    Object.assign(c.attribToNum, this.attribToNum);
+    c.nextNum = this.nextNum;
+    return c;
+  }
+
+  /**
+   * Add an attribute to the attribute set, or query for an existing attribute identifier.
+   *
+   * @param {Attribute} attrib - The attribute's `[key, value]` pair of strings.
+   * @param {boolean} [dontAddIfAbsent=false] - If true, do not insert the attribute into the pool
+   *     if the attribute does not already exist in the pool. This can be used to test for
+   *     membership in the pool without mutating the pool.
+   * @returns {number} The attribute's identifier, or -1 if the attribute is not in the pool.
+   */
+  putAttrib(attrib, dontAddIfAbsent = false) {
+    const str = String(attrib);
+    if (str in this.attribToNum) {
+      return this.attribToNum[str];
+    }
+    if (dontAddIfAbsent) {
+      return -1;
+    }
+    const num = this.nextNum++;
+    this.attribToNum[str] = num;
+    this.numToAttrib[num] = [String(attrib[0] || ''), String(attrib[1] || '')];
+    return num;
+  }
+
+  /**
+   * @param {number} num - The identifier of the attribute to fetch.
+   * @returns {Attribute} The attribute with the given identifier, or nullish if there is no such
+   *     attribute.
+   */
+  getAttrib(num) {
+    const pair = this.numToAttrib[num];
+    if (!pair) {
+      return pair;
+    }
+    return [pair[0], pair[1]]; // return a mutable copy
+  }
+
+  /**
+   * @param {number} num - The identifier of the attribute to fetch.
+   * @returns {string} Eqivalent to `getAttrib(num)[0]` if the attribute exists, otherwise the empty
+   *     string.
+   */
+  getAttribKey(num) {
+    const pair = this.numToAttrib[num];
+    if (!pair) return '';
+    return pair[0];
+  }
+
+  /**
+   * @param {number} num - The identifier of the attribute to fetch.
+   * @returns {string} Eqivalent to `getAttrib(num)[1]` if the attribute exists, otherwise the empty
+   *     string.
+   */
+  getAttribValue(num) {
+    const pair = this.numToAttrib[num];
+    if (!pair) return '';
+    return pair[1];
+  }
+
+  /**
+   * Executes a callback for each attribute in the pool.
+   *
+   * @param {Function} func - Callback to call with two arguments: key and value. Its return value
+   *     is ignored.
+   */
+  eachAttrib(func) {
+    for (const n of Object.keys(this.numToAttrib)) {
+      const pair = this.numToAttrib[n];
+      func(pair[0], pair[1]);
+    }
+  }
+
+  /**
+   * @returns {Jsonable} An object that can be passed to `fromJsonable` to reconstruct this
+   *     attribute pool. The returned object can be converted to JSON. WARNING: The returned object
+   *     has references to internal state (it is not a deep copy). Use the `clone()` method to copy
+   *     a pool -- do NOT do `new AttributePool().fromJsonable(pool.toJsonable())` to copy because
+   *     the resulting shared state will lead to pool corruption.
+   */
+  toJsonable() {
+    return {
+      numToAttrib: this.numToAttrib,
+      nextNum: this.nextNum,
+    };
+  }
+
+  /**
+   * Replace the contents of this attribute pool with values from a previous call to `toJsonable`.
+   *
+   * @param {Jsonable} obj - Object returned by `toJsonable` containing the attributes and their
+   *     identifiers. WARNING: This function takes ownership of the object (it does not make a deep
+   *     copy). Use the `clone()` method to copy a pool -- do NOT do
+   *     `new AttributePool().fromJsonable(pool.toJsonable())` to copy because the resulting shared
+   *     state will lead to pool corruption.
+   */
+  fromJsonable(obj) {
+    this.numToAttrib = obj.numToAttrib;
+    this.nextNum = obj.nextNum;
+    this.attribToNum = {};
+    for (const n of Object.keys(this.numToAttrib)) {
+      this.attribToNum[String(this.numToAttrib[n])] = Number(n);
+    }
+    return this;
+  }
+
+  /**
+   * Asserts that the data in the pool is consistent. Throws if inconsistent.
+   */
+  check() {
+    if (!Number.isInteger(this.nextNum)) throw new Error('nextNum property is not an integer');
+    if (this.nextNum < 0) throw new Error('nextNum property is negative');
+    for (const prop of ['numToAttrib', 'attribToNum']) {
+      const obj = this[prop];
+      if (obj == null) throw new Error(`${prop} property is null`);
+      if (typeof obj !== 'object') throw new TypeError(`${prop} property is not an object`);
+      const keys = Object.keys(obj);
+      if (keys.length !== this.nextNum) {
+        throw new Error(`${prop} size mismatch (want ${this.nextNum}, got ${keys.length})`);
+      }
+    }
+    for (let i = 0; i < this.nextNum; ++i) {
+      const attr = this.numToAttrib[`${i}`];
+      if (!Array.isArray(attr)) throw new TypeError(`attrib ${i} is not an array`);
+      if (attr.length !== 2) throw new Error(`attrib ${i} is not an array of length 2`);
+      const [k, v] = attr;
+      if (k == null) throw new TypeError(`attrib ${i} key is null`);
+      if (typeof k !== 'string') throw new TypeError(`attrib ${i} key is not a string`);
+      if (v == null) throw new TypeError(`attrib ${i} value is null`);
+      if (typeof v !== 'string') throw new TypeError(`attrib ${i} value is not a string`);
+      const attrStr = String(attr);
+      if (this.attribToNum[attrStr] !== i) throw new Error(`attribToNum for ${attrStr} !== ${i}`);
+    }
+  }
+}
+
+module.exports = AttributePool;

--- a/record-and-playback/presentation/scripts/utils/Changeset.js
+++ b/record-and-playback/presentation/scripts/utils/Changeset.js
@@ -1,0 +1,909 @@
+'use strict';
+
+/*
+ * Copyright 2009 Google Inc., 2011 Peter 'Pita' Martischka (Primary Technology Ltd)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This is the Changeset library copied from the old Etherpad with some modifications
+ * to use it in node.js. The original can be found at:
+ * https://github.com/ether/pad/blob/master/infrastructure/ace/www/easysync2.js
+ */
+
+const AttributeMap = require('./AttributeMap');
+const AttributePool = require('./AttributePool');
+const attributes = require('./attributes');
+
+/**
+ * A `[key, value]` pair of strings describing a text attribute.
+ *
+ * @typedef {[string, string]} Attribute
+ */
+
+/**
+ * A concatenated sequence of zero or more attribute identifiers, each one represented by an
+ * asterisk followed by a base-36 encoded attribute number.
+ *
+ * Examples: '', '*0', '*3*j*z*1q'
+ *
+ * @typedef {string} AttributeString
+ */
+
+/**
+ * This method is called whenever there is an error in the sync process.
+ *
+ * @param {string} msg - Just some message
+ */
+const error = (msg) => {
+  const e = new Error(msg);
+  e.easysync = true;
+  throw e;
+};
+
+/**
+ * Assert that a condition is truthy. If the condition is falsy, the `error` function is called to
+ * throw an exception.
+ *
+ * @param {boolean} b - assertion condition
+ * @param {string} msg - error message to include in the exception
+ * @type {(b: boolean, msg: string) => asserts b}
+ */
+const assert = (b, msg) => {
+  if (!b) error(`Failed assertion: ${msg}`);
+};
+
+/**
+ * Parses a number from string base 36.
+ *
+ * @param {string} str - string of the number in base 36
+ * @returns {number} number
+ */
+exports.parseNum = (str) => parseInt(str, 36);
+
+/**
+ * Writes a number in base 36 and puts it in a string.
+ *
+ * @param {number} num - number
+ * @returns {string} string
+ */
+exports.numToString = (num) => num.toString(36).toLowerCase();
+
+/**
+ * An operation to apply to a shared document.
+ */
+class Op {
+  /**
+   * @param {(''|'='|'+'|'-')} [opcode=''] - Initial value of the `opcode` property.
+   */
+  constructor(opcode = '') {
+    /**
+     * The operation's operator:
+     *   - '=': Keep the next `chars` characters (containing `lines` newlines) from the base
+     *     document.
+     *   - '-': Remove the next `chars` characters (containing `lines` newlines) from the base
+     *     document.
+     *   - '+': Insert `chars` characters (containing `lines` newlines) at the current position in
+     *     the document. The inserted characters come from the changeset's character bank.
+     *   - '' (empty string): Invalid operator used in some contexts to signifiy the lack of an
+     *     operation.
+     *
+     * @type {(''|'='|'+'|'-')}
+     * @public
+     */
+    this.opcode = opcode;
+
+    /**
+     * The number of characters to keep, insert, or delete.
+     *
+     * @type {number}
+     * @public
+     */
+    this.chars = 0;
+
+    /**
+     * The number of characters among the `chars` characters that are newlines. If non-zero, the
+     * last character must be a newline.
+     *
+     * @type {number}
+     * @public
+     */
+    this.lines = 0;
+
+    /**
+     * Identifiers of attributes to apply to the text, represented as a repeated (zero or more)
+     * sequence of asterisk followed by a non-negative base-36 (lower-case) integer. For example,
+     * '*2*1o' indicates that attributes 2 and 60 apply to the text affected by the operation. The
+     * identifiers come from the document's attribute pool.
+     *
+     * For keep ('=') operations, the attributes are merged with the base text's existing
+     * attributes:
+     *   - A keep op attribute with a non-empty value replaces an existing base text attribute that
+     *     has the same key.
+     *   - A keep op attribute with an empty value is interpreted as an instruction to remove an
+     *     existing base text attribute that has the same key, if one exists.
+     *
+     * This is the empty string for remove ('-') operations.
+     *
+     * @type {string}
+     * @public
+     */
+    this.attribs = '';
+  }
+
+  toString() {
+    if (!this.opcode) throw new TypeError('null op');
+    if (typeof this.attribs !== 'string') throw new TypeError('attribs must be a string');
+    const l = this.lines ? `|${exports.numToString(this.lines)}` : '';
+    return this.attribs + l + this.opcode + exports.numToString(this.chars);
+  }
+}
+exports.Op = Op;
+
+/**
+ * Describes changes to apply to a document. Does not include the attribute pool or the original
+ * document.
+ *
+ * @typedef {object} Changeset
+ * @property {number} oldLen - The length of the base document.
+ * @property {number} newLen - The length of the document after applying the changeset.
+ * @property {string} ops - Serialized sequence of operations. Use `deserializeOps` to parse this
+ *     string.
+ * @property {string} charBank - Characters inserted by insert operations.
+ */
+
+/**
+ * Returns the required length of the text before changeset can be applied.
+ *
+ * @param {string} cs - String representation of the Changeset
+ * @returns {number} oldLen property
+ */
+exports.oldLen = (cs) => exports.unpack(cs).oldLen;
+
+/**
+ * Returns the length of the text after changeset is applied.
+ *
+ * @param {string} cs - String representation of the Changeset
+ * @returns {number} newLen property
+ */
+exports.newLen = (cs) => exports.unpack(cs).newLen;
+
+/**
+ * Parses a string of serialized changeset operations.
+ *
+ * @param {string} ops - Serialized changeset operations.
+ * @yields {Op}
+ * @returns {Generator<Op>}
+ */
+exports.deserializeOps = function* (ops) {
+  // TODO: Migrate to String.prototype.matchAll() once there is enough browser support.
+  const regex = /((?:\*[0-9a-z]+)*)(?:\|([0-9a-z]+))?([-+=])([0-9a-z]+)|(.)/g;
+  let match;
+  while ((match = regex.exec(ops)) != null) {
+    if (match[5] === '$') return; // Start of the insert operation character bank.
+    if (match[5] != null) error(`invalid operation: ${ops.slice(regex.lastIndex - 1)}`);
+    const op = new Op(match[3]);
+    op.lines = exports.parseNum(match[2] || '0');
+    op.chars = exports.parseNum(match[4]);
+    op.attribs = match[1];
+    yield op;
+  }
+};
+
+/**
+ * Iterator over a changeset's operations.
+ *
+ * Note: This class does NOT implement the ECMAScript iterable or iterator protocols.
+ *
+ * @deprecated Use `deserializeOps` instead.
+ */
+class OpIter {
+  /**
+   * @param {string} ops - String encoding the change operations to iterate over.
+   */
+  constructor(ops) {
+    this._gen = exports.deserializeOps(ops);
+    this._next = this._gen.next();
+  }
+
+  /**
+   * @returns {boolean} Whether there are any remaining operations.
+   */
+  hasNext() {
+    return !this._next.done;
+  }
+
+  /**
+   * Returns the next operation object and advances the iterator.
+   *
+   * Note: This does NOT implement the ECMAScript iterator protocol.
+   *
+   * @param {Op} [opOut] - Deprecated. Operation object to recycle for the return value.
+   * @returns {Op} The next operation, or an operation with a falsy `opcode` property if there are
+   *     no more operations.
+   */
+  next(opOut = new Op()) {
+    if (this.hasNext()) {
+      copyOp(this._next.value, opOut);
+      this._next = this._gen.next();
+    } else {
+      clearOp(opOut);
+    }
+    return opOut;
+  }
+}
+
+/**
+ * Creates an iterator which decodes string changeset operations.
+ *
+ * @deprecated Use `deserializeOps` instead.
+ * @param {string} opsStr - String encoding of the change operations to perform.
+ * @returns {OpIter} Operator iterator object.
+ */
+exports.opIterator = (opsStr) => {
+  padutils.warnDeprecated(
+      'Changeset.opIterator() is deprecated; use Changeset.deserializeOps() instead');
+  return new OpIter(opsStr);
+};
+
+/**
+ * Cleans an Op object.
+ *
+ * @param {Op} op - object to clear
+ */
+const clearOp = (op) => {
+  op.opcode = '';
+  op.chars = 0;
+  op.lines = 0;
+  op.attribs = '';
+};
+
+/**
+ * Creates a new Op object
+ *
+ * @deprecated Use the `Op` class instead.
+ * @param {('+'|'-'|'='|'')} [optOpcode=''] - The operation's operator.
+ * @returns {Op}
+ */
+exports.newOp = (optOpcode) => {
+  padutils.warnDeprecated('Changeset.newOp() is deprecated; use the Changeset.Op class instead');
+  return new Op(optOpcode);
+};
+
+/**
+ * Copies op1 to op2
+ *
+ * @param {Op} op1 - src Op
+ * @param {Op} [op2] - dest Op. If not given, a new Op is used.
+ * @returns {Op} `op2`
+ */
+const copyOp = (op1, op2 = new Op()) => Object.assign(op2, op1);
+
+/**
+ * Serializes a sequence of Ops.
+ *
+ * @typedef {object} OpAssembler
+ * @property {Function} append -
+ * @property {Function} clear -
+ * @property {Function} toString -
+ */
+
+/**
+ * Efficiently merges consecutive operations that are mergeable, ignores no-ops, and drops final
+ * pure "keeps". It does not re-order operations.
+ *
+ * @typedef {object} MergingOpAssembler
+ * @property {Function} append -
+ * @property {Function} clear -
+ * @property {Function} endDocument -
+ * @property {Function} toString -
+ */
+
+/**
+ * Generates operations from the given text and attributes.
+ *
+ * @param {('-'|'+'|'=')} opcode - The operator to use.
+ * @param {string} text - The text to remove/add/keep.
+ * @param {(Iterable<Attribute>|AttributeString)} [attribs] - The attributes to insert into the pool
+ *     (if necessary) and encode. If an attribute string, no checking is performed to ensure that
+ *     the attributes exist in the pool, are in the canonical order, and contain no duplicate keys.
+ *     If this is an iterable of attributes, `pool` must be non-null.
+ * @param {?AttributePool} pool - Attribute pool. Required if `attribs` is an iterable of
+ *     attributes, ignored if `attribs` is an attribute string.
+ * @yields {Op} One or two ops (depending on the presense of newlines) that cover the given text.
+ * @returns {Generator<Op>}
+ */
+const opsFromText = function* (opcode, text, attribs = '', pool = null) {
+  const op = new Op(opcode);
+  op.attribs = typeof attribs === 'string'
+    ? attribs : new AttributeMap(pool).update(attribs || [], opcode === '+').toString();
+  const lastNewlinePos = text.lastIndexOf('\n');
+  if (lastNewlinePos < 0) {
+    op.chars = text.length;
+    op.lines = 0;
+    yield op;
+  } else {
+    op.chars = lastNewlinePos + 1;
+    op.lines = text.match(/\n/g).length;
+    yield op;
+    const op2 = copyOp(op);
+    op2.chars = text.length - (lastNewlinePos + 1);
+    op2.lines = 0;
+    yield op2;
+  }
+};
+
+/**
+ * @returns {SmartOpAssembler}
+ */
+exports.smartOpAssembler = () => {
+  const minusAssem = exports.mergingOpAssembler();
+  const plusAssem = exports.mergingOpAssembler();
+  const keepAssem = exports.mergingOpAssembler();
+  const assem = exports.stringAssembler();
+  let lastOpcode = '';
+  let lengthChange = 0;
+
+  const flushKeeps = () => {
+    assem.append(keepAssem.toString());
+    keepAssem.clear();
+  };
+
+  const flushPlusMinus = () => {
+    assem.append(minusAssem.toString());
+    minusAssem.clear();
+    assem.append(plusAssem.toString());
+    plusAssem.clear();
+  };
+
+  const append = (op) => {
+    if (!op.opcode) return;
+    if (!op.chars) return;
+
+    if (op.opcode === '-') {
+      if (lastOpcode === '=') {
+        flushKeeps();
+      }
+      minusAssem.append(op);
+      lengthChange -= op.chars;
+    } else if (op.opcode === '+') {
+      if (lastOpcode === '=') {
+        flushKeeps();
+      }
+      plusAssem.append(op);
+      lengthChange += op.chars;
+    } else if (op.opcode === '=') {
+      if (lastOpcode !== '=') {
+        flushPlusMinus();
+      }
+      keepAssem.append(op);
+    }
+    lastOpcode = op.opcode;
+  };
+
+  const toString = () => {
+    flushPlusMinus();
+    flushKeeps();
+    return assem.toString();
+  };
+
+  const clear = () => {
+    minusAssem.clear();
+    plusAssem.clear();
+    keepAssem.clear();
+    assem.clear();
+    lengthChange = 0;
+  };
+
+  const endDocument = () => {
+    keepAssem.endDocument();
+  };
+
+  const getLengthChange = () => lengthChange;
+
+  return {
+    append,
+    toString,
+    clear,
+    endDocument,
+    getLengthChange,
+  };
+};
+
+/**
+ * @returns {MergingOpAssembler}
+ */
+exports.mergingOpAssembler = () => {
+  const assem = exports.opAssembler();
+  const bufOp = new Op();
+
+  // If we get, for example, insertions [xxx\n,yyy], those don't merge,
+  // but if we get [xxx\n,yyy,zzz\n], that merges to [xxx\nyyyzzz\n].
+  // This variable stores the length of yyy and any other newline-less
+  // ops immediately after it.
+  let bufOpAdditionalCharsAfterNewline = 0;
+
+  /**
+   * @param {boolean} [isEndDocument]
+   */
+  const flush = (isEndDocument) => {
+    if (!bufOp.opcode) return;
+    if (isEndDocument && bufOp.opcode === '=' && !bufOp.attribs) {
+      // final merged keep, leave it implicit
+    } else {
+      assem.append(bufOp);
+      if (bufOpAdditionalCharsAfterNewline) {
+        bufOp.chars = bufOpAdditionalCharsAfterNewline;
+        bufOp.lines = 0;
+        assem.append(bufOp);
+        bufOpAdditionalCharsAfterNewline = 0;
+      }
+    }
+    bufOp.opcode = '';
+  };
+
+  const append = (op) => {
+    if (op.chars <= 0) return;
+    if (bufOp.opcode === op.opcode && bufOp.attribs === op.attribs) {
+      if (op.lines > 0) {
+        // bufOp and additional chars are all mergeable into a multi-line op
+        bufOp.chars += bufOpAdditionalCharsAfterNewline + op.chars;
+        bufOp.lines += op.lines;
+        bufOpAdditionalCharsAfterNewline = 0;
+      } else if (bufOp.lines === 0) {
+        // both bufOp and op are in-line
+        bufOp.chars += op.chars;
+      } else {
+        // append in-line text to multi-line bufOp
+        bufOpAdditionalCharsAfterNewline += op.chars;
+      }
+    } else {
+      flush();
+      copyOp(op, bufOp);
+    }
+  };
+
+  const endDocument = () => {
+    flush(true);
+  };
+
+  const toString = () => {
+    flush();
+    return assem.toString();
+  };
+
+  const clear = () => {
+    assem.clear();
+    clearOp(bufOp);
+  };
+  return {
+    append,
+    toString,
+    clear,
+    endDocument,
+  };
+};
+
+/**
+ * @returns {OpAssembler}
+ */
+exports.opAssembler = () => {
+  let serialized = '';
+
+  /**
+   * @param {Op} op - Operation to add. Ownership remains with the caller.
+   */
+  const append = (op) => {
+    assert(op instanceof Op, 'argument must be an instance of Op');
+    serialized += op.toString();
+  };
+
+  const toString = () => serialized;
+
+  const clear = () => {
+    serialized = '';
+  };
+  return {
+    append,
+    toString,
+    clear,
+  };
+};
+
+/**
+ * A custom made String Iterator
+ *
+ * @typedef {object} StringIterator
+ * @property {Function} newlines -
+ * @property {Function} peek -
+ * @property {Function} remaining -
+ * @property {Function} skip -
+ * @property {Function} take -
+ */
+
+/**
+ * @param {string} str - String to iterate over
+ * @returns {StringIterator}
+ */
+exports.stringIterator = (str) => {
+  let curIndex = 0;
+  // newLines is the number of \n between curIndex and str.length
+  let newLines = str.split('\n').length - 1;
+  const getnewLines = () => newLines;
+
+  const assertRemaining = (n) => {
+    assert(n <= remaining(), `!(${n} <= ${remaining()})`);
+  };
+
+  const take = (n) => {
+    assertRemaining(n);
+    const s = str.substr(curIndex, n);
+    newLines -= s.split('\n').length - 1;
+    curIndex += n;
+    return s;
+  };
+
+  const peek = (n) => {
+    assertRemaining(n);
+    const s = str.substr(curIndex, n);
+    return s;
+  };
+
+  const skip = (n) => {
+    assertRemaining(n);
+    curIndex += n;
+  };
+
+  const remaining = () => str.length - curIndex;
+  return {
+    take,
+    skip,
+    remaining,
+    peek,
+    newlines: getnewLines,
+  };
+};
+
+/**
+ * A custom made StringBuffer
+ *
+ * @typedef {object} StringAssembler
+ * @property {Function} append -
+ * @property {Function} toString -
+ */
+
+/**
+ * @returns {StringAssembler}
+ */
+exports.stringAssembler = () => ({
+  _str: '',
+  clear() { this._str = ''; },
+  /**
+   * @param {string} x -
+   */
+  append(x) { this._str += String(x); },
+  toString() { return this._str; },
+});
+
+/**
+ * Apply operations to other operations.
+ *
+ * @param {string} in1 - first Op string
+ * @param {string} in2 - second Op string
+ * @param {Function} func - Callback that applies an operation to another operation. Will be called
+ *     multiple times depending on the number of operations in `in1` and `in2`. `func` has signature
+ * @returns {string} the integrated changeset
+ */
+const applyZip = (in1, in2, func) => {
+  const ops1 = exports.deserializeOps(in1);
+  const ops2 = exports.deserializeOps(in2);
+  let next1 = ops1.next();
+  let next2 = ops2.next();
+  const assem = exports.smartOpAssembler();
+  while (!next1.done || !next2.done) {
+    if (!next1.done && !next1.value.opcode) next1 = ops1.next();
+    if (!next2.done && !next2.value.opcode) next2 = ops2.next();
+    if (next1.value == null) next1.value = new Op();
+    if (next2.value == null) next2.value = new Op();
+    if (!next1.value.opcode && !next2.value.opcode) break;
+    const opOut = func(next1.value, next2.value);
+    if (opOut && opOut.opcode) assem.append(opOut);
+  }
+  assem.endDocument();
+  return assem.toString();
+};
+
+/**
+ * Parses an encoded changeset.
+ *
+ * @param {string} cs - The encoded changeset.
+ * @returns {Changeset}
+ */
+exports.unpack = (cs) => {
+  const headerRegex = /Z:([0-9a-z]+)([><])([0-9a-z]+)|/;
+  const headerMatch = headerRegex.exec(cs);
+  if ((!headerMatch) || (!headerMatch[0])) error(`Not a changeset: ${cs}`);
+  const oldLen = exports.parseNum(headerMatch[1]);
+  const changeSign = (headerMatch[2] === '>') ? 1 : -1;
+  const changeMag = exports.parseNum(headerMatch[3]);
+  const newLen = oldLen + changeSign * changeMag;
+  const opsStart = headerMatch[0].length;
+  let opsEnd = cs.indexOf('$');
+  if (opsEnd < 0) opsEnd = cs.length;
+  return {
+    oldLen,
+    newLen,
+    ops: cs.substring(opsStart, opsEnd),
+    charBank: cs.substring(opsEnd + 1),
+  };
+};
+
+/**
+ * Applies a Changeset to a string.
+ *
+ * @param {string} cs - String encoded Changeset
+ * @param {string} str - String to which a Changeset should be applied
+ * @returns {string}
+ */
+exports.applyToText = (cs, str) => {
+  const unpacked = exports.unpack(cs);
+  assert(str.length === unpacked.oldLen, `mismatched apply: ${str.length} / ${unpacked.oldLen}`);
+  const bankIter = exports.stringIterator(unpacked.charBank);
+  const strIter = exports.stringIterator(str);
+  const assem = exports.stringAssembler();
+  for (const op of exports.deserializeOps(unpacked.ops)) {
+    switch (op.opcode) {
+      case '+':
+      // op is + and op.lines 0: no newlines must be in op.chars
+      // op is + and op.lines >0: op.chars must include op.lines newlines
+        if (op.lines !== bankIter.peek(op.chars).split('\n').length - 1) {
+          throw new Error(`newline count is wrong in op +; cs:${cs} and text:${str}`);
+        }
+        assem.append(bankIter.take(op.chars));
+        break;
+      case '-':
+      // op is - and op.lines 0: no newlines must be in the deleted string
+      // op is - and op.lines >0: op.lines newlines must be in the deleted string
+        if (op.lines !== strIter.peek(op.chars).split('\n').length - 1) {
+          throw new Error(`newline count is wrong in op -; cs:${cs} and text:${str}`);
+        }
+        strIter.skip(op.chars);
+        break;
+      case '=':
+      // op is = and op.lines 0: no newlines must be in the copied string
+      // op is = and op.lines >0: op.lines newlines must be in the copied string
+        if (op.lines !== strIter.peek(op.chars).split('\n').length - 1) {
+          throw new Error(`newline count is wrong in op =; cs:${cs} and text:${str}`);
+        }
+        assem.append(strIter.take(op.chars));
+        break;
+    }
+  }
+  assem.append(strIter.take(strIter.remaining()));
+  return assem.toString();
+};
+
+/**
+ * Composes two attribute strings (see below) into one.
+ *
+ * @param {AttributeString} att1 - first attribute string
+ * @param {AttributeString} att2 - second attribue string
+ * @param {boolean} resultIsMutation -
+ * @param {AttributePool} pool - attribute pool
+ * @returns {string}
+ */
+exports.composeAttributes = (att1, att2, resultIsMutation, pool) => {
+  if ((!att1) && resultIsMutation) {
+    return att2;
+  }
+  if (!att2) return att1;
+  return AttributeMap.fromString(att1, pool).updateFromString(att2, !resultIsMutation).toString();
+};
+
+/**
+ * Function used as parameter for applyZip to apply a Changeset to an attribute.
+ *
+ * @param {Op} attOp - The op from the sequence that is being operated on, either an attribution
+ *     string or the earlier of two exportss being composed.
+ * @param {Op} csOp -
+ * @param {AttributePool} pool - Can be null if definitely not needed.
+ * @returns {Op} The result of applying `csOp` to `attOp`.
+ */
+const slicerZipperFunc = (attOp, csOp, pool) => {
+  const opOut = new Op();
+  if (!attOp.opcode) {
+    copyOp(csOp, opOut);
+    csOp.opcode = '';
+  } else if (!csOp.opcode) {
+    copyOp(attOp, opOut);
+    attOp.opcode = '';
+  } else if (attOp.opcode === '-') {
+    copyOp(attOp, opOut);
+    attOp.opcode = '';
+  } else if (csOp.opcode === '+') {
+    copyOp(csOp, opOut);
+    csOp.opcode = '';
+  } else {
+    for (const op of [attOp, csOp]) {
+      assert(op.chars >= op.lines, `op has more newlines than chars: ${op.toString()}`);
+    }
+    assert(
+        attOp.chars < csOp.chars ? attOp.lines <= csOp.lines
+        : attOp.chars > csOp.chars ? attOp.lines >= csOp.lines
+        : attOp.lines === csOp.lines,
+        'line count mismatch when composing changesets A*B; ' +
+        `opA: ${attOp.toString()} opB: ${csOp.toString()}`);
+    assert(['+', '='].includes(attOp.opcode), `unexpected opcode in op: ${attOp.toString()}`);
+    assert(['-', '='].includes(csOp.opcode), `unexpected opcode in op: ${csOp.toString()}`);
+    opOut.opcode = {
+      '+': {
+        '-': '', // The '-' cancels out (some of) the '+', leaving any remainder for the next call.
+        '=': '+',
+      },
+      '=': {
+        '-': '-',
+        '=': '=',
+      },
+    }[attOp.opcode][csOp.opcode];
+    const [fullyConsumedOp, partiallyConsumedOp] = [attOp, csOp].sort((a, b) => a.chars - b.chars);
+    opOut.chars = fullyConsumedOp.chars;
+    opOut.lines = fullyConsumedOp.lines;
+    opOut.attribs = csOp.opcode === '-'
+      // csOp is a remove op and remove ops normally never have any attributes, so this should
+      // normally be the empty string. However, padDiff.js adds attributes to remove ops and needs
+      // them preserved so they are copied here.
+      ? csOp.attribs
+      : exports.composeAttributes(attOp.attribs, csOp.attribs, attOp.opcode === '=', pool);
+    partiallyConsumedOp.chars -= fullyConsumedOp.chars;
+    partiallyConsumedOp.lines -= fullyConsumedOp.lines;
+    if (!partiallyConsumedOp.chars) partiallyConsumedOp.opcode = '';
+    fullyConsumedOp.opcode = '';
+  }
+  return opOut;
+};
+
+/**
+ * Applies a Changeset to the attribs string of a AText.
+ *
+ * @param {string} cs - Changeset
+ * @param {string} astr - the attribs string of a AText
+ * @param {AttributePool} pool - the attibutes pool
+ * @returns {string}
+ */
+exports.applyToAttribution = (cs, astr, pool) => {
+  const unpacked = exports.unpack(cs);
+  return applyZip(astr, unpacked.ops, (op1, op2) => slicerZipperFunc(op1, op2, pool));
+};
+
+exports.splitAttributionLines = (attrOps, text) => {
+  const assem = exports.mergingOpAssembler();
+  const lines = [];
+  let pos = 0;
+
+  const appendOp = (op) => {
+    assem.append(op);
+    if (op.lines > 0) {
+      lines.push(assem.toString());
+      assem.clear();
+    }
+    pos += op.chars;
+  };
+
+  for (const op of exports.deserializeOps(attrOps)) {
+    let numChars = op.chars;
+    let numLines = op.lines;
+    while (numLines > 1) {
+      const newlineEnd = text.indexOf('\n', pos) + 1;
+      assert(newlineEnd > 0, 'newlineEnd <= 0 in splitAttributionLines');
+      op.chars = newlineEnd - pos;
+      op.lines = 1;
+      appendOp(op);
+      numChars -= op.chars;
+      numLines -= op.lines;
+    }
+    if (numLines === 1) {
+      op.chars = numChars;
+      op.lines = 1;
+    }
+    appendOp(op);
+  }
+
+  return lines;
+};
+
+/**
+ * Create an attribution inserting a text.
+ *
+ * @param {string} text - text to insert
+ * @returns {string}
+ */
+exports.makeAttribution = (text) => {
+  const assem = exports.smartOpAssembler();
+  for (const op of opsFromText('+', text)) assem.append(op);
+  return assem.toString();
+};
+
+/**
+ * Create a Changeset going from Identity to a certain state.
+ *
+ * @param {string} text - text of the final change
+ * @param {string} attribs - optional, operations which insert the text and also puts the right
+ *     attributes
+ * @returns {AText}
+ */
+exports.makeAText = (text, attribs) => ({
+  text,
+  attribs: (attribs || exports.makeAttribution(text)),
+});
+
+/**
+ * Apply a Changeset to a AText.
+ *
+ * @param {string} cs - Changeset to apply
+ * @param {AText} atext -
+ * @param {AttributePool} pool - Attribute Pool to add to
+ * @returns {AText}
+ */
+exports.applyToAText = (cs, atext, pool) => ({
+  text: exports.applyToText(cs, atext.text),
+  attribs: exports.applyToAttribution(cs, atext.attribs, pool),
+});
+
+/**
+ * Like "substring" but on a single-line attribution string.
+ */
+exports.subattribution = (astr, start, optEnd) => {
+  const attOps = exports.deserializeOps(astr);
+  let attOpsNext = attOps.next();
+  const assem = exports.smartOpAssembler();
+  let attOp = new Op();
+  const csOp = new Op();
+
+  const doCsOp = () => {
+    if (!csOp.chars) return;
+    while (csOp.opcode && (attOp.opcode || !attOpsNext.done)) {
+      if (!attOp.opcode) {
+        attOp = attOpsNext.value;
+        attOpsNext = attOps.next();
+      }
+      if (csOp.opcode && attOp.opcode && csOp.chars >= attOp.chars &&
+          attOp.lines > 0 && csOp.lines <= 0) {
+        csOp.lines++;
+      }
+      const opOut = slicerZipperFunc(attOp, csOp, null);
+      if (opOut.opcode) assem.append(opOut);
+    }
+  };
+
+  csOp.opcode = '-';
+  csOp.chars = start;
+
+  doCsOp();
+
+  if (optEnd === undefined) {
+    if (attOp.opcode) {
+      assem.append(attOp);
+    }
+    while (!attOpsNext.done) {
+      assem.append(attOpsNext.value);
+      attOpsNext = attOps.next();
+    }
+  } else {
+    csOp.opcode = '=';
+    csOp.chars = optEnd - start;
+    doCsOp();
+  }
+
+  return assem.toString();
+};

--- a/record-and-playback/presentation/scripts/utils/ExportHtml.js
+++ b/record-and-playback/presentation/scripts/utils/ExportHtml.js
@@ -1,0 +1,507 @@
+'use strict';
+/**
+ * Copyright 2009 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const Changeset = require('./Changeset');
+const attributes = require('./attributes');
+const AttributeMap = require('./AttributeMap');
+
+const nativeSome = Array.prototype.some
+
+const has = function(obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+};
+
+const each = function(obj, iterator, context) {
+  if (obj == null) return;
+  if (nativeForEach && obj.forEach === nativeForEach) {
+    obj.forEach(iterator, context);
+  } else if (obj.length === +obj.length) {
+    for (var i = 0, l = obj.length; i < l; i++) {
+      if (iterator.call(context, obj[i], i, obj) === breaker) return;
+    }
+  } else {
+    for (var key in obj) {
+      if (has(obj, key)) {
+        if (iterator.call(context, obj[key], key, obj) === breaker) return;
+      }
+    }
+  }
+};
+
+const any = function(obj, iterator, context) {
+  iterator || (iterator = _.identity);
+  var result = false;
+  if (obj == null) return result;
+  if (nativeSome && obj.some === nativeSome) return obj.some(iterator, context);
+  each(obj, function(value, index, list) {
+    if (result || (result = iterator.call(context, value, index, list))) return breaker;
+  });
+  return !!result;
+};
+
+const find = function(obj, iterator, context) {
+  var result;
+  any(obj, function(value, index, list) {
+    if (iterator.call(context, value, index, list)) {
+      result = value;
+      return true;
+    }
+  });
+  return result;
+};
+
+function escapeHTML(s) {
+  var n = s;
+  n = n.replace(/&/g, '&amp;');
+  n = n.replace(/</g, '&lt;');
+  n = n.replace(/>/g, '&gt;');
+  n = n.replace(/"/g, '&quot;');
+
+  return n;
+}
+
+const _encodeWhitespace =
+  (s) => s.replace(/[^\x21-\x7E\s\t\n\r]/gu, (c) => `&#${c.codePointAt(0)};`);
+
+const _analyzeLine = (text, aline, apool) => {
+  const line = {};
+
+  // identify list
+  let lineMarker = 0;
+  line.listLevel = 0;
+  if (aline) {
+    const [op] = Changeset.deserializeOps(aline);
+    if (op != null) {
+      const attribs = AttributeMap.fromString(op.attribs, apool);
+      let listType = attribs.get('list');
+      if (listType) {
+        lineMarker = 1;
+        listType = /([a-z]+)([0-9]+)/.exec(listType);
+        if (listType) {
+          line.listTypeName = listType[1];
+          line.listLevel = Number(listType[2]);
+        }
+      }
+      const start = attribs.get('start');
+      if (start) {
+        line.start = start;
+      }
+    }
+  }
+  if (lineMarker) {
+    line.text = text.substring(1);
+    line.aline = Changeset.subattribution(aline, 1);
+  } else {
+    line.text = text;
+    line.aline = aline;
+  }
+  return line;
+};
+
+const wordCharRegex = new RegExp(`[${[
+  '\u0030-\u0039',
+  '\u0041-\u005A',
+  '\u0061-\u007A',
+  '\u00C0-\u00D6',
+  '\u00D8-\u00F6',
+  '\u00F8-\u00FF',
+  '\u0100-\u1FFF',
+  '\u3040-\u9FFF',
+  '\uF900-\uFDFF',
+  '\uFE70-\uFEFE',
+  '\uFF10-\uFF19',
+  '\uFF21-\uFF3A',
+  '\uFF41-\uFF5A',
+  '\uFF66-\uFFDC',
+].join('')}]`);
+
+const urlRegex = (() => {
+  // TODO: wordCharRegex matches many characters that are not permitted in URIs. Are they included
+  // here as an attempt to support IRIs? (See https://tools.ietf.org/html/rfc3987.)
+  const urlChar = `[-:@_.,~%+/?=&#!;()\\[\\]$'*${wordCharRegex.source.slice(1, -1)}]`;
+  // Matches a single character that should not be considered part of the URL if it is the last
+  // character that matches urlChar.
+  const postUrlPunct = '[:.,;?!)\\]\'*]';
+  // Schemes that must be followed by ://
+  const withAuth = `(?:${[
+    '(?:x-)?man',
+    'afp',
+    'file',
+    'ftps?',
+    'gopher',
+    'https?',
+    'nfs',
+    'sftp',
+    'smb',
+    'txmt',
+  ].join('|')})://`;
+  // Schemes that do not need to be followed by ://
+  const withoutAuth = `(?:${[
+    'about',
+    'geo',
+    'mailto',
+    'tel',
+  ].join('|')}):`;
+  return new RegExp(
+      `(?:${withAuth}|${withoutAuth}|www\\.)${urlChar}*(?!${postUrlPunct})${urlChar}`, 'g');
+})();
+
+const regexUtils = {
+  urlRegex
+}
+
+const findURLs = (text) => {
+  // Copy padutils.urlRegex so that the use of .exec() below (which mutates the RegExp object)
+  // does not break other concurrent uses of padutils.urlRegex.
+  const urlRegex = new RegExp(regexUtils.urlRegex, 'g');
+  urlRegex.lastIndex = 0;
+  let urls = null;
+  let execResult;
+  // TODO: Switch to String.prototype.matchAll() after support for Node.js < 12.0.0 is dropped.
+  while ((execResult = urlRegex.exec(text))) {
+    urls = (urls || []);
+    const startIndex = execResult.index;
+    const url = execResult[0];
+    urls.push([startIndex, url]);
+  }
+  return urls;
+}
+
+const getHTMLFromAtext = (attrPool, atext, authorColors) => {
+  const apool = attrPool;
+  const textLines = atext.text.slice(0, -1).split('\n');
+  const attribLines = Changeset.splitAttributionLines(atext.attribs, atext.text);
+
+  const tags = ['h1', 'h2', 'strong', 'em', 'u', 's'];
+  const props = ['heading1', 'heading2', 'bold', 'italic', 'underline', 'strikethrough'];
+
+  const anumMap = {};
+  let css = '';
+
+  // iterates over all props(h1,h2,strong,...), checks if it is used in
+  // this pad, and if yes puts its attrib id->props value into anumMap
+  props.forEach((propName, i) => {
+    let attrib = [propName, true];
+    if (Array.isArray(propName)) {
+      // propName can be in the form of ['color', 'red'],
+      // see hook exportHtmlAdditionalTagsWithData
+      attrib = propName;
+    }
+    const propTrueNum = apool.putAttrib(attrib, true);
+    if (propTrueNum >= 0) {
+      anumMap[propTrueNum] = i;
+    }
+  });
+
+  const getLineHTML = (text, attribs) => {
+    const taker = Changeset.stringIterator(text);
+    const assem = Changeset.stringAssembler();
+    const openTags = [];
+
+    // tags added by exportHtmlAdditionalTagsWithData will be exported as <span> with
+    // data attributes
+    const isSpanWithData = (i) => {
+      const property = props[i];
+      return Array.isArray(property);
+    };
+
+    const emitOpenTag = (i) => {
+      openTags.unshift(i);
+      
+      assem.append('<');
+      assem.append(tags[i]);
+      assem.append('>');
+    };
+
+    // this closes an open tag and removes its reference from openTags
+    const emitCloseTag = (i) => {
+      openTags.shift();
+      const spanWithData = isSpanWithData(i);
+
+      if (spanWithData) {
+        assem.append('</span>');
+      } else {
+        assem.append('</');
+        assem.append(tags[i]);
+        assem.append('>');
+      }
+    };
+
+    const urls = findURLs(text);
+
+    let idx = 0;
+
+    const processNextChars = (numChars) => {
+      if (numChars <= 0) {
+        return;
+      }
+
+      const ops = Changeset.deserializeOps(Changeset.subattribution(attribs, idx, idx + numChars));
+      idx += numChars;
+
+      // this iterates over every op string and decides which tags to open or to close
+      // based on the attribs used
+      for (const o of ops) {
+        const usedAttribs = [];
+
+        // mark all attribs as used
+        for (const a of attributes.decodeAttribString(o.attribs)) {
+          if (a in anumMap) {
+            usedAttribs.push(anumMap[a]); // i = 0 => bold, etc.
+          }
+        }
+        let outermostTag = -1;
+        // find the outer most open tag that is no longer used
+        for (let i = openTags.length - 1; i >= 0; i--) {
+          if (usedAttribs.indexOf(openTags[i]) === -1) {
+            outermostTag = i;
+            break;
+          }
+        }
+
+        // close all tags upto the outer most
+        if (outermostTag !== -1) {
+          while (outermostTag >= 0) {
+            emitCloseTag(openTags[0]);
+            outermostTag--;
+          }
+        }
+
+        // open all tags that are used but not open
+        for (let i = 0; i < usedAttribs.length; i++) {
+          if (openTags.indexOf(usedAttribs[i]) === -1) {
+            emitOpenTag(usedAttribs[i]);
+          }
+        }
+
+        let chars = o.chars;
+        if (o.lines) {
+          chars--; // exclude newline at end of line, if present
+        }
+
+        let s = taker.take(chars);
+
+        // removes the characters with the code 12. Don't know where they come
+        // from but they break the abiword parser and are completly useless
+        s = s.replace(String.fromCharCode(12), '');
+
+        assem.append(_encodeWhitespace(escapeHTML(s)));
+      } // end iteration over spans in line
+
+      // close all the tags that are open after the last op
+      while (openTags.length > 0) {
+        emitCloseTag(openTags[0]);
+      }
+    };
+    // end processNextChars
+    if (urls) {
+      urls.forEach((urlData) => {
+        const startIndex = urlData[0];
+        const url = urlData[1];
+        const urlLength = url.length;
+        processNextChars(startIndex - idx);
+
+        assem.append(`<a href="${escapeHTML(url)}" rel="noreferrer noopener">`);
+        processNextChars(urlLength);
+        assem.append('</a>');
+      });
+    }
+    processNextChars(text.length - idx);
+
+    return _processSpaces(assem.toString());
+  };
+  // end getLineHTML
+  const pieces = [css];
+
+  let openLists = [];
+  for (let i = 0; i < textLines.length; i++) {
+    let context;
+    const line = _analyzeLine(textLines[i], attribLines[i], apool);
+    const lineContent = getLineHTML(line.text, line.aline);
+    // If we are inside a list
+    if (line.listLevel) {
+      context = {
+        line,
+        lineContent,
+        apool,
+        attribLine: attribLines[i],
+        text: textLines[i],
+      };
+      let prevLine = null;
+      let nextLine = null;
+      if (i > 0) {
+        prevLine = _analyzeLine(textLines[i - 1], attribLines[i - 1], apool);
+      }
+      if (i < textLines.length) {
+        nextLine = _analyzeLine(textLines[i + 1], attribLines[i + 1], apool);
+      }
+      // await hooks.aCallAll('getLineHTMLForExport', context);
+      // To create list parent elements
+      if ((!prevLine || prevLine.listLevel !== line.listLevel) ||
+          (line.listTypeName !== prevLine.listTypeName)) {
+        const exists = find(openLists, (item) => (
+          item.level === line.listLevel && item.type === line.listTypeName));
+        if (!exists) {
+          let prevLevel = 0;
+          if (prevLine && prevLine.listLevel) {
+            prevLevel = prevLine.listLevel;
+          }
+          if (prevLine && line.listTypeName !== prevLine.listTypeName) {
+            prevLevel = 0;
+          }
+
+          for (let diff = prevLevel; diff < line.listLevel; diff++) {
+            openLists.push({level: diff, type: line.listTypeName});
+            const prevPiece = pieces[pieces.length - 1];
+
+            if (prevPiece.indexOf('<ul') === 0 ||
+                prevPiece.indexOf('<ol') === 0 ||
+                prevPiece.indexOf('</li>') === 0) {
+              if ((nextLine.listTypeName === 'number') && (nextLine.text === '')) {
+                // is the listTypeName check needed here?  null text might be completely fine!
+                // TODO Check against Uls
+                // don't do anything because the next item is a nested ol openener so
+                // we need to keep the li open
+              } else {
+                pieces.push('<li>');
+              }
+            }
+
+            if (line.listTypeName === 'number') {
+              if (line.start) {
+                pieces.push(`<ol start="${Number(line.start)}" class="${line.listTypeName}">`);
+              } else {
+                pieces.push(`<ol class="${line.listTypeName}">`);
+              }
+            } else {
+              pieces.push(`<ul class="${line.listTypeName}">`);
+            }
+          }
+        }
+      }
+      // if we're going up a level we shouldn't be adding..
+      if (context.lineContent) {
+        pieces.push('<li>', context.lineContent);
+      }
+
+      // To close list elements
+      if (nextLine &&
+          nextLine.listLevel === line.listLevel &&
+          line.listTypeName === nextLine.listTypeName) {
+        if (context.lineContent) {
+          if ((nextLine.listTypeName === 'number') && (nextLine.text === '')) {
+            // is the listTypeName check needed here?  null text might be completely fine!
+          } else {
+            pieces.push('</li>');
+          }
+        }
+      }
+      if ((!nextLine ||
+           !nextLine.listLevel ||
+           nextLine.listLevel < line.listLevel) ||
+          (line.listTypeName !== nextLine.listTypeName)) {
+        let nextLevel = 0;
+        if (nextLine && nextLine.listLevel) {
+          nextLevel = nextLine.listLevel;
+        }
+        if (nextLine && line.listTypeName !== nextLine.listTypeName) {
+          nextLevel = 0;
+        }
+
+        for (let diff = nextLevel; diff < line.listLevel; diff++) {
+          openLists = openLists.filter((el) => el.level !== diff && el.type !== line.listTypeName);
+
+          if (pieces[pieces.length - 1].indexOf('</ul') === 0 ||
+              pieces[pieces.length - 1].indexOf('</ol') === 0) {
+            pieces.push('</li>');
+          }
+
+          if (line.listTypeName === 'number') {
+            pieces.push('</ol>');
+          } else {
+            pieces.push('</ul>');
+          }
+        }
+      }
+    } else {
+      // outside any list, need to close line.listLevel of lists
+      context = {
+        line,
+        lineContent,
+        apool,
+        attribLine: attribLines[i],
+        text: textLines[i],
+      };
+
+      // await hooks.aCallAll('getLineHTMLForExport', context);
+      pieces.push(context.lineContent, '<br>');
+    }
+  }
+
+  return pieces.join('');
+};
+
+// copied from ACE
+const _processSpaces = (s) => {
+  const doesWrap = true;
+  if (s.indexOf('<') < 0 && !doesWrap) {
+    // short-cut
+    return s.replace(/ /g, '&nbsp;');
+  }
+  const parts = [];
+  s.replace(/<[^>]*>?| |[^ <]+/g, (m) => {
+    parts.push(m);
+  });
+  if (doesWrap) {
+    let endOfLine = true;
+    let beforeSpace = false;
+    // last space in a run is normal, others are nbsp,
+    // end of line is nbsp
+    for (let i = parts.length - 1; i >= 0; i--) {
+      const p = parts[i];
+      if (p === ' ') {
+        if (endOfLine || beforeSpace) parts[i] = '&nbsp;';
+        endOfLine = false;
+        beforeSpace = true;
+      } else if (p.charAt(0) !== '<') {
+        endOfLine = false;
+        beforeSpace = false;
+      }
+    }
+    // beginning of line is nbsp
+    for (let i = 0; i < parts.length; i++) {
+      const p = parts[i];
+      if (p === ' ') {
+        parts[i] = '&nbsp;';
+        break;
+      } else if (p.charAt(0) !== '<') {
+        break;
+      }
+    }
+  } else {
+    for (let i = 0; i < parts.length; i++) {
+      const p = parts[i];
+      if (p === ' ') {
+        parts[i] = '&nbsp;';
+      }
+    }
+  }
+  return parts.join('');
+};
+
+// exports.getPadHTML = getPadHTML;
+exports.getHTMLFromAtext = getHTMLFromAtext;

--- a/record-and-playback/presentation/scripts/utils/attributes.js
+++ b/record-and-playback/presentation/scripts/utils/attributes.js
@@ -1,0 +1,130 @@
+'use strict';
+
+// Low-level utilities for manipulating attribute strings. For a high-level API, see AttributeMap.
+
+/**
+ * A `[key, value]` pair of strings describing a text attribute.
+ *
+ * @typedef {[string, string]} Attribute
+ */
+
+/**
+ * A concatenated sequence of zero or more attribute identifiers, each one represented by an
+ * asterisk followed by a base-36 encoded attribute number.
+ *
+ * Examples: '', '*0', '*3*j*z*1q'
+ *
+ * @typedef {string} AttributeString
+ */
+
+/**
+ * Converts an attribute string into a sequence of attribute identifier numbers.
+ *
+ * WARNING: This only works on attribute strings. It does NOT work on serialized operations or
+ * changesets.
+ *
+ * @param {AttributeString} str - Attribute string.
+ * @yields {number} The attribute numbers (to look up in the associated pool), in the order they
+ *     appear in `str`.
+ * @returns {Generator<number>}
+ */
+exports.decodeAttribString = function* (str) {
+  const re = /\*([0-9a-z]+)|./gy;
+  let match;
+  while ((match = re.exec(str)) != null) {
+    const [m, n] = match;
+    if (n == null) throw new Error(`invalid character in attribute string: ${m}`);
+    yield Number.parseInt(n, 36);
+  }
+};
+
+const checkAttribNum = (n) => {
+  if (typeof n !== 'number') throw new TypeError(`not a number: ${n}`);
+  if (n < 0) throw new Error(`attribute number is negative: ${n}`);
+  if (n !== Math.trunc(n)) throw new Error(`attribute number is not an integer: ${n}`);
+};
+
+/**
+ * Inverse of `decodeAttribString`.
+ *
+ * @param {Iterable<number>} attribNums - Sequence of attribute numbers.
+ * @returns {AttributeString}
+ */
+exports.encodeAttribString = (attribNums) => {
+  let str = '';
+  for (const n of attribNums) {
+    checkAttribNum(n);
+    str += `*${n.toString(36).toLowerCase()}`;
+  }
+  return str;
+};
+
+/**
+ * Converts a sequence of attribute numbers into a sequence of attributes.
+ *
+ * @param {Iterable<number>} attribNums - Attribute numbers to look up in the pool.
+ * @param {AttributePool} pool - Attribute pool.
+ * @yields {Attribute} The identified attributes, in the same order as `attribNums`.
+ * @returns {Generator<Attribute>}
+ */
+exports.attribsFromNums = function* (attribNums, pool) {
+  for (const n of attribNums) {
+    checkAttribNum(n);
+    const attrib = pool.getAttrib(n);
+    if (attrib == null) throw new Error(`attribute ${n} does not exist in pool`);
+    yield attrib;
+  }
+};
+
+/**
+ * Inverse of `attribsFromNums`.
+ *
+ * @param {Iterable<Attribute>} attribs - Attributes. Any attributes not already in `pool` are
+ *     inserted into `pool`. No checking is performed to ensure that the attributes are in the
+ *     canonical order and that there are no duplicate keys. (Use an AttributeMap and/or `sort()` if
+ *     required.)
+ * @param {AttributePool} pool - Attribute pool.
+ * @yields {number} The attribute number of each attribute in `attribs`, in order.
+ * @returns {Generator<number>}
+ */
+exports.attribsToNums = function* (attribs, pool) {
+  for (const attrib of attribs) yield pool.putAttrib(attrib);
+};
+
+/**
+ * Convenience function that is equivalent to `attribsFromNums(decodeAttribString(str), pool)`.
+ *
+ * WARNING: This only works on attribute strings. It does NOT work on serialized operations or
+ * changesets.
+ *
+ * @param {AttributeString} str - Attribute string.
+ * @param {AttributePool} pool - Attribute pool.
+ * @yields {Attribute} The attributes identified in `str`, in order.
+ * @returns {Generator<Attribute>}
+ */
+exports.attribsFromString = function* (str, pool) {
+  yield* exports.attribsFromNums(exports.decodeAttribString(str), pool);
+};
+
+/**
+ * Inverse of `attribsFromString`.
+ *
+ * @param {Iterable<Attribute>} attribs - Attributes. The attributes to insert into the pool (if
+ *     necessary) and encode. No checking is performed to ensure that the attributes are in the
+ *     canonical order and that there are no duplicate keys. (Use an AttributeMap and/or `sort()` if
+ *     required.)
+ * @param {AttributePool} pool - Attribute pool.
+ * @returns {AttributeString}
+ */
+exports.attribsToString =
+    (attribs, pool) => exports.encodeAttribString(exports.attribsToNums(attribs, pool));
+
+/**
+ * Sorts the attributes in canonical order. The order of entries with the same attribute name is
+ * unspecified.
+ *
+ * @param {Attribute[]} attribs - Attributes to sort in place.
+ * @returns {Attribute[]} `attribs` (for chaining).
+ */
+exports.sort =
+    (attribs) => attribs.sort(([keyA], [keyB]) => (keyA > keyB ? 1 : 0) - (keyA < keyB ? 1 : 0));

--- a/record-and-playback/presentation/scripts/utils/extractEventsFromDiffs.js
+++ b/record-and-playback/presentation/scripts/utils/extractEventsFromDiffs.js
@@ -1,0 +1,37 @@
+let fs = require('fs');
+const Changeset = require("./Changeset")
+const AttributePool = require("./AttributePool");
+const ExportHtml = require("./ExportHtml")
+
+const pathOfFile = process.argv[2];
+const fileNameToRead = process.argv[3];
+const fileNameToWrite = process.argv[4]
+const eventsToReturn = [];
+
+const fileToRead = `${pathOfFile}/${fileNameToRead}`;
+const fileToWrite = `${pathOfFile}/${fileNameToWrite}`;
+
+fs.readFile(fileToRead, {encoding: 'utf-8'}, (err, data) => {
+    if (err) throw err;
+    const data_json = JSON.parse(data)
+    let attr = new AttributePool();
+    let actualAText = Changeset.makeAText("\n", "|1+1");
+    for (var prop in data_json) {
+        if (data_json[prop].changeset !== undefined && data_json[prop].meta !== undefined) {
+            const currentEvent = {}
+            currentEvent.timestamp = data_json[prop].meta.timestamp;
+            actualAText = Changeset.applyToAText(data_json[prop].changeset, actualAText, attr)
+            const actualATextHtml = ExportHtml.getHTMLFromAtext(attr, actualAText)
+            currentEvent.text = actualATextHtml;
+            eventsToReturn.push(JSON.parse(JSON.stringify(currentEvent)));
+        }else if(data_json[prop].pool !== undefined) {
+            for (var index in data_json[prop].pool.numToAttrib) {
+                attr.putAttrib(data_json[prop].pool.numToAttrib[index]);
+            }
+        }
+    }
+
+    fs.writeFile(fileToWrite, JSON.stringify(eventsToReturn), (err) => {
+        if (err) throw err;
+    })
+})


### PR DESCRIPTION
### What does this PR do?

It Prevents playback from showing notes written after the recording was stopped, a leak of information.
It also introduces a new method to show the notes dynamically (showing them exactly as it was at that time of the meeting)

To picture the leakage, imagine a scenario where the user records a whole session, but at the end, when they stop it, they write something that others are not supposed to see in the shared notes, let it there and finish the session. Without this PR, when watching the recording, anyone can see what has been written after the recording had been stopped, because the `notes.html` is only fetched in the end of the meeting.

### More

Some demonstration of the new feature:

https://user-images.githubusercontent.com/69865537/198392810-c050b8da-403a-44c2-8141-c55a39be60d2.mp4

More things to add:
 - This is closely related to the changes in playback to support this new feature (https://github.com/bigbluebutton/bbb-playback/pull/217);
 - I am open to suggestions, please, comment them.

#### Edit

As latest comments and reviews popped out, it was suggested to make the default behavior for the playback configurable, as there are divergent opinions on the shared notes format. So in order to configure it, the user needs to change the `/var/bigbluebutton/playback/presentation/2.3/config.json` file, with the two possibilities being:

 - "static";
 - "dynamic";

Now, even though it can be configurable, it is also possible to send this param in the URL, such as showed below:

```url
https://<your-host>/playback/presentation/2.3/<meeting-id>?typeOfSharedNotes=static
```

Reminder: this URL parameter has priority over the config.

### Flow and technical details

With this PR, the flow in RAP will ignore the fetched html file done in the archive part, on the grounds that it has leak of information, as showed. Despite that, the static content is still going to be supported, therefore, in this new flow we create a new file coincidentally called `notes.html` (which is not the same as before), that derives from the events processing done in the publish parte of RAP