### PR TITLE
docs: Insert documentation for hidePresentationOnJoin

### DIFF
--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1328,6 +1328,7 @@ Useful tools for development:
 | `userdata-bbb_skip_check_audio=`               | If set to `true`, the user will not see the "echo test" prompt when sharing audio                                                                                                                                                                                                                                               | `false`       |
 | `userdata-bbb_skip_check_audio_on_first_join=` | (Introduced in BigBlueButton 2.3) If set to `true`, the user will not see the "echo test" when sharing audio for the first time in the session. If the user stops sharing, next time they try to share audio the echo test window will be displayed, allowing for configuration changes to be made prior to sharing audio again | `false`       |
 | `userdata-bbb_override_default_locale=`        | (Introduced in BigBlueButton 2.3) If set to `de`, the user's browser preference will be ignored - the client will be shown in 'de' (i.e. German) regardless of the otherwise preferred locale 'en' (or other)                                                                                                                   | `null`        |
+| `userdata-bbb_hide_presentation_on_join`        | (Introduced in BigBlueButton 2.6) If set to `true` it will make the user enter the meeting with presentation minimized (Only for non-presenters), not peremanent.                                                                                                                   | `false`        |
 
 #### Branding parameters
 

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -86,6 +86,8 @@ Updated in 2.6:
 
 - **getRecordings** - **Added:** Added support for pagination using `offset`, `limit`
 
+- **join**: Added `userdata-bbb_hide_presentation_on_join`.
+
 ## API Data Types
 
 There are three types in the API.

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -149,9 +149,9 @@ Learn more about [how to enable generating MP4 (h264 video) output](https://docs
 
 #### Change of parameters naming
 
-In 2.5 we had the hidePresentation which was responsible for disabling presentation Area, and it was configured in the join call. Now we have a new disabled feature which is responsible for that. it is called `disabledFeatures=presentation`, and it is configured in the create call, for more details see the [docs](https://docs.bigbluebutton.org/dev/api.html#create).
+In 2.5 we had the hidePresentation which was responsible for disabling presentation Area, and it was configured in the join call. Now we have a new disabled feature which is responsible for that. it is called `disabledFeatures=presentation`, and it is configured in the create call, for more details see the [docs](https://docs.bigbluebutton.org/2.6/development/api#create).
 
-There is another parameter renamed in 2.6, it is `swapLayout`, or `userdata-bbb_auto_swap_layout` in the join call. Now, this parameter is set to `hidePresentationOnJoin` or `userdata-bbb_hide_presentation_on_join` in the join call, and it does essentially the same thing: it starts meeting with presentation minimized.
+There is another parameter renamed in 2.6, it is `swapLayout`, or `userdata-bbb_auto_swap_layout` in the join call. Now, this parameter is set to `hidePresentationOnJoin` or `userdata-bbb_hide_presentation_on_join` in the join call, and it does essentially the same thing: it starts meeting with presentation minimized. And lastly, we've got another way to configure it: which is to set `public.layout.hidePresentationOnJoin: true` in the override settings file: `/etc/bigbluebutton/bbb-html5.yml`
 
 In brief:
 


### PR DESCRIPTION
### What does this PR do?

It inserts documentation for `hidePresentationOnJoin` as suggested in comment https://github.com/bigbluebutton/bigbluebutton/pull/16769#issuecomment-1454662628

### More

Related to https://github.com/bigbluebutton/bigbluebutton/pull/16769.

See snapshots of the update:

![image](https://user-images.githubusercontent.com/69865537/229530398-4f0af948-357d-4536-b05d-02d0e0014ac6.png)

![image](https://user-images.githubusercontent.com/69865537/229530799-ba5fdc50-89c9-42e4-91e9-2ff2e6e42e88.png)

![image](https://user-images.githubusercontent.com/69865537/229531207-23f558ae-8bad-4919-9e7b-c6bfeee17f3f.png)

