### PR TITLE
Add External Videos To Smart Slides

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -10,6 +10,7 @@ import {
 } from '/imports/utils/slideCalcUtils';
 import Styled from './styles';
 import ZoomTool from './zoom-tool/component';
+import SmartMediaShareContainer from './smart-video-share/container';
 import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 import KEY_CODES from '/imports/utils/keyCodes';
 
@@ -106,7 +107,7 @@ class PresentationToolbar extends PureComponent {
     document.addEventListener('keydown', this.switchSlide);
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     const { zoom, setIsPanning, fitToWidth } = this.props;
     if (zoom <= HUNDRED_PERCENT && zoom !== prevProps.zoom && !fitToWidth) setIsPanning();
   }
@@ -239,7 +240,7 @@ class PresentationToolbar extends PureComponent {
       optionList.push(
         <option value={i} key={i}>
           {intl.formatMessage(intlMessages.goToSlide, { 0: i })}
-        </option>
+        </option>,
       );
     }
 
@@ -290,7 +291,7 @@ class PresentationToolbar extends PureComponent {
         id="presentationToolbarWrapper"
       >
         {this.renderAriaDescs()}
-        <div>
+        <div style={{ display: 'flex' }}>
           {isPollingEnabled ? (
             <Styled.QuickPollButton
               {...{
@@ -303,6 +304,8 @@ class PresentationToolbar extends PureComponent {
               }}
             />
           ) : null}
+
+          <SmartMediaShareContainer {...{ intl, currentSlide }} />
         </div>
         <Styled.PresentationSlideControls>
           <Styled.PrevSlideButton

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/smart-video-share/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/smart-video-share/component.jsx
@@ -30,6 +30,8 @@ export const SmartMediaShare = (props) => {
     }
   });
 
+  if (actions?.length === 0) return null;
+
   const customStyles = { top: '-1rem' };
 
   return (

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/smart-video-share/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/smart-video-share/component.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { defineMessages } from 'react-intl';
+import { safeMatch } from '/imports/utils/string-utils';
+import { isUrlValid, startWatching } from '/imports/ui/components/external-video-player/service';
+import BBBMenu from '/imports/ui/components/common/menu/component';
+import Styled from './styles';
+
+const intlMessages = defineMessages({
+  externalVideo: {
+    id: 'app.smartMediaShare.externalVideo',
+  },
+});
+
+export const SmartMediaShare = (props) => {
+  const {
+    currentSlide, intl, isMobile, isRTL,
+  } = props;
+  const linkPatt = /(https?:\/\/[^\s]+)/gm;
+  const externalLinks = safeMatch(linkPatt, currentSlide?.content, false);
+  if (!externalLinks) return null;
+
+  const actions = [];
+
+  externalLinks.forEach((lnk) => {
+    if (isUrlValid(lnk)) {
+      actions.push({
+        label: lnk,
+        onClick: () => startWatching(lnk),
+      });
+    }
+  });
+
+  const customStyles = { top: '-1rem' };
+
+  return (
+    <BBBMenu
+      customStyles={!isMobile ? customStyles : null}
+      trigger={(
+        <Styled.QuickVideoButton
+          role="button"
+          label={intl.formatMessage(intlMessages.externalVideo)}
+          color="light"
+          circle
+          icon="external-video"
+          size="md"
+          onClick={() => null}
+          hideLabel
+        />
+      )}
+      actions={actions}
+      opts={{
+        id: 'external-video-dropdown-menu',
+        keepMounted: true,
+        transitionDuration: 0,
+        elevation: 3,
+        getContentAnchorEl: null,
+        fullwidth: 'true',
+        anchorOrigin: { vertical: 'top', horizontal: isRTL ? 'right' : 'left' },
+        transformOrigin: { vertical: 'bottom', horizontal: isRTL ? 'right' : 'left' },
+      }}
+    />
+  );
+};
+
+export default SmartMediaShare;

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/smart-video-share/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/smart-video-share/container.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { withTracker } from 'meteor/react-meteor-data';
+import { SmartMediaShare } from './component';
+
+import { layoutSelect } from '/imports/ui/components/layout/context';
+import { isMobile } from '/imports/ui/components/layout/utils';
+
+const SmartMediaShareContainer = (props) => (
+  <SmartMediaShare {...{
+    ...props,
+  }}
+  />
+);
+
+export default withTracker(() => {
+  const isRTL = layoutSelect((i) => i.isRTL);
+  return {
+    isRTL,
+    isMobile: isMobile(),
+  };
+})(SmartMediaShareContainer);

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/smart-video-share/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/smart-video-share/styles.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+import Button from '/imports/ui/components/common/button/component';
+
+const QuickVideoButton = styled(Button)`
+  i {
+    font-size: 1rem;
+    padding-left: 20%;
+    right: 2px;
+
+    [dir="rtl"] & {
+      -webkit-transform: scale(-1, 1);
+      -moz-transform: scale(-1, 1);
+      -ms-transform: scale(-1, 1);
+      -o-transform: scale(-1, 1);
+      transform: scale(-1, 1);
+    }
+  }
+`;
+
+export default {
+  QuickVideoButton,
+};

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1062,6 +1062,7 @@
     "app.updateBreakoutRoom.title": "Update Breakout Rooms",
     "app.updateBreakoutRoom.confirm": "Apply",
     "app.updateBreakoutRoom.userChangeRoomNotification": "You were moved to room {0}.",
+    "app.smartMediaShare.externalVideo": "External video(s)",
     "app.update.resetRoom": "Reset user room",
     "app.externalVideo.start": "Share a new video",
     "app.externalVideo.title": "Share an external video",


### PR DESCRIPTION
### What does this PR do?
Adds a quick play dropdown menu on the presentation toolbar for available external video links in the slide content.
![26-smart-external-video](https://user-images.githubusercontent.com/22058534/199521534-201f7fb9-c965-417f-9e9e-cdec2d5afb27.gif)


### Closes Issue(s)
Closes #15928
