### PR TITLE
docs: Added a note for recording processing with recordFullDurationMedia

### DIFF
--- a/docs/docs/development/recording.md
+++ b/docs/docs/development/recording.md
@@ -808,6 +808,8 @@ Its error message describes the issue.
 
 ### How do I change the Start/Stop recording marks?
 
+Note: In BigBlueButton 2.6.9 we [made a change](https://github.com/bigbluebutton/bigbluebutton/pull/18044) which ensures media files are not being saved to file unless the recording is actively being recorded. The instructions below only work up to BigBlueButton 2.6.8 or if you are overriding `recordFullDurationMedia=true` in `/etc/bigbluebutton/bbb-web.properties` in BigBlueButton 2.6.9+.
+
 In a scenario where a user forgot to press the Start/Stop recording button 30 minutes into a session, resulting in the playback missing that initial segment, its content can still be included by editing the intervals to be processed in the `events.xml` file.
 
 First, use `bbb-record --list` to find the internal `meetingId` for the recording. For example, to get the last three recordings, execute


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Adds a note in the beginning of the docs section on changing the Start/Stop recording marks under Recording.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
Community member @defnull pointed out that since the introduction of https://github.com/bigbluebutton/bigbluebutton/pull/18044 our docs for changing the Start/Stop recording marks are no longer applicable in their old form. Thank you!
<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->
