### PR TITLE
fix: unpin shared notes after switching presenter

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.jsx
@@ -151,7 +151,6 @@ const Notes = ({
         value: true,
       });
     }
-    return null;
   }, []);
 
   const renderHeaderOnMedia = () => {


### PR DESCRIPTION
### What does this PR do?

Fix crash that happens if shared notes is unpinned by a different presenter.