### PR TITLE
fix: Notifications on export presentation with annotations

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/service.js
@@ -378,7 +378,7 @@ const exportPresentationToChat = (presentationId, observer) => {
     const cursor = Presentations.find({ id: presentationId });
 
     const checkStatus = (exportation) => {
-      const shouldStop = lastStatus.status === 'PROCESSING' && exportation.status === 'EXPORTED';
+      const shouldStop = lastStatus.status === 'RUNNING' && exportation.status === 'EXPORTED';
 
       if (shouldStop) {
         observer(exportation, true);


### PR DESCRIPTION
### What does this PR do?
this PR fixes the sent to chat success notification not being displayed.

Before:
![sendToChat-noNotify](https://user-images.githubusercontent.com/22058534/222478819-894f9bc3-09d0-4fab-a0a1-c6034bbdf798.gif)

After:
![sendToChat-withNotify](https://user-images.githubusercontent.com/22058534/222478844-f887e754-d195-4b19-a96a-b3586d6a8d10.gif)

### Motivation
When sharing a presentation to the chat for users to download, no indication is provided to the user that the presentation was shared in the chat.
