### PR TITLE
test: separate create and join parameters

### DIFF
--- a/bigbluebutton-tests/playwright/core/helpers.js
+++ b/bigbluebutton-tests/playwright/core/helpers.js
@@ -4,6 +4,7 @@ const axios = require('axios');
 const { test, expect } = require('@playwright/test');
 const xml2js = require('xml2js');
 const { runScript } = require('./util');
+const { env } = require('node:process');
 
 const parameters = require('./parameters');
 
@@ -26,36 +27,49 @@ function apiCall(name, callParams) {
   return axios.get(url, { adapter: 'http' }).then(response => xml2js.parseStringPromise(response.data));
 }
 
-function createMeetingUrl(params, customParameter, customMeetingId) {
+function createMeetingUrl(params, createParameter, customMeetingId) {
   const meetingID = (customMeetingId) ? customMeetingId : `random-${getRandomInt(1000000, 10000000).toString()}`;
   const mp = params.moderatorPW;
   const ap = params.attendeePW;
   const baseQuery = `name=${meetingID}&meetingID=${meetingID}&attendeePW=${ap}&moderatorPW=${mp}`
     + `&allowStartStopRecording=true&autoStartRecording=false&welcome=${params.welcome}`;
-  const query = customParameter !== undefined ? `${baseQuery}&${customParameter}` : baseQuery;
+  const query = createParameter !== undefined ? `${baseQuery}&${createParameter}` : baseQuery;
   const apiCall = `create${query}${params.secret}`;
   const checksum = sha1(apiCall);
   const url = `${params.server}/create?${query}&checksum=${checksum}`;
   return url;
 }
 
-function createMeetingPromise(params, customParameter, customMeetingId) {
-  const url = createMeetingUrl(params, customParameter, customMeetingId);
+function createMeetingPromise(params, createParameter, customMeetingId) {
+  const url = createMeetingUrl(params, createParameter, customMeetingId);
   return axios.get(url, { adapter: 'http' });
 }
 
-async function createMeeting(params, customParameter) {
-  const promise = createMeetingPromise(params, customParameter);
+async function createMeeting(params, createParameter, page) {
+  const promise = createMeetingPromise(params, createParameter);
   const response = await promise;
   expect(response.status).toEqual(200);
   const xmlResponse = await xml2js.parseStringPromise(response.data);
+
+  if (env.CONSOLE !== undefined) {
+    const CONSOLE_strings = env.CONSOLE.split(',').map(opt => opt.trim().toLowerCase());
+    const CONSOLE_options = {
+      colorize: CONSOLE_strings.includes('color') || CONSOLE_strings.includes('colour'),
+      drop_references: CONSOLE_strings.includes('norefs'),
+      drop_timestamps: CONSOLE_strings.includes('nots'),
+      line_label: CONSOLE_strings.includes('label') ? this.username + " " : undefined,
+      noClientLogger: CONSOLE_strings.includes('nocl') || CONSOLE_strings.includes('noclientlogger'),
+    };
+    page.on('console', async (msg) => console.log(await console_format(msg, CONSOLE_options)));
+  }
+
   return xmlResponse.response.meetingID[0];
 }
 
-function getJoinURL(meetingID, params, moderator, customParameter) {
+function getJoinURL(meetingID, params, moderator, joinParameter) {
   const pw = moderator ? params.moderatorPW : params.attendeePW;
   const baseQuery = `fullName=${params.fullName}&meetingID=${meetingID}&password=${pw}`;
-  const query = customParameter !== undefined ? `${baseQuery}&${customParameter}` : baseQuery;
+  const query = joinParameter !== undefined ? `${baseQuery}&${joinParameter}` : baseQuery;
   const apiCall = `join${query}${params.secret}`;
   const checksum = sha1(apiCall);
   return `${params.server}/join?${query}&checksum=${checksum}`;

--- a/bigbluebutton-tests/playwright/core/helpers.js
+++ b/bigbluebutton-tests/playwright/core/helpers.js
@@ -6,6 +6,9 @@ const xml2js = require('xml2js');
 const { runScript } = require('./util');
 const { env } = require('node:process');
 
+const { format } = require('node:util');
+// This is version 4 of chalk, not version 5, which uses ESM
+const chalk = require('chalk');
 const parameters = require('./parameters');
 
 function getRandomInt(min, max) {
@@ -50,19 +53,6 @@ async function createMeeting(params, createParameter, page) {
   const response = await promise;
   expect(response.status).toEqual(200);
   const xmlResponse = await xml2js.parseStringPromise(response.data);
-
-  if (env.CONSOLE !== undefined) {
-    const CONSOLE_strings = env.CONSOLE.split(',').map(opt => opt.trim().toLowerCase());
-    const CONSOLE_options = {
-      colorize: CONSOLE_strings.includes('color') || CONSOLE_strings.includes('colour'),
-      drop_references: CONSOLE_strings.includes('norefs'),
-      drop_timestamps: CONSOLE_strings.includes('nots'),
-      line_label: CONSOLE_strings.includes('label') ? this.username + " " : undefined,
-      noClientLogger: CONSOLE_strings.includes('nocl') || CONSOLE_strings.includes('noclientlogger'),
-    };
-    page.on('console', async (msg) => console.log(await console_format(msg, CONSOLE_options)));
-  }
-
   return xmlResponse.response.meetingID[0];
 }
 
@@ -80,6 +70,83 @@ async function checkRootPermission() {
     handleOutput: (output) => output ? true : false
   })
   await expect(checkSudo, 'Sudo failed: need to run this test with root permission (can be fixed by running "sudo -v" and entering the password)').toBeTruthy();
+}
+
+async function console_format(msg, CONSOLE_options) {
+  const args = await Promise.all(msg.args().map(itm => itm.jsonValue()));
+  // For Chrome, args[0] is a format string that we will process using
+  // node.js's util.format, but that function discards css style
+  // information from "%c" format specifiers.  So first loop over the
+  // format string, replacing every "%c" with "%s" and replacing the
+  // corresponding css style with an ANSI color sequence.
+  //
+  // See https://console.spec.whatwg.org/ sections 2.2.1 and 2.3.4
+
+  let split_arg0 = args[0].split("%");
+  for (let i = 1, j = 1; i < split_arg0.length; i++, j++) {
+    if (split_arg0[i].startsWith('c')) {
+      split_arg0[i] = 's' + split_arg0[i].substr(1);
+      const styles = args[j].split(';');
+      args[j] = '';
+      for (const style of styles) {
+        const stdStyle = style.trim().toLowerCase();
+        if (stdStyle.startsWith('color:') && CONSOLE_options.colorize) {
+          const color = stdStyle.substr(6).trim();
+          args[j] = chalk.keyword(color)._styler.open;
+        } else if (stdStyle.startsWith('font-size:') && CONSOLE_options.drop_references) {
+          // For Chrome, we "drop references" by discarding everything after a font size change
+          split_arg0.length = i;
+          args.length = j;
+        }
+      }
+    } else if (split_arg0[i] == "") {
+      // format is "%%", so don't do special processing for
+      // split_arg0[i+1], and only increment i, not j
+      i++;  // NOSONAR
+    }
+  }
+  args[0] = split_arg0.join('%');
+
+  // see playwright consoleMessage class documentation
+  let result = format(...args);
+
+  if (CONSOLE_options.drop_references) {
+    // For Firefox, we "drop references" by discarding a URL at the end of the line
+    result = result.replace(/https:\/\/\S*$/, '');
+  }
+
+  if (CONSOLE_options.noClientLogger) {
+    result = result.replace(/clientLogger: /, '');
+  }
+
+  if (CONSOLE_options.drop_timestamps) {
+    // timestamp formatting is a bit complicated, with four "%s" fields and corresponding arguments,
+    // so just filter them out (if requested) after all the other formatting is done
+    result = result.replace(/\[\d\d:\d\d:\d\d:\d\d\d\d\] /, '');
+  }
+
+  if (CONSOLE_options.line_label) {
+    if (CONSOLE_options.colorize) {
+      result = chalk.keyword('green')(CONSOLE_options.line_label) + result;
+    } else {
+      result = CONSOLE_options.line_label + result;
+    }
+  }
+
+  return result;
+}
+
+async function setBrowserLogs(page) {
+  const CONSOLE_strings = env.CONSOLE.split(',').map(opt => opt.trim().toLowerCase());
+  const CONSOLE_options = {
+    colorize: CONSOLE_strings.includes('color') || CONSOLE_strings.includes('colour'),
+    drop_references: CONSOLE_strings.includes('norefs'),
+    drop_timestamps: CONSOLE_strings.includes('nots'),
+    line_label: CONSOLE_strings.includes('label') ? this.username + " " : undefined,
+    noClientLogger: CONSOLE_strings.includes('nocl') || CONSOLE_strings.includes('noclientlogger'),
+  };
+
+  page.on('console', async (msg) => console.log(await console_format(msg, CONSOLE_options)));
 }
 
 function linkIssue(issueNumber) {
@@ -105,3 +172,4 @@ exports.getJoinURL = getJoinURL;
 exports.checkRootPermission = checkRootPermission;
 exports.linkIssue = linkIssue;
 exports.sleep = sleep;
+exports.setBrowserLogs = setBrowserLogs;

--- a/bigbluebutton-tests/playwright/core/page.js
+++ b/bigbluebutton-tests/playwright/core/page.js
@@ -1,10 +1,6 @@
 require('dotenv').config();
 const { expect, default: test } = require('@playwright/test');
 const { readFileSync } = require('fs');
-const { format } = require('node:util');
-
-// This is version 4 of chalk, not version 5, which uses ESM
-const chalk = require('chalk');
 
 const parameters = require('./parameters');
 const helpers = require('./helpers');
@@ -13,73 +9,6 @@ const { env } = require('node:process');
 const { ELEMENT_WAIT_TIME, ELEMENT_WAIT_LONGER_TIME, VIDEO_LOADING_WAIT_TIME } = require('./constants');
 const { checkElement, checkElementLengthEqualTo } = require('./util');
 const { generateSettingsData, getSettings } = require('./settings');
-
-function formatWithCss(CONSOLE_options, ...args) {
-  // For Chrome, args[0] is a format string that we will process using
-  // node.js's util.format, but that function discards css style
-  // information from "%c" format specifiers.  So first loop over the
-  // format string, replacing every "%c" with "%s" and replacing the
-  // corresponding css style with an ANSI color sequence.
-  //
-  // See https://console.spec.whatwg.org/ sections 2.2.1 and 2.3.4
-
-  let split_arg0 = args[0].split("%");
-  for (let i = 1, j = 1; i < split_arg0.length; i++, j++) {
-    if (split_arg0[i].startsWith('c')) {
-      split_arg0[i] = 's' + split_arg0[i].substr(1);
-      const styles = args[j].split(';');
-      args[j] = '';
-      for (const style of styles) {
-        const stdStyle = style.trim().toLowerCase();
-        if (stdStyle.startsWith('color:') && CONSOLE_options.colorize) {
-          const color = stdStyle.substr(6).trim();
-          args[j] = chalk.keyword(color)._styler.open;
-        } else if (stdStyle.startsWith('font-size:') && CONSOLE_options.drop_references) {
-          // For Chrome, we "drop references" by discarding everything after a font size change
-          split_arg0.length = i;
-          args.length = j;
-        }
-      }
-    } else if (split_arg0[i] == "") {
-      // format is "%%", so don't do special processing for
-      // split_arg0[i+1], and only increment i, not j
-      i++;  // NOSONAR
-    }
-  }
-  args[0] = split_arg0.join('%');
-  return format(...args);
-}
-
-async function console_format(msg, CONSOLE_options) {
-  // see playwright consoleMessage class documentation
-  const args = await Promise.all(msg.args().map(itm => itm.jsonValue()));
-  let result = formatWithCss(CONSOLE_options, ...args);
-
-  if (CONSOLE_options.drop_references) {
-    // For Firefox, we "drop references" by discarding a URL at the end of the line
-    result = result.replace(/https:\/\/\S*$/, '');
-  }
-
-  if (CONSOLE_options.noClientLogger) {
-    result = result.replace(/clientLogger: /, '');
-  }
-
-  if (CONSOLE_options.drop_timestamps) {
-    // timestamp formatting is a bit complicated, with four "%s" fields and corresponding arguments,
-    // so just filter them out (if requested) after all the other formatting is done
-    result = result.replace(/\[\d\d:\d\d:\d\d:\d\d\d\d\] /, '');
-  }
-
-  if (CONSOLE_options.line_label) {
-    if (CONSOLE_options.colorize) {
-      result = chalk.keyword('green')(CONSOLE_options.line_label) + result;
-    } else {
-      result = CONSOLE_options.line_label + result;
-    }
-  }
-
-  return result;
-}
 
 class Page {
   constructor(browser, page) {
@@ -103,6 +32,8 @@ class Page {
     if (!isModerator) this.initParameters.moderatorPW = '';
     if (fullName) this.initParameters.fullName = fullName;
     this.username = this.initParameters.fullName;
+    
+    if (env.CONSOLE !== undefined) await helpers.setBrowserLogs(this.page);
 
     this.meetingId = (meetingId) ? meetingId : await helpers.createMeeting(parameters, createParameter, customMeetingId, this.page);
     const joinUrl = helpers.getJoinURL(this.meetingId, this.initParameters, isModerator, joinParameter);

--- a/bigbluebutton-tests/playwright/core/page.js
+++ b/bigbluebutton-tests/playwright/core/page.js
@@ -98,26 +98,14 @@ class Page {
   }
 
   async init(isModerator, shouldCloseAudioModal, initOptions) {
-    const { fullName, meetingId, customParameter, customMeetingId } = initOptions || {};
+    const { fullName, meetingId, createParameter, joinParameter, customMeetingId } = initOptions || {};
 
     if (!isModerator) this.initParameters.moderatorPW = '';
     if (fullName) this.initParameters.fullName = fullName;
     this.username = this.initParameters.fullName;
 
-    if (env.CONSOLE !== undefined) {
-      const CONSOLE_strings = env.CONSOLE.split(',').map(opt => opt.trim().toLowerCase());
-      const CONSOLE_options = {
-        colorize: CONSOLE_strings.includes('color') || CONSOLE_strings.includes('colour'),
-        drop_references: CONSOLE_strings.includes('norefs'),
-        drop_timestamps: CONSOLE_strings.includes('nots'),
-        line_label: CONSOLE_strings.includes('label') ? this.username + " " : undefined,
-        noClientLogger: CONSOLE_strings.includes('nocl') || CONSOLE_strings.includes('noclientlogger'),
-      };
-      this.page.on('console', async (msg) => console.log(await console_format(msg, CONSOLE_options)));
-    }
-
-    this.meetingId = (meetingId) ? meetingId : await helpers.createMeeting(parameters, customParameter, customMeetingId);
-    const joinUrl = helpers.getJoinURL(this.meetingId, this.initParameters, isModerator, customParameter);
+    this.meetingId = (meetingId) ? meetingId : await helpers.createMeeting(parameters, createParameter, customMeetingId, this.page);
+    const joinUrl = helpers.getJoinURL(this.meetingId, this.initParameters, isModerator, joinParameter);
     const response = await this.page.goto(joinUrl);
     await expect(response.ok()).toBeTruthy();
     const hasErrorLabel = await this.checkElement(e.errorMessageLabel);

--- a/bigbluebutton-tests/playwright/parameters/customparameters.js
+++ b/bigbluebutton-tests/playwright/parameters/customparameters.js
@@ -133,8 +133,8 @@ class CustomParameters extends MultiUsers {
     await this.modPage.wasRemoved(e.presentationPlaceholder);
   }
 
-  async forceRestorePresentationOnNewEvents(customParameter) {
-    await this.initUserPage(true, this.context, { useModMeetingId: true, customParameter });
+  async forceRestorePresentationOnNewEvents(joinParameter) {
+    await this.initUserPage(true, this.context, { useModMeetingId: true, joinParameter });
     const { presentationHidden, pollEnabled } = getSettings();
     if (!presentationHidden) await this.userPage.waitAndClick(e.minimizePresentation);
     const zoomInCase = await util.zoomIn(this.modPage);
@@ -148,8 +148,8 @@ class CustomParameters extends MultiUsers {
     await this.userPage.checkElement(e.restorePresentation);
   }
 
-  async forceRestorePresentationOnNewPollResult(customParameter) {
-    await this.initUserPage(true, this.context, { useModMeetingId: true, customParameter })
+  async forceRestorePresentationOnNewPollResult(joinParameter) {
+    await this.initUserPage(true, this.context, { useModMeetingId: true, joinParameter })
     const { presentationHidden,pollEnabled } = getSettings();
     if (!presentationHidden) await this.userPage.waitAndClick(e.minimizePresentation);
     if (pollEnabled) await util.poll(this.modPage, this.userPage);

--- a/bigbluebutton-tests/playwright/parameters/parameters.spec.js
+++ b/bigbluebutton-tests/playwright/parameters/parameters.spec.js
@@ -8,87 +8,87 @@ const { CreateParameters } = require('./createParameters');
 test.describe.parallel('Create Parameters', () => {
   test('Record Meeting', async ({ browser, context, page }) => {
     const createParam = new CreateParameters(browser, context);
-    await createParam.initModPage(page, true, { customParameter: c.recordMeeting });
+    await createParam.initModPage(page, true, { createParameter: c.recordMeeting });
     await createParam.recordMeeting();
   });
 
   test.describe.parallel('Banner', () => {
     test('Banner Text @ci', async ({ browser, context, page }) => {
       const createParam = new CreateParameters(browser, context);
-      await createParam.initModPage(page, true, { customParameter: encodeCustomParams(c.bannerText) });
+      await createParam.initModPage(page, true, { createParameter: encodeCustomParams(c.bannerText) });
       await createParam.bannerText();
     });
 
     test('Banner Color @ci', async ({ browser, context, page }) => {
       const createParam = new CreateParameters(browser, context);
       const colorToRGB = hexToRgb(c.color);
-      await createParam.initModPage(page, true, { customParameter: `${c.bannerColor}&${encodeCustomParams(c.bannerText)}` });
+      await createParam.initModPage(page, true, { createParameter: `${c.bannerColor}&${encodeCustomParams(c.bannerText)}` });
       await createParam.bannerColor(colorToRGB);
     });
   });
 
   test('Max Participants', async ({ browser, context, page }) => {
     const createParam = new CreateParameters(browser, context);
-    await createParam.initModPage(page, true, { customParameter: c.maxParticipants });
+    await createParam.initModPage(page, true, { createParameter: c.maxParticipants });
     await createParam.initModPage2(true, context);
     await createParam.maxParticipants(context);
   });
 
   test('Meeting Duration', async ({ browser, context, page }) => {
     const createParam = new CreateParameters(browser, context);
-    await createParam.initModPage(page, true, { customParameter: c.duration });
+    await createParam.initModPage(page, true, { createParameter: c.duration });
     await createParam.duration();
   });
 
   test('Message Only To Moderators', async ({ browser, context, page }) => {
     const createParam = new CreateParameters(browser, context);
-    await createParam.initModPage(page, true, { customParameter: c.moderatorOnlyMessage });
+    await createParam.initModPage(page, true, { createParameter: c.moderatorOnlyMessage });
     await createParam.moderatorOnlyMessage(context);
   });
 
   test('Webcams Shows Only For Moderators', async ({ browser, context, page }) => {
     const createParam = new CreateParameters(browser, context);
-    await createParam.initModPage(page, true, { customParameter: c.webcamsOnlyForModerator });
+    await createParam.initModPage(page, true, { createParameter: c.webcamsOnlyForModerator });
     await createParam.initUserPage2(true, context);
     await createParam.webcamsOnlyForModerator(context);
   });
 
   test('Mute On Start', async ({ browser, context, page }) => {
     const createParam = new CreateParameters(browser, context);
-    await createParam.initModPage(page, true, { customParameter: c.muteOnStart });
+    await createParam.initModPage(page, true, { createParameter: c.muteOnStart });
     await createParam.muteOnStart();
   });
 
   test('Allow Mods To Unmute Users', async ({ browser, context, page }) => {
     const createParam = new CreateParameters(browser, context);
-    await createParam.initModPage(page, true, { customParameter: c.allowModsToUnmuteUsers });
+    await createParam.initModPage(page, true, { createParameter: c.allowModsToUnmuteUsers });
     await createParam.allowModsToUnmuteUsers(context);
   });
 
   test('Lock Settings Disable Webcam', async ({ browser, context, page }) => {
     const createParam = new CreateParameters(browser, context);
-    await createParam.initModPage(page, true, { customParameter: c.lockSettingsDisableCam });
+    await createParam.initModPage(page, true, { createParameter: c.lockSettingsDisableCam });
     await createParam.initUserPage(true, context);
     await createParam.lockSettingsDisableCam();
   });
 
   test('Lock Settings Disable Microphone', async ({ browser, context, page }) => {
     const createParam = new CreateParameters(browser, context);
-    await createParam.initModPage(page, true, { customParameter: c.lockSettingsDisableMic });
+    await createParam.initModPage(page, true, { createParameter: c.lockSettingsDisableMic });
     await createParam.initUserPage(false, context);
     await createParam.lockSettingsDisableMic();
   });
 
   test('Lock Settings Disable Public Chat', async ({ browser, context, page }) => {
     const createParam = new CreateParameters(browser, context);
-    await createParam.initModPage(page, true, { customParameter: c.lockSettingsDisablePublicChat });
+    await createParam.initModPage(page, true, { createParameter: c.lockSettingsDisablePublicChat });
     await createParam.initUserPage(true, context);
     await createParam.lockSettingsDisablePublicChat();
   });
 
   test('Lock Settings Hide User List', async ({ browser, context, page }) => {
     const createParam = new CreateParameters(browser, context);
-    await createParam.initModPage(page, true, { customParameter: c.lockSettingsHideUserList });
+    await createParam.initModPage(page, true, { createParameter: c.lockSettingsHideUserList });
     await createParam.initUserPage(true, context);
     await createParam.initUserPage2(true, context);
     await createParam.lockSettingsHideUserList();
@@ -96,7 +96,7 @@ test.describe.parallel('Create Parameters', () => {
 
   test('Allow Moderator To Eject Cameras', async ({ browser, context, page }) => {
     const createParam = new CreateParameters(browser, context);
-    await createParam.initModPage(page, true, { customParameter: c.allowModsToEjectCameras });
+    await createParam.initModPage(page, true, { createParameter: c.allowModsToEjectCameras });
     await createParam.initUserPage(true, context);
     await createParam.allowModsToEjectCameras();
   });
@@ -105,12 +105,12 @@ test.describe.parallel('Create Parameters', () => {
     test.describe.serial(() => {
       test('Breakout rooms', async ({ browser, context, page}) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.breakoutRoomsDisabled });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.breakoutRoomsDisabled });
         await disabledFeatures.breakoutRooms();
       });
       test('Breakout rooms (exclude)', async ({ browser, context, page}) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.breakoutRoomsExclude });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.breakoutRoomsExclude });
         await disabledFeatures.breakoutRoomsExclude();
       });
     });
@@ -118,12 +118,12 @@ test.describe.parallel('Create Parameters', () => {
     test.describe.serial(() => {
       test('Speech Recognition', async ({ browser, context, page}) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, false, { customParameter: c.speechRecognitionDisabled });
+        await disabledFeatures.initModPage(page, false, { createParameter: c.speechRecognitionDisabled });
         await disabledFeatures.speechRecognition();
       });
       test('Speech Recognition (exclude)', async ({ browser, context, page}) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, false, { customParameter: c.speechRecognitionExclude });
+        await disabledFeatures.initModPage(page, false, { createParameter: c.speechRecognitionExclude });
         await disabledFeatures.speechRecognitionExclude();
       });
     });
@@ -131,12 +131,12 @@ test.describe.parallel('Create Parameters', () => {
     test.describe.serial(() => {
       test('Captions', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.captionsDisabled });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.captionsDisabled });
         await disabledFeatures.captions();
       });
       test('Captions (exclude)', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.captionsExclude });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.captionsExclude });
         await disabledFeatures.captionsExclude();
       });
     });
@@ -144,12 +144,12 @@ test.describe.parallel('Create Parameters', () => {
     test.describe.serial(() => {
       test('Chat', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.chatDisabled });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.chatDisabled });
         await disabledFeatures.chat();
       });
       test('Chat (exclude)', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.chatExclude });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.chatExclude });
         await disabledFeatures.chatExclude();
       });
     });
@@ -157,12 +157,12 @@ test.describe.parallel('Create Parameters', () => {
     test.describe.serial(() => {
       test('External Videos', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.externalVideosDisabled });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.externalVideosDisabled });
         await disabledFeatures.externalVideos();
       });
       test('External Videos (exclude)', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.externalVideosExclude });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.externalVideosExclude });
         await disabledFeatures.externalVideosExclude();
       });
     });
@@ -170,12 +170,12 @@ test.describe.parallel('Create Parameters', () => {
     test.describe.serial(() => {
       test('Layouts', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.layoutsDisabled });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.layoutsDisabled });
         await disabledFeatures.layouts();
       });
       test('Layouts (exclude)', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.layoutsExclude });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.layoutsExclude });
         await disabledFeatures.layoutsExclude();
       });
     });
@@ -183,12 +183,12 @@ test.describe.parallel('Create Parameters', () => {
     test.describe.serial(() => {
       test('Learning Dashboard', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.learningDashboardDisabled });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.learningDashboardDisabled });
         await disabledFeatures.learningDashboard();
       });
       test('Learning Dashboard (exclude)', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.learningDashboardExclude });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.learningDashboardExclude });
         await disabledFeatures.learningDashboardExclude();
       });
     });
@@ -196,12 +196,12 @@ test.describe.parallel('Create Parameters', () => {
     test.describe.serial(() => {
       test('Polls', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.pollsDisabled });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.pollsDisabled });
         await disabledFeatures.polls();
       });
       test('Polls (exclude)', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.pollsExclude });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.pollsExclude });
         await disabledFeatures.pollsExclude();
       });
     });
@@ -209,12 +209,12 @@ test.describe.parallel('Create Parameters', () => {
     test.describe.serial(() => {
       test('Screenshare', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.screenshareDisabled });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.screenshareDisabled });
         await disabledFeatures.screenshare();
       });
       test('Screenshare (exclude)', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.screenshareExclude });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.screenshareExclude });
         await disabledFeatures.screenshareExclude();
       });
     });
@@ -222,12 +222,12 @@ test.describe.parallel('Create Parameters', () => {
     test.describe.serial(() => {
       test('Shared Notes', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.sharedNotesDisabled });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.sharedNotesDisabled });
         await disabledFeatures.sharedNotes();
       });
       test('Shared Notes (exclude)', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.sharedNotesExclude });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.sharedNotesExclude });
         await disabledFeatures.sharedNotesExclude();
       });
     });
@@ -235,12 +235,12 @@ test.describe.parallel('Create Parameters', () => {
     test.describe.serial(() => {
       test('Virtual Background', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.virtualBackgroundsDisabled });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.virtualBackgroundsDisabled });
         await disabledFeatures.virtualBackgrounds();
       });
       test('Virtual Background (exclude)', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.virtualBackgroundsExclude });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.virtualBackgroundsExclude });
         await disabledFeatures.virtualBackgroundsExclude();
       });
     });
@@ -248,12 +248,12 @@ test.describe.parallel('Create Parameters', () => {
     test.describe.serial(() => {
       test('Download Presentation With Annotations', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.downloadPresentationWithAnnotationsDisabled });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.downloadPresentationWithAnnotationsDisabled });
         await disabledFeatures.downloadPresentationWithAnnotations();
       });
       test('Download Presentation With Annotations (exclude)', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.downloadPresentationWithAnnotationsExclude });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.downloadPresentationWithAnnotationsExclude });
         await disabledFeatures.downloadPresentationWithAnnotationsExclude();
       });
     });
@@ -261,12 +261,12 @@ test.describe.parallel('Create Parameters', () => {
     test.describe.serial(() => {
       test('Import Presentation With Annotations From Breakout Rooms', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.importPresentationWithAnnotationsFromBreakoutRoomsDisabled });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.importPresentationWithAnnotationsFromBreakoutRoomsDisabled });
         await disabledFeatures.importPresentationWithAnnotationsFromBreakoutRooms();
       });
       test('Import Presentation With Annotations From Breakout Rooms (exclude)', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.importPresentationWithAnnotationsFromBreakoutRoomsExclude });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.importPresentationWithAnnotationsFromBreakoutRoomsExclude });
         await disabledFeatures.importPresentationWithAnnotationsFromBreakoutRoomsExclude();
       });
     });
@@ -274,12 +274,12 @@ test.describe.parallel('Create Parameters', () => {
     test.describe.serial(() => {
       test('Import Shared Notes From Breakout Rooms', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.importSharedNotesFromBreakoutRoomsDisabled });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.importSharedNotesFromBreakoutRoomsDisabled });
         await disabledFeatures.importSharedNotesFromBreakoutRooms();
       });
       test('Import Shared Notes From Breakout Rooms (exclude)', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.importSharedNotesFromBreakoutRoomsExclude });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.importSharedNotesFromBreakoutRoomsExclude });
         await disabledFeatures.importSharedNotesFromBreakoutRoomsExclude();
       });
     });
@@ -287,12 +287,12 @@ test.describe.parallel('Create Parameters', () => {
     test.describe.serial(() => {
       test('Presentation', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.presentationDisabled });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.presentationDisabled });
         await disabledFeatures.presentation();
       });
       test('Presentation (exclude)', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.presentationExclude });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.presentationExclude });
         await disabledFeatures.presentationExclude();
       });
     });
@@ -300,12 +300,12 @@ test.describe.parallel('Create Parameters', () => {
     test.describe.serial(() => {
       test('Custom Virtual Background', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.customVirtualBackgroundDisabled });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.customVirtualBackgroundDisabled });
         await disabledFeatures.customVirtualBackground();
       });
       test('Custom Virtual Background (exclude)', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { customParameter: c.customVirtualBackgroundExclude });
+        await disabledFeatures.initModPage(page, true, { createParameter: c.customVirtualBackgroundExclude });
         await disabledFeatures.customVirtualBackgroundExclude();
       });
     });
@@ -315,113 +315,113 @@ test.describe.parallel('Create Parameters', () => {
 test.describe.parallel('Custom Parameters', () => {
   test('Show Public Chat On Login', async ({ browser, context, page }) => {
     const customParam = new CustomParameters(browser, context);
-    await customParam.initModPage(page, true, { customParameter: c.showPublicChatOnLogin });
+    await customParam.initModPage(page, true, { joinParameter: c.showPublicChatOnLogin });
     await customParam.showPublicChatOnLogin();
   });
 
   test('Show Participants on Login', async ({ browser, context, page }) => {
     const customParam = new CustomParameters(browser, context);
-    await customParam.initModPage(page, true, { customParameter: c.showParticipantsOnLogin });
+    await customParam.initModPage(page, true, { joinParameter: c.showParticipantsOnLogin });
     await customParam.showParticipantsOnLogin();
   });
 
   test('Client title', async ({ browser, context, page }) => {
     const customParam = new CustomParameters(browser, context);
-    await customParam.initModPage(page, true, { customParameter: c.clientTitle });
+    await customParam.initModPage(page, true, { joinParameter: c.clientTitle });
     await customParam.clientTitle();
   });
 
   test('Ask For Feedback On Logout', async ({ browser, context, page }) => {
     const customParam = new CustomParameters(browser, context);
-    await customParam.initModPage(page, true, { customParameter: c.askForFeedbackOnLogout });
+    await customParam.initModPage(page, true, { joinParameter: c.askForFeedbackOnLogout });
     await customParam.askForFeedbackOnLogout();
   });
 
   test('Display Branding Area', async ({ browser, context, page }) => {
     const customParam = new CustomParameters(browser, context);
-    await customParam.initModPage(page, true, { customParameter: `${c.displayBrandingArea}&${encodeCustomParams(c.logo)}` });
+    await customParam.initModPage(page, true, { joinParameter: `${c.displayBrandingArea}&${encodeCustomParams(c.logo)}` });
     await customParam.displayBrandingArea();
   });
 
   test('Shortcuts', async ({ browser, context, page }) => {
     const customParam = new CustomParameters(browser, context);
     const shortcutParam = getAllShortcutParams();
-    await customParam.initModPage(page, true, { customParameter: encodeCustomParams(shortcutParam) });
+    await customParam.initModPage(page, true, { joinParameter: encodeCustomParams(shortcutParam) });
     await customParam.initUserPage(true, context, { useModMeetingId: true });
     await customParam.shortcuts();
   });
 
   test('Custom Styles: CSS code @ci', async ({ browser, context, page }) => {
     const customParam = new CustomParameters(browser, context);
-    await customParam.initModPage(page, true, { customParameter: encodeCustomParams(c.customStyle) });
+    await customParam.initModPage(page, true, { joinParameter: encodeCustomParams(c.customStyle) });
     await customParam.customStyle();
   });
 
   test('Custom Styles: URL', async ({ browser, context, page }) => {
     test.fixme();
     const customParam = new CustomParameters(browser, context);
-    await customParam.initModPage(page, true, { customParameter: encodeCustomParams(c.customStyleUrl) });
+    await customParam.initModPage(page, true, { joinParameter: encodeCustomParams(c.customStyleUrl) });
     await customParam.customStyle();
   });
 
   test('Auto Swap Layout', async ({ browser, context, page }) => {
     const customParam = new CustomParameters(browser, context);
-    await customParam.initModPage(page, true, { customParameter: c.autoSwapLayout });
+    await customParam.initModPage(page, true, { joinParameter: c.autoSwapLayout });
     await customParam.autoSwapLayout();
   });
 
   test('Hide Actions Bar @ci', async ({ browser, context, page }) => {
     const customParam = new CustomParameters(browser, context);
-    await customParam.initModPage(page, true, { customParameter: c.hideActionsBar });
+    await customParam.initModPage(page, true, { joinParameter: c.hideActionsBar });
     await customParam.hideActionsBarTest();
   });
 
   test('Override Default Locale', async ({ browser, context, page }) => {
     const customParam = new CustomParameters(browser, context);
-    await customParam.initModPage(page, true, { customParameter: c.overrideDefaultLocale });
+    await customParam.initModPage(page, true, { joinParameter: c.overrideDefaultLocale });
     await customParam.overrideDefaultLocaleTest();
   });
 
   test('Hide NavBar @ci', async ({ browser, context, page }) => {
     const customParam = new CustomParameters(browser, context);
-    await customParam.initModPage(page, true, { customParameter: c.hideNavBar });
+    await customParam.initModPage(page, true, { joinParameter: c.hideNavBar });
     await customParam.hideNavBarTest();
   });
 
   test('Preferred Camera Profile', async ({ browser, context, page }) => {
     const customParam = new CustomParameters(browser, context);
-    await customParam.initModPage(page, true, { customParameter: c.preferredCameraProfile });
+    await customParam.initModPage(page, true, { joinParameter: c.preferredCameraProfile });
     await customParam.preferredCameraProfileTest();
   });
 
   test.describe.parallel('Audio', () => {
     test('Auto join @ci', async ({ browser, context, page }) => {
       const customParam = new CustomParameters(browser, context);
-      await customParam.initModPage(page, false, { customParameter: c.autoJoin });
+      await customParam.initModPage(page, false, { joinParameter: c.autoJoin });
       await customParam.autoJoin();
     });
 
     test('Disable Listen Only Mode @ci', async ({ browser, context, page }) => {
       const customParam = new CustomParameters(browser, context);
-      await customParam.initModPage(page, false, { customParameter: c.listenOnlyMode });
+      await customParam.initModPage(page, false, { joinParameter: c.listenOnlyMode });
       await customParam.listenOnlyMode();
     });
 
     test('Force Listen Only @ci', async ({ browser, context, page }) => {
       const customParam = new CustomParameters(browser, context);
-      await customParam.initUserPage(false, context, { useModMeetingId: false, customParameter: c.forceListenOnly });
+      await customParam.initUserPage(false, context, { useModMeetingId: false, joinParameter: c.forceListenOnly });
       await customParam.forceListenOnly(page);
     });
 
     test('Skip audio check', async ({ browser, context, page }) => {
       const customParam = new CustomParameters(browser, context);
-      await customParam.initModPage(page, false, { customParameter: c.skipCheck });
+      await customParam.initModPage(page, false, { joinParameter: c.skipCheck });
       await customParam.skipCheck();
     });
 
     test('Skip audio check on first join', async ({ browser, context, page }) => {
       const customParam = new CustomParameters(browser, context);
-      await customParam.initModPage(page, false, { customParameter: c.skipCheckOnFirstJoin });
+      await customParam.initModPage(page, false, { joinParameter: c.skipCheckOnFirstJoin });
       await customParam.skipCheckOnFirstJoin();
     });
   });
@@ -429,47 +429,47 @@ test.describe.parallel('Custom Parameters', () => {
   test.describe.parallel('Presentation', () => {
     test('Hide Presentation on join @ci', async ({ browser, context, page }) => {
       const customParam = new CustomParameters(browser, context);
-      await customParam.initModPage(page, true, { customParameter: encodeCustomParams(c.hidePresentationOnJoin) });
+      await customParam.initModPage(page, true, { joinParameter: encodeCustomParams(c.hidePresentationOnJoin) });
       await customParam.hidePresentationOnJoin();
     });
 
     test('Force Restore Presentation On New Events @ci', async ({ browser, context, page }) => {
       const customParam = new CustomParameters(browser, context);
-      const customParameter = c.forceRestorePresentationOnNewEvents;
-      await customParam.initModPage(page, true, { customParameter });
-      await customParam.forceRestorePresentationOnNewEvents(customParameter);
+      const joinParameter = c.forceRestorePresentationOnNewEvents;
+      await customParam.initModPage(page, true, { joinParameter });
+      await customParam.forceRestorePresentationOnNewEvents(joinParameter);
     });
 
     test('Force Restore Presentation On New Poll Result', async ({ browser, context, page }) => {
       const customParam = new CustomParameters(browser, context);
-      const customParameter = c.forceRestorePresentationOnNewEvents;
-      await customParam.initModPage(page, true, { customParameter });
-      await customParam.forceRestorePresentationOnNewPollResult(customParameter);
+      const joinParameter = c.forceRestorePresentationOnNewEvents;
+      await customParam.initModPage(page, true, { joinParameter });
+      await customParam.forceRestorePresentationOnNewPollResult(joinParameter);
     });
   });
 
   test.describe.parallel('Webcam', () => {
     test('Disable Webcam Sharing @ci', async ({ browser, context, page }) => {
       const customParam = new CustomParameters(browser, context);
-      await customParam.initModPage(page, true, { customParameter: c.enableVideo });
+      await customParam.initModPage(page, true, { joinParameter: c.enableVideo });
       await customParam.enableVideo();
     });
 
     test('Skip Video Preview', async ({ browser, context, page }) => {
       const customParam = new CustomParameters(browser, context);
-      await customParam.initModPage(page, true, { customParameter: c.skipVideoPreview });
+      await customParam.initModPage(page, true, { joinParameter: c.skipVideoPreview });
       await customParam.skipVideoPreview();
     });
 
     test('Skip Video Preview on First Join @ci', async ({ browser, context, page }) => {
       const customParam = new CustomParameters(browser, context);
-      await customParam.initModPage(page, true, { customParameter: c.skipVideoPreviewOnFirstJoin });
+      await customParam.initModPage(page, true, { joinParameter: c.skipVideoPreviewOnFirstJoin });
       await customParam.skipVideoPreviewOnFirstJoin();
     });
 
     test('Mirror Own Webcam @ci', async ({ browser, context, page }) => {
       const customParam = new CustomParameters(browser, context);
-      await customParam.initModPage(page, true, { customParameter: c.mirrorOwnWebcam });
+      await customParam.initModPage(page, true, { joinParameter: c.mirrorOwnWebcam });
       await customParam.mirrorOwnWebcam();
     });
   });
@@ -478,21 +478,21 @@ test.describe.parallel('Custom Parameters', () => {
     test.skip();
     test('Multi Users Pen Only', async ({ browser, context, page }) => {
       const customParam = new CustomParameters(browser, context);
-      await customParam.initModPage(page, true, { customParameter: c.multiUserPenOnly });
+      await customParam.initModPage(page, true, { joinParameter: c.multiUserPenOnly });
       await customParam.initUserPage(true, context, { useModMeetingId: true, customParameter: c.multiUserPenOnly });
       await customParam.multiUserPenOnly();
     });
 
     test('Presenter Tools', async ({ browser, context, page }) => {
       const customParam = new CustomParameters(browser, context);
-      await customParam.initModPage(page, true, { customParameter: encodeCustomParams(c.presenterTools) });
+      await customParam.initModPage(page, true, { joinParameter: encodeCustomParams(c.presenterTools) });
       await customParam.presenterTools();
     });
 
     test('Multi Users Tools', async ({ browser, context, page }) => {
       const customParam = new CustomParameters(browser, context);
-      await customParam.initModPage(page, true, { customParameter: encodeCustomParams(c.multiUserTools) });
-      await customParam.initUserPage(true, context, { useModMeetingId: true, customParameter: encodeCustomParams(c.multiUserTools) });
+      await customParam.initModPage(page, true, { joinParameter: encodeCustomParams(c.multiUserTools) });
+      await customParam.initUserPage(true, context, { useModMeetingId: true, joinParameter: encodeCustomParams(c.multiUserTools) });
       await customParam.multiUserTools();
     });
   });


### PR DESCRIPTION
### What does this PR do?

Separates the create and join parameters, so the create parameter will be used on creating the meeting, and the join parameter will be used on joining the meeting. Before, it wasn't clear which type of parameter was being used, because it had only the custom parameter type.