### PR TITLE
recording: Increase quality of libx264 intermediate files

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video.rb
@@ -25,7 +25,10 @@ module BigBlueButton
   module EDL
     module Video
       FFMPEG_WF_CODEC = 'libx264'
-      FFMPEG_WF_ARGS = ['-codec', FFMPEG_WF_CODEC.to_s, '-preset', 'veryfast', '-crf', '30', '-force_key_frames', 'expr:gte(t,n_forced*10)', '-pix_fmt', 'yuv420p']
+      FFMPEG_WF_ARGS = [
+        '-codec', FFMPEG_WF_CODEC.to_s, '-preset', 'fast', '-crf', '23',
+        '-x264opts', 'stitchable=1', '-force_key_frames', 'expr:gte(t,n_forced*10)', '-pix_fmt', 'yuv420p',
+      ]
       WF_EXT = 'mp4'
 
       def self.dump(edl)


### PR DESCRIPTION
The encoding settings for intermediate files was using `-preset veryfast -crf 30`, which resulted in very poor quality video.

After a bit of experimenting, I decided to change this to `-preset veryfast -crf 23`. This results in files which are roughly twice the size of before, but they look significantly better.

There's improvements possible at the same filesize by switching to a slower encoding mode. But in the case of -preset medium for example, when normalized to the same output file size, you end up using about 1.5 times as much cpu time to gain only a very small amount of video quality.