### PR TITLE
build: Process recordings with Niceness 19

### DIFF
--- a/record-and-playback/core/systemd/bbb-rap-caption-inbox.service
+++ b/record-and-playback/core/systemd/bbb-rap-caption-inbox.service
@@ -9,6 +9,7 @@ WorkingDirectory=/usr/local/bigbluebutton/core
 User=bigbluebutton
 Slice=bbb_record_core.slice
 Restart=on-failure
+Nice=19
 
 [Install]
 WantedBy=multi-user.target bigbluebutton.target

--- a/record-and-playback/core/systemd/bbb-rap-resque-worker.service
+++ b/record-and-playback/core/systemd/bbb-rap-resque-worker.service
@@ -14,6 +14,7 @@ Environment=COUNT=1
 User=bigbluebutton
 Restart=always
 RestartSec=3
+Nice=19
 
 [Install]
 WantedBy=multi-user.target bigbluebutton.target


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->
Adds Nice=19 to the service files of bbb-rap-resque-worker and bbb-caption-inbox.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation

<!-- What inspired you to submit this pull request? -->
The ffmpeg calls in the recording processing services can lead to significant spikes in CPU usage, especially when called without limitation on number of threads. In high load scenarios (very large conferences), this may lead to competition for CPU resources with other, more critical, processes.

Setting a high nice level to de-prioritize the recording processing makes sense, since it is generally not critical to process these as fast as possible.

### More

<!-- Anything else we should know when reviewing? -->
There is also a ffmpeg call within bbb-presentation-video, but it is bottlenecked and therefore doesn't lead to very high CPU usage.

Furthermore, I have a patch to set a (hardcoded) fixed number of threads to all ffmpeg calls, for input and output processing. I'd like to have it so that this number can be configured via config files. If this is interesting, let me know and I'll try to work it out.

