### PR TITLE
fix (html5): Fix "Invalid Date" on Connection Status modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
@@ -351,7 +351,7 @@ class ConnectionStatusComponent extends PureComponent {
       const dateTime = new Date(conn.timestamp);
       return (
         <Styled.Item
-          key={`${conn?.name}-${dateTime}`}
+          key={`${conn?.name}-${conn.userId}`}
           last={(index + 1) === connections.length}
           data-test="connectionStatusItemUser"
         >
@@ -388,13 +388,16 @@ class ConnectionStatusComponent extends PureComponent {
                 </Styled.ClientNotRespondingText>
               ) : null }
           </Styled.Left>
-          <Styled.Right>
-            <Styled.Time>
-              <time dateTime={dateTime}>
-                <FormattedTime value={dateTime} />
-              </time>
-            </Styled.Time>
-          </Styled.Right>
+            <Styled.Right>
+              <Styled.Time>
+                { conn.timestamp ?
+                  <time dateTime={dateTime}>
+                    <FormattedTime value={dateTime} />
+                  </time>
+                  : null
+                }
+              </Styled.Time>
+            </Styled.Right>
         </Styled.Item>
       );
     });

--- a/bigbluebutton-html5/imports/ui/components/connection-status/service.js
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/service.js
@@ -208,6 +208,7 @@ const getConnectionStatus = () => {
     if (userStatus) {
       if (userStatus.status || (!loggedOut && userStatus.clientNotResponding)) {
         result.push({
+          userId,
           name,
           avatar,
           offline: loggedOut,


### PR DESCRIPTION
### What does this PR do?

It fixes the incorrectly displayed message "Invalid Date" to not displaying anything when this property (`conn.timestamp`) is not sent.

![status_connection](https://user-images.githubusercontent.com/69865537/219078257-4cc8b1a4-0229-4d58-8f2c-c0e0ef53080a.png)

