### PR TITLE
fix: hide export presentation hint if feature is disabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -19,6 +19,7 @@ import Checkbox from '/imports/ui/components/common/checkbox/component';
 const { isMobile } = deviceInfo;
 
 const propTypes = {
+  allowDownloadable: PropTypes.bool.isRequired,
   intl: PropTypes.object.isRequired,
   fileUploadConstraintsHint: PropTypes.bool.isRequired,
   fileSizeMax: PropTypes.number.isRequired,
@@ -954,6 +955,18 @@ class PresentationUploader extends Component {
     }
   }
 
+  renderDownloadableWithAnnotationsHint() {
+    const {
+      intl,
+      allowDownloadable
+    } = this.props;
+
+    return allowDownloadable ? (
+        <Styled.ExportHint>
+          {intl.formatMessage(intlMessages.exportHint)}
+        </Styled.ExportHint>)
+      : null;
+  }
   renderPresentationItem(item) {
     const { disableActions } = this.state;
     const {
@@ -1218,10 +1231,8 @@ class PresentationUploader extends Component {
               {`${intl.formatMessage(intlMessages.message)}`}
               {fileUploadConstraintsHint ? this.renderExtraHint() : null}
             </Styled.ModalHint>
-              {this.renderPresentationList()}
-            <Styled.ExportHint>
-              {intl.formatMessage(intlMessages.exportHint)}
-            </Styled.ExportHint>
+            {this.renderPresentationList()}
+            {this.renderDownloadableWithAnnotationsHint()}
             {isMobile ? this.renderPicDropzone() : null}
             {this.renderDropzone()}
             {this.renderExternalUpload()}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Hides the hint explaining about presentation with annotations exporting when the feature is disabled.


before:

![Screenshot from 2022-12-19 12-54-46](https://user-images.githubusercontent.com/6312397/208509433-5090d6d5-8f63-4ae7-ae89-4b6dc06094b1.png)

after:

![Screenshot from 2022-12-19 12-57-10](https://user-images.githubusercontent.com/6312397/208509457-f4f63ddf-8072-462f-a46b-6b3a115a1d03.png)
![Screenshot from 2022-12-19 13-11-47](https://user-images.githubusercontent.com/6312397/208509473-96fc76b7-cb62-4ccd-950c-f8ddbc1fe7f4.png)


<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none


### Motivation

The label is out of place if the feature is not enabled for the meeting
<!-- What inspired you to submit this pull request? -->

### More

- To test this simply pass `disabledFeatures=downloadPresentationWithAnnotations` in API MATE vs not passing it in a different meeting