### PR TITLE
test: Add `npm run test:ssh` command to test suite

### DIFF
--- a/bigbluebutton-tests/playwright/README.md
+++ b/bigbluebutton-tests/playwright/README.md
@@ -50,6 +50,12 @@ You can also use this also through the test tree, adding the test suite / group 
 $ npm run test:filter "notifications chat"
 ```
 
+If you don't have `BBB_URL` and `BBB_SECRET` set, but have ssh access to the test server, you can use the following command to obtain `BBB_URL` and `BBB_SECRET` via ssh:
+
+```bash
+$ npm run test:ssh -- HOSTNAME
+```
+
 #### Recording Meteor messages
 
 A modified version of `websockify` can be used to record the Meteor messages exchanged between client and server, by inserted a WebSocket proxy between the client and server, configured to record the sessions.

--- a/bigbluebutton-tests/playwright/package.json
+++ b/bigbluebutton-tests/playwright/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
     "test": "npx playwright test",
+    "test:ssh": "set -e; fn () { target=$1; shift; secret=$(ssh $target sudo bbb-conf --secret); env=$(echo \"$secret\" | sed -e 's/^ *URL: /BBB_URL=/' -e '/^BBB_URL/s/$/api/' -e 's/^ *Secret: /BBB_SECRET=/' -e '/^BBB/p' -e d); env $env npx playwright test $@; }; fn",
     "test:filter": "npx playwright test -g",
     "test:headed": "npx playwright test --headed",
     "test:debug": "npx playwright test --debug -g",


### PR DESCRIPTION
This npm script will ssh to a BigBlueButton server, obtain its URL and SECRET, then run the test suite using these settings.

This reduces the complexity of running tests (no need to set environment variables) if you have ssh access to the server.

The shell script is a bit obscure, and comments are not allowed in JSON.

The "set -e" switch is used to exit the script if the ssh fails, but this only works if the ssh is not part of a pipeline, which is why it is assigned to a separate variable. (see https://unix.stackexchange.com/a/23099/37949)
