### PR TITLE
conf: Check for necessary permissions in bbb-conf

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -68,9 +68,18 @@
 #   2020-06-23 JFS  Remove defaultGuestPolicy warning for HTML5 client
 #   2020-10-22 AGG  Removing Flash/Red5 related code (yay!)
 #   2021-07-16 JFS  Add defaultMeetingLayout information
+#   2023-07-13  LK  Check for necessary permissions
 
 #set -x
 #set -e
+
+# The user should have read access to /etc/bigbluebutton/bbb-web.properties
+# Otherwise the script will fail later or report weird results
+if ! head -n0 /etc/bigbluebutton/bbb-web.properties &> /dev/null
+then
+    echo Insufficient permissions to run this tool
+    exit 1
+fi
 
 PATH=$PATH:/sbin
 


### PR DESCRIPTION
Running `bbb-conf` as an unprivileged user will give you a lot of errors and a broken result:

```
❯ bbb-conf --secret
grep: /etc/bigbluebutton/bbb-web.properties: Permission denied
grep: /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties: Permission denied
grep: /etc/bigbluebutton/bbb-web.properties: Permission denied
grep: /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties: Permission denied
grep: /etc/bigbluebutton/bbb-web.properties: Permission denied
grep: /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties: Permission denied
/usr/bin/bbb-conf: line 206: /etc/bigbluebutton/bbb-web.properties: Permission denied
grep: /etc/bigbluebutton/bbb-web.properties: Permission denied
grep: /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties: Permission denied
grep: /etc/bigbluebutton/bbb-web.properties: Permission denied
grep: /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties: Permission denied

    URL: /bigbluebutton/
    Secret:

    Link to the API-Mate:
    https://mconf.github.io/api-mate/#server=/bigbluebutton/&sharedSecret=
```

This patch makes the tool check for read permissions on one of the protected configuration files. If the user has permissions to access that file, things should be fine. If not, complain and fail fast.
