### PR TITLE
refactor(imex): Docker Compose Postgres Improvements

### DIFF
--- a/bbb-common-web/docker-compose.yml
+++ b/bbb-common-web/docker-compose.yml
@@ -11,4 +11,5 @@ services:
     ports:
       - "${HOST_PORT}:${CONTAINER_PORT}"
     volumes:
+      - "./postgres-data:/var/lib/postgresql/data"      
       - "./src/main/java/db/migration:/docker-entrypoint-initdb.d"

--- a/bbb-common-web/hibernate-cfg.sh
+++ b/bbb-common-web/hibernate-cfg.sh
@@ -8,7 +8,7 @@ echo '<!DOCTYPE hibernate-configuration PUBLIC
         <session-factory>
           <!-- JDBC Database connection settings -->
 	  <property name="connection.driver_class">org.postgresql.Driver</property>
-          <property name="connection.url">jdbc:postgresql://localhost:'"$HOST_PORT"'/bbb</property>
+          <property name="connection.url">jdbc:postgresql://localhost:'"$HOST_PORT"'/'"$POSTGRES_USER"'</property>
           <property name="connection.username">'"$POSTGRES_USER"'</property>
           <property name="connection.password">'"$POSTGRES_PASSWORD"'</property>
           <!-- JDBC connection pool settings -->

--- a/bbb-common-web/src/main/java/db/migration/V1__Initial_create.sql
+++ b/bbb-common-web/src/main/java/db/migration/V1__Initial_create.sql
@@ -1,6 +1,3 @@
-CREATE DATABASE bbb;
-\c bbb;
-
 CREATE TABLE IF NOT EXISTS recordings (
 	id BIGSERIAL PRIMARY KEY,
 	record_id VARCHAR(64),


### PR DESCRIPTION
### What does this PR do?

Removes the explicit database creation in the Postgres startup script and adds permanent volume to the Postgres container to ensure that data is not lost of the container is deleted.

### Motivation

The Postgres docker container would fail to startup after being initially created because it would fail to run the initialization script due to the database already existing. In addition, when the container was deleted any information in that container would be disconnected from future instances of the container due to there not being an explicit Postgres data volume to store the information in.
