### PR TITLE
refactor(bbb-html5): Explicitly state MIME type in notes to presentation conversion

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/service.js
+++ b/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/service.js
@@ -38,7 +38,7 @@ async function convertAndUpload() {
   const data = await sharedNotesAsFile.blob();
 
   const sharedNotesData = new File([data], filename, {
-    type: data.type,
+    type: 'application/pdf',
   });
 
   PresentationUploaderService.handleSavePresentation([], isFromPresentationUploaderInterface = false, {

--- a/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/service.js
+++ b/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/service.js
@@ -8,10 +8,10 @@ import _ from 'lodash';
 const PADS_CONFIG = Meteor.settings.public.pads;
 
 async function convertAndUpload() {
-
   let filename = 'Shared_Notes';
   const presentations = PresentationUploaderService.getPresentations();
-  const duplicates = presentations.filter((pres) => pres.filename?.startsWith(filename) || pres.name?.startsWith(filename)).length;
+  const duplicates = presentations.filter((pres) => pres.filename?.startsWith(filename)
+    || pres.name?.startsWith(filename)).length;
 
   if (duplicates !== 0) { filename = `${filename}(${duplicates})`; }
 
@@ -27,7 +27,7 @@ async function convertAndUpload() {
     lastModifiedUploader: false,
     upload: {
       done: false,
-      error: false
+      error: false,
     },
     uploadTimestamp: new Date(),
   });


### PR DESCRIPTION
### What does this PR do?
This Pull Request aims to resolve a problem with the Etherpad-to-presentation conversion functionality. The identified issue manifested in an incorrect MIME type (`text/html`) being associated with the generated PDF, deviating from the expected `application/pdf` type.

To rectify this, this PR proposes a change in the construction of the file object intended for conversion. Specifically, the MIME type of the file object is now explicitly set as `application/pdf`.

### Closes Issue
Closes #17122

### Additional Information:
Please note: this suggested fix is based on an analysis of the reported issue, as the problem could not be reproduced locally. As such, this fix is theoretical and will require further testing to confirm its efficacy.