### PR TITLE
(fix) - fix presentation modal freeze when cleaning errors

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -497,10 +497,22 @@ class PresentationUploader extends Component {
         ...filteredPresentations,
         ...filteredPropPresentations,
       ];
+      let hasUploading
+      merged.forEach(d => {
+        if (!d.upload?.done || !d.conversion?.done) {
+          hasUploading = true;
+        }})
       this.hasError = false;
-      return this.setState({
-        presentations: merged,
-      });
+      if (hasUploading) {
+        return this.setState({
+          presentations: merged,
+        });
+      } else {
+        return this.setState({
+          presentations: merged,
+          disableActions: false,
+        });
+      }
     }
 
     const { presentations } = this.state;


### PR DESCRIPTION
### What does this PR do?

It fixes the presentation-uploader modal when trying to cleaning errors and it is not uploading anything else. See error ahead:


https://user-images.githubusercontent.com/69865537/227521804-5338d79f-6d2a-498c-8cd4-3a22e07232a5.mp4
