### PR TITLE
fix(presentation conversion): downscale large images

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageToSwfSlidesGenerationService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageToSwfSlidesGenerationService.java
@@ -127,6 +127,11 @@ public class ImageToSwfSlidesGenerationService {
 	
 	private void createSvgImages(UploadedPresentation pres, int page) throws TimeoutException{
 		log.debug("Creating SVG images.");
+		if (pres.getUploadedFile().length() > maxImageSize) {
+	        DecimalFormat percentFormat= new DecimalFormat("#.##%");
+			resizeImage(pres, percentFormat
+					.format(Double.valueOf(maxImageSize) / Double.valueOf(pres.getUploadedFile().length())));
+		}
 		notifier.sendCreatingSvgImagesUpdateMessage(pres);
 		svgImageCreator.createSvgImage(pres, page);
 	}


### PR DESCRIPTION
### What does this PR do?

Properly downscales large images when generating SVG images.

### Closes Issue(s)

Closes #15913