### PR TITLE
fix: webcam self view toggle label

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -460,7 +460,7 @@ class ApplicationMenu extends BaseMenu {
             </Styled.Col>
             <Styled.Col>
               <Styled.FormElementRight>
-                {displaySettingsStatus(settings.disableCam)}
+                {displaySettingsStatus(settings.selfViewDisable)}
                 <Toggle
                   icons={false}
                   defaultChecked={settings.selfViewDisable}


### PR DESCRIPTION
### What does this PR do?

Adjusts webcam settings toggle so the correct value is displayed. 

#### before
[Screencast from 2023-05-22 10-21-24.webm](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/b114e384-c95e-4f6c-810e-edc3095c76f4)

#### after
[Screencast from 2023-05-22 10-22-28.webm](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/b81f8c42-0a37-41c4-9e99-82425eea9160)
