### PR TITLE
Add Aria Label to Webcam Options Button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.jsx
@@ -51,7 +51,7 @@ const intlMessages = defineMessages({
 const UserActions = (props) => {
   const {
     name, cameraId, numOfStreams, onHandleVideoFocus, user, focused, onHandleMirror,
-    isVideoSqueezed, videoContainer, isRTL
+    isVideoSqueezed, videoContainer, isRTL,
   } = props;
 
   const intl = useIntl();
@@ -119,6 +119,7 @@ const UserActions = (props) => {
         trigger={(
           <Styled.OptionsButton
             label={intl.formatMessage(intlMessages.squeezedLabel)}
+            aria-label={`${name} ${intl.formatMessage(intlMessages.squeezedLabel)}`}
             data-test="webcamOptionsMenuSqueezed"
             icon="device_list_selector"
             ghost


### PR DESCRIPTION
### What does this PR do?
Adds aria label to the squeezed webcam options button. This provides more context to screen readers so they know which user options they have focused.

### Closes Issue(s)
Closes #16048
