### PR TITLE
fix(whiteboard): take notification bar and banner bar into account when calculating cursor offset

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
@@ -153,6 +153,7 @@ export default function Cursors(props) {
     const sl = document.getElementById('layout')?.getAttribute('data-layout');
     const presentationContainer = document.querySelector('[data-test="presentationContainer"]');
     const presentation = document.getElementById('currentSlideText')?.parentElement;
+    const banners = document.querySelectorAll('[data-test="notificationBannerBar"]');
     let yOffset = 0;
     let xOffset = 0;
     const calcPresOffset = () => {
@@ -249,6 +250,12 @@ export default function Cursors(props) {
       if (presentationContainer && presentation) {
         calcPresOffset();
       }
+    }
+
+    if (banners) {
+      banners.forEach((el) => {
+        yOffset += parseFloat(window.getComputedStyle(el).height);
+      });
     }
 
     return setPos({ x: event.x - xOffset, y: event.y - yOffset });


### PR DESCRIPTION
Fixes cursor position when notification bar and banner bar are present.

#### Before

https://user-images.githubusercontent.com/62393923/199795087-c09b803d-dff9-47ba-bd83-47cff0401ae5.mp4

#### After

https://user-images.githubusercontent.com/62393923/199795068-c1a4f870-24f1-45a9-8f04-7be6cf613bf6.mp4
