### PR TITLE
fix: presentation uploader dropdown styles

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/presentation-download-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/presentation-download-dropdown/component.jsx
@@ -135,11 +135,14 @@ class PresentationDownloadDropdown extends PureComponent {
       disabled,
     } = this.props;
 
+    const customStyles = { zIndex: 9999 };
+
     return (
       <PresentationDownloadDropdownWrapper
         disabled={disabled}
       >
         <BBBMenu
+          customStyles={customStyles}
           trigger={
             (
               <Trigger


### PR DESCRIPTION
### What does this PR do?

Fix presentation uploader export options dropdown not working on 2.7.

[Screencast from 2023-06-01 09-31-04.webm](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/21348b08-21f6-4757-9179-15d467f9c8be)
