### PR TITLE
build(akka-fsesl): Fix permission denied to bbb-fsesl-akka logging

### DIFF
--- a/akka-bbb-fsesl/src/debian/DEBIAN/postinst
+++ b/akka-bbb-fsesl/src/debian/DEBIAN/postinst
@@ -1,3 +1,4 @@
+#!/bin/sh
 #
 # Update ESL password to match the password from bbb-freeswitch-core, which is
 # listed as a package dependency to ensure that it configures first.
@@ -8,3 +9,6 @@ ESL_PASSWORD=$(xmlstarlet sel -t -m 'configuration/settings/param[@name="passwor
 if [ -n "$ESL_PASSWORD" ]; then
     sed -i "s/ClueCon/$ESL_PASSWORD/g" /etc/bigbluebutton/bbb-fsesl-akka.conf
 fi
+
+# Change ownership of the logging directory
+chown bigbluebutton:bigbluebutton '/var/log/bbb-fsesl-akka'


### PR DESCRIPTION
### What does this PR do?

Fix error of `bbb-fsesl-akka` logging:

```log
ERROR in ch.qos.logback.core.rolling.RollingFileAppender[FILE] - openFile(logs/bbb-fsesl-akka.log,true) call failed. java.io.FileNotFoundException: logs/bbb-fsesl-akka.log (Permission denied)
```

### Closes Issue(s)

Closes #16590

### More

After lots of digging, I looked up into some logs I inserted in the `bbb-install.sh` script, and it seemed, at first sight, that the folder `/var/log/bbb-fsesl-akka` was not yet created when the install script tried to first run the component. But some new debugs and information came, and from the looks of it, while `bbb-apps-akka` had the changing of ownership in its `postinst` script in the debian package, `bbb-fsesl-akka` didn't.

So, a simple solution was to insert the ownership directly in the `postinst` script in `fsesl` debian package, but this should be discussed and analyzed better, because if `bbb-apps-akka` is doing it already, why would this component not? My first hunch is that it may have something to do with the fact that in this package, we define explicitly what we want the `postinst` script to be, and it is built on top of it. But I am open for suggestions and also I am going to look a little deeper on it!

#### To test/review:

It was a little tricky for me to test and expose some logs to properly debug this problem. But what I do recommend is that the reviewer opens a PR to it's own repository with one little change: the install script to which [the CI will point](https://github.com/bigbluebutton/bigbluebutton/blob/745bd7e42d82fc7abef7d90cfb08e25b146dca3f/.github/workflows/automated-tests.yml#L117)  needs to be adjusted to point to another install script which will contain the logs you'll want to analyze.

Or it is also possible to simply wait for this PR to run its CI and see the `artifacts.tar.zip` which will contain the debian packages and with that you will be able to properly install it in your own server and test it there following the steps mentioned in the issue.
 