### PR TITLE
Fixed: Note notification removed when shared notes pinned.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -168,11 +168,12 @@ class NavBar extends Component {
       amIModerator,
       style,
       main,
+      isPinned,
       sidebarNavigation,
       currentUserId,
     } = this.props;
 
-    const hasNotification = hasUnreadMessages || hasUnreadNotes;
+    const hasNotification = hasUnreadMessages || (hasUnreadNotes && !isPinned);
 
     let ariaLabel = intl.formatMessage(intlMessages.toggleUserListAria);
     ariaLabel += hasNotification ? (` ${intl.formatMessage(intlMessages.newMessages)}`) : '';

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/container.jsx
@@ -115,6 +115,7 @@ export default withTracker(() => {
   }
 
   return {
+    isPinned: NotesService.isSharedNotesPinned(),
     currentUserId: Auth.userID,
     meetingId,
     presentationTitle: meetingTitle,


### PR DESCRIPTION
### What does this PR do?

This PR removes the red dot indicating change on shared notes when they're pinned.

### Closes Issue(s)

#16943 