### PR TITLE
CI: Include bbb logs and configs as artifacts (when fail)

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -158,3 +158,45 @@ jobs:
           path: |
             bigbluebutton-tests/playwright/playwright-report
             bigbluebutton-tests/playwright/test-results
+      - if: failure()
+        name: Prepare artifacts (configs and logs)
+        run: |
+          sudo sh -c '
+          mkdir configs
+          cp /etc/haproxy/haproxy.cfg configs/haproxy.cfg
+          touch /etc/bigbluebutton/turn-stun-servers.xml
+          cp /etc/bigbluebutton/turn-stun-servers.xml configs/turn-stun-servers.xml
+          cp /opt/freeswitch/etc/freeswitch/vars.xml configs/freeswitch_vars.xml
+          cp /opt/freeswitch/etc/freeswitch/sip_profiles/external.xml configs/freeswitch_sip_profiles_external.xml
+          cp /etc/bigbluebutton/bbb-apps-akka.conf configs/bbb-apps-akka.conf
+          cp /etc/bigbluebutton/bbb-fsesl-akka.conf configs/bbb-fsesl-akka.conf
+          cp /etc/bigbluebutton/bbb-html5.yml configs/bbb-html5.yml
+          cp /etc/bigbluebutton/bbb-web.properties configs/bbb-web.properties
+          cp /etc/bigbluebutton/bigbluebutton-release configs/bigbluebutton-release
+          cp /etc/bigbluebutton/turn-stun-servers.xml configs/turn-stun-servers.xml
+          cp /usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml configs/bbb-webrtc-sfu-default.yml
+          cp /usr/share/bigbluebutton/nginx/sip.nginx configs/nginx_sip.nginx
+          cp /etc/hosts /configs/hosts
+          chmod a+r -R configs
+          mkdir logs
+          cp /var/log/haproxy.log logs/haproxy.log
+          bbb-conf --status > logs/bbb-status.log
+          journalctl -u bbb-html5-frontend@1.service --since today > logs/bbb-html5-frontend.log
+          journalctl -u bbb-html5-backend@1.service --since today > logs/bbb-html5-backend.log
+          cp /var/log/bigbluebutton/bbb-web.log logs/bbb-web.log
+          cp /var/log/bbb-apps-akka/bbb-apps-akka.log logs/bbb-apps-akka.log
+          cp /var/log/turnserver/turnserver.log logs/turnserver.log
+          cp /var/log/haproxy.log logs/haproxy.log
+          cp /opt/freeswitch/log/freeswitch.log logs/freeswitch.log
+          chmod a+r -R logs
+          '
+      - if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: bbb-configs
+          path: configs
+      - if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: bbb-logs
+          path: logs


### PR DESCRIPTION
While investigating the problem fixed in #16730, it was very useful to analyze the Logs and Configs of the server running in CI.
So this PR propose to include this information as artifacts always when the test fail!

It includes:
![artifacts](https://user-images.githubusercontent.com/5660191/219687351-f467a9a9-6845-4b4a-b10a-baa3de006b60.png)

![artifacts-logs](https://user-images.githubusercontent.com/5660191/219687376-9c419e03-6bf5-4e7d-a078-7fe5b78c472c.png)

![artifacts-configs](https://user-images.githubusercontent.com/5660191/219687394-050cfd0d-cb4c-4285-b1d9-26ab45441e14.png)

Probably this PR will not fail in the testing check... so the artifacts will not be generated here.
But it's possible to check in this draft: #16687