### PR TITLE
fix: connection status modal "adjusting your settings" button not working as expected

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/modal/base/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/modal/base/component.jsx
@@ -31,6 +31,7 @@ const BaseModal = (props) => {
     onRequestClose={onRequestClose}
     className={className}
     overlayClassName={overlayClassName}
+    shouldReturnFocusAfterClose={false}
   >
     {children}
   </Styled.BaseModal>

--- a/bigbluebutton-html5/imports/ui/components/connection-status/status-helper/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/status-helper/component.jsx
@@ -81,7 +81,7 @@ class ConnectionStatusIcon extends PureComponent {
         <Styled.Label>
           {intl.formatMessage(intlMessages.label)}
         </Styled.Label>
-        {(level === 'critical' || level === 'danger') || true
+        {(level === 'critical' || level === 'danger') || isSettingsMenuModalOpen
           ? (
             <div>
               <Styled.Settings
@@ -94,7 +94,7 @@ class ConnectionStatusIcon extends PureComponent {
                 selectedTab={2} 
                 {...{
                   onRequestClose: () => this.setSettingsMenuModalIsOpen(false),
-                  priority: "low",
+                  priority: "medium",
                   setIsOpen: this.setSettingsMenuModalIsOpen,
                   isOpen: isSettingsMenuModalOpen,
                 }}


### PR DESCRIPTION
### What does this PR do?

- fix "adjusting your settings" button appearing only when connection level is danger or critical
- fix settings modal priority when inside connection status modal