### PR TITLE
Fix: Empty 'E' on polls answer options

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -434,7 +434,7 @@ class Poll extends Component {
 
   handleAddOption() {
     const { optList } = this.state;
-    this.setState({ optList: [...optList, { val: '' }] });
+    this.setState({ optList: [...optList, { val: 'E' }] });
   }
 
   handleToggle() {

--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -223,13 +223,6 @@ const MAX_CUSTOM_FIELDS = POLL_SETTINGS.maxCustom;
 const MAX_INPUT_CHARS = POLL_SETTINGS.maxTypedAnswerLength;
 const MIN_OPTIONS_LENGTH = 2;
 const QUESTION_MAX_INPUT_CHARS = 1200;
-const POLL_OPTIONS_PLACEHOLDERS = [
-  { val: intlMessages.a },
-  { val: intlMessages.b },
-  { val: intlMessages.c },
-  { val: intlMessages.d },
-  { val: intlMessages.e },
-];
 
 class Poll extends Component {
   constructor(props) {

--- a/bigbluebutton-html5/imports/ui/components/poll/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.jsx
@@ -434,7 +434,7 @@ class Poll extends Component {
 
   handleAddOption() {
     const { optList } = this.state;
-    this.setState({ optList: [...optList, { val: 'E' }] });
+    this.setState({ optList: [...optList, { val: '' }] });
   }
 
   handleToggle() {
@@ -537,11 +537,7 @@ class Poll extends Component {
             <Styled.PollOptionInput
               type="text"
               value={o.val}
-              placeholder={
-                `${i < MAX_CUSTOM_FIELDS && POLL_OPTIONS_PLACEHOLDERS[i] 
-                  ? intl.formatMessage(POLL_OPTIONS_PLACEHOLDERS[i].val)
-                  : intl.formatMessage(intlMessages.customPlaceholder)}`
-              }
+              placeholder={intl.formatMessage(intlMessages.customPlaceholder)}
               data-test="pollOptionItem"
               onChange={(e) => this.handleInputChange(e, i)}
               maxLength={MAX_INPUT_CHARS}


### PR DESCRIPTION
### What does this PR do?

This PR removes the empty 'E' on Letter type polls.

### Closes Issue(s)

#17893 

