### PR TITLE
feat: compact sidebar navigation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
@@ -557,14 +557,15 @@ class BreakoutRoom extends PureComponent {
     return (
       <Styled.Panel ref={(n) => this.panel = n}>
         <Header
-          leftButtonProps={{
+          title={intl.formatMessage(intlMessages.breakoutTitle)}
+          rightButtonProps={{
             'aria-label': intl.formatMessage(intlMessages.breakoutAriaTitle),
             label: intl.formatMessage(intlMessages.breakoutTitle),
             onClick: () => {
               this.closePanel();
             },
           }}
-          customRightButton={amIModerator && (
+          customLeftButton={amIModerator && (
             <BreakoutDropdown
               openBreakoutTimeManager={this.showSetTimeForm}
               endAllBreakouts={() => {

--- a/bigbluebutton-html5/imports/ui/components/captions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/component.jsx
@@ -73,7 +73,8 @@ const Captions = ({
   return (
     <Styled.Captions isChrome={isChrome}>
       <Header
-        leftButtonProps={{
+        title={name}
+        rightButtonProps={{
           onClick: () => {
             layoutContextDispatch({
               type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
@@ -87,7 +88,7 @@ const Captions = ({
           'aria-label': intl.formatMessage(intlMessages.hide),
           label: name,
         }}
-        customRightButton={Service.amICaptionsOwner(ownerId) ? (
+        customLeftButton={Service.amICaptionsOwner(ownerId) ? (
           <span>
             <Button
               onClick={dictating

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-dropdown/component.jsx
@@ -141,6 +141,7 @@ class ChatDropdown extends PureComponent {
               label={intl.formatMessage(intlMessages.options)}
               aria-label={intl.formatMessage(intlMessages.options)}
               onClick={() => null}
+              hideLabel
             />                    
           }
           opts={{

--- a/bigbluebutton-html5/imports/ui/components/chat/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/component.jsx
@@ -70,11 +70,11 @@ const Chat = (props) => {
     >
       <Header
         data-test="chatTitle"
-        leftButtonProps={{
+        title={title}
+        rightButtonProps={{
           accessKey: chatID !== 'public' ? HIDE_CHAT_AK : null,
           'aria-label': intl.formatMessage(intlMessages.hideChatLabel, { 0: title }),
           'data-test': isPublicChat ? 'hidePublicChat' : 'hidePrivateChat',
-          label: title,
           onClick: () => {
             layoutContextDispatch({
               type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
@@ -90,7 +90,7 @@ const Chat = (props) => {
             });
           },
         }}
-        rightButtonProps={{
+        leftButtonProps={{
           accessKey: CLOSE_CHAT_AK,
           'aria-label': intl.formatMessage(intlMessages.closeChatLabel, { 0: title }),
           'data-test': "closePrivateChat",
@@ -112,7 +112,7 @@ const Chat = (props) => {
             });
           },
         }}
-        customRightButton={isPublicChat && (
+        customLeftButton={isPublicChat && (
           <ChatDropdownContainer {...{
             meetingIsBreakout, isMeteorConnected, amIModerator, timeWindowsValues,
           }}

--- a/bigbluebutton-html5/imports/ui/components/common/control-header/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/control-header/component.jsx
@@ -7,28 +7,30 @@ import Right from './right/component';
 const Header = ({
   leftButtonProps,
   rightButtonProps,
-  customRightButton,
+  customLeftButton,
   'data-test': dataTest,
+  title,
   ...rest
 }) => {
   const renderCloseButton = () => (
-    <Right {...rightButtonProps} />
+    <Left {...leftButtonProps} />
   );
 
-  const renderCustomRightButton = () => (
-    <Styled.RightWrapper>
-      {customRightButton}
-    </Styled.RightWrapper>
+  const renderCustomLeftButton = () => (
+    <Styled.LeftWrapper>
+      {customLeftButton}
+    </Styled.LeftWrapper>
   );
 
   return (
     <Styled.Header data-test={dataTest ? dataTest : ''} {...rest}>
-      {leftButtonProps ? <Left {...leftButtonProps} /> : <div />}
-      {customRightButton
-        ? renderCustomRightButton()
-        : rightButtonProps
+      { customLeftButton
+        ? renderCustomLeftButton()
+        : leftButtonProps
           ? renderCloseButton()
-          : null}
+          : <div />}
+      { title ? <Styled.Title>{title}</Styled.Title> : null}
+      { rightButtonProps ? <Right {...rightButtonProps} /> : null}
     </Styled.Header>
   );
 }
@@ -36,7 +38,7 @@ const Header = ({
 Header.propTypes = {
   leftButtonProps: PropTypes.object,
   rightButtonProps: PropTypes.object,
-  customRightButton: PropTypes.element,
+  customLeftButton: PropTypes.element,
   dataTest: PropTypes.string,
 };
 

--- a/bigbluebutton-html5/imports/ui/components/common/control-header/left/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/control-header/left/component.jsx
@@ -9,10 +9,11 @@ class Left extends Component {
 
   render() {
     return (
-      <Styled.HideButton
-        className="buttonWrapper"
-        icon="left_arrow"
-        tabIndex={0}
+      <Styled.CloseButton
+        size="md"
+        color="light"
+        hideLabel
+        circle
         {...this.props}
       />
     );
@@ -23,6 +24,7 @@ Left.propTypes = {
   accessKey: PropTypes.any,
   'aria-label': PropTypes.string,
   'data-test': PropTypes.string,
+  icon: PropTypes.string,
   label: PropTypes.string,
   onClick: PropTypes.func,
 };

--- a/bigbluebutton-html5/imports/ui/components/common/control-header/left/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/control-header/left/styles.js
@@ -2,30 +2,17 @@ import styled from 'styled-components';
 import Button from '/imports/ui/components/common/button/component';
 import { fontSizeBase } from '/imports/ui/stylesheets/styled-components/typography';
 
-const HideButton = styled(Button)`
-  padding: 0;
-  margin: 0;
-  line-height: normal;
-  display: flex;
-  align-items: center;
-  min-width: 0;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+const CloseButton = styled(Button)`
+  span:first-of-type {
+    padding: 0;
+    margin: 0;
 
-  & > i,
-  & > i::before {
-    width: auto;
-    font-size: ${fontSizeBase} !important;
-
-    [dir="rtl"] & {
-      -webkit-transform: scale(-1, 1);
-      -moz-transform: scale(-1, 1);
-      -ms-transform: scale(-1, 1);
-      -o-transform: scale(-1, 1);
-      transform: scale(-1, 1);
+    & > i,
+    & > i::before {
+      width: auto;
+      font-size: ${fontSizeBase};
     }
   }
 `;
 
-export default { HideButton };
+export default { CloseButton };

--- a/bigbluebutton-html5/imports/ui/components/common/control-header/right/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/control-header/right/component.jsx
@@ -9,11 +9,11 @@ class Right extends Component {
 
   render() {
     return (
-      <Styled.CloseButton
-        size="md"
-        color="light"
+      <Styled.HideButton
+        className="buttonWrapper"
+        icon="left_arrow"
+        tabIndex={0}
         hideLabel
-        circle
         {...this.props}
       />
     );
@@ -24,7 +24,6 @@ Right.propTypes = {
   accessKey: PropTypes.any,
   'aria-label': PropTypes.string,
   'data-test': PropTypes.string,
-  icon: PropTypes.string,
   label: PropTypes.string,
   onClick: PropTypes.func,
 };

--- a/bigbluebutton-html5/imports/ui/components/common/control-header/right/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/control-header/right/styles.js
@@ -2,17 +2,30 @@ import styled from 'styled-components';
 import Button from '/imports/ui/components/common/button/component';
 import { fontSizeBase } from '/imports/ui/stylesheets/styled-components/typography';
 
-const CloseButton = styled(Button)`
-  span:first-of-type {
-    padding: 0;
-    margin: 0;
+const HideButton = styled(Button)`
+  padding: 0;
+  margin: 0;
+  line-height: normal;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
-    & > i,
-    & > i::before {
-      width: auto;
-      font-size: ${fontSizeBase};
+  & > i,
+  & > i::before {
+    width: auto;
+    font-size: ${fontSizeBase} !important;
+
+    [dir="rtl"] & {
+      -webkit-transform: scale(-1, 1);
+      -moz-transform: scale(-1, 1);
+      -ms-transform: scale(-1, 1);
+      -o-transform: scale(-1, 1);
+      transform: scale(-1, 1);
     }
   }
 `;
 
-export default { CloseButton };
+export default { HideButton };

--- a/bigbluebutton-html5/imports/ui/components/common/control-header/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/control-header/styles.js
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 import { jumboPaddingY } from '/imports/ui/stylesheets/styled-components/general';
+import { fontSizeBase, headingsFontWeight} from '/imports/ui/stylesheets/styled-components/typography';
+import { colorGray } from '/imports/ui/stylesheets/styled-components/palette';
 
 const Header = styled.header`
   display: flex;
@@ -8,7 +10,14 @@ const Header = styled.header`
   padding-bottom: ${jumboPaddingY};
 `;
 
-const RightWrapper = styled.div`
+const Title = styled.h1`
+  font-size: ${fontSizeBase};
+  color: ${colorGray};
+  font-weight: ${headingsFontWeight};
+  margin: 0;
+`;
+
+const LeftWrapper = styled.div`
   & > div {
     display: flex;
   }
@@ -16,5 +25,6 @@ const RightWrapper = styled.div`
 
 export default {
   Header,
-  RightWrapper,
+  Title,
+  LeftWrapper,
 };

--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -300,6 +300,22 @@ const reducer = (state, action) => {
         },
       };
     }
+    case ACTIONS.SET_SIDEBAR_NAVIGATION_IS_COMPACT: {
+      const { sidebarNavigation } = state.input;
+      if (sidebarNavigation.isCompact === action.value) {
+        return state;
+      }
+      return {
+        ...state,
+        input: {
+          ...state.input,
+          sidebarNavigation: {
+            ...sidebarNavigation,
+            isCompact: action.value,
+          },
+        },
+      };
+    }
     case ACTIONS.SET_SIDEBAR_NAVIGATION_PANEL: {
       const { sidebarNavigation } = state.input;
       if (sidebarNavigation.sidebarNavPanel === action.value) {

--- a/bigbluebutton-html5/imports/ui/components/layout/enums.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/enums.js
@@ -49,6 +49,7 @@ export const ACTIONS = {
   SET_ACTIONBAR_OUTPUT: 'setActionBarOutput',
 
   SET_SIDEBAR_NAVIGATION_IS_OPEN: 'setSidebarNavigationIsOpen',
+  SET_SIDEBAR_NAVIGATION_IS_COMPACT: 'setSidebarNavigationIsCompact',
   SET_SIDEBAR_NAVIGATION_SIZE: 'setSidebarNavigationSize',
   SET_SIDEBAR_NAVIGATION_OUTPUT: 'setSidebarNavigationOutput',
   SET_SIDEBAR_NAVIGATION_IS_RESIZABLE: 'setSidebarNavigationIsResizable',

--- a/bigbluebutton-html5/imports/ui/components/layout/initState.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/initState.js
@@ -25,6 +25,7 @@ export const INITIAL_INPUT_STATE = {
   },
   sidebarNavigation: {
     isOpen: true,
+    isCompact: false,
     width: 0,
     height: 0,
     browserWidth: 0,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -558,7 +558,7 @@ const CustomLayout = (props) => {
         left: sidebarNavBounds.left,
         right: sidebarNavBounds.right,
         tabOrder: DEFAULT_VALUES.sidebarNavTabOrder,
-        isResizable: !isMobile && !isTablet,
+        isResizable: !isMobile && !isTablet && !sidebarNavigationInput.isCompact,
         zIndex: sidebarNavBounds.zIndex,
       },
     });

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
@@ -136,7 +136,7 @@ const LayoutEngine = ({ layoutType }) => {
       sidebarNavMaxWidth,
     } = DEFAULT_VALUES;
 
-    const { isOpen, width: sidebarNavWidth } = sidebarNavigationInput;
+    const { isOpen, isCompact, width: sidebarNavWidth } = sidebarNavigationInput;
 
     let minWidth = 0;
     let width = 0;
@@ -147,13 +147,19 @@ const LayoutEngine = ({ layoutType }) => {
         width = windowWidth();
         maxWidth = windowWidth();
       } else {
-        if (sidebarNavWidth === 0) {
-          width = min(max((windowWidth() * 0.2), sidebarNavMinWidth), sidebarNavMaxWidth);
-        } else {
-          width = min(max(sidebarNavWidth, sidebarNavMinWidth), sidebarNavMaxWidth);
+        if ( isCompact ) {
+          minWidth = sidebarNavMinWidth;
+          width = sidebarNavMinWidth;
+          maxWidth = sidebarNavMinWidth;
+        }else{
+          if (sidebarNavWidth === 0) {
+            width = min(max((windowWidth() * 0.2), sidebarNavMinWidth), sidebarNavMaxWidth);
+          } else {
+            width = min(max(sidebarNavWidth, sidebarNavMinWidth), sidebarNavMaxWidth);
+          }
+          minWidth = sidebarNavMinWidth;
+          maxWidth = sidebarNavMaxWidth;
         }
-        minWidth = sidebarNavMinWidth;
-        maxWidth = sidebarNavMaxWidth;
       }
     }
     return {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -353,7 +353,7 @@ const PresentationFocusLayout = (props) => {
         left: sidebarNavBounds.left,
         right: sidebarNavBounds.right,
         tabOrder: DEFAULT_VALUES.sidebarNavTabOrder,
-        isResizable: !isMobile && !isTablet,
+        isResizable: !isMobile && !isTablet && !sidebarNavigationInput.isCompact,
         zIndex: sidebarNavBounds.zIndex,
       },
     });

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -421,7 +421,7 @@ const SmartLayout = (props) => {
         left: sidebarNavBounds.left,
         right: sidebarNavBounds.right,
         tabOrder: DEFAULT_VALUES.sidebarNavTabOrder,
-        isResizable: !isMobile && !isTablet,
+        isResizable: !isMobile && !isTablet && !sidebarNavigationInput.isCompact,
         zIndex: sidebarNavBounds.zIndex,
       },
     });

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -365,7 +365,7 @@ const VideoFocusLayout = (props) => {
         left: sidebarNavBounds.left,
         right: sidebarNavBounds.right,
         tabOrder: DEFAULT_VALUES.sidebarNavTabOrder,
-        isResizable: !isMobile && !isTablet,
+        isResizable: !isMobile && !isTablet && !sidebarNavigationInput.isCompact,
         zIndex: sidebarNavBounds.zIndex,
       },
     });

--- a/bigbluebutton-html5/imports/ui/components/notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.jsx
@@ -132,7 +132,8 @@ const Notes = ({
     <Styled.Notes data-test="notes" isChrome={isChrome} style={style}>
       {!isOnMediaArea ? (
         <Header
-          leftButtonProps={{
+          title={intl.formatMessage(intlMessages.title)}
+          rightButtonProps={{
             onClick: () => {
               layoutContextDispatch({
                 type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
@@ -147,7 +148,7 @@ const Notes = ({
             'aria-label': intl.formatMessage(intlMessages.hide),
             label: intl.formatMessage(intlMessages.title),
           }}
-          customRightButton={
+          customLeftButton={
             <NotesDropdown />
           }
         />

--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -984,7 +984,8 @@ class Poll extends Component {
     return (
       <div>
         <Header
-          leftButtonProps={{
+          title={intl.formatMessage(intlMessages.pollPaneTitle)}
+          rightButtonProps={{
             'aria-label': intl.formatMessage(intlMessages.hidePollDesc),
             'data-test': "hidePollDesc",
             label: intl.formatMessage(intlMessages.pollPaneTitle),
@@ -1000,7 +1001,7 @@ class Poll extends Component {
             },
             ref: (node) => { this.hideBtn = node; },
           }}
-          rightButtonProps={{
+          leftButtonProps={{
             'aria-label': `${intl.formatMessage(intlMessages.closeLabel)} ${intl.formatMessage(intlMessages.pollPaneTitle)}`,
             'data-test': "closePolling",
             icon: "close",

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.jsx
@@ -16,6 +16,7 @@ const propTypes = {
   isResizable: PropTypes.bool.isRequired,
   resizableEdge: PropTypes.objectOf(PropTypes.bool).isRequired,
   contextDispatch: PropTypes.func.isRequired,
+  isCompact: PropTypes.bool.isRequired,
 };
 
 const defaultProps = {
@@ -36,6 +37,7 @@ const SidebarNavigation = (props) => {
     isResizable,
     resizableEdge,
     contextDispatch,
+    isCompact,
   } = props;
 
   const [resizableWidth, setResizableWidth] = useState(width);
@@ -103,7 +105,7 @@ const SidebarNavigation = (props) => {
         height,
       }}
     >
-      <UserListContainer />
+      <UserListContainer compact={isCompact}/>
     </Resizable>
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/container.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { layoutDispatch, layoutSelectOutput } from '../layout/context';
+import { layoutDispatch, layoutSelectInput, layoutSelectOutput } from '../layout/context';
 import SidebarNavigation from './component';
 
 const SidebarNavigationContainer = () => {
   const sidebarNavigation = layoutSelectOutput((i) => i.sidebarNavigation);
+  const sidebarNavigationInput = layoutSelectInput((i) => i.sidebarNavigation);
+  const { isCompact } = sidebarNavigationInput;
   const layoutContextDispatch = layoutDispatch();
 
   if (sidebarNavigation.display === false) return null;
@@ -11,6 +13,7 @@ const SidebarNavigationContainer = () => {
   return (
     <SidebarNavigation
       {...sidebarNavigation}
+      isCompact={isCompact}
       contextDispatch={layoutContextDispatch}
     />
   );

--- a/bigbluebutton-html5/imports/ui/components/user-list/captions-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/captions-list-item/component.jsx
@@ -30,6 +30,7 @@ const CaptionsListItem = (props) => {
     tabIndex,
     sidebarContentPanel,
     layoutContextDispatch,
+    compact,
   } = props;
 
   const handleClickToggleCaptions = () => {
@@ -68,9 +69,10 @@ const CaptionsListItem = (props) => {
       onClick={handleClickToggleCaptions}
       aria-label={`${name} ${intl.formatMessage(intlMessages.captionLabel)}`}
       onKeyPress={() => {}}
+      compact={compact}
     >
       <Icon iconName="closed_caption" />
-      <span aria-hidden>{name}</span>
+      {!compact ? <span aria-hidden>{name}</span> : null}
     </Styled.ListItem>
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
@@ -184,7 +184,7 @@ const ChatListItem = (props) => {
         </Styled.ChatName>
         {(stateUreadCount > 0)
           ? (
-            <Styled.UnreadMessages aria-label={arialabel}>
+            <Styled.UnreadMessages aria-label={arialabel} compact={compact}>
               <Styled.UnreadMessagesText aria-hidden="true">
                 {stateUreadCount}
               </Styled.UnreadMessagesText>

--- a/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
@@ -152,6 +152,7 @@ const ChatListItem = (props) => {
       id="chat-toggle-button"
       aria-label={isPublicChat(chat) ? intl.formatMessage(intlMessages.titlePublic) : chat.name}
       onKeyPress={() => {}}
+      $compact={compact}
     >
       <Styled.ChatListItemLink>
         <Styled.ChatIcon>

--- a/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
@@ -154,7 +154,7 @@ const ChatListItem = (props) => {
       id="chat-toggle-button"
       aria-label={isPublicChat(chat) ? intl.formatMessage(intlMessages.titlePublic) : chat.name}
       onKeyPress={() => {}}
-      $compact={compact}
+      compact={compact}
     >
       <Styled.ChatListItemLink>
         <Styled.ChatIcon>

--- a/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
@@ -7,6 +7,7 @@ import Styled from './styles';
 import UserAvatar from '/imports/ui/components/user-avatar/component';
 import { ACTIONS, PANELS } from '../../layout/enums';
 import Icon from '/imports/ui/components/common/icon/component';
+import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 
 const DEBOUNCE_TIME = 1000;
 const CHAT_CONFIG = Meteor.settings.public.chat;
@@ -141,6 +142,7 @@ const ChatListItem = (props) => {
       : intl.formatMessage(intlMessages.unreadSingular)}`;
 
   return (
+    <TooltipContainer title={isPublicChat(chat) ? intl.formatMessage(intlMessages.titlePublic) : chat.name}>
     <Styled.ChatListItem
       data-test="chatButton"
       role="button"
@@ -191,6 +193,7 @@ const ChatListItem = (props) => {
           : null}
       </Styled.ChatListItemLink>
     </Styled.ChatListItem>
+    </TooltipContainer>
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/styles.js
@@ -82,6 +82,18 @@ const ListItem = styled.div`
     i {
       margin: 0.3rem;
     }
+
+    [dir="rtl"] & {
+      border-top-left-radius: 5px;
+      border-bottom-left-radius: 5px;
+      border-top-right-radius: 5px;
+      border-bottom-right-radius: 5px;
+
+      & > i {
+        margin-left: 0 !important;
+        margin-right: 0.3rem !important;
+      }
+    }
   `}
 
 `;

--- a/bigbluebutton-html5/imports/ui/components/user-list/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/styles.js
@@ -8,7 +8,7 @@ import {
   listItemBgHover,
   itemFocusBorder,
 } from '/imports/ui/stylesheets/styled-components/palette';
-import { smPaddingX, borderSize } from '/imports/ui/stylesheets/styled-components/general';
+import { smPaddingX, borderSize, lgPaddingY } from '/imports/ui/stylesheets/styled-components/general';
 
 const UserList = styled(FlexColumn)`
   justify-content: flex-start;
@@ -70,6 +70,20 @@ const ListItem = styled.div`
     background-color: ${listItemBgHover};
     box-shadow: inset 0 0 0 ${borderSize} ${itemFocusBorder}, inset 1px 0 0 1px ${itemFocusBorder};
   }
+
+  ${({ compact }) => compact && `
+    border-top-left-radius: 5px;
+    border-bottom-left-radius: 5px;
+    border-top-right-radius: 5px;
+    border-bottom-right-radius: 5px;
+
+    padding: ${lgPaddingY} !important;
+
+    i {
+      margin: 0.3rem;
+    }
+  `}
+
 `;
 
 export default {

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/breakout-room/component.jsx
@@ -61,19 +61,22 @@ const BreakoutRoomItem = ({
               data-test="breakoutRoomsItem"
               aria-label={intl.formatMessage(intlMessages.breakoutTitle)}
               onKeyPress={() => {}}
+              compact={compact}
             >
               <Icon iconName="rooms" />
-              <div aria-hidden>
-                <Styled.BreakoutTitle>
-                  {intl.formatMessage(intlMessages.breakoutTitle)}
-                </Styled.BreakoutTitle>
-                <Styled.BreakoutDuration>
-                  <BreakoutRemainingTime
-                    messageDuration={intlMessages.breakoutTimeRemaining}
-                    breakoutRoom={breakoutRoom}
-                  />
-                </Styled.BreakoutDuration>
-              </div>
+              {!compact ? (
+                <div aria-hidden>
+                  <Styled.BreakoutTitle>
+                    {intl.formatMessage(intlMessages.breakoutTitle)}
+                  </Styled.BreakoutTitle>
+                  <Styled.BreakoutDuration>
+                    <BreakoutRemainingTime
+                      messageDuration={intlMessages.breakoutTimeRemaining}
+                      breakoutRoom={breakoutRoom}
+                    />
+                  </Styled.BreakoutDuration>
+                </div>
+              ) : null}
             </Styled.ListItem>
             </TooltipContainer>
           </Styled.List>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/breakout-room/component.jsx
@@ -5,6 +5,7 @@ import Icon from '/imports/ui/components/common/icon/component';
 import Styled from './styles';
 import { ACTIONS, PANELS } from '../../../layout/enums';
 import BreakoutRemainingTime from '/imports/ui/components/breakout-room/breakout-remaining-time/container';
+import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 
 const intlMessages = defineMessages({
   breakoutTitle: {
@@ -23,6 +24,7 @@ const BreakoutRoomItem = ({
   sidebarContentPanel,
   layoutContextDispatch,
   intl,
+  compact,
 }) => {
   const toggleBreakoutPanel = () => {
     layoutContextDispatch({
@@ -40,13 +42,18 @@ const BreakoutRoomItem = ({
   if (hasBreakoutRoom) {
     return (
       <Styled.Messages>
-        <Styled.Container>
-          <Styled.SmallTitle>
-            {intl.formatMessage(intlMessages.breakoutTitle)}
-          </Styled.SmallTitle>
-        </Styled.Container>
+        {!compact
+          ? (
+            <Styled.Container>
+              <Styled.SmallTitle>
+                {intl.formatMessage(intlMessages.breakoutTitle)}
+              </Styled.SmallTitle>
+            </Styled.Container>
+          ) : null
+        }
         <Styled.ScrollableList>
           <Styled.List>
+            <TooltipContainer title={intl.formatMessage(intlMessages.breakoutTitle)}>
             <Styled.ListItem
               role="button"
               tabIndex={0}
@@ -68,6 +75,7 @@ const BreakoutRoomItem = ({
                 </Styled.BreakoutDuration>
               </div>
             </Styled.ListItem>
+            </TooltipContainer>
           </Styled.List>
         </Styled.ScrollableList>
       </Styled.Messages>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/breakout-room/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/breakout-room/container.jsx
@@ -5,7 +5,7 @@ import { layoutSelectInput, layoutDispatch } from '../../../layout/context';
 import Breakouts from '/imports/api/breakouts';
 import Auth from '/imports/ui/services/auth';
 
-const BreakoutRoomContainer = ({ breakoutRoom }) => {
+const BreakoutRoomContainer = ({ breakoutRoom, compact }) => {
   const sidebarContent = layoutSelectInput((i) => i.sidebarContent);
   const { sidebarContentPanel } = sidebarContent;
   const layoutContextDispatch = layoutDispatch();
@@ -18,6 +18,7 @@ const BreakoutRoomContainer = ({ breakoutRoom }) => {
       sidebarContentPanel,
       hasBreakoutRoom,
       breakoutRoom,
+      compact,
     }}
     />
   );

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
@@ -31,10 +31,10 @@ class UserContent extends PureComponent {
       || pendingUsers.length > 0;
 
     return (
-      <Styled.Content data-test="userListContent">
-        {isChatEnabled() ? <UserMessagesContainer /> : null}
+      <Styled.Content data-test="userListContent" compact={compact}>
+        {isChatEnabled() ? <UserMessagesContainer compact={compact}/> : null}
         {currentUser.role === ROLE_MODERATOR ? <UserCaptionsContainer /> : null}
-        <UserNotesContainer />
+        <UserNotesContainer compact={compact}/>
         {showWaitingRoom && currentUser.role === ROLE_MODERATOR
           ? (
             <WaitingUsersContainer {...{ pendingUsers }} />

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
@@ -33,14 +33,14 @@ class UserContent extends PureComponent {
     return (
       <Styled.Content data-test="userListContent" compact={compact}>
         {isChatEnabled() ? <UserMessagesContainer compact={compact}/> : null}
-        {currentUser.role === ROLE_MODERATOR ? <UserCaptionsContainer /> : null}
+        {currentUser.role === ROLE_MODERATOR ? <UserCaptionsContainer compact={compact}/> : null}
         <UserNotesContainer compact={compact}/>
         {showWaitingRoom && currentUser.role === ROLE_MODERATOR
           ? (
-            <WaitingUsersContainer {...{ pendingUsers }} />
+            <WaitingUsersContainer {...{ pendingUsers }} compact={compact}/>
           ) : null}
-        <UserPollsContainer isPresenter={currentUser.presenter} />
-        <BreakoutRoomContainer />
+        <UserPollsContainer isPresenter={currentUser.presenter} compact={compact}/>
+        <BreakoutRoomContainer compact={compact}/>
         <UserParticipantsContainer compact={compact}/>
       </Styled.Content>
     );

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/styles.js
@@ -27,6 +27,10 @@ import { ScrollboxVertical } from '/imports/ui/stylesheets/styled-components/scr
 const Content = styled(FlexColumn)`
   flex-grow: 1;
   overflow: hidden;
+
+  ${({ compact }) => compact && `
+    padding: ${lgPaddingY};
+  `}
 `;
 
 const Container = styled.div`
@@ -65,11 +69,13 @@ const ScrollableList = styled(ScrollboxVertical)`
 `;
 
 const List = styled.div`
-  margin: 0 0 1px ${mdPaddingY};
+  ${({ compact }) => !compact && `
+    margin: 0 0 1px ${mdPaddingY};
 
-  [dir="rtl"] & {
-    margin: 0 ${mdPaddingY} 1px 0;
-  }
+    [dir="rtl"] & {
+      margin: 0 ${mdPaddingY} 1px 0;
+    }
+  `}
 `;
 
 const ListItem = styled(Styled.ListItem)`

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/styles.js
@@ -81,6 +81,14 @@ const List = styled.div`
       margin: 0 ${mdPaddingY} 1px 0;
     }
   `}
+
+  ${({ compact }) => compact && `
+    margin: 0;
+
+    [dir="rtl"] & {
+      margin: 0;
+    }
+  `}
 `;
 
 const ListItem = styled(Styled.ListItem)`
@@ -155,8 +163,14 @@ const UnreadMessages = styled(FlexColumn)`
   }
 
   ${({ compact }) => compact && `
-    margin-left: -20px;
+    margin-left: -20px !important;
     z-index: 1;
+
+    [dir="rtl"] & {
+      margin-left: 0 !important;
+      margin-right: -20px;
+      z-index: 1;
+    }
   `}
 `;
 
@@ -165,7 +179,7 @@ const UnreadMessagesText = styled(FlexColumn)`
   justify-content: center;
   color: ${colorWhite};
   line-height: calc(1rem + 1px);
-  padding: 0 0.5rem;
+  padding: 0 0.5rem !important;
   text-align: center;
   border-radius: 0.5rem/50%;
   font-size: 0.8rem;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/styles.js
@@ -30,6 +30,11 @@ const Content = styled(FlexColumn)`
 
   ${({ compact }) => compact && `
     padding: ${lgPaddingY};
+
+    & div {
+      margin: 0;
+      padding: 0;
+    }
   `}
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/styles.js
@@ -148,6 +148,11 @@ const UnreadMessages = styled(FlexColumn)`
     margin-right: auto;
     margin-left: 0;
   }
+
+  ${({ compact }) => compact && `
+    margin-left: -20px;
+    z-index: 1;
+  `}
 `;
 
 const UnreadMessagesText = styled(FlexColumn)`

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-captions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-captions/component.jsx
@@ -25,6 +25,7 @@ class UserCaptions extends Component {
       ownedLocales,
       sidebarContentPanel,
       layoutContextDispatch,
+      compact,
     } = this.props;
 
     return ownedLocales.map((ownedLocale) => (
@@ -44,6 +45,7 @@ class UserCaptions extends Component {
               name: ownedLocale.name,
               layoutContextDispatch,
               sidebarContentPanel,
+              compact,
             }}
             tabIndex={-1}
           />

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-captions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-captions/component.jsx
@@ -4,6 +4,7 @@ import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import CaptionsListItem from '/imports/ui/components/user-list/captions-list-item/component';
 import { defineMessages, injectIntl } from 'react-intl';
 import Styled from './styles';
+import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 
 const propTypes = {
   ownedLocales: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -55,26 +56,33 @@ class UserCaptions extends Component {
     const {
       intl,
       ownedLocales,
+      compact,
     } = this.props;
 
     if (ownedLocales.length < 1) return null;
 
     return (
       <Styled.Messages>
-        <Styled.Container>
-          <Styled.SmallTitle>
-            {intl.formatMessage(intlMessages.title)}
-          </Styled.SmallTitle>
-        </Styled.Container>
+        {!compact
+          ? (
+            <Styled.Container>
+              <Styled.SmallTitle>
+                {intl.formatMessage(intlMessages.title)}
+              </Styled.SmallTitle>
+            </Styled.Container>
+          ) : null
+        }
         <Styled.ScrollableList
           role="tabpanel"
           tabIndex={0}
           ref={(ref) => { this._msgsList = ref; }}
         >
           <Styled.List>
+            <TooltipContainer title={intl.formatMessage(intlMessages.title)}>
             <TransitionGroup ref={(ref) => { this._msgItems = ref; }}>
               {this.renderCaptions()}
             </TransitionGroup>
+            </TooltipContainer>
           </Styled.List>
         </Styled.ScrollableList>
       </Styled.Messages>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/component.jsx
@@ -140,7 +140,7 @@ class UserMessages extends PureComponent {
                   <Styled.List compact={compact}>
                     <TooltipContainer title={intl.formatMessage(intlMessages.toggleCompactView)}>
                       <Styled.ListItem
-                        $compact={compact}
+                        compact={compact}
                         onClick={() => {
                           layoutContextDispatch({
                             type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_COMPACT,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/component.jsx
@@ -8,6 +8,7 @@ import ChatListItemContainer from '../../chat-list-item/container';
 import { injectIntl } from 'react-intl';
 import { ACTIONS } from '/imports/ui/components/layout/enums';
 import Icon from '/imports/ui/components/common/icon/component';
+import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 
 const propTypes = {
   activeChats: PropTypes.arrayOf(String).isRequired,
@@ -23,6 +24,10 @@ const intlMessages = defineMessages({
   messagesTitle: {
     id: 'app.userList.messagesTitle',
     description: 'Title for the messages list',
+  },
+  toggleCompactView: {
+    id: 'app.userList.toggleCompactView.label',
+    description: 'Title for the compact userlist toggle button',
   },
 });
 
@@ -117,7 +122,7 @@ class UserMessages extends PureComponent {
               <Styled.MinimizeButton
                 size="md"
                 color="light"
-                label="Minimize userlist"
+                label={intl.formatMessage(intlMessages.toggleCompactView)}
                 hideLabel
                 circle
                 icon="left_arrow"
@@ -133,18 +138,19 @@ class UserMessages extends PureComponent {
               <>
                 <Styled.ScrollableList>
                   <Styled.List compact={compact}>
-                    <Styled.ListItem
-                      label="Expand userlist"
-                      $compact={compact}
-                      onClick={() => {
-                        layoutContextDispatch({
-                          type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_COMPACT,
-                          value: !compact,
-                        });
-                      }}
-                    >
-                      <Icon iconName="right_arrow" />
-                    </Styled.ListItem>
+                    <TooltipContainer title={intl.formatMessage(intlMessages.toggleCompactView)}>
+                      <Styled.ListItem
+                        $compact={compact}
+                        onClick={() => {
+                          layoutContextDispatch({
+                            type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_COMPACT,
+                            value: !compact,
+                          });
+                        }}
+                      >
+                        <Icon iconName="right_arrow" />
+                      </Styled.ListItem>
+                    </TooltipContainer>
                   </Styled.List>
                 </Styled.ScrollableList>
                 <Styled.Separator />

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/component.jsx
@@ -109,6 +109,7 @@ class UserMessages extends PureComponent {
       intl,
       layoutContextDispatch,
       compact,
+      isMobile,
     } = this.props;
 
     return (
@@ -119,22 +120,23 @@ class UserMessages extends PureComponent {
               <Styled.MessagesTitle data-test="messageTitle">
                 {intl.formatMessage(intlMessages.messagesTitle)}
               </Styled.MessagesTitle>
-              <Styled.MinimizeButton
-                size="md"
-                color="light"
-                label={intl.formatMessage(intlMessages.toggleCompactView)}
-                hideLabel
-                circle
-                icon="left_arrow"
-                onClick={() => {
-                  layoutContextDispatch({
-                    type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_COMPACT,
-                    value: !compact,
-                  });
-                }}
-              />
+              {!isMobile ? (
+                <Styled.MinimizeButton
+                  size="md"
+                  color="light"
+                  label={intl.formatMessage(intlMessages.toggleCompactView)}
+                  hideLabel
+                  circle
+                  icon="left_arrow"
+                  onClick={() => {
+                    layoutContextDispatch({
+                      type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_COMPACT,
+                      value: !compact,
+                    });
+                  }}
+                />) : null}
             </Styled.Container>
-            ) : (
+            ) : !isMobile && (
               <>
                 <Styled.ScrollableList>
                   <Styled.List compact={compact}>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/component.jsx
@@ -6,18 +6,17 @@ import Styled from './styles';
 import { findDOMNode } from 'react-dom';
 import ChatListItemContainer from '../../chat-list-item/container';
 import { injectIntl } from 'react-intl';
+import { ACTIONS } from '/imports/ui/components/layout/enums';
+import Icon from '/imports/ui/components/common/icon/component';
 
 const propTypes = {
   activeChats: PropTypes.arrayOf(String).isRequired,
-  compact: PropTypes.bool,
+  compact: PropTypes.bool.isRequired,
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
   roving: PropTypes.func.isRequired,
-};
-
-const defaultProps = {
-  compact: false,
+  layoutContextDispatch: PropTypes.func.isRequired,
 };
 
 const intlMessages = defineMessages({
@@ -103,28 +102,61 @@ class UserMessages extends PureComponent {
   render() {
     const {
       intl,
+      layoutContextDispatch,
       compact,
     } = this.props;
 
     return (
       <Styled.Messages>
-        <Styled.Container>
           {
             !compact ? (
+            <Styled.Container>
               <Styled.MessagesTitle data-test="messageTitle">
                 {intl.formatMessage(intlMessages.messagesTitle)}
               </Styled.MessagesTitle>
+              <Styled.MinimizeButton
+                size="md"
+                color="light"
+                label="Minimize userlist"
+                hideLabel
+                circle
+                icon="left_arrow"
+                onClick={() => {
+                  layoutContextDispatch({
+                    type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_COMPACT,
+                    value: !compact,
+                  });
+                }}
+              />
+            </Styled.Container>
             ) : (
-              <Styled.Separator />
+              <>
+                <Styled.ScrollableList>
+                  <Styled.List compact={compact}>
+                    <Styled.ListItem
+                      label="Expand userlist"
+                      $compact={compact}
+                      onClick={() => {
+                        layoutContextDispatch({
+                          type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_COMPACT,
+                          value: !compact,
+                        });
+                      }}
+                    >
+                      <Icon iconName="right_arrow" />
+                    </Styled.ListItem>
+                  </Styled.List>
+                </Styled.ScrollableList>
+                <Styled.Separator />
+              </>
             )
           }
-        </Styled.Container>
         <Styled.ScrollableList
           role="tabpanel"
           tabIndex={0}
           ref={(ref) => { this._msgsList = ref; }}
         >
-          <Styled.List aria-live="polite">
+          <Styled.List aria-live="polite" compact={compact}>
             <TransitionGroup ref={(ref) => { this._msgItems = ref; }}>
               {this.getActiveChats()}
             </TransitionGroup>
@@ -136,6 +168,5 @@ class UserMessages extends PureComponent {
 }
 
 UserMessages.propTypes = propTypes;
-UserMessages.defaultProps = defaultProps;
 
 export default injectIntl(UserMessages);

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/container.jsx
@@ -7,10 +7,11 @@ import Service from '/imports/ui/components/user-list/service';
 import Auth from '/imports/ui/services/auth';
 import { withTracker } from 'meteor/react-meteor-data';
 import Storage from '/imports/ui/services/storage/session';
+import { layoutDispatch } from '/imports/ui/components/layout/context';
 
 const CLOSED_CHAT_LIST_KEY = 'closedChatList';
 
-const UserMessagesContainer = () => {
+const UserMessagesContainer = ({compact}) => {
   const usingChatContext = useContext(ChatContext);
   const usingUsersContext = useContext(UsersContext);
   const usingGroupChatContext = useContext(GroupChatContext);
@@ -19,8 +20,9 @@ const UserMessagesContainer = () => {
   const { groupChat: groupChats } = usingGroupChatContext;
   const activeChats = Service.getActiveChats({ groupChatsMessages, groupChats, users:users[Auth.meetingID] });
   const { roving } = Service;
+  const layoutContextDispatch = layoutDispatch();
 
-  return <UserMessages {...{ activeChats, roving }} />;
+  return <UserMessages {...{ activeChats, roving, layoutContextDispatch, compact }} />;
 };
 
 export default withTracker(() => {

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/container.jsx
@@ -7,7 +7,8 @@ import Service from '/imports/ui/components/user-list/service';
 import Auth from '/imports/ui/services/auth';
 import { withTracker } from 'meteor/react-meteor-data';
 import Storage from '/imports/ui/services/storage/session';
-import { layoutDispatch } from '/imports/ui/components/layout/context';
+import { layoutSelectInput, layoutDispatch } from '/imports/ui/components/layout/context';
+import { SMALL_VIEWPORT_BREAKPOINT } from '/imports/ui/components/layout/enums';
 
 const CLOSED_CHAT_LIST_KEY = 'closedChatList';
 
@@ -21,8 +22,10 @@ const UserMessagesContainer = ({compact}) => {
   const activeChats = Service.getActiveChats({ groupChatsMessages, groupChats, users:users[Auth.meetingID] });
   const { roving } = Service;
   const layoutContextDispatch = layoutDispatch();
+  const { width: browserWidth } = layoutSelectInput((i) => i.browser);
+  const isMobile = browserWidth <= SMALL_VIEWPORT_BREAKPOINT;
 
-  return <UserMessages {...{ activeChats, roving, layoutContextDispatch, compact }} />;
+  return <UserMessages {...{ activeChats, roving, layoutContextDispatch, compact, isMobile }} />;
 };
 
 export default withTracker(() => {

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/styles.js
@@ -71,11 +71,19 @@ const MinimizeButton = styled(Button)`
   i {
     font-size: ${fontSizeBase} !important;
   }
+
+  [dir="rtl"]  & {
+    transform: scale(-1, 1);
+  }
 `;
 
 const ListItem = styled(StyledContent.ListItem)`
   i {
     margin-left:0.7rem;
+  }
+
+  [dir="rtl"]  & {
+    transform: scale(-1, 1);
   }
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/styles.js
@@ -75,7 +75,7 @@ const MinimizeButton = styled(Button)`
 
 const ListItem = styled(StyledContent.ListItem)`
   i {
-    margin:auto;
+    margin-left:0.7rem;
   }
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/styles.js
@@ -2,7 +2,9 @@ import styled from 'styled-components';
 
 import Styled from '/imports/ui/components/user-list/styles';
 import StyledContent from '/imports/ui/components/user-list/user-list-content/styles';
-import { borderSize } from '/imports/ui/stylesheets/styled-components/general';
+import { borderSize, lgPaddingY } from '/imports/ui/stylesheets/styled-components/general';
+import { fontSizeBase } from '/imports/ui/stylesheets/styled-components/typography';
+import Button from '/imports/ui/components/common/button/component';
 
 const Messages = styled(Styled.Messages)``;
 
@@ -56,6 +58,27 @@ const ListTransition = styled.div`
   }
 `;
 
+const MinimizeButton = styled(Button)`
+  border-radius: 50%;
+  display: block;
+  padding: 0;
+  margin: 0 0.25rem;
+
+  span {
+    padding: inherit;
+  }
+
+  i {
+    font-size: ${fontSizeBase} !important;
+  }
+`;
+
+const ListItem = styled(StyledContent.ListItem)`
+  i {
+    margin:auto;
+  }
+`;
+
 export default {
   Messages,
   Container,
@@ -64,4 +87,6 @@ export default {
   ScrollableList,
   List,
   ListTransition,
+  MinimizeButton,
+  ListItem,
 };

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-notes/component.jsx
@@ -114,7 +114,7 @@ class UserNotes extends Component {
         as={isPinned ? 'button' : 'div'}
         disabled={isPinned}
         $disabled={isPinned}
-        $compact={compact}
+        compact={compact}
       >
         <Icon iconName="copy" />
         <div aria-hidden>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-notes/component.jsx
@@ -94,7 +94,7 @@ class UserNotes extends Component {
     let notification = null;
     if (unread && !isPinned) {
       notification = (
-        <Styled.UnreadMessages aria-label={intl.formatMessage(intlMessages.unreadContent)}>
+        <Styled.UnreadMessages aria-label={intl.formatMessage(intlMessages.unreadContent)} compact={compact}>
           <Styled.UnreadMessagesText aria-hidden="true">
             ···
           </Styled.UnreadMessagesText>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-notes/component.jsx
@@ -5,6 +5,7 @@ import Icon from '/imports/ui/components/common/icon/component';
 import NotesService from '/imports/ui/components/notes/service';
 import Styled from './styles';
 import { PANELS } from '/imports/ui/components/layout/enums';
+import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 
 const propTypes = {
   intl: PropTypes.shape({
@@ -102,6 +103,7 @@ class UserNotes extends Component {
     }
 
     return (
+      <TooltipContainer title={intl.formatMessage(intlMessages.sharedNotes)}>
       <Styled.ListItem
         aria-label={intl.formatMessage(intlMessages.sharedNotes)}
         aria-describedby="lockedNotes"
@@ -136,6 +138,7 @@ class UserNotes extends Component {
         </div>
         {notification}
       </Styled.ListItem>
+      </TooltipContainer>
     );
   }
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-notes/component.jsx
@@ -86,6 +86,7 @@ class UserNotes extends Component {
       sidebarContentPanel,
       layoutContextDispatch,
       isPinned,
+      compact,
     } = this.props;
     const { unread } = this.state;
 
@@ -111,12 +112,16 @@ class UserNotes extends Component {
         as={isPinned ? 'button' : 'div'}
         disabled={isPinned}
         $disabled={isPinned}
+        $compact={compact}
       >
         <Icon iconName="copy" />
         <div aria-hidden>
-          <Styled.NotesTitle data-test="sharedNotes">
-            {intl.formatMessage(intlMessages.sharedNotes)}
-          </Styled.NotesTitle>
+          {!compact
+            ? (
+              <Styled.NotesTitle data-test="sharedNotes">
+                {intl.formatMessage(intlMessages.sharedNotes)}
+              </Styled.NotesTitle>
+            ) : null}          
           {disableNotes
             ? (
               <Styled.NotesLock>
@@ -135,19 +140,22 @@ class UserNotes extends Component {
   }
 
   render() {
-    const { intl } = this.props;
+    const { intl, compact } = this.props;
 
     if (!NotesService.isEnabled()) return null;
 
     return (
       <Styled.Messages>
-        <Styled.Container>
-          <Styled.SmallTitle data-test="notesTitle">
-            {intl.formatMessage(intlMessages.title)}
-          </Styled.SmallTitle>
-        </Styled.Container>
+        {!compact
+          ? (
+            <Styled.Container>
+              <Styled.SmallTitle data-test="notesTitle">
+                {intl.formatMessage(intlMessages.title)}
+              </Styled.SmallTitle>
+            </Styled.Container>
+          ) : null}
         <Styled.ScrollableList>
-          <Styled.List>
+          <Styled.List compact={compact}>
             {this.renderNotes()}
           </Styled.List>
         </Styled.ScrollableList>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
@@ -201,30 +201,41 @@ class UserParticipants extends Component {
 
     return (
       <Styled.UserListColumn data-test="userList">
-        {
-          !compact
-            ? (
-              <Styled.Container>
-                <Styled.SmallTitle>
-                  {intl.formatMessage(intlMessages.usersTitle)}
-                  {users.length > 0 ? ` (${users.length})` : null}
-                </Styled.SmallTitle>
-                {currentUser?.role === ROLE_MODERATOR
-                  ? (
-                    <UserOptionsContainer {...{
-                      users,
-                      clearAllEmojiStatus,
-                      meetingIsBreakout,
-                      isMeetingMuteOnStart,
-                    }}
-                    />
-                  ) : null
-                }
-
-              </Styled.Container>
-            )
-            : <Styled.Separator />
-        }
+        {compact ? (
+          <>
+            <Styled.Separator />
+            {currentUser?.role === ROLE_MODERATOR
+              ? (
+                <UserOptionsContainer {...{
+                  users,
+                  clearAllEmojiStatus,
+                  meetingIsBreakout,
+                  isMeetingMuteOnStart,
+                  compact,
+                }}
+                />
+              ) : null
+            }
+          </>
+        ) : (
+          <Styled.Container>
+            <Styled.SmallTitle>
+              {intl.formatMessage(intlMessages.usersTitle)}
+              {users.length > 0 ? ` (${users.length})` : null}
+            </Styled.SmallTitle>
+            {currentUser?.role === ROLE_MODERATOR
+              ? (
+                <UserOptionsContainer {...{
+                  users,
+                  clearAllEmojiStatus,
+                  meetingIsBreakout,
+                  isMeetingMuteOnStart,
+                }}
+                />
+              ) : null
+            }
+          </Styled.Container>
+        )}
         <Styled.VirtualizedScrollableList
           id={'user-list-virtualized-scroll'}
           aria-label="Users list"

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
@@ -244,6 +244,7 @@ class UserParticipants extends Component {
           ref={(ref) => {
             this.refScrollContainer = ref;
           }}
+          compact={compact}
         >
           <span id="participants-destination" />
           <AutoSizer>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/styles.js
@@ -60,6 +60,13 @@ const VirtualizedScrollableList = styled(ScrollboxVertical)`
   }
   margin-left: 0;
   padding-top: 1px;
+
+
+  ${({ compact }) => compact && `
+    [dir="rtl"] & {
+      margin: 0;
+    }
+  `}
 `;
 
 const VirtualizedList = styled(VirtualizedScrollboxVertical)`

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
@@ -761,42 +761,42 @@ class UserListItem extends PureComponent {
     }
 
     const innerContents = (
-      <Styled.UserItemInnerContents>
-        <Styled.UserAvatar data-test="userAvatar" data-test-presenter={user.presenter ? '' : undefined}>
-          {this.renderUserAvatar()}
-        </Styled.UserAvatar>
-        {!compact
-          ? (
-            <Styled.UserName
-              role="button"
-              aria-label={userAriaLabel}
-              aria-expanded={isActionsOpen}
-            >
-              <Styled.UserNameMain>
-                <TooltipContainer title={user.name}>
+      <TooltipContainer title={user.name}>
+        <Styled.UserItemInnerContents>
+          <Styled.UserAvatar data-test="userAvatar" data-test-presenter={user.presenter ? '' : undefined}>
+            {this.renderUserAvatar()}
+          </Styled.UserAvatar>
+          {!compact
+            ? (
+              <Styled.UserName
+                role="button"
+                aria-label={userAriaLabel}
+                aria-expanded={isActionsOpen}
+              >
+                <Styled.UserNameMain>
                   <span>
                     {user.name}
                     &nbsp;
                   </span>
-                </TooltipContainer>
-                <i>{(isMe(user.userId)) ? `(${intl.formatMessage(messages.you)})` : ''}</i>
-              </Styled.UserNameMain>
-              {
-                userNameSub.length
-                  ? (
-                    <Styled.UserNameSub
-                      aria-hidden
-                      data-test={user.mobile ? 'mobileUser' : undefined}
-                    >
-                      {userNameSub.reduce((prev, curr) => [prev, ' | ', curr])}
-                    </Styled.UserNameSub>
-                  )
-                  : null
-              }
-            </Styled.UserName>
-          )
-          : null}
-      </Styled.UserItemInnerContents>
+                  <i>{(isMe(user.userId)) ? `(${intl.formatMessage(messages.you)})` : ''}</i>
+                </Styled.UserNameMain>
+                {
+                  userNameSub.length
+                    ? (
+                      <Styled.UserNameSub
+                        aria-hidden
+                        data-test={user.mobile ? 'mobileUser' : undefined}
+                      >
+                        {userNameSub.reduce((prev, curr) => [prev, ' | ', curr])}
+                      </Styled.UserNameSub>
+                    )
+                    : null
+                }
+              </Styled.UserName>
+            )
+            : null}
+        </Styled.UserItemInnerContents>
+      </TooltipContainer>
     );
 
     const contents = !actions.length

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
@@ -762,7 +762,7 @@ class UserListItem extends PureComponent {
 
     const innerContents = (
       <TooltipContainer title={user.name}>
-        <Styled.UserItemInnerContents>
+        <Styled.UserItemInnerContents compact={compact}>
           <Styled.UserAvatar data-test="userAvatar" data-test-presenter={user.presenter ? '' : undefined}>
             {this.renderUserAvatar()}
           </Styled.UserAvatar>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
@@ -830,6 +830,7 @@ class UserListItem extends PureComponent {
               onClick={() => this.setState({ selected: true }, () => Session.set('dropdownOpenUserId', user.userId))}
               onKeyPress={() => { }}
               role="button"
+              compact={compact}
             >
               {contents}
             </Styled.UserItemContents>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/styles.js
@@ -97,6 +97,13 @@ const UserItemContents = styled.div`
     i {
       margin: 0.3rem;
     }
+
+    [dir="rtl"] & {
+      border-top-left-radius: 5px;
+      border-bottom-left-radius: 5px;
+      border-top-right-radius: 5px;
+      border-bottom-right-radius: 5px;
+    }
   `}
 `;
 
@@ -117,6 +124,12 @@ const UserItemInnerContents = styled.div`
   [dir="rtl"] & {
     padding: ${lgPaddingY} ${lgPaddingY} ${lgPaddingY} 0;
   }
+
+  ${({ compact }) => compact && `
+    [dir="rtl"] & {
+      padding: 0;
+    }
+  `}
 `;
 
 const UserAvatar = styled.div`

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/styles.js
@@ -17,7 +17,10 @@ const UserItemContents = styled.div`
   position: static;
   padding: .45rem;
   width: 100%;
-  margin-left: .5rem;
+
+  ${({ compact }) => !compact && `
+    margin-left: .5rem;
+  `}
 
   ${({ selected }) => selected && `
     background-color: ${listItemBgHover};

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/styles.js
@@ -85,6 +85,19 @@ const UserItemContents = styled.div`
       outline-color: transparent !important;
     }
   `}
+
+  ${({ compact }) => compact && `
+    border-top-left-radius: 5px;
+    border-bottom-left-radius: 5px;
+    border-top-right-radius: 5px;
+    border-bottom-right-radius: 5px;
+
+    padding: ${lgPaddingY} !important;
+
+    i {
+      margin: 0.3rem;
+    }
+  `}
 `;
 
 const SkeletonUserItemContents = styled.div`

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -212,7 +212,7 @@ class UserOptions extends PureComponent {
           <Styled.List compact={compact}>
             <TooltipContainer title={intl.formatMessage(intlMessages.optionsLabel)}>
             <Styled.ListItem
-              $compact={compact}
+              compact={compact}
               onClick={() => null}
             >
               <Icon iconName="settings" />

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -13,6 +13,7 @@ import Styled from './styles';
 import { getUserNamesLink } from '/imports/ui/components/user-list/service';
 import Settings from '/imports/ui/services/settings';
 import { isBreakoutRoomsEnabled, isLearningDashboardEnabled } from '/imports/ui/services/features';
+import Icon from '/imports/ui/components/common/icon/component.jsx';
 
 const propTypes = {
   intl: PropTypes.shape({
@@ -201,6 +202,38 @@ class UserOptions extends PureComponent {
     mountModal(<CaptionsWriterMenu />);
   }
 
+  renderTriggerButton() {
+    const { intl, compact } = this.props;
+
+    if (compact) {
+      return (
+        <Styled.ScrollableList>
+          <Styled.List compact={compact}>
+            <Styled.ListItem
+              label={intl.formatMessage(intlMessages.optionsLabel)}
+              $compact={compact}
+              onClick={() => null}
+            >
+              <Icon iconName="settings" />
+            </Styled.ListItem>
+          </Styled.List>
+        </Styled.ScrollableList>);
+    }
+
+    return (
+      <Styled.OptionsButton
+        label={intl.formatMessage(intlMessages.optionsLabel)}
+        data-test="manageUsers"
+        icon="settings"
+        color="light"
+        hideLabel
+        size="md"
+        circle
+        onClick={() => null}
+      />
+    );
+  }
+
   renderMenuItems() {
     const {
       intl,
@@ -327,22 +360,11 @@ class UserOptions extends PureComponent {
   }
 
   render() {
-    const { intl, isRTL } = this.props;
+    const { isRTL } = this.props;
 
     return (
       <BBBMenu
-        trigger={(
-          <Styled.OptionsButton
-            label={intl.formatMessage(intlMessages.optionsLabel)}
-            data-test="manageUsers"
-            icon="settings"
-            color="light"
-            hideLabel
-            size="md"
-            circle
-            onClick={() => null}
-          />
-        )}
+        trigger={this.renderTriggerButton()}
         actions={this.renderMenuItems()}
         opts={{
           id: "user-options-dropdown-menu",

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -14,6 +14,7 @@ import { getUserNamesLink } from '/imports/ui/components/user-list/service';
 import Settings from '/imports/ui/services/settings';
 import { isBreakoutRoomsEnabled, isLearningDashboardEnabled } from '/imports/ui/services/features';
 import Icon from '/imports/ui/components/common/icon/component.jsx';
+import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 
 const propTypes = {
   intl: PropTypes.shape({
@@ -209,13 +210,14 @@ class UserOptions extends PureComponent {
       return (
         <Styled.ScrollableList>
           <Styled.List compact={compact}>
+            <TooltipContainer title={intl.formatMessage(intlMessages.optionsLabel)}>
             <Styled.ListItem
-              label={intl.formatMessage(intlMessages.optionsLabel)}
               $compact={compact}
               onClick={() => null}
             >
               <Icon iconName="settings" />
             </Styled.ListItem>
+            </TooltipContainer>
           </Styled.List>
         </Styled.ScrollableList>);
     }

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/styles.js
@@ -23,11 +23,7 @@ const ScrollableList = styled(StyledContent.ScrollableList)``;
 
 const List = styled(StyledContent.List)``;
 
-const ListItem = styled(StyledContent.ListItem)`
-  i {
-    margin:auto;
-  }
-`;
+const ListItem = styled(StyledContent.ListItem)``;
 
 export default {
   OptionsButton,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/styles.js
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 import Button from '/imports/ui/components/common/button/component';
 import { fontSizeBase } from '/imports/ui/stylesheets/styled-components/typography';
+import StyledContent from '/imports/ui/components/user-list/user-list-content/styles';
 
 const OptionsButton = styled(Button)`
   border-radius: 50%;
@@ -18,6 +19,19 @@ const OptionsButton = styled(Button)`
   }
 `;
 
+const ScrollableList = styled(StyledContent.ScrollableList)``;
+
+const List = styled(StyledContent.List)``;
+
+const ListItem = styled(StyledContent.ListItem)`
+  i {
+    margin:auto;
+  }
+`;
+
 export default {
   OptionsButton,
+  ScrollableList,
+  List,
+  ListItem,
 };

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-polls/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-polls/component.jsx
@@ -58,9 +58,10 @@ const UserPolls = ({
             data-test="pollMenuButton"
             onClick={handleClickTogglePoll}
             onKeyPress={() => {}}
+            compact={compact}
           >
             <Icon iconName="polling" />
-            <span>{intl.formatMessage(intlMessages.pollLabel)}</span>
+            {!compact ? <span>{intl.formatMessage(intlMessages.pollLabel)}</span> : null}
           </Styled.ListItem>
           </TooltipContainer>
         </Styled.ScrollableList>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-polls/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-polls/component.jsx
@@ -4,6 +4,7 @@ import { defineMessages, injectIntl } from 'react-intl';
 import Icon from '/imports/ui/components/common/icon/component';
 import Styled from './styles';
 import { ACTIONS, PANELS } from '../../../layout/enums';
+import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 
 const intlMessages = defineMessages({
   pollLabel: {
@@ -19,6 +20,7 @@ const UserPolls = ({
   forcePollOpen,
   sidebarContentPanel,
   layoutContextDispatch,
+  compact,
 }) => {
   if (!isPresenter) return null;
   if (!pollIsOpen && !forcePollOpen) return null;
@@ -38,13 +40,18 @@ const UserPolls = ({
 
   return (
     <Styled.Messages>
-      <Styled.Container>
-        <Styled.SmallTitle>
-          {intl.formatMessage(intlMessages.pollLabel)}
-        </Styled.SmallTitle>
-      </Styled.Container>
+      {!compact
+        ? (
+          <Styled.Container>
+            <Styled.SmallTitle>
+              {intl.formatMessage(intlMessages.pollLabel)}
+            </Styled.SmallTitle>
+          </Styled.Container>
+        ) : null
+      }
       <Styled.List>
         <Styled.ScrollableList>
+          <TooltipContainer title={intl.formatMessage(intlMessages.pollLabel)}>
           <Styled.ListItem
             role="button"
             tabIndex={0}
@@ -55,6 +62,7 @@ const UserPolls = ({
             <Icon iconName="polling" />
             <span>{intl.formatMessage(intlMessages.pollLabel)}</span>
           </Styled.ListItem>
+          </TooltipContainer>
         </Styled.ScrollableList>
       </Styled.List>
     </Styled.Messages>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/waiting-users/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/waiting-users/component.jsx
@@ -63,9 +63,10 @@ const WaitingUsers = ({
             tabIndex={0}
             onClick={toggleWaitingPanel}
             onKeyPress={() => { }}
+            compact={compact}
           >
             <Icon iconName="user" />
-            <span>{intl.formatMessage(intlMessages.title)}</span>
+            {!compact ? <span>{intl.formatMessage(intlMessages.title)}</span> : null}
             {pendingUsers.length > 0 && (
               <Styled.UnreadMessages>
                 <Styled.UnreadMessagesText>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/waiting-users/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/waiting-users/component.jsx
@@ -4,6 +4,7 @@ import { defineMessages, injectIntl } from 'react-intl';
 import Icon from '/imports/ui/components/common/icon/component';
 import Styled from './styles';
 import { ACTIONS, PANELS } from '../../../layout/enums';
+import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 
 const propTypes = {
   intl: PropTypes.shape({
@@ -27,6 +28,7 @@ const WaitingUsers = ({
   pendingUsers,
   sidebarContentPanel,
   layoutContextDispatch,
+  compact,
 }) => {
   const toggleWaitingPanel = () => {
     layoutContextDispatch({
@@ -43,13 +45,18 @@ const WaitingUsers = ({
 
   return (
     <Styled.Messages>
-      <Styled.Container>
-        <Styled.SmallTitle>
-          {intl.formatMessage(intlMessages.waitingUsersTitle)}
-        </Styled.SmallTitle>
-      </Styled.Container>
+      {!compact
+        ? (
+          <Styled.Container>
+            <Styled.SmallTitle>
+              {intl.formatMessage(intlMessages.waitingUsersTitle)}
+            </Styled.SmallTitle>
+          </Styled.Container>
+        ) : null
+      }
       <Styled.ScrollableList>
         <Styled.List>
+          <TooltipContainer title={intl.formatMessage(intlMessages.waitingUsersTitle)}>
           <Styled.ListItem
             role="button"
             data-test="waitingUsersBtn"
@@ -67,6 +74,7 @@ const WaitingUsers = ({
               </Styled.UnreadMessages>
             )}
           </Styled.ListItem>
+          </TooltipContainer>
         </Styled.List>
       </Styled.ScrollableList>
     </Styled.Messages>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/waiting-users/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/waiting-users/container.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import WaitingUsers from './component';
 import { layoutSelectInput, layoutDispatch } from '/imports/ui/components/layout/context';
 
-const WaitingUsersContainer = ({ pendingUsers }) => {
+const WaitingUsersContainer = ({ pendingUsers, compact }) => {
   const sidebarContent = layoutSelectInput((i) => i.sidebarContent);
   const layoutContextDispatch = layoutDispatch();
   const { sidebarContentPanel } = sidebarContent;
@@ -13,6 +13,7 @@ const WaitingUsersContainer = ({ pendingUsers }) => {
         pendingUsers,
         sidebarContentPanel,
         layoutContextDispatch,
+        compact,
       }}
     />
   );

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
@@ -332,7 +332,8 @@ const WaitingUsers = (props) => {
   return (
     <Styled.Panel data-test="note" isChrome={isChrome}>
       <Header
-        leftButtonProps={{
+        title={intl.formatMessage(intlMessages.title)}
+        rightButtonProps={{
           onClick: () => closePanel(),
           label: intl.formatMessage(intlMessages.title),
         }}


### PR DESCRIPTION
### What does this PR do?

Implements part of the suggestions made in #15812:
- adds new button to toggle compact mode in sidebar
- changes sidebar content header to include text in the middle and close button in the right
- improves styling of sidebar buttons in compact mode


https://user-images.githubusercontent.com/3728706/205361525-d4b43624-ee82-4c4d-8a81-6944196feac5.mp4


### Closes Issue(s)
(partially) #15812