### PR TITLE
(fix:screenshare) fixes screenshare using BigBlueButton-Tablet app

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
@@ -16,7 +16,7 @@ import { SCREENSHARING_ERRORS } from '/imports/api/screenshare/client/bridge/err
 import Button from '/imports/ui/components/common/button/component';
 
 const { isMobile } = deviceInfo;
-const { isSafari, isMobileApp } = browserInfo;
+const { isSafari, isTabletApp } = browserInfo;
 
 const propTypes = {
   intl: PropTypes.objectOf(Object).isRequired,
@@ -163,7 +163,7 @@ const ScreenshareButton = ({
     ? intlMessages.stopDesktopShareDesc : intlMessages.desktopShareDesc;
 
   const shouldAllowScreensharing = enabled
-    && ( !isMobile || isMobileApp)
+    && ( !isMobile || isTabletApp)
     && amIPresenter;
 
   const dataTest = isVideoBroadcasting ? 'stopScreenShare' : 'startScreenShare';

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -131,8 +131,8 @@ const getVolume = () => KurentoBridge.getVolume();
 const shouldEnableVolumeControl = () => VOLUME_CONTROL_ENABLED && screenshareHasAudio();
 
 const attachLocalPreviewStream = (mediaElement) => {
-  const {isMobileApp} = browserInfo;
-  if (isMobileApp) {
+  const {isTabletApp} = browserInfo;
+  if (isTabletApp) {
     // We don't show preview for mobile app, as the stream is only available in native code
     return;
   }

--- a/bigbluebutton-html5/imports/ui/services/mobile-app/index.js
+++ b/bigbluebutton-html5/imports/ui/services/mobile-app/index.js
@@ -1,10 +1,13 @@
 import browserInfo from '/imports/utils/browserInfo';
 import logger from '/imports/startup/client/logger';
+import Auth from '/imports/ui/services/auth';
+import { fetchStunTurnServers } from '/imports/utils/fetchStunTurnServers';
+
 (function (){
     // This function must be executed during the import time, that's why it's not exported to the caller component.
     // It's needed because it changes some functions provided by browser, and these functions are verified during 
     // import time (like in ScreenshareBridgeService)
-    if(browserInfo.isMobileApp) {
+    if(browserInfo.isTabletApp) {
         logger.debug(`BBB-MOBILE - Mobile APP detected`);
 
         const WEBRTC_CALL_TYPE_FULL_AUDIO = 'full_audio';
@@ -30,9 +33,9 @@ import logger from '/imports/startup/client/logger';
             const stackTrace = e.stack;
             logger.info(`BBB-MOBILE - detectWebRtcCallType (evaluating)`, {caller, peerConnection, stackTrace: stackTrace.split('\n'), detectWebRtcCallTypeEvaluations: peerConnection.detectWebRtcCallTypeEvaluations, args});
             
-            // addTransceiver is the first call for screensharing and it has a startScreensharing in its stackTrace
+            // addEventListener is the first call for screensharing and it has a startScreensharing in its stackTrace
             if( peerConnection.detectWebRtcCallTypeEvaluations == 1) {
-                if(caller == 'addTransceiver' && stackTrace.indexOf('startScreensharing') !== -1) {
+                if(caller == 'addEventListener' && stackTrace.indexOf('startScreensharing') !== -1) {
                     peerConnection.webRtcCallType = WEBRTC_CALL_TYPE_SCREEN_SHARE; // this uses mobile app broadcast upload extension
                 } else if(caller == 'addEventListener' && stackTrace.indexOf('invite') !== -1) {
                     peerConnection.webRtcCallType = WEBRTC_CALL_TYPE_FULL_AUDIO; // this uses mobile app webRTC
@@ -131,7 +134,7 @@ import logger from '/imports/startup/client/logger';
         const prototype = window.RTCPeerConnection.prototype;
 
         prototype.originalCreateOffer = prototype.createOffer;
-        prototype.createOffer = function (options) {
+        prototype.createOffer = async function (options) {
             const webRtcCallType = detectWebRtcCallType('createOffer', this);
 
             if(webRtcCallType === WEBRTC_CALL_TYPE_STANDARD){
@@ -139,10 +142,12 @@ import logger from '/imports/startup/client/logger';
             }
             logger.info(`BBB-MOBILE - createOffer called`, {options});
 
+            const stunTurn = await fetchStunTurnServers(Auth._authToken);
+
             const createOfferMethod = (webRtcCallType === WEBRTC_CALL_TYPE_SCREEN_SHARE) ? 'createScreenShareOffer' : 'createFullAudioOffer';
 
-            return new Promise( (resolve, reject) => {
-                callNativeMethod(createOfferMethod).then ( sdp => {
+            return await new Promise( (resolve, reject) => {
+                callNativeMethod(createOfferMethod, [stunTurn]).then ( sdp => {
                     logger.info(`BBB-MOBILE - createOffer resolved`, {sdp});
 
                     // send offer to BBB code

--- a/bigbluebutton-html5/imports/utils/browserInfo.js
+++ b/bigbluebutton-html5/imports/utils/browserInfo.js
@@ -16,7 +16,7 @@ const isValidSafariVersion = Bowser.getParser(userAgent).satisfies({
   safari: '>12',
 });
 
-const isMobileApp =  !!(userAgent.match(/BBBMobile/i));
+const isTabletApp =  !!(userAgent.match(/BigBlueButton-Tablet/i));
 
 const browserInfo = {
   isChrome,
@@ -27,7 +27,7 @@ const browserInfo = {
   browserName,
   versionNumber,
   isValidSafariVersion,
-  isMobileApp
+  isTabletApp
 };
 
 export default browserInfo;


### PR DESCRIPTION
The screenshare was not working for version 2.6, mainly because of a change in the order of methods called, it broke the mechanism used to detect the type of call in the webRTC library shim.

This pull request also propagates the configuration of STUN/TURN servers, for situations in which the direct connection is not possible.

With this PR, the screenshare works just fine:
<img width="1319" alt="image" src="https://user-images.githubusercontent.com/2075267/200717523-a185c6b0-066e-4a04-a661-4a09a4dd1f56.png">


PS: to try it, please use the version in TestFlight: https://testflight.apple.com/join/7k0KWvF6
