### PR TITLE
fix(config): Open 3478 on ufw only if haproxy running

### DIFF
--- a/bigbluebutton-config/bin/apply-lib.sh
+++ b/bigbluebutton-config/bin/apply-lib.sh
@@ -110,12 +110,25 @@ enableUFWRules() {
   ufw allow "Nginx Full"
   ufw allow 16384:32768/udp
 
-  # Check if coturn is running on this server and, if so, open firewall port
-  if systemctl status coturn > /dev/null; then
-    echo "  - Local turnserver detected -- opening port 3478"
-    ufw allow 3478
-    # echo "  - Forcing FireFox to use turn server"
-    # yq w -i $HTML5_CONFIG public.kurento.forceRelayOnFirefox true 
+   # Check if haproxy is running on this server and, if so, open port 3478 on ufw
+
+  if systemctl is-enabled haproxy> /dev/null 2>&1; then
+    if systemctl -q is-active haproxy; then
+      echo "  - Local haproxy detected and running -- opening port 3478"
+      ufw allow 3478
+      # echo "  - Forcing FireFox to use turn server"
+      # yq w -i $HTML5_CONFIG public.kurento.forceRelayOnFirefox true
+    else
+      if grep -q 3478 /etc/ufw/user.rules; then
+        echo "  - Local haproxy not running -- closing port 3478"
+        ufw delete allow 3478
+      fi
+    fi
+  else
+    if grep -q 3478 /etc/ufw/user.rules; then
+      echo "  - Local haproxy not running -- closing port 3478"
+      ufw delete allow 3478
+    fi
   fi
 
   ufw --force enable


### PR DESCRIPTION

### What does this PR do?

Open 3478 on ufw only if haproxy running

### Motivation

If the administrator installs BigBlueButton with the [bbb-install-2.6.sh](https://github.com/bigbluebutton/bbb-install/blob/master/bbb-install-2.6.sh) using the option

```
-c <hostname>:<secret> Configure with coturn server at <hostname> using <secret> (instead of built-in TURN server)
```

then don't open port 3478.

