### PR TITLE
fix: Notes notification perpetually unread

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.jsx
@@ -63,7 +63,6 @@ const Notes = ({
   isToSharedNotesBeShow,
   shouldShowSharedNotesOnPresentationArea,
 }) => {
-  useEffect(() => Service.setLastRev());
   const [shouldRenderNotes, setShouldRenderNotes] = useState(false);
   const { isChrome } = browserInfo;
   const isOnMediaArea = area === 'media';

--- a/bigbluebutton-html5/imports/ui/components/notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.jsx
@@ -63,7 +63,7 @@ const Notes = ({
   isToSharedNotesBeShow,
   shouldShowSharedNotesOnPresentationArea,
 }) => {
-  useEffect(() => () => Service.setLastRev(), []);
+  useEffect(() => Service.setLastRev());
   const [shouldRenderNotes, setShouldRenderNotes] = useState(false);
   const { isChrome } = browserInfo;
   const isOnMediaArea = area === 'media';

--- a/bigbluebutton-html5/imports/ui/components/notes/service.js
+++ b/bigbluebutton-html5/imports/ui/components/notes/service.js
@@ -34,28 +34,13 @@ const hasPermission = () => {
   return true;
 };
 
-const getLastRev = () => {
-  const lastRev = Session.get('notesLastRev');
-  if (!lastRev) return -1;
+const getLastRev = () => (Session.get('notesLastRev') || 0);
 
-  return lastRev;
-};
+const getRev = () => PadsService.getRev(NOTES_CONFIG.id);
 
-const setLastRev = () => {
-  const rev = PadsService.getRev(NOTES_CONFIG.id);
-  const lastRev = getLastRev();
+const markNotesAsRead = () => Session.set('notesLastRev', getRev());
 
-  if (rev !== 0 && rev > lastRev) {
-    Session.set('notesLastRev', rev);
-  }
-};
-
-const hasUnreadNotes = () => {
-  const rev = PadsService.getRev(NOTES_CONFIG.id);
-  const lastRev = getLastRev();
-
-  return rev !== 0 && rev > lastRev;
-};
+const hasUnreadNotes = () => (getRev() > getLastRev());
 
 const isEnabled = () => isSharedNotesEnabled();
 
@@ -87,8 +72,7 @@ export default {
   toggleNotesPanel,
   hasPermission,
   isEnabled,
-  setLastRev,
-  getLastRev,
+  markNotesAsRead,
   hasUnreadNotes,
   isSharedNotesPinned,
   pinSharedNotes,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-notes/component.jsx
@@ -45,7 +45,7 @@ class UserNotes extends Component {
     super(props);
 
     this.state = {
-      unread: false,
+      unread: NotesService.hasUnreadNotes(),
     };
     this.setUnread = this.setUnread.bind(this);
   }

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-notes/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-notes/container.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
-import PadsService from '/imports/ui/components/pads/service';
 import NotesService from '/imports/ui/components/notes/service';
 import lockContextContainer from '/imports/ui/components/lock-viewers/context/container';
 import UserNotes from './component';
@@ -16,7 +15,7 @@ const UserNotesContainer = (props) => {
 export default lockContextContainer(withTracker(({ userLocks }) => {
   const shouldDisableNotes = userLocks.userNotes;
   return {
-    rev: PadsService.getRev(NotesService.ID),
+    unread: NotesService.hasUnreadNotes(),
     disableNotes: shouldDisableNotes,
     isPinned: NotesService.isSharedNotesPinned(),
   };


### PR DESCRIPTION
### What does this PR do?
Prevents the shared notes notification from always being lit.

### Closes Issue
Closes #16598 

https://user-images.githubusercontent.com/33319791/218263134-75788f4b-afb6-4780-bd7f-860d96119ef0.mov


