### PR TITLE
fix: Prevent Lines Being Drawn While Panning | Style Updates

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -59,6 +59,12 @@ const TldrawGlobalStyle = createGlobalStyle`
       display: none;
     }
   `}
+  ${({ isRTL }) => `
+    #TD-StylesMenu {
+      position: relative;
+      right: ${isRTL ? '7rem' : '-7rem'};
+    }
+  `}
   #TD-PrimaryTools-Image {
     display: none;
   }
@@ -609,6 +615,12 @@ export default function Whiteboard(props) {
         tldrawAPI?.zoomTo(zoomCamera);
       }, 50);
     }
+
+    if (zoomValue <= HUNDRED_PERCENT) {
+      setPanSelected(false);
+      setIsPanning(false);
+      tldrawAPI?.selectTool('select');
+  }
   }, [zoomValue]);
 
   // update zoom when presenter changes if the aspectRatio has changed
@@ -1044,7 +1056,7 @@ export default function Whiteboard(props) {
   const size = ((props.height < SMALL_HEIGHT) || (props.width < SMALL_WIDTH))
   ? TOOLBAR_SMALL : TOOLBAR_LARGE;
 
-  if (isPanning && tldrawAPI) {
+  if ((panSelected||isPanning) && tldrawAPI) {
     tldrawAPI.isForcePanning = isPanning;
   }
 
@@ -1065,9 +1077,10 @@ export default function Whiteboard(props) {
         whiteboardId={whiteboardId}
         isViewersCursorLocked={isViewersCursorLocked}
         isMultiUserActive={isMultiUserActive}
-        isPanning={isPanning}
+        isPanning={isPanning||panSelected}
         isMoving={isMoving}
         currentTool={currentTool}
+        disabledPan={(zoomValue <= HUNDRED_PERCENT && !fitToWidth)}
       >
         {enable && (hasWBAccess || isPresenter) ? editableWB : readOnlyWB}
         <TldrawGlobalStyle
@@ -1076,7 +1089,8 @@ export default function Whiteboard(props) {
             hasWBAccess,
             isPresenter,
             size,
-            darkTheme
+            darkTheme,
+            isRTL
           }}
         />
       </Cursors>

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -620,7 +620,7 @@ export default function Whiteboard(props) {
       setPanSelected(false);
       setIsPanning(false);
       tldrawAPI?.selectTool('select');
-  }
+    }
   }, [zoomValue]);
 
   // update zoom when presenter changes if the aspectRatio has changed
@@ -793,7 +793,21 @@ export default function Whiteboard(props) {
   };
 
   const onPatch = (e, t, reason) => {
-    if (!e?.pageState) return;
+    if (!e?.pageState || !reason) return;
+    if ((isPanning || panSelected) && reason === 'selected' || reason === 'set_hovered_id') {
+      return e.patchState(
+        {
+          document: {
+            pageStates: {
+              [e.getPage()?.id]: {
+                selectedIds: [],
+                hoveredId: null,
+              },
+            },
+          },
+        }
+      );
+    }
 
     // don't allow select others shapes for editing if don't have permission
     if (reason && reason.includes("set_editing_id")) {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
@@ -1,5 +1,4 @@
-
-import React, { useCallback, useEffect, useRef } from "react";
+import * as React from 'react';
 import { Meteor } from 'meteor/meteor';
 import { throttle } from 'lodash';
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
@@ -29,7 +29,6 @@ class PanToolInjector extends React.Component {
     ) {
       this.addPanTool();
       if (panSelected) {
-        // tldrawAPI?.selectTool('draw');
         setIsPanning(true);
         setPanSelected(true);
       } else {
@@ -51,22 +50,19 @@ class PanToolInjector extends React.Component {
       setPanSelected
     } = this.props;
 
+    if (panSelected) {
+      tldrawAPI?.selectTool('draw');
+    }
+
     const tools = document.querySelectorAll('[id*="TD-PrimaryTools-"]');
     tools.forEach(tool => {
       const classList = tool.firstElementChild.classList;
       if (panSelected) {
         classList.add('overrideSelect');
-        tldrawAPI?.selectTool('draw');
       } else {
         classList.remove('overrideSelect');
       }
     });
-
-    if (zoomValue === HUNDRED_PERCENT) {
-      setPanSelected(false);
-      setIsPanning(false);
-      tldrawAPI?.selectTool('select');
-    }
 
     const parentElement = document.getElementById('TD-PrimaryTools');
     if (!parentElement) return;
@@ -80,6 +76,11 @@ class PanToolInjector extends React.Component {
         id: 'app.whiteboard.toolbar.tools.hand',
         description: 'presentation toolbar pan label',
       });
+      const disabledLabel = formatMessage({
+        id: `app.whiteboard.toolbar.tools.disabled.pan`,
+        description: 'pan label when disabled',
+      });
+      const disabled = (zoomValue <= HUNDRED_PERCENT && !fitToWidth);
       const container = document.createElement('span');
       parentElement.appendChild(container);
       ReactDOM.render(
@@ -88,12 +89,13 @@ class PanToolInjector extends React.Component {
           role="button"
           data-test="panButton"
           data-zoom={zoomValue}
-          className={"overrideSelect"}
+          className={panSelected ? "select" : "overrideSelect"}
           color="light"
           icon="hand"
           size="md"
-          aria-label={label}
-          disabled={(zoomValue <= HUNDRED_PERCENT && !fitToWidth)}
+          label={disabled ? disabledLabel : label}
+          aria-label={disabled ? disabledLabel : label}
+          disabled={disabled}
           onClick={() => {
             setPanSelected(true);
             setIsPanning(true);
@@ -105,7 +107,6 @@ class PanToolInjector extends React.Component {
               }
             }
           }}
-          label={label}
           hideLabel
         />,
         container

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
@@ -51,7 +51,7 @@ class PanToolInjector extends React.Component {
     } = this.props;
 
     if (panSelected) {
-      tldrawAPI?.selectTool('draw');
+      tldrawAPI?.selectTool('select');
     }
 
     const tools = document.querySelectorAll('[id*="TD-PrimaryTools-"]');

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1049,6 +1049,7 @@
     "app.whiteboard.annotations.numberExceeded": "The number of annotations exceeded the limit ({0})",
     "app.whiteboard.toolbar.tools": "Tools",
     "app.whiteboard.toolbar.tools.hand": "Pan",
+    "app.whiteboard.toolbar.tools.disabled.pan": "Zoom to enable pan",
     "app.whiteboard.toolbar.tools.pencil": "Pencil",
     "app.whiteboard.toolbar.tools.rectangle": "Rectangle",
     "app.whiteboard.toolbar.tools.triangle": "Triangle",


### PR DESCRIPTION
### What does this PR do?
This PR does the following:

- Stops lines being drawn while panning. 
- Moves the styles menu closer to the whiteboard toolbar.
- Update the pan cursor and include grabbing.
- Update the pan tool label when disabled.
- Fixes a bug where the pan tool selected style would not stay applied when zooming in.

### Motivation
Zooming in was causing the pan tool to remove it's selected style
![pan-unselect-onzoom](https://user-images.githubusercontent.com/22058534/222040573-cc44422a-e9b9-4671-99d0-4e90e247b12d.gif)
Lines were being drawn while panning on occasion
![pan-with-lines](https://user-images.githubusercontent.com/22058534/222040607-f5b235e2-879c-4936-90f1-72b5e18dab59.gif)
Styles menu to far from the whiteboard toolbar
![styles-left](https://user-images.githubusercontent.com/22058534/222040623-aa5a9e84-ea02-4a22-b821-7fb235b1a5e9.gif)

The cursor icons for panning were different when using the shortcut vs toolbar to pan.

