### PR TITLE
[2.6] Hide tldraw toolbar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -259,12 +259,16 @@ const PresentationMenu = (props) => {
     }
     
     const tools = document.querySelector('#TD-Tools');
-    //if (props.hasWBAccess || props.amIPresenter){
-    //  const isFocusMode = tldrawAPI?.settings.isFocusMode;
     if (tools && (props.hasWBAccess || props.amIPresenter)){
       const isVisible = tools.style.visibility == 'hidden' ? false : true;
       const styles = document.querySelector('#TD-Styles').parentElement;
       const option = document.querySelector('#WhiteboardOptionButton');
+      if (option) {
+        //When the RTL-LTR changed, the toolbar appears again,
+        // while the opacity of this button remains the same.
+        //So we need to reset the opacity here.
+        option.style.opacity = isVisible ? 'unset' : '0.2';
+      }
       menuItems.push(
         {
           key: 'list-item-toolvisibility',
@@ -272,14 +276,11 @@ const PresentationMenu = (props) => {
           label: formattedVisibilityLabel(isVisible),
           icon: isVisible ? 'close' : 'minus',
           onClick: () => {
-            //with this API, the CSS setting (e.g. toolbar height) is reverted to the original tldraw setting.
-            //tldrawAPI?.setSetting('isFocusMode', !isFocusMode);
             tools.style.visibility = isVisible ? 'hidden' : 'visible';
             if (styles) {
               styles.style.visibility = isVisible ? 'hidden' : 'visible';
             }
             if (option) {
-              //option.style.opacity = isFocusMode ? 'unset' : '0.2';
               option.style.opacity = isVisible ? '0.2' : 'unset';
             }
           },

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -274,7 +274,7 @@ const PresentationMenu = (props) => {
           key: 'list-item-toolvisibility',
           dataTest: 'toolVisibility',
           label: formattedVisibilityLabel(isVisible),
-          icon: isVisible ? 'close' : 'minus',
+          icon: isVisible ? 'close' : 'pen_tool',
           onClick: () => {
             tools.style.visibility = isVisible ? 'hidden' : 'visible';
             if (styles) {

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -56,6 +56,14 @@ const intlMessages = defineMessages({
     description: 'used for aria whiteboard options button label',
     defaultMessage: 'Whiteboard',
   },
+  hideToolsDesc: {
+    id: 'app.presentation.presentationToolbar.hideToolsDesc',
+    description: 'Hide toolbar label',
+  },
+  showToolsDesc: {
+    id: 'app.presentation.presentationToolbar.showToolsDesc',
+    description: 'Show toolbar label',
+  },
 });
 
 const propTypes = {
@@ -125,6 +133,11 @@ const PresentationMenu = (props) => {
   const formattedLabel = (fullscreen) => (fullscreen
     ? intl.formatMessage(intlMessages.exitFullscreenLabel)
     : intl.formatMessage(intlMessages.fullscreenLabel)
+  );
+  
+  const formattedVisibilityLabel = (visible) => (visible
+    ? intl.formatMessage(intlMessages.hideToolsDesc)
+    : intl.formatMessage(intlMessages.showToolsDesc)
   );
 
   function renderToastContent() {
@@ -244,6 +257,35 @@ const PresentationMenu = (props) => {
         },
       );
     }
+    
+    const tools = document.querySelector('#TD-Tools');
+    //if (props.hasWBAccess || props.amIPresenter){
+    //  const isFocusMode = tldrawAPI?.settings.isFocusMode;
+    if (tools && (props.hasWBAccess || props.amIPresenter)){
+      const isVisible = tools.style.visibility == 'hidden' ? false : true;
+      const styles = document.querySelector('#TD-Styles').parentElement;
+      const option = document.querySelector('#WhiteboardOptionButton');
+      menuItems.push(
+        {
+          key: 'list-item-toolvisibility',
+          dataTest: 'toolVisibility',
+          label: formattedVisibilityLabel(isVisible),
+          icon: isVisible ? 'close' : 'minus',
+          onClick: () => {
+            //with this API, the CSS setting (e.g. toolbar height) is reverted to the original tldraw setting.
+            //tldrawAPI?.setSetting('isFocusMode', !isFocusMode);
+            tools.style.visibility = isVisible ? 'hidden' : 'visible';
+            if (styles) {
+              styles.style.visibility = isVisible ? 'hidden' : 'visible';
+            }
+            if (option) {
+              //option.style.opacity = isFocusMode ? 'unset' : '0.2';
+              option.style.opacity = isVisible ? '0.2' : 'unset';
+            }
+          },
+        },
+      );
+    }
 
     return menuItems;
   }
@@ -283,7 +325,7 @@ const PresentationMenu = (props) => {
   }
 
   return (
-    <Styled.Right>
+    <Styled.Right id='WhiteboardOptionButton'>
       <BBBMenu
         trigger={(
           <TooltipContainer title={intl.formatMessage(intlMessages.optionsLabel)}>

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/container.jsx
@@ -6,6 +6,8 @@ import FullscreenService from '/imports/ui/components/common/fullscreen-button/s
 import Auth from '/imports/ui/services/auth';
 import Meetings from '/imports/api/meetings';
 import { layoutSelect, layoutDispatch } from '/imports/ui/components/layout/context';
+import WhiteboardService from '/imports/ui/components/whiteboard/service';
+import UserService from '/imports/ui/components/user-list/service';
 
 const PresentationMenuContainer = (props) => {
   const fullscreen = layoutSelect((i) => i.fullscreen);
@@ -34,6 +36,8 @@ export default withTracker((props) => {
   const isIphone = !!(navigator.userAgent.match(/iPhone/i));
   const meetingId = Auth.meetingID;
   const meetingObject = Meetings.findOne({ meetingId }, { fields: { 'meetingProp.name': 1 } });
+  const hasWBAccess = WhiteboardService.hasMultiUserAccess(WhiteboardService.getCurrentWhiteboardId(), Auth.userID);
+  const amIPresenter = UserService.isUserPresenter(Auth.userID);
 
   return {
     ...props,
@@ -41,6 +45,8 @@ export default withTracker((props) => {
     isIphone,
     isDropdownOpen: Session.get('dropdownOpen'),
     meetingName: meetingObject.meetingProp.name,
+    hasWBAccess,
+    amIPresenter,
   };
 })(PresentationMenuContainer);
 

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -235,6 +235,8 @@
     "app.presentation.presentationToolbar.fitToWidth": "Fit to width",
     "app.presentation.presentationToolbar.fitToPage": "Fit to page",
     "app.presentation.presentationToolbar.goToSlide": "Slide {0}",
+    "app.presentation.presentationToolbar.hideToolsDesc": "Hide Toolbars",
+    "app.presentation.presentationToolbar.showToolsDesc": "Show Toolbars",
     "app.presentation.placeholder": "There is no currently active presentation",
     "app.presentationUploder.title": "Presentation",
     "app.presentationUploder.message": "As a presenter you have the ability to upload any office document or PDF file.  We recommend PDF file for best results. Please ensure that a presentation is selected using the circle checkbox on the left hand side.",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Adds a button to toggle the visibility of toolbars.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #15739


### Motivation

Testing 2.6, I am a bit frustrated that the new tldraw toolbar is not (re)movable. It's larger than the old whiteboard toolbar and hide more space within the slide. It's more problematic when I use a laptop with a small screen.
To solve this problem, I have implemented a button that enables hiding/showing the toolbars. 

### More

As @KDSBrowne suggested in #15739, using the "focus mode" of tldraw native API would be more elegant. However I found this approach makes other problems on the layout of toolbars. 

The menu icon should be better refined (for now they are assigned on "better-than-nothing" basis).

![225169920-cde20e99-504e-4522-a88a-d666da3947be](https://user-images.githubusercontent.com/45039819/225593318-52c3e1f0-1d21-4d38-bc48-9af411bf9ed9.gif)
