### PR TITLE
Fix: restoreOnUpdate feature does not work when switching presentation

### DIFF
--- a/bigbluebutton-html5/imports/api/presentations/server/modifiers/setCurrentPresentation.js
+++ b/bigbluebutton-html5/imports/api/presentations/server/modifiers/setCurrentPresentation.js
@@ -50,6 +50,14 @@ export default function setCurrentPresentation(meetingId, podId, presentationId)
 
   const oldPresentation = Presentations.findOne(oldCurrent.selector);
   const newPresentation = Presentations.findOne(newCurrent.selector);
+// We update it before unset current to avoid the case where theres no current presentation.
+  if (newPresentation) {
+    try{
+      Presentations.update(newPresentation._id, newCurrent.modifier);
+    } catch(e){
+      newCurrent.callback(e);
+    }
+  }
 
   if (oldPresentation) {
     try{
@@ -59,12 +67,5 @@ export default function setCurrentPresentation(meetingId, podId, presentationId)
     }
   }
 
-  if (newPresentation) {
-    try{
-      Presentations.update(newPresentation._id, newCurrent.modifier);
-    } catch(e){
-      newCurrent.callback(e);
-    }
-  }
 }
  

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -265,7 +265,7 @@ class Presentation extends PureComponent {
         });
       }
 
-      if (!presentationIsOpen && restoreOnUpdate && !userIsPresenter && currentSlide) {
+      if (!presentationIsOpen && restoreOnUpdate && currentSlide) {
         const slideChanged = currentSlide.id !== prevProps.currentSlide.id;
         const positionChanged = slidePosition
           .viewBoxHeight !== prevProps.slidePosition.viewBoxHeight


### PR DESCRIPTION
### What does this PR do?

This PR fixes the restoreOnUpdate feature, The bug was caused because the meeting was without a current presentation for some time, this generated some inconsistencies when deciding whether to update the layout or not.

### Closes Issue(s)
Closes #16824
