### PR TITLE
fix: Prevent Canvas Selection While Using Stylus On iPad

### DIFF
--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -116,6 +116,14 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     .fade-out {
       opacity: 0 !important;
     }
+
+    html, div, span {
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+      -webkit-tap-highlight-color: transparent;
+    }
   </style>
   <script>
     document.addEventListener('gesturestart', function (e) {


### PR DESCRIPTION
### What does this PR do?
This PR addresses an issue with the stylus and iPad, enhancing the drawing experience. Previously, during drawing sessions, elements were getting unintentionally selected and highlighted, causing interruptions. This update ensures that the stylus and iPad work without any selection interference. Now the magnifying glass is displayed instead of the highlight / selection.