### PR TITLE
fix: do not render video list item if user data is unavailable

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/container.jsx
@@ -7,13 +7,15 @@ import VideoListItem from './component';
 import { layoutSelect, layoutDispatch } from '/imports/ui/components/layout/context';
 
 const VideoListItemContainer = (props) => {
-  const { cameraId } = props;
+  const { cameraId, user } = props;
 
   const fullscreen = layoutSelect((i) => i.fullscreen);
   const { element } = fullscreen;
   const isFullscreenContext = (element === cameraId);
   const layoutContextDispatch = layoutDispatch();
   const isRTL = layoutSelect((i) => i.isRTL);
+
+  if (!user) return null;
 
   return (
     <VideoListItem


### PR DESCRIPTION
### What does this PR do?

Prevents client crash due to unavailable data by adding early return in VideoListItemContainer if user data is unavailable.