### PR TITLE
fix: Toast notifications shows again when the language is switched

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notifications/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications/container.jsx
@@ -9,6 +9,8 @@ import UserService from '/imports/ui/components/user-list/service';
 export default injectIntl(withTracker(({ intl }) => {
   NotificationsCollection.find({}).observe({
     added: (obj) => {
+      NotificationsCollection.remove(obj);
+
       if (obj.messageId === 'app.userList.guest.pendingGuestAlert') {
         return WaitingUsersAlertService.alert(obj, intl);
       }


### PR DESCRIPTION
### What does this PR do?

Removes notification from local collection after displaying so they don't appear again if language is changed.

### Closes Issue(s)
Closes #17720