### PR TITLE
docs: Fix the version build script

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -8,8 +8,11 @@ current_branch=$(git rev-parse --abbrev-ref HEAD)
 git branch --remotes | grep '/v' | while read -r version; do
   branch=${version##*/}
   remote=${version%/*}
-  git fetch "$remote" "$branch":"$branch"
+  if [ "$branch" != "$current_branch" ]; then
+    git fetch "$remote" "$branch":"$branch"
+  fi
 done
+
 
 git branch | sed --quiet 's/^.*v\(.*\).x-release/\1/p' \
   | while read -r version; do


### PR DESCRIPTION
The script that adds the different versions to docusaurus was broken when not running it from the develop branch. This commit should fix that.
