### PR TITLE
fix: add TURN preflight check when iceTransportPolicy=relay

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -50,6 +50,7 @@ import AudioService from '/imports/ui/components/audio/service';
 import NotesContainer from '/imports/ui/components/notes/container';
 import DEFAULT_VALUES from '../layout/defaultValues';
 import AppService from '/imports/ui/components/app/service';
+import { runRelayPreflightCheck } from '/imports/ui/services/bbb-webrtc-sfu/utils';
 
 const MOBILE_MEDIA = 'only screen and (max-width: 40em)';
 const APP_CONFIG = Meteor.settings.public.app;
@@ -211,6 +212,16 @@ class App extends Component {
     if (deviceInfo.isMobile) makeCall('setMobileUser');
 
     ConnectionStatusService.startRoundTripTime();
+
+    runRelayPreflightCheck().catch((error) => {
+      logger.error({
+        logCode: 'relay_preflight_failed',
+        extraInfo: {
+          errorMessage: error.message,
+          errorCode: error.code,
+        },
+      }, 'Relay preflight check failed, iceTransportPolicy will not be enforced');
+    });
 
     logger.info({ logCode: 'app_component_componentdidmount' }, 'Client loaded successfully');
   }
@@ -558,7 +569,7 @@ class App extends Component {
               ? <ExternalVideoContainer isLayoutSwapped={!presentationIsOpen} isPresenter={isPresenter} />
               : null
           }
-          {shouldShowSharedNotes 
+          {shouldShowSharedNotes
             ? (
               <NotesContainer
                 area="media"

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/utils.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/utils.js
@@ -1,25 +1,66 @@
 import browserInfo from '/imports/utils/browserInfo';
 import deviceInfo from '/imports/utils/deviceInfo';
-import { hasTurnServer } from '/imports/utils/fetchStunTurnServers';
+import {
+  hasWorkingTurnServer,
+  relayPreflightCheck,
+} from '/imports/utils/fetchStunTurnServers';
+import Auth from '/imports/ui/services/auth';
 
 const FORCE_RELAY_ON_FF = Meteor.settings.public.media.forceRelayOnFirefox;
 const FORCE_RELAY = Meteor.settings.public.media.forceRelay;
 
 /*
- * Whether TURN/relay usage should be forced to work around Firefox's lack of
+ * Whether TURN/relay usage is configured to work around Firefox's lack of
  * support for regular nomination when dealing with ICE-litee peers (e.g.:
  * mediasoup). See: https://bugzilla.mozilla.org/show_bug.cgi?id=1034964
  *
  * iOS endpoints are ignored from the trigger because _all_ iOS browsers
  * are either native WebKit or WKWebView based (so they shouldn't be affected)
  */
+const isForceRelayConfigured = () => {
+  const { isFirefox } = browserInfo;
+  const { isIos } = deviceInfo;
+
+  return FORCE_RELAY || (isFirefox && !isIos) && FORCE_RELAY_ON_FF;
+};
+
 const shouldForceRelay = () => {
   const { isFirefox } = browserInfo;
   const { isIos } = deviceInfo;
 
-  return FORCE_RELAY || ((isFirefox && !isIos) && FORCE_RELAY_ON_FF && hasTurnServer());
+  return isForceRelayConfigured() && hasWorkingTurnServer();
+};
+
+/*
+ * This function is used to check if the TURN server is working properly.
+ * It is called when the user joins a room, and if it fails, FORCE_RELAY* flags
+ * will be ineffective.
+ *
+ * The check runs relayPreflightCheck at most three times (less if it works)
+ * and the result will be cached for the duration of the session.
+ *
+ * The default state of a relay server is false, so if shouldForceRelay is called
+ * before the check is run, it will return false.
+ *
+ */
+const runRelayPreflightCheck = () => {
+  if (!isForceRelayConfigured() || hasWorkingTurnServer()) {
+    return Promise.resolve();
+  }
+
+  const timedPreflightCheck = (retries) => {
+    if (retries === 0) {
+      return Promise.reject(new Error('Relay candidates not generated in time'));
+    }
+
+    return relayPreflightCheck(Auth.sessionToken)
+      .catch((error) => timedPreflightCheck(retries - 1));
+  };
+
+  return timedPreflightCheck(3);
 };
 
 export {
   shouldForceRelay,
+  runRelayPreflightCheck,
 };


### PR DESCRIPTION
### What does this PR do?

Adds a TURN preflight check for endpoints submitted to one of the FORCE_RELAY flags. It runs once the application is loaded to check whether the provided TURN server is working. The check retries _at most_ three times until it succeeds or fails, and results are cached for a session. 

If it fails, transport policy will fall back to default instead of trying to force relay.

### Closes Issue(s)

None

### Motivation

The built-in coturn+haproxy setup works most of times. Some folks do have problems with it, though, and the transport policy for Firefox is to force relay by default. That causes scenarios where Firefox fails unconditionally with borked coturn setups and that causes more damage than what we were trying to fix with it.

eg https://github.com/bigbluebutton/bigbluebutton/issues/17696, https://github.com/bigbluebutton/bigbluebutton/issues/17694

### More

There's a few other tweaks that we can do to this setup:
  - [ ] Add coturn/haproxy to bigbluebutton.target so it is rotated alongside the other BBB services via bbb-conf et al
  - [ ] Add TURN checks + warnings to bbb-conf itself (with coturn's turnutils or some other tool)
