### PR TITLE
refactor: Avoid flood moderators with useless connection status

### DIFF
--- a/bigbluebutton-html5/imports/api/connection-status/server/modifiers/updateConnectionStatus.js
+++ b/bigbluebutton-html5/imports/api/connection-status/server/modifiers/updateConnectionStatus.js
@@ -3,6 +3,10 @@ import Logger from '/imports/startup/server/logger';
 import { check } from 'meteor/check';
 import changeHasConnectionStatus from '/imports/api/users-persistent-data/server/modifiers/changeHasConnectionStatus';
 
+const STATS = Meteor.settings.public.stats;
+const STATS_INTERVAL = STATS.interval;
+const STATS_CRITICAL_RTT = STATS.rtt[STATS.rtt.length - 1];
+
 export default function updateConnectionStatus(meetingId, userId, status) {
   check(meetingId, String);
   check(userId, String);
@@ -18,6 +22,7 @@ export default function updateConnectionStatus(meetingId, userId, status) {
     meetingId,
     userId,
     connectionAliveAt: now,
+    clientNotResponding: false,
   };
 
   // Store last not-normal status
@@ -32,6 +37,26 @@ export default function updateConnectionStatus(meetingId, userId, status) {
       changeHasConnectionStatus(true, userId, meetingId);
       Logger.verbose(`Updated connection status meetingId=${meetingId} userId=${userId} status=${status}`);
     }
+
+    Meteor.setTimeout(() => {
+      const connectionLossTimeThreshold = new Date().getTime() - (STATS_INTERVAL + STATS_CRITICAL_RTT);
+
+      const selectorNotResponding = {
+        meetingId,
+        userId,
+        connectionAliveAt: { $lte: connectionLossTimeThreshold },
+        clientNotResponding: false,
+      };
+
+      const numberAffectedNotResponding = ConnectionStatus.update(selectorNotResponding, {
+        $set: { clientNotResponding: true }
+      });
+
+      if (numberAffectedNotResponding) {
+        Logger.info(`Updated clientNotResponding=true meetingId=${meetingId} userId=${userId}`);
+      }
+    }, STATS_INTERVAL + STATS_CRITICAL_RTT);
+
   } catch (err) {
     Logger.error(`Updating connection status meetingId=${meetingId} userId=${userId}: ${err}`);
   }

--- a/bigbluebutton-html5/imports/api/connection-status/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/connection-status/server/publishers.js
@@ -21,6 +21,14 @@ function connectionStatus() {
   check(meetingId, String);
   check(userId, String);
 
+  const fields = {
+    meetingId: 1,
+    userId: 1,
+    status: 1,
+    statusUpdatedAt: 1,
+    clientNotResponding: 1,
+  }
+
   const User = Users.findOne({ userId, meetingId }, { fields: { role: 1 } });
   Logger.info(`Publishing connection status for ${meetingId} ${userId}`);
 
@@ -38,10 +46,10 @@ function connectionStatus() {
       return condition;
     };
     publicationSafeGuard(comparisonFunc, this);
-    return ConnectionStatus.find({ meetingId });
+    return ConnectionStatus.find({ meetingId }, { fields: fields });
   }
 
-  return ConnectionStatus.find({ meetingId, userId });
+  return ConnectionStatus.find({ meetingId, userId }, { fields: fields });
 }
 
 function publish(...args) {


### PR DESCRIPTION
Currently all clients (users) update the collection `connection-status` with `connectionAliveAt: now` every 10 seconds (by default).
And moderators receive this information for each update.

It is necessary to check if the client didn't update `connectionAliveAt` for more than 10 seconds , which means the client is facing some connection problem.

It turned out that in meeting with a lot of users, Moderators are receiving too much information about `connectionAliveAt` updated.
And what moderators really need to know is if someone is not responding.. the exact timestamp is not important.

So this PR introduces a new field called `clientNotResponding`.

Now `connection-status-Publisher` will stop sending the `connectionAliveAt` and will send just a flag `clientNotResponding` instead.
And the main advantage of it is that Moderators will receive the update only if the flag changed its value! And not every 10 seconds anymore.

New fields of collection `connection-status`:
```
{
    "_id" : "yh2FXoW5mpJq2n2Ps",
    "meetingId" : "ed9295e21083a4143570639d45a863be33663db3-1676396431548",
    "userId" : "w_pea82atznsnb",
    "clientNotResponding" : false,
    "connectionAliveAt" : 1676397293743.0,
    "status" : "critical",
    "statusUpdatedAt" : 1676396850511.0
}
```

Closes #16711.