### PR TITLE
style: increase breakout room box size

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.js
@@ -40,13 +40,6 @@ const Alert = styled.div`
       color: ${colorDanger};
     }
   `}
-
-  grid-row: span 3;
-
-  & > div {
-    height: 25.2rem;
-    max-height: 25.2rem;
-  }
 `;
 
 const FreeJoinLabel = styled.label`
@@ -85,8 +78,7 @@ const BreakoutNameInput = styled.input`
 
 const BreakoutBox = styled(ScrollboxVertical)`
   width: 100%;
-  min-height: 6rem;
-  max-height: 8rem;
+  height: 21rem;
   border: 1px solid ${colorGrayLightest};
   border-radius: ${borderRadius};
   padding: ${lgPaddingY} 0;


### PR DESCRIPTION
### What does this PR do?

Adjusts breakout room creation boxes so they all have the same height (enough to display ~10 items without scrolling)

#### before
![breakout-before](https://user-images.githubusercontent.com/3728706/206705639-0f59585b-27e9-4af2-96e3-dcac2cd5fe1e.png)

#### after
![breakout-after](https://user-images.githubusercontent.com/3728706/206705629-48f65d5e-40a7-4ad5-8899-230ab82250d8.png)


### Closes Issue(s)
Closes #15944
