### PR TITLE
Remove Disabled Functionality From Pan Tool

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -410,12 +410,6 @@ export default function Whiteboard(props) {
         tldrawAPI?.zoomTo(zoomCamera);
       }, 50);
     }
-
-    if (zoomValue <= HUNDRED_PERCENT) {
-      setPanSelected(false);
-      setIsPanning(false);
-      tldrawAPI?.selectTool('select');
-    }
   }, [zoomValue]);
 
   // update zoom when presenter changes if the aspectRatio has changed
@@ -937,7 +931,6 @@ export default function Whiteboard(props) {
         isPanning={isPanning || panSelected}
         isMoving={isMoving}
         currentTool={currentTool}
-        disabledPan={(zoomValue <= HUNDRED_PERCENT && !fitToWidth)}
       >
         {enable && (hasWBAccess || isPresenter) ? editableWB : readOnlyWB}
         <Styled.TldrawGlobalStyle

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
@@ -46,7 +46,6 @@ const Cursors = (props) => {
     isPanning,
     isMoving,
     currentTool,
-    disabledPan,
   } = props;
 
   const [panGrabbing, setPanGrabbing] = React.useState(false);
@@ -226,7 +225,7 @@ const Cursors = (props) => {
   }, [cursorWrapper, whiteboardId, currentUser.presenter]);
 
   let cursorType = multiUserAccess || currentUser?.presenter ? TOOL_CURSORS[currentTool] || 'none' : 'default';
-  if (isPanning && !disabledPan) {
+  if (isPanning) {
     if (panGrabbing) {
       cursorType = TOOL_CURSORS.grabbing;
     } else {
@@ -320,7 +319,6 @@ Cursors.propTypes = {
   isPanning: PropTypes.bool.isRequired,
   isMoving: PropTypes.bool.isRequired,
   currentTool: PropTypes.string,
-  disabledPan: PropTypes.bool.isRequired,
 };
 
 Cursors.defaultProps = {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
@@ -75,11 +75,6 @@ class PanToolInjector extends React.Component {
         id: 'app.whiteboard.toolbar.tools.hand',
         description: 'presentation toolbar pan label',
       });
-      const disabledLabel = formatMessage({
-        id: 'app.whiteboard.toolbar.tools.disabled.pan',
-        description: 'pan label when disabled',
-      });
-      const disabled = (zoomValue <= HUNDRED_PERCENT && !fitToWidth);
       const container = document.createElement('span');
       parentElement.appendChild(container);
       ReactDOM.render(
@@ -92,9 +87,8 @@ class PanToolInjector extends React.Component {
           color="light"
           icon="hand"
           size="md"
-          label={disabled ? disabledLabel : label}
-          aria-label={disabled ? disabledLabel : label}
-          disabled={disabled}
+          label={label}
+          aria-label={label}
           onClick={() => {
             setPanSelected(true);
             setIsPanning(true);

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1049,7 +1049,6 @@
     "app.whiteboard.annotations.numberExceeded": "The number of annotations exceeded the limit ({0})",
     "app.whiteboard.toolbar.tools": "Tools",
     "app.whiteboard.toolbar.tools.hand": "Pan",
-    "app.whiteboard.toolbar.tools.disabled.pan": "Zoom to enable pan",
     "app.whiteboard.toolbar.tools.pencil": "Pencil",
     "app.whiteboard.toolbar.tools.rectangle": "Rectangle",
     "app.whiteboard.toolbar.tools.triangle": "Triangle",


### PR DESCRIPTION
### What does this PR do?
This PR removes the disabling of the pan tool at 100%.
![remove-pan-disable](https://user-images.githubusercontent.com/22058534/224498237-f9b0f102-0793-4ad5-827b-bbd662579d12.gif)


### Closes Issue(s)
Closes #16992 

