### PR TITLE
fix: Reset Fit To Width On Presentation Change

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -282,7 +282,8 @@ class Presentation extends PureComponent {
       if (presentationChanged) {
         this.setState({
           presentationId: currentPresentationId,
-          hadPresentation: true
+          hadPresentation: true,
+          fitToWidth: false,
         });
       }
 


### PR DESCRIPTION
### What does this PR do?
This PR resets the `fitToWidth` when the presentation changes. Now the correct size and aspect ratio of presentation is shown to viewers. 

### Closes Issue(s)
Closes #17982 