### PR TITLE
fix(whiteboard): change cursor when moving shapes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -152,6 +152,7 @@ export default function Whiteboard(props) {
   const prevSvgUri = usePrevious(svgUri);
   const language = mapLanguage(Settings?.application?.locale?.toLowerCase() || 'en');
   const [currentTool, setCurrentTool] = React.useState(null);
+  const [isMoving, setIsMoving] = React.useState(false);
 
   const throttledResetCurrentPoint = React.useRef(_.throttle(() => {
     setEnable(false);
@@ -730,6 +731,12 @@ export default function Whiteboard(props) {
       }
     }
 
+    // change cursor when moving shapes
+    if (e?.session?.type === "translate" && e?.session?.status === "translating") {
+      if (!isMoving) setIsMoving(true);
+      if (reason === "set_status:idle") setIsMoving(false);
+    }
+
     if (reason && isPresenter && slidePosition && (reason.includes("zoomed") || reason.includes("panned"))) {
       const camera = tldrawAPI.getPageState()?.camera;
 
@@ -967,6 +974,7 @@ export default function Whiteboard(props) {
         isViewersCursorLocked={isViewersCursorLocked}
         isMultiUserActive={isMultiUserActive}
         isPanning={isPanning}
+        isMoving={isMoving}
         currentTool={currentTool}
       >
         {enable && (hasWBAccess || isPresenter) ? editableWB : readOnlyWB}

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
@@ -22,6 +22,7 @@ const TOOL_CURSORS = {
   text: `url('${makeCursorUrl('text.png')}'), default`,
   sticky: `url('${makeCursorUrl('square.png')}'), default`,
   pan: `url('${makeCursorUrl('pan.png')}'), default`,
+  moving: 'move',
 };
 
 const Cursor = (props) => {
@@ -148,6 +149,7 @@ export default function Cursors(props) {
     hasMultiUserAccess,
     isMultiUserActive,
     isPanning,
+    isMoving,
     currentTool,
   } = props;
 
@@ -322,6 +324,7 @@ export default function Cursors(props) {
   const multiUserAccess = hasMultiUserAccess(whiteboardId, currentUser?.userId);
   let cursorType = multiUserAccess || currentUser?.presenter ? TOOL_CURSORS[currentTool] || 'none' : 'default';
   if (isPanning) cursorType = TOOL_CURSORS.pan;
+  if (isMoving) cursorType = TOOL_CURSORS.moving;
 
   return (
     <span key={`cursor-wrapper-${whiteboardId}`} ref={cursorWrapper}>


### PR DESCRIPTION
### What does this PR do?

Sets cursor to `move` when moving an annotation in the whiteboard.

[Screencast from 2023-02-10 15-33-56.webm](https://user-images.githubusercontent.com/3728706/218170446-43efebb2-feaa-47eb-95ff-9ea674ea7da2.webm)


### Closes Issue(s)
Closes #16664