### PR TITLE
refactor: enforce max characters limit in chat input

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/message-form/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/message-form/component.jsx
@@ -115,14 +115,15 @@ class MessageForm extends PureComponent {
       maxMessageLength,
     } = this.props;
 
-    const message = e.target.value;
+    let message = e.target.value;
     let error = null;
 
     if (message.length > maxMessageLength) {
       error = intl.formatMessage(
         messages.errorMaxMessageLength,
-        { 0: message.length - maxMessageLength },
+        { 0: maxMessageLength },
       );
+      message = message.substring(0, maxMessageLength);
     }
 
     this.setState({

--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/component.jsx
@@ -227,8 +227,9 @@ class MessageForm extends PureComponent {
     if (message.length > maxMessageLength) {
       error = intl.formatMessage(
         messages.errorMaxMessageLength,
-        { 0: message.length - maxMessageLength },
+        { 0: maxMessageLength },
       );
+      message = message.substring(0, maxMessageLength);
     }
 
     this.setState({

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -2,7 +2,7 @@
     "app.home.greeting": "Your presentation will begin shortly ...",
     "app.chat.submitLabel": "Send message",
     "app.chat.loading": "Chat messages loaded: {0}%",
-    "app.chat.errorMaxMessageLength": "The message is {0} characters(s) too long",
+    "app.chat.errorMaxMessageLength": "The message is too long, exceeded the maximum of {0} characters",
     "app.chat.disconnected": "You are disconnected, messages can't be sent",
     "app.chat.locked": "Chat is locked, messages can't be sent",
     "app.chat.inputLabel": "Message input for chat {0}",


### PR DESCRIPTION
### What does this PR do?

Applies the following changes to chat input:
- changes the error message to _"The message is too long, exceeded the maximum of X characters"_ instead of counting and updating the message after every new character
- do not add any new character to the text input after _maxMessageLength_ is exceeded

### Closes Issue(s)
Closes #16049