### PR TITLE
fix: Patch Auto Hidden Tools To Stay Invisible On Page Change

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -896,6 +896,10 @@ export default function Whiteboard(props) {
       setHistory(app.history);
     }
 
+    if (whiteboardToolbarAutoHide && command && command.id === "change_page") {
+      toggleToolsAnimations('fade-in', 'fade-out', '0s');
+    }
+
     if (command?.id?.includes('style')) {
       setCurrentStyle({ ...currentStyle, ...command?.after?.appState?.currentStyle });
     }


### PR DESCRIPTION
### What does this PR do?
This PR ensures the whiteboard toolbars stay hidden when switching pages and the auto hide feature is enabled.

### Motivation
There was a bug that was causing the toolbars to stay visible after switching the page when auto hide was enabled.

before:
![auto-hide-change-page-bug](https://user-images.githubusercontent.com/22058534/232904801-1fafc5c9-c9dc-4e54-949b-3e581c80955e.gif)

After:
![auto-hide-change-page](https://user-images.githubusercontent.com/22058534/232904831-633ab031-d60d-4bb4-af4e-b7aa9f8c1f41.gif)
