### PR TITLE
Enhancement: Mods not being listed in raised hands toast.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/raisehand-notifier/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/raisehand-notifier/component.jsx
@@ -57,7 +57,7 @@ class RaiseHandNotifier extends Component {
       raiseHandUsers, raiseHandAudioAlert, raiseHandPushAlert, isViewer, isPresenter,
     } = this.props;
 
-    if (isViewer && !isPresenter) {
+    if ((isViewer || ROLE_MODERATOR) && !isPresenter) {
       if (this.statusNotifierId) toast.dismiss(this.statusNotifierId);
       return false;
     }


### PR DESCRIPTION
### What does this PR do?

This PR implements code that allow the mods to be on the raised hands queue and participate better in on going discussions.

### Closes Issue(s)

#16510 