### PR TITLE
fix(tldraw): show tool cursors

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import _ from "lodash";
-import { createGlobalStyle } from "styled-components";
+import styled, { createGlobalStyle } from "styled-components";
 import Cursors from "./cursors/container";
 import { TldrawApp, Tldraw } from "@tldraw/tldraw";
 import SlideCalcUtil, {HUNDRED_PERCENT} from '/imports/utils/slideCalcUtils';
@@ -67,6 +67,12 @@ const TldrawGlobalStyle = createGlobalStyle`
   }
 `;
 
+const EditableWBWrapper = styled.div`
+  &, & > :first-child {
+    cursor: inherit !important;
+  }
+`;
+
 export default function Whiteboard(props) {
   const {
     isPresenter,
@@ -119,6 +125,7 @@ export default function Whiteboard(props) {
   const prevFitToWidth = usePrevious(fitToWidth);
   const prevSvgUri = usePrevious(svgUri);
   const language = mapLanguage(Settings?.application?.locale?.toLowerCase() || 'en');
+  const [currentTool, setCurrentTool] = React.useState(null);
 
   const calculateZoom = (width, height) => {
     let zoom = fitToWidth 
@@ -639,6 +646,12 @@ export default function Whiteboard(props) {
         persistShape(diff, whiteboardId);
       }
     }
+
+    if (reason && reason.includes('selected_tool')) {
+      const tool = reason.split(':')[1];
+
+      setCurrentTool(tool);
+    }
   };
 
   const onUndo = (app) => {
@@ -719,7 +732,7 @@ export default function Whiteboard(props) {
   const webcams = document.getElementById('cameraDock');
   const dockPos = webcams?.getAttribute("data-position");
   const editableWB = (
-    <div onPaste={onPaste}>
+    <EditableWBWrapper onPaste={onPaste}>
       <Tldraw
         key={`wb-${isRTL}-${dockPos}-${forcePanning}`}
         document={doc}
@@ -741,7 +754,7 @@ export default function Whiteboard(props) {
         onRedo={onRedo}
         onCommand={onCommand}
       />
-    </div>
+    </EditableWBWrapper>
   );
 
   const readOnlyWB = (
@@ -775,11 +788,11 @@ export default function Whiteboard(props) {
         isViewersCursorLocked={isViewersCursorLocked}
         isMultiUserActive={isMultiUserActive}
         isPanning={isPanning}
+        currentTool={currentTool}
       >
         {hasWBAccess || isPresenter ? editableWB : readOnlyWB}
         <TldrawGlobalStyle 
           hideContextMenu={!hasWBAccess && !isPresenter} 
-          hideCursor={!isPanning && (isPresenter || hasWBAccess)}
         />
       </Cursors>
     </>

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -57,11 +57,6 @@ const TldrawGlobalStyle = createGlobalStyle`
       display: none;
     }
   `}
-  ${({ hideCursor }) => hideCursor && `
-    #canvas {
-      cursor: none;
-    }
-  `}
   #TD-PrimaryTools-Image {
     display: none;
   }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
@@ -1,10 +1,28 @@
 import * as React from 'react';
+import { Meteor } from 'meteor/meteor';
 
 const XS_OFFSET = 8;
 const SMALL_OFFSET = 18;
 const XL_OFFSET = 85;
 const BOTTOM_CAM_HANDLE_HEIGHT = 10;
 const PRES_TOOLBAR_HEIGHT = 35;
+
+const baseName = Meteor.settings.public.app.cdn + Meteor.settings.public.app.basename;
+const makeCursorUrl = (filename) => `${baseName}/resources/images/whiteboard-cursor/${filename}`;
+
+const TOOL_CURSORS = {
+  select: 'none',
+  erase: 'none',
+  arrow: 'none',
+  draw: `url('${makeCursorUrl('pencil.png')}') 2 22, default`,
+  rectangle: `url('${makeCursorUrl('square.png')}'), default`,
+  ellipse: `url('${makeCursorUrl('ellipse.png')}'), default`,
+  triangle: `url('${makeCursorUrl('triangle.png')}'), default`,
+  line: `url('${makeCursorUrl('line.png')}'), default`,
+  text: `url('${makeCursorUrl('text.png')}'), default`,
+  sticky: `url('${makeCursorUrl('square.png')}'), default`,
+  pan: `url('${makeCursorUrl('pan.png')}'), default`,
+};
 
 const Cursor = (props) => {
   const {
@@ -130,6 +148,7 @@ export default function Cursors(props) {
     hasMultiUserAccess,
     isMultiUserActive,
     isPanning,
+    currentTool,
   } = props;
 
   const start = () => setActive(true);
@@ -311,8 +330,8 @@ export default function Cursors(props) {
   });
 
   const multiUserAccess = hasMultiUserAccess(whiteboardId, currentUser?.userId);
-  let cursorType = multiUserAccess || currentUser?.presenter ? 'none' : 'default';
-  if (isPanning) cursorType = 'grab';
+  let cursorType = multiUserAccess || currentUser?.presenter ? TOOL_CURSORS[currentTool] || 'none' : 'default';
+  if (isPanning) cursorType = TOOL_CURSORS.pan;
 
   return (
     <span ref={(r) => { cursorWrapper = r; }}>


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Displays Tldraw tool cursors:

https://user-images.githubusercontent.com/62393923/211910857-3f38104c-ef15-46da-9c0e-e5a608320363.mp4


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #16130


### Motivation

n/a

### More

Note:

1. Currently BBB has neither custom `png`'s nor `svg`'s for the _select_, _erase_ and _arrow_ tools, so those will keep being `none`.
2. Both Rectangle and Sticky will have the same cursor (not good, but it's a way to go until we have a custom svg for the sticky cursor).