### PR TITLE
Restore Per Character Updates In Sticky Note

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -590,6 +590,16 @@ export default function Whiteboard(props) {
         persistShape(diff, whiteboardId);
       }
     }
+
+    if (reason && reason === 'patched_shapes') {
+      const patchedShape = e?.getShape(e?.getPageState()?.editingId);
+      const diff = {
+        id: patchedShape.id,
+        point: patchedShape.point,
+        text: patchedShape.text
+      }
+      persistShape(diff, whiteboardId);
+    }
   };
 
   const onUndo = (app) => {


### PR DESCRIPTION
### What does this PR do?
Restores per character updates in the sticky notes.
This fixes the text clearing in sticky notes while writing and new shapes are being added or updated.