### PR TITLE
build: copy tldraw fonts to be served in files/

### DIFF
--- a/build/packages-template/bbb-html5/build.sh
+++ b/build/packages-template/bbb-html5/build.sh
@@ -73,8 +73,8 @@ cd -
 cp -r /tmp/html5-build/bundle staging/usr/share/meteor
 
 # copy over tl;draw fonts due to a preset path
-mkdir -p staging/usr/share/meteor/bundle/programs/web.browser/app/public/files
-cp node_modules/@fontsource/*/files/*.woff[2] staging/usr/share/meteor/bundle/programs/web.browser/app/public/files/
+mkdir -p staging/usr/share/meteor/bundle/programs/web.browser/app/files
+cp node_modules/@fontsource/*/files/*.woff[2] staging/usr/share/meteor/bundle/programs/web.browser/app/files/
 
 cp systemd_start.sh staging/usr/share/meteor/bundle
 chmod +x staging/usr/share/meteor/bundle/systemd_start.sh


### PR DESCRIPTION
Cont'd from https://github.com/bigbluebutton/bigbluebutton/pull/16443

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Removes the "public" directory created for the fonts.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
Looks like `public` was only needed for development environments to fit into Meteor's structure. On production nodejs app all other files are outside of `public`
<!-- What inspired you to submit this pull request? -->

### More


