### PR TITLE
fix(bbb-conf): Crontab New routine to remove unused docker images

### DIFF
--- a/bigbluebutton-config/cron.daily/bigbluebutton
+++ b/bigbluebutton-config/cron.daily/bigbluebutton
@@ -117,7 +117,7 @@ remove_raw_of_published_recordings
 #
 # Remove untagged and unamed docker images, cleanning /var/lib/docker/overlay2
 #
-docker images --filter "dangling=true" -q --no-trunc | xargs -r docker rmi -f
+docker image prune -f
 
 #
 # Remove old *.afm and *.pfb files from /tmp directory (if any exist)

--- a/bigbluebutton-config/cron.daily/bigbluebutton
+++ b/bigbluebutton-config/cron.daily/bigbluebutton
@@ -117,7 +117,7 @@ remove_raw_of_published_recordings
 #
 # Remove untagged and unamed docker images, cleanning /var/lib/docker/overlay2
 #
-docker rmi $(docker images --filter "dangling=true" -q --no-trunc)
+docker images --filter "dangling=true" -q --no-trunc | xargs -r docker rmi -f
 
 #
 # Remove old *.afm and *.pfb files from /tmp directory (if any exist)

--- a/bigbluebutton-config/cron.daily/bigbluebutton
+++ b/bigbluebutton-config/cron.daily/bigbluebutton
@@ -115,6 +115,11 @@ remove_raw_of_published_recordings(){
 remove_raw_of_published_recordings
 
 #
+# Remove untagged and unamed docker images, cleanning /var/lib/docker/overlay2
+#
+docker rmi $(docker images --filter "dangling=true" -q --no-trunc)
+
+#
 # Remove old *.afm and *.pfb files from /tmp directory (if any exist)
 #
 find /tmp -name "*.afm" -mtime +$history -delete


### PR DESCRIPTION
### What does this PR do?

It just cleans unused docker images on a daily basis. By doing that, it removes folders with plenty of data inside `/var/lib/docker/overlay2` directory

### Closes Issue(s)

Closes #16381

