### PR TITLE
[2.6 fix] Show the pan tool tip at the same timing and position as other tools

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/button/component.jsx
@@ -123,6 +123,8 @@ export default class Button extends BaseButton {
       'aria-label': ariaLabel,
       'aria-expanded': ariaExpanded,
       tooltipLabel,
+      tooltipDelay,
+      tooltipPlacement,
     } = this.props;
 
     const renderFuncName = circle ? 'renderCircle' : 'renderDefault';
@@ -132,6 +134,8 @@ export default class Button extends BaseButton {
       return (
         <TooltipContainer
           title={tooltipLabel || buttonLabel}
+          delay={tooltipDelay}
+          placement={tooltipPlacement}
         >
           {this[renderFuncName]()}
         </TooltipContainer>

--- a/bigbluebutton-html5/imports/ui/components/common/button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/button/component.jsx
@@ -123,8 +123,8 @@ export default class Button extends BaseButton {
       'aria-label': ariaLabel,
       'aria-expanded': ariaExpanded,
       tooltipLabel,
-      tooltipDelay,
-      tooltipPlacement,
+      tooltipdelay,
+      tooltipplacement,
     } = this.props;
 
     const renderFuncName = circle ? 'renderCircle' : 'renderDefault';
@@ -134,8 +134,8 @@ export default class Button extends BaseButton {
       return (
         <TooltipContainer
           title={tooltipLabel || buttonLabel}
-          delay={tooltipDelay}
-          placement={tooltipPlacement}
+          delay={tooltipdelay}
+          placement={tooltipplacement}
         >
           {this[renderFuncName]()}
         </TooltipContainer>

--- a/bigbluebutton-html5/imports/ui/components/common/tooltip/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/tooltip/component.jsx
@@ -57,9 +57,19 @@ class Tooltip extends Component {
     const {
       position,
       title,
+      delay,
+      placement,
     } = this.props;
 
     const { animations } = Settings.application;
+    
+    const overridePlacement = placement ? placement : position;
+    let overrideDelay;
+    if (animations) {
+      overrideDelay = delay ? [delay, ANIMATION_DELAY[1]] : ANIMATION_DELAY;
+    } else {
+      overrideDelay = delay ? [delay, 0] : [ANIMATION_DELAY[0], 0];
+    }
 
     const options = {
       aria: null,
@@ -69,14 +79,14 @@ class Tooltip extends Component {
       arrow: roundArrow,
       boundary: 'window',
       content: title,
-      delay: animations ? ANIMATION_DELAY : [ANIMATION_DELAY[0], 0],
+      delay: overrideDelay,
       duration: animations ? ANIMATION_DURATION : 0,
       interactive: true,
       interactiveBorder: 10,
       onShow: this.onShow,
       onHide: this.onHide,
       offset: TIP_OFFSET,
-      placement: position,
+      placement: overridePlacement,
       touch: 'hold',
       theme: 'bbbtip',
       multiple: false,

--- a/bigbluebutton-html5/imports/ui/components/common/tooltip/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/tooltip/component.jsx
@@ -111,12 +111,15 @@ class Tooltip extends Component {
       return true;
     }).forEach((e) => {
       const instance = e._tippy;
-      instance.setProps({
+      const newProps = {
         animation: animations
           ? DEFAULT_ANIMATION : ANIMATION_NONE,
-        delay: animations ? ANIMATION_DELAY : [ANIMATION_DELAY[0], 0],
         duration: animations ? ANIMATION_DURATION : 0,
-      });
+      };
+      if (!e.getAttribute("delay")) {
+        newProps["delay"] = animations ? ANIMATION_DELAY : [ANIMATION_DELAY[0], 0];
+      }
+      instance.setProps(newProps);
     });
 
     const elem = document.getElementById(this.tippySelectorId);

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
@@ -89,6 +89,8 @@ class PanToolInjector extends React.Component {
           size="md"
           label={label}
           aria-label={label}
+          tooltipDelay={700}
+          tooltipPlacement="top"
           onClick={() => {
             setPanSelected(true);
             setIsPanning(true);

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/pan-tool-injector/component.jsx
@@ -89,8 +89,8 @@ class PanToolInjector extends React.Component {
           size="md"
           label={label}
           aria-label={label}
-          tooltipDelay={700}
-          tooltipPlacement="top"
+          tooltipdelay={700}
+          tooltipplacement="top"
           onClick={() => {
             setPanSelected(true);
             setIsPanning(true);


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Making the injected pan tool show the tooltip in a similar way as the other wb tools.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes the issue 2 in the comment on #16801

### Motivation

The tooltip of pan tool appeared a bit faster than the other tools, and it hide the next button (pen tool) almost completely because it shows up at the bottom of the icon, while the other tools show tooltips above the icons.

### More
Together with the PR #17395, the new whiteboard toolbar looks almost consistent.

Before:
(look at the pan tool behaving differently from others, showing no hover effect, tooltips appearing very fast and its position is different from others)
![Animation0](https://user-images.githubusercontent.com/45039819/229453022-e93c8e90-0c39-435f-964d-27e7398eaff0.gif)

After:
![Animation1](https://user-images.githubusercontent.com/45039819/229453084-887a852d-613f-420f-a10a-d9b4dffe40fc.gif)
