### PR TITLE
fix: Display error message when guest is denied access to a meeting

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiErrors.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiErrors.java
@@ -72,6 +72,10 @@ public class ApiErrors {
 		errors.add(new String[] {"maxParticipantsReached", "The number of participants allowed for this meeting has been reached."});
 	}
 
+	public void guestDeniedAccess() {
+		errors.add(new String[] {"guestDeniedAccess", "You have been denied access to this meeting based on the meeting's guest policy"});
+	}
+
 	public void addError(String[] error) {
 		errors.add(error);
 	}

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -455,9 +455,8 @@ class ApiController {
       msgKey = "guestWait"
       msgValue = "Guest waiting for approval to join meeting."
     } else if (guestStatusVal.equals(GuestPolicy.DENY)) {
-      destUrl = meeting.getLogoutUrl()
-      msgKey = "guestDeny"
-      msgValue = "Guest denied to join meeting."
+      invalid("guestDeniedAccess", "You have been denied access to this meeting based on the meeting's guest policy", REDIRECT_RESPONSE)
+      return
     }
 
     Map<String, Object> logData = new HashMap<String, Object>();


### PR DESCRIPTION
### What does this PR do?

Displays an error message to a user when they are denied access to a meeting to explain why they cannot join.

### Closes Issue(s)
Closes #12335