### PR TITLE
Prevent Yes/No Quick Poll Without Options or Question

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/polling/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/polling/component.jsx
@@ -148,7 +148,7 @@ class Polling extends Component {
                   {answers.map((pollAnswer) => {
                     const formattedMessageIndex = pollAnswer?.key?.toLowerCase();
                     let label = pollAnswer.key;
-                    if (defaultPoll && pollAnswerIds[formattedMessageIndex]) {
+                    if ((defaultPoll || pollType.includes('CUSTOM')) && pollAnswerIds[formattedMessageIndex]) {
                       label = intl.formatMessage(pollAnswerIds[formattedMessageIndex]);
                     }
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -83,7 +83,7 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
     content,
   } = currentSlide;
 
-  const questionRegex = /.*?\?$/gm;
+  const questionRegex = /.*?\?/gm;
   const question = safeMatch(questionRegex, content, '');
 
   const doubleQuestionRegex = /\?{2}/gm;
@@ -95,6 +95,11 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
   const pollRegex = /[1-9A-Ia-i][.)].*/g;
   let optionsPoll = safeMatch(pollRegex, content, []);
   const optionsWithLabels = [];
+
+  if (hasYN) {
+    optionsPoll = ['Yes', 'No'];
+  }
+
   if (optionsPoll) {
     optionsPoll = optionsPoll.map((opt) => {
       const MAX_CHAR_LIMIT = 30;

--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -97,7 +97,7 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
   const optionsWithLabels = [];
 
   if (hasYN) {
-    optionsPoll = ['Yes', 'No'];
+    optionsPoll = ['yes', 'no'];
   }
 
   if (optionsPoll) {


### PR DESCRIPTION
### What does this PR do?
This ensures that yes / no polls initiated via smart slides displays the question and options for the cases described in the issue below.
### Closes Issue(s)
Closes #16013