### PR TITLE
fix (bbb-web): invalid default value for disabledFeatures when config is missing

### DIFF
--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -415,9 +415,11 @@ endWhenNoModerator=false
 endWhenNoModeratorDelayInMinutes=1
 
 # List of features to disable (comma-separated)
-# Available options: breakoutRooms, liveTranscription, captions, chat, externalVideos, layouts, learningDashboard, polls, screenshare,
-# sharedNotes, virtualBackgrounds, downloadPresentationWithAnnotations, importPresentationWithAnnotationsFromBreakoutRooms, importSharedNotesFromBreakoutRooms
-# disabledFeatures=
+# Available options:
+# chat, sharedNotes, polls, screenshare, externalVideos, presentation, downloadPresentationWithAnnotations
+# learningDashboard, layouts, captions, liveTranscription, virtualBackgrounds, customVirtualBackgrounds
+# breakoutRooms, importSharedNotesFromBreakoutRooms, importPresentationWithAnnotationsFromBreakoutRooms
+disabledFeatures=
 
 # Notify users that recording is on
 notifyRecordingIsOn=false


### PR DESCRIPTION
Currently, if no `disabledFeatures` is provided in `bbb-web.properties`, the default value is set as:
```json
"disabledFeatures" : [ "${disabledFeatures}" ]
```

![disabledFeatures-invalid-value](https://user-images.githubusercontent.com/5660191/230920391-943545f1-a4a0-4861-8761-b021e0264934.png)

It seems that over the upgrades of spring, grails, etc.. we had to tweak how this config is read.
Tweaked first in #15467, then in #15782.

Turned out that now it accepts the current value as `disabledFeatures=` (which used to throw error in the past).
And it fixes the problem of the invalid default value:
![image](https://user-images.githubusercontent.com/5660191/230922556-60383add-260d-4aab-b865-b6a21d1755fe.png)




Besides that:
This PR also includes options `customVirtualBackgrounds` and `presentation` to the list of `# Available options:`
![image](https://user-images.githubusercontent.com/5660191/230921962-5c76289a-cd71-4d73-915b-00eb5ba578ef.png)
