### PR TITLE
Heuristic thumbnail selection

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/captions/live/user/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/live/user/component.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import UserAvatar from '/imports/ui/components/user-avatar/component';
+
+const User = ({
+  avatar,
+  background,
+  color,
+  moderator,
+  name,
+}) => (
+  <div
+    style={{
+      background,
+      minHeight: '3.25rem',
+      //padding: '.5rem',
+      textTransform: 'capitalize',
+      //width: '3.25rem',
+    }}
+  >
+    <UserAvatar
+      avatar={avatar}
+      color={color}
+      moderator={moderator}
+    >
+      {name.slice(0, 2)}
+    </UserAvatar>
+  </div>
+);
+
+User.propTypes = {
+  avatar: PropTypes.string.isRequired,
+  background: PropTypes.string.isRequired,
+  color: PropTypes.string.isRequired,
+  moderator: PropTypes.bool.isRequired,
+  name: PropTypes.string.isRequired,
+};
+
+export default User;

--- a/bigbluebutton-html5/imports/ui/components/captions/live/user/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/captions/live/user/container.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { withTracker } from 'meteor/react-meteor-data';
+import Users from '/imports/api/users';
+import User from './component';
+
+const MODERATOR = Meteor.settings.public.user.role_moderator;
+
+const Container = (props) => <User {...props} />;
+
+const getUser = (userId) => {
+  const user = Users.findOne(
+    { userId },
+    {
+      fields: {
+        avatar: 1,
+        color: 1,
+        role: 1,
+        name: 1,
+      },
+    },
+  );
+
+  if (user) {
+    return {
+      avatar: user.avatar,
+      color: user.color,
+      moderator: user.role === MODERATOR,
+      name: user.name,
+    };
+  }
+
+  return {
+    avatar: '',
+    color: '',
+    moderator: false,
+    name: '',
+  };
+};
+
+export default withTracker(({ userId }) => {
+  return getUser(userId);
+})(Container);

--- a/record-and-playback/core/lib/recordandplayback/generators/presentation.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/presentation.rb
@@ -147,7 +147,7 @@ module BigBlueButton
       slide_time = slide_time.sort_by{|_, v| -v} if heuristic_thumbnails
       slide_time.each do |st|
         break if presentation.size > 2
-        p,s = st[0].split(':')
+        p, s = st[0].split(':')
         presentation_filename = presentation_filenames[p]
         next if presentation_filename == "default.pdf"
         textfiles_dir = "#{process_dir}/presentation/#{p}/textfiles"

--- a/record-and-playback/core/lib/recordandplayback/generators/presentation.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/presentation.rb
@@ -110,7 +110,7 @@ module BigBlueButton
     end
 
     # Get from events the presentation that will be used for preview.
-    def self.get_presentation_for_preview(process_dir, heuristic_thumbnails)
+    def self.get_presentation_for_preview(process_dir, heuristic_thumbnails, number_thumbnails)
       events_xml = "#{process_dir}/events.xml"
       BigBlueButton.logger.info("Task: Getting from events the presentation to be used for preview")
       presentation = []
@@ -145,14 +145,15 @@ module BigBlueButton
       end
 
       slide_time = slide_time.sort_by{|_, v| -v} if heuristic_thumbnails
+      BigBlueButton.logger.info("Thumbnail candidates: #{slide_time}")
       slide_time.each do |st|
-        break if presentation.size > 2
+        break if presentation.size >= number_thumbnails
         p, s = st[0].split(':')
         presentation_filename = presentation_filenames[p]
         next if presentation_filename == "default.pdf"
         textfiles_dir = "#{process_dir}/presentation/#{p}/textfiles"
         text_from_slide = self.get_text_from_slide(textfiles_dir, s) if File.file?("#{textfiles_dir}/slide-#{s}.txt")
-        presentation.push({:id => p, :filename => presentation_filename, :i => s, :alt => text_from_slide == nil ? '' : text_from_slide})
+        presentation.push({ :id => p, :filename => presentation_filename, :i => s, :alt => text_from_slide == nil ? '' : text_from_slide, :duration => st[1] })
       end
       presentation
     end

--- a/record-and-playback/presentation/scripts/presentation.yml
+++ b/record-and-playback/presentation/scripts/presentation.yml
@@ -12,7 +12,7 @@ audio_offset: 0
 include_deskshare: true
 
 # generate thumbnails from most viewed slides
-heuristic_thumbnails : true
+heuristic_thumbnails : false
 
 # For PRODUCTION
 publish_dir: /var/bigbluebutton/published/presentation

--- a/record-and-playback/presentation/scripts/presentation.yml
+++ b/record-and-playback/presentation/scripts/presentation.yml
@@ -11,7 +11,7 @@ deskshare_output_framerate: 5
 audio_offset: 0
 include_deskshare: true
 
-# generate thumbnails from most viewed slides
+# Generate thumbnails from most viewed slides
 heuristic_thumbnails: false
 number_thumbnails: 3
 

--- a/record-and-playback/presentation/scripts/presentation.yml
+++ b/record-and-playback/presentation/scripts/presentation.yml
@@ -13,6 +13,7 @@ include_deskshare: true
 
 # generate thumbnails from most viewed slides
 heuristic_thumbnails: false
+number_thumbnails: 3
 
 # For PRODUCTION
 publish_dir: /var/bigbluebutton/published/presentation

--- a/record-and-playback/presentation/scripts/presentation.yml
+++ b/record-and-playback/presentation/scripts/presentation.yml
@@ -11,6 +11,9 @@ deskshare_output_framerate: 5
 audio_offset: 0
 include_deskshare: true
 
+# generate thumbnails from most viewed slides
+heuristic_thumbnails : true
+
 # For PRODUCTION
 publish_dir: /var/bigbluebutton/published/presentation
 video_formats:

--- a/record-and-playback/presentation/scripts/presentation.yml
+++ b/record-and-playback/presentation/scripts/presentation.yml
@@ -12,7 +12,7 @@ audio_offset: 0
 include_deskshare: true
 
 # generate thumbnails from most viewed slides
-heuristic_thumbnails : false
+heuristic_thumbnails: false
 
 # For PRODUCTION
 publish_dir: /var/bigbluebutton/published/presentation

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1388,7 +1388,7 @@ begin
         ## Remove empty playback
         metadata.search('recording/playback').each(&:remove)
         ## Add the actual playback
-        presentation = BigBlueButton::Presentation.get_presentation_for_preview(@process_dir.to_s, @presentation_props['heuristic_thumbnails'])
+        presentation = BigBlueButton::Presentation.get_presentation_for_preview(@process_dir.to_s, @presentation_props['heuristic_thumbnails'], @presentation_props['number_thumbnails'])
         Nokogiri::XML::Builder.with(metadata.at('recording')) do |xml|
           xml.playback do
             xml.format('presentation')
@@ -1400,7 +1400,7 @@ begin
                 xml.preview do
                   xml.images do
                     presentation.each do |p|
-                      attributes = { width: '176', height: '136', alt: p[:alt]&.to_s || '' }
+                      attributes = { width: '176', height: '136', alt: p[:alt]&.to_s || '', duration: p[:duration]/1000 }
                       xml.image(attributes) do
                         xml.text("#{playback_protocol}://#{playback_host}/presentation/#{@meeting_id}/presentation/#{p[:id]}/thumbnails/thumb-#{p[:i]}.png")
                       end

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1388,7 +1388,7 @@ begin
         ## Remove empty playback
         metadata.search('recording/playback').each(&:remove)
         ## Add the actual playback
-        presentation = BigBlueButton::Presentation.get_presentation_for_preview(@process_dir.to_s)
+        presentation = BigBlueButton::Presentation.get_presentation_for_preview(@process_dir.to_s, @presentation_props['heuristic_thumbnails'])
         Nokogiri::XML::Builder.with(metadata.at('recording')) do |xml|
           xml.playback do
             xml.format('presentation')
@@ -1399,10 +1399,10 @@ begin
               xml.extensions do
                 xml.preview do
                   xml.images do
-                    presentation[:slides].each do |key, val|
-                      attributes = { width: '176', height: '136', alt: val[:alt]&.to_s || '' }
+                    presentation.each do |p|
+                      attributes = { width: '176', height: '136', alt: p[:alt]&.to_s || '' }
                       xml.image(attributes) do
-                        xml.text("#{playback_protocol}://#{playback_host}/presentation/#{@meeting_id}/presentation/#{presentation[:id]}/thumbnails/thumb-#{key}.png")
+                        xml.text("#{playback_protocol}://#{playback_host}/presentation/#{@meeting_id}/presentation/#{p[:id]}/thumbnails/thumb-#{p[:i]}.png")
                       end
                     end
                   end


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Heuristically searches thumbnail pictures by checking how long the slides have been recorded (in other words, how much the presenter stayed and explained at that slides). Such slides are considered to be the representative pictures of a presentation.
In addition, some users may want to have more than 3 thumbnails.
For that purpose, I added the two parameters heuristic_thumbnails (default: false) and number_thumbnails (default: 3) in the yml setting file. The chosen thumbnails will be added to the metadata.xml file.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #18221


### Motivation

For now BBB chooses the first three slides without considering their relevance for the lecture. It would be better for students to choose those that are more relevant (heavily explained) slides.

### More

GLv3 does not have the function of presentation thumbnails yet, but there are still some frontends that need them.
