### PR TITLE
refactor: reduce groupChat.find calls in group-chat-context

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/components-data/group-chat-context/adapter.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/group-chat-context/adapter.jsx
@@ -7,31 +7,19 @@ const Adapter = () => {
   const { dispatch } = usingGroupChatContext;
 
   useEffect(() => {
-    const alreadyDispatched = new Set();
-    const notDispatchedCount = { count: 100 };
-    // TODO: listen to websocket message to avoid full list comparsion
-    const diffAndDispatch = () => {
-      setTimeout(() => {
-        const groupChatCursor = GroupChat.find({}, { reactive: false }).fetch();
-        const notDispatched = groupChatCursor.filter(objMsg => !alreadyDispatched.has(objMsg._id));
-        notDispatchedCount.count = notDispatched.length;
+    const groupChatCursor = GroupChat.find({});
 
-        notDispatched.forEach((groupChat) => {
-          dispatch({
-            type: ACTIONS.ADDED,
-            value: {
-              groupChat,
-            },
-          });
-
-          alreadyDispatched.add(groupChat._id);
+    groupChatCursor.observe({
+      added: (obj) => {
+        dispatch({
+          type: ACTIONS.ADDED,
+          value: {
+            groupChat: obj,
+          },
         });
-        diffAndDispatch();
-      }, notDispatchedCount.count >= 10 ? 1000 : 500);
-    };
-    diffAndDispatch();
+      },
+    });
   }, []);
-
   return null;
 };
 


### PR DESCRIPTION
### What does this PR do?

Replaces `diffAndDispatch` function with `groupChatCursor.observe` method, reducing the number of `.find()` calls in group chat context adapter.