### PR TITLE
feature(layout): Moderators can now setPushLayout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -488,6 +488,7 @@ class App extends Component {
       pushLayoutMeeting,
       selectedLayout,
       setMeetingLayout,
+      setPushLayout,
       shouldShowScreenshare,
       shouldShowExternalVideo,
     } = this.props;
@@ -517,6 +518,7 @@ class App extends Component {
           pushLayoutMeeting,
           selectedLayout,
           setMeetingLayout,
+          setPushLayout,
           shouldShowScreenshare,
           shouldShowExternalVideo,
         }}

--- a/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
@@ -14,6 +14,7 @@ const LayoutModalComponent = (props) => {
   const {
     intl,
     closeModal,
+    isModerator,
     isPresenter,
     showToggleLabel,
     application,
@@ -101,7 +102,7 @@ const LayoutModalComponent = (props) => {
   };
 
   const renderPushLayoutsOptions = () => {
-    if (!isPresenter) {
+    if (!isModerator && !isPresenter) {
       return null;
     }
 
@@ -187,6 +188,7 @@ const propTypes = {
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
   closeModal: PropTypes.func.isRequired,
+  isModerator: PropTypes.bool.isRequired,
   isPresenter: PropTypes.bool.isRequired,
   showToggleLabel: PropTypes.bool.isRequired,
   application: PropTypes.shape({

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -39,6 +39,7 @@ const propTypes = {
   pushLayoutMeeting: PropTypes.bool,
   selectedLayout: PropTypes.string,
   setMeetingLayout: PropTypes.func,
+  setPushLayout: PropTypes.func,
   shouldShowScreenshare: PropTypes.bool,
   shouldShowExternalVideo: PropTypes.bool,
 };
@@ -136,6 +137,7 @@ class PushLayoutEngine extends React.Component {
       pushLayoutMeeting,
       selectedLayout,
       setMeetingLayout,
+      setPushLayout,
     } = this.props;
 
     const meetingLayoutDidChange = meetingLayout !== prevProps.meetingLayout;
@@ -240,9 +242,13 @@ class PushLayoutEngine extends React.Component {
       || focusedCamera !== prevProps.focusedCamera
       || !equalDouble(presentationVideoRate, prevProps.presentationVideoRate);
 
-    if ((pushLayout && layoutChanged) // change layout sizes / states
-      || (pushLayout !== prevProps.pushLayout) // push layout once after presenter toggles / special case where we set pushLayout to false in all viewers
-    ) {
+    if (pushLayout !== prevProps.pushLayout) { // push layout once after presenter toggles / special case where we set pushLayout to false in all viewers
+      if (isPresenter || isModerator) {
+        setPushLayout(pushLayout);
+      }
+    }
+
+    if (pushLayout && layoutChanged) { // change layout sizes / states
       if (isPresenter) {
         setMeetingLayout();
       }

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -243,12 +243,12 @@ class PushLayoutEngine extends React.Component {
       || !equalDouble(presentationVideoRate, prevProps.presentationVideoRate);
 
     if (pushLayout !== prevProps.pushLayout) { // push layout once after presenter toggles / special case where we set pushLayout to false in all viewers
-      if (isPresenter || isModerator) {
+      if (isModerator) {
         setPushLayout(pushLayout);
       }
     }
 
-    if (pushLayout && layoutChanged) { // change layout sizes / states
+    if (pushLayout && layoutChanged || pushLayout !== prevProps.pushLayout) { // change layout sizes / states
       if (isPresenter) {
         setMeetingLayout();
       }


### PR DESCRIPTION
Now moderators with see the 'Push layout' toggle in the layout modal. This will set layout synchronization on/off, but everyone will still follow the presenters layout.