### PR TITLE
refactor: Move Pan Tool Next To The Pointer Tool

### DIFF
--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -98,6 +98,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     main {
       display: initial;
     }
+
+    .overrideSelect {
+      background-color: #FFF !important;
+      color: #000 !important;
+    }
   </style>
   <script>
     document.addEventListener('gesturestart', function (e) {

--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -103,6 +103,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
       background-color: #FFF !important;
       color: #000 !important;
     }
+
+    .select {
+      background-color: rgba(66, 133, 244, 1) !important;
+      color: #FFF !important;
+    }
   </style>
   <script>
     document.addEventListener('gesturestart', function (e) {

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -264,9 +264,7 @@ class PresentationToolbar extends PureComponent {
       currentSlide,
       slidePosition,
       multiUserSize,
-      multiUser,
-      setIsPanning,
-      isPanning,
+      multiUser
     } = this.props;
 
     const { isMobile } = deviceInfo;
@@ -400,20 +398,6 @@ class PresentationToolbar extends PureComponent {
               />
             </TooltipContainer>
           ) : null}
-          <Styled.FitToWidthButton
-            role="button"
-            data-test="panButton"
-            aria-label={intl.formatMessage(intlMessages.pan)}
-            color="light"
-            disabled={(zoom <= HUNDRED_PERCENT && !fitToWidth)}
-            icon="hand"
-            size="md"
-            circle
-            onClick={setIsPanning}
-            label={intl.formatMessage(intlMessages.pan)}
-            hideLabel
-            panning={isPanning}
-          />
           <Styled.FitToWidthButton
             role="button"
             data-test="fitToWidthButton"

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -11,7 +11,7 @@ import KEY_CODES from '/imports/utils/keyCodes';
 import { presentationMenuHeight, borderSize, borderSizeLarge } from '/imports/ui/stylesheets/styled-components/general';
 import { colorWhite, colorBlack } from '/imports/ui/stylesheets/styled-components/palette';
 import Styled from './styles';
-import { PanToolInjector } from './pan-tool-injector/component';
+import PanToolInjector from './pan-tool-injector/component';
 
 function usePrevious(value) {
   const ref = React.useRef();
@@ -194,18 +194,15 @@ export default function Whiteboard(props) {
   const toggleOffCheck = (evt) => {
     const clickedElement = evt.target;
     const toolbar = document.getElementById("TD-PrimaryTools");
+    const panBtnClicked = clickedElement?.getAttribute('data-test') === 'panButton'
+    || clickedElement?.parentElement?.getAttribute('data-test') === 'panButton';
+    if (panBtnClicked) {
+      return
+    }
     
     if (toolbar?.contains(clickedElement)) {
       setPanSelected(false);
       setIsPanning(false);
-    }
-    
-    const panBtnClicked = clickedElement?.getAttribute('data-test') === 'panButton'
-      || clickedElement?.parentElement?.getAttribute('data-test') === 'panButton';
-    
-    if (panBtnClicked && zoomValue <= HUNDRED_PERCENT && !fitToWidth) {
-      setPanSelected(true);
-      setIsPanning(true);
     }
   };
 
@@ -1074,6 +1071,7 @@ export default function Whiteboard(props) {
             zoomValue,
             panSelected,
             setPanSelected,
+            currentTool,
           }}
           formatMessage={intl?.formatMessage}
         />

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -196,29 +196,33 @@ export default function Whiteboard(props) {
     const toolbar = document.getElementById("TD-PrimaryTools");
     const panBtnClicked = clickedElement?.getAttribute('data-test') === 'panButton'
     || clickedElement?.parentElement?.getAttribute('data-test') === 'panButton';
+    const panButton = document.querySelector('[data-test="panButton"]');
     if (panBtnClicked) {
-      return
-    }
-    
-    if (toolbar?.contains(clickedElement)) {
-      setPanSelected(false);
+      const dataZoom = panButton.getAttribute('data-zoom');
+      if ((dataZoom <= HUNDRED_PERCENT && !fitToWidth)) {
+        return; 
+      }
+      panButton.classList.add('select');
+      panButton.classList.remove('selectOverride');
+      return;
+    } else {
       setIsPanning(false);
+      setPanSelected(false);
+      panButton.classList.add('selectOverride');
+      panButton.classList.remove('select');
     }
   };
 
   React.useEffect(() => {
     const toolbar = document.getElementById("TD-PrimaryTools");
-    
     const handleClick = (evt) => {
       toggleOffCheck(evt);
     };
-    
     toolbar?.addEventListener('click', handleClick);
-    
     return () => {
       toolbar?.removeEventListener('click', handleClick);
     };
-  }, []);
+  }, [tldrawAPI]);
 
   const throttledResetCurrentPoint = React.useRef(_.throttle(() => {
     setEnable(false);
@@ -710,10 +714,6 @@ export default function Whiteboard(props) {
   const onMount = (app) => {
     const menu = document.getElementById("TD-Styles")?.parentElement;
     setCurrentTool('select');
-    const toolbar = document.getElementById("TD-PrimaryTools");
-    if (toolbar) {
-      toolbar?.addEventListener('click', toggleOffCheck);
-    }
 
     if (menu) {
       const MENU_OFFSET = `48px`;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1075,7 +1075,6 @@ export default function Whiteboard(props) {
             zoomValue,
             panSelected,
             setPanSelected,
-            currentTool
           }}
           formatMessage={intl?.formatMessage}
         />

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -190,6 +190,25 @@ export default function Whiteboard(props) {
   const [isMoving, setIsMoving] = React.useState(false);
   const [isPanning, setIsPanning] = React.useState(shortcutPanning);
   const [panSelected, setPanSelected] = React.useState(isPanning);
+  const isMountedRef = React.useRef(true);
+
+  React.useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const setSafeTLDrawAPI = (api) => {
+    if (isMountedRef.current) {
+      setTLDrawAPI(api);
+    }
+  };
+
+  const setSafeCurrentTool = (tool) => {
+    if (isMountedRef.current) {
+      setCurrentTool(tool);
+    }
+  };
 
   const toggleOffCheck = (evt) => {
     const clickedElement = evt.target;
@@ -713,7 +732,7 @@ export default function Whiteboard(props) {
 
   const onMount = (app) => {
     const menu = document.getElementById("TD-Styles")?.parentElement;
-    setCurrentTool('select');
+    setSafeCurrentTool('select');
 
     if (menu) {
       const MENU_OFFSET = `48px`;
@@ -742,7 +761,7 @@ export default function Whiteboard(props) {
       }
     );
 
-    setTLDrawAPI(app);
+    setSafeTLDrawAPI(app);
     props.setTldrawAPI(app);
     // disable for non presenter that doesn't have multi user access
     if (!hasWBAccess && !isPresenter) {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import ReactDOM from 'react-dom';
 import _ from "lodash";
 import styled, { createGlobalStyle } from "styled-components";
 import Cursors from "./cursors/container";

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
@@ -1,0 +1,90 @@
+import * as React from "react";
+import ReactDOM from 'react-dom';
+import { HUNDRED_PERCENT } from '/imports/utils/slideCalcUtils';
+import Styled from '../styles';
+
+const DEFAULT_TOOL_COUNT = 9;
+
+export const PanToolInjector = (props) => {
+  const {
+    zoomValue,
+    fitToWidth,
+    isPanning,
+    setIsPanning,
+    formatMessage,
+    currentTool,
+    tldrawAPI,
+    panSelected,
+    setPanSelected
+  } = props;
+
+  React.useEffect(() => {
+    const tools = document.querySelectorAll('[id*="TD-PrimaryTools-"]');
+    tools.forEach(tool => {
+      const classList = tool.firstElementChild.classList;
+      if (panSelected) {
+        classList.add('overrideSelect');
+        tldrawAPI?.selectTool('draw');
+        setIsPanning(true);
+        setPanSelected(true);
+      } else {
+        classList.remove('overrideSelect');
+      }
+    });
+  }, [panSelected]);
+
+  React.useEffect(() => {
+    if (zoomValue === HUNDRED_PERCENT) {
+      setPanSelected(false);
+      setIsPanning(false);
+      tldrawAPI?.selectTool('select');
+    }
+  }, [zoomValue]);
+
+  const parentElement = document.getElementById('TD-PrimaryTools');
+  if (!parentElement) return null;
+
+  if (parentElement?.childElementCount === DEFAULT_TOOL_COUNT) {
+    parentElement?.removeChild(parentElement.children[1]);
+  }
+
+  if (parentElement?.childElementCount < DEFAULT_TOOL_COUNT) {
+    const label = formatMessage({
+      id: 'app.whiteboard.toolbar.tools.hand',
+      description: 'presentation toolbar pan label',
+    });
+    const container = document.createElement('span');
+    parentElement?.appendChild(container);
+    ReactDOM.render(
+      <Styled.PanTool
+        key={'bbb-panBtn'}
+        role="button"
+        data-test="panButton"
+        color="light"
+        icon="hand"
+        size="md"
+        aria-label={label}
+        disabled={(zoomValue <= HUNDRED_PERCENT && !fitToWidth)}
+        onClick={() => {
+          if (!panSelected) {
+            setPanSelected(true);
+            setIsPanning(true);
+          }
+        }}
+        label={label}
+        hideLabel
+        selected={panSelected || isPanning}
+      />,
+      container
+    );
+    const lastChild = parentElement?.lastChild;
+    const secondChild = parentElement?.children[1];
+    parentElement.insertBefore(lastChild, secondChild);
+  }
+
+  return null;
+};
+
+export default {
+  PanToolInjector
+};

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
@@ -29,7 +29,7 @@ class PanToolInjector extends React.Component {
     ) {
       this.addPanTool();
       if (panSelected) {
-        tldrawAPI?.selectTool('draw');
+        // tldrawAPI?.selectTool('draw');
         setIsPanning(true);
         setPanSelected(true);
       } else {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
@@ -64,8 +64,8 @@ export const PanToolInjector = (props) => {
         size="md"
         aria-label={label}
         disabled={(zoomValue <= HUNDRED_PERCENT && !fitToWidth)}
-        onClick={() => {
-          if (!panSelected) {
+        onClick={(event) => {
+          if (!panSelected && !event.currentTarget.disabled) {
             setPanSelected(true);
             setIsPanning(true);
           }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
@@ -5,19 +5,44 @@ import Styled from '../styles';
 
 const DEFAULT_TOOL_COUNT = 9;
 
-export const PanToolInjector = (props) => {
-  const {
-    zoomValue,
-    fitToWidth,
-    isPanning,
-    setIsPanning,
-    formatMessage,
-    tldrawAPI,
-    panSelected,
-    setPanSelected
-  } = props;
+class PanToolInjector extends React.Component {
+  componentDidMount() {
+    this.addPanTool();
+  }
 
-  React.useEffect(() => {
+  componentDidUpdate(prevProps) {
+    const {
+      zoomValue,
+      fitToWidth,
+      isPanning,
+      setIsPanning,
+      formatMessage,
+      tldrawAPI,
+      panSelected,
+      setPanSelected
+    } = this.props;
+    if (prevProps.zoomValue !== zoomValue
+      || prevProps.fitToWidth !== fitToWidth
+      || prevProps.isPanning !== isPanning
+      || prevProps.tldrawAPI !== tldrawAPI
+      || prevProps.panSelected !== panSelected
+    ) {
+      this.addPanTool();
+    }
+  }
+
+  addPanTool() {
+    const {
+      zoomValue,
+      fitToWidth,
+      isPanning,
+      setIsPanning,
+      formatMessage,
+      tldrawAPI,
+      panSelected,
+      setPanSelected
+    } = this.props;
+
     const tools = document.querySelectorAll('[id*="TD-PrimaryTools-"]');
     tools.forEach(tool => {
       const classList = tool.firstElementChild.classList;
@@ -30,60 +55,58 @@ export const PanToolInjector = (props) => {
         classList.remove('overrideSelect');
       }
     });
-  }, [panSelected]);
 
-  React.useEffect(() => {
     if (zoomValue === HUNDRED_PERCENT) {
       setPanSelected(false);
       setIsPanning(false);
       tldrawAPI?.selectTool('select');
     }
-  }, [zoomValue]);
 
-  const parentElement = document.getElementById('TD-PrimaryTools');
-  if (!parentElement) return null;
+    const parentElement = document.getElementById('TD-PrimaryTools');
+    if (!parentElement) return;
 
-  if (parentElement?.childElementCount === DEFAULT_TOOL_COUNT) {
-    parentElement?.removeChild(parentElement.children[1]);
+    if (parentElement.childElementCount === DEFAULT_TOOL_COUNT) {
+      parentElement.removeChild(parentElement.children[1]);
+    }
+
+    if (parentElement.childElementCount < DEFAULT_TOOL_COUNT) {
+      const label = formatMessage({
+        id: 'app.whiteboard.toolbar.tools.hand',
+        description: 'presentation toolbar pan label',
+      });
+      const container = document.createElement('span');
+      parentElement.appendChild(container);
+      ReactDOM.render(
+        <Styled.PanTool
+          key={'bbb-panBtn'}
+          role="button"
+          data-test="panButton"
+          color="light"
+          icon="hand"
+          size="md"
+          aria-label={label}
+          disabled={(zoomValue <= HUNDRED_PERCENT && !fitToWidth)}
+          onClick={() => {
+            if (!panSelected) {
+              setPanSelected(true);
+              setIsPanning(true);
+            }
+          }}
+          label={label}
+          hideLabel
+          selected={panSelected || isPanning}
+        />,
+        container
+      );
+      const lastChild = parentElement.lastChild;
+      const secondChild = parentElement.children[1];
+      parentElement.insertBefore(lastChild, secondChild);
+    }
   }
 
-  if (parentElement?.childElementCount < DEFAULT_TOOL_COUNT) {
-    const label = formatMessage({
-      id: 'app.whiteboard.toolbar.tools.hand',
-      description: 'presentation toolbar pan label',
-    });
-    const container = document.createElement('span');
-    parentElement?.appendChild(container);
-    ReactDOM.render(
-      <Styled.PanTool
-        key={'bbb-panBtn'}
-        role="button"
-        data-test="panButton"
-        color="light"
-        icon="hand"
-        size="md"
-        aria-label={label}
-        disabled={(zoomValue <= HUNDRED_PERCENT && !fitToWidth)}
-        onClick={(event) => {
-          if (!panSelected && !event.currentTarget.disabled) {
-            setPanSelected(true);
-            setIsPanning(true);
-          }
-        }}
-        label={label}
-        hideLabel
-        selected={panSelected || isPanning}
-      />,
-      container
-    );
-    const lastChild = parentElement?.lastChild;
-    const secondChild = parentElement?.children[1];
-    parentElement.insertBefore(lastChild, secondChild);
+  render() {
+    return null;
   }
+}
 
-  return null;
-};
-
-export default {
-  PanToolInjector
-};
+export default PanToolInjector;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
@@ -12,7 +12,6 @@ export const PanToolInjector = (props) => {
     isPanning,
     setIsPanning,
     formatMessage,
-    currentTool,
     tldrawAPI,
     panSelected,
     setPanSelected

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
@@ -28,6 +28,14 @@ class PanToolInjector extends React.Component {
       || prevProps.panSelected !== panSelected
     ) {
       this.addPanTool();
+      if (panSelected) {
+        tldrawAPI?.selectTool('draw');
+        setIsPanning(true);
+        setPanSelected(true);
+      } else {
+        setIsPanning(false);
+        setPanSelected(false);
+      }
     }
   }
 
@@ -49,8 +57,6 @@ class PanToolInjector extends React.Component {
       if (panSelected) {
         classList.add('overrideSelect');
         tldrawAPI?.selectTool('draw');
-        setIsPanning(true);
-        setPanSelected(true);
       } else {
         classList.remove('overrideSelect');
       }
@@ -81,20 +87,26 @@ class PanToolInjector extends React.Component {
           key={'bbb-panBtn'}
           role="button"
           data-test="panButton"
+          data-zoom={zoomValue}
+          className={"overrideSelect"}
           color="light"
           icon="hand"
           size="md"
           aria-label={label}
           disabled={(zoomValue <= HUNDRED_PERCENT && !fitToWidth)}
           onClick={() => {
-            if (!panSelected) {
-              setPanSelected(true);
-              setIsPanning(true);
+            setPanSelected(true);
+            setIsPanning(true);
+            if (!(zoomValue <= HUNDRED_PERCENT && !fitToWidth)) {
+              const panButton = document.querySelector('[data-test="panButton"]');
+              if (panButton) {
+                panButton.classList.remove('selectOverride');
+                panButton.classList.add('select');
+              }
             }
           }}
           label={label}
           hideLabel
-          selected={panSelected || isPanning}
         />,
         container
       );

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -1,0 +1,44 @@
+import styled from 'styled-components';
+import {
+  toolbarButtonColor,
+  colorWhite,
+} from '/imports/ui/stylesheets/styled-components/palette';
+import {
+  fontSizeLarger
+} from '/imports/ui/stylesheets/styled-components/typography';
+import Button from '/imports/ui/components/common/button/component';
+
+const PanTool = styled(Button)`
+  border: none !important;
+  padding: 0;
+  margin: 0;
+  border-radius: 7px;
+  background-color: ${colorWhite};
+  color: ${toolbarButtonColor};
+
+  & > i {
+    font-size: ${fontSizeLarger} !important;
+    [dir="rtl"] & {
+      -webkit-transform: scale(-1, 1);
+      -moz-transform: scale(-1, 1);
+      -ms-transform: scale(-1, 1);
+      -o-transform: scale(-1, 1);
+      transform: scale(-1, 1);
+    }
+  }
+
+  &:hover,
+  &:focus {
+    background-color: var(--colors-hover);
+  }
+
+  ${({ selected }) => selected && ` {
+      background-color: var(--colors-selected) !important;
+      color: ${colorWhite};
+    }
+  `}
+`;
+
+export default {
+  PanTool,
+};

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -4,7 +4,7 @@ import {
   colorWhite,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import {
-  fontSizeLarger
+  fontSizeLarger,
 } from '/imports/ui/stylesheets/styled-components/typography';
 import Button from '/imports/ui/components/common/button/component';
 
@@ -31,12 +31,6 @@ const PanTool = styled(Button)`
   &:focus {
     background-color: var(--colors-hover);
   }
-
-  ${({ selected }) => selected && ` {
-      background-color: var(--colors-selected) !important;
-      color: ${colorWhite};
-    }
-  `}
 `;
 
 export default {


### PR DESCRIPTION
### What does this PR do?
Moves the Pan tool from the presentation toolbar to the tldraw toolbar (below the pointer tool).

![pan-tool-moved](https://user-images.githubusercontent.com/22058534/221058164-f9a7e2c4-b465-46e3-b47f-d75fb3d7b762.gif)


### Closes Issue(s)
Closes #16662 

