### PR TITLE
fix(accessibility): Enhance Color Contrast, Language Dropdown, and Screen Reader Feedback

### DIFF
--- a/bbb-learning-dashboard/src/components/StatusTable.jsx
+++ b/bbb-learning-dashboard/src/components/StatusTable.jsx
@@ -204,7 +204,7 @@ class StatusTable extends React.Component {
         <tbody className="bg-white divide-y whitespace-nowrap">
           { hasSlides ? (
             <tr className="bg-inherit">
-              <td className={`bg-inherit z-30 sticky ${isRTL ? 'right-0' : 'left-0'}`} />
+              <th className={`bg-inherit z-30 sticky ${isRTL ? 'right-0' : 'left-0'}`} scope="row" aria-label={intl.formatMessage(intlMessages.thumbnail)} />
               { periods.map((period) => {
                 const { slide, start, end } = period;
                 const padding = isRTL ? 'paddingLeft' : 'paddingRight';
@@ -260,7 +260,14 @@ class StatusTable extends React.Component {
               })
               .map((user) => (
                 <tr className="text-gray-700 bg-inherit">
-                  <td className={`z-30 px-4 py-3 bg-inherit sticky ${isRTL ? 'right-0' : 'left-0'}`}>
+                  <th
+                    className={`z-30 px-4 py-3 bg-inherit sticky ${isRTL ? 'right-0' : 'left-0'}`}
+                    scope="row"
+                    aria-label={intl.formatMessage({
+                      id: 'app.learningDashboard.user',
+                      defaultMessage: 'User',
+                    })}
+                  >
                     <div className="flex items-center text-sm">
                       <div className="relative hidden w-8 h-8 rounded-full md:block">
                         <UserAvatar user={user} />
@@ -270,7 +277,7 @@ class StatusTable extends React.Component {
                         <p className="font-semibold truncate xl:max-w-sm max-w-xs">{user.name}</p>
                       </div>
                     </div>
-                  </td>
+                  </th>
                   { periods.map((period) => {
                     const boundaryLeft = period.start;
                     const boundaryRight = period.end;

--- a/bbb-learning-dashboard/src/components/UsersTable.jsx
+++ b/bbb-learning-dashboard/src/components/UsersTable.jsx
@@ -472,12 +472,12 @@ class UsersTable extends React.Component {
                       !user.isModerator ? (
                         <td className={`px-4 py-3 text-sm text-center items ${opacity}`} data-test="userActivityScoreDashboard">
                           <svg viewBox="0 0 82 12" width="82" height="12" className="flex-none m-auto inline">
-                            <rect width="12" height="12" fill={usersActivityScore[user.userKey] > 0 ? '#A7F3D0' : '#e4e4e7'} />
-                            <rect width="12" height="12" x="14" fill={usersActivityScore[user.userKey] > 2 ? '#6EE7B7' : '#e4e4e7'} />
-                            <rect width="12" height="12" x="28" fill={usersActivityScore[user.userKey] > 4 ? '#34D399' : '#e4e4e7'} />
-                            <rect width="12" height="12" x="42" fill={usersActivityScore[user.userKey] > 6 ? '#10B981' : '#e4e4e7'} />
-                            <rect width="12" height="12" x="56" fill={usersActivityScore[user.userKey] > 8 ? '#059669' : '#e4e4e7'} />
-                            <rect width="12" height="12" x="70" fill={usersActivityScore[user.userKey] === 10 ? '#047857' : '#e4e4e7'} />
+                            <rect width="12" height="12" fill={usersActivityScore[user.userKey] > 0 ? '#4BA381' : '#e4e4e7'} />
+                            <rect width="12" height="12" x="14" fill={usersActivityScore[user.userKey] > 2 ? '#338866' : '#e4e4e7'} />
+                            <rect width="12" height="12" x="28" fill={usersActivityScore[user.userKey] > 4 ? '#1A6653' : '#e4e4e7'} />
+                            <rect width="12" height="12" x="42" fill={usersActivityScore[user.userKey] > 6 ? '#055C42' : '#e4e4e7'} />
+                            <rect width="12" height="12" x="56" fill={usersActivityScore[user.userKey] > 8 ? '#023B34' : '#e4e4e7'} />
+                            <rect width="12" height="12" x="70" fill={usersActivityScore[user.userKey] === 10 ? '#02362B' : '#e4e4e7'} />
                           </svg>
                           &nbsp;
                           <span className="text-xs bg-gray-200 rounded-full px-2">

--- a/bigbluebutton-html5/imports/ui/components/common/locales-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/locales-dropdown/component.jsx
@@ -70,7 +70,7 @@ class LocalesDropdown extends PureComponent {
           });
 
           return (
-            <option key={localeItem.locale} value={localeItem.locale}>
+            <option key={localeItem.locale} value={localeItem.locale} lang={localeItem.locale}>
               {localeItem.name}{localizedName && ` - ${localizedName}`}
             </option>
           );

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -88,6 +88,10 @@ const TldrawGlobalStyle = createGlobalStyle`
         border: solid ${borderSize} ${colorWhite} !important;
       }
     }
+    [id="TD-Styles-Color-Container"],
+    [id="TD-StylesMenu"] {
+      filter: invert(0%) hue-rotate(180deg) contrast(100%) !important;
+    }
   `}
   ${({ isPresenter, hasWBAccess }) => (!isPresenter && !hasWBAccess) && `
     #presentationInnerWrapper div{


### PR DESCRIPTION
### What does this PR do?
* Add lang attribute to locale select options
* Improve style menu color contrast in dark mode
* Darken activity score green boxes for compliant contrast ratio
* Convert first column from `td` to `th` / add scope & label

### Motivation
* The user language dropdown fails to identify the change of language.
* When in the dark mode theme, The “Color” label lacks sufficient contrast within the “Styles” menu. The contrast between the foreground and background text colors is insufficient (1.3:1), falling short of the 4.5:1 required for normal text.
* Multiple activity score colors lack sufficient contrast. A user interface component (Activity score) has a contrast between foreground and background that is insufficient (1.2:1); falling short of the 3:1 contrast ratio required.
* The timeline tab contains a complex table that fails to provide sufficient feedback about the row information for screen reader users. The first column “User” information should be a row header for each entry and is not.