### PR TITLE
fix(access): Presentation Interference With Keyboard Access in Breakout Management

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -9,7 +9,7 @@ import Modal from '/imports/ui/components/common/modal/fullscreen/component';
 import { withModalMounter } from '/imports/ui/components/common/modal/service';
 import SortList from './sort-user-list/component';
 import Styled from './styles';
-import Icon from '/imports/ui/components/common/icon/component.jsx';
+import Icon from '/imports/ui/components/common/icon/component';
 import { isImportSharedNotesFromBreakoutRoomsEnabled, isImportPresentationWithAnnotationsFromBreakoutRoomsEnabled } from '/imports/ui/services/features';
 import { addNewAlert } from '/imports/ui/components/screenreader-alert/service';
 import PresentationUploaderService from '/imports/ui/components/presentation/presentation-uploader/service';
@@ -195,6 +195,13 @@ const propTypes = {
   isBreakoutRecordable: PropTypes.bool,
 };
 
+const setPresentationVisibility = (state) => {
+  const presentationInnerWrapper = document.getElementById('presentationInnerWrapper');
+  if (presentationInnerWrapper) {
+    presentationInnerWrapper.style.display = state;
+  }
+}
+
 class BreakoutRoom extends PureComponent {
   constructor(props) {
     super(props);
@@ -263,6 +270,7 @@ class BreakoutRoom extends PureComponent {
       allowUserChooseRoomByDefault, captureSharedNotesByDefault,
       captureWhiteboardByDefault,
     } = this.props;
+    setPresentationVisibility('none');
     this.setRoomUsers();
     if (isUpdate) {
       const usersToMerge = []
@@ -403,7 +411,7 @@ class BreakoutRoom extends PureComponent {
 
   handleDismiss() {
     const { mountModal } = this.props;
-
+    setPresentationVisibility('block');
     return new Promise((resolve) => {
       mountModal(null);
 
@@ -414,6 +422,7 @@ class BreakoutRoom extends PureComponent {
   }
 
   onCreateBreakouts() {
+    setPresentationVisibility('block');
     const {
       createBreakoutRoom,
     } = this.props;
@@ -505,6 +514,7 @@ class BreakoutRoom extends PureComponent {
   }
 
   onUpdateBreakouts() {
+    setPresentationVisibility('block');
     const { users } = this.state;
     const leastOneUserIsValid = users.some((user) => user.from !== user.room);
 

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.js
@@ -241,6 +241,11 @@ const RoomUserItem = styled.p`
     font-size: ${fontSizeSmaller};
   }
 
+  &:focus {
+    background-color: ${colorPrimary};
+    color: ${colorWhite};
+  }
+
   ${({ selected }) => selected && `
     background-color: ${colorPrimary};
     color: ${colorWhite};

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -713,6 +713,7 @@ class Presentation extends PureComponent {
                   textAlign: 'center',
                   display: !presentationIsOpen ? 'none' : 'block',
                 }}
+                id={"presentationInnerWrapper"}
               >
                 <Styled.VisuallyHidden id="currentSlideText">{slideContent}</Styled.VisuallyHidden>
                 {!tldrawIsMounting && currentSlide && this.renderPresentationMenu()}


### PR DESCRIPTION
### What does this PR do?
This PR restores the keyboard access to breakout management by preventing the presentation moving focus outside the modal.

before:
![br-manage-keyboard-no-access](https://user-images.githubusercontent.com/22058534/224412355-e0897ebe-eb58-4191-9f16-a9a0718f1778.gif)

after:
![br-manage-keyboard-access](https://user-images.githubusercontent.com/22058534/224412379-fb4dfc35-9174-43a3-b626-38f18d77901e.gif)

### Motivation
A11y issue where keyboard controls didn't allow for assigning users to breakout rooms.