### PR TITLE
fix: Allow for existing dir 'exploded' in bbb-web deploy_to_usr_share.sh

### DIFF
--- a/bigbluebutton-web/deploy_to_usr_share.sh
+++ b/bigbluebutton-web/deploy_to_usr_share.sh
@@ -4,7 +4,7 @@ sudo service bbb-web stop
 ./build.sh
 
 grails assemble
-mkdir exploded && cd exploded
+mkdir -p exploded && cd exploded
 jar -xvf ../build/libs/bigbluebutton-0.10.0.war
 
 if [ ! -d /usr/share/bbb-web-old ] ; then


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Adjusts the deployment script of bbb-web to not interrupt if dir `exploded` is present
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
deployment was consistently interrupted for me while testing https://github.com/bigbluebutton/bigbluebutton/pull/16919
<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->
