### PR TITLE
fix: Stop Tool Lock Being Reset on Updates

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -200,7 +200,7 @@ export default function Whiteboard(props) {
   const [isPanning, setIsPanning] = React.useState(shortcutPanning);
   const [panSelected, setPanSelected] = React.useState(isPanning);
   const isMountedRef = React.useRef(true);
-  const [isToolLocked, setIsToolLocked] = React.useState(tldrawAPI?.appState.tool);
+  const [isToolLocked, setIsToolLocked] = React.useState(tldrawAPI?.appState?.isToolLocked);
 
   React.useEffect(() => {
     return () => {


### PR DESCRIPTION
### What does this PR do?
This PR ensures that the tool remains locked after drawing shapes when it is activated.
![tool-lock](https://user-images.githubusercontent.com/22058534/223846758-3be22a51-ed7d-49b7-ab96-e4b988562729.gif)


### Closes Issue(s)

Closes #16959 