### PR TITLE
style: adjust presentation menu buttons

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.js
@@ -47,6 +47,9 @@ const DtfInvert = `
   .tl-container {
     background-color: var(--tl-background) !important;
   }
+  #TD-Tools button, #TD-TopPanel-Undo, #TD-TopPanel-Redo, #TD-Styles {
+    border-color: transparent !important;
+  }
   [id="TD-StylesMenu"],
   [id="TD-Styles-Color-Container"],
   #connectionBars > div

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -265,10 +265,8 @@ const PresentationMenu = (props) => {
     return null
   };
 
-  const toolbarHeight = document.getElementById('TD-Styles')?.parentElement?.parentElement?.clientHeight || 'auto';
-
   return (
-    <Styled.Right style={{ height: toolbarHeight }}>
+    <Styled.Right>
       <BBBMenu 
         trigger={
           <TooltipContainer title={intl.formatMessage(intlMessages.optionsLabel)}>

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -265,8 +265,10 @@ const PresentationMenu = (props) => {
     return null
   };
 
+  const toolbarHeight = document.getElementById('TD-Styles')?.parentElement?.parentElement?.clientHeight || 'auto';
+
   return (
-    <Styled.Right>
+    <Styled.Right style={{ height: toolbarHeight }}>
       <BBBMenu 
         trigger={
           <TooltipContainer title={intl.formatMessage(intlMessages.optionsLabel)}>

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/styles.js
@@ -15,6 +15,7 @@ import {
   statusIconSize,
   borderSize,
   statusInfoHeight,
+  presentationMenuHeight,
 } from '/imports/ui/stylesheets/styled-components/general';
 
 const DropdownButton = styled.button`
@@ -40,6 +41,7 @@ const Right = styled.div`
   z-index: 999;
   box-shadow: 0 4px 2px -2px rgba(0, 0, 0, 0.05);
   border-bottom: 1px solid ${colorWhite};
+  height: ${presentationMenuHeight};
 
   > div {
     padding: 2px 4px 2px 4px;

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/styles.js
@@ -38,15 +38,21 @@ const Right = styled.div`
   left: auto;
   right: 0px;
   z-index: 999;
+  box-shadow: 0 4px 2px -2px rgba(0, 0, 0, 0.05);
+  border-bottom: 1px solid ${colorWhite};
 
   > div {
+    padding: 2px 4px 2px 4px;
     background-color: ${colorWhite};
     width: 50px;
-    height: 41px;
+    height: 100%;
+    margin-top: 1px;
+
   }
 
   button {
-    margin-top: .45rem;
+    height: 100%;
+    width: 100%;
   }
 
   [dir="rtl"] & {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -8,6 +8,7 @@ import { Utils } from "@tldraw/core";
 import Settings from '/imports/ui/services/settings';
 import logger from '/imports/startup/client/logger';
 import KEY_CODES from '/imports/utils/keyCodes';
+import { presentationMenuHeight } from '/imports/ui/stylesheets/styled-components/general';
 
 function usePrevious(value) {
   const ref = React.useRef();
@@ -644,6 +645,7 @@ export default function Whiteboard(props) {
     if (menu) {
       const MENU_OFFSET = `48px`;
       menu.style.position = `relative`;
+      menu.style.height = presentationMenuHeight;
       if (isRTL) {
         menu.style.left = MENU_OFFSET;
       } else {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -78,6 +78,9 @@ const TldrawGlobalStyle = createGlobalStyle`
         height: ${size}px;
         width: ${size}px;
     }
+    #TD-Styles {
+      height: 100%;
+    }
   `}
 `;
 

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/general.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/general.js
@@ -84,6 +84,8 @@ const btnSpacing = '.35rem';
 const toastIconMd = '2rem';
 const toastIconSm = '1.2rem';
 
+const presentationMenuHeight = '45px';
+
 export {
   borderSizeSmall,
   borderSize,
@@ -162,4 +164,5 @@ export {
   btnSpacing,
   toastIconMd,
   toastIconSm,
+  presentationMenuHeight,
 };


### PR DESCRIPTION
### What does this PR do?

- adjusts presentation menu buttons so they all have the same size and position
- removes border from presentation menu and whiteboard toolbar buttons in dark mode

#### before
[Screencast from 2023-02-10 10-34-12.webm](https://user-images.githubusercontent.com/3728706/218105756-b9698762-9275-4f7f-8fdd-b19937f4b7ba.webm)

[Screencast from 2023-02-10 10-35-14.webm](https://user-images.githubusercontent.com/3728706/218105721-f8cff7b7-6f7e-4d63-b338-7a15597d62cf.webm)

![Screenshot from 2023-02-10 10-35-30](https://user-images.githubusercontent.com/3728706/218105710-f2ad145b-0fe7-4498-bfc1-b9ca2f970f93.png)

#### after
[Screencast from 2023-02-10 10-34-37.webm](https://user-images.githubusercontent.com/3728706/218105738-c24f5584-6ff6-40e0-934d-2cc2d1b2c403.webm)

[Screencast from 2023-02-10 10-34-57.webm](https://user-images.githubusercontent.com/3728706/218105727-b8741849-2bcc-4eb0-8e5d-f0031a9da099.webm)

![Screenshot from 2023-02-10 10-35-38](https://user-images.githubusercontent.com/3728706/218105703-40977b24-a55d-4962-b0bc-cfc4601299ff.png)

