### PR TITLE
Allow non-guests to bypass always deny guest policy

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -518,11 +518,11 @@ public class Meeting {
 		}
 	}
 
-	public String calcGuestStatus(String role, Boolean guest, Boolean authned) {
+	public String calcGuestStatus(String role, Boolean guest, Boolean authned, Boolean guestParamProvided) {
 		if (!authenticatedGuest) return getUnauthenticatedGuestStatus(guest);
 
 		// Allow moderators all the time.
-		if (ROLE_MODERATOR.equals(role)) {
+		if (ROLE_MODERATOR.equals(role) || (guestParamProvided && !guest)) {
 			return GuestPolicy.ALLOW;
 		}
 

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -207,19 +207,21 @@ class ApiController {
 
     HashMap<String, String> roles = new HashMap<String, String>();
 
-    roles.put("moderator", ROLE_MODERATOR);
-    roles.put("viewer", ROLE_ATTENDEE);
+    roles.put("moderator", ROLE_MODERATOR)
+    roles.put("viewer", ROLE_ATTENDEE)
 
     if(!(validationResponse == null)) {
       invalid(validationResponse.getKey(), validationResponse.getValue(), REDIRECT_RESPONSE)
       return
     }
 
-    Boolean authenticated = false;
+    Boolean authenticated = false
 
-    Boolean guest = false;
+    Boolean guest = false
+    Boolean guestParamProvided = false
     if (!StringUtils.isEmpty(params.guest)) {
       guest = Boolean.parseBoolean(params.guest)
+      guestParamProvided = true;
     } else {
       // guest param has not been passed. Make user as
       // authenticated by default. (ralam july 3, 2018)
@@ -338,7 +340,7 @@ class ApiController {
     if (userCustomData.size() > 0)
       meetingService.addUserCustomData(meeting.getInternalId(), externUserID, userCustomData);
 
-    String guestStatusVal = meeting.calcGuestStatus(role, guest, authenticated)
+    String guestStatusVal = meeting.calcGuestStatus(role, guest, authenticated, guestParamProvided)
 
     UserSession us = new UserSession();
     us.authToken = authToken;


### PR DESCRIPTION
### What does this PR do?

Modifies how guest status is calculated to allow non-guests to bypass the always deny guest policy if a `guest` parameter is provided in the join request. If no guest parameter is provided then both guests and non-guests will still be denied access to the meeting.

### Closes Issue(s)
Closes #16839