### PR TITLE
fix(bbb-html5): Successful annotated export toast

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -888,32 +888,18 @@ class PresentationUploader extends Component {
 
   renderToastExportItem(item) {
     const { status } = item.exportation;
-    const loading = (status === EXPORT_STATUSES.RUNNING
-      || status === EXPORT_STATUSES.COLLECTING
-      || status === EXPORT_STATUSES.PROCESSING);
+    const loading = [EXPORT_STATUSES.RUNNING, EXPORT_STATUSES.COLLECTING, EXPORT_STATUSES.PROCESSING].includes(status);
     const done = status === EXPORT_STATUSES.EXPORTED;
-    let icon;
-
-    switch (status) {
-      case EXPORT_STATUSES.RUNNING:
-        icon = 'blank';
-        break;
-      case EXPORT_STATUSES.COLLECTING:
-        icon = 'blank';
-        break;
-      case EXPORT_STATUSES.PROCESSING:
-        icon = 'blank';
-        break;
-      case EXPORT_STATUSES.EXPORTED:
-        icon = 'check';
-        break;
-      case EXPORT_STATUSES.TIMEOUT:
-        icon = 'warning';
-        break;
-      default:
-        break;
-    }
-
+    const statusIconMap = {
+      [EXPORT_STATUSES.RUNNING]: 'blank',
+      [EXPORT_STATUSES.COLLECTING]: 'blank',
+      [EXPORT_STATUSES.PROCESSING]: 'blank',
+      [EXPORT_STATUSES.EXPORTED]: 'check',
+      [EXPORT_STATUSES.TIMEOUT]: 'warning',
+    };
+    
+    const icon = statusIconMap[status] || '';
+    
     return (
       <Styled.UploadRow
         key={item.id || item.temporaryPresentationId}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -888,7 +888,8 @@ class PresentationUploader extends Component {
 
   renderToastExportItem(item) {
     const { status } = item.exportation;
-    const loading = [EXPORT_STATUSES.RUNNING, EXPORT_STATUSES.COLLECTING, EXPORT_STATUSES.PROCESSING].includes(status);
+    const loading = [EXPORT_STATUSES.RUNNING, EXPORT_STATUSES.COLLECTING,
+      EXPORT_STATUSES.PROCESSING].includes(status);
     const done = status === EXPORT_STATUSES.EXPORTED;
     const statusIconMap = {
       [EXPORT_STATUSES.RUNNING]: 'blank',
@@ -897,9 +898,9 @@ class PresentationUploader extends Component {
       [EXPORT_STATUSES.EXPORTED]: 'check',
       [EXPORT_STATUSES.TIMEOUT]: 'warning',
     };
-    
+
     const icon = statusIconMap[status] || '';
-    
+
     return (
       <Styled.UploadRow
         key={item.id || item.temporaryPresentationId}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/service.js
@@ -384,7 +384,7 @@ const exportPresentationToChat = (presentationId, observer) => {
     const cursor = Presentations.find({ id: presentationId });
 
     const checkStatus = (exportation) => {
-      const shouldStop = lastStatus.status === 'RUNNING' && exportation.status === 'EXPORTED';
+      const shouldStop = ['RUNNING', 'PROCESSING'].includes(lastStatus.status) && exportation.status === 'EXPORTED';
 
       if (shouldStop) {
         observer(exportation, true);


### PR DESCRIPTION
### What does this PR do?
The system will now display a confirmation toast each time a file is downloaded, regardless of whether it is annotated. This PR also rectifies a previously encountered issue that resulted in the display of multiple toasts.

![Screenshot 2023-05-15 at 18 22 50](https://github.com/bigbluebutton/bigbluebutton/assets/33319791/df56ef93-427f-49b6-ab44-04d8a25eff9b)

### Closes Issue(s)
Not reported.

### Motivation
@GuiLeme's PR https://github.com/bigbluebutton/bigbluebutton/pull/17648 highlighted an existing edge-case issue where multiple export confirmation toasts could be triggered. These steps replicate the issue:

1. Join a meeting
2. Add some annotations to the whiteboard
3. Export the same file repeatedly
4. Erase the annotations
5. Export annotations again
6. See multiple toasts confirming export.

![Screenshot 2023-05-15 at 18 08 55](https://github.com/bigbluebutton/bigbluebutton/assets/33319791/bbc4ab2c-1afb-485d-9f38-62411fc9b6b6)

### More
This PR should be merged in before https://github.com/bigbluebutton/bigbluebutton/pull/17648 to prevent any conflicts from occurring. Thanks to @GuiLeme as well for a small initial fix suggestion!