### PR TITLE
Allow default presentation to bypass URL validation

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/PresentationUrlDownloadService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/PresentationUrlDownloadService.java
@@ -222,6 +222,7 @@ public class PresentationUrlDownloadService {
     }
 
     private boolean isValidRedirectUrl(String redirectUrl) {
+        log.info("Validating redirect URL [{}]", redirectUrl);
         URL url;
 
         try {
@@ -259,7 +260,7 @@ public class PresentationUrlDownloadService {
                     return false;
                 }
 
-                if(localhostBlocked) {
+                if(localhostBlocked && !url.getFile().equalsIgnoreCase("/default.pdf")) {
                     if(address.isAnyLocalAddress()) {
                         log.error("Address [{}] is a local address", address.getHostAddress());
                         return false;


### PR DESCRIPTION
### What does this PR do?

Allows the default presentation, `default.pdf`, to bypass the URL validation used by `insertDocument` when `localhost` is blocked.


### Motivation

Currently if the BBB fully qualified domain name is configured as an alias for `localhost` the default presentation will fail to pass the validation check used by `insertDocument` and cannot be uploaded. This change allows for the `default.pdf` to be exempt from this check so that it can be successfully uploaded.
