### PR TITLE
fix: only display clear status if status is enabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -128,6 +128,8 @@ const intlMessages = defineMessages({
   }
 });
 
+const USER_STATUS_ENABLED = Meteor.settings.public.userStatus.enabled;
+
 class UserOptions extends PureComponent {
   constructor(props) {
     super(props);
@@ -273,17 +275,20 @@ class UserOptions extends PureComponent {
           onClick: this.onSaveUserNames,
           icon: 'download',
           dataTest: 'downloadUserNamesList',
+          divider: !USER_STATUS_ENABLED,
         });
       }
 
-      this.menuItems.push({
-        key: this.clearStatusId,
-        label: intl.formatMessage(intlMessages.clearAllLabel),
-        description: intl.formatMessage(intlMessages.clearAllDesc),
-        onClick: toggleStatus,
-        icon: 'clear_status',
-        divider: true,
-      });
+      if (USER_STATUS_ENABLED) {
+        this.menuItems.push({
+          key: this.clearStatusId,
+          label: intl.formatMessage(intlMessages.clearAllLabel),
+          description: intl.formatMessage(intlMessages.clearAllDesc),
+          onClick: toggleStatus,
+          icon: 'clear_status',
+          divider: true,
+        });
+      }
 
       if (canCreateBreakout) {
         this.menuItems.push({


### PR DESCRIPTION
### What does this PR do?

Do not display "clear all status icons" action in presenter menu if user status is disabled.

![2023-06-20_17-41](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/c9eb42c3-d052-4ccf-8d6a-3d8d1c81a52e)
