### PR TITLE
build: Newer FreeSWITCH - up to merged PR 2069

### DIFF
--- a/build/packages-template/bbb-freeswitch-core/1914.patch
+++ b/build/packages-template/bbb-freeswitch-core/1914.patch
@@ -309,8 +309,7 @@ index e8a3d30da1a..63fbfc75d76 100644
 -					}
 -				}
 -				
--				
--				if (ice->ice_params && ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].cand_type &&
+-				if (ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].cand_type &&
 -					!strcasecmp(ice->ice_params->cands[ice->ice_params->chosen[ice->proto]][ice->proto].cand_type, "relay")) {
 -					do_adj++;
 -				}

--- a/freeswitch.placeholder.sh
+++ b/freeswitch.placeholder.sh
@@ -2,5 +2,8 @@ mkdir freeswitch
 cd freeswitch
 git init
 git remote add origin https://github.com/signalwire/freeswitch.git
-git fetch --depth 1 origin v1.10.9
-git checkout FETCH_HEAD
+#git fetch --depth 1 origin v1.10.9
+#git checkout FETCH_HEAD
+git fetch origin master
+git checkout 67840823c178153cb013014c4fa780fe233612cb
+


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Builds FreeSWITCH with new (untagged) commits, up to and including https://github.com/signalwire/freeswitch/commit/67840823c178153cb013014c4fa780fe233612cb -- https://github.com/signalwire/freeswitch/pull/2069

Latest tag was 1.10.9 (Feb 3 2023)
This change pulls **all** changes up to June 23, 2023.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none
Related: #18268 


### Motivation

https://github.com/bigbluebutton/bigbluebutton/issues/18268#issuecomment-1627415937

<!-- What inspired you to submit this pull request? -->

### More
Possibility to backport to BBB 2.6
