### PR TITLE
Add Lock Setting For Viewer Annotations

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
@@ -32,7 +32,8 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
         lockedLayout = msg.body.lockedLayout,
         lockOnJoin = msg.body.lockOnJoin,
         lockOnJoinConfigurable = msg.body.lockOnJoinConfigurable,
-        hideViewersCursor = msg.body.hideViewersCursor
+        hideViewersCursor = msg.body.hideViewersCursor,
+        hideViewersAnnotation = msg.body.hideViewersAnnotation
       )
 
       if (!MeetingStatus2x.permissionsEqual(liveMeeting.status, settings) || !MeetingStatus2x.permisionsInitialized(liveMeeting.status)) {
@@ -229,6 +230,7 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
           lockOnJoin = settings.lockOnJoin,
           lockOnJoinConfigurable = settings.lockOnJoinConfigurable,
           hideViewersCursor = settings.hideViewersCursor,
+          hideViewersAnnotation = settings.hideViewersAnnotation,
           msg.body.setBy
         )
         val header = BbbClientMsgHeader(

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetLockSettingsReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetLockSettingsReqMsgHdlr.scala
@@ -25,7 +25,8 @@ trait GetLockSettingsReqMsgHdlr {
       lockedLayout = settings.lockedLayout,
       lockOnJoin = settings.lockOnJoin,
       lockOnJoinConfigurable = settings.lockOnJoinConfigurable,
-      hideViewersCursor = settings.hideViewersCursor
+      hideViewersCursor = settings.hideViewersCursor,
+      hideViewersAnnotation = settings.hideViewersAnnotation
     )
     val header = BbbClientMsgHeader(GetLockSettingsRespMsg.NAME, meetingId, requestedBy)
     val event = GetLockSettingsRespMsg(header, body)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -301,7 +301,8 @@ class MeetingActor(
       lockedLayout = lockSettingsProp.lockedLayout,
       lockOnJoin = lockSettingsProp.lockOnJoin,
       lockOnJoinConfigurable = lockSettingsProp.lockOnJoinConfigurable,
-      hideViewersCursor = lockSettingsProp.hideViewersCursor
+      hideViewersCursor = lockSettingsProp.hideViewersCursor,
+      hideViewersAnnotation = lockSettingsProp.hideViewersAnnotation
     )
 
     MeetingStatus2x.initializePermissions(liveMeeting.status)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/MeetingStatus2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/MeetingStatus2x.scala
@@ -14,7 +14,8 @@ case class Permissions(
     lockedLayout:           Boolean = false,
     lockOnJoin:             Boolean = true,
     lockOnJoinConfigurable: Boolean = false,
-    hideViewersCursor:      Boolean = false
+    hideViewersCursor:      Boolean = false,
+    hideViewersAnnotation:  Boolean = false
 )
 
 case class MeetingExtensionProp(maxExtensions: Int = 2, numExtensions: Int = 0, extendByMinutes: Int = 20,

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
@@ -64,7 +64,8 @@ case class LockSettingsProps(
     lockedLayout:           Boolean,
     lockOnJoin:             Boolean,
     lockOnJoinConfigurable: Boolean,
-    hideViewersCursor:      Boolean
+    hideViewersCursor:      Boolean,
+    hideViewersAnnotation:  Boolean
 )
 
 case class SystemProps(

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
@@ -252,7 +252,7 @@ case class ChangeLockSettingsInMeetingCmdMsg(
 ) extends StandardMsg
 case class ChangeLockSettingsInMeetingCmdMsgBody(disableCam: Boolean, disableMic: Boolean, disablePrivChat: Boolean,
                                                  disablePubChat: Boolean, disableNotes: Boolean, hideUserList: Boolean, lockedLayout: Boolean, lockOnJoin: Boolean,
-                                                 lockOnJoinConfigurable: Boolean, hideViewersCursor: Boolean, setBy: String)
+                                                 lockOnJoinConfigurable: Boolean, hideViewersCursor: Boolean, hideViewersAnnotation: Boolean, setBy: String)
 
 object LockSettingsInMeetingChangedEvtMsg { val NAME = "LockSettingsInMeetingChangedEvtMsg" }
 case class LockSettingsInMeetingChangedEvtMsg(
@@ -261,7 +261,7 @@ case class LockSettingsInMeetingChangedEvtMsg(
 ) extends BbbCoreMsg
 case class LockSettingsInMeetingChangedEvtMsgBody(disableCam: Boolean, disableMic: Boolean, disablePrivChat: Boolean,
                                                   disablePubChat: Boolean, disableNotes: Boolean, hideUserList: Boolean, lockedLayout: Boolean, lockOnJoin: Boolean,
-                                                  lockOnJoinConfigurable: Boolean, hideViewersCursor: Boolean, setBy: String)
+                                                  lockOnJoinConfigurable: Boolean, hideViewersCursor: Boolean, hideViewersAnnotation: Boolean, setBy: String)
 
 /**
  * Sent by client to query the lock settings.
@@ -277,7 +277,7 @@ object GetLockSettingsRespMsg { val NAME = "GetLockSettingsRespMsg" }
 case class GetLockSettingsRespMsg(header: BbbClientMsgHeader, body: GetLockSettingsRespMsgBody) extends BbbCoreMsg
 case class GetLockSettingsRespMsgBody(disableCam: Boolean, disableMic: Boolean, disablePrivChat: Boolean,
                                       disablePubChat: Boolean, disableNotes: Boolean, hideUserList: Boolean, lockedLayout: Boolean, lockOnJoin: Boolean,
-                                      lockOnJoinConfigurable: Boolean, hideViewersCursor: Boolean)
+                                      lockOnJoinConfigurable: Boolean, hideViewersCursor: Boolean, hideViewersAnnotation: Boolean)
 
 object LockSettingsNotInitializedRespMsg { val NAME = "LockSettingsNotInitializedRespMsg" }
 case class LockSettingsNotInitializedRespMsg(header: BbbClientMsgHeader, body: LockSettingsNotInitializedRespMsgBody) extends BbbCoreMsg

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -93,6 +93,7 @@ public class ApiParams {
     public static final String LOCK_SETTINGS_LOCK_ON_JOIN = "lockSettingsLockOnJoin";
     public static final String LOCK_SETTINGS_LOCK_ON_JOIN_CONFIGURABLE = "lockSettingsLockOnJoinConfigurable";
     public static final String LOCK_SETTINGS_HIDE_VIEWERS_CURSOR = "lockSettingsHideViewersCursor";
+    public static final String LOCK_SETTINGS_HIDE_VIEWERS_ANNOTATION = "lockSettingsHideViewersAnnotation";
 
     // New param passed on create call to callback when meeting ends.
     // This is a duplicate of the endCallbackUrl meta param as we want this

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -122,6 +122,7 @@ public class ParamsProcessorUtil {
 		private boolean defaultLockSettingsLockOnJoin;
 		private boolean defaultLockSettingsLockOnJoinConfigurable;
 		private boolean defaultLockSettingsHideViewersCursor;
+        private boolean defaultLockSettingsHideViewersAnnotation;
 
     private Long maxPresentationFileUpload = 30000000L; // 30MB
 
@@ -364,6 +365,12 @@ public class ParamsProcessorUtil {
                 lockSettingsHideViewersCursor = Boolean.parseBoolean(lockSettingsHideViewersCursorParam);
 			}
 
+            Boolean lockSettingsHideViewersAnnotation = defaultLockSettingsHideViewersAnnotation;
+			String lockSettingsHideViewersAnnotationParam = params.get(ApiParams.LOCK_SETTINGS_HIDE_VIEWERS_ANNOTATION);
+			if (!StringUtils.isEmpty(lockSettingsHideViewersAnnotationParam)) {
+                lockSettingsHideViewersAnnotation = Boolean.parseBoolean(lockSettingsHideViewersAnnotationParam);
+			}
+
 			return new LockSettingsParams(lockSettingsDisableCam,
 							lockSettingsDisableMic,
 							lockSettingsDisablePrivateChat,
@@ -373,7 +380,8 @@ public class ParamsProcessorUtil {
 							lockSettingsLockedLayout,
 							lockSettingsLockOnJoin,
 							lockSettingsLockOnJoinConfigurable,
-                            lockSettingsHideViewersCursor);
+                            lockSettingsHideViewersCursor,
+                            lockSettingsHideViewersAnnotation);
 		}
 
     private ArrayList<Group> processGroupsParams(Map<String, String> params) {
@@ -1418,6 +1426,10 @@ public class ParamsProcessorUtil {
 
 	public void setLockSettingsHideViewersCursor(Boolean lockSettingsHideViewersCursor) {
 		this.defaultLockSettingsHideViewersCursor = lockSettingsHideViewersCursor;
+	}
+
+    public void setLockSettingsHideViewersAnnotation(Boolean lockSettingsHideViewersAnnotation) {
+		this.defaultLockSettingsHideViewersAnnotation = lockSettingsHideViewersAnnotation;
 	}
 
 	public void setAllowDuplicateExtUserid(Boolean allow) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/LockSettingsParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/LockSettingsParams.java
@@ -11,6 +11,7 @@ public class LockSettingsParams {
 	public final Boolean lockOnJoin;
 	public final Boolean lockOnJoinConfigurable;
 	public final Boolean hideViewersCursor;
+	public final Boolean hideViewersAnnotation;
 
 	public LockSettingsParams(Boolean disableCam,
 					Boolean disableMic,
@@ -21,7 +22,8 @@ public class LockSettingsParams {
 					Boolean lockedLayout,
 					Boolean lockOnJoin,
 					Boolean lockOnJoinConfigurable,
-					Boolean hideViewersCursor) {
+					Boolean hideViewersCursor,
+					Boolean hideViewersAnnotation) {
 		this.disableCam = disableCam;
 		this.disableMic = disableMic;
 		this.disablePrivateChat = disablePrivateChat;
@@ -32,5 +34,6 @@ public class LockSettingsParams {
 		this.lockOnJoin = lockOnJoin;
 		this.lockOnJoinConfigurable = lockOnJoinConfigurable;
 		this.hideViewersCursor = hideViewersCursor;
+		this.hideViewersAnnotation = hideViewersAnnotation;
 	}
 }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -219,7 +219,8 @@ class BbbWebApiGWApp(
       lockedLayout = lockSettingsParams.lockedLayout.booleanValue(),
       lockOnJoin = lockSettingsParams.lockOnJoin.booleanValue(),
       lockOnJoinConfigurable = lockSettingsParams.lockOnJoinConfigurable.booleanValue(),
-      hideViewersCursor = lockSettingsParams.hideViewersCursor.booleanValue()
+      hideViewersCursor = lockSettingsParams.hideViewersCursor.booleanValue(),
+      hideViewersAnnotation = lockSettingsParams.hideViewersAnnotation.booleanValue()
     )
 
     val systemProps = SystemProps(

--- a/bigbluebutton-html5/imports/api/meetings/server/methods/toggleLockSettings.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/methods/toggleLockSettings.js
@@ -25,6 +25,7 @@ export default function toggleLockSettings(lockSettingsProps) {
       lockOnJoin: Boolean,
       lockOnJoinConfigurable: Boolean,
       hideViewersCursor: Boolean,
+      hideViewersAnnotation: Boolean,
       setBy: Match.Maybe(String),
     });
 
@@ -39,6 +40,7 @@ export default function toggleLockSettings(lockSettingsProps) {
       lockOnJoin,
       lockOnJoinConfigurable,
       hideViewersCursor,
+      hideViewersAnnotation,
     } = lockSettingsProps;
 
     const payload = {
@@ -52,6 +54,7 @@ export default function toggleLockSettings(lockSettingsProps) {
       lockOnJoin,
       lockOnJoinConfigurable,
       hideViewersCursor,
+      hideViewersAnnotation,
       setBy: requesterUserId,
     };
 

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -146,6 +146,7 @@ export default function addMeeting(meeting) {
       lockOnJoinConfigurable: Boolean,
       lockedLayout: Boolean,
       hideViewersCursor: Boolean,
+      hideViewersAnnotation: Boolean,
     },
     systemProps: {
       html5InstanceId: Number,

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/changeLockSettings.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/changeLockSettings.js
@@ -15,6 +15,7 @@ export default function changeLockSettings(meetingId, payload) {
     lockOnJoin: Boolean,
     lockOnJoinConfigurable: Boolean,
     hideViewersCursor: Boolean,
+    hideViewersAnnotation: Boolean,
     setBy: Match.Maybe(String),
   });
 
@@ -29,6 +30,7 @@ export default function changeLockSettings(meetingId, payload) {
     lockOnJoin,
     lockOnJoinConfigurable,
     hideViewersCursor,
+    hideViewersAnnotation,
     setBy,
   } = payload;
 
@@ -49,6 +51,7 @@ export default function changeLockSettings(meetingId, payload) {
         lockOnJoin,
         lockOnJoinConfigurable,
         hideViewersCursor,
+        hideViewersAnnotation,
         setBy,
       },
     },

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
@@ -78,6 +78,10 @@ const intlMessages = defineMessages({
   hideCursorsLabel: {
     id: "app.lock-viewers.hideViewersCursor",
     description: 'label for other viewers cursor',
+  },
+  hideAnnotationsLabel: {
+    id: "app.lock-viewers.hideAnnotationsLabel",
+    description: 'label for other viewers annotation',
   }
 });
 
@@ -376,6 +380,32 @@ class LockViewersComponent extends Component {
                     showToggleLabel={showToggleLabel}
                     invertColors={invertColors}
                     data-test="hideViewersCursor"
+                  />
+                </Styled.FormElementRight>
+              </Styled.Col>
+            </Styled.Row>
+
+            <Styled.Row data-test="hideViewersAnnotation">
+              <Styled.Col aria-hidden="true">
+                <Styled.FormElement>
+                  <Styled.Label>
+                    {intl.formatMessage(intlMessages.hideAnnotationsLabel)}
+                  </Styled.Label>
+                </Styled.FormElement>
+              </Styled.Col>
+              <Styled.Col>
+                <Styled.FormElementRight>
+                  {this.displayLockStatus(lockSettingsProps.hideViewersAnnotation)}
+                  <Toggle
+                    icons={false}
+                    defaultChecked={lockSettingsProps.hideViewersAnnotation}
+                    onChange={() => {
+                      this.toggleLockSettings('hideViewersAnnotation');
+                    }}
+                    ariaLabel={intl.formatMessage(intlMessages.hideAnnotationsLabel)}
+                    showToggleLabel={showToggleLabel}
+                    invertColors={invertColors}
+                    data-test="hideViewersAnnotation"
                   />
                 </Styled.FormElementRight>
               </Styled.Col>

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/context/context.js
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/context/context.js
@@ -13,6 +13,7 @@ export function LockStruct() {
       lockOnJoinConfigurable: false,
       lockedLayout: false,
       hideViewersCursor: false,
+      hideViewersAnnotation: false,
     },
     userLocks: {
       userWebcam: false,

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -831,6 +831,7 @@
     "app.lock-viewers.button.cancel": "Cancel",
     "app.lock-viewers.locked": "Locked",
     "app.lock-viewers.hideViewersCursor": "See other viewers cursors",
+    "app.lock-viewers.hideAnnotationsLabel": "See other viewers annotations",
     "app.guest-policy.ariaTitle": "Guest policy settings modal",
     "app.guest-policy.title": "Guest policy",
     "app.guest-policy.description": "Change meeting guest policy setting",

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -395,6 +395,7 @@ lockSettingsLockedLayout=false
 lockSettingsLockOnJoin=true
 lockSettingsLockOnJoinConfigurable=false
 lockSettingsHideViewersCursor=false
+lockSettingsHideViewersAnnotation=false
 
 defaultTextTrackUrl=${bigbluebutton.web.serverURL}/bigbluebutton
 

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -190,6 +190,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="lockSettingsLockOnJoin" value="${lockSettingsLockOnJoin}"/>
         <property name="lockSettingsLockOnJoinConfigurable" value="${lockSettingsLockOnJoinConfigurable}"/>
         <property name="lockSettingsHideViewersCursor" value="${lockSettingsHideViewersCursor}"/>
+        <property name="lockSettingsHideViewersAnnotation" value="${lockSettingsHideViewersAnnotation}"/>
         <property name="allowDuplicateExtUserid" value="${allowDuplicateExtUserid:true}"/>
         <property name="maxUserConcurrentAccesses" value="${maxUserConcurrentAccesses}"/>
         <property name="endWhenNoModerator" value="${endWhenNoModerator}"/>


### PR DESCRIPTION
### What does this PR do?
This PR adds a new lock setting for viewer annotations to the back end.

### Motivation
This will be needed for the whiteboard vision feature.