### PR TITLE
fix: getMeetings returns wrong number of participantCount

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -681,6 +681,15 @@ public class Meeting {
 		return this.users.size();
 	}
 
+	public int getNumUsersOnline(){
+		int countUsersOnline = 0;
+		for (User user : this.users.values()) {
+			if(!user.hasLeft()) countUsersOnline++;
+		}
+
+		return countUsersOnline;
+	}
+
     public int getNumModerators() {
         int sum = 0;
         for (Map.Entry<String, User> entry : users.entrySet()) {

--- a/bbb-common-web/src/test/resources/get-meeting-info.ftlx
+++ b/bbb-common-web/src/test/resources/get-meeting-info.ftlx
@@ -19,7 +19,7 @@
   <hasBeenForciblyEnded>${meeting.isForciblyEnded()?c}</hasBeenForciblyEnded>
   <startTime>${meeting.getStartTime()?c}</startTime>
   <endTime>${meeting.getEndTime()?c}</endTime>
-  <participantCount>${meeting.getNumUsers()}</participantCount>
+  <participantCount>${meeting.getNumUsersOnline()}</participantCount>
   <listenerCount>${meeting.getNumListenOnly()}</listenerCount>
   <voiceParticipantCount>${meeting.getNumVoiceJoined()}</voiceParticipantCount>
   <videoCount>${meeting.getNumVideos()}</videoCount>

--- a/bbb-common-web/src/test/resources/get-meetings.ftlx
+++ b/bbb-common-web/src/test/resources/get-meetings.ftlx
@@ -24,7 +24,7 @@
         <hasBeenForciblyEnded>${meeting.isForciblyEnded()?c}</hasBeenForciblyEnded>
         <startTime>${meeting.getStartTime()?c}</startTime>
         <endTime>${meeting.getEndTime()?c}</endTime>
-        <participantCount>${meeting.getNumUsers()}</participantCount>
+        <participantCount>${meeting.getNumUsersOnline()}</participantCount>
         <listenerCount>${meeting.getNumListenOnly()}</listenerCount>
         <voiceParticipantCount>${meeting.getNumVoiceJoined()}</voiceParticipantCount>
         <videoCount>${meeting.getNumVideos()}</videoCount>

--- a/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/get-meeting-info.ftlx
+++ b/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/get-meeting-info.ftlx
@@ -23,7 +23,7 @@
   <hasBeenForciblyEnded>${meeting.isForciblyEnded()?c}</hasBeenForciblyEnded>
   <startTime>${meeting.getStartTime()?c}</startTime>
   <endTime>${meeting.getEndTime()?c}</endTime>
-  <participantCount>${meeting.getNumUsers()?c}</participantCount>
+  <participantCount>${meeting.getNumUsersOnline()?c}</participantCount>
   <listenerCount>${meeting.getNumListenOnly()?c}</listenerCount>
   <voiceParticipantCount>${meeting.getNumVoiceJoined()?c}</voiceParticipantCount>
   <videoCount>${meeting.getNumVideos()?c}</videoCount>

--- a/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/get-meetings.ftlx
+++ b/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/get-meetings.ftlx
@@ -28,7 +28,7 @@
         <hasBeenForciblyEnded>${meeting.isForciblyEnded()?c}</hasBeenForciblyEnded>
         <startTime>${meeting.getStartTime()?c}</startTime>
         <endTime>${meeting.getEndTime()?c}</endTime>
-        <participantCount>${meeting.getNumUsers()}</participantCount>
+        <participantCount>${meeting.getNumUsersOnline()}</participantCount>
         <listenerCount>${meeting.getNumListenOnly()}</listenerCount>
         <voiceParticipantCount>${meeting.getNumVoiceJoined()}</voiceParticipantCount>
         <videoCount>${meeting.getNumVideos()}</videoCount>


### PR DESCRIPTION
When a user leave the meeting:
1.  It waits between 10 and 20 seconds to remove users from the UI Userlist (to prevent from removing users facing connection instability)
2. Once the user was removed from the Userlist, the API wait 1 more minute to remove the user from the memory (waiting for re-connection attempts)

And the API endpoints `getMeetingInfo` and ` getMeetings` considers all users that are in the memory to calc `participantCount`.
It cause a strong delay between the user leave the meeting the the API shows the correct `participantCount`.

https://user-images.githubusercontent.com/5660191/201402154-f3b5ea81-a3a6-41f7-b57d-8527d0a77a62.mp4

This PR removes the delay of the step 2. And count only users that are currently online. It will make the API `participantCount` be synced with the UI.

https://user-images.githubusercontent.com/5660191/201402284-1719eaff-172a-4163-ac5a-3bac2d4db1e9.mp4

Closes #13394