### PR TITLE
fix (html5): Set proper query to get current user in graphql

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/component.tsx
@@ -110,7 +110,7 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
                   tabIndex={0}
                   />
                 );
-              }}            
+              }}
         </AutoSizer>
       }
     </Styled.UserListColumn>
@@ -120,7 +120,7 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
 const UserListParticipantsContainer: React.FC = () => {
   const [offset, setOffset] = React.useState(0);
   const [limit, setLimit] = React.useState(0);
-  
+
   const { loading: usersLoading, error: usersError, data: usersData } = useSubscription(USERS_SUBSCRIPTION, {
     variables:{
       offset,
@@ -141,13 +141,9 @@ const UserListParticipantsContainer: React.FC = () => {
     loading: currentUserLoading,
     error: currentUserError,
     data: currentUserData,
-  } = useSubscription(CURRENT_USER_SUBSCRIPTION, {
-    variables:{
-      userId: Auth.userID,
-    }
-  });
+  } = useSubscription(CURRENT_USER_SUBSCRIPTION);
 
-  const { user: currentUserArr } = (currentUserData || {});
+  const { user_current: currentUserArr } = (currentUserData || {});
   const currentUser = currentUserArr && currentUserArr[0];
 
   const {

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/queries.ts
@@ -82,11 +82,13 @@ export const MEETING_PERMISSIONS_SUBSCRIPTION = gql`subscription {
   }
 }`;
 
-export const CURRENT_USER_SUBSCRIPTION   = gql`subscription User($userId: String!) {
-  user(where: {userId: {_eq: $userId}}) {
+export const CURRENT_USER_SUBSCRIPTION   = gql`subscription {
+  user_current {
+    userId 
     isModerator
     guest
     presenter
+    locked
   }
 }`;
 


### PR DESCRIPTION
It should use the endpoint `user_current` instead of the generic `user`.