### PR TITLE
fix (bbb-conf): property 'disabledFeatures' has no value

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -744,14 +744,18 @@ check_configuration() {
     # Look for properties with no values set
     #
     CONFIG_FILES="$SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties"
+    ignore_configs_args=()
+    ignore_configs_args+=(-e "redis.pass")
+    ignore_configs_args+=(-e "redisPassword")
+    ignore_configs_args+=(-e "disabledFeatures")
 
     for file in $CONFIG_FILES ; do
         if [ ! -f $file ]; then
             echo "# Error: File not found: $file"
         else
-            if cat $file | grep -v redis.pass | grep -v redisPassword  | grep -v ^# | grep -q "^[^=]*=[ ]*$"; then
+            if cat $file | grep -v "${ignore_configs_args[@]}"  | grep -v ^# | grep -q "^[^=]*=[ ]*$"; then
                 echo "# The following properties in $file have no value:"
-                echo "#     $(grep '^[^=#]*=[ ]*$' $file | grep -v redis.pass | grep -v redisPassword | sed 's/=//g')"
+                echo "#     $(grep '^[^=#]*=[ ]*$' $file | grep -v "${ignore_configs_args[@]}" | sed 's/=//g')"
             fi
         fi
     done


### PR DESCRIPTION
As reported by @mwuttke at https://github.com/bigbluebutton/bigbluebutton/pull/17506#issuecomment-1514283860

Since #17506 was merged `bbb-conf --check` started to alert about `disabledFeatures` property is empty.
But it turns out that this param is designed to be empty by default.
So the best solution for this case is just remove this property from validation.

Before:

![image](https://user-images.githubusercontent.com/5660191/233064798-2e0c8071-3535-4356-a6e6-b1cbf1a1d202.png)

After:

![image](https://user-images.githubusercontent.com/5660191/233064848-b0c4aa9b-188c-4d35-b888-d9508bdf1873.png)
