### PR TITLE
Fix client reconnection after meeting end

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -304,6 +304,7 @@ class Base extends Component {
   render() {
     const {
       meetingExist,
+      codeError,
     } = this.props;
     const { meetingExisted } = this.state;
 
@@ -311,7 +312,7 @@ class Base extends Component {
       <>
         {meetingExist && Auth.loggedIn && <DebugWindow />}
         {
-          (!meetingExisted && !meetingExist && Auth.loggedIn)
+          (!meetingExisted && !meetingExist && Auth.loggedIn && !codeError)
             ? <LoadingScreen />
             : this.renderByState()
         }

--- a/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
@@ -211,7 +211,8 @@ class JoinHandler extends Component {
       }, 'User successfully went through main.joinRouteHandler');
     } else {
       const e = new Error(response.message);
-      if (!Session.get('codeError')) Session.set('errorMessageDescription', response.message);
+      JoinHandler.setError('401');
+      Session.set('errorMessageDescription', response.message);
       logger.error({
         logCode: 'joinhandler_component_joinroutehandler_error',
         extraInfo: {


### PR DESCRIPTION
### What does this PR do?

This PR fixes the state where the client keeps looking normal after the meeting is already ended, It happens in the cases where the client is disconnected and the meeting is ended before client reconnection

### How to reproduce:
1. Join with two user in different devices at same meeting.
2. In one of the devices disconnects from internet.
3. Ih the another one finish the meeting.
4. Reconnects the internet.

### Motivation
Improve client reconnection.
