### PR TITLE
Preserve Local Edited Shape State During Memo Updates

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -198,6 +198,10 @@ export default function Whiteboard(props) {
     let changed = false;
 
     if (next.pageStates[curPageId] && !_.isEqual(prevShapes, shapes)) {
+      const editingShape = tldrawAPI?.getShape(tldrawAPI?.getPageState()?.editingId);
+      if (editingShape) {
+        shapes[editingShape?.id] = editingShape;
+      }
       // set shapes as locked for those who aren't allowed to edit it
       Object.entries(shapes).forEach(([shapeId, shape]) => {
         if (!shape.isLocked && !hasShapeAccess(shapeId)) {


### PR DESCRIPTION
### What does this PR do?
Preserves the state of the local shape being edited during.  

### Motivation
fixes characters being reset while typing
![26-sn-typing-loss](https://user-images.githubusercontent.com/22058534/202083742-93f7950d-ada5-4083-b909-ae66fdecfa65.gif)
