### PR TITLE
fix: Add Active Status to Presentation Menu Item for SR

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -261,6 +261,7 @@ class ActionsDropdown extends PureComponent {
             customStyles: p.current ? customStyles : null,
             icon: "file",
             iconRight: p.current ? 'check' : null,
+            selected: p.current ? true : false,
             label: p.name,
             description: "uploaded presentation file",
             key: `uploaded-presentation-${p.id}`,

--- a/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
@@ -65,7 +65,7 @@ class BBBMenu extends React.Component {
   };
 
   makeMenuItems() {
-    const { actions, selectedEmoji } = this.props;
+    const { actions, selectedEmoji, intl } = this.props;
 
     return actions?.map(a => {
       const { dataTest, label, onClick, key, disabled, description, selected } = a;

--- a/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
@@ -64,8 +64,7 @@ class BBBMenu extends React.Component {
     const { actions, selectedEmoji } = this.props;
 
     return actions?.map(a => {
-      const { dataTest, label, onClick, key, disabled, description } = a;
-
+      const { dataTest, label, onClick, key, disabled, description, selected } = a;
       const emojiSelected = key?.toLowerCase()?.includes(selectedEmoji?.toLowerCase());
 
       let customStyles = {
@@ -101,7 +100,7 @@ class BBBMenu extends React.Component {
           <Styled.MenuItemWrapper>
             {a.icon ? <Icon iconName={a.icon} key="icon" /> : null}
             <Styled.Option aria-describedby={`${key}-option-desc`}>{label}</Styled.Option>
-            {description && <div className="sr-only" id={`${key}-option-desc`}>{description}</div>}
+            {description && <div className="sr-only" id={`${key}-option-desc`}>{`${description}${selected ? ' - selected' : ''}`}</div>}
             {a.iconRight ? <Styled.IconRight iconName={a.iconRight} key="iconRight" /> : null}
           </Styled.MenuItemWrapper>
         </Styled.BBBMenuItem>,

--- a/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
@@ -16,6 +16,10 @@ const intlMessages = defineMessages({
     id: 'app.dropdown.close',
     description: 'Close button label',
   },
+  active: {
+    id: 'app.dropdown.list.item.activeLabel',
+    description: 'active item label',
+  },
 });
 
 class BBBMenu extends React.Component {
@@ -100,7 +104,7 @@ class BBBMenu extends React.Component {
           <Styled.MenuItemWrapper>
             {a.icon ? <Icon iconName={a.icon} key="icon" /> : null}
             <Styled.Option aria-describedby={`${key}-option-desc`}>{label}</Styled.Option>
-            {description && <div className="sr-only" id={`${key}-option-desc`}>{`${description}${selected ? ' - selected' : ''}`}</div>}
+            {description && <div className="sr-only" id={`${key}-option-desc`}>{`${description}${selected ? ` - ${intl.formatMessage(intlMessages.active)}` : ''}`}</div>}
             {a.iconRight ? <Styled.IconRight iconName={a.iconRight} key="iconRight" /> : null}
           </Styled.MenuItemWrapper>
         </Styled.BBBMenuItem>,


### PR DESCRIPTION
### What does this PR do?
Adds the `active` context to the currently selected presentation in the actions dropdown menu for screen readers.

Before:
`default.pdf uploaded presentation file  1 of 8`
`DifferentSizes.pdf uploaded presentation file 2 of 8`

After:
`default.pdf uploaded presentation file  1 of 8`
`DifferentSizes.pdf uploaded presentation file - Active  2 of 8`

### Motivation
The currently selected presentation fails to indicate that it is active to screen reader users