### PR TITLE
fix(video): ensure streams are always attached on reconnections

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -65,8 +65,8 @@ const VideoListItem = (props) => {
 
   // component did mount
   useEffect(() => {
-    onVideoItemMount(videoTag.current);
     subscribeToStreamStateChange(cameraId, onStreamStateChange);
+    onVideoItemMount(videoTag.current);
     resizeObserver.observe(videoContainer.current);
     videoTag?.current?.addEventListener('loadeddata', onLoadedData);
 


### PR DESCRIPTION
### What does this PR do?

* [fix(video): ensure streams are always attached on reconnections](https://github.com/bigbluebutton/bigbluebutton/commit/022a14c42eefc2d0459c921ad39547a4591d6d27)
  - Always propagate the current stream state on attachment
  - Refactor the attachment pre-requisites away from a static boolean to a required data + diff check (based on target and current attached streams)

### Closes Issue(s)

n/a

### Motivation

There's a scenario where remote streams won't be attached again if the sharer experienced a Meteor/client disconnection.
The disconnection empties some necessary user data temporarily, which causes the corresponding video-list-item to be unmounted while the peer persists for a little longer.
If the sharer re-connects fast enough, video-list-item will re-mount but will 1) miss the current stream state (ie stuck in loading) 2) fail to re-attach the streams since the peer was already flagged as attached.

> **Describe the bug**
> 
> Remote cameras may get stuck in their loading state if the sharer re-connects (Meteor, usually).
> 
> **To Reproduce**
> Steps to reproduce the behavior:
> 1. Go to a room with two users (u1, u2)
> 2. Share a camera with u1
> 3. See camera in u2
> 4. u1: input `Meteor.disconnect() | Meteor.reconnect()` in the browser's console
> 5. u2: see bug
