### PR TITLE
fix(config): check status of other recording formats

### DIFF
--- a/bigbluebutton-config/cron.daily/bigbluebutton
+++ b/bigbluebutton-config/cron.daily/bigbluebutton
@@ -92,9 +92,11 @@ remove_raw_of_recordings_without_marks
 #
 
 remove_raw_of_published_recordings(){
-    #TYPES=$(cd /usr/local/bigbluebutton/core/scripts/process; ls *.rb | sed s/.rb//g)
+    TYPES=$(cd /usr/local/bigbluebutton/core/scripts/process; ls *.rb | sed s/.rb//g)
     logger "Removing raw directory of old recordings:"
-    TYPES="presentation"
+    if [ "$TYPES" == "" ]; then
+        TYPES="presentation"
+    fi
     cd /var/bigbluebutton/recording/raw/
     old_meetings=$(find . -name events.xml -mtime +$published_days | cut -d"/" -f2 )
     for meeting in $old_meetings


### PR DESCRIPTION
### What does this PR do?

It checks for the status (`.done`) of the other recording formats, as well as for presentation.

### Closes Issue(s)

Closes #16646
