### PR TITLE
chore: Merge BBB 2.5 into 2.6

### DIFF
--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -71,7 +71,7 @@ dependencies {
   implementation "org.grails:grails-plugin-url-mappings"
   implementation "org.grails:grails-plugin-interceptors"
   implementation 'org.grails.plugins:external-config:1.2.2'
-  //implementation "org.grails.plugins:cache"
+  implementation "org.yaml:snakeyaml:1.31"
   implementation "org.grails.plugins:views-json:2.1.1"
   implementation "org.grails.plugins:cache"
   implementation "org.apache.xmlbeans:xmlbeans:5.0.3"


### PR DESCRIPTION
Carry forward fixes from BBB 2.5 to 2.6
In this case only https://github.com/bigbluebutton/bigbluebutton/pull/16526 is relevant