### PR TITLE
fix(presentation): dark mode

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -450,7 +450,7 @@ class App extends Component {
     return darkTheme
       ? DarkReader.enable(
         { brightness: 100, contrast: 90 },
-        { invert: [Styled.DtfInvert], ignoreInlineStyle: [Styled.DtfCss] },
+        { invert: [Styled.DtfInvert], ignoreInlineStyle: [Styled.DtfCss], ignoreImageAnalysis: [Styled.DtfImages] },
       )
       : DarkReader.disable();
   }

--- a/bigbluebutton-html5/imports/ui/components/app/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.js
@@ -39,11 +39,22 @@ const DtfInvert = `
   div[data-test="presentationContainer"] {
     background-color: var(--darkreader-neutral-background) !important;
   }
+  .tl-container {
+    background-color: var(--tl-background) !important;
+  }
+  [id="TD-StylesMenu"],
+  [id="TD-Styles-Color-Container"],
   #connectionBars > div
 `;
 
 const DtfCss = `
-  [id="colorPicker"]
+  [id="colorPicker"],
+  path,
+  svg
+`;
+
+const DtfImages = `
+  svg
 `;
 
 export default {
@@ -52,4 +63,5 @@ export default {
   Layout,
   DtfInvert,
   DtfCss,
+  DtfImages,
 };


### PR DESCRIPTION
### What does this PR do?

Adds css parameters to invert presentation background color when in dark mode.
Ensures the background is white.
Bypasses svg images.

### Closes Issue(s)
Closes #16605 
Closes #16625
