### PR TITLE
chore: Enable ReactionsBar by default

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -143,7 +143,7 @@ public:
       enabled: false
       centered: true
     interactionsButton:
-      enabled: false
+      enabled: true
     # If enabled, before joining microphone the client will perform a trickle
     # ICE against Kurento and use the information about successfull
     # candidate-pairs to filter out local candidates in SIP.js's SDP.

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -140,9 +140,13 @@ public:
     # If not set, default value is true.
     showAudioFilters: true
     raiseHandActionButton:
+      # Enables the old raiseHand icon
       enabled: false
+      # If true, positions the icon next to the screenshare button, if false positions it where BBB had raisedHand button up to BBB 2.6 (right-hand bottom corner in LRT)
       centered: true
     interactionsButton:
+      # Enables the new raiseHand icon inside of the reaction menu (introduced in BBB 2.7)
+      # If both interactionsButton and raiseHandActionButton are enabled, interactionsButton takes precedence.
       enabled: true
     # If enabled, before joining microphone the client will perform a trickle
     # ICE against Kurento and use the information about successfull


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
* enables by default the newly introduced reactions bar (emoji - raise hand button)
* adds inline comments on which option takes precedence
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation

BBB 2.7 has alternatives for reactions/raise hand action, see https://github.com/bigbluebutton/bigbluebutton/pull/17764
