### PR TITLE
fix(video): drag-and-drop virtual background isn't applied

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -1061,7 +1061,7 @@ class VideoProvider extends Component {
       const { bbbVideoStream } = peer;
       const video = this.getVideoElement(stream);
 
-      if (peer && video && peer.attached && video.srcObject) {
+      if (peer && video && video.srcObject) {
         bbbVideoStream.startVirtualBackground(type, name, { file: data })
           .then(resolve)
           .catch(reject);


### PR DESCRIPTION
### What does this PR do?

- [fix(video): drag-and-drop virtual background isnt applied](https://github.com/bigbluebutton/bigbluebutton/commit/cf112454bf7fabef4c552464eb134918675dc8f9)
  * Drag-and-drop based virtual BG activation isn`t working since I refactored the logic to determine whether a peer is attached or not

### Closes Issue(s)

n/a, stumbled upon this while doing a cursory reading for some other thing


### More

This should be targeted at 2.6, but I checked out the wrong branch - will rebase later.
