### PR TITLE
fix(video): autoplay handling fails due to wrong mediaElement reference

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -83,7 +83,7 @@ const VideoListItem = (props) => {
         elem.play().catch((error) => {
           // NotAllowedError equals autoplay issues, fire autoplay handling event
           if (error.name === 'NotAllowedError') {
-            const tagFailedEvent = new CustomEvent('videoPlayFailed', { detail: { mediaTag: elem } });
+            const tagFailedEvent = new CustomEvent('videoPlayFailed', { detail: { mediaElement: elem } });
             window.dispatchEvent(tagFailedEvent);
           }
         });


### PR DESCRIPTION
### What does this PR do?

- [fix(video): autoplay handling fails due to wrong mediaElement reference](https://github.com/bigbluebutton/bigbluebutton/commit/f34f8e5a9c7c5a73320b005a688d68590cbb35b9)
  * Either the emitted event or the event handler was changed somewhere down the road and that led to inconsistent mediaElement references - the handler is dealing with undefined media elements so they are never playing when an autoplay block is triggered.
  
### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/18047
