### PR TITLE
fix(sec): Upgrade tomcat (backport from BBB 2.6)

### DIFF
--- a/bigbluebutton-web/gradle.properties
+++ b/bigbluebutton-web/gradle.properties
@@ -3,5 +3,5 @@ gormVersion=7.1.0
 gradleWrapperVersion=7.3.1
 grailsGradlePluginVersion=5.0.0
 groovyVersion=3.0.9
-tomcatEmbedVersion=9.0.71
+tomcatEmbedVersion=9.0.74
 springVersion=2.7.1


### PR DESCRIPTION
### What does this PR do?

Upgrades Tomcat dependency to 9.0.74.

### Motivation

Previous version of the dependency was vulnerable to:
-[CVE-2023-28708](https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHETOMCATEMBED-3369687)
-[CVE-2023-28708](https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHETOMCATEMBED-3369687)
