### PR TITLE
fix(screenshare): size dispatch fails due to wrong scope

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -101,9 +101,10 @@ class ScreenshareComponent extends React.Component {
     this.onSwitched = this.onSwitched.bind(this);
     this.handleOnVolumeChanged = this.handleOnVolumeChanged.bind(this);
     this.handleOnMuted = this.handleOnMuted.bind(this);
+    this.dispatchScreenShareSize = this.dispatchScreenShareSize.bind(this);
     this.debouncedDispatchScreenShareSize = debounce(
       { delay: SCREEN_SIZE_DISPATCH_INTERVAL },
-      this.dispatchScreenShareSize
+      this.dispatchScreenShareSize,
     );
     this.volume = getVolume();
     this.mobileHoverSetTimeout = null;


### PR DESCRIPTION
### What does this PR do?

- fix(screenshare): size dispatch fails due to wrong scope
  * Screen size dispatch (layout) was failing in one of its callers due to borked function scope
  
### Closes Issue(s)

None

### Motivation

Found this while looking into other stuff.

