### PR TITLE
refactor: Fix original presentation download link in cluster setups

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationWithAnnotationsMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationWithAnnotationsMsgHdlr.scala
@@ -162,7 +162,7 @@ trait PresentationWithAnnotationsMsgHdlr extends RightsManagementTrait {
 
         PresentationSender.broadcastSetPresentationDownloadableEvtMsg(bus, meetingId, "DEFAULT_PRESENTATION_POD", "not-used", presId, true, filename)
 
-        val fileURI = List("bigbluebutton", "presentation", "download", meetingId, s"${presId}?presFilename=${presId}.${presFilenameExt}").mkString(File.separator, File.separator, "")
+        val fileURI = List("presentation", "download", meetingId, s"${presId}?presFilename=${presId}.${presFilenameExt}").mkString(File.separator, File.separator, "")
         val event = buildNewPresAnnFileAvailable(fileURI, presId)
 
         handle(event, liveMeeting, bus)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationWithAnnotationsMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationWithAnnotationsMsgHdlr.scala
@@ -162,7 +162,7 @@ trait PresentationWithAnnotationsMsgHdlr extends RightsManagementTrait {
 
         PresentationSender.broadcastSetPresentationDownloadableEvtMsg(bus, meetingId, "DEFAULT_PRESENTATION_POD", "not-used", presId, true, filename)
 
-        val fileURI = List("presentation", "download", meetingId, s"${presId}?presFilename=${presId}.${presFilenameExt}").mkString(File.separator, File.separator, "")
+        val fileURI = List("presentation", "download", meetingId, s"${presId}?presFilename=${presId}.${presFilenameExt}").mkString("", File.separator, "")
         val event = buildNewPresAnnFileAvailable(fileURI, presId)
 
         handle(event, liveMeeting, bus)

--- a/bbb-export-annotations/config/index.js
+++ b/bbb-export-annotations/config/index.js
@@ -1,13 +1,4 @@
-let _ = require('lodash');
-let fs = require('fs');
 const settings = require('./settings');
-const LOCAL_SETTINGS_FILE_PATH = '/etc/bigbluebutton/bbb-export-annotations.json';
-
 const config = settings;
-
-if (fs.existsSync(LOCAL_SETTINGS_FILE_PATH)) {
-  const local_config = JSON.parse(fs.readFileSync(LOCAL_SETTINGS_FILE_PATH));
-  _.mergeWith(config, local_config, (a, b) => (_.isArray(b) ? b : undefined));
-}
 
 module.exports = config;

--- a/bbb-export-annotations/config/settings.json
+++ b/bbb-export-annotations/config/settings.json
@@ -28,7 +28,6 @@
       "msgName": "NewPresAnnFileAvailableMsg"
     },
     "bbbWebAPI": "http://127.0.0.1:8090",
-    "bbbWebPublicAPI": "/bigbluebutton/",
     "bbbPadsAPI": "http://127.0.0.1:9002",
     "redis": {
       "host": "127.0.0.1",

--- a/bbb-export-annotations/package-lock.json
+++ b/bbb-export-annotations/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "axios": "^0.26.0",
         "form-data": "^4.0.0",
-        "lodash": "^4.17.21",
         "perfect-freehand": "^1.0.16",
         "probe-image-size": "^7.2.3",
         "redis": "^4.0.3",
@@ -924,11 +923,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -2053,11 +2047,6 @@
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
       }
-    },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/bbb-export-annotations/package.json
+++ b/bbb-export-annotations/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "axios": "^0.26.0",
     "form-data": "^4.0.0",
-    "lodash": "^4.17.21",
     "perfect-freehand": "^1.0.16",
     "probe-image-size": "^7.2.3",
     "redis": "^4.0.3",

--- a/bbb-export-annotations/workers/notifier.js
+++ b/bbb-export-annotations/workers/notifier.js
@@ -28,7 +28,7 @@ async function notifyMeetingActor() {
   await client.connect();
   client.on('error', (err) => logger.info('Redis Client Error', err));
 
-  const link = config.bbbWebPublicAPI + path.join('presentation',
+  const link = path.join('presentation',
       exportJob.parentMeetingId, exportJob.parentMeetingId,
       exportJob.presId, 'pdf', jobId, filename);
 

--- a/bigbluebutton-html5/imports/ui/components/chat/service.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/service.js
@@ -11,6 +11,7 @@ import { meetingIsBreakout } from '/imports/ui/components/app/service';
 import { defineMessages } from 'react-intl';
 import PollService from '/imports/ui/components/poll/service';
 
+const APP = Meteor.settings.public.app;
 const CHAT_CONFIG = Meteor.settings.public.chat;
 const GROUPING_MESSAGES_WINDOW = CHAT_CONFIG.grouping_messages_window;
 const CHAT_EMPHASIZE_TEXT = CHAT_CONFIG.moderatorChatEmphasized;
@@ -329,10 +330,11 @@ const removePackagedClassAttribute = (classnames, attribute) => {
 };
 
 const getExportedPresentationString = (fileURI, filename, intl) => {
-  const warningIcon = `<i class="icon-bbb-warning"></i>`;
+  const href = `${APP.bbbWebBase}/${fileURI}`;
+  const warningIcon = '<i class="icon-bbb-warning"></i>';
   const label = `<span>${intl.formatMessage(intlMessages.download)}</span>`;
   const notAccessibleWarning = `<span title="${intl.formatMessage(intlMessages.notAccessibleWarning)}">${warningIcon}</span>`;
-  const link = `<a aria-label="${intl.formatMessage(intlMessages.notAccessibleWarning)}" href=${fileURI} type="application/pdf" target="_blank" rel="noopener, noreferrer" download>${label}&nbsp;${notAccessibleWarning}</a>`;
+  const link = `<a aria-label="${intl.formatMessage(intlMessages.notAccessibleWarning)}" href=${href} type="application/pdf" target="_blank" rel="noopener, noreferrer" download>${label}&nbsp;${notAccessibleWarning}</a>`;
   const name = `<span>${filename}</span>`;
   return `${name}</br>${link}`;
 };


### PR DESCRIPTION
### What does this PR do?
This pull request fixes the link in the "Download" button for original presentation files (i.e, no annotations) when they are sent to chat in cluster setups.

It also removes any cluster-specific settings from `akka-bbb-apps` and `bbb-export-annotations` for downloads, exports, and captures. From now on, links will be created without the need for the `bbbWebBase` information, letting Meteor alone handle this on the client side. The goal of this change is to decrease the coupling between components, making it easier for system admins to maintain and configure them.

### Motivation
Only the link in the toast notification was working properly when downloading files without annotations in cluster setups. This issue was reported by @schrd. His feedback on this pull request would be appreciated.