### PR TITLE
adjust horizontal tooltip padding

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/tooltip/bbbtip.css
+++ b/bigbluebutton-html5/imports/ui/components/common/tooltip/bbbtip.css
@@ -1,7 +1,7 @@
 .tippy-tooltip.bbbtip-theme{
     color:#fff;
     background-color:#333333;
-    padding: .25rem;
+    padding: .25rem .5rem;
     border-radius: 4px;
 }
 

--- a/bigbluebutton-html5/imports/ui/components/common/tooltip/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/tooltip/component.jsx
@@ -83,7 +83,7 @@ class Tooltip extends Component {
 
   componentDidUpdate() {
     const { animations } = Settings.application;
-    const { title, fullscreen } = this.props;
+    const { title } = this.props;
     const elements = document.querySelectorAll('[id^="tippy-"]');
 
     Array.from(elements).filter((e) => {
@@ -107,7 +107,7 @@ class Tooltip extends Component {
     });
 
     const elem = document.getElementById(this.tippySelectorId);
-    const opts = { content: title, appendTo: fullscreen || document.body };
+    const opts = { content: title, appendTo: document.body };
     if (elem && elem._tippy) elem._tippy.setProps(opts);
   }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->
This increases the horizontal padding of all tooltips. 
Additionally, it also fixes an issue where the top padding of some tooltips decreases when using fullscreen mode (see examplary screenshots).

Fixed padding (non fullscreen):
<img width="211" alt="Bildschirmfoto 2022-11-10 um 15 31 42" src="https://user-images.githubusercontent.com/94838646/201118946-39d1fc7c-d77b-49d8-b7dd-e99fcfbe3a6c.png">
Weird padding (fullscreen):
<img width="211" alt="Bildschirmfoto 2022-11-10 um 15 32 00" src="https://user-images.githubusercontent.com/94838646/201119091-8f10dea7-d7cb-4995-95bf-830fe108897a.png">
Fixed padding (fullscreeen):
<img width="211" alt="Bildschirmfoto 2022-11-10 um 15 32 36" src="https://user-images.githubusercontent.com/94838646/201119234-30c7dc66-a91e-4c4e-88d3-1b33e78de3cc.png">




### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #15979


### Motivation

<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
