### PR TITLE
Html5: Add config to hide names in typing indicator

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/typing-indicator/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/typing-indicator/component.jsx
@@ -15,6 +15,10 @@ const messages = defineMessages({
     id: 'app.chat.multi.typing',
     description: 'displayed when 4 or more users are typing',
   },
+  someoneTyping: {
+    id: 'app.chat.someone.typing',
+    description: 'label used when one user is typing with disabled name',
+  },
 });
 
 class TypingIndicator extends PureComponent {
@@ -26,62 +30,85 @@ class TypingIndicator extends PureComponent {
 
   renderTypingElement() {
     const {
-      typingUsers, indicatorEnabled, intl,
+      typingUsers, indicatorEnabled, indicatorShowNames, intl,
     } = this.props;
 
     if (!indicatorEnabled || !typingUsers) return null;
 
     const { length } = typingUsers;
-    const isSingleTyper = length === 1;
-    const isCoupleTyper = length === 2;
-    const isMultiTypers = length > 2;
 
     let element = null;
 
-    if (isSingleTyper) {
-      const { name } = typingUsers[0];
-      element = (
-        <FormattedMessage
-          id="app.chat.one.typing"
-          description="label used when one user is typing"
-          values={{
-            0: <Styled.SingleTyper>
-              {`${name}`}
-&nbsp;
-            </Styled.SingleTyper>,
-          }}
-        />
-      );
-    }
+    if (indicatorShowNames) {
+      const isSingleTyper = length === 1;
+      const isCoupleTyper = length === 2;
+      const isMultiTypers = length > 2;
 
-    if (isCoupleTyper) {
-      const { name } = typingUsers[0];
-      const { name: name2 } = typingUsers[1];
-      element = (
-        <FormattedMessage
-          id="app.chat.two.typing"
-          description="label used when two users are typing"
-          values={{
-            0: <Styled.CoupleTyper>
-              {`${name}`}
+      if (isSingleTyper) {
+        const { name } = typingUsers[0];
+        element = (
+          <FormattedMessage
+            id="app.chat.one.typing"
+            description="label used when one user is typing"
+            values={{
+              0: <Styled.SingleTyper>
+                {`${name}`}
 &nbsp;
-            </Styled.CoupleTyper>,
-            1: <Styled.CoupleTyper>
-&nbsp;
-              {`${name2}`}
-&nbsp;
-            </Styled.CoupleTyper>,
-          }}
-        />
-      );
-    }
+              </Styled.SingleTyper>,
+            }}
+          />
+        );
+      }
 
-    if (isMultiTypers) {
-      element = (
-        <span>
-          {`${intl.formatMessage(messages.severalPeople)}`}
-        </span>
-      );
+      if (isCoupleTyper) {
+        const {name} = typingUsers[0];
+        const {name: name2} = typingUsers[1];
+        element = (
+          <FormattedMessage
+            id="app.chat.two.typing"
+            description="label used when two users are typing"
+            values={{
+              0: <Styled.CoupleTyper>
+                {`${name}`}
+&nbsp;
+              </Styled.CoupleTyper>,
+              1: <Styled.CoupleTyper>
+&nbsp;
+                {`${name2}`}
+&nbsp;
+              </Styled.CoupleTyper>,
+            }}
+          />
+        );
+      }
+
+      if (isMultiTypers) {
+        element = (
+          <span>
+            {`${intl.formatMessage(messages.severalPeople)}`}
+          </span>
+        );
+      }
+    } else {
+      // Show no names in typing indicator
+      const isSingleTyper = length === 1;
+      const isMultiTypers = length > 1;
+
+      if (isSingleTyper) {
+        element = (
+          <span>
+            {`${intl.formatMessage(messages.someoneTyping)}`}
+          </span>
+        );
+      }
+
+      if (isMultiTypers) {
+        element = (
+          <span>
+            {`${intl.formatMessage(messages.severalPeople)}`}
+          </span>
+        );
+      }
     }
 
     return element;

--- a/bigbluebutton-html5/imports/ui/components/chat/message-form/typing-indicator/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/message-form/typing-indicator/container.jsx
@@ -10,6 +10,7 @@ const CHAT_CONFIG = Meteor.settings.public.chat;
 const USER_CONFIG = Meteor.settings.public.user;
 const PUBLIC_CHAT_KEY = CHAT_CONFIG.public_id;
 const TYPING_INDICATOR_ENABLED = CHAT_CONFIG.typingIndicator.enabled;
+const TYPING_SHOW_NAMES = CHAT_CONFIG.typingIndicator.showNames;
 
 const TypingIndicatorContainer = props => <TypingIndicator {...props} />;
 
@@ -48,5 +49,6 @@ export default withTracker(({ idChatOpen }) => {
   return {
     typingUsers,
     indicatorEnabled: TYPING_INDICATOR_ENABLED,
+    indicatorShowNames: TYPING_SHOW_NAMES,
   };
 })(TypingIndicatorContainer);

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -572,6 +572,7 @@ public:
       chat_status_message: PUBLIC_CHAT_STATUS
     typingIndicator:
       enabled: true
+      showNames: true
     moderatorChatEmphasized: true
     autoConvertEmoji: true
     emojiPicker:

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -29,6 +29,7 @@
     "app.chat.notAway": "Is not away anymore",
     "app.chat.clearPublicChatMessage": "The public chat history was cleared by a moderator",
     "app.chat.multi.typing": "Multiple users are typing",
+    "app.chat.someone.typing": "Someone is typing",
     "app.chat.one.typing": "{0} is typing",
     "app.chat.two.typing": "{0} and {1} are typing",
     "app.chat.copySuccess": "Copied chat transcript",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->
Instructors would like to see if anyone in the chat still wants to participate. This is very important for the moderation.
Showing the names could lead to people not wanting to participate (self-awareness that others are watching when you type).

The provided changes should solve this issue by adding a new configuration option. This option allows to enable or disable the names in the typing indicator.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
No issue associated.

### Motivation

<!-- What inspired you to submit this pull request? -->
More participation by students (especially introverted and timid people) in chat when typing indication is enabled.

### More

<!-- Anything else we should know when reviewing? -->
<!-- - [ ] Added/updated documentation -->
