### PR TITLE
backport 2.5: bbb-web: Adds mavenCentral as replacement for jcenter in repositories

### DIFF
--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
   repositories {
+    mavenCentral()
     mavenLocal()
     maven { url "https://repo1.maven.org/maven2" }
     maven { url "https://repo.grails.org/artifactory/core" }
@@ -43,6 +44,7 @@ task copyWebInf(type: Copy) {
 processResources.dependsOn copyWebInf
 
 repositories {
+  mavenCentral()
   mavenLocal()
   maven { url "https://repo1.maven.org/maven2" }
   maven { url "https://repo.grails.org/artifactory/core" }

--- a/bigbluebutton-web/pres-checker/build.gradle
+++ b/bigbluebutton-web/pres-checker/build.gradle
@@ -15,6 +15,7 @@ task resolveDeps(type: Copy) {
 }
 
 repositories {
+    mavenCentral()
     mavenLocal()
 }
 


### PR DESCRIPTION
Backport of #15940