### PR TITLE
test: Improve notification test execution time and reintroduce skipped test

### DIFF
--- a/bigbluebutton-tests/playwright/notifications/notifications.spec.js
+++ b/bigbluebutton-tests/playwright/notifications/notifications.spec.js
@@ -69,7 +69,6 @@ test.describe.parallel('Notifications', () => {
 
   test.describe.parallel('Presenter @ci', () => {
     test('Poll results notification', async ({ browser, context, page }) => {
-      test.fixme(true, 'Different behaviors in the development and production environment');
       const presenterNotifications = new PresenterNotifications(browser, context);
       await presenterNotifications.initModPage(page);
       await presenterNotifications.publishPollResults();

--- a/bigbluebutton-tests/playwright/notifications/presenterNotifications.js
+++ b/bigbluebutton-tests/playwright/notifications/presenterNotifications.js
@@ -4,7 +4,7 @@ const e = require('../core/elements');
 const utilPolling = require('../polling/util');
 const utilScreenShare = require('../screenshare/util');
 const utilPresentation = require('../presentation/util');
-const { UPLOAD_PDF_WAIT_TIME } = require('../core/constants');
+const { ELEMENT_WAIT_LONGER_TIME } = require('../core/constants');
 
 class PresenterNotifications extends MultiUsers {
   constructor(browser, context) {
@@ -19,7 +19,7 @@ class PresenterNotifications extends MultiUsers {
   }
 
   async fileUploaderNotification() {
-    await utilPresentation.uploadSinglePresentation(this.modPage, e.pdfFileName, UPLOAD_PDF_WAIT_TIME);
+    await utilPresentation.uploadSinglePresentation(this.modPage, e.uploadPresentationFileName, ELEMENT_WAIT_LONGER_TIME);
     await util.checkNotificationText(this.userPage, e.presentationUploadedToast);
   }
 


### PR DESCRIPTION
### What does this PR do?
- Change the uploaded file for `Presentation upload notification` test in order to decrease unnecessary wait time;
- Reintroduce `Poll results notification` test since it's not failing locally for a while;