### PR TITLE
build(bbb-webrtc-sfu): v2.9.11

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.9.10 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.9.11 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

* [build(bbb-webrtc-sfu): v2.9.11](https://github.com/bigbluebutton/bigbluebutton/commit/129c03d389196190fff64464a7115477959f4d67)
  - See https://github.com/bigbluebutton/bbb-webrtc-sfu/releases/tag/v2.9.11
  - fix(audio): properly track FS crashes and react to them
    * Tackles scenarios where listen only and full audio bridges would not recover from 
      FreeSWITCH crashes (nor notify end users about them)
  - feat(audio): add global audio sessions and crashes metrics
  - feat(freeswitch): add freeswitch_crashes metric
  - build(mediasoup): 3.11.24

### Closes Issue(s)

n/æ