### PR TITLE
fix: modal initialisation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/modal/service.js
+++ b/bigbluebutton-html5/imports/ui/components/common/modal/service.js
@@ -20,6 +20,12 @@ export const getModal = () => {
 
 export const withModalMounter = ComponentToWrap =>
   class ModalMounterWrapper extends PureComponent {
+
+    componentDidMount(){
+      // needs to ne executed as initialization
+      currentModal.tracker.changed();
+    }
+
     static mount(modalComponent) {
       showModal(null);
       // defer the execution to a subsequent event loop


### PR DESCRIPTION
### What does this PR do?

Adds execution of Meteor tracker change function on creation of the modal component

### Closes Issue(s)

Closes #16474

### Motivation

Previously this functionality was done via 
https://github.com/bigbluebutton/bigbluebutton/blob/develop/bigbluebutton-html5/imports/ui/components/audio/container.jsx#L176

However, it would stop working in case that line was not to be executed because of audio modal being turned off, which resulted in app crash;

