### PR TITLE
fix(bbb-export-annotations): Reduce max canvas size

### DIFF
--- a/bbb-export-annotations/config/settings.json
+++ b/bbb-export-annotations/config/settings.json
@@ -16,8 +16,8 @@
     },
     "process": {
       "whiteboardTextEncoding": "utf-8",
-      "maxImageWidth": 2048,
-      "maxImageHeight": 1536,
+      "maxImageWidth": 1440,
+      "maxImageHeight": 1080,
       "textScaleFactor": 4,
       "pointsPerInch": 72,
       "pixelsPerInch": 96


### PR DESCRIPTION
### What does this PR do?
Reduce the maximum size of the canvas page to `maxImageWidth = 1440`, `maxImageHeight = 1080`.

### Closes Issue(s)
Closes #17086

### More
This change should only be merged once the same changes in `bbb-html5` have been applied.