### PR TITLE
fix: Omit liveTranscription message if it is not enabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/captions/select/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/captions/select/component.jsx
@@ -16,6 +16,10 @@ const intlMessages = defineMessages({
     id: 'app.audio.captions.speech.unsupported',
     description: 'Audio speech recognition unsupported',
   },
+  captionsNotEnabled: {
+    id: 'app.audio.captions.speech.captionsNotEnabled',
+    description: 'Audio speech recognition is not enabled for this meeting or this server',
+  },
   'de-DE': {
     id: 'app.audio.captions.select.de-DE',
     description: 'Audio speech recognition german language',
@@ -64,6 +68,19 @@ const Select = ({
   locale,
   voices,
 }) => {
+  if (!enabled || SpeechService.useFixedLocale()) {
+    return (
+      <div
+        style={{
+          fontSize: '.75rem',
+          padding: '1rem 0',
+        }}
+      >
+        {`*${intl.formatMessage(intlMessages.captionsNotEnabled)}`}
+      </div>
+    );  
+  }
+
   if (voices.length === 0) {
     return (
       <div
@@ -76,8 +93,6 @@ const Select = ({
       </div>
     );
   }
-
-  if (!enabled || SpeechService.useFixedLocale()) return null;
 
   const onChange = (e) => {
     const { value } = e.target;

--- a/bigbluebutton-html5/imports/ui/components/audio/captions/select/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/captions/select/component.jsx
@@ -16,10 +16,6 @@ const intlMessages = defineMessages({
     id: 'app.audio.captions.speech.unsupported',
     description: 'Audio speech recognition unsupported',
   },
-  captionsNotEnabled: {
-    id: 'app.audio.captions.speech.captionsNotEnabled',
-    description: 'Audio speech recognition is not enabled for this meeting or this server',
-  },
   'de-DE': {
     id: 'app.audio.captions.select.de-DE',
     description: 'Audio speech recognition german language',
@@ -68,18 +64,7 @@ const Select = ({
   locale,
   voices,
 }) => {
-  if (!enabled || SpeechService.useFixedLocale()) {
-    return (
-      <div
-        style={{
-          fontSize: '.75rem',
-          padding: '1rem 0',
-        }}
-      >
-        {`*${intl.formatMessage(intlMessages.captionsNotEnabled)}`}
-      </div>
-    );  
-  }
+  if (!enabled || SpeechService.useFixedLocale()) return null
 
   if (voices.length === 0) {
     return (

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -712,7 +712,6 @@
     "app.audio.captions.speech.title": "Automatic transcription",
     "app.audio.captions.speech.disabled": "Disabled",
     "app.audio.captions.speech.unsupported": "Your browser doesn't support speech recognition. Your audio won't be transcribed",
-    "app.audio.captions.speech.captionsNotEnabled": "Audio speech recognition is not enabled to this meeting or server.",
     "app.audio.captions.select.de-DE": "German",
     "app.audio.captions.select.en-US": "English",
     "app.audio.captions.select.es-ES": "Spanish",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -712,6 +712,7 @@
     "app.audio.captions.speech.title": "Automatic transcription",
     "app.audio.captions.speech.disabled": "Disabled",
     "app.audio.captions.speech.unsupported": "Your browser doesn't support speech recognition. Your audio won't be transcribed",
+    "app.audio.captions.speech.captionsNotEnabled": "Audio speech recognition is not enabled to this meeting or server.",
     "app.audio.captions.select.de-DE": "German",
     "app.audio.captions.select.en-US": "English",
     "app.audio.captions.select.es-ES": "Spanish",


### PR DESCRIPTION
### What does this PR do?

It simply changes the message that appear in the microphone activation toast when the live transcription is not enabled. Instead of saying that the browser doesn't support the feature, it now says that this feature is not enabled for the meeting or for the server.

 
![image](https://user-images.githubusercontent.com/69865537/212150993-89e950dc-70e3-4187-bb76-b951aeaca9f9.png)


### Closes Issue(s)

Closes #16375 

### More

This PR is slightly related to #16170, so in order to test, feel free to play around with the possibilities explained in it.
