### PR TITLE
fix: Wrong style for set status dropdown button on iPhone

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/button/button-emoji/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/button/button-emoji/styles.js
@@ -44,6 +44,7 @@ const EmojiButton = styled.button`
   overflow: hidden;
   z-index: 2;
   border: none;
+  padding: 0;
 
   [dir="rtl"] & {
     right: initial;


### PR DESCRIPTION
### What does this PR do?

fix incorrect size for raise hand dropdown on ios

### Closes Issue(s)
Closes #16944