### PR TITLE
fix(export-annotations): Display poll results

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationWithAnnotationsMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationWithAnnotationsMsgHdlr.scala
@@ -13,6 +13,12 @@ import java.io.File
 trait PresentationWithAnnotationsMsgHdlr extends RightsManagementTrait {
   this: PresentationPodHdlrs =>
 
+  object JobTypes {
+    val DOWNLOAD = "PresentationWithAnnotationDownloadJob"
+    val CAPTURE_PRESENTATION = "PresentationWithAnnotationExportJob"
+    val CAPTURE_NOTES = "PadCaptureJob"
+  }
+
   def buildStoreAnnotationsInRedisSysMsg(annotations: StoredAnnotations, liveMeeting: LiveMeeting): BbbCommonEnvCoreMsg = {
     val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
     val envelope = BbbCoreEnvelope(StoreAnnotationsInRedisSysMsg.NAME, routing)
@@ -111,7 +117,6 @@ trait PresentationWithAnnotationsMsgHdlr extends RightsManagementTrait {
       log.error(s"Presentation ${presId} not found in meeting ${meetingId}")
     } else {
 
-      val jobType: String = "PresentationWithAnnotationDownloadJob"
       val jobId: String = RandomStringGenerator.randomAlphanumericString(16);
       val allPages: Boolean = m.body.allPages
       val pageCount = currentPres.get.pages.size
@@ -120,7 +125,7 @@ trait PresentationWithAnnotationsMsgHdlr extends RightsManagementTrait {
       val pages: List[Int] = m.body.pages // Desired presentation pages for export
       val pagesRange: List[Int] = if (allPages) (1 to pageCount).toList else pages
 
-      val exportJob: ExportJob = new ExportJob(jobId, jobType, "annotated_slides", presId, presLocation, allPages, pagesRange, meetingId, "");
+      val exportJob: ExportJob = new ExportJob(jobId, JobTypes.DOWNLOAD, "annotated_slides", presId, presLocation, allPages, pagesRange, meetingId, "");
       val storeAnnotationPages: List[PresentationPageForExport] = getPresentationPagesForExport(pagesRange, pageCount, presId, currentPres, liveMeeting);
 
       // Send Export Job to Redis
@@ -147,7 +152,6 @@ trait PresentationWithAnnotationsMsgHdlr extends RightsManagementTrait {
     } else {
 
       val jobId: String = RandomStringGenerator.randomAlphanumericString(16);
-      val jobType = "PresentationWithAnnotationExportJob"
       val allPages: Boolean = m.allPages
       val pageCount = currentPres.get.pages.size
 
@@ -172,7 +176,7 @@ trait PresentationWithAnnotationsMsgHdlr extends RightsManagementTrait {
       // Informs bbb-web about the token so that when we use it to upload the presentation, it is able to look it up in the list of tokens
       bus.outGW.send(buildPresentationUploadTokenSysPubMsg(parentMeetingId, userId, presentationUploadToken, filename))
 
-      val exportJob: ExportJob = new ExportJob(jobId, jobType, filename, presId, presLocation, allPages, pagesRange, parentMeetingId, presentationUploadToken)
+      val exportJob: ExportJob = new ExportJob(jobId, JobTypes.CAPTURE_PRESENTATION, filename, presId, presLocation, allPages, pagesRange, parentMeetingId, presentationUploadToken)
       val storeAnnotationPages: List[PresentationPageForExport] = getPresentationPagesForExport(pagesRange, pageCount, presId, currentPres, liveMeeting);
 
       // Send Export Job to Redis
@@ -210,13 +214,12 @@ trait PresentationWithAnnotationsMsgHdlr extends RightsManagementTrait {
 
     val userId: String = "system"
     val jobId: String = s"${m.body.breakoutId}-notes" // Used as the temporaryPresentationId upon upload
-    val jobType = "PadCaptureJob"
     val filename = m.body.filename
     val presentationUploadToken: String = PresentationPodsApp.generateToken("DEFAULT_PRESENTATION_POD", userId)
 
     bus.outGW.send(buildPresentationUploadTokenSysPubMsg(m.body.parentMeetingId, userId, presentationUploadToken, filename))
 
-    val exportJob = new ExportJob(jobId, jobType, filename, m.body.padId, "", true, List(), m.body.parentMeetingId, presentationUploadToken)
+    val exportJob = new ExportJob(jobId, JobTypes.CAPTURE_NOTES, filename, m.body.padId, "", true, List(), m.body.parentMeetingId, presentationUploadToken)
     val job = buildStoreExportJobInRedisSysMsg(exportJob, liveMeeting)
 
     bus.outGW.send(job)

--- a/bbb-export-annotations/lib/utils/logger.js
+++ b/bbb-export-annotations/lib/utils/logger.js
@@ -1,13 +1,13 @@
 const config = require('../../config');
 
-const { level } = config.log;
+const {level} = config.log;
 const trace = level.toLowerCase() === 'trace';
 const debug = trace || level.toLowerCase() === 'debug';
 
 const date = () => new Date().toISOString();
 
 const parse = (messages) => {
-  return messages.map(message => {
+  return messages.map((message) => {
     if (typeof message === 'object') return JSON.stringify(message);
 
     return message;

--- a/bbb-export-annotations/lib/utils/message-builder.js
+++ b/bbb-export-annotations/lib/utils/message-builder.js
@@ -1,0 +1,88 @@
+const config = require('../../config');
+
+const EXPORT_STATUSES = Object.freeze({
+  COLLECTING: 'COLLECTING',
+  PROCESSING: 'PROCESSING',
+});
+
+class PresAnnStatusMsg {
+  constructor(exportJob, status = EXPORT_STATUSES.COLLECTING) {
+    this.message = {
+      envelope: {
+        name: config.log.msgName,
+        routing: {
+          sender: exportJob.module,
+        },
+        timestamp: (new Date()).getTime(),
+      },
+      core: {
+        header: {
+          name: config.log.msgName,
+          meetingId: exportJob.parentMeetingId,
+          userId: '',
+        },
+        body: {
+          presId: exportJob.presId,
+          pageNumber: 1,
+          totalPages: JSON.parse(exportJob.pages).length,
+          status,
+          error: false,
+        },
+      },
+    };
+  }
+
+  build = (pageNumber = 1) => {
+    this.message.core.body.pageNumber = pageNumber;
+    this.message.envelope.timestamp = (new Date()).getTime();
+    const event = JSON.stringify(this.message);
+    this.message.core.body.error = false;
+    return event;
+  };
+
+  setError = (error = true) => {
+    this.message.core.body.error = error;
+  };
+
+  setStatus = (status) => {
+    this.message.core.body.status = status;
+  };
+
+  static get EXPORT_STATUSES() {
+    return EXPORT_STATUSES;
+  }
+};
+
+class NewPresAnnFileAvailableMsg {
+  constructor(exportJob, link) {
+    this.message = {
+      envelope: {
+        name: config.notifier.msgName,
+        routing: {
+          sender: exportJob.module,
+        },
+        timestamp: (new Date()).getTime(),
+      },
+      core: {
+        header: {
+          name: config.notifier.msgName,
+          meetingId: exportJob.parentMeetingId,
+          userId: '',
+        },
+        body: {
+          fileURI: link,
+          presId: exportJob.presId,
+        },
+      },
+    };
+  }
+
+  build = () => {
+    return JSON.stringify(this.message);
+  };
+};
+
+module.exports = {
+  PresAnnStatusMsg,
+  NewPresAnnFileAvailableMsg,
+};

--- a/bbb-export-annotations/package-lock.json
+++ b/bbb-export-annotations/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^0.26.0",
         "form-data": "^4.0.0",
+        "lodash": "^4.17.21",
         "perfect-freehand": "^1.0.16",
         "probe-image-size": "^7.2.3",
         "redis": "^4.0.3",
@@ -919,6 +920,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -2043,6 +2049,11 @@
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/bbb-export-annotations/workers/notifier.js
+++ b/bbb-export-annotations/workers/notifier.js
@@ -5,6 +5,7 @@ const FormData = require('form-data');
 const redis = require('redis');
 const axios = require('axios').default;
 const path = require('path');
+const {NewPresAnnFileAvailableMsg} = require('../lib/utils/message-builder');
 
 const {workerData} = require('worker_threads');
 const [jobType, jobId, filename] = [workerData.jobType, workerData.jobId, workerData.filename];
@@ -31,30 +32,10 @@ async function notifyMeetingActor() {
       exportJob.parentMeetingId, exportJob.parentMeetingId,
       exportJob.presId, 'pdf', jobId, filename);
 
-  const notification = {
-    envelope: {
-      name: config.notifier.msgName,
-      routing: {
-        sender: exportJob.module,
-      },
-      timestamp: (new Date()).getTime(),
-    },
-    core: {
-      header: {
-        name: config.notifier.msgName,
-        meetingId: exportJob.parentMeetingId,
-        userId: '',
-      },
-      body: {
-        fileURI: link,
-        presId: exportJob.presId,
-      },
-    },
-  };
+  const notification = new NewPresAnnFileAvailableMsg(exportJob, link);
 
   logger.info(`Annotated PDF available at ${link}`);
-  await client.publish(config.redis.channels.publish,
-      JSON.stringify(notification));
+  await client.publish(config.redis.channels.publish, notification.build());
   client.disconnect();
 }
 

--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -596,7 +596,7 @@ function overlay_shape_label(svg, annotation) {
   const fontSize = text_size_to_px(annotation.style.size, annotation.style.scale);
   const textAlign = 'center';
   const text = annotation.label;
-  const id = annotation.id;
+  const id = sanitize(annotation.id);
   const rotation = rad_to_degree(annotation.rotation);
 
   const [shape_width, shape_height] = annotation.size;
@@ -641,7 +641,7 @@ function overlay_sticky(svg, annotation) {
 
   const textColor = '#0d0d0d'; // For sticky notes
   const text = annotation.text;
-  const id = annotation.id;
+  const id = sanitize(annotation.id);
 
   render_textbox(textColor, font, fontSize, textAlign, text, id, textBoxWidth);
 
@@ -701,7 +701,7 @@ function overlay_text(svg, annotation) {
   const fontSize = text_size_to_px(annotation.style.size, annotation.style.scale);
   const textAlign = align_to_pango(annotation.style.textAlign);
   const text = annotation.text;
-  const id = annotation.id;
+  const id = sanitize(annotation.id);
 
   const rotation = rad_to_degree(annotation.rotation);
   const [textBox_x, textBox_y] = annotation.point;
@@ -854,14 +854,7 @@ async function process_presentation_annotations() {
       }
     });
 
-    // Dimensions converted to a pixel size which,
-    // when converted to points, will yield the desired
-    // dimension in pixels when read without conversion
-
-    // e.g. say the background SVG dimensions are set to 1920x1080 pt
-    // Resize output to 2560x1440 px so that the SVG
-    // generates with the original size in pt.
-
+    // Scale slide back to its original size
     const convertAnnotatedSlide = [
       SVGfile,
       '--output-width', to_px(slideWidth),


### PR DESCRIPTION
### What does this PR do?
A change in how poll shape ids are stored in the client made them unusable in the annotation export due to the presence of path characters. This PR sanitizes incoming ids to display polling results in the generated PDF again.

### Closes Issue(s)
Closes #16151

### Motivation
Having all annotations in the exported PDF.

![Screenshot 2022-12-18 at 19 35 14](https://user-images.githubusercontent.com/33319791/208314259-73509583-5973-40e2-86a7-efc4a774f4cf.png)

### More
Refactors how progress messages are sent back to the client to lay the groundwork necessary to inform instructors of e.g. breakout rooms without content.
