### PR TITLE
fix(Meeting API): Only include online users in attendee list

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.Lock;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.RandomStringUtils;
 
@@ -195,6 +196,10 @@ public class Meeting {
 
 	public Collection<User> getUsers() {
 		return users.isEmpty() ? Collections.<User>emptySet() : Collections.unmodifiableCollection(users.values());
+	}
+
+	public Collection<User> getOnlineUsers() {
+    	return users.isEmpty() ? Collections.emptySet() : users.values().stream().filter(user -> !user.hasLeft()).collect(Collectors.toSet());
 	}
 
 	public ConcurrentMap<String, User> getUsersMap() {

--- a/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/get-meeting-info.ftlx
+++ b/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/get-meeting-info.ftlx
@@ -30,7 +30,7 @@
   <maxUsers>${meeting.getMaxUsers()?c}</maxUsers>
   <moderatorCount>${meeting.getNumModerators()?c}</moderatorCount>
   <attendees>
-  <#list meeting.getUsers() as att>
+  <#list meeting.getOnlineUsers() as att>
     <attendee>
         <userID>${att.getExternalUserId()}</userID>
         <fullName>${att.getFullname()}</fullName>


### PR DESCRIPTION
### What does this PR do?

The list of attendees in `getMeetingInfo` responses did not accurately reflect the number of participants in a meeting since the list was including users that were offline. The list of attendees would only be correct once the offline users had been purged from the meeting after 60 seconds of being offline. The attendee list now only includes users that are online.

### Closes Issue(s)
Closes #17936
