### PR TITLE
fix: whiteboard crash with new presentation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -460,6 +460,15 @@ export default function Whiteboard(props) {
   const doc = React.useMemo(() => {
     const currentDoc = rDocument.current;
 
+    // update document if the number of pages has changed
+    if (currentDoc.id !== whiteboardId && currentDoc?.pages.length !== curPres?.pages.length) {
+      const { pages, pageStates } = initDefaultPages(curPres?.pages.length || 1);
+
+      currentDoc.id = whiteboardId;
+      currentDoc.pages = pages;
+      currentDoc.pageStates = pageStates;
+    }
+
     let next = { ...currentDoc };
 
     let changed = false;


### PR DESCRIPTION
### What does this PR do?

Updates tldraw document when a new presentation is added in order to avoid a crash that happens when a page is not available.

### Closes Issue(s)


### Motivation

This issue was spotted during the community call on Monday March 6.
It can be reproduced if you upload a new presentation with more pages than the default one and switch to a page that does not exist in default presentation.

### More
![Screenshot from 2023-03-08 10-06-00](https://user-images.githubusercontent.com/3728706/223720743-cdf4375d-8e80-4623-81db-e0b5a6bb63b9.png)
