### PR TITLE
fix: main element styles

### DIFF
--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -94,6 +94,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       color: var(--palette-placeholder-text);
       opacity: 1;
     }
+
+    main {
+      display: initial;
+    }
   </style>
   <script>
     document.addEventListener('gesturestart', function (e) {


### PR DESCRIPTION
### What does this PR do?
Adjust `main` element style so "meeting ended" message appears in the middle of the page.

#### before
![Screenshot from 2023-01-13 09-42-16](https://user-images.githubusercontent.com/3728706/212322862-a35d521a-5043-4441-9bef-4195b3d7c16f.png)

#### after
![Screenshot from 2023-01-13 09-41-46](https://user-images.githubusercontent.com/3728706/212322871-ae90bf57-c8d9-45ac-9d0b-2e53a4f016a6.png)

