### PR TITLE
test: Update rewrite snapshots script

### DIFF
--- a/bigbluebutton-tests/playwright/core/scripts/rewrite-snapshots.sh
+++ b/bigbluebutton-tests/playwright/core/scripts/rewrite-snapshots.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Save string of folders containg reference snapshots files
-folders_string=$(find . -type d -name "*js-snapshots" -printf "%h\n" | sort | uniq | tr -d './')
+folders_string=$(find . -type d -name "*js-snapshots" -printf "%h\n" | sort | uniq | tr -d './' | tr '\n' ' ')
 
 # Find folders
 folders=$(find . -type d -name "*js-snapshots")
@@ -12,5 +12,6 @@ do
   rm -r "$folder"
 done
 
+echo "Running test suites: $folders_string"
 # Run the test suites for these deleted folders
-npm test "$folders_string" -- --project=chromium
+npm test $folders_string -- --project=chromium


### PR DESCRIPTION
### What does this PR do?
Updates script that deletes and recreates reference snapshots by formatting the folders string to be in one line, logging which test suites are running, and removing double quotes to avoid misruns