### PR TITLE
build(bbb-web): Added 'file' as a dependency necessary to process presentation

### DIFF
--- a/build/packages-template/bbb-web/opts-focal.sh
+++ b/build/packages-template/bbb-web/opts-focal.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d zip,unzip,imagemagick,redis-server,xpdf-utils,bbb-libreoffice-docker,psmisc,fonts-crosextra-carlito,fonts-crosextra-caladea,fonts-noto,openjdk-11-jdk"
+OPTS="$OPTS -t deb -d zip,unzip,imagemagick,redis-server,xpdf-utils,bbb-libreoffice-docker,psmisc,fonts-crosextra-carlito,fonts-crosextra-caladea,fonts-noto,openjdk-11-jdk,file"


### PR DESCRIPTION
### What does this PR do?

It configures the `file` command as a dependency of `bbb-web`, otherwise it will fail to process and convert whatever presentation the user tries to upload.

### Closes Issue(s)

Closes #16363 
