### PR TITLE
build(bbb-webrtc-sfu): v2.10.0-alpha.3

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.10.0-alpha.2 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.10.0-alpha.3 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

Full changelog: https://github.com/bigbluebutton/bbb-webrtc-sfu/compare/v2.10.0-alpha.2...v2.10.0-alpha.3
  - bbb-webrtc-recorder adjustments
  - mediasoup@3.11.24 (reminder: backport to 2.6)
  - Fixes to procedures responsible for tracking and recovering from  FreeSWITCH crashes (reminder: backport to 2.6)

### Closes Issue(s)

n/a