### PR TITLE
fix: Propagate layout and layout setting don't show up when disabled features is enabled as a custom parameter. 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -11,7 +11,7 @@ import BBBMenu from '/imports/ui/components/common/menu/component';
 import Styled from './styles';
 import { colorPrimary } from '/imports/ui/stylesheets/styled-components/palette';
 import { PANELS, ACTIONS, LAYOUT_TYPE } from '../../layout/enums';
-import isLayoutsEnabled from '/imports/ui/services/features/index.js'
+import {isLayoutsEnabled} from '/imports/ui/services/features';
 
 const propTypes = {
   amIPresenter: PropTypes.bool.isRequired,
@@ -219,21 +219,24 @@ class ActionsDropdown extends PureComponent {
       })
     }
 
-    if (amIPresenter && showPushLayout && !isLayoutsEnabled) {
+    if (amIPresenter && showPushLayout && isLayoutsEnabled()) {
       actions.push({
         icon: 'send',
         label: intl.formatMessage(intlMessages.propagateLayoutLabel),
         key: 'propagate layout',
         onClick: amIPresenter ? setMeetingLayout : setPushLayout,
       });
-      actions.push({
-        icon: 'send',
-        label: intl.formatMessage(intlMessages.layoutModal),
-        key: 'layoutModal',
-        onClick: () => mountModal(<LayoutModalContainer {...this.props} />),
-      });
+      
     }
 
+    if (isLayoutsEnabled()){
+    actions.push({
+      icon: 'send',
+      label: intl.formatMessage(intlMessages.layoutModal),
+      key: 'layoutModal',
+      onClick: () => mountModal(<LayoutModalContainer {...this.props} />),
+    });
+  }
     
     return actions;
   }

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -11,6 +11,7 @@ import BBBMenu from '/imports/ui/components/common/menu/component';
 import Styled from './styles';
 import { colorPrimary } from '/imports/ui/stylesheets/styled-components/palette';
 import { PANELS, ACTIONS, LAYOUT_TYPE } from '../../layout/enums';
+import isLayoutsEnabled from '/imports/ui/services/features/index.js'
 
 const propTypes = {
   amIPresenter: PropTypes.bool.isRequired,
@@ -218,22 +219,22 @@ class ActionsDropdown extends PureComponent {
       })
     }
 
-    if (amIPresenter && showPushLayout) {
+    if (amIPresenter && showPushLayout && !isLayoutsEnabled) {
       actions.push({
         icon: 'send',
         label: intl.formatMessage(intlMessages.propagateLayoutLabel),
         key: 'propagate layout',
         onClick: amIPresenter ? setMeetingLayout : setPushLayout,
       });
+      actions.push({
+        icon: 'send',
+        label: intl.formatMessage(intlMessages.layoutModal),
+        key: 'layoutModal',
+        onClick: () => mountModal(<LayoutModalContainer {...this.props} />),
+      });
     }
 
-    actions.push({
-      icon: 'send',
-      label: intl.formatMessage(intlMessages.layoutModal),
-      key: 'layoutModal',
-      onClick: () => mountModal(<LayoutModalContainer {...this.props} />),
-    });
-
+    
     return actions;
   }
 


### PR DESCRIPTION
### What does this PR do?

This PR deactivates 'propagate layout and layout settings' when disabledFeatures is passed as a custom parameter.

### Closes Issue(s)
#16777 

