### PR TITLE
GNS3 placeholder

### DIFF
--- a/bigbluebutton-tests/gns3/.gitignore
+++ b/bigbluebutton-tests/gns3/.gitignore
@@ -1,0 +1,3 @@
+NPDC
+bbb-dev-ca.crt
+bbb-dev-ca.key

--- a/bigbluebutton-tests/gns3/NPDC.placeholder.sh
+++ b/bigbluebutton-tests/gns3/NPDC.placeholder.sh
@@ -1,0 +1,1 @@
+git clone --branch master --depth 1 https://github.com/BrentBaccala/NPDC NPDC

--- a/bigbluebutton-tests/gns3/README.md
+++ b/bigbluebutton-tests/gns3/README.md
@@ -35,11 +35,10 @@ Some special names are defined.  Requesting a device name starting with `testcli
 
 ## Usage
 
-1. You'll need several tools from Brent Baccala's NPDC repository on github, which is a submodule in the NPDC directory, so run this command to fetch it:
+1. You'll need several tools from Brent Baccala's NPDC repository on github, so run this command to fetch it:
 
    ```
-   git submodule init
-   git submodule update
+   ./NPDC.placeholder.sh
    ```
 
 1. Read, understand, and run the `install-gns3.sh` script in `NPDC/GNS3`


### PR DESCRIPTION
Add a script to checkout the NPDC repository, which is used by the gns3 script.

It was originally a submodule, but there's a backwards compatibility issue (the need to convert to SVN to support the Jenkins build system) that prevents using submodules.

I currently have it set to checkout the `master` branch of NPDC.  Git submodules are typically tied to a single commit (not a branch).  Not sure if there will be a problem pointing the script to `master`.

There's also a `.gitignore` file to ignore the (untracked) NPDC directory, as well as ignoring SSL certs and keys.  The certs and keys should probably be moved to a different location, but that's a different PR.