### PR TITLE
docs: Correcting the virtual background images upload path

### DIFF
--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -640,9 +640,9 @@ HERE
 
 Starting from version 2.4 BigBlueButton offers virtual background for webcams.
 To use your own background images copy them into the directory
-`/usr/share/meteor/bundle/programs/web.browser/app/resources/img/virtual-backgrounds`.
+`/usr/share/meteor/bundle/programs/web.browser/app/resources/images/virtual-backgrounds`.
 For each image copy a thumbnail of the image of 50x50 pixels size into
-`/usr/share/meteor/bundle/programs/web.browser/app/resources/img/virtual-backgrounds/thumbnails`.
+`/usr/share/meteor/bundle/programs/web.browser/app/resources/images/virtual-backgrounds/thumbnails`.
 
 To generate thumbnails you can use the following shell snippet:
 


### PR DESCRIPTION
### What does this PR do?

Update the "[Server Customization](https://docs.bigbluebutton.org/2.5/administration/customize)" doc to match the correct virtual background images path.

Before :
`/usr/share/meteor/bundle/programs/web.browser/app/resources/img/virtual-backgrounds`

After :
`/usr/share/meteor/bundle/programs/web.browser/app/resources/images/virtual-backgrounds`

## More
Might need to be backported to 2.5/2.6 docs.

Regards,