### PR TITLE
docs: fix - 2.6 route does not exist now that 2.6 is current

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -61,11 +61,11 @@ const config = {
                 fromExtensions: ["html"],
                 redirects: [
                     {
-                        to: "/2.6/new-features",
+                        to: "/new-features",
                         from: "/2.6/new"
                     },
                     {
-                        to: "/2.6/new-features",
+                        to: "/new-features",
                         from: "/2.6/new.html"
                     },
                     {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
After setting `lastVersion: '2.6'`, routes for 2.6 version are no longer prefixed with `2.6/` so some redirects were failing
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #
reated: https://github.com/bigbluebutton/bigbluebutton/pull/17398

### Motivation
![Screenshot from 2023-04-04 10-50-23](https://user-images.githubusercontent.com/6312397/229831401-5a26abe3-53b9-43a6-8ffb-7d8b22a569d6.png)

![Screenshot from 2023-04-04 10-50-34](https://user-images.githubusercontent.com/6312397/229831436-f88aff68-9f14-404e-b69d-e28325e407e1.png)

<!-- What inspired you to submit this pull request? -->

### More

