### PR TITLE
Fix bbb-conf restart

### DIFF
--- a/bigbluebutton-config/bin/apply-lib.sh
+++ b/bigbluebutton-config/bin/apply-lib.sh
@@ -109,6 +109,15 @@ enableUFWRules() {
   ufw allow OpenSSH
   ufw allow "Nginx Full"
   ufw allow 16384:32768/udp
+
+  # Check if coturn is running on this server and, if so, open firewall port
+  if systemctl status coturn > /dev/null; then
+    echo "  - Local turnserver detected -- opening port 3478"
+    ufw allow 3478
+    # echo "  - Forcing FireFox to use turn server"
+    # yq w -i $HTML5_CONFIG public.kurento.forceRelayOnFirefox true 
+  fi
+
   ufw --force enable
 }
 

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -1686,8 +1686,7 @@ if [ -n "$HOST" ]; then
 
 
     echo "Restarting BigBlueButton $BIGBLUEBUTTON_RELEASE ..."
-    stop_bigbluebutton
-    start_bigbluebutton
+    systemctl restart bigbluebutton.target
 
     exit 0
 fi
@@ -1699,8 +1698,7 @@ if [ $RESTART ]; then
 
     echo "Restarting BigBlueButton $BIGBLUEBUTTON_RELEASE ..."
 
-    stop_bigbluebutton
-    start_bigbluebutton
+    systemctl restart bigbluebutton.target
     check_state
 fi
 


### PR DESCRIPTION

### What does this PR do?
`bbb-conf` now uses `systemctl restart bigbluebutton.target` for a more deterministic restart.

Also adds a firewall entry for 3478 if local turn server is detected (experimental)

### Closes Issue(s)
Closes #16304
