### PR TITLE
feat(bbb-export-annotations): Support arrow and line labels

### DIFF
--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -11,6 +11,7 @@ const {getStrokePoints, getStrokeOutlinePoints} = require('perfect-freehand');
 const probe = require('probe-image-size');
 const redis = require('redis');
 const {PresAnnStatusMsg} = require('../lib/utils/message-builder');
+const { round } = require('lodash');
 
 const jobId = workerData.jobId;
 const logger = new Logger('presAnn Process Worker');
@@ -371,6 +372,8 @@ function overlay_arrow(svg, annotation) {
   const [x, y] = annotation.point;
   const bend = annotation.bend;
   const decorations = annotation.decorations;
+  const hasLabel = annotation.label;
+  const id = sanitize(annotation.id);
 
   let dash = annotation.style.dash;
   dash = (dash == 'draw') ? 'solid' : dash; // Use 'solid' thickness
@@ -418,19 +421,11 @@ function overlay_arrow(svg, annotation) {
     }
   }
 
-  if (annotation.label) {
-    if (!isStraightLine) {
-      const [shape_width, shape_height] = annotation.size;
-      const bendOffset = [bend_x - shape_width, bend_y - shape_height];
-      annotation["bendOffset"] = bendOffset;
-    }
-    overlay_shape_label(svg, annotation);
-  }
-
   // The arrowhead is purposely not styled (e.g., dashed / dotted)
   svg.ele('g', {
     style: `stroke:${shapeColor};stroke-width:${sw};fill:none;`,
     transform: `translate(${x} ${y})`,
+    'clip-path': hasLabel ? `url(#clip-${id})` : '',
   }).ele('path', {
     'style': stroke_dasharray,
     'd': line.join(' '),
@@ -438,6 +433,16 @@ function overlay_arrow(svg, annotation) {
       .ele('path', {
         d: arrowHead.join(' '),
       }).up();
+  
+  if (hasLabel) {
+    if (!isStraightLine) {
+      const [shape_width, shape_height] = annotation.size;
+      const bendOffset = [bend_x - shape_width, bend_y - shape_height];
+      annotation["bendOffset"] = bendOffset;
+    }
+
+    overlay_shape_label(svg, annotation);
+  }
 }
 
 function overlay_draw(svg, annotation) {
@@ -612,6 +617,9 @@ function overlay_shape_label(svg, annotation) {
 
   const bendOffset = annotation.bendOffset;
   
+  // Clip path for arrow and line labels (masking not supported in cairosvg)
+  const hasClipPath = annotation.type === 'arrow';
+
   // Label position of curved arrows and lines not determined by labelPoint
   const [x_offset, y_offset] = annotation.labelPoint;
 
@@ -635,6 +643,29 @@ function overlay_shape_label(svg, annotation) {
       const dimensions = probe.sync(fs.readFileSync(shape_label));
       labelWidth = dimensions.width / config.process.textScaleFactor;
       labelHeight = dimensions.height / config.process.textScaleFactor;
+    }
+
+    if (hasClipPath) {
+      // Clip path coordinates are relative to the shapes's position
+      const [rel_x, rel_y] = [label_x - shape_x, label_y - shape_y];
+      const [left_x, right_x] = [Math.floor(rel_x - (labelWidth / 2)),  Math.ceil(rel_x + (labelWidth / 2))];
+      const [top_y, bottom_y] = [Math.floor(rel_y - (labelHeight / 2)), Math.ceil(rel_y + (labelHeight / 2))];
+     
+      svg.ele('defs')
+        .ele('clipPath', { id: `clip-${id}` })
+        .ele('rect', {
+          x: 0, y: 0, width: left_x, height: '100%',
+        }).up()
+        .ele('rect', {
+          x: right_x, y: 0,
+          width:'100%', height: '100%',
+        }).up()
+        .ele('rect', {
+          x: 0, y: 0, width: '100%', height: top_y,
+        }).up()
+        .ele('rect', {
+          x: 0, y: bottom_y, width: '100%', height: '100%'
+        }).up()
     }
         
     svg.ele('g', {

--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -425,8 +425,8 @@ function overlay_arrow(svg, annotation) {
   svg.ele('g', {
     style: `stroke:${shapeColor};stroke-width:${sw};fill:none;`,
     transform: `translate(${x} ${y})`,
-    'clip-path': hasLabel ? `url(#clip-${id})` : '',
   }).ele('path', {
+    'clip-path': hasLabel ? `url(#clip-${id})` : '',
     'style': stroke_dasharray,
     'd': line.join(' '),
   }).up()
@@ -648,8 +648,8 @@ function overlay_shape_label(svg, annotation) {
     if (hasClipPath) {
       // Clip path coordinates are relative to the shapes's position
       const [rel_x, rel_y] = [label_x - shape_x, label_y - shape_y];
-      const [left_x, right_x] = [Math.floor(rel_x - (labelWidth / 2)),  Math.ceil(rel_x + (labelWidth / 2))];
-      const [top_y, bottom_y] = [Math.floor(rel_y - (labelHeight / 2)), Math.ceil(rel_y + (labelHeight / 2))];
+      const [left_x, right_x] = [Math.round(rel_x - (labelWidth / 2)),  Math.round(rel_x + (labelWidth / 2))];
+      const [top_y, bottom_y] = [Math.round(rel_y - (labelHeight / 2)), Math.round(rel_y + (labelHeight / 2))];
      
       svg.ele('defs')
         .ele('clipPath', { id: `clip-${id}` })
@@ -657,8 +657,7 @@ function overlay_shape_label(svg, annotation) {
           x: 0, y: 0, width: left_x, height: '100%',
         }).up()
         .ele('rect', {
-          x: right_x, y: 0,
-          width:'100%', height: '100%',
+          x: right_x, y: 0, width: '100%', height: '100%',
         }).up()
         .ele('rect', {
           x: 0, y: 0, width: '100%', height: top_y,

--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -11,7 +11,6 @@ const {getStrokePoints, getStrokeOutlinePoints} = require('perfect-freehand');
 const probe = require('probe-image-size');
 const redis = require('redis');
 const {PresAnnStatusMsg} = require('../lib/utils/message-builder');
-const { round } = require('lodash');
 
 const jobId = workerData.jobId;
 const logger = new Logger('presAnn Process Worker');


### PR DESCRIPTION
### What does this PR do?
Tldraw lets users place labels on arrows and lines that differ in appearance and behavior from a regular textbox. However, such labels still needed to be shown in files generated by the annotation export component.

### Closes Issue(s)
Had not been reported.

### Sample PDF output
![Screenshot 2023-04-14 at 22 43 01](https://user-images.githubusercontent.com/33319791/232151995-66fd2736-4e98-4333-b0e8-bc8859261bd3.png)

### More
The SVG renderer used by `bbb-export-annotations` (CairoSVG) does not support masking, which is necessary to erase the part of the arrow covered by text. As a workaround, I used `clipPath` to manually insert four rectangular areas that make the line visible except where the text is located. This may cause minor visual inconsistencies when comparing the output to the client.