### PR TITLE
fix: bbb-conf --setip command does not follow symlinks

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -1665,7 +1665,7 @@ if [ -n "$HOST" ]; then
     fi
 
     echo -n "Assigning $HOST for playback of recordings: "
-    for metadata in $(find /var/bigbluebutton/published /var/bigbluebutton/unpublished -name metadata.xml); do
+    for metadata in $(find -L /var/bigbluebutton/published /var/bigbluebutton/unpublished -name metadata.xml); do
         echo -n "."
         # Ensure we update both types of URLs
         xmlstarlet edit --inplace --update '//link[starts-with(normalize-space(), "https://")]' --expr "concat(\"https://\", \"$HOST/\", substring-after(substring-after(., \"https://\"),\"/\"))" $metadata


### PR DESCRIPTION
The command `bbb-conf --setip` modify the recordings metadata updating the URL to the new host.
It is not being successful when the directory `/var/bigbluebutton/published` is a symlink to another disk.

This PR adds the param `-L` to the command `find` in order to make it follow symbolic links.

![image](https://user-images.githubusercontent.com/5660191/201245061-bc0f3cd5-9869-43e6-b5ef-0f5f0ce69cf5.png)
Source: https://man7.org/linux/man-pages/man1/find.1.html

Closes #15887