### PR TITLE
build: bump libks to v1.8.2 (FreeSWITCH)

### DIFF
--- a/build/packages-template/bbb-freeswitch-core/build.sh
+++ b/build/packages-template/bbb-freeswitch-core/build.sh
@@ -62,7 +62,7 @@ if [ ! -d libks ]; then
   git clone https://github.com/signalwire/libks.git
 fi
 cd libks/
-git checkout 707bda51db7b1a858a5e608bb5484632cc84a349
+git checkout v1.8.2
 
 cmake .
 make


### PR DESCRIPTION
I missed this in #17990 when backporting. It was applied on BBB 2.6 via https://github.com/bigbluebutton/bigbluebutton/pull/16672