### PR TITLE
fix(whiteboard): complete draw session when clicking outside of viewport

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -204,6 +204,27 @@ export default function Whiteboard(props) {
     props.setTldrawIsMounting(true);
   }, []);
 
+  const checkClientBounds = (e) => {
+    if (
+      e.clientX > document.documentElement.clientWidth ||
+      e.clientX < 0 ||
+      e.clientY > document.documentElement.clientHeight ||
+      e.clientY < 0
+    ) {
+      if (tldrawAPI?.session) {
+        tldrawAPI?.completeSession?.();
+      }
+    }
+  };
+
+  React.useEffect(() => {
+    document.addEventListener('mouseup', checkClientBounds);
+
+    return () => {
+      document.removeEventListener('mouseup', checkClientBounds);
+    };
+  }, [tldrawAPI]);
+
   const doc = React.useMemo(() => {
     const currentDoc = rDocument.current;
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -217,11 +217,19 @@ export default function Whiteboard(props) {
     }
   };
 
+  const checkVisibility = () => {
+    if (document.visibilityState === 'hidden' && tldrawAPI?.session) {
+      tldrawAPI?.completeSession?.();
+    }
+  };
+
   React.useEffect(() => {
     document.addEventListener('mouseup', checkClientBounds);
+    document.addEventListener('visibilitychange', checkVisibility);
 
     return () => {
       document.removeEventListener('mouseup', checkClientBounds);
+      document.removeEventListener('visibilitychange', checkVisibility);
     };
   }, [tldrawAPI]);
 


### PR DESCRIPTION
### What does this PR do?

Properly completes a draw session when clicking outside of the viewport.

### Closes Issue(s)

Closes #16479
