### PR TITLE
refactor(api): Recording pagination changes

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -547,26 +547,29 @@ public class MeetingService implements MessageListener {
     return recordingService.isRecordingExist(recordId);
   }
 
-  public String getRecordings2x(List<String> idList, List<String> states, Map<String, String> metadataFilters, String page, String size) {
-    int p;
-    int s;
+  public String getRecordings2x(List<String> idList, List<String> states, Map<String, String> metadataFilters, String offset, String limit) {
+    Pageable pageable = null;
+    int o = -1;
+    int l = -1;
 
     try {
-      p = Integer.parseInt(page);
+      o = Integer.parseInt(offset);
+      if(o < 0) o = 0;
     } catch(NumberFormatException e) {
-      p = 0;
+      log.info("Invalid offset parameter {}", offset);
+      o = 0;
     }
 
     try {
-      s = Integer.parseInt(size);
+      l = Integer.parseInt(limit);
+      if(l < 1) l = 1;
+      else if(l > 100) l = 100;
     } catch(NumberFormatException e) {
-      s = 25;
+      log.info("Invalid limit parameter {}", limit);
     }
 
-    log.info("{} {}", p, s);
-
-    Pageable pageable = PageRequest.of(p, s);
-    return recordingService.getRecordings2x(idList, states, metadataFilters, pageable);
+    if(l != -1) pageable = PageRequest.ofSize(l);
+    return recordingService.getRecordings2x(idList, states, metadataFilters, o, pageable);
   }
 
   public boolean existsAnyRecording(List<String> idList) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/RecordingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/RecordingService.java
@@ -37,7 +37,7 @@ public interface RecordingService {
     String getCaptionTrackInboxDir();
     String getCaptionsDir();
     boolean isRecordingExist(String recordId);
-    String getRecordings2x(List<String> idList, List<String> states, Map<String, String> metadataFilters, Pageable pageable);
+    String getRecordings2x(List<String> idList, List<String> states, Map<String, String> metadataFilters, int offset, Pageable pageable);
     boolean existAnyRecording(List<String> idList);
     boolean changeState(String recordingId, String state);
     void updateMetaParams(List<String> recordIDs, Map<String,String> metaParams);
@@ -47,9 +47,9 @@ public interface RecordingService {
     void processMakePresentationDownloadableMsg(MakePresentationDownloadableMsg msg);
     File getDownloadablePresentationFile(String meetingId, String presId, String presFilename);
 
-    default <T> Page<T> listToPage(List<T> list, Pageable pageable) {
-        int start = (int) pageable.getOffset();
-        int end = (int) (Math.min((start + pageable.getPageSize()), list.size()));
-        return new PageImpl<>(list.subList(start, end), pageable, list.size());
+    // Construct page using offset and limit parameters
+    default <T> Page<T> listToPage(List<T> list, int offset, Pageable pageable) {
+        int end = (int) (Math.min((offset + pageable.getPageSize()), list.size()));
+        return new PageImpl<>(list.subList(offset, end), pageable, list.size());
     }
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/XmlService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/XmlService.java
@@ -14,7 +14,7 @@ public interface XmlService {
     String thumbnailToXml(Thumbnail thumbnail);
     String callbackDataToXml(CallbackData callbackData);
     String constructResponseFromRecordingsXml(String xml);
-    String constructPaginatedResponse(Page<?> page, String response);
+    String constructPaginatedResponse(Page<?> page, int offset, String response);
     Recording xmlToRecording(String recordId, String xml);
     String noRecordings();
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/XmlService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/XmlService.java
@@ -16,4 +16,5 @@ public interface XmlService {
     String constructResponseFromRecordingsXml(String xml);
     String constructPaginatedResponse(Page<?> page, String response);
     Recording xmlToRecording(String recordId, String xml);
+    String noRecordings();
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/RecordingServiceDbImpl.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/RecordingServiceDbImpl.java
@@ -74,61 +74,73 @@ public class RecordingServiceDbImpl implements RecordingService {
     @Override
     public String getRecordings2x(List<String> idList, List<String> states, Map<String, String> metadataFilters, int offset, Pageable pageable) {
         // If no IDs or limit were provided return no recordings instead of every recording
-        if(idList.isEmpty() && pageable == null) return xmlService.noRecordings();
+        if((idList == null || idList.isEmpty()) && pageable == null) return xmlService.noRecordings();
 
         logger.info("Retrieving all recordings");
-        Set<Recording> recordings = new HashSet<>();
-        recordings.addAll(dataStore.findAll(Recording.class));
+        Set<Recording> recordings = new HashSet<>(dataStore.findAll(Recording.class));
+        logger.info("{} recordings found", recordings.size());
 
-        Set<Recording> recordingsById = new HashSet<>();
-        for(String id: idList) {
-            List<Recording> r = dataStore.findRecordingsByMeetingId(id);
+        if(idList != null && !idList.isEmpty()) {
+            Set<Recording> recordingsById = new HashSet<>();
 
-            if(r == null || r.size() == 0) {
-                Recording recording = dataStore.findRecordingByRecordId(id);
-                if(recording != null) {
-                    r = new ArrayList<>();
-                    r.add(recording);
+            for(String id: idList) {
+                logger.info("Finding recordings using meeting ID with value {}", id);
+                List<Recording> recordingsByMeetingId = dataStore.findRecordingsByMeetingId(id);
+
+                if(recordingsByMeetingId == null || recordingsByMeetingId.isEmpty()) {
+                    logger.info("Finding recordings using recording ID with value {}", id);
+                    Recording recording = dataStore.findRecordingByRecordId(id);
+                    if(recording != null) {
+                        logger.info("Recording found");
+                        recordingsById.add(recording);
+                    }
+                } else {
+                    logger.info("{} recordings found", recordingsByMeetingId.size());
+                    recordingsById.addAll(recordingsByMeetingId);
                 }
             }
 
-            if(r != null) recordingsById.addAll(r);
-        }
-
-        logger.info("Filtering recordings by meeting ID");
-        if(recordingsById.size() > 0) {
+            logger.info("Filtering recordings by ID");
             recordings.retainAll(recordingsById);
-        }
-        logger.info("{} recordings remaining", recordings.size());
-
-        Set<Recording> recordingsByState = new HashSet<>();
-        for(String state: states) {
-            List<Recording> r = dataStore.findRecordingsByState(state);
-            if(r != null) recordingsByState.addAll(r);
+            logger.info("{} recordings remain", recordings.size());
         }
 
-        logger.info("Filtering recordings by state");
-        if(recordingsByState.size() > 0) {
+        if(states != null && !states.isEmpty()) {
+            Set<Recording> recordingsByState = new HashSet<>();
+
+            for(String state: states) {
+                logger.info("Finding recordings by state {}", state);
+                List<Recording> r = dataStore.findRecordingsByState(state);
+                if(state != null && !state.isEmpty()) {
+                    logger.info("{} recordings found", r.size());
+                    recordingsByState.addAll(r);
+                }
+            }
+
+            logger.info("Filtering recordings by state");
             recordings.retainAll(recordingsByState);
-        }
-        logger.info("{} recordings remaining", recordings.size());
-
-        List<Metadata> metadata = new ArrayList<>();
-        for(Map.Entry<String, String> metadataFilter: metadataFilters.entrySet()) {
-            List<Metadata> m = dataStore.findMetadataByFilter(metadataFilter.getKey(), metadataFilter.getValue());
-            if(m != null) metadata.addAll(m);
+            logger.info("{} recordings remain", recordings.size());
         }
 
-        Set<Recording> recordingsByMetadata = new HashSet<>();
-        for(Metadata m: metadata) {
-            recordingsByMetadata.add(m.getRecording());
-        }
+        if(metadataFilters != null && !metadataFilters.isEmpty()) {
+            List<Metadata> metadata = new ArrayList<>();
 
-        logger.info("Filtering recordings by metadata");
-        if(recordingsByMetadata.size() > 0) {
+            for(Map.Entry<String, String> filter: metadataFilters.entrySet()) {
+                logger.info("Finding metadata using filter {} {}", filter.getKey(), filter.getValue());
+                List<Metadata> metadataByFilter = dataStore.findMetadataByFilter(filter.getKey(), filter.getValue());
+                if(metadataByFilter != null) {
+                    logger.info("{} metadata found", metadataByFilter.size());
+                    metadata.addAll(metadataByFilter);
+                }
+            }
+
+            Set<Recording> recordingsByMetadata = new HashSet<>();
+            for(Metadata m: metadata) recordingsByMetadata.add(m.getRecording());
+
+            logger.info("Filtering recordings by metadata");
             recordings.retainAll(recordingsByMetadata);
+            logger.info("{} recordings remain", recordings.size());
         }
-        logger.info("{} recordings remaining", recordings.size());
 
         // If no/invalid pagination parameters were given do not paginate the response
         if(pageable == null) {
@@ -140,7 +152,7 @@ public class RecordingServiceDbImpl implements RecordingService {
         String recordingsXml = xmlService.recordingsToXml(recordingsPage.getContent());
         String response = xmlService.constructResponseFromRecordingsXml(recordingsXml);
 
-        return xmlService.constructPaginatedResponse(recordingsPage, response);
+        return xmlService.constructPaginatedResponse(recordingsPage, offset, response);
     }
 
     @Override

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/RecordingServiceFileImpl.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/RecordingServiceFileImpl.java
@@ -201,11 +201,18 @@ public class RecordingServiceFileImpl implements RecordingService {
         return recordingServiceHelper.putRecordingTextTrack(track);
     }
 
-    public String getRecordings2x(List<String> idList, List<String> states, Map<String, String> metadataFilters, Pageable pageable) {
+    public String getRecordings2x(List<String> idList, List<String> states, Map<String, String> metadataFilters, int offset, Pageable pageable) {
+        // If no IDs or limit were provided return no recordings instead of every recording
+        if(idList.isEmpty() && pageable == null) return xmlService.noRecordings();
+
         List<RecordingMetadata> recsList = getRecordingsMetadata(idList, states);
         ArrayList<RecordingMetadata> recs = filterRecordingsByMetadata(recsList, metadataFilters);
-        Page<RecordingMetadata> recordingsPage = listToPage(recs, pageable);
-        String response = recordingServiceHelper.getRecordings2x(recs);
+
+        // If no/invalid pagination parameters were given do not paginate the response
+        if(pageable == null) return recordingServiceHelper.getRecordings2x(recs);
+
+        Page<RecordingMetadata> recordingsPage = listToPage(recs, offset, pageable);
+        String response = recordingServiceHelper.getRecordings2x(new ArrayList<RecordingMetadata>(recordingsPage.getContent()));
         return xmlService.constructPaginatedResponse(recordingsPage, response);
     }
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/RecordingServiceFileImpl.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/RecordingServiceFileImpl.java
@@ -213,7 +213,7 @@ public class RecordingServiceFileImpl implements RecordingService {
 
         Page<RecordingMetadata> recordingsPage = listToPage(recs, offset, pageable);
         String response = recordingServiceHelper.getRecordings2x(new ArrayList<RecordingMetadata>(recordingsPage.getContent()));
-        return xmlService.constructPaginatedResponse(recordingsPage, response);
+        return xmlService.constructPaginatedResponse(recordingsPage, offset, response);
     }
 
     private RecordingMetadata getRecordingMetadata(File dir) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/XmlServiceImpl.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/XmlServiceImpl.java
@@ -72,7 +72,7 @@ public class XmlServiceImpl implements XmlService {
 
     @Override
     public String recordingToXml(Recording recording) {
-        logger.info("Converting {} to xml", recording);
+//        logger.info("Converting {} to xml", recording);
         try {
             setup();
             Document document = builder.newDocument();
@@ -125,7 +125,7 @@ public class XmlServiceImpl implements XmlService {
 
     @Override
     public String metadataToXml(Metadata metadata) {
-        logger.info("Converting {} to xml", metadata);
+//        logger.info("Converting {} to xml", metadata);
 
         try {
             setup();
@@ -148,7 +148,7 @@ public class XmlServiceImpl implements XmlService {
 
     @Override
     public String playbackFormatToXml(PlaybackFormat playbackFormat) {
-        logger.info("Converting {} to xml", playbackFormat);
+//        logger.info("Converting {} to xml", playbackFormat);
 
         try {
             setup();
@@ -187,7 +187,7 @@ public class XmlServiceImpl implements XmlService {
 
     @Override
     public String thumbnailToXml(Thumbnail thumbnail) {
-        logger.info("Converting {} to xml", thumbnail);
+//        logger.info("Converting {} to xml", thumbnail);
 
         try {
             setup();
@@ -211,7 +211,7 @@ public class XmlServiceImpl implements XmlService {
 
     @Override
     public String callbackDataToXml(CallbackData callbackData) {
-        logger.info("Converting {} to xml", callbackData);
+//        logger.info("Converting {} to xml", callbackData);
 
         try {
             setup();
@@ -296,7 +296,7 @@ public class XmlServiceImpl implements XmlService {
     }
 
     @Override
-    public String constructPaginatedResponse(Page<?> page, String response) {
+    public String constructPaginatedResponse(Page<?> page, int offset, String response) {
         logger.info("Constructing paginated response");
 
         try {
@@ -315,7 +315,7 @@ public class XmlServiceImpl implements XmlService {
             Document secondDoc;
             Node node;
 
-            xml = pageableToXml(page.getPageable());
+            xml = pageableToXml(page.getPageable(), offset);
             secondDoc = builder.parse(new ByteArrayInputStream(xml.getBytes()));
             node = document.importNode(secondDoc.getDocumentElement(), true);
             pagination.appendChild(node);
@@ -326,8 +326,8 @@ public class XmlServiceImpl implements XmlService {
 //            Element last = createElement(document, "last", String.valueOf(page.isLast()));
 //            pagination.appendChild(last);
 
-            Element totalPages = createElement(document, "totalPages", String.valueOf(page.getTotalPages()));
-            pagination.appendChild(totalPages);
+//            Element totalPages = createElement(document, "totalPages", String.valueOf(page.getTotalPages()));
+//            pagination.appendChild(totalPages);
 
 //            Element first = createElement(document, "first", String.valueOf(page.isFirst()));
 //            pagination.appendChild(first);
@@ -349,7 +349,7 @@ public class XmlServiceImpl implements XmlService {
         return null;
     }
 
-    private String pageableToXml(Pageable pageable) {
+    private String pageableToXml(Pageable pageable, int o) {
         logger.info("Converting {} to xml", pageable);
 
         try {
@@ -373,7 +373,7 @@ public class XmlServiceImpl implements XmlService {
 //
 //            rootElement.appendChild(sortElement);
 
-            Element offset = createElement(document, "offset", String.valueOf(pageable.getOffset()));
+            Element offset = createElement(document, "offset", String.valueOf(o));
             rootElement.appendChild(offset);
 
             Element limit = createElement(document, "limit", String.valueOf(pageable.getPageSize()));

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/XmlServiceImpl.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/XmlServiceImpl.java
@@ -264,6 +264,38 @@ public class XmlServiceImpl implements XmlService {
     }
 
     @Override
+    public String noRecordings() {
+        logger.info("Constructing no recordings response");
+
+        try {
+            setup();
+            Document document = builder.newDocument();
+
+            Element rootElement = createElement(document, "response", null);
+            document.appendChild(rootElement);
+
+            Element returnCode = createElement(document, "returncode", "SUCCESS");
+            rootElement.appendChild(returnCode);
+
+            Element messageKey = createElement(document, "messageKey", "noRecordings");
+            rootElement.appendChild(messageKey);
+
+            Element message = createElement(document, "message", "No recordings found. This may occur if you attempt to retrieve all recordings.");
+            rootElement.appendChild(message);
+
+            String result = documentToString(document);
+//            logger.info("========== Result ==========");
+//            logger.info("{}", result);
+//            logger.info("============================");
+            return result;
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+
+    @Override
     public String constructPaginatedResponse(Page<?> page, String response) {
         logger.info("Constructing paginated response");
 
@@ -291,14 +323,14 @@ public class XmlServiceImpl implements XmlService {
             Element totalElements = createElement(document, "totalElements", String.valueOf(page.getTotalElements()));
             pagination.appendChild(totalElements);
 
-            Element last = createElement(document, "last", String.valueOf(page.isLast()));
-            pagination.appendChild(last);
+//            Element last = createElement(document, "last", String.valueOf(page.isLast()));
+//            pagination.appendChild(last);
 
             Element totalPages = createElement(document, "totalPages", String.valueOf(page.getTotalPages()));
             pagination.appendChild(totalPages);
 
-            Element first = createElement(document, "first", String.valueOf(page.isFirst()));
-            pagination.appendChild(first);
+//            Element first = createElement(document, "first", String.valueOf(page.isFirst()));
+//            pagination.appendChild(first);
 
             Element empty = createElement(document, "empty", String.valueOf(!page.hasContent()));
             pagination.appendChild(empty);
@@ -327,28 +359,28 @@ public class XmlServiceImpl implements XmlService {
             Element rootElement = createElement(document, "pageable", null);
             document.appendChild(rootElement);
 
-            Sort sort = pageable.getSort();
-            Element sortElement = createElement(document, "sort", null);
-
-            Element unsorted = createElement(document, "unsorted", String.valueOf(sort.isUnsorted()));
-            sortElement.appendChild(unsorted);
-
-            Element sorted = createElement(document, "sorted", String.valueOf(sort.isSorted()));
-            sortElement.appendChild(sorted);
-
-            Element empty = createElement(document, "empty", String.valueOf(sort.isEmpty()));
-            sortElement.appendChild(empty);
-
-            rootElement.appendChild(sortElement);
+//            Sort sort = pageable.getSort();
+//            Element sortElement = createElement(document, "sort", null);
+//
+//            Element unsorted = createElement(document, "unsorted", String.valueOf(sort.isUnsorted()));
+//            sortElement.appendChild(unsorted);
+//
+//            Element sorted = createElement(document, "sorted", String.valueOf(sort.isSorted()));
+//            sortElement.appendChild(sorted);
+//
+//            Element empty = createElement(document, "empty", String.valueOf(sort.isEmpty()));
+//            sortElement.appendChild(empty);
+//
+//            rootElement.appendChild(sortElement);
 
             Element offset = createElement(document, "offset", String.valueOf(pageable.getOffset()));
             rootElement.appendChild(offset);
 
-            Element pageSize = createElement(document, "pageSize", String.valueOf(pageable.getPageSize()));
-            rootElement.appendChild(pageSize);
+            Element limit = createElement(document, "limit", String.valueOf(pageable.getPageSize()));
+            rootElement.appendChild(limit);
 
-            Element pageNumber = createElement(document, "pageNumber", String.valueOf(pageable.getPageNumber()));
-            rootElement.appendChild(pageNumber);
+//            Element pageNumber = createElement(document, "pageNumber", String.valueOf(pageable.getPageNumber()));
+//            rootElement.appendChild(pageNumber);
 
             Element paged = createElement(document, "paged", String.valueOf(pageable.isPaged()));
             rootElement.appendChild(paged);

--- a/bbb-recording-imex/get-recordings.sh
+++ b/bbb-recording-imex/get-recordings.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-while getopts i:r:s:m: flag
+while getopts i:r:s:m:o:l: flag
 do
    case "${flag}" in
       i) MEETING_ID=${OPTARG};;
       r) RECORD_ID=${OPTARG};;
       s) STATE=${OPTARG};;
       m) META=${OPTARG};;
+      o) OFFSET=${OPTARG};;
+      l) LIMIT=${OPTARG};;
    esac
 done
 
@@ -17,7 +19,9 @@ QUERY=""
 if ! [[ -z ${MEETING_ID+x} ]]; then QUERY+="meetingID=$MEETING_ID&"; fi
 if ! [[ -z ${RECORD_ID+x} ]]; then QUERY+="recordID=$RECORD_ID&"; fi
 if ! [[ -z ${STATE+x} ]]; then QUERY+="state=$STATE&"; fi
-if ! [[ -z ${META+x} ]]; then QUERY+="meta=$META"; fi
+if ! [[ -z ${META+x} ]]; then QUERY+="meta=$META&"; fi
+if ! [[ -z ${OFFSET+x} ]]; then QUERY+="offset=$OFFSET&"; fi
+if ! [[ -z ${LIMIT+x} ]]; then QUERY+="limit=$LIMIT"; fi
 
 echo "query: $QUERY"
 
@@ -26,7 +30,7 @@ if [ "${QUERY:$INDEX:1}" = "&" ]; then QUERY=${QUERY:0:$INDEX}; fi
 
 echo "query: $QUERY"
 
-SALT=
+SALT=""
 DATA="$ENDPOINT$QUERY$SALT"
 
 echo "data: $DATA"

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/RecordingController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/RecordingController.groovy
@@ -104,19 +104,19 @@ class RecordingController {
 
     Map<String, String> metadataFilters = ParamsProcessorUtil.processMetaParam(params)
 
-    String page
-    if(!StringUtils.isEmpty(params.page)) {
-      page = params.page
-      log.info("Requested page [${page}]")
+    String offset
+    if(!StringUtils.isEmpty(params.offset)) {
+      offset = params.offset
+      log.info("Requested offset [${offset}]")
     }
 
-    String size
-    if(!StringUtils.isEmpty(params.size)) {
-      size = params.size
-      log.info("Requested page size [${size}]")
+    String limit
+    if(!StringUtils.isEmpty(params.limit)) {
+      limit = params.limit
+      log.info("Requested item limit [${limit}]")
     }
 
-    def getRecordingsResult = meetingService.getRecordings2x(internalRecordIds, states, metadataFilters, page, size)
+    def getRecordingsResult = meetingService.getRecordings2x(internalRecordIds, states, metadataFilters, offset, limit)
 
     withFormat {
       xml {


### PR DESCRIPTION
### What does this PR do?

Modifies the pagination in getRecordings requests to use limit/offset based pagination instead of page/size style pagination.

This results in the following changes:
1.  Support for page/size parameters in getRecordings requests has been removed.
2.  Support for offset/limit parameters has been added.
     - offset: The index of the first recording to return. Must be greater than or equal to 0
     - limit: The maximum number of recordings to return. Must be between 1 and 100.
     - If only the limit parameter is provided a default offset value of 0 will be used.
     - If the offset and limit parameters are not provided then the response will not be paginated.
3. If no IDs and no limit parameters are provided in the request (i.e. the request seeks to return every recording in a single response)  then no recordings will be returned in order to prevent poor performance from a slow API call.

Paginated responses will contain additional pagination information using the following format:
![image](https://user-images.githubusercontent.com/35616208/213488658-ae1dd148-2d25-4154-8b7b-2956eae1e1e8.png)

