### PR TITLE
fix(bbb-conf): ensure BBB target restarts (retake)

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -388,7 +388,7 @@ start_bigbluebutton () {
         }
     fi
 
-    systemctl start bigbluebutton.target
+    systemctl restart bigbluebutton.target
 
     if [ -f /usr/lib/systemd/system/bbb-html5.service ]; then
         systemctl start mongod
@@ -1686,7 +1686,8 @@ if [ -n "$HOST" ]; then
 
 
     echo "Restarting BigBlueButton $BIGBLUEBUTTON_RELEASE ..."
-    systemctl restart bigbluebutton.target
+    stop_bigbluebutton
+    start_bigbluebutton
 
     exit 0
 fi
@@ -1698,7 +1699,8 @@ if [ $RESTART ]; then
 
     echo "Restarting BigBlueButton $BIGBLUEBUTTON_RELEASE ..."
 
-    systemctl restart bigbluebutton.target
+    stop_bigbluebutton
+    start_bigbluebutton
     check_state
 fi
 


### PR DESCRIPTION
reverts a78248331ce914c5cf358126f20593b7c56eb7f2

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
This is a different take on https://github.com/bigbluebutton/bigbluebutton/pull/16347 and partially reverting it.
After #16347 we were no longer running `start_bigbluebutton()` https://github.com/bigbluebutton/bigbluebutton/blob/develop/bigbluebutton-config/bin/bbb-conf#L355-L398 aside from `--clean`.
As a result `nginx` configs were not reloaded and possibly Mongo was not starting correctly in rare cases (although this is hypothetical).

This pull request also likely cancels out https://github.com/bigbluebutton/bbb-install/pull/586


<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation

Reports that nginx needed to be explicitly reloaded on freshly installed systems of BBB 2.6.0-beta.5 that do not utilize `bbb-install-2.6.sh`
<!-- What inspired you to submit this pull request? -->

### More

