### PR TITLE
fix: Add dedupe to messages based on referenceId (backport of #18230 from 2.7)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
@@ -19,6 +19,8 @@ const TIME_BETWEEN_FETCHS = CHAT_CONFIG.timeBetweenFetchs;
 const EVENT_NAME = 'bbb-group-chat-messages-subscription-has-stoppped';
 const EVENT_NAME_SUBSCRIPTION_READY = 'bbb-group-chat-messages-subscriptions-ready';
 
+const referenceIds = {};
+
 const getMessagesBeforeJoinCounter = async () => {
   const counter = await makeCall('chatMessageBeforeJoinCounter');
   return counter;
@@ -26,8 +28,11 @@ const getMessagesBeforeJoinCounter = async () => {
 
 const startSyncMessagesbeforeJoin = async (dispatch) => {
   const chatsMessagesCount = await getMessagesBeforeJoinCounter();
-  const pagesPerChat = chatsMessagesCount
-    .map((chat) => ({ ...chat, pages: Math.ceil(chat.count / ITENS_PER_PAGE), syncedPages: 0 }));
+  const pagesPerChat = chatsMessagesCount.map((chat) => ({
+    ...chat,
+    pages: Math.ceil(chat.count / ITENS_PER_PAGE),
+    syncedPages: 0,
+  }));
 
   const syncRoutine = async (chatsToSync) => {
     if (!chatsToSync.length) return;
@@ -35,7 +40,11 @@ const startSyncMessagesbeforeJoin = async (dispatch) => {
     const pagesToFetch = [...chatsToSync].sort((a, b) => a.pages - b.pages);
     const chatWithLessPages = pagesToFetch[0];
     chatWithLessPages.syncedPages += 1;
-    const messagesFromPage = await makeCall('fetchMessagePerPage', chatWithLessPages.chatId, chatWithLessPages.syncedPages);
+    const messagesFromPage = await makeCall(
+      'fetchMessagePerPage',
+      chatWithLessPages.chatId,
+      chatWithLessPages.syncedPages,
+    );
 
     if (messagesFromPage.length) {
       dispatch({
@@ -110,15 +119,19 @@ const Adapter = () => {
     dispatch({
       type: ACTIONS.CLEAR_ALL,
     });
-    const throttledDispatch = _.throttle(() => {
-      const dispatchedMessageQueue = [...messageQueue];
-      messageQueue = [];
-      dispatch({
-        type: ACTIONS.ADDED,
-        value: dispatchedMessageQueue,
-        messageType: MESSAGE_TYPES.STREAM,
-      });
-    }, 1000, { trailing: true, leading: true });
+    const throttledDispatch = _.throttle(
+      () => {
+        const dispatchedMessageQueue = [...messageQueue];
+        messageQueue = [];
+        dispatch({
+          type: ACTIONS.ADDED,
+          value: dispatchedMessageQueue,
+          messageType: MESSAGE_TYPES.STREAM,
+        });
+      },
+      1000,
+      { trailing: true, leading: true },
+    );
 
     const insertToContext = (fields) => {
       if (fields.id === `${SYSTEM_CHAT_TYPE}-${CHAT_CLEAR_MESSAGE}`) {
@@ -127,7 +140,9 @@ const Adapter = () => {
           type: ACTIONS.REMOVED,
         });
       }
+      if (referenceIds[fields.referenceId]) return;
 
+      referenceIds[fields.referenceId] = true;
       messageQueue.push(fields);
       throttledDispatch();
     };

--- a/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/chat-context/adapter.jsx
@@ -19,7 +19,7 @@ const TIME_BETWEEN_FETCHS = CHAT_CONFIG.timeBetweenFetchs;
 const EVENT_NAME = 'bbb-group-chat-messages-subscription-has-stoppped';
 const EVENT_NAME_SUBSCRIPTION_READY = 'bbb-group-chat-messages-subscriptions-ready';
 
-const referenceIds = {};
+let referenceIds = {};
 
 const getMessagesBeforeJoinCounter = async () => {
   const counter = await makeCall('chatMessageBeforeJoinCounter');
@@ -108,6 +108,7 @@ const Adapter = () => {
     if (users[Auth.meetingID] && users[Auth.meetingID][Auth.userID]) {
       if (currentUserData?.role !== users[Auth.meetingID][Auth.userID]?.role) {
         prevUserData = currentUserData;
+        referenceIds = {};
       }
       currentUserData = users[Auth.meetingID][Auth.userID];
     }


### PR DESCRIPTION
### What does this PR do?

This PRs adds dedupe in message insertion to avoid duplicated messages on chat.