### PR TITLE
build(freeswitch): apply opusfile fix from upstream as a patch

### DIFF
--- a/build/packages-template/bbb-freeswitch-core/8e5dc5a087634145e5fc68b4e6a693d7723fe643.patch
+++ b/build/packages-template/bbb-freeswitch-core/8e5dc5a087634145e5fc68b4e6a693d7723fe643.patch
@@ -1,0 +1,22 @@
+From 8e5dc5a087634145e5fc68b4e6a693d7723fe643 Mon Sep 17 00:00:00 2001
+From: Andrey Volk <andywolk@gmail.com>
+Date: Wed, 29 Dec 2021 22:05:20 +0300
+Subject: [PATCH] [mod_opusfile] Fix missing rdlock unlock in
+ switch_opusfile_open()
+
+---
+ src/mod/formats/mod_opusfile/mod_opusfile.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/mod/formats/mod_opusfile/mod_opusfile.c b/src/mod/formats/mod_opusfile/mod_opusfile.c
+index afd5f512676..15601422631 100644
+--- a/src/mod/formats/mod_opusfile/mod_opusfile.c
++++ b/src/mod/formats/mod_opusfile/mod_opusfile.c
+@@ -295,6 +295,7 @@ static switch_status_t switch_opusfile_open(switch_file_handle_t *handle, const
+ 	context->of = op_open_file(path, &ret);
+ 	if (!context->of) {
+ 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "[OGG/OPUS File] Error opening %s\n", path);
++		switch_thread_rwlock_unlock(context->rwlock);
+ 		return SWITCH_STATUS_GENERR;
+ 	}
+ 

--- a/build/packages-template/bbb-freeswitch-core/build.sh
+++ b/build/packages-template/bbb-freeswitch-core/build.sh
@@ -93,6 +93,11 @@ patch -p0 --ignore-whitespace < $BUILDDIR/audio.patch       # Provisional patch 
 #   rather well and seems sound.
 patch -p1 < $BUILDDIR/1914.patch
 
+# Applies https://github.com/signalwire/freeswitch/commit/8e5dc5a087634145e5fc68b4e6a693d7723fe6430
+# as a patch to try to fix a crash when starting recordings - revert if it doesn't work
+# or, if it works, once we adopt a release with it (still unreleased as of 1.10.9) - prlanzarin May 22 2023
+patch -p1 < $BUILDDIR/8e5dc5a087634145e5fc68b4e6a693d7723fe643.patch
+
 ./bootstrap.sh
 
 ./configure --disable-core-odbc-support --disable-core-pgsql-support \


### PR DESCRIPTION
### What does this PR do?

Applies commit 8e5dc5a087634145e5fc68b4e6a693d7723fe6430 from signalwire as a patch to try to fix a crash when starting recordings. 
Backtraces I've looked into point to somewhere closer to where that commit is tweaking things and behavior seems similar. Testing is still underway.

Revert if it doesn't work or, if it works, once we adopt a release with it (still unreleased as of 1.10.9).

### Closes Issue(s)

n/a