### PR TITLE
recording-and-playback/presentation: Fix hiding tldraw cursors

### DIFF
--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1035,11 +1035,11 @@ def process_presentation(package_dir)
 
     # Perform cursor finalization
     if cursor_changed || panzoom_changed
-      if !tldraw
-        unless cursor_x >= 0 && cursor_x <= 100 &&
-            cursor_y >= 0 && cursor_y <= 100
-          cursor_visible = false
-        end
+      if cursor_x < 0 || cursor_y < 0
+        cursor_visible = false
+      end
+      if cursor_x >= 100 || cursor_y >= 100 && !tldraw
+        cursor_visible = false
       end
 
       panzoom = panzooms.last


### PR DESCRIPTION
The code was skipping the check for cursor x or y position < 0 when the tldraw whiteboard was in use. That condition is still needed on the tldraw whiteboard to indicate that the cursor should be hidden.

Only the check for cursor x or y position >100 needs to be skipped when the tldraw whiteboard is in use (since tldraw cursors are in the slide coordinate space, they can go up to x=1440 or y=1080)