### PR TITLE
fix(sec): Switched PRNG to secure PRNG

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/util/RandomStringGenerator.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/util/RandomStringGenerator.scala
@@ -1,17 +1,19 @@
 package org.bigbluebutton.core.util
 
+import java.security.SecureRandom
+
 object RandomStringGenerator {
   // From: http://www.bindschaedler.com/2012/04/07/elegant-random-string-generation-in-scala/
 
   // Random generator
-  val random = new scala.util.Random
+  val random = new SecureRandom()
 
   // Generate a random string of length n from the given alphabet
   def randomString(alphabet: String)(n: Int): String =
-    Stream.continually(random.nextInt(alphabet.size)).map(alphabet).take(n).mkString
+    LazyList.continually(random.nextInt(alphabet.length)).map(alphabet).take(n).mkString
 
   // Generate a random alphabnumeric string of length n
-  def randomAlphanumericString(n: Int) =
+  def randomAlphanumericString(n: Int): String =
     randomString("abcdefghijklmnopqrstuvwxyz0123456789")(n)
 
 }


### PR DESCRIPTION
### What does this PR do?

Switches the PRNG used to generate user IDs to a cryptographically secure PRNG.


### Motivation

Given any two outputs from a non-cryptographically secure PRNG a person is able to recover the seed of the PRNG which will allow them to know all future outputs. This could potentially lead to a security issue if someone would be able to predict all future user IDs. 
