### PR TITLE
Shortcut expression (replace up-arrow with Shift and omit +)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
@@ -316,19 +316,19 @@ const ShortcutHelpComponent = (props) => {
   //views
   whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.zoomIn), 'Ctrl +'));
   whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.zoomOut), 'Ctrl -'));
-  whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.zoomFit), '↑ + 1'));
-  whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.zoomSelect), '↑ + 2'));
+  whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.zoomFit), 'Shift 1'));
+  whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.zoomSelect), 'Shift 2'));
 //transform
-  whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.flipH), '↑ + H'));
-  whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.flipV), '↑ + V'));
-  whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.lock), 'Ctrl ↑ L'));
-  whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.moveToFront), '↑ ]'));
+  whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.flipH), 'Shift H'));
+  whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.flipV), 'Shift V'));
+  whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.lock), 'Ctrl Shift L'));
+  whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.moveToFront), 'Shift ]'));
   whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.moveForward), ']'));
   whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.moveBackward), '['));
-  whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.moveToBack), '↑ ['));
+  whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.moveToBack), 'Shift ['));
   //edit
   whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.undo), 'Ctrl Z'));
-  whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.redo), 'Ctrl ↑ Z'));
+  whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.redo), 'Ctrl Shift Z'));
   whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.cut), 'Ctrl X'));
   whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.copy), 'Ctrl C'));
   whiteboardShortcutItems.push(renderItem(intl.formatMessage(intlMessages.paste), 'Ctrl V'));


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Proposing a different way of short cut key expression.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation

We developers know up-arrow means the shift key, but ordinary people may not. It may be mixed up with the actual arrow key. 
Also, key combo expression is a bit confusing; in one place "Ctrl A" but in another "Shift + V". It would be more comfortable without "+" (there is "Ctrl Shift U", which could be too long with "+", and there is also "Ctrl +" for zooming in). In the worst case, people may try to push the "+" button as well.

### More

Whether we include "+" or not may be related to the UI design. In the general shortcut everything includes "+", which I don't touch for now.
