### PR TITLE
recording/video: Fix typo in area layout

### DIFF
--- a/record-and-playback/video/scripts/video.yml
+++ b/record-and-playback/video/scripts/video.yml
@@ -22,7 +22,7 @@ layout:
     - name: deskshare
       x: 0
       y: 0
-      width: 920
+      width: 960
       height: 720
       pad: true
 nopresentation_layout:


### PR DESCRIPTION
The deskshare video was accidentally set to 920px wide instead of 960px wide, so it was not completely covering the presentation area.