### PR TITLE
fix: locked label in userlist

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -393,6 +393,7 @@ const isMeetingLocked = (id) => {
       || lockSettings.disableNotes
       || lockSettings.hideUserList
       || lockSettings.hideViewersCursor
+      || lockSettings.hideViewersAnnotation
       || usersProp.webcamsOnlyForModerator) {
       isLocked = true;
     }


### PR DESCRIPTION
### What does this PR do?

Fix locked label not appearing in userlist if only "See other viewers annotations" lock is enabled.