### PR TITLE
fix(sec): Exclude GraalVM and H2 Dependencies

### DIFF
--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -122,6 +122,7 @@ tasks.named('bootWarMainClassName') {
 
 configurations.implementation {
     exclude group: 'io.micronaut', module: 'micronaut-aop'
+    exclude group: 'org.graalvm.sdk', module: 'graal-sdk'
 }
 
 configurations {

--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -122,6 +122,7 @@ tasks.named('bootWarMainClassName') {
 
 configurations.implementation {
     exclude group: 'io.micronaut', module: 'micronaut-aop'
+    exclude group: 'com.h2database', module: 'h2'
     exclude group: 'org.graalvm.sdk', module: 'graal-sdk'
 }
 


### PR DESCRIPTION
### What does this PR do?

Excludes the H2 database and GraalVM SDK dependencies brought in by asset-pipeline-grails. After these changes running the `deplpy_to_usr_share.sh` should remove the `h2.jar` and `graal-sdk-22.0.0.2.jar` from `/usr/share/bbb-web/WEB-INF/lib/'.


### Motivation

There is no H2 database being used by bbb-web so there is no need to include the transitive dependency for it.
The version of GraalVM SDK that is brought in to bbb-web by asset-pipeline-grails has many vulnerabilities
- [CVE-2022-21443](https://www.cve.org/CVERecord?id=CVE-2022-21443)
- [CVE-2022-21434](https://www.cve.org/CVERecord?id=CVE-2022-21434)
- [CVE-2022-21426](https://www.cve.org/CVERecord?id=CVE-2022-21426)
- [CVE-2022-21496](https://www.cve.org/CVERecord?id=CVE-2022-21496)
- [CVE-2022-21449](https://www.cve.org/CVERecord?id=CVE-2022-21449)
- [CVE-2022-21476](https://www.cve.org/CVERecord?id=CVE-2022-21476)