### PR TITLE
refactor: adjust guest policy component name

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/waiting-users/guest-policy/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/guest-policy/container.jsx
@@ -8,7 +8,7 @@ import { UsersContext } from '/imports/ui/components/components-data/users-conte
 
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 
-const guestPolicyContainer = (props) => {
+const GuestPolicyContainer = (props) => {
   const usingUsersContext = useContext(UsersContext);
   const { users } = usingUsersContext;
   const currentUser = users[Auth.meetingID][Auth.userID];
@@ -21,4 +21,4 @@ export default withModalMounter(withTracker(({ mountModal }) => ({
   closeModal: () => mountModal(null),
   guestPolicy: Service.getGuestPolicy(),
   changeGuestPolicy: Service.changeGuestPolicy,
-}))(guestPolicyContainer));
+}))(GuestPolicyContainer));


### PR DESCRIPTION
### What does this PR do?

Adjust guest policy container name (reported by sonarcloud alerts).

### Motivation
_React component names must start with an uppercase letter._