### PR TITLE
Fix: pinning shared notes should restore presentation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.jsx
@@ -115,7 +115,7 @@ const Notes = ({
           type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
           value: false,
         });
-  
+
         layoutContextDispatch({
           type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
           value: PANELS.NONE,
@@ -145,6 +145,10 @@ const Notes = ({
       if(shouldShowSharedNotesOnPresentationArea) {
         layoutContextDispatch({
           type: ACTIONS.SET_NOTES_IS_PINNED,
+          value: true,
+        });
+        layoutContextDispatch({
+          type: ACTIONS.SET_PRESENTATION_IS_OPEN,
           value: true,
         });
       }

--- a/bigbluebutton-html5/imports/ui/components/notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.jsx
@@ -141,8 +141,8 @@ const Notes = ({
           value: Session.get('presentationLastState'),
         });
       };
-    }else{
-      if(shouldShowSharedNotesOnPresentationArea) {
+    }
+    if(shouldShowSharedNotesOnPresentationArea) {
         layoutContextDispatch({
           type: ACTIONS.SET_NOTES_IS_PINNED,
           value: true,
@@ -152,7 +152,7 @@ const Notes = ({
           value: true,
         });
       }
-    }
+      return null;
   }, []);
 
   const renderHeaderOnMedia = () => {


### PR DESCRIPTION
### What does this PR do?

This PR fixes the bug where the pin to the shared notes wasn't restoring presentation.

### Closes Issue(s)

#18040 

