### PR TITLE
fix: text overflow in sidebar drop area

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/webcam/drop-areas/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/webcam/drop-areas/styles.js
@@ -31,6 +31,7 @@ const DropZoneBg = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
 `;
 
 export default {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fixes sidebar content webcam drop area text overflowing when sidebar content is closed.

**Before**
![2022-11-17_09-10](https://user-images.githubusercontent.com/62393923/202450775-fbc9aec3-76bb-4c02-8576-88b8122c2bdc.png)

**After**
![Screenshot from 2022-11-17 09-44-54](https://user-images.githubusercontent.com/62393923/202450940-02520df1-ab90-4948-9a5c-fe297f76303d.png)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
None