### PR TITLE
fix: undo createRoot changes in main

### DIFF
--- a/bigbluebutton-html5/client/main.jsx
+++ b/bigbluebutton-html5/client/main.jsx
@@ -19,7 +19,7 @@
 
 import React from 'react';
 import { Meteor } from 'meteor/meteor';
-import { createRoot } from 'react-dom/client';
+import { render } from 'react-dom';
 import logger from '/imports/startup/client/logger';
 import '/imports/ui/services/mobile-app';
 import Base from '/imports/startup/client/base';
@@ -77,10 +77,8 @@ Meteor.startup(() => {
     }, message);
   });
 
-  const root = createRoot(document.getElementById('app'));
-
   // TODO make this a Promise
-  root.render(
+  render(
     <ContextProviders>
       <>
         <JoinHandler>
@@ -97,5 +95,6 @@ Meteor.startup(() => {
         <GroupChatAdapter />
       </>
     </ContextProviders>,
+    document.getElementById('app'),
   );
 });

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/rating/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/rating/component.jsx
@@ -46,7 +46,7 @@ class Rating extends Component {
         <fieldset>
           <Styled.Legend>{intl.formatMessage(intlMessages.legendTitle)}</Styled.Legend>
           {
-            range(num)
+            range(0, num)
               .map(i => [
                 (
                   <input


### PR DESCRIPTION
### What does this PR do?

replaces [createRoot](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis) with react-dom render

### Closes Issue(s)
Closes #18215
Closes #18224
Closes #18234

### More
A warning is displayed if render is used in react 18:

![react-create-root](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/efd92da7-9be8-41f0-9d99-b194f3faed1c)

