### PR TITLE
fix: Disable paste file in whiteboard

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -145,7 +145,7 @@ export default function Whiteboard(props) {
   }
 
   const isValidShapeType = (shape) => {
-    const invalidTypes = ['image'];
+    const invalidTypes = ['image', 'video'];
     return !invalidTypes.includes(shape?.type);
   }
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -144,10 +144,19 @@ export default function Whiteboard(props) {
     return hasShapeAccess;
   }
 
+  const isValidShapeType = (shape) => {
+    const invalidTypes = ['image'];
+    return !invalidTypes.includes(shape?.type);
+  }
+
   const sendShapeChanges= (app, changedShapes, redo = false) => {
     const invalidChange = Object.keys(changedShapes)
-                                .find(id => !hasShapeAccess(id));
-    if (invalidChange) {
+      .find(id => !hasShapeAccess(id));
+
+    const invalidShapeType = Object.keys(changedShapes)
+      .find(id => !isValidShapeType(changedShapes[id]));
+
+    if (invalidChange || invalidShapeType) {
       notifyNotAllowedChange(intl);
       // undo last command without persisting to not generate the onUndo/onRedo callback
       if (!redo) {
@@ -716,22 +725,10 @@ export default function Whiteboard(props) {
     }
   };
 
-  const onPaste = (e) => {
-    // disable file pasting
-    const clipboardData = e.clipboardData || window.clipboardData;
-    const { types } = clipboardData;
-    const hasFiles = types && types.indexOf && types.indexOf('Files') !== -1;
-
-    if (hasFiles) {
-      e.preventDefault();
-      e.stopPropagation();
-    }
-  };
-
   const webcams = document.getElementById('cameraDock');
   const dockPos = webcams?.getAttribute("data-position");
   const editableWB = (
-    <EditableWBWrapper onPaste={onPaste}>
+    <EditableWBWrapper>
       <Tldraw
         key={`wb-${isRTL}-${dockPos}-${forcePanning}`}
         document={doc}


### PR DESCRIPTION
### What does this PR do?

Adding another way of disabling copy-paste of images in the whiteboard, as the current one only works if the whiteboard is focused.