### PR TITLE
fix: dial-in guest join

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/guests/GuestsWaitingApprovedMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/guests/GuestsWaitingApprovedMsgHdlr.scala
@@ -5,6 +5,7 @@ import org.bigbluebutton.core.apps.users.UsersApp
 import org.bigbluebutton.core.apps.voice.VoiceApp
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core.bus.InternalEventBus
+import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core.running.{ BaseMeetingActor, HandlerHelpers, LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
@@ -41,7 +42,7 @@ trait GuestsWaitingApprovedMsgHdlr extends HandlerHelpers with RightsManagementT
                     "none",
                     dialInUser.name,
                     dialInUser.name,
-                    false,
+                    MeetingStatus2x.isMeetingMuted(liveMeeting.status),
                     false,
                     "freeswitch"
                   )


### PR DESCRIPTION
### What does this PR do?

It fixes the way dial-in users join via guest lobby.

### Closes Issue(s)

Closes #16596

### Motivation

Previously a hard-coded default value was used, but now a dynamic one based on meeting mute status is implemented

