### PR TITLE
fix: Add Quick Poll Options For 'F' And 'G'

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -137,7 +137,7 @@ const QuickPollDropdown = (props) => {
       itemLabel = itemLabel?.replace(/\s+/g, '').toUpperCase();
 
       const numChars = {
-        1: 'A', 2: 'B', 3: 'C', 4: 'D', 5: 'E',
+        1: 'A', 2: 'B', 3: 'C', 4: 'D', 5: 'E', 6: 'F', 7: 'G'
       };
       itemLabel = itemLabel.split('').map((c) => {
         if (numChars[c]) return numChars[c];


### PR DESCRIPTION
### What does this PR do?
Adds 'F' and 'G' to the quick poll options to prevent a mix of letter and numbers being displayed when parsing a poll with 7 options.

### Closes Issue(s)
Closes  #18223 
