### PR TITLE
Fix: Presentation un-minimizing when exiting external video or screen sharing.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
 import Button from '/imports/ui/components/common/button/component';
 
+
 const propTypes = {
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired,
@@ -47,7 +48,8 @@ const PresentationOptionsContainer = ({
     buttonType = 'desktop';
   }
 
-  const isThereCurrentPresentation = hasExternalVideo || hasScreenshare || hasPresentation || hasPinnedSharedNotes;
+  const isThereCurrentPresentation = hasExternalVideo || hasScreenshare
+  || hasPresentation || hasPinnedSharedNotes;
   return (
     <Button
       icon={`${buttonType}${!presentationIsOpen ? '_off' : ''}`}
@@ -59,7 +61,12 @@ const PresentationOptionsContainer = ({
       hideLabel
       circle
       size="lg"
-      onClick={() => setPresentationIsOpen(layoutContextDispatch, !presentationIsOpen)}
+      onClick={() => {
+        setPresentationIsOpen(layoutContextDispatch, !presentationIsOpen);
+        if (!hasExternalVideo && !hasScreenshare && !hasPinnedSharedNotes) {
+          Session.set('presentationLastState', !presentationIsOpen);
+        }
+      }}
       id="restore-presentation"
       ghost={!presentationIsOpen}
       disabled={!isThereCurrentPresentation}

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
@@ -231,6 +231,10 @@ class VideoPlayer extends Component {
       type: ACTIONS.SET_HAS_EXTERNAL_VIDEO,
       value: false,
     });
+    layoutContextDispatch({
+      type: ACTIONS.SET_PRESENTATION_IS_OPEN,
+      value: Session.get('presentationLastState'),
+    });
 
     if (hidePresentationOnJoin) {
       layoutContextDispatch({

--- a/bigbluebutton-html5/imports/ui/components/notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.jsx
@@ -136,6 +136,10 @@ const Notes = ({
           type: ACTIONS.SET_NOTES_IS_PINNED,
           value: false,
         });
+        layoutContextDispatch({
+          type: ACTIONS.SET_PRESENTATION_IS_OPEN,
+          value: Session.get('presentationLastState'),
+        });
       };
     }
   }, []);

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -182,6 +182,10 @@ class ScreenshareComponent extends React.Component {
     }
 
     this.clearMediaFlowingMonitor();
+    layoutContextDispatch({
+      type: ACTIONS.SET_PRESENTATION_IS_OPEN,
+      value: Session.get('presentationLastState'),
+    });
   }
 
   clearMediaFlowingMonitor() {


### PR DESCRIPTION
### What does this PR do?

This PR makes the minimized presentation stay minimized even though the screen sharing or external video sharing get deactivated.

### Closes Issue(s)

#17464 