### PR TITLE
fix(audio): decouple remote media setup (play) from state callback

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -758,9 +758,18 @@ class SIPSession {
 
       const setupRemoteMedia = () => {
         const mediaElement = document.querySelector(MEDIA_TAG);
+        const { sdp } = this.currentSession.sessionDescriptionHandler
+          .peerConnection.remoteDescription;
+
+        logger.info({
+          logCode: 'sip_js_session_setup_remote_media',
+          extraInfo: {
+            callerIdName: this.user.callerIdName,
+            sdp,
+          },
+        }, 'Audio call - setup remote media');
 
         this.remoteStream = new MediaStream();
-
         this.currentSession.sessionDescriptionHandler
           .peerConnection.getReceivers().forEach((receiver) => {
             if (receiver.track) {
@@ -792,22 +801,15 @@ class SIPSession {
             fsReady,
           },
         }, 'Audio call - check if ICE is finished and FreeSWITCH is ready');
-        if (iceCompleted && fsReady) {
+
+        if (iceCompleted) {
           this.webrtcConnected = true;
           setupRemoteMedia();
+        }
 
-          const { sdp } = this.currentSession.sessionDescriptionHandler
-            .peerConnection.remoteDescription;
-
-          logger.info({
-            logCode: 'sip_js_session_setup_remote_media',
-            extraInfo: {
-              callerIdName: this.user.callerIdName,
-              sdp,
-            },
-          }, 'Audio call - setup remote media');
-
+        if (fsReady) {
           this.callback({ status: this.baseCallStates.started, bridge: this.bridgeName });
+
           resolve();
         }
       };


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): decouple remote media setup (play) from state callback](https://github.com/bigbluebutton/bigbluebutton/commit/48d623a4da11def12647dc84b41512c59bee1528) 
  * Audio state callback and remote media setup both depend on FS's state
(comes through Meteor) and the ICE state (local, peer connection). The
caveat: FS's state can come delayed on reconnection scenarios because
Meteor's websocket generally takes significantly longer to re-connect than
the peer connection, which means the ICE state gets completed way before FS
is flagged as ready.
  * The practical issue: while outbound audio (client -> FS) will work, inbound
audio (FS -> client) won't _just because it wasn't played_ (even though
data is  coming through).
  * This commit decouples the remote media setup step from the state via:
    - Setup remote media when ICE state is completed
    - Run the state callback only after FS is flagged as ready. This
    should maintain the UI states consistent across client-server.
    Keep in mind the assumption that if FS is ready, ICE is completed by
    consequence.


### Closes Issue(s)

n/æ

### Additional context

Partial salvage of https://github.com/bigbluebutton/bigbluebutton/pull/14436