### PR TITLE
refactor(audio): remove unused VU ejection on socket disconnection

### DIFF
--- a/bigbluebutton-html5/imports/api/voice-users/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/voice-users/server/publishers.js
@@ -2,8 +2,6 @@ import VoiceUsers from '/imports/api/voice-users';
 import { Meteor } from 'meteor/meteor';
 import Logger from '/imports/startup/server/logger';
 import AuthTokenValidation, { ValidationStates } from '/imports/api/auth-token-validation';
-import ejectUserFromVoice from './methods/ejectUserFromVoice';
-import { debounce } from 'radash';
 
 async function voiceUser() {
   const tokenValidation = await AuthTokenValidation
@@ -15,22 +13,8 @@ async function voiceUser() {
   }
 
   const { meetingId, userId: requesterUserId } = tokenValidation;
-
-  const onCloseConnection = Meteor.bindEnvironment(async () => {
-    try {
-      // I used user because voiceUser is the function's name
-      const User = await VoiceUsers.findOneAsync({ meetingId, requesterUserId });
-      if (User) {
-        await ejectUserFromVoice(requesterUserId);
-      }
-    } catch (e) {
-      Logger.error(`Exception while executing ejectUserFromVoice for ${requesterUserId}: ${e}`);
-    }
-  });
-
   Logger.debug('Publishing Voice User', { meetingId, requesterUserId });
 
-  this._session.socket.on('close', debounce({ delay: 100 }, onCloseConnection));
   return VoiceUsers.find({ meetingId });
 }
 


### PR DESCRIPTION
### What does this PR do?

- [refactor: remove unused VU ejection on socket disconnection](https://github.com/bigbluebutton/bigbluebutton/commit/24aaea8168a08e2a8f3308c6552d891f56671e7f)
  * I'm unaware of the original goal behind this code and there's already ejections in place in other components (akka-apps, for instance), so this is basically a revert of #9888.

### Closes Issue(s)

n/æ

### Motivation

The voice user ejection callback tethered to Meteor's socket
disconnection seems broken (since its introduction). The VU selector
uses an invalid field (requesterUserId) - so no VU is ever returned.

Stumbled upon this doing while digging some other stuff.