### PR TITLE
test: Disable three tests that are failing in CI: shared notes + upload presentation

### DIFF
--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.js
@@ -48,7 +48,7 @@ test.describe.parallel('Presentation', () => {
 
   test.describe.parallel('Manage', () => {
     // https://docs.bigbluebutton.org/2.6/release-tests.html#uploading-a-presentation-automated
-    test('Upload single presentation @ci', async ({ browser, context, page }) => {
+    test.fixme('Upload single presentation @ci', async ({ browser, context, page }) => {
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page, true);
       await presentation.uploadSinglePresentationTest();

--- a/bigbluebutton-tests/playwright/sharednotes/sharednotes.spec.js
+++ b/bigbluebutton-tests/playwright/sharednotes/sharednotes.spec.js
@@ -2,7 +2,7 @@ const { test } = require('@playwright/test');
 const { SharedNotes } = require('./sharednotes');
 
 test.describe.parallel('Shared Notes', () => {
-  test('Open Shared notes @ci', async ({ browser, page, context }) => {
+  test.fixme('Open Shared notes @ci', async ({ browser, page, context }) => {
     const sharedNotes = new SharedNotes(browser, context);
     await sharedNotes.initModPage(page);
     await sharedNotes.openSharedNotes();

--- a/bigbluebutton-tests/playwright/user/user.spec.js
+++ b/bigbluebutton-tests/playwright/user/user.spec.js
@@ -195,7 +195,7 @@ test.describe.parallel('User', () => {
       });
 
       // https://docs.bigbluebutton.org/2.6/release-tests.html#shared-notes-1
-      test('Lock Edit Shared Notes', async ({ browser, context, page }) => {
+      test.fixme('Lock Edit Shared Notes', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initPages(page);
         await lockViewers.lockEditSharedNotes();


### PR DESCRIPTION
### What does this PR do?

This PR disables three tests that are failing in CI. They require further investigations/fixes.

Two shared notes tests required further investigation. Manual testing doesn't show any issues. Looks like a CI-specific issue.
Issue: https://github.com/bigbluebutton/bigbluebutton/issues/16928.

Presentation upload test failure is caused by the different order of attributes within the HTML of moderator and viewer presentations. It is a good idea to start using visual regression for this test, it looks like an easy fix that way.
Issue: https://github.com/bigbluebutton/bigbluebutton/issues/16927.