### PR TITLE
Add List and List Item Roles to Chat Elements

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
@@ -158,6 +158,16 @@ class TimeWindowList extends PureComponent {
     ) {
       this.listRef.forceUpdateGrid();
     }
+
+    const msgListItem = document.querySelector('span[data-test="msgListItem"]');
+    if (msgListItem) {
+      const virtualizedGridInnerScrollContainer = msgListItem.parentElement;
+      const virtualizedGrid = virtualizedGridInnerScrollContainer.parentElement;
+      virtualizedGridInnerScrollContainer.setAttribute('role', 'list');
+      virtualizedGridInnerScrollContainer.setAttribute('tabIndex', '0');
+      virtualizedGrid.removeAttribute('tabIndex');
+      virtualizedGrid.removeAttribute('aria-label');
+    }
   }
 
   handleScrollUpdate(position, target) {
@@ -219,6 +229,8 @@ class TimeWindowList extends PureComponent {
         <span
           style={style}
           key={`span-${key}-${index}`}
+          role="listitem"
+          data-test="msgListItem"
         >
           <TimeWindowChatItem
             key={key}


### PR DESCRIPTION
### What does this PR do?

This PR uses the ARIA `role=list` and `role=listitem`  to create the correct semantic structure in the chat while working within the constraints of the `List` element provided by `react-virtualized`. 

![image](https://user-images.githubusercontent.com/22058534/223525242-669743bb-04e2-4596-8e6e-65439fb7ca4d.png)


### Motivation

The chat incorrectly uses a `<span>` element as the parent element for each message (thus no semantic relationship is created between the message components). Ideally the structure of the chat should be a `<ul>` with `<li>`'s  in order to allow for assistive technologies to navigate each message more easily when reading back the chat log.