### PR TITLE
fix(access): Make Timeline Actions Visible to Screen Reader

### DIFF
--- a/bbb-learning-dashboard/src/components/StatusTable.jsx
+++ b/bbb-learning-dashboard/src/components/StatusTable.jsx
@@ -302,7 +302,11 @@ class StatusTable extends React.Component {
                                   return (
                                     <div
                                       className="flex absolute p-1 border-white border-2 rounded-full text-sm z-20 bg-purple-500 text-purple-200 timeline-emoji"
-                                      role="status"
+                                      role="generic"
+                                      aria-label={intl.formatMessage({
+                                        id: emojiConfigs[emoji.name].intlId,
+                                        defaultMessage: emojiConfigs[emoji.name].defaultMessage,
+                                      })}
                                       style={{
                                         top: `calc(50% - ${redress})`,
                                         [origin]: `calc(${offset}% - ${redress})`,


### PR DESCRIPTION
### What does this PR do?
This allows screen readers access to the actions on the timeline. 

### Motivation
Some actions within the timeline view are not announced to screen reader users (e.g.,  “Raise hand”)
![image](https://user-images.githubusercontent.com/22058534/214609179-878c7bd5-32de-4280-a082-abe9cb74160c.png)
