### PR TITLE
fix: Poll results are difficult to read and not scaled to fit slide

### DIFF
--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -127,6 +127,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
   <link rel="preload" href="fonts/SourceSansPro/SourceSansPro-Italic.woff?v=VERSION" as="font" crossorigin="anonymous"/>
   <link rel="preload" href="fonts/SourceSansPro/SourceSansPro-SemiboldItalic.woff?v=VERSION" as="font" crossorigin="anonymous"/>
   <link rel="preload" href="fonts/SourceSansPro/SourceSansPro-BoldItalic.woff?v=VERSION" as="font" crossorigin="anonymous"/>
+  <link rel="preload" href="files/source-code-pro-latin-400-normal.woff2" as="font" crossorigin="anonymous"/>
 
   <style>
     @font-face {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -306,15 +306,22 @@ export default function Whiteboard(props) {
         .filter(([, shape]) => shape.name?.includes('poll-result'));
       pollResults.forEach(([id, shape]) => {
         if (_.isEqual(shape.point, [0, 0])) {
-          const shapeBounds = tldrawAPI?.getShapeBounds(id);
-          if (shapeBounds) {
-            const editedShape = shape;
-            editedShape.point = [
-              slidePosition.width - shapeBounds.width,
-              slidePosition.height - shapeBounds.height,
-            ];
-            editedShape.size = [shapeBounds.width, shapeBounds.height];
-            if (isPresenter) persistShape(editedShape, whiteboardId);
+          try {
+            const shapeBounds = tldrawAPI?.getShapeBounds(id);
+            if (shapeBounds) {
+              const editedShape = shape;
+              editedShape.point = [
+                slidePosition.width - shapeBounds.width,
+                slidePosition.height - shapeBounds.height,
+              ];
+              editedShape.size = [shapeBounds.width, shapeBounds.height];
+              if (isPresenter) persistShape(editedShape, whiteboardId);
+            }
+          } catch (error) {
+            logger.error({
+              logCode: 'whiteboard_poll_results_error',
+              extraInfo: { error },
+            }, 'Whiteboard catch error on moving unpublished poll results');
           }
         }
       });

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -284,25 +284,46 @@ const getShapes = (whiteboardId, curPageId, intl) => {
       modAnnotation.annotationInfo.answers = annotation.annotationInfo.answers.reduce(
         caseInsensitiveReducer, [],
       );
-      const pollResult = PollService.getPollResultString(annotation.annotationInfo, intl)
+      let pollResult = PollService.getPollResultString(annotation.annotationInfo, intl)
         .split('<br/>').join('\n').replace(/(<([^>]+)>)/ig, '');
+
+      const lines = pollResult.split('\n');
+      const longestLine = lines.reduce((a, b) => a.length > b.length ? a : b, '').length;
+
+      // add empty spaces before first | in each of the lines to make them all the same length
+      pollResult = lines.map((line) => {
+        if (!line.includes('|') || line.length === longestLine) return line;
+
+        const splitLine = line.split(' |');
+        const spaces = ' '.repeat(longestLine - line.length);
+        return `${splitLine[0]} ${spaces}|${splitLine[1]}`;
+      }).join('\n');
+
+      // aproximate the size of the text frame
+      const characterWidth = 16;
+      const lineHeight = 40;
+      const framePadding = 20;
+
+      const frameWidth = (characterWidth * longestLine) + framePadding;
+      const frameHeight = lineHeight * (lines.length - 1);
+
       modAnnotation.annotationInfo = {
-        childIndex: 2,
+        childIndex: 0,
         id: annotation.annotationInfo.id,
         name: `poll-result-${annotation.annotationInfo.id}`,
-        type: 'text',
-        text: pollResult,
+        type: 'rectangle',
+        label: pollResult,
+        labelPoint: [0.5, 0.5],
         parentId: `${curPageId}`,
         point: [0, 0],
-        rotation: 0,
+        size: [frameWidth, frameHeight],
         style: {
-          isFilled: false,
-          size: 'medium',
+          color: 'white',
+          dash: 'solid',
+          font: 'mono',
+          isFilled: true,
+          size: 'small',
           scale: 1,
-          color: 'black',
-          textAlign: 'start',
-          font: 'script',
-          dash: 'draw',
         },
       };
       modAnnotation.annotationInfo.questionType = false;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -10,6 +10,7 @@ import logger from '/imports/startup/client/logger';
 import { defineMessages } from 'react-intl';
 import { notify } from '/imports/ui/services/notification';
 import caseInsensitiveReducer from '/imports/utils/caseInsensitiveReducer';
+import { getTextSize } from './utils';
 
 const Annotations = new Mongo.Collection(null);
 
@@ -299,13 +300,16 @@ const getShapes = (whiteboardId, curPageId, intl) => {
         return `${splitLine[0]} ${spaces}|${splitLine[1]}`;
       }).join('\n');
 
-      // aproximate the size of the text frame
-      const characterWidth = 16;
-      const lineHeight = 40;
-      const framePadding = 20;
+      const style = {
+        color: 'white',
+        dash: 'solid',
+        font: 'mono',
+        isFilled: true,
+        size: 'small',
+        scale: 1,
+      };
 
-      const frameWidth = (characterWidth * longestLine) + framePadding;
-      const frameHeight = lineHeight * (lines.length - 1);
+      const textSize = getTextSize(pollResult, style, padding = 20);
 
       modAnnotation.annotationInfo = {
         childIndex: 0,
@@ -316,15 +320,8 @@ const getShapes = (whiteboardId, curPageId, intl) => {
         labelPoint: [0.5, 0.5],
         parentId: `${curPageId}`,
         point: [0, 0],
-        size: [frameWidth, frameHeight],
-        style: {
-          color: 'white',
-          dash: 'solid',
-          font: 'mono',
-          isFilled: true,
-          size: 'small',
-          scale: 1,
-        },
+        size: textSize,
+        style,
       };
       modAnnotation.annotationInfo.questionType = false;
     }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -7,9 +7,6 @@ import {
 import Button from '/imports/ui/components/common/button/component';
 
 const TldrawGlobalStyle = createGlobalStyle`
-  div[data-shape="rectangle"] div div div {
-    width: auto !important;
-  }
   ${({ hideContextMenu }) => hideContextMenu && `
     #TD-ContextMenu {
       display: none;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -7,6 +7,9 @@ import {
 import Button from '/imports/ui/components/common/button/component';
 
 const TldrawGlobalStyle = createGlobalStyle`
+  div[data-shape="rectangle"] div div div {
+    width: auto !important;
+  }
   ${({ hideContextMenu }) => hideContextMenu && `
     #TD-ContextMenu {
       display: none;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/utils.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/utils.js
@@ -212,11 +212,90 @@ const mapLanguage = (language) => {
   }
 };
 
+const getFontStyle = (style) => {
+  const fontSizes = {
+    small: 28,
+    medium: 48,
+    large: 96,
+    auto: 'auto',
+  };
+
+  const fontFaces = {
+    script: '"Caveat Brush"',
+    sans: '"Source Sans Pro"',
+    serif: '"Crimson Pro"',
+    mono: '"Source Code Pro"',
+  }
+
+  const fontSize = fontSizes[style.size];
+  const fontFace = fontFaces[style.font];
+  const { scale = 1 } = style;
+
+  return `${fontSize * scale}px/1 ${fontFace}`;
+}
+
+const getMeasurementDiv = (font) => {
+  // A div used for measurement
+  document.getElementById('__textMeasure')?.remove();
+
+  const pre = document.createElement('pre');
+  pre.id = '__textMeasure';
+
+  Object.assign(pre.style, {
+    whiteSpace: 'pre',
+    width: 'auto',
+    border: '1px solid transparent',
+    padding: '4px',
+    margin: '0px',
+    letterSpacing: '-0.03em',
+    opacity: '0',
+    position: 'absolute',
+    top: '-500px',
+    left: '0px',
+    zIndex: '9999',
+    pointerEvents: 'none',
+    userSelect: 'none',
+    alignmentBaseline: 'mathematical',
+    dominantBaseline: 'mathematical',
+    font,
+  });
+
+  pre.tabIndex = -1;
+
+  document.body.appendChild(pre);
+  return pre;
+}
+
+const getTextSize = (text, style, padding) => {
+  const font = getFontStyle(style);
+
+  if (!text) {
+    return [16, 32];
+  }
+
+  const melm = getMeasurementDiv(font);
+
+  if (!melm) {
+    // We're in SSR
+    return [10, 10];
+  }
+
+  if (!melm.parent) document.body.appendChild(melm);
+
+  melm.textContent = text;
+
+  // In tests, offsetWidth and offsetHeight will be 0
+  const width = melm.offsetWidth || 1;
+  const height = melm.offsetHeight || 1;
+
+  return [width + padding, height + padding];
+};
+
 const Utils = {
-  usePrevious, findRemoved, filterInvalidShapes, mapLanguage, sendShapeChanges,
+  usePrevious, findRemoved, filterInvalidShapes, mapLanguage, sendShapeChanges, getTextSize,
 };
 
 export default Utils;
 export {
-  usePrevious, findRemoved, filterInvalidShapes, mapLanguage, sendShapeChanges,
+  usePrevious, findRemoved, filterInvalidShapes, mapLanguage, sendShapeChanges, getTextSize,
 };

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/utils.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/utils.js
@@ -212,6 +212,8 @@ const mapLanguage = (language) => {
   }
 };
 
+/* getFontStyle adapted from tldraw source code
+  https://github.com/tldraw/tldraw/blob/55a8831a6b036faae0dfd77d6733a8f585f5ae23/packages/tldraw/src/state/shapes/shared/shape-styles.ts#L123 */
 const getFontStyle = (style) => {
   const fontSizes = {
     small: 28,
@@ -234,6 +236,8 @@ const getFontStyle = (style) => {
   return `${fontSize * scale}px/1 ${fontFace}`;
 }
 
+/* getMeasurementDiv and getTextSize adapted from tldraw source code
+  https://github.com/tldraw/tldraw/blob/55a8831a6b036faae0dfd77d6733a8f585f5ae23/packages/tldraw/src/state/shapes/shared/getTextSize.ts */
 const getMeasurementDiv = (font) => {
   // A div used for measurement
   document.getElementById('__textMeasure')?.remove();


### PR DESCRIPTION
### What does this PR do?

Makes the following changes to the poll results displayed in whiteboard:
- adds border and solid background
- changes the font to monospaced
- align percent values to the right

#### before
![Screenshot from 2023-03-14 15-19-29](https://user-images.githubusercontent.com/3728706/225100748-a75942e4-324a-4c29-ae4a-9b7994db77b3.png)

#### after
![Screenshot from 2023-03-14 15-15-17x](https://user-images.githubusercontent.com/3728706/225100475-1cd507e2-3f73-4c57-9f9b-f36d3de106dc.png)




### Closes Issue(s)
Closes #16682
Closes #16917