### PR TITLE
docs: Improve docs readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,20 +9,21 @@ To test build the docs locally you can either use `yarn` or `npm`.
 
 ```
 $ yarn install  # install docusaurus and dependencies
-$ ./build.sh  # add all versions to build
 $ yarn start  # start local dev server
 ```
-
-The script `build.sh` goes through all branches of the repository and adds all
-release branches that have a `docusaurus.config.js`-file as versions to the docs.
-Note that you can not have uncommited local changes before you run `/build.sh`,
-otherwise git will refuse to change branches.
-This step is optional and if you don't run it docusaurus will only build the
-currently checkout out version.
 
 The last command starts a local development server and opens up a browser window.
 Most changes are reflected live without having to restart the server.
 
+There is also a  script `build.sh` that goes through all branches of the repository
+and adds all release branches that have a `docusaurus.config.js`-file as versions
+to the docs.
+Note that you can not have uncommited local changes before you run `/build.sh`,
+otherwise git will refuse to change branches.
+This step is optional and if you don't run it, docusaurus will only build the
+currently checkout out version which is recommended for local development
+(building all the versions locally can lead to problems with the live
+updates when using `yarn start`).
 
 ### Build
 


### PR DESCRIPTION
The build-script is only used for the deployment and can lead to confusing problems with local development if run locally.