### PR TITLE
fix: Inability to Move a Group of Objects | Add Select Cursor

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -824,7 +824,7 @@ export default function Whiteboard(props) {
 
   const onPatch = (e, t, reason) => {
     if (!e?.pageState || !reason) return;
-    if ((isPanning || panSelected) && reason === 'selected' || reason === 'set_hovered_id') {
+    if (((isPanning || panSelected) && (reason === 'selected' || reason === 'set_hovered_id'))) {
       return e.patchState(
         {
           document: {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
@@ -13,7 +13,7 @@ const baseName = Meteor.settings.public.app.cdn + Meteor.settings.public.app.bas
 const makeCursorUrl = (filename) => `${baseName}/resources/images/whiteboard-cursor/${filename}`;
 
 const TOOL_CURSORS = {
-  select: 'none',
+  select: 'default',
   erase: 'none',
   arrow: 'none',
   draw: `url('${makeCursorUrl('pencil.png')}') 2 22, default`,


### PR DESCRIPTION
### What does this PR do?
This PR contains a fix for not being unable to move a group of objects, along with the addition of the select cursor.

### Closes Issue(s)
Closes: #16910 , #16892

