### PR TITLE
Allow webcam focus if only two webcams exist

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
@@ -188,7 +188,7 @@ class VideoList extends Component {
     const gridGutter = parseInt(window.getComputedStyle(this.grid)
       .getPropertyValue('grid-row-gap'), 10);
 
-    const hasFocusedItem = streams.filter(s => s.stream === focusedId).length && numItems > 2;
+    const hasFocusedItem = streams.filter(s => s.stream === focusedId).length && numItems >= 2;
 
     // Has a focused item so we need +3 cells
     if (hasFocusedItem) {
@@ -201,7 +201,7 @@ class VideoList extends Component {
           ASPECT_RATIO, numItems, col,
         );
         // We need a minimun of 2 rows and columns for the focused
-        const focusedConstraint = hasFocusedItem ? testGrid.rows > 1 && testGrid.columns > 1 : true;
+        const focusedConstraint = hasFocusedItem ? testGrid.rows > 1 || testGrid.columns > 1 : true;
         const betterThanCurrent = testGrid.filledArea > currentGrid.filledArea;
         return focusedConstraint && betterThanCurrent ? testGrid : currentGrid;
       }, { filledArea: 0 });
@@ -302,7 +302,7 @@ class VideoList extends Component {
 
     return streams.map((vs) => {
       const { stream, userId, name } = vs;
-      const isFocused = focusedId === stream && numOfStreams > 2;
+      const isFocused = focusedId === stream && numOfStreams >= 2;
 
       return (
         <Styled.VideoListItem

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.jsx
@@ -92,7 +92,7 @@ const UserActions = (props) => {
       onClick: () => onHandleMirror(),
     });
 
-    if (numOfStreams > 2) {
+    if (numOfStreams >= 2) {
       menuItems.push({
         key: `${cameraId}-focus`,
         label: intl.formatMessage(intlMessages[`${isFocusedIntlKey}Label`]),


### PR DESCRIPTION
This patch allows users to focus a webcam even if only two webcams exist. The previous lower bound for this was three webcams.

This allows viewers to focus and therefor enlarge one webcam in situations were two moderators share their cameras but one is the interesting one you want to actually follow.

This fixes #15978

![Screenshot from 2022-11-10 14-40-01](https://user-images.githubusercontent.com/1008395/201109207-598fdf37-6211-401d-899c-753a37b82d83.png)

The user interface with only two webcams where one of them is focused.