### PR TITLE
feat (learning-dashboard): Adds number of answers of each user to Poll Grid

### DIFF
--- a/bbb-learning-dashboard/src/components/PollsTable.jsx
+++ b/bbb-learning-dashboard/src/components/PollsTable.jsx
@@ -49,14 +49,14 @@ const PollsTable = (props) => {
 
   const commonUserProps = {
     field: 'User',
-    headerName: intl.formatMessage({ id: 'app.learningDashboard.pollsTable.userLabel', default: 'User' }),
+    headerName: intl.formatMessage({ id: 'app.learningDashboard.pollsTable.userLabel', defaultMessage: 'User' }),
     flex: 1,
     sortable: true,
   };
 
   const commonCountProps = {
     field: 'count',
-    headerName: intl.formatMessage({ id: 'app.learningDashboard.pollsTable.answerTotal', default: 'Total of answers' }),
+    headerName: intl.formatMessage({ id: 'app.learningDashboard.pollsTable.answerTotal', defaultMessage: 'Total of answers' }),
     flex: 1,
     sortable: true,
   };

--- a/bbb-learning-dashboard/src/components/PollsTable.jsx
+++ b/bbb-learning-dashboard/src/components/PollsTable.jsx
@@ -47,16 +47,23 @@ const PollsTable = (props) => {
     );
   }
 
-  const commonFieldProps = {
+  const commonUserProps = {
     field: 'User',
     headerName: 'User',
     flex: 1,
     sortable: true,
   };
 
+  const commonCountProps = {
+    field: 'count',
+    headerName: 'Counter',
+    width: 100,
+    sortable: true,
+  };
+
   const anonGridCols = [
     {
-      ...commonFieldProps,
+      ...commonUserProps,
       valueGetter: (params) => params?.row?.User?.name,
       renderCell: () => (
         <div className="flex items-center text-sm">
@@ -92,7 +99,7 @@ const PollsTable = (props) => {
 
   const gridCols = [
     {
-      ...commonFieldProps,
+      ...commonUserProps,
       valueGetter: (params) => params?.row?.User?.name,
       renderCell: (params) => (
         <>
@@ -104,6 +111,17 @@ const PollsTable = (props) => {
       ),
     },
   ];
+
+  anonGridCols.push({
+    ...commonCountProps,
+    renderCell: () => '',
+  });
+
+  gridCols.push({
+    ...commonCountProps,
+    valueGetter: (params) => Object.keys(params?.row?.User?.answers)?.length || 0,
+    renderCell: (params) => params?.value,
+  });
 
   const isOverflown = (element) => (
     element.scrollHeight > element.clientHeight

--- a/bbb-learning-dashboard/src/components/PollsTable.jsx
+++ b/bbb-learning-dashboard/src/components/PollsTable.jsx
@@ -57,7 +57,7 @@ const PollsTable = (props) => {
   const commonCountProps = {
     field: 'count',
     headerName: 'Counter',
-    width: 100,
+    flex: 1,
     sortable: true,
   };
 

--- a/bbb-learning-dashboard/src/components/PollsTable.jsx
+++ b/bbb-learning-dashboard/src/components/PollsTable.jsx
@@ -49,14 +49,14 @@ const PollsTable = (props) => {
 
   const commonUserProps = {
     field: 'User',
-    headerName: 'User',
+    headerName: intl.formatMessage({ id: 'app.learningDashboard.pollsTable.userLabel', default: 'User' }),
     flex: 1,
     sortable: true,
   };
 
   const commonCountProps = {
     field: 'count',
-    headerName: 'Counter',
+    headerName: intl.formatMessage({ id: 'app.learningDashboard.pollsTable.answerTotal', default: 'Total of answers' }),
     flex: 1,
     sortable: true,
   };

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -453,8 +453,18 @@ export default function Whiteboard(props) {
         .sort((a,b)=> a?.id>b?.id?-1:1)
         .forEach(n=> menu.appendChild(n));
     }
-
     app.setSetting('language', language);
+    app?.setSetting('isDarkMode', false);
+    app?.patchState(
+      {
+        appState: {
+          currentStyle: {
+            textAlign: isRTL ? "end" : "start",
+          },
+        },
+      }
+    );
+
     setTLDrawAPI(app);
     props.setTldrawAPI(app);
     // disable for non presenter that doesn't have multi user access

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1204,6 +1204,8 @@
     "app.learningDashboard.pollsTable.anonymousRowName": "Anonymous",
     "app.learningDashboard.pollsTable.noPollsCreatedHeading": "No polls have been created",
     "app.learningDashboard.pollsTable.noPollsCreatedMessage": "Once a poll has been sent to users, their results will appear in this list.",
+    "app.learningDashboard.pollsTable.answerTotal": "Total of answers",
+    "app.learningDashboard.pollsTable.userLabel": "User",
     "app.learningDashboard.statusTimelineTable.title": "Timeline",
     "app.learningDashboard.statusTimelineTable.thumbnail": "Presentation thumbnail",
     "app.learningDashboard.errors.invalidToken": "Invalid session token",


### PR DESCRIPTION
### What does this PR do?
* Add counter column to poll grid (displays the number of answers given by the corresponding user).

also:
* Set `Tldraw` theme to light on mount.
* Default to correct text justification on mount (no longer start at center - based on RTL direction).


