### PR TITLE
fix (bbb-web): users stuck in waiting room (purging waiting guests)

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -727,8 +727,7 @@ public class MeetingService implements MessageListener {
     Meeting m = getMeeting(message.meetingId);
     if (m != null) {
       for (GuestsStatus guest : message.guests) {
-        User user = m.getUserById(guest.userId);
-        if (user != null) user.setGuestStatus(guest.status);
+        m.setGuestStatusWithId(guest.userId, guest.status);
       }
     }
 


### PR DESCRIPTION
### What does this PR do?

Changes the point at which  a `RegistedUser` has their guest status set to `ALLOW` to be the same as the corresponding `User` and `UserSession` instances.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #14582


### Motivation

Currently when a user is approved to enter a meeting by a moderator their guest status is set to ALLOW in the `User` and `UserSession` related to them, but the corresponding `RegisteredUser` instance does not have its guest status updated until after the `enter` API endpoint has been called and the user has fully entered the meeting. This discrepancy can lead to situation where users that join slowly may be purged by the `WaitingGuestCleanup` service. If this occurs the user will be stuck in an infinite loop trying to authenticate which will always fail since they are no longer registered in the meeting. By updating the `RegisteredUser` guest status at the same time as the `User` and `UserSession` instances the user is not at risk of being purged and will be able successfully join the meeting even if the process takes a while to complete.
