### PR TITLE
feat: add user name to checkAuthorization response

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
@@ -42,6 +42,7 @@ class ConnectionController {
         response.addHeader("User-Id", userSession.internalUserId)
         response.addHeader("Meeting-Id", userSession.meetingID)
         response.addHeader("Voice-Bridge", userSession.voicebridge )
+        response.addHeader("User-Name", userSession.fullname)
         response.setStatus(200)
         response.outputStream << 'authorized'
       } else {

--- a/build/packages-template/bbb-webrtc-sfu/webrtc-sfu.nginx
+++ b/build/packages-template/bbb-webrtc-sfu/webrtc-sfu.nginx
@@ -5,6 +5,7 @@ location /bbb-webrtc-sfu {
     auth_request_set $user_id $sent_http_user_id;
     auth_request_set $meeting_id $sent_http_meeting_id;
     auth_request_set $voice_bridge $sent_http_voice_bridge;
+    auth_request_set $user_name $sent_http_user_name;
 
     proxy_pass http://127.0.0.1:3008;
     proxy_http_version 1.1;
@@ -14,6 +15,8 @@ location /bbb-webrtc-sfu {
     proxy_set_header User-Id $user_id;
     proxy_set_header Meeting-Id $meeting_id;
     proxy_set_header Voice-Bridge $voice_bridge;
+    proxy_set_header User-Name $user_name;
+
     proxy_read_timeout 60s;
     proxy_send_timeout 60s;
     client_body_timeout 60s;


### PR DESCRIPTION

### What does this PR do?

Backports 6225042148558da73fffeb8317c6e62a0838a6b7 from v2.6.x-release.
This should have no direct impact to v2.5.x-release as it is currently.

> Audio's callerId depends on the user name and there isn't an "on-demand" way of fetching that field internally, making callerId assembly with trusted attributes (server-side generated) impossible in bbb-webrtc-sfu.
> 
> The new extra header (User-Name, mapped to user_name in the proxied connection) allows fetching the user name field in a cheap way and consequently provides a cheap+safe way of assembling the callerId.


### Closes Issue(s)

None

### Motivation

The motivation is to make BBB 2.5 compatible with  BBB v2.6 (or later) bbb-webrtc-sfu releases, both for ease of development and for using newer SFU versions in 2.5 down the road if necessary.

