### PR TITLE
fix: Fix error when meetingID is not trimed. 

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -124,7 +124,7 @@ class ApiController {
       invalid(validationResponse.getKey(), validationResponse.getValue())
       return
     } else if (ParamsUtil.sanitizeString(params.meetingID) != params.meetingID) {
-      invalid("idInvaid", "Meeting ID is invalid")
+      invalid("validationError", "Invalid meeting ID")
       return
     }
 

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -123,6 +123,9 @@ class ApiController {
     if(!(validationResponse == null)) {
       invalid(validationResponse.getKey(), validationResponse.getValue())
       return
+    } else if (ParamsUtil.sanitizeString(params.meetingID) != params.meetingID) {
+      invalid("idInvaid", "Meeting ID is invalid")
+      return
     }
 
     // Ensure unique TelVoice. Uniqueness is not guaranteed by paramsProcessorUtil.


### PR DESCRIPTION
### What does this PR do?

It fixes error that happened when creating a meeting with meetingID not trimmed.
When this happens, it is not possible to enter a meeting, nor ending it.
 
### Motivation

Comment https://github.com/bigbluebutton/bigbluebutton/pull/16144#pullrequestreview-1219919588

### More

I would like to raise a discussion here about the way parameters are being treated in back-end.

So, apparently, this error was just happening, because after the validation of the parameters https://github.com/bigbluebutton/bigbluebutton/blob/775dfd05af2fe5ba930988e46578af8c51b11d6b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy#L117 the code still saves the meetingID not sanitized, and because of that, for some reason, when the comparison is made in the join endpoint, the controller doesn't find the meeting.

So, we could maybe return the sanitized params, instead of raw ones, or we could even make the validation of those params before the sanitizing, which is not currently the case, see:
This
https://github.com/bigbluebutton/bigbluebutton/blob/775dfd05af2fe5ba930988e46578af8c51b11d6b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/ValidationService.java#L72
Cames before this one:
https://github.com/bigbluebutton/bigbluebutton/blob/775dfd05af2fe5ba930988e46578af8c51b11d6b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/ValidationService.java#L81

Thus, if the order of those two lines were somehow inverted (or even the sanitize weren't apply to IDs), the validation could be apply in meetingID to verify whether it begins with whitespaces, and the resolution to this problem would be much simpler and less confusing.