### PR TITLE
fix: adjust confirmation modal label

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/modal/confirmation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/modal/confirmation/component.jsx
@@ -6,7 +6,7 @@ import Styled from './styles';
 
 const messages = defineMessages({
   yesLabel: {
-    id: 'app.endMeeting.yesLabel',
+    id: 'app.confirmationModal.yesLabel',
     description: 'confirm button label',
   },
   noLabel: {
@@ -46,6 +46,7 @@ class ConfirmationModal extends Component {
       titleMessageExtra,
       checkboxMessageId,
       confirmButtonColor,
+      confirmButtonLabel,
       confirmButtonDataTest,
       confirmParam,
       disableConfirmButton,
@@ -86,7 +87,7 @@ class ConfirmationModal extends Component {
           <Styled.Footer>
             <Styled.ConfirmationButton
               color={confirmButtonColor}
-              label={intl.formatMessage(messages.yesLabel)}
+              label={confirmButtonLabel ? confirmButtonLabel : intl.formatMessage(messages.yesLabel)}
               disabled={disableConfirmButton}
               data-test={confirmButtonDataTest}
               onClick={() => {

--- a/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/component.jsx
@@ -20,6 +20,10 @@ const intlMessages = defineMessages({
     id: 'app.endMeeting.contentWarning',
     description: 'end meeting content warning',
   },
+  confirmButtonLabel: {
+    id: 'app.endMeeting.yesLabel',
+    description: 'end meeting confirm button label',
+  },
 });
 
 const { warnAboutUnsavedContentOnMeetingEnd } = Meteor.settings.public.app;
@@ -58,6 +62,7 @@ class EndMeetingComponent extends PureComponent {
         description={description}
         confirmButtonColor="danger"
         confirmButtonDataTest="confirmEndMeeting"
+        confirmButtonLabel={intl.formatMessage(intlMessages.confirmButtonLabel)}
       />
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
@@ -117,7 +117,7 @@ const messages = defineMessages({
     description: 'Directory lookup',
   },
   yesLabel: {
-    id: 'app.endMeeting.yesLabel',
+    id: 'app.confirmationModal.yesLabel',
     description: 'confirm button label',
   },
   noLabel: {

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -79,6 +79,7 @@
     "app.confirmation.skipConfirm": "Don't ask again",
     "app.confirmation.virtualBackground.title": "Start new virtual background",
     "app.confirmation.virtualBackground.description": "{0} will be added as virtual background. Continue?",
+    "app.confirmationModal.yesLabel": "Yes",
     "app.textInput.sendLabel": "Send",
     "app.title.defaultViewLabel": "Default presentation view",
     "app.notes.title": "Shared Notes",


### PR DESCRIPTION
### What does this PR do?

Adjusts confirmation modal to allow setting a custom label for the confirmation button.

### Motivation
The `app.endMeeting.yesLabel` was changed recently, and it affected other confirmation buttons that were using the same message string.