### PR TITLE
test: wait for public chat element when openning it and improve test config file

### DIFF
--- a/bigbluebutton-tests/playwright/chat/chat.spec.js
+++ b/bigbluebutton-tests/playwright/chat/chat.spec.js
@@ -33,11 +33,11 @@ test.describe.serial('Chat', () => {
   test('Save chat @ci', async ({}, testInfo) => {
     await chat.saveChat(testInfo);
   });
-  
+
   test('Verify character limit', async () => {
     await chat.characterLimit();
   });
-  
+
   // https://docs.bigbluebutton.org/2.6/release-tests.html#sending-empty-chat-message-automated
   test('Not able to send an empty message @ci', async () => {
     await chat.emptyMessage();

--- a/bigbluebutton-tests/playwright/chat/chat.spec.js
+++ b/bigbluebutton-tests/playwright/chat/chat.spec.js
@@ -30,7 +30,7 @@ test.describe.serial('Chat', () => {
     await chat.copyChat(context);
   });
 
-  test('Save chat @ci', async ({ context }, testInfo) => {
+  test('Save chat @ci', async ({}, testInfo) => {
     await chat.saveChat(testInfo);
   });
   

--- a/bigbluebutton-tests/playwright/chat/util.js
+++ b/bigbluebutton-tests/playwright/chat/util.js
@@ -2,12 +2,20 @@ const { default: test, expect } = require('@playwright/test');
 const e = require('../core/elements');
 const { getSettings } = require('../core/settings');
 
-async function openChat(testPage) {
+async function openPublicChat(testPage) {
   const { chatEnabled } = getSettings();
   test.fail(!chatEnabled, 'Chat is disabled');
 
   await testPage.waitForSelector(e.chatBox);
   await testPage.waitForSelector(e.chatMessages);
+  try {
+    await testPage.waitForSelector(e.chatWelcomeMessageText);
+  } catch {
+    await testPage.waitAndClick(e.chatMessages);
+    await testPage.down('Home');
+    await testPage.waitForSelector(e.chatWelcomeMessageText);
+    await testPage.down('End');
+  }
 }
 
 async function openPrivateChat(testPage) {
@@ -23,6 +31,6 @@ async function checkLastMessageSent(testPage, expectedMessage) {
   await expect(lastMessageSent).toHaveText(expectedMessage);
 }
 
-exports.openChat = openChat;
+exports.openPublicChat = openPublicChat;
 exports.openPrivateChat = openPrivateChat;
 exports.checkLastMessageSent = checkLastMessageSent;

--- a/bigbluebutton-tests/playwright/connectionFailure/connectionFailure.spec.js
+++ b/bigbluebutton-tests/playwright/connectionFailure/connectionFailure.spec.js
@@ -1,6 +1,6 @@
 const { test, devices } = require('@playwright/test');
 const { ScreenShare, MultiUserScreenShare } = require('../screenshare/screenshare');
-const { sleep } = require('../core/helpers');
+const { sleep, checkRootPermission } = require('../core/helpers');
 const e = require('../core/elements');
 const { getCurrentTCPSessions, killTCPSessions } = require('./util');
 const notificationsUtil = require('../notifications/util');
@@ -9,6 +9,7 @@ const deepEqual = require('deep-equal');
 test.describe.parallel('Connection failure', () => {
   // https://docs.bigbluebutton.org/2.6/release-tests.html#sharing-screen-in-full-screen-mode-automated
   test('Screen sharer', async ({ browser, browserName, page }) => {
+    await checkRootPermission(); // check sudo permission before starting test
     test.skip(browserName === 'firefox' && process.env.DISPLAY === undefined,
               "Screenshare tests not able in Firefox browser without desktop");
     const screenshare = new ScreenShare(browser, page);
@@ -26,6 +27,7 @@ test.describe.parallel('Connection failure', () => {
   });
 
   test('Screen share viewer', async ({ browser, browserName, page, context }) => {
+    await checkRootPermission(); // check sudo permission before starting test
     test.skip(browserName === 'firefox' && process.env.DISPLAY === undefined,
               "Screenshare tests not able in Firefox browser without desktop");
     const screenshare = new MultiUserScreenShare(browser, context);

--- a/bigbluebutton-tests/playwright/core/helpers.js
+++ b/bigbluebutton-tests/playwright/core/helpers.js
@@ -3,6 +3,7 @@ const sha1 = require('sha1');
 const axios = require('axios');
 const { test, expect } = require('@playwright/test');
 const xml2js = require('xml2js');
+const { runScript } = require('./util');
 
 const parameters = require('./parameters');
 
@@ -60,6 +61,13 @@ function getJoinURL(meetingID, params, moderator, customParameter) {
   return `${params.server}/join?${query}&checksum=${checksum}`;
 }
 
+async function checkRootPermission() {
+  const checkSudo = await runScript('timeout -k 1 1 sudo id', {
+    handleOutput: (output) => output ? true : false
+  })
+  await expect(checkSudo, 'Sudo failed: need to run this test with root permission (can be fixed by running "sudo -v" and entering the password)').toBeTruthy();
+}
+
 function linkIssue(issueNumber) {
   test.info().annotations.push({
     type: 'Issue/PR',
@@ -80,5 +88,6 @@ exports.createMeetingUrl = createMeetingUrl;
 exports.createMeetingPromise = createMeetingPromise;
 exports.createMeeting = createMeeting;
 exports.getJoinURL = getJoinURL;
+exports.checkRootPermission = checkRootPermission;
 exports.linkIssue = linkIssue;
 exports.sleep = sleep;

--- a/bigbluebutton-tests/playwright/layouts/util.js
+++ b/bigbluebutton-tests/playwright/layouts/util.js
@@ -14,13 +14,11 @@ async function reopenChatSidebar(page) {
 async function checkScreenshots(layoutTest, maskedSelectors, screenshotName, screenshotNumber) {
   const modPageWebcamsLocator = layoutTest.modPage.getLocator(maskedSelectors);
   await expect(layoutTest.modPage.page).toHaveScreenshot(`moderator-${screenshotName}${screenshotNumber ? '-' + screenshotNumber : ''}.png`, {
-    maxDiffPixelRatio: 0.005,
     mask: [modPageWebcamsLocator],
   });
 
   const userWebcamsLocator = layoutTest.userPage.getLocator(maskedSelectors);
   await expect(layoutTest.userPage.page).toHaveScreenshot(`user-${screenshotName}${screenshotNumber ? '-' + screenshotNumber : ''}.png`, {
-    maxDiffPixelRatio: 0.005,
     mask: [userWebcamsLocator],
   });
 }

--- a/bigbluebutton-tests/playwright/learningdashboard/learningdashboard.js
+++ b/bigbluebutton-tests/playwright/learningdashboard/learningdashboard.js
@@ -1,6 +1,6 @@
 const { MultiUsers } = require("../user/multiusers");
 const e = require('../core/elements');
-const { openChat } = require('../chat/util');
+const { openPublicChat } = require('../chat/util');
 const { expect } = require("@playwright/test");
 const Page = require("../core/page");
 const { sleep } = require("../core/helpers");
@@ -26,7 +26,7 @@ class LearningDashboard extends MultiUsers {
   }
 
   async writeOnPublicChat() {
-    await openChat(this.modPage);
+    await openPublicChat(this.modPage);
     await this.modPage.checkElementCount(e.chatUserMessageText, 0);
 
     await this.modPage.type(e.chatBox, e.message);

--- a/bigbluebutton-tests/playwright/playwright.config.js
+++ b/bigbluebutton-tests/playwright/playwright.config.js
@@ -29,7 +29,7 @@ const config = {
   expect: {
     timeout: ELEMENT_WAIT_TIME,
     toMatchSnapshot: {
-      maxDiffPixelRatio: 0.005,
+      maxDiffPixelRatio: 0.05,
     },
   }
 };

--- a/bigbluebutton-tests/playwright/playwright.config.js
+++ b/bigbluebutton-tests/playwright/playwright.config.js
@@ -31,7 +31,10 @@ const config = {
     toMatchSnapshot: {
       maxDiffPixelRatio: 0.05,
     },
-  }
+    toHaveScreenshot: {
+      maxDiffPixelRatio: 0.05,
+    },
+  },
 };
 
 if (CI) config.retries = 1;

--- a/bigbluebutton-tests/playwright/playwright.config.js
+++ b/bigbluebutton-tests/playwright/playwright.config.js
@@ -1,5 +1,6 @@
 require('dotenv').config();
 const { chromiumConfig, firefoxConfig, webkitConfig } = require('./core/browsersConfig');
+const { ELEMENT_WAIT_TIME } = require('./core/constants');
 
 const CI = process.env.CI === 'true';
 const DEBUG_MODE = process.env.DEBUG_MODE === 'true';
@@ -25,6 +26,12 @@ const config = {
     firefoxConfig,
     webkitConfig,
   ],
+  expect: {
+    timeout: ELEMENT_WAIT_TIME,
+    toMatchSnapshot: {
+      maxDiffPixelRatio: 0.005,
+    },
+  }
 };
 
 if (CI) config.retries = 1;

--- a/bigbluebutton-tests/playwright/presentation/presentation.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.js
@@ -241,9 +241,6 @@ class Presentation extends MultiUsers {
     await this.modPage.waitForSelector(e.resetZoomButton, ELEMENT_WAIT_LONGER_TIME);
 
     const wbBox = await this.modPage.getLocator(e.whiteboard);
-    const screenshotOptions = {
-      maxDiffPixelRatio: 0.05,
-    };
 
     const zoomOutButtonLocator = this.modPage.getLocator(e.zoomOutButton);
     await expect(zoomOutButtonLocator).toBeDisabled();
@@ -255,35 +252,32 @@ class Presentation extends MultiUsers {
     await this.modPage.waitAndClick(e.zoomInButton);
     await expect(zoomOutButtonLocator).toBeEnabled();
     await expect(resetZoomButtonLocator).toContainText(/150%/);
-    await expect(wbBox).toHaveScreenshot('moderator1-zoom150.png', screenshotOptions);
+    await expect(wbBox).toHaveScreenshot('moderator1-zoom150.png');
 
     //Zoom out 125%
     await this.modPage.waitAndClick(e.zoomOutButton);
     await expect(resetZoomButtonLocator).toContainText(/125%/);
-    await expect(wbBox).toHaveScreenshot('moderator1-zoom125.png', screenshotOptions);
+    await expect(wbBox).toHaveScreenshot('moderator1-zoom125.png');
 
     //Reset Zoom 100%
     await this.modPage.waitAndClick(e.resetZoomButton);
     await expect(resetZoomButtonLocator).toContainText(/100%/);
-    await expect(wbBox).toHaveScreenshot('moderator1-zoom100.png', screenshotOptions);
+    await expect(wbBox).toHaveScreenshot('moderator1-zoom100.png');
   }
 
   async selectSlide() {
     await this.modPage.waitForSelector(e.skipSlide);
 
     const wbBox = await this.modPage.getLocator(e.whiteboard);
-    const screenshotOptions = {
-      maxDiffPixelRatio: 0.05,
-    };
 
     await this.modPage.selectSlide('Slide 10');
-    await expect(wbBox).toHaveScreenshot('moderator1-select-slide10.png', screenshotOptions);
+    await expect(wbBox).toHaveScreenshot('moderator1-select-slide10.png');
 
     await this.modPage.selectSlide('Slide 5');
-    await expect(wbBox).toHaveScreenshot('moderator1-select-slide5.png', screenshotOptions);
+    await expect(wbBox).toHaveScreenshot('moderator1-select-slide5.png');
 
     await this.modPage.selectSlide('Slide 13');
-    await expect(wbBox).toHaveScreenshot('moderator1-select-slide13.png', screenshotOptions);
+    await expect(wbBox).toHaveScreenshot('moderator1-select-slide13.png');
   }
 }
 

--- a/bigbluebutton-tests/playwright/reconnection/reconnection.js
+++ b/bigbluebutton-tests/playwright/reconnection/reconnection.js
@@ -48,13 +48,6 @@ class Reconnection extends MultiUsers {
     await this.modPage.hasElement(e.muteMicButton);
     await this.modPage.hasElement(e.isTalking);
   }
-
-  async checkRootPermission() {
-    const checkSudo = await runScript('timeout -k 1 1 sudo id', {
-      handleOutput: (output) => output ? true : false
-    })
-    await expect(checkSudo, 'Sudo failed: need to run this test with root permission (can be fixed by running "sudo -v" and entering the password)').toBeTruthy();
-  }
 }
 
 exports.Reconnection = Reconnection;

--- a/bigbluebutton-tests/playwright/reconnection/reconnection.spec.js
+++ b/bigbluebutton-tests/playwright/reconnection/reconnection.spec.js
@@ -1,17 +1,18 @@
 const { test } = require('@playwright/test');
 const { Reconnection } = require('./reconnection');
+const { checkRootPermission } = require('../core/helpers');
 
 test.describe.serial('Reconnection', () => {
   test('Chat', async ({ browser, context, page }) => {
+    await checkRootPermission(); // check sudo permission before starting test
     const reconnection = new Reconnection(browser, context);
-    await reconnection.checkRootPermission(); // check sudo permission before starting test
     await reconnection.initModPage(page);
     await reconnection.chat();
   });
 
   test('Audio', async ({ browser, context, page }) => {
+    await checkRootPermission(); // check sudo permission before starting test
     const reconnection = new Reconnection(browser, context);
-    await reconnection.checkRootPermission(); // check sudo permission before starting test
     await reconnection.initModPage(page);
     await reconnection.microphone();
   });

--- a/bigbluebutton-tests/playwright/webcam/util.js
+++ b/bigbluebutton-tests/playwright/webcam/util.js
@@ -60,9 +60,7 @@ async function uploadBackgroundVideoImage(testPage) {
   ]);
   await fileChooser.setFiles(resolve(__dirname, '../core/media/simpsons-background.png'));
   const uploadedBackgroundLocator = testPage.getLocator(e.selectCustomBackground);
-  await expect(uploadedBackgroundLocator).toHaveScreenshot('custom-background-item.png', {
-    maxDiffPixelRatio: 0.1,
-  });
+  await expect(uploadedBackgroundLocator).toHaveScreenshot('custom-background-item.png');
 }
 
 exports.webcamContentCheck = webcamContentCheck;

--- a/bigbluebutton-tests/playwright/webcam/webcam.js
+++ b/bigbluebutton-tests/playwright/webcam/webcam.js
@@ -69,9 +69,7 @@ class Webcam extends Page {
     await this.waitAndClick(e.startSharingWebcam);
     await this.waitForSelector(e.webcamContainer);
     const webcamVideoLocator = await this.getLocator(e.webcamContainer);
-    await expect(webcamVideoLocator).toHaveScreenshot('webcam-with-home-background.png', {
-      maxDiffPixelRatio: 0.1,
-    });
+    await expect(webcamVideoLocator).toHaveScreenshot('webcam-with-home-background.png');
   }
 
   async webcamFullscreen() {
@@ -101,9 +99,7 @@ class Webcam extends Page {
     await this.waitAndClick(e.startSharingWebcam);
     await this.waitForSelector(e.webcamContainer);
     const webcamVideoLocator = await this.getLocator(e.webcamContainer);
-    await expect(webcamVideoLocator).toHaveScreenshot('webcam-with-new-background.png', {
-      maxDiffPixelRatio: 0.1,
-    });
+    await expect(webcamVideoLocator).toHaveScreenshot('webcam-with-new-background.png');
 
     // Remove
     await this.waitAndClick(e.videoDropdownMenu);

--- a/bigbluebutton-tests/playwright/whiteboard/changeStyles.js
+++ b/bigbluebutton-tests/playwright/whiteboard/changeStyles.js
@@ -13,9 +13,6 @@ class ChangeStyles extends MultiUsers {
 
     const modWbLocator = this.modPage.getLocator(e.whiteboard);
     const wbBox = await modWbLocator.boundingBox();
-    const screenshotOptions = {
-      maxDiffPixelRatio: 0.05,
-    };
 
     await this.modPage.waitAndClick(e.wbShapesButton);
     await this.modPage.waitAndClick(e.wbEllipseShape);
@@ -29,10 +26,10 @@ class ChangeStyles extends MultiUsers {
     await this.modPage.waitAndClick(e.wbColorRed);
     await this.modPage.waitAndClick(e.wbStyles);
 
-    await expect(modWbLocator).toHaveScreenshot('moderator-change-color.png', screenshotOptions);
+    await expect(modWbLocator).toHaveScreenshot('moderator-change-color.png');
 
     const userWbLocator = this.userPage.getLocator(e.whiteboard);
-    await expect(userWbLocator).toHaveScreenshot('viewer-change-color.png', screenshotOptions);
+    await expect(userWbLocator).toHaveScreenshot('viewer-change-color.png');
   }
 
   async fillDrawing() {
@@ -40,9 +37,6 @@ class ChangeStyles extends MultiUsers {
 
     const modWbLocator = this.modPage.getLocator(e.whiteboard);
     const wbBox = await modWbLocator.boundingBox();
-    const screenshotOptions = {
-      maxDiffPixelRatio: 0.05,
-    };
 
     await this.modPage.waitAndClick(e.wbShapesButton);
     await this.modPage.waitAndClick(e.wbEllipseShape);
@@ -56,10 +50,10 @@ class ChangeStyles extends MultiUsers {
     await this.modPage.waitAndClick(e.wbFillDrawing);
     await this.modPage.press('Escape');
 
-    await expect(modWbLocator).toHaveScreenshot('moderator-fill-drawing.png', screenshotOptions);
+    await expect(modWbLocator).toHaveScreenshot('moderator-fill-drawing.png');
 
     const userWbLocator = this.userPage.getLocator(e.whiteboard);
-    await expect(userWbLocator).toHaveScreenshot('viewer-fill-drawing.png', screenshotOptions);
+    await expect(userWbLocator).toHaveScreenshot('viewer-fill-drawing.png');
   }
 
   async dashDrawing() {
@@ -67,9 +61,6 @@ class ChangeStyles extends MultiUsers {
 
     const modWbLocator = this.modPage.getLocator(e.whiteboard);
     const wbBox = await modWbLocator.boundingBox();
-    const screenshotOptions = {
-      maxDiffPixelRatio: 0.05,
-    };
 
     await this.modPage.waitAndClick(e.wbShapesButton);
     await this.modPage.waitAndClick(e.wbEllipseShape);
@@ -83,10 +74,10 @@ class ChangeStyles extends MultiUsers {
     await this.modPage.waitAndClick(e.wbDashDotted);
     await this.modPage.waitAndClick(e.wbStyles);
 
-    await expect(this.modPage.page).toHaveScreenshot('moderator-dash-drawing.png', screenshotOptions);
+    await expect(this.modPage.page).toHaveScreenshot('moderator-dash-drawing.png');
 
     const userWbLocator = this.userPage.getLocator(e.whiteboard);
-    await expect(userWbLocator).toHaveScreenshot('viewer-dash-drawing.png', screenshotOptions);
+    await expect(userWbLocator).toHaveScreenshot('viewer-dash-drawing.png');
   }
 
   async sizeDrawing() {
@@ -94,9 +85,6 @@ class ChangeStyles extends MultiUsers {
 
     const modWbLocator = this.modPage.getLocator(e.whiteboard);
     const wbBox = await modWbLocator.boundingBox();
-    const screenshotOptions = {
-      maxDiffPixelRatio: 0.05,
-    };
 
     await this.modPage.waitAndClick(e.wbShapesButton);
     await this.modPage.waitAndClick(e.wbEllipseShape);
@@ -110,10 +98,10 @@ class ChangeStyles extends MultiUsers {
     await this.modPage.waitAndClick(e.wbSizeLarge);
     await this.modPage.waitAndClick(e.wbStyles);
 
-    await expect(this.modPage.page).toHaveScreenshot('moderator-size-drawing.png', screenshotOptions);
+    await expect(this.modPage.page).toHaveScreenshot('moderator-size-drawing.png');
 
     const userWbLocator = this.userPage.getLocator(e.whiteboard);
-    await expect(userWbLocator).toHaveScreenshot('viewer-size-drawing.png', screenshotOptions);
+    await expect(userWbLocator).toHaveScreenshot('viewer-size-drawing.png');
   }
 }
 

--- a/bigbluebutton-tests/playwright/whiteboard/deleteDrawing.js
+++ b/bigbluebutton-tests/playwright/whiteboard/deleteDrawing.js
@@ -13,9 +13,6 @@ class DeleteDrawing extends MultiUsers {
 
     const modWbLocator = this.modPage.getLocator(e.whiteboard);
     const wbBox = await modWbLocator.boundingBox();
-    const screenshotOptions = {
-      maxDiffPixelRatio: 0.05,
-    };
 
     await this.modPage.waitAndClick(e.wbArrowShape);
 
@@ -26,10 +23,10 @@ class DeleteDrawing extends MultiUsers {
 
     await this.modPage.waitAndClick(e.wbDelete);
 
-    await expect(modWbLocator).toHaveScreenshot('moderator-delete-drawing.png', screenshotOptions);
+    await expect(modWbLocator).toHaveScreenshot('moderator-delete-drawing.png');
 
     const userWbLocator = this.userPage.getLocator(e.whiteboard);
-    await expect(userWbLocator).toHaveScreenshot('viewer-delete-drawing.png', screenshotOptions);
+    await expect(userWbLocator).toHaveScreenshot('viewer-delete-drawing.png');
   }
 }
 

--- a/bigbluebutton-tests/playwright/whiteboard/drawEllipse.js
+++ b/bigbluebutton-tests/playwright/whiteboard/drawEllipse.js
@@ -13,9 +13,6 @@ class DrawEllipse extends MultiUsers {
 
     const modWbLocator = this.modPage.getLocator(e.whiteboard);
     const wbBox = await modWbLocator.boundingBox();
-    const screenshotOptions = {
-      maxDiffPixelRatio: 0.05,
-    };
 
     await this.modPage.waitAndClick(e.wbShapesButton);
     await this.modPage.waitAndClick(e.wbEllipseShape);
@@ -25,10 +22,10 @@ class DrawEllipse extends MultiUsers {
     await this.modPage.page.mouse.move(wbBox.x + 0.7 * wbBox.width, wbBox.y + 0.7 * wbBox.height);
     await this.modPage.page.mouse.up();
 
-    await expect(modWbLocator).toHaveScreenshot('moderator-ellipse.png', screenshotOptions);
+    await expect(modWbLocator).toHaveScreenshot('moderator-ellipse.png');
 
     const userWbLocator = this.userPage.getLocator(e.whiteboard);
-    await expect(userWbLocator).toHaveScreenshot('viewer-ellipse.png', screenshotOptions);
+    await expect(userWbLocator).toHaveScreenshot('viewer-ellipse.png');
   }
 }
 

--- a/bigbluebutton-tests/playwright/whiteboard/realTimeText.js
+++ b/bigbluebutton-tests/playwright/whiteboard/realTimeText.js
@@ -13,23 +13,20 @@ class RealTimeText extends MultiUsers {
 
     const modWbLocator = this.modPage.getLocator(e.whiteboard);
     const wbBox = await modWbLocator.boundingBox();
-    const screenshotOptions = {
-      maxDiffPixelRatio: 0.05,
-    };
 
     await this.modPage.waitAndClick(e.wbTextShape);
     await this.modPage.page.mouse.click(wbBox.x + 0.3 * wbBox.width, wbBox.y + 0.3 * wbBox.height);
     await this.modPage.press('A');
     
     const userWbLocator = this.userPage.getLocator(e.whiteboard);
-    await expect(modWbLocator).toHaveScreenshot('moderator-realtime-text.png', screenshotOptions);
-    await expect(userWbLocator).toHaveScreenshot('viewer-realtime-text.png', screenshotOptions);
+    await expect(modWbLocator).toHaveScreenshot('moderator-realtime-text.png');
+    await expect(userWbLocator).toHaveScreenshot('viewer-realtime-text.png');
 
     await this.modPage.press('A');
     await this.modPage.page.mouse.click(wbBox.x + 0.6 * wbBox.width, wbBox.y + 0.6 * wbBox.height);
 
-    await expect(modWbLocator).toHaveScreenshot('moderator-realtime-text-2.png', screenshotOptions);
-    await expect(userWbLocator).toHaveScreenshot('viewer-realtime-text-2.png', screenshotOptions);
+    await expect(modWbLocator).toHaveScreenshot('moderator-realtime-text-2.png');
+    await expect(userWbLocator).toHaveScreenshot('viewer-realtime-text-2.png');
     await expect(modWbLocator).toHaveText('AA');
   }
 }

--- a/bigbluebutton-tests/playwright/whiteboard/redoDraw.js
+++ b/bigbluebutton-tests/playwright/whiteboard/redoDraw.js
@@ -13,9 +13,6 @@ class RedoDrawing extends MultiUsers {
 
     const modWbLocator = this.modPage.getLocator(e.whiteboard);
     const wbBox = await modWbLocator.boundingBox();
-    const screenshotOptions = {
-      maxDiffPixelRatio: 0.05,
-    };
 
     await this.modPage.waitAndClick(e.wbArrowShape);
 
@@ -27,10 +24,10 @@ class RedoDrawing extends MultiUsers {
     await this.modPage.waitAndClick(e.wbUndo);
     await this.modPage.waitAndClick(e.wbRedo);
 
-    await expect(modWbLocator).toHaveScreenshot('moderator-redo-drawing.png', screenshotOptions);
+    await expect(modWbLocator).toHaveScreenshot('moderator-redo-drawing.png');
 
     const userWbLocator = this.userPage.getLocator(e.whiteboard);
-    await expect(userWbLocator).toHaveScreenshot('viewer-redo-drawing.png', screenshotOptions);
+    await expect(userWbLocator).toHaveScreenshot('viewer-redo-drawing.png');
   }
 }
 

--- a/bigbluebutton-tests/playwright/whiteboard/undoDraw.js
+++ b/bigbluebutton-tests/playwright/whiteboard/undoDraw.js
@@ -13,9 +13,6 @@ class UndoDrawing extends MultiUsers {
 
     const modWbLocator = this.modPage.getLocator(e.whiteboard);
     const wbBox = await modWbLocator.boundingBox();
-    const screenshotOptions = {
-      maxDiffPixelRatio: 0.05,
-    };
 
     await this.modPage.waitAndClick(e.wbArrowShape);
 
@@ -26,10 +23,10 @@ class UndoDrawing extends MultiUsers {
 
     await this.modPage.waitAndClick(e.wbUndo);
 
-    await expect(modWbLocator).toHaveScreenshot('moderator-undo-drawing.png', screenshotOptions);
+    await expect(modWbLocator).toHaveScreenshot('moderator-undo-drawing.png');
 
     const userWbLocator = this.userPage.getLocator(e.whiteboard);
-    await expect(userWbLocator).toHaveScreenshot('viewer-undo-drawing.png', screenshotOptions);
+    await expect(userWbLocator).toHaveScreenshot('viewer-undo-drawing.png');
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
- Waits for `chatWelcomeMessageText` element when opening public chat to avoid unexpected failures;
- Defines default pixel ratio match value for screenshot comparisons;
- Isolates function that checks root permission when running `connectionFailure` tests;