### PR TITLE
Improve 16x9 Support

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.jsx
@@ -358,7 +358,7 @@ class VideoList extends Component {
             }}
             style={{
               width: `${optimalGrid.width}px`,
-              height: `${optimalGrid.height}px`,
+              maxHeight: `${optimalGrid.height}px`,
               gridTemplateColumns: `repeat(${optimalGrid.columns}, 1fr)`,
               gridTemplateRows: `repeat(${optimalGrid.rows}, 1fr)`,
             }}


### PR DESCRIPTION
This is a very simple patch improving the support for 16x9 cameras.

In mixed mode – if 4x3 and 16x9 cameras are present – everything looks like it did before but if only 16x9 (or wider) cameras are present, BigBlueButton will drop the letter boxes and show a 16x9 video container.

This fixes #10912 without resulting in #11229

---

16:9 only

![Screenshot from 2022-11-10 17-28-04](https://user-images.githubusercontent.com/1008395/201156918-7603622a-15a3-4422-b2c9-8b1417baa01c.png)

---

16:9 and 4:3

![Screenshot from 2022-11-10 17-28-08](https://user-images.githubusercontent.com/1008395/201157108-8a62ece6-3947-45f6-b75e-a13fc98b384b.png)

---

And this time, it also works on mobile in portrait mode

![index](https://user-images.githubusercontent.com/1008395/201157247-16d09839-ce65-4c1e-a1a1-cada3a2be6bc.jpg)

