### PR TITLE
(feature) Send message from back end

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChatHdlrs.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChatHdlrs.scala
@@ -9,7 +9,8 @@ class GroupChatHdlrs(implicit val context: ActorContext)
   with GetGroupChatMsgsReqMsgHdlr
   with GetGroupChatsReqMsgHdlr
   with SendGroupChatMessageMsgHdlr
-  with SyncGetGroupChatsInfoMsgHdlr {
+  with SyncGetGroupChatsInfoMsgHdlr
+  with SendGroupChatMessageMsgFromApiHdlr {
 
   val log = Logging(context.system, getClass)
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgFromApiHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgFromApiHdlr.scala
@@ -1,0 +1,37 @@
+package org.bigbluebutton.core.apps.groupchats
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.bus.MessageBus
+import org.bigbluebutton.core.domain.MeetingState2x
+import org.bigbluebutton.core.models.{ Roles, Users2x }
+import org.bigbluebutton.core.running.{ HandlerHelpers, LiveMeeting }
+import org.bigbluebutton.core2.MeetingStatus2x
+
+trait SendGroupChatMessageMsgFromApiHdlr extends HandlerHelpers {
+  this: GroupChatHdlrs =>
+
+  def handle(msg: SendMessageToChatFromApiSysPubMsg, state: MeetingState2x,
+             liveMeeting: LiveMeeting, bus: MessageBus): MeetingState2x = {
+
+    val groupChat = state.groupChats.findDefaultChat();
+    if (groupChat.nonEmpty) {
+      val chatFound = groupChat.apply(0);
+      val systemUser = GroupChatUser(chatFound.createdBy.id, msg.body.userName, "MODERATOR");
+
+      val message = GroupChatMsgFromUser(systemUser.id, systemUser, true, msg.body.message);
+      val gcm = GroupChatApp.toGroupChatMessage(systemUser, message);
+      val gcs = GroupChatApp.addGroupChatMessage(chatFound, state.groupChats, gcm);
+
+      val event = buildGroupChatMessageBroadcastEvtMsg(
+        liveMeeting.props.meetingProp.intId,
+        systemUser.id, chatFound.id, gcm
+      );
+
+      bus.outGW.send(event)
+      state.update(gcs)
+    }
+    state
+  }
+
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/GroupChats.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/GroupChats.scala
@@ -14,6 +14,8 @@ object GroupChatFactory {
 
 case class GroupChats(chats: collection.immutable.Map[String, GroupChat]) {
   def find(id: String): Option[GroupChat] = chats.get(id)
+  def findDefaultChat(): Vector[GroupChat] = chats.values.toVector filter (c => c.access == GroupChatAccess.PUBLIC &&
+    c.createdBy.id == "SYSTEM")
   def add(chat: GroupChat): GroupChats = copy(chats = chats + (chat.id -> chat))
   def remove(id: String): GroupChats = copy(chats = chats - id)
   def update(chat: GroupChat): GroupChats = add(chat)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -394,6 +394,8 @@ class ReceivedJsonMsgHandlerActor(
         routeGenericMsg[GetGroupChatMsgsReqMsg](envelope, jsonNode)
       case CreateGroupChatReqMsg.NAME =>
         routeGenericMsg[CreateGroupChatReqMsg](envelope, jsonNode)
+      case SendMessageToChatFromApiSysPubMsg.NAME =>
+        routeGenericMsg[SendMessageToChatFromApiSysPubMsg](envelope, jsonNode)
 
       // ExternalVideo
       case StartExternalVideoPubMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -578,7 +578,8 @@ class MeetingActor(
       case m: SendGroupChatMessageMsg =>
         state = groupChatApp.handle(m, state, liveMeeting, msgBus)
         updateUserLastActivity(m.body.msg.sender.id)
-
+      case m: SendMessageToChatFromApiSysPubMsg =>
+        groupChatApp.handle(m, state, liveMeeting, msgBus)
       // Webcams
       case m: UserBroadcastCamStartMsg            => webcamApp2x.handle(m, liveMeeting, msgBus)
       case m: UserBroadcastCamStopMsg             => webcamApp2x.handle(m, liveMeeting, msgBus)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
@@ -7,6 +7,18 @@ object GroupChatAccess {
 
 case class GroupChatUser(id: String, name: String = "", role: String = "VIEWER")
 case class GroupChatMsgFromUser(correlationId: String, sender: GroupChatUser, chatEmphasizedText: Boolean = false, message: String)
+object SendMessageToChatFromApiSysPubMsg { val NAME = "SendMessageToChatFromApiSysPubMsg" }
+
+case class SendMessageToChatFromApiSysPubMsg(
+    header: BbbClientMsgHeader,
+    body:   SendMessageToChatFromApiSysPubMsgBody
+) extends StandardMsg
+case class SendMessageToChatFromApiSysPubMsgBody(
+                                  userName: String,
+                                  message: String,
+                                  meetingId: String,
+                                )
+
 case class GroupChatMsgToUser(id: String, timestamp: Long, correlationId: String, sender: GroupChatUser, chatEmphasizedText: Boolean = false, message: String)
 case class GroupChatInfo(id: String, access: String, createdBy: GroupChatUser, users: Vector[GroupChatUser])
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/request/SendMessage.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/request/SendMessage.java
@@ -1,0 +1,50 @@
+package org.bigbluebutton.api.model.request;
+
+import org.bigbluebutton.api.model.constraint.MeetingIDConstraint;
+import org.bigbluebutton.api.model.shared.Checksum;
+
+import java.util.Map;
+
+public class SendMessage extends RequestWithChecksum<InsertDocument.Params> {
+
+    public enum Params implements RequestParameters {
+        MEETING_ID("meetingID");
+
+        private final String value;
+
+        Params(String value) { this.value = value; }
+
+        public String getValue() { return value; }
+    }
+
+    @MeetingIDConstraint
+    private String meetingID;
+
+    private String message;
+
+    public SendMessage(Checksum checksum) {
+        super(checksum);
+    }
+
+    public String getMeetingID() {
+        return meetingID;
+    }
+
+    public void setMeetingID(String meetingID) {
+        this.meetingID = meetingID;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+
+    @Override
+    public void populateFromParamsMap(Map<String, String[]> params) {
+        if(params.containsKey(SendMessage.Params.MEETING_ID.getValue())) setMeetingID(params.get(SendMessage.Params.MEETING_ID.getValue())[0]);
+    }
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/ValidationService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/ValidationService.java
@@ -41,7 +41,8 @@ public class ValidationService {
         SIGN_OUT("signOut", RequestType.GET),
         LEARNING_DASHBOARD("learningDashboard", RequestType.GET),
         GET_JOIN_URL("getJoinUrl", RequestType.GET),
-        INSERT_DOCUMENT("insertDocument", RequestType.GET);
+        INSERT_DOCUMENT("insertDocument", RequestType.GET),
+        SEND_MESSAGE("sendMessage", RequestType.GET);
 
         private final String name;
         private final RequestType requestType;
@@ -122,6 +123,9 @@ public class ValidationService {
                         break;
                     case INSERT_DOCUMENT:
                         request = new InsertDocument(checksum);
+                        break;
+                    case SEND_MESSAGE:
+                        request = new SendMessage(checksum);
                         break;
                     case GUEST_WAIT:
                         request = new GuestWait();

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ResponseBuilder.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ResponseBuilder.java
@@ -231,6 +231,19 @@ public class ResponseBuilder {
         return xmlText.toString();
     }
 
+    public String buildSendMessageResponse(String message, String returnCode) {
+
+        StringWriter xmlText = new StringWriter();
+
+        Map<String, Object> data = new HashMap<String, Object>();
+        data.put("returnCode", returnCode);
+        data.put("message", message);
+
+        processData(getTemplate("insert-document.ftlx"), data, xmlText);
+
+        return xmlText.toString();
+    }
+
     private Template getTemplate(String templateName) {
         Template ftl = null;
         try {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
@@ -11,6 +11,7 @@ import org.bigbluebutton.api.messaging.converters.messages.EndMeetingMessage;
 import org.bigbluebutton.api.messaging.converters.messages.PublishedRecordingMessage;
 import org.bigbluebutton.api.messaging.converters.messages.UnpublishedRecordingMessage;
 import org.bigbluebutton.api.messaging.converters.messages.DeletedRecordingMessage;
+import org.bigbluebutton.chat.messages.ISendToChatMsg;
 import org.bigbluebutton.presentation.messages.IDocConversionMsg;
 
 public interface IBbbWebApiGWApp {
@@ -58,4 +59,5 @@ public interface IBbbWebApiGWApp {
   void unpublishedRecording(UnpublishedRecordingMessage msg);
   void deletedRecording(DeletedRecordingMessage msg);
   void sendDocConversionMsg(IDocConversionMsg msg);
+  void sendMessageInChatFromApiMsg(ISendToChatMsg msg);
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/chat/messages/ISendToChatMsg.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/chat/messages/ISendToChatMsg.java
@@ -1,0 +1,4 @@
+package org.bigbluebutton.chat.messages;
+
+public interface ISendToChatMsg {
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/chat/messages/SendMessageToChatFromAPI.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/chat/messages/SendMessageToChatFromAPI.java
@@ -1,0 +1,13 @@
+package org.bigbluebutton.chat.messages;
+
+public class SendMessageToChatFromAPI implements ISendToChatMsg{
+    public String meetingId;
+    public String name;
+    public String message;
+    public SendMessageToChatFromAPI(String meetingId, String name,
+                                    String message){
+        this.meetingId = meetingId;
+        this.name = name;
+        this.message = message;
+    }
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/web/services/MessageInGroupChat.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/web/services/MessageInGroupChat.java
@@ -1,0 +1,25 @@
+package org.bigbluebutton.web.services;
+
+import org.bigbluebutton.api2.IBbbWebApiGWApp;
+import org.bigbluebutton.chat.messages.SendMessageToChatFromAPI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MessageInGroupChat {
+    private static Logger log = LoggerFactory.getLogger(MessageInGroupChat.class);
+
+    private IBbbWebApiGWApp gw;
+
+    public void sendMessageInChatFromApi(String meetingId, String name,
+                                         String message) {
+        SendMessageToChatFromAPI messageInChatFromApi = new SendMessageToChatFromAPI(
+                meetingId, name, message
+        );
+        log.debug("message ====------- {} ", gw);
+        gw.sendMessageInChatFromApiMsg(messageInChatFromApi);
+    }
+
+    public void setGw(IBbbWebApiGWApp gw) {
+        this.gw = gw;
+    }
+}

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -3,12 +3,13 @@ package org.bigbluebutton.api2
 import scala.collection.JavaConverters._
 import akka.actor.ActorSystem
 import akka.event.Logging
-import org.bigbluebutton.api.domain.{ BreakoutRoomsParams, Group, LockSettingsParams }
+import org.bigbluebutton.api.domain.{BreakoutRoomsParams, Group, LockSettingsParams}
 import org.bigbluebutton.api.messaging.converters.messages._
 import org.bigbluebutton.api2.bus._
 import org.bigbluebutton.api2.endpoint.redis.WebRedisSubscriberActor
 import org.bigbluebutton.common2.redis.MessageSender
-import org.bigbluebutton.api2.meeting.{ OldMeetingMsgHdlrActor, RegisterUser }
+import org.bigbluebutton.api2.meeting.{OldMeetingMsgHdlrActor, RegisterUser}
+import org.bigbluebutton.chat.messages.{ISendToChatMsg, SendMessageToChatFromAPI}
 import org.bigbluebutton.common2.domain._
 import org.bigbluebutton.common2.util.JsonUtil
 import org.bigbluebutton.presentation.messages._
@@ -348,6 +349,13 @@ class BbbWebApiGWApp(
       msgToAkkaAppsEventBus.publish(MsgToAkkaApps(toAkkaAppsChannel, event))
     } else if (msg.isInstanceOf[DocInvalidMimeType]) {
       val event = MsgBuilder.buildPresentationHasInvalidMimeType(msg.asInstanceOf[DocInvalidMimeType])
+      msgToAkkaAppsEventBus.publish(MsgToAkkaApps(toAkkaAppsChannel, event))
+    }
+  }
+
+  def sendMessageInChatFromApiMsg(msg: ISendToChatMsg): Unit ={
+    if (msg.isInstanceOf[SendMessageToChatFromAPI]){
+      val event = MsgBuilder.buildSendMessageToChatFromApi(msg.asInstanceOf[SendMessageToChatFromAPI])
       msgToAkkaAppsEventBus.publish(MsgToAkkaApps(toAkkaAppsChannel, event))
     }
   }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -2,6 +2,7 @@ package org.bigbluebutton.api2
 
 import org.bigbluebutton.api.messaging.converters.messages._
 import org.bigbluebutton.api2.meeting.RegisterUser
+import org.bigbluebutton.chat.messages.SendMessageToChatFromAPI
 import org.bigbluebutton.common2.domain.{ DefaultProps, PageVO, PresentationPageConvertedVO, PresentationVO }
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.presentation.messages._
@@ -295,6 +296,18 @@ object MsgBuilder {
       messageKey = msg.messageKey, fileMime = msg.fileMime, fileExtension = msg.fileExtension)
 
     val req = PresentationHasInvalidMimeTypeErrorSysPubMsg(header, body)
+    BbbCommonEnvCoreMsg(envelope, req)
+  }
+  def buildSendMessageToChatFromApi(msg: SendMessageToChatFromAPI): BbbCommonEnvCoreMsg = {
+    val routing = collection.immutable.HashMap("sender" -> "bbb-web")
+    val envelope = BbbCoreEnvelope(SendMessageToChatFromApiSysPubMsg.NAME, routing)
+    val header = BbbClientMsgHeader(SendMessageToChatFromApiSysPubMsg.NAME, msg.meetingId, "not-used")
+
+    val body = SendMessageToChatFromApiSysPubMsgBody(
+      userName = msg.name, message = msg.message, meetingId = msg.meetingId
+    )
+
+    val req = SendMessageToChatFromApiSysPubMsg(header, body)
     BbbCommonEnvCoreMsg(envelope, req)
   }
 

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -113,6 +113,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="learningDashboardFilesDir" value="${learningDashboardFilesDir}"/>
     </bean>
 
+    <bean id="messageInGroupChat" class="org.bigbluebutton.web.services.MessageInGroupChat">
+        <property name="gw" ref="bbbWebApiGWApp"/>
+    </bean>
+
     <bean id="html5LoadBalancingService" class="org.bigbluebutton.api.HTML5LoadBalancingService" init-method="init" />
 
     <bean id="configServiceHelper" class="org.bigbluebutton.api.ClientConfigServiceHelperImp"/>

--- a/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/send-message.ftlx
+++ b/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/send-message.ftlx
@@ -1,0 +1,8 @@
+<#ftl output_format="XML" auto_esc=true>
+<#compress>
+<response>
+  <#-- Where code is a 'SUCCESS' or 'FAILED' String -->
+  <returncode>${returnCode}</returncode>
+  <message>${message}</message>
+</response>
+</#compress>


### PR DESCRIPTION
### What does this PR do?

With this feature it is possible to send a message from the API via an endpoint, as it is pictured afterwards:


https://user-images.githubusercontent.com/69865537/205012596-e2338c94-182d-4748-be7a-e67c4c6848c7.mp4



### More

After merged, this feature must be added to the documentation.

To test this out it is necessary to run akka, common-message, common-web and bbb-web from the code.

One can use the following script:

```bash
#!/bin/bash
set -e

# Memorized variables
meetingID="<Name-of-the-meeting-you-want-to-send-the-message-to>"
sharedSecret="<shared-secret>"

BASE_URL="https://<your-host>/bigbluebutton/api"

SEND_MESSAGE="sendMessage"
query_arguments="meetingID=$meetingID&message=<message-you-want>&name=<name-you-want-to-appear-in-the-message>"

checksum=$( printf "$SEND_MESSAGE$query_arguments$sharedSecret" | sha1sum | sed 's/  -//g' )

endpoint_complete="$SEND_MESSAGE?$query_arguments&checksum=$checksum"

URL="$BASE_URL/$endpoint_complete"
echo antes $URL
curl -s -X GET "$URL" --header "Content-Type: application/xml" 

``` 

One can play around with the parameters. Despite, bare in mind that the message and meetingID are mandatory to be sent, but name is not.

Parameters available:
```
name;
message;
meetingID (externalMeetingID);
```