### PR TITLE
fix: Switching from breakout room to parent meeting no longer keeps the webcam activated.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/webcam/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/container.jsx
@@ -4,7 +4,6 @@ import { withModalMounter } from '/imports/ui/components/common/modal/service';
 import { withTracker } from 'meteor/react-meteor-data';
 import MediaService from '/imports/ui/components/media/service';
 import Auth from '/imports/ui/services/auth';
-import breakoutService from '/imports/ui/components/breakout-room/service';
 import VideoService from '/imports/ui/components/video-provider/service';
 import { UsersContext } from '../components-data/users-context/context';
 import {
@@ -56,17 +55,12 @@ const WebcamContainer = ({
     : null;
 };
 
-let userWasInBreakout = false;
-
 export default withModalMounter(withTracker((props) => {
   const { current_presentation: hasPresentation } = MediaService.getPresentationInfo();
   const data = {
     audioModalIsOpen: Session.get('audioModalIsOpen'),
     isMeteorConnected: Meteor.status().connected,
   };
-
-  const userIsInBreakout = breakoutService.getBreakoutUserIsIn(Auth.userID);
-  let deviceIds = Session.get('deviceIds');
 
   const { streams: usersVideo } = VideoService.getVideoStreams();
   data.usersVideo = usersVideo;

--- a/bigbluebutton-html5/imports/ui/components/webcam/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/container.jsx
@@ -68,28 +68,6 @@ export default withModalMounter(withTracker((props) => {
   const userIsInBreakout = breakoutService.getBreakoutUserIsIn(Auth.userID);
   let deviceIds = Session.get('deviceIds');
 
-  if (!userIsInBreakout && userWasInBreakout && deviceIds && deviceIds !== '') {
-    /* used when re-sharing cameras after leaving a breakout room.
-    it is needed in cases where the user has more than one active camera
-    so we only share the second camera after the first
-    has finished loading (can't share more than one at the same time) */
-    const canConnect = Session.get('canConnect');
-
-    deviceIds = deviceIds.split(',');
-
-    if (canConnect) {
-      const deviceId = deviceIds.shift();
-
-      Session.set('canConnect', false);
-      Session.set('WebcamDeviceId', deviceId);
-      Session.set('deviceIds', deviceIds.join(','));
-
-      VideoService.joinVideo(deviceId);
-    }
-  } else {
-    userWasInBreakout = userIsInBreakout;
-  }
-
   const { streams: usersVideo } = VideoService.getVideoStreams();
   data.usersVideo = usersVideo;
   data.swapLayout = !hasPresentation || props.isLayoutSwapped;


### PR DESCRIPTION
### What does this PR do?

This PR erases the part of the code that keeps webcam activated when returning from breakout rooms.

### Closes Issue(s)
#16437 