### PR TITLE
Refactor: removing dependencies that aren't necessary to back-port

### DIFF
--- a/bbb-common-web/build.sbt
+++ b/bbb-common-web/build.sbt
@@ -107,8 +107,4 @@ libraryDependencies ++= Seq(
   "org.springframework.data" % "spring-data-commons" % "2.7.6",
   "org.glassfish" % "javax.el" % "3.0.1-b12",
   "org.apache.httpcomponents" % "httpclient" % "4.5.13",
-  "org.postgresql" % "postgresql" % "42.2.16",
-  "org.hibernate" % "hibernate-core" % "5.6.1.Final",
-  "org.flywaydb" % "flyway-core" % "7.8.2",
-  "com.zaxxer" % "HikariCP" % "4.0.3"
 )


### PR DESCRIPTION
### What does this PR do?
It removes the dependencies that were backported from 2.6 to 2.5, but aren't necessary in 2.5.
(Introduced in https://github.com/bigbluebutton/bigbluebutton/pull/16397/files )

### More

An error that was occurring because of it:
`ERROR com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Exception during pool initialization.`