### PR TITLE
feat(audio): add userdata-bbb_fullaudio_bridge

### DIFF
--- a/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
+++ b/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
@@ -34,6 +34,7 @@ const currentParameters = [
   'bbb_listen_only_mode',
   'bbb_skip_check_audio',
   'bbb_skip_check_audio_on_first_join',
+  'bbb_fullaudio_bridge',
   // BRANDING
   'bbb_display_branding_area',
   // SHORTCUTS

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -13,6 +13,7 @@ import AudioErrors from './error-codes';
 import { Meteor } from 'meteor/meteor';
 import browserInfo from '/imports/utils/browserInfo';
 import getFromMeetingSettings from '/imports/ui/services/meeting-settings';
+import getFromUserSettings from '/imports/ui/services/users-settings';
 import {
   DEFAULT_INPUT_DEVICE_ID,
   reloadAudioElement,
@@ -181,9 +182,9 @@ class AudioManager {
     if (MEDIA.audio) {
       const { bridges, defaultFullAudioBridge, defaultListenOnlyBridge } = MEDIA.audio;
 
-      const _fullAudioBridge = getFromMeetingSettings(
-        'fullaudio-bridge',
-        defaultFullAudioBridge
+      const _fullAudioBridge = getFromUserSettings(
+        'bbb_fullaudio_bridge',
+        getFromMeetingSettings('fullaudio-bridge', defaultFullAudioBridge),
       );
 
       this.bridges = {};

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1353,6 +1353,8 @@ Useful tools for development:
 | `userdata-bbb_skip_video_preview=`               | If set to `true`, the user will not see a preview of their webcam before sharing it                                                                                                                                                                                                                                                     | `false`       |
 | `userdata-bbb_skip_video_preview_on_first_join=` | (Introduced in BigBlueButton 2.3) If set to `true`, the user will not see a preview of their webcam before sharing it when sharing for the first time in the session. If the user stops sharing, next time they try to share webcam the video preview will be displayed, allowing for configuration changes to be made prior to sharing | `false`       |
 | `userdata-bbb_mirror_own_webcam=`                | If set to `true`, the client will see a mirrored version of their webcam. Doesn't affect the incoming video stream for other users.                                                                                                                                                                                                     | `false`       |
+| `userdata-bbb_fullaudio_bridge=`                 | Specifies the audio bridge to be used in the client. Supported values: `sipjs`, `fullaudio`.                                                                                       | `fullaudio`   |
+
 
 #### Presentation parameters
 

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -104,7 +104,7 @@ Updated in 2.6:
 
 Updated in 2.7:
 
-- **join** - **Added:** `redirectErrorUrl`
+- **join** - **Added:** `redirectErrorUrl`, `userdata-bbb_fullaudio_bridge`
 
 ## API Data Types
 


### PR DESCRIPTION
### What does this PR do?

- [feat(audio): add userdata-bbb_fullaudio_bridge](https://github.com/bigbluebutton/bigbluebutton/commit/d3286011e33dff22c63a301286cb3ec17640afdf) 
  * Allows controlling which audio bridge should be used, per user

### Closes Issue(s)

n/a

### Motivation

We have a metadata for the audio bridge to be used which is meeting-wide.
This could also be controlled on a per user basis, so I'm adding an userdata parameter because it's useful for experiments and field trials.