### PR TITLE
Client: self-view disabled changed, overlay over avatar.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-nested-ternary */
 import React, { useEffect, useRef, useState } from 'react';
-import { injectIntl, defineMessages, useIntl } from 'react-intl';
+import { injectIntl, useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import UserActions from '/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component';
 import UserStatus from '/imports/ui/components/video-provider/video-list/video-list-item/user-status/component';
@@ -18,22 +18,14 @@ import Styled from './styles';
 import { withDragAndDrop } from './drag-and-drop/component';
 import Auth from '/imports/ui/services/auth';
 
-const intlMessages = defineMessages({
-  disableDesc: {
-    id: 'app.videoDock.webcamDisableDesc',
-  },
-});
-
 const VIDEO_CONTAINER_WIDTH_BOUND = 125;
 
 const VideoListItem = (props) => {
   const {
     name, voiceUser, isFullscreenContext, layoutContextDispatch, user, onHandleVideoFocus,
-    cameraId, numOfStreams, focused, onVideoItemMount, onVideoItemUnmount, onVirtualBgDrop,
-    makeDragOperations, dragging, draggingOver, isRTL, isStream, settingsSelfViewDisable, 
+    cameraId, numOfStreams, focused, onVideoItemMount, onVideoItemUnmount,
+    makeDragOperations, dragging, draggingOver, isRTL, isStream, settingsSelfViewDisable,
   } = props;
-
-  const intl = useIntl();
 
   const [videoDataLoaded, setVideoDataLoaded] = useState(false);
   const [isStreamHealthy, setIsStreamHealthy] = useState(false);
@@ -232,12 +224,9 @@ const VideoListItem = (props) => {
       }}
     >
 
-      <Styled.VideoContainer>
-        {isStream && isSelfViewDisabled && user.userId === Auth.userID && (
-          <Styled.VideoDisabled>
-            {intl.formatMessage(intlMessages.disableDesc)}
-          </Styled.VideoDisabled>
-        )}
+      <Styled.VideoContainer
+        $selfViewDisabled={isSelfViewDisabled}
+      >
         <Styled.Video
           mirrored={isMirrored}
           unhealthyStream={videoDataLoaded && !isStreamHealthy}
@@ -257,7 +246,7 @@ const VideoListItem = (props) => {
       {!videoIsReady && (!isSelfViewDisabled || !isStream) && (
         isVideoSqueezed ? renderWebcamConnectingSqueezed() : renderWebcamConnecting()
       )}
-
+      {isSelfViewDisabled && renderWebcamConnecting()}
     </Styled.Content>
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-nested-ternary */
 import React, { useEffect, useRef, useState } from 'react';
-import { injectIntl, useIntl } from 'react-intl';
+import { injectIntl, defineMessages, useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import UserActions from '/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component';
 import UserStatus from '/imports/ui/components/video-provider/video-list/video-list-item/user-status/component';
@@ -18,6 +18,12 @@ import Styled from './styles';
 import { withDragAndDrop } from './drag-and-drop/component';
 import Auth from '/imports/ui/services/auth';
 
+const intlMessages = defineMessages({
+  disableDesc: {
+    id: 'app.videoDock.webcamDisableDesc',
+  },
+});
+
 const VIDEO_CONTAINER_WIDTH_BOUND = 125;
 
 const VideoListItem = (props) => {
@@ -26,6 +32,8 @@ const VideoListItem = (props) => {
     cameraId, numOfStreams, focused, onVideoItemMount, onVideoItemUnmount,
     makeDragOperations, dragging, draggingOver, isRTL, isStream, settingsSelfViewDisable,
   } = props;
+
+  const intl = useIntl();
 
   const [videoDataLoaded, setVideoDataLoaded] = useState(false);
   const [isStreamHealthy, setIsStreamHealthy] = useState(false);
@@ -224,9 +232,12 @@ const VideoListItem = (props) => {
       }}
     >
 
-      <Styled.VideoContainer
-        $selfViewDisabled={isSelfViewDisabled}
-      >
+      <Styled.VideoContainer>
+        {isStream && isSelfViewDisabled && user.userId === Auth.userID && (
+          <Styled.VideoDisabled>
+            {intl.formatMessage(intlMessages.disableDesc)}
+          </Styled.VideoDisabled>
+        )}
         <Styled.Video
           mirrored={isMirrored}
           unhealthyStream={videoDataLoaded && !isStreamHealthy}
@@ -255,9 +266,9 @@ export default withDragAndDrop(injectIntl(VideoListItem));
 
 VideoListItem.defaultProps = {
   numOfStreams: 0,
-  onVideoItemMount: () => {},
-  onVideoItemUnmount: () => {},
-  onVirtualBgDrop: () => {},
+  onVideoItemMount: () => { },
+  onVideoItemUnmount: () => { },
+  onVirtualBgDrop: () => { },
 };
 
 VideoListItem.propTypes = {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/styles.js
@@ -119,6 +119,8 @@ const VideoContainer = styled.div`
   justify-content: center;
   width: 100%;
   height: 100%;
+
+  ${({ $selfViewDisabled }) => $selfViewDisabled && 'display: none'}
 `;
 
 const Video = styled.video`

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/styles.js
@@ -91,6 +91,7 @@ const WebcamConnecting = styled.div`
   min-width: 100%;
   border-radius: 10px;
   background-color: ${webcamBackgroundColor};
+  scale: 1.5;
   z-index: 0;
 
   &::after {
@@ -152,6 +153,9 @@ color: white;
   border-radius: 10px;
   z-index: 2;
   top: 40%;
+  transform: translate(-50%, -50%);
+  top: 50%;
+  left: 50%;
   padding: 20px;
   backdrop-filter: blur(10px); 
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
### What does this PR do?

This PR changes the way self-view disabling behaves, showing now the avatar when self-view is disabled, instead of last frame.

### Closes Issue(s)

#18217

Example: 
![selfviewavatar](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/2926eb2d-ab62-4f14-8211-1a494c8276a6)
