### PR TITLE
fix: return logoutUrl on logout even if the user is not logged in

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/auth/index.js
+++ b/bigbluebutton-html5/imports/ui/services/auth/index.js
@@ -184,9 +184,11 @@ class Auth {
 
   logout() {
     if (!this.loggedIn) {
+      if (allowRedirectToLogoutURL()) {
+        return Promise.resolve(this._logoutURL);
+      }
       return Promise.resolve();
     }
-
 
     return new Promise((resolve) => {
       if (allowRedirectToLogoutURL()) {


### PR DESCRIPTION
### What does this PR do?

Fix "OK" button not working for removed user after refresh (related to #16754, the button was not appearing before these changes).