### PR TITLE
fix(bbb-html5): Inconsistent current presentation indicator

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -36,6 +36,7 @@ const propTypes = {
     conversion: PropTypes.shape,
     upload: PropTypes.shape,
   })).isRequired,
+  currentPresentation: PropTypes.string.isRequired,
   isOpen: PropTypes.bool.isRequired,
   handleFiledrop: PropTypes.func.isRequired,
   selectedToBeNextCurrent: PropTypes.string,
@@ -53,7 +54,7 @@ const defaultProps = {
 };
 
 const intlMessages = defineMessages({
-  current: {
+  currentBadge: {
     id: 'app.presentationUploder.currentBadge',
   },
   title: {
@@ -357,7 +358,7 @@ class PresentationUploader extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { isOpen, presentations: propPresentations, intl } = this.props;
+    const { isOpen, presentations: propPresentations, currentPresentation, intl } = this.props;
     const { presentations } = this.state;
     const { presentations: prevPropPresentations } = prevProps;
 
@@ -432,7 +433,7 @@ class PresentationUploader extends Component {
       unregisterTitleView();
     }
 
-    // Updates presentation list when chat modal opens to avoid missing presentations
+    // Updates presentation list when modal opens to avoid missing presentations
     if (isOpen && !prevProps.isOpen) {
       registerTitleView(intl.formatMessage(intlMessages.uploadViewTitle));
       const focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
@@ -456,6 +457,10 @@ class PresentationUploader extends Component {
           e.preventDefault();
         }
       });
+    }
+
+    if (currentPresentation && currentPresentation !== prevProps.currentPresentation) {
+       this.handleCurrentChange(currentPresentation);
     }
 
     if (presentations.length > 0) {
@@ -547,7 +552,7 @@ class PresentationUploader extends Component {
   handleCurrentChange(id) {
     const { presentations, disableActions } = this.state;
 
-    if (disableActions) return;
+    if (disableActions || presentations?.length === 0) return;
 
     const currentIndex = presentations.findIndex((p) => p.isCurrent);
     const newCurrentIndex = presentations.findIndex((p) => p.id === id);
@@ -1039,7 +1044,7 @@ class PresentationUploader extends Component {
             ? (
               <Styled.TableItemCurrent>
                 <Styled.CurrentLabel>
-                  {intl.formatMessage(intlMessages.current)}
+                  {intl.formatMessage(intlMessages.currentBadge)}
                 </Styled.CurrentLabel>
               </Styled.TableItemCurrent>
             )

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/container.jsx
@@ -26,7 +26,8 @@ const PresentationUploaderContainer = (props) => {
 };
 
 export default withTracker(() => {
-  const currentPresentations = Service.getPresentations();
+  const presentations = Service.getPresentations();
+  const currentPresentation = presentations.find((p) => p.isCurrent)?.id || '';
   const {
     dispatchDisableDownloadable,
     dispatchEnableDownloadable,
@@ -36,7 +37,8 @@ export default withTracker(() => {
   const isOpen = isPresentationEnabled() && (Session.get('showUploadPresentationView') || false);
 
   return {
-    presentations: currentPresentations,
+    presentations,
+    currentPresentation,
     fileUploadConstraintsHint: PRESENTATION_CONFIG.fileUploadConstraintsHint,
     fileSizeMax: PRESENTATION_CONFIG.mirroredFromBBBCore.uploadSizeMax,
     filePagesMax: PRESENTATION_CONFIG.mirroredFromBBBCore.uploadPagesMax,


### PR DESCRIPTION
### What does this PR do?
Currently, when switching presentations using the `(+)` dropdown menu, the change is not being properly propagated to the presentation uploader modal. The same issue occurs when moving shared notes to the presentation area, where an incorrect presentation is displayed as the selected current presentation.

### Motivation
This inconsistency causes confusion and makes it difficult for users to keep track of their active presentation. If the modal is quickly opened and dismissed with `Confirm`, an undesired presentation change occurs.

### Example
**Dropdown**

https://user-images.githubusercontent.com/33319791/235474833-caf78bfa-d24e-4765-81d9-8909a801690e.mov



**Shared notes**
State of the presentation uploader modal after moving notes to the presentation area. The blue `CURRENT` badge does not match the checked circle.

<img width="587" alt="current-pres-issue" src="https://user-images.githubusercontent.com/33319791/235474225-bf1b3b03-a743-4cfb-9be8-68f704f50db4.png">

### Fixed behavior demo

**Fixed dropdown:**

https://user-images.githubusercontent.com/33319791/235474871-88ca134a-7906-42c4-be43-3d3095854c09.mov



**Shared notes:**



https://user-images.githubusercontent.com/33319791/235474966-1e02f935-e71a-40c5-986c-ce2611fdecf8.mov


