### PR TITLE
fix: hidePresentation parameter has no effect

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/default-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/default-content/component.jsx
@@ -18,7 +18,7 @@ export default (props) => {
         timeout={{ enter: 400 }}
       >
         <Styled.Content animations={animations}>
-          <Styled.DefaultContent hideContent={autoSwapLayout && hidePresentation}>
+          <Styled.DefaultContent hideContent={hidePresentation}>
             <p>
               <FormattedMessage
                 id="app.home.greeting"


### PR DESCRIPTION
PR #14833 removed the `autoSwapLayout` configuration. This PR removes leftover code which caused the `hidePresentation` to have no effect.

To start a meeting with the default presentation hidden, set `hidePresentation = true` instead.

#### Closes:
#16067
#16257