### PR TITLE
refactor (graphql-server): Implements connection status control through graphql

### DIFF
--- a/bbb-graphql-client-test/src/App.js
+++ b/bbb-graphql-client-test/src/App.js
@@ -20,6 +20,8 @@ import CursorsAll from "./CursorsAll";
 import TalkingStream from "./TalkingStream";
 import MyInfo from "./MyInfo";
 import UserLocalSettings from "./UserLocalSettings";
+import UserConnectionStatus from "./UserConnectionStatus";
+import UserConnectionStatusReport from "./UserConnectionStatusReport";
 
 
 function App() {
@@ -105,6 +107,10 @@ function App() {
             <MeetingInfo />
             <br />
             <MyInfo />
+            <br />
+            <UserConnectionStatus />
+            <br />
+            <UserConnectionStatusReport />
             <br />
             <UserLocalSettings userId={userId} />
             <br />

--- a/bbb-graphql-client-test/src/TotalOfUsersTalking.js
+++ b/bbb-graphql-client-test/src/TotalOfUsersTalking.js
@@ -4,7 +4,7 @@ import React, { useState } from "react";
 export default function TotalOfUsersTalking() {
   const { loading, error, data } = useSubscription(
       gql`subscription {
-      user(where: {voices: {talking: {_eq: true}}}) {
+      user(where: {voice: {talking: {_eq: true}}}) {
         userId
       }
     }`

--- a/bbb-graphql-client-test/src/UserConnectionStatus.js
+++ b/bbb-graphql-client-test/src/UserConnectionStatus.js
@@ -1,0 +1,125 @@
+import {gql, useMutation, useSubscription} from '@apollo/client';
+import React, {useEffect} from "react";
+import {applyPatch} from "fast-json-patch";
+
+export default function UserConnectionStatus() {
+
+    //example specifying where and time (new Date().toISOString())
+    //but its not necessary
+    // const [updateConnectionAliveAt] = useMutation(gql`
+    //   mutation UpdateConnectionAliveAt($userId: String, $connectionAliveAt: timestamp) {
+    //     update_user_connectionStatus(
+    //         where: { userId: { _eq: $userId } },
+    //         _set: { connectionAliveAt: $connectionAliveAt }
+    //       ) {
+    //         affected_rows
+    //       }
+    //   }
+    // `);
+
+
+    //where is not necessary once user can update only its own status
+    //Hasura accepts "now()" as value to timestamp fields
+    const [updateUserClientResponseAtToMeAsNow] = useMutation(gql`
+      mutation UpdateConnectionAliveAt($userId: String, $userClientResponseAt: timestamp) {
+        update_user_connectionStatus(
+            where: {userClientResponseAt: {_is_null: true}}
+            _set: { userClientResponseAt: "now()" }
+          ) {
+            affected_rows
+          }
+      }
+    `);
+
+    const handleUpdateUserClientResponseAt = () => {
+        updateUserClientResponseAtToMeAsNow();
+    };
+
+
+    const [updateConnectionAliveAtToMeAsNow] = useMutation(gql`
+      mutation UpdateConnectionAliveAt($userId: String, $connectionAliveAt: timestamp) {
+        update_user_connectionStatus(
+            where: {},
+            _set: { connectionAliveAt: "now()" }
+          ) {
+            affected_rows
+          }
+      }
+    `);
+
+    const handleUpdateConnectionAliveAt = () => {
+        updateConnectionAliveAtToMeAsNow();
+
+        setTimeout(() => {
+            handleUpdateConnectionAliveAt();
+        }, 5000);
+    };
+
+    useEffect(() => {
+        handleUpdateConnectionAliveAt();
+    }, []);
+
+
+
+  const { loading, error, data } = useSubscription(
+    gql`subscription {
+      user_connectionStatus {
+        connectionAliveAt
+        userClientResponseAt
+        rttInMs
+        status
+        statusUpdatedAt
+      }
+    }`
+  );
+
+  return  !loading && !error &&
+    (<table border="1">
+      <thead>
+        <tr>
+            <th colSpan={3}>Connection Status</th>
+        </tr>
+        <tr>
+            {/*<th>Id</th>*/}
+            <th>connectionAliveAt</th>
+            <th>userClientResponseAt</th>
+            <th>rttInMs</th>
+            <th>status</th>
+            <th>statusUpdatedAt</th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.user_connectionStatus.map((curr) => {
+            console.log('user_connectionStatus', curr);
+
+            // if(curr.userClientResponseAt == null) {
+            //     handleUpdateConnectionAliveAt();
+            // }
+
+            if(curr.userClientResponseAt == null) {
+                console.log('entrou!');
+                console.log('curr.connectionAliveAt',curr.connectionAliveAt);
+                console.log('curr.userClientResponseAt',curr.userClientResponseAt);
+                // handleUpdateUserClientResponseAt();
+                const delay = 500;
+                setTimeout(() => {
+                    handleUpdateUserClientResponseAt();
+                },delay);
+            }
+
+          return (
+              <tr key={curr.connectionAliveAt}>
+                  <td>{curr.connectionAliveAt}
+                      <button onClick={() => handleUpdateConnectionAliveAt()}>Update now!</button>
+                  </td>
+                  <td>{curr.userClientResponseAt}</td>
+                  <td>{curr.rttInMs}</td>
+                  <td>{curr.status}</td>
+                  <td>{curr.statusUpdatedAt}</td>
+              </tr>
+          );
+        })}
+      </tbody>
+    </table>);
+}
+

--- a/bbb-graphql-client-test/src/UserConnectionStatusReport.js
+++ b/bbb-graphql-client-test/src/UserConnectionStatusReport.js
@@ -1,0 +1,49 @@
+import {gql, useMutation, useSubscription} from '@apollo/client';
+import React, {useEffect} from "react";
+import {applyPatch} from "fast-json-patch";
+
+export default function UserConnectionStatusReport() {
+
+  const { loading, error, data } = useSubscription(
+    gql`subscription {
+          user_connectionStatusReport {
+            user {
+              userId
+              name
+            }
+            clientNotResponding
+            lastUnstableStatus
+            lastUnstableStatusAt
+          }
+        }`
+  );
+
+  return  !loading && !error &&
+    (<table border="1">
+      <thead>
+        <tr>
+            <th colSpan={3}>Connection Status</th>
+        </tr>
+        <tr>
+            <th>name</th>
+            <th>clientNotResponding</th>
+            <th>lastUnstableStatus</th>
+            <th>lastUnstableStatusAt</th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.user_connectionStatusReport.map((curr) => {
+            console.log('user_connectionStatusReport', curr);
+          return (
+              <tr key={curr.user.userId}>
+                  <td>{curr.user.name}</td>
+                  <td>{curr.clientNotResponding ? 'True' : 'False'}</td>
+                  <td>{curr.lastUnstableStatus}</td>
+                  <td>{curr.lastUnstableStatusAt}</td>
+              </tr>
+          );
+        })}
+      </tbody>
+    </table>);
+}
+

--- a/bbb-graphql-client-test/src/UserList.js
+++ b/bbb-graphql-client-test/src/UserList.js
@@ -1,4 +1,4 @@
-import {useSubscription, gql, useMutation} from '@apollo/client';
+import {gql} from '@apollo/client';
  import React, { useState } from "react";
 import usePatchedSubscription from "./usePatchedSubscription";
 
@@ -19,44 +19,6 @@ const ParentOfUserList = ({userId}) => {
 }
 
 function UserList({userId}) {
-
-    //example specifying where and time (new Date().toISOString())
-    //but its not necessary
-    // const [updateConnectionAliveAt] = useMutation(gql`
-    //   mutation UpdateConnectionAliveAt($userId: String, $connectionAliveAt: timestamp) {
-    //     update_user_connectionStatus(
-    //         where: { userId: { _eq: $userId } },
-    //         _set: { connectionAliveAt: $connectionAliveAt }
-    //       ) {
-    //         affected_rows
-    //       }
-    //   }
-    // `);
-
-    //where is not necessary once user can update only its own status
-    //Hasura accepts "now()" as value to timestamp fields
-    const [updateConnectionAliveAtToMeAsNow] = useMutation(gql`
-      mutation UpdateConnectionAliveAt($userId: String, $connectionAliveAt: timestamp) {
-        update_user_connectionStatus(
-            where: {},
-            _set: { connectionAliveAt: "now()" }
-          ) {
-            affected_rows
-          }
-      }
-    `);
-
-    const handleUpdateConnectionAliveAt = (userId) => {
-        // updateConnectionAliveAt({
-        //     variables: {
-        //         userId,
-        //         connectionAliveAt: new Date().toISOString()
-        //     },
-        // });
-
-        updateConnectionAliveAtToMeAsNow();
-    };
-
   const { loading, error, data } = usePatchedSubscription(
     gql`subscription {
       user(limit: 50, order_by: [
@@ -156,13 +118,7 @@ function UserList({userId}) {
                   <td style={{backgroundColor: user.lastBreakoutRoom?.currentlyInRoom === true ? '#A0DAA9' : ''}}>
                       {user.lastBreakoutRoom?.shortName}{user.lastBreakoutRoom?.currentlyInRoom === true ? ' (Online)' : ''}
                   </td>
-                  <td>
-                      {user?.connectionStatus?.connectionAliveAt}
-                      <br />
-                      { user?.userId === userId ? <button onClick={() => handleUpdateConnectionAliveAt(user.userId)}>Update now!</button>
-                       : ''
-                      }
-                  </td>
+                  <td>{user?.connectionStatus?.connectionAliveAt}</td>
                   <td style={{backgroundColor: user.disconnected === true ? '#A0DAA9' : ''}}>{user.disconnected === true ? 'Yes' : 'No'}</td>
                   <td style={{backgroundColor: user.loggedOut === true ? '#A0DAA9' : ''}}>{user.loggedOut === true ? 'Yes' : 'No'}</td>
               </tr>

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_user_connectionStatus.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_user_connectionStatus.yaml
@@ -17,8 +17,10 @@ select_permissions:
       columns:
         - connectionAliveAt
         - meetingId
+        - rttInMs
         - status
         - statusUpdatedAt
+        - userClientResponseAt
         - userId
       filter:
         _and:
@@ -31,8 +33,7 @@ update_permissions:
     permission:
       columns:
         - connectionAliveAt
-        - status
-        - statusUpdatedAt
+        - userClientResponseAt
       filter:
         _and:
           - meetingId:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_connectionStatusReport.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_connectionStatusReport.yaml
@@ -1,0 +1,34 @@
+table:
+  name: v_user_connectionStatusReport
+  schema: public
+configuration:
+  column_config: {}
+  custom_column_names: {}
+  custom_name: user_connectionStatusReport
+  custom_root_fields: {}
+object_relationships:
+  - name: user
+    using:
+      manual_configuration:
+        column_mapping:
+          userId: userId
+        insertion_order: null
+        remote_table:
+          name: v_user_ref
+          schema: public
+select_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - clientNotResponding
+        - connectionAliveAt
+        - currentStatus
+        - lastUnstableStatus
+        - lastUnstableStatusAt
+        - userId
+      filter:
+        _or:
+          - userId:
+              _eq: X-Hasura-UserId
+          - meetingId:
+              _eq: X-Hasura-ModeratorInMeeting

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -32,6 +32,7 @@
 - "!include public_v_user.yaml"
 - "!include public_v_user_breakoutRoom.yaml"
 - "!include public_v_user_camera.yaml"
+- "!include public_v_user_connectionStatusReport.yaml"
 - "!include public_v_user_current.yaml"
 - "!include public_v_user_customParameter.yaml"
 - "!include public_v_user_guest.yaml"


### PR DESCRIPTION
Each client will need to update its `connectionAliveAt` prop each 10 seconds:
```
mutation UpdateConnectionAliveAt($userId: String, $connectionAliveAt: timestamp) {
        update_user_connectionStatus(
            where: {},
            _set: { connectionAliveAt: "now()" }
          ) {
            affected_rows
          }
      }
```
When the prop `connectionAliveAt` is updated, the server automatically set `userClientResponseAt=null`.
Once the client check that the prop `userClientResponseAt` is `null`. The client will update this prop:
```
mutation UpdateConnectionAliveAt($userId: String, $userClientResponseAt: timestamp) {
        update_user_connectionStatus(
            where: {userClientResponseAt: {_is_null: true}}
            _set: { userClientResponseAt: "now()" }
          ) {
            affected_rows
          }
      }
```

Using both fields the server will be able to calculate the client rtt `rtt = userClientResponseAt - connectionAliveAt`.
And then define the `status` of this client:
```
"newStatus" := CASE WHEN COALESCE("newRttInMs",0) > 2000 THEN 'critical'
	   					WHEN COALESCE("newRttInMs",0) > 1000 THEN 'danger'
	   					WHEN COALESCE("newRttInMs",0) > 500 THEN 'warning'
	   					ELSE 'normal' END;
```

- Report query
```
subscription {
  user_connectionStatusReport {
    user {
      userId
      name
    }
    clientNotResponding
    lastUnstableStatus
    lastUnstableStatusAt
  }
}
```