### PR TITLE
fix: Restore presentation on layout push

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -59,6 +59,8 @@ const AppContainer = (props) => {
     return ref.current;
   }
 
+  const layoutType = useRef(null);
+
   const {
     actionsbar,
     selectedLayout,
@@ -97,6 +99,15 @@ const AppContainer = (props) => {
     && (presentationIsOpen || presentationRestoreOnUpdate);
 
   const { focusedId } = cameraDock;
+
+  if(
+    layoutContextDispatch 
+    &&  (typeof meetingLayout != "undefined")
+    && (layoutType.current != meetingLayout)
+    ) {
+      layoutType.current = meetingLayout;
+      MediaService.setPresentationIsOpen(layoutContextDispatch, true);
+  }
 
   const horizontalPosition = cameraDock.position === 'contentLeft' || cameraDock.position === 'contentRight';
   // this is not exactly right yet


### PR DESCRIPTION
### What does this PR do?

Restores presentation area when layout change is pushed

### Closes Issue(s)
Closes #16436

### Motivation

Behaviour:
Layout push did not restore presentation area (unless it's custom layout & you use `Push layout` button)

Expected:
If you have `Push to all` toggle on - you expect everyone's layout to become what's on image

