### PR TITLE
fix: Connection status tabs confusion

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
@@ -338,7 +338,7 @@ class ConnectionStatusComponent extends PureComponent {
     if (isConnectionStatusEmpty(connectionStatus)) return this.renderEmpty();
 
     let connections = connectionStatus;
-    if (selectedTab === 2) {
+    if (selectedTab === 1) {
       connections = connections.filter(conn => conn.you);
       if (isConnectionStatusEmpty(connections)) return this.renderEmpty();
     }


### PR DESCRIPTION
### What does this PR do?

Fix incorrect content being displayed in connection status modal tabs.

### Closes Issue(s)
Closes #16440