### PR TITLE
fix(sec): bump jackson to 2.13.5; logback to 1.2.11 (backport)

### DIFF
--- a/akka-bbb-apps/project/Dependencies.scala
+++ b/akka-bbb-apps/project/Dependencies.scala
@@ -16,8 +16,8 @@ object Dependencies {
     val akkaVersion = "2.6.17"
     val akkaHttpVersion = "10.2.7"
     val gson = "2.8.9"
-    val jackson = "2.13.0"
-    val logback = "1.2.10"
+    val jackson = "2.13.5"
+    val logback = "1.2.11"
     val quicklens = "1.7.5"
     val spray = "1.3.6"
 

--- a/bbb-common-message/project/Dependencies.scala
+++ b/bbb-common-message/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
     // Libraries
     val akkaVersion = "2.6.17"
     val gson = "2.8.9"
-    val jackson = "2.13.0"
+    val jackson = "2.13.5"
     val sl4j = "1.7.32"
     val pool = "2.11.1"
     val codec = "1.15"

--- a/bbb-common-web/project/Dependencies.scala
+++ b/bbb-common-web/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
     // Libraries
     val akkaVersion = "2.6.17"
     val gson = "2.8.9"
-    val jackson = "2.13.0"
+    val jackson = "2.13.5"
     val freemarker = "2.3.31"
     val apacheHttp = "4.5.13"
     val apacheHttpAsync = "4.1.4"


### PR DESCRIPTION
Backport to BBB 2.5 of #16567 and #16491

https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698
https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424
https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244


