### PR TITLE
fix: wrap connection.close in Meteor.bindEnvironment

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/handlers/validateAuthToken.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/validateAuthToken.js
@@ -43,7 +43,7 @@ export default async function handleValidateAuthToken({ body }, meetingId) {
 
   if (!valid) {
     await Promise.all(pendingAuths.map(
-      async (pendingAuth) => {
+      Meteor.bindEnvironment(async (pendingAuth) => {
         try {
           const { methodInvocationObject } = pendingAuth;
           const connectionId = methodInvocationObject.connection.id;
@@ -68,7 +68,7 @@ export default async function handleValidateAuthToken({ body }, meetingId) {
         } catch (e) {
           Logger.error(`Error closing socket for meetingId '${meetingId}', userId '${userId}', authToken ${authToken}`);
         }
-      },
+      }),
     ));
 
     return;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Wrapping the closing of a connection in `Meteor.bindEnvironment` wrapper to avoid running on different fibre
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation

```
syslog.5:2023-04-28T16:21:50.290355+00:00  systemd[1]: bbb-html5-frontend@8.service: Main process exited, code=exited, status=1/FAILURE
2023-04-28T16:21:50.201636+00:00  systemd_start_frontend.sh[1895918]: 2023-04-28T16:21:50.199Z frontend-8 [#033[31merror#033[39m] : uncaughtException: Meteor code must always run within a Fiber. Try wrapping callbacks that you pass to non-Meteor libraries with Meteor.bindEnvironment.
2023-04-28T16:21:50.201978+00:00  systemd_start_frontend.sh[1895918]: Error: Meteor code must always run within a Fiber. Try wrapping callbacks that you pass to non-Meteor libraries with Meteor.bindEnvironment.
2023-04-28T16:21:50.202049+00:00  systemd_start_frontend.sh[1895918]:     at Object.Meteor._nodeCodeMustBeInFiber (packages/meteor.js:1260:11)
2023-04-28T16:21:50.202122+00:00  systemd_start_frontend.sh[1895918]:     at Meteor.EnvironmentVariable.EVp.get (packages/meteor.js:1285:10)
2023-04-28T16:21:50.202174+00:00  systemd_start_frontend.sh[1895918]:     at withoutInvocation (packages/meteor.js:581:40)
2023-04-28T16:21:50.202220+00:00  systemd_start_frontend.sh[1895918]:     at bindAndCatch (packages/meteor.js:595:33)
2023-04-28T16:21:50.202244+00:00  systemd_start_frontend.sh[1895918]:     at Object.Meteor.defer (packages/meteor.js:656:24)
2023-04-28T16:21:50.202269+00:00  systemd_start_frontend.sh[1895918]:     at Session.close (packages/ddp-server/livedata_server.js:490:12)
2023-04-28T16:21:50.202292+00:00  systemd_start_frontend.sh[1895918]:     at Object.close (packages/ddp-server/livedata_server.js:315:12)
2023-04-28T16:21:50.202314+00:00  systemd_start_frontend.sh[1895918]:     at Timeout._onTimeout (imports/api/users/server/handlers/validateAuthToken.js:63:49)
2023-04-28T16:21:50.202345+00:00  systemd_start_frontend.sh[1895918]:     at listOnTimeout (internal/timers.js:557:17)
2023-04-28T16:21:50.202452+00:00  systemd_start_frontend.sh[1895918]:     at processTimers (internal/timers.js:500:7) {"error":{},"stack":"Error: Meteor code must always run within a Fiber. Try wrapping callbacks that you pass to non-Meteor libraries with Meteor.bindEnvironment.\n    at Object.Meteor._nodeCodeMustBeInFiber 
```

<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
