### PR TITLE
chore: Bump Etherpad to 1.9.0

### DIFF
--- a/bbb-etherpad.placeholder.sh
+++ b/bbb-etherpad.placeholder.sh
@@ -1,2 +1,2 @@
-git clone --branch 1.8.17 --depth 1 https://github.com/ether/etherpad-lite bbb-etherpad
+git clone --branch 1.9.0 --depth 1 https://github.com/ether/etherpad-lite bbb-etherpad
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Upgrades `bbb-etherpad` to use Etherpad lite 1.9.0 https://github.com/ether/etherpad-lite/releases/tag/v1.9.0
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none
Related to #

### Motivation
This release is over a year newer than the one we use (1.8.17)
<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->
Note: I've had inconsistent results when building locally -- in several cases there were complaints about using another npm version while installing the dependencies although we specifically set 6.14 to be used (to match the version package-lock.json was generated with).