### PR TITLE
fix: Whiteboard Crash When Switching Between Zoomed-In Slides

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -528,9 +528,9 @@ export default function Whiteboard(props) {
   // Reset zoom to default when current presentation changes.
   React.useEffect(() => {
     if (isPresenter && slidePosition && tldrawAPI) {
-      tldrawAPI.zoomTo(0);
+      tldrawAPI?.zoomTo(0);
       setHistory(null);
-      tldrawAPI.resetHistory();
+      tldrawAPI?.resetHistory();
     }
   }, [curPres?.id]);
 
@@ -930,8 +930,8 @@ export default function Whiteboard(props) {
 
     if (command && command?.id?.includes('change_page')) {
       const camera = tldrawAPI?.getPageState()?.camera;
-      if (currentCameraPoint[app?.currentPageId]) {
-        tldrawAPI?.setCamera([currentCameraPoint[app?.currentPageId][0], currentCameraPoint[app?.currentPageId][1]], camera.zoom);
+      if (currentCameraPoint[app?.currentPageId] && camera) {
+        tldrawAPI?.setCamera([currentCameraPoint[app?.currentPageId][0], currentCameraPoint[app?.currentPageId][1]], camera?.zoom);
       }
     }
 


### PR DESCRIPTION
### What does this PR do?
This PR resolves a bug causing the whiteboard to crash when switching between between presentation with zoomed-in slides. The fix involves a null check for the 'camera' object before attempting to access its 'zoom' property.

### Closes Issue(s)
Closes #18231 