### PR TITLE
fix(bbb-com-web): Change video state to published and get meetingIds from meta tag

### DIFF
--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/domain/Recording.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/domain/Recording.scala
@@ -136,7 +136,8 @@ object RecMeta {
 
   def getRecMeta(metaXml: Elem): Option[RecMeta] = {
     val id = getText(metaXml, "id", "unknown")
-    val state = getText(metaXml, "state", "unknown")
+    val stateVal = getText(metaXml, "state", "unknown")
+    val state = if (stateVal.equals("available")) "published" else stateVal
     val published = getText(metaXml, "published", "true").toString.toBoolean
     val startTime = getValLong(metaXml, "start_time", 0)
     val endTime = getValLong(metaXml, "end_time", 0)

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/domain/Recording.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/domain/Recording.scala
@@ -151,7 +151,11 @@ object RecMeta {
 
     val meetingId = meeting match {
       case Some(m) => m.externalId
-      case None    => id
+      case None =>
+        meta match {
+          case Some(m) => m.getOrElse("meetingId", id)
+          case None    => id
+        }
     }
 
     val meetingName = meeting match {
@@ -165,7 +169,7 @@ object RecMeta {
 
     val internalMeetingId = meeting match {
       case Some(m) => Some(m.id)
-      case None    => None
+      case None    => Some(id)
     }
 
     val isBreakout = meeting match {

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/domain/Recording.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/domain/Recording.scala
@@ -137,7 +137,7 @@ object RecMeta {
   def getRecMeta(metaXml: Elem): Option[RecMeta] = {
     val id = getText(metaXml, "id", "unknown")
     val stateVal = getText(metaXml, "state", "unknown")
-    val state = if (stateVal.equals("available")) "published" else stateVal
+    val state = if (stateVal.equalsIgnoreCase("available")) "published" else stateVal
     val published = getText(metaXml, "published", "true").toString.toBoolean
     val startTime = getValLong(metaXml, "start_time", 0)
     val endTime = getValLong(metaXml, "end_time", 0)

--- a/record-and-playback/video/scripts/process/video.rb
+++ b/record-and-playback/video/scripts/process/video.rb
@@ -277,7 +277,7 @@ logger.info 'Generating metadata xml'
 metadata_xml = Nokogiri::XML::Builder.new do |xml|
   xml.recording do
     xml.id(meeting_id)
-    xml.state('available')
+    xml.state('published')
     xml.published('true')
     xml.start_time(start_real_time)
     xml.end_time(start_real_time + final_timestamp - initial_timestamp)

--- a/record-and-playback/video/scripts/process/video.rb
+++ b/record-and-playback/video/scripts/process/video.rb
@@ -277,7 +277,7 @@ logger.info 'Generating metadata xml'
 metadata_xml = Nokogiri::XML::Builder.new do |xml|
   xml.recording do
     xml.id(meeting_id)
-    xml.state('published')
+    xml.state('available')
     xml.published('true')
     xml.start_time(start_real_time)
     xml.end_time(start_real_time + final_timestamp - initial_timestamp)


### PR DESCRIPTION
### What does this PR do?

Changes the state of video recordings to `published` instead of `available`, following the same approach as [Scalelite](https://github.com/blindsidenetworks/scalelite/blob/master/app/models/recording.rb#L47), and retrieves meetingId info from `meta` tag if there is no `meeting` tag present.

### Closes
#16791
