### PR TITLE
Fix: Draggable cameras when presentation minimized.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -6,6 +6,7 @@ import { INITIAL_INPUT_STATE } from '/imports/ui/components/layout/initState';
 import { ACTIONS, CAMERADOCK_POSITION, PANELS } from '../enums';
 import Storage from '/imports/ui/services/storage/session';
 import { isPresentationEnabled } from '/imports/ui/services/features';
+import Draggable from 'react-draggable';
 
 const windowWidth = () => window.document.documentElement.clientWidth;
 const windowHeight = () => window.document.documentElement.clientHeight;
@@ -645,7 +646,7 @@ const CustomLayout = (props) => {
         left: cameraDockBounds.left,
         right: cameraDockBounds.right,
         tabOrder: 4,
-        isDraggable: !isMobile && !isTablet,
+        isDraggable: !isMobile && !isTablet && presentationInput.isOpen,
         resizableEdge: {
           top: (input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_BOTTOM)
             || (input.cameraDock.position === CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM


### PR DESCRIPTION
### What does this PR do?

This PR makes the cameras not available for dragging when presentation is minimized and layout is custom. 


![fixCameraDrag](https://user-images.githubusercontent.com/36093456/233149227-7e992903-49dc-435f-9e13-09a182455f36.gif)

