### PR TITLE
fix(accessibility): Restore Roving Functionality To User Chats And Captions List

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
@@ -51,7 +51,7 @@ const propTypes = {
 
 const defaultProps = {
   shortcuts: '',
-  tabIndex: 0,
+  tabIndex: -1,
 };
 
 const ChatListItem = (props) => {

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-captions/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-captions/container.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import UserCaptionsItem from './component';
+import Service from '/imports/ui/components/user-list/service';
 import CaptionsService from '/imports/ui/components/captions/service';
 import { layoutSelectInput, layoutDispatch } from '../../../layout/context';
 
@@ -8,8 +9,8 @@ const Container = (props) => {
   const sidebarContent = layoutSelectInput((i) => i.sidebarContent);
   const { sidebarContentPanel } = sidebarContent;
   const layoutContextDispatch = layoutDispatch();
-
-  return <UserCaptionsItem {...{ sidebarContentPanel, layoutContextDispatch, ...props }} />;
+  const { roving } = Service;
+  return <UserCaptionsItem {...{ sidebarContentPanel, layoutContextDispatch, roving, ...props }} />;
 };
 
 export default withTracker(() => ({

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/component.jsx
@@ -47,13 +47,13 @@ class UserMessages extends PureComponent {
       this._msgsList.addEventListener(
         'keydown',
         this.rove,
+        true,
       );
     }
   }
 
   componentDidUpdate(prevProps, prevState) {
     const { selectedChat } = this.state;
-
     if (selectedChat && selectedChat !== prevState.selectedChat) {
       const { firstChild } = selectedChat;
       if (firstChild) firstChild.focus();
@@ -97,6 +97,7 @@ class UserMessages extends PureComponent {
     const { selectedChat } = this.state;
     const msgItemsRef = findDOMNode(this._msgItems);
     roving(event, this.changeState, msgItemsRef, selectedChat);
+    event.stopPropagation();
   }
 
   render() {
@@ -120,7 +121,7 @@ class UserMessages extends PureComponent {
         </Styled.Container>
         <Styled.ScrollableList
           role="tabpanel"
-          tabIndex={-1}
+          tabIndex={0}
           ref={(ref) => { this._msgsList = ref; }}
         >
           <Styled.List>


### PR DESCRIPTION
### What does this PR do?

This PR reinstates roving `tabindex` functionality in the `UserMessages` list and introduces it to the `UserCaptions` list, thereby enabling keyboard navigation and enhancing keyboard accessibility.

### Motivation
To enhance user experience by making the Captions list keyboard-navigable and restoring the tab stop element in the Chats list, reducing the need for excessive tabbing.
