### PR TITLE
Enhancement: Unread and read privet chats now order by unread and alphabetical order.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -322,8 +322,30 @@ const getActiveChats = ({ groupChatsMessages, groupChats, users }) => {
   });
 
   const currentClosedChats = Storage.getItem(CLOSED_CHAT_LIST_KEY) || [];
-  return chatInfo.filter((chat) => !currentClosedChats.includes(chat.chatId)
+  const removeClosedChats = chatInfo.filter((chat) => !currentClosedChats.includes(chat.chatId)
     && chat.shouldDisplayInChatList);
+  const sortByChatIdAndUnread = removeClosedChats.sort((a, b) => {
+    if (a.chatId === PUBLIC_GROUP_CHAT_ID) {
+      return -1;
+    }
+    if (b.chatId === PUBLIC_CHAT_ID) {
+      return 0;
+    }
+    if (a.unreadCounter > 0 && b.unreadCounter === 0) {
+      return -1;
+    } else if (a.unreadCounter === 0 && b.unreadCounter > 0) {
+      return 1;
+    } else {
+        if (a.name < b.name) {
+          return -1;
+        }
+        if (a.name > b.name) {
+          return 1;
+        }
+      return 0;
+      }
+  });
+  return sortByChatIdAndUnread;
 };
 
 const isVoiceOnlyUser = (userId) => userId.toString().startsWith('v_');

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -331,15 +331,15 @@ const getActiveChats = ({ groupChatsMessages, groupChats, users }) => {
     if (b.chatId === PUBLIC_CHAT_ID) {
       return 0;
     }
-    if (a.unreadCounter > 0 && b.unreadCounter === 0) {
+    if (a.unreadCounter > b.unreadCounter) {
       return -1;
-    } else if (a.unreadCounter === 0 && b.unreadCounter > 0) {
+    } else if (b.unreadCounter > a.unreadCounter) {
       return 1;
     } else {
-        if (a.name < b.name) {
+        if (a.name.toLowerCase() < b.name.toLowerCase()) {
           return -1;
         }
-        if (a.name > b.name) {
+        if (a.name.toLowerCase() > b.name.toLowerCase()) {
           return 1;
         }
       return 0;


### PR DESCRIPTION
### What does this PR do?

This PR sets the priority of privet chats in the following order:

1. Unread messages (and if more than one alphabetical).
2. Alphabetical (if none is unread). 

### Closes Issue(s)
#17403 