### PR TITLE
fix(bbb-html5): Dismiss uploading toast after content capture

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/service.js
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/service.js
@@ -52,6 +52,7 @@ const upsertCapturedContent = (filename, temporaryPresentationId) => {
         error: false,
       },
       uploadTimestamp: new Date(),
+      renderedInToast: false,
     },
   });
 };

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toast/presentation-uploader-toast/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toast/presentation-uploader-toast/component.jsx
@@ -314,8 +314,9 @@ export const PresentationUploaderToast = ({ intl }) => {
     // main goal of this mapping is to sort out what doesn't need to be displayed
     UploadingPresentations.find().fetch().forEach((p) => {
       if (
-        ('upload' in p && p.upload.done) // if presentation is marked as done - it's potentially to be removed
-        && !p.subscriptionId // at upload stage or already converted
+        (('upload' in p && p.upload.done) // if presentation is marked as done - it's potentially to be removed
+        && !p.subscriptionId) // at upload stage or already converted
+        || (p.lastModifiedUploader === false) // if presentation uploaded internally (e.g., breakout capture)
       ) {
         if (convertingPresentations[0]) { // there are presentations being converted
           convertingPresentations.forEach((cp) => {
@@ -326,7 +327,7 @@ export const PresentationUploaderToast = ({ intl }) => {
                 .push({ temporaryPresentationId: p.temporaryPresentationId, id: p.id });
             }
           });
-          // upload stage is done and pesentation is entering conversion stage
+          // upload stage is done and presentation is entering conversion stage
         } else if (!enteredConversion[p.temporaryPresentationId]) {
           // we mark that it has entered conversion stage
           enteredConversion[p.temporaryPresentationId] = true;


### PR DESCRIPTION
### What does this PR do?
The processing dialog showing `"To be uploaded..."` for content captured from breakout rooms was not being replaced by the toast showing successful upload. Instead, a duplicate entry was created.

<img src="https://user-images.githubusercontent.com/33319791/227588979-7cb016bb-733e-4e41-97ef-05960979a376.png" width="50%" />

### Closes Issue
Reported by @ffdixon 

### Motivation
Make the recent refactor of the presentation uploading logic consider files uploaded without using the modal, such as those captured in breakout rooms or sent to the presentation are from the shared notes.

### Fixed behavior
![Screenshot 2023-03-24 at 17 03 43](https://user-images.githubusercontent.com/33319791/227589137-48849ec4-708b-412f-b397-df7da1c1917a.png)

