### PR TITLE
fix(screenshare) autoplay overlay

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/media/autoplay-overlay/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/media/autoplay-overlay/styles.js
@@ -13,7 +13,7 @@ const AutoplayOverlay = styled.div`
   font-size: ${fontSizeLarge};
   border-radius: 5px;
   position: absolute;
-  z-index: 9999;
+  z-index: 999;
   text-align: center;
 `;
 


### PR DESCRIPTION
### Problem
Autoplay overlay is shown over the audio modal

![Captura de tela de 2023-04-10 16-42-50](https://user-images.githubusercontent.com/39932802/230985935-95153187-9e8b-463a-8f44-578889e6c6d3.png)


### What does this PR do?
Changed z-index of autoplay overlay to be behind the modals.

### Screenshots


https://user-images.githubusercontent.com/39932802/230986236-5d7eca74-f40c-4d5e-b1db-af9af6f54aed.mp4

