### PR TITLE
refactor: Migrate the breakout room backend to new async api

### DIFF
--- a/bigbluebutton-html5/imports/api/breakouts/index.js
+++ b/bigbluebutton-html5/imports/api/breakouts/index.js
@@ -11,8 +11,8 @@ if (Meteor.isServer) {
   // 1. breakoutId ( handleJoinUrl, roomStarted, clearBreakouts )
   // 2. parentMeetingId ( updateTimeRemaining )
 
-  Breakouts._ensureIndex({ breakoutId: 1 });
-  Breakouts._ensureIndex({ parentMeetingId: 1 });
+  Breakouts.createIndexAsync({ breakoutId: 1 });
+  Breakouts.createIndexAsync({ parentMeetingId: 1 });
 }
 
 export default Breakouts;

--- a/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutClosed.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutClosed.js
@@ -1,9 +1,9 @@
 import { check } from 'meteor/check';
 import clearBreakouts from '../modifiers/clearBreakouts';
 
-export default function handleBreakoutClosed({ body }) {
+export default async function handleBreakoutClosed({ body }) {
   const { breakoutId } = body;
   check(breakoutId, String);
-
-  return clearBreakouts(breakoutId);
+  const result = await clearBreakouts(breakoutId);
+  return result;
 }

--- a/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutJoinURL.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutJoinURL.js
@@ -28,15 +28,13 @@ export default function handleBreakoutJoinURL({ body }) {
     const ATTEMPT_EVERY_MS = 1000;
 
     let numberAffected = 0;
-
-    const updateBreakout = Meteor.bindEnvironment(() => {
-      numberAffected = Breakouts.update(selector, modifier);
-    });
+    const updateBreakout = async () => {
+      numberAffected = await Breakouts.updateAsync(selector, modifier);
+    };
 
     const updateBreakoutPromise = new Promise((resolve) => {
-      const updateBreakoutInterval = setInterval(() => {
-        updateBreakout();
-
+      const updateBreakoutInterval = setInterval(async () => {
+        await updateBreakout();
         if (numberAffected) {
           resolve(clearInterval(updateBreakoutInterval));
         }

--- a/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutJoinURL.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutJoinURL.js
@@ -2,7 +2,7 @@ import { check } from 'meteor/check';
 import Logger from '/imports/startup/server/logger';
 import Breakouts from '/imports/api/breakouts';
 
-export default function handleBreakoutJoinURL({ body }) {
+export default async function handleBreakoutJoinURL({ body }) {
   const {
     redirectToHtml5JoinURL,
     userId,
@@ -32,7 +32,7 @@ export default function handleBreakoutJoinURL({ body }) {
       numberAffected = await Breakouts.updateAsync(selector, modifier);
     };
 
-    const updateBreakoutPromise = new Promise((resolve) => {
+    await new Promise((resolve) => {
       const updateBreakoutInterval = setInterval(async () => {
         await updateBreakout();
         if (numberAffected) {
@@ -40,10 +40,7 @@ export default function handleBreakoutJoinURL({ body }) {
         }
       }, ATTEMPT_EVERY_MS);
     });
-
-    updateBreakoutPromise.then(() => {
-      Logger.info(`Upserted breakout id=${breakoutId}`);
-    });
+    Logger.info(`Upserted breakout id=${breakoutId}`);
   } catch (err) {
     Logger.error(`Adding breakout to collection: ${err}`);
   }

--- a/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutList.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutList.js
@@ -43,18 +43,15 @@ export default function handleBreakoutRoomsList({ body }, meetingId) {
         ...urls,
       },
     };
-
-    try {
-      const { numberAffected } = Breakouts.upsert(selector, modifier);
-
-      if (numberAffected) {
+    Breakouts.upsertAsync(selector, modifier).then((res) => {
+      if (res.numberAffected) {
         Logger.info('Updated timeRemaining and externalMeetingId '
             + `for breakout id=${breakoutId}`);
       }
-    } catch (err) {
+    }).catch((err) => {
       Logger.error(`updating breakout: ${err}`);
-    }
+    }).finally(() => {
+      handleBreakoutRoomsListHist({ body });
+    });
   });
-
-  handleBreakoutRoomsListHist({ body });
 }

--- a/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutList.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/handlers/breakoutList.js
@@ -4,7 +4,7 @@ import { check } from 'meteor/check';
 import flat from 'flat';
 import handleBreakoutRoomsListHist from '/imports/api/breakouts-history/server/handlers/breakoutRoomsList';
 
-export default function handleBreakoutRoomsList({ body }, meetingId) {
+export default async function handleBreakoutRoomsList({ body }, meetingId) {
   // 0 seconds default breakout time, forces use of real expiration time
   const DEFAULT_TIME_REMAINING = 0;
 
@@ -14,7 +14,7 @@ export default function handleBreakoutRoomsList({ body }, meetingId) {
   } = body;
 
   // set firstly the last seq, then client will know when receive all
-  rooms.sort((a, b) => ((a.sequence < b.sequence) ? 1 : -1)).forEach((breakout) => {
+  await rooms.sort((a, b) => ((a.sequence < b.sequence) ? 1 : -1)).forEach(async (breakout) => {
     const { breakoutId, html5JoinUrls, ...breakoutWithoutUrls } = breakout;
 
     check(meetingId, String);
@@ -43,15 +43,13 @@ export default function handleBreakoutRoomsList({ body }, meetingId) {
         ...urls,
       },
     };
-    Breakouts.upsertAsync(selector, modifier).then((res) => {
-      if (res.numberAffected) {
-        Logger.info('Updated timeRemaining and externalMeetingId '
-            + `for breakout id=${breakoutId}`);
-      }
-    }).catch((err) => {
-      Logger.error(`updating breakout: ${err}`);
-    }).finally(() => {
-      handleBreakoutRoomsListHist({ body });
-    });
+    const numberAffected = await Breakouts.upsertAsync(selector, modifier);
+    if (numberAffected) {
+      Logger.info('Updated timeRemaining and externalMeetingId '
+          + `for breakout id=${breakoutId}`);
+    } else {
+      Logger.error(`updating breakout: ${numberAffected}`);
+    }
+    handleBreakoutRoomsListHist({ body });
   });
 }

--- a/bigbluebutton-html5/imports/api/breakouts/server/handlers/joinedUsersChanged.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/handlers/joinedUsersChanged.js
@@ -4,7 +4,7 @@ import Logger from '/imports/startup/server/logger';
 import { check } from 'meteor/check';
 import { lowercaseTrim } from '/imports/utils/string-utils';
 
-export default function joinedUsersChanged({ body }) {
+export default async function joinedUsersChanged({ body }) {
   check(body, Object);
 
   const {
@@ -22,20 +22,29 @@ export default function joinedUsersChanged({ body }) {
     breakoutId,
   };
 
-  const usersMapped = users.map(user => ({ userId: user.id, name: user.name, sortName: lowercaseTrim(user.name) }));
+  const usersMapped = users
+    .map((user) => ({ userId: user.id, name: user.name, sortName: lowercaseTrim(user.name) }));
   const modifier = {
     $set: {
       joinedUsers: usersMapped,
     },
   };
 
-  Breakouts.updateAsync(selector, modifier).then((res) => {
-    if (res.numberAffected) {
-      updateUserBreakoutRoom(parentId, breakoutId, users);
+  const numberAffected = await Breakouts.updateAsync(selector, modifier);
+  if (numberAffected) {
+    updateUserBreakoutRoom(parentId, breakoutId, users);
 
-      Logger.info(`Updated joined users in breakout id=${breakoutId}`);
-    }
-  }).catch((err) => {
-    Logger.error(`updating joined users in breakout: ${err}`);
-  });
+    Logger.info(`Updated joined users in breakout id=${breakoutId}`);
+  } else {
+    Logger.error(`updating joined users in breakout: ${numberAffected}`);
+  }
+  // .then((res) => {
+  //   if (res.numberAffected) {
+  //     updateUserBreakoutRoom(parentId, breakoutId, users);
+
+  //     Logger.info(`Updated joined users in breakout id=${breakoutId}`);
+  //   }
+  // }).catch((err) => {
+  //   Logger.error(`updating joined users in breakout: ${err}`);
+  // });
 }

--- a/bigbluebutton-html5/imports/api/breakouts/server/handlers/joinedUsersChanged.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/handlers/joinedUsersChanged.js
@@ -29,15 +29,13 @@ export default function joinedUsersChanged({ body }) {
     },
   };
 
-  try {
-    const numberAffected = Breakouts.update(selector, modifier);
-
-    if (numberAffected) {
+  Breakouts.updateAsync(selector, modifier).then((res) => {
+    if (res.numberAffected) {
       updateUserBreakoutRoom(parentId, breakoutId, users);
 
       Logger.info(`Updated joined users in breakout id=${breakoutId}`);
     }
-  } catch (err) {
+  }).catch((err) => {
     Logger.error(`updating joined users in breakout: ${err}`);
-  }
+  });
 }

--- a/bigbluebutton-html5/imports/api/breakouts/server/handlers/updateTimeRemaining.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/handlers/updateTimeRemaining.js
@@ -23,14 +23,11 @@ export default function handleUpdateTimeRemaining({ body }, meetingId) {
   const options = {
     multi: true,
   };
-
-  try {
-    const numberAffected = Breakouts.update(selector, modifier, options);
-
-    if (numberAffected) {
+  Breakouts.updateAsync(selector, modifier, options).then((res) => {
+    if (res.numberAffected) {
       Logger.info(`Updated breakout time remaining for breakouts where parentMeetingId=${meetingId}`);
     }
-  } catch (err) {
+  }).catch((err) => {
     Logger.error(`Updating breakouts: ${err}`);
-  }
+  });
 }

--- a/bigbluebutton-html5/imports/api/breakouts/server/handlers/updateTimeRemaining.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/handlers/updateTimeRemaining.js
@@ -2,7 +2,7 @@ import { check } from 'meteor/check';
 import Logger from '/imports/startup/server/logger';
 import Breakouts from '/imports/api/breakouts';
 
-export default function handleUpdateTimeRemaining({ body }, meetingId) {
+export default async function handleUpdateTimeRemaining({ body }, meetingId) {
   const {
     timeRemaining,
   } = body;
@@ -23,11 +23,11 @@ export default function handleUpdateTimeRemaining({ body }, meetingId) {
   const options = {
     multi: true,
   };
-  Breakouts.updateAsync(selector, modifier, options).then((res) => {
-    if (res.numberAffected) {
-      Logger.info(`Updated breakout time remaining for breakouts where parentMeetingId=${meetingId}`);
-    }
-  }).catch((err) => {
-    Logger.error(`Updating breakouts: ${err}`);
-  });
+  const numberAffected = Breakouts.updateAsync(selector, modifier, options);
+
+  if (numberAffected) {
+    Logger.info(`Updated breakout time remaining for breakouts where parentMeetingId=${meetingId}`);
+  } else {
+    Logger.error(`Updating breakouts: ${numberAffected}`);
+  }
 }

--- a/bigbluebutton-html5/imports/api/breakouts/server/handlers/userBreakoutChanged.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/handlers/userBreakoutChanged.js
@@ -2,7 +2,7 @@ import Breakouts from '/imports/api/breakouts';
 import Logger from '/imports/startup/server/logger';
 import { check } from 'meteor/check';
 
-export default function userBreakoutChanged({ body }) {
+export default async function userBreakoutChanged({ body }) {
   check(body, Object);
 
   const {
@@ -49,11 +49,11 @@ export default function userBreakoutChanged({ body }) {
     let numberAffectedRows = 0;
 
     if (oldBreakoutSelector.breakoutId !== '') {
-      numberAffectedRows += Breakouts.update(oldBreakoutSelector, oldModifier);
+      numberAffectedRows += await Breakouts.updateAsync(oldBreakoutSelector, oldModifier);
     }
 
     if (newBreakoutSelector.breakoutId !== '') {
-      numberAffectedRows += Breakouts.update(newBreakoutSelector, newModifier);
+      numberAffectedRows += await Breakouts.updateAsync(newBreakoutSelector, newModifier);
     }
 
     if (numberAffectedRows > 0) {

--- a/bigbluebutton-html5/imports/api/breakouts/server/modifiers/clearBreakouts.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/modifiers/clearBreakouts.js
@@ -1,14 +1,14 @@
 import Logger from '/imports/startup/server/logger';
 import Breakouts from '/imports/api/breakouts';
 
-export default function clearBreakouts(breakoutId) {
+export default async function clearBreakouts(breakoutId) {
   if (breakoutId) {
     const selector = {
       breakoutId,
     };
 
     try {
-      const numberAffected = Breakouts.remove(selector);
+      const numberAffected = await Breakouts.remove(selector);
 
       if (numberAffected) {
         Logger.info(`Cleared Breakouts (${breakoutId})`);
@@ -18,7 +18,7 @@ export default function clearBreakouts(breakoutId) {
     }
   } else {
     try {
-      const numberAffected = Breakouts.remove({});
+      const numberAffected = await Breakouts.remove({});
       if (numberAffected) {
         Logger.info('Cleared Breakouts (all)');
       }

--- a/bigbluebutton-html5/imports/api/breakouts/server/modifiers/clearBreakouts.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/modifiers/clearBreakouts.js
@@ -8,7 +8,7 @@ export default async function clearBreakouts(breakoutId) {
     };
 
     try {
-      const numberAffected = await Breakouts.remove(selector);
+      const numberAffected = await Breakouts.removeAsync(selector);
 
       if (numberAffected) {
         Logger.info(`Cleared Breakouts (${breakoutId})`);
@@ -18,7 +18,7 @@ export default async function clearBreakouts(breakoutId) {
     }
   } else {
     try {
-      const numberAffected = await Breakouts.remove({});
+      const numberAffected = await Breakouts.removeAsync({});
       if (numberAffected) {
         Logger.info('Cleared Breakouts (all)');
       }

--- a/bigbluebutton-html5/imports/api/breakouts/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/breakouts/server/publishers.js
@@ -7,8 +7,9 @@ import { publicationSafeGuard } from '/imports/api/common/server/helpers';
 
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 
-function breakouts() {
-  const tokenValidation = AuthTokenValidation.findOne({ connectionId: this.connection.id });
+async function breakouts() {
+  const tokenValidation = await AuthTokenValidation
+    .findOneAsync({ connectionId: this.connection.id });
 
   if (!tokenValidation || tokenValidation.validationStatus !== ValidationStates.VALIDATED) {
     Logger.warn(`Publishing Breakouts was requested by unauth connection ${this.connection.id}`);
@@ -16,7 +17,7 @@ function breakouts() {
   }
   const { meetingId, userId } = tokenValidation;
 
-  const User = Users.findOne({ userId, meetingId }, { fields: { role: 1 } });
+  const User = await Users.findOneAsync({ userId, meetingId }, { fields: { role: 1 } });
   Logger.debug('Publishing Breakouts', { meetingId, userId });
 
   const fields = {
@@ -45,8 +46,8 @@ function breakouts() {
       ],
     };
     // Monitor this publication and stop it when user is not a moderator anymore
-    const comparisonFunc = () => {
-      const user = Users.findOne({ userId, meetingId }, { fields: { role: 1, userId: 1 } });
+    const comparisonFunc = async () => {
+      const user = await Users.findOneAsync({ userId, meetingId }, { fields: { role: 1, userId: 1 } });
       const condition = user.role === ROLE_MODERATOR;
 
       if (!condition) {

--- a/bigbluebutton-html5/imports/api/common/server/helpers.js
+++ b/bigbluebutton-html5/imports/api/common/server/helpers.js
@@ -51,9 +51,10 @@ export const extractCredentials = (credentials) => {
 // The provided function is publication-specific and must check the "survival condition" of the publication.
 export const publicationSafeGuard = function (fn, self) {
   let stopped = false;
-  const periodicCheck = function () {
+  const periodicCheck = async function () {
     if (stopped) return;
-    if (!fn()) {
+    const result = await fn();
+    if (!result) {
       self.added(self._name, 'publication-stop-marker', { id: 'publication-stop-marker', stopped: true });
       self.stop();
     } else Meteor.setTimeout(periodicCheck, 1000);

--- a/bigbluebutton-html5/imports/ui/services/api/index.js
+++ b/bigbluebutton-html5/imports/ui/services/api/index.js
@@ -15,15 +15,11 @@ export function makeCall(name, ...args) {
 
   // const { credentials } = Auth;
 
-  return new Promise((resolve, reject) => {
+  return new Promise(async (resolve, reject) => {
     if (Meteor.status().connected) {
-      Meteor.call(name, ...args, (error, result) => {
-        if (error) {
-          reject(error);
-        }
-
-        resolve(result);
-      });
+      const result = await Meteor.callAsync(name, ...args);
+      // all tested cases it returnd 0, empty array or undefined
+      resolve(result);
     } else {
       const failureString = `Call to ${name} failed because Meteor is not connected`;
       // We don't want to send a log message if the call that failed was a log message.


### PR DESCRIPTION
### What does this PR do?

This PR Migrates the backend of the breakout rooms for the new Metor async api introduced in the Meteor version 2.8 (Migration guide [here](https://guide.meteor.com/2.8-migration.html)).

### Closes Issue(s)

Closes #16101 in part.


### Motivation
In Meteor 3.0 the fibers will be descontinued due incompatibility with node 16, so we need migrate our code base for the new async api, discussions:
https://github.com/meteor/meteor/discussions/11505
https://github.com/meteor/meteor/pull/12028
https://github.com/meteor/meteor/pull/11605


### More
My idea is migrate it by rounds to make it easy to review and mitigate the impact of every change.

OBS: we don't need to migrate the collections calls in frontend, but the async api is avaible for the client-side too.

> Fibers don't exist in the client so you don't need to use the new API in the client but if you want it's also supported there. We support these async operations in the client as well because it's important that you can still write methods to run in the client and in the server.

quote from: https://github.com/meteor/meteor/pull/11605

