### PR TITLE
fix: Add trim to name parameter

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ParamsUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ParamsUtil.java
@@ -18,7 +18,7 @@ public class ParamsUtil {
   public static final String INVALID_CHARS = ",";
 
   public static String stripControlChars(String text) {
-    return text.replaceAll("\\p{Cc}", "");
+    return text.replaceAll("\\p{Cc}", "").trim();
   }
 
   public static String escapeHTMLTags(String value) {


### PR DESCRIPTION
### What does this PR do?

It adds trim to name parameter to improve the string sanitising in bbb-web

### Motivation

Having white-spaces in front of name used to mess up the list sorting 

### More

Related: https://github.com/bigbluebutton/bigbluebutton/pull/16127
