### PR TITLE
fix(whiteboard): Prevent infinite zoom levels

### DIFF
--- a/bigbluebutton-html5/imports/api/slides/server/methods/zoomSlide.js
+++ b/bigbluebutton-html5/imports/api/slides/server/methods/zoomSlide.js
@@ -16,6 +16,12 @@ export default function zoomSlide(slideNumber, podId, widthRatio, heightRatio, x
 
     check(meetingId, String);
     check(requesterUserId, String);
+    check(slideNumber, Number);
+    check(podId, String);
+    check(widthRatio, Number);
+    check(heightRatio, Number);
+    check(x, Number);
+    check(y, Number);
 
     const selector = {
       meetingId,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -152,14 +152,12 @@ export default function Whiteboard(props) {
   }, 1000, { trailing: true }));
 
   const calculateZoom = (width, height) => {
-    let zoom = fitToWidth 
-      ? presentationWidth / width
-      : Math.min(
-          (presentationWidth) / width,
-          (presentationHeight) / height
-        );
+    const calcedZoom = fitToWidth ? (presentationWidth / width) : Math.min(
+      (presentationWidth) / width,
+      (presentationHeight) / height
+    );
 
-    return zoom;
+    return (calcedZoom === 0 || calcedZoom === Infinity) ? HUNDRED_PERCENT : calcedZoom;
   }
 
   const isValidShapeType = (shape) => {
@@ -663,7 +661,7 @@ export default function Whiteboard(props) {
       if (camera.zoom < zoomFitSlide) {
         camera.zoom = zoomFitSlide;
       }
-      
+
       tldrawAPI?.setCamera([camera.point[0], camera.point[1]], camera.zoom);
 
       const zoomToolbar = Math.round((HUNDRED_PERCENT * camera.zoom) / zoomFitSlide * 100) / 100;


### PR DESCRIPTION
### What does this PR do?
Uses 100% as default fallback for the whiteboard zoom level calculation should it reach 0 or infinity.

### Closes Issue(s)
Closes #16544
Closes #16515

### Motivation
Increase whiteboard resilience by preventing issues arising from divisions by zero and NaN values.