### PR TITLE
(docs/ci): Docs deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,51 @@
+name: Deploy Docs to GitHub Pages
+
+on:  # only on changes
+  push:
+    branches:
+      - '/v*'
+      - 'develop'
+    paths:
+      - 'docs/'
+
+concurrency:
+  group: docs
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./docs
+    steps:
+      # Setup
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+          cache-dependency-path: ./docs/yarn.lock
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      # Build static docs
+      - name: Build all versions
+        run: ./build.sh
+      - name: Build website
+        run: yarn build
+
+      # Deploy
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/build
+          # The following lines assign commit authorship to the official
+          # GH-Actions bot for deploys to `gh-pages` branch:
+          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+          # The GH actions bot is used by default if you didn't specify the two fields.
+          # You can swap them out with your own user credentials.
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,12 +1,16 @@
 name: Deploy Docs to GitHub Pages
 
-on:  # only on changes
+on:
+  workflow_dispatch:
   push:
     branches:
       - '/v*'
       - 'develop'
     paths:
       - 'docs/'
+
+permissions:
+  contents: write
 
 concurrency:
   group: docs
@@ -42,10 +46,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/build
-          # The following lines assign commit authorship to the official
-          # GH-Actions bot for deploys to `gh-pages` branch:
-          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
-          # The GH actions bot is used by default if you didn't specify the two fields.
-          # You can swap them out with your own user credentials.
-          user_name: github-actions[bot]
-          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -3,6 +3,9 @@
 
 # Production
 /build
+/versioned_docs/
+/versioned_sidebars/
+versions.json
 
 # Generated files
 .docusaurus

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,41 +1,36 @@
-# Website
+# BigBlueButton Docs
 
-This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+These docs are automatically built using [Docusaurus 2](https://docusaurus.io/)
+and GitHub Actions (see [deploy-docs.yml](../.github/workflows/deploy-docs.yml)).
 
-### Installation
+## Local Development
 
-```
-$ yarn
-```
-
-### Local Development
+To test build the docs locally you can either use `yarn` or `npm`.
 
 ```
-$ yarn start
+$ yarn install  # install docusaurus and dependencies
+$ ./build.sh  # add all versions to build
+$ yarn start  # start local dev server
 ```
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
+The script `build.sh` goes through all branches of the repository and adds all
+release branches that have a `docusaurus.config.js`-file as versions to the docs.
+Note that you can not have uncommited local changes before you run `/build.sh`,
+otherwise git will refuse to change branches.
+This step is optional and if you don't run it docusaurus will only build the
+currently checkout out version.
+
+The last command starts a local development server and opens up a browser window.
+Most changes are reflected live without having to restart the server.
+
 
 ### Build
+
+If you only want to build the docs you can run:
 
 ```
 $ yarn build
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
-
-### Deployment
-
-Using SSH:
-
-```
-$ USE_SSH=true yarn deploy
-```
-
-Not using SSH:
-
-```
-$ GIT_USER=<Your GitHub username> yarn deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+This command generates static content into the `build` directory
+and can be served using any static contents hosting service.

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,27 +1,25 @@
 #!/bin/bash
 
-curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-sudo apt install -y yarn
-yarn set version berry
-yarn install
+set -eu
 
-git branch -r | grep '/v' | while read -r version; do
+git fetch --all
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+git branch --remotes | grep '/v' | while read -r version; do
   branch=${version##*/}
   remote=${version%/*}
-  git fetch $remote $branch:$branch
+  git fetch "$remote" "$branch":"$branch"
 done
 
-git branch | sed -n 's/^.*v\(.*\).x-release/\1/p' \
+git branch | sed --quiet 's/^.*v\(.*\).x-release/\1/p' \
   | while read -r version; do
 
+  git checkout "v${version}.x-release"
   if [ -f docusaurus.config.js ]; then
     echo "Adding documentation for $version"
-    git checkout "v${version}.x-release"
     yarn docusaurus docs:version "${version}"
   fi
 
 done
 
-git checkout develop
-npm start
+git checkout "$current_branch"

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -70,6 +70,11 @@ const config = {
                     {to: '/greenlight/overview', label: 'Greenlight', position: 'left'},
                     {to: '/new-features', label: 'New Features', position: 'left'},
                     {
+                        type: 'docsVersionDropdown',
+                        position: 'right',
+                        dropdownActiveClassDisabled: true,
+                    },
+                    {
                         href: 'https://github.com/bigbluebutton/bigbluebutton/docs',
                         label: 'GitHub',
                         position: 'right',

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -8,8 +8,8 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const config = {
     title: 'BigBlueButton',
     tagline: 'Official Documentation',
-    url: 'https://docs.bigbluebutton.org/',
-    baseUrl: '/',
+    url: 'https://bigbluebutton.github.io/',
+    baseUrl: '/bigbluebutton/',
     onBrokenLinks: 'throw',
     onBrokenMarkdownLinks: 'warn',
     favicon: 'img/favicon.ico',
@@ -17,7 +17,7 @@ const config = {
     // GitHub pages deployment config.
     // If you aren't using GitHub pages, you don't need these.
     organizationName: 'bigbluebutton', // Usually your GitHub org/user name.
-    projectName: 'bigbluebutton-docs', // Usually your repo name.
+    projectName: 'bigbluebutton', // Usually your repo name.
 
     // Even if you don't use internalization, you can use this field to set useful
     // metadata like html lang. For example, if your site is Chinese, you may want


### PR DESCRIPTION
This pull request introduces github actions to build the new docs and deploy them to github pages (#16665). It builds all versions that are on a release branch or on 'develop' and have a docusaurus-config (#16671). There is also an updated readme to explain local development (#16666).

The behavior for the versioning is that 2.6 is currently both the 'latest' version as well as the 'next' version. As soon as 2.7 is built, it will then be displayed as the 'next' version.

Details can be found in the commit descriptions.

An example deployment can be seen at https://tibroc.github.io/bigbluebutton/