### PR TITLE
fix(tldraw): cannot select multiple objects

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -65,6 +65,10 @@ const TldrawGlobalStyle = createGlobalStyle`
   #TD-PrimaryTools-Image {
     display: none;
   }
+
+  #slide-background-shape div {
+    pointer-events: none;
+  }
 `;
 
 export default function Whiteboard(props) {


### PR DESCRIPTION
### What does this PR do?

Restores drag-to-select feature in whiteboard annotations.

### Closes Issue(s)
Closes #16356