### PR TITLE
fix: snapshot of current slide

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -514,7 +514,7 @@ class Presentation extends PureComponent {
       multiUser,
     } = this.props;
     const {
-      zoom, fitToWidth, isPanning, tldrawAPI,
+      zoom, fitToWidth, isPanning,
     } = this.state;
 
     if (!currentSlide) return null;
@@ -541,7 +541,6 @@ class Presentation extends PureComponent {
         }}
         setIsPanning={this.setIsPanning}
         isPanning={isPanning}
-        curPageId={tldrawAPI?.getPage()?.id}
         currentSlideNum={currentSlide.num}
         presentationId={currentSlide.presentationId}
         zoomChanger={this.zoomChanger}
@@ -642,6 +641,7 @@ class Presentation extends PureComponent {
       zoom,
       tldrawIsMounting,
       isPanning,
+      tldrawAPI,
     } = this.state;
 
     let viewBoxDimensions;
@@ -725,6 +725,7 @@ class Presentation extends PureComponent {
                   podId={podId}
                   slidePosition={slidePosition}
                   getSvgRef={this.getSvgRef}
+                  tldrawAPI={tldrawAPI}
                   setTldrawAPI={this.setTldrawAPI}
                   curPageId={currentSlide?.num.toString() || '0'}
                   svgUri={currentSlide?.svgUri}

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -62,6 +62,8 @@ export default function Whiteboard(props) {
     width,
     height,
     hasMultiUserAccess,
+    tldrawAPI,
+    setTldrawAPI,
   } = props;
   const { pages, pageStates } = initDefaultPages(curPres?.pages.length || 1);
   const rDocument = React.useRef({
@@ -73,7 +75,6 @@ export default function Whiteboard(props) {
     bindings: {},
     assets: {},
   });
-  const [tldrawAPI, setTLDrawAPI] = React.useState(null);
   const [history, setHistory] = React.useState(null);
   const [zoom, setZoom] = React.useState(HUNDRED_PERCENT);
   const [tldrawZoom, setTldrawZoom] = React.useState(1);
@@ -100,7 +101,7 @@ export default function Whiteboard(props) {
 
   const setSafeTLDrawAPI = (api) => {
     if (isMountedRef.current) {
-      setTLDrawAPI(api);
+      setTldrawAPI(api);
     }
   };
 


### PR DESCRIPTION
### What does this PR do?

fix "Could not download current presentation" error when trying to download a snapshot of the current slide in presentation.