### PR TITLE
fix: typo when parsing recordFullDurationMedia API param

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -505,7 +505,7 @@ public class ParamsProcessorUtil {
         }
 
         boolean _recordFullDurationMedia = recordFullDurationMedia;
-        if (!StringUtils.isEmpty(params.get(ApiParams.ALLOW_START_STOP_RECORDING))) {
+        if (!StringUtils.isEmpty(params.get(ApiParams.RECORD_FULL_DURATION_MEDIA))) {
             try {
                 _recordFullDurationMedia = Boolean.parseBoolean(params
                         .get(ApiParams.RECORD_FULL_DURATION_MEDIA));


### PR DESCRIPTION
### What does this PR do?

- [fix: typo when parsing recordFullDurationMedia API param](https://github.com/bigbluebutton/bigbluebutton/commit/9f46b104854a190eb1ab6f6a6968632d63440133)

### Motivation

Follow up to #18044 