### PR TITLE
fix: re-connection improvements for cameras and screen sharing

### DIFF
--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -63,7 +63,7 @@ export default class KurentoScreenshareBridge {
 
   _shouldReconnect() {
     // Sender/presenter reconnect is *not* implemented yet
-    return this.broker.started && this.role === RECV_ROLE;
+    return this.reconnectionTimeout == null && this.role === RECV_ROLE;
   }
 
   /**
@@ -218,7 +218,6 @@ export default class KurentoScreenshareBridge {
 
     // Screensharing was already successfully negotiated and error occurred during
     // during call; schedule a reconnect
-    // If the session has not yet started, a reconnect should already be scheduled
     if (this._shouldReconnect()) {
       // this.broker.started => whether the reconnect should happen immediately.
       // If this session had alredy been established, it should.

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/service.js
@@ -16,6 +16,7 @@ const {
   maxTimeout: MAX_MEDIA_TIMEOUT,
   maxConnectionAttempts: MAX_CONN_ATTEMPTS,
   timeoutIncreaseFactor: TIMEOUT_INCREASE_FACTOR,
+  baseReconnectionTimeout: BASE_RECONNECTION_TIMEOUT,
 } = MEDIA_TIMEOUTS;
 
 const HAS_DISPLAY_MEDIA = (typeof navigator.getDisplayMedia === 'function'
@@ -111,7 +112,7 @@ const getMediaServerAdapter = () => {
 
 const getNextReconnectionInterval = (oldInterval) => {
   return Math.min(
-    TIMEOUT_INCREASE_FACTOR * oldInterval,
+    (TIMEOUT_INCREASE_FACTOR * Math.max(oldInterval, BASE_RECONNECTION_TIMEOUT)),
     MAX_MEDIA_TIMEOUT,
   );
 }
@@ -157,6 +158,7 @@ export default {
   screenshareLoadAndPlayMediaStream,
   getMediaServerAdapter,
   BASE_MEDIA_TIMEOUT,
+  BASE_RECONNECTION_TIMEOUT,
   MAX_CONN_ATTEMPTS,
   BASE_BITRATE,
 };

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
@@ -125,7 +125,7 @@ const ScreenshareButton = ({
   const handleFailure = (error) => {
     const {
       errorCode = SCREENSHARING_ERRORS.UNKNOWN_ERROR.errorCode,
-      errorMessage,
+      errorMessage = error.message,
     } = error;
 
     const localizedError = getErrorLocale(errorCode);

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -242,9 +242,16 @@ class ScreenshareComponent extends React.Component {
 
       try {
         mediaFlowing = isMediaFlowing(previousStats, currentStats);
-      } catch (_error) {
+      } catch (error) {
         // Stats processing failed for whatever reason - maintain previous state
         mediaFlowing = prevMediaFlowing;
+        logger.warn({
+          logCode: 'screenshare_media_monitor_stats_failed',
+          extraInfo: {
+            errorName: error.name,
+            errorMessage: error.message,
+          },
+        }, 'Failed to collect screenshare stats, flow monitor');
       }
 
       previousStats = currentStats;
@@ -323,9 +330,7 @@ class ScreenshareComponent extends React.Component {
       this.clearMediaFlowingMonitor();
       // Current state is media not flowing - stream is now healthy so flip it
       if (!mediaFlowing) this.setState({ mediaFlowing: isStreamHealthy });
-    } else {
-      if (this.mediaFlowMonitor == null) this.monitorMediaFlow();
-    }
+    } else if (this.mediaFlowMonitor == null) this.monitorMediaFlow();
   }
 
   renderFullscreenButton() {

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -245,8 +245,8 @@ const getStats = async (statsTypes = DEFAULT_SCREENSHARE_STATS_TYPES) => {
 // This method may throw errors
 const isMediaFlowing = (previousStats, currentStats) => {
   const bpsData = ConnectionStatusService.calculateBitsPerSecond(
-    currentStats.screenshareStats,
-    previousStats.screenshareStats,
+    currentStats?.screenshareStats,
+    previousStats?.screenshareStats,
   );
   const bpsDataAggr = Object.values(bpsData)
     .reduce((sum, partialBpsData = 0) => sum + parseFloat(partialBpsData), 0);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/container.jsx
@@ -25,6 +25,7 @@ export default withTracker(({ swapLayout, ...rest }) => {
     totalNumberOfStreams,
     isUserLocked: VideoService.isUserLocked(),
     currentVideoPageIndex: VideoService.getCurrentVideoPageIndex(),
+    isMeteorConnected: Meteor.status().connected,
     ...rest,
   };
 })(VideoProviderContainer);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -26,7 +26,7 @@ const VideoListItem = (props) => {
     makeDragOperations, dragging, draggingOver, isRTL
   } = props;
 
-  const [videoIsReady, setVideoIsReady] = useState(false);
+  const [videoDataLoaded, setVideoDataLoaded] = useState(false);
   const [isStreamHealthy, setIsStreamHealthy] = useState(false);
   const [isMirrored, setIsMirrored] = useState(VideoService.mirrorOwnWebcam(user?.userId));
   const [isVideoSqueezed, setIsVideoSqueezed] = useState(false);
@@ -41,7 +41,7 @@ const VideoListItem = (props) => {
   const videoTag = useRef();
   const videoContainer = useRef();
 
-  const shouldRenderReconnect = !isStreamHealthy && videoIsReady;
+  const videoIsReady = isStreamHealthy && videoDataLoaded;
   const { animations } = Settings.application;
   const talking = voiceUser?.talking;
 
@@ -49,14 +49,11 @@ const VideoListItem = (props) => {
     const { streamState } = e.detail;
     const newHealthState = !isStreamStateUnhealthy(streamState);
     e.stopPropagation();
-
-    if (newHealthState !== isStreamHealthy) {
-      setIsStreamHealthy(newHealthState);
-    }
+    setIsStreamHealthy(newHealthState);
   };
 
-  const handleSetVideoIsReady = () => {
-    setVideoIsReady(true);
+  const onLoadedData = () => {
+    setVideoDataLoaded(true);
     window.dispatchEvent(new Event('resize'));
 
     /* used when re-sharing cameras after leaving a breakout room.
@@ -71,10 +68,10 @@ const VideoListItem = (props) => {
     onVideoItemMount(videoTag.current);
     subscribeToStreamStateChange(cameraId, onStreamStateChange);
     resizeObserver.observe(videoContainer.current);
-    videoTag?.current?.addEventListener('loadeddata', handleSetVideoIsReady);
+    videoTag?.current?.addEventListener('loadeddata', onLoadedData);
 
     return () => {
-      videoTag?.current?.removeEventListener('loadeddata', handleSetVideoIsReady);
+      videoTag?.current?.removeEventListener('loadeddata', onLoadedData);
       resizeObserver.disconnect();
     };
   }, []);
@@ -96,10 +93,10 @@ const VideoListItem = (props) => {
     // This is here to prevent the videos from freezing when they're
     // moved around the dom by react, e.g., when  changing the user status
     // see https://bugs.chromium.org/p/chromium/issues/detail?id=382879
-    if (videoIsReady) {
+    if (videoDataLoaded) {
       playElement(videoTag.current);
     }
-  }, [videoIsReady]);
+  }, [videoDataLoaded]);
 
   // component will unmount
   useEffect(() => () => {
@@ -130,7 +127,7 @@ const VideoListItem = (props) => {
       <UserAvatarVideo
         user={user}
         voiceUser={voiceUser}
-        unhealthyStream={shouldRenderReconnect}
+        unhealthyStream={videoDataLoaded && !isStreamHealthy}
         squeezed={false}
       />
       <Styled.BottomBar>
@@ -158,7 +155,7 @@ const VideoListItem = (props) => {
     >
       <UserAvatarVideo
         user={user}
-        unhealthyStream={shouldRenderReconnect}
+        unhealthyStream={videoDataLoaded && !isStreamHealthy}
         squeezed
       />
       {renderSqueezedButton()}
@@ -213,7 +210,7 @@ const VideoListItem = (props) => {
       <Styled.VideoContainer>
         <Styled.Video
           mirrored={isMirrored}
-          unhealthyStream={shouldRenderReconnect}
+          unhealthyStream={videoDataLoaded && !isStreamHealthy}
           data-test={isMirrored ? 'mirroredVideoContainer' : 'videoContainer'}
           ref={videoTag}
           autoPlay
@@ -229,8 +226,6 @@ const VideoListItem = (props) => {
         : (isVideoSqueezed)
           ? renderWebcamConnectingSqueezed()
           : renderWebcamConnecting()}
-
-      {shouldRenderReconnect && <Styled.Reconnecting animations={animations} />}
     </Styled.Content>
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/styles.js
@@ -109,29 +109,6 @@ const LoadingText = styled(TextElipsis)`
   font-size: 100%;
 `;
 
-const Reconnecting = styled.div`
-  position: absolute;
-  height: 100%;
-  width: 100%;
-  display: flex;
-  font-size: 2.5rem;
-  z-index: 1;
-  align-items: center;
-  justify-content: center;
-  background-color: transparent;
-  color: ${colorWhite};
-
-  &::before {
-    font-family: 'bbb-icons' !important;
-    content: "\\e949";
-    /* ascii code for the ellipsis character */
-    display: inline-block;
-    ${({ animations }) => animations && css`
-      animation: ${rotate360} 2s infinite linear;
-    `}
-  }
-`;
-
 const VideoContainer = styled.div`
   display: flex;
   justify-content: center;
@@ -180,7 +157,6 @@ export default {
   Content,
   WebcamConnecting,
   LoadingText,
-  Reconnecting,
   VideoContainer,
   Video,
   TopBar,

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/sfu-base-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/sfu-base-broker.js
@@ -2,7 +2,10 @@ import logger from '/imports/startup/client/logger';
 import { notifyStreamStateChange } from '/imports/ui/services/bbb-webrtc-sfu/stream-state-service';
 import { SFU_BROKER_ERRORS } from '/imports/ui/services/bbb-webrtc-sfu/broker-base-errors';
 
-const PING_INTERVAL_MS = 15000;
+const WS_HEARTBEAT_OPTS = {
+  interval: 15000,
+  delay: 3000,
+};
 
 class BaseBroker {
   static assembleError(code, reason) {
@@ -21,13 +24,14 @@ class BaseBroker {
     this.sfuComponent = sfuComponent;
     this.ws = null;
     this.webRtcPeer = null;
-    this.pingInterval = null;
+    this.wsHeartbeat = null;
     this.started = false;
     this.signallingTransportOpen = false;
     this.logCodePrefix = `${this.sfuComponent}_broker`;
     this.peerConfiguration = {};
 
     this.onbeforeunload = this.onbeforeunload.bind(this);
+    this._onWSError = this._onWSError.bind(this);
     window.addEventListener('beforeunload', this.onbeforeunload);
   }
 
@@ -63,48 +67,125 @@ class BaseBroker {
     // To be implemented by inheritors
   }
 
+  _onWSMessage(message) {
+    this._updateLastMsgTime();
+    this.onWSMessage(message);
+  }
+
+  onWSMessage(message) {
+    // To be implemented by inheritors
+  }
+
+  _onWSError(error) {
+    let normalizedError;
+
+    logger.error({
+      logCode: `${this.logCodePrefix}_websocket_error`,
+      extraInfo: {
+        errorMessage: error.name || error.message || 'Unknown error',
+        sfuComponent: this.sfuComponent,
+      }
+    }, 'WebSocket connection to SFU failed');
+
+    if (this.signallingTransportOpen) {
+      // 1301: "WEBSOCKET_DISCONNECTED", transport was already open
+      normalizedError = BaseBroker.assembleError(1301);
+    } else {
+      // 1302: "WEBSOCKET_CONNECTION_FAILED", transport errored before establishment
+      normalizedError = BaseBroker.assembleError(1302);
+    }
+
+    this.onerror(normalizedError);
+    return normalizedError;
+  }
+
   openWSConnection () {
     return new Promise((resolve, reject) => {
       this.ws = new WebSocket(this.wsUrl);
 
-      this.ws.onmessage = this.onWSMessage.bind(this);
+      this.ws.onmessage = this._onWSMessage.bind(this);
 
       this.ws.onclose = () => {
         // 1301: "WEBSOCKET_DISCONNECTED",
         this.onerror(BaseBroker.assembleError(1301));
       };
 
-      this.ws.onerror = (error) => {
-        logger.error({
-          logCode: `${this.logCodePrefix}_websocket_error`,
-          extraInfo: {
-            errorMessage: error.name || error.message || 'Unknown error',
-            sfuComponent: this.sfuComponent,
-          }
-        }, 'WebSocket connection to SFU failed');
-
-        if (this.signallingTransportOpen) {
-          // 1301: "WEBSOCKET_DISCONNECTED", transport was already open
-          this.onerror(BaseBroker.assembleError(1301));
-        } else {
-          // 1302: "WEBSOCKET_CONNECTION_FAILED", transport errored before establishment
-          const normalized1302 = BaseBroker.assembleError(1302);
-          this.onerror(normalized1302);
-          return reject(normalized1302);
-        }
-      };
+      this.ws.onerror = (error) => reject(this._onWSError(error));
 
       this.ws.onopen = () => {
-        this.pingInterval = setInterval(this.ping.bind(this), PING_INTERVAL_MS);
+        this.setupWSHeartbeat();
         this.signallingTransportOpen = true;
         return resolve();
       };
     });
   }
 
+  closeWs() {
+    this.clearWSHeartbeat();
+
+    if (this.ws !== null) {
+      this.ws.onclose = function (){};
+      this.ws.close();
+    }
+  }
+
+  _updateLastMsgTime() {
+    this.ws.isAlive = true;
+    this.ws.lastMsgTime = Date.now();
+  }
+
+  _getTimeSinceLastMsg() {
+    return Date.now() - this.ws.lastMsgTime;
+  }
+
+  setupWSHeartbeat() {
+    if (WS_HEARTBEAT_OPTS.interval === 0 || this.ws == null) return;
+
+    this.ws.isAlive = true;
+    this.wsHeartbeat = setInterval(() => {
+      if (this.ws.isAlive === false) {
+        logger.warn({
+          logCode: `${this.logCodePrefix}_ws_heartbeat_failed`,
+        }, `WS heartbeat failed (${this.sfuComponent})`);
+        this.closeWs();
+        this._onWSError(new Error('HeartbeatFailed'));
+        return;
+      }
+
+      if (this._getTimeSinceLastMsg() < (
+        WS_HEARTBEAT_OPTS.interval - WS_HEARTBEAT_OPTS.delay
+      )) {
+        return;
+      }
+
+      this.ws.isAlive = false;
+      this.ping();
+    }, WS_HEARTBEAT_OPTS.interval);
+
+    this.ping();
+  }
+
+  clearWSHeartbeat() {
+    if (this.wsHeartbeat) {
+      clearInterval(this.wsHeartbeat);
+    }
+  }
+
   sendMessage (message) {
     const jsonMessage = JSON.stringify(message);
-    this.ws.send(jsonMessage);
+
+    try {
+      this.ws.send(jsonMessage);
+    } catch (error) {
+      logger.error({
+        logCode: `${this.logCodePrefix}_ws_send_error`,
+        extraInfo: {
+          errorName: error.name,
+          errorMessage: error.message,
+          sfuComponent: this.sfuComponent,
+        },
+      }, `Failed to send WebSocket message (${this.sfuComponent})`);
+    }
   }
 
   ping () {
@@ -266,15 +347,7 @@ class BaseBroker {
       this.webRtcPeer.peerConnection.onconnectionstatechange = null;
     }
 
-    if (this.ws !== null) {
-      this.ws.onclose = function (){};
-      this.ws.close();
-    }
-
-    if (this.pingInterval) {
-      clearInterval(this.pingInterval);
-    }
-
+    this.closeWs();
     this.disposePeer();
     this.started = false;
 

--- a/bigbluebutton-html5/imports/ui/services/webrtc-base/peer.js
+++ b/bigbluebutton-html5/imports/ui/services/webrtc-base/peer.js
@@ -194,16 +194,20 @@ export default class WebRtcPeer extends EventEmitter2 {
   }
 
   getLocalStream() {
-    if (this.localStream) {
-      return this.localStream;
-    }
-
     if (this.peerConnection) {
-      this.localStream = new MediaStream();
+      if (this.localStream == null) this.localStream = new MediaStream();
       const senders = this.peerConnection.getSenders();
+      const oldTracks = this.localStream.getTracks();
+
       senders.forEach(({ track }) => {
-        if (track) {
+        if (track && !oldTracks.includes(track)) {
           this.localStream.addTrack(track);
+        }
+      });
+
+      oldTracks.forEach((oldTrack) => {
+        if (!senders.some(({ track }) => track && track.id === oldTrack.id)) {
+          this.localStream.removeTrack(oldTrack);
         }
       });
 

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -303,11 +303,13 @@ public:
       bitrate: 1500
       mediaTimeouts:
         maxConnectionAttempts: 2
-        # Base screen media timeout (send|recv)
-        baseTimeout: 30000
-        # Max timeout: used as the max camera subscribe reconnection timeout. Each
+        # Base screen media timeout (send|recv) - first connections
+        baseTimeout: 20000
+        # Base screen media timeout (send|recv) - re-connections
+        baseReconnectionTimeout: 8000
+        # Max timeout: used as the max camera subscribe connection timeout. Each
         # subscribe reattempt increases the reconnection timer up to this
-        maxTimeout: 60000
+        maxTimeout: 25000
         timeoutIncreaseFactor: 1.5
       constraints:
         video:

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -263,9 +263,18 @@ public:
     enabled: true
   kurento:
     wsUrl: HOST
-    # Valid for video-provider. Time (ms) before its WS connection times out
-    # and tries to reconnect.
-    wsConnectionTimeout: 4000
+    cameraWsOptions:
+      # Valid for video-provider. Time (ms) before its WS connection times out
+      # and tries to reconnect.
+      wsConnectionTimeout: 4000
+      # maxRetries: max reconnection retries
+      maxRetries: 5
+      # debug: console trace logging for video-provider's ws
+      debug: false
+      heartbeat:
+        interval: 15000
+        delay: 3000
+        reconnectOnFailure: true
     # Time in milis to wait for the browser to return a gUM call (used in video-preview)
     gUMTimeout: 20000
     # Controls whether ICE candidates should be signaled to bbb-webrtc-sfu.

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -268,7 +268,7 @@ public:
       # and tries to reconnect.
       wsConnectionTimeout: 4000
       # maxRetries: max reconnection retries
-      maxRetries: 5
+      maxRetries: 7
       # debug: console trace logging for video-provider's ws
       debug: false
       heartbeat:


### PR DESCRIPTION
### What does this PR do?

Introduces a bunch of improvements to cam/screen re-connection procedures 
I've found to have regressed (in behavior) when migrating to 2.5+-based 
environments. In detail, per commit:

- [fix(video): properly render reconnecting view](https://github.com/bigbluebutton/bigbluebutton/commit/728877b68a7c89556824c6bab31984a70fe8dc91) 
  * The stream state change handler in video-list-item is using a component
state reference inside a DOM event callback - which means it is always
presuming `isStreamHealthy` is false (initial value). That prevents the
health state from actually transitioning when necessary (and
consequently rendering the reconnecting view in video-list item).
- [fix(video): add proper signaling WS heartbeat, +](https://github.com/bigbluebutton/bigbluebutton/commit/ab1807adc23fd66ba62b11ef625d8dd57328511e) 
  * video-provider's current ping-pong is as good as nothing in 2.5+. We
were counting on Meteor's (and consequently the component's mount state)
before 2.5 to act as a "heartbeat" as far as the socket is concerned.
The ping-pong served only to sustain traffic for finnicky,
traffic-dependant firewall.
Since 2.5, the component's state is _kind of_ detached from Meteor's -
which means it won't unmount when Meteor disconnects. That causes the
video-provider websocket to lose its borrowed heartbeat and leads to a
bunch of reconnectiong inconsistencies, the worst of them being a stuck,
useless signaling socket that will cause cameras not to work until a
client refresh.
- [fix(screenshare): add proper signaling heartbeat, +](https://github.com/bigbluebutton/bigbluebutton/commit/d81c1c2c48a81d38982fe26dafe987ac2f5c8b68) 
  * Same rationale as in video-provider's commit ab1807adc23fd66ba62b11ef625d8dd57328511e
- [fix(screenshare): always try to reconnect to screen as viewer](https://github.com/bigbluebutton/bigbluebutton/commit/e69a99c12e05407130c7976e8d4209b155575d5e) 
  * The reconnect routine is stopping for viewers if a broker cannot
re-connect in the first try. That is wrong: viewers should try to
reconnect as long as there's signaling data that mandates so.
- [fix(screenshare): default to not flowing is peer was lost](https://github.com/bigbluebutton/bigbluebutton/commit/677132cbae7b921f267ba08ca3cb2249c3965448) 
  * The media monitor responsible for triggering the reconnecting view in
the screen sharing component was maintaing the previous state (eg
flowing) in cases where the peer just failed before media stopped
flowing. That triggered an error in the bps calculations that caused the
previous state to be preserved - eg stuck in flowing while it should be
not_flowing.
- [fix(screenshare): better reconnection timers and UI for abrupt failures](https://github.com/bigbluebutton/bigbluebutton/commit/d3e10dc8e5bea3e8b792458e41f7a4578601f17c) 
  * Reconnection timers are far too long for abrupt failures because we
are waiting the original timeouts to elapse (30-60s) before trying it
again - even if a connection worked N-sessions back in that session's
history. The ideal thing to have is another intermediate, smaller and
fixed reconnection timer for sessions that had a working screen share
at least once.
The UI is also not being updated to the reconnecting state on negotiation
failures.
- [fix(video): signaling and reconnection edge cases](https://github.com/bigbluebutton/bigbluebutton/commit/5cb830ecf4c930f1ea94e4a662cd2aa01e8be9af) 
  * There were still a bunch of edge cases and issues with reconnection
scenarios for video:
    - Signaling socket refuses to reconnect once maxRetries expire
    - Race conditions on local stream attachment: local camera wouldn't be
    correctly rendered _if_ the attached stream existed _without_ video
    tracks yet
    - Video tracks leak on local streams when replacing them (virtual bgs)
    - Completely ignoring Meteor state when trying to reconnect cameras
    - Streams aren't proactively stopped when the signaling socket dies
    - Outbound request queues aren't isolated by stream nor are they
    flushed when a newer peer with the same ID is created
    - Server originated negotiation errors won't trigger a local peer
    cleanup - thus leaving dangling peers that take way too long to
    reconnect

### Closes Issue(s)

n/a (yet)

### Additional info

Backports to relevant versions TBD
