### PR TITLE
fix: overlapping screen end alerts and invisible cameras on reconnections

### DIFF
--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -272,8 +272,9 @@ export default class KurentoScreenshareBridge {
 
     this.broker.onstart = this.handleViewerStart.bind(this);
     this.broker.onerror = this.handleBrokerFailure.bind(this);
-    this.broker.onended = this.handleEnded.bind(this);
-
+    if (!this.reconnecting) {
+      this.broker.onended = this.handleEnded.bind(this);
+    }
     return this.broker.view().finally(this.scheduleReconnect.bind(this));
   }
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.jsx
@@ -3,6 +3,7 @@ import { withTracker } from 'meteor/react-meteor-data';
 import VideoList from '/imports/ui/components/video-provider/video-list/component';
 import VideoService from '/imports/ui/components/video-provider/service';
 import { layoutSelect, layoutSelectOutput, layoutDispatch } from '../../layout/context';
+import Users from '/imports/api/users';
 
 const VideoListContainer = ({ children, ...props }) => {
   const layoutType = layoutSelect((i) => i.layoutType);
@@ -27,7 +28,17 @@ const VideoListContainer = ({ children, ...props }) => {
   );
 };
 
-export default withTracker((props) => ({
-  numberOfPages: VideoService.getNumberOfPages(),
-  ...props,
-}))(VideoListContainer);
+export default withTracker((props) => {
+  const { streams } = props;
+
+  return {
+    ...props,
+    numberOfPages: VideoService.getNumberOfPages(),
+    streams: streams.filter((stream) => Users.findOne({ userId: stream.userId },
+      {
+        fields: {
+          userId: 1,
+        },
+      })),
+  };
+})(VideoListContainer);


### PR DESCRIPTION
### What does this PR do?

Invisible grid no longer appears because streams are filtered with userId before going to video-list-item to render.
Screenshare's end alert only play on started -> ended or starting -> ended transitions, not * -> reconnecting -> ended.

### Motivation
There might be an invisible camera container in the grid when a webcam sharer reconnects.
Screenshare's end alert plays on intermediate reconnection attempts while it should only play on started -> ended or starting -> ended transitions, not * -> reconnecting -> ended.


