### PR TITLE
Fix: Promoted moderators see everyone

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/components-data/users-context/adapter.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/users-context/adapter.jsx
@@ -1,46 +1,12 @@
 import { useContext, useEffect } from 'react';
 import { CurrentUser } from '/imports/api/users';
 import Users from '/imports/api/users';
-import UsersPersistentData from '/imports/api/users-persistent-data';
 import { UsersContext, ACTIONS } from './context';
 import ChatLogger from '/imports/ui/components/chat/chat-logger/ChatLogger';
 
 const Adapter = () => {
   const usingUsersContext = useContext(UsersContext);
   const { dispatch } = usingUsersContext;
-
-  useEffect(() => {
-    const usersPersistentDataCursor = UsersPersistentData.find({}, { sort: { timestamp: 1 } });
-    usersPersistentDataCursor.observe({
-      added: (obj) => {
-        ChatLogger.debug('usersAdapter::observe::added_persistent_user', obj);
-        dispatch({
-          type: ACTIONS.ADDED_USER_PERSISTENT_DATA,
-          value: {
-            user: obj,
-          },
-        });
-      },
-      changed: (obj) => {
-        ChatLogger.debug('usersAdapter::observe::changed_persistent_user', obj);
-        dispatch({
-          type: ACTIONS.CHANGED_USER_PERSISTENT_DATA,
-          value: {
-            user: obj,
-          },
-        });
-      },
-      removed: (obj) => {
-        ChatLogger.debug('usersAdapter::observe::removed', obj);
-        dispatch({
-          type: ACTIONS.REMOVED,
-          value: {
-            user: obj,
-          },
-        });
-      },
-    });
-  }, []);
 
   useEffect(() => {
     const usersCursor = Users.find({}, { sort: { timestamp: 1 } });

--- a/bigbluebutton-html5/imports/ui/components/components-data/users-context/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/users-context/context.jsx
@@ -53,7 +53,7 @@ const reducer = (state, action) => {
 
         return newState;
       }
-      return state;    
+      return state;
     }
 
     // USER PERSISTENT DATA
@@ -64,10 +64,9 @@ const reducer = (state, action) => {
           const newState = { ...state };
           newState[user.meetingId][user.userId] = {
             ...state[user.meetingId][user.userId],
-            loggedOut: false,
           };
-  
-          return newState;  
+
+          return newState;
         }
         return state;
       }

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -219,7 +219,7 @@ const getUsers = () => {
 };
 
 const formatUsers = (contextUsers, videoUsers, whiteboardUsers) => {
-  let users = contextUsers.filter((user) => user.loggedOut === false && user.left === false);
+  let users = contextUsers.filter((user) => !user.loggedOut).filter((user) => !user.left);
 
   const currentUser = Users.findOne({ userId: Auth.userID }, { fields: { role: 1, locked: 1 } });
   if (currentUser && currentUser.role === ROLE_VIEWER && currentUser.locked) {


### PR DESCRIPTION
### What does this PR do?

This PR fixes the bug where a user promote to moderator can see other users that have left the call by separating the filter in two steps instead of checking both states required only once. The filters was separated in two steps, because checking both states together was causing a conflict due to one of the states being "left" which was a state that waited for the user's re-connection for a certain amount of time and the "loggedOut" which did not have such property. 

### Closes Issue(s)

#18237