### PR TITLE
fix(sec): Upgrade org.json (backport from BBB 2.6)

### DIFF
--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -95,7 +95,7 @@ dependencies {
   implementation "io.projectreactor:reactor-core:3.4.12"
   implementation "org.freemarker:freemarker:2.3.31"
   implementation "com.google.code.gson:gson:2.8.9"
-  implementation "org.json:json:20211205"
+  implementation "org.json:json:20230227"
   implementation "com.zaxxer:nuprocess:2.0.6"
   implementation "net.java.dev.jna:jna:5.10.0"
   implementation "org.springframework.data:spring-data-commons:2.7.6"


### PR DESCRIPTION
### What does this PR do?

Upgrades `org.json` dependency to 20230227.


### Motivation

Previous version of the dependency was vulnerable to [CVE-2022-45688](https://security.snyk.io/vuln/SNYK-JAVA-ORGJSON-5488379)