### PR TITLE
fix: The indicator for disabled self view should hide on webcam unshare

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -229,7 +229,7 @@ const VideoListItem = (props) => {
     >
 
       <Styled.VideoContainer>
-        {isSelfViewDisabled && user.userId === Auth.userID && (
+        {isStream && isSelfViewDisabled && user.userId === Auth.userID && (
           <Styled.VideoDisabled>
             {intl.formatMessage(intlMessages.disableDesc)}
           </Styled.VideoDisabled>


### PR DESCRIPTION
### What does this PR do?

Hide self view disabled message if camera is not being shared

### Closes Issue(s)
Closes #17945