### PR TITLE
refactor (graphql-server): Introduces flags disconnected and expired to Graphql

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
@@ -2,6 +2,7 @@ package org.bigbluebutton.core.apps.users
 
 import org.bigbluebutton.common2.msgs.UserJoinMeetingReqMsg
 import org.bigbluebutton.core.apps.breakout.BreakoutHdlrHelpers
+import org.bigbluebutton.core.db.UserDAO
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models.{ RegisteredUser, RegisteredUsers, Users2x, VoiceUsers }
 import org.bigbluebutton.core.running.{ HandlerHelpers, LiveMeeting, MeetingActor, OutMsgRouter }
@@ -67,6 +68,7 @@ trait UserJoinMeetingReqMsgHdlr extends HandlerHelpers {
 
           // fresh user joined (not due to reconnection). Clear (pop) the cached voice user
           VoiceUsers.recoverVoiceUser(liveMeeting.voiceUsers, msg.body.userId)
+          UserDAO.updateExpired(msg.body.userId, false)
 
           newState
         } else {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
@@ -171,7 +171,6 @@ object RegisteredUsers {
   def setUserLoggedOutFlag(users: RegisteredUsers, user: RegisteredUser): RegisteredUser = {
     val u = user.copy(loggedOut = true)
     users.save(u)
-    println("seeeeeeeeeeeeeeeeeeeeeeeting userLoggedOut----------------------------------")
     UserDAO.update(u)
     u
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
@@ -171,6 +171,7 @@ object RegisteredUsers {
   def setUserLoggedOutFlag(users: RegisteredUsers, user: RegisteredUser): RegisteredUser = {
     val u = user.copy(loggedOut = true)
     users.save(u)
+    println("seeeeeeeeeeeeeeeeeeeeeeeting userLoggedOut----------------------------------")
     UserDAO.update(u)
     u
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -27,7 +27,7 @@ object Users2x {
   }
 
   def remove(users: Users2x, intId: String): Option[UserState] = {
-    UserDAO.delete(intId)
+    //UserDAO.delete(intId)
     users.remove(intId)
   }
 
@@ -49,6 +49,7 @@ object Users2x {
       val newUser = u.copy(userLeftFlag = UserLeftFlag(false, 0))
       users.save(newUser)
       UserDAO.update(newUser)
+      UserDAO.updateExpired(u.intId, false)
       newUser
     }
   }
@@ -124,7 +125,7 @@ object Users2x {
       _ <- users.remove(intId)
       ejectedUser <- users.removeFromCache(intId)
     } yield {
-      UserDAO.delete(intId)
+      //      UserDAO.delete(intId)
       ejectedUser
     }
   }
@@ -189,7 +190,7 @@ object Users2x {
     } yield {
       val newUser = u.modify(_.emoji).setTo(emoji)
       users.save(newUser)
-      UserDAO.updateEmoji(newUser)
+      UserDAO.update(newUser)
       newUser
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -41,8 +41,9 @@ import scala.concurrent.duration._
 import org.bigbluebutton.core.apps.layout.LayoutApp2x
 import org.bigbluebutton.core.apps.meeting.{ SyncGetMeetingInfoRespMsgHdlr, ValidateConnAuthTokenSysMsgHdlr }
 import org.bigbluebutton.core.apps.users.ChangeLockSettingsInMeetingCmdMsgHdlr
+import org.bigbluebutton.core.db.UserDAO
 import org.bigbluebutton.core.models.VoiceUsers.{ findAllFreeswitchCallers, findAllListenOnlyVoiceUsers }
-import org.bigbluebutton.core.models.Webcams.{ findAll }
+import org.bigbluebutton.core.models.Webcams.findAll
 import org.bigbluebutton.core2.MeetingStatus2x.{ hasAuthedUserJoined, isVoiceRecording }
 import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
 
@@ -895,6 +896,8 @@ class MeetingActor(
           // request ongoing poll to end
           Polls.handleStopPollReqMsg(state, u.intId, liveMeeting)
         }
+
+        UserDAO.updateExpired(u.intId, true)
       }
     }
 

--- a/bbb-graphql-client-test/src/UserList.js
+++ b/bbb-graphql-client-test/src/UserList.js
@@ -78,7 +78,7 @@ function UserList({userId}) {
         authed
         mobile
         clientType
-        leftFlag
+        disconnected
         loggedOut
         voice {
           joined
@@ -125,7 +125,7 @@ function UserList({userId}) {
             <th>Locked</th>
             <th>Last BreakoutRoom</th>
             <th>connectionAliveAt</th>
-            <th>LeftFlag</th>
+            <th>Disconnected (leftFlag)</th>
             <th>LoggedOut</th>
         </tr>
       </thead>
@@ -162,7 +162,7 @@ function UserList({userId}) {
                        : ''
                       }
                   </td>
-                  <td style={{backgroundColor: user.leftFlag === true ? '#A0DAA9' : ''}}>{user.leftFlag === true ? 'Yes' : 'No'}</td>
+                  <td style={{backgroundColor: user.disconnected === true ? '#A0DAA9' : ''}}>{user.disconnected === true ? 'Yes' : 'No'}</td>
                   <td style={{backgroundColor: user.loggedOut === true ? '#A0DAA9' : ''}}>{user.loggedOut === true ? 'Yes' : 'No'}</td>
               </tr>
           );

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -221,7 +221,7 @@ CREATE TABLE "user" (
 --	"ejected" bool null,
 --	"ejectReason" varchar(255),
 	"banned" bool NULL,
-	"loggedOut" bool NULL,  -- when user clicked to exit or after some time he is expired
+	"loggedOut" bool NULL,  -- when user clicked Leave meeting button
 	"registeredOn" bigint NULL,
 	"presenter" bool NULL,
 	"pinned" bool NULL,
@@ -232,6 +232,10 @@ CREATE INDEX "idx_user_meetingId" ON "user"("meetingId");
 
 --hasDrawPermissionOnCurrentPage is necessary to improve the performance of the order by of userlist
 COMMENT ON COLUMN "user"."hasDrawPermissionOnCurrentPage" IS 'This column is dynamically populated by triggers of tables: user, pres_presentation, pres_page, pres_page_writers';
+COMMENT ON COLUMN "user"."disconnected" IS 'This column is set true when the user closes the window or his with the server is over';
+COMMENT ON COLUMN "user"."expired" IS 'This column is set true after 10 seconds with disconnected=true';
+COMMENT ON COLUMN "user"."loggedOut" IS 'This column is set to true when the user click the button to Leave meeting';
+COMMENT ON COLUMN "user"."loggedOut" IS 'This column is set to true when the user click the button to Leave meeting';
 
 --Virtual columns isDialIn, isModerator and isOnline
 ALTER TABLE "user" ADD COLUMN "isDialIn" boolean GENERATED ALWAYS AS (CASE WHEN "clientType" = 'dial-in-user' THEN true ELSE false END) STORED;

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_user.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_user.yaml
@@ -68,7 +68,7 @@ select_permissions:
         - isModerator
         - isOnline
         - joined
-        - leftFlag
+        - disconnected
         - locked
         - loggedOut
         - meetingId

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
@@ -82,7 +82,7 @@ select_permissions:
         - isModerator
         - isOnline
         - joined
-        - leftFlag
+        - disconnected
         - locked
         - loggedOut
         - meetingId

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
@@ -89,7 +89,7 @@ select_permissions:
         - isDialIn
         - isModerator
         - joined
-        - leftFlag
+        - disconnected
         - locked
         - loggedOut
         - meetingId

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_ref.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_ref.yaml
@@ -24,7 +24,7 @@ select_permissions:
         - isModerator
         - isOnline
         - joined
-        - leftFlag
+        - disconnected
         - locked
         - loggedOut
         - meetingId

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/queries.ts
@@ -25,7 +25,7 @@ export const USERS_SUBSCRIPTION = gql`subscription Users($offset: Int!, $limit: 
     mobile
     guest
     clientType
-    leftFlag
+    disconnected
     loggedOut
     voice {
       joined
@@ -82,7 +82,7 @@ export const MEETING_PERMISSIONS_SUBSCRIPTION = gql`subscription {
   }
 }`;
 
-export const CURRENT_USER_SUBSCRIPTION = gql`subscription User($userId: String!) {
+export const CURRENT_USER_SUBSCRIPTION   = gql`subscription User($userId: String!) {
   user(where: {userId: {_eq: $userId}}) {
     isModerator
     guest


### PR DESCRIPTION
- `Disconnected` (old `userLeftFlag`)
Currently when the user closes the window or he lost connection with the server, BBB set `leftFlag: true` to this user.
But this flag's name is not self explanatory, once it's name suggest the user left the meeting, what sometimes is not the case.
So we renamed it to `disconnected` that explains much better what really happend.

- `Expired`
And after 10 seconds with `disconnected == true` the user is removed from the userList. And we need some flag in graphql `user` collection to indicate that the user is with this status. So the name for it is `expired` that means BBB waited for 10 seconds for some re-connection but this time expired.