### PR TITLE
fix: Improve Whiteboard Zoom After Resize

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -83,7 +83,6 @@ export default function Whiteboard(props) {
   const [history, setHistory] = React.useState(null);
   const [zoom, setZoom] = React.useState(HUNDRED_PERCENT);
   const [tldrawZoom, setTldrawZoom] = React.useState(1);
-  const [enable, setEnable] = React.useState(true);
   const [isMounting, setIsMounting] = React.useState(true);
   const prevShapes = usePrevious(shapes);
   const prevSlidePosition = usePrevious(slidePosition);
@@ -159,11 +158,6 @@ export default function Whiteboard(props) {
       toolbar?.removeEventListener('dblclick', handleDBClick);
     };
   }, [tldrawAPI, isToolLocked]);
-
-  const throttledResetCurrentPoint = React.useRef(_.throttle(() => {
-    setEnable(false);
-    setEnable(true);
-  }, 1000, { trailing: true }));
 
   const calculateZoom = (localWidth, localHeight) => {
     const calcedZoom = fitToWidth ? (presentationWidth / localWidth) : Math.min(
@@ -517,11 +511,8 @@ export default function Whiteboard(props) {
 
   React.useEffect(() => {
     const currentZoom = tldrawAPI?.getPageState()?.camera?.zoom;
-
     if (currentZoom !== tldrawZoom) {
       setTldrawZoom(currentZoom);
-    } else {
-      throttledResetCurrentPoint.current();
     }
   }, [presentationAreaHeight, presentationAreaWidth]);
 
@@ -933,7 +924,7 @@ export default function Whiteboard(props) {
   const editableWB = (
     <Styled.EditableWBWrapper onKeyDown={handleOnKeyDown}>
       <Tldraw
-        key={`wb-${isRTL}-${dockPos}`}
+        key={`wb-${isRTL}-${dockPos}-${presentationAreaHeight}-${presentationAreaWidth}`}
         document={doc}
         // disable the ability to drag and drop files onto the whiteboard
         // until we handle saving of assets in akka.
@@ -1014,7 +1005,7 @@ export default function Whiteboard(props) {
         isMoving={isMoving}
         currentTool={currentTool}
       >
-        {enable && (hasWBAccess || isPresenter) ? editableWB : readOnlyWB}
+        {(hasWBAccess || isPresenter) ? editableWB : readOnlyWB}
         <Styled.TldrawGlobalStyle
           hideContextMenu={!hasWBAccess && !isPresenter}
           {...{

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -69,6 +69,7 @@ export default function Whiteboard(props) {
     tldrawAPI,
     setTldrawAPI,
     isIphone,
+    sidebarNavigationWidth,
   } = props;
   const { pages, pageStates } = initDefaultPages(curPres?.pages.length || 1);
   const rDocument = React.useRef({
@@ -924,7 +925,7 @@ export default function Whiteboard(props) {
   const editableWB = (
     <Styled.EditableWBWrapper onKeyDown={handleOnKeyDown}>
       <Tldraw
-        key={`wb-${isRTL}-${dockPos}-${presentationAreaHeight}-${presentationAreaWidth}`}
+        key={`wb-${isRTL}-${dockPos}-${presentationAreaHeight}-${presentationAreaWidth}-${sidebarNavigationWidth}`}
         document={doc}
         // disable the ability to drag and drop files onto the whiteboard
         // until we handle saving of assets in akka.
@@ -1100,6 +1101,7 @@ Whiteboard.propTypes = {
   nextSlide: PropTypes.func.isRequired,
   numberOfSlides: PropTypes.number.isRequired,
   previousSlide: PropTypes.func.isRequired,
+  sidebarNavigationWidth: PropTypes.number,
 };
 
 Whiteboard.defaultProps = {
@@ -1108,4 +1110,5 @@ Whiteboard.defaultProps = {
   slidePosition: undefined,
   svgUri: undefined,
   whiteboardId: undefined,
+  sidebarNavigationWidth: 0,
 };

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -35,6 +35,7 @@ const WhiteboardContainer = (props) => {
   const isRTL = layoutSelect((i) => i.isRTL);
   const width = layoutSelect((i) => i?.output?.presentation?.width);
   const height = layoutSelect((i) => i?.output?.presentation?.height);
+  const sidebarNavigationWidth = layoutSelect((i) => i?.output?.sidebarNavigation?.width);
   const { users } = usingUsersContext;
   const currentUser = users[Auth.meetingID][Auth.userID];
   const isPresenter = currentUser.presenter;
@@ -73,6 +74,7 @@ const WhiteboardContainer = (props) => {
         fontFamily,
         hasShapeAccess,
         handleToggleFullScreen,
+        sidebarNavigationWidth,
       }}
       {...props}
       meetingId={Auth.meetingID}


### PR DESCRIPTION
### What does this PR do?
This removes the `throttledResetCurrentPoint` function which was being used to force a re-render on the whiteboard element.

### Motivation
Makes the whiteboard annotations return to their correct placements after being resized.

before:
![resize-zoom-incorrect](https://user-images.githubusercontent.com/22058534/231535117-df0d06ef-3cae-4646-8636-e928636de97a.gif)

after:
![resize-zoom-correct](https://user-images.githubusercontent.com/22058534/231535138-85a34b03-9b53-412c-96b9-f003ab0bbd48.gif)
