### PR TITLE
refactor(video): remove stale iOSWarning locale declaration

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
@@ -53,10 +53,6 @@ const intlMessages = defineMessages({
     id: 'app.video.clientDisconnected',
     description: 'Meteor disconnected label',
   },
-  iOSWarning: {
-    id: 'app.iOSWarning.label',
-    description: 'message indicating to upgrade ios version',
-  },
 });
 
 const JOIN_VIDEO_DELAY_MILLISECONDS = 500;


### PR DESCRIPTION
### What does this PR do?

- [refactor(video): remove stale iOSWarning locale declaration](https://github.com/bigbluebutton/bigbluebutton/commit/bf482fa373f0d8b5d7e928971817a091b286eb5c)
  * Removed in https://github.com/bigbluebutton/bigbluebutton/pull/17904, accidentally re-added I think 

### Closes Issue(s)

n/a