### PR TITLE
fix: Speaking person tooltip has wrong encoding

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/component.jsx
@@ -45,6 +45,7 @@ class TalkingIndicator extends PureComponent {
       talkers,
       amIModerator,
       moreThanMaxIndicators,
+      users,
     } = this.props;
     if (!talkers) return null;
 
@@ -58,9 +59,13 @@ class TalkingIndicator extends PureComponent {
         callerName,
       } = talkers[`${id}`];
 
+      const user = users[id];
+
+      const name = user?.name ?? callerName;
+
       const ariaLabel = intl.formatMessage(talking
         ? intlMessages.isTalking : intlMessages.wasTalking, {
-        0: callerName,
+        0: name,
       });
 
       let icon = talking ? 'unmute' : 'blank';
@@ -68,7 +73,7 @@ class TalkingIndicator extends PureComponent {
 
       return (
         <Styled.TalkingIndicatorWrapper
-          key={_.uniqueId(`${callerName}-`)}
+          key={_.uniqueId(`${name}-`)}
           muted={muted}
           talking={talking}
           floor={floor}
@@ -84,11 +89,11 @@ class TalkingIndicator extends PureComponent {
             $spoke={!talking || undefined}
             $muted={muted}
             $isViewer={!amIModerator || undefined}
-            key={_.uniqueId(`${callerName}-`)}
+            key={_.uniqueId(`${name}-`)}
             onClick={() => this.handleMuteUser(id)}
-            label={callerName}
+            label={name}
             tooltipLabel={!muted && amIModerator
-              ? `${intl.formatMessage(intlMessages.muteLabel)} ${callerName}`
+              ? `${intl.formatMessage(intlMessages.muteLabel)} ${name}`
               : null}
             data-test={talking ? 'isTalking' : 'wasTalking'}
             aria-label={ariaLabel}

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/talking-indicator/container.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import VoiceUsers from '/imports/api/voice-users';
 import Auth from '/imports/ui/services/auth';
@@ -8,6 +8,7 @@ import { makeCall } from '/imports/ui/services/api';
 import { meetingIsBreakout } from '/imports/ui/components/app/service';
 import { layoutSelectInput, layoutDispatch } from '../../layout/context';
 import SpeechService from '/imports/ui/components/audio/captions/speech/service';
+import { UsersContext } from '/imports/ui/components/components-data/users-context/context';
 
 const APP_CONFIG = Meteor.settings.public.app;
 const { enableTalkingIndicator } = APP_CONFIG;
@@ -23,12 +24,16 @@ const TalkingIndicatorContainer = (props) => {
   const { sidebarNavPanel } = sidebarNavigation;
   const layoutContextDispatch = layoutDispatch();
 
+  const usingUsersContext = useContext(UsersContext);
+  const { users } = usingUsersContext;
+
   return (
     <TalkingIndicator
       {...{
         sidebarNavPanel,
         sidebarContentPanel,
         layoutContextDispatch,
+        users: users[Auth.meetingID],
         ...props,
       }}
     />


### PR DESCRIPTION
### What does this PR do?

Prioritizes the user name from the `Users` collection for the talking indicator tooltip, otherwise it uses the one from the `VoiceUsers` collection.

### Closes Issue(s)

Closes #16058