### PR TITLE
fix(sec): Upgrade embedded Tomcat to 9.0.78

### DIFF
--- a/bigbluebutton-web/gradle.properties
+++ b/bigbluebutton-web/gradle.properties
@@ -3,5 +3,5 @@ gormVersion=7.1.0
 gradleWrapperVersion=7.3.1
 grailsGradlePluginVersion=5.0.0
 groovyVersion=3.0.9
-tomcatEmbedVersion=9.0.74
+tomcatEmbedVersion=9.0.78
 springVersion=2.7.12


### PR DESCRIPTION
### What does this PR do?

Upgrades the embedded Tomcat version in `bbb-web` from `9.0.74` to `9.0.78`.

### Motivation

The current Tomcat version is vulnerable to [CVE-2023-34981](https://www.cve.org/CVERecord?id=CVE-2023-34981).
