### PR TITLE
build: Retry to download nodejs on http 404 or 522 errors

### DIFF
--- a/build/packages-template/bbb-html5-nodejs/build.sh
+++ b/build/packages-template/bbb-html5-nodejs/build.sh
@@ -18,7 +18,7 @@ pushd .
 mkdir -p staging/usr/lib/bbb-html5/node
 cd staging/usr/lib/bbb-html5/node
 
-wget https://nodejs.org/dist/v${NODE_VERSION}/${NODE_DIRNAME}.tar.gz
+wget --waitretry=30 --timeout=20 --retry-connrefused --retry-on-host-error --retry-on-http-error=404,522 https://nodejs.org/dist/v${NODE_VERSION}/${NODE_DIRNAME}.tar.gz
 if [ -f ${NODE_DIRNAME}.tar.gz ]; then
     tar xfz ${NODE_DIRNAME}.tar.gz
     mv ${NODE_DIRNAME}/* .


### PR DESCRIPTION
During the tests it very often fails because of this error while downloading Nodejs:
```
+ wget https://nodejs.org/dist/v14.21.2/node-v14.21.2-linux-x64.tar.gz
--2023-03-16 15:45:48--  https://nodejs.org/dist/v14.21.2/node-v14.21.2-linux-x64.tar.gz
Resolving nodejs.org (nodejs.org)... 104.20.22.46, 104.20.23.46, 2606:4700:10::6814:172e, ...
Connecting to nodejs.org (nodejs.org)|104.20.22.46|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2023-03-16 15:45:48 ERROR 404: Not Found.
```

or

```
Connecting to nodejs.org (nodejs.org)|104.20.22.46|:443... connected.
HTTP request sent, awaiting response... 522 
2023-03-20 10:22:11 ERROR 522: (no description).
``` 

Sometimes it can be fixed just pressing the button to "Re-run jobs".
It seems that the error is temporary and could be fixed just trying again...

So this PR adds some parameters to the command `wget` that download Node:

`wget --waitretry=30 --timeout=20 --retry-connrefused --retry-on-host-error --retry-on-http-error=404,522`

`--waitretry=30` : Wait 30 seconds before trying again
`--timeout=20` : It will wait max 20 seconds before the initial connection times out
`--retry-connrefused` : Consider “connection refused” a transient error and try again
`--retry-on-host-error` : Consider host errors as non-fatal
`--retry-on-http-error=404,522` : Consider given HTTP response codes as non-fatal (404 "not found" and 522 "connection timed out" are the errors I saw happening)
`--tries` is absent because the default is 20 already

More info in https://www.gnu.org/software/wget/manual/wget.html