### PR TITLE
fix(sec): upgrade org.yaml:snakeyaml 1.31

### DIFF
--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -71,7 +71,7 @@ dependencies {
   implementation "org.grails:grails-plugin-url-mappings"
   implementation "org.grails:grails-plugin-interceptors"
   implementation 'org.grails.plugins:external-config:1.2.2'
-  //implementation "org.grails.plugins:cache"
+  implementation "org.yaml:snakeyaml:1.31"
   implementation "org.grails.plugins:views-json:2.1.1"
   implementation "org.grails.plugins:cache"
   implementation "org.apache.xmlbeans:xmlbeans:5.0.3"


### PR DESCRIPTION
### What does this PR do?

Upgrades version of org.yaml:snakeyaml from 1.28 to 1.31

### Closes
https://www.cve.org/CVERecord?id=CVE-2022-38751
