### PR TITLE
fix: (bbb-web) Set default value for learningDashboardEnabled and breakoutRoomsEnabled in bigbluebutton.properties instead

### DIFF
--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -434,3 +434,4 @@ allowRevealOfBBBVersion=false
 
 learningDashboardEnabled=true
 breakoutRoomsEnabled=true
+

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -432,3 +432,5 @@ endWhenNoModeratorDelayInMinutes=1
 # Allow endpoint with current BigBlueButton version
 allowRevealOfBBBVersion=false
 
+learningDashboardEnabled=true
+breakoutRoomsEnabled=true

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -153,7 +153,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="disableRecordingDefault" value="${disableRecordingDefault}"/>
         <property name="autoStartRecording" value="${autoStartRecording}"/>
         <property name="allowStartStopRecording" value="${allowStartStopRecording}"/>
-        <property name="learningDashboardEnabled" value="${learningDashboardEnabled:true}"/>
+        <property name="learningDashboardEnabled" value="${learningDashboardEnabled}"/>
         <property name="learningDashboardCleanupDelayInMinutes" value="${learningDashboardCleanupDelayInMinutes}"/>
         <property name="webcamsOnlyForModerator" value="${webcamsOnlyForModerator}"/>
         <property name="defaultMeetingCameraCap" value="${meetingCameraCap}"/>
@@ -173,7 +173,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="muteOnStart" value="${muteOnStart}"/>
         <property name="allowModsToUnmuteUsers" value="${allowModsToUnmuteUsers}"/>
         <property name="allowModsToEjectCameras" value="${allowModsToEjectCameras}"/>
-        <property name="breakoutRoomsEnabled" value="${breakoutRoomsEnabled:true}"/>
+        <property name="breakoutRoomsEnabled" value="${breakoutRoomsEnabled}"/>
         <property name="breakoutRoomsRecord" value="${breakoutRoomsRecord}"/>
         <property name="breakoutRoomsPrivateChatEnabled" value="${breakoutRoomsPrivateChatEnabled}"/>
         <property name="lockSettingsDisableCam" value="${lockSettingsDisableCam}"/>


### PR DESCRIPTION
### What does this PR do?

It moves setting the default value from xml file to bigbluebutton.properties

The change we are doing is including these properties + the default value in bigbluebutton.properties so that they can be overriden in `/etc/bigbluebutton/bbb-web.properties

### Closes Issue(s)

Closes #16416


### Motivation

During the upgraded version of Spring two properties were affected:
`learningDashboardEnabled` and `breakoutRoomsEnabled` https://github.com/bigbluebutton/bigbluebutton/blob/v2.5.x-release/bigbluebutton-web/grails-app/conf/spring/resources.xml#L156
