### PR TITLE
ci: Prevents CI triggering on push events

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -5,6 +5,9 @@ on:
       - 'develop'
       - 'v2.[5-9].x-release'
       - 'v[3-9].*.x-release'
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:


### PR DESCRIPTION
### What does this PR do?

Keeps `paths-ignore` on push in order to avoid triggering it 