### PR TITLE
fix(whiteboard): Reduce max canvas size

### DIFF
--- a/bigbluebutton-html5/imports/api/slides/server/helpers.js
+++ b/bigbluebutton-html5/imports/api/slides/server/helpers.js
@@ -5,8 +5,8 @@ const calculateSlideData = (slideData) => {
   } = slideData;
 
   // calculating viewBox and offsets for the current presentation
-  const maxImageWidth = 2048;
-  const maxImageHeight = 1536;
+  const maxImageWidth = 1440;
+  const maxImageHeight = 1080;
 
   const ratio = Math.min(maxImageWidth / width, maxImageHeight / height);
   const scaledWidth = width * ratio;

--- a/record-and-playback/core/scripts/bigbluebutton.yml
+++ b/record-and-playback/core/scripts/bigbluebutton.yml
@@ -1,4 +1,4 @@
-bbb_version: '2.6.0'
+bbb_version: '2.6.1'
 raw_audio_src: /var/freeswitch/meetings
 kurento_video_src: /var/kurento/recordings
 kurento_screenshare_src: /var/kurento/screenshare

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -893,7 +893,7 @@ def process_presentation(package_dir)
   cursors = []
   shapes = {}
   tldraw = @version_atleast_2_6_0
-  tldraw_shapes = {}
+  tldraw_shapes = {'bbb_version': BigBlueButton::Events.bbb_version(@doc)}
 
   # Iterate through the events.xml and store the events, building the
   # xml files as we go


### PR DESCRIPTION
### What does this PR do?
Reduce the maximum size of the whiteboard canvas page to `maxImageWidth = 1440`, `maxImageHeight = 1080`.

### Closes Issue(s)
Closes #17086