### PR TITLE
fix: Only moderators should hear connection-status for all; otherwise…

### DIFF
--- a/bigbluebutton-html5/imports/api/connection-status/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/connection-status/server/publishers.js
@@ -3,6 +3,10 @@ import { check } from 'meteor/check';
 import Logger from '/imports/startup/server/logger';
 import ConnectionStatus from '/imports/api/connection-status';
 import AuthTokenValidation, { ValidationStates } from '/imports/api/auth-token-validation';
+import Users from '/imports/api/users';
+import { publicationSafeGuard } from '/imports/api/common/server/helpers';
+
+const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 
 function connectionStatus() {
   const tokenValidation = AuthTokenValidation.findOne({ connectionId: this.connection.id });
@@ -17,9 +21,27 @@ function connectionStatus() {
   check(meetingId, String);
   check(userId, String);
 
+  const User = Users.findOne({ userId, meetingId }, { fields: { role: 1 } });
   Logger.info(`Publishing connection status for ${meetingId} ${userId}`);
 
-  return ConnectionStatus.find({ meetingId });
+  if (!!User && User.role === ROLE_MODERATOR) {
+    // Monitor this publication and stop it when user is not a moderator anymore
+    const comparisonFunc = () => {
+      const user = Users.findOne({ userId, meetingId }, { fields: { role: 1, userId: 1 } });
+      const condition = user.role === ROLE_MODERATOR;
+
+      if (!condition) {
+        Logger.info(`conditions aren't filled anymore in publication ${this._name}: 
+        user.role === ROLE_MODERATOR :${condition}, user.role: ${user.role} ROLE_MODERATOR: ${ROLE_MODERATOR}`);
+      }
+
+      return condition;
+    };
+    publicationSafeGuard(comparisonFunc, this);
+    return ConnectionStatus.find({ meetingId });
+  }
+
+  return ConnectionStatus.find({ meetingId, userId });
 }
 
 function publish(...args) {

--- a/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
@@ -118,6 +118,7 @@ export default withTracker(() => {
         SubscriptionRegistry.getSubscription('users'),
         SubscriptionRegistry.getSubscription('breakouts'),
         SubscriptionRegistry.getSubscription('breakouts-history'),
+        SubscriptionRegistry.getSubscription('connection-status'),
         SubscriptionRegistry.getSubscription('guestUser'),
       ].forEach((item) => {
         if (item) item.stop();


### PR DESCRIPTION
… only hear your own

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Introduces a check in the publishing mechanism for connection-status. This check allows us to control if a user should receive only their own connection-status updates (viewer case) or everyone's (moderator case)
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #16708 

After:
viewer sees own info only:
![Screenshot from 2023-02-13 11-29-41](https://user-images.githubusercontent.com/6312397/218522122-abceacf1-2327-4e10-a1be-d0228a880764.png)

moderator sees own + viewers + offline users (to be able to see if someone is gone due to disconnect)
![Screenshot from 2023-02-13 11-30-01](https://user-images.githubusercontent.com/6312397/218522470-7e891b08-6a23-4c6e-90f3-25be6b64f9bc.png)
![Screenshot from 2023-02-13 11-28-05](https://user-images.githubusercontent.com/6312397/218522624-e6939352-e430-42d9-8c4f-962db297932e.png)



### Motivation
It is unnecessary for viewers to be subscribed for other viewer's connection info. We don't expose such info via UI. Also it leads to lots of unnecessary traffic (see #16708)
<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->
- [ ] There will still be an issue for the moderators' client (receiving lots of events, one per meeting member, every 10s), which will cause delays on large meetings.
