### PR TITLE
Disable paste file in whiteboard

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -696,30 +696,44 @@ export default function Whiteboard(props) {
     }
   };
 
+  const onPaste = (e) => {
+    // disable file pasting
+    const clipboardData = e.clipboardData || window.clipboardData;
+    const { types } = clipboardData;
+    const hasFiles = types && types.indexOf && types.indexOf('Files') !== -1;
+
+    if (hasFiles) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
+
   const webcams = document.getElementById('cameraDock');
   const dockPos = webcams?.getAttribute("data-position");
   const editableWB = (
-    <Tldraw
-      key={`wb-${isRTL}-${dockPos}-${forcePanning}`}
-      document={doc}
-      // disable the ability to drag and drop files onto the whiteboard
-      // until we handle saving of assets in akka.
-      disableAssets={true}
-      // Disable automatic focus. Users were losing focus on shared notes
-      // and chat on presentation mount.
-      autofocus={false}
-      onMount={onMount}
-      showPages={false}
-      showZoom={false}
-      showUI={curPres ? (isPresenter || hasWBAccess) : true}
-      showMenu={curPres ? false : true}
-      showMultiplayerMenu={false}
-      readOnly={false}
-      onPatch={onPatch}
-      onUndo={onUndo}
-      onRedo={onRedo}
-      onCommand={onCommand}
-    />
+    <div onPaste={onPaste}>
+      <Tldraw
+        key={`wb-${isRTL}-${dockPos}-${forcePanning}`}
+        document={doc}
+        // disable the ability to drag and drop files onto the whiteboard
+        // until we handle saving of assets in akka.
+        disableAssets={true}
+        // Disable automatic focus. Users were losing focus on shared notes
+        // and chat on presentation mount.
+        autofocus={false}
+        onMount={onMount}
+        showPages={false}
+        showZoom={false}
+        showUI={curPres ? (isPresenter || hasWBAccess) : true}
+        showMenu={curPres ? false : true}
+        showMultiplayerMenu={false}
+        readOnly={false}
+        onPatch={onPatch}
+        onUndo={onUndo}
+        onRedo={onRedo}
+        onCommand={onCommand}
+      />
+    </div>
   );
 
   const readOnlyWB = (


### PR DESCRIPTION
### What does this PR do?

Disabling copy-paste of files, as we currently don't support the propagation of copy-pasted images on the whiteboard.

### Closes Issue(s)
Closes #16059