### PR TITLE
fix(sec): Removed glassfish el dependency

### DIFF
--- a/bbb-common-web/build.sbt
+++ b/bbb-common-web/build.sbt
@@ -105,7 +105,6 @@ libraryDependencies ++= Seq(
   "javax.validation" % "validation-api" % "2.0.1.Final",
   "org.springframework.boot" % "spring-boot-starter-validation" % "2.7.1",
   "org.springframework.data" % "spring-data-commons" % "2.7.6",
-  "org.glassfish" % "javax.el" % "3.0.1-b12",
   "org.apache.httpcomponents" % "httpclient" % "4.5.13",
   "org.postgresql" % "postgresql" % "42.4.3",
   "org.hibernate" % "hibernate-core" % "5.6.1.Final",


### PR DESCRIPTION
### What does this PR do?

Removes the Glassfish expression language dependency from bbb-common-web.


### Motivation

Dependency has an unpatched security vulnerability [CVE-2021-28170](https://www.cve.org/CVERecord?id=CVE-2021-28170).