### PR TITLE
build: resetting mcs-address from localhost to 127.0.0.1

### DIFF
--- a/build/packages-template/bbb-webrtc-sfu/after-install.sh
+++ b/build/packages-template/bbb-webrtc-sfu/after-install.sh
@@ -43,6 +43,11 @@ case "$1" in
     touch /var/log/bbb-webrtc-sfu/bbb-webrtc-sfu.log
 
     yq w -i $TARGET recordWebcams true
+
+
+    echo "Resetting mcs-address from localhost to 127.0.0.1'
+    yq w -i $TARGET mcs-address 127.0.0.1
+    
     if id bigbluebutton > /dev/null 2>&1 ; then
       chown -R bigbluebutton:bigbluebutton /usr/local/bigbluebutton/bbb-webrtc-sfu /var/log/bbb-webrtc-sfu/
     else


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Resetting mcs-address from localhost to 127.0.0.1
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none


### Motivation
After upgrading system NodeJS from 16 to 18 #18159 `bbb-webrtc-sfu` shows
`Jun 21 11:07:24 droplet-4171 bbb-webrtc-sfu[60316]: {"errorMessage":"connect ECONNREFUSED ::1:3010","label":"video","level":"error","message
":"MCS connection ungracefully terminated: connect ECONNREFUSED ::1:3010","timestamp":"2023-06-21T11:07:24.274Z"}`

Thanks to @lfzawacki for the investigation on why we could not connect.

This can be temporarily resolved with the following two commands :
`# yq w -i /usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml mcs-address 127.0.0.1` (changing from localhost to 127.0.0.1)
`# systemctl restart bbb-webrtc-sfu.service` (restarting the sfu component)


<!-- What inspired you to submit this pull request? -->

### More

This will likely need to be reverted when a better solution is found (likely later alphas of BBB 2.7)
