### PR TITLE
style: increase video modal max-height 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/styles.js
@@ -162,7 +162,7 @@ const ExtraActions = styled.div`
 const VideoPreviewModal = styled(Modal)`
   padding: 1rem;
   min-height: 25rem;
-  max-height: 60vh;
+  max-height: 100vh;
 
   @media ${smallOnly} {
     height: unset;


### PR DESCRIPTION
### What does this PR do?

Adjusts video preview modal max-height in (small) desktop devices.

#### before
![before](https://user-images.githubusercontent.com/3728706/206524278-4e894b6a-adbb-4bc7-a62f-66226968cdf8.png)

#### after
![after](https://user-images.githubusercontent.com/3728706/206524304-99af86f1-b7d7-4be3-b9e7-13d8703a426e.png)


### Closes Issue(s)
Closes #16080