### PR TITLE
fix: recover drawing area (minimum version)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-overlay/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-overlay/component.jsx
@@ -5,6 +5,7 @@ import SlideCalcUtil, {
   HUNDRED_PERCENT, MAX_PERCENT, STEP,
 } from '/imports/utils/slideCalcUtils';
 import {Meteor} from "meteor/meteor";
+import browserInfo from '/imports/utils/browserInfo';
 // After lots of trial and error on why synching doesn't work properly, I found I had to
 // multiply the coordinates by 2. There's something I don't understand probably on the
 // canvas coordinate system. (ralam feb 22, 2012)
@@ -542,10 +543,12 @@ export default class PresentationOverlay extends Component {
       zIndex: MAX_Z_INDEX,
       cursor,
     };
+    
+    const { isChrome } = browserInfo;
 
     return (
       <foreignObject
-        clipPath="url(#viewBox)"
+        clipPath={ isChrome ? "" : "url(#viewBox)" }
         x="0"
         y="0"
         width={slideWidth}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Removes a clippath that is making a problem on the recently updated Chromium-based browsers.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #18066 
Related discussion: https://groups.google.com/g/bigbluebutton-dev/c/r35CE7Z1zfU

### Motivation

I need a quick fix because my class is starting from next week!

### More

To me this clippath seems not necessary at all. I will post another PR (#18085) that removes all.
This PR itself might not be necessary if the bug (which I suppose so) is fixed on the Chromium side. But even so, removing this clippath does not harm anything as far as I checked.
