### PR TITLE
fix(sec): Upgrade spring-webmvc

### DIFF
--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -64,7 +64,7 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-tomcat:${springVersion}"
 
   implementation "org.grails:grails-web-boot:5.2.5"
-  implementation "org.springframework:spring-webmvc:5.3.26"
+  implementation "org.springframework:spring-webmvc:5.3.27"
 
   implementation "org.grails:grails-logging"
   implementation "org.grails:grails-plugin-rest:5.2.5"


### PR DESCRIPTION
### What does this PR do?

Upgrades `spring-webmvc` dependency to 5.3.27.

### Motivation

Previous version of the dependency was vulnerable to [CVE-2023-20863](https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-5422217).
