### PR TITLE
Remove commons file upload

### DIFF
--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -100,8 +100,6 @@ dependencies {
   implementation "com.zaxxer:nuprocess:2.0.6"
   implementation "net.java.dev.jna:jna:5.10.0"
   implementation "org.springframework.data:spring-data-commons:2.7.6"
-  // https://mvnrepository.com/artifact/commons-fileupload/commons-fileupload
-  //implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
 
   implementation 'javax.validation:validation-api:2.0.1.Final'
   implementation "org.springframework.boot:spring-boot-starter-validation:${springVersion}"

--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -101,7 +101,7 @@ dependencies {
   implementation "net.java.dev.jna:jna:5.10.0"
   implementation "org.springframework.data:spring-data-commons:2.7.6"
   // https://mvnrepository.com/artifact/commons-fileupload/commons-fileupload
-  implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
+  //implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
 
   implementation 'javax.validation:validation-api:2.0.1.Final'
   implementation "org.springframework.boot:spring-boot-starter-validation:${springVersion}"


### PR DESCRIPTION
### What does this PR do?

Removes the unused `commons-fileupload` dependency from bbb-web.
