### PR TITLE
Fix: Cameras behind drop areas and presentation when dragging

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
@@ -158,8 +158,8 @@ const WebcamComponent = ({
 
   const mobileWidth = `${isDragging ? cameraSize.width : cameraDock.width}pt`;
   const mobileHeight = `${isDragging ? cameraSize.height : cameraDock.height}pt`;
-  const isDesktopWidth = isDragging ? cameraSize.width : cameraDock.width;
-  const isDesktopHeight = isDragging ? cameraSize.height : cameraDock.height;
+  const isDesktopWidth = isDragging || isCameraSidebar ? cameraSize.width : cameraDock.width;
+  const isDesktopHeight = isDragging || isCameraSidebar ? cameraSize.height : cameraDock.height;
   const camOpacity = isDragging ? 0.5 : undefined;
   return (
     <>
@@ -222,7 +222,8 @@ const WebcamComponent = ({
             }}
             enable={{
               top: !isFullscreen && !isDragging && !swapLayout && cameraDock.resizableEdge.top,
-              bottom: !isFullscreen && !isDragging && !swapLayout && cameraDock.resizableEdge.bottom,
+              bottom: !isFullscreen && !isDragging && !swapLayout
+              && cameraDock.resizableEdge.bottom,
               left: !isFullscreen && !isDragging && !swapLayout && cameraDock.resizableEdge.left,
               right: !isFullscreen && !isDragging && !swapLayout && cameraDock.resizableEdge.right,
               topLeft: false,
@@ -232,7 +233,7 @@ const WebcamComponent = ({
             }}
             style={{
               position: 'absolute',
-              zIndex: isCameraSidebar ? 0 : cameraDock.zIndex,
+              zIndex: cameraDock.zIndex,
             }}
           >
             <Styled.Draggable
@@ -245,7 +246,7 @@ const WebcamComponent = ({
                 width: isIphone ? mobileWidth : isDesktopWidth,
                 height: isIphone ? mobileHeight : isDesktopHeight,
                 opacity: camOpacity,
-                background: isCameraSidebar ? colorContentBackground : null,
+                background: null,
               }}
             >
               <VideoProviderContainer

--- a/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
@@ -158,8 +158,8 @@ const WebcamComponent = ({
 
   const mobileWidth = `${isDragging ? cameraSize.width : cameraDock.width}pt`;
   const mobileHeight = `${isDragging ? cameraSize.height : cameraDock.height}pt`;
-  const isDesktopWidth = isDragging || isCameraSidebar ? cameraSize.width : cameraDock.width;
-  const isDesktopHeight = isDragging || isCameraSidebar ? cameraSize.height : cameraDock.height;
+  const isDesktopWidth = isDragging ? cameraSize.width : cameraDock.width;
+  const isDesktopHeight = isDragging ? cameraSize.height : cameraDock.height;
   const camOpacity = isDragging ? 0.5 : undefined;
   return (
     <>

--- a/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/component.jsx
@@ -233,7 +233,7 @@ const WebcamComponent = ({
             }}
             style={{
               position: 'absolute',
-              zIndex: cameraDock.zIndex,
+              zIndex: isCameraSidebar && !isDragging ? 0 : cameraDock.zIndex,
             }}
           >
             <Styled.Draggable


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug related to the dragging cameras in custom layouts, mentioned in the issue linked bellow. 

### Closes Issue(s)

#17906
