### PR TITLE
fix: recover drawing area - Microsoft Edge

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-overlay/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-overlay/component.jsx
@@ -544,11 +544,11 @@ export default class PresentationOverlay extends Component {
       cursor,
     };
     
-    const { isChrome } = browserInfo;
+    const { isChrome, isEdge } = browserInfo;
 
     return (
       <foreignObject
-        clipPath={ isChrome ? "" : "url(#viewBox)" }
+        clipPath={ isChrome || isEdge ? "" : "url(#viewBox)" }
         x="0"
         y="0"
         width={slideWidth}


### PR DESCRIPTION
### What does this PR do?

Removes a clippath that is making a problem on Microsoft Edge.

Suggested by @hiroshisuga in https://github.com/bigbluebutton/bigbluebutton/pull/18084#issuecomment-1597203201

### Closes Issue(s)
Closes #18066