### PR TITLE
chore: Bump Etherpad to 1.9.1

### DIFF
--- a/bbb-etherpad.placeholder.sh
+++ b/bbb-etherpad.placeholder.sh
@@ -1,2 +1,2 @@
-git clone --branch 1.8.17 --depth 1 https://github.com/ether/etherpad-lite bbb-etherpad
+git clone --branch 1.9.1 --depth 1 https://github.com/ether/etherpad-lite bbb-etherpad
 

--- a/build/packages-template/bbb-etherpad/settings.json
+++ b/build/packages-template/bbb-etherpad/settings.json
@@ -220,9 +220,10 @@
   */
 
   /*
-   * The default text of a pad
-   */
-  "defaultPadText" : "",
+  * The default text of a pad: A zero-width-space is used to work around an issue with Etherpad 1.9.1 where empty pads are not being created.
+  * See: https://github.com/ether/etherpad-lite/issues/5787
+  */
+   "defaultPadText" : "\u200b",
 
   /*
    * Default Pad behavior.


### PR DESCRIPTION
### What does this PR do?
This PR upgrades `bbb-etherpad` to use Etherpad 1.9.1.

### Motivation
The current release (1.8.17) is over a year old.

### More
There's a known bug in Etherpad 1.9.1 that prevents empty pads from being created through the HTTP API. This results in a "You do not have permission to access this pad" message being shown to the shared notes user. To work around this issue, the pad's default text is set to a zero-width space character. For more information, see the [relevant Etherpad issue](https://github.com/ether/etherpad-lite/issues/5787).

In Etherpad 1.9.1, serializing the Pad object with `JSON.stringify()` removes the `id` attribute of the pad since it implements its own `toJSON` method (see https://github.com/ether/etherpad-lite/issues/5814). As a workaround, a `padId` attribute is manually added in such cases. The lack of a `padId` breaks BBB's captions and ability to bring back notes from breakout rooms.

Hence, the following changes have to be in place before merging this PR:

- `ep_redis_publisher`: https://github.com/mconf/ep_redis_publisher/pull/7 
- `bbb-pads`:  https://github.com/bigbluebutton/bbb-pads/pull/26