### PR TITLE
graphql: Introduces a new flag isRunningEchoTest

### DIFF
--- a/bbb-graphql-client-test/src/MyInfo.js
+++ b/bbb-graphql-client-test/src/MyInfo.js
@@ -1,14 +1,36 @@
-import {gql, useQuery} from '@apollo/client';
+import {gql, useMutation, useQuery, useSubscription} from '@apollo/client';
+import React from "react";
 
 export default function MyInfo() {
-  const { loading, error, data } = useQuery(
-    gql`query {
+
+    //where is not necessary once user can update only its own status
+    //Hasura accepts "now()" as value to timestamp fields
+    const [updateUserClientEchoTestRunningAtMeAsNow] = useMutation(gql`
+      mutation UpdateUserClientEchoTestRunningAt {
+        update_user_current(
+            where: {}
+            _set: { echoTestRunningAt: "now()" }
+          ) {
+            affected_rows
+          }
+      }
+    `);
+
+    const handleUpdateUserEchoTestRunningAt = () => {
+        updateUserClientEchoTestRunningAtMeAsNow();
+    };
+
+
+  const { loading, error, data } = useSubscription(
+    gql`subscription {
       user_current {
         userId
         name
         meeting {
             name
         }
+        echoTestRunningAt
+        isRunningEchoTest
       }
     }`
   );
@@ -24,6 +46,8 @@ export default function MyInfo() {
             <th>userId</th>
             <th>name</th>
             <th>Meeting</th>
+            <th>echoTestRunningAt</th>
+            <th>isRunningEchoTest</th>
         </tr>
       </thead>
       <tbody>
@@ -34,6 +58,10 @@ export default function MyInfo() {
                   <td>{curr.userId}</td>
                   <td>{curr.name}</td>
                   <td>{curr.meeting.name}</td>
+                  <td>{curr.echoTestRunningAt}
+                      <button onClick={() => handleUpdateUserEchoTestRunningAt()}>Set running now!</button>
+                  </td>
+                  <td>{curr.isRunningEchoTest ? 'Yes' : 'No'}</td>
               </tr>
           );
         })}

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -286,7 +286,8 @@ CREATE TABLE "user" (
 	"pinned" bool,
 	"locked" bool,
 	"speechLocale" varchar(255),
-	"hasDrawPermissionOnCurrentPage" bool default FALSE
+	"hasDrawPermissionOnCurrentPage" bool default FALSE,
+	"echoTestRunningAt" timestamp
 );
 CREATE INDEX "idx_user_meetingId" ON "user"("meetingId");
 CREATE INDEX "idx_user_extId" ON "user"("meetingId", "extId");
@@ -373,6 +374,7 @@ AS SELECT "user"."userId",
     "user"."pinned",
     "user"."locked",
     "user"."speechLocale",
+    CASE WHEN "user"."echoTestRunningAt" > current_timestamp - INTERVAL '3 seconds' THEN TRUE ELSE FALSE END "isRunningEchoTest",
     "user"."hasDrawPermissionOnCurrentPage",
     CASE WHEN "user"."role" = 'MODERATOR' THEN true ELSE false END "isModerator",
     CASE WHEN "user"."joined" IS true AND "user"."expired" IS false AND "user"."loggedOut" IS false THEN true ELSE false END "isOnline"
@@ -423,6 +425,8 @@ AS SELECT "user"."userId",
     "user"."locked",
     "user"."speechLocale",
     "user"."hasDrawPermissionOnCurrentPage",
+    "user"."echoTestRunningAt",
+    CASE WHEN "user"."echoTestRunningAt" > current_timestamp - INTERVAL '3 seconds' THEN TRUE ELSE FALSE END "isRunningEchoTest",
     CASE WHEN "user"."role" = 'MODERATOR' THEN true ELSE false END "isModerator"
    FROM "user";
 

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
@@ -85,6 +85,7 @@ select_permissions:
         - isDialIn
         - isModerator
         - isOnline
+        - isRunningEchoTest
         - joined
         - locked
         - loggedOut

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
@@ -119,6 +119,7 @@ select_permissions:
         - clientType
         - color
         - disconnected
+        - echoTestRunningAt
         - ejectReason
         - ejectReasonCode
         - ejected
@@ -129,6 +130,7 @@ select_permissions:
         - hasDrawPermissionOnCurrentPage
         - isDialIn
         - isModerator
+        - isRunningEchoTest
         - joined
         - locked
         - loggedOut
@@ -147,3 +149,15 @@ select_permissions:
               _eq: X-Hasura-MeetingId
           - userId:
               _eq: X-Hasura-UserId
+update_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - echoTestRunningAt
+      filter:
+        _and:
+          - meetingId:
+              _eq: X-Hasura-MeetingId
+          - userId:
+              _eq: X-Hasura-UserId
+      check: null


### PR DESCRIPTION
Currently, it's easy to identify if a user is configuring their microphone and is not yet able to listen by noting a particular icon:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/c8e34902-2a6a-40d6-aacb-1ee0e8eb221e)

An exciting update, identified as #14021, is set to be added to BBB, introducing the feature of "transparent listen only". This new feature paves the way for us to change the system behavior and enables a user to join the audio automatically upon opening the BBB interface. This contrasts with the current system, where the user needs to manually click to join audio.

However, if we implement this new default behavior, we face a challenge. While a user is configuring their microphone and performing the Echo Test, the meeting audio is automatically muted. During this time, other users might presume the first user is already listening, which is not the case. To address this, we propose the introduction of a new flag indicating whether a user is actively running the Echo Test (and consequently not listening to others). In the future, we could visually represent this state in the User Interface with a badge.

We will add a new property for users, named `echoTestRunningAt`, which will be updated every second while the Echo Test is being performed. During this period, the `isRunningEchoTest` flag will be set to true. If `echoTestRunningAt` isn't updated for 3 consecutive seconds, the `isRunningEchoTest` flag will automatically revert to false.
![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/b852c12e-f27f-4439-82bc-3d83f2729274)




Query to get this flag:
```
user {
        isRunningEchoTest
}
```

Query to get this flag in user_current:
```
user_current {
        echoTestRunningAt
        isRunningEchoTest
}
```

Mutation to update `echoTestRunningAt`. 
```
mutation UpdateUserClientEchoTestRunningAt {
        update_user_current(
            where: {}
            _set: { echoTestRunningAt: "now()" }
          ) {
            affected_rows
          }
      }
```