### PR TITLE
fix(whiteboard): Prevent Parent Id Crash when Erasing Grouped Shapes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -190,7 +190,18 @@ export default function Whiteboard(props) {
               persistShape(shape, whiteboardId);
             }
           });
-    removeShapes(deletedShapes, whiteboardId);
+
+    //order the ids of shapes being deleted to prevent crash when removing a group shape before its children
+    const orderedDeletedShapes = [];
+    deletedShapes.forEach(eid => {
+      if (shapes[eid]?.type !== 'group') {
+        orderedDeletedShapes.unshift(eid);
+      } else {
+        orderedDeletedShapes.push(eid)
+      }
+    });
+
+    removeShapes(orderedDeletedShapes, whiteboardId);
   }
 
   React.useEffect(() => {
@@ -217,7 +228,7 @@ export default function Whiteboard(props) {
         }
       });
 
-      const removed = prevShapes && findRemoved(Object.keys(prevShapes),Object.keys((shapes)))
+      const removed = prevShapes && findRemoved(Object.keys(prevShapes),Object.keys((shapes)));
       if (removed && removed.length > 0) {
         tldrawAPI?.patchState(
           {
@@ -236,6 +247,7 @@ export default function Whiteboard(props) {
           },
         );
       }
+
       next.pages[curPageId].shapes = shapes;
       changed = true;
     }


### PR DESCRIPTION
### What does this PR do?
This PR orders the id's of the shapes to be deleted, making sure the shapes of type group are removed last.

### Motivation
Prevents the following parent id crash when deleting grouped shapes with the eraser.
![image](https://user-images.githubusercontent.com/22058534/211394558-dd098deb-d5b0-42f8-b9dd-09b871d25b3b.png)
