### PR TITLE
fix: presenter permission for poll results annotation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -57,7 +57,7 @@ const WhiteboardContainer = (props) => {
   };
   // set shapes as locked for those who aren't allowed to edit it
   Object.entries(shapes).forEach(([shapeId, shape]) => {
-    if (!shape.isLocked && !hasShapeAccess(shapeId)) {
+    if (!shape.isLocked && !hasShapeAccess(shapeId) && !shape.name?.includes('poll-result')) {
       const modShape = shape;
       modShape.isLocked = true;
     }


### PR DESCRIPTION
### What does this PR do?

Fix presenter permission for editing/moving poll results annotation if presenter is changed.