### PR TITLE
fix: copy shortcut does not work on chat

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
@@ -309,6 +309,7 @@ class TimeWindowList extends PureComponent {
           data-test="chatMessages"
           aria-live="polite"
           ref={node => this.messageListWrapper = node}
+          onCopy={(e) => { e.stopPropagation(); }}
         >
           <AutoSizer disableWidth>
             {({ height }) => {


### PR DESCRIPTION
### What does this PR do?

Fixes issue with the copy shortcut not working in the chat area