### PR TITLE
Add Focus Ring To Items In Top Tldraw Toolbar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -537,6 +537,7 @@ class App extends Component {
       isPresenter,
       selectedLayout,
       presentationIsOpen,
+      darkTheme,
     } = this.props;
 
     return (
@@ -561,7 +562,7 @@ class App extends Component {
           <SidebarContentContainer isSharedNotesPinned={shouldShowSharedNotes} />
           <NavBarContainer main="new" />
           <NewWebcamContainer isLayoutSwapped={!presentationIsOpen} />
-          {shouldShowPresentation ? <PresentationAreaContainer presentationIsOpen={presentationIsOpen} /> : null}
+          {shouldShowPresentation ? <PresentationAreaContainer darkTheme={darkTheme} presentationIsOpen={presentationIsOpen} /> : null}
           {shouldShowScreenshare ? <ScreenshareContainer isLayoutSwapped={!presentationIsOpen} /> : null}
           {
             shouldShowExternalVideo

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -918,6 +918,7 @@ class Presentation extends PureComponent {
       fullscreenElementId,
       layoutContextDispatch,
       presentationIsOpen,
+      darkTheme,
     } = this.props;
 
     const {
@@ -1041,6 +1042,7 @@ class Presentation extends PureComponent {
                   layoutContextDispatch={layoutContextDispatch}
                   fullscreenRef={this.refPresentationContainer}
                   presentationId={currentPresentation?.id}
+                  darkTheme={darkTheme}
                 />
                 {isFullscreen && <PollingContainer />}
               </div>

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-area/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-area/component.jsx
@@ -5,13 +5,14 @@ const PresentationArea = ({
   width,
   height,
   presentationIsOpen,
+  darkTheme,
 }) => {
   const presentationAreaSize = {
     presentationAreaWidth: width,
     presentationAreaHeight: height,
   };
   return (
-    <PresentationPodsContainer {...{ presentationAreaSize, presentationIsOpen }} />
+    <PresentationPodsContainer {...{ presentationAreaSize, presentationIsOpen, darkTheme }} />
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-area/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-area/container.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { layoutSelectOutput } from '../../layout/context';
 import PresentationArea from './component';
 
-const PresentationAreaContainer = ({ presentationIsOpen }) => {
+const PresentationAreaContainer = ({ presentationIsOpen, darkTheme }) => {
   const presentation = layoutSelectOutput((i) => i.presentation);
 
-  return <PresentationArea {...{ ...presentation, presentationIsOpen }} />;
+  return <PresentationArea {...{ ...presentation, presentationIsOpen, darkTheme }} />;
 };
 
 export default PresentationAreaContainer;

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/styles.js
@@ -41,15 +41,13 @@ const Right = styled.div`
   z-index: 999;
   box-shadow: 0 4px 2px -2px rgba(0, 0, 0, 0.05);
   border-bottom: 1px solid ${colorWhite};
-  height: ${presentationMenuHeight};
+  height: 44px;
 
   > div {
     padding: 2px 4px 2px 4px;
     background-color: ${colorWhite};
     width: 50px;
     height: 100%;
-    margin-top: 1px;
-
   }
 
   button {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -8,7 +8,8 @@ import { Utils } from "@tldraw/core";
 import Settings from '/imports/ui/services/settings';
 import logger from '/imports/startup/client/logger';
 import KEY_CODES from '/imports/utils/keyCodes';
-import { presentationMenuHeight } from '/imports/ui/stylesheets/styled-components/general';
+import { presentationMenuHeight, borderSize, borderSizeLarge } from '/imports/ui/stylesheets/styled-components/general';
+import { colorWhite, colorBlack } from '/imports/ui/stylesheets/styled-components/palette';
 
 function usePrevious(value) {
   const ref = React.useRef();
@@ -64,6 +65,9 @@ const TldrawGlobalStyle = createGlobalStyle`
   [aria-expanded*="false"][aria-controls*="radix-"] {
     display: none;
   }
+  [class$="-side-right"] {
+    top: -1px;
+  }
   ${({ hasWBAccess, isPresenter, size }) => (hasWBAccess || isPresenter) && `
     #TD-Tools-Dots {
       height: ${size}px;
@@ -80,7 +84,35 @@ const TldrawGlobalStyle = createGlobalStyle`
         width: ${size}px;
     }
     #TD-Styles {
-      height: 100%;
+      border-width: ${borderSize};
+    }
+    #TD-TopPanel-Undo,
+    #TD-TopPanel-Redo,
+    #TD-Styles {
+      height: 92%;
+      border-radius: 7px;
+
+      &:hover {
+        border: solid ${borderSize} #ECECEC;
+        background-color: #ECECEC;
+      }
+      &:focus {
+        border: solid ${borderSize} ${colorBlack};
+      }
+    }
+    #TD-Styles,
+    #TD-TopPanel-Undo,
+    #TD-TopPanel-Redo {
+      margin: ${borderSize} ${borderSizeLarge} 0px ${borderSizeLarge};
+    }
+  `}
+  ${({ darkTheme }) => darkTheme && `
+    #TD-TopPanel-Undo,
+    #TD-TopPanel-Redo,
+    #TD-Styles {
+      &:focus {
+        border: solid ${borderSize} ${colorWhite} !important;
+      }
     }
   `}
 `;
@@ -127,6 +159,7 @@ export default function Whiteboard(props) {
     presentationAreaWidth,
     maxNumberOfAnnotations,
     notifyShapeNumberExceeded,
+    darkTheme,
   } = props;
 
   const { pages, pageStates } = initDefaultPages(curPres?.pages.length || 1);
@@ -979,10 +1012,13 @@ export default function Whiteboard(props) {
       >
         {enable && (hasWBAccess || isPresenter) ? editableWB : readOnlyWB}
         <TldrawGlobalStyle
-          hasWBAccess={hasWBAccess}
-          isPresenter={isPresenter}
           hideContextMenu={!hasWBAccess && !isPresenter}
-          size={size}
+          {...{
+            hasWBAccess,
+            isPresenter,
+            size,
+            darkTheme
+          }}
         />
       </Cursors>
     </>

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -85,6 +85,7 @@ export default withTracker(({
   svgUri,
   podId,
   presentationId,
+  darkTheme,
 }) => {
   const shapes = getShapes(whiteboardId, curPageId, intl);
   const curPres = getCurrentPres();
@@ -131,5 +132,6 @@ export default withTracker(({
     numberOfSlides: PresentationToolbarService.getNumberOfSlides(podId, presentationId),
     notifyNotAllowedChange,
     notifyShapeNumberExceeded,
+    darkTheme,
   };
 })(WhiteboardContainer);


### PR DESCRIPTION
### What does this PR do?
This will add a focus ring around the interactive elements in the top tldraw toolbar. 
Also removes the gap between the toolbar and top of the presentation (more visible in dark mode).

Before:
![image](https://user-images.githubusercontent.com/22058534/218633032-e3f47aee-1813-4daa-93a6-aead1857d966.png)
![image](https://user-images.githubusercontent.com/22058534/218633258-002ebe23-83c0-4e87-bf7d-aa6f5e517a42.png)
After:
![image](https://user-images.githubusercontent.com/22058534/218633455-4ab5eb5a-89fd-41bd-9849-2f65e831d6cc.png)
![image](https://user-images.githubusercontent.com/22058534/218633569-367cf43e-3322-4f88-b7e9-2a00a1301910.png)

### Motivation
As part of the a11y issues, the “Styles / undo and redo” controls lacked a visible focus indicator different from the hover style.
