### PR TITLE
feat (graphql-server): Add flags moderatorsCanMute/Unmute to usersPolicies

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -129,7 +129,21 @@ create table "meeting_usersPolicies" (
 );
 create index "idx_meeting_usersPolicies_meetingId" on "meeting_usersPolicies"("meetingId");
 
-CREATE OR REPLACE VIEW "v_meeting_usersPolicies" AS SELECT * FROM "meeting_usersPolicies";
+CREATE OR REPLACE VIEW "v_meeting_usersPolicies" AS
+SELECT "meeting_usersPolicies"."meetingId",
+    "meeting_usersPolicies"."maxUsers",
+    "meeting_usersPolicies"."maxUserConcurrentAccesses",
+    "meeting_usersPolicies"."webcamsOnlyForModerator",
+    "meeting_usersPolicies"."userCameraCap",
+    "meeting_usersPolicies"."guestPolicy",
+    "meeting_usersPolicies"."meetingLayout",
+    "meeting_usersPolicies"."allowModsToUnmuteUsers",
+    "meeting_usersPolicies"."allowModsToEjectCameras",
+    "meeting_usersPolicies"."authenticatedGuest",
+    "meeting"."isBreakout" is false "moderatorsCanMuteAudio",
+    "meeting"."isBreakout" is false and "meeting_usersPolicies"."allowModsToUnmuteUsers" is true "moderatorsCanUnmuteAudio"
+   FROM "meeting_usersPolicies"
+   JOIN "meeting" using("meetingId");
 
 create table "meeting_metadata"(
 	"meetingId" varchar(100) references "meeting"("meetingId") ON DELETE CASCADE,

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_usersPolicies.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_usersPolicies.yaml
@@ -8,13 +8,15 @@ select_permissions:
         - allowModsToEjectCameras
         - allowModsToUnmuteUsers
         - authenticatedGuest
-        - webcamsOnlyForModerator
         - guestPolicy
-        - meetingId
-        - meetingLayout
         - maxUserConcurrentAccesses
         - maxUsers
+        - meetingId
+        - meetingLayout
+        - moderatorsCanMuteAudio
+        - moderatorsCanUnmuteAudio
         - userCameraCap
+        - webcamsOnlyForModerator
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId


### PR DESCRIPTION
Motivation: To avoid this kind of rule on the client side.

How to use:
```
query {
  meeting {
    usersPolicies {
      moderatorsCanMuteAudio
      moderatorsCanUnmuteAudio
    }
  }
}
```

- `moderatorsCanMuteAudio`: False when it's a breakout room
- `moderatorsCanUnmuteAudio`: False when it's a breakout room or it has the config `allowModsToUnmuteUsers=false`