### PR TITLE
Allow Poll Start From Smart Slides With Active Poll

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -8,6 +8,7 @@ import { PANELS, ACTIONS } from '../../layout/enums';
 
 const POLL_SETTINGS = Meteor.settings.public.poll;
 const MAX_CUSTOM_FIELDS = POLL_SETTINGS.maxCustom;
+const CANCELED_POLL_DELAY = 250;
 
 const intlMessages = defineMessages({
   quickPollLabel: {
@@ -54,6 +55,7 @@ const QuickPollDropdown = (props) => {
     intl,
     parseCurrentSlideContent,
     startPoll,
+    stopPoll,
     currentSlide,
     activePoll,
     className,
@@ -101,8 +103,13 @@ const QuickPollDropdown = (props) => {
             label={intl.formatMessage(intlMessages.typedRespLabel)}
             key={_.uniqueId('quick-poll-item')}
             onClick={() => {
-              handleClickQuickPoll(_layoutContextDispatch);
-              funcStartPoll(type, slideId, letterAnswers, pollData?.question);
+              if (activePoll) {
+                stopPoll();
+              }
+              setTimeout(() => {
+                handleClickQuickPoll(_layoutContextDispatch);
+                funcStartPoll(type, slideId, letterAnswers, pollData?.question);
+              }, CANCELED_POLL_DELAY);
             }}
             question={pollData?.question}
           />
@@ -142,8 +149,13 @@ const QuickPollDropdown = (props) => {
           label={itemLabel}
           key={_.uniqueId('quick-poll-item')}
           onClick={() => {
-            handleClickQuickPoll(_layoutContextDispatch);
-            funcStartPoll(type, slideId, letterAnswers, pollQuestion, pollData?.multiResp);
+            if (activePoll) {
+              stopPoll();
+            }
+            setTimeout(() => {
+              handleClickQuickPoll(_layoutContextDispatch);
+              funcStartPoll(type, slideId, letterAnswers, pollQuestion, pollData?.multiResp);
+            }, CANCELED_POLL_DELAY);
           }}
           answers={letterAnswers}
           multiResp={pollData?.multiResp}
@@ -191,21 +203,26 @@ const QuickPollDropdown = (props) => {
       label={quickPollLabel}
       tooltipLabel={intl.formatMessage(intlMessages.quickPollLabel)}
       onClick={() => {
-        handleClickQuickPoll(layoutContextDispatch);
-        if (singlePollType === 'R-' || singlePollType === 'TF') {
-          startPoll(singlePollType, currentSlide.id, answers, pollQuestion, multiResponse);
-        } else {
-          startPoll(
-            pollTypes.Custom,
-            currentSlide.id,
-            optionsWithLabels,
-            pollQuestion,
-            multiResponse,
-          );
+        if (activePoll) {
+            stopPoll();
         }
+
+        setTimeout(() => {
+          handleClickQuickPoll(layoutContextDispatch);
+          if (singlePollType === 'R-' || singlePollType === 'TF') {
+            startPoll(singlePollType, currentSlide.id, answers, pollQuestion, multiResponse);
+          } else {
+            startPoll(
+              pollTypes.Custom,
+              currentSlide.id,
+              optionsWithLabels,
+              pollQuestion,
+              multiResponse,
+            );
+          }
+        }, CANCELED_POLL_DELAY);
       }}
       size="lg"
-      disabled={!!activePoll}
       data-test="quickPollBtn"
     />
   );
@@ -221,7 +238,6 @@ const QuickPollDropdown = (props) => {
         tooltipLabel={intl.formatMessage(intlMessages.quickPollLabel)}
         onClick={() => null}
         size="lg"
-        disabled={!!activePoll}
       />
     );
 

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/container.jsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import { injectIntl } from 'react-intl';
+import { makeCall } from '/imports/ui/services/api';
+import PollService from '/imports/ui/components/poll/service';
 import QuickPollDropdown from './component';
 import { layoutDispatch } from '../../layout/context';
-import PollService from '/imports/ui/components/poll/service';
 
 const QuickPollDropdownContainer = (props) => {
   const layoutContextDispatch = layoutDispatch();
-
   return <QuickPollDropdown {...{ layoutContextDispatch, ...props }} />;
 };
 
 export default withTracker(() => ({
   activePoll: Session.get('pollInitiated') || false,
   pollTypes: PollService.pollTypes,
+  stopPoll: () => makeCall('stopPoll'),
 }))(injectIntl(QuickPollDropdownContainer));


### PR DESCRIPTION
### What does this PR do?
Removes the disabled flag for poll items in the smart slides. 

![26-sp-stop-start](https://user-images.githubusercontent.com/22058534/199804515-0b5a7690-5cd8-44dd-aa2b-025776220865.gif)

