### PR TITLE
fix: maxParticipants check counting users that have left

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ValidateAuthTokenReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ValidateAuthTokenReqMsgHdlr.scala
@@ -27,6 +27,11 @@ trait ValidateAuthTokenReqMsgHdlr extends HandlerHelpers {
       case Some(u) =>
         // Check if maxParticipants has been reached
         // User are able to reenter if he already joined previously with the same extId
+        log.info("===== MaxParticipants Check =====")
+        log.info("Max users: [{}]", liveMeeting.props.usersProp.maxUsers)
+        log.info("Number of unique joined users: [{}]", RegisteredUsers.numUniqueJoinedUsers(liveMeeting.registeredUsers))
+        log.info("Is the user rejoining with the same external ID? [{}]", RegisteredUsers.checkUserExtIdHasJoined(u.externId, liveMeeting.registeredUsers))
+        log.info("=================================")
         val hasReachedMaxParticipants = liveMeeting.props.usersProp.maxUsers > 0 &&
           RegisteredUsers.numUniqueJoinedUsers(liveMeeting.registeredUsers) >= liveMeeting.props.usersProp.maxUsers &&
           RegisteredUsers.checkUserExtIdHasJoined(u.externId, liveMeeting.registeredUsers) == false

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ValidateAuthTokenReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ValidateAuthTokenReqMsgHdlr.scala
@@ -27,11 +27,6 @@ trait ValidateAuthTokenReqMsgHdlr extends HandlerHelpers {
       case Some(u) =>
         // Check if maxParticipants has been reached
         // User are able to reenter if he already joined previously with the same extId
-        log.info("===== MaxParticipants Check =====")
-        log.info("Max users: [{}]", liveMeeting.props.usersProp.maxUsers)
-        log.info("Number of unique joined users: [{}]", RegisteredUsers.numUniqueJoinedUsers(liveMeeting.registeredUsers))
-        log.info("Is the user rejoining with the same external ID? [{}]", RegisteredUsers.checkUserExtIdHasJoined(u.externId, liveMeeting.registeredUsers))
-        log.info("=================================")
         val hasReachedMaxParticipants = liveMeeting.props.usersProp.maxUsers > 0 &&
           RegisteredUsers.numUniqueJoinedUsers(liveMeeting.registeredUsers) >= liveMeeting.props.usersProp.maxUsers &&
           RegisteredUsers.checkUserExtIdHasJoined(u.externId, liveMeeting.registeredUsers) == false

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
@@ -146,8 +146,8 @@ object RegisteredUsers {
     u
   }
 
-  def updateUserJoin(users: RegisteredUsers, user: RegisteredUser): RegisteredUser = {
-    val u = user.copy(joined = true)
+  def updateUserJoin(users: RegisteredUsers, user: RegisteredUser, joined: Boolean): RegisteredUser = {
+    val u = user.copy(joined = joined)
     users.save(u)
     u
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -21,7 +21,7 @@ trait HandlerHelpers extends SystemConfiguration {
       regUser:     RegisteredUser
   ): Unit = {
     if (!regUser.joined) {
-      RegisteredUsers.updateUserJoin(liveMeeting.registeredUsers, regUser)
+      RegisteredUsers.updateUserJoin(liveMeeting.registeredUsers, regUser, joined = true)
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -869,8 +869,11 @@ class MeetingActor(
     leftUsers foreach { leftUser =>
       for {
         u <- Users2x.remove(liveMeeting.users2x, leftUser.intId)
+        ru <- RegisteredUsers.findWithUserId(leftUser.intId, liveMeeting.registeredUsers)
       } yield {
         log.info("Removing user from meeting. meetingId=" + props.meetingProp.intId + " userId=" + u.intId + " user=" + u)
+
+        RegisteredUsers.updateUserJoin(liveMeeting.registeredUsers, ru, joined = false)
 
         captionApp2x.handleUserLeavingMsg(leftUser.intId, liveMeeting, msgBus)
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -202,7 +202,7 @@ public class Meeting {
 	}
 
 	public Integer countUniqueExtIds() {
-		List<String> uniqueExtIds = new ArrayList<String>();
+		List<String> uniqueExtIds = new ArrayList<>();
 		for (User user : users.values()) {
 			if(!uniqueExtIds.contains(user.getExternalUserId())) {
 				uniqueExtIds.add(user.getExternalUserId());


### PR DESCRIPTION
### What does this PR do?

When users would leave a meeting the `joined` attribute in their corresponding `RegisteredUser` in akka-apps was not being updated to false which was resulting in future users not being able to join when the `maxParticpants` property was set on a meeting since any users who had joined were still being counted against the current number of participants even if they had left. Now whenever a user is removed from a meeting their `joined` status is set to false so that they are not counted in the `maxParticipants` check. 

### Closes Issue(s)
Closes #15070
Closes #17699


### Motivation

<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
