### PR TITLE
fix: Disable Canvas Magnifier On iPad While Using Canvas

### DIFF
--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -116,14 +116,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     .fade-out {
       opacity: 0 !important;
     }
-
-    html, div, span {
-      -webkit-user-select: none;
-      -moz-user-select: none;
-      -ms-user-select: none;
-      user-select: none;
-      -webkit-tap-highlight-color: transparent;
-    }
   </style>
   <script>
     document.addEventListener('gesturestart', function (e) {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
@@ -53,7 +53,15 @@ const Cursors = (props) => {
 
   const [panGrabbing, setPanGrabbing] = React.useState(false);
 
-  const start = () => {
+  const start = (event) => {
+    const targetElement = event.target;
+    const className = targetElement instanceof SVGElement
+      ? targetElement?.className?.baseVal
+      : targetElement?.className;
+    const hasTlPartial = className?.includes('tl-');
+    if (hasTlPartial) {
+      event?.preventDefault();
+    }
     if (whiteboardToolbarAutoHide) toggleToolsAnimations('fade-out', 'fade-in', application?.animations ? '.3s' : '0s');
     setActive(true);
   };

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/component.jsx
@@ -54,7 +54,7 @@ const Cursors = (props) => {
   const [panGrabbing, setPanGrabbing] = React.useState(false);
 
   const start = (event) => {
-    const targetElement = event.target;
+    const targetElement = event?.target;
     const className = targetElement instanceof SVGElement
       ? targetElement?.className?.baseVal
       : targetElement?.className;


### PR DESCRIPTION
### What does this PR do?
This PR serves as a follow-up to #17678, which previously disabled the text copying functionality in the chat via selection. The initial fix successfully prevented the selection of unintended elements but inadvertently introduced a side effect where the magnifier would appear frequently during drawing. This update restores the chat's text copying capability and resolves the issue with the selection and magnifier's interruptions.

Closes: #17679