### PR TITLE
Enable Sorting On All Poll Grid Columns

### DIFF
--- a/bbb-learning-dashboard/src/components/PollsTable.jsx
+++ b/bbb-learning-dashboard/src/components/PollsTable.jsx
@@ -249,16 +249,18 @@ const PollsTable = (props) => {
       field: v?.pollId,
       headerName,
       flex: 1,
-      sortable: false,
     };
 
     anonGridCols.push({
       ...commonColProps,
+      sortable: false,
       renderCell: (params) => <GridCellExpand value={params?.value || ''} width={params?.colDef?.computedWidth} />,
     });
 
     gridCols.push({
       ...commonColProps,
+      sortable: true,
+      valueGetter: (params) => params?.row[params?.field]?.join(', '),
       renderCell: (params) => {
         // Here we count each poll vote in order to find out the most common answer.
         const pollVotesCount = Object.keys(polls || {}).reduce((prevPollVotesCount, pollId) => {


### PR DESCRIPTION
### What does this PR do?
Enables sorting for all poll columns in the data grid.

![26-ld-polls-table-sort](https://user-images.githubusercontent.com/22058534/201367617-5fbd5b05-c10f-449a-a6a2-09198688b1d7.gif)

