### PR TITLE
Bump FreeSWITCH build to 1.10.8

### DIFF
--- a/freeswitch.placeholder.sh
+++ b/freeswitch.placeholder.sh
@@ -2,5 +2,5 @@ mkdir freeswitch
 cd freeswitch
 git init
 git remote add origin https://github.com/signalwire/freeswitch.git
-git fetch --depth 1 origin v1.10.7
+git fetch --depth 1 origin v1.10.8
 git checkout FETCH_HEAD


### PR DESCRIPTION

### What does this PR do?

Bump the build of FreeSWITCH from 1.10.7 to 1.10.8.  See https://github.com/signalwire/freeswitch/releases/tag/v1.10.8

### Motivation

Bring in the most recent build of FreeSWITCH for testing in 2.6
