### PR TITLE
fix(breakout rooms): video and audio modal appearing for all mods when rejoining

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -5,8 +5,10 @@ import { Session } from 'meteor/session';
 import { withModalMounter } from '/imports/ui/components/common/modal/service';
 import { injectIntl, defineMessages } from 'react-intl';
 import _ from 'lodash';
+import Auth from '/imports/ui/services/auth';
 import Breakouts from '/imports/api/breakouts';
 import AppService from '/imports/ui/components/app/service';
+import BreakoutsService from '/imports/ui/components/breakout-room/service';
 import { notify } from '/imports/ui/services/notification';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import VideoPreviewContainer from '/imports/ui/components/video-preview/container';
@@ -189,28 +191,31 @@ export default lockContextContainer(withModalMounter(injectIntl(withTracker(({ m
       notify(intl.formatMessage(intlMessages.reconectingAsListener), 'info', 'volume_level_2');
     }
   }
-
-  Breakouts.find().observeChanges({
-    removed() {
-      // if the user joined a breakout room, the main room's audio was
-      // programmatically dropped to avoid interference. On breakout end,
-      // offer to rejoin main room audio only if the user is not in audio already
-      if (Service.isUsingAudio()
-        || userSelectedMicrophone
-        || userSelectedListenOnly) {
-        if (enableVideo && autoShareWebcam) {
-          openVideoPreviewModal();
-        }
-
-        return;
-      }
-      setTimeout(() => openAudioModal().then(() => {
-         if (enableVideo && autoShareWebcam) {
-           openVideoPreviewModal();
+  const breakoutUserIsIn = BreakoutsService.getBreakoutUserIsIn(Auth.userID);
+  if(!!breakoutUserIsIn && !meetingIsBreakout) {
+    const userBreakout = Breakouts.find({id: breakoutUserIsIn.id})
+    userBreakout.observeChanges({
+      removed() {
+        // if the user joined a breakout room, the main room's audio was
+        // programmatically dropped to avoid interference. On breakout end,
+        // offer to rejoin main room audio only if the user is not in audio already
+        if (Service.isUsingAudio()
+          || userSelectedMicrophone
+          || userSelectedListenOnly) {
+          if (enableVideo && autoShareWebcam) {
+            openVideoPreviewModal();
           }
-        }), 0);
-    },
-  });
+
+          return; 
+        }
+        setTimeout(() => openAudioModal().then(() => {
+          if (enableVideo && autoShareWebcam) {
+            openVideoPreviewModal();
+            }
+          }), 0);
+      },
+    });
+  }
 
   return {
     hasBreakoutRooms,


### PR DESCRIPTION
### What does this PR do?
There was an observer being linked to all breakout rooms that the user has access to. This logic works for attendees, but not for moderators. Moderators have access to the list of all breakout rooms, so they were set with an observer to breakout rooms that they didn't participate, which caused the audio and video modals to appear everytime the breakout rooms were closed.
So, this commit:
- hangs an breakout rooms' observer only on those mods that have joined any breakout room. This way, mods that didn't participate in any breakout room won't be disturbed by the audio and video modal.
- adds an extra check to ensure that the observer will only be run in non-breakout meetings.

### Closes Issue(s)
Closes #15716
