### PR TITLE
fix(sec): Upgrade Spring

### DIFF
--- a/bbb-common-web/build.sbt
+++ b/bbb-common-web/build.sbt
@@ -103,7 +103,7 @@ homepage := Some(url("http://www.bigbluebutton.org"))
 
 libraryDependencies ++= Seq(
   "javax.validation" % "validation-api" % "2.0.1.Final",
-  "org.springframework.boot" % "spring-boot-starter-validation" % "2.7.1",
+  "org.springframework.boot" % "spring-boot-starter-validation" % "2.7.12",
   "org.springframework.data" % "spring-data-commons" % "2.7.6",
   "org.apache.httpcomponents" % "httpclient" % "4.5.13",
   "org.postgresql" % "postgresql" % "42.4.3",

--- a/bigbluebutton-web/gradle.properties
+++ b/bigbluebutton-web/gradle.properties
@@ -4,4 +4,4 @@ gradleWrapperVersion=7.3.1
 grailsGradlePluginVersion=5.0.0
 groovyVersion=3.0.9
 tomcatEmbedVersion=9.0.71
-springVersion=2.7.1
+springVersion=2.7.12


### PR DESCRIPTION
### What does this PR do?

Upgrade Spring dependency to 2.7.12.

### Motivation

Previous version of Spring was vulnerable to:
- [CVE-2023-20883](https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKBOOT-5564390)
- [CVE-2023-20883](https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKBOOT-5564390)
- [CVE-2023-20873](https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKBOOT-5441321)
