### PR TITLE
Usability: Text indicating pinned shared notes altered and notification added 

### DIFF
--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -83,6 +83,8 @@
     "app.textInput.sendLabel": "Send",
     "app.title.defaultViewLabel": "Default presentation view",
     "app.notes.title": "Shared Notes",
+    "app.notes.titlePinned": "Shared Notes (Pinned)",
+    "app.notes.pinnedNotification": "The Shared Notes are now pinned in the whiteboard.",
     "app.notes.label": "Notes",
     "app.notes.hide": "Hide notes",
     "app.notes.locked": "Locked",


### PR DESCRIPTION
### What does this PR do?
Shared Notes label altered to show "Pinned" text when on whiteboard and notification added to warn the users.

### Closes Issue(s)
#16438
