### PR TITLE
Handle Whiteboard Crash When Typing Quickly

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -199,6 +199,7 @@ export default function Whiteboard(props) {
 
     if (next.pageStates[curPageId] && !_.isEqual(prevShapes, shapes)) {
       const editingShape = tldrawAPI?.getShape(tldrawAPI?.getPageState()?.editingId);
+
       if (editingShape) {
         shapes[editingShape?.id] = editingShape;
       }
@@ -607,12 +608,14 @@ export default function Whiteboard(props) {
 
     if (reason && reason === 'patched_shapes') {
       const patchedShape = e?.getShape(e?.getPageState()?.editingId);
-      const diff = {
-        id: patchedShape.id,
-        point: patchedShape.point,
-        text: patchedShape.text
+      if (patchedShape) {
+        const diff = {
+          id: patchedShape.id,
+          point: patchedShape.point,
+          text: patchedShape.text
+        }
+        persistShape(diff, whiteboardId);
       }
-      persistShape(diff, whiteboardId);
     }
   };
 


### PR DESCRIPTION
### What does this PR do?
Add check to see if patched shape exists before sending data to update.

This fixes a whiteboard crash when a user is typing quickly.
![image](https://user-images.githubusercontent.com/22058534/202216514-31311dae-5bde-4d1a-ad9d-d946d2fbf0ac.png)
