### PR TITLE
[Fix 2.5] recover drawing area (a neat solution)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -638,9 +638,7 @@ class Presentation extends PureComponent {
           xmlns="http://www.w3.org/2000/svg"
         >
           <defs>
-            <clipPath id="viewBox">
-              <rect x={viewBoxPosition.x} y={viewBoxPosition.y} width="100%" height="100%" fill="none" />
-            </clipPath>
+            <rect id="viewBox" x={viewBoxPosition.x} y={viewBoxPosition.y} width="100%" height="100%" fill="none" />
           </defs>
           <g clipPath="url(#viewBox)">
             <Slide


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Recover the drawing area shrunken by the recent update on Chromium-based browsers. This PR, unlike #18085 and #18084, perhaps hits the problem directly.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #18066 

### More

This PR implies what has happened in the recent Chromium update. 
Although this PR fixes the problem in the cleanest way, I prefer #18085 as it may improve the whiteboard performance.
