### PR TITLE
fix: Whiteboard component crash

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -583,6 +583,8 @@ export default function Whiteboard(props) {
   };
 
   const onPatch = (e, t, reason) => {
+    if (!e?.pageState) return;
+
     // don't allow select others shapes for editing if don't have permission
     if (reason && reason.includes("set_editing_id")) {
       if (!hasShapeAccess(e.pageState.editingId)) {


### PR DESCRIPTION
### What does this PR do?

Prevents `pageState is undefined` error by adding an early return if pageState is unavailable.

### Closes Issue(s)
Closes #16153