### PR TITLE
fix: Prevent Yes/No Quick Poll Without Options or Question (2.5)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/polling/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/polling/component.jsx
@@ -148,7 +148,7 @@ class Polling extends Component {
                   {answers.map((pollAnswer) => {
                     const formattedMessageIndex = pollAnswer?.key?.toLowerCase();
                     let label = pollAnswer.key;
-                    if (defaultPoll && pollAnswerIds[formattedMessageIndex]) {
+                    if ((defaultPoll || pollType.includes('CUSTOM')) && pollAnswerIds[formattedMessageIndex]) {
                       label = intl.formatMessage(pollAnswerIds[formattedMessageIndex]);
                     }
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -95,7 +95,7 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
   const optionsWithLabels = [];
 
   if (hasYN) {
-    optionsPoll = ['Yes', 'No'];
+    optionsPoll = ['yes', 'no'];
   }
 
   if (optionsPoll) {

--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -84,7 +84,7 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
     content,
   } = currentSlide;
 
-  const questionRegex = /.*?\?$/gm;
+  const questionRegex = /.*?\?/gm;
   const question = safeMatch(questionRegex, content, '');
 
   const doubleQuestionRegex = /\?{2}/gm;
@@ -93,6 +93,11 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
   const pollRegex = /[1-9A-Ia-i][.)].*/g;
   let optionsPoll = safeMatch(pollRegex, content, []);
   const optionsWithLabels = [];
+
+  if (hasYN) {
+    optionsPoll = ['Yes', 'No'];
+  }
+
   if (optionsPoll) {
     optionsPoll = optionsPoll.map((opt) => {
       const MAX_CHAR_LIMIT = 30;

--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -90,7 +90,7 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
   const doubleQuestionRegex = /\?{2}/gm;
   const doubleQuestion = safeMatch(doubleQuestionRegex, content, false);
 
-  const yesNoPatt = /.*yes\/no|no\/yes.*/gm;
+  const yesNoPatt = /.*(yes\/no|no\/yes).*/gm;
   const hasYN = safeMatch(yesNoPatt, content, false);
 
   const pollRegex = /[1-9A-Ia-i][.)].*/g;

--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -90,6 +90,9 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
   const doubleQuestionRegex = /\?{2}/gm;
   const doubleQuestion = safeMatch(doubleQuestionRegex, content, false);
 
+  const yesNoPatt = /.*yes\/no|no\/yes.*/gm;
+  const hasYN = safeMatch(yesNoPatt, content, false);
+
   const pollRegex = /[1-9A-Ia-i][.)].*/g;
   let optionsPoll = safeMatch(pollRegex, content, []);
   const optionsWithLabels = [];
@@ -161,7 +164,7 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
     }
   });
 
-  if (question.length > 0 && optionsPoll.length === 0 && !doubleQuestion) {
+  if (question.length > 0 && optionsPoll.length === 0 && !doubleQuestion && !hasYN) {
     quickPollOptions.push({
       type: 'R-',
       poll: {


### PR DESCRIPTION
### What does this PR do?

This is a port of #16609 and #15935 from 2.6 to 2.5.

_- Display single yes/no poll option for the given example. No longer also presents the typed response._
_- This ensures that yes / no polls initiated via smart slides displays the question and options for the cases described in the issue below._