### PR TITLE
fix(presentation): reset slide position if zoom is 100%

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -790,6 +790,7 @@ export default function Whiteboard(props) {
       if (!fitToWidth && camera.zoom === zoomFitSlide) {
         viewedRegionW = HUNDRED_PERCENT;
         viewedRegionH = HUNDRED_PERCENT;
+        camera.point = [0,0];
       }
 
       if (e?.currentPageId == curPageId) {


### PR DESCRIPTION
### What does this PR do?

Fix wrong slide position if zoom is changed back to 100% after being increased.

#### before

https://github.com/bigbluebutton/bigbluebutton/assets/3728706/c36ecffe-dfbf-4098-b174-0ab9e89e6528

#### after

https://github.com/bigbluebutton/bigbluebutton/assets/3728706/c59458f2-cb4e-4784-9f1d-675eda589f28



