### PR TITLE
refactor (graphql-server): Fix some conflicts on updating graphql-database

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateDefaultPublicGroupChat.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateDefaultPublicGroupChat.scala
@@ -2,7 +2,6 @@ package org.bigbluebutton.core.apps.groupchats
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.MessageBus
-import org.bigbluebutton.core.db.ChatDAO
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models.GroupChat
 import org.bigbluebutton.core.running.LiveMeeting
@@ -34,7 +33,6 @@ trait CreateDefaultPublicGroupChat {
 
     bus.outGW.send(respMsg)
     val groupChats = state.groupChats.add(groupChat)
-    ChatDAO.insert(liveMeeting.props.meetingProp.intId, groupChat)
     state.update(groupChats)
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
@@ -3,12 +3,13 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.LockSettingsUtil
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
+import org.bigbluebutton.core.db.MeetingLockSettingsDAO
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core.running.OutMsgRouter
 import org.bigbluebutton.core.running.MeetingActor
 import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core2.Permissions
-import org.bigbluebutton.core2.message.senders.{ MsgBuilder }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
@@ -40,7 +41,8 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
 
         val oldPermissions = MeetingStatus2x.getPermissions(liveMeeting.status)
 
-        MeetingStatus2x.setPermissions(liveMeeting.props.meetingProp.intId, liveMeeting.status, settings)
+        MeetingStatus2x.setPermissions(liveMeeting.status, settings)
+        MeetingLockSettingsDAO.update(liveMeeting.props.meetingProp.intId, settings)
 
         // Dial-in
         def buildLockMessage(meetingId: String, userId: String, lockedBy: String, locked: Boolean): BbbCommonEnvCoreMsg = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingDAO.scala
@@ -2,6 +2,8 @@ package org.bigbluebutton.core.db
 
 import org.bigbluebutton.common2.domain.DefaultProps
 import PostgresProfile.api._
+import org.bigbluebutton.core.apps.groupchats.GroupChatApp
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{ Failure, Success }
 
@@ -80,6 +82,7 @@ object MeetingDAO {
           MeetingMetadataDAO.insert(meetingProps.meetingProp.intId, meetingProps.metadataProp)
           MeetingRecordingDAO.insert(meetingProps.meetingProp.intId, meetingProps.recordProp)
           MeetingVoiceDAO.insert(meetingProps.meetingProp.intId, meetingProps.voiceProp)
+          ChatDAO.insert(meetingProps.meetingProp.intId, GroupChatApp.createDefaultPublicGroupChat())
           MeetingWelcomeDAO.insert(meetingProps.meetingProp.intId, meetingProps.welcomeProp)
           MeetingGroupDAO.insert(meetingProps.meetingProp.intId, meetingProps.groups)
           MeetingBreakoutDAO.insert(meetingProps.meetingProp.intId, meetingProps.breakoutProps)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserDAO.scala
@@ -1,5 +1,5 @@
 package org.bigbluebutton.core.db
-import org.bigbluebutton.core.models.{RegisteredUser, UserState}
+import org.bigbluebutton.core.models.{RegisteredUser}
 import slick.jdbc.PostgresProfile.api._
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -306,9 +306,7 @@ class MeetingActor(
     )
 
     MeetingStatus2x.initializePermissions(liveMeeting.status)
-
-    MeetingStatus2x.setPermissions(liveMeeting.props.meetingProp.intId, liveMeeting.status, settings)
-
+    MeetingStatus2x.setPermissions(liveMeeting.status, settings)
   }
 
   private def updateVoiceUserLastActivity(userId: String) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/MeetingStatus2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/MeetingStatus2x.scala
@@ -1,7 +1,5 @@
 package org.bigbluebutton.core2
 
-import org.bigbluebutton.core.db.MeetingLockSettingsDAO
-
 import java.util.concurrent.TimeUnit
 import org.bigbluebutton.core.util.TimeUtil
 
@@ -100,10 +98,9 @@ object MeetingStatus2x {
   def initializeAudioSettings(status: MeetingStatus2x) = status.audioSettingsInited = true
   def permissionsEqual(status: MeetingStatus2x, other: Permissions): Boolean = status.permissions == other
   def getPermissions(status: MeetingStatus2x): Permissions = status.permissions
-  def setPermissions(meetingId: String, status: MeetingStatus2x, p: Permissions) = {
+  def setPermissions(status: MeetingStatus2x, p: Permissions) = {
     status.permissions = p
     status.permissionsChangedOn = System.currentTimeMillis()
-    MeetingLockSettingsDAO.update(meetingId, p)
   }
   def getPermissionsChangedOn(status: MeetingStatus2x): Long = status.permissionsChangedOn
   def areNotesDisabled(status: MeetingStatus2x): Boolean = status.permissions.disableNotes


### PR DESCRIPTION
This PR will:

- Make sure that Public Chat is created after the Meeting
- Avoid to update Locksettings before it's created
- Set `null` value on Db when the moderator that approved guest was `SYSTEM`