### PR TITLE
Zoom By Mouse Wheel Only Operation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -209,8 +209,8 @@ export default function Whiteboard(props) {
         clientX: event.clientX,
         clientY: event.clientY,
       });
-
-      canvas.dispatchEvent(newEvent);
+      const canvas = document.getElementById('canvas');
+      canvas && canvas.dispatchEvent(newEvent);
     }
   }
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -196,6 +196,24 @@ export default function Whiteboard(props) {
     }
   };
 
+  const handleWheelEvent = (event) => {
+    if (!event.ctrlKey) {
+      // Prevent the event from reaching the tldraw library
+      event.stopPropagation();
+      event.preventDefault();
+      const newEvent = new WheelEvent('wheel', {
+        deltaX: event.deltaX,
+        deltaY: event.deltaY,
+        deltaZ: event.deltaZ,
+        ctrlKey: true,
+        clientX: event.clientX,
+        clientY: event.clientY,
+      });
+
+      canvas.dispatchEvent(newEvent);
+    }
+  }
+
   React.useEffect(() => {
     document.addEventListener('mouseup', checkClientBounds);
     document.addEventListener('visibilitychange', checkVisibility);
@@ -203,6 +221,10 @@ export default function Whiteboard(props) {
     return () => {
       document.removeEventListener('mouseup', checkClientBounds);
       document.removeEventListener('visibilitychange', checkVisibility);
+      const canvas = document.getElementById('canvas');
+      if (canvas) {
+        canvas.removeEventListener('wheel', handleWheelEvent);
+      }
     };
   }, [tldrawAPI]);
 
@@ -549,6 +571,11 @@ export default function Whiteboard(props) {
   const onMount = (app) => {
     const menu = document.getElementById('TD-Styles')?.parentElement;
     setSafeCurrentTool('select');
+
+    const canvas = document.getElementById('canvas');
+    if (canvas) {
+      canvas.addEventListener('wheel', handleWheelEvent, { capture: true });
+    }
 
     if (menu) {
       const MENU_OFFSET = '48px';


### PR DESCRIPTION
### What does this PR do?
This PR removes the need to hold `CRTL` key down while using the mouse wheel to zoom in and out.
![wheel-only-zoom](https://user-images.githubusercontent.com/22058534/224764324-fe3741c8-2d71-4e04-aafd-9e2940bf02ef.gif)

### Closes Issue(s)
Closes #16379 

