### PR TITLE
[fix] Cannot pick an escaping student who knows he will be picked next

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/SelectRandomViewerReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/SelectRandomViewerReqMsgHdlr.scala
@@ -37,7 +37,7 @@ trait SelectRandomViewerReqMsgHdlr extends RightsManagementTrait {
       val usersPicked = Users2x.getRandomlyPickableUsers(liveMeeting.users2x, reduceDuplicatedPick)
 
       val randNum = new scala.util.Random
-      val pickedUser = if (usersPicked.size == 0) "" else usersPicked(randNum.nextInt(usersPicked.size)).intId
+      var pickedUser = if (usersPicked.size == 0) "" else usersPicked(randNum.nextInt(usersPicked.size)).intId
 
       if (reduceDuplicatedPick) {
         if (usersPicked.size <= 1) {
@@ -45,6 +45,12 @@ trait SelectRandomViewerReqMsgHdlr extends RightsManagementTrait {
           val usersToUnexempt = Users2x.findAll(liveMeeting.users2x)
           usersToUnexempt foreach { u =>
             Users2x.setUserExempted(liveMeeting.users2x, u.intId, false)
+          }
+          if (usersPicked.size == 0) {
+            // Pick again
+            val usersRepicked = Users2x.getRandomlyPickableUsers(liveMeeting.users2x, reduceDuplicatedPick)
+            pickedUser = if (usersRepicked.size == 0) "" else usersRepicked(randNum.nextInt(usersRepicked.size)).intId
+            Users2x.setUserExempted(liveMeeting.users2x, pickedUser, true)
           }
         } else if (usersPicked.size > 1) {
           Users2x.setUserExempted(liveMeeting.users2x, pickedUser, true)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

This PR enable the teacher to randomly pick a student again, even when a student who knows he will be picked next escaped in the previous pick session. Actually, he would not be picked when the option reduceDuplicatedPick is set true because the exemption list will be cleared when only one student is left. Unfortunately he would never know that.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #18278


### Motivation

<!-- What inspired you to submit this pull request? -->

### More

It's a minimum change. When the situation depicted in #18278 happens, there will be a message "There is no viewer to be picked up" once, then the teacher can start to pick a student out of the remaining two again. We can also change the code so that this "no viewer to be picked" message does not appear and the teacher can pick one again out of the remaining two immediately. However, I thought that this message is actually telling the truth (the one to be picked up has escaped!), so I took this solution. It may be even a fun for the class that the teacher says "nobody to pick up? no way, there should have been one unpicked....oh he escaped! okey, let's pick up once again from you two".
Any further suggestion is welcome.