### PR TITLE
fix(export-annotations): change slide scaling calculation

### DIFF
--- a/bbb-export-annotations/config/settings.json
+++ b/bbb-export-annotations/config/settings.json
@@ -16,6 +16,8 @@
     },
     "process": {
       "whiteboardTextEncoding": "utf-8",
+      "maxImageWidth": 2048,
+      "maxImageHeight": 1536,
       "textScaleFactor": 4,
       "pointsPerInch": 72,
       "pixelsPerInch": 96

--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -123,7 +123,6 @@ function to_px(pt) {
 function escapeText(string) {
   return string
       .replace(/[~`!.*+?%^${}()|[\]\\/]/g, '\\$&')
-      .replace(/-/g, '\\&#x2D;')
       .replace(/&/g, '\\&amp;')
       .replace(/'/g, '\\&#39;')
       .replace(/"/g, '\\&quot;')


### PR DESCRIPTION
### What does this PR do?
Implements the new slide scaling logic implemented in #16721.

### Closes Issue(s)
Closes #16827

### Motivation
Annotation positioning was incorrect in the exported slides.

### More
Stops hyphens from being escaped with a `/` in the generated PDF.