### PR TITLE
build: consistent naming of gitlab ci jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -99,7 +99,7 @@ bbb-html5-build:
   script:
     - build/setup-inside-docker.sh bbb-html5
 
-bbb-learning-dashboard:
+bbb-learning-dashboard-build:
   extends: .build_job
   script:
     - build/setup-inside-docker.sh bbb-learning-dashboard


### PR DESCRIPTION
### What does this PR do?

renames gitlab ci job bbb-learning-dashboard to bbb-learning-dashboard-build, so it's consistent with the others.

### Motivation

this fixes my tooling