### PR TITLE
feat(config): Default values for checkbox in breakout rooms modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -251,6 +251,8 @@ class BreakoutRoom extends PureComponent {
   componentDidMount() {
     const {
       breakoutJoinedUsers, getLastBreakouts, groups, isUpdate,
+      startWithAllowUserToChooseABreakout, startWithCaptureWhiteboardForBreakout,
+      startWithCaptureSharedNotesForBreakout
     } = this.props;
     this.setRoomUsers();
     if (isUpdate) {
@@ -276,6 +278,11 @@ class BreakoutRoom extends PureComponent {
         };
       });
     }
+    this.setState({
+      freeJoin: startWithAllowUserToChooseABreakout,
+      captureSlides: startWithCaptureWhiteboardForBreakout,
+      captureNotes: startWithCaptureSharedNotesForBreakout,
+    });
 
     const lastBreakouts = getLastBreakouts();
     if (lastBreakouts.length > 0) {

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/container.jsx
@@ -10,9 +10,9 @@ const METEOR_SETTINGS_APP = Meteor.settings.public.app;
 const CreateBreakoutRoomContainer = (props) => {
   const { setAllowUserToChooseABreakout } = METEOR_SETTINGS_APP.breakouts;
   const setCaptureBreakoutWhiteboard = METEOR_SETTINGS_APP.breakouts.setCaptureBreakoutWhiteboard
-                                    && isImportPresentationWithAnnotationsFromBreakoutRoomsEnabled;
-  const setCaptureBreakoutNotes = METEOR_SETTINGS_APP.breakouts.setCaptureBreakoutWhiteboard
-                                    && isImportSharedNotesFromBreakoutRoomsEnabled;
+                                    && isImportPresentationWithAnnotationsFromBreakoutRoomsEnabled();
+  const setCaptureBreakoutNotes = METEOR_SETTINGS_APP.breakouts.setCaptureBreakoutNotes
+                                    && isImportSharedNotesFromBreakoutRoomsEnabled();
   const { amIModerator } = props;
   return (
     amIModerator

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/container.jsx
@@ -5,12 +5,24 @@ import BreakoutRoomService from '/imports/ui/components/breakout-room/service';
 
 import CreateBreakoutRoomModal from './component';
 
+const METEOR_SETTINGS_APP = Meteor.settings.public.app;
+
 const CreateBreakoutRoomContainer = (props) => {
+  const startWithAllowUserToChooseABreakout = METEOR_SETTINGS_APP.breakouts.startWithAllowUserToChooseABreakout;
+  const startWithCaptureWhiteboardForBreakout = METEOR_SETTINGS_APP.breakouts.startWithCaptureWhiteboardForBreakout;
+  const startWithCaptureSharedNotesForBreakout = METEOR_SETTINGS_APP.breakouts.startWithCaptureSharedNotesForBreakout;
   const { amIModerator } = props;
   return (
     amIModerator
     && (
-      <CreateBreakoutRoomModal {...props} />
+      <CreateBreakoutRoomModal 
+        {...props}  
+        {...{
+          startWithAllowUserToChooseABreakout,
+          startWithCaptureWhiteboardForBreakout,
+          startWithCaptureSharedNotesForBreakout,
+        }}
+      />
     )
   );
 };

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -121,6 +121,10 @@ public:
     # can generate excessive overhead to the server. We recommend
     # this value to be kept under 16.
     breakouts:
+      startWithAllowUserToChooseABreakout: false
+      startWithCaptureWhiteboardForBreakout: false
+      startWithCaptureSharedNotesForBreakout: false
+
       breakoutRoomLimit: 16
       sendInvitationToIncludedModerators: false
     # https://github.com/bigbluebutton/bigbluebutton/pull/10826


### PR DESCRIPTION
### What does this PR do?

It creates 3 new configurations to start the checkbox, as specified, when mounting the modal for creation of breakout rooms.

Those are (settings.yml):  

```
breakouts:
      startWithAllowUserToChooseABreakout: false
      startWithCaptureWhiteboardForBreakout: false
      startWithCaptureSharedNotesForBreakout: false
```

PS.: If you guys want the names to change, just say so.

### Closes Issue(s)

Closes #16141
