### PR TITLE
fix: First slide appears on slide transition later on

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -1023,7 +1023,7 @@ class Presentation extends PureComponent {
                   slidePosition={slidePosition}
                   getSvgRef={this.getSvgRef}
                   setTldrawAPI={this.setTldrawAPI}
-                  curPageId={currentSlide?.num.toString()}
+                  curPageId={currentSlide?.num.toString() || '0'}
                   svgUri={currentSlide?.svgUri}
                   intl={intl}
                   presentationWidth={svgWidth}

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -382,7 +382,7 @@ const getCurrentPres = () => {
 const initDefaultPages = (count = 1) => {
   const pages = {};
   const pageStates = {};
-  let i = 1;
+  let i = 0;
   while (i < count + 1) {
     pages[`${i}`] = {
       id: `${i}`,


### PR DESCRIPTION
### What does this PR do?

Fix an issue with the first slide of the presentation appearing when switching slides.

#### before
[Screencast from 2023-02-27 13-13-12.webm](https://user-images.githubusercontent.com/3728706/221618017-5b50a728-990b-4b6c-823c-d18273c34c62.webm)

#### after
[Screencast from 2023-02-27 13-12-32.webm](https://user-images.githubusercontent.com/3728706/221618064-f8a130fa-4321-4b76-ab42-de6be66b07c2.webm)



### Closes Issue(s)
Closes #16725