### PR TITLE
[2.6.0] Add icons to presentation menu

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -152,6 +152,7 @@ const PresentationMenu = (props) => {
           key: 'list-item-fullscreen',
           dataTest: 'presentationFullscreen',
           label: formattedLabel(isFullscreen),
+          icon: isFullscreen ? 'exit_fullscreen' : 'fullscreen',
           onClick: () => {
             handleToggleFullscreen(fullscreenRef);
             const newElement = (elementId === currentElement) ? '' : elementId;
@@ -177,6 +178,7 @@ const PresentationMenu = (props) => {
           key: 'list-item-screenshot',
           label: intl.formatMessage(intlMessages.snapshotLabel),
           dataTest: "presentationSnapshot",
+          icon: 'video',
           onClick: async () => {
             setState({
               loading: true,


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Add icons to the presentation menu items for a better accessibility.

### Motivation

The current menu items show just texts, which take a while to understand for some locales (such as Japanese) and for some people due to the their lengths.

### More

For the snapshot, the video icon may not be the best one. It should be changed if somebody designs a camera icon. But for now it's good enough.
<img width="276" alt="スクリーンショット 2023-02-06 22 26 48" src="https://user-images.githubusercontent.com/45039819/216985298-2e375bf2-a682-4dd2-aea5-add28622be39.png">


