### PR TITLE
Docs: Don't display 'unmaintained' banner for 2.5

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -35,6 +35,11 @@ const config = {
                 docs: {
                     routeBasePath: "/",
                     sidebarPath: require.resolve('./sidebars.js'),
+                    versions: {
+                        current: {
+                            banner: 'none'
+                        }
+                    },
                 },
                 theme: {
                     customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
This commits adds configuration to docusaurus that prevents the 'unmaintained' banner to be shown for version 2.5.