### PR TITLE
refactor: conditional hooks

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/captions/button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/captions/button/component.jsx
@@ -89,8 +89,6 @@ const CaptionsButton = ({
   isSupported,
   isVoiceUser,
 }) => {
-  if (!enabled) return null;
-
   const isTranscriptionDisabled = () => (
     currentSpeechLocale === DISABLED
   );
@@ -105,6 +103,8 @@ const CaptionsButton = ({
   useEffect(() => {
     if (!isTranscriptionDisabled()) selectedLocale.current = getSelectedLocaleValue;
   }, [currentSpeechLocale]);
+
+  if (!enabled) return null;
 
   const shouldRenderChevron = isSupported && isVoiceUser;
 

--- a/bigbluebutton-html5/imports/ui/components/audio/captions/select/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/captions/select/component.jsx
@@ -64,8 +64,6 @@ const Select = ({
   locale,
   voices,
 }) => {
-  if (!enabled) return null;
-
   if (voices.length === 0) {
     return (
       <div
@@ -79,7 +77,7 @@ const Select = ({
     );
   }
 
-  if (SpeechService.useFixedLocale()) return null;
+  if (!enabled || SpeechService.useFixedLocale()) return null;
 
   const onChange = (e) => {
     const { value } = e.target;


### PR DESCRIPTION
### What does this PR do?

Fix issues with conditional hooks reported by sonarcloud alerts.

### Motivation
_React Hooks must be called in the exact same order in every component render._

_From React documentation:_

_"Always use Hooks at the top level of your React function, before any early returns. By following this rule, you ensure that Hooks are called in the same order each time a component renders. That’s what allows React to correctly preserve the state of Hooks between multiple useState and useEffect calls."_

_React is relying on the order of the Hook calls to know which local state matches which Hook call. That is why it’s important that the Hooks are not called inside loops, conditions, or nested functions._

_Also this rule ensures that the Hooks are called only from React function components or custom Hooks so that the stateful logic of a component is clearly visible from its source code._