### PR TITLE
fix (Learning Dashboard): Emoji not working on Learning Dashboard

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
@@ -48,7 +48,7 @@ public class LearningDashboardService {
             File jsonFile = this.getJsonDataFile(meetingId,learningDashboardAccessToken);
 
             FileOutputStream fileOutput = new FileOutputStream(jsonFile);
-            fileOutput.write(activityJson.getBytes());
+            fileOutput.write(activityJson.getBytes("UTF-8"));
 
             fileOutput.close();
 


### PR DESCRIPTION
Fix the encoding of the file that stores Learning Dashboard data to support Emoji chars.

### Before this PR:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/e46b322f-5dbc-409f-a3f3-bc9970005f1f)
----

### After this PR:
![emojis-after](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/b2d1cfb5-1708-41a2-8156-1baa785fdacd)

This fix will be specially useful when Learning Dashboard shows Reactions!