### PR TITLE
Fix: note appearing instead of breakout room panel

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.jsx
@@ -79,6 +79,7 @@ const Notes = ({
 
   if (isHidden) {
     style.padding = 0;
+    style.display = 'none';
   }
   useEffect(() => {
     if (isToSharedNotesBeShow) {


### PR DESCRIPTION
### What does this PR do?

Fixes the bug where the shared notes were appearing when open the breakouts room panel, it was introduced in the PR #16072, were was cached the connection for etherpad, looks the state was not applying the display none for when the element is hide

### Closes Issue(s)
#16541

