### PR TITLE
Remove Typed Response Option For Smart Slides Yes/No Poll

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -90,7 +90,7 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
   const doubleQuestionRegex = /\?{2}/gm;
   const doubleQuestion = safeMatch(doubleQuestionRegex, content, false);
 
-  const yesNoPatt = /.*yes\/no|no\/yes.*/gm;
+  const yesNoPatt = /.*(yes\/no|no\/yes).*/gm;
   const hasYN = safeMatch(yesNoPatt, content, false);
 
   const pollRegex = /[1-9A-Ia-i][.)].*/g;

--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -90,6 +90,9 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
   const doubleQuestionRegex = /\?{2}/gm;
   const doubleQuestion = safeMatch(doubleQuestionRegex, content, false);
 
+  const yesNoPatt = /.*yes\/no|no\/yes.*/gm;
+  const hasYN = safeMatch(yesNoPatt, content, false);
+
   const pollRegex = /[1-9A-Ia-i][.)].*/g;
   let optionsPoll = safeMatch(pollRegex, content, []);
   const optionsWithLabels = [];
@@ -156,7 +159,7 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
     }
   });
 
-  if (question.length > 0 && optionsPoll.length === 0 && !doubleQuestion) {
+  if (question.length > 0 && optionsPoll.length === 0 && !doubleQuestion && !hasYN) {
     quickPollOptions.push({
       type: 'R-',
       poll: {


### PR DESCRIPTION
### What does this PR do?
Display single yes/no poll option for the given example. No longer also presents the typed response.
![image](https://user-images.githubusercontent.com/22058534/198894556-8ffee233-3f20-457a-bce9-3de1ed3db7ca.png)

### Closes Issue(s)
Closes #15933
