### PR TITLE
fix: Use meteor.setTimeout to keep call inside fiber

### DIFF
--- a/bigbluebutton-html5/imports/api/users/server/handlers/validateAuthToken.js
+++ b/bigbluebutton-html5/imports/api/users/server/handlers/validateAuthToken.js
@@ -59,10 +59,10 @@ export default async function handleValidateAuthToken({ body }, meetingId) {
           // Schedule socket disconnection for this user
           // giving some time for client receiving the reason of disconnection
           new Promise((resolve) => {
-            setTimeout(() => {
+            Meteor.setTimeout(() => {
               methodInvocationObject.connection.close();
               Logger.info(`Closed connection ${connectionId} due to invalid auth token.`);
-              resolve();
+              resolve(); 
             }, 2000);
           });
         } catch (e) {


### PR DESCRIPTION
### What does this PR do?

Meteor code must always run in a fiber, but the `setTimeout` handler was breaking out from the Meteor fiber which would cause meteor to crash since it could not re-enter the fiber once left. Meteor provides a built-in version of `setTimeout` to handle this situation. 