### PR TITLE
docs: fixed reseting to default version in bbb documentation

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -97,10 +97,30 @@ const config = {
                 },
                 items: [
                     {to: 'https://bigbluebutton.org/teachers/tutorials/', label: 'Teaching', position: 'left'},
-                    {to: '/development/guide', label: 'Development', position: 'left'},
-                    {to: '/administration/install', label: 'Administration', position: 'left'},
-                    {to: '/greenlight/v2/overview', label: 'Greenlight', position: 'left'},
-                    {to: '/new-features', label: 'New Features', position: 'left'},
+                    {
+                        type: 'doc',
+                        position: 'left',
+                        docId: 'development/guide',
+                        label: 'Development',
+                    },
+                    {
+                        type: 'doc',
+                        position: 'left',
+                        docId: 'administration/install',
+                        label: 'Administration',
+                    },
+                    {
+                        type: 'doc',
+                        position: 'left',
+                        docId: 'greenlight/v2/overview',
+                        label: 'Greenlight',
+                    },
+                    {
+                        type: 'doc',
+                        position: 'left',
+                        docId: 'new-features',
+                        label: 'New Features',
+                    },
                     {
                         type: 'docsVersionDropdown',
                         position: 'right',


### PR DESCRIPTION
### What does this PR do?

It fixes the restoring to default version when changing from one tab to another in bbb documentation `navbar`. 

### Closes Issue(s)

Closes  #17157

### More

Just a demo of the final result:

https://user-images.githubusercontent.com/69865537/229228566-8d5601f5-1025-45ad-88c6-8099338a6925.mp4



