### PR TITLE
feat(config): Configurable presentation pointer size

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/cursor/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/cursor/component.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Meteor } from 'meteor/meteor';
+
+const { pointerDiameter } = Meteor.settings.public.whiteboard;
 
 const Cursor = (props) => {
   const {
@@ -28,10 +31,10 @@ const Cursor = (props) => {
         style={{
           zIndex: z,
           position: 'absolute',
-          left: (_x || x) - 2.5,
-          top: (_y || y) - 2.5,
-          width: 5,
-          height: 5,
+          left: (_x || x) - pointerDiameter/2,
+          top: (_y || y) - pointerDiameter/2,
+          width: pointerDiameter,
+          height: pointerDiameter,
           borderRadius: '50%',
           background: `${color}`,
           pointerEvents: 'none',

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -759,7 +759,7 @@ public:
   whiteboard:
     annotationsQueueProcessInterval: 60
     cursorInterval: 150
-    pointerDiameter: 10
+    pointerDiameter: 5
     maxStickyNoteLength: 1000
     # limit number of annotations per slide
     maxNumberOfAnnotations: 300

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -759,6 +759,7 @@ public:
   whiteboard:
     annotationsQueueProcessInterval: 60
     cursorInterval: 150
+    pointerDiameter: 10
     maxStickyNoteLength: 1000
     # limit number of annotations per slide
     maxNumberOfAnnotations: 300


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Enables users to change the size of presentation pointer and sets the default value 10 in diameter, which is what BBB 2.5 adopted.

### Motivation

Starting lectures using BBB 2.6, I realised that the presentation (cursor) pointer is way smaller than it has been until 2.5. Not sure if it's intended change or confusion of radius with diameter, but I prefer a larger pointer. For those who prefer different size, I set this value configurable. 

### More

Until 2.5:
<img width="369" alt="スクリーンショット 2023-06-07 22 41 01" src="https://github.com/bigbluebutton/bigbluebutton/assets/45039819/e259ef86-a18a-4346-a2f3-798c87b1d496">

On 2.6:
<img width="415" alt="スクリーンショット 2023-06-07 22 44 00" src="https://github.com/bigbluebutton/bigbluebutton/assets/45039819/14c5d48f-c421-4a04-a30e-05182be7c181">

After the change (configurable at setting.yml):
<img width="415" alt="スクリーンショット 2023-06-07 22 41 34" src="https://github.com/bigbluebutton/bigbluebutton/assets/45039819/46444c6a-bc44-4dae-be15-db0212a42a9c">
