### PR TITLE
(fix) - Adds redirect of all /2.6 links

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -76,7 +76,15 @@ const config = {
                         to: "/greenlight/v3/migration",
                         from: "/greenlight_v3/gl3-migration.html"
                     }
-                ]
+                ],
+                createRedirects: (path) =>  {
+                    // TODO: remove default route to /
+                    if ( path.startsWith("/2.6") ) {
+                        // remove the /2.6 from the path, for example:
+                        // /2.6/redirect -> /redirect
+                        return [ path.replace("/2.6","") ];
+                    }
+                },
             }
         ],
     ],


### PR DESCRIPTION
### What does this PR do?

It basically adds a redirect to all `/2.6` paths so that old links pointing at this version won't fall into a 404 page.

