### PR TITLE
fix: Freeswitch status check hangs during `bbb-conf --(re)start`

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -954,7 +954,7 @@ check_state() {
     #
 
     ESL_PASSWORD=$(xmlstarlet sel -t -m 'configuration/settings/param[@name="password"]' -v @value /opt/freeswitch/etc/freeswitch/autoload_configs/event_socket.conf.xml)
-    if ! echo "/quit" | /opt/freeswitch/bin/fs_cli -p $ESL_PASSWORD - > /dev/null 2>&1; then
+    if ! echo "/quit" | timeout -v 5 /opt/freeswitch/bin/fs_cli -p $ESL_PASSWORD - > /dev/null 2>&1; then
         echo
         echo "#"
         echo "# Error: Unable to connect to the FreeSWITCH Event Socket Layer on port 8021"


### PR DESCRIPTION
### What does this PR do?

When (re)starting BBB, the freeswitch status check may be run too early. The `fs_cli` call can connect, but the piped in `/quit` command is ignored and the session never terminates. This patch will fail the check after 5 seconds and print a warning, instead of stalling the (re)start of BBB indefinitely.

### Closes Issue(s)

closes #18140

### Motivation

This rare but annoying race condition causes some of your ansible based BBB deployments to fail on first try.

