### PR TITLE
recording: video format updates & fixes

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -936,6 +936,7 @@ module BigBlueButton
     # Check whether any webcams were shared during the recording
     # This can be used to e.g. skip webcam processing or change the layout
     # of the final recording
+    # TODO: check only within recording start/stop markers?
     def self.have_webcam_events(events_xml)
       BigBlueButton.logger.debug("Checking if webcams were used...")
       webcam_events = events_xml.xpath('/recording/event[@eventname="StartWebcamShareEvent" or @eventname="StartWebRTCShareEvent"]')
@@ -948,9 +949,27 @@ module BigBlueButton
       end
     end
 
+    # Check whether any desktop sharing was performed during the recording
+    # This can be used to e.g. skip deskshare processing or change the layout
+    # of the final recording
+    # TODO: check only within recording start/stop markers?
+    def self.have_deskshare_events(events_xml)
+      BigBlueButton.logger.debug('Checking if desktop sharing was used...')
+      deskshare_events = events_xml.xpath('/recording/event[@module="Deskshare" or (@module="bbb-webrtc-sfu" and @eventname="StartWebRTCDesktopShareEvent")]')
+      if deskshare_events.length > 0
+        BigBlueButton.logger.debug('Deskshare events seen in recording')
+        true
+      else
+        BigBlueButton.logger.debug('No deskshare events were seen in recording')
+        false
+      end
+    end
+
     # Check whether any of the presentation features were used in the recording
     # This can be used to e.g. skip presentation processing or change the
     # layout of the final recording.
+    # This should include things done before recording is started, since they
+    # might be visible during the recording.
     def self.have_presentation_events(events_xml)
       BigBlueButton.logger.debug("Checking if presentation area was used...")
       pres_events = events_xml.xpath('/recording/event[@module="PRESENTATION" or @module="WHITEBOARD"]')

--- a/record-and-playback/video/scripts/process/video.rb
+++ b/record-and-playback/video/scripts/process/video.rb
@@ -72,7 +72,7 @@ metadata = events.at_xpath('/recording/metadata')
 logger.info 'Generating video events list'
 
 # Webcams
-webcam_edl = BigBlueButton::Events.create_webcam_edl(events, raw_archive_dir, false)
+webcam_edl = BigBlueButton::Events.create_webcam_edl(events, raw_archive_dir, props['show_moderator_viewpoint'])
 logger.debug 'Webcam EDL:'
 BigBlueButton::EDL::Video.dump(webcam_edl)
 
@@ -97,6 +97,14 @@ if have_webcams
   logger.info('Webcams were use in this session')
 else
   logger.info('No webcams were used in this session')
+end
+
+logger.info('Checking whether desktop sharing was used')
+have_deskshare = BigBlueButton::Events.have_deskshare_events(events)
+if have_deskshare
+  logger.info('Desktop sharing was used in this session')
+else
+  logger.info('No desktop sharing was used in this session')
 end
 
 logger.info 'Checking whether the presentation area was used'
@@ -177,12 +185,14 @@ end
 
 # Select the layout based on what video sections are available
 layout = \
-  if have_presentation && have_webcams
-    video_props['layout']
-  elsif have_presentation
-    video_props['nowebcam_layout']
+  if have_webcams
+    if have_presentation || have_deskshare
+      video_props['layout']
+    else
+      video_props['nopresentation_layout']
+    end
   else
-    video_props['nopresentation_layout']
+    video_props['nowebcam_layout']
   end
 
 layout.symbolize_keys!
@@ -273,7 +283,7 @@ metadata_xml = Nokogiri::XML::Builder.new do |xml|
     xml.end_time(start_real_time + final_timestamp - initial_timestamp)
     xml.playback do
       xml.format('video')
-      xml.link("http://#{props['playback_host']}/playback/video/#{meeting_id}/")
+      xml.link("#{props['playback_protocol']}://#{props['playback_host']}/playback/video/#{meeting_id}/")
       xml.duration(duration)
     end
     xml.meta do

--- a/record-and-playback/video/scripts/video.yml
+++ b/record-and-playback/video/scripts/video.yml
@@ -22,7 +22,7 @@ layout:
     - name: deskshare
       x: 0
       y: 0
-      width: 1280
+      width: 920
       height: 720
       pad: true
 nopresentation_layout:
@@ -35,12 +35,6 @@ nopresentation_layout:
       y: 0
       width: 1280
       height: 720
-    - name: deskshare
-      x: 0
-      y: 0
-      width: 1280
-      height: 720
-      pad: true
 nowebcam_layout:
   width: 1280
   height: 720


### PR DESCRIPTION
A few minor updates and fixes to the video recording format:

* The `show_moderator_viewpoint` recording setting is now honoured.
* The desktop sharing video replaces the presentation area - it no longer hides webcams (it now matches the live meeting).
* The `playback_protocol` recording setting is now honoured (recording links will correctly use https when that's configured).
