### PR TITLE
fix: clear timeout on shared notes unmount

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.jsx
@@ -91,6 +91,7 @@ const Notes = ({
       || shouldShowSharedNotesOnPresentationArea)
         ? 0 : DELAY_UNMOUNT_SHARED_NOTES);
     }
+    return () => clearTimeout(timoutRef);
   }, [isToSharedNotesBeShow, sidebarContent.sidebarContentPanel]);
   useEffect(() => {
     if (


### PR DESCRIPTION
### What does this PR do?

Add `clearTimeout` as the return of the shared notes unmount timeout to make sure that the timeout is always cleared.

### More
Prevents an issue where the shared notes would unexpectedly close because of a timeout that was not cleared.