### PR TITLE
fix: bbb-web is not building (JCenter repository failing)

### DIFF
--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
   repositories {
-    jcenter()
     mavenLocal()
     maven { url "https://repo1.maven.org/maven2" }
     maven { url "https://repo.grails.org/artifactory/core" }
@@ -45,7 +44,6 @@ task copyWebInf(type: Copy) {
 processResources.dependsOn copyWebInf
 
 repositories {
-  jcenter()
   mavenLocal()
   maven { url "https://repo1.maven.org/maven2" }
   maven { url "https://repo.grails.org/artifactory/core" }

--- a/bigbluebutton-web/pres-checker/build.gradle
+++ b/bigbluebutton-web/pres-checker/build.gradle
@@ -15,7 +15,6 @@ task resolveDeps(type: Copy) {
 }
 
 repositories {
-    jcenter()
     mavenLocal()
 }
 


### PR DESCRIPTION
Today the build of `bigbluebutton-web` started to fail!
![image(16)](https://user-images.githubusercontent.com/5660191/199013664-640d0577-a987-4d97-82c4-e8dc38f87410.png)

It seems that the repository JCenter has been shutdown!
https://blog.gradle.org/jcenter-shutdown

In order to fix this problem this PR removes this repository from the list.