### PR TITLE
Update install.md, Hetzner AX51 are not available any more. Use AX52 instead.

### DIFF
--- a/docs/docs/administration/install.md
+++ b/docs/docs/administration/install.md
@@ -32,7 +32,7 @@ For production, we recommend the following minimum requirements
 - A hostname (such as bbb.example.com) for setup of a SSL certificate
 - IPV4 and IPV6 address
 
-If you install BigBlueButton on a virtual machine in the cloud, we recommend you choose an instance type that has dedicated CPU.  These are usually called "compute-intensive" instances.  On Digital Ocean we recommend the c-8 compute intensive instances (or larger). On AWS we recommend c5a.2xlarge (or larger).  On Hetzner we recommend the AX51 servers or CCX32 instances.
+If you install BigBlueButton on a virtual machine in the cloud, we recommend you choose an instance type that has dedicated CPU.  These are usually called "compute-intensive" instances.  On Digital Ocean we recommend the c-8 compute intensive instances (or larger). On AWS we recommend c5a.2xlarge (or larger).  On Hetzner we recommend the AX52 servers or CCX32 instances.
 
 If you are setting up BigBlueButton for local development on your workstation, you can relax some of the above requirements as there will only be few users on the server. Starting with the above requirements, you can reduce them as follows
 


### PR DESCRIPTION
### What does this PR do?

Updates install.md documentation related to suggested server examples, Hetzner AX51 are not available any more. Use AX52 instead (AMD Ryzen 7700).

### Motivation

Docs should not point to server size which is not available any more.

### More

See https://www.hetzner.com/dedicated-rootserver/matrix-ax