### PR TITLE
Recording: move tpad ffmpeg filter before fps (2.5 backport)

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video.rb
@@ -541,8 +541,8 @@ module BigBlueButton
             ffmpeg_filter << "[#{input_index}]"
             # Scale the video length for the deskshare timestamp workaround
             ffmpeg_filter << "setpts=PTS*#{scale}," unless scale.nil?
-            # Clean up the video framerate and extend the video if needed
-            ffmpeg_filter << "fps=#{layout[:framerate]},tpad=stop=-1:stop_mode=clone"
+            # Extend the video if needed and clean up the framerate
+            ffmpeg_filter << "tpad=stop=-1:stop_mode=clone,fps=#{layout[:framerate]}"
             # Apply PTS offset so '0' time is aligned, and trim frames before start point
             ffmpeg_filter << ",setpts=PTS-#{ms_to_s(video[:timestamp])}/TB,trim=start=0"
             ffmpeg_filter << "[#{pad_name}];"


### PR DESCRIPTION
In cases of extremely short (single frame) input videos, the fps filter can sometimes generate 0-frame output videos, resulting in the tpad filter having no input (this breaks it, causing a busy loop).

Move the tpad filter to before the fps filter to solve this problem. This isn't perfect, since the tpad filter doesn't work well on variable- framerate video (it generates extremely high framerate video with a lot of frames that will be discarded), but this only happens between the tpad and fps filters, and only at the end of an input video (usually right before a cut) so this seems acceptable.

Since the tpad and fps filter are in the same process, these duplicate frames don't actually require copying any data (the frame is reference-counted), and still process reasonably quickly.

Backport of #16409 to BigBlueButton 2.5