### PR TITLE
fix: avoid wb crash when switching presentation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1023,7 +1023,9 @@ export default function Whiteboard(props) {
     const changedShapes = command.after?.document?.pages[app.currentPageId]?.shapes;
     if (!isMounting && app.currentPageId !== curPageId) {
       // can happen then the "move to page action" is called, or using undo after changing a page
-      const newWhiteboardId = curPres.pages.find(page => page.num === Number.parseInt(app.currentPageId)).id;
+      const currentPage = curPres.pages.find(page => page.num === Number.parseInt(app.currentPageId));
+      if (!currentPage) return;
+      const newWhiteboardId = currentPage.id;
       //remove from previous page and persist on new
       changedShapes && removeShapes(Object.keys(changedShapes), whiteboardId);
       changedShapes && Object.entries(changedShapes)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Performs an extra check to ensure that we have a page before checking its id (to use it as a new whiteboard Id)
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
This issue was spotted during the community call on Monday March 6.
It can be reproduced if you switch back and forth between uploaded presentations quickly.

<!-- What inspired you to submit this pull request? -->

### More
![Screenshot from 2023-03-07 16-10-11](https://user-images.githubusercontent.com/6312397/223554398-8d5a2f52-604c-4293-8a68-0bd0394c2314.png)


