### PR TITLE
fix: string in selectedTab comparison - connection status modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
@@ -338,7 +338,7 @@ class ConnectionStatusComponent extends PureComponent {
     if (isConnectionStatusEmpty(connectionStatus)) return this.renderEmpty();
 
     let connections = connectionStatus;
-    if (selectedTab === '2') {
+    if (selectedTab === 2) {
       connections = connections.filter(conn => conn.you);
       if (isConnectionStatusEmpty(connections)) return this.renderEmpty();
     }


### PR DESCRIPTION
### What does this PR do?

Fix selectedTab check in connection-status modal (selectTab is an integer, and would always be false if checked against a string).