### PR TITLE
fix(timer): sidebar content when activated

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -161,9 +161,9 @@ class ActionsDropdown extends PureComponent {
   }
 
   handleTimerClick() {
-    const { isTimerActive } = this.props;
+    const { isTimerActive, layoutContextDispatch } = this.props;
     if (!isTimerActive) {
-      TimerService.activateTimer();
+      TimerService.activateTimer(layoutContextDispatch);
     } else {
       TimerService.deactivateTimer();
     }

--- a/bigbluebutton-html5/imports/ui/components/timer/service.js
+++ b/bigbluebutton-html5/imports/ui/components/timer/service.js
@@ -93,7 +93,25 @@ const setTimer = (time) => makeCall('setTimer', time);
 
 const resetTimer = () => makeCall('resetTimer');
 
-const activateTimer = () => makeCall('activateTimer');
+const activateTimer = (layoutContextDispatch) => {
+    makeCall('activateTimer');
+    //Set an observer to switch to timer tab as soon as the timer is activated
+    const handle =Timer.find({ meetingId: Auth.meetingID }).observeChanges({
+      changed(id, timer) {
+        if (timer.active === true) {
+          layoutContextDispatch({
+            type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+            value: true,
+          });
+          layoutContextDispatch({
+            type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+            value: PANELS.TIMER,
+          });
+        }
+        handle.stop();
+      }
+    });
+  };
 
 const deactivateTimer = () => makeCall('deactivateTimer');
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/timer/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/timer/component.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
 import Icon from '/imports/ui/components/common/icon/component';
 import TimerService from '/imports/ui/components/timer/service';
-import { PANELS, ACTIONS } from '../../../layout/enums';
 import Styled from './styles';
 
 const propTypes = {
@@ -32,18 +31,6 @@ const intlMessages = defineMessages({
 });
 
 class Timer extends PureComponent {
-  componentDidMount() {
-    const { layoutContextDispatch } = this.props;
-    layoutContextDispatch({
-      type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
-      value: true,
-    });
-    layoutContextDispatch({
-      type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
-      value: PANELS.TIMER,
-    });
-  }
-
   render() {
     const {
       intl,


### PR DESCRIPTION
### What does this PR do?

Changes the behavior of activating the timer. The behavior set by this commit is: when the timer is activated, only the moderator who triggered it will see the sidebar content switch to the timer. This change required hanging an observer to catch the timer activation and dispatch the sidebar content change since timer messages are passing through akka.

### Closes Issue(s)

Closes #18251
