### PR TITLE
refactor (graphql-middleware): Support enable json-patch per subscription

### DIFF
--- a/bbb-graphql-client-test/src/usePatchedSubscription.js
+++ b/bbb-graphql-client-test/src/usePatchedSubscription.js
@@ -10,7 +10,7 @@ export default function usePatchedSubscription(subscriptionGQL, options) {
 
     const { loading, error, data } = useSubscription(
         newSubscriptionGQL,
-        {fetchPolicy: 'no-cache', ...options}
+        {...options, fetchPolicy: 'no-cache'}
     );
     const [currentData, setCurrentData] = useState([]);
 

--- a/bbb-graphql-client-test/src/usePatchedSubscription.js
+++ b/bbb-graphql-client-test/src/usePatchedSubscription.js
@@ -5,7 +5,12 @@ import {applyPatch} from "fast-json-patch";
 export default function usePatchedSubscription(subscriptionGQL, options) {
     //Prepend `Patched_` to the query operationName to inform the middleware that this subscription support json patch
     //It will also set {fetchPolicy: 'no-cache'} because the cache would not work properly when using json-patch
-    const newQueryString = subscriptionGQL.loc.source.body.replace(/subscription\s+(.*)\{/g, 'subscription Patched_$1 {');
+    const regexSubscriptionOperationName = /subscription\s+([^\{]*)\{/g
+    if(!regexSubscriptionOperationName.exec(subscriptionGQL.loc.source.body)) {
+        throw new Error('Error prepending Patched_ to subscription name - check the provided gql');
+    }
+
+    const newQueryString = subscriptionGQL.loc.source.body.replace(regexSubscriptionOperationName, 'subscription Patched_$1 {');
     const newSubscriptionGQL = gql`${newQueryString}`;
 
     const { loading, error, data } = useSubscription(

--- a/bbb-graphql-middleware/internal/common/types.go
+++ b/bbb-graphql-middleware/internal/common/types.go
@@ -21,6 +21,7 @@ type GraphQlSubscription struct {
 	Id                        string
 	Message                   interface{}
 	Type                      QueryType
+	JsonPatchSupported        bool   // indicate if client support Json Patch for this subscription
 	LastSeenOnHasuraConnetion string // id of the hasura connection that this query was active
 }
 
@@ -32,7 +33,6 @@ type BrowserConnection struct {
 	ActiveSubscriptionsMutex sync.Mutex                     // mutex to control the map usage
 	ConnectionInitMessage    interface{}                    // init message received in this connection (to be used on hasura reconnect)
 	HasuraConnection         *HasuraConnection              // associated hasura connection
-	JsonPatchSupported       bool                           // indicate if client support Json Patch
 	Disconnected             bool                           // indicate if the connection is gone
 }
 

--- a/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
@@ -53,7 +53,7 @@ func HasuraConnectionReader(hc *common.HasuraConnection, fromHasuraToBrowserChan
 				}
 
 				//Apply msg patch when it supports it
-				if hc.Browserconn.JsonPatchSupported &&
+				if subscription.JsonPatchSupported &&
 					messageType == "data" &&
 					subscription.Type == common.Subscription {
 					msgpatch.PatchMessage(&messageAsMap, hc.Browserconn)

--- a/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
@@ -83,7 +83,10 @@ RangeLoop:
 
 				if fromBrowserMessageAsMap["type"] == "stop" {
 					var queryId = fromBrowserMessageAsMap["id"].(string)
-					if browserConnection.ActiveSubscriptions[queryId].JsonPatchSupported {
+					browserConnection.ActiveSubscriptionsMutex.Lock()
+					jsonPatchSupported := browserConnection.ActiveSubscriptions[queryId].JsonPatchSupported
+					browserConnection.ActiveSubscriptionsMutex.Unlock()
+					if jsonPatchSupported {
 						msgpatch.RemoveConnSubscriptionCacheFile(browserConnection, queryId)
 					}
 					browserConnection.ActiveSubscriptionsMutex.Lock()

--- a/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
@@ -61,11 +61,20 @@ RangeLoop:
 						}
 					}
 
+					//Identify if the client that requested this subscription expects to receive json-patch
+					//Client append `Patched_` to the query operationName to indicate that it supports
+					jsonPatchSupported := false
+					operationName, ok := payload["operationName"].(string)
+					if ok && strings.HasPrefix(operationName, "Patched_") {
+						jsonPatchSupported = true
+					}
+
 					browserConnection.ActiveSubscriptionsMutex.Lock()
 					browserConnection.ActiveSubscriptions[queryId] = common.GraphQlSubscription{
 						Id:                        queryId,
 						Message:                   fromBrowserMessage,
 						LastSeenOnHasuraConnetion: hc.Id,
+						JsonPatchSupported:        jsonPatchSupported,
 						Type:                      messageType,
 					}
 					// log.Tracef("Current queries: %v", browserConnection.ActiveSubscriptions)
@@ -74,7 +83,7 @@ RangeLoop:
 
 				if fromBrowserMessageAsMap["type"] == "stop" {
 					var queryId = fromBrowserMessageAsMap["id"].(string)
-					if browserConnection.JsonPatchSupported {
+					if browserConnection.ActiveSubscriptions[queryId].JsonPatchSupported {
 						msgpatch.RemoveConnSubscriptionCacheFile(browserConnection, queryId)
 					}
 					browserConnection.ActiveSubscriptionsMutex.Lock()

--- a/bbb-graphql-middleware/internal/msgpatch/jsonpatch.go
+++ b/bbb-graphql-middleware/internal/msgpatch/jsonpatch.go
@@ -50,8 +50,8 @@ func RemoveConnCacheDir(connectionId string) {
 	log.Infof("Directory of patch caches removed successfully for client %s.", connectionId)
 }
 
-func RemoveConnSubscriptionCacheFile(bConn *common.BrowserConnection, subscritionId string) {
-	subsCacheDirPath, err := getSubscriptionCacheDirPath(bConn, subscritionId, false)
+func RemoveConnSubscriptionCacheFile(bConn *common.BrowserConnection, subscriptionId string) {
+	subsCacheDirPath, err := getSubscriptionCacheDirPath(bConn, subscriptionId, false)
 	if err == nil {
 		err = os.RemoveAll(subsCacheDirPath)
 		if err != nil {
@@ -61,7 +61,7 @@ func RemoveConnSubscriptionCacheFile(bConn *common.BrowserConnection, subscritio
 			return
 		}
 
-		log.Infof("Directory of patch caches removed successfully for client %s, subscription %s.", bConn.Id, subscritionId)
+		log.Infof("Directory of patch caches removed successfully for client %s, subscription %s.", bConn.Id, subscriptionId)
 	}
 }
 

--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -59,7 +59,7 @@ func ConnectionHandler(w http.ResponseWriter, r *http.Request) {
 	BrowserConnectionsMutex.Unlock()
 
 	defer func() {
-		msgpatch.RemoveConnCacheDir(BrowserConnections[browserConnectionId])
+		msgpatch.RemoveConnCacheDir(browserConnectionId)
 		BrowserConnectionsMutex.Lock()
 		delete(BrowserConnections, browserConnectionId)
 		BrowserConnectionsMutex.Unlock()

--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -59,9 +59,7 @@ func ConnectionHandler(w http.ResponseWriter, r *http.Request) {
 	BrowserConnectionsMutex.Unlock()
 
 	defer func() {
-		if thisConnection.JsonPatchSupported {
-			msgpatch.RemoveConnCacheDir(BrowserConnections[browserConnectionId])
-		}
+		msgpatch.RemoveConnCacheDir(BrowserConnections[browserConnectionId])
 		BrowserConnectionsMutex.Lock()
 		delete(BrowserConnections, browserConnectionId)
 		BrowserConnectionsMutex.Unlock()

--- a/bbb-graphql-middleware/internal/websrv/sessiontokenreader.go
+++ b/bbb-graphql-middleware/internal/websrv/sessiontokenreader.go
@@ -31,15 +31,6 @@ func SessionTokenReader(connectionId string, browserConnectionContext context.Co
 					log.Infof("[SessionTokenReader] intercepted session token %v", sessionToken)
 					browserConnection.SessionToken = sessionToken
 				}
-
-				var jsonPatchSupported = headersAsMap["json-patch-supported"]
-				if jsonPatchSupported != nil {
-					jsonPatchSupported := headersAsMap["json-patch-supported"].(string)
-					log.Infof("[SessionTokenReader] intercepted json-patch-supported %v", jsonPatchSupported)
-					browserConnection.JsonPatchSupported = jsonPatchSupported == "true"
-				} else {
-					browserConnection.JsonPatchSupported = false
-				}
 			}
 		}
 	}


### PR DESCRIPTION
A few graphql subscriptions will take advantage of the **cache** provided by apollo-client.
For example when two components needs exactly the same information, it will be smart to use the same query for both and the second one will receive the data immediately once the first component already received it and apollo-client stored it in its cache.

When using json-patch, the cache benefit will not be possible once the last data might be only the patch and not the entire object.
In this case the second component would receive the patch and it would be useless once it doesn't have the previous data to apply the patch.

In order make possible the use of cache, now the component will be able to opt if its subscription support patch or not.
It is a trade-off case:

- `usePatchedSubscription`: If it is a big and specific query (such as Chat Messages and Userlist) the component should use the hook `usePatchedSubscription`.
The hook will append the string `Patched_` to the query `operationName` and the middleware identify that this subscription supports json-patch.
The hook will also disable cache for this subscription.
![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/c510389b-1db3-400f-be6b-f2c07b987907)



- `useSubscription`: If it is a small and reusable query (such as CurrentUser info or Meeting Settings) the component should use the original `useSubscription` provided by apollo-client.
Using the original function the client will be able to make use of the cache. And will always receive the entire object as result.