### PR TITLE
refactor: Improve error message on meeting or session invalid

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/constraint/MeetingExistsConstraint.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/constraint/MeetingExistsConstraint.java
@@ -16,7 +16,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 public @interface MeetingExistsConstraint {
 
-    String key() default "notFound";
+    String key() default "meetingNotFound";
     String message() default "A meeting with that ID does not exist";
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/constraint/UserSessionConstraint.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/constraint/UserSessionConstraint.java
@@ -16,7 +16,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 public @interface UserSessionConstraint {
 
-    String key() default "missingSession";
+    String key() default "sessionMissing";
     String message() default "Invalid session token";
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};

--- a/bigbluebutton-html5/imports/ui/components/error-screen/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/error-screen/component.jsx
@@ -37,6 +37,9 @@ const intlMessages = defineMessages({
   400: {
     id: 'app.error.400',
   },
+  meeting_ended: {
+    id: 'app.meeting.endedMessage',
+  },
   user_logged_out_reason: {
     id: 'app.error.userLoggedOut',
   },
@@ -57,6 +60,9 @@ const intlMessages = defineMessages({
   },
   max_participants_reason: {
     id: 'app.meeting.logout.maxParticipantsReached',
+  },
+  guest_deny: {
+    id: 'app.guest.guestDeny',
   },
   duplicate_user_in_meeting_eject_reason: {
     id: 'app.meeting.logout.duplicateUserEjectReason',

--- a/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
@@ -210,14 +210,26 @@ class JoinHandler extends Component {
         },
       }, 'User successfully went through main.joinRouteHandler');
     } else {
-      const e = new Error(response.message);
-      JoinHandler.setError('401');
-      Session.set('errorMessageDescription', response.message);
+
+      if(['sessionMissing','meetingForciblyEnded','meetingNotFound'].includes(response.messageKey)) {
+        JoinHandler.setError('410');
+        Session.set('errorMessageDescription', 'meeting_ended');
+      } else if(response.messageKey == "guestDeny") {
+        JoinHandler.setError('401');
+        Session.set('errorMessageDescription', 'guest_deny');
+      } else if(response.messageKey == "maxParticipantsReached") {
+        JoinHandler.setError('401');
+        Session.set('errorMessageDescription', 'max_participants_reason');
+      } else {
+        JoinHandler.setError('401');
+        Session.set('errorMessageDescription', response.message);
+      }
+
       logger.error({
         logCode: 'joinhandler_component_joinroutehandler_error',
         extraInfo: {
           response,
-          error: e,
+          error: new Error(response.message),
         },
       }, 'User faced an error on main.joinRouteHandler.');
     }


### PR DESCRIPTION
This PR introduces a new prop `messageKey` to the return of API `/enter` requests. It will allow the client (html5) handle the error messages and show the properly error.
```
{
    "response": {
        "returncode": "FAILED",
        "message": "Invalid session token",
        "messageKey": "sessionMissing",
        "logoutURL": "https://bbb26.bbbvm.imdt.com.br"
    }
}
```
### Before
Since #12693 the API was always returning `guestDeny` error even when the meeting doesn't exist.
And once the client-html5 doesn't know the correct error it use to show a generic error for example when returning from disconnection:
![image](https://user-images.githubusercontent.com/5660191/203806092-e7818f8e-d25a-48f5-9674-f1ab36ac09c0.png)

https://user-images.githubusercontent.com/5660191/203804536-ffe0e3e7-4674-4a1a-b552-56e049e814b9.mp4

### After
This PR will follow an order to check if error exists and return to the client something more meaningful.
Using the same example as above now it shows the error "Meeting has ended" which is much more useful.
![image](https://user-images.githubusercontent.com/5660191/203806010-7eefc5f8-e9c4-4e75-b12a-4155df3197ba.png)

https://user-images.githubusercontent.com/5660191/203804889-2838db77-5dff-4508-85f9-94cf219daf92.mp4

Possibly closes: #16036 and #16037
It can still be improved in the API version 2. The current one doesn't know the error because once the meeting is ended, the API removes all informations about that including the users sessions. So it is impossible to know if the problem is related with the sessionToken or if the meeting ended.