### PR TITLE
build: recover installation of bbb-webhooks

### DIFF
--- a/build/packages-template/bbb-webhooks/after-install.sh
+++ b/build/packages-template/bbb-webhooks/after-install.sh
@@ -18,12 +18,6 @@ case "$1" in
     yq w -i $TARGET server.port "3005"
     yq w -i $TARGET hooks.getRaw "false"
 
-    cd /usr/local/bigbluebutton/bbb-webhooks
-    mkdir -p node_modules
-
-    npm config set unsafe-perm true
-    npm rebuild || true
-
     mkdir -p /var/log/bbb-webhooks/
     touch /var/log/bbb-webhooks/bbb-webhooks.log
     chown -R bigbluebutton:bigbluebutton /usr/local/bigbluebutton/bbb-webhooks /var/log/bbb-webhooks/

--- a/build/packages-template/bbb-webhooks/build.sh
+++ b/build/packages-template/bbb-webhooks/build.sh
@@ -26,7 +26,7 @@ find -maxdepth 1 ! -path . ! -name staging $(printf "! -name %s " $(cat .build-f
 
 pushd .
 cd staging/usr/local/bigbluebutton/bbb-webhooks/
-npm install --production
+npm install --unsafe-perm --production
 popd
 
 cp webhooks.nginx staging/usr/share/bigbluebutton/nginx/webhooks.nginx


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Mimics setting unsafe-perm from package `bbb-webrtc-sfu` to replace the way it was done in `bbb-webhooks`. `npm config set unsafe-perm` seems discontinued after npm v6
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #18142 


### Motivation

<!-- What inspired you to submit this pull request? -->

### More
- More testing of the resulting bbb-webhooks would be great
- This (or a better solution) should be backported to BBB 2.5