### PR TITLE
fix(audio): add delay for loopback test

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/local-echo/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/local-echo/service.js
@@ -3,12 +3,56 @@ import browserInfo from '/imports/utils/browserInfo';
 
 const MEDIA_TAG = Meteor.settings.public.media.mediaTag;
 const USE_RTC_LOOPBACK_CHR = Meteor.settings.public.media.localEchoTest.useRtcLoopbackInChromium;
+const {
+  enabled: DELAY_ENABLED = true,
+  delayTime = 0.5,
+  maxDelayTime = 2,
+} = Meteor.settings.public.media.localEchoTest.delay;
+
+let audioContext = null;
+let sourceContext = null;
+let delayNode = null;
 
 const useRTCLoopback = () => (browserInfo.isChrome || browserInfo.isEdge) && USE_RTC_LOOPBACK_CHR;
 const createAudioRTCLoopback = () => new LocalPCLoopback({ audio: true });
 
+const cleanupDelayNode = () => {
+  if (delayNode) {
+    delayNode.disconnect();
+    delayNode = null;
+  }
+
+  if (sourceContext) {
+    sourceContext.disconnect();
+    sourceContext = null;
+  }
+
+  if (audioContext) {
+    audioContext.close();
+    audioContext = null;
+  }
+};
+
+const addDelayNode = (stream) => {
+  if (stream) {
+    if (delayNode || audioContext || sourceContext) cleanupDelayNode();
+
+    audioContext = new AudioContext();
+    sourceContext = audioContext.createMediaStreamSource(stream);
+    delayNode = new DelayNode(audioContext, { delayTime, maxDelayTime });
+    sourceContext.connect(delayNode);
+    delayNode.connect(audioContext.destination);
+    delayNode.delayTime.setValueAtTime(delayTime, audioContext.currentTime);
+  }
+};
 const deattachEchoStream = () => {
   const audioElement = document.querySelector(MEDIA_TAG);
+
+  if (DELAY_ENABLED) {
+    audioElement.muted = false;
+    cleanupDelayNode();
+  }
+
   audioElement.pause();
   audioElement.srcObject = null;
 };
@@ -27,14 +71,13 @@ const playEchoStream = async (stream, loopbackAgent = null) => {
         loopbackAgent.stop();
       }
     }
-    const audioCtx = new AudioContext();
-    const source = audioCtx.createMediaStreamSource(stream);
-    const delayNode = new DelayNode(audioCtx, {delayTime: 0.5, maxDelayTime: 2});
-    delayNode.delayTime.setValueAtTime(0.5, audioCtx.currentTime);
-    const streamdest = audioCtx.createMediaStreamDestination();
-    source.connect(delayNode);
-    delayNode.connect(audioCtx.destination)
-    audioElement.srcObject = streamdest.stream;
+
+    if (DELAY_ENABLED) {
+      // Start muted to avoid weird artifacts and prevent playing the stream twice (Chromium)
+      audioElement.muted = true;
+      addDelayNode(streamToPlay);
+    }
+    audioElement.srcObject = streamToPlay;
     audioElement.play();
   }
 };

--- a/bigbluebutton-html5/imports/ui/components/audio/local-echo/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/local-echo/service.js
@@ -27,8 +27,14 @@ const playEchoStream = async (stream, loopbackAgent = null) => {
         loopbackAgent.stop();
       }
     }
-
-    audioElement.srcObject = streamToPlay;
+    const audioCtx = new AudioContext();
+    const source = audioCtx.createMediaStreamSource(stream);
+    const delayNode = new DelayNode(audioCtx, {delayTime: 0.5, maxDelayTime: 2});
+    delayNode.delayTime.setValueAtTime(0.5, audioCtx.currentTime);
+    const streamdest = audioCtx.createMediaStreamDestination();
+    source.connect(delayNode);
+    delayNode.connect(audioCtx.destination)
+    audioElement.srcObject = streamdest.stream;
     audioElement.play();
   }
 };

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -647,6 +647,11 @@ public:
       enabled: true
       initialHearingState: true
       useRtcLoopbackInChromium: true
+      # delay: delay (seconds) to be added to the audio feedback return
+      delay:
+        enabled: true
+        delayTime: 0.5
+        maxDelayTime: 2
     # showVolumeMeter: shows an energy bar for microphones in the AudioSettings view
     showVolumeMeter: true
     # networkPriorities: DSCP markings for each media type. Chromium only, applies


### PR DESCRIPTION
### What does this PR do?

Adds delay to the loopback audio test.

### Motivation

If BBB 2.6 is used without headphones, the audio test works differently than in 2.5. In 2.5 audio traffic is routed to freeswitch and then returned to the browser. This adds usually some latency which makes it easy to hear you audio quality. In 2.6 there is a local loopback. As there is almost no latency, it is either difficult or even impossible to check your own audio quality as echo cancellation of the browser will filter out your own signal.

This patch adds a delay node to the audio loopback test, which makes is easier to check your quality.

### More

As this is my first change on media related stuf and I do not completely understand what is going on, someone with deeper insight should double check that. Ping @prlanzarin 

I tested this on Firefox and Chrome for Linux and Android.