### PR TITLE
Move Visible Accessibility Warning Note To Aria Tag / Tooltip

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/service.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/service.js
@@ -331,8 +331,8 @@ const removePackagedClassAttribute = (classnames, attribute) => {
 const getExportedPresentationString = (fileURI, filename, intl) => {
   const warningIcon = `<i class="icon-bbb-warning"></i>`;
   const label = `<span>${intl.formatMessage(intlMessages.download)}</span>`;
-  const notAccessibleWarning = `<span>(${warningIcon} ${intl.formatMessage(intlMessages.notAccessibleWarning)})</span>`;
-  const link = `<a href=${fileURI} type="application/pdf" rel="noopener, noreferrer" download>${label}&nbsp;${notAccessibleWarning}</a>`;
+  const notAccessibleWarning = `<span title="${intl.formatMessage(intlMessages.notAccessibleWarning)}">${warningIcon}</span>`;
+  const link = `<a aria-label="${intl.formatMessage(intlMessages.notAccessibleWarning)}" href=${fileURI} type="application/pdf" rel="noopener, noreferrer" download>${label}&nbsp;${notAccessibleWarning}</a>`;
   const name = `<span>${filename}</span>`;
   return `${name}</br>${link}`;
 };

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -247,7 +247,7 @@
     "app.presentationUploader.exportingTimeout": "The export is taking too long...",
     "app.presentationUploader.export": "Send to chat",
     "app.presentationUploader.export.linkAvailable": "Link for downloading {0} available on the public chat.",
-    "app.presentationUploader.export.notAccessibleWarning": "may be not accessible",
+    "app.presentationUploader.export.notAccessibleWarning": "may be not accessibility compliant",
     "app.presentationUploader.currentPresentationLabel": "Current presentation",
     "app.presentationUploder.extraHint": "IMPORTANT: each file may not exceed {0} MB and {1} pages.",
     "app.presentationUploder.uploadLabel": "Upload",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -247,7 +247,7 @@
     "app.presentationUploader.exportingTimeout": "The export is taking too long...",
     "app.presentationUploader.export": "Send to chat",
     "app.presentationUploader.export.linkAvailable": "Link for downloading {0} available on the public chat.",
-    "app.presentationUploader.export.notAccessibleWarning": "may be not accessibility compliant",
+    "app.presentationUploader.export.notAccessibleWarning": "may not be accessibility compliant",
     "app.presentationUploader.currentPresentationLabel": "Current presentation",
     "app.presentationUploder.extraHint": "IMPORTANT: each file may not exceed {0} MB and {1} pages.",
     "app.presentationUploder.uploadLabel": "Upload",


### PR DESCRIPTION
### What does this PR do?
Moves the visible accessibility warning label on the presentation download links in the chat to an `aria` tag / tooltip.

### Closes Issue(s)
Closes #16554 

