### PR TITLE
fix(access): Move Focus To Polling Option When Presented

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/polling/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/polling/component.jsx
@@ -54,6 +54,7 @@ class Polling extends Component {
       checkedAnswers: [],
     };
 
+    this.pollingContainer = null;
     this.play = this.play.bind(this);
     this.handleUpdateResponseInput = this.handleUpdateResponseInput.bind(this);
     this.renderButtonAnswers = this.renderButtonAnswers.bind(this);
@@ -65,6 +66,7 @@ class Polling extends Component {
 
   componentDidMount() {
     this.play();
+    this.pollingContainer && this.pollingContainer?.focus();
   }
 
   play() {
@@ -303,6 +305,8 @@ class Polling extends Component {
           autoWidth={stackOptions}
           data-test="pollingContainer"
           role="alert"
+          ref={el => this.pollingContainer = el}
+          tabIndex={-1}
         >
           {
             question.length > 0 && (

--- a/bigbluebutton-html5/imports/ui/components/polling/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/polling/component.jsx
@@ -304,7 +304,7 @@ class Polling extends Component {
         <Styled.PollingContainer
           autoWidth={stackOptions}
           data-test="pollingContainer"
-          role="alert"
+          role="complementary"
           ref={el => this.pollingContainer = el}
           tabIndex={-1}
         >

--- a/bigbluebutton-html5/imports/ui/components/polling/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/polling/styles.js
@@ -161,6 +161,10 @@ const PollingContainer = styled.div`
   bottom: ${pollBottomOffset};
   right: ${jumboPaddingX};
 
+  &:focus {
+    border: 1px solid ${colorPrimary};
+  }
+
   [dir="rtl"] & {
     left: ${jumboPaddingX};
     right: auto;

--- a/bigbluebutton-html5/imports/ui/components/polling/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/polling/styles.js
@@ -144,7 +144,7 @@ const QText = styled.div`
   padding-right: ${smPaddingX};
 `;
 
-const PollingContainer = styled.div`
+const PollingContainer = styled.aside`
   pointer-events:auto;
   min-width: ${pollWidth};
   position: absolute;


### PR DESCRIPTION
### What does this PR do?

- Automatically move user focus to the polling options when they are mounted.

- Updates the polling container to an `<aside>` with `role="complementary"`  in order to provide an additional means for a screen reader user to navigate to the poll region easily.

### Motivation
 The resulting poll modal fails to meet the a11y standard for gaining keyboard focus automatically when presented
![image](https://user-images.githubusercontent.com/22058534/219715695-22e9fe84-9e25-4f52-ae8b-25107aae2c87.png)
