### PR TITLE
test: Updates hide presentation

### DIFF
--- a/bigbluebutton-tests/playwright/customparameters/customparameters.js
+++ b/bigbluebutton-tests/playwright/customparameters/customparameters.js
@@ -129,8 +129,7 @@ class CustomParameters extends MultiUsers {
 
   async hidePresentationOnJoin() {
     await this.modPage.waitForSelector(e.actions);
-    const checkPresentationButton = await this.modPage.checkElement(e.restorePresentation);
-    await expect(checkPresentationButton).toBeTruthy();
+    await this.modPage.hasElement(e.restorePresentation);
     await this.modPage.wasRemoved(e.presentationPlaceholder);
   }
 


### PR DESCRIPTION
### What does this PR do?

Changes the check for the restorePresentation button that was failling on ci.
