### PR TITLE
fix(poll): Improve Poll Regular Expression

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -92,7 +92,7 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
   const yesNoPatt = /.*(yes\/no|no\/yes).*/gm;
   const hasYN = safeMatch(yesNoPatt, content, false);
 
-  const pollRegex = /[1-9A-Ia-i][.)].*/g;
+  const pollRegex = /\b[1-9A-Ia-i][.)].*/g;
   let optionsPoll = safeMatch(pollRegex, content, []);
   const optionsWithLabels = [];
 


### PR DESCRIPTION
### What does this PR do?
Improves the poll regex so it does not detect parts of words as poll options. 
Prevents slide content like `à mettre en garde contre sa dangerosité sociale.`  being detected as a poll option `e.`

### Motivation
There are cases where smart slides may not detect a response poll due to invalid detection of poll options.  

A slide with the following text should display a response poll in smart slides.
```
This is a test sentence.  more text.
Can you find these words in the paragraphs? 
```

Another improvement on https://github.com/bigbluebutton/bigbluebutton/pull/16622