### PR TITLE
fix: guarantee cleanup of stale data on re-subscriptions

### DIFF
--- a/bigbluebutton-html5/client/collection-mirror-initializer.js
+++ b/bigbluebutton-html5/client/collection-mirror-initializer.js
@@ -27,72 +27,51 @@ import Users, { CurrentUser } from '/imports/api/users';
 import { Slides, SlidePositions } from '/imports/api/slides';
 
 // Custom Publishers
-export const localCurrentPollSync = new AbstractCollection(CurrentPoll, CurrentPoll);
-export const localCurrentUserSync = new AbstractCollection(CurrentUser, CurrentUser);
-export const localSlidesSync = new AbstractCollection(Slides, Slides);
-export const localSlidePositionsSync = new AbstractCollection(SlidePositions, SlidePositions);
-export const localPollsSync = new AbstractCollection(Polls, Polls);
-export const localPresentationsSync = new AbstractCollection(Presentations, Presentations);
-export const localPresentationPodsSync = new AbstractCollection(PresentationPods, PresentationPods);
-export const localPresentationUploadTokenSync = new AbstractCollection(PresentationUploadToken, PresentationUploadToken);
-export const localScreenshareSync = new AbstractCollection(Screenshare, Screenshare);
-export const localUserInfosSync = new AbstractCollection(UserInfos, UserInfos);
-export const localUsersPersistentDataSync = new AbstractCollection(UsersPersistentData, UsersPersistentData);
-export const localUserSettingsSync = new AbstractCollection(UserSettings, UserSettings);
-export const localVideoStreamsSync = new AbstractCollection(VideoStreams, VideoStreams);
-export const localVoiceUsersSync = new AbstractCollection(VoiceUsers, VoiceUsers);
-export const localWhiteboardMultiUserSync = new AbstractCollection(WhiteboardMultiUser, WhiteboardMultiUser);
-export const localGroupChatSync = new AbstractCollection(GroupChat, GroupChat);
-export const localConnectionStatusSync = new AbstractCollection(ConnectionStatus, ConnectionStatus);
-export const localCaptionsSync = new AbstractCollection(Captions, Captions);
-export const localPadsSync = new AbstractCollection(Pads, Pads);
-export const localPadsSessionsSync = new AbstractCollection(PadsSessions, PadsSessions);
-export const localPadsUpdatesSync = new AbstractCollection(PadsUpdates, PadsUpdates);
-export const localAuthTokenValidationSync = new AbstractCollection(AuthTokenValidation, AuthTokenValidation);
-export const localAnnotationsSync = new AbstractCollection(Annotations, Annotations);
-export const localRecordMeetingsSync = new AbstractCollection(RecordMeetings, RecordMeetings);
-export const localExternalVideoMeetingsSync = new AbstractCollection(ExternalVideoMeetings, ExternalVideoMeetings);
-export const localMeetingTimeRemainingSync = new AbstractCollection(MeetingTimeRemaining, MeetingTimeRemaining);
-export const localUsersTypingSync = new AbstractCollection(UsersTyping, UsersTyping);
-export const localBreakoutsSync = new AbstractCollection(Breakouts, Breakouts);
-export const localBreakoutsHistorySync = new AbstractCollection(BreakoutsHistory, BreakoutsHistory);
-export const localGuestUsersSync = new AbstractCollection(guestUsers, guestUsers);
-export const localMeetingsSync = new AbstractCollection(Meetings, Meetings);
-export const localUsersSync = new AbstractCollection(Users, Users);
+export const localCollectionRegistry = {
+  localCurrentPollSync: new AbstractCollection(CurrentPoll, CurrentPoll),
+  localCurrentUserSync: new AbstractCollection(CurrentUser, CurrentUser),
+  localSlidesSync: new AbstractCollection(Slides, Slides),
+  localSlidePositionsSync: new AbstractCollection(SlidePositions, SlidePositions),
+  localPollsSync: new AbstractCollection(Polls, Polls),
+  localPresentationsSync: new AbstractCollection(Presentations, Presentations),
+  localPresentationPodsSync: new AbstractCollection(PresentationPods, PresentationPods),
+  localPresentationUploadTokenSync: new AbstractCollection(
+    PresentationUploadToken,
+    PresentationUploadToken,
+  ),
+  localScreenshareSync: new AbstractCollection(Screenshare, Screenshare),
+  localUserInfosSync: new AbstractCollection(UserInfos, UserInfos),
+  localUsersPersistentDataSync: new AbstractCollection(UsersPersistentData, UsersPersistentData),
+  localUserSettingsSync: new AbstractCollection(UserSettings, UserSettings),
+  localVideoStreamsSync: new AbstractCollection(VideoStreams, VideoStreams),
+  localVoiceUsersSync: new AbstractCollection(VoiceUsers, VoiceUsers),
+  localWhiteboardMultiUserSync: new AbstractCollection(WhiteboardMultiUser, WhiteboardMultiUser),
+  localGroupChatSync: new AbstractCollection(GroupChat, GroupChat),
+  localConnectionStatusSync: new AbstractCollection(ConnectionStatus, ConnectionStatus),
+  localCaptionsSync: new AbstractCollection(Captions, Captions),
+  localPadsSync: new AbstractCollection(Pads, Pads),
+  localPadsSessionsSync: new AbstractCollection(PadsSessions, PadsSessions),
+  localPadsUpdatesSync: new AbstractCollection(PadsUpdates, PadsUpdates),
+  localAuthTokenValidationSync: new AbstractCollection(AuthTokenValidation, AuthTokenValidation),
+  localAnnotationsSync: new AbstractCollection(Annotations, Annotations),
+  localRecordMeetingsSync: new AbstractCollection(RecordMeetings, RecordMeetings),
+  localExternalVideoMeetingsSync: new AbstractCollection(
+    ExternalVideoMeetings,
+    ExternalVideoMeetings,
+  ),
+  localMeetingTimeRemainingSync: new AbstractCollection(MeetingTimeRemaining, MeetingTimeRemaining),
+  localUsersTypingSync: new AbstractCollection(UsersTyping, UsersTyping),
+  localBreakoutsSync: new AbstractCollection(Breakouts, Breakouts),
+  localBreakoutsHistorySync: new AbstractCollection(BreakoutsHistory, BreakoutsHistory),
+  localGuestUsersSync: new AbstractCollection(guestUsers, guestUsers),
+  localMeetingsSync: new AbstractCollection(Meetings, Meetings),
+  localUsersSync: new AbstractCollection(Users, Users),
+};
 
 const collectionMirrorInitializer = () => {
-  localCurrentPollSync.setupListeners();
-  localCurrentUserSync.setupListeners();
-  localSlidesSync.setupListeners();
-  localSlidePositionsSync.setupListeners();
-  localPollsSync.setupListeners();
-  localPresentationsSync.setupListeners();
-  localPresentationPodsSync.setupListeners();
-  localPresentationUploadTokenSync.setupListeners();
-  localScreenshareSync.setupListeners();
-  localUserInfosSync.setupListeners();
-  localUsersPersistentDataSync.setupListeners();
-  localUserSettingsSync.setupListeners();
-  localVideoStreamsSync.setupListeners();
-  localVoiceUsersSync.setupListeners();
-  localWhiteboardMultiUserSync.setupListeners();
-  localGroupChatSync.setupListeners();
-  localConnectionStatusSync.setupListeners();
-  localCaptionsSync.setupListeners();
-  localPadsSync.setupListeners();
-  localPadsSessionsSync.setupListeners();
-  localPadsUpdatesSync.setupListeners();
-  localAuthTokenValidationSync.setupListeners();
-  localAnnotationsSync.setupListeners();
-  localRecordMeetingsSync.setupListeners();
-  localExternalVideoMeetingsSync.setupListeners();
-  localMeetingTimeRemainingSync.setupListeners();
-  localUsersTypingSync.setupListeners();
-  localBreakoutsSync.setupListeners();
-  localBreakoutsHistorySync.setupListeners();
-  localGuestUsersSync.setupListeners();
-  localMeetingsSync.setupListeners();
-  localUsersSync.setupListeners();
+  Object.values(localCollectionRegistry).forEach((localCollection) => {
+    localCollection.setupListeners();
+  });
 };
 
 export default collectionMirrorInitializer;

--- a/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
@@ -8,11 +8,7 @@ import Users from '/imports/api/users';
 import AnnotationsTextService from '/imports/ui/components/whiteboard/annotations/text/service';
 import { Annotations as AnnotationsLocal } from '/imports/ui/components/whiteboard/service';
 import {
-  localBreakoutsSync,
-  localBreakoutsHistorySync,
-  localGuestUsersSync,
-  localMeetingsSync,
-  localUsersSync,
+  localCollectionRegistry,
 } from '/client/collection-mirror-initializer';
 import SubscriptionRegistry, { subscriptionReactivity } from '../../services/subscription-registry/subscriptionRegistry';
 import { isChatEnabled } from '/imports/ui/services/features';
@@ -29,6 +25,13 @@ const SUBSCRIPTIONS = [
   'connection-status', 'voice-call-states', 'external-video-meetings', 'breakouts', 'breakouts-history',
   'pads', 'pads-sessions', 'pads-updates',
 ];
+const {
+  localBreakoutsSync,
+  localBreakoutsHistorySync,
+  localGuestUsersSync,
+  localMeetingsSync,
+  localUsersSync,
+} = localCollectionRegistry;
 
 const EVENT_NAME = 'bbb-group-chat-messages-subscription-has-stoppped';
 const EVENT_NAME_SUBSCRIPTION_READY = 'bbb-group-chat-messages-subscriptions-ready';
@@ -164,6 +167,10 @@ export default withTracker(() => {
       },
       ...subscriptionErrorHandler,
     });
+
+    Object.values(localCollectionRegistry).forEach(
+      (localCollection) => localCollection.checkForStaleData(),
+    );
   }
 
   return {


### PR DESCRIPTION
### What does this PR do?

- [fix: guarantee cleanup of stale data on re-subscriptions](https://github.com/bigbluebutton/bigbluebutton/commit/401ddc401424a1e6775752800940baf8a0af3a92)
  * Currently, collection cleanup code is only run when an added event is received from the server. Where that fails is in scenarios where a server-side collection turns empty while an affected users is disconnected - and then reconnects. There's no removed (or updated) event so no cleanup code is run and you have stale data.
  * This commit guarantees a stale data check is run whenever a subscription is established again. The `added` check was also maintained, although I'm not too sure it's still needed. That may need to be revisited.
  
### Closes Issue(s)

Part of https://github.com/bigbluebutton/bigbluebutton/issues/15829
Part of https://github.com/bigbluebutton/bigbluebutton/issues/15823

### Motivation

See https://github.com/bigbluebutton/bigbluebutton/issues/15823#issuecomment-1293960329


