### PR TITLE
fix(sec): Upgrade Spring WebMVC Version

### DIFF
--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -62,7 +62,10 @@ dependencies {
   implementation "org.grails:grails-core:5.2.4"
   implementation "org.springframework.boot:spring-boot-starter-actuator:${springVersion}"
   implementation "org.springframework.boot:spring-boot-starter-tomcat:${springVersion}"
+
   implementation "org.grails:grails-web-boot:5.2.5"
+  implementation "org.springframework:spring-webmvc:5.3.26"
+
   implementation "org.grails:grails-logging"
   implementation "org.grails:grails-plugin-rest:5.2.5"
   implementation "org.grails:grails-plugin-databinding:5.2.4"

--- a/bigbluebutton-web/gradle.properties
+++ b/bigbluebutton-web/gradle.properties
@@ -1,4 +1,4 @@
-grailsVersion=5.2.4
+grailsVersion=5.3.2
 gormVersion=7.1.0
 gradleWrapperVersion=7.3.1
 grailsGradlePluginVersion=5.0.0


### PR DESCRIPTION
### What does this PR do?

Upgrades Spring WebMVC dependency to version 5.3.26 as well upgrades Grails version to 5.3.2.

### Motivation

The Spring WebMVC dependency is vulnerable to [CWE-284](https://cwe.mitre.org/data/definitions/284.html) and upgrading to latest version without the vulnerability requires an upgrade to the Grails version.
