### PR TITLE
refactor (bbb-soffice): Switch parent image to amazoncorretto:17-alpine (backport)

### DIFF
--- a/bbb-libreoffice/docker/Dockerfile
+++ b/bbb-libreoffice/docker/Dockerfile
@@ -1,13 +1,3 @@
-FROM openjdk:17-slim-bullseye
-ENV DEBIAN_FRONTEND noninteractive
+FROM amazoncorretto:17-alpine
 
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
-RUN apt update && apt -y install locales-all fontconfig libxt6 libxrender1
-RUN apt update && apt -y install libreoffice \
-  && rm -f \
-  /usr/share/java/ant-apache-log4j-1.10.9.jar \
-  /usr/share/java/log4j-1.2-1.2.17.jar /usr/share/java/log4j-1.2.jar \
-  /usr/share/maven-repo/log4j/log4j/1.2.17/log4j-1.2.17.jar \
-  /usr/share/maven-repo/log4j/log4j/1.2.x/log4j-1.2.x.jar \
-  /usr/share/maven-repo/org/apache/ant/ant-apache-log4j/1.10.9/ant-apache-log4j-1.10.9.jar
-
+RUN apk add fontconfig libreoffice


### PR DESCRIPTION
Backporting https://github.com/bigbluebutton/bigbluebutton/pull/15743 to BBB 2.5
(due to the deprecation notice, see #15743 for more info)
