### PR TITLE
fix(tldraw): fallback es-xx locales to es

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -23,25 +23,20 @@ const findRemoved = (A, B) => {
 
 // map different localeCodes from bbb to tldraw
 const mapLanguage = (language) => {
-  switch(language) {
-    case 'fa-ir':
-      return 'fa';
-    case 'it-it':
-      return 'it';
+  // bbb has xx-xx but in tldraw it's only xx
+  if (['es', 'fa', 'it', 'pl', 'sv', 'uk'].some((lang) => language.startsWith(lang))) {
+    return language.substring(0, 2);
+  }
+  // exceptions
+  switch (language) {
     case 'nb-no':
       return 'no';
-    case 'pl-pl':
-      return 'pl';
-    case 'sv-se':
-      return 'sv';
-    case 'uk-ua':
-      return 'uk';
     case 'zh-cn':
       return 'zh-ch';
     default:
       return language;
   }
-}
+};
 
 const SMALL_HEIGHT = 435;
 const SMALLEST_HEIGHT = 363;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fallback different `es` locales to the one compatible with tldraw.
Refactored the code a bit.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes https://github.com/bigbluebutton/bigbluebutton/issues/16507


### Motivation

We have different es locales ('es', 'es-es', 'es-419', 'es-mx'), while tldraw only has 'es'. Fallback the other ones so tldraw shows 'es' in all cases.
