### PR TITLE
nginx config: Allow overriding the $scheme variable

### DIFF
--- a/build/packages-template/bbb-etherpad/notes.nginx
+++ b/build/packages-template/bbb-etherpad/notes.nginx
@@ -15,7 +15,7 @@ location /pad/p/ {
 
     proxy_set_header X-Real-IP $remote_addr;  # http://wiki.nginx.org/HttpProxyModule
     proxy_set_header X-Forwarded-For $remote_addr; # EP logs to show the actual remote IP
-    proxy_set_header X-Forwarded-Proto $scheme; # for EP to set secure cookie flag when https is used
+    proxy_set_header X-Forwarded-Proto $real_scheme; # for EP to set secure cookie flag when https is used
     proxy_http_version 1.1;
 
     auth_request /bigbluebutton/connection/checkAuthorization;
@@ -57,7 +57,7 @@ location /pad/socket.io {
     proxy_buffering off;
     proxy_set_header X-Real-IP $remote_addr;  # http://wiki.nginx.org/HttpProxyModule
     proxy_set_header X-Forwarded-For $remote_addr; # EP logs to show the actual remote IP
-    proxy_set_header X-Forwarded-Proto $scheme; # for EP to set secure cookie flag when https is used
+    proxy_set_header X-Forwarded-Proto $real_scheme; # for EP to set secure cookie flag when https is used
     proxy_set_header Host $host;  # pass the host header
     proxy_http_version 1.1;  # recommended with keepalive connections
     # WebSocket proxying - from http://nginx.org/en/docs/http/websocket.html

--- a/build/packages-template/bbb-html5/bigbluebutton.nginx
+++ b/build/packages-template/bbb-html5/bigbluebutton.nginx
@@ -1,17 +1,21 @@
 server {
-     listen   80;
-     listen [::]:80;
-     server_name  192.168.0.103;
+    listen   80;
+    listen [::]:80;
+    server_name  192.168.0.103;
 
-     access_log  /var/log/nginx/bigbluebutton.access.log;
+    access_log  /var/log/nginx/bigbluebutton.access.log;
 
-	# BigBlueButton assets and static content.
-        location / {
-          root   /var/www/bigbluebutton-default/assets;
-          index  index.html index.htm;
-	  expires 1m;
-        }
+    # This variable is used instead of $scheme by bigbluebutton nginx include
+    # files, so $scheme can be overridden in reverse-proxy configurations.
+    set $real_scheme $scheme;
 
-	# Include specific rules for record and playback
-        include /etc/bigbluebutton/nginx/*.nginx; # an overriding set of files, possibly present
+    # BigBlueButton assets and static content.
+    location / {
+      root   /var/www/bigbluebutton-default/assets;
+      index  index.html index.htm;
+      expires 1m;
+    }
+
+    # Include specific rules for record and playback
+    include /etc/bigbluebutton/nginx/*.nginx; # an overriding set of files, possibly present
 }


### PR DESCRIPTION
The etherpad component's nginx configuration needs to know the request scheme in order to set some variables that influence whether the 'Secure' flag is set on cookies. Right now it directly uses the $scheme variable, but this variable does not get set to the expected value if nginx is behind a reverse-proxy where the proxy handles TLS termination.

Adjust the etherpad nginx config to use a variable with a different name $real_scheme, which can be set in the nginx server block to match the configuration of the nginx listeners.

This variable is set to the value of $scheme in the default /etc/sites-available/bigbluebutton file.

This needs to be merged along with the corresponding update to the bbb-install.sh script: https://github.com/bigbluebutton/bbb-install/pull/642 People using other installation scripts will need to add this variable to their nginx configuration file, or etherpad might not operate correctly.