### PR TITLE
feat(audio): microphone bridge set to mediasoup by default

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -567,7 +567,7 @@ public:
       #
       # Default bridge to be used by full audio mechanism.
       # This is the bridge's name as contained in 'bridges' array
-      defaultFullAudioBridge: sipjs
+      defaultFullAudioBridge: fullaudio
       #
       #
       # Server wide configuration to choose which bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

[feat(audio): microphone bridge set to mediasoup by default](https://github.com/bigbluebutton/bigbluebutton/commit/6326a81123d90a8c9809f507a90b666469ecc919) 

### Closes Issue(s)

n/æ

### Motivation

The initial goal is for this to be default in 2.7.
Use it early in the cycle so folks can test for longer.
If there's any deal-breaking issue with it nearing release we can just flip back to the old (2.6, FS/SIP.js) default.