### PR TITLE
docs: Add instructions for resolving Java version conflicts

### DIFF
--- a/docs/docs/development/dev-guide.md
+++ b/docs/docs/development/dev-guide.md
@@ -663,6 +663,18 @@ sudo /etc/init.d/ntp restart
 
 The above will re-sync your clock.
 
+### Resolving Conflicts Between Java Versions
+
+In situations where multiple versions of Java are installed, BBB components may encounter build errors. One such error message could state, for example, that `'17' is not a valid choice for '-release'`. This specific error arises when the `bbb-common-message` component requires Java 17 for its operation, but the `sbt` build tool is using Java 11 instead.
+
+To address this, you need to set the appropriate Java version. The following command will set Java 17 as the active version:
+
+```bash
+update-java-alternatives -s java-1.17.0-openjdk-amd64
+```
+
+By executing this command, the system is instructed to use Java 17, i.e., the version with which BBB is currently compatible.
+
 ## Set up HTTPS
 
 See the [installation instructions](/administration/install) on how to configure ssl on your BigBlueButton server.


### PR DESCRIPTION
### What does this PR do?
Modifies BBB's documentation to include instructions for resolving potential conflicts when multiple versions of Java are installed. The modifications suggest using the `update-java-alternatives` command to set Java 17 as the active version. This is necessary as `bbb-common-message` now requires Java 17, but might mistakenly use Java 11 if it's also installed.

### Motivation

The motivation for this change comes from running into repeated build errors myself. The command suggested is in line with the one used in a previous [commit](https://github.com/bigbluebutton/bbb-install/pull/660/files#diff-b02a2e8accf3dc268b4cc8c4a6ce2b6b51cbaee1a254fb674c6429fbfdf5ef81R320).

### More
- [x] Added/updated documentation
