### PR TITLE
fix: Ctrl+A shortcut selects objects at outside of whiteboard

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -550,8 +550,8 @@ export default function Whiteboard(props) {
     previousSlide(+curPageId, podId);
   };
 
-  const switchSlide = (event) => {
-    const { which } = event;
+  const handleOnKeyDown = (event) => {
+    const { which, ctrlKey } = event;
 
     switch (which) {
       case KEY_CODES.ARROW_LEFT:
@@ -564,6 +564,13 @@ export default function Whiteboard(props) {
         break;
       case KEY_CODES.ENTER:
         fullscreenToggleHandler();
+        break;
+      case KEY_CODES.A:
+        if (ctrlKey) {
+          event.preventDefault();
+          event.stopPropagation();
+          tldrawAPI?.selectAll();
+        }
         break;
       default:
     }
@@ -886,7 +893,7 @@ export default function Whiteboard(props) {
   if (currentTool && !isPanning) tldrawAPI?.selectTool(currentTool);
 
   const editableWB = (
-    <Styled.EditableWBWrapper onKeyDown={switchSlide}>
+    <Styled.EditableWBWrapper onKeyDown={handleOnKeyDown}>
       <Tldraw
         key={`wb-${isRTL}-${dockPos}`}
         document={doc}

--- a/bigbluebutton-html5/imports/utils/keyCodes.js
+++ b/bigbluebutton-html5/imports/utils/keyCodes.js
@@ -8,6 +8,7 @@ export const ARROW_RIGHT = 39;
 export const ARROW_LEFT = 37;
 export const PAGE_UP = 33;
 export const PAGE_DOWN = 34;
+export const A = 65;
 
 export default {
   SPACE,
@@ -20,4 +21,5 @@ export default {
   ARROW_LEFT,
   PAGE_UP,
   PAGE_DOWN,
+  A,
 };


### PR DESCRIPTION
### What does this PR do?

Handle ctrl+A shortcut when the whiteboard is focused so it selects all shapes instead of selecting objects outside of the whiteboard.

### Closes Issue(s)
Closes #17029