### PR TITLE
fix: copy event in breakout panel

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/component.jsx
@@ -555,7 +555,7 @@ class BreakoutRoom extends PureComponent {
       isRTL,
     } = this.props;
     return (
-      <Styled.Panel ref={(n) => this.panel = n}>
+      <Styled.Panel ref={(n) => this.panel = n} onCopy={(e) => { e.stopPropagation(); }}>
         <Header
           leftButtonProps={{
             'aria-label': intl.formatMessage(intlMessages.breakoutAriaTitle),


### PR DESCRIPTION
### What does this PR do?

Allow copy of the contents in breakout panel (list of users in each breakout room)

### More

**Expected behavior**
If the user tries to copy the list of users in each breakout room (ctrl+c or select copy from the context menu), the contents should be added to the clipboard.

**Actual behavior**
`{"type":"tldr/clipboard"}` is added instead of the breakout panel content.


#### before

[Screencast from 2023-06-19 15-42-31.webm](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/91366775-7f86-41f5-84c7-81cdaf42a662)

#### after

[Screencast from 2023-06-19 15-45-36.webm](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/c145b8a1-380e-448a-8683-574277e47db6)
