### PR TITLE
Remove duplicated muted indicator from grid mode

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-avatar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-avatar/component.jsx
@@ -13,7 +13,6 @@ const UserAvatarVideo = (props) => {
     presenter, clientType,
   } = user;
 
-  const muted = voiceUser?.muted || false;
   const talking = voiceUser?.talking || false;
 
   const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
@@ -41,7 +40,6 @@ const UserAvatarVideo = (props) => {
       avatar={avatar}
       unhealthyStream={unhealthyStream}
       talking={talking}
-      muted={muted}
     >
       {handleUserIcon()}
     </Styled.UserAvatarStyled>


### PR DESCRIPTION
### What does this PR do?

Removes duplicated muted indicator from grid mode avatar.

#### before

![2023-06-27_17-02](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/4996177b-8ddb-43f1-84c4-27c858fd3a1a)

#### after

![2023-06-27_17-01](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/0f0a3309-c479-4ede-942e-c7e9f779a29f)
