### PR TITLE
fix: Improve Focus When Changing Modal Tabs With Keyboard

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/modal/simple/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/modal/simple/component.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
+import FocusTrap from 'focus-trap-react';
 import { withModalState } from '../base/component';
 import Styled from './styles';
 
@@ -21,28 +22,67 @@ const propTypes = {
     callback: PropTypes.func,
   }),
   headerPosition: PropTypes.string,
+  shouldCloseOnOverlayClick: PropTypes.bool,
+  shouldShowCloseButton: PropTypes.bool,
+  overlayClassName: PropTypes.string,
+  modalisOpen: PropTypes.bool,
 };
 
 const defaultProps = {
+  title: '',
+  dismiss: {
+    callback: null,
+  },
   shouldCloseOnOverlayClick: true,
   shouldShowCloseButton: true,
   overlayClassName: 'modalOverlay',
   headerPosition: 'inner',
+  modalisOpen: false,
 };
 
 class ModalSimple extends Component {
   constructor(props) {
     super(props);
+    this.modalRef = React.createRef();
     this.handleDismiss = this.handleDismiss.bind(this);
+    this.handleRequestClose = this.handleRequestClose.bind(this);
+    this.handleOutsideClick = this.handleOutsideClick.bind(this);
+  }
+
+  componentDidMount() {
+    document.addEventListener('mousedown', this.handleOutsideClick, false);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('mousedown', this.handleOutsideClick, false);
   }
 
   handleDismiss() {
-    const {
-      modalHide,
-      dismiss,
-    } = this.props;
+    const { modalHide, dismiss } = this.props;
     if (!dismiss || !modalHide) return;
     modalHide(dismiss.callback);
+  }
+
+  handleRequestClose(event) {
+    const { onRequestClose } = this.props;
+    const closeModal = onRequestClose || this.handleDismiss;
+
+    closeModal();
+
+    if (event && event.type === 'click') {
+      setTimeout(() => {
+        if (document.activeElement) {
+          document.activeElement.blur();
+        }
+      }, 0);
+    }
+  }
+
+  handleOutsideClick(e) {
+    const { modalisOpen } = this.props;
+    if (this.modalRef.current && !this.modalRef.current.contains(e.target) && modalisOpen) {
+      this.handleRequestClose(e);
+    }
   }
 
   render() {
@@ -59,53 +99,42 @@ class ModalSimple extends Component {
       contentLabel,
       headerPosition,
       'data-test': dataTest,
+      children,
       ...otherProps
     } = this.props;
 
-    const closeModal = (onRequestClose || this.handleDismiss);
-
-    const handleRequestClose = (event) => {
-      closeModal();
-
-      if (event) {
-        event.persist();
-
-        if (event.type === 'click') {
-          setTimeout(() => {
-            document.activeElement.blur();
-          }, 0);
-        }
-      }
-    }
-
     return (
       <Styled.SimpleModal
-        id="simpleModal"
+        id={id || 'simpleModal'}
         isOpen={modalisOpen}
         className={className}
-        onRequestClose={handleRequestClose}
+        onRequestClose={this.handleRequestClose}
         contentLabel={title || contentLabel}
         data={{
           test: dataTest ?? null,
         }}
         {...otherProps}
       >
-        <Styled.Header
-          hideBorder={hideBorder}
-          headerPosition={headerPosition}
-          shouldShowCloseButton={shouldShowCloseButton}
-          modalDismissDescription={intl.formatMessage(intlMessages.modalCloseDescription)}
-          closeButtonProps={{
-            label: intl.formatMessage(intlMessages.modalClose),
-            'aria-label': `${intl.formatMessage(intlMessages.modalClose)} ${title || contentLabel}`,
-            onClick: handleRequestClose,
-          }}
-        >
-          {title}
-        </Styled.Header>
-        <Styled.Content>
-          {this.props.children}
-        </Styled.Content>
+        <FocusTrap active={modalisOpen}>
+          <div ref={this.modalRef}>
+            <Styled.Header
+              hideBorder={hideBorder}
+              headerPosition={headerPosition}
+              shouldShowCloseButton={shouldShowCloseButton}
+              modalDismissDescription={intl.formatMessage(intlMessages.modalCloseDescription)}
+              closeButtonProps={{
+                label: intl.formatMessage(intlMessages.modalClose),
+                'aria-label': `${intl.formatMessage(intlMessages.modalClose)} ${title || contentLabel}`,
+                onClick: this.handleRequestClose,
+              }}
+            >
+              {title || ''}
+            </Styled.Header>
+            <Styled.Content>
+              {children}
+            </Styled.Content>
+          </div>
+        </FocusTrap>
       </Styled.SimpleModal>
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/common/modal/simple/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/modal/simple/component.jsx
@@ -115,7 +115,7 @@ class ModalSimple extends Component {
         }}
         {...otherProps}
       >
-        <FocusTrap active={modalisOpen}>
+        <FocusTrap active={modalisOpen} focusTrapOptions={{ initialFocus: false }}>
           <div ref={this.modalRef}>
             <Styled.Header
               hideBorder={hideBorder}

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -3430,6 +3430,23 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
+    "focus-trap": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
+      "integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
+      "requires": {
+        "tabbable": "^6.2.0"
+      }
+    },
+    "focus-trap-react": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-10.2.1.tgz",
+      "integrity": "sha512-UrAKOn52lvfHF6lkUMfFhlQxFgahyNW5i6FpHWkDxAeD4FSk3iwx9n4UEA4Sims0G5WiGIi0fAyoq3/UVeNCYA==",
+      "requires": {
+        "focus-trap": "^7.5.2",
+        "tabbable": "^6.2.0"
+      }
+    },
     "follow-redirects": {
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
@@ -6767,6 +6784,11 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
+    },
+    "tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "table": {
       "version": "6.8.0",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -47,6 +47,7 @@
     "fastdom": "^1.0.10",
     "fibers": "^4.0.2",
     "flat": "^5.0.2",
+    "focus-trap-react": "^10.2.1",
     "hark": "^1.2.3",
     "html-to-image": "^1.9.0",
     "immutability-helper": "~2.8.1",


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where focus was lost when using tab controls with keyboard within a modal. With this fix, user focus will stay within the modal when navigating through controls.

### Motivation
Using the tab controls for both the keyboard shortcuts and the connection status controls result in the user focus moving from the control to the main landmark of the page (outside of the modal) when a tab is actioned.