### PR TITLE
refactor (nginx): Set limit_conn only for location /html5client/sockjs

### DIFF
--- a/build/packages-template/bbb-config/after-install.sh
+++ b/build/packages-template/bbb-config/after-install.sh
@@ -130,7 +130,7 @@ if [ -d /var/mediasoup/screenshare ]; then
 fi
 
 sed -i 's/worker_connections 768/worker_connections 4000/g' /etc/nginx/nginx.conf
-echo 'limit_conn_zone $uri zone=ws_zone:5m;' > /etc/nginx/conf.d/html5-conn-limit.conf
+
 if grep -q "worker_rlimit_nofile" /etc/nginx/nginx.conf; then
   num=$(grep worker_rlimit_nofile /etc/nginx/nginx.conf | grep -o '[0-9]*')
   if [[ "$num" -lt 10000 ]]; then

--- a/build/packages-template/bbb-html5/after-install.sh
+++ b/build/packages-template/bbb-html5/after-install.sh
@@ -8,6 +8,11 @@ if [ ! -L /etc/nginx/sites-enabled/bigbluebutton ]; then
   ln -s /etc/nginx/sites-available/bigbluebutton /etc/nginx/sites-enabled/bigbluebutton
 fi
 
+# This config file was renamed, remove from old path if exists
+if [ -f /etc/nginx/conf.d/html5-conn-limit.conf ]; then
+  rm -r /etc/nginx/conf.d/html5-conn-limit.conf
+fi
+
 cd /usr/share/meteor
 
 # meteor code should be owned by root, config file by meteor user

--- a/build/packages-template/bbb-html5/bbb-html5-conn-limit.conf
+++ b/build/packages-template/bbb-html5/bbb-html5-conn-limit.conf
@@ -1,0 +1,1 @@
+limit_conn_zone $uri zone=ws_zone:5m;

--- a/build/packages-template/bbb-html5/bbb-html5.nginx
+++ b/build/packages-template/bbb-html5/bbb-html5.nginx
@@ -4,7 +4,6 @@ location @html5client {
   proxy_http_version 1.1;
   proxy_set_header Upgrade $http_upgrade;
   proxy_set_header Connection "Upgrade";
-  limit_conn ws_zone 3;
 }
 
 location /html5client/locales {
@@ -44,4 +43,9 @@ location /html5client {
   gzip_static on;
   alias /usr/share/meteor/bundle/programs/web.browser;
   try_files $uri @html5client;
+}
+
+location /html5client/sockjs {
+  try_files $uri @html5client;
+  limit_conn ws_zone 3;
 }

--- a/build/packages-template/bbb-html5/build.sh
+++ b/build/packages-template/bbb-html5/build.sh
@@ -26,6 +26,7 @@ cp bbb-html5.nginx staging/usr/share/bigbluebutton/nginx
 
 mkdir -p staging/etc/nginx/conf.d
 cp bbb-html5-loadbalancer.conf staging/etc/nginx/conf.d
+cp bbb-html5-conn-limit.conf staging/etc/nginx/conf.d
 
 
 mkdir -p staging/etc/systemd/system


### PR DESCRIPTION
Currently the config `limit_conn ws_zone 3;` is being set to all request of location `/html5client`.
Which can cause problems once the var `$uri` ignores the query string `?sessionToken=umztpwmivztkapmi` and thus all join requests are aiming the exact same `$uri` (`/html5client/join`).

This PR will set this limit of 3 simultaneous connections (by uri) only for location `/html5client/sockjs`, in which the `$uri` is always different (`/html5client/sockjs/998/06d05kqd/websocket`).

Improves #15977
Might help to fix #14582

---
_Plus: Also removes limit_conn_zone config from `bbb-config/after-install.sh` and follow the pattern of `bbb-html5-loadbalancer.conf` instead._