### PR TITLE
fix: encode user-name before sending it as header to checkAuthorization users

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
@@ -22,6 +22,7 @@ import org.bigbluebutton.api.MeetingService
 import org.bigbluebutton.api.domain.UserSession
 import org.bigbluebutton.api.util.ParamsUtil
 import org.bigbluebutton.api.ParamsProcessorUtil
+import java.nio.charset.StandardCharsets
 
 class ConnectionController {
   MeetingService meetingService
@@ -42,7 +43,7 @@ class ConnectionController {
         response.addHeader("User-Id", userSession.internalUserId)
         response.addHeader("Meeting-Id", userSession.meetingID)
         response.addHeader("Voice-Bridge", userSession.voicebridge )
-        response.addHeader("User-Name", userSession.fullname)
+        response.addHeader("User-Name", URLEncoder.encode(userSession.fullname, StandardCharsets.UTF_8.name()))
         response.setStatus(200)
         response.outputStream << 'authorized'
       } else {


### PR DESCRIPTION
### What does this PR do?

* [fix: encode user-name before sending it as header to checkAuthorization users](https://github.com/bigbluebutton/bigbluebutton/commit/58f7fa3df6001b4eb4fc4f25facd99f3296cf30b) 
  - Lack of encoding is causing some specific languages to have the user-name header stripped out from the HTTP Upgrade requests used by the checkAuthorization users (bbb-webrtc-sfu). That translates to webcam/screenshare/listen only failing due to an incomplete header set.

### Closes Issue(s)

Closes #16909 

### Motivation

https://github.com/bigbluebutton/bigbluebutton/issues/16909#issuecomment-1455881716

### More

This regression was introduced in 2.6-alpha.2 via https://github.com/bigbluebutton/bigbluebutton/pull/15281. Seems to have surfaced on RC.6 due to bbb-web dependency upgrades - it was dormant from alpha.2 through RC.5.
