### PR TITLE
build-config: change yq syntax to v4.16.2; readded yq as dep

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -121,8 +121,8 @@ jobs:
       - name: Install BBB
         run: |
             sudo sh -c '
-            cd /root/ && wget -q https://ubuntu.bigbluebutton.org/bbb-install-2.6.sh -O bbb-install.sh
-            cat bbb-install.sh | sed "s|> /etc/apt/sources.list.d/bigbluebutton.list||g" | bash -s -- -v focal-26-dev -s bbb-ci.test -j -d /certs/
+            cd /root/ && wget -q https://ubuntu.bigbluebutton.org/bbb-install-2.8.sh -O bbb-install.sh
+            cat bbb-install.sh | sed "s|> /etc/apt/sources.list.d/bigbluebutton.list||g" | bash -s -- -v jammy-28-develop -s bbb-ci.test -j -d /certs/
             bbb-conf --salt bbbci
             echo "NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/bbb-dev/bbb-dev-ca.crt" >> /usr/share/meteor/bundle/bbb-html5-with-roles.conf
             sed -i "s/\"minify\": true,/\"minify\": false,/" /usr/share/etherpad-lite/settings.json

--- a/bigbluebutton-config/bin/apply-lib.sh
+++ b/bigbluebutton-config/bin/apply-lib.sh
@@ -55,9 +55,9 @@ fi
 enableHTML5ClientLog() {
   echo "  - Enable HTML5 client log to /var/log/nginx/html5-client.log"
 
-  yq -i '.public.clientLog.external.enabled = true' $HTML5_CONFIG
-  yq -i ".public.clientLog.external.url = \"$PROTOCOL://$HOST/html5log\"" $HTML5_CONFIG
-  yq -i '.public.app.askForFeedbackOnLogout = true' $HTML5_CONFIG
+  yq e -i '.public.clientLog.external.enabled = true' $HTML5_CONFIG
+  yq e -i ".public.clientLog.external.url = \"$PROTOCOL://$HOST/html5log\"" $HTML5_CONFIG
+  yq e -i '.public.app.askForFeedbackOnLogout = true' $HTML5_CONFIG
   chown meteor:meteor $HTML5_CONFIG
 
   cat > /usr/share/bigbluebutton/nginx/html5-client-log.nginx << HERE
@@ -106,7 +106,7 @@ enableUFWRules() {
       echo "  - Local haproxy detected and running -- opening port 3478"
       ufw allow 3478
       # echo "  - Forcing FireFox to use turn server"
-      # yq -i '.public.kurento.forceRelayOnFirefox = true' $HTML5_CONFIG
+      # yq e -i '.public.kurento.forceRelayOnFirefox = true' $HTML5_CONFIG
     else
       if grep -q 3478 /etc/ufw/user.rules; then
         echo "  - Local haproxy not running -- closing port 3478"

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -159,7 +159,7 @@ WEBRTC_RECORDER_ETC_CONFIG=/etc/bigbluebutton/bbb-webrtc-recorder.yml
 if [ -f $WEBRTC_RECORDER_ETC_CONFIG ]; then
     WEBRTC_RECORDER_CONFIG=$(yq m -x $WEBRTC_RECORDER_DEFAULT_CONFIG $WEBRTC_RECORDER_ETC_CONFIG)
 else
-    WEBRTC_RECORDER_CONFIG=$(yq $WEBRTC_RECORDER_DEFAULT_CONFIG)
+    WEBRTC_RECORDER_CONFIG=$(yq e $WEBRTC_RECORDER_DEFAULT_CONFIG)
 fi
 
 HTML5_DEFAULT_CONFIG=/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml
@@ -167,7 +167,7 @@ HTML5_ETC_CONFIG=/etc/bigbluebutton/bbb-html5.yml
 if [ -f $HTML5_ETC_CONFIG ]; then
     HTML5_CONFIG=$(yq m -x $HTML5_DEFAULT_CONFIG $HTML5_ETC_CONFIG)
 else
-    HTML5_CONFIG=$(yq $HTML5_DEFAULT_CONFIG)
+    HTML5_CONFIG=$(yq e $HTML5_DEFAULT_CONFIG)
 fi
 
 WEBRTC_SFU_DEFAULT_CONFIG=/usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml
@@ -176,7 +176,7 @@ if [ -f $WEBRTC_SFU_ETC_CONFIG ]; then
     # -a overwrite: merges arrays by replacement (yq 3.4+, like the override)
     WEBRTC_SFU_CONFIG=$(yq m -a overwrite -x $WEBRTC_SFU_DEFAULT_CONFIG $WEBRTC_SFU_ETC_CONFIG)
 else
-    WEBRTC_SFU_CONFIG=$(yq $WEBRTC_SFU_DEFAULT_CONFIG)
+    WEBRTC_SFU_CONFIG=$(yq e $WEBRTC_SFU_DEFAULT_CONFIG)
 fi
 
 BBB_WEB_CONFIG="$SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties"
@@ -707,11 +707,11 @@ if [[ $PORT_RANGE ]]; then
 
         mkdir -p $(dirname $WEBRTC_SFU_ETC_CONFIG)
         touch $WEBRTC_SFU_ETC_CONFIG
-        yq -i ".mediasoup.worker.rtcMinPort = \"$START_PORT\"" $WEBRTC_SFU_ETC_CONFIG
-        yq -i ".mediasoup.worker.rtcMaxPort = \"$END_PORT\"" $WEBRTC_SFU_ETC_CONFIG
+        yq e -i ".mediasoup.worker.rtcMinPort = \"$START_PORT\"" $WEBRTC_SFU_ETC_CONFIG
+        yq e -i ".mediasoup.worker.rtcMaxPort = \"$END_PORT\"" $WEBRTC_SFU_ETC_CONFIG
 
-        yq -i ".webrtc.rtcMinPort = \"$START_PORT\"" $WEBRTC_RECORDER_DEFAULT_CONFIG
-        yq -i ".webrtc.rtcMaxPort = \"$END_PORT\"" $WEBRTC_RECORDER_DEFAULT_CONFIG
+        yq e -i ".webrtc.rtcMinPort = \"$START_PORT\"" $WEBRTC_RECORDER_DEFAULT_CONFIG
+        yq e -i ".webrtc.rtcMaxPort = \"$END_PORT\"" $WEBRTC_RECORDER_DEFAULT_CONFIG
 
         echo
         echo "BigBlueButton's UDP port range is now $START_PORT-$END_PORT"
@@ -790,7 +790,7 @@ check_configuration() {
 
     if [ -f /usr/lib/systemd/system/bbb-webhooks.service ]; then
         WEBHOOKS_CONF=/usr/local/bigbluebutton/bbb-webhooks/config/default.yml
-        WEBHOOKS_SECRET=$(yq '.bbb.sharedSecret' $WEBHOOKS_CONF)
+        WEBHOOKS_SECRET=$(yq e '.bbb.sharedSecret' $WEBHOOKS_CONF)
 
         if [ "$BBB_SECRET" != "$WEBHOOKS_SECRET" ]; then
             echo "# Warning: Webhooks API Shared Secret mismatch: "
@@ -800,7 +800,7 @@ check_configuration() {
         fi
 
         WEBHOOKS_PROXY_PORT=$(cat /usr/share/bigbluebutton/nginx/webhooks.nginx | grep -v '#' | grep '^[ \t]*proxy_pass[ \t]*' | sed 's|.*http[s]\?://[^:]*:\([^;]*\);.*|\1|g')
-        WEBHOOKS_APP_PORT=$(yq '.server.port' $WEBHOOKS_CONF)
+        WEBHOOKS_APP_PORT=$(yq e '.server.port' $WEBHOOKS_CONF)
 
         if [ "$WEBHOOKS_PROXY_PORT" != "$WEBHOOKS_APP_PORT" ]; then
             echo "# Warning: Webhooks port mismatch: "
@@ -1143,7 +1143,7 @@ check_state() {
         echo "#"
     fi
 
-    if [ `yq '.public.media.sipjsHackViaWs'` != "true" ]; then
+    if [ `yq e '.public.media.sipjsHackViaWs' "$HTML5_CONFIG" ` != "true" ]; then
       if [ "$PROTOCOL" == "https" ]; then
         if ! cat $SIP_CONFIG |  grep -v '#' | grep proxy_pass | head -n 1 | grep -q https; then
           echo "# Warning: You have this server defined for https, but in"
@@ -1228,7 +1228,7 @@ check_state() {
     fi
 
     FREESWITCH_SIP=$(ss -anlt4 | grep :5066 | grep -v tcp6 | grep LISTEN | sed 's/ [ ]*/ /g' | cut -d' ' -f4 | sed 's/:5066//g')
-    WEBRTC_SFU_SIP_IP=$(yq '.freeswitch.sip_ip' "$WEBRTC_SFU_CONFIG" )
+    WEBRTC_SFU_SIP_IP=$(yq e '.freeswitch.sip_ip' "$WEBRTC_SFU_CONFIG" )
 
     if [ ! -z "$FREESWITCH_SIP" ]; then
       if [ "$FREESWITCH_SIP" != "$WEBRTC_SFU_SIP_IP" ]; then
@@ -1238,7 +1238,7 @@ check_state() {
         echo "#"
         echo "# To fix, run the commands"
         echo "#"
-        echo "# sudo yq -i 'freeswitch.sip_ip = $FREESWITCH_SIP /etc/bigbluebutton/bbb-webrtc-sfu/production.yml"
+        echo "# sudo yq e -i 'freeswitch.sip_ip = $FREESWITCH_SIP /etc/bigbluebutton/bbb-webrtc-sfu/production.yml"
         echo "# sudo chown bigbluebutton:bigbluebutton /etc/bigbluebutton/bbb-webrtc-sfu/production.yml"
         echo "#"
       fi
@@ -1690,8 +1690,8 @@ if [ -n "$HOST" ]; then
     # Update HTML5 client
     #
     if [ -f $HTML5_DEFAULT_CONFIG ]; then
-        yq -i ".public.kurento.wsUrl = \"wss://$HOST/bbb-webrtc-sfu\"" $HTML5_DEFAULT_CONFIG
-        yq -i ".public.pads.url = \"$PROTOCOL://$HOST/pad\"" $HTML5_DEFAULT_CONFIG
+        yq e -i ".public.kurento.wsUrl = \"wss://$HOST/bbb-webrtc-sfu\"" $HTML5_DEFAULT_CONFIG
+        yq e -i ".public.pads.url = \"$PROTOCOL://$HOST/pad\"" $HTML5_DEFAULT_CONFIG
         chown meteor:meteor $HTML5_DEFAULT_CONFIG
     fi
 
@@ -1704,7 +1704,7 @@ if [ -n "$HOST" ]; then
         sudo sed -i "s/ClueCon/$ESL_PASSWORD/g" /etc/bigbluebutton/bbb-fsesl-akka.conf
     fi
 
-    sudo yq -i ".freeswitch.esl_password = \"$ESL_PASSWORD\"" /etc/bigbluebutton/bbb-webrtc-sfu/production.yml
+    sudo yq e -i ".freeswitch.esl_password = \"$ESL_PASSWORD\"" /etc/bigbluebutton/bbb-webrtc-sfu/production.yml
     sudo xmlstarlet edit --inplace --update 'configuration/settings//param[@name="password"]/@value' --value $ESL_PASSWORD /opt/freeswitch/etc/freeswitch/autoload_configs/event_socket.conf.xml
 
 

--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -54,7 +54,7 @@ declare -r BBB_YML=/usr/local/bigbluebutton/core/scripts/bigbluebutton.yml
 # $1: Desired property
 # Only returns 'PRODUCTION' values
 get_yml_value(){
-   yq ".\"$1\"" "$BBB_YML" --prettyPrint
+   yq e ".\"$1\"" "$BBB_YML" --prettyPrint
 }
 
 PLAYBACK_PROTOCOL=$(get_yml_value playback_protocol)

--- a/build/packages-template/bbb-config/after-install.sh
+++ b/build/packages-template/bbb-config/after-install.sh
@@ -138,7 +138,7 @@ BBB_HTML5_SETTINGS_FILE=/usr/share/meteor/bundle/programs/server/assets/app/conf
 if [ -f $BBB_RELEASE_FILE ] && [ -f $BBB_HTML5_SETTINGS_FILE ]; then
   BBB_FULL_VERSION=$(cat $BBB_RELEASE_FILE | sed -n '/^BIGBLUEBUTTON_RELEASE/{s/.*=//;p}' | tail -n 1)
   echo "setting public.app.bbbServerVersion: $BBB_FULL_VERSION in $BBB_HTML5_SETTINGS_FILE "
-  yq -i ".public.app.bbbServerVersion = \"$BBB_FULL_VERSION\"" $BBB_HTML5_SETTINGS_FILE
+  yq e -i ".public.app.bbbServerVersion = \"$BBB_FULL_VERSION\"" $BBB_HTML5_SETTINGS_FILE
 fi
 
 # Fix permissions for logging

--- a/build/packages-template/bbb-config/opts-jammy.sh
+++ b/build/packages-template/bbb-config/opts-jammy.sh
@@ -1,4 +1,4 @@
 . ./opts-global.sh
 
 AKKA_APPS="bbb-fsesl-akka,bbb-apps-akka"
-OPTS="$OPTS -t deb -d netcat-openbsd,stun-client,bbb-html5,bbb-playback-presentation,bbb-playback,bbb-freeswitch-core,$AKKA_APPS"
+OPTS="$OPTS -t deb -d netcat-openbsd,stun-client,bbb-html5,bbb-playback-presentation,bbb-playback,bbb-freeswitch-core,$AKKA_APPS,yq"

--- a/build/packages-template/bbb-html5/after-install.sh
+++ b/build/packages-template/bbb-html5/after-install.sh
@@ -25,9 +25,9 @@ TARGET=/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml
 
   WSURL=$(cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties | grep -v '#' | sed -n '/^bigbluebutton.web.serverURL/{s/.*=//;p}' | sed 's/https/wss/g' | sed s'/http/ws/g')
 
-  yq -i ".public.kurento.wsUrl = \"$WSURL/bbb-webrtc-sfu\"" $TARGET
+  yq e -i ".public.kurento.wsUrl = \"$WSURL/bbb-webrtc-sfu\"" $TARGET
 
-  yq -i  ".public.pads.url = \"$PROTOCOL://$HOST/pad\"" $TARGET
+  yq e -i  ".public.pads.url = \"$PROTOCOL://$HOST/pad\"" $TARGET
 
   sed -i "s/proxy_pass .*/proxy_pass http:\/\/$IP:5066;/g" /usr/share/bigbluebutton/nginx/sip.nginx
   sed -i "s/server_name  .*/server_name  $IP;/g" /etc/nginx/sites-available/bigbluebutton
@@ -46,7 +46,7 @@ BBB_HTML5_SETTINGS_FILE=/usr/share/meteor/bundle/programs/server/assets/app/conf
 if [ -f $BBB_RELEASE_FILE ] && [ -f $BBB_HTML5_SETTINGS_FILE ]; then
   BBB_FULL_VERSION=$(cat $BBB_RELEASE_FILE | sed -n '/^BIGBLUEBUTTON_RELEASE/{s/.*=//;p}' | tail -n 1)
   echo "setting public.app.bbbServerVersion: $BBB_FULL_VERSION in $BBB_HTML5_SETTINGS_FILE "
-  yq -i ".public.app.bbbServerVersion = \"$BBB_FULL_VERSION\"" $BBB_HTML5_SETTINGS_FILE
+  yq e -i ".public.app.bbbServerVersion = \"$BBB_FULL_VERSION\"" $BBB_HTML5_SETTINGS_FILE
 fi    
 
 

--- a/build/packages-template/bbb-html5/opts-jammy.sh
+++ b/build/packages-template/bbb-html5/opts-jammy.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -d bc,bbb-pads,bbb-webrtc-sfu,bbb-export-annotations,bbb-web,bbb-html5-nodejs,mongodb-org -t deb"
+OPTS="$OPTS -d bc,bbb-pads,bbb-webrtc-sfu,bbb-export-annotations,bbb-web,bbb-html5-nodejs,yq,mongodb-org -t deb"

--- a/build/packages-template/bbb-playback-podcast/after-install.sh
+++ b/build/packages-template/bbb-playback-podcast/after-install.sh
@@ -14,7 +14,7 @@ case "$1" in
   fi
 
   if [ -f $TARGET ]; then
-    yq -i ".playback_host = \"$HOST\"" $TARGET
+    yq e -i ".playback_host = \"$HOST\"" $TARGET
   else
     echo "No: $TARGET"
     exit 1

--- a/build/packages-template/bbb-playback-podcast/opts-jammy.sh
+++ b/build/packages-template/bbb-playback-podcast/opts-jammy.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d bbb-record-core"
+OPTS="$OPTS -t deb -d bbb-record-core,yq"

--- a/build/packages-template/bbb-playback-presentation/opts-jammy.sh
+++ b/build/packages-template/bbb-playback-presentation/opts-jammy.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d bbb-record-core"
+OPTS="$OPTS -t deb -d bbb-record-core,yq"

--- a/build/packages-template/bbb-record-core/after-install.sh
+++ b/build/packages-template/bbb-record-core/after-install.sh
@@ -21,7 +21,7 @@ case "$1" in
       HOST=$IP
     fi
 
-    yq -i ".playback_host = \"$HOST\"" $TARGET
+    yq e -i ".playback_host = \"$HOST\"" $TARGET
 
     chmod +r $TARGET
 

--- a/build/packages-template/bbb-record-core/opts-jammy.sh
+++ b/build/packages-template/bbb-record-core/opts-jammy.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d bbb-mkclean,ffmpeg,gir1.2-pango-1.0,libcurl4,libncurses5,libsystemd0,poppler-utils,python3,python3-attr,python3-cairo,python3-gi,python3-gi-cairo,python3-icu,python3-lxml,redis-server,rsync,ruby,ruby-bundler,zlib1g"
+OPTS="$OPTS -t deb -d bbb-mkclean,ffmpeg,gir1.2-pango-1.0,libcurl4,libncurses5,libsystemd0,poppler-utils,python3,python3-attr,python3-cairo,python3-gi,python3-gi-cairo,python3-icu,python3-lxml,redis-server,rsync,ruby,ruby-bundler,zlib1g,yq"

--- a/build/packages-template/bbb-webhooks/after-install.sh
+++ b/build/packages-template/bbb-webhooks/after-install.sh
@@ -12,11 +12,11 @@ case "$1" in
     BBB_SECRET=$(cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties | grep securitySalt | cut -d= -f2)
     BBB_HOST=$(cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties | sed -n '/^bigbluebutton.web.serverURL/{s/.*\///;p}')
 
-    yq -i  ".bbb.sharedSecret  = \"$BBB_SECRET\"" $TARGET
-    yq -i  ".bbb.serverDomain = \"$BBB_HOST\"" $TARGET
-    yq -i  '.bbb.auth2_0 = true' $TARGET
-    yq -i  '.server.port = 3005' $TARGET
-    yq -i  '.hooks.getRaw = false' $TARGET
+    yq e -i  ".bbb.sharedSecret  = \"$BBB_SECRET\"" $TARGET
+    yq e -i  ".bbb.serverDomain = \"$BBB_HOST\"" $TARGET
+    yq e -i  '.bbb.auth2_0 = true' $TARGET
+    yq e -i  '.server.port = 3005' $TARGET
+    yq e -i  '.hooks.getRaw = false' $TARGET
 
     cd /usr/local/bigbluebutton/bbb-webhooks
     mkdir -p node_modules

--- a/build/packages-template/bbb-webhooks/opts-jammy.sh
+++ b/build/packages-template/bbb-webhooks/opts-jammy.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d nodejs,npm"
+OPTS="$OPTS -t deb -d nodejs,npm,yq"

--- a/build/packages-template/bbb-webrtc-sfu/after-install.sh
+++ b/build/packages-template/bbb-webrtc-sfu/after-install.sh
@@ -11,17 +11,17 @@ case "$1" in
     chown bigbluebutton:bigbluebutton $TARGET
 
       # Set mediasoup IPs
-      yq -i ".mediasoup.webrtc.listenIps[0].announcedIp = \"$IP\"" $TARGET
-      yq -i ".mediasoup.plainRtp.listenIp.announcedIp = \"$IP\"" $TARGET
+      yq e -i ".mediasoup.webrtc.listenIps[0].announcedIp = \"$IP\"" $TARGET
+      yq e -i ".mediasoup.plainRtp.listenIp.announcedIp = \"$IP\"" $TARGET
 
       FREESWITCH_IP=$(xmlstarlet sel -t -v '//X-PRE-PROCESS[@cmd="set" and starts-with(@data, "local_ip_v4=")]/@data' /opt/freeswitch/conf/vars.xml | sed 's/local_ip_v4=//g')
       if [ "$FREESWITCH_IP" != "" ]; then
-        yq -i ".freeswitch.ip = \"$FREESWITCH_IP\"" $TARGET
-        yq -i ".freeswitch.sip_ip = \"$FREESWITCH_IP\"" $TARGET
+        yq e -i ".freeswitch.ip = \"$FREESWITCH_IP\"" $TARGET
+        yq e -i ".freeswitch.sip_ip = \"$FREESWITCH_IP\"" $TARGET
       else
         # Looks like the FreeSWITCH package is being installed, let's fall back to the default value
-        yq -i ".freeswitch.ip = \"$IP\"" $TARGET
-        yq -i ".freeswitch.sip_ip = \"$IP\"" $TARGET
+        yq e -i ".freeswitch.ip = \"$IP\"" $TARGET
+        yq e -i ".freeswitch.sip_ip = \"$IP\"" $TARGET
       fi
  
     cd /usr/local/bigbluebutton/bbb-webrtc-sfu
@@ -35,7 +35,7 @@ case "$1" in
     mkdir -p /var/log/bbb-webrtc-sfu/
     touch /var/log/bbb-webrtc-sfu/bbb-webrtc-sfu.log
 
-    yq -i ".recordWebcams = true" $TARGET
+    yq e -i ".recordWebcams = true" $TARGET
     if id bigbluebutton > /dev/null 2>&1 ; then
       chown -R bigbluebutton:bigbluebutton /usr/local/bigbluebutton/bbb-webrtc-sfu /var/log/bbb-webrtc-sfu/
     else

--- a/build/packages-template/bbb-webrtc-sfu/opts-jammy.sh
+++ b/build/packages-template/bbb-webrtc-sfu/opts-jammy.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d git-core,nginx,bbb-apps-akka,nodejs,npm,build-essential,xmlstarlet,bbb-webrtc-recorder"
+OPTS="$OPTS -t deb -d git-core,nginx,bbb-apps-akka,nodejs,npm,build-essential,xmlstarlet,bbb-webrtc-recorder,yq"

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -37,7 +37,7 @@ source /etc/bigbluebutton/bbb-conf/apply-lib.sh
 enableUFWRules
 
 echo " - Disable screen sharing"
-yq -i $HTML5_CONFIG public.kurento.enableScreensharing false
+yq e -i $HTML5_CONFIG public.kurento.enableScreensharing false
 chown meteor:meteor $HTML5_CONFIG
 ```
 
@@ -455,7 +455,7 @@ To do this automatically between package upgrades and restarts of BigBlueButton,
 
 ```bash
 echo " - Disable webcams"
-yq i '.public.kurento.enableVideo = false' $HTML5_CONFIG
+yq e -i '.public.kurento.enableVideo = false' $HTML5_CONFIG
 chown meteor:meteor $HTML5_CONFIG
 ```
 
@@ -469,7 +469,7 @@ To do this automatically between package upgrades and restarts of BigBlueButton,
 
 ```bash
 echo " - Disable screen sharing"
-yq -i '.public.kurento.enableScreensharing = false' $HTML5_CONFIG 
+yq e -i '.public.kurento.enableScreensharing = false' $HTML5_CONFIG 
 chown meteor:meteor $HTML5_CONFIG
 ```
 
@@ -481,15 +481,15 @@ To do this automatically between package upgrades and restarts of BigBlueButton,
 
 ```bash
 echo "  - Setting camera defaults"
-yq -i '.public.kurento.cameraProfiles.(id==low).bitrate = 50' $HTML5_CONFIG 
-yq -i '.public.kurento.cameraProfiles.(id==medium).bitrate = 100' $HTML5_CONFIG 
-yq -i '.public.kurento.cameraProfiles.(id==high).bitrate = 200' $HTML5_CONFIG 
-yq -i '.public.kurento.cameraProfiles.(id==hd).bitrate = 300' $HTML5_CONFIG 
+yq e -i '.public.kurento.cameraProfiles.(id==low).bitrate = 50' $HTML5_CONFIG 
+yq e -i '.public.kurento.cameraProfiles.(id==medium).bitrate = 100' $HTML5_CONFIG 
+yq e -i '.public.kurento.cameraProfiles.(id==high).bitrate = 200' $HTML5_CONFIG 
+yq e -i '.public.kurento.cameraProfiles.(id==hd).bitrate = 300' $HTML5_CONFIG 
 
-yq -i '.public.kurento.cameraProfiles.(id==low).default = true' $HTML5_CONFIG 
-yq -i '.public.kurento.cameraProfiles.(id==medium).default = false' $HTML5_CONFIG 
-yq -i '.public.kurento.cameraProfiles.(id==high).default = false' $HTML5_CONFIG 
-yq -i '.public.kurento.cameraProfiles.(id==hd).default = false' $HTML5_CONFIG 
+yq e -i '.public.kurento.cameraProfiles.(id==low).default = true' $HTML5_CONFIG 
+yq e -i '.public.kurento.cameraProfiles.(id==medium).default = false' $HTML5_CONFIG 
+yq e -i '.public.kurento.cameraProfiles.(id==high).default = false' $HTML5_CONFIG 
+yq e -i '.public.kurento.cameraProfiles.(id==hd).default = false' $HTML5_CONFIG 
 chown meteor:meteor $HTML5_CONFIG
 ```
 
@@ -1197,7 +1197,7 @@ You'll need to update this entry each time the package `bbb-html5` updates. The 
 
 ```bash
 $ TARGET=/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml
-$ yq -i ".public.app.clientTitle = \"New Title\"" $TARGET
+$ yq e -i ".public.app.clientTitle = \"New Title\"" $TARGET
 $ chown meteor:meteor $TARGET
 ```
 
@@ -1442,9 +1442,9 @@ PROTOCOL=$(cat /etc/bigbluebutton/bbb-web.properties | grep -v '#' | grep '^bigb
 
 apt-get install -y nginx-full
 
-yq -i '.public.clientLog.external.enabled = true' $HTML5_CONFIG
-yq -i ".public.clientLog.external.url = \"$PROTOCOL://$HOST/html5log\"" $HTML5_CONFIG
-yq -i '.public.app.askForFeedbackOnLogout = true' $HTML5_CONFIG
+yq e -i '.public.clientLog.external.enabled = true' $HTML5_CONFIG
+yq e -i ".public.clientLog.external.url = \"$PROTOCOL://$HOST/html5log\"" $HTML5_CONFIG
+yq e -i '.public.app.askForFeedbackOnLogout = true' $HTML5_CONFIG
 chown meteor:meteor $HTML5_CONFIG
 
 mkdir -p /etc/bigbluebutton/nginx/

--- a/docs/docs/support/troubleshooting.md
+++ b/docs/docs/support/troubleshooting.md
@@ -131,7 +131,7 @@ Accepted values are:
    * The default and fallback values are `auto`.
 
 For example:
-   * To set the number of workers to `cores`: `yq -i '.mediasoup.workers = "cores"' /etc/bigbluebutton/bbb-webrtc-sfu/production.yml`
+   * To set the number of workers to `cores`: `yq e -i '.mediasoup.workers = "cores"' /etc/bigbluebutton/bbb-webrtc-sfu/production.yml`
 
 #### mediasoup.dedicatedMediaTypeWorkers
 
@@ -154,7 +154,7 @@ The media types semantics are:
    * `content`: screen sharing streams (audio and video).
 
 For example:
-  * To set the number of dedicated audio workers to `auto`: `yq -i '.mediasoup.dedicatedMediaTypeWorkers.audio = "auto"' /etc/bigbluebutton/bbb-webrtc-sfu/production.yml`
+  * To set the number of dedicated audio workers to `auto`: `yq e -i '.mediasoup.dedicatedMediaTypeWorkers.audio = "auto"' /etc/bigbluebutton/bbb-webrtc-sfu/production.yml`
 
 ### Can I scale the number of streams up indefinitely with mediasoup?
 
@@ -564,7 +564,7 @@ Then do `systemctl daemon-reload` and restart BigBlueButton.
 
 When installing the latest build of BigBlueButton, the package `bbb-conf` now uses `yq` to manage YAML files.
 
-You need to add the repository `ppa:rmescandon/yq` to your server. For steps on how to do this, see [Update your server](/administration/install#1-update-your-server) in the BigBlueButton 2.2 install guide.
+You need to add the repository `ppa:rmescandon/yq` to your server. For steps on how to do this, see `https://launchpad.net/~rmescandon/+archive/ubuntu/yq?field.series_filter=jammy`.
 
 Alternatively, if you have not made any customizations to BigBlueButton (outside of using `bbb-conf`), you can use [bbb-install.sh](https://github.com/bigbluebutton/bbb-install) to install/upgrade to the latest version (the `bbb-install.sh` script will automatically install the repository for `yq`).
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
I tried using `yq` v4 (latest is 4.30) but I only found a Debian package for v4.16.2 which was using a slightly more verbose syntax.
In this PR I tweaked the commands that were part of #17747 
I also reverted #17752 because I am now adding a ppa in bbb-install-2.8.sh https://launchpad.net/~rmescandon/+archive/ubuntu/yq?field.series_filter=jammy

The reason why there's no newer `yq` for `apt`: https://github.com/mikefarah/yq/issues/1308#issuecomment-1483952510
I tried using either of

```


<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #
Reverts #17752
Related #17747

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
