### PR TITLE
fix(dark mode): logo colors inversion

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.js
@@ -49,6 +49,7 @@ const DtfInvert = `
   }
   [id="TD-StylesMenu"],
   [id="TD-Styles-Color-Container"],
+  div[data-test="brandingArea"],
   #connectionBars > div
 `;
 


### PR DESCRIPTION
### What does this PR do?

Adds a new style that tells darkReader lib to invert the logo image colors.

![logo_resolt](https://user-images.githubusercontent.com/32987232/217082578-a0ea67ad-6a97-4776-8c7c-d1788bf3827a.PNG)
