### PR TITLE
fix: Update Question Regex to Exclude URLs

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
@@ -131,7 +131,7 @@ class BBBMenu extends React.Component {
           style={customStyles}
           onClick={(event) => {
             onClick();
-            const close = !key.includes('setstatus') && !key.includes('back');
+            const close = !key?.includes('setstatus') && !key?.includes('back');
             // prevent menu close for sub menu actions
             if (close) this.handleClose(event);
             event.stopPropagation();

--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -56,9 +56,7 @@ const getCurrentSlide = (podId) => {
   });
 };
 
-const getSlidesLength = (podId) => {
-  return getCurrentPresentation(podId)?.pages?.length || 0;
-}
+const getSlidesLength = (podId) => getCurrentPresentation(podId)?.pages?.length || 0;
 
 const getSlidePosition = (podId, presentationId, slideId) => SlidePositions.findOne({
   podId,
@@ -87,7 +85,7 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
     content,
   } = currentSlide;
 
-  const questionRegex = /.*?\?/gm;
+  const questionRegex = /^.+\?\s*$/gm;
   const question = safeMatch(questionRegex, content, '');
 
   if (question?.length > 0) {


### PR DESCRIPTION
### What does this PR do?
This updates the question regex so it excludes urls as matches and fixes a console error for undefined of includes when using the dropdown menu to play detected links.

### Motivation
url triggering typed response option:
![image](https://user-images.githubusercontent.com/22058534/231873963-cce1a49f-4c57-4eda-82e5-9788a2fd2f45.png)

error:
![image](https://user-images.githubusercontent.com/22058534/231873641-b85255bc-1191-413f-84f9-e13563a48d55.png)
