### PR TITLE
chore: increase default value for max number of annotations per slide

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -749,7 +749,7 @@ public:
     cursorInterval: 150
     maxStickyNoteLength: 1000
     # limit number of annotations per slide
-    maxNumberOfAnnotations: 100
+    maxNumberOfAnnotations: 300
     annotations:
       status:
         start: DRAW_START


### PR DESCRIPTION
### What does this PR do?

Increase default value for `maxNumberOfAnnotations` from 100 to 300.

### Motivation

Current default is too low.

### More
#16624