### PR TITLE
fix(recording): Recording stability & A/V sync fixes

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video.rb
@@ -430,6 +430,8 @@ module BigBlueButton
         ffmpeg_filter = '[0]null'
         layout[:areas].each do |layout_area|
           area = cut[:areas][layout_area[:name]]
+          next if area.nil?
+
           video_count = area.length
           BigBlueButton.logger.debug "  Laying out #{video_count} videos in #{layout_area[:name]}"
           next if video_count == 0

--- a/record-and-playback/core/lib/recordandplayback/edl/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video.rb
@@ -582,12 +582,8 @@ module BigBlueButton
             ffmpeg_filter << "[#{input_index}]"
             # Scale the video length for the deskshare timestamp workaround
             ffmpeg_filter << "setpts=PTS*#{scale}," unless scale.nil?
-            # If the video start time is after the seek point, extend the video backwards
-            if in_time < video_start_offset
-              ffmpeg_filter << "tpad=start_duration=#{ms_to_s(video_start_offset - in_time)}:start_mode=clone,"
-            end
             # Extend the video if needed and clean up the framerate
-            ffmpeg_filter << "tpad=stop=-1:stop_mode=clone,fps=#{layout[:framerate]}"
+            ffmpeg_filter << "tpad=stop=-1:stop_mode=clone,fps=#{layout[:framerate]}:start_time=#{ms_to_s(in_time)}"
             # Apply PTS offset so '0' time is aligned, and trim frames before start point
             ffmpeg_filter << ",setpts=PTS-#{ms_to_s(in_time)}/TB,trim=start=0"
             ffmpeg_filter << "[#{pad_name}];"


### PR DESCRIPTION
Includes two fixes:

* Fix a bug introduced in 1dd40b838036aa33b28436b5f6172a6433d0c008 that caused the start of some deskshare videos to be delayed, possibly by as much as several seconds. This could also cause a recording to fail to process, because sometimes the compositing ffmpeg process would exit without reading all of its input.
* Fix a bug exposed by 49cf81f4a0712ae461f0486047aa95df6d693578 where if an EDL entry (cut) was missing an area that was present in the layout, recording processing would crash. This case is now treated the same way as if the area was present but had no videos.