### PR TITLE
Preserve pinned notes after screenshare

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
+import { Session } from 'meteor/session';
 import FullscreenButtonContainer from '/imports/ui/components/common/fullscreen-button/container';
 import SwitchButtonContainer from './switch-button/container';
 import Styled from './styles';
@@ -117,6 +118,7 @@ class ScreenshareComponent extends React.Component {
       layoutContextDispatch,
       intl,
       isPresenter,
+      isSharedNotesPinned,
     } = this.props;
 
     screenshareHasStarted(isPresenter);
@@ -140,6 +142,7 @@ class ScreenshareComponent extends React.Component {
         value: true,
       });
     }
+    Session.set('pinnedNotesLastState', isSharedNotesPinned);
   }
 
   componentDidUpdate(prevProps) {
@@ -155,6 +158,7 @@ class ScreenshareComponent extends React.Component {
       fullscreenContext,
       layoutContextDispatch,
       toggleSwapLayout,
+      pinSharedNotes,
     } = this.props;
     screenshareHasEnded();
     window.removeEventListener('screensharePlayFailed', this.handlePlayElementFailed);
@@ -186,6 +190,8 @@ class ScreenshareComponent extends React.Component {
       type: ACTIONS.SET_PRESENTATION_IS_OPEN,
       value: Session.get('presentationLastState'),
     });
+
+    pinSharedNotes(Session.get('pinnedNotesLastState'));
   }
 
   clearMediaFlowingMonitor() {

--- a/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
@@ -11,6 +11,7 @@ import getFromUserSettings from '/imports/ui/services/users-settings';
 import { UsersContext } from '/imports/ui/components/components-data/users-context/context';
 import { shouldEnableVolumeControl } from './service';
 import MediaService from '/imports/ui/components/media/service';
+import NotesService from '/imports/ui/components/notes/service';
 
 const ScreenshareContainer = (props) => {
   const screenShare = layoutSelectOutput((i) => i.screenShare);
@@ -53,5 +54,7 @@ export default withTracker(() => {
     toggleSwapLayout: MediaService.toggleSwapLayout,
     hidePresentationOnJoin: getFromUserSettings('bbb_hide_presentation_on_join', LAYOUT_CONFIG.hidePresentationOnJoin),
     enableVolumeControl: shouldEnableVolumeControl(),
+    isSharedNotesPinned: MediaService.shouldShowSharedNotes(),
+    pinSharedNotes: NotesService.pinSharedNotes,
   };
 })(ScreenshareContainer);


### PR DESCRIPTION
### What does this PR do?

Restores pinned shared notes when screenshare ends.

### Closes Issue(s)
Closes #18220