### PR TITLE
fix(sec): Upgrade ch.qos.logback to 1.2.11

### DIFF
--- a/akka-bbb-apps/project/Dependencies.scala
+++ b/akka-bbb-apps/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
     val akkaHttpVersion = "10.2.7"
     val gson = "2.8.9"
     val jackson = "2.13.0"
-    val logback = "1.2.10"
+    val logback = "1.2.11"
     val quicklens = "1.7.5"
     val spray = "1.3.6"
 

--- a/bbb-recording-imex/pom.xml
+++ b/bbb-recording-imex/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.2.3</version>
+            <version>1.2.11</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>1.2.11</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR upgrades `logback-classic` to the last 1.2.x version available which is `1.2.11`. 
Versions available: https://mvnrepository.com/artifact/ch.qos.logback/logback-classic

Projects impacted: `akka-bbb-apps` and `bbb-recording-imex`.

Motivation:
`bbb-recording-imex` project is using a version that contains known vulnerabilities.
https://security.snyk.io/package/maven/ch.qos.logback:logback-core/1.2.3

Closes #16446 once it will become behind.