### PR TITLE
Fix: dismiss toast on uploader unmount

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toast/presentation-uploader-toast/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toast/presentation-uploader-toast/component.jsx
@@ -300,6 +300,17 @@ const alreadyRenderedPresList = []
 export const PresentationUploaderToast = ({ intl }) => {
 
 	useTracker(() => {
+		presentationsAlreadyRenderedIds = Presentations.find({renderedInToast: true}).fetch().map(p => {
+			return {
+				id: p.id,
+				temporaryPresentationId: p.temporaryPresentationId,
+			}
+		});
+		// Check if there are inconsistencies between UploadingPresentation and Presentation (corner case)
+		presentationsAlreadyRenderedIds.forEach(p => {
+			UploadingPresentations.remove({$or: [{temporaryPresentationId: p.temporaryPresentationId}, 
+				{id: p.id}]})
+		})
 		
 		const presentationsRenderedFalseAndConversionFalse = Presentations.find({ $or: [{renderedInToast: false}, {"conversion.done": false}] }).fetch();
 		const convertingPresentations = presentationsRenderedFalseAndConversionFalse.filter(p => !p.renderedInToast )
@@ -307,7 +318,7 @@ export const PresentationUploaderToast = ({ intl }) => {
 			.map(p => { return {temporaryPresentationId: p.temporaryPresentationId, id: p.id}; })
 		UploadingPresentations.find({}).fetch().filter(p => tmpIdconvertingPresentations.findIndex(pres => pres.temporaryPresentationId === p.temporaryPresentationId || pres.id === p.id) !== -1)
 			.map(p => {
-				return UploadingPresentations.remove({$or: [{temporaryPresentationId: p.temporaryPresentationId }, {id: p.id}]})});
+				return UploadingPresentations.remove({$or: [{temporaryPresentationId: p.temporaryPresentationId}, {id: p.id}]})});
 		const uploadingPresentations = UploadingPresentations.find().fetch();
 		let presentationsToConvert = convertingPresentations.concat(uploadingPresentations);
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -459,6 +459,11 @@ class PresentationUploader extends Component {
   }
 
   componentWillUnmount() {
+    let id = Session.get("presentationUploaderToastId");
+    if (id) {
+      toast.dismiss(id);
+      Session.set("presentationUploaderToastId", null);
+    }
     Session.set('showUploadPresentationView', false);
   }
 


### PR DESCRIPTION
### What does this PR do?

It basically fixes the toast when `presentation-uploader` modal gets unmounted (i.e.: when some user takes presenter status from the current one).

### More

Credits to @zhem0004 for doing https://github.com/bigbluebutton/bigbluebutton/pull/15999

