### PR TITLE
fix(sec): Upgrade embedded Tomcat version

### DIFF
--- a/bigbluebutton-web/gradle.properties
+++ b/bigbluebutton-web/gradle.properties
@@ -3,5 +3,5 @@ gormVersion=7.1.0
 gradleWrapperVersion=7.3.1
 grailsGradlePluginVersion=5.0.0
 groovyVersion=3.0.9
-tomcatEmbedVersion=9.0.70
+tomcatEmbedVersion=9.0.71
 springVersion=2.7.1


### PR DESCRIPTION
### What does this PR do?

Upgrades the embedded Tomcat server version from 9.0.70 to 9.0.71.


### Motivation

Version 9.0.70 is vulnerable to [CVE-2023-24998](https://www.cve.org/CVERecord?id=CVE-2023-24998).