### PR TITLE
fix: camera options tooltip pt

### DIFF
--- a/bigbluebutton-html5/public/locales/pt.json
+++ b/bigbluebutton-html5/public/locales/pt.json
@@ -1096,7 +1096,7 @@
     "app.videoDock.webcamPinLabel": "Fixar",
     "app.videoDock.webcamPinDesc": "Fixar a webcam selecionada",
     "app.videoDock.webcamFullscreenLabel": "Webcam em ecrã inteiro",
-    "app.videoDock.webcamSqueezedButtonLabel": "Opçções da webcam",
+    "app.videoDock.webcamSqueezedButtonLabel": "Opções da webcam",
     "app.videoDock.webcamUnpinLabel": "Soltar",
     "app.videoDock.webcamUnpinLabelDisabled": "Apenas moderadores podem soltar utilizadores",
     "app.videoDock.webcamUnpinDesc": "Soltar a webcam escolhida",


### PR DESCRIPTION

### What does this PR do?
Fix the camera options tooltip that had an extra letter in Portuguese.
