### PR TITLE
fix(whiteboard): group answers case insensitive in the poll text

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -9,6 +9,7 @@ import PollService from '/imports/ui/components/poll/service';
 import logger from '/imports/startup/client/logger';
 import { defineMessages } from 'react-intl';
 import { notify } from '/imports/ui/services/notification';
+import caseInsensitiveReducer from '/imports/utils/caseInsensitiveReducer';
 
 const Annotations = new Mongo.Collection(null);
 
@@ -340,6 +341,7 @@ const getShapes = (whiteboardId, curPageId, intl) => {
   annotations.forEach((annotation) => {
     if (annotation.annotationInfo.questionType) {
       // poll result, convert it to text and create tldraw shape
+      annotation.annotationInfo.answers = annotation.annotationInfo.answers.reduce(caseInsensitiveReducer, []);
       const pollResult = PollService.getPollResultString(annotation.annotationInfo, intl)
         .split('<br/>').join('\n').replace( /(<([^>]+)>)/ig, '');
       annotation.annotationInfo = {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fixes the poll annotation in the whiteboard to be consistent to the chat message and also live result, grouping the answers case insensitive

![poll_group_](https://user-images.githubusercontent.com/2726293/210836672-3c9f6e19-71f6-474f-83d6-85ebfb81a333.png)


