### PR TITLE
fix: Promote and demote users is reopening closed private chats

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/service.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/service.js
@@ -5,7 +5,6 @@ import Auth from '/imports/ui/services/auth';
 import UnreadMessages from '/imports/ui/services/unread-messages';
 import Storage from '/imports/ui/services/storage/session';
 import { makeCall } from '/imports/ui/services/api';
-import _ from 'lodash';
 import { stripTags, unescapeHtml } from '/imports/utils/string-utils';
 import { meetingIsBreakout } from '/imports/ui/components/app/service';
 import { defineMessages } from 'react-intl';
@@ -164,6 +163,11 @@ const isChatLocked = (receiverID) => {
   return false;
 };
 
+const isChatClosed = (chatId) => {
+  const currentClosedChats = Storage.getItem(CLOSED_CHAT_LIST_KEY) || [];
+  return !!currentClosedChats.find(closedChat => closedChat.chatId === chatId);
+};
+
 const lastReadMessageTime = (receiverID) => {
   const isPublic = receiverID === PUBLIC_CHAT_ID;
   const chatType = isPublic ? PUBLIC_GROUP_CHAT_ID : receiverID;
@@ -210,8 +214,9 @@ const sendGroupMessage = (message, idChatOpen) => {
   const currentClosedChats = Storage.getItem(CLOSED_CHAT_LIST_KEY);
 
   // Remove the chat that user send messages from the session.
-  if (_.indexOf(currentClosedChats, receiverId.id) > -1) {
-    Storage.setItem(CLOSED_CHAT_LIST_KEY, _.without(currentClosedChats, receiverId.id));
+  if (isChatClosed(receiverId.id)) {
+    const closedChats = currentClosedChats.filter(closedChat => closedChat.chatId !== receiverId.id);
+    Storage.setItem(CLOSED_CHAT_LIST_KEY,closedChats);
   }
 
   return makeCall('sendGroupChatMsg', destinationChatId, payload);
@@ -240,8 +245,8 @@ const clearPublicChatHistory = () => (makeCall('clearPublicChatHistory'));
 const closePrivateChat = (chatId) => {
   const currentClosedChats = Storage.getItem(CLOSED_CHAT_LIST_KEY) || [];
 
-  if (_.indexOf(currentClosedChats, chatId) < 0) {
-    currentClosedChats.push(chatId);
+  if (!isChatClosed(chatId)) {
+    currentClosedChats.push({ chatId, timestamp: Date.now() });
 
     Storage.setItem(CLOSED_CHAT_LIST_KEY, currentClosedChats);
   }
@@ -251,8 +256,10 @@ const closePrivateChat = (chatId) => {
 const removeFromClosedChatsSession = (idChatOpen) => {
   const chatID = idChatOpen;
   const currentClosedChats = Storage.getItem(CLOSED_CHAT_LIST_KEY);
-  if (_.indexOf(currentClosedChats, chatID) > -1) {
-    Storage.setItem(CLOSED_CHAT_LIST_KEY, _.without(currentClosedChats, chatID));
+
+  if (isChatClosed(chatID)) {
+    const closedChats = currentClosedChats.filter(closedChat => closedChat.chatId !== chatID);
+    Storage.setItem(CLOSED_CHAT_LIST_KEY,closedChats);
   }
 };
 
@@ -350,6 +357,7 @@ export default {
   getScrollPosition,
   lastReadMessageTime,
   isChatLocked,
+  isChatClosed,
   updateScrollPosition,
   updateUnreadMessage,
   sendGroupMessage,

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -19,6 +19,7 @@ import Settings from '/imports/ui/services/settings';
 import { notify } from '/imports/ui/services/notification';
 import { FormattedMessage } from 'react-intl';
 import { getDateString } from '/imports/utils/string-utils';
+import ChatService from '/imports/ui/components/chat/service';
 
 const CHAT_CONFIG = Meteor.settings.public.chat;
 const PUBLIC_CHAT_ID = CHAT_CONFIG.public_id;
@@ -322,7 +323,7 @@ const getActiveChats = ({ groupChatsMessages, groupChats, users }) => {
   });
 
   const currentClosedChats = Storage.getItem(CLOSED_CHAT_LIST_KEY) || [];
-  const removeClosedChats = chatInfo.filter((chat) => !currentClosedChats.includes(chat.chatId)
+  const removeClosedChats = chatInfo.filter((chat) => !currentClosedChats.find(closedChat => closedChat.chatId === chat.chatId)
     && chat.shouldDisplayInChatList);
   const sortByChatIdAndUnread = removeClosedChats.sort((a, b) => {
     if (a.chatId === PUBLIC_GROUP_CHAT_ID) {
@@ -625,8 +626,10 @@ const getGroupChatPrivate = (senderUserId, receiver) => {
     }
 
     const currentClosedChats = Storage.getItem(CLOSED_CHAT_LIST_KEY);
-    if (_.indexOf(currentClosedChats, chat.chatId) > -1) {
-      Storage.setItem(CLOSED_CHAT_LIST_KEY, _.without(currentClosedChats, chat.chatId));
+
+    if (ChatService.isChatClosed(chat.chatId)) {
+      const closedChats = currentClosedChats.filter(closedChat => closedChat.chatId !== chat.chatId);
+      Storage.setItem(CLOSED_CHAT_LIST_KEY,closedChats);
     }
   }
 };


### PR DESCRIPTION
### What does this PR do?

Add timestamp to closed chat list, so it can be used to not reopen a chat unless a new message is received.

### Closes Issue(s)
Closes #18258