### PR TITLE
Makefile 2.5

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - run: ./build/get_external_dependencies.sh
       - run: make REPOSITORY=/repo SIGNWITH=none
       - run: tar cvf artifacts.tar artifacts/
       - name: Archive packages

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt install reprepro
-      - run: sudo make REPOSITORY=/repo SIGNWITH=none
+      - run: sudo make REPOSITORY=/repo
       - run: tar cvf artifacts.tar artifacts/
       - name: Archive packages
         uses: actions/upload-artifact@v3

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt install reprepro
-      - run: make REPOSITORY=/repo SIGNWITH=none
+      - run: sudo make REPOSITORY=/repo SIGNWITH=none
       - run: tar cvf artifacts.tar artifacts/
       - name: Archive packages
         uses: actions/upload-artifact@v3

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - run: apt install reprepro
       - run: make REPOSITORY=/repo SIGNWITH=none
       - run: tar cvf artifacts.tar artifacts/
       - name: Archive packages

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - run: apt install reprepro
+      - run: sudo apt install reprepro
       - run: make REPOSITORY=/repo SIGNWITH=none
       - run: tar cvf artifacts.tar artifacts/
       - name: Archive packages

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Setup local repository
         run: |
             sudo sh -c '
-            echo "deb [trusted=yes] file:/repo/ ./" >> /etc/apt/sources.list
+            echo "deb [trusted=yes] file:/repo/ bigbluebutton-focal main" >> /etc/apt/sources.list
             '
       - name: Prepare for install
         run: |

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt install reprepro
-      - run: sudo make REPOSITORY=/repo
+        # default github CI runner has two cores, so tell make to run two jobs simultaneously
+      - run: sudo make REPOSITORY=/repo -j2
       - run: tar cvf artifacts.tar artifacts/
       - name: Archive packages
         uses: actions/upload-artifact@v3

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -15,26 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: ./build/get_external_dependencies.sh
-      - run: ./build/setup.sh bbb-apps-akka
-      - run: ./build/setup.sh bbb-config
-      - run: ./build/setup.sh bbb-etherpad
-      - run: ./build/setup.sh bbb-freeswitch-core
-      - run: ./build/setup.sh bbb-freeswitch-sounds
-      - run: ./build/setup.sh bbb-fsesl-akka
-      - run: ./build/setup.sh bbb-html5
-      - run: ./build/setup.sh bbb-learning-dashboard
-      - run: ./build/setup.sh bbb-libreoffice-docker
-      - run: ./build/setup.sh bbb-mkclean
-      - run: ./build/setup.sh bbb-pads
-      - run: ./build/setup.sh bbb-playback
-      - run: ./build/setup.sh bbb-playback-notes
-      - run: ./build/setup.sh bbb-playback-podcast
-      - run: ./build/setup.sh bbb-playback-presentation
-      - run: ./build/setup.sh bbb-playback-screenshare
-      - run: ./build/setup.sh bbb-record-core
-      - run: ./build/setup.sh bbb-web
-      - run: ./build/setup.sh bbb-webrtc-sfu
-      - run: ./build/setup.sh bigbluebutton
+      - run: make REPOSITORY=/repo SIGNWITH=none
       - run: tar cvf artifacts.tar artifacts/
       - name: Archive packages
         uses: actions/upload-artifact@v3
@@ -96,12 +77,7 @@ jobs:
       - name: Setup local repository
         run: |
             sudo sh -c '
-            apt install -yq dpkg-dev
-            cd /root && wget -q http://ci.bbbvm.imdt.com.br/cache-3rd-part-packages.tar
-            cp -r /home/runner/work/bigbluebutton/bigbluebutton/artifacts/ /artifacts/
-            cd /artifacts && tar xf /root/cache-3rd-part-packages.tar
-            cd /artifacts && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
-            echo "deb [trusted=yes] file:/artifacts/ ./" >> /etc/apt/sources.list
+            echo "deb [trusted=yes] file:/repo/ ./" >> /etc/apt/sources.list
             '
       - name: Prepare for install
         run: |

--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,12 @@ $(REPOSITORY)/conf/distributions:
 
 $(REPOSITORY):: $(REPOSITORY)/conf/distributions
 
+# reprepro won't overwrite an existing package in the repository, so when updating,
+# remove the packages first and just ignore any errors that occur
+
 $(REPOSITORY):: $(PACKAGES)
-	reprepro -b $(REPOSITORY) includedeb $(CODENAME) $(PACKAGES)
+	reprepro -b $(REPOSITORY) remove $(CODENAME) $(shell basename -a $? | sed 's/_[^ ]*//g')
+	reprepro -b $(REPOSITORY) includedeb $(CODENAME) $?
 	touch $(REPOSITORY)
 
 # It's not clear which placeholders need to be created to be any given package, so depend

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+
+# Makefile to build a Debian repository in a directory named $(COMMIT),
+# which is the first six characters of our current git commit.
+
+# These are the list of packages that we'll build
+
+TARGETS := $(shell grep build/setup .github/workflows/automated-tests.yml  | sed 's|^.*./build/setup.sh ||')
+
+COMMIT := $(shell git rev-parse HEAD | cut -c 1-6)
+COMMIT_DATE := $(shell git log -n1 --pretty='format:%cd' --date=format:'%Y%m%dT%H%M%S')
+
+RELEASE := $(shell cut -d = -f 2 bigbluebutton-config/bigbluebutton-release | sed 's/-/~/')
+
+$(COMMIT):
+
+define makerule =
+  EPOCH_$1 = $(shell if echo $1 | grep -q -e bbb-apps-akka -e bbb-fsesl-akka; then echo 2\\:; fi)
+  ARCH_$1 = $(shell if echo $1 | grep -q -e bbb-apps-akka -e bbb-fsesl-akka; then echo all; else echo amd64; fi)
+  PACKAGE_$1 = $1_$$(EPOCH_$1)$(RELEASE)+$(COMMIT_DATE)-git._$$(ARCH_$1).deb
+  packages: artifacts/$$(PACKAGE_$1)
+  artifacts/$$(PACKAGE_$1):
+	./build/setup.sh $1
+endef
+
+$(foreach _,${TARGETS},$(eval $(call makerule,$_)))
+
+PACKAGES=$(foreach pkg,${TARGETS},artifacts/$(PACKAGE_$(pkg)))
+DOTDOT_ARTIFACTS_PACKAGES=$(foreach pkg,${TARGETS},../artifacts/$(PACKAGE_$(pkg)))
+
+
+$(COMMIT)/conf/distributions:
+	mkdir -p $(COMMIT)/conf/
+	sed 's/bigbluebutton-bionic/bigbluebutton-focal/' distributions > $(COMMIT)/conf/distributions
+
+$(COMMIT): $(COMMIT)/conf/distributions packages cache-3rd-part-packages
+	cd $(COMMIT); reprepro includedeb bigbluebutton-focal $(shell find cache-3rd-part-packages -name '*.deb' -exec echo ../{} \;)
+	cd $(COMMIT); reprepro includedeb bigbluebutton-focal $(DOTDOT_ARTIFACTS_PACKAGES)
+
+cache-3rd-part-packages: cache-3rd-part-packages.tar
+	mkdir cache-3rd-part-packages
+	cd cache-3rd-part-packages; tar xf ../cache-3rd-part-packages.tar
+
+cache-3rd-part-packages.tar:
+	wget http://ci.bbbvm.imdt.com.br/cache-3rd-part-packages.tar

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,11 @@ TARGETS := bbb-apps-akka bbb-config bbb-etherpad bbb-freeswitch-core bbb-freeswi
 COMMIT := $(shell git rev-parse HEAD | cut -c 1-6)
 COMMIT_DATE := $(shell git log -n1 --pretty='format:%cd' --date=format:'%Y%m%dT%H%M%S')
 
-# The BigBlueButton release, only used to determine the Ubuntu distribution
-RELEASE := $(shell cut -d = -f 2 bigbluebutton-config/bigbluebutton-release | sed 's/-/~/')
+# The BigBlueButton version number
+VERSION_NUMBER := $(shell cat "bigbluebutton-config/bigbluebutton-release" | cut -d '=' -f2 | cut -d "-" -f1)
 
 # Ubuntu distribution, currently bionic for BigBlueButton 2.4 and focal for BigBlueButton 2.5 and 2.6
-DISTRO := $(shell if echo $(RELEASE) | grep -q 2\\.4; then echo bionic; else echo focal; fi)
+DISTRO := $(shell if echo $(VERSION_NUMBER) | grep -q 2\\.4; then echo bionic; else echo focal; fi)
 
 # Package repository codename
 CODENAME := bigbluebutton-$(DISTRO)
@@ -52,8 +52,14 @@ $(REPOSITORY)::
 # The point is to trigger a build when the file doesn't exist, even
 # though all we know is its wildcard pattern
 
+ifeq ($(BUILD_TYPE),release)
+   PACKAGE_LABEL=$(VERSION_NUMBER)
+else
+   PACKAGE_LABEL=$(COMMIT_DATE)
+endif
+
 define makerule =
-  PACKAGE_$1 = artifacts/$1_*$(COMMIT_DATE)*.deb
+  PACKAGE_$1 = artifacts/$1_*$(PACKAGE_LABEL)*.deb
   $$(PACKAGE_$1):
 	./build/setup.sh $1
 endef

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ CODENAME := bigbluebutton-$(DISTRO)
 REPOSITORY := $(DISTRO)-$(COMMIT)
 
 $(REPOSITORY)::
+	@if ! which reprepro >/dev/null; then echo apt install reprepro is required; exit 1; fi
 
 # PACKAGE_$(pkg) contains the package filename with wildcards NOT expanded
 #
@@ -61,7 +62,6 @@ $(REPOSITORY)/conf/distributions:
 $(REPOSITORY):: $(REPOSITORY)/conf/distributions
 
 $(REPOSITORY):: $(PACKAGES)
-	@if ! which reprepro >/dev/null; then echo apt install reprepro is required; exit 1; fi
 	reprepro -b $(REPOSITORY) includedeb $(CODENAME) $(PACKAGES)
 
 # Download the third party packages tar file, but only if it's been updated on the Internet.
@@ -89,7 +89,6 @@ EXTRA_PACKAGES_TAR := cache-3rd-part-packages.tar
 
 $(REPOSITORY)::
 	$(eval MYTMP := $(shell mktemp))
-	@if ! which reprepro >/dev/null; then echo apt install reprepro is required; exit 1; fi
 	wget --timestamping http://ci.bbbvm.imdt.com.br/cache-3rd-part-packages.tar
 	mkdir -p $(REPOSITORY)/pool/main
 	tar -f $(EXTRA_PACKAGES_TAR) -C $(REPOSITORY)/pool/main -x --skip-old-files

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ export BUILD_TYPE
 
 TARGETS := bbb-apps-akka bbb-config bbb-etherpad bbb-freeswitch-core bbb-freeswitch-sounds bbb-fsesl-akka bbb-html5 bbb-learning-dashboard bbb-libreoffice-docker bbb-mkclean bbb-pads bbb-playback bbb-playback-notes bbb-playback-podcast bbb-playback-presentation bbb-playback-screenshare bbb-record-core bbb-web bbb-webrtc-sfu bigbluebutton
 
+# Placeholders are shell scripts that are run to create subdirectories, typically by running a git checkout.
+
+PLACEHOLDERS := $(shell echo *.placeholder.sh | sed 's/.placeholder.sh//g')
+
 # The current commit's hash (used for the name of the repository) and date (used for the package names)
 COMMIT := $(shell git rev-parse HEAD | cut -c 1-6)
 COMMIT_DATE := $(shell git log -n1 --pretty='format:%cd' --date=format:'%Y%m%dT%H%M%S')
@@ -84,6 +88,14 @@ $(REPOSITORY):: $(REPOSITORY)/conf/distributions
 
 $(REPOSITORY):: $(PACKAGES)
 	reprepro -b $(REPOSITORY) includedeb $(CODENAME) $(PACKAGES)
+
+# It's not clear which placeholders need to be created to be any given package, so depend
+# all of the packages on all of the placeholders.
+
+$(PACKAGES): $(PLACEHOLDERS)
+
+%: %.placeholder.sh
+	./$<
 
 # Download the third party packages tar file, but only if it's been updated on the Internet.
 # Untar any files in it that are missing from the repository.

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ export BUILD_TYPE
 
 # These are the list of packages that we'll build
 
-TARGETS := bbb-apps-akka bbb-config bbb-etherpad bbb-freeswitch-core bbb-freeswitch-sounds bbb-fsesl-akka bbb-html5 bbb-learning-dashboard bbb-libreoffice-docker bbb-mkclean bbb-pads bbb-playback bbb-playback-notes bbb-playback-podcast bbb-playback-presentation bbb-playback-screenshare bbb-record-core bbb-web bbb-webrtc-sfu bigbluebutton
+TARGETS := $(shell basename -a $(shell dirname build/packages-template/*/build.sh))
 
 # Placeholders are shell scripts that are run to create subdirectories, typically by running a git checkout.
 
@@ -68,7 +68,7 @@ endef
 
 $(foreach pkg,${TARGETS},$(eval $(call makerule,$(pkg))))
 
-# PACKAGES is the list of package with wildcards NOT expanded
+# PACKAGES is the list of packages with wildcards NOT expanded
 
 PACKAGES=$(foreach pkg,${TARGETS},$(PACKAGE_$(pkg)))
 
@@ -82,6 +82,7 @@ $(REPOSITORY):: $(REPOSITORY)/conf/distributions
 
 $(REPOSITORY):: $(PACKAGES)
 	reprepro -b $(REPOSITORY) includedeb $(CODENAME) $(PACKAGES)
+	touch $(REPOSITORY)
 
 # It's not clear which placeholders need to be created to be any given package, so depend
 # all of the packages on all of the placeholders.

--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,84 @@
 
-# Makefile to build a Debian repository in a directory named $(COMMIT),
-# which is the first six characters of our current git commit.
+# Makefile to build a Debian repository in a directory named
+# $(DISTRO)-$(COMMIT), where $(DISTRO) is either focal or bionic and
+# $(COMMIT) is the first six characters of the current git commit.
+#
+# All package builds are done using docker.  This Makefile expects the
+# build scripts to leave the .deb packages in the "artifacts"
+# directory.
+#
+# The repository is signed with the current user's GPG key.
+#
+# Requirements: docker and reprepro
+#
+# sudo access is required to run docker
 
-# These are the list of packages that we'll build
-
+# These are the list of packages that we'll build, pulled from the CI configuration
 TARGETS := $(shell grep build/setup .github/workflows/automated-tests.yml  | sed 's|^.*./build/setup.sh ||')
 
+# The current commit's hash (used for the name of the repository) and date (used for the package names)
 COMMIT := $(shell git rev-parse HEAD | cut -c 1-6)
 COMMIT_DATE := $(shell git log -n1 --pretty='format:%cd' --date=format:'%Y%m%dT%H%M%S')
 
+# The BigBlueButton release, only used to determine the Ubuntu distribution
 RELEASE := $(shell cut -d = -f 2 bigbluebutton-config/bigbluebutton-release | sed 's/-/~/')
 
-$(COMMIT):
+# Ubuntu distribution, currently bionic for BigBlueButton 2.4 and focal for BigBlueButton 2.5 and 2.6
+DISTRO := $(shell if echo $(RELEASE) | grep -q 2\\.4; then echo bionic; else echo focal; fi)
+
+# Package repository codename
+CODENAME := bigbluebutton-$(DISTRO)
+
+# The directory in which we'll build the Debian package repository
+REPOSITORY := $(DISTRO)-$(COMMIT)
+
+$(REPOSITORY)::
+
+# PACKAGE_$(pkg) contains the package filename with wildcards NOT expanded
+#
+# The point is to trigger a build when the file doesn't exist, even
+# though all we know is its wildcard pattern
 
 define makerule =
-  EPOCH_$1 = $(shell if echo $1 | grep -q -e bbb-apps-akka -e bbb-fsesl-akka; then echo 2\\:; fi)
-  ARCH_$1 = $(shell if echo $1 | grep -q -e bbb-apps-akka -e bbb-fsesl-akka; then echo all; else echo amd64; fi)
-  PACKAGE_$1 = $1_$$(EPOCH_$1)$(RELEASE)+$(COMMIT_DATE)-git._$$(ARCH_$1).deb
-  packages: artifacts/$$(PACKAGE_$1)
-  artifacts/$$(PACKAGE_$1):
+  PACKAGE_$1 = artifacts/$1_*$(COMMIT_DATE)*.deb
+  $$(PACKAGE_$1):
 	./build/setup.sh $1
 endef
 
-$(foreach _,${TARGETS},$(eval $(call makerule,$_)))
+$(foreach pkg,${TARGETS},$(eval $(call makerule,$(pkg))))
 
-PACKAGES=$(foreach pkg,${TARGETS},artifacts/$(PACKAGE_$(pkg)))
-DOTDOT_ARTIFACTS_PACKAGES=$(foreach pkg,${TARGETS},../artifacts/$(PACKAGE_$(pkg)))
+# PACKAGES is the list of package with wildcards NOT expanded
 
+PACKAGES=$(foreach pkg,${TARGETS},$(PACKAGE_$(pkg)))
 
-$(COMMIT)/conf/distributions:
-	mkdir -p $(COMMIT)/conf/
-	sed 's/bigbluebutton-bionic/bigbluebutton-focal/' distributions > $(COMMIT)/conf/distributions
+$(REPOSITORY)/conf/distributions:
+	mkdir -p $(REPOSITORY)/conf/
+	echo Codename: $(CODENAME)  > $(REPOSITORY)/conf/distributions
+	echo Architectures: amd64  >> $(REPOSITORY)/conf/distributions
+	echo Components: main      >> $(REPOSITORY)/conf/distributions
+	echo SignWith: yes         >> $(REPOSITORY)/conf/distributions
 
-$(COMMIT): $(COMMIT)/conf/distributions packages cache-3rd-part-packages
-	cd $(COMMIT); reprepro includedeb bigbluebutton-focal $(shell find cache-3rd-part-packages -name '*.deb' -exec echo ../{} \;)
-	cd $(COMMIT); reprepro includedeb bigbluebutton-focal $(DOTDOT_ARTIFACTS_PACKAGES)
+$(REPOSITORY):: $(REPOSITORY)/conf/distributions
 
-cache-3rd-part-packages: cache-3rd-part-packages.tar
-	mkdir cache-3rd-part-packages
-	cd cache-3rd-part-packages; tar xf ../cache-3rd-part-packages.tar
+$(REPOSITORY):: $(PACKAGES)
+	@if ! which reprepro >/dev/null; then echo apt install reprepro is required; exit 1; fi
+	reprepro -b $(REPOSITORY) includedeb $(CODENAME) $(PACKAGES)
 
-cache-3rd-part-packages.tar:
-	wget http://ci.bbbvm.imdt.com.br/cache-3rd-part-packages.tar
+# double-colon rules always get run, even if the target already exists
+# wget --timestamping only downloads the file if it's newer
+
+EXTRA_PACKAGES_TAR := cache-3rd-part-packages.tar
+
+$(EXTRA_PACKAGES_TAR)::
+	wget --timestamping http://ci.bbbvm.imdt.com.br/cache-3rd-part-packages.tar
+
+# The cleanest way to include the 3rd-part-packages would be to extract the tar file
+# to a temporary directory, then call "reprepro includedeb" on all of the package
+# files therein.  I've found that I can extract the tar file directly into the
+# repository directory and call "reprepro includedeb" on the packages there.
+
+$(REPOSITORY):: $(EXTRA_PACKAGES_TAR)
+	@if ! which reprepro >/dev/null; then echo apt install reprepro is required; exit 1; fi
+	mkdir -p $(REPOSITORY)/pool/main
+	tar -f $(EXTRA_PACKAGES_TAR) -C $(REPOSITORY)/pool/main -x
+	reprepro -b $(REPOSITORY) includedeb $(CODENAME) $(shell tar -f $(EXTRA_PACKAGES_TAR) -t --wildcards '*.deb' | sed s:^:$(REPOSITORY)/pool/main/:)

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,14 @@
 # build scripts to leave the .deb packages in the "artifacts"
 # directory.
 #
-# The repository is signed with the current user's GPG key.
+# The repository by default is unsigned, but the SIGNWITH variable,
+# if present, is passed to reprepro via a config file.
+#
+# SIGNWITH=yes signs with the current user's default GPG key.
+#
+# The BUILD_TYPE variable is passed on to the docker build scripts.
+#
+# BUILD_TYPE=release is the sensible alternative.
 #
 # Requirements: docker and reprepro
 #
@@ -57,12 +64,15 @@ $(foreach pkg,${TARGETS},$(eval $(call makerule,$(pkg))))
 
 PACKAGES=$(foreach pkg,${TARGETS},$(PACKAGE_$(pkg)))
 
-$(REPOSITORY)/conf/distributions:
+# double-colon to recreate this file every time we call make,
+# so that SIGNWITH always reflects the current setting
+
+$(REPOSITORY)/conf/distributions::
 	mkdir -p $(REPOSITORY)/conf/
 	echo Codename: $(CODENAME)  > $(REPOSITORY)/conf/distributions
 	echo Architectures: amd64  >> $(REPOSITORY)/conf/distributions
 	echo Components: main      >> $(REPOSITORY)/conf/distributions
-	echo SignWith: yes         >> $(REPOSITORY)/conf/distributions
+	if [ -n "$(SIGNWITH)" ]; then echo SignWith: $(SIGNWITH) >> $(REPOSITORY)/conf/distributions; fi
 
 $(REPOSITORY):: $(REPOSITORY)/conf/distributions
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 
-# Makefile to build a Debian repository in a directory named
+# Makefile to build a Debian repository in directory REPOSITORY.
+#
+# If REPOSITORY isn't specified as a make option, the default is
 # $(DISTRO)-$(COMMIT), where $(DISTRO) is either focal or bionic and
 # $(COMMIT) is the first six characters of the current git commit.
 #
@@ -13,8 +15,11 @@
 #
 # sudo access is required to run docker
 
-# These are the list of packages that we'll build, pulled from the CI configuration
-TARGETS := $(shell grep build/setup .github/workflows/automated-tests.yml  | sed 's|^.*./build/setup.sh ||')
+export BUILD_TYPE
+
+# These are the list of packages that we'll build
+
+TARGETS := bbb-apps-akka bbb-config bbb-etherpad bbb-freeswitch-core bbb-freeswitch-sounds bbb-fsesl-akka bbb-html5 bbb-learning-dashboard bbb-libreoffice-docker bbb-mkclean bbb-pads bbb-playback bbb-playback-notes bbb-playback-podcast bbb-playback-presentation bbb-playback-screenshare bbb-record-core bbb-web bbb-webrtc-sfu bigbluebutton
 
 # The current commit's hash (used for the name of the repository) and date (used for the package names)
 COMMIT := $(shell git rev-parse HEAD | cut -c 1-6)
@@ -30,7 +35,7 @@ DISTRO := $(shell if echo $(RELEASE) | grep -q 2\\.4; then echo bionic; else ech
 CODENAME := bigbluebutton-$(DISTRO)
 
 # The directory in which we'll build the Debian package repository
-REPOSITORY := $(DISTRO)-$(COMMIT)
+REPOSITORY ?= $(DISTRO)-$(COMMIT)
 
 $(REPOSITORY)::
 	@if ! which reprepro >/dev/null; then echo apt install reprepro is required; exit 1; fi

--- a/build/setup.sh
+++ b/build/setup.sh
@@ -43,7 +43,7 @@ trap 'kill_docker' SIGINT SIGTERM
 
 # -v "$CACHE_DIR/dev":/root/dev
 sudo docker run --rm --detach --cidfile $DOCKER_CONTAINER_ID_FILE \
-        --env GIT_REV=$GIT_REV --env COMMIT_DATE=$COMMIT_DATE --env "LOCAL_BUILD=1" \
+        --env GIT_REV=$GIT_REV --env COMMIT_DATE=$COMMIT_DATE --env "LOCAL_BUILD=1" --env BUILD_TYPE=$BUILD_TYPE \
         --mount type=bind,src="$PWD",dst=/mnt \
         --mount type=bind,src="${PWD}/artifacts,dst=/artifacts" \
         -t "$DOCKER_IMAGE" /mnt/build/setup-inside-docker.sh "$PACKAGE_TO_BUILD"

--- a/build/setup.sh
+++ b/build/setup.sh
@@ -23,8 +23,26 @@ else
 fi
 COMMIT_DATE="$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%dT%H%M%S')"
 
+# Arrange to write the docker container ID to a temp file, then run
+# the container detached and immediately attach it (without stdin) so
+# we can catch CTRL-C in this script and kill the container if so.
+
+DOCKER_CONTAINER_ID_FILE=$(mktemp)
+rm $DOCKER_CONTAINER_ID_FILE
+
+kill_docker() {
+   if [[ -r $DOCKER_CONTAINER_ID_FILE ]]; then
+      sudo docker kill $(cat $DOCKER_CONTAINER_ID_FILE)
+      sudo rm $DOCKER_CONTAINER_ID_FILE
+   fi
+   tput cnorm
+   exit 1
+}
+
+trap 'kill_docker' SIGINT SIGTERM
+
 # -v "$CACHE_DIR/dev":/root/dev
-sudo docker run --rm \
+sudo docker run --rm --detach --cidfile $DOCKER_CONTAINER_ID_FILE \
         --env GIT_REV=$GIT_REV --env COMMIT_DATE=$COMMIT_DATE --env "LOCAL_BUILD=1" \
         --mount type=bind,src="$PWD",dst=/mnt \
         --mount type=bind,src="${PWD}/artifacts,dst=/artifacts" \
@@ -35,5 +53,8 @@ sudo docker run --rm \
 #        -v "$CACHE_DIR/$DISTRO/.ivy2:/root/.ivy2" \
 #        -v "$CACHE_DIR/$DISTRO/.m2:/root/.m2" \
 #        -v "$TMP/$TARGET:$TMP/$TARGET"  \
+
+docker attach --no-stdin $(cat $DOCKER_CONTAINER_ID_FILE)
+sudo rm $DOCKER_CONTAINER_ID_FILE
 
 find artifacts


### PR DESCRIPTION
Add a `Makefile` that will build a Debian repository suitable for installing a server.

For example, if the current git commit is `ec84f1`, running `make` will build a full set of BigBlueButton packages and generate a directory called `focal-ec84f1` that, when placed in the root directory of a web server, allows a BigBlueButton server to be installed using `bbb-install` by passing it `-r WEBSERVER -v focal-ec84f1`.

Issues:

* `Makefile` doesn't follow the naming convention for released packages, so it will not generate a release repository in quite the same way as our release packaging scripts

* `Makefile` is currently in the project home directory; should it be in the `build` directory instead?  I didn't put it there for several reasons:

  * new developers will see it immediately in the home directory
  * the build scripts already create an `artifacts` directory in the home directory, so why not create repositories there?

* `automated-tests.yml` now calls `make` instead of calling `build/setup.sh`

* the list of packages to build is no longer listed manually in `automated-tests.yml`, but rather every subdirectory in `build/packages-template` with a `build.sh` file is treated as a package to be built

* placeholder directories are not read from `.gitlab-ci.yml` (though that file is not changed), but rather every file in the home directory ending in `.placeholder.sh` is treated as a placeholder script to be run to generate the corresponding directory

* `build/change_detection.sh` is not used; no attempt is made to determine if an older package can be reused.  All packages are rebuilt for every git commit.

* [fix(ci): Allow builds to be interrupted #15734](https://github.com/bigbluebutton/bigbluebutton/pull/15734) is included in this PR; that other pull request was merged to `develop`, while this one is targeted at `v2.5.x-release`

