### PR TITLE
fix(access): Remove Aria-Live From Chat Area

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/time-window-list/component.jsx
@@ -329,7 +329,6 @@ class TimeWindowList extends PureComponent {
           }}
           key="chat-list"
           data-test="chatMessages"
-          aria-live="polite"
           ref={node => this.messageListWrapper = node}
           onCopy={(e) => { e.stopPropagation(); }}
         >

--- a/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
@@ -176,7 +176,7 @@ const ChatListItem = (props) => {
               </UserAvatar>
             )}
         </Styled.ChatIcon>
-        <Styled.ChatName aria-live="off">
+        <Styled.ChatName>
           {!compact
             ? (
               <Styled.ChatNameMain>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/component.jsx
@@ -123,7 +123,7 @@ class UserMessages extends PureComponent {
           tabIndex={-1}
           ref={(ref) => { this._msgsList = ref; }}
         >
-          <Styled.List aria-live="polite">
+          <Styled.List>
             <TransitionGroup ref={(ref) => { this._msgItems = ref; }}>
               {this.getActiveChats()}
             </TransitionGroup>


### PR DESCRIPTION
### What does this PR do?
This removes the `aria-live` properties from the chat area. When new messages come in, the screen reader no longer announces the entire chat log.

### Motivation
Currently, some users are experiencing a problem where screen readers start reading the entire chat repeatedly, causing a constant disruption to their browsing experience.