### PR TITLE
fix(whiteboard): Presentation showing wrong slide (when capturing whiteboard from breakout room)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -255,6 +255,7 @@ export default function Whiteboard(props) {
           },
         },
       );
+      changed = true;
     }
 
     if (changed && tldrawAPI) {


### PR DESCRIPTION
### What does this PR do?

Fix issue with breakout slides not appearing correctly in main room.

### Closes Issue(s)
Closes #16489