### PR TITLE
fix(docs): set Greenlight v3 as default reference for Greenlight

### DIFF
--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -68,7 +68,7 @@ Major features in this release include:
 
 * **Faster Screen Sharing** - Screen sharing now is faster, works across all browsers (using a Java application that launches outside the browser), and captures the cursor (see [video](https://www.youtube.com/watch?v=xTFuEvmEqB0)).
 
-* **Greenlight** - Administrators can install a new front-end, called Greenlight, that makes it easy for users to quickly creating meetings, invite others, and manage recordings on a BigBlueButton server.  Using Docker, administrators can [install](/greenlight/v2/overview) on the BigBlueButton server itself (no need for a separate server).  Greenlight is written in Rails 5 and can be easily customized by any rails developer (see [source on GitHub](https://github.com/bigbluebutton/greenlight)).
+* **Greenlight** - Administrators can install a new front-end, called Greenlight, that makes it easy for users to quickly creating meetings, invite others, and manage recordings on a BigBlueButton server.  Using Docker, administrators can [install](/greenlight/v3/install) on the BigBlueButton server itself (no need for a separate server).  Greenlight is written in Rails 5 and can be easily customized by any rails developer (see [source on GitHub](https://github.com/bigbluebutton/greenlight)).
 
 * **Ubuntu 16.04 packages** - This release installs on Ubuntu 16.04 64-bit (the most recent long-term support release from Canonical) and uses `systemd` for new start/stop scripts for individual components.
 

--- a/docs/docs/support/faq.md
+++ b/docs/docs/support/faq.md
@@ -448,7 +448,7 @@ Since BigBlueButton is controlled by its [API](/development/api), there isn't an
 
 The most common way to use BigBlueButton is to use an existing application that has a plugin. See [list of integrations](https://bigbluebutton.org/integrations/).
 
-BigBlueButton also comes with an easy-to-use front-end called [Greenlight](/greenlight/v2/overview).
+BigBlueButton also comes with an easy-to-use front-end called [Greenlight](/greenlight/v3/install).
 
 
 ### Where do I schedule a meeting in BigBlueButton?
@@ -528,7 +528,7 @@ Absolutely. To see an example of this, check out [GreenLight on our pool of demo
 
 If you are using Sakai, Moodle, Drupal, Joomla, Wordpress or other systems that already have a [BigBlueButton integration](https://bigbluebutton.org/support), then installing the integration provides the easiest way to enable your users to access BigBlueButton sessions.
 
-Alternatively, you can set up [Greenlight](/greenlight/v2/overview) to be able to easily manage classrooms.
+Alternatively, you can set up [Greenlight](/greenlight/v3/install) to be able to easily manage classrooms.
 
 #### How do I integrate BigBlueButton with my own server
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -63,7 +63,7 @@ const config = {
                     {to: 'https://bigbluebutton.org/teachers/tutorials/', label: 'Teaching', position: 'left'},
                     {to: '/development/guide', label: 'Development', position: 'left'},
                     {to: '/administration/install', label: 'Administration', position: 'left'},
-                    {to: '/greenlight/v2/overview', label: 'Greenlight', position: 'left'},
+                    {to: '/greenlight/v3/install', label: 'Greenlight', position: 'left'},
                     {to: '/new-features', label: 'New Features', position: 'left'},
                     {
                         type: 'docsVersionDropdown',

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -64,7 +64,7 @@ const sidebars = {
             ],
             link: {
                 type: 'doc',
-                id: 'greenlight/v2/overview',
+                id: 'greenlight/v3/install',
             },
         }
     ],

--- a/docs/src/components/HomepageFeatures/index.tsx
+++ b/docs/src/components/HomepageFeatures/index.tsx
@@ -58,7 +58,7 @@ const FeatureList: FeatureItem[] = [
             </>
         ),
         actionText: "Greenlight guide",
-        docId: "/greenlight/v2/overview"
+        docId: "/greenlight/v3/install"
     },
     {
         title: 'What\'s new?',


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

The Greenlight references points to GLv2 docs `greenlight/v2/overview`.
Fix it so that it now redirects you to the GLv3 docs instead `greenlight/v3/install`.


