### PR TITLE
Implement cap for max number of annotations per slide

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -120,6 +120,8 @@ export default function Whiteboard(props) {
     hasShapeAccess,
     presentationAreaHeight,
     presentationAreaWidth,
+    maxNumberOfAnnotations,
+    notifyShapeNumberExceeded,
   } = props;
 
   const { pages, pageStates } = initDefaultPages(curPres?.pages.length || 1);
@@ -211,8 +213,19 @@ export default function Whiteboard(props) {
     const invalidShapeType = Object.keys(changedShapes)
       .find(id => !isValidShapeType(changedShapes[id]));
 
-    if (invalidChange || invalidShapeType) {
-      notifyNotAllowedChange(intl);
+    const shapeNumberExceeded = Object.keys(shapes).length > maxNumberOfAnnotations;
+    const isInserting = Object.keys(changedShapes)
+      .filter(
+        shape => typeof changedShapes[shape] === 'object'
+          && changedShapes[shape].type
+      ).length !== 0;
+
+    if (invalidChange || invalidShapeType || (shapeNumberExceeded && isInserting)) {
+      if (shapeNumberExceeded) {
+        notifyShapeNumberExceeded(intl, maxNumberOfAnnotations);
+      } else {
+        notifyNotAllowedChange(intl);
+      }
       // undo last command without persisting to not generate the onUndo/onRedo callback
       if (!redo) {
         const command = app.stack[app.pointer];

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -16,6 +16,7 @@ import {
   hasMultiUserAccess,
   changeCurrentSlide,
   notifyNotAllowedChange,
+  notifyShapeNumberExceeded,
 } from './service';
 import Whiteboard from './component';
 import { UsersContext } from '../components-data/users-context/context';
@@ -25,6 +26,7 @@ import { layoutSelect } from '../layout/context';
 
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 const WHITEBOARD_CONFIG = Meteor.settings.public.whiteboard;
+const { maxNumberOfAnnotations } = WHITEBOARD_CONFIG;
 
 const WhiteboardContainer = (props) => {
   const usingUsersContext = useContext(UsersContext);
@@ -63,6 +65,7 @@ const WhiteboardContainer = (props) => {
         width,
         height,
         maxStickyNoteLength,
+        maxNumberOfAnnotations,
         fontFamily,
         hasShapeAccess,
       }}
@@ -79,7 +82,7 @@ export default withTracker(({
   slidePosition,
   svgUri,
 }) => {
-  const shapes = getShapes(whiteboardId, curPageId, intl);
+  const shapes = getShapes(whiteboardId, curPageId, intl, maxNumberOfAnnotations);
   const curPres = getCurrentPres();
 
   shapes['slide-background-shape'] = {
@@ -120,5 +123,6 @@ export default withTracker(({
     zoomSlide: PresentationToolbarService.zoomSlide,
     skipToSlide: PresentationToolbarService.skipToSlide,
     notifyNotAllowedChange,
+    notifyShapeNumberExceeded,
   };
 })(WhiteboardContainer);

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -26,7 +26,6 @@ import { layoutSelect } from '../layout/context';
 
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 const WHITEBOARD_CONFIG = Meteor.settings.public.whiteboard;
-const { maxNumberOfAnnotations } = WHITEBOARD_CONFIG;
 
 const WhiteboardContainer = (props) => {
   const usingUsersContext = useContext(UsersContext);
@@ -37,7 +36,7 @@ const WhiteboardContainer = (props) => {
   const currentUser = users[Auth.meetingID][Auth.userID];
   const isPresenter = currentUser.presenter;
   const isModerator = currentUser.role === ROLE_MODERATOR;
-  const { maxStickyNoteLength } = WHITEBOARD_CONFIG;
+  const { maxStickyNoteLength, maxNumberOfAnnotations } = WHITEBOARD_CONFIG;
   const fontFamily = WHITEBOARD_CONFIG.styles.text.family;
 
   const { shapes } = props;
@@ -82,7 +81,7 @@ export default withTracker(({
   slidePosition,
   svgUri,
 }) => {
-  const shapes = getShapes(whiteboardId, curPageId, intl, maxNumberOfAnnotations);
+  const shapes = getShapes(whiteboardId, curPageId, intl);
   const curPres = getCurrentPres();
 
   shapes['slide-background-shape'] = {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -330,14 +330,13 @@ const changeCurrentSlide = (s) => {
   makeCall("changeCurrentSlide", s);
 }
 
-const getShapes = (whiteboardId, curPageId, intl, limit) => {
+const getShapes = (whiteboardId, curPageId, intl) => {
   const annotations =  Annotations.find(
     {
       whiteboardId,
     },
     {
       fields: { annotationInfo: 1, userId: 1, },
-      limit,
     },
   ).fetch();
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -22,6 +22,10 @@ const intlMessages = defineMessages({
     id: 'app.whiteboard.annotations.notAllowed',
     description: 'Label shown in toast when the user make a change on a shape he doesnt have permission',
   },
+  shapeNumberExceeded: {
+    id: 'app.whiteboard.annotations.numberExceeded',
+    description: 'Label shown in toast when the user tries to add more shapes than the limit',
+  },
 });
 
 let annotationsStreamListener = null;
@@ -326,13 +330,14 @@ const changeCurrentSlide = (s) => {
   makeCall("changeCurrentSlide", s);
 }
 
-const getShapes = (whiteboardId, curPageId, intl) => {
+const getShapes = (whiteboardId, curPageId, intl, limit) => {
   const annotations =  Annotations.find(
     {
       whiteboardId,
     },
     {
       fields: { annotationInfo: 1, userId: 1, },
+      limit,
     },
   ).fetch();
 
@@ -403,6 +408,10 @@ const notifyNotAllowedChange = (intl) => {
   if (intl) notify(intl.formatMessage(intlMessages.notifyNotAllowedChange), 'warning', 'whiteboard');
 };
 
+const notifyShapeNumberExceeded = (intl, limit) => {
+  if (intl) notify(intl.formatMessage(intlMessages.shapeNumberExceeded, { 0: limit }), 'warning', 'whiteboard');
+};
+
 export {
   initDefaultPages,
   Annotations,
@@ -427,4 +436,5 @@ export {
   changeCurrentSlide,
   clearFakeAnnotations,
   notifyNotAllowedChange,
+  notifyShapeNumberExceeded,
 };

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -748,6 +748,7 @@ public:
     annotationsQueueProcessInterval: 60
     cursorInterval: 150
     maxStickyNoteLength: 1000
+    maxNumberOfAnnotations: 100
     annotations:
       status:
         start: DRAW_START

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -748,6 +748,7 @@ public:
     annotationsQueueProcessInterval: 60
     cursorInterval: 150
     maxStickyNoteLength: 1000
+    # limit number of annotations per slide
     maxNumberOfAnnotations: 100
     annotations:
       status:

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1043,6 +1043,7 @@
     "app.whiteboard.annotations.pollResult": "Poll Result",
     "app.whiteboard.annotations.noResponses": "No responses",
     "app.whiteboard.annotations.notAllowed": "You are not allowed to make this change",
+    "app.whiteboard.annotations.numberExceeded": "The number of annotations exceeded the limit ({0})",
     "app.whiteboard.toolbar.tools": "Tools",
     "app.whiteboard.toolbar.tools.hand": "Pan",
     "app.whiteboard.toolbar.tools.pencil": "Pencil",


### PR DESCRIPTION
### What does this PR do?

Adds `maxNumberOfAnnotations` in `settings.yml`  to limit the number of annotations per slide (default: 100).

### Closes Issue(s)
Closes #16552
