### PR TITLE
build: add bbb-webrtc-recorder

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -43,6 +43,7 @@ jobs:
       - run: ./build/setup.sh bbb-record-core
       - run: ./build/setup.sh bbb-web
       - run: ./build/setup.sh bbb-webrtc-sfu
+      - run: ./build/setup.sh bbb-webrtc-recorder
       - run: ./build/setup.sh bigbluebutton
       - run: tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -182,6 +183,7 @@ jobs:
           cp /etc/bigbluebutton/bigbluebutton-release configs/bigbluebutton-release
           cp /etc/bigbluebutton/turn-stun-servers.xml configs/turn-stun-servers.xml
           cp /usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml configs/bbb-webrtc-sfu-default.yml
+          cp /etc/bbb-webrtc-recorder/bbb-webrtc-recorder.yml configs/bbb-webrtc-recorder-default.yml
           cp /usr/share/bigbluebutton/nginx/sip.nginx configs/nginx_sip.nginx
           cp /etc/hosts /configs/hosts
           chmod a+r -R configs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ stages:
 
 # define which docker image to use for builds
 default:
-  image: gitlab.senfcall.de:5050/senfcall-public/docker-bbb-build:v2022-12-29-grails-524
+  image: gitlab.senfcall.de:5050/senfcall-public/docker-bbb-build:v2023-04-18
 
 # This stage uses git to find out since when each package has been unmodified.
 # it then checks an API endpoint on the package server to find out for which of
@@ -47,11 +47,12 @@ get_external_dependencies:
       - bbb-etherpad
       - bbb-webhooks
       - bbb-webrtc-sfu
+      - bbb-webrtc-recorder
       - freeswitch
       - bbb-pads
       - bbb-playback
     expire_in: 1h 30min
-    
+
 # template job for build step
 .build_job:
   stage: build
@@ -170,6 +171,11 @@ bbb-webrtc-sfu-build:
   script:
     - build/setup-inside-docker.sh bbb-webrtc-sfu
 
+bbb-webrtc-recorder-build:
+  extends: .build_job
+  script:
+    - build/setup-inside-docker.sh bbb-webrtc-recorder
+
 bigbluebutton-build:
   extends: .build_job
   script:
@@ -180,12 +186,12 @@ push_packages:
   stage: push packages
   script: build/push_packages.sh
   resource_group: push_packages
-  
-  # uncomment the lines below if you want one final 
-  # "artifacts" dir with all packages (increases runtime, fills up space on gitlab server) 
+
+  # uncomment the lines below if you want one final
+  # "artifacts" dir with all packages (increases runtime, fills up space on gitlab server)
   #artifacts:
   #    paths:
   #      - artifacts/*
   #    expire_in: 2 days
- 
- 
+
+

--- a/bbb-webrtc-recorder.placeholder.sh
+++ b/bbb-webrtc-recorder.placeholder.sh
@@ -1,0 +1,1 @@
+git clone --branch v0.2.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-recorder bbb-webrtc-recorder

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -154,6 +154,14 @@ get_bbb_web_config_value() {
 
 RECORD_CONFIG=/usr/local/bigbluebutton/core/scripts/bigbluebutton.yml
 
+WEBRTC_RECORDER_DEFAULT_CONFIG=/etc/bbb-webrtc-recorder/bbb-webrtc-recorder.yml
+WEBRTC_RECORDER_ETC_CONFIG=/etc/bigbluebutton/bbb-webrtc-recorder.yml
+if [ -f $WEBRTC_RECORDER_ETC_CONFIG ]; then
+    WEBRTC_RECORDER_CONFIG=$(yq m -x $WEBRTC_RECORDER_DEFAULT_CONFIG $WEBRTC_RECORDER_ETC_CONFIG)
+else
+    WEBRTC_RECORDER_CONFIG=$(yq r $WEBRTC_RECORDER_DEFAULT_CONFIG)
+fi
+
 HTML5_DEFAULT_CONFIG=/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml
 HTML5_ETC_CONFIG=/etc/bigbluebutton/bbb-html5.yml
 if [ -f $HTML5_ETC_CONFIG ]; then
@@ -407,16 +415,7 @@ display_bigbluebutton_status () {
     fi
 
     if [ -f /usr/lib/systemd/system/bbb-html5.service ]; then
-        units="$units mongod bbb-html5 bbb-webrtc-sfu kurento-media-server"
-
-        for i in `seq 8888 8890`; do
-            # check if multi-kurento setup is configured
-            if [ -f /usr/lib/systemd/system/kurento-media-server-${i}.service ]; then
-                if systemctl is-enabled kurento-media-server-${i}.service > /dev/null; then
-                    units="$units kurento-media-server-${i}"
-                fi
-            fi
-        done
+        units="$units mongod bbb-html5"
 
         source /usr/share/meteor/bundle/bbb-html5-with-roles.conf
 
@@ -432,6 +431,27 @@ display_bigbluebutton_status () {
           units="$units bbb-html5-frontend@$i"
         done
     fi
+
+    if [ -f /usr/lib/systemd/system/bbb-webrtc-sfu.service ]; then
+        units="$units bbb-webrtc-sfu"
+    fi
+
+    if [ -f /usr/lib/systemd/system/bbb-webrtc-recorder.service ]; then
+        units="$units bbb-webrtc-recorder"
+    fi
+
+    if [ -f /usr/lib/systemd/system/kurento-media-server.service ]; then
+        units="$units kurento-media-server"
+    fi
+
+    for i in `seq 8888 8890`; do
+        # check if multi-kurento setup is configured
+        if [ -f /usr/lib/systemd/system/kurento-media-server-${i}.service ]; then
+            if systemctl is-enabled kurento-media-server-${i}.service > /dev/null; then
+                units="$units kurento-media-server-${i}"
+            fi
+        fi
+    done
 
     if [ -f /usr/share/etherpad-lite/settings.json ]; then
         units="$units etherpad"
@@ -705,6 +725,9 @@ if [[ $PORT_RANGE ]]; then
         touch $WEBRTC_SFU_ETC_CONFIG
         yq w -i $WEBRTC_SFU_ETC_CONFIG mediasoup.worker.rtcMinPort $START_PORT
         yq w -i $WEBRTC_SFU_ETC_CONFIG mediasoup.worker.rtcMaxPort $END_PORT
+
+        yq w -i $WEBRTC_RECORDER_DEFAULT_CONFIG webrtc.rtcMinPort $START_PORT
+        yq w -i $WEBRTC_RECORDER_DEFAULT_CONFIG webrtc.rtcMaxPort $END_PORT
 
         echo
         echo "BigBlueButton's UDP port range is now $START_PORT-$END_PORT"
@@ -1393,6 +1416,8 @@ if [ $CHECK ]; then
     echo "                           kurento: $(awk -F '=' '{if (! ($0 ~ /^;/) && $0 ~ /minPort/) print $2}' /etc/kurento/modules/kurento/BaseRtpEndpoint.conf.ini)-$(awk -F '=' '{if (! ($0 ~ /^;/) && $0 ~ /maxPort/) print $2}' /etc/kurento/modules/kurento/BaseRtpEndpoint.conf.ini)"
 
     echo "                    bbb-webrtc-sfu: $(echo "$WEBRTC_SFU_CONFIG" | yq r - mediasoup.worker.rtcMinPort)-$(echo "$WEBRTC_SFU_CONFIG" | yq r - mediasoup.worker.rtcMaxPort)"
+    echo "                    bbb-webrtc-recorder: $(echo "$WEBRTC_RECORDER_CONFIG" | yq r - webrtc.rtcMinPort)-$(echo "$WEBRTC_RECORDER_CONFIG" | yq r - webrtc.rtcMaxPort)"
+
 
 
 #     if [ -f ${LTI_DIR}/WEB-INF/classes/lti-config.properties ]; then
@@ -1427,10 +1452,20 @@ if [ $CHECK ]; then
         echo "                        kurento.ip: $(echo "$WEBRTC_SFU_CONFIG" | yq r - kurento[0].ip)"
         echo "                       kurento.url: $(echo "$WEBRTC_SFU_CONFIG" | yq r - kurento[0].url)"
         echo "                 freeswitch.sip_ip: $(echo "$WEBRTC_SFU_CONFIG" | yq r - freeswitch.sip_ip)"
+        echo "                  recordingAdapter: $(echo "$WEBRTC_SFU_CONFIG" | yq r - recordingAdapter)"
         echo "               recordScreenSharing: $(echo "$WEBRTC_SFU_CONFIG" | yq r - recordScreenSharing)"
         echo "                     recordWebcams: $(echo "$WEBRTC_SFU_CONFIG" | yq r - recordWebcams)"
         echo "                  codec_video_main: $(echo "$WEBRTC_SFU_CONFIG" | yq r - conference-media-specs.codec_video_main)"
         echo "               codec_video_content: $(echo "$WEBRTC_SFU_CONFIG" | yq r - conference-media-specs.codec_video_content)"
+
+    fi
+
+    if [ -n "$WEBRTC_RECORDER_CONFIG" ]; then
+        echo
+        echo "/etc/bbb-webrtc-recorder/bbb-webrtc-recorder.yml (bbb-webrtc-recorder)"
+        echo "/etc/bigbluebutton/bbb-webrtc-recorder.yml (bbb-webrtc-recorder - override)"
+        echo "               debug: $(echo "$WEBRTC_RECORDER_CONFIG" | yq r - debug)"
+        echo "               recorder.directory: $(echo "$WEBRTC_RECORDER_CONFIG" | yq r - recorder.directory)"
     fi
 
     if [ -n "$HTML5_CONFIG" ]; then

--- a/build/package-names.inc.sh
+++ b/build/package-names.inc.sh
@@ -24,6 +24,7 @@ DEBNAME_TO_SOURCEDIR[bbb-record-core]="record-and-playback/core"
 DEBNAME_TO_SOURCEDIR[bbb-web]="bigbluebutton-web bbb-common-web bbb-common-message"
 DEBNAME_TO_SOURCEDIR[bbb-webhooks]="bbb-webhooks"
 DEBNAME_TO_SOURCEDIR[bbb-webrtc-sfu]="bbb-webrtc-sfu"
+DEBNAME_TO_SOURCEDIR[bbb-webrtc-recorder]="bbb-webrtc-recorder"
 DEBNAME_TO_SOURCEDIR[bigbluebutton]="do_not_copy_anything"
 
 export DEBNAME_TO_SOURCEDIR

--- a/build/packages-template/bbb-webrtc-recorder/.build-files
+++ b/build/packages-template/bbb-webrtc-recorder/.build-files
@@ -1,0 +1,5 @@
+after-install.sh
+bbb-webrtc-recorder.service
+before-remove.sh
+build.sh
+opts-focal.sh

--- a/build/packages-template/bbb-webrtc-recorder/after-install.sh
+++ b/build/packages-template/bbb-webrtc-recorder/after-install.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+BIGBLUEBUTTON_USER=bigbluebutton
+
+case "$1" in
+  configure|upgrade|1|2)
+
+    if id $BIGBLUEBUTTON_USER > /dev/null 2>&1 ; then
+      chown $BIGBLUEBUTTON_USER:$BIGBLUEBUTTON_USER /var/lib/bbb-webrtc-recorder
+      chmod 0700 /var/lib/bbb-webrtc-recorder
+    fi
+
+    systemctl enable bbb-webrtc-recorder
+  ;;
+
+  *)
+    echo "## postinst called with unknown argument \`$1'" >&2
+  ;;
+esac
+
+systemctl daemon-reload

--- a/build/packages-template/bbb-webrtc-recorder/bbb-webrtc-recorder.service
+++ b/build/packages-template/bbb-webrtc-recorder/bbb-webrtc-recorder.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=BigBlueButton WebRTC Recorder
+Wants=redis-server.service
+After=syslog.target network.target redis-server.service
+PartOf=bigbluebutton.target
+
+[Service]
+EnvironmentFile=-/etc/default/bbb-webrtc-recorder
+ExecStart=/usr/bin/bbb-webrtc-recorder $ARGS
+SyslogIdentifier=bbb-webrtc-recorder
+Restart=always
+User=bigbluebutton
+Group=bigbluebutton
+RestartSec=3s
+Nice=-10
+
+[Install]
+WantedBy=multi-user.target bigbluebutton.target

--- a/build/packages-template/bbb-webrtc-recorder/before-remove.sh
+++ b/build/packages-template/bbb-webrtc-recorder/before-remove.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+stopService bbb-webrtc-recorder || echo "bbb-webrtc-recorer could not be registered or started"
+

--- a/build/packages-template/bbb-webrtc-recorder/build.sh
+++ b/build/packages-template/bbb-webrtc-recorder/build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -ex
+
+TARGET=`basename $(pwd)`
+
+
+PACKAGE=$(echo $TARGET | cut -d'_' -f1)
+VERSION=$(echo $TARGET | cut -d'_' -f2)
+DISTRO=$(echo $TARGET | cut -d'_' -f3)
+BUILD=$1
+
+# Clean up directories
+rm -rf staging
+rm -rf ./build
+
+# Create directories for fpm to process
+DIRS="/usr/lib/systemd/system /usr/bin /etc/default/ /etc/bbb-webrtc-recorder /var/lib/bbb-webrtc-recorder"
+for dir in $DIRS; do
+  mkdir -p staging$dir
+done
+
+mkdir -p ./build
+cp ./packaging/env ./build/env
+git config --global --add safe.directory ${PWD}
+APP_VERSION=$(cat ./VERSION)
+GOMOD=$(go list -m)
+APP_REV=$(git rev-parse --short HEAD)
+echo $GOMOD ${APP_VERSION[@]} $COMMIT
+go mod tidy
+go build -o ./build/bbb-webrtc-recorder \
+  -ldflags="-X '$GOMOD/internal.AppVersion=v${APP_VERSION[0]}-${APP_VERSION[1]} (${APP_REV})'" \
+  ./cmd/bbb-webrtc-recorder
+
+cp ./build/bbb-webrtc-recorder staging/usr/bin
+cp ./build/env staging/etc/default/bbb-webrtc-recorder
+cp ./config/bbb-webrtc-recorder.yml staging/etc/bbb-webrtc-recorder/bbb-webrtc-recorder.yml
+cp bbb-webrtc-recorder.service staging/usr/lib/systemd/system
+
+. ./opts-$DISTRO.sh
+
+fpm -s dir -C ./staging -n $PACKAGE                 \
+    --version $VERSION --epoch $EPOCH               \
+    --after-install after-install.sh                \
+    --before-remove before-remove.sh                \
+    --description "BigBlueButton WebRTC Recorder"   \
+    $DIRECTORIES                                    \
+    $OPTS

--- a/build/packages-template/bbb-webrtc-recorder/opts-focal.sh
+++ b/build/packages-template/bbb-webrtc-recorder/opts-focal.sh
@@ -1,0 +1,3 @@
+. ./opts-global.sh
+
+OPTS="$OPTS -t deb -d redis-server"

--- a/build/packages-template/bbb-webrtc-sfu/bbb-webrtc-sfu.service
+++ b/build/packages-template/bbb-webrtc-sfu/bbb-webrtc-sfu.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=BigBlueButton WebRTC SFU
 Wants=redis-server.service
-After=syslog.target network.target freeswitch.service kurento-media-server.service redis-server.service
+After=syslog.target network.target freeswitch.service bbb-webrtc-recorder.service kurento-media-server.service redis-server.service
 PartOf=bigbluebutton.target
 
 [Service]

--- a/build/packages-template/bbb-webrtc-sfu/opts-focal.sh
+++ b/build/packages-template/bbb-webrtc-sfu/opts-focal.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d git-core,nginx,kurento-media-server,openh264-gst-plugins-bad-1.5,bbb-apps-akka,nodejs,npm,build-essential,xmlstarlet"
+OPTS="$OPTS -t deb -d git-core,nginx,kurento-media-server,openh264-gst-plugins-bad-1.5,bbb-apps-akka,nodejs,npm,build-essential,xmlstarlet,bbb-webrtc-recorder"

--- a/build/packages-template/bigbluebutton/build.sh
+++ b/build/packages-template/bigbluebutton/build.sh
@@ -29,7 +29,8 @@ bbb-playback
 bbb-playback-presentation
 bbb-record-core
 bbb-web
-bbb-webrtc-sfu"
+bbb-webrtc-sfu
+bbb-webrtc-recorder"
 
 DEPENDENCIES=$(
   for PKG in $PKGS; do

--- a/record-and-playback/core/scripts/archive/archive.rb
+++ b/record-and-playback/core/scripts/archive/archive.rb
@@ -180,6 +180,8 @@ kurento_video_dir = props['kurento_video_src']
 kurento_screenshare_dir = props['kurento_screenshare_src']
 mediasoup_video_dir = props['mediasoup_video_src']
 mediasoup_screenshare_dir = props['mediasoup_screenshare_src']
+webrtc_recorder_video_dir = props['webrtc_recorder_video_src']
+webrtc_recorder_screenshare_dir = props['webrtc_recorder_screenshare_src']
 log_dir = props['log_dir']
 notes_endpoint = props['notes_endpoint']
 notes_formats = props['notes_formats']
@@ -210,6 +212,9 @@ archive_directory("#{kurento_video_dir}/#{meeting_id}", "#{target_dir}/video/#{m
 # mediasoup media
 archive_directory("#{mediasoup_screenshare_dir}/#{meeting_id}", "#{target_dir}/deskshare")
 archive_directory("#{mediasoup_video_dir}/#{meeting_id}", "#{target_dir}/video/#{meeting_id}")
+# bbb-webrtc-recorder media
+archive_directory("#{webrtc_recorder_screenshare_dir}/#{meeting_id}", "#{target_dir}/deskshare")
+archive_directory("#{webrtc_recorder_video_dir}/#{meeting_id}", "#{target_dir}/video/#{meeting_id}")
 
 # If this was the last (or only) segment in a recording, delete the original media files
 if break_timestamp.nil?
@@ -222,6 +227,9 @@ if break_timestamp.nil?
   # mediasoup media
   FileUtils.rm_rf("#{mediasoup_screenshare_dir}/#{meeting_id}")
   FileUtils.rm_rf("#{mediasoup_video_dir}/#{meeting_id}")
+  # bbb-webrtc-recorder media
+  FileUtils.rm_rf("#{webrtc_recorder_screenshare_dir}/#{meeting_id}")
+  FileUtils.rm_rf("#{webrtc_recorder_video_dir}/#{meeting_id}")
 end
 
 if not archive_has_recording_marks?(meeting_id, raw_archive_dir, break_timestamp)

--- a/record-and-playback/core/scripts/bigbluebutton.yml
+++ b/record-and-playback/core/scripts/bigbluebutton.yml
@@ -4,6 +4,8 @@ kurento_video_src: /var/kurento/recordings
 kurento_screenshare_src: /var/kurento/screenshare
 mediasoup_video_src: /var/mediasoup/recordings
 mediasoup_screenshare_src: /var/mediasoup/screenshare
+webrtc_recorder_video_src: /var/lib/bbb-webrtc-recorder/recordings
+webrtc_recorder_screenshare_src: /var/lib/bbb-webrtc-recorder/screenshare
 raw_deskshare_src: /var/bigbluebutton/deskshare
 raw_presentation_src: /var/bigbluebutton
 notes_endpoint: http://127.0.0.1:9002/p


### PR DESCRIPTION
### What does this PR do?

Partial port of bbb-webrtc-recorder's own build scripts.
The app's build uses nfpm. That's fine - I just ported most of the stuff to BBB's pattern (fpm + scripts) so we don't need to add nfpm to the mix or deal with package importing from the external repo's CI pipeline.

### Closes Issue(s)

None

### Motivation

Ref #13999 

### More

* Testing:
  - build + install
  - set `recordingAdapter: bbb-webrtc-recorder` in `/etc/bigbluebutton/bbb-webrtc-sfu/production.yml`
  - restart bbb-webrtc-sfu
  - record something
    * captured files can be verified in /var/lib/bbb-webrtc-recorder
    * logs will end up in bbb-webrtc-recorder.service's journal

   
- Pending:
  * [x] Upgrade the base build image:
  * [x] Full installation testing
  * [x] Tag an initial alpha in the recorder's repo (still using main branch in the placeholder)
  * [x] Sane defaults in the recorder's repo
  * [x] Add it to bbb-conf's routines (start|stop|restart|clean et al)
  * [ ] Later: docs, config file override