### PR TITLE
ci: Set private IP address instead of loopback address

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           sudo sh -c '
           cd /root/bbb-ci-ssl/
-          echo "127.0.0.1 bbb-ci.test" >> /etc/hosts
+          echo "$(hostname -I | cut -d" " -f1) bbb-ci.test" >> /etc/hosts
           openssl genrsa -out bbb-ci.test.key 2048
           rm bbb-ci.test.csr bbb-ci.test.crt bbb-ci.test.key
           cat > bbb-ci.test.ext << EOF


### PR DESCRIPTION
The automated tests are failing during the audio tests.
![image](https://user-images.githubusercontent.com/5660191/219129916-ceead5bd-f500-477e-bdab-f35296fe062b.png)

It seems that it happens because the loopback address entry in `/etc/hosts`
![image](https://user-images.githubusercontent.com/5660191/219130217-d94afd07-d7d0-42b4-b2c9-80df6dbf215f.png)

This PR fixes it setting the private IP address instead! e.g: `10.1.0.156 bbb-ci.test`

The problem was happening probably because of the sip_profile it got when connecting to 127.0.0.1.