### PR TITLE
docs: Add lockSettingsHideUserList param and fix lockSettingsDisableNotes

### DIFF
--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -196,11 +196,18 @@ const createEndpointTableData = [
     "description": (<>Setting to <code className="language-plaintext highlighter-rouge">true</code> will disable public chat in the meeting. (added 2.2)</>)
   },
   {
-    "name": "lockSettingsDisableNote",
+    "name": "lockSettingsDisableNotes",
     "required": false,
     "type": "Boolean",
     "default": "false",
     "description": (<>Setting to <code className="language-plaintext highlighter-rouge">true</code> will disable notes in the meeting. (added 2.2)</>)
+  },
+  {
+    "name": "lockSettingsHideUserList",
+    "required": false,
+    "type": "Boolean",
+    "default": "false",
+    "description": (<>Setting to <code className="language-plaintext highlighter-rouge">true</code> will prevent viewers from seeing other viewers in the user list. (added 2.2)</>)
   },
   {
     "name": "lockSettingsLockOnJoin",


### PR DESCRIPTION
The param `lockSettingsHideUserList` of `/create` endpoint is missing in the new Docs.

And the param `lockSettingsDisableNote` (without "s" at the end) is DEPRECATED, so I tweaked it to `lockSettingsDisableNotes` which is the current param.