### PR TITLE
Docs: Fix bold font rendering

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -86,7 +86,7 @@ html {
     font-family: 'Open Sans';
     src: url('/static/fonts/OpenSans-Bold.ttf');
     font-weight: bold;
-    font-style: italic;
+    font-style: normal;
 }
 
 @font-face {
@@ -100,7 +100,7 @@ html {
     font-family: 'Open Sans';
     src: url('/static/fonts/OpenSans-ExtraBold.ttf');
     font-weight: bold;
-    font-style: italic;
+    font-style: normal;
 }
 
 @font-face {
@@ -112,7 +112,7 @@ html {
 
 .col {
     padding-bottom: 48px;
-} 
+}
 
 .button.button--install {
     background-color: #273d85;


### PR DESCRIPTION
Bold fonts were not rendered due to wrong naming of font-styles.
This commit fixes that.
    
Closes #17119

@dmtrhfr contributed to this