### PR TITLE
docs: Update breakout capture API reference

### DIFF
--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -92,6 +92,18 @@ const createEndpointTableData = [
     "description": (<>If set to true, the client will give the user the choice to choose the breakout rooms he wants to join.</>)
   },
   {
+    "name": "breakoutRoomsCaptureNotes",
+    "required": "(only breakout room)",
+    "type": "Boolean",
+    "description": (<>Whether the breakout shared notes should be sent to the parent upon the meeting's end.</>)
+  },
+  {
+    "name": "breakoutRoomsCaptureSlides",
+    "required": "(only breakout room)",
+    "type": "Boolean",
+    "description": (<>Whether the breakout presentation with annotations should be sent to the parent upon the meeting's end.</>)
+  },
+  {
     "name": "breakoutRoomsEnabled",
     "required": "Optional(Breakout Room)",
     "type": "Boolean",

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -92,18 +92,6 @@ const createEndpointTableData = [
     "description": (<>If set to true, the client will give the user the choice to choose the breakout rooms he wants to join.</>)
   },
   {
-    "name": "breakoutRoomsCaptureNotes",
-    "required": "(only breakout room)",
-    "type": "Boolean",
-    "description": (<>Whether the breakout shared notes should be sent to the parent upon the meeting's end.</>)
-  },
-  {
-    "name": "breakoutRoomsCaptureSlides",
-    "required": "(only breakout room)",
-    "type": "Boolean",
-    "description": (<>Whether the breakout presentation with annotations should be sent to the parent upon the meeting's end.</>)
-  },
-  {
     "name": "breakoutRoomsEnabled",
     "required": "Optional(Breakout Room)",
     "type": "Boolean",
@@ -349,7 +337,7 @@ const createEndpointTableData = [
     "name": "disabledFeatures",
     "required": false,
     "type": "String",
-    "description": (<>List (comma-separated) of features to disable in a particular meeting. (added 2.5)<br /><br />Available options to disable:<br /><ul><li><code className="language-plaintext highlighter-rouge">breakoutRooms</code>- <b>Breakout Rooms</b> </li><li><code className="language-plaintext highlighter-rouge">captions</code>- <b>Closed Caption</b> </li><li><code className="language-plaintext highlighter-rouge">chat</code>- <b>Chat</b></li><li><code className="language-plaintext highlighter-rouge">downloadPresentationWithAnnotations</code>- <b>Annotated presentation download</b></li><li><code className="language-plaintext highlighter-rouge">externalVideos</code>- <b>Share an external video</b> </li><li><code className="language-plaintext highlighter-rouge">importPresentationWithAnnotationsFromBreakoutRooms</code>- <b>Bring back breakout slides</b></li><li><code className="language-plaintext highlighter-rouge">layouts</code>- <b>Layouts</b> (allow only default layout)</li><li><code className="language-plaintext highlighter-rouge">learningDashboard</code>- <b>Learning Analytics Dashboard</b></li><li><code className="language-plaintext highlighter-rouge">polls</code>- <b>Polls</b> </li><li><code className="language-plaintext highlighter-rouge">screenshare</code>- <b>Screen Sharing</b></li><li><code className="language-plaintext highlighter-rouge">sharedNotes</code>- <b>Shared Notes</b></li><li><code className="language-plaintext highlighter-rouge">virtualBackgrounds</code>- <b>Virtual Backgrounds</b></li><li><code className="language-plaintext highlighter-rouge">customVirtualBackgrounds</code>- <b>Virtual Backgrounds Upload</b></li><li><code className="language-plaintext highlighter-rouge">liveTranscription</code>- <b>Live Transcription</b></li><li><code className="language-plaintext highlighter-rouge">presentation</code>- <b>Presentation</b></li></ul></>)
+    "description": (<>List (comma-separated) of features to disable in a particular meeting. (added 2.5)<br /><br />Available options to disable:<br /><ul><li><code className="language-plaintext highlighter-rouge">breakoutRooms</code>- <b>Breakout Rooms</b> </li><li><code className="language-plaintext highlighter-rouge">captions</code>- <b>Closed Caption</b> </li><li><code className="language-plaintext highlighter-rouge">chat</code>- <b>Chat</b></li><li><code className="language-plaintext highlighter-rouge">downloadPresentationWithAnnotations</code>- <b>Annotated presentation download</b></li><li><code className="language-plaintext highlighter-rouge">externalVideos</code>- <b>Share an external video</b> </li><li><code className="language-plaintext highlighter-rouge">importPresentationWithAnnotationsFromBreakoutRooms</code>- <b>Capture breakout presentation</b></li><li><code className="language-plaintext highlighter-rouge">importSharedNotesFromBreakoutRooms</code>- <b>Capture breakout shared notes</b></li><li><code className="language-plaintext highlighter-rouge">layouts</code>- <b>Layouts</b> (allow only default layout)</li><li><code className="language-plaintext highlighter-rouge">learningDashboard</code>- <b>Learning Analytics Dashboard</b></li><li><code className="language-plaintext highlighter-rouge">polls</code>- <b>Polls</b> </li><li><code className="language-plaintext highlighter-rouge">screenshare</code>- <b>Screen Sharing</b></li><li><code className="language-plaintext highlighter-rouge">sharedNotes</code>- <b>Shared Notes</b></li><li><code className="language-plaintext highlighter-rouge">virtualBackgrounds</code>- <b>Virtual Backgrounds</b></li><li><code className="language-plaintext highlighter-rouge">customVirtualBackgrounds</code>- <b>Virtual Backgrounds Upload</b></li><li><code className="language-plaintext highlighter-rouge">liveTranscription</code>- <b>Live Transcription</b></li><li><code className="language-plaintext highlighter-rouge">presentation</code>- <b>Presentation</b></li></ul></>)
   },
   {
     "name": "preUploadedPresentationOverrideDefault",

--- a/docs/docs/development/dev-guide.md
+++ b/docs/docs/development/dev-guide.md
@@ -27,6 +27,7 @@ A BigBlueButton server is built from a number of components that correspond to U
 - bbb-learning-dashboard -- a live dashboard available to moderators, which displays user activity information that can be useful for instructors
 - bbb-fsesl-akka -- Component to send commands to FreeSWITCH
 - bbb-playback-presentation -- Record and playback script to create presentation layout
+- bbb-export-annotations -- Handles capture of breakout content and annotated presentation download
 - bbb-webrtc-sfu -- Server that bridges incoming requests from client to Kurento
 - kurento-media-server -- WebRTC media server for sending/receiving/recording video (webcam and screen share)
 - bbb-freeswitch-core -- WebRTC media server for sending/receiving/recording audio
@@ -621,7 +622,10 @@ followed by
 npm start
 ```
 
-to begin exporting presentations with annotations.
+to begin exporting presentations with annotations. If you run into permission issues, change `presAnnDropboxDir` in `config/settings.json` to a folder in your home directory
+and make sure your user account has access to the presentation directory (see "Developing BBB-Web").
+
+Use `journalctl -u bbb-export-annotations -e` to see recent logs.
 
 ## Troubleshooting
 


### PR DESCRIPTION
### What does this PR do?
Updates the docs for `bbb-export-annotations`, adding API references for `breakoutRoomCaptureSlides` and `breakoutRoomCaptureNotes` as well as more detailed development/maintenance instructions.

### Closes Issue(s)
Requested in https://github.com/bigbluebutton/bigbluebutton/pull/15755#issuecomment-1501735814
