### PR TITLE
chore: upgrade tomcat to 9.0.70

### DIFF
--- a/bigbluebutton-web/gradle.properties
+++ b/bigbluebutton-web/gradle.properties
@@ -3,5 +3,5 @@ gormVersion=7.1.0
 gradleWrapperVersion=7.3.1
 grailsGradlePluginVersion=5.0.0
 groovyVersion=3.0.9
-tomcatEmbedVersion=9.0.62
+tomcatEmbedVersion=9.0.70
 springVersion=2.7.1


### PR DESCRIPTION
### What does this PR do?

Bumps up tomcat-embedded version as a first step in progress to major version upgrade

### Related
 #16102
