### PR TITLE
Skip reading of turn-stun-servers.xml in bbb-conf --secret

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -181,12 +181,14 @@ NCPU=$(nproc --all)
 
 BBB_USER=bigbluebutton
 
-TURN=$SERVLET_DIR/WEB-INF/classes/spring/turn-stun-servers.xml
-TURN_ETC_CONFIG=/etc/bigbluebutton/turn-stun-servers.xml
-if [ -f "$TURN_ETC_CONFIG" ]; then
+if [ $EUID == 0 ]; then
+  TURN=$SERVLET_DIR/WEB-INF/classes/spring/turn-stun-servers.xml
+  TURN_ETC_CONFIG=/etc/bigbluebutton/turn-stun-servers.xml
+  if [ -f "$TURN_ETC_CONFIG" ]; then
     TURN=$TURN_ETC_CONFIG
+  fi
+  STUN="$(xmlstarlet sel -N x="http://www.springframework.org/schema/beans" -t -m '_:beans/_:bean[@class="org.bigbluebutton.web.services.turn.StunTurnService"]/_:property[@name="stunServers"]/_:set/_:ref' -v @bean -nl $TURN)"
 fi
-STUN="$(xmlstarlet sel -N x="http://www.springframework.org/schema/beans" -t -m '_:beans/_:bean[@class="org.bigbluebutton.web.services.turn.StunTurnService"]/_:property[@name="stunServers"]/_:set/_:ref' -v @bean -nl $TURN)"
 
 PROTOCOL=http
 if [ -f $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties ]; then


### PR DESCRIPTION
### What does this PR do?

When running `bbb-conf --secret` as a non-root user, a needless check is done against `/etc/bigbluebutton/turn-stun-servers.xml` and throwing an error.

### Closes Issue(s)
Closes #16814
