### PR TITLE
Fix custom virtual background not being disabled when removed

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
@@ -228,6 +228,13 @@ const VirtualBgSelector = ({
           lastActivityDate: Date.now(),
         },
       });
+      const { filename, data, uniqueId } = background;
+      _virtualBgSelected(
+        EFFECT_TYPES.IMAGE_TYPE,
+        filename,
+        0,
+        { file: data, uniqueId },
+      );
     };
 
     const onError = (error) => {
@@ -354,6 +361,7 @@ const VirtualBgSelector = ({
                   type: 'delete',
                   uniqueId,
                 });
+                _virtualBgSelected(EFFECT_TYPES.NONE_TYPE);
               }}
             />
           </Styled.ButtonWrapper>


### PR DESCRIPTION
### What does this PR do?

Fix the bug where the custom background keeps being shared after be removed in the selector.

### Closes Issue(s)
Closes #17072

### More
Also I made it set the new background when it's uploaded.

https://user-images.githubusercontent.com/15806883/226457456-ee86f420-746c-48cf-b974-1a3965b7cf33.mp4

