### PR TITLE
test(notes): Pinning notes improvement

### DIFF
--- a/bigbluebutton-tests/playwright/sharednotes/sharednotes.js
+++ b/bigbluebutton-tests/playwright/sharednotes/sharednotes.js
@@ -191,26 +191,38 @@ class SharedNotes extends MultiUsers {
     await this.userPage.wasRemoved(e.hideNotesLabel);
   }
 
-  async pinNotesOntoWhiteboard() {
+  async pinAndUnpinNotesOntoWhiteboard() {
     const { sharedNotesEnabled } = getSettings();
     test.fail(!sharedNotesEnabled, 'Shared notes is disabled');
 
     await this.userPage.waitAndClick(e.minimizePresentation);
     await this.userPage.hasElement(e.restorePresentation);
-
     await startSharedNotes(this.modPage);
     await this.modPage.waitAndClick(e.notesOptions);
     await this.modPage.waitAndClick(e.pinNotes);
     await this.modPage.hasElement(e.unpinNotes);
 
     await this.userPage.hasElement(e.minimizePresentation);
-
     const notesLocator = getNotesLocator(this.modPage);
     await notesLocator.type('Hello');
     const notesLocatorUser = getNotesLocator(this.userPage);
-
     await expect(notesLocator).toContainText(/Hello/, { timeout: 20000 });
     await expect(notesLocatorUser).toContainText(/Hello/);
+
+    // unpin notes
+    await this.modPage.waitAndClick(e.unpinNotes);
+    await this.modPage.hasElement(e.whiteboard);
+    await this.userPage.hasElement(e.whiteboard);
+    await startSharedNotes(this.modPage);
+    await this.modPage.waitAndClick(e.notesOptions);
+    await this.modPage.waitAndClick(e.pinNotes);
+    await this.modPage.hasElement(e.unpinNotes);
+    // make viewer as presenter and unpin pinned notes
+    await this.modPage.waitAndClick(e.userListItem);
+    await this.modPage.waitAndClick(e.makePresenter);
+    await this.userPage.waitAndClick(e.unpinNotes);
+    await this.userPage.hasElement(e.whiteboard);
+    await this.modPage.hasElement(e.whiteboard);
   }
 
   async editMessage() {

--- a/bigbluebutton-tests/playwright/sharednotes/sharednotes.spec.js
+++ b/bigbluebutton-tests/playwright/sharednotes/sharednotes.spec.js
@@ -38,7 +38,7 @@ test.describe.parallel('Shared Notes', () => {
     await sharedNotes.seeNotesWithoutEditPermission();
   });
 
-  test('Pin notes onto whiteboard', async () => {
-    await sharedNotes.pinNotesOntoWhiteboard();
+  test('Pin and unpin notes onto whiteboard', async () => {
+    await sharedNotes.pinAndUnpinNotesOntoWhiteboard();
   });
 });


### PR DESCRIPTION
### What does this PR do?
- Changes test name to `Pin and unpin notes onto whiteboard` - now also checking the unpin action;
- Adds steps to cover crash-bug fixed in https://github.com/bigbluebutton/bigbluebutton/pull/18343;

Note: we're facing some inconsistencies running shared notes tests, since opening 2 or more tabs in the same window/browser type might show an alert with a button to force the user to use only one of them. We don't want to hit this in the tests, but no workaround has been found yet. if necessary, we'll skip them temporally but, for now, all shared notes tests are available
