### PR TITLE
Docs: add missing configuration option for cluster setup

### DIFF
--- a/docs/docs/administration/cluster-proxy.md
+++ b/docs/docs/administration/cluster-proxy.md
@@ -179,6 +179,12 @@ Create the file `/etc/bigbluebutton/etherpad.json` with the following content:
 }
 ```
 
+Adjust the CORS settings in `/etc/default/bbb-web`:
+
+```shell
+JDK_JAVA_OPTIONS="-Dgrails.cors.enabled=true -Dgrails.cors.allowCredentials=true -Dgrails.cors.allowedOrigins=https://bbb-proxy.example.org,https://https://bbb-01.example.com"
+```
+
 
 Restart BigBlueButton:
 


### PR DESCRIPTION


<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Adds missing documentation for cluster proxy setup.

### Closes Issue(s)

Closes #16542


### Motivation

`bbb-web` needs configuration for correct CORS headers in cluster setup. Otherwise API calls from `bbb-html5` to `bbb-web` will be rejected by grails and the html5 client wont work properly.

It was not properly documented yet, just hidden in https://github.com/bigbluebutton/bigbluebutton/issues/16542#issuecomment-1418668932

