### PR TITLE
fix(bbb-presentation-video): Update to 4.0.0

### DIFF
--- a/bbb-presentation-video.placeholder.sh
+++ b/bbb-presentation-video.placeholder.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -ex
-RELEASE=4.0.0-rc.2
+RELEASE=4.0.0
 cat <<MSG
 This tool downloads prebuilt packages built on Github Actions
 The corresponding source can be browsed at https://github.com/bigbluebutton/bbb-presentation-video/tree/${RELEASE}


### PR DESCRIPTION
This is the release of bbb-presentation-video for BigBlueButton 2.6.1.

## What's Changed since 4.0.0-rc.2
* https://github.com/bigbluebutton/bbb-presentation-video/pull/31 by @kepstin
* https://github.com/bigbluebutton/bbb-presentation-video/pull/30 by @germanocaumo
* https://github.com/bigbluebutton/bbb-presentation-video/pull/33 by @kepstin
* https://github.com/bigbluebutton/bbb-presentation-video/pull/34 by @kepstin


**Full Changelog**: https://github.com/bigbluebutton/bbb-presentation-video/compare/4.0.0-rc.2...4.0.0