### PR TITLE
[2.6 fix] recover hover effect on icons of whiteboard toolbar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1015,6 +1015,7 @@ export default function Whiteboard(props) {
             size,
             darkTheme,
             menuOffset,
+            panSelected,
           }}
         />
       </Cursors>

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
@@ -101,6 +101,9 @@ class PanToolInjector extends React.Component {
             }
           }}
           hideLabel
+          {...{
+            panSelected,
+          }}
         />,
         container,
       );

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -123,7 +123,7 @@ const PanTool = styled(Button)`
   ${({ panSelected }) => !panSelected && `
     &:hover,
     &:focus {
-      background-color: var(--colors-hover);
+      background-color: var(--colors-hover) !important;
     }
   `}
 `;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -73,8 +73,9 @@ const TldrawGlobalStyle = createGlobalStyle`
     }
   `}
   ${({ hasWBAccess, isPresenter, panSelected }) => (hasWBAccess || isPresenter) && panSelected && `
-    [id^="TD-PrimaryTools-"]:hover,:focus {
-      & > div {
+    [id^="TD-PrimaryTools-"] {
+      &:hover > div,
+      &:focus > div {
         background-color: var(--colors-hover) !important;
       }
     }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -73,7 +73,7 @@ const TldrawGlobalStyle = createGlobalStyle`
     }
   `}
   ${({ hasWBAccess, isPresenter, panSelected }) => (hasWBAccess || isPresenter) && panSelected && `
-    [id^="TD-PrimaryTools-"]:hover {
+    [id^="TD-PrimaryTools-"]:hover,:focus {
       & > div {
         background-color: var(--colors-hover) !important;
       }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -72,6 +72,13 @@ const TldrawGlobalStyle = createGlobalStyle`
       margin: ${borderSize} ${borderSizeLarge} 0px ${borderSizeLarge};
     }
   `}
+  ${({ hasWBAccess, isPresenter, panSelected }) => (hasWBAccess || isPresenter) && panSelected && `
+    [id^="TD-PrimaryTools-"]:hover {
+      & > div {
+        background-color: var(--colors-hover) !important;
+      }
+    }
+  `}
   ${({ darkTheme }) => darkTheme && `
     #TD-TopPanel-Undo,
     #TD-TopPanel-Redo,
@@ -113,10 +120,12 @@ const PanTool = styled(Button)`
     }
   }
 
-  &:hover,
-  &:focus {
-    background-color: var(--colors-hover);
-  }
+  ${({ panSelected }) => !panSelected && `
+    &:hover,
+    &:focus {
+      background-color: var(--colors-hover);
+    }
+  `}
 `;
 
 export default {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fix darkening wb toolbar icons when pointer hovered. 
In the previous toolbar I found three problems (commented in #16801):

1. The pan tool does not darken when the pointer hovered
2. The tooltip of pan tool appears a bit faster than the other tools, and it hide the next button (pen tool) almost completely
3. When the pan tool is selected, the other buttons do not darken when the pointer hovered on them.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes the problems 1 and 3 listed above.


### Motivation

Since the injection of pan tool into the tldraw toolbar (which is really nice indeed), the icon darkening has not been working correctly.

### More

The problem 2 in which the tooltip appears too much faster remains to be solved.

Before:
![225808090-94dc5450-5709-48c3-9d9e-45332710aa15](https://user-images.githubusercontent.com/45039819/229360437-3cbbb0c8-e874-4a21-ad74-4e79c796f52c.gif)

After:
<video src="https://user-images.githubusercontent.com/45039819/229360584-9dce90f2-35d2-414e-ab28-2ecb53a257cd.mov" controls="controls" style="max-height: 200px;">
</video>

