### PR TITLE
recording: Enforce minimum length of video segments, etc.

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video.rb
@@ -167,6 +167,48 @@ module BigBlueButton
         merged_edl
       end
 
+      # Edit the EDL to make sure that every cut has a minimum length to ensure processing will work properly
+      def self.enforce_cut_lengths(edl, framerate)
+        # Set the minimum cut length to 2 frames long
+        # This can range from 83ms for 24fps video (video format), up to 400ms (presentation format deskshare)
+        min_cut_len = (1000 / framerate * 2).round
+
+        # Iterate through the edl entries from end to just after the start
+        (edl.length - 1).downto(1).each do |i|
+          duration = edl[i][:timestamp] - edl[i - 1][:timestamp]
+          # If the cut that *ends* at EDL entry i is less than the minimum cut length
+          next unless duration < min_cut_len
+
+          # Then delete edl entry i - 1 from the list
+          BigBlueButton.logger.debug("Dropping EDL entry index #{i - 1} (#{duration} < #{min_cut_len})")
+          edl.delete_at(i - 1)
+          # On the next iteration through the loop, we'll be re-checking from the same end point, but a new start
+        end
+
+        # What if the first cut got deleted?
+        if edl[0][:timestamp] != 0
+          # Need to reset the first cut to start at timestamp 0
+          BigBlueButton.logger.debug('Resetting timestamp of first EDL entry to 0')
+          offset = edl[0][:timestamp]
+          edl[0][:timestamp] = 0
+          # And offset the start times of every video to compensate
+          edl[0][:areas].each_value do |videos|
+            videos.each do |video|
+              video[:timestamp] -= offset # This might become negative, that's ok.
+            end
+          end
+        end
+
+        # What if all of the cuts got deleted?
+        if edl.length == 1
+          BigBlueButton.logger.debug('EDL contains no cuts - enforcing minimum length')
+          # Add a new end point at the minimum cut length
+          edl << { timestamp: min_cut_len, areas: {} }
+        end
+
+        nil
+      end
+
       def self.render(edl, layout, output_basename)
         videoinfo = {}
 
@@ -174,6 +216,8 @@ module BigBlueButton
         remux_flv_videos = Set.new
 
         BigBlueButton.logger.info "Pre-processing EDL"
+        enforce_cut_lengths(edl, layout[:framerate])
+
         for i in 0...(edl.length - 1)
           # The render scripts need this to calculate cut lengths
           edl[i][:next_timestamp] = edl[i+1][:timestamp]
@@ -254,13 +298,9 @@ module BigBlueButton
         render = "#{output_basename}.#{WF_EXT}"
         concat = []
         for i in 0...(edl.length - 1)
-          if edl[i][:timestamp] == edl[i][:next_timestamp]
-            warn 'Skipping 0-length edl entry'
-            next
-          end
           segment = "#{output_basename}_#{i}.#{WF_EXT}"
           composite_cut(segment, edl[i], layout, videoinfo)
-          concat += [segment] unless video_info(segment).empty?
+          concat << segment
         end
 
         concat_file = "#{output_basename}.txt"
@@ -445,7 +485,7 @@ module BigBlueButton
             BigBlueButton.logger.debug "      scaled size: #{scale_width}x#{scale_height}"
 
             seek = video[:timestamp]
-            BigBlueButton.logger.debug("      start timestamp: #{video[:timestamp]}")
+            BigBlueButton.logger.debug("      start timestamp: #{seek}")
             seek_offset = this_videoinfo[:start_time]
             video_start_offset = this_videoinfo[:video][:start_time]
             BigBlueButton.logger.debug("      seek offset: #{seek_offset}, video start offset: #{video_start_offset}")

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -740,8 +740,6 @@ module BigBlueButton
     #   sender: The display name of the sender
     #   message: The chat message, with link cleanup already applied
     #   date: The real time of when the message was sent (if available) as a DateTime
-    #   text_color: The RGB color value of the chat message text as an integer (old BBB versions only)
-    #   avatar_color: The color of the user's avatar (initials) box (newer BBB versions only)
     def self.get_chat_events(events, start_time, end_time, bbb_props = {})
       BigBlueButton.logger.info('Getting chat events')
 
@@ -776,6 +774,7 @@ module BigBlueButton
 
           date = event.at_xpath('./date')&.content
           date = DateTime.iso8601(date) unless date.nil?
+          sender = event.at_xpath('./sender')&.content
           sender_id = event.at_xpath('./senderId')&.content
           senderRole = event.at_xpath('./senderRole')&.content
           chatEmphasizedText = event.at_xpath('./chatEmphasizedText')&.content
@@ -784,7 +783,7 @@ module BigBlueButton
             in: timestamp - offset,
             out: nil,
             sender_id: sender_id,
-            sender: user_map.fetch(sender_id),
+            sender: sender_id.nil? ? sender : user_map.fetch(sender_id),
             senderRole: senderRole,
             chatEmphasizedText: chatEmphasizedText,
             message: linkify(event.at_xpath('./message').content.strip),

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -356,8 +356,14 @@ module BigBlueButton
             webcamsOnlyForModerator = BigBlueButton::Events.to_boolean(event.at_xpath('webcamsOnlyForModerator').text)
 
           when "WebcamsOnlyForModeratorEvent"
+            webcamsOnlyElement = event.at_xpath("webcamsOnlyForModerator")
+            # Handle typo in some BigBlueButton versions
+            webcamsOnlyElement = event.at_xpath("webacmsOnlyForModerator") if webcamsOnlyElement.nil?
+
+            webcamsOnlyForModerator = BigBlueButton::Events.to_boolean(webcamsOnlyElement.text)
+
             # Change active and inactive videos.
-            BigBlueButton::Events.process_webcamsOnlyForModerator(list_user_info, active_videos, inactive_videos, BigBlueButton::Events.to_boolean(event.at_xpath("webcamsOnlyForModerator").text))
+            BigBlueButton::Events.process_webcamsOnlyForModerator(list_user_info, active_videos, inactive_videos, webcamsOnlyForModerator)
             
             edl_entry = {
               :timestamp => timestamp,
@@ -371,8 +377,6 @@ module BigBlueButton
               }
             end
             video_edl << edl_entry
-            
-            webcamsOnlyForModerator = BigBlueButton::Events.to_boolean(event.at_xpath('webcamsOnlyForModerator').text)
           end
         end
       end

--- a/record-and-playback/core/test/recordandplayback/edl/test_video.rb
+++ b/record-and-playback/core/test/recordandplayback/edl/test_video.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'nokogiri'
+
+require 'recordandplayback'
+
+class TestEvents < Minitest::Test
+  def test_enforce_cut_lengths_short_cut_start
+    edl = [
+      {
+        timestamp: 0,
+        areas: { webcam: [{ timestamp: 0, filename: 'a' }] },
+      },
+      {
+        timestamp: 10,
+        areas: { webcam: [{ timestamp: 10, filename: 'a' }, { timestamp: 0, filename: 'b' }] },
+      },
+      {
+        timestamp: 10_000, areas: { webcam: [] },
+      },
+    ]
+
+    BigBlueButton::EDL::Video.enforce_cut_lengths(edl, 25)
+
+    assert_equal(2, edl.length)
+    assert_equal(0, edl[0][:timestamp])
+    # In this special case, it deletes the original first entry, but then offsets start timestamps
+    # back to 0, which can result in negative video timestamps
+    assert_equal(2, edl[0][:areas][:webcam].length)
+    assert_equal({ timestamp: 0, filename: 'a' }, edl[0][:areas][:webcam][0])
+    assert_equal({ timestamp: -10, filename: 'b' }, edl[0][:areas][:webcam][1])
+    assert_equal(10_000, edl[1][:timestamp])
+  end
+
+  def test_enforce_cut_lengths_short_cut_middle
+    edl = [
+      {
+        timestamp: 0,
+        areas: { webcam: [{ timestamp: 0, filename: 'a' }, { timestamp: 0, filename: 'b' }, { timestamp: 0, filename: 'c' }] },
+      },
+      {
+        timestamp: 1000,
+        areas: { webcam: [{ timestamp: 1000, filename: 'a' }, { timestamp: 1000, filename: 'b' }] },
+      },
+      {
+        timestamp: 1010,
+        areas: { webcam: [{ timestamp: 1010, filename: 'a' }] },
+      },
+      {
+        timestamp: 10_000, areas: { webcam: [] },
+      },
+    ]
+
+    BigBlueButton::EDL::Video.enforce_cut_lengths(edl, 25)
+
+    assert_equal(3, edl.length)
+    assert_equal(0, edl[0][:timestamp])
+    assert_equal(1010, edl[1][:timestamp])
+    assert_equal(1, edl[1][:areas][:webcam].length)
+    assert_equal({ timestamp: 1010, filename: 'a' }, edl[1][:areas][:webcam][0])
+    assert_equal(10_000, edl[2][:timestamp])
+  end
+
+  def test_enforce_cut_lengths_short_cut_end
+    edl = [
+      {
+        timestamp: 0,
+        areas: { webcam: [{ timestamp: 0, filename: 'a' }, { timestamp: 0, filename: 'b' }] },
+      },
+      {
+        timestamp: 9990,
+        areas: { webcam: [{ timestamp: 9990, filename: 'a' }] },
+      },
+      {
+        timestamp: 10_000, areas: { webcam: [] },
+      },
+    ]
+
+    BigBlueButton::EDL::Video.enforce_cut_lengths(edl, 25)
+
+    assert_equal(2, edl.length)
+    assert_equal(0, edl[0][:timestamp])
+    assert_equal(2, edl[0][:areas][:webcam].length)
+    assert_equal({ timestamp: 0, filename: 'a' }, edl[0][:areas][:webcam][0])
+    assert_equal({ timestamp: 0, filename: 'b' }, edl[0][:areas][:webcam][1])
+    assert_equal(10_000, edl[1][:timestamp])
+    assert_equal(0, edl[1][:areas][:webcam].length)
+  end
+
+  def test_enforce_cut_lengths_combines_multiple
+    edl = [
+      {
+        timestamp: 0,
+        areas: { webcam: [{ timestamp: 0, filename: 'a' }] },
+      },
+      {
+        timestamp: 1000,
+        areas: { webcam: [{ timestamp: 1000, filename: 'a' }, { timestamp: 0, filename: 'b' }] },
+      },
+      {
+        timestamp: 1005,
+        areas: { webcam: [{ timestamp: 5, filename: 'b' }] },
+      },
+      {
+        timestamp: 1010,
+        areas: { webcam: [{ timestamp: 10, filename: 'b' }, { timestamp: 0, filename: 'c' }] },
+      },
+      {
+        timestamp: 10_000, areas: { webcam: [] },
+      },
+    ]
+
+    BigBlueButton::EDL::Video.enforce_cut_lengths(edl, 25)
+
+    assert_equal(3, edl.length)
+    assert_equal(0, edl[0][:timestamp])
+    assert_equal(1, edl[0][:areas][:webcam].length)
+    assert_equal({ timestamp: 0, filename: 'a' }, edl[0][:areas][:webcam][0])
+    assert_equal(1010, edl[1][:timestamp])
+    assert_equal(2, edl[1][:areas][:webcam].length)
+    assert_equal({ timestamp: 10, filename: 'b' }, edl[1][:areas][:webcam][0])
+    assert_equal({ timestamp: 0, filename: 'c' }, edl[1][:areas][:webcam][1])
+    assert_equal(10_000, edl[2][:timestamp])
+  end
+
+  def test_enforce_cut_lengths_extend_full_recording
+    edl = [
+      { timestamp: 0, areas: {} },
+      { timestamp: 10, areas: {} },
+    ]
+
+    BigBlueButton::EDL::Video.enforce_cut_lengths(edl, 25)
+
+    assert_equal(2, edl.length)
+    assert_equal(0, edl[0][:timestamp])
+    assert_equal(1000 / 25 * 2, edl[1][:timestamp])
+  end
+
+  def test_enforce_cut_lengths_no_change_above_min
+    edl = [
+      {
+        timestamp: 0,
+        areas: { webcam: [{ timestamp: 0, filename: 'a' }, { timestamp: 0, filename: 'b' }, { timestamp: 0, filename: 'c' }] },
+      },
+      {
+        timestamp: 1000,
+        areas: { webcam: [{ timestamp: 1000, filename: 'a' }, { timestamp: 1000, filename: 'b' }] },
+      },
+      {
+        timestamp: 1080,
+        areas: { webcam: [{ timestamp: 1080, filename: 'a' }] },
+      },
+      {
+        timestamp: 10_000, areas: { webcam: [] },
+      },
+    ]
+
+    BigBlueButton::EDL::Video.enforce_cut_lengths(edl, 25)
+
+    assert_equal(4, edl.length)
+    assert_equal(0, edl[0][:timestamp])
+    assert_equal(1000, edl[1][:timestamp])
+    assert_equal(2, edl[1][:areas][:webcam].length)
+    assert_equal({ timestamp: 1000, filename: 'a' }, edl[1][:areas][:webcam][0])
+    assert_equal({ timestamp: 1000, filename: 'b' }, edl[1][:areas][:webcam][1])
+    assert_equal(1080, edl[2][:timestamp])
+    assert_equal(1, edl[2][:areas][:webcam].length)
+    assert_equal({ timestamp: 1080, filename: 'a' }, edl[2][:areas][:webcam][0])
+    assert_equal(10_000, edl[3][:timestamp])
+  end
+end

--- a/record-and-playback/core/test/recordandplayback/generators/test_events.rb
+++ b/record-and-playback/core/test/recordandplayback/generators/test_events.rb
@@ -100,7 +100,6 @@ class TestEvents < Minitest::Test
     assert_equal('FRED', chat[:sender])
     assert_equal('hello', chat[:message])
     assert_nil(chat.fetch(:date))
-    assert_equal(0, chat[:text_color])
     chat = chats_enum.next
     assert_equal(42_388, chat[:in])
     assert_nil(chat.fetch(:out))
@@ -125,7 +124,6 @@ class TestEvents < Minitest::Test
     assert_equal('Xhesika De Lange', chat[:sender])
     assert_equal('Public chat 1', chat[:message])
     assert_nil(chat.fetch(:date))
-    assert_equal(0, chat[:text_color])
     chat = chats_enum.next
     assert_equal(972_022, chat[:in])
     assert_equal(988_028, chat[:out])
@@ -233,8 +231,6 @@ class TestEvents < Minitest::Test
     assert_equal(148_701, chat[:out])
     assert_equal('w_kmm96j1as24f', chat[:sender_id])
     assert_equal('Mario', chat[:sender])
-    assert_equal('#7b1fa2', chat[:avatar_color])
-    assert_nil(chat.fetch(:text_color))
     assert_equal(DateTime.rfc3339('2021-08-31T18:06:14.330+00:00'), chat[:date])
     # rubocop:disable Layout/LineLength
     assert_equal(
@@ -248,8 +244,6 @@ class TestEvents < Minitest::Test
     assert_nil(chat.fetch(:out))
     assert_equal('w_vk0ebqjxox9d', chat[:sender_id])
     assert_equal('Anton G', chat[:sender])
-    assert_equal('#0277bd', chat[:avatar_color])
-    assert_nil(chat.fetch(:text_color))
     assert_equal(DateTime.rfc3339('2021-08-31T18:26:38.332+00:00'), chat[:date])
     assert_equal('Nice!', chat[:message])
   end


### PR DESCRIPTION
This PR includes a few fixes to recording processing.

The most major one is [Enforce minimum length of video segments](https://github.com/bigbluebutton/bigbluebutton/commit/7d17ffc5f960be776d0ef3414144771118d38245) - this fixes an issue where recording processing could break if there's a too-short gap between two changes to what video streams are visible, or between the start and stop events. It merges events and extends the generated recording slightly if needed to ensure that processing succeeds. There's negligible impact on audio/video sync. This change includes tests.

I have updated the tests for the `get_chat_events` function, which no longer passed due to changes in the code. The tests found a bug that had been introduced in handling of very old recordings - I have included the trivial fix.

I have a test recording made with the `webacmsOnlyForModerator` event name typo from early in 2.5 development. While this typo was fixed before release, it would still be helpful to me to handle this typo in the processing scripts.

These changes should also be backported to 2.5.

(At some point, the recording processing tests should be hooked up to run in CI…)