### PR TITLE
recording: Fix handling deskshare with delayed video

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video.rb
@@ -447,7 +447,8 @@ module BigBlueButton
             seek = video[:timestamp]
             BigBlueButton.logger.debug("      start timestamp: #{video[:timestamp]}")
             seek_offset = this_videoinfo[:start_time]
-            BigBlueButton.logger.debug("      seek offset: #{seek_offset}")
+            video_start_offset = this_videoinfo[:video][:start_time]
+            BigBlueButton.logger.debug("      seek offset: #{seek_offset}, video start offset: #{video_start_offset}")
             BigBlueButton.logger.debug("      codec: #{this_videoinfo[:video][:codec_name].inspect}")
             BigBlueButton.logger.debug("      duration: #{this_videoinfo[:duration]}, original duration: #{video[:original_duration]}")
 
@@ -507,10 +508,17 @@ module BigBlueButton
             FileUtils.rm_f(ffmpeg_preprocess_output)
             File.mkfifo(ffmpeg_preprocess_output)
 
+            in_time = video[:timestamp] + seek_offset
+            out_time = in_time + duration
+
             # Pre-filtering: scaling, padding, and extending.
-            ffmpeg_preprocess_filter = \
-              "[0:v:0]scale=w=#{tile_width}:h=#{tile_height}:force_original_aspect_ratio=decrease,setsar=1,"\
-              "pad=w=#{tile_width}:h=#{tile_height}:x=-1:y=-1:color=white[out]"
+            ffmpeg_preprocess_filter = String.new
+            ffmpeg_preprocess_filter << '[0:v:0]'
+            ffmpeg_preprocess_filter << "scale=w=#{tile_width}:h=#{tile_height}:force_original_aspect_ratio=decrease,"
+            ffmpeg_preprocess_filter << "setsar=1,pad=w=#{tile_width}:h=#{tile_height}:x=-1:y=-1:color=white,"
+            # The trim command combines its arguments - end at the timestamp but only if at least one frame has been output.
+            ffmpeg_preprocess_filter << "trim=end=#{ms_to_s(out_time)}:end_frame=1"
+            ffmpeg_preprocess_filter << '[out]'
 
             # Set up filters and inputs for video pre-processing ffmpeg command
             ffmpeg_preprocess_command = [
@@ -519,9 +527,7 @@ module BigBlueButton
               '-vsync', 'passthrough', '-noaccurate_seek',
               '-ss', ms_to_s(seek).to_s, '-itsoffset', ms_to_s(seek).to_s, '-i', video[:filename],
               '-filter_complex', ffmpeg_preprocess_filter, '-map', '[out]',
-              # Trim to end point so process exits cleanly
-              '-to', ms_to_s(video[:timestamp] + duration).to_s,
-              '-c:v', 'rawvideo', "#{output}.#{pad_name}.nut"
+              '-c:v', 'rawvideo', "#{output}.#{pad_name}.nut",
             ]
             BigBlueButton.logger.debug("Executing: #{Shellwords.join(ffmpeg_preprocess_command)}")
             ffmpeg_preprocess_pid = spawn(*ffmpeg_preprocess_command, err: [ffmpeg_preprocess_log, 'w'])
@@ -536,10 +542,14 @@ module BigBlueButton
             ffmpeg_filter << "[#{input_index}]"
             # Scale the video length for the deskshare timestamp workaround
             ffmpeg_filter << "setpts=PTS*#{scale}," unless scale.nil?
+            # If the video start time is after the seek point, extend the video backwards
+            if in_time < video_start_offset
+              ffmpeg_filter << "tpad=start_duration=#{ms_to_s(video_start_offset - in_time)}:start_mode=clone,"
+            end
             # Extend the video if needed and clean up the framerate
             ffmpeg_filter << "tpad=stop=-1:stop_mode=clone,fps=#{layout[:framerate]}"
             # Apply PTS offset so '0' time is aligned, and trim frames before start point
-            ffmpeg_filter << ",setpts=PTS-#{ms_to_s(video[:timestamp])}/TB,trim=start=0"
+            ffmpeg_filter << ",setpts=PTS-#{ms_to_s(in_time)}/TB,trim=start=0"
             ffmpeg_filter << "[#{pad_name}];"
           end
 


### PR DESCRIPTION
When a deskshare stream with combined audio + video starts up, it can happen that the audio starts before the video - so the first video frame will be some amount of time after the file start.

If there's a recording processing cut in this gap, the procesing can crash because it can generate an output video with no video frames.

There are two parts to the fix:
  * Trim input videos with the trim filter, configured to ensure at least 1 output frame is generated, even if it would be after the end timestamp.
  * Use the tpad filter to pad the *start* of a video stream to make sure there's something in the gap.

An example where this happened has a deskshare file that looks like this:
```
$ ffprobe -v fatal -show_entries format=start_time:stream=start_time,codec_type,index 850285446-1675257945844.webm
[STREAM]
index=0
codec_type=video
start_time=1.922000
[/STREAM]
[STREAM]
index=1
codec_type=audio
start_time=0.000000
[/STREAM]
[FORMAT]
start_time=0.000000
[/FORMAT]
```

And the video format in this recording generated a cut about 1.5 seconds after the deskshare video started due to a webcam dropping. This was before the first frame in the deskshare video, so 0 frames were read from the input video and the compositing ffmpeg exited with an error.