### PR TITLE
fix: Disable the hidden help icon of tldraw

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -65,7 +65,7 @@ const TldrawGlobalStyle = createGlobalStyle`
   #slide-background-shape div {
     pointer-events: none;
   }
-  div[dir*="ltr"]:has([aria-expanded*="false"][aria-controls*="radix-"]) {
+  div[dir*="ltr"]:has(button[aria-expanded*="false"][aria-controls*="radix-"]) {
     pointer-events: none;
   }
   [aria-expanded*="false"][aria-controls*="radix-"] {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fix the problem that there is a small area that does not accept a drawing start. It turned out to be the '?' icon of tldraw. It's hidden but steals all pointer events.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #16853 


### Motivation

We want to draw shapes anywhere on the whiteboard.
