### PR TITLE
fix: reduce whiteboard cursor updates

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Meteor } from 'meteor/meteor';
+import { throttle } from 'lodash';
 
 const XS_OFFSET = 8;
 const SMALL_OFFSET = 18;
@@ -7,6 +8,7 @@ const XL_OFFSET = 85;
 const BOTTOM_CAM_HANDLE_HEIGHT = 10;
 const PRES_TOOLBAR_HEIGHT = 35;
 
+const { cursorInterval: CURSOR_INTERVAL } = Meteor.settings.public.whiteboard;
 const baseName = Meteor.settings.public.app.cdn + Meteor.settings.public.app.basename;
 const makeCursorUrl = (filename) => `${baseName}/resources/images/whiteboard-cursor/${filename}`;
 
@@ -100,7 +102,7 @@ const PositionLabel = (props) => {
   const { name, color, userId } = currentUser;
   const { x, y } = pos;
 
-  React.useEffect(() => {
+  const cursorUpdate = (x,y) => {
     try {
       const point = [x, y];
       publishCursorUpdate({
@@ -113,6 +115,15 @@ const PositionLabel = (props) => {
     } catch (e) {
       console.log(e);
     }
+  };
+
+  const throttledCursorUpdate = React.useRef(throttle((x,y) => {
+    cursorUpdate(x,y);
+  },
+  CURSOR_INTERVAL, { trailing: false }));
+
+  React.useEffect(() => {
+    throttledCursorUpdate.current(x,y);
   }, [x, y]);
 
   return (

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
@@ -33,7 +33,7 @@ const Cursor = (props) => {
     x,
     y,
     currentPoint,
-    pageState,
+    tldrawCamera,
     isMultiUserActive,
     owner = false,
   } = props;
@@ -43,8 +43,8 @@ const Cursor = (props) => {
   let _y = null;
 
   if (!currentPoint) {
-    _x = (x + pageState?.camera?.point[0]) * pageState?.camera?.zoom;
-    _y = (y + pageState?.camera?.point[1]) * pageState?.camera?.zoom;
+    _x = (x + tldrawCamera?.point[0]) * tldrawCamera?.zoom;
+    _y = (y + tldrawCamera?.point[1]) * tldrawCamera?.zoom;
   }
 
   return (
@@ -92,7 +92,7 @@ const PositionLabel = (props) => {
   const {
     currentUser,
     currentPoint,
-    pageState,
+    tldrawCamera,
     publishCursorUpdate,
     whiteboardId,
     pos,
@@ -107,9 +107,9 @@ const PositionLabel = (props) => {
       const point = [x, y];
       publishCursorUpdate({
         xPercent:
-          point[0] / pageState?.camera?.zoom - pageState?.camera?.point[0],
+          point[0] / tldrawCamera?.zoom - tldrawCamera?.point[0],
         yPercent:
-          point[1] / pageState?.camera?.zoom - pageState?.camera?.point[1],
+          point[1] / tldrawCamera?.zoom - tldrawCamera?.point[1],
         whiteboardId,
       });
     } catch (e) {
@@ -136,7 +136,7 @@ const PositionLabel = (props) => {
           x={x}
           y={y}
           currentPoint={currentPoint}
-          pageState={pageState}
+          tldrawCamera={tldrawCamera}
           isMultiUserActive={isMultiUserActive(whiteboardId)}
         />
       </div>
@@ -152,7 +152,8 @@ export default function Cursors(props) {
     whiteboardId,
     otherCursors,
     currentUser,
-    tldrawAPI,
+    currentPoint,
+    tldrawCamera,
     publishCursorUpdate,
     children,
     isViewersCursorLocked,
@@ -342,8 +343,8 @@ export default function Cursors(props) {
             pos={pos}
             otherCursors={otherCursors}
             currentUser={currentUser}
-            currentPoint={tldrawAPI?.currentPoint}
-            pageState={tldrawAPI?.getPageState()}
+            currentPoint={currentPoint}
+            tldrawCamera={tldrawCamera}
             publishCursorUpdate={publishCursorUpdate}
             whiteboardId={whiteboardId}
             isMultiUserActive={isMultiUserActive}
@@ -372,7 +373,7 @@ export default function Cursors(props) {
                   color="#C70039"
                   x={c?.xPercent}
                   y={c?.yPercent}
-                  pageState={tldrawAPI?.getPageState()}
+                  tldrawCamera={tldrawCamera}
                   isMultiUserActive={isMultiUserActive(whiteboardId)}
                   owner
                 />
@@ -387,7 +388,7 @@ export default function Cursors(props) {
                 color="#AFE1AF"
                 x={c?.xPercent}
                 y={c?.yPercent}
-                pageState={tldrawAPI?.getPageState()}
+                tldrawCamera={tldrawCamera}
                 isMultiUserActive={isMultiUserActive(whiteboardId)}
                 owner
               />

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/container.jsx
@@ -3,9 +3,10 @@ import React from "react";
 import SettingsService from '/imports/ui/services/settings';
 import Cursors from "./component";
 import Service from "./service";
+import _ from 'lodash';
 
 const CursorsContainer = (props) => {
-  return <Cursors {...props}/>
+  return <Cursors {..._.omit(props, ['tldrawAPI'])} />
 };
 
 export default
@@ -15,7 +16,8 @@ export default
       currentUser: params.currentUser,
       publishCursorUpdate: Service.publishCursorUpdate,
       otherCursors: Service.getCurrentCursors(params.whiteboardId),
-      tldrawAPI: params.tldrawAPI,
+      currentPoint: params.tldrawAPI?.currentPoint,
+      tldrawCamera: params.tldrawAPI?.getPageState().camera,
       isViewersCursorLocked: params.isViewersCursorLocked,
       hasMultiUserAccess: params.hasMultiUserAccess,
       isMultiUserActive: params.isMultiUserActive,


### PR DESCRIPTION
### What does this PR do?

Makes the following changes in order to reduce the number of renders in whiteboard cursors: 
- restores BBB 2.5 `cursorInterval` behavior
- do not pass tldrawAPI object to cursor component (only pass the parts needed by Cursors component)