### PR TITLE
test: Adds bbb-pad logs for CI artifacts (when fail)

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -186,6 +186,7 @@ jobs:
           bbb-conf --status > logs/bbb-status.log
           journalctl -u bbb-html5-frontend@1.service --since today > logs/bbb-html5-frontend.log
           journalctl -u bbb-html5-backend@1.service --since today > logs/bbb-html5-backend.log
+          journalctl -u bbb-pads.service --since today > logs/bbb-pads.log
           cp /var/log/bigbluebutton/bbb-web.log logs/bbb-web.log
           cp /var/log/bbb-apps-akka/bbb-apps-akka.log logs/bbb-apps-akka.log
           cp /var/log/turnserver/turnserver.log logs/turnserver.log

--- a/bigbluebutton-tests/playwright/sharednotes/sharednotes.spec.js
+++ b/bigbluebutton-tests/playwright/sharednotes/sharednotes.spec.js
@@ -2,7 +2,7 @@ const { test } = require('@playwright/test');
 const { SharedNotes } = require('./sharednotes');
 
 test.describe.parallel('Shared Notes', () => {
-  test.fixme('Open Shared notes @ci', async ({ browser, page, context }) => {
+  test('Open Shared notes @ci', async ({ browser, page, context }) => {
     const sharedNotes = new SharedNotes(browser, context);
     await sharedNotes.initModPage(page);
     await sharedNotes.openSharedNotes();

--- a/bigbluebutton-tests/playwright/user/user.spec.js
+++ b/bigbluebutton-tests/playwright/user/user.spec.js
@@ -195,7 +195,7 @@ test.describe.parallel('User', () => {
       });
 
       // https://docs.bigbluebutton.org/2.6/release-tests.html#shared-notes-1
-      test.fixme('Lock Edit Shared Notes', async ({ browser, context, page }) => {
+      test('Lock Edit Shared Notes', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initPages(page);
         await lockViewers.lockEditSharedNotes();


### PR DESCRIPTION
This PR also re-enable SharedNotes-Tests (disabled in #16929). In order to make further investigation on it.

(I ran automated-tests twice to this current PR and I was not able to make it fails. Chances are that it is fixed already by some previous PR).