### PR TITLE
fix: panning with space bar shortcut does not work

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -734,7 +734,8 @@ export default function Whiteboard(props) {
 
     if (reason && isPresenter && slidePosition && (reason.includes('zoomed') || reason.includes('panned'))) {
       const camera = tldrawAPI?.getPageState()?.camera;
-      if (currentCameraPoint[curPageId] && !isPanning) {
+      const isForcePanning = tldrawAPI?.isForcePanning;
+      if (currentCameraPoint[curPageId] && !isPanning && !isForcePanning) {
         camera.point = currentCameraPoint[curPageId];
       }
 


### PR DESCRIPTION
### What does this PR do?

Fix force panning (by pressing space bar) in the whiteboard.