### PR TITLE
fix(bbb-web): Case Insensitive Checksum Validation

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -1062,7 +1062,7 @@ public class ParamsProcessorUtil {
                 log.info("No algorithm could be found that matches the provided checksum length");
         }
 
-		if (cs == null || !cs.equals(checksum)) {
+		if (cs == null || !cs.equalsIgnoreCase(checksum)) {
 			log.info("query string after checksum removed: [{}]", queryString);
 			log.info("checksumError: query string checksum failed. our: [{}], client: [{}]", cs, checksum);
 			return false;
@@ -1122,7 +1122,7 @@ public class ParamsProcessorUtil {
 		String baseString = csbuf.toString();
 		String cs = DigestUtils.sha1Hex(baseString);
 
-		if (cs == null || !cs.equals(checksum)) {
+		if (cs == null || !cs.equalsIgnoreCase(checksum)) {
 			log.info("POST basestring = {}", baseString);
 			log.info("checksumError: failed checksum. our checksum: [{}], client: [{}]", cs, checksum);
 			return false;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/GetChecksumValidator.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/GetChecksumValidator.java
@@ -75,7 +75,7 @@ public class GetChecksumValidator implements ConstraintValidator<GetChecksumCons
                 log.info("No algorithm could be found that matches the provided checksum length");
         }
 
-        if (createdCheckSum == null || !createdCheckSum.equals(providedChecksum)) {
+        if (createdCheckSum == null || !createdCheckSum.equalsIgnoreCase(providedChecksum)) {
             log.info("checksumError: query string checksum failed. our: [{}], client: [{}]", createdCheckSum, providedChecksum);
             return false;
         }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/PostChecksumValidator.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/PostChecksumValidator.java
@@ -43,7 +43,7 @@ public class PostChecksumValidator implements ConstraintValidator<PostChecksumCo
         String data = checksum.getApiCall() + queryStringWithoutChecksum + securitySalt;
         String createdCheckSum = DigestUtils.sha1Hex(data);
 
-        if (createdCheckSum == null || !createdCheckSum.equals(providedChecksum)) {
+        if (createdCheckSum == null || !createdCheckSum.equalsIgnoreCase(providedChecksum)) {
             log.info("checksumError: failed checksum. our checksum: [{}], client: [{}]", createdCheckSum, providedChecksum);
             return false;
         }


### PR DESCRIPTION
### What does this PR do?

Modifies the checksum validation done by bbb-common-web to be case insensitive.

### Closes Issue(s)
Closes #11561


### Motivation

Two checksums containing the same characters, but with different character cases, are considered to have the same value and therefore the checksum validation should ignore case when evaluating the equality of two checksum strings.
