### PR TITLE
[2.5 chore] add color light to button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/button/component.jsx
@@ -11,7 +11,7 @@ const SIZES = [
 ];
 
 const COLORS = [
-  'default', 'primary', 'danger', 'warning', 'success', 'dark', 'offline', 'muted',
+  'default', 'primary', 'danger', 'warning', 'success', 'dark', 'light', 'offline', 'muted',
 ];
 
 const propTypes = {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Suppress warning of the color 'light' not found in the preset list.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation

I've also found that it's been fixed in 2.6 source code. We'd better fix it also for 2.5. Although 2.5 is not the developmental mainstream anymore, I suppose there are still many users who haven't migrated to 2.6.
