### PR TITLE
[2.6] darken the color of pan tool icon when hovered

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -115,7 +115,7 @@ const PanTool = styled(Button)`
 
   &:hover,
   &:focus {
-    background-color: var(--colors-hover);
+    background-color: var(--colors-hover) !important;
   }
 `;
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Darkening the pan tool icon when the pointer is hovered.

### Closes Issue(s)

Closes the problem 1 I listed up in the comment on #16801

### More

The problem 2 and 3 remain to be solved.