### PR TITLE
feat(whiteboard): configurable text tool font family

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -102,6 +102,7 @@ export default function Whiteboard(props) {
     intl,
     svgUri,
     maxStickyNoteLength,
+    fontFamily,
   } = props;
 
   const { pages, pageStates } = initDefaultPages(curPres?.pages.length || 1);
@@ -488,6 +489,7 @@ export default function Whiteboard(props) {
         appState: {
           currentStyle: {
             textAlign: isRTL ? "end" : "start",
+            font: fontFamily,
           },
         },
       }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -26,7 +26,8 @@ const WhiteboardContainer = (props) => {
     const isPresenter = currentUser.presenter;
     const isModerator = currentUser.role === ROLE_MODERATOR;
     const maxStickyNoteLength = WHITEBOARD_CONFIG.maxStickyNoteLength;
-    return <Whiteboard {...{ isPresenter, isModerator, currentUser, isRTL, width, height, maxStickyNoteLength }} {...props} meetingId={Auth.meetingID} />
+    const fontFamily = WHITEBOARD_CONFIG.styles.text.family;
+    return <Whiteboard {...{ isPresenter, isModerator, currentUser, isRTL, width, height, maxStickyNoteLength, fontFamily }} {...props} meetingId={Auth.meetingID} />
 };
 
 export default withTracker(({ whiteboardId, curPageId, intl, zoomChanger, slidePosition, svgUri }) => {

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -748,7 +748,7 @@ public:
       text:
         # Initial font family.
         # family: mono|sans|script|serif
-        family: sans
+        family: script
     toolbar:
       multiUserPenOnly: false
       colors:

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -744,6 +744,11 @@ public:
         start: DRAW_START
         update: DRAW_UPDATE
         end: DRAW_END
+    styles:
+      text:
+        # Initial font family.
+        # family: mono|sans|script|serif
+        family: sans
     toolbar:
       multiUserPenOnly: false
       colors:


### PR DESCRIPTION
Add config option for setting the default font family for the text tool.

Partially addresses #15964.