### PR TITLE
refactor (graphql-server): Alter graphql database name to bbb_graphql

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
@@ -6,7 +6,7 @@ import slick.jdbc.PostgresProfile.api._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object DatabaseConnection {
-  val db = Database.forConfig("bbb_graphql")
+  val db = Database.forConfig("postgres")
   //  implicit val session: Session = db.createSession()
   val logger = LoggerFactory.getLogger(this.getClass)
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
@@ -6,7 +6,7 @@ import slick.jdbc.PostgresProfile.api._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object DatabaseConnection {
-  val db = Database.forConfig("postgres")
+  val db = Database.forConfig("bbb_graphql")
   //  implicit val session: Session = db.createSession()
   val logger = LoggerFactory.getLogger(this.getClass)
 }

--- a/akka-bbb-apps/src/universal/conf/application.conf
+++ b/akka-bbb-apps/src/universal/conf/application.conf
@@ -40,9 +40,9 @@ postgres {
         properties = {
             serverName = "localhost"
             portNumber = "5432"
-            databaseName = "bigbluebutton"
+            databaseName = "bbb_graphql"
             user = "postgres"
-            password = "bigbluebutton"
+            password = "bbb_graphql"
         }
         numThreads = 1
         maxConnections = 1

--- a/bbb-graphql-server/hasura-config.env
+++ b/bbb-graphql-server/hasura-config.env
@@ -1,5 +1,5 @@
-HASURA_GRAPHQL_DATABASE_URL=postgres://postgres:bigbluebutton@localhost:5432/hasura_app
-#HASURA_GRAPHQL_METADATA_DATABASE_URL=postgres://postgres:bigbluebutton@localhost:5432/hasura_app
+HASURA_GRAPHQL_DATABASE_URL=postgres://postgres:bbb_graphql@localhost:5432/hasura_app
+#HASURA_GRAPHQL_METADATA_DATABASE_URL=postgres://postgres:bbb_graphql@localhost:5432/hasura_app
 #HASURA_GRAPHQL_NO_OF_RETRIES
 HASURA_GRAPHQL_ENABLE_CONSOLE=false
 HASURA_GRAPHQL_LIVE_QUERIES_MULTIPLEXED_REFETCH_INTERVAL=250

--- a/bbb-graphql-server/install-hasura.sh
+++ b/bbb-graphql-server/install-hasura.sh
@@ -10,9 +10,11 @@ cd "$(dirname "$0")"
 # Install Postgresql
 apt update
 apt install postgresql postgresql-contrib -y
-sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'bigbluebutton'"
-sudo -u postgres psql -c "create database bigbluebutton"
-sudo -u postgres psql -U postgres -d bigbluebutton -a -f bbb_schema.sql --set ON_ERROR_STOP=on
+sudo -u postgres psql -c "alter user postgres password 'bbb_graphql'"
+sudo -u postgres psql -c "drop database if exists bbb_graphql"
+sudo -u postgres psql -c "create database bbb_graphql"
+sudo -u postgres psql -U postgres -d bbb_graphql -a -f bbb_schema.sql --set ON_ERROR_STOP=on
+sudo -u postgres psql -c "drop database if exists hasura_app"
 sudo -u postgres psql -c "create database hasura_app"
 
 echo "Postgresql installed!"
@@ -35,7 +37,7 @@ systemctl restart nginx
 #wget https://graphql-engine-cdn.hasura.io/server/latest/linux-amd64 -O /usr/local/bin/hasura-graphql-engine
 #chmod +x /usr/local/bin/hasura-graphql-engine
 
-git clone --branch v2.22.1 https://github.com/iMDT/hasura-graphql-engine.git
+git clone --branch v2.23.0 https://github.com/iMDT/hasura-graphql-engine.git
 cat hasura-graphql-engine/hasura-graphql.part-a* > hasura-graphql
 rm -rf hasura-graphql-engine/
 chmod +x hasura-graphql
@@ -43,6 +45,9 @@ mv hasura-graphql /usr/local/bin/hasura-graphql-engine
 
 apt-get install -y gnupg2 curl apt-transport-https ca-certificates libkrb5-3 libpq5 libnuma1 unixodbc-dev libmariadb-dev-compat mariadb-client-10.3
 cp ./hasura-config.env /etc/default/bbb-graphql-server
+#Enable Console --Desenv only!!
+sudo sed -i 's/HASURA_GRAPHQL_ENABLE_CONSOLE=false/HASURA_GRAPHQL_ENABLE_CONSOLE=true/' /etc/default/bbb-graphql-server
+
 cp ./bbb-graphql-server.service /lib/systemd/system/bbb-graphql-server.service
 systemctl enable bbb-graphql-server
 systemctl start bbb-graphql-server

--- a/bbb-graphql-server/metadata/databases/databases.yaml
+++ b/bbb-graphql-server/metadata/databases/databases.yaml
@@ -18,9 +18,9 @@
     connection_info:
       database_url:
         connection_parameters:
-          database: bigbluebutton
+          database: bbb_graphql
           host: localhost
-          password: bigbluebutton
+          password: bbb_graphql
           port: 5432
           username: postgres
       isolation_level: read-committed


### PR DESCRIPTION
Maybe in the future bbb will have more Postgresql databases.
So it is better to specify the service name in the database name.

This PR renames it from `bigbluebutton` to `bbb_graphql`.