### PR TITLE
fix: index auth-token-validation by connectionId

### DIFF
--- a/bigbluebutton-html5/imports/api/auth-token-validation/index.js
+++ b/bigbluebutton-html5/imports/api/auth-token-validation/index.js
@@ -7,7 +7,7 @@ const collectionOptions = Meteor.isClient ? {
 const AuthTokenValidation = new Mongo.Collection('auth-token-validation', collectionOptions);
 
 if (Meteor.isServer) {
-  AuthTokenValidation._ensureIndex({ meetingId: 1, userId: 1 });
+  AuthTokenValidation._ensureIndex({ connectionId: 1 });
 }
 
 export const ValidationStates = Object.freeze({


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Change the indexing for collection `auth-token-validation` to improve read times
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
In some tests I had read times to this collection take as much as 200ms. The existing indexing did not match how we use the collection

![Screenshot from 2023-02-27 08-44-03](https://user-images.githubusercontent.com/6312397/221581663-1a85ba25-2759-45ea-a6f7-cd27b772e384.png)

<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->

