### PR TITLE
Prevent URLs Triggering Typed Response Poll Option

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -86,6 +86,12 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
   const questionRegex = /.*?\?/gm;
   const question = safeMatch(questionRegex, content, '');
 
+  if (question?.length > 0) {
+    const urlRegex = /\bhttps?:\/\/\S+\b/g;
+    const hasUrl = safeMatch(urlRegex, question[0], '');
+    if (hasUrl.length > 0) question.pop();
+  }
+
   const doubleQuestionRegex = /\?{2}/gm;
   const doubleQuestion = safeMatch(doubleQuestionRegex, content, false);
 


### PR DESCRIPTION
### What does this PR do?
This prevents URLs triggering typed response poll option in smart slides.
![url-no-poll-option](https://user-images.githubusercontent.com/22058534/226404862-e986a723-90e9-4290-90af-c34835b60de9.gif)

### Closes Issue(s)

Closes #17093 
