### PR TITLE
fix: Prevent Response Poll Displaying For True / False

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -92,6 +92,9 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
   const yesNoPatt = /.*(yes\/no|no\/yes).*/gm;
   const hasYN = safeMatch(yesNoPatt, content, false);
 
+  const trueFalsePatt = /.*(true\/false|false\/true).*/gm;
+  const hasTF = safeMatch(trueFalsePatt, content, false);
+
   const pollRegex = /\b[1-9A-Ia-i][.)] .*/g;
   let optionsPoll = safeMatch(pollRegex, content, []);
   const optionsWithLabels = [];
@@ -163,7 +166,7 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
     }
   });
 
-  if (question.length > 0 && optionsPoll.length === 0 && !doubleQuestion && !hasYN) {
+  if (question.length > 0 && optionsPoll.length === 0 && !doubleQuestion && !hasYN && !hasTF) {
     quickPollOptions.push({
       type: 'R-',
       poll: {


### PR DESCRIPTION
### What does this PR do?
Fixes the response poll option displaying for True / False
![true-false-sp](https://user-images.githubusercontent.com/22058534/225326108-5c46526b-17a7-48f5-9e5a-b25fb7519fb9.gif)


### Closes Issue(s)

Closes #17046 
