### PR TITLE
fix(access): Darken Color Contrast For Non Compliant Elements

### DIFF
--- a/bbb-learning-dashboard/src/App.js
+++ b/bbb-learning-dashboard/src/App.js
@@ -430,7 +430,7 @@ class App extends React.Component {
                       maximumFractionDigits: 1,
                     })}
                     cardClass={tab === TABS.OVERVIEW_ACTIVITY_SCORE ? 'border-green-500' : 'hover:border-green-500 border-white'}
-                    iconClass="bg-green-200 text-green-500"
+                    iconClass="bg-green-200 text-green-700"
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"

--- a/bbb-learning-dashboard/src/App.js
+++ b/bbb-learning-dashboard/src/App.js
@@ -557,7 +557,7 @@ class App extends React.Component {
         <hr className="my-8" />
         <div className="flex justify-between pb-8 text-xs text-gray-800 dark:text-gray-400 whitespace-nowrap flex-col sm:flex-row">
           <div className="flex flex-col justify-center mb-4 sm:mb-0">
-            <p>
+            <p className="text-gray-700">
               {
                 lastUpdated && (
                   <>
@@ -583,7 +583,7 @@ class App extends React.Component {
           </div>
           <button
             type="button"
-            className="border-2 border-gray-200 rounded-md px-4 py-2 bg-white focus:outline-none focus:ring ring-offset-2 focus:ring-gray-500 focus:ring-opacity-50"
+            className="border-2 text-gray-700 border-gray-200 rounded-md px-4 py-2 bg-white focus:outline-none focus:ring ring-offset-2 focus:ring-gray-500 focus:ring-opacity-50"
             onClick={this.handleSaveSessionData.bind(this)}
           >
             <FormattedMessage

--- a/bbb-learning-dashboard/src/components/UsersTable.jsx
+++ b/bbb-learning-dashboard/src/components/UsersTable.jsx
@@ -253,7 +253,7 @@ class UsersTable extends React.Component {
                         </button>
                         { Object.values(user.intIds || {}).map((intId, index) => (
                           <>
-                            <p className="text-xs text-gray-600 dark:text-gray-400">
+                            <p className="text-xs text-gray-700 dark:text-gray-400">
                               <svg
                                 xmlns="http://www.w3.org/2000/svg"
                                 className="h-4 w-4 inline"
@@ -279,7 +279,7 @@ class UsersTable extends React.Component {
                             </p>
                             { intId.leftOn > 0
                               ? (
-                                <p className="text-xs text-gray-600 dark:text-gray-400">
+                                <p className="text-xs text-gray-700 dark:text-gray-400">
                                   <svg
                                     xmlns="http://www.w3.org/2000/svg"
                                     className="h-4 w-4 inline"

--- a/bbb-learning-dashboard/src/index.css
+++ b/bbb-learning-dashboard/src/index.css
@@ -3,6 +3,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  .text-gray-700 {
+    color: #374151 !important;
+  }
+}
+
 @layer utilities {
   .bg-inherit {
     background-color: inherit;


### PR DESCRIPTION
### What does this PR do?
This PR improves the color of some elements in the learning dashboard that did not meet the minimum required contrast ratio.
before:
![image](https://user-images.githubusercontent.com/22058534/219423612-d426a428-9448-499b-a030-a62f0c1f2c29.png)
![image](https://user-images.githubusercontent.com/22058534/219423968-d53b1771-5652-4c88-8a23-feb4da914777.png)

after:
![image](https://user-images.githubusercontent.com/22058534/219423484-0d486108-7627-45d5-a3a3-a02bf9f4e1ab.png)
![image](https://user-images.githubusercontent.com/22058534/219423869-356920c5-c873-4cb3-9697-1268949f642d.png)

### Motivation
fixes the contrast errors
![image](https://user-images.githubusercontent.com/22058534/219419253-633b00b5-9c32-472b-a4c0-08f11a27381e.png)
![image](https://user-images.githubusercontent.com/22058534/219419324-23dfe4a7-46d6-4390-abc9-7bc96327e71f.png)


