### PR TITLE
fix: Remove Aria Live From Captions

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/captions/live/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/live/component.jsx
@@ -74,11 +74,7 @@ class LiveCaptions extends PureComponent {
         <div style={captionStyles}>
           {clear ? '' : data}
         </div>
-        <div
-          style={visuallyHidden}
-          aria-atomic
-          aria-live="polite"
-        >
+        <div style={visuallyHidden}>
           {clear ? '' : data}
         </div>
       </div>


### PR DESCRIPTION
### What does this PR do?
Removes the `aria-live` and `aria-atomic` props
### Motivation
Functional accessibility issue: If a screen reader user enables the closed captions (which is highly unlikely for a screen reader user to choose to do, as a screen reader user could hear a cacophony of both the person speaking the words in the meeting, as well as the screen reader announcing the captions of those same words shortly thereafter. Perhaps an admin would want to check if these captions are working) Additionally, the closed captioning contains an aria-atomic="true" attribute, causing the presented captions to be announced in full upon every presented change, and thus announcing a given caption snippet often more than once (e.g., You could hear the screen reader announce “Welcome to the… Welcome to the meeting everyone… Welcome to the meeting everyone please settle in.”)