### PR TITLE
refactor (bbb-web): getRecordings - introduce new config allowFetchAllRecordings

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/RecordingServiceDbImpl.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/RecordingServiceDbImpl.java
@@ -30,7 +30,7 @@ public class RecordingServiceDbImpl implements RecordingService {
     private RecordingMetadataReaderHelper recordingServiceHelper;
     private String recordStatusDir;
     private String captionsDir;
-    private Boolean allowAllRecordingsRetrieval;
+    private Boolean allowFetchAllRecordings;
     private String presentationBaseDir;
     private String defaultServerUrl;
     private String defaultTextTrackUrl;
@@ -75,7 +75,7 @@ public class RecordingServiceDbImpl implements RecordingService {
     @Override
     public String getRecordings2x(List<String> idList, List<String> states, Map<String, String> metadataFilters, int offset, Pageable pageable) {
         // If no IDs or limit were provided return no recordings instead of every recording
-        if((idList == null || idList.isEmpty()) && pageable == null && !allowAllRecordingsRetrieval) return xmlService.noRecordings();
+        if((idList == null || idList.isEmpty()) && pageable == null && !allowFetchAllRecordings) return xmlService.noRecordings();
 
         logger.info("Retrieving all recordings");
         Set<Recording> recordings = new HashSet<>(dataStore.findAll(Recording.class));
@@ -263,8 +263,8 @@ public class RecordingServiceDbImpl implements RecordingService {
         captionsDir = dir;
     }
 
-    public void setAllowAllRecordingsRetrieval(Boolean allowAllRecordingsRetrieval) {
-        this.allowAllRecordingsRetrieval = allowAllRecordingsRetrieval;
+    public void setAllowFetchAllRecordings(Boolean allowFetchAllRecordings) {
+        this.allowFetchAllRecordings = allowFetchAllRecordings;
     }
 
     public void setRecordingServiceHelper(RecordingMetadataReaderHelper r) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/RecordingServiceDbImpl.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/RecordingServiceDbImpl.java
@@ -30,6 +30,7 @@ public class RecordingServiceDbImpl implements RecordingService {
     private RecordingMetadataReaderHelper recordingServiceHelper;
     private String recordStatusDir;
     private String captionsDir;
+    private Boolean allowAllRecordingsRetrieval;
     private String presentationBaseDir;
     private String defaultServerUrl;
     private String defaultTextTrackUrl;
@@ -74,7 +75,7 @@ public class RecordingServiceDbImpl implements RecordingService {
     @Override
     public String getRecordings2x(List<String> idList, List<String> states, Map<String, String> metadataFilters, int offset, Pageable pageable) {
         // If no IDs or limit were provided return no recordings instead of every recording
-        if((idList == null || idList.isEmpty()) && pageable == null) return xmlService.noRecordings();
+        if((idList == null || idList.isEmpty()) && pageable == null && !allowAllRecordingsRetrieval) return xmlService.noRecordings();
 
         logger.info("Retrieving all recordings");
         Set<Recording> recordings = new HashSet<>(dataStore.findAll(Recording.class));
@@ -260,6 +261,10 @@ public class RecordingServiceDbImpl implements RecordingService {
 
     public void setCaptionsDir(String dir) {
         captionsDir = dir;
+    }
+
+    public void setAllowAllRecordingsRetrieval(Boolean allowAllRecordingsRetrieval) {
+        this.allowAllRecordingsRetrieval = allowAllRecordingsRetrieval;
     }
 
     public void setRecordingServiceHelper(RecordingMetadataReaderHelper r) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/RecordingServiceFileImpl.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/RecordingServiceFileImpl.java
@@ -62,7 +62,7 @@ public class RecordingServiceFileImpl implements RecordingService {
     private XmlService xmlService;
     private String recordStatusDir;
     private String captionsDir;
-    private Boolean allowAllRecordingsRetrieval;
+    private Boolean allowFetchAllRecordings;
     private String presentationBaseDir;
     private String defaultServerUrl;
     private String defaultTextTrackUrl;
@@ -204,7 +204,7 @@ public class RecordingServiceFileImpl implements RecordingService {
 
     public String getRecordings2x(List<String> idList, List<String> states, Map<String, String> metadataFilters, int offset, Pageable pageable) {
         // If no IDs or limit were provided return no recordings instead of every recording
-        if(idList.isEmpty() && pageable == null && !allowAllRecordingsRetrieval) return xmlService.noRecordings();
+        if(idList.isEmpty() && pageable == null && !allowFetchAllRecordings) return xmlService.noRecordings();
 
         List<RecordingMetadata> recsList = getRecordingsMetadata(idList, states);
         ArrayList<RecordingMetadata> recs = filterRecordingsByMetadata(recsList, metadataFilters);
@@ -435,7 +435,7 @@ public class RecordingServiceFileImpl implements RecordingService {
         captionsDir = dir;
     }
 
-    public void setAllowAllRecordingsRetrieval(Boolean allowAllRecordingsRetrieval) { this.allowAllRecordingsRetrieval = allowAllRecordingsRetrieval; }
+    public void setAllowFetchAllRecordings(Boolean allowFetchAllRecordings) { this.allowFetchAllRecordings = allowFetchAllRecordings; }
 
     public void setRecordingServiceHelper(RecordingMetadataReaderHelper r) {
         recordingServiceHelper = r;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/RecordingServiceFileImpl.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/RecordingServiceFileImpl.java
@@ -62,6 +62,7 @@ public class RecordingServiceFileImpl implements RecordingService {
     private XmlService xmlService;
     private String recordStatusDir;
     private String captionsDir;
+    private Boolean allowAllRecordingsRetrieval;
     private String presentationBaseDir;
     private String defaultServerUrl;
     private String defaultTextTrackUrl;
@@ -203,7 +204,7 @@ public class RecordingServiceFileImpl implements RecordingService {
 
     public String getRecordings2x(List<String> idList, List<String> states, Map<String, String> metadataFilters, int offset, Pageable pageable) {
         // If no IDs or limit were provided return no recordings instead of every recording
-        if(idList.isEmpty() && pageable == null) return xmlService.noRecordings();
+        if(idList.isEmpty() && pageable == null && !allowAllRecordingsRetrieval) return xmlService.noRecordings();
 
         List<RecordingMetadata> recsList = getRecordingsMetadata(idList, states);
         ArrayList<RecordingMetadata> recs = filterRecordingsByMetadata(recsList, metadataFilters);
@@ -433,6 +434,8 @@ public class RecordingServiceFileImpl implements RecordingService {
     public void setCaptionsDir(String dir) {
         captionsDir = dir;
     }
+
+    public void setAllowAllRecordingsRetrieval(Boolean allowAllRecordingsRetrieval) { this.allowAllRecordingsRetrieval = allowAllRecordingsRetrieval; }
 
     public void setRecordingServiceHelper(RecordingMetadataReaderHelper r) {
         recordingServiceHelper = r;

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -337,6 +337,8 @@ publishedDir=/var/bigbluebutton/published
 unpublishedDir=/var/bigbluebutton/unpublished
 captionsDir=/var/bigbluebutton/captions
 
+allowAllRecordingsRetrieval=true
+
 # The directory where the pre-built configs are stored
 configDir=/var/bigbluebutton/configs
 

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -337,7 +337,8 @@ publishedDir=/var/bigbluebutton/published
 unpublishedDir=/var/bigbluebutton/unpublished
 captionsDir=/var/bigbluebutton/captions
 
-allowAllRecordingsRetrieval=true
+# Determines if the API should allow all recordings on the server to be returned in a single request
+allowFetchAllRecordings=true
 
 # The directory where the pre-built configs are stored
 configDir=/var/bigbluebutton/configs

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -337,7 +337,7 @@ publishedDir=/var/bigbluebutton/published
 unpublishedDir=/var/bigbluebutton/unpublished
 captionsDir=/var/bigbluebutton/captions
 
-# Determines if the API should allow all recordings on the server to be returned in a single request
+# when set to true, a single call of getRecordings with no specified meetingID will return a (potentially massive) response listing all recordings on the system
 allowFetchAllRecordings=true
 
 # The directory where the pre-built configs are stored

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -102,7 +102,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="publishedDir" value="${publishedDir}"/>
         <property name="unpublishedDir" value="${unpublishedDir}"/>
         <property name="captionsDir" value="${captionsDir}"/>
-        <property name="allowAllRecordingsRetrieval" value="${allowAllRecordingsRetrieval}"/>
+        <property name="allowFetchAllRecordings" value="${allowFetchAllRecordings}"/>
         <property name="recordingServiceHelper" ref="recordingServiceHelper"/>
         <property name="xmlService" ref="xmlService" />
         <property name="presentationBaseDir" value="${presentationDir}"/>

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -102,6 +102,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="publishedDir" value="${publishedDir}"/>
         <property name="unpublishedDir" value="${unpublishedDir}"/>
         <property name="captionsDir" value="${captionsDir}"/>
+        <property name="allowAllRecordingsRetrieval" value="${allowAllRecordingsRetrieval}"/>
         <property name="recordingServiceHelper" ref="recordingServiceHelper"/>
         <property name="xmlService" ref="xmlService" />
         <property name="presentationBaseDir" value="${presentationDir}"/>


### PR DESCRIPTION
### What does this PR do?

Adds a new property `allowFetchAllRecordings` to bigbluebutton properties that controls whether every recording on a server can be returned in a single response. By default this property is set to true and allows all recordings to be returned in a single response. When switched to false a `no meetings` response will be returned if a user attempts to get all recordings without using pagination.

### Closes Issue(s)
Closes #16753