### PR TITLE
fix: empty slide on presentation change

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -239,8 +239,10 @@ export default function Whiteboard(props) {
 
     // update document if the number of pages has changed
     if (currentDoc.id !== whiteboardId && currentDoc?.pages.length !== curPres?.pages.length) {
+      const currentPageShapes = currentDoc?.pages[curPageId]?.shapes;
       currentDoc.id = whiteboardId;
       currentDoc.pages = pages;
+      currentDoc.pages[curPageId].shapes = currentPageShapes;
       currentDoc.pageStates = pageStates;
     }
 


### PR DESCRIPTION
### What does this PR do?

Restores background slide when presentation is changed.