### PR TITLE
docs: Build docs only on develop

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,11 +4,9 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'v*'
       - 'develop'
     paths:
       - 'docs/**'
-      - '.github/**'
 
 # Do not build the docs concurrently
 concurrency:

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -4,6 +4,7 @@ set -eu
 
 # Build the docs only for these release branches
 BRANCHES=(
+  v2.5.x-release
   v2.6.x-release
   # v2.7.x-release
 )
@@ -16,15 +17,14 @@ for branch in "${BRANCHES[@]}"; do
 
   if [ "$branch" != "$current_branch" ]; then
     git fetch "$REMOTE" "$branch":"$branch"
-  fi
-
-  git checkout "$branch"
-  if [ -f docusaurus.config.js ]; then
-    version=${branch:1:3}
-    echo "Adding documentation for $version"
-    yarn docusaurus docs:version "${version}"
-  else
-    echo "Warning: branch $(branch) does not contain a docusaurus.config.js!"
+    git checkout "$branch"
+    if [ -f docusaurus.config.js ]; then
+      version=${branch:1:3}
+      echo "Adding documentation for ${version}"
+      yarn docusaurus docs:version "${version}"
+    else
+      echo "Warning: branch $(branch) does not contain a docusaurus.config.js!"
+    fi
   fi
 
 done

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -35,6 +35,16 @@ const config = {
                 docs: {
                     routeBasePath: "/",
                     sidebarPath: require.resolve('./sidebars.js'),
+                    lastVersion: '2.5',
+                    includeCurrentVersion: false,
+                    versions: {
+                        '2.5': {
+                            banner: 'none'
+                        },
+                        '2.6': {
+                            banner: 'none'
+                        },
+                    }
                 },
                 theme: {
                     customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
From now on the docs will only be build on develop and not on the release branches.

This commit adjusts the build script and the `docusaurus.config` on develop and the gh-action workflow accordingly.
