### PR TITLE
fix: Previous slide button icon inverted in RTL

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.js
@@ -87,7 +87,7 @@ const PresentationSlideControls = styled.div`
 const PrevSlideButton = styled(Button)`
   border: none !important;
 
-  & > i {
+  i {
     font-size: 1rem;
 
     [dir="rtl"] & {


### PR DESCRIPTION
### What does this PR do?

Adjusts previous slide styles in RTL.

### Closes Issue(s)
Closes #15951