### PR TITLE
Refactor: upgrade databinding to 5.2.4

### DIFF
--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -65,7 +65,7 @@ dependencies {
   implementation "org.grails:grails-web-boot:5.2.0"
   implementation "org.grails:grails-logging"
   implementation "org.grails:grails-plugin-rest:5.2.0"
-  implementation "org.grails:grails-plugin-databinding"
+  implementation "org.grails:grails-plugin-databinding:5.2.4"
   implementation "org.grails:grails-plugin-i18n"
   implementation "org.grails:grails-plugin-services"
   implementation "org.grails:grails-plugin-url-mappings"


### PR DESCRIPTION
### What does this PR do?
Upgrade grails databinding to version 5.2.4


### Motivation
A vulnerability was introduced in grails plugin rest, but it is resolved in grails databinding 5.2.1, yet we upgrade to 5.2.4 to match the current version of grails