### PR TITLE
fix: Only cache TURN Servers as long as credentials are valid and force firefox to use the turn server

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -614,7 +614,6 @@ class VideoProvider extends Component {
       },
       onicecandidate: this._getOnIceCandidateCallback(stream, isLocal),
       configuration: {
-        iceTransportPolicy: shouldForceRelay() ? 'relay' : undefined,
       },
       trace: TRACE_LOGS,
       networkPriorities: NETWORK_PRIORITY ? { video: NETWORK_PRIORITY } : undefined,
@@ -635,6 +634,9 @@ class VideoProvider extends Component {
       // Use fallback STUN server
       iceServers = getMappedFallbackStun();
     } finally {
+      // we need to set iceTransportPolicy after `fetchWebRTCMappedStunTurnServers`
+      // because `shouldForceRelay` uses the information from the stun API
+      peerOptions.configuration.iceTransportPolicy = shouldForceRelay() ? 'relay' : undefined;
       if (iceServers.length > 0) {
         peerOptions.configuration.iceServers = iceServers;
       }

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/utils.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/utils.js
@@ -1,7 +1,7 @@
 import browserInfo from '/imports/utils/browserInfo';
 import deviceInfo from '/imports/utils/deviceInfo';
+import { hasTurnServer } from '/imports/utils/fetchStunTurnServers';
 
-const FORCE_RELAY_ON_FF = Meteor.settings.public.kurento.forceRelayOnFirefox;
 const FORCE_RELAY = Meteor.settings.public.media.forceRelay;
 
 /*
@@ -16,7 +16,7 @@ const shouldForceRelay = () => {
   const { isFirefox } = browserInfo;
   const { isIos } = deviceInfo;
 
-  return FORCE_RELAY || ((isFirefox && !isIos) && FORCE_RELAY_ON_FF);
+  return FORCE_RELAY || ((isFirefox && !isIos) && hasTurnServer());
 };
 
 export {

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/utils.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/utils.js
@@ -2,6 +2,7 @@ import browserInfo from '/imports/utils/browserInfo';
 import deviceInfo from '/imports/utils/deviceInfo';
 import { hasTurnServer } from '/imports/utils/fetchStunTurnServers';
 
+const FORCE_RELAY_ON_FF = Meteor.settings.public.media.forceRelayOnFirefox;
 const FORCE_RELAY = Meteor.settings.public.media.forceRelay;
 
 /*
@@ -16,7 +17,7 @@ const shouldForceRelay = () => {
   const { isFirefox } = browserInfo;
   const { isIos } = deviceInfo;
 
-  return FORCE_RELAY || ((isFirefox && !isIos) && hasTurnServer());
+  return FORCE_RELAY || ((isFirefox && !isIos) && FORCE_RELAY_ON_FF && hasTurnServer());
 };
 
 export {

--- a/bigbluebutton-html5/imports/utils/fetchStunTurnServers.js
+++ b/bigbluebutton-html5/imports/utils/fetchStunTurnServers.js
@@ -7,9 +7,11 @@ const FALLBACK_STUN_SERVER = MEDIA.fallbackStunServer;
 
 let STUN_TURN_DICT;
 let MAPPED_STUN_TURN_DICT;
+let TURN_CACHE_VALID_UNTIL = Math.floor(Date.now() / 1000);
 
 const fetchStunTurnServers = function (sessionToken) {
-  if (STUN_TURN_DICT && CACHE_STUN_TURN) return Promise.resolve(STUN_TURN_DICT);
+  const now = Math.floor(Date.now() / 1000);
+  if (STUN_TURN_DICT && CACHE_STUN_TURN && now < TURN_CACHE_VALID_UNTIL) return Promise.resolve(STUN_TURN_DICT);
 
   const handleStunTurnResponse = ({ stunServers, turnServers }) => {
     if (!stunServers && !turnServers) {
@@ -17,14 +19,22 @@ const fetchStunTurnServers = function (sessionToken) {
     }
 
     const turnReply = [];
+    let max_ttl = null;
     _.each(turnServers, (turnEntry) => {
       const { password, url, username } = turnEntry;
+      const valid_until = parseInt(username.split(':')[0]);
+      if (!max_ttl) {
+        max_ttl = valid_until;
+      } else if (valid_until < max_ttl) {
+        max_ttl = valid_until;
+      }
       turnReply.push({
         urls: url,
         password,
         username,
       });
     });
+    TURN_CACHE_VALID_UNTIL = max_ttl;
 
     const stDictionary = {
       stun: stunServers.map(server => server.url),
@@ -58,7 +68,8 @@ const getMappedFallbackStun = () => (FALLBACK_STUN_SERVER ? [{ urls: FALLBACK_ST
 const fetchWebRTCMappedStunTurnServers = function (sessionToken) {
   return new Promise(async (resolve, reject) => {
     try {
-      if (MAPPED_STUN_TURN_DICT && CACHE_STUN_TURN) {
+      const now = Math.floor(Date.now() / 1000);
+      if (MAPPED_STUN_TURN_DICT && CACHE_STUN_TURN && now < TURN_CACHE_VALID_UNTIL) {
         return resolve(MAPPED_STUN_TURN_DICT);
       }
 

--- a/bigbluebutton-html5/imports/utils/fetchStunTurnServers.js
+++ b/bigbluebutton-html5/imports/utils/fetchStunTurnServers.js
@@ -8,6 +8,7 @@ const FALLBACK_STUN_SERVER = MEDIA.fallbackStunServer;
 let STUN_TURN_DICT;
 let MAPPED_STUN_TURN_DICT;
 let TURN_CACHE_VALID_UNTIL = Math.floor(Date.now() / 1000);
+let HAS_SEEN_TURN_SERVER = false;
 
 const fetchStunTurnServers = function (sessionToken) {
   const now = Math.floor(Date.now() / 1000);
@@ -33,6 +34,7 @@ const fetchStunTurnServers = function (sessionToken) {
         password,
         username,
       });
+      HAS_SEEN_TURN_SERVER = true;
     });
     TURN_CACHE_VALID_UNTIL = max_ttl;
 
@@ -83,9 +85,14 @@ const fetchWebRTCMappedStunTurnServers = function (sessionToken) {
   });
 };
 
+const hasTurnServer = () => {
+  return HAS_SEEN_TURN_SERVER;
+}
+
 export {
   fetchStunTurnServers,
   fetchWebRTCMappedStunTurnServers,
   getFallbackStun,
   getMappedFallbackStun,
+  hasTurnServer,
 };

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -267,8 +267,6 @@ public:
     # Controls whether ICE candidates should be signaled to bbb-webrtc-sfu.
     # Enable this if you want to use Kurento as the media server.
     signalCandidates: false
-    # Forces relay usage only on Firefox. Applies to listen only, webcams and screenshare.
-    forceRelayOnFirefox: false
     # traceLogs: <Boolean> - enable trace logs in SFU peers
     traceLogs: false
     cameraTimeouts:

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -585,6 +585,9 @@ public:
     # Forces relay usage on all browsers, environments and media modules.
     # If true, supersedes public.kurento.forceRelayOnFirefox
     forceRelay: false
+    # Firefox has a buggy ICE implementation. With mediasoup this leads to
+    # connection problems unless all traffic is relayed through a turn server.
+    forceRelayOnFirefox: true
     mediaTag: '#remote-media'
     callTransferTimeout: 5000
     callHangupTimeout: 2000


### PR DESCRIPTION
### What does this PR do?

TURN credentials were cached forever. However they expire. So refresh them when required.

Force Firefox to use a turn server if there is one configured. Get rid of `public.kurento.forceRelayOnFirefox` configuration option

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
closes #16171
closes #16164 

### Motivation

* BBB should not stop working when users have long running sessions.
* BBB should work in all supported browsers, no matter how weird network conditions are