### PR TITLE
fix: Button "Show Welcome Message" with errors

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingWelcomeDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingWelcomeDAO.scala
@@ -10,15 +10,15 @@ import scala.util.{ Failure, Success }
 case class MeetingWelcomeDbModel(
     meetingId:               String,
     welcomeMsgTemplate:      String,
-    welcomeMsg:              String,
-    welcomeMsgForModerators: String
+    welcomeMsg:              Option[String],
+    welcomeMsgForModerators: Option[String]
 )
 
 class MeetingWelcomeDbTableDef(tag: Tag) extends Table[MeetingWelcomeDbModel](tag, "meeting_welcome") {
   val meetingId = column[String]("meetingId", O.PrimaryKey)
   val welcomeMsgTemplate = column[String]("welcomeMsgTemplate")
-  val welcomeMsg = column[String]("welcomeMsg")
-  val welcomeMsgForModerators = column[String]("welcomeMsgForModerators")
+  val welcomeMsg = column[Option[String]]("welcomeMsg")
+  val welcomeMsgForModerators = column[Option[String]]("welcomeMsgForModerators")
 
   //  def fk_meetingId: ForeignKeyQuery[MeetingDbTableDef, MeetingDbModel] = foreignKey("fk_meetingId", meetingId, TableQuery[MeetingDbTableDef])(_.meetingId)
 
@@ -32,8 +32,14 @@ object MeetingWelcomeDAO {
         MeetingWelcomeDbModel(
           meetingId = meetingId,
           welcomeMsgTemplate = welcomeProp.welcomeMsgTemplate,
-          welcomeMsg = welcomeProp.welcomeMsg,
-          welcomeMsgForModerators = welcomeProp.modOnlyMessage
+          welcomeMsg = welcomeProp.welcomeMsg match {
+            case "" => None
+            case m  => Some(m)
+          },
+          welcomeMsgForModerators = welcomeProp.modOnlyMessage match {
+            case "" => None
+            case m  => Some(m)
+          }
         )
       )
     ).onComplete {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/component.tsx
@@ -98,7 +98,8 @@ export const ChatActions: React.FC = () => {
     if (dataPermissions) {
       setUserIsmoderator(dataPermissions.user_current[0].isModerator);
       setMeetingIsBreakout(dataPermissions.meeting[0].isBreakout);
-      if (!isEmpty(dataPermissions.user_welcomeMsgs[0].welcomeMsg)) {
+      if (!isEmpty(dataPermissions.user_welcomeMsgs[0].welcomeMsg || '') ||
+          !isEmpty(dataPermissions.user_welcomeMsgs[0].welcomeMsgForModerators || '')) {
         setShowShowWelcomeMessages(true);
       }
     }
@@ -132,13 +133,13 @@ export const ChatActions: React.FC = () => {
       {
         key: uniqueIdsRef.current[2],
         enable: userIsModerator && !meetingIsBreakout,
-        icon: 'download',
+        icon: 'delete',
         dataTest: 'chatClear',
         label: intl.formatMessage(intlMessages.clear),
         onClick: () => clearPublicChatHistory(),
       },
       {
-        key: uniqueIdsRef.current[4],
+        key: uniqueIdsRef.current[3],
         enable: showShowWelcomeMessages,
         icon: 'about',
         dataTest: 'restoreWelcomeMessages',
@@ -150,7 +151,7 @@ export const ChatActions: React.FC = () => {
       },
     ];
     return dropdownActions.filter((action) => action.enable);
-  }, [userIsModerator, meetingIsBreakout]);
+  }, [userIsModerator, meetingIsBreakout, showShowWelcomeMessages]);
   if (errorHistory) return <p>Error loading chat history: {JSON.stringify(errorHistory)}</p>;
   if (errorPermissions) return <p>Error loading permissions: {JSON.stringify(errorPermissions)}</p>;
   return (


### PR DESCRIPTION
Related to this button:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/431f324d-aded-498d-ac43-f23fc5af535b)

This PR fix the following bugs:

- Not showing "Show Welcome Message" to Viewers
- Not showing "Show Welcome Message" to Moderators if there is only `welcomeMsgForModerators` and not `welcomeMsg`
- It's showing "Show Welcome Message" if the value of `welcomeMsg` is `null` (instead of `""`)
- Wrong icon for `Clear` button
- Akka-apps: Set `welcomeMsgs` as `null` instead of `""` in Database
- Fix a console error about BBBMenu

![console-error-BBBMenu](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/ecc03b06-c4f8-4236-ba0d-6558a8225962)

