### PR TITLE
fix: Transfer button not displayed in tablets

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/mobile-app-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/mobile-app-modal/component.jsx
@@ -116,7 +116,7 @@ class MobileAppModal extends Component {
               color="primary"
               disabled={url === ''}
               label={intl.formatMessage(intlMessages.openApp)}
-              onClick={() => window.open(`${BBB_TABLET_APP_CONFIG.iosAppUrlScheme}://${meetingName}/${url}`, '_blank')}
+              onClick={() => window.open(`${BBB_TABLET_APP_CONFIG.iosAppUrlScheme}://${meetingName}/${encodeURIComponent(url)}`, '_blank')}
               role="button"
               size="lg"
             />

--- a/bigbluebutton-html5/imports/utils/deviceInfo.js
+++ b/bigbluebutton-html5/imports/utils/deviceInfo.js
@@ -10,7 +10,7 @@ const isMobile = isPhone || isTablet;
 const hasMediaDevices = !!navigator.mediaDevices;
 const osName = BOWSER_RESULTS.os.name;
 const osVersion = BOWSER_RESULTS.os.version;
-const isIos = osName === 'iOS';
+const isIos = osName === 'iOS' || (isTablet && osName=="macOS");
 const isMacos = osName === 'macOS';
 const isIphone = !!(userAgent.match(/iPhone/i));
 

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -35,7 +35,7 @@ public:
     helpLink: https://bigbluebutton.org/html5/
     delayForUnmountOfSharedNote: 120000
     bbbTabletApp:
-      enabled: false
+      enabled: true
       iosAppStoreUrl: 'https://apps.apple.com/us/app/bigbluebutton-tablet/id1641156756'
       iosAppUrlScheme: 'bigbluebutton-tablet'
     lockOnJoin: true


### PR DESCRIPTION
For tablet users the user agent returns macOS instead of iOs.

This PR improves the iOS detection to consider tablet as iOs instead of macOS, so that the transfer button is displayed correctly.

Also, it fixes the url concatenation to encode its parameters and avoid breaking.

https://user-images.githubusercontent.com/7821065/234858078-fcd9c2c4-5884-44ba-a6e5-14d21a39a1ce.mov

Closes #17360 