### PR TITLE
fix: add delay for shared note true unmount

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -559,7 +559,14 @@ class App extends Component {
               ? <ExternalVideoContainer isLayoutSwapped={!presentationIsOpen} isPresenter={isPresenter} />
               : null
           }
-          {shouldShowSharedNotes ? <NotesContainer area="media" layoutType={selectedLayout} /> : null}
+          {shouldShowSharedNotes 
+            ? (
+              <NotesContainer
+                isToSharedNotesBeShow={shouldShowSharedNotes}
+                area="media"
+                layoutType={selectedLayout}
+              />
+            ) : null}
           {this.renderCaptions()}
           <AudioCaptionsSpeechContainer />
           {this.renderAudioCaptions()}

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -562,7 +562,6 @@ class App extends Component {
           {shouldShowSharedNotes 
             ? (
               <NotesContainer
-                isToSharedNotesBeShow={shouldShowSharedNotes}
                 area="media"
                 layoutType={selectedLayout}
               />

--- a/bigbluebutton-html5/imports/ui/components/notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.jsx
@@ -74,10 +74,12 @@ const Notes = ({
 
   const isHidden = (isOnMediaArea && (style.width === 0 || style.height === 0))
                    || (!isToSharedNotesBeShow
-                    && sidebarContentToIgnoreDelay.includes(sidebarContent.sidebarContentPanel))
+                    && !sidebarContentToIgnoreDelay.includes(sidebarContent.sidebarContentPanel))
                     || shouldShowSharedNotesOnPresentationArea;
 
-  if (isHidden) style.padding = 0;
+  if (isHidden) {
+    style.padding = 0;
+  }
   useEffect(() => {
     if (isToSharedNotesBeShow) {
       setShouldRenderNotes(true);
@@ -148,7 +150,7 @@ const Notes = ({
     ) : null;
   };
 
-  return shouldRenderNotes && (
+  return (shouldRenderNotes || shouldShowSharedNotesOnPresentationArea) && (
     <Styled.Notes data-test="notes" isChrome={isChrome} style={style}>
       {!isOnMediaArea ? (
         <Header

--- a/bigbluebutton-html5/imports/ui/components/notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.jsx
@@ -61,6 +61,7 @@ const Notes = ({
   sharedNotesOutput,
   amIPresenter,
   isToSharedNotesBeShow,
+  shouldShowSharedNotesOnPresentationArea,
 }) => {
   useEffect(() => () => Service.setLastRev(), []);
   const [shouldRenderNotes, setShouldRenderNotes] = useState(false);
@@ -73,7 +74,8 @@ const Notes = ({
 
   const isHidden = (isOnMediaArea && (style.width === 0 || style.height === 0))
                    || (!isToSharedNotesBeShow
-                    && sidebarContentToIgnoreDelay.includes(sidebarContent));
+                    && sidebarContentToIgnoreDelay.includes(sidebarContent.sidebarContentPanel))
+                    || shouldShowSharedNotesOnPresentationArea;
 
   if (isHidden) style.padding = 0;
   useEffect(() => {
@@ -83,9 +85,11 @@ const Notes = ({
     } else {
       timoutRef = setTimeout(() => {
         setShouldRenderNotes(false);
-      }, sidebarContentToIgnoreDelay.includes(sidebarContent) ? 0 : DELAY_UNMOUNT_SHARED_NOTES);
+      }, (sidebarContentToIgnoreDelay.includes(sidebarContent.sidebarContentPanel)
+      || shouldShowSharedNotesOnPresentationArea)
+        ? 0 : DELAY_UNMOUNT_SHARED_NOTES);
     }
-  }, [isToSharedNotesBeShow, sidebarContent]);
+  }, [isToSharedNotesBeShow, sidebarContent.sidebarContentPanel]);
   useEffect(() => {
     if (
       isOnMediaArea

--- a/bigbluebutton-html5/imports/ui/components/notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.jsx
@@ -48,7 +48,7 @@ const defaultProps = {
 };
 
 let timoutRef = null;
-
+const sidebarContentToIgnoreDelay = ['captions'];
 const Notes = ({
   hasPermission,
   intl,
@@ -72,7 +72,8 @@ const Notes = ({
   } : {};
 
   const isHidden = (isOnMediaArea && (style.width === 0 || style.height === 0))
-                   || !isToSharedNotesBeShow;
+                   || (!isToSharedNotesBeShow
+                    && sidebarContentToIgnoreDelay.includes(sidebarContent));
 
   if (isHidden) style.padding = 0;
   useEffect(() => {
@@ -82,9 +83,9 @@ const Notes = ({
     } else {
       timoutRef = setTimeout(() => {
         setShouldRenderNotes(false);
-      }, DELAY_UNMOUNT_SHARED_NOTES);
+      }, sidebarContentToIgnoreDelay.includes(sidebarContent) ? 0 : DELAY_UNMOUNT_SHARED_NOTES);
     }
-  }, [isToSharedNotesBeShow]);
+  }, [isToSharedNotesBeShow, sidebarContent]);
   useEffect(() => {
     if (
       isOnMediaArea

--- a/bigbluebutton-html5/imports/ui/components/notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.jsx
@@ -13,7 +13,6 @@ import NotesDropdown from '/imports/ui/components/notes/notes-dropdown/container
 const CHAT_CONFIG = Meteor.settings.public.chat;
 const PUBLIC_CHAT_ID = CHAT_CONFIG.public_id;
 const DELAY_UNMOUNT_SHARED_NOTES = Meteor.settings.public.app.delayForUnmountOfSharedNote;
-console.log(DELAY_UNMOUNT_SHARED_NOTES);
 const intlMessages = defineMessages({
   hide: {
     id: 'app.notes.hide',
@@ -71,11 +70,11 @@ const Notes = ({
     position: 'absolute',
     ...sharedNotesOutput,
   } : {};
+
   const isHidden = (isOnMediaArea && (style.width === 0 || style.height === 0))
                    || !isToSharedNotesBeShow;
 
   if (isHidden) style.padding = 0;
-  console.log();
   useEffect(() => {
     if (isToSharedNotesBeShow) {
       setShouldRenderNotes(true);

--- a/bigbluebutton-html5/imports/ui/components/notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
 import injectWbResizeEvent from '/imports/ui/components/presentation/resize-wrapper/component';
@@ -12,7 +12,8 @@ import NotesDropdown from '/imports/ui/components/notes/notes-dropdown/container
 
 const CHAT_CONFIG = Meteor.settings.public.chat;
 const PUBLIC_CHAT_ID = CHAT_CONFIG.public_id;
-
+const DELAY_UNMOUNT_SHARED_NOTES = Meteor.settings.public.app.delayForUnmountOfSharedNote;
+console.log(DELAY_UNMOUNT_SHARED_NOTES);
 const intlMessages = defineMessages({
   hide: {
     id: 'app.notes.hide',
@@ -47,6 +48,8 @@ const defaultProps = {
   layoutType: null,
 };
 
+let timoutRef = null;
+
 const Notes = ({
   hasPermission,
   intl,
@@ -58,18 +61,31 @@ const Notes = ({
   sidebarContent,
   sharedNotesOutput,
   amIPresenter,
+  isToSharedNotesBeShow,
 }) => {
   useEffect(() => () => Service.setLastRev(), []);
+  const [shouldRenderNotes, setShouldRenderNotes] = useState(false);
   const { isChrome } = browserInfo;
   const isOnMediaArea = area === 'media';
   const style = isOnMediaArea ? {
     position: 'absolute',
     ...sharedNotesOutput,
   } : {};
-  const isHidden = isOnMediaArea && (style.width === 0 || style.height === 0);
+  const isHidden = (isOnMediaArea && (style.width === 0 || style.height === 0))
+                   || !isToSharedNotesBeShow;
 
   if (isHidden) style.padding = 0;
-
+  console.log();
+  useEffect(() => {
+    if (isToSharedNotesBeShow) {
+      setShouldRenderNotes(true);
+      clearTimeout(timoutRef);
+    } else {
+      timoutRef = setTimeout(() => {
+        setShouldRenderNotes(false);
+      }, DELAY_UNMOUNT_SHARED_NOTES);
+    }
+  }, [isToSharedNotesBeShow]);
   useEffect(() => {
     if (
       isOnMediaArea
@@ -128,7 +144,7 @@ const Notes = ({
     ) : null;
   };
 
-  return (
+  return shouldRenderNotes && (
     <Styled.Notes data-test="notes" isChrome={isChrome} style={style}>
       {!isOnMediaArea ? (
         <Header

--- a/bigbluebutton-html5/imports/ui/components/notes/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/container.jsx
@@ -3,6 +3,7 @@ import { withTracker } from 'meteor/react-meteor-data';
 import Notes from './component';
 import Service from './service';
 import Auth from '/imports/ui/services/auth';
+import MediaService from '/imports/ui/components/media/service';
 import { layoutSelectInput, layoutDispatch, layoutSelectOutput } from '../layout/context';
 import { UsersContext } from '../components-data/users-context/context';
 
@@ -29,9 +30,10 @@ const Container = ({ ...props }) => {
 export default withTracker(() => {
   const hasPermission = Service.hasPermission();
   const isRTL = document.documentElement.getAttribute('dir') === 'rtl';
-
+  const shouldShowSharedNotesOnPresentationArea = MediaService.shouldShowSharedNotes();
   return {
     hasPermission,
     isRTL,
+    shouldShowSharedNotesOnPresentationArea,
   };
 })(Container);

--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
@@ -137,7 +137,10 @@ const SidebarContent = (props) => {
         <ChatContainer width={width} />
       </ErrorBoundary>
       )}
-      <NotesContainer isToSharedNotesBeShow={sidebarContentPanel === PANELS.SHARED_NOTES} />
+      <NotesContainer
+        sidebarContent={sidebarContentPanel}
+        isToSharedNotesBeShow={sidebarContentPanel === PANELS.SHARED_NOTES}
+      />
       {sidebarContentPanel === PANELS.CAPTIONS && <CaptionsContainer />}
       {sidebarContentPanel === PANELS.BREAKOUT && <BreakoutRoomContainer />}
       {sidebarContentPanel === PANELS.WAITING_USERS && <WaitingUsersPanel />}

--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
@@ -134,10 +134,10 @@ const SidebarContent = (props) => {
       <ErrorBoundary
         Fallback={FallbackView}
       >
-        <ChatContainer width={width}/>
+        <ChatContainer width={width} />
       </ErrorBoundary>
       )}
-      {sidebarContentPanel === PANELS.SHARED_NOTES && <NotesContainer />}
+      <NotesContainer isToSharedNotesBeShow={sidebarContentPanel === PANELS.SHARED_NOTES} />
       {sidebarContentPanel === PANELS.CAPTIONS && <CaptionsContainer />}
       {sidebarContentPanel === PANELS.BREAKOUT && <BreakoutRoomContainer />}
       {sidebarContentPanel === PANELS.WAITING_USERS && <WaitingUsersPanel />}

--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
@@ -138,7 +138,6 @@ const SidebarContent = (props) => {
       </ErrorBoundary>
       )}
       <NotesContainer
-        sidebarContent={sidebarContentPanel}
         isToSharedNotesBeShow={sidebarContentPanel === PANELS.SHARED_NOTES}
       />
       {sidebarContentPanel === PANELS.CAPTIONS && <CaptionsContainer />}

--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/container.jsx
@@ -13,8 +13,6 @@ const SidebarContentContainer = () => {
   const { users } = usingUsersContext;
   const amIPresenter = users[Auth.meetingID][Auth.userID].presenter;
 
-  if (sidebarContentOutput.display === false) return null;
-
   return (
     <SidebarContent
       {...sidebarContentOutput}

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -33,6 +33,7 @@ public:
     copyright: '©2023 BigBlueButton Inc.'
     html5ClientBuild: HTML5_CLIENT_VERSION
     helpLink: https://bigbluebutton.org/html5/
+    delayForUnmountOfSharedNote: 120000
     bbbTabletApp:
       enabled: false
       iosAppStoreUrl: 'https://apps.apple.com/us/app/bigbluebutton-tablet/id1641156756'


### PR DESCRIPTION
### What does this PR do?

Add a delay to truely unmount the shared notes, when the shared notes is unmounted the connection with the etherpad is closed ans takes a few second to reconnect, delaying it we hold the connection when the user is navigating through other panels (chat, poll and etc)

### Motivation

Remove the speed bump though the navigation to another panels.

### More
2.6

https://user-images.githubusercontent.com/15806883/204860716-4289a01c-4cc8-48d0-9530-9958892a16db.mp4

PR:

https://user-images.githubusercontent.com/15806883/204860813-ac7e12ff-8780-4eec-926b-221ec0ed3db0.mp4



