### PR TITLE
fix: Add check for no passwords in meeting create

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -159,7 +159,11 @@ class ApiController {
       if (existing != null) {
         log.debug "Existing conference found"
         Map<String, Object> updateParams = paramsProcessorUtil.processUpdateCreateParams(params);
-        if (existing.getViewerPassword().equals(params.get("attendeePW")) && existing.getModeratorPassword().equals(params.get("moderatorPW"))) {
+        if (
+          (existing.getViewerPassword().equals(params.get("attendeePW")) && existing.getModeratorPassword().equals(params.get("moderatorPW")))
+          ||
+          (!params.attendeePW && !params.moderatorPW)
+        ) {
           //paramsProcessorUtil.updateMeeting(updateParams, existing);
           // trying to create a conference a second time, return success, but give extra info
           // Ignore pre-uploaded presentations. We only allow uploading of presentation once.


### PR DESCRIPTION
### What does this PR do?

Adds a new condition to the check for duplicate meetings to ensure that meetings with the same ID and name, but no moderator or attendee passwords return a success response instead of an error.

### Closes Issue(s)
Closes #17886
