### PR TITLE
fix: Bump bbb-common-message version #16185

### DIFF
--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -85,7 +85,7 @@ dependencies {
   implementation "org.apache.tomcat.embed:tomcat-embed-websocket:${tomcatEmbedVersion}"
   implementation "org.apache.tomcat:tomcat-annotations-api:${tomcatEmbedVersion}"
   //--- BigBlueButton Dependencies Start - Transitive dependencies have to be re-defined below
-  implementation "org.bigbluebutton:bbb-common-message_2.13:0.0.21-SNAPSHOT"
+  implementation "org.bigbluebutton:bbb-common-message_2.13:0.0.22-SNAPSHOT"
   implementation "org.bigbluebutton:bbb-common-web:0.0.3-SNAPSHOT"
   implementation "io.lettuce:lettuce-core:6.1.9.RELEASE"
   implementation "org.reactivestreams:reactive-streams:1.0.3"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Bumping the version of `bbb-common-message` required for `bigbluebutton-web`.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation
I missed this in https://github.com/bigbluebutton/bigbluebutton/pull/16185 and is only showing up now that https://github.com/bigbluebutton/bigbluebutton/pull/15679 was also included. Without the change from this current PR, development environments (or any env which had .21-SNAPSHOT cached) would not allow bbb-web <-> akka-apps interoperability.
<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->

