### PR TITLE
Fix: use connection id to determine if a user is ejected or not

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -388,7 +388,11 @@ export default withTracker(() => {
   const connectionIdUpdateTime = User?.connectionIdUpdateTime;
   
   if (ejected) {
-    BBBStorage.setItem(USER_WAS_EJECTED, ejected);
+    // use the connectionID to block users, so we can detect if the user was
+    // blocked by the current connection. This is the case when a a user is
+    // ejected from a meeting but not permanently ejected. Permanent ejects are
+    // managed by the server, not by the client.
+    BBBStorage.setItem(USER_WAS_EJECTED, connectionID);
   }
 
   if (currentConnectionId && currentConnectionId !== connectionID && connectionIdUpdateTime > connectionAuthTime) {
@@ -402,7 +406,7 @@ export default withTracker(() => {
   const { streams: usersVideo } = VideoService.getVideoStreams();
 
   return {
-    userWasEjected: BBBStorage.getItem(USER_WAS_EJECTED),
+    userWasEjected: (BBBStorage.getItem(USER_WAS_EJECTED) == connectionID),
     approved,
     ejected,
     ejectedReason,


### PR DESCRIPTION
### What does this PR do?

Fix issue #18297 


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #18297


### Motivation

I want to use localStorage to keep client settings across meetings. Permanently banning users from using free software is not an option.
