### PR TITLE
fix: Allow viewing of longer names in guest waiting queue

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
@@ -119,36 +119,36 @@ const renderGuestUserItem = (
     </Styled.UserContentContainer>
 
     <Styled.ButtonContainer key={`userlist-btns-${userId}`}>
-    { isGuestLobbyMessageEnabled ? ( 
       <Styled.WaitingUsersButton
-        key={`userbtn-message-${userId}`}
-        color="primary"
-        size="lg"
+        key={`userbtn-accept-${userId}`}
+        size="md"
+        aria-label={intl.formatMessage(intlMessages.accept)}
         ghost
-        label={intl.formatMessage(intlMessages.privateMessageLabel)}
+        hideLabel
+        icon="add"
+        onClick={handleAccept}
+        data-test="acceptGuest"
+      />
+      { isGuestLobbyMessageEnabled ? ( 
+      <Styled.WaitingUsersButtonMsg
+        key={`userbtn-message-${userId}`}
+        size="lg"
+        aria-label={intl.formatMessage(intlMessages.privateMessageLabel)}
+        ghost
+        hideLabel
         onClick={privateMessageVisible}
         data-test="privateMessageGuest" 
       />
     ) : null}
-        |
-      <Styled.WaitingUsersButton
-        key={`userbtn-accept-${userId}`}
-        color="primary"
-        size="lg"
-        ghost
-        label={intl.formatMessage(intlMessages.accept)}
-        onClick={handleAccept}
-        data-test="acceptGuest"
-      />
-      |
-      <Styled.WaitingUsersButton
+      <Styled.WaitingUsersButtonDeny
         key={`userbtn-deny-${userId}`}
-        color="danger"
-        size="lg"
+        aria-label={intl.formatMessage(intlMessages.deny)}
         ghost
-        label={intl.formatMessage(intlMessages.deny)}
+        hideLabel
         onClick={handleDeny}
         data-test="denyGuest"
+        size="sm"
+        icon="close"
       />
     </Styled.ButtonContainer>
   </Styled.ListItem>

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/styles.js
@@ -24,7 +24,6 @@ const ListItem = styled.div`
   flex-direction: row;
   align-items: center;
   border-radius: 5px;
-  cursor: pointer;
 
   ${({ animations }) => animations && `
     transition: all .3s;
@@ -40,9 +39,6 @@ const ListItem = styled.div`
     outline: none;
   }
 
-  &:hover {
-    background-color: ${listItemBgHover};
-  }
   flex-shrink: 0;
 `;
 
@@ -65,6 +61,7 @@ const UserName = styled.p`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: initial;
 `;
 
 const ButtonContainer = styled.div`
@@ -79,6 +76,8 @@ const ButtonContainer = styled.div`
 
 const WaitingUsersButton = styled(Button)`
   font-weight: 400;
+  border-radius: 5px;
+  color: ${colorPrimary};
 
   &:focus {
     background-color: ${listItemBgHover} !important;
@@ -87,6 +86,45 @@ const WaitingUsersButton = styled(Button)`
   }
 
   &:hover {
+    color: ${colorPrimary};
+    background-color: ${listItemBgHover} !important;
+  }
+`;
+const WaitingUsersButtonMsg = styled(Button)`
+font-weight: 400;
+  font-weight: 400;
+  border-radius: 5px;
+  color: ${colorPrimary};
+
+  &:after {
+    font-family: 'bbb-icons';
+    content: "\\E910";
+  }
+
+  &:focus {
+    background-color: ${listItemBgHover} !important;
+    box-shadow: inset 0 0 0 ${borderSize} ${itemFocusBorder}, inset 1px 0 0 1px ${itemFocusBorder} ;
+    outline: none;
+  }
+
+  &:hover {
+    color: ${colorPrimary};
+    background-color: ${listItemBgHover} !important;
+  }
+`;
+const WaitingUsersButtonDeny = styled(Button)`
+  font-weight: 400;
+  border-radius: 5px;
+  color: #ff0e0e;
+
+  &:focus {
+    background-color: ${listItemBgHover} !important;
+    box-shadow: inset 0 0 0 ${borderSize} ${itemFocusBorder}, inset 1px 0 0 1px ${itemFocusBorder} ;
+    outline: none;
+  }
+
+  &:hover {
+    color: #ff0e0e;
     background-color: ${listItemBgHover} !important;
   }
 `;
@@ -205,6 +243,8 @@ export default {
   UserName,
   ButtonContainer,
   WaitingUsersButton,
+  WaitingUsersButtonDeny,
+  WaitingUsersButtonMsg,
   PendingUsers,
   NoPendingUsers,
   MainTitle,

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/styles.js
@@ -70,13 +70,14 @@ const ButtonContainer = styled.div`
   align-items: center;
   color: ${colorPrimary};
   & > button {
-    padding: 0 .25rem 0 .25rem;
+    padding: ${mdPaddingY};
+    font-size: ${fontSizeBase};
+    border-radius: 50%;
   }
 `;
 
 const WaitingUsersButton = styled(Button)`
   font-weight: 400;
-  border-radius: 5px;
   color: ${colorPrimary};
 
   &:focus {
@@ -91,9 +92,7 @@ const WaitingUsersButton = styled(Button)`
   }
 `;
 const WaitingUsersButtonMsg = styled(Button)`
-font-weight: 400;
   font-weight: 400;
-  border-radius: 5px;
   color: ${colorPrimary};
 
   &:after {
@@ -114,7 +113,6 @@ font-weight: 400;
 `;
 const WaitingUsersButtonDeny = styled(Button)`
   font-weight: 400;
-  border-radius: 5px;
   color: #ff0e0e;
 
   &:focus {


### PR DESCRIPTION
### What does this PR do?

Improves usability of waiting user element by:
replacing buttons `Message | Accept | Deny` with icons to free up space for the name, also by making name capable of occupying multiple lines for more visibility

![Screenshot from 2023-03-16 18-37-23](https://user-images.githubusercontent.com/80958763/225923218-13d9d389-6cae-452c-bb0b-fb876a55364e.png)


### Closes Issue(s)

Closes #16390


### Motivation

Previously the buttons used to cover the name on smaller screens which, especially on certain locales

### More

PR removes background and cursor change on hovering over waiting user as it may mislead into thinking that user is clickable
