### PR TITLE
fix(sec): Upgrade file upload dependency

### DIFF
--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -97,7 +97,7 @@ dependencies {
   implementation "net.java.dev.jna:jna:5.10.0"
   implementation "org.springframework.data:spring-data-commons:2.7.6"
   // https://mvnrepository.com/artifact/commons-fileupload/commons-fileupload
-  implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.4'
+  implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
 
   implementation 'javax.validation:validation-api:2.0.1.Final'
   implementation "org.springframework.boot:spring-boot-starter-validation:${springVersion}"


### PR DESCRIPTION
### What does this PR do?

Upgrades the commons fileupload dependency from version 1.4 to 1.5.

### Motivation

Version 1.4 of the dependency was vulnerable to [CVE-2023-24998](https://www.cve.org/CVERecord?id=CVE-2023-24998).