### PR TITLE
fix: Close poll on slide change

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -161,19 +161,21 @@ class PresentationToolbar extends PureComponent {
 
   nextSlideHandler(event) {
     const {
-      nextSlide, currentSlideNum, numberOfSlides, podId,
+      nextSlide, currentSlideNum, numberOfSlides, podId, endCurrentPoll,
     } = this.props;
 
     if (event) event.currentTarget.blur();
-    this.props.endCurrentPoll();
+    endCurrentPoll();
     nextSlide(currentSlideNum, numberOfSlides, podId);
   }
 
   previousSlideHandler(event) {
-    const { previousSlide, currentSlideNum, podId } = this.props;
+    const {
+      previousSlide, currentSlideNum, podId, endCurrentPoll,
+    } = this.props;
 
     if (event) event.currentTarget.blur();
-    this.props.endCurrentPoll();
+    endCurrentPoll();
     previousSlide(currentSlideNum, podId);
   }
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { makeCall } from '/imports/ui/services/api';
 import { defineMessages, injectIntl } from 'react-intl';
 import deviceInfo from '/imports/utils/deviceInfo';
 import injectWbResizeEvent from '/imports/ui/components/presentation/resize-wrapper/component';
@@ -13,6 +14,7 @@ import ZoomTool from './zoom-tool/component';
 import SmartMediaShareContainer from './smart-video-share/container';
 import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 import KEY_CODES from '/imports/utils/keyCodes';
+import { currentPoll } from './service';
 
 const intlMessages = defineMessages({
   previousSlideLabel: {
@@ -165,6 +167,7 @@ class PresentationToolbar extends PureComponent {
     } = this.props;
 
     if (event) event.currentTarget.blur();
+    if (currentPoll()) makeCall('stopPoll');
     nextSlide(currentSlideNum, numberOfSlides, podId);
   }
 
@@ -172,6 +175,7 @@ class PresentationToolbar extends PureComponent {
     const { previousSlide, currentSlideNum, podId } = this.props;
 
     if (event) event.currentTarget.blur();
+    if (currentPoll()) makeCall('stopPoll');
     previousSlide(currentSlideNum, podId);
   }
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { makeCall } from '/imports/ui/services/api';
 import { defineMessages, injectIntl } from 'react-intl';
 import deviceInfo from '/imports/utils/deviceInfo';
 import injectWbResizeEvent from '/imports/ui/components/presentation/resize-wrapper/component';
@@ -14,7 +13,6 @@ import ZoomTool from './zoom-tool/component';
 import SmartMediaShareContainer from './smart-video-share/container';
 import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 import KEY_CODES from '/imports/utils/keyCodes';
-import { currentPoll } from './service';
 
 const intlMessages = defineMessages({
   previousSlideLabel: {
@@ -167,7 +165,7 @@ class PresentationToolbar extends PureComponent {
     } = this.props;
 
     if (event) event.currentTarget.blur();
-    if (currentPoll()) makeCall('stopPoll');
+    this.props.endCurrentPoll();
     nextSlide(currentSlideNum, numberOfSlides, podId);
   }
 
@@ -175,7 +173,7 @@ class PresentationToolbar extends PureComponent {
     const { previousSlide, currentSlideNum, podId } = this.props;
 
     if (event) event.currentTarget.blur();
-    if (currentPoll()) makeCall('stopPoll');
+    this.props.endCurrentPoll();
     previousSlide(currentSlideNum, podId);
   }
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -24,7 +24,7 @@ const PresentationToolbarContainer = (props) => {
 
   const endCurrentPoll = () => {
     if (CurrentPoll.findOne({ meetingId: Auth.meetingID })) makeCall('stopPoll');
-  }
+  };
 
   if (userIsPresenter && !layoutSwapped) {
     // Only show controls if user is presenter and layout isn't swapped
@@ -84,6 +84,7 @@ PresentationToolbarContainer.propTypes = {
   previousSlide: PropTypes.func.isRequired,
   skipToSlide: PropTypes.func.isRequired,
   layoutSwapped: PropTypes.bool,
+  endCurrentPoll: PropTypes.func.isRequired,
 };
 
 PresentationToolbarContainer.defaultProps = {

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -10,6 +10,7 @@ import { UsersContext } from '/imports/ui/components/components-data/users-conte
 import Auth from '/imports/ui/services/auth';
 import FullscreenService from '/imports/ui/components/common/fullscreen-button/service';
 import { isPollingEnabled } from '/imports/ui/services/features';
+import { CurrentPoll } from '/imports/api/polls';
 
 const PresentationToolbarContainer = (props) => {
   const usingUsersContext = useContext(UsersContext);
@@ -21,6 +22,10 @@ const PresentationToolbarContainer = (props) => {
 
   const handleToggleFullScreen = (ref) => FullscreenService.toggleFullScreen(ref);
 
+  const endCurrentPoll = () => {
+    if (CurrentPoll.findOne({ meetingId: Auth.meetingID })) makeCall('stopPoll');
+  }
+
   if (userIsPresenter && !layoutSwapped) {
     // Only show controls if user is presenter and layout isn't swapped
 
@@ -28,6 +33,7 @@ const PresentationToolbarContainer = (props) => {
       <PresentationToolbar
         {...props}
         amIPresenter={userIsPresenter}
+        endCurrentPoll={endCurrentPoll}
         {...{
           handleToggleFullScreen,
         }}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/service.js
@@ -2,8 +2,11 @@ import Auth from '/imports/ui/services/auth';
 import Presentations from '/imports/api/presentations';
 import { makeCall } from '/imports/ui/services/api';
 import { throttle } from 'lodash';
+import { CurrentPoll } from '/imports/api/polls';
 
 const PAN_ZOOM_INTERVAL = Meteor.settings.public.presentation.panZoomInterval || 200;
+
+export const currentPoll = () => CurrentPoll.findOne({ meetingId: Auth.meetingID });
 
 const getNumberOfSlides = (podId, presentationId) => {
   const meetingId = Auth.meetingID;

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/service.js
@@ -2,11 +2,8 @@ import Auth from '/imports/ui/services/auth';
 import Presentations from '/imports/api/presentations';
 import { makeCall } from '/imports/ui/services/api';
 import { throttle } from 'lodash';
-import { CurrentPoll } from '/imports/api/polls';
 
 const PAN_ZOOM_INTERVAL = Meteor.settings.public.presentation.panZoomInterval || 200;
-
-export const currentPoll = () => CurrentPoll.findOne({ meetingId: Auth.meetingID });
 
 const getNumberOfSlides = (podId, presentationId) => {
   const meetingId = Auth.meetingID;


### PR DESCRIPTION
### What does this PR do?

Closes poll modal when moderator changes slide

### Closes Issue(s)
Closes #16870


### Motivation

Previously - if the user hasn't answered - the modal would remain open permanently

