### PR TITLE
fix: Localize Regular Expressions for Quick Poll Options

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -91,10 +91,11 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
     content,
   } = currentSlide;
 
-  const questionRegex = /^.+\?\s*$/gm;
+  const questionRegex = /^[\s\S]+\?\s*$/gm;
   const question = safeMatch(questionRegex, content, '');
 
   if (question?.length > 0) {
+    question[0] = question[0]?.replace(/\n/g, ' ');
     const urlRegex = /\bhttps?:\/\/\S+\b/g;
     const hasUrl = safeMatch(urlRegex, question[0], '');
     if (hasUrl.length > 0) question.pop();

--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -75,6 +75,12 @@ const currentSlidHasContent = () => {
   return !!content.length;
 };
 
+// Utility function to escape special characters for regex
+const escapeRegExp = (string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Function to create a regex pattern
+const createPattern = (values) => new RegExp(`.*(${escapeRegExp(values[0])}\\/${escapeRegExp(values[1])}|${escapeRegExp(values[1])}\\/${escapeRegExp(values[0])}).*`, 'gmi');
+
 const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue, falseValue) => {
   const { pollTypes } = PollService;
   const currentSlide = getCurrentSlide('DEFAULT_PRESENTATION_POD');
@@ -97,10 +103,10 @@ const parseCurrentSlideContent = (yesValue, noValue, abstentionValue, trueValue,
   const doubleQuestionRegex = /\?{2}/gm;
   const doubleQuestion = safeMatch(doubleQuestionRegex, content, false);
 
-  const yesNoPatt = /.*(yes\/no|no\/yes).*/gm;
+  const yesNoPatt = createPattern([yesValue, noValue]);
   const hasYN = safeMatch(yesNoPatt, content, false);
 
-  const trueFalsePatt = /.*(true\/false|false\/true).*/gm;
+  const trueFalsePatt = createPattern([trueValue, falseValue]);
   const hasTF = safeMatch(trueFalsePatt, content, false);
 
   const pollRegex = /\b[1-9A-Ia-i][.)] .*/g;


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue with quick poll options, where the regular expressions were hardcoded to English, leading to inconsistent behaviour for non-English locales.

the regular expression has been updated to dynamically adjust based on the currently selected locale. This results in consistent quick poll options across different languages, improving the overall user experience.

![localized-quick-polls](https://github.com/bigbluebutton/bigbluebutton/assets/22058534/4ccd343a-927b-4816-9abe-082d35208062)


### Closes Issue(s)
Closes #17466 
