### PR TITLE
fix: typing indicator does not work in private chat

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/typing-indicator/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/typing-indicator/container.jsx
@@ -27,8 +27,7 @@ export default withTracker(({ idChatOpen }) => {
   };
 
   if (idChatOpen !== PUBLIC_CHAT_KEY) {
-    selector.isTypingTo = Auth.userID;
-    selector.userId = idChatOpen;
+    selector.isTypingTo = idChatOpen;
   }
 
   const currentUser = Users.findOne({


### PR DESCRIPTION
### What does this PR do?

Fix chatId parameter in typing indicator for private chats