### PR TITLE
fix: Added check for parentMeetingId if isBreakout is true

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -128,6 +128,11 @@ class ApiController {
       return
     }
 
+    if(params.isBreakout && !params.parentIdMeetingId) {
+      invalid("parentMeetingIdMissing", "No parent meeting ID was provided for the breakout room")
+      return
+    }
+
     // Ensure unique TelVoice. Uniqueness is not guaranteed by paramsProcessorUtil.
     if (!params.voiceBridge) {
       // Try up to 10 times. We should find a valid telVoice quickly unless


### PR DESCRIPTION
### What does this PR do?

An uncaught exception was being thrown if a `create` request was sent with `isBreakout` set to true and no `parentMeetingID` provided, since the parent meeting could not be found. Added a check in the `create` request handler to ensure that a `parentMeetingID` is always passed when `isBreakout` is true.

### Closes Issue(s)
Closes #17949
