### PR TITLE
refactor (graphql-middleware): Use RWMutex to improve performance

### DIFF
--- a/bbb-graphql-middleware/internal/common/types.go
+++ b/bbb-graphql-middleware/internal/common/types.go
@@ -30,7 +30,7 @@ type BrowserConnection struct {
 	SessionToken             string                         // session token of this connection
 	Context                  context.Context                // browser connection context
 	ActiveSubscriptions      map[string]GraphQlSubscription // active subscriptions of this connection (start, but no stop)
-	ActiveSubscriptionsMutex sync.Mutex                     // mutex to control the map usage
+	ActiveSubscriptionsMutex sync.RWMutex                   // mutex to control the map usage
 	ConnectionInitMessage    interface{}                    // init message received in this connection (to be used on hasura reconnect)
 	HasuraConnection         *HasuraConnection              // associated hasura connection
 	Disconnected             bool                           // indicate if the connection is gone

--- a/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
@@ -30,15 +30,16 @@ func HasuraConnectionReader(hc *common.HasuraConnection, fromHasuraToBrowserChan
 		log.Tracef("received from hasura: %v", message)
 
 		var messageAsMap = message.(map[string]interface{})
+
 		if messageAsMap != nil {
 			var messageType = messageAsMap["type"]
 			var queryId, _ = messageAsMap["id"].(string)
 
 			//Check if subscription is still active!
 			if queryId != "" {
-				hc.Browserconn.ActiveSubscriptionsMutex.Lock()
+				hc.Browserconn.ActiveSubscriptionsMutex.RLock()
 				subscription, ok := hc.Browserconn.ActiveSubscriptions[queryId]
-				hc.Browserconn.ActiveSubscriptionsMutex.Unlock()
+				hc.Browserconn.ActiveSubscriptionsMutex.RUnlock()
 				if !ok {
 					log.Debugf("Subscription with Id %s doesn't exist anymore, skiping response.", queryId)
 					return
@@ -46,9 +47,9 @@ func HasuraConnectionReader(hc *common.HasuraConnection, fromHasuraToBrowserChan
 
 				//When Hasura send msg type "complete", this query is finished
 				if messageType == "complete" {
-					hc.Browserconn.ActiveSubscriptionsMutex.Lock()
+					hc.Browserconn.ActiveSubscriptionsMutex.RLock()
 					delete(hc.Browserconn.ActiveSubscriptions, queryId)
-					hc.Browserconn.ActiveSubscriptionsMutex.Unlock()
+					hc.Browserconn.ActiveSubscriptionsMutex.RUnlock()
 					log.Infof("Subscription with Id %s finished by Hasura.", queryId)
 				}
 

--- a/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
@@ -47,9 +47,9 @@ func HasuraConnectionReader(hc *common.HasuraConnection, fromHasuraToBrowserChan
 
 				//When Hasura send msg type "complete", this query is finished
 				if messageType == "complete" {
-					hc.Browserconn.ActiveSubscriptionsMutex.RLock()
+					hc.Browserconn.ActiveSubscriptionsMutex.Lock()
 					delete(hc.Browserconn.ActiveSubscriptions, queryId)
-					hc.Browserconn.ActiveSubscriptionsMutex.RUnlock()
+					hc.Browserconn.ActiveSubscriptionsMutex.Unlock()
 					log.Infof("Subscription with Id %s finished by Hasura.", queryId)
 				}
 

--- a/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
@@ -83,9 +83,9 @@ RangeLoop:
 
 				if fromBrowserMessageAsMap["type"] == "stop" {
 					var queryId = fromBrowserMessageAsMap["id"].(string)
-					browserConnection.ActiveSubscriptionsMutex.Lock()
+					browserConnection.ActiveSubscriptionsMutex.RLock()
 					jsonPatchSupported := browserConnection.ActiveSubscriptions[queryId].JsonPatchSupported
-					browserConnection.ActiveSubscriptionsMutex.Unlock()
+					browserConnection.ActiveSubscriptionsMutex.RUnlock()
 					if jsonPatchSupported {
 						msgpatch.RemoveConnSubscriptionCacheFile(browserConnection, queryId)
 					}

--- a/bbb-graphql-middleware/internal/hascli/replayer/replayer.go
+++ b/bbb-graphql-middleware/internal/hascli/replayer/replayer.go
@@ -8,12 +8,12 @@ import (
 func ReplaySubscriptionStartMessages(hc *common.HasuraConnection, fromBrowserChannel chan interface{}) {
 	log := log.WithField("_routine", "ReplaySubscriptionStartMessages").WithField("browserConnectionId", hc.Browserconn.Id).WithField("hasuraConnectionId", hc.Id)
 
-	hc.Browserconn.ActiveSubscriptionsMutex.Lock()
+	hc.Browserconn.ActiveSubscriptionsMutex.RLock()
 	for _, subscription := range hc.Browserconn.ActiveSubscriptions {
 		if subscription.LastSeenOnHasuraConnetion != hc.Id {
 			log.Tracef("replaying subscription start: %v", subscription.Message)
 			fromBrowserChannel <- subscription.Message
 		}
 	}
-	hc.Browserconn.ActiveSubscriptionsMutex.Unlock()
+	hc.Browserconn.ActiveSubscriptionsMutex.RUnlock()
 }

--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -22,7 +22,7 @@ var bufferSize = 100
 
 // active browser connections
 var BrowserConnections = make(map[string]*common.BrowserConnection)
-var BrowserConnectionsMutex = &sync.Mutex{}
+var BrowserConnectionsMutex = &sync.RWMutex{}
 
 // Handle client connection
 // This is the connection that comes from browser
@@ -85,7 +85,7 @@ func ConnectionHandler(w http.ResponseWriter, r *http.Request) {
 			default:
 				{
 					log.Printf("creating hasura client")
-					BrowserConnectionsMutex.Lock()
+					BrowserConnectionsMutex.RLock()
 					thisBrowserConnection := BrowserConnections[browserConnectionId]
 					BrowserConnectionsMutex.Unlock()
 					if thisBrowserConnection != nil {

--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -87,7 +87,7 @@ func ConnectionHandler(w http.ResponseWriter, r *http.Request) {
 					log.Printf("creating hasura client")
 					BrowserConnectionsMutex.RLock()
 					thisBrowserConnection := BrowserConnections[browserConnectionId]
-					BrowserConnectionsMutex.Unlock()
+					BrowserConnectionsMutex.RUnlock()
 					if thisBrowserConnection != nil {
 						hascli.HasuraClient(thisBrowserConnection, r.Cookies(), fromBrowserChannel1, toBrowserChannel)
 					}

--- a/bbb-graphql-middleware/internal/websrv/invalidator/invalidator.go
+++ b/bbb-graphql-middleware/internal/websrv/invalidator/invalidator.go
@@ -60,7 +60,7 @@ func BrowserConnectionInvalidator() {
 					}
 				}
 			}
-			websrv.BrowserConnectionsMutex.Unlock()
+			websrv.BrowserConnectionsMutex.RUnlock()
 		}
 	}
 }

--- a/bbb-graphql-middleware/internal/websrv/invalidator/invalidator.go
+++ b/bbb-graphql-middleware/internal/websrv/invalidator/invalidator.go
@@ -50,7 +50,7 @@ func BrowserConnectionInvalidator() {
 			sessionTokenToInvalidate := messageBodyAsMap["sessionToken"]
 			log.Infof("Received invalidate request for sessionToken %v", sessionTokenToInvalidate)
 
-			websrv.BrowserConnectionsMutex.Lock()
+			websrv.BrowserConnectionsMutex.RLock()
 			for _, browserConnection := range websrv.BrowserConnections {
 				if browserConnection.SessionToken == sessionTokenToInvalidate {
 					if browserConnection.HasuraConnection != nil {

--- a/bbb-graphql-middleware/internal/websrv/sessiontokenreader.go
+++ b/bbb-graphql-middleware/internal/websrv/sessiontokenreader.go
@@ -14,7 +14,7 @@ func SessionTokenReader(connectionId string, browserConnectionContext context.Co
 
 	BrowserConnectionsMutex.RLock()
 	browserConnection := BrowserConnections[connectionId]
-	BrowserConnectionsMutex.Unlock()
+	BrowserConnectionsMutex.RUnlock()
 
 	// Intercept the fromBrowserMessage channel to get the sessionToken
 	for fromBrowserMessage := range fromBrowser {

--- a/bbb-graphql-middleware/internal/websrv/sessiontokenreader.go
+++ b/bbb-graphql-middleware/internal/websrv/sessiontokenreader.go
@@ -12,7 +12,7 @@ func SessionTokenReader(connectionId string, browserConnectionContext context.Co
 	defer wg.Done()
 	defer log.Info("finished")
 
-	BrowserConnectionsMutex.Lock()
+	BrowserConnectionsMutex.RLock()
 	browserConnection := BrowserConnections[connectionId]
 	BrowserConnectionsMutex.Unlock()
 


### PR DESCRIPTION
This PR will migrate from the Go locker `Mutex` to `RWMutex`.
Using `RWMutex` the graphql-middleware will be able to process several messages simultaneously once the read of a message will not lock `ActiveSubscriptions` anymore.
Using `RWMutex`, the map `ActiveSubscriptions` will be locked only when it needs to write into it (when new subscriptions are created or one is deleted). But most of the time the middleware will only read from it, so it is not necessary to completely lock.

In some slightly tests I could see the process of 50 messages running in half of the time than previously! 

More info at: https://pkg.go.dev/sync#RWMutex