### PR TITLE
fix(screenshare): client crash due to stale lodash usage

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -319,7 +319,7 @@ class ScreenshareComponent extends React.Component {
 
     return (
       <FullscreenButtonContainer
-        key={_.uniqueId('fullscreenButton-')}
+        key={uniqueId('fullscreenButton-')}
         elementName={intl.formatMessage(this.locales.label)}
         fullscreenRef={this.screenshareContainer}
         elementId={fullscreenElementId}
@@ -334,7 +334,7 @@ class ScreenshareComponent extends React.Component {
 
     return (
       <AutoplayOverlay
-        key={_.uniqueId('screenshareAutoplayOverlay')}
+        key={uniqueId('screenshareAutoplayOverlay')}
         autoplayBlockedDesc={intl.formatMessage(this.locales.autoplayBlockedDesc)}
         autoplayAllowLabel={intl.formatMessage(this.locales.autoplayAllowLabel)}
         handleAllowAutoplay={this.handleAllowAutoplay}


### PR DESCRIPTION
### What does this PR do?

- [fix(screenshare): client crash due to stale lodash usage](https://github.com/bigbluebutton/bigbluebutton/commit/4961bfdf73177b123762efe3418ec22b3a7276b5)
  * Regression from the latest 2.6 merge

### Closes Issue(s)

n/æ