### PR TITLE
[doc] open 80 and 443 for Let's Encrypt

### DIFF
--- a/docs/docs/administration/install.md
+++ b/docs/docs/administration/install.md
@@ -131,7 +131,8 @@ $ grep -c ^processor /proc/cpuinfo
 8
 ```
 
-Next, if you choose the option -e for Let's Encrypt, check that your server has the port 80 and 443 open
+Next check that your server has the port 80 and 443 open
+
 
 ```bash
 $ sudo ufw status

--- a/docs/docs/administration/install.md
+++ b/docs/docs/administration/install.md
@@ -131,6 +131,25 @@ $ grep -c ^processor /proc/cpuinfo
 8
 ```
 
+Next, if you choose the option -e for Let's Encrypt, check that your server has the port 80 and 443 open
+
+```bash
+$ sudo ufw status
+...
+80       ALLOW   Anywhere
+443      ALLOW   Anywhere
+...
+80 (v6)  ALLOW   Anywhere
+443 (v6) ALLOW   Anywhere
+...
+```
+
+If you don't see these lines, you need to open them by
+```bash
+sudo ufw allow 80
+sudo ufw allow 443
+```
+
 Sometimes we get asked "Why are you only supporting Ubuntu 20.04 64-bit?". The answer is based on choosing quality over quantity. Long ago we concluded that its better for the project to have solid, well-tested, well-documented installation for a specific version of Linux that works really, really well than to try and support may variants of Linux and have none of them work well.
 
 At the moment, the requirement for docker may preclude running 2.6 within some virtualized environments; however, it ensures libreoffice runs within a restricted sandbox for document conversion.  We are exploring if we can run libreoffice within systemd (such as systemd-nspawn).


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Add a description to open port 443 and 80 when -e option is chosen.

### Motivation

I failed in a clean install of BBB 2,5 without this operation.

### More

I am not sure if it's the same for 2.6. 
I saw a post in the past that somebody suffered this issue.
