### PR TITLE
fix(dark mode): consecutive enables

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -446,13 +446,22 @@ class App extends Component {
 
   renderDarkMode() {
     const { darkTheme } = this.props;
+    if (darkTheme && !DarkReader.isEnabled()) {
+        DarkReader.enable(
+          { brightness: 100, contrast: 90 },
+          { invert: [Styled.DtfInvert], ignoreInlineStyle: [Styled.DtfCss], ignoreImageAnalysis: [Styled.DtfImages] },
+        )
+        logger.info({
+          logCode: 'dark_mode',
+        }, 'Dark mode is on.');
+    }
 
-    return darkTheme
-      ? DarkReader.enable(
-        { brightness: 100, contrast: 90 },
-        { invert: [Styled.DtfInvert], ignoreInlineStyle: [Styled.DtfCss], ignoreImageAnalysis: [Styled.DtfImages] },
-      )
-      : DarkReader.disable();
+    if (!darkTheme && DarkReader.isEnabled()){
+      DarkReader.disable();
+      logger.info({
+        logCode: 'dark_mode',
+      }, 'Dark mode is off.');
+    }
   }
 
   mountPushLayoutEngine() {


### PR DESCRIPTION
### What does this PR do?

Adds extra check to prevent executing dark mode's enable method when already enabled and the same to disable.
This should have some impact over performance(lighter), because the call to the `enable` method of the dark mode API is inside the `componentDidUpdate` function in the `App` component. It means that every time the App was updated, a call to enable the dark mode was executed regardless of its state.
Also logs when dark mode is enabled and disabled.
