### PR TITLE
ci: Fix paths-ignore to docs folder

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -5,11 +5,11 @@ on:
       - 'develop'
       - 'v2.[5-9].x-release'
       - 'v[3-9].*.x-release'
+  pull_request:
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
-  pull_request:
-    types: [opened, synchronize, reopened]
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
### What does this PR do?
Moves `paths-ignore` to **pull_request** setting