### PR TITLE
feat: add option to force/extend gathering window in SFU components, +

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
@@ -21,6 +21,7 @@ const SFU_URL = Meteor.settings.public.kurento.wsUrl;
 const DEFAULT_LISTENONLY_MEDIA_SERVER = Meteor.settings.public.kurento.listenOnlyMediaServer;
 const SIGNAL_CANDIDATES = Meteor.settings.public.kurento.signalCandidates;
 const TRACE_LOGS = Meteor.settings.public.kurento.traceLogs;
+const GATHERING_TIMEOUT = Meteor.settings.public.kurento.gatheringTimeout;
 const MEDIA = Meteor.settings.public.media;
 const DEFAULT_FULLAUDIO_MEDIA_SERVER = MEDIA.audio.fullAudioMediaServer;
 const LISTEN_ONLY_OFFERING = MEDIA.listenOnlyOffering;
@@ -265,6 +266,7 @@ export default class SFUAudioBridge extends BaseAudioBridge {
           traceLogs: TRACE_LOGS,
           networkPriority: NETWORK_PRIORITY,
           mediaStreamFactory: this.mediaStreamFactory,
+          gatheringTimeout: GATHERING_TIMEOUT,
         };
 
         this.broker = new AudioBroker(
@@ -352,6 +354,7 @@ export default class SFUAudioBridge extends BaseAudioBridge {
               iceServers,
               offering: LISTEN_ONLY_OFFERING,
               traceLogs: TRACE_LOGS,
+              gatheringTimeout: GATHERING_TIMEOUT,
             };
 
             this.broker = new AudioBroker(

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -13,6 +13,7 @@ const OFFERING = SFU_CONFIG.screenshare.subscriberOffering;
 const SIGNAL_CANDIDATES = Meteor.settings.public.kurento.signalCandidates;
 const TRACE_LOGS = Meteor.settings.public.kurento.traceLogs;
 const { screenshare: NETWORK_PRIORITY } = Meteor.settings.public.media.networkPriorities || {};
+const GATHERING_TIMEOUT = Meteor.settings.public.kurento.gatheringTimeout;
 
 const BRIDGE_NAME = 'kurento'
 const SCREENSHARE_VIDEO_TAG = 'screenshareVideo';
@@ -241,6 +242,7 @@ export default class KurentoScreenshareBridge {
       signalCandidates: SIGNAL_CANDIDATES,
       forceRelay: shouldForceRelay(),
       traceLogs: TRACE_LOGS,
+      gatheringTimeout: GATHERING_TIMEOUT,
     };
 
     this.broker = new ScreenshareBroker(
@@ -309,6 +311,7 @@ export default class KurentoScreenshareBridge {
         forceRelay: shouldForceRelay(),
         traceLogs: TRACE_LOGS,
         networkPriority: NETWORK_PRIORITY,
+        gatheringTimeout: GATHERING_TIMEOUT,
       };
 
       this.broker = new ScreenshareBroker(

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -505,7 +505,9 @@ class VideoProvider extends Component {
 
     if (peer) {
       if (peer && peer.bbbVideoStream) {
-        peer.bbbVideoStream.removeListener('inactive', peer.inactivationHandler);
+        if (typeof peer.inactivationHandler === 'function') {
+          peer.bbbVideoStream.removeListener('inactive', peer.inactivationHandler);
+        }
         peer.bbbVideoStream.stop();
       }
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -39,6 +39,7 @@ const {
 const PING_INTERVAL = 15000;
 const SIGNAL_CANDIDATES = Meteor.settings.public.kurento.signalCandidates;
 const TRACE_LOGS = Meteor.settings.public.kurento.traceLogs;
+const GATHERING_TIMEOUT = Meteor.settings.public.kurento.gatheringTimeout;
 
 const intlClientErrors = defineMessages({
   permissionError: {
@@ -618,6 +619,7 @@ class VideoProvider extends Component {
       },
       trace: TRACE_LOGS,
       networkPriorities: NETWORK_PRIORITY ? { video: NETWORK_PRIORITY } : undefined,
+      gatheringTimeout: GATHERING_TIMEOUT,
     };
 
     try {

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/audio-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/audio-broker.js
@@ -29,6 +29,7 @@ class AudioBroker extends BaseBroker {
     // signalCandidates
     // traceLogs
     // networkPriority
+    // gatheringTimeout
     Object.assign(this, options);
   }
 
@@ -85,6 +86,7 @@ class AudioBroker extends BaseBroker {
           trace: this.traceLogs,
           networkPriorities: this.networkPriority ? { audio: this.networkPriority } : undefined,
           mediaStreamFactory: this.mediaStreamFactory,
+          gatheringTimeout: this.gatheringTimeout,
         };
 
         const peerRole = this.role === 'sendrecv' ? this.role : 'recvonly';

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/screenshare-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/screenshare-broker.js
@@ -38,6 +38,7 @@ class ScreenshareBroker extends BaseBroker {
     // signalCandidates,
     // traceLogs
     // networkPriority
+    // gatheringTimeout
     Object.assign(this, options);
   }
 
@@ -189,6 +190,7 @@ class ScreenshareBroker extends BaseBroker {
           configuration: this.populatePeerConfiguration(),
           trace: this.traceLogs,
           networkPriorities: this.networkPriority ? { video: this.networkPriority } : undefined,
+          gatheringTimeout: this.gatheringTimeout,
         };
         this.webRtcPeer = new WebRtcPeer('sendonly', options);
         this.webRtcPeer.iceQueue = [];
@@ -248,6 +250,7 @@ class ScreenshareBroker extends BaseBroker {
           onicecandidate: this.signalCandidates ? this.onIceCandidate.bind(this) : null,
           configuration: this.populatePeerConfiguration(),
           trace: this.traceLogs,
+          gatheringTimeout: this.gatheringTimeout,
         };
 
         this.webRtcPeer = new WebRtcPeer('recvonly', options);

--- a/bigbluebutton-html5/imports/ui/services/webrtc-base/peer.js
+++ b/bigbluebutton-html5/imports/ui/services/webrtc-base/peer.js
@@ -326,10 +326,10 @@ export default class WebRtcPeer extends EventEmitter2 {
     switch (this.mode) {
       case 'recvonly': {
         const useAudio = this.mediaConstraints
-        && ((typeof this.mediaConstraints.audio === 'boolean')
+        && ((typeof this.mediaConstraints.audio === 'boolean' && this.mediaConstraints.audio)
           || (typeof this.mediaConstraints.audio === 'object'));
         const useVideo = this.mediaConstraints
-        && ((typeof this.mediaConstraints.video === 'boolean')
+        && ((typeof this.mediaConstraints.video === 'boolean' && this.mediaConstraints.video)
           || (typeof this.mediaConstraints.video === 'object'));
 
         if (useAudio) {


### PR DESCRIPTION
### What does this PR do?

* [feat: add option to force/extend gathering window in SFU components](https://github.com/bigbluebutton/bigbluebutton/commit/be6a23a00350dd25eb7c94da103ecbc7e88d1239) 
  - There's an edge case in finnicky networks where firewalls with ALG-like sorcery
tamper with USE-CANDIDATE STUN packets and, consequently, bork ICE-lite
connectivity establishment. The odd part is that client-side gathering
seems to complete if intermediate STUN bindings work (before the final
USE-CANDIDATE), which may cause the peer not to generate relay
candidates == connectivity fails.
  - This adds the `public.kurento.gatheringTimeout` option to forcefully extend
the candidate gathering window in peers that act as offerers. The
behavior is as follows: if the flag is set (ms), the peer will wait
either the gathering completed stage or, _at most_,
`public.kurento.gatheringTimeout`ms before proceeding with calls chained
to setLocalDescription. That option is disabled by default and intentionally ommited from the
base settings.yml file as to not encourage its use. Don't use it unless
you know what you're doing :)

* [fix: properly check constraints before creating transceivers in peer.js](https://github.com/bigbluebutton/bigbluebutton/commit/c81a7e70f253cc3c3e4f10deb5c04c3c457b40f2) 
  - This commit should prevent useless transceivers from being added when
explictly specifying audio/video as `false`

* [fix(video): prevent a client crash when cleaning up video peers](https://github.com/bigbluebutton/bigbluebutton/commit/f4b4de6f88aefa3e3bbc470e2e871eab6401f670) 
  - There's a very rare scenario where the client may crash if a video
publisher is released before the source stream had its inactivation
listener callback set up.

### Closes Issue(s)

n/æ