### PR TITLE
fix: Sticky notes are giant on portrait view slides

### DIFF
--- a/bigbluebutton-html5/imports/api/slides/server/helpers.js
+++ b/bigbluebutton-html5/imports/api/slides/server/helpers.js
@@ -5,13 +5,22 @@ const calculateSlideData = (slideData) => {
   } = slideData;
 
   // calculating viewBox and offsets for the current presentation
+  const maxImageWidth = 2048;
+  const maxImageHeight = 1536;
+
+  const ratio = Math.min(maxImageWidth / width, maxImageHeight / height);
+  const scaledWidth = width * ratio;
+  const scaledHeight = height * ratio;
+  const scaledViewBoxWidth = width * widthRatio / 100 * ratio;
+  const scaledViewBoxHeight = height * heightRatio / 100 * ratio;
+
   return {
-    width,
-    height,
+    width: scaledWidth,
+    height: scaledHeight,
     x: xOffset,
     y: yOffset,
-    viewBoxWidth: (width * widthRatio) / 100,
-    viewBoxHeight: (height * heightRatio) / 100,
+    viewBoxWidth: scaledViewBoxWidth,
+    viewBoxHeight: scaledViewBoxHeight,
   };
 };
 


### PR DESCRIPTION
### What does this PR do?

Force slide scaling to a fixed size, fixing annotation size issues.

#### before

[Screencast from 2023-02-14 13-35-35.webm](https://user-images.githubusercontent.com/3728706/218799927-899504aa-6f05-4ac3-b009-95c96dc050a0.webm)

#### after

[Screencast from 2023-02-14 13-34-06.webm](https://user-images.githubusercontent.com/3728706/218799942-7eb3b812-325a-4151-8c4d-72e0d5e93a65.webm)


### Closes Issue(s)
Closes #16145
