### PR TITLE
fix: Part of the camera border is not resizable when positioned below the chat

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
@@ -232,7 +232,7 @@ const WebcamComponent = ({
             }}
             style={{
               position: 'absolute',
-              zIndex: cameraDock.zIndex,
+              zIndex: isCameraSidebar ? 0 : cameraDock.zIndex,
             }}
           >
             <Styled.Draggable


### PR DESCRIPTION
### What does this PR do?

Fix sidebar resizing when cameras are being displayed on the sidebar.

### Closes Issue(s)
Closes #17739