### PR TITLE
docs: Fix for tables broken references

### DIFF
--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -8,6 +8,20 @@ keywords:
 - api
 ---
 
+import APITableComponent from '@site/src/components/APITableComponent';
+import createEndpointTableData from '@site/src/data/create.tsx';
+import deleteRecordingsEndpointTableData from '@site/src/data/deleteRecordings.tsx';
+import endEndpointTableData from '@site/src/data/end.tsx';
+import getMeetingInfoEndpointTableData from '@site/src/data/getMeetingInfo.tsx';
+import getRecordingsEndpointTableData from '@site/src/data/getRecordings.tsx';
+import getRecordingTextTracksEndpointTableData from '@site/src/data/getRecordingTextTracks.tsx';
+import insertDocumentEndpointTableData from '@site/src/data/insertDocument.tsx';
+import isMeetingRunningEndpointTableData from '@site/src/data/isMeetingRunning.tsx';
+import joinEndpointTableData from '@site/src/data/join.tsx';
+import publishRecordingsEndpointTableData from '@site/src/data/publishRecordings.tsx';
+import putRecordingTextTrackEndpointTableData from '@site/src/data/putRecordingTextTrack.tsx';
+import updateRecordingsEndpointTableData from '@site/src/data/updateRecordings.tsx';
+
 ## Overview
 
 This document describes the BigBlueButton application programming interface (API).
@@ -255,66 +269,9 @@ http&#58;//yourserver.com/bigbluebutton/api/create?[parameters]&checksum=[checks
 
 **Parameters:**
 
-| Param Name | Type | Description |
-|---|---|---|
-| `name` *(required)* | String | A name for the meeting.  This is now required as of BigBlueButton 2.4. |
-| `meetingID` *(required)* | String | A meeting ID that can be used to identify this meeting by the 3rd-party application.<br /><br />This must be unique to the server that you are calling: different active meetings can not have the same meeting ID.<br /><br />If you supply a non-unique meeting ID (a meeting is already in progress with the same meeting ID), then if the other parameters in the create call are identical, the create call will succeed (but will receive a warning message in the response). The create call is idempotent: calling multiple times does not have any side effect.  This enables a 3rd-party applications to avoid checking if the meeting is running and always call create before joining each user.<br /><br />Meeting IDs should only contain upper/lower ASCII letters, numbers, dashes, or underscores  A good choice for the meeting ID is to generate a [GUID](https://en.wikipedia.org/wiki/Globally_unique_identifier) value as this all but guarantees that different meetings will not have the same meetingID. |
-| `attendeePW `| String | **[DEPRECATED]** The password that the join URL can later provide as its `password` parameter to indicate the user will join as a viewer.  If no `attendeePW` is provided, the `create` call will return a randomly generated `attendeePW` password for the meeting. |
-| `moderatorPW` | String | **[DEPRECATED]** The password that will join URL can later provide as its `password` parameter to indicate the user will as a moderator.  if no `moderatorPW` is provided, `create` will return a randomly generated `moderatorPW` password for the meeting. |
-| `welcome` | String | A welcome message that gets displayed on the chat window when the participant joins. You can include keywords (`%%CONFNAME%%`, `%%DIALNUM%%`, `%%CONFNUM%%`) which will be substituted automatically.<br /><br />This parameter overrides the default `defaultWelcomeMessage` in [bigbluebutton.properties](https://github.com/bigbluebutton/bigbluebutton/blob/master/bigbluebutton-web/grails-app/conf/bigbluebutton.properties).<br /><br />The welcome message has limited support for HTML formatting. Be careful about copy/pasted HTML from e.g. MS Word, as it can easily exceed the maximum supported URL length when used on a GET request. |
-| `dialNumber` | String | The dial access number that participants can call in using regular phone. You can set a default dial number via `defaultDialAccessNumber` in [bigbluebutton.properties](https://github.com/bigbluebutton/bigbluebutton/blob/master/bigbluebutton-web/grails-app/conf/bigbluebutton.properties) |
-| `voiceBridge` | String | Voice conference number for the FreeSWITCH voice conference associated with this meeting.  This must be a 5-digit number in the range 10000 to 99999.  If you [add a phone number](https://docs.bigbluebutton.org/bigbluebutton/administration/customize#add-a-phone-number-to-the-conference-bridge) to your BigBlueButton server, This parameter sets the personal identification number (PIN) that FreeSWITCH will prompt for a phone-only user to enter.  If you want to change this range, edit FreeSWITCH dialplan and `defaultNumDigitsForTelVoice` of [bigbluebutton.properties](https://github.com/bigbluebutton/bigbluebutton/blob/master/bigbluebutton-web/grails-app/conf/bigbluebutton.properties).<br /><br />The `voiceBridge` number must be different for every meeting.<br /><br />This parameter is optional. If you do not specify a `voiceBridge` number, then BigBlueButton will assign a random unused number for the meeting.<br /><br />If do you pass a `voiceBridge` number, then you must ensure that each meeting has a unique `voiceBridge` number; otherwise, reusing same `voiceBridge` number for two different meetings will cause users from one meeting to appear as phone users in the other, which will be very confusing to users in both meetings. |
-| `maxParticipants` | Number | Set the maximum number of users allowed to joined the conference at the same time. |
-| `logoutURL` | String | The URL that the BigBlueButton client will go to after users click the OK button on the ‘You have been logged out message’.  This overrides the value for `bigbluebutton.web.logoutURL` in [bigbluebutton.properties](https://github.com/bigbluebutton/bigbluebutton/blob/master/bigbluebutton-web/grails-app/conf/bigbluebutton.properties). |
-| `record` | Boolean | Setting `record=true` instructs the BigBlueButton server to record the media and events in the session for later playback. The default is false.<br /><br />In order for a playback file to be generated, a moderator must click the Start/Stop Recording button at least once during the sesssion; otherwise, in the absence of any recording marks, the record and playback scripts will not generate a playback file. See also the `autoStartRecording` and `allowStartStopRecording` parameters in [bigbluebutton.properties](https://github.com/bigbluebutton/bigbluebutton/blob/master/bigbluebutton-web/grails-app/conf/bigbluebutton.properties). |
-| `duration` | Number | The maximum length (in minutes) for the meeting.<br /><br />Normally, the BigBlueButton server will end the meeting when either (a) the last person leaves (it takes a minute or two for the server to clear the meeting from memory) or when the server receives an [end](https://docs.bigbluebutton.org/bigbluebutton/development/api#end) API request with the associated meetingID (everyone is kicked and the meeting is immediately cleared from memory).<br /><br />BigBlueButton begins tracking the length of a meeting when it is created.  If duration contains a non-zero value, then when the length of the meeting exceeds the duration value the server will immediately end the meeting (equivalent to receiving an end API request at that moment). |
-| `isBreakout` | Boolean | Must be set to `true` to create a breakout room. |
-| `parentMeetingID` *(required for breakout room)* | String | Must be provided when creating a breakout room, the parent room must be running. |
-| `sequence` *(required for breakout room)* | Number | The sequence number of the breakout room. |
-| `freeJoin` *(only breakout room)* | Boolean | If set to true, the client will give the user the choice to choose the breakout rooms he wants to join. |
-| `breakoutRoomsEnabled` *Optional(Breakout Room)* | Boolean | **[DEPRECATED]** Removed in 2.5, temporarily still handled, please transition to disabledFeatures.<br /><br />If set to false, breakout rooms will be disabled.<br /><br />*Default: `true`* |
-| `breakoutRoomsPrivateChatEnabled` *Optional(Breakout Room)* | Boolean | If set to false, the private chat will be disabled in breakout rooms.<br /><br />*Default: `true`* |
-| `breakoutRoomsRecord` *Optional(Breakout Room*) | Boolean | If set to false, breakout rooms will not be recorded.<br /><br />*Default: `true`* |
-| `meta` | String | This is a special parameter type (there is no parameter named just `meta`).<br /><br />You can pass one or more metadata values when creating a meeting. These will be stored by BigBlueButton can be retrieved later via the getMeetingInfo and getRecordings calls.<br /><br />Examples of the use of the meta parameters are `meta_Presenter=Jane%20Doe, meta_category=FINANCE`, and `meta_TERM=Fall2016`. |
-| `moderatorOnlyMessage` | String | Display a message to all moderators in the public chat.<br /><br />The value is interpreted in the same way as the welcome parameter. |
-| `autoStartRecording` | Boolean | Whether to automatically start recording when first user joins. <br /><br />When this parameter is `true`, the recording UI in BigBlueButton will be initially active. Moderators in the session can still pause and restart recording using the UI control. <br /><br />**NOTE:** Don’t pass `autoStartRecording=false` and `allowStartStopRecording=false` - the moderator won’t be able to start recording! <br /><br />*Default: `false`*|
-| `allowStartStopRecording` | Boolean | Allow the user to start/stop recording.<br /><br />If you set both allowStartStopRecording=false and autoStartRecording=true, then the entire length of the session will be recorded, and the moderators in the session will not be able to pause/resume the recording.<br /><br />*Default: `true`*|
-| `webcamsOnlyForModerator` | Boolean | Setting `webcamsOnlyForModerator=true` will cause all webcams shared by viewers during this meeting to only appear for moderators (added 1.1) |
-| `bannerText` | String | Will set the banner text in the client. (added 2.0) |
-| `bannerColor` | String | Will set the banner background color in the client. The required format is color hex #FFFFFF. (added 2.0) |
-| `muteOnStart` | Boolean | Setting `true` will mute all users when the meeting starts. (added 2.0) |
-| `allowModsToUnmuteUsers` | Boolean | Setting to `true` will allow moderators to unmute other users in the meeting. (added 2.2)<br /><br />*Default: `false`* |
-| `lockSettingsDisableCam` | Boolean | Setting `true` will prevent users from sharing their camera in the meeting. (added 2.2)<br /><br />*Default: `false`* |
-| `lockSettingsDisableMic` | Boolean | Setting to `true` will only allow user to join listen only. (added 2.2<br /><br />*Default: `false`* |
-| `lockSettingsDisablePrivateChat` | Boolean | Setting to `true` will disable private chats in the meeting. (added 2.2)<br /><br />*Default: `false`* |
-| `lockSettingsDisablePublicChat` | Boolean | Setting to `true` will disable public chat in the meeting. (added 2.2)<br /><br />*Default: `false`* |
-| `lockSettingsDisableNote` | Boolean | Setting to `true` will disable notes in the meeting. (added 2.2) <br /><br />*Default: `false`* |
-| `lockSettingsLockOnJoin` | Boolean | Setting to `false` will not apply lock setting to users when they join. (added 2.2) <br /><br />*Default: `true`* |
-| `lockSettingsLockOnJoinConfigurable` | Boolean | Setting to `true` will allow applying of `lockSettingsLockOnJoin`. <br /><br />*Default: `false`* |
-| `lockSettingsHideViewersCursor` | Boolean | Setting to `true` will prevent viewers to see other viewers cursor when multi-user whiteboard is on. (added 2.5) <br /><br />*Default: `false`* |
-| `guestPolicy` | Enum | Will set the guest policy for the meeting. The guest policy determines whether or not users who send a join request with `guest=true` will be allowed to join the meeting. Possible values are ALWAYS_ACCEPT, ALWAYS_DENY, and ASK_MODERATOR. <br /><br />`Default: ALWAYS_ACCEPT` |
-| ~~`keepEvents`~~ | Boolean | Removed in 2.3 in favor of `meetingKeepEvents` and bigbluebutton.properties `defaultKeepEvents`. |
-| `meetingKeepEvents` | Boolean | Defaults to the value of `defaultKeepEvents`. If `meetingKeepEvents` is true BigBlueButton saves meeting events even if the meeting is not recorded (added in 2.3) <br /><br />*Default: `false`* |
-| `endWhenNoModerator` | Boolean | Default `endWhenNoModerator=false`. If `endWhenNoModerator` is true the meeting will end automatically after a delay - see `endWhenNoModeratorDelayInMinutes` (added in 2.3) <br /><br />*Default: `false`* |
-| `endWhenNoModeratorDelayInMinutes` | Number | Defaults to the value of `endWhenNoModeratorDelayInMinutes=1`. If `endWhenNoModerator` is true, the meeting will be automatically ended after this many minutes (added in 2.2) <br /><br />*Default: `1`* |
-| `meetingLayout` | Enum | Will set the default layout for the meeting. Possible values are: CUSTOM_LAYOUT, SMART_LAYOUT, PRESENTATION_FOCUS, VIDEO_FOCUS. (added 2.4) <br /><br />*Default: `SMART_LAYOUT`* |
-| `learningDashboardEnabled` | Boolean | **[DEPRECATED]** Removed in 2.5, temporarily still handled, please transition to `disabledFeatures`.<br /><br />Default `learningDashboardEnabled=true`. When this option is enabled BigBlueButton generates a Dashboard where moderators can view a summary of the activities of the meeting. (added 2.4)<br /><br />*Default: `true`* |
-| `learningDashboardCleanupDelayInMinutes` | Number |  This option set the delay (in minutes) before the Learning Dashboard become unavailable after the end of the meeting. If this value is zero, the Learning Dashboard will keep available permanently. (added 2.4)<br /><br />*Default: `2`* |
-| `allowModsToEjectCameras` | Boolean | Setting to true will allow moderators to close other users cameras in the meeting. (added 2.4)<br /><br />*Default: `false`* |
-| `allowRequestsWithoutSession` | Boolean | Setting to true will allow users to join meetings without session cookie's validation. (added 2.4.3)<br /><br />*Default: `false`* |
-| `virtualBackgroundsDisabled` | Boolean | **[DEPRECATED]** Removed in 2.5, temporarily still handled, please transition to `disabledFeatures`.<br /><br />Setting to true will disable Virtual Backgrounds for all users in the meeting. (added 2.4.3)<br /><br />*Default: `false`* |
-| `userCameraCap` | Number | Setting to `0` will disable this threshold. Defines the max number of webcams a single user can share simultaneously. (added 2.4.5)<br /><br />*Default: `3`* |
-| `meetingCameraCap` | Number | Setting to `0` will disable this threshold. Defines the max number of webcams a meeting can have simultaneously. (added 2.5.0) <br /><br />*Default: `0`* |
-| `meetingExpireIfNoUserJoinedInMinutes` | Number | Automatically end meeting if no user joined within a period of time after meeting created. (added 2.5) <br /><br />*Default: `5`* |
-| `meetingExpireWhenLastUserLeftInMinutes` | Number | Number of minutes to automatically end meeting after last user left. (added 2.5)Setting to `0` will disable this function. <br /><br />*Default: `1`* |
-| `groups` | String | Pre-defined groups to automatically assign the students to a given breakout room. (added 2.5) <dl><dt>**Expected value:** Json with Array of groups.</dt><dt>**Group properties:**</dt></dl><ul><li>`id` - String with group unique</li><li>`id.name` - String with name of the group (optional)</li><li>`roster` - Array with IDs of the users.</li></ul>E.g: <br />`[`<br />`{id:'1',name:'GroupA',roster:['1235']},{id:'2',name:'GroupB',roster:['2333','2335']},{id:'3',roster:[]}`<br />`]`|
-| `logo` | String | Pass a URL to an image which will then be visible in the area above the participants list if `displayBrandingArea` is set to `true` in bbb-html5's configuration |
-| `disabledFeatures` | String | List (comma-separated) of features to disable in a particular meeting. (added 2.5)<br /><br />Available options to disable:<ul><li>`breakoutRooms` - Breakout Rooms</li><li>`captions` - Closed Caption</li><li>`chat` - Chat</li><li>`downloadPresentationWithAnnotations` - Annotated presentation download</li><li>`externalVideos` - Share an external video</li><li>`importPresentationWithAnnotationsFromBreakoutRooms` - Bring back breakout slides</li><li>`layouts` - Layouts (allow only default layout)</li><li>`learningDashboard` - Learning Analytics Dashboard</li><li>`polls` - Polls</li><li>`screenshare`  - Screen Sharing</li><li>`sharedNotes` - Shared Notes</li><li>`virtualBackgrounds` - Virtual Backgrounds</li><li>`customVirtualBackgrounds` - Virtual Backgrounds Upload</li><li>`liveTranscription` - Live Transcription</li><li>`presentation` - Presentation</li></ul> |
-| `preUploadedPresentationOverrideDefault` | Boolean | If it is true, the `default.pdf` document is not sent along with the other presentations in the /create endpoint, on the other hand, if that's false, the `default.pdf` is sent with the other documents. By default it is true. <br /><br />`Default: true` |
-| `notifyRecordingIsOn` | Boolean | If it is true, a modal will be displayed to collect recording consent from users when meeting recording starts (only if `remindRecordingIsOn=true`). By default it is false. (added 2.6) <br /><br />*Default: `false`* |
-| `presentationUploadExternalUrl` | String | Pass a URL to a specific page in external application to select files for inserting documents into a live presentation. Only works if `presentationUploadExternalDescription` is also set. (added 2.6) |
-| `presentationUploadExternalDescription` | String | Message to be displayed in presentation uploader modal describing how to use an external application to upload presentation files. Only works if `presentationUploadExternalUrl` is also set. (added 2.6) |
-
+```mdx-code-block
+<APITableComponent data={createEndpointTableData}/>
+```
 
 **Example Requests:**
 
@@ -477,22 +434,9 @@ http&#58;//yourserver.com/bigbluebutton/api/join?[parameters]&checksum=[checksum
 
 **Parameters:**
 
-| Param Name | Type | Description |
---- | --- | --- |
-| `fullName` *(required)*| String | The full name that is to be used to identify this user to other conference attendees. |
-| `meetingID` *(required)* | String | The meeting ID that identifies the meeting you are attempting to join. |
-| `password` *(required)* | String | **[DEPRECATED]** This password value is used to determine the role of the user based on whether it matches the moderator or attendee password.  Note: This parameter is not required when the role parameter is passed. |
-| `role` *(required)* | String | Define user role for the meeting.  Valid values are MODERATOR or VIEWER (case insensitive). If the role parameter is present and valid, it overrides the password parameter.  You must specify either password parameter or role parameter in the join request. |
-| `createTime` | String | Third-party apps using the API can now pass createTime parameter (which was created in the create call), BigBlueButton will ensure it matches the ‘createTime’ for the session.  If they differ, BigBlueButton will not proceed with the join request. This prevents a user from reusing their join URL for a subsequent session with the same meetingID. |
-| `userID` | String | An identifier for this user that will help your application to identify which person this is.  This user ID will be returned for this user in the getMeetingInfo API call so that you can check |
-| `webVoiceConf` | String | If you want to pass in a custom voice-extension when a user joins the voice conference using voip. This is useful if you want to collect more info in you Call Detail Records about the user joining the conference. You need to modify your /etc/asterisk/bbb-extensions.conf to handle this new extensions. |
-| `defaultLayout` | String | The layout name to be loaded first when the application is loaded. |
-| `avatarURL` | String | The link for the user’s avatar to be displayed (default can be enabled/disabled and set with “useDefaultAvatar“ and “defaultAvatarURL“ in bbb-web.properties). |
-| `redirect` | String | The default behaviour of the JOIN API is to redirect the browser to the HTML5 client when the JOIN call succeeds. There have been requests if it’s possible to embed the HTML5 client in a “container” page and that the client starts as a hidden DIV tag which becomes visible on the successful JOIN. Setting this variable to FALSE will not redirect the browser but returns an XML instead whether the JOIN call has succeeded or not. The third party app is responsible for displaying the client to the user. |
-| ~~`joinViaHtml5`~~ | String | Set to “true” to force the HTML5 client to load for the user. (removed in 2.3 since HTML5 is the only client) |
-| `guest` | String | Set to “true” to indicate that the user is a guest, otherwise do NOT send this parameter. |
-| `excludeFromDashboard` | String | If the parameter is passed on JOIN with value `true`, the user will be omitted from being displayed in the Learning Dashboard. The use case is for support agents who drop by to support the meeting / resolve tech difficulties. Added in BBB 2.4 |
-
+```mdx-code-block
+<APITableComponent data={joinEndpointTableData}/>
+```
 
 **Example Requests:**
 
@@ -527,9 +471,9 @@ https&#58;//yourserver.com/bigbluebutton/api/insertDocument?[parameters]&checksu
 
 **Parameters:**
 
-|Param Name|Type|Description|
-|:----|:----|:----|
-|`meetingID` *(required)*|String|The meeting ID that identifies the meeting you want to insert documents.|
+```mdx-code-block
+<APITableComponent data={insertDocumentEndpointTableData}/>
+```
 
 **Example Requests:**
 
@@ -577,9 +521,9 @@ http&#58;//yourserver.com/bigbluebutton/api/isMeetingRunning?[parameters]&checks
 
 **Parameters:**
 
-|Param Name|Type|Description|
-|:----|:----|:----|
-|`meetingID` *(required)*|String|The meeting ID that identifies the meeting you are attempting to check on.|
+```mdx-code-block
+<APITableComponent data={isMeetingRunningEndpointTableData}/>
+```
 
 **Example Requests:**
 
@@ -606,11 +550,9 @@ Use this to forcibly end a meeting and kick all participants out of the meeting.
 
 **Parameters:**
 
-|Param Name|Type|Description|
-|:----|:----|:----|
-|`meetingID` *(required)*|String|The meeting ID that identifies the meeting you are attempting to end.|
-|`password` *(required)*|String|**[DEPRECATED]** The moderator password for this meeting. You can not end a meeting using the attendee password.|
-
+```mdx-code-block
+<APITableComponent data={endEndpointTableData}/>
+```
 
 **Example Requests:**
 
@@ -652,10 +594,9 @@ Resource URL:
 
 **Parameters:**
 
-|Param Name|Type|Description|
-|:----|:----|:----|
-|`meetingID` *(required)*|String|The meeting ID that identifies the meeting you are attempting to check on.|
-
+```mdx-code-block
+<APITableComponent data={getMeetingInfoEndpointTableData}/>
+```
 
 **Example Requests:**
 
@@ -806,15 +747,9 @@ http&#58;//yourserver.com/bigbluebutton/api/getRecordings?[parameters]&checksum=
 
 **Parameters:**
 
-|Param Name|Type|Description|
-|:----|:----|:----|
-|`meetingID`|String|A meeting ID for get the recordings. It can be a set of meetingIDs separate by commas. If the meeting ID is not specified, it will get ALL the recordings. If a recordID is specified, the meetingID is ignored.|
-|`recordID`|String|A record ID for get the recordings. It can be a set of recordIDs separate by commas. If the record ID is not specified, it will use meeting ID as the main criteria. If neither the meeting ID is specified, it will get ALL the recordings. The recordID can also be used as a wildcard by including only the first characters in the string.|
-|`state`|String|Since version 1.0 the recording has an attribute that shows a state that Indicates if the recording is [processing\|processed\|published\|unpublished\|deleted]. The parameter state can be used to filter results. It can be a set of states separate by commas. If it is not specified only the states [published\|unpublished] are considered (same as in previous versions). If it is specified as “any”, recordings in all states are included.|
-|`meta`|String|You can pass one or more metadata values to filter the recordings returned. The format of these parameters is the same as the metadata passed to the `create` call. For more information see [the docs for the create call](https://docs.bigbluebutton.org/dev/api.html#create).|
-|`offset`|Integer|The starting index for returned recordings. Number must greater than or equal to 0.|
-|`limit`|Integer|The maximum number of recordings to be returned. Number must be between 1 and 100.|
-
+```mdx-code-block
+<APITableComponent data={getRecordingsEndpointTableData}/>
+```
 
 **Example Requests:**
 
@@ -927,10 +862,9 @@ Publish and unpublish recordings for a given recordID (or set of record IDs).
 
 **Parameters:**
 
-|Param Name|Type|Description|
-|:----|:----|:----|
-|`recordID` *(required)*|String|A record ID for specify the recordings to apply the publish action. It can be a set of record IDs separated by commas.|
-|`publish` *(required)*|String|The value for publish or unpublish the recording(s). Available values: true or false.|
+```mdx-code-block
+<APITableComponent data={publishRecordingsEndpointTableData}/>
+```
 
 **Example Requests:**
 
@@ -956,7 +890,9 @@ http&#58;//yourserver.com/bigbluebutton/api/deleteRecordings?[parameters]&checks
 
 **Parameters:**
 
-{% include api_table.html endpoint="deleteRecordings" %}
+```mdx-code-block
+<APITableComponent data={deleteRecordingsEndpointTableData}/>
+```
 
 **Example Requests:**
 
@@ -982,9 +918,9 @@ Update metadata for a given recordID (or set of record IDs). Available since ver
 
 **Parameters:**
 
-|Param Name|Type|Description|
-|:----|:----|:----|
-|`recordID` *(required)*|String|A record ID for specify the recordings to delete. It can be a set of record IDs separated by commas.|
+```mdx-code-block
+<APITableComponent data={updateRecordingsEndpointTableData}/>
+```
 
 **Example Requests:**
 
@@ -1009,9 +945,9 @@ Get a list of the caption/subtitle files currently available for a recording. It
 
 **Parameters:**
 
-|Param Name|Type|Description|
-|:----|:----|:----|
-|`recordID` *(required)*|String|A single recording ID to retrieve the available captions for. (Unlike other recording APIs, you cannot provide a comma-separated list of recordings.)|
+```mdx-code-block
+<APITableComponent data={getRecordingTextTracksEndpointTableData}/>
+```
 
 **Example Response:**
 
@@ -1097,13 +1033,9 @@ This API is asynchronous. It can take several minutes for the uploaded file to b
 
 **Parameters:**
 
-|Param Name|Type|Description|
-|:----|:----|:----|
-|`recordID` *(required)*|String|A single recording ID to retrieve the available captions for. (Unlike other recording APIs| you cannot provide a comma-separated list of recordings.)|
-|`kind` *(required)*|String|Indicates the intended use of the text track. See the getRecordingTextTracks description for details. Using a value other than one listed in this document will cause an error to be returned.|
-|`lang` *(required)*|String|Indicates the intended use of the text track. See the getRecordingTextTracks description for details. Using a value other than one listed in this document will cause an error to be returned.|
-|`label` *(required)*|String|A human-readable label for the text track. If not specified| the system will automatically generate a label containing the name of the language identified by the lang parameter.|
-
+```mdx-code-block
+<APITableComponent data={putRecordingTextTrackEndpointTableData}/>
+```
 
 **POST Body:** <br />If the request has a body, the Content-Type header must specify multipart/form-data. The following parameters may be encoded in the post body.
 

--- a/docs/src/components/APITableComponent/index.tsx
+++ b/docs/src/components/APITableComponent/index.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import styles from './styles.module.css';
+
+function TableBody({ data }): JSX.Element {
+  const rows = data.map((entry: {deprecated: Boolean; name: String; 
+    required: Boolean; description: JSX.Element; type: String; default: String;
+    }) => {
+    return (<>
+      <tr>
+        <td>
+          { 
+            entry.deprecated !== undefined ?
+            <code className={styles.apiDeprecated}>{ entry.name }</code>
+            : <code>{ entry.name }</code>
+          }
+          { entry.required !== undefined ?
+            <>
+            { entry?.required === true ?
+              <p className={styles.apiRequired}>{"(required)"}</p> : null
+            }
+            </>
+          : null}
+        </td>
+        <td>{ entry.type }</td>
+        <td>
+          {entry.description}
+          { entry.default !== undefined ?
+            <p className={styles.apiDefault}>Default: <code>{entry.default.toString()}</code></p> : null
+          }
+        </td>
+      </tr>
+    </>)
+  }) 
+  return rows
+}
+
+
+export default function APITableComponent({ data }): JSX.Element {  
+  return (
+          <>
+           {data ? 
+            <table className="api-params">
+              <thead>
+                <tr className="header">
+                  <th>Param Name</th>
+                  <th>Type</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <TableBody data={data} />
+              </tbody>
+            </table> : null
+            }   
+          </>
+  );
+}

--- a/docs/src/components/APITableComponent/styles.module.css
+++ b/docs/src/components/APITableComponent/styles.module.css
@@ -1,0 +1,24 @@
+.apiParams th {
+	white-space: nowrap;
+}
+
+.apiParams td {
+	padding: 1em 5px;
+	vertical-align: top;
+}
+
+.apiDeprecated {
+	text-decoration: line-through;
+}
+
+.apiRequired {
+	font-size: 0.7em;
+	font-style: italic;
+	margin: 0;
+}
+
+.apiDefault {
+	font-style: italic;
+	margin-top: 20px;
+	margin-bottom: 0;
+}

--- a/docs/src/data/create.tsx
+++ b/docs/src/data/create.tsx
@@ -1,0 +1,370 @@
+import React from 'react';
+
+const createEndpointTableData = [
+  {
+    "name": "name",
+    "required": true,
+    "type": "String",
+    "description": (<>A name for the meeting.  This is now required as of BigBlueButton 2.4.</>)
+  },
+  {
+    "name": "meetingID",
+    "required": true,
+    "type": "String",
+    "description": (<>A meeting ID that can be used to identify this meeting by the 3rd-party application. <br /><br /> This must be unique to the server that you are calling: different active meetings can not have the same meeting ID. <br /><br /> If you supply a non-unique meeting ID (a meeting is already in progress with the same meeting ID), then if the other parameters in the create call are identical, the create call will succeed (but will receive a warning message in the response). The create call is idempotent: calling multiple times does not have any side effect.  This enables a 3rd-party applications to avoid checking if the meeting is running and always call create before joining each user.<br /><br /> Meeting IDs should only contain upper/lower ASCII letters, numbers, dashes, or underscores.  A good choice for the meeting ID is to generate a <a href='https://en.wikipedia.org/wiki/Globally_unique_identifier'>GUID</a> value as this all but guarantees that different meetings will not have the same meetingID.</>)
+  },
+  {
+    "name": "attendeePW",
+    "type": "String",
+    "description": (<>
+      <b>[DEPRECATED]</b> The password that the <a href="#join">join</a> URL can later provide as its <code className="language-plaintext highlighter-rouge">password</code> parameter to indicate the user will join as a viewer.  If no <code className="language-plaintext highlighter-rouge">attendeePW</code> is provided, the <code className="language-plaintext highlighter-rouge">create</code> call will return a randomly generated <code className="language-plaintext highlighter-rouge">attendeePW</code> password for the meeting.
+      </>)
+  },
+  {
+    "name": "moderatorPW",
+    "type": "String",
+    "description": (<><b>[DEPRECATED]</b> The password that will <a href="#join">join</a> URL can later provide as its <code className="language-plaintext highlighter-rouge">password</code> parameter to indicate the user will as a moderator.  if no <code className="language-plaintext highlighter-rouge">moderatorPW</code> is provided, <code className="language-plaintext highlighter-rouge">create</code> will return a randomly generated <code className="language-plaintext highlighter-rouge">moderatorPW</code> password for the meeting.</>)
+  },
+  {
+    "name": "welcome",
+    "required": false,
+    "type": "String",
+    "description": (<>A welcome message that gets displayed on the chat window when the participant joins. You can include keywords (<code className="language-plaintext highlighter-rouge">%%CONFNAME%%</code>, <code className="language-plaintext highlighter-rouge">%%DIALNUM%%</code>, <code className="language-plaintext highlighter-rouge">%%CONFNUM%%</code>) which will be substituted automatically.<br /><br /> This parameter overrides the default <code className="language-plaintext highlighter-rouge">defaultWelcomeMessage</code> in <code className="language-plaintext highlighter-rouge">bigbluebutton.properties</code>.<br /><br /> The welcome message has limited support for HTML formatting. Be careful about copy/pasted HTML from e.g. MS Word, as it can easily exceed the maximum supported URL length when used on a GET request.</>)
+  },
+  {
+    "name": "dialNumber",
+    "required": false,
+    "type": "String",
+    "description": (<>The dial access number that participants can call in using regular phone. You can set a default dial number via <code className="language-plaintext highlighter-rouge">defaultDialAccessNumber</code> in <a href="https://github.com/bigbluebutton/bigbluebutton/blob/master/bigbluebutton-web/grails-app/conf/bigbluebutton.properties">bigbluebutton.properties</a></>)
+  },
+  {
+    "name": "voiceBridge",
+    "required": false,
+    "type": "String",
+    "description": (<>Voice conference number for the FreeSWITCH voice conference associated with this meeting.  This must be a 5-digit number in the range 10000 to 99999.  If you <a href="/2.2/customize.html#add-a-phone-number-to-the-conference-bridge">add a phone number</a> to your BigBlueButton server, This parameter sets the personal identification number (PIN) that FreeSWITCH will prompt for a phone-only user to enter.  If you want to change this range, edit FreeSWITCH dialplan and <code className="language-plaintext highlighter-rouge">defaultNumDigitsForTelVoice</code> of <a href="https://github.com/bigbluebutton/bigbluebutton/blob/master/bigbluebutton-web/grails-app/conf/bigbluebutton.properties">bigbluebutton.properties</a>.<br /><br />The <code className="language-plaintext highlighter-rouge">voiceBridge</code> number must be different for every meeting.<br /><br />This parameter is optional. If you do not specify a <code className="language-plaintext highlighter-rouge">voiceBridge</code> number, then BigBlueButton will assign a random unused number for the meeting.<br /><br />If do you pass a <code className="language-plaintext highlighter-rouge">voiceBridge</code> number, then you must ensure that each meeting has a unique <code className="language-plaintext highlighter-rouge">voiceBridge</code> number; otherwise, reusing same <code className="language-plaintext highlighter-rouge">voiceBridge</code> number for two different meetings will cause users from one meeting to appear as phone users in the other, which will be very confusing to users in both meetings.</>)
+  },
+  {
+    "name": "maxParticipants",
+    "required": false,
+    "type": "Number",
+    "description": (<>Set the maximum number of users allowed to joined the conference at the same time.</>)
+  },
+  {
+    "name": "logoutURL",
+    "required": false,
+    "type": "String",
+    "description": (<>The URL that the BigBlueButton client will go to after users click the OK button on the ‘You have been logged out message’.  This overrides the value for <code className="language-plaintext highlighter-rouge">bigbluebutton.web.logoutURL</code> in <a href="https://github.com/bigbluebutton/bigbluebutton/blob/master/bigbluebutton-web/grails-app/conf/bigbluebutton.properties">bigbluebutton.properties</a>.</>)
+  },
+  {
+    "name": "record",
+    "required": false,
+    "type": "Boolean",
+    "description": (<>Setting ‘record=true’ instructs the BigBlueButton server to record the media and events in the session for later playback. The default is false.<br /><br /> In order for a playback file to be generated, a moderator must click the Start/Stop Recording button at least once during the sesssion; otherwise, in the absence of any recording marks, the record and playback scripts will not generate a playback file. See also the <code className="language-plaintext highlighter-rouge">autoStartRecording</code> and <code className="language-plaintext highlighter-rouge">allowStartStopRecording</code> parameters in <a href="https://github.com/bigbluebutton/bigbluebutton/blob/master/bigbluebutton-web/grails-app/conf/bigbluebutton.properties">bigbluebutton.properties</a>.</>)
+  },
+  {
+    "name": "duration",
+    "required": false,
+    "type": "Number",
+    "description": (<>The maximum length (in minutes) for the meeting.<br /><br /> Normally, the BigBlueButton server will end the meeting when either (a) the last person leaves (it takes a minute or two for the server to clear the meeting from memory) or when the server receives an <a href="#end">end</a> API request with the associated meetingID (everyone is kicked and the meeting is immediately cleared from memory).<br /><br /> BigBlueButton begins tracking the length of a meeting when it is created.  If duration contains a non-zero value, then when the length of the meeting exceeds the duration value the server will immediately end the meeting (equivalent to receiving an end API request at that moment).</>)
+  },
+  {
+    "name": "isBreakout",
+    "required": false,
+    "type": "Boolean",
+    "description": (<>Must be set to <code className="language-plaintext highlighter-rouge">true</code> to create a breakout room.</>)
+  },
+  {
+    "name": "parentMeetingID",
+    "required": "(required for breakout room)",
+    "type": "String",
+    "description": (<>Must be provided when creating a breakout room, the parent room must be running.</>)
+  },
+  {
+    "name": "sequence",
+    "required": "(required for breakout room)",
+    "type": "Number",
+    "description": (<>The sequence number of the breakout room.</>)
+  },
+  {
+    "name": "freeJoin",
+    "required": "(only breakout room)",
+    "type": "Boolean",
+    "description": (<>If set to true, the client will give the user the choice to choose the breakout rooms he wants to join.</>)
+  },
+  {
+    "name": "breakoutRoomsEnabled",
+    "required": "Optional(Breakout Room)",
+    "type": "Boolean",
+    "default": "true",
+    "description": (<><b>[DEPRECATED]</b> Removed in 2.5, temporarily still handled, please transition to disabledFeatures.<br /><br />If set to false, breakout rooms will be disabled.</>)
+  },
+  {
+    "name": "breakoutRoomsPrivateChatEnabled",
+    "required": "Optional(Breakout Room)",
+    "type": "Boolean",
+    "default": "true",
+    "description": (<>If set to false, the private chat will be disabled in breakout rooms.</>)
+  },
+  {
+    "name": "breakoutRoomsRecord",
+    "required": "Optional(Breakout Room)",
+    "type": "Boolean",
+    "default": "true",
+    "description": (<>If set to false, breakout rooms will not be recorded.</>)
+  },
+  {
+    "name": "meta",
+    "required": false,
+    "type": "String",
+    "description": (<>This is a special parameter type (there is no parameter named just <code className="language-plaintext highlighter-rouge">meta</code>).<br /><br /> You can pass one or more metadata values when creating a meeting. These will be stored by BigBlueButton can be retrieved later via the getMeetingInfo and getRecordings calls.<br /><br /> Examples of the use of the meta parameters are <code className="language-plaintext highlighter-rouge">meta_Presenter=Jane%20Doe</code>, <code className="language-plaintext highlighter-rouge">meta_category=FINANCE</code>, and <code className="language-plaintext highlighter-rouge">meta_TERM=Fall2016</code>.</>)
+  },
+  {
+    "name": "moderatorOnlyMessage",
+    "required": false,
+    "type": "String",
+    "description": (<>Display a message to all moderators in the public chat.<br /><br /> The value is interpreted in the same way as the <code className="language-plaintext highlighter-rouge">welcome</code> parameter.</>)
+  },
+  {
+    "name": "autoStartRecording",
+    "required": false,
+    "type": "Boolean",
+    "description": (<>Whether to automatically start recording when first user joins (default <code className="language-plaintext highlighter-rouge">false</code>).<br /><br /> When this parameter is <code className="language-plaintext highlighter-rouge">true</code>, the recording UI in BigBlueButton will be initially active. Moderators in the session can still pause and restart recording using the UI control.&lt;br/<br /> NOTE: Don’t pass <code className="language-plaintext highlighter-rouge">autoStartRecording=false</code> and <code className="language-plaintext highlighter-rouge">allowStartStopRecording=false</code> - the moderator won’t be able to start recording!</>)
+  },
+  {
+    "name": "allowStartStopRecording",
+    "required": false,
+    "type": "Boolean",
+    "description": (<>Allow the user to start/stop recording. (default true)<br /><br /> If you set both <code className="language-plaintext highlighter-rouge">allowStartStopRecording=false</code> and <code className="language-plaintext highlighter-rouge">autoStartRecording=true</code>, then the entire length of the session will be recorded, and the moderators in the session will not be able to pause/resume the recording.</>)
+  },
+  {
+    "name": "webcamsOnlyForModerator",
+    "required": false,
+    "type": "Boolean",
+    "description": (<>Setting <code className="language-plaintext highlighter-rouge">webcamsOnlyForModerator=true</code> will cause all webcams shared by viewers during this meeting to only appear for moderators (added 1.1)</>)
+  },
+  {
+    "name": "bannerText",
+    "required": false,
+    "type": "String",
+    "description": (<>Will set the banner text in the client. (added 2.0)</>)
+  },
+  {
+    "name": "bannerColor",
+    "required": false,
+    "type": "String",
+    "description": (<>Will set the banner background color in the client. The required format is color hex #FFFFFF. (added 2.0)</>)
+  },
+  {
+    "name": "muteOnStart",
+    "required": false,
+    "type": "Boolean",
+    "description": (<>Setting <code className="language-plaintext highlighter-rouge">true</code> will mute all users when the meeting starts. (added 2.0)</>)
+  },
+  {
+    "name": "allowModsToUnmuteUsers",
+    "required": false,
+    "type": "Boolean",
+    "default": "false",
+    "description": (<>Setting to <code className="language-plaintext highlighter-rouge">true</code> will allow moderators to unmute other users in the meeting. (added 2.2)</>)
+  },
+  {
+    "name": "lockSettingsDisableCam",
+    "required": false,
+    "type": "Boolean",
+    "default": "false",
+    "description": (<>Setting <code className="language-plaintext highlighter-rouge">true</code> will prevent users from sharing their camera in the meeting. (added 2.2)</>)
+  },
+  {
+    "name": "lockSettingsDisableMic",
+    "required": false,
+    "type": "Boolean",
+    "default": "false",
+    "description": (<>Setting to <code className="language-plaintext highlighter-rouge">true</code> will only allow user to join listen only. (added 2.2)</>)
+  },
+  {
+    "name": "lockSettingsDisablePrivateChat",
+    "required": false,
+    "type": "Boolean",
+    "default": "false",
+    "description": (<>Setting to <code className="language-plaintext highlighter-rouge">true</code> will disable private chats in the meeting. (added 2.2)</>)
+  },
+  {
+    "name": "lockSettingsDisablePublicChat",
+    "required": false,
+    "type": "Boolean",
+    "default": "false",
+    "description": (<>Setting to <code className="language-plaintext highlighter-rouge">true</code> will disable public chat in the meeting. (added 2.2)</>)
+  },
+  {
+    "name": "lockSettingsDisableNote",
+    "required": false,
+    "type": "Boolean",
+    "default": "false",
+    "description": (<>Setting to <code className="language-plaintext highlighter-rouge">true</code> will disable notes in the meeting. (added 2.2)</>)
+  },
+  {
+    "name": "lockSettingsLockOnJoin",
+    "required": false,
+    "type": "Boolean",
+    "default": "true",
+    "description": (<>Setting to <code className="language-plaintext highlighter-rouge">false</code> will not apply lock setting to users when they join. (added 2.2)</>)
+  },
+  {
+    "name": "lockSettingsLockOnJoinConfigurable",
+    "required": false,
+    "type": "Boolean",
+    "default": "false",
+    "description": (<>Setting to <code className="language-plaintext highlighter-rouge">true</code> will allow applying of <code className="language-plaintext highlighter-rouge">lockSettingsLockOnJoin</code>.</>)
+  },
+  {
+    "name": "lockSettingsHideViewersCursor",
+    "required": false,
+    "type": "Boolean",
+    "default": "false",
+    "description": (<>Setting to <code className="language-plaintext highlighter-rouge">true</code> will prevent viewers to see other viewers cursor when multi-user whiteboard is on. (added 2.5)</>)
+  },
+  {
+    "name": "guestPolicy",
+    "required": false,
+    "type": "Enum",
+    "default": "ALWAYS_ACCEPT",
+    "description": (<>Will set the guest policy for the meeting. The guest policy determines whether or not users who send a join request with <code className="language-plaintext highlighter-rouge">guest=true</code> will be allowed to join the meeting. Possible values are ALWAYS_ACCEPT, ALWAYS_DENY, and ASK_MODERATOR.</>)
+  },
+  {
+    "name": "keepEvents",
+    "type": "Boolean",
+    "deprecated": true,
+    "description": (<>Removed in 2.3 in favor of <code className="language-plaintext highlighter-rouge">meetingKeepEvents</code> and bigbluebutton.properties <code className="language-plaintext highlighter-rouge">defaultKeepEvents</code>.</>)
+  },
+  {
+    "name": "meetingKeepEvents",
+    "type": "Boolean",
+    "default": "false",
+    "description": (<>Defaults to the value of <code className="language-plaintext highlighter-rouge">defaultKeepEvents</code>. If <code className="language-plaintext highlighter-rouge">meetingKeepEvents</code> is true BigBlueButton saves meeting events even if the meeting is not recorded (added in 2.3)</>)
+  },
+  {
+    "name": "endWhenNoModerator",
+    "type": "Boolean",
+    "default": "false",
+    "description": (<>Default <code className="language-plaintext highlighter-rouge">endWhenNoModerator=false</code>. If <code className="language-plaintext highlighter-rouge">endWhenNoModerator</code> is true the meeting will end automatically after a delay - see <code className="language-plaintext highlighter-rouge">endWhenNoModeratorDelayInMinutes</code> (added in 2.3)</>)
+  },
+  {
+    "name": "endWhenNoModeratorDelayInMinutes",
+    "type": "Number",
+    "default": "1",
+    "description": (<>Defaults to the value of <code className="language-plaintext highlighter-rouge">endWhenNoModeratorDelayInMinutes=1</code>. If <code className="language-plaintext highlighter-rouge">endWhenNoModerator</code> is true, the meeting will be automatically ended after this many minutes (added in 2.2)</>)
+  },
+  {
+    "name": "meetingLayout",
+    "type": "Enum",
+    "default": "SMART_LAYOUT",
+    "description": (<>Will set the default layout for the meeting. Possible values are: CUSTOM_LAYOUT, SMART_LAYOUT, PRESENTATION_FOCUS, VIDEO_FOCUS. (added 2.4)</>)
+  },
+  {
+    "name": "learningDashboardEnabled",
+    "type": "Boolean",
+    "default": "true",
+    "description": (<><b>[DEPRECATED]</b> Removed in 2.5, temporarily still handled, please transition to disabledFeatures.<br /><br />Default <code className="language-plaintext highlighter-rouge">learningDashboardEnabled=true</code>. When this option is enabled BigBlueButton generates a Dashboard where moderators can view a summary of the activities of the meeting. (added 2.4)</>)
+  },
+  {
+    "name": "learningDashboardCleanupDelayInMinutes",
+    "type": "Number",
+    "default": "2",
+    "description": (<>Default <code className="language-plaintext highlighter-rouge">learningDashboardCleanupDelayInMinutes=2</code>. This option set the delay (in minutes) before the Learning Dashboard become unavailable after the end of the meeting. If this value is zero, the Learning Dashboard will keep available permanently. (added 2.4)</>)
+  },
+  {
+    "name": "allowModsToEjectCameras",
+    "required": false,
+    "type": "Boolean",
+    "default": "false",
+    "description": (<>Setting to <code className="language-plaintext highlighter-rouge">true</code> will allow moderators to close other users cameras in the meeting. (added 2.4)</>)
+  },
+  {
+    "name": "allowRequestsWithoutSession",
+    "required": false,
+    "type": "Boolean",
+    "default": "false",
+    "description": (<>Setting to <code className="language-plaintext highlighter-rouge">true</code> will allow users to join meetings without session cookie's validation. (added 2.4.3)</>)
+  },
+  {
+    "name": "virtualBackgroundsDisabled",
+    "required": false,
+    "type": "Boolean",
+    "default": "false",
+    "description": (<><b>[DEPRECATED]</b> Removed in 2.5, temporarily still handled, please transition to disabledFeatures.<br /><br />Setting to <code className="language-plaintext highlighter-rouge">true</code> will disable Virtual Backgrounds for all users in the meeting. (added 2.4.3)</>)
+  },
+  {
+    "name": "userCameraCap",
+    "required": false,
+    "type": "Number",
+    "default": "3",
+    "description": (<>Setting to <code className="language-plaintext highlighter-rouge">0</code> will disable this threshold. Defines the max number of webcams a single user can share simultaneously. (added 2.4.5)</>)
+  },
+  {
+    "name": "meetingCameraCap",
+    "required": false,
+    "type": "Number",
+    "default": "0",
+    "description": (<>Setting to <code className="language-plaintext highlighter-rouge">0</code> will disable this threshold. Defines the max number of webcams a meeting can have simultaneously. (added 2.5.0)</>)
+  },
+  {
+    "name": "meetingExpireIfNoUserJoinedInMinutes",
+    "required": false,
+    "type": "Number",
+    "default": "5",
+    "description": (<>Automatically end meeting if no user joined within a period of time after meeting created. (added 2.5)</>)
+  },
+  {
+    "name": "meetingExpireWhenLastUserLeftInMinutes",
+    "required": false,
+    "type": "Number",
+    "default": "1",
+    "description": (<>Number of minutes to automatically end meeting after last user left. (added 2.5)<br />Setting to <code className="language-plaintext highlighter-rouge">0</code> will disable this function.</>)
+  },
+  {
+    "name": "groups",
+    "required": false,
+    "type": "String",
+    "description": (<>Pre-defined groups to automatically assign the students to a given breakout room. (added 2.5)<br /><br /><b>Expected value:</b> Json with Array of groups.<br /><b>Group properties:</b><br /><ul><li><code className="language-plaintext highlighter-rouge">id</code> - String with group unique id.</li><li><code className="language-plaintext highlighter-rouge">name</code> - String with name of the group <i>(optional)</i>.</li><li><code className="language-plaintext highlighter-rouge">roster</code> - Array with IDs of the users.</li></ul><br />E.g:<br /><code className="language-json highlighter-rouge">[<br />{"{\"id\":'1',name:'GroupA',roster:['1235']}"}, <br />{"{\"id\":'2',name:'GroupB',roster:['2333','2335']}"},<br />{"{\"id\":'3',roster:[]}"}<br />]</code></>)
+  },
+  {
+    "name": "logo",
+    "required": false,
+    "type": "String",
+    "description": (<>Pass a URL to an image which will then be visible in the area above the participants list if <code>displayBrandingArea</code> is set to <code>true</code> in bbb-html5's configuration</>)
+  },
+  {
+    "name": "disabledFeatures",
+    "required": false,
+    "type": "String",
+    "description": (<>List (comma-separated) of features to disable in a particular meeting. (added 2.5)<br /><br />Available options to disable:<br /><ul><li><code className="language-plaintext highlighter-rouge">breakoutRooms</code>- <b>Breakout Rooms</b> </li><li><code className="language-plaintext highlighter-rouge">captions</code>- <b>Closed Caption</b> </li><li><code className="language-plaintext highlighter-rouge">chat</code>- <b>Chat</b></li><li><code className="language-plaintext highlighter-rouge">downloadPresentationWithAnnotations</code>- <b>Annotated presentation download</b></li><li><code className="language-plaintext highlighter-rouge">externalVideos</code>- <b>Share an external video</b> </li><li><code className="language-plaintext highlighter-rouge">importPresentationWithAnnotationsFromBreakoutRooms</code>- <b>Bring back breakout slides</b></li><li><code className="language-plaintext highlighter-rouge">layouts</code>- <b>Layouts</b> (allow only default layout)</li><li><code className="language-plaintext highlighter-rouge">learningDashboard</code>- <b>Learning Analytics Dashboard</b></li><li><code className="language-plaintext highlighter-rouge">polls</code>- <b>Polls</b> </li><li><code className="language-plaintext highlighter-rouge">screenshare</code>- <b>Screen Sharing</b></li><li><code className="language-plaintext highlighter-rouge">sharedNotes</code>- <b>Shared Notes</b></li><li><code className="language-plaintext highlighter-rouge">virtualBackgrounds</code>- <b>Virtual Backgrounds</b></li><li><code className="language-plaintext highlighter-rouge">customVirtualBackgrounds</code>- <b>Virtual Backgrounds Upload</b></li><li><code className="language-plaintext highlighter-rouge">liveTranscription</code>- <b>Live Transcription</b></li><li><code className="language-plaintext highlighter-rouge">presentation</code>- <b>Presentation</b></li></ul></>)
+  },
+  {
+    "name": "preUploadedPresentationOverrideDefault",
+    "required": false,
+    "type": "Boolean",
+    "default": "true",
+    "description": (<>If it is true, the <code>default.pdf</code> document is not sent along with the other presentations in the /create endpoint, on the other hand, if that's false, the <code>default.pdf</code> is sent with the other documents. By default it is true.</>)
+  },
+  {
+    "name": "notifyRecordingIsOn",
+    "required": false,
+    "type": "Boolean",
+    "default": "false",
+    "description": (<>If it is true, a modal will be displayed to collect recording consent from users when meeting recording starts (only if <code className="language-plaintext highlighter-rouge">remindRecordingIsOn=true</code>). By default it is false. (added 2.6)</>)
+  },
+  {
+    "name": "presentationUploadExternalUrl",
+    "required": false,
+    "type": "String",
+    "description": (<>Pass a URL to a specific page in external application to select files for inserting documents into a live presentation. Only works if <code className="language-plaintext highlighter-rouge">presentationUploadExternalDescription</code> is also set. (added 2.6)</>)
+  },
+  {
+    "name": "presentationUploadExternalDescription",
+    "required": false,
+    "type": "String",
+    "description": (<>Message to be displayed in presentation uploader modal describing how to use an external application to upload presentation files. Only works if <code className="language-plaintext highlighter-rouge">presentationUploadExternalUrl</code> is also set. (added 2.6)</>)
+  }
+]
+
+export default createEndpointTableData

--- a/docs/src/data/deleteRecordings.tsx
+++ b/docs/src/data/deleteRecordings.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const deleteRecordingsEndpointTableData = [
+    {
+        "name": "recordID",
+        "required": true,
+        "type": "String",
+        "description": (<>A record ID for specify the recordings to delete. It can be a set of record IDs separated by commas.</>)
+    }
+];
+
+export default deleteRecordingsEndpointTableData;

--- a/docs/src/data/end.tsx
+++ b/docs/src/data/end.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const endEndpointTableData = [
+  {
+    "name": "meetingID",
+    "required": true,
+    "type": "String",
+    "description": (<>The meeting ID that identifies the meeting you are attempting to end.</>)
+  },
+  {
+    "name": "password",
+    "required": true,
+    "type": "String",
+    "description": (<><b>[DEPRECATED]</b> The moderator password for this meeting. You can not end a meeting using the attendee password.</>)
+  }
+];
+
+export default endEndpointTableData;

--- a/docs/src/data/getMeetingInfo.tsx
+++ b/docs/src/data/getMeetingInfo.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const getMeetingInfoEndpointTableData = [
+  {
+    "name": "meetingID",
+    "required": true,
+    "type": "String",
+    "description": (<>The meeting ID that identifies the meeting you are attempting to check on.</>)
+  }
+];
+
+export default getMeetingInfoEndpointTableData;

--- a/docs/src/data/getRecordingTextTracks.tsx
+++ b/docs/src/data/getRecordingTextTracks.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const getRecordingTextTracksEndpointTableData = [
+  {
+    "name": "recordID",
+    "required": true,
+    "type": "String",
+    "description": (<>A single recording ID to retrieve the available captions for. (Unlike other recording APIs, you cannot provide a comma-separated list of recordings.)</>)
+  }
+];
+
+export default getRecordingTextTracksEndpointTableData;

--- a/docs/src/data/getRecordings.tsx
+++ b/docs/src/data/getRecordings.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+const getRecordingsEndpointTableData = [
+  {
+    "name": "meetingID",
+    "required": false,
+    "type": "String",
+    "description": (<>A meeting ID for get the recordings. It can be a set of meetingIDs separate by commas. If the meeting ID is not specified, it will get ALL the recordings. If a recordID is specified, the meetingID is ignored.</>)
+  },
+  {
+    "name": "recordID",
+    "required": false,
+    "type": "String",
+    "description": (<>A record ID for get the recordings. It can be a set of recordIDs separate by commas. If the record ID is not specified, it will use meeting ID as the main criteria. If neither the meeting ID is specified, it will get ALL the recordings. The recordID can also be used as a wildcard by including only the first characters in the string.</>)
+  },
+  {
+    "name": "state",
+    "required": false,
+    "type": "String",
+    "description": (<>Since version 1.0 the recording has an attribute that shows a state that Indicates if the recording is [processing|processed|published|unpublished|deleted]. The parameter state can be used to filter results. It can be a set of states separate by commas. If it is not specified only the states [published|unpublished] are considered (same as in previous versions). If it is specified as “any”, recordings in all states are included.</>)
+  },
+  {
+    "name": "meta",
+    "required": false,
+    "type": "String",
+    "description": (<>You can pass one or more metadata values to filter the recordings returned. The format of these parameters is the same as the metadata passed to the <code className="language-plaintext highlighter-rouge">create</code> call. For more information see <a href="https://docs.bigbluebutton.org/dev/api.html#create">the docs for the create call</a>.</>)
+  },
+  {
+    "name": "offset",
+    "required": false,
+    "type": "Integer",
+    "description": (<>The starting index for returned recordings. Number must greater than or equal to 0.</>)
+  },
+  {
+    "name": "limit",
+    "required": false,
+    "type": "Integer",
+    "description": (<>The maximum number of recordings to be returned. Number must be between 1 and 100.</>)
+  }
+];
+
+export default getRecordingsEndpointTableData;

--- a/docs/src/data/insertDocument.tsx
+++ b/docs/src/data/insertDocument.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const insertDocumentEndpointTableData = [
+  {
+    "name": "meetingID",
+    "required": true,
+    "type": "String",
+    "description": (<>The meeting ID that identifies the meeting you want to insert documents.</>)
+  }
+];
+
+export default insertDocumentEndpointTableData;

--- a/docs/src/data/isMeetingRunning.tsx
+++ b/docs/src/data/isMeetingRunning.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const isMeetingRunningEndpointTableData = [
+  {
+    "name": "meetingID",
+    "required": true,
+    "type": "String",
+    "description": (<>The meeting ID that identifies the meeting you are attempting to check on.</>)
+  }
+];
+
+export default isMeetingRunningEndpointTableData;

--- a/docs/src/data/join.tsx
+++ b/docs/src/data/join.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+
+const joinEndpointTableData = [
+  {
+    "name": "fullName",
+    "required": true,
+    "type": "String",
+    "description": (<>The full name that is to be used to identify this user to other conference attendees.</>)
+  },
+  {
+    "name": "meetingID",
+    "required": true,
+    "type": "String",
+    "description": (<>The meeting ID that identifies the meeting you are attempting to join.</>)
+  },
+  {
+    "name": "password",
+    "required": true,
+    "type": "String",
+    "description": (<><b>[DEPRECATED]</b> This password value is used to determine the role of the user based on whether it matches the moderator or attendee password.  Note: This parameter is <b>not</b> required when the role parameter is passed.</>)
+  },
+  {
+    "name": "role",
+    "required": true,
+    "type": "String",
+    "description": (<>Define user role for the meeting.  Valid values are MODERATOR or VIEWER (case insensitive). If the role parameter is present and valid, it overrides the password parameter.  You must specify either password parameter or role parameter in the join request.</>)
+  },
+  {
+    "name": "createTime",
+    "required": false,
+    "type": "String",
+    "description": (<>Third-party apps using the API can now pass createTime parameter (which was created in the create call), BigBlueButton will ensure it matches the ‘createTime’ for the session.  If they differ, BigBlueButton will not proceed with the join request. This prevents a user from reusing their join URL for a subsequent session with the same meetingID.</>)
+  },
+  {
+    "name": "userID",
+    "required": false,
+    "type": "String",
+    "description": (<>An identifier for this user that will help your application to identify which person this is.  This user ID will be returned for this user in the getMeetingInfo API call so that you can check</>)
+  },
+  {
+    "name": "webVoiceConf",
+    "required": false,
+    "type": "String",
+    "description": (<>If you want to pass in a custom voice-extension when a user joins the voice conference using voip. This is useful if you want to collect more info in you Call Detail Records about the user joining the conference. You need to modify your /etc/asterisk/bbb-extensions.conf to handle this new extensions.</>)
+  },
+  {
+    "name": "defaultLayout",
+    "required": false,
+    "type": "String",
+    "description": (<>The layout name to be loaded first when the application is loaded.</>)
+  },
+  {
+    "name": "avatarURL",
+    "required": false,
+    "type": "String",
+    "description": (<>The link for the user’s avatar to be displayed (default can be enabled/disabled and set with “useDefaultAvatar“ and “defaultAvatarURL“ in bbb-web.properties).</>)
+  },
+  {
+    "name": "redirect",
+    "required": false,
+    "type": "String",
+    "description": (<>The default behaviour of the JOIN API is to redirect the browser to the HTML5 client when the JOIN call succeeds. There have been requests if it’s possible to embed the HTML5 client in a “container” page and that the client starts as a hidden DIV tag which becomes visible on the successful JOIN. Setting this variable to FALSE will not redirect the browser but returns an XML instead whether the JOIN call has succeeded or not. The third party app is responsible for displaying the client to the user.</>)
+  },
+  {
+    "name": "joinViaHtml5",
+    "required": false,
+    "type": "String",
+    "description": (<>Set to “true” to force the HTML5 client to load for the user. (removed in 2.3 since HTML5 is the only client)</>),
+    "deprecated": true
+  },
+  {
+    "name": "guest",
+    "required": false,
+    "type": "String",
+    "description": (<>Set to “true” to indicate that the user is a guest, otherwise do NOT send this parameter.</>)
+  },
+  {
+    "name": "excludeFromDashboard",
+    "required": false,
+    "type": "String",
+    "description": (<>If the parameter is passed on JOIN with value `true`, the user will be omitted from being displayed in the Learning Dashboard. The use case is for support agents who drop by to support the meeting / resolve tech difficulties. Added in BBB 2.4</>)
+  }
+];
+
+export default joinEndpointTableData;

--- a/docs/src/data/publishRecordings.tsx
+++ b/docs/src/data/publishRecordings.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const publishRecordingsEndpointTableData = [
+  {
+    "name": "recordID",
+    "required": true,
+    "type": "String",
+    "description": (<>A record ID for specify the recordings to apply the publish action. It can be a set of record IDs separated by commas.</>)
+  },
+  {
+    "name": "publish",
+    "required": true,
+    "type": "String",
+    "description": (<>The value for publish or unpublish the recording(s). Available values: true or false.</>)
+  }
+];
+
+export default publishRecordingsEndpointTableData;

--- a/docs/src/data/putRecordingTextTrack.tsx
+++ b/docs/src/data/putRecordingTextTrack.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+const putRecordingTextTrackEndpointTableData = [
+  {
+    "name": "recordID",
+    "required": true,
+    "type": "String",
+    "description": (<>A single recording ID to retrieve the available captions for. (Unlike other recording APIs, you cannot provide a comma-separated list of recordings.)</>)
+  },
+  {
+    "name": "kind",
+    "required": true,
+    "type": "String",
+    "description": (<>Indicates the intended use of the text track. See the <a href="#getrecordingtexttracks">getRecordingTextTracks</a> description for details. Using a value other than one listed in this document will cause an error to be returned.</>)
+  },
+  {
+    "name": "lang",
+    "required": true,
+    "type": "String",
+    "description": (<>Indicates the intended use of the text track. See the <a href="#getrecordingtexttracks">getRecordingTextTracks</a> description for details. Using a value other than one listed in this document will cause an error to be returned.</>)
+  },
+  {
+    "name": "label",
+    "required": true,
+    "type": "String",
+    "description": (<>A human-readable label for the text track. If not specified, the system will automatically generate a label containing the name of the language identified by the lang parameter.</>)
+  }
+];
+
+export default putRecordingTextTrackEndpointTableData;

--- a/docs/src/data/updateRecordings.tsx
+++ b/docs/src/data/updateRecordings.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const updateRecordingsEndpointTableData = [
+  {
+    "name": "recordID",
+    "required": true,
+    "type": "String",
+    "description": (<>A record ID for specify the recordings to apply the publish action. It can be a set of record IDs separated by commas.</>)
+  },
+  {
+    "name": "meta",
+    "required": false,
+    "type": "String",
+    "description": (<>You can pass one or more metadata values to be updated. The format of these parameters is the same as the metadata passed to the <code className="language-plaintext highlighter-rouge">create</code> call. For more information see <a href="https://docs.bigbluebutton.org/dev/api.html#create">the docs for the create call</a>. When meta_parameter=NOT EMPTY and meta_parameter exists its value is updated, if it doesn’t exist, the parameter is added. When meta_parameter=, and meta_parameter exists the key is removed, when it doesn’t exist the action is ignored.</>)
+  }
+];
+
+export default updateRecordingsEndpointTableData;


### PR DESCRIPTION
### What does this PR do?

It mainly refactors the current table structure to follow a similar pattern as we had with the previous documentation.

### Closes Issue(s)

Closes #16930

### More

There were 2 other attempts of making this table referencing work: 
 - With `yaml` files as the data source for the tables;
 - And with `json` files as the data source;

Both of them were unsuccessful on the grounds that it would be too much refactor for too little return, and also, I am not sure if we would be able to use the index search that `docusaurus` has.

On the other hand, with `tsx` files as the data source, not only do we have the indexing search, but also, `docusaurus` themselves already use this approach, see [`src/data/quotes.tsx`](https://github.com/facebook/docusaurus/blob/bf9b69cfbf4b71d3124e9d876c57efba90688754/website/src/data/quotes.tsx) file, which is under `scr/data` just like ours.  

### Comments for testing

Overall, there are too many additions mainly because of the new data files that have been added, which have a similar structure as those in the previous Bigbluebutton's documentation.