### PR TITLE
fix: remove legacy iOS UA checks that borked camera sharing in iPads

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -71,10 +71,6 @@ const intlMessages = defineMessages({
     id: 'app.actionsBar.label',
     description: 'Aria-label for ActionsBar Section',
   },
-  iOSWarning: {
-    id: 'app.iOSWarning.label',
-    description: 'message indicating to upgrade ios version',
-  },
   clearedEmoji: {
     id: 'app.toast.clearedEmoji.label',
     description: 'message for cleared emoji status',
@@ -148,7 +144,6 @@ class App extends Component {
     const {
       notify,
       intl,
-      validIOSVersion,
       layoutContextDispatch,
       isRTL,
     } = this.props;
@@ -180,12 +175,6 @@ class App extends Component {
     }
 
     body.classList.add(`os-${osName.split(' ').shift().toLowerCase()}`);
-
-    if (!validIOSVersion()) {
-      notify(
-        intl.formatMessage(intlMessages.iOSWarning), 'error', 'warning',
-      );
-    }
 
     this.handleWindowResize();
     window.addEventListener('resize', this.handleWindowResize, false);
@@ -558,7 +547,7 @@ class App extends Component {
               ? <ExternalVideoContainer isLayoutSwapped={!presentationIsOpen} isPresenter={isPresenter} />
               : null
           }
-          {shouldShowSharedNotes 
+          {shouldShowSharedNotes
             ? (
               <NotesContainer
                 area="media"

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -28,7 +28,6 @@ const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 import {
   getFontSize,
   getBreakoutRooms,
-  validIOSVersion,
 } from './service';
 
 import { withModalMounter, getModal } from '/imports/ui/components/common/modal/service';
@@ -96,7 +95,7 @@ const AppContainer = (props) => {
   const { focusedId } = cameraDock;
 
   if(
-    layoutContextDispatch 
+    layoutContextDispatch
     &&  (typeof meetingLayout != "undefined")
     && (layoutType.current != meetingLayout)
     ) {
@@ -140,7 +139,7 @@ const AppContainer = (props) => {
 
   useEffect(() => {
     MediaService.buildLayoutWhenPresentationAreaIsDisabled(layoutContextDispatch)});
-  
+
   return currentUserId
     ? (
       <App
@@ -283,7 +282,6 @@ export default withModalMounter(withTracker(() => {
     customStyleUrl,
     UserInfo,
     notify,
-    validIOSVersion,
     isPhone: deviceInfo.isPhone,
     isRTL: document.documentElement.getAttribute('dir') === 'rtl',
     currentUserEmoji: currentUserEmoji(currentUser),

--- a/bigbluebutton-html5/imports/ui/components/app/service.js
+++ b/bigbluebutton-html5/imports/ui/components/app/service.js
@@ -20,15 +20,6 @@ function meetingIsBreakout() {
   return (meeting && meeting.meetingProp.isBreakout);
 }
 
-const validIOSVersion = () => {
-  const { isIos, isIosVersionSupported } = deviceInfo;
-
-  if (isIos) {
-    return isIosVersionSupported();
-  }
-  return true;
-};
-
 const setDarkTheme = (value) => {
   if (value && !DarkReader.isEnabled()) {
       DarkReader.enable(
@@ -56,7 +47,6 @@ export {
   getFontSize,
   meetingIsBreakout,
   getBreakoutRooms,
-  validIOSVersion,
   setDarkTheme,
   isDarkThemeEnabled,
 };

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
@@ -4,7 +4,6 @@ import ButtonEmoji from '/imports/ui/components/common/button/button-emoji/Butto
 import VideoService from '../service';
 import { defineMessages, injectIntl } from 'react-intl';
 import Styled from './styles';
-import { validIOSVersion } from '/imports/ui/components/app/service';
 import deviceInfo from '/imports/utils/deviceInfo';
 import { debounce } from 'lodash';
 import BBBMenu from '/imports/ui/components/common/menu/component';
@@ -51,10 +50,6 @@ const intlMessages = defineMessages({
     id: 'app.video.clientDisconnected',
     description: 'Meteor disconnected label',
   },
-  iOSWarning: {
-    id: 'app.iOSWarning.label',
-    description: 'message indicating to upgrade ios version',
-  },
 });
 
 const JOIN_VIDEO_DELAY_MILLISECONDS = 500;
@@ -86,10 +81,6 @@ const JoinVideoButton = ({
     || shouldEnableWebcamSelectorButton);
 
   const handleOnClick = debounce(() => {
-    if (!validIOSVersion()) {
-      return VideoService.notify(intl.formatMessage(intlMessages.iOSWarning));
-    }
-
     switch (status) {
       case 'videoConnecting':
         VideoService.stopVideo();

--- a/bigbluebutton-html5/imports/utils/deviceInfo.js
+++ b/bigbluebutton-html5/imports/utils/deviceInfo.js
@@ -9,13 +9,9 @@ const isTablet = BOWSER_RESULTS.platform.type === 'tablet' || (BOWSER_RESULTS.os
 const isMobile = isPhone || isTablet;
 const hasMediaDevices = !!navigator.mediaDevices;
 const osName = BOWSER_RESULTS.os.name;
-const osVersion = BOWSER_RESULTS.os.version;
 const isIos = osName === 'iOS' || (isTablet && osName=="macOS");
 const isMacos = osName === 'macOS';
 const isIphone = !!(userAgent.match(/iPhone/i));
-
-const SUPPORTED_IOS_VERSION = 12.2;
-const isIosVersionSupported = () => parseFloat(osVersion) >= SUPPORTED_IOS_VERSION;
 
 const isPortrait = () => window.innerHeight > window.innerWidth;
 
@@ -29,7 +25,6 @@ const deviceInfo = {
   isIos,
   isMacos,
   isIphone,
-  isIosVersionSupported,
 };
 
 export default deviceInfo;

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1169,7 +1169,6 @@
     "app.externalVideo.subtitlesOff": "Turn on (if available)",
     "app.actionsBar.actionsDropdown.shareExternalVideo": "Share an external video",
     "app.actionsBar.actionsDropdown.stopShareExternalVideo": "Stop sharing external video",
-    "app.iOSWarning.label": "Please upgrade to iOS 12.2 or higher",
     "app.legacy.unsupportedBrowser": "It looks like you're using a browser that is not supported. Please use either {0} or {1} for full support.",
     "app.legacy.upgradeBrowser": "It looks like you're using an older version of a supported browser. Please upgrade your browser for full support.",
     "app.legacy.criosBrowser": "On iOS please use Safari for full support.",


### PR DESCRIPTION
### What does this PR do?

- [fix: remove legacy iOS UA checks that borked camera sharing in iPads](https://github.com/bigbluebutton/bigbluebutton/commit/a693133b5a721031a964016d5f9e5ff7cb63ed4d)
  * There are a couple of hardcoded UA checks targeted at iOS endpoints introduced circa 2.2-beta. One of those pops up an "unsupported" toast when the device joins a conference - the other blocks camera sharing.
  * Those checks are outdated since we transitioned to minBrowserVersions approach that redirects the client to an unsupported view upon join. I also assume the checks are bugged since, in some environments, it flags iPadOS endpoints as iOS and version-checks it to a hardcoded "12.2" threshold (which is incompatible with iPadOS versioning). That caused camera sharing not to work, which is a false negative.
  * I consider the checks to be outdated, so I removed all references to them.

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/17882