### PR TITLE
Fix: pinning shared notes should restore presentation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.jsx
@@ -141,14 +141,17 @@ const Notes = ({
           value: Session.get('presentationLastState'),
         });
       };
-    } else {
-      if (shouldShowSharedNotesOnPresentationArea) {
-        layoutContextDispatch({
-          type: ACTIONS.SET_NOTES_IS_PINNED,
-          value: true,
-        });
-      }
+    } if (shouldShowSharedNotesOnPresentationArea) {
+      layoutContextDispatch({
+        type: ACTIONS.SET_NOTES_IS_PINNED,
+        value: true,
+      });
+      layoutContextDispatch({
+        type: ACTIONS.SET_PRESENTATION_IS_OPEN,
+        value: true,
+      });
     }
+    return null;
   }, []);
 
   const renderHeaderOnMedia = () => {


### PR DESCRIPTION
### What does this PR do?

This PR fixes the pinning of the shared notes restore presentation.

### Closes Issue(s)

#18040 