### PR TITLE
build: (TEMP) drop yq as a dependency -- it is a script not package on 22.04

### DIFF
--- a/build/packages-template/bbb-config/opts-jammy.sh
+++ b/build/packages-template/bbb-config/opts-jammy.sh
@@ -1,4 +1,4 @@
 . ./opts-global.sh
 
 AKKA_APPS="bbb-fsesl-akka,bbb-apps-akka"
-OPTS="$OPTS -t deb -d netcat-openbsd,stun-client,bbb-html5,bbb-playback-presentation,bbb-playback,bbb-freeswitch-core,$AKKA_APPS,yq"
+OPTS="$OPTS -t deb -d netcat-openbsd,stun-client,bbb-html5,bbb-playback-presentation,bbb-playback,bbb-freeswitch-core,$AKKA_APPS"

--- a/build/packages-template/bbb-html5/opts-jammy.sh
+++ b/build/packages-template/bbb-html5/opts-jammy.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -d bc,bbb-pads,bbb-webrtc-sfu,bbb-export-annotations,bbb-web,bbb-html5-nodejs,yq,mongodb-org -t deb"
+OPTS="$OPTS -d bc,bbb-pads,bbb-webrtc-sfu,bbb-export-annotations,bbb-web,bbb-html5-nodejs,mongodb-org -t deb"

--- a/build/packages-template/bbb-playback-podcast/opts-jammy.sh
+++ b/build/packages-template/bbb-playback-podcast/opts-jammy.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d bbb-record-core,yq"
+OPTS="$OPTS -t deb -d bbb-record-core"

--- a/build/packages-template/bbb-playback-presentation/opts-jammy.sh
+++ b/build/packages-template/bbb-playback-presentation/opts-jammy.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d bbb-record-core,yq"
+OPTS="$OPTS -t deb -d bbb-record-core"

--- a/build/packages-template/bbb-record-core/opts-jammy.sh
+++ b/build/packages-template/bbb-record-core/opts-jammy.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d bbb-mkclean,ffmpeg,gir1.2-pango-1.0,libcurl4,libncurses5,libsystemd0,poppler-utils,python3,python3-attr,python3-cairo,python3-gi,python3-gi-cairo,python3-icu,python3-lxml,redis-server,rsync,ruby,ruby-bundler,zlib1g,yq"
+OPTS="$OPTS -t deb -d bbb-mkclean,ffmpeg,gir1.2-pango-1.0,libcurl4,libncurses5,libsystemd0,poppler-utils,python3,python3-attr,python3-cairo,python3-gi,python3-gi-cairo,python3-icu,python3-lxml,redis-server,rsync,ruby,ruby-bundler,zlib1g"

--- a/build/packages-template/bbb-webhooks/opts-jammy.sh
+++ b/build/packages-template/bbb-webhooks/opts-jammy.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d nodejs,npm,yq"
+OPTS="$OPTS -t deb -d nodejs,npm"

--- a/build/packages-template/bbb-webrtc-sfu/opts-jammy.sh
+++ b/build/packages-template/bbb-webrtc-sfu/opts-jammy.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d git-core,nginx,openh264-gst-plugins-bad-1.5,bbb-apps-akka,nodejs,npm,build-essential,xmlstarlet,bbb-webrtc-recorder,yq"
+OPTS="$OPTS -t deb -d git-core,nginx,openh264-gst-plugins-bad-1.5,bbb-apps-akka,nodejs,npm,build-essential,xmlstarlet,bbb-webrtc-recorder"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Temporarily removing the dependency `yq` until an Ubuntu 22.04 version v4 of it is packaged in our ppa. `bbb-install-2.8.sh` already downloads+links it correctly.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation
7 BBB packages use `yq` within their scripts (mostly post-install).
On Ubuntu 20.04 we had packaged `yq` v3 as a ppa package. We are transitioning to v4 on Ubuntu 22.04 but have not yet packaged it in the support ppa. Therefore even if we install `yq` in the recommended way (https://github.com/mikefarah/yq/#install) and is usable locally, it is not recognized as an installed dependency of these BBB packages.
<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->
