### PR TITLE
fix (ci): SharedNotes tests failing randomly (disabling minify to improve performance)

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -121,6 +121,7 @@ jobs:
             cat bbb-install.sh | sed "s|> /etc/apt/sources.list.d/bigbluebutton.list||g" | bash -s -- -v focal-26-dev -s bbb-ci.test -j -d /certs/
             bbb-conf --salt bbbci
             echo "NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/bbb-dev/bbb-dev-ca.crt" >> /usr/share/meteor/bundle/bbb-html5-with-roles.conf
+            sed -i 's/"minify": true,/"minify": false,/' /usr/share/etherpad-lite/settings.json
             bbb-conf --restart
             '
       - name: Install test dependencies


### PR DESCRIPTION
Investigating why Shared Notes tests are failing I found this error in Etherpad logs:

`Error: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().`

Full log:

```
Mar 18 11:45:59 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:45:59.525] [INFO] settings - #033[39mAll relative paths will be interpreted relative to the identified Etherpad base dir: /usr/share/etherpad-lite
Mar 18 11:45:59 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:45:59.636] [INFO] settings - #033[39msettings loaded from: /usr/share/etherpad-lite/settings.json
Mar 18 11:45:59 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:45:59.637] [INFO] settings - #033[39mNo credentials file found in /usr/share/etherpad-lite/credentials.json. Ignoring.
Mar 18 11:45:59 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:45:59.641] [INFO] settings - #033[39mUsing skin "bigbluebutton" in dir: /usr/share/etherpad-lite/src/static/skins/bigbluebutton
Mar 18 11:45:59 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:45:59.649] [INFO] settings - #033[39mSession key loaded from: /usr/share/etherpad-lite/SESSIONKEY.txt
Mar 18 11:45:59 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:45:59.651] [INFO] settings - #033[39mRandom string used for versioning assets: 45297b02
Mar 18 11:46:00 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:46:00.682] [INFO] server - #033[39mStarting Etherpad...
Mar 18 11:46:00 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:46:00.693] [INFO] plugins - #033[39mRunning npm to get a list of installed plugins...
Mar 18 11:46:01 fv-az467-714 node[136994]: #033[33m[2023-03-18 11:46:01.280] [WARN] console - #033[39mUpdate available: Download the actual version 1.8.18
Mar 18 11:46:01 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:46:01.304] [INFO] plugins - #033[39mnpm --version: 6.14.15
Mar 18 11:46:05 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:46:05.036] [INFO] plugins - #033[39mLoading plugin ep_auth_session...
Mar 18 11:46:05 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:46:05.036] [INFO] plugins - #033[39mLoading plugin ep_bigbluebutton_patches...
Mar 18 11:46:05 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:46:05.036] [INFO] plugins - #033[39mLoading plugin ep_cursortrace...
Mar 18 11:46:05 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:46:05.036] [INFO] plugins - #033[39mLoading plugin ep_disable_chat...
Mar 18 11:46:05 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:46:05.037] [INFO] plugins - #033[39mLoading plugin ep_etherpad-lite...
Mar 18 11:46:05 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:46:05.037] [INFO] plugins - #033[39mLoading plugin ep_pad_ttl...
Mar 18 11:46:05 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:46:05.037] [INFO] plugins - #033[39mLoading plugin ep_redis_publisher...
Mar 18 11:46:05 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:46:05.038] [INFO] plugins - #033[39mLoaded 7 plugins
Mar 18 11:46:05 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:46:05.656] [INFO] APIHandler - #033[39mApi key file read from: "/usr/share/etherpad-lite/APIKEY.txt"
Mar 18 11:46:06 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:46:06.816] [INFO] server - #033[39mInstalled plugins: ep_auth_session@1.1.1, ep_bigbluebutton_patches@0.0.1, ep_cursortrace@3.1.16, ep_disable_chat@0.0.8, ep_pad_ttl@1.0.0, ep_redis_publisher@0.0.3
Mar 18 11:46:07 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:46:07.044] [INFO] console - #033[39mReport bugs at https://github.com/ether/etherpad-lite/issues
Mar 18 11:46:07 fv-az467-714 node[136994]: #033[33m[2023-03-18 11:46:07.045] [WARN] settings - #033[39mCan't get git version for server header
Mar 18 11:46:07 fv-az467-714 node[136994]: ENOENT: no such file or directory, lstat '/usr/share/etherpad-lite/.git'
Mar 18 11:46:07 fv-az467-714 node[136994]: #033[33m[2023-03-18 11:46:07.045] [WARN] settings - #033[39mCan't get git version for server header
Mar 18 11:46:07 fv-az467-714 node[136994]: ENOENT: no such file or directory, lstat '/usr/share/etherpad-lite/.git'
Mar 18 11:46:07 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:46:07.045] [INFO] console - #033[39mYour Etherpad version is 1.8.17 ()
Mar 18 11:46:17 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:46:17.087] [INFO] http - #033[39mHTTP server listening for connections
Mar 18 11:46:17 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:46:17.088] [INFO] console - #033[39mYou can access your Etherpad instance at http://127.0.0.1:9001/
Mar 18 11:46:17 fv-az467-714 node[136994]: #033[33m[2023-03-18 11:46:17.088] [WARN] console - #033[39mAdmin username and password not set in settings.json. To access admin please uncomment and edit "users" in settings.json
Mar 18 11:46:17 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:46:17.088] [INFO] server - #033[39mEtherpad is running
Mar 18 11:46:37 fv-az467-714 node[136994]: #033[32m[2023-03-18 11:46:37.056] [INFO] console - #033[39m[ep_pad_ttl] checking pads...
Mar 18 11:56:50 fv-az467-714 node[136994]: #033[31m[2023-03-18 11:56:50.198] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 11:56:50 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 11:56:50 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 11:56:50 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 11:56:50 fv-az467-714 node[136994]: #033[31m[2023-03-18 11:56:50.213] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 11:56:50 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 11:56:50 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 11:56:50 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 11:56:50 fv-az467-714 node[136994]: #033[31m[2023-03-18 11:56:50.220] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 11:56:50 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 11:56:50 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 11:56:50 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 11:56:50 fv-az467-714 node[136994]: #033[31m[2023-03-18 11:56:50.228] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 11:56:50 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 11:56:50 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 11:56:50 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 11:56:50 fv-az467-714 node[136994]: #033[31m[2023-03-18 11:56:50.234] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 11:56:50 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 11:56:50 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 11:56:50 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 11:56:50 fv-az467-714 node[136994]: #033[31m[2023-03-18 11:56:50.326] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 11:56:50 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 11:56:50 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 11:56:50 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 11:56:50 fv-az467-714 node[136994]: #033[31m[2023-03-18 11:56:50.330] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 11:56:50 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 11:56:50 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 11:56:50 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 11:56:50 fv-az467-714 node[136994]: #033[31m[2023-03-18 11:56:50.380] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 11:56:50 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 11:56:50 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 11:56:50 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 11:56:50 fv-az467-714 node[136994]: #033[31m[2023-03-18 11:56:50.548] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 11:56:50 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 11:56:50 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 11:56:50 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 11:57:08 fv-az467-714 node[136994]: #033[31m[2023-03-18 11:57:08.158] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 11:57:08 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 11:57:08 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 11:57:08 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 11:57:08 fv-az467-714 node[136994]: #033[31m[2023-03-18 11:57:08.163] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 11:57:08 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 11:57:08 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 11:57:08 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 11:57:08 fv-az467-714 node[136994]: #033[31m[2023-03-18 11:57:08.167] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 11:57:08 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 11:57:08 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 11:57:08 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 11:57:08 fv-az467-714 node[136994]: #033[31m[2023-03-18 11:57:08.168] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 11:57:08 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 11:57:08 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 11:57:08 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 11:57:08 fv-az467-714 node[136994]: #033[31m[2023-03-18 11:57:08.169] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 11:57:08 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 11:57:08 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 11:57:08 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 11:57:08 fv-az467-714 node[136994]: #033[31m[2023-03-18 11:57:08.226] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 11:57:08 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 11:57:08 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 11:57:08 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 11:57:08 fv-az467-714 node[136994]: #033[31m[2023-03-18 11:57:08.229] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 11:57:08 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 11:57:08 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 11:57:08 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 11:57:08 fv-az467-714 node[136994]: #033[31m[2023-03-18 11:57:08.252] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 11:57:08 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 11:57:08 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 11:57:08 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 11:57:08 fv-az467-714 node[136994]: #033[31m[2023-03-18 11:57:08.287] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 11:57:08 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 11:57:08 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 11:57:08 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 12:00:55 fv-az467-714 node[136994]: #033[31m[2023-03-18 12:00:55.156] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 12:00:55 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 12:00:55 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 12:00:55 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 12:00:55 fv-az467-714 node[136994]: #033[31m[2023-03-18 12:00:55.157] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 12:00:55 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 12:00:55 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 12:00:55 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 12:00:55 fv-az467-714 node[136994]: #033[31m[2023-03-18 12:00:55.157] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 12:00:55 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 12:00:55 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 12:00:55 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 12:00:55 fv-az467-714 node[136994]: #033[31m[2023-03-18 12:00:55.157] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 12:00:55 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 12:00:55 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 12:00:55 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 12:00:55 fv-az467-714 node[136994]: #033[31m[2023-03-18 12:00:55.158] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 12:00:55 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 12:00:55 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 12:00:55 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 12:00:55 fv-az467-714 node[136994]: #033[31m[2023-03-18 12:00:55.181] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 12:00:55 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 12:00:55 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 12:00:55 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 12:00:55 fv-az467-714 node[136994]: #033[31m[2023-03-18 12:00:55.203] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 12:00:55 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 12:00:55 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 12:00:55 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 12:00:55 fv-az467-714 node[136994]: #033[31m[2023-03-18 12:00:55.207] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 12:00:55 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 12:00:55 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 12:00:55 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 12:00:55 fv-az467-714 node[136994]: #033[31m[2023-03-18 12:00:55.233] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 12:00:55 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 12:00:55 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 12:00:55 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 12:01:20 fv-az467-714 node[136994]: #033[31m[2023-03-18 12:01:20.248] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 12:01:20 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 12:01:20 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 12:01:20 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 12:01:20 fv-az467-714 node[136994]: #033[31m[2023-03-18 12:01:20.257] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 12:01:20 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 12:01:20 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 12:01:20 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 12:01:20 fv-az467-714 node[136994]: #033[31m[2023-03-18 12:01:20.259] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 12:01:20 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 12:01:20 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 12:01:20 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 12:01:20 fv-az467-714 node[136994]: #033[31m[2023-03-18 12:01:20.261] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 12:01:20 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 12:01:20 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 12:01:20 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 12:01:20 fv-az467-714 node[136994]: #033[31m[2023-03-18 12:01:20.261] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 12:01:20 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 12:01:20 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 12:01:20 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 12:01:20 fv-az467-714 node[136994]: #033[31m[2023-03-18 12:01:20.278] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 12:01:20 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 12:01:20 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 12:01:20 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 12:01:20 fv-az467-714 node[136994]: #033[31m[2023-03-18 12:01:20.281] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 12:01:20 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 12:01:20 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 12:01:20 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 12:01:20 fv-az467-714 node[136994]: #033[31m[2023-03-18 12:01:20.292] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 12:01:20 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 12:01:20 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 12:01:20 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
Mar 18 12:01:20 fv-az467-714 node[136994]: #033[31m[2023-03-18 12:01:20.313] [ERROR] console - #033[39mError: Timeout: Did not receive an init message from worker after 10000ms. Make sure the worker calls expose().
Mar 18 12:01:20 fv-az467-714 node[136994]:     at Timeout._onTimeout (/usr/share/etherpad-lite/src/node_modules/threads/dist/master/spawn.js:35:53)
Mar 18 12:01:20 fv-az467-714 node[136994]:     at listOnTimeout (node:internal/timers:559:17)
Mar 18 12:01:20 fv-az467-714 node[136994]:     at processTimers (node:internal/timers:502:7)
```

It seems CI runners are slow and (most of times) can't init Etherpad within 10 seconds. In order to improve performance this PR disables `minify` feature of Etherpad. 

Possibly closes #16928
