### PR TITLE
style: Remove space on the right of style tool on iPhone

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -264,6 +264,10 @@ const PresentationMenu = (props) => {
     if (undoCtrls?.style) {
       undoCtrls.style = "padding:0px";
     }
+    const styleTool = document.getElementById('TD-Styles')?.parentNode;
+    if (styleTool?.style) {
+      styleTool.style = "right:0px";
+    }
     return null
   };
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Removes the space that appears if there is no item under the "more" button of style tool. It is usually the case for iPhone.

### Motivation

On iPhone the panel doesn't look very pretty.

### More

Confirmed that it works for RTL languages. I didn't check it on a real iPhone. Please somebody do it.

Before:
<img width="393" alt="スクリーンショット 2023-02-11 13 21 21" src="https://user-images.githubusercontent.com/45039819/218240078-37a5e332-1f0c-4a99-a11d-abe985d2e7f2.png">
After:
<img width="397" alt="スクリーンショット 2023-02-11 13 21 29" src="https://user-images.githubusercontent.com/45039819/218240087-a2b66b1c-d437-4837-b2a2-288b9b089f1a.png">
