### PR TITLE
fix(poll): improve quick poll regex

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -92,7 +92,7 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
   const yesNoPatt = /.*(yes\/no|no\/yes).*/gm;
   const hasYN = safeMatch(yesNoPatt, content, false);
 
-  const pollRegex = /[1-9A-Ia-i][.)].*/g;
+  const pollRegex = /[1-9A-Ia-i][.)] .*/g;
   let optionsPoll = safeMatch(pollRegex, content, []);
   const optionsWithLabels = [];
 


### PR DESCRIPTION
### What does this PR do?

Makes quick poll regex only match when a space comes after `)` or `.`

After the changes, it should work for `a) text` and `b. text`, but not for `c.text` or `d)text`

### Motivation
Reducing the number of wrong matches.

#### before
![Screenshot from 2023-02-02 09-21-24](https://user-images.githubusercontent.com/3728706/216323413-f1e6c3b9-d111-44fd-9b28-98454e730240.png)

#### after

![Screenshot from 2023-02-02 09-21-17](https://user-images.githubusercontent.com/3728706/216323430-27b1594e-1516-4841-a9c1-17b1ce22488f.png)

