### PR TITLE
fix (graphql-server): Locked viewers can see other viewers typing

### DIFF
--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_typing_public.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_typing_public.yaml
@@ -14,7 +14,7 @@ object_relationships:
           userId: userId
         insertion_order: null
         remote_table:
-          name: v_user
+          name: v_user_ref
           schema: public
 select_permissions:
   - role: bbb_client
@@ -26,5 +26,21 @@ select_permissions:
         - typingAt
         - isCurrentlyTyping
       filter:
-        meetingId:
-          _eq: X-Hasura-MeetingId
+        _and:
+          - meetingId:
+              _eq: X-Hasura-MeetingId
+          - _or:
+              - meetingId:
+                  _eq: X-Hasura-ModeratorInMeeting
+              - user:
+                  isModerator:
+                    _eq: true
+              - meetingId:
+                  _neq: X-Hasura-LockedInMeeting
+              - _exists:
+                  _table:
+                    name: v_meeting_showUserlist
+                    schema: public
+                  _where:
+                    meetingId:
+                      _eq: X-Hasura-MeetingId


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5660191/234578076-ae84b7a0-ac4d-4fb9-ab34-ea7614417684.png)

When this option is `true`, viewers should not see when other viewers are typing.
This PR set this permission in Hasura.