### PR TITLE
fix: crash on leave if shared notes is open

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.jsx
@@ -152,7 +152,6 @@ const Notes = ({
           value: true,
         });
       }
-      return null;
   }, []);
 
   const renderHeaderOnMedia = () => {


### PR DESCRIPTION
### What does this PR do?

Fix crash when leaving meeting with shared notes open

### Motivation

![Screenshot from 2023-06-07 15-34-27](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/c593933f-675a-4ddf-990a-58402590caee)
