### PR TITLE
tests: Improve the handling of failures during the workflow

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -55,12 +55,13 @@ jobs:
       #       artifacts.tar
       - name: Fake package build
         run: |
-          sudo sh -c '
+          sudo -i <<EOF
+          set -e
           echo "Faking a package build (to speed up installation test)"
           cd /
-          wget -q "http://ci.bbb.imdt.dev/artifacts.tar"
+          wget -nv "http://ci.bbb.imdt.dev/artifacts.tar"
           tar xf artifacts.tar
-          '
+          EOF
       - name: Generate CA
         run: |
           sudo -i <<EOF
@@ -127,7 +128,7 @@ jobs:
         run: |
             sudo -i <<EOF
             set -e
-            cd /root/ && wget -q https://raw.githubusercontent.com/bigbluebutton/bbb-install/v2.7.x-release/bbb-install.sh -O bbb-install.sh
+            cd /root/ && wget -nv https://raw.githubusercontent.com/bigbluebutton/bbb-install/v2.7.x-release/bbb-install.sh -O bbb-install.sh
             cat bbb-install.sh | sed "s|> /etc/apt/sources.list.d/bigbluebutton.list||g" | bash -s -- -v focal-27-dev -s bbb-ci.test -j -d /certs/
             bbb-conf --salt bbbci
             echo "NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/bbb-dev/bbb-dev-ca.crt" >> /usr/share/meteor/bundle/bbb-html5-with-roles.conf

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -88,7 +88,7 @@ jobs:
           cd /root/bbb-ci-ssl/
           echo "$(hostname -I | cut -d" " -f1) bbb-ci.test" >> /etc/hosts
           openssl genrsa -out bbb-ci.test.key 2048
-          rm bbb-ci.test.csr bbb-ci.test.crt bbb-ci.test.key
+          rm -f bbb-ci.test.csr bbb-ci.test.crt bbb-ci.test.key
           cat > bbb-ci.test.ext << EOF
           authorityKeyIdentifier=keyid,issuer
           basicConstraints=CA:FALSE

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -72,7 +72,6 @@ jobs:
           openssl genrsa -des3 -out bbb-dev-ca.key -passout file:/root/bbb-ci-ssl/bbb-dev-ca.pass 2048 ;
           openssl req -x509 -new -nodes -key bbb-dev-ca.key -sha256 -days 1460 -passin file:/root/bbb-ci-ssl/bbb-dev-ca.pass -out bbb-dev-ca.crt -subj "/C=CA/ST=BBB/L=BBB/O=BBB/OU=BBB/CN=BBB-DEV" ;
           EOF
-          '
       - name: Trust CA
         run: |
           sudo -i <<EOF
@@ -82,7 +81,6 @@ jobs:
           sudo chmod 644 /usr/local/share/ca-certificates/bbb-dev/bbb-dev-ca.crt
           sudo update-ca-certificates
           EOF
-          '
       - name: Generate certificate
         run: |
           sudo sh -c '
@@ -120,7 +118,6 @@ jobs:
             cd /artifacts && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
             echo "deb [trusted=yes] file:/artifacts/ ./" >> /etc/apt/sources.list
             EOF
-            '
       - name: Prepare for install
         run: |
             sudo sh -c '

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -107,8 +107,9 @@ jobs:
       - name: Setup local repository
         run: |
             sudo sh -c '
+            set -e
             apt install -yq dpkg-dev
-            cd /root && wget -q http://ci.bbb.imdt.dev/cache-3rd-part-packages.tar
+            cd /root && wget -q http://ci.bbbvm.imdt.com.br/cache-3rd-part-packages.tar
             cp -r /home/runner/work/bigbluebutton/bigbluebutton/artifacts/ /artifacts/
             cd /artifacts && tar xf /root/cache-3rd-part-packages.tar
             cd /artifacts && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -106,14 +106,12 @@ jobs:
           '
       - name: Setup local repository
         run: |
-            sudo sh -c '
-            set -e
-            apt install -yq dpkg-dev
-            cd /root && wget -q http://ci.bbbvm.imdt.com.br/cache-3rd-part-packages.tar
-            cp -r /home/runner/work/bigbluebutton/bigbluebutton/artifacts/ /artifacts/
-            cd /artifacts && tar xf /root/cache-3rd-part-packages.tar
-            cd /artifacts && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
-            echo "deb [trusted=yes] file:/artifacts/ ./" >> /etc/apt/sources.list
+            sudo apt install -yq dpkg-dev
+            sudo cd /root && wget -q http://ci.bbbvm.imdt.com.br/cache-3rd-part-packages.tar
+            sudo cp -r /home/runner/work/bigbluebutton/bigbluebutton/artifacts/ /artifacts/
+            sudo cd /artifacts && tar xf /root/cache-3rd-part-packages.tar
+            sudo cd /artifacts && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
+            sudo echo "deb [trusted=yes] file:/artifacts/ ./" >> /etc/apt/sources.list
             '
       - name: Prepare for install
         run: |

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -108,10 +108,10 @@ jobs:
         shell: bash
         run: |
             sudo apt install -yq dpkg-dev
-            sudo cd /root && wget -q http://ci.bbbvm.imdt.com.br/cache-3rd-part-packages.tar
+            cd /root && sudo wget -q http://ci.bbbvm.imdt.com.br/cache-3rd-part-packages.tar
             sudo cp -r /home/runner/work/bigbluebutton/bigbluebutton/artifacts/ /artifacts/
-            sudo cd /artifacts && tar xf /root/cache-3rd-part-packages.tar
-            sudo cd /artifacts && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
+            cd /artifacts && sudo tar xf /root/cache-3rd-part-packages.tar
+            cd /artifacts && sudo dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
             sudo echo "deb [trusted=yes] file:/artifacts/ ./" >> /etc/apt/sources.list
             '
       - name: Prepare for install

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -134,7 +134,6 @@ jobs:
             sed -i "s/\"minify\": true,/\"minify\": false,/" /usr/share/etherpad-lite/settings.json
             bbb-conf --restart
             EOF
-            '
       - name: Install test dependencies
         working-directory: ./bigbluebutton-tests/playwright
         run: |
@@ -197,7 +196,6 @@ jobs:
           bbb-conf --zip
           cp $(ls -t /root/*.tar.gz | head -1) ./bbb-logs.tar.gz
           EOF
-          '
       - if: failure()
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -63,21 +63,25 @@ jobs:
           '
       - name: Generate CA
         run: |
-          sudo sh -c '
+          sudo -i <<EOF
+          set -e
           mkdir /root/bbb-ci-ssl/
           cd /root/bbb-ci-ssl/
           openssl rand -base64 48 > /root/bbb-ci-ssl/bbb-dev-ca.pass ;
           chmod 600 /root/bbb-ci-ssl/bbb-dev-ca.pass ;
           openssl genrsa -des3 -out bbb-dev-ca.key -passout file:/root/bbb-ci-ssl/bbb-dev-ca.pass 2048 ;
           openssl req -x509 -new -nodes -key bbb-dev-ca.key -sha256 -days 1460 -passin file:/root/bbb-ci-ssl/bbb-dev-ca.pass -out bbb-dev-ca.crt -subj "/C=CA/ST=BBB/L=BBB/O=BBB/OU=BBB/CN=BBB-DEV" ;
+          EOF
           '
       - name: Trust CA
         run: |
-          sudo sh -c '
+          sudo -i <<EOF
+          set -e
           sudo mkdir /usr/local/share/ca-certificates/bbb-dev/
           sudo cp /root/bbb-ci-ssl/bbb-dev-ca.crt /usr/local/share/ca-certificates/bbb-dev/
           sudo chmod 644 /usr/local/share/ca-certificates/bbb-dev/bbb-dev-ca.crt
           sudo update-ca-certificates
+          EOF
           '
       - name: Generate certificate
         run: |
@@ -124,13 +128,15 @@ jobs:
             '
       - name: Install BBB
         run: |
-            sudo sh -c '
+            sudo -i <<EOF
+            set -e
             cd /root/ && wget -q https://raw.githubusercontent.com/bigbluebutton/bbb-install/v2.7.x-release/bbb-install.sh -O bbb-install.sh
             cat bbb-install.sh | sed "s|> /etc/apt/sources.list.d/bigbluebutton.list||g" | bash -s -- -v focal-27-dev -s bbb-ci.test -j -d /certs/
             bbb-conf --salt bbbci
             echo "NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/bbb-dev/bbb-dev-ca.crt" >> /usr/share/meteor/bundle/bbb-html5-with-roles.conf
             sed -i "s/\"minify\": true,/\"minify\": false,/" /usr/share/etherpad-lite/settings.json
             bbb-conf --restart
+            EOF
             '
       - name: Install test dependencies
         working-directory: ./bigbluebutton-tests/playwright
@@ -173,7 +179,7 @@ jobs:
       - if: failure()
         name: Prepare artifacts (configs and logs)
         run: |
-          sudo sh -c '
+          sudo -i <<EOF
           mkdir configs
           cp /etc/haproxy/haproxy.cfg configs/haproxy.cfg
           touch /etc/bigbluebutton/turn-stun-servers.xml
@@ -193,6 +199,7 @@ jobs:
           chmod a+r -R configs
           bbb-conf --zip
           cp $(ls -t /root/*.tar.gz | head -1) ./bbb-logs.tar.gz
+          EOF
           '
       - if: failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -107,12 +107,14 @@ jobs:
       - name: Setup local repository
         shell: bash
         run: |
-            sudo apt install -yq dpkg-dev
-            cd /root && sudo wget -q http://ci.bbbvm.imdt.com.br/cache-3rd-part-packages.tar
-            sudo cp -r /home/runner/work/bigbluebutton/bigbluebutton/artifacts/ /artifacts/
-            cd /artifacts && sudo tar xf /root/cache-3rd-part-packages.tar
-            cd /artifacts && sudo dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
-            sudo echo "deb [trusted=yes] file:/artifacts/ ./" >> /etc/apt/sources.list
+            sudo -i <<EOF
+            apt install -yq dpkg-dev
+            cd /root && wget -q http://ci.bbbvm.imdt.com.br/cache-3rd-part-packages.tar
+            cp -r /home/runner/work/bigbluebutton/bigbluebutton/artifacts/ /artifacts/
+            cd /artifacts && tar xf /root/cache-3rd-part-packages.tar
+            cd /artifacts && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
+            echo "deb [trusted=yes] file:/artifacts/ ./" >> /etc/apt/sources.list
+            EOF
             '
       - name: Prepare for install
         run: |

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -61,6 +61,7 @@ jobs:
       #     cd /
       #     wget -nv "http://ci.bbb.imdt.dev/artifacts.tar"
       #     tar xf artifacts.tar
+      #     mv artifacts /home/runner/work/bigbluebutton/bigbluebutton/artifacts/
       #     EOF
       - name: Generate CA
         run: |
@@ -193,9 +194,10 @@ jobs:
           cp /etc/bbb-webrtc-recorder/bbb-webrtc-recorder.yml configs/bbb-webrtc-recorder-default.yml
           cp /usr/share/bigbluebutton/nginx/sip.nginx configs/nginx_sip.nginx
           cp /etc/hosts /configs/hosts
-          chmod a+r -R configs
+          mv configs /home/runner/work/bigbluebutton/bigbluebutton/configs
+          chmod a+r -R /home/runner/work/bigbluebutton/bigbluebutton/configs
           bbb-conf --zip
-          ls -t /root/*.tar.gz | head -1 | xargs -I '{}' cp '{}' ./bbb-logs.tar.gz
+          ls -t /root/*.tar.gz | head -1 | xargs -I '{}' cp '{}' /home/runner/work/bigbluebutton/bigbluebutton/bbb-logs.tar.gz
           EOF
       - if: failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -195,7 +195,7 @@ jobs:
           cp /etc/hosts /configs/hosts
           chmod a+r -R configs
           bbb-conf --zip
-          cp $(ls -t /root/*.tar.gz | head -1) ./bbb-logs.tar.gz
+          ls -t /root/*.tar.gz | head -1 | xargs -I '{}' cp '{}' ./bbb-logs.tar.gz
           EOF
       - if: failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -19,49 +19,49 @@ jobs:
   build-install-and-test:
     runs-on: ubuntu-20.04
     steps:
-      # - uses: actions/checkout@v3
-      # - run: ./build/get_external_dependencies.sh
-      # - run: ./build/setup.sh bbb-apps-akka
-      # - run: ./build/setup.sh bbb-config
-      # - run: ./build/setup.sh bbb-etherpad
-      # - run: ./build/setup.sh bbb-export-annotations
-      # - run: ./build/setup.sh bbb-freeswitch-core
-      # - run: ./build/setup.sh bbb-freeswitch-sounds
-      # - run: ./build/setup.sh bbb-fsesl-akka
-      # - run: ./build/setup.sh bbb-html5-nodejs
-      # - run: ./build/setup.sh bbb-html5
-      # - run: ./build/setup.sh bbb-learning-dashboard
-      # - run: ./build/setup.sh bbb-libreoffice-docker
-      # - run: ./build/setup.sh bbb-mkclean
-      # - run: ./build/setup.sh bbb-pads
-      # - run: ./build/setup.sh bbb-playback
-      # - run: ./build/setup.sh bbb-playback-notes
-      # - run: ./build/setup.sh bbb-playback-podcast
-      # - run: ./build/setup.sh bbb-playback-presentation
-      # - run: ./build/setup.sh bbb-playback-screenshare
-      # - run: ./build/setup.sh bbb-playback-video
-      # - run: ./build/setup.sh bbb-record-core
-      # - run: ./build/setup.sh bbb-web
-      # - run: ./build/setup.sh bbb-webrtc-sfu
-      # - run: ./build/setup.sh bbb-webrtc-recorder
-      # - run: ./build/setup.sh bbb-transcription-controller
-      # - run: ./build/setup.sh bigbluebutton
-      # - run: tar cvf artifacts.tar artifacts/
-      # - name: Archive packages
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     name: artifacts.tar
-      #     path: |
-      #       artifacts.tar
-      - name: Fake package build
-        run: |
-          sudo -i <<EOF
-          set -e
-          echo "Faking a package build (to speed up installation test)"
-          cd /
-          wget -nv "http://ci.bbb.imdt.dev/artifacts.tar"
-          tar xf artifacts.tar
-          EOF
+      - uses: actions/checkout@v3
+      - run: ./build/get_external_dependencies.sh
+      - run: ./build/setup.sh bbb-apps-akka
+      - run: ./build/setup.sh bbb-config
+      - run: ./build/setup.sh bbb-etherpad
+      - run: ./build/setup.sh bbb-export-annotations
+      - run: ./build/setup.sh bbb-freeswitch-core
+      - run: ./build/setup.sh bbb-freeswitch-sounds
+      - run: ./build/setup.sh bbb-fsesl-akka
+      - run: ./build/setup.sh bbb-html5-nodejs
+      - run: ./build/setup.sh bbb-html5
+      - run: ./build/setup.sh bbb-learning-dashboard
+      - run: ./build/setup.sh bbb-libreoffice-docker
+      - run: ./build/setup.sh bbb-mkclean
+      - run: ./build/setup.sh bbb-pads
+      - run: ./build/setup.sh bbb-playback
+      - run: ./build/setup.sh bbb-playback-notes
+      - run: ./build/setup.sh bbb-playback-podcast
+      - run: ./build/setup.sh bbb-playback-presentation
+      - run: ./build/setup.sh bbb-playback-screenshare
+      - run: ./build/setup.sh bbb-playback-video
+      - run: ./build/setup.sh bbb-record-core
+      - run: ./build/setup.sh bbb-web
+      - run: ./build/setup.sh bbb-webrtc-sfu
+      - run: ./build/setup.sh bbb-webrtc-recorder
+      - run: ./build/setup.sh bbb-transcription-controller
+      - run: ./build/setup.sh bigbluebutton
+      - run: tar cvf artifacts.tar artifacts/
+      - name: Archive packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts.tar
+          path: |
+            artifacts.tar
+      # - name: Fake package build
+      #   run: |
+      #     sudo -i <<EOF
+      #     set -e
+      #     echo "Faking a package build (to speed up installation test)"
+      #     cd /
+      #     wget -nv "http://ci.bbb.imdt.dev/artifacts.tar"
+      #     tar xf artifacts.tar
+      #     EOF
       - name: Generate CA
         run: |
           sudo -i <<EOF

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -108,6 +108,7 @@ jobs:
         shell: bash
         run: |
             sudo -i <<EOF
+            set -e
             apt install -yq dpkg-dev
             cd /root && wget -q http://ci.bbbvm.imdt.com.br/cache-3rd-part-packages.tar
             cp -r /home/runner/work/bigbluebutton/bigbluebutton/artifacts/ /artifacts/

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -19,48 +19,48 @@ jobs:
   build-install-and-test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-      - run: ./build/get_external_dependencies.sh
-      - run: ./build/setup.sh bbb-apps-akka
-      - run: ./build/setup.sh bbb-config
-      - run: ./build/setup.sh bbb-etherpad
-      - run: ./build/setup.sh bbb-export-annotations
-      - run: ./build/setup.sh bbb-freeswitch-core
-      - run: ./build/setup.sh bbb-freeswitch-sounds
-      - run: ./build/setup.sh bbb-fsesl-akka
-      - run: ./build/setup.sh bbb-html5-nodejs
-      - run: ./build/setup.sh bbb-html5
-      - run: ./build/setup.sh bbb-learning-dashboard
-      - run: ./build/setup.sh bbb-libreoffice-docker
-      - run: ./build/setup.sh bbb-mkclean
-      - run: ./build/setup.sh bbb-pads
-      - run: ./build/setup.sh bbb-playback
-      - run: ./build/setup.sh bbb-playback-notes
-      - run: ./build/setup.sh bbb-playback-podcast
-      - run: ./build/setup.sh bbb-playback-presentation
-      - run: ./build/setup.sh bbb-playback-screenshare
-      - run: ./build/setup.sh bbb-playback-video
-      - run: ./build/setup.sh bbb-record-core
-      - run: ./build/setup.sh bbb-web
-      - run: ./build/setup.sh bbb-webrtc-sfu
-      - run: ./build/setup.sh bbb-webrtc-recorder
-      - run: ./build/setup.sh bbb-transcription-controller
-      - run: ./build/setup.sh bigbluebutton
-      - run: tar cvf artifacts.tar artifacts/
-      - name: Archive packages
-        uses: actions/upload-artifact@v3
-        with:
-          name: artifacts.tar
-          path: |
-            artifacts.tar
-      # - name: Fake package build
-      #   run: |
-      #     sudo sh -c '
-      #     echo "Faking a package build (to speed up installation test)"
-      #     cd /
-      #     wget -q "http://ci.bbb.imdt.dev/artifacts.tar"
-      #     tar xf artifacts.tar
-      #     '
+      # - uses: actions/checkout@v3
+      # - run: ./build/get_external_dependencies.sh
+      # - run: ./build/setup.sh bbb-apps-akka
+      # - run: ./build/setup.sh bbb-config
+      # - run: ./build/setup.sh bbb-etherpad
+      # - run: ./build/setup.sh bbb-export-annotations
+      # - run: ./build/setup.sh bbb-freeswitch-core
+      # - run: ./build/setup.sh bbb-freeswitch-sounds
+      # - run: ./build/setup.sh bbb-fsesl-akka
+      # - run: ./build/setup.sh bbb-html5-nodejs
+      # - run: ./build/setup.sh bbb-html5
+      # - run: ./build/setup.sh bbb-learning-dashboard
+      # - run: ./build/setup.sh bbb-libreoffice-docker
+      # - run: ./build/setup.sh bbb-mkclean
+      # - run: ./build/setup.sh bbb-pads
+      # - run: ./build/setup.sh bbb-playback
+      # - run: ./build/setup.sh bbb-playback-notes
+      # - run: ./build/setup.sh bbb-playback-podcast
+      # - run: ./build/setup.sh bbb-playback-presentation
+      # - run: ./build/setup.sh bbb-playback-screenshare
+      # - run: ./build/setup.sh bbb-playback-video
+      # - run: ./build/setup.sh bbb-record-core
+      # - run: ./build/setup.sh bbb-web
+      # - run: ./build/setup.sh bbb-webrtc-sfu
+      # - run: ./build/setup.sh bbb-webrtc-recorder
+      # - run: ./build/setup.sh bbb-transcription-controller
+      # - run: ./build/setup.sh bigbluebutton
+      # - run: tar cvf artifacts.tar artifacts/
+      # - name: Archive packages
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: artifacts.tar
+      #     path: |
+      #       artifacts.tar
+      - name: Fake package build
+        run: |
+          sudo sh -c '
+          echo "Faking a package build (to speed up installation test)"
+          cd /
+          wget -q "http://ci.bbb.imdt.dev/artifacts.tar"
+          tar xf artifacts.tar
+          '
       - name: Generate CA
         run: |
           sudo sh -c '
@@ -105,6 +105,7 @@ jobs:
           cat /root/bbb-ci-ssl/bbb-ci.test.key > /local/certs/privkey.pem
           '
       - name: Setup local repository
+        shell: bash
         run: |
             sudo apt install -yq dpkg-dev
             sudo cd /root && wget -q http://ci.bbbvm.imdt.com.br/cache-3rd-part-packages.tar

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -110,7 +110,7 @@ jobs:
             sudo -i <<EOF
             set -e
             apt install -yq dpkg-dev
-            cd /root && wget -q http://ci.bbbvm.imdt.com.br/cache-3rd-part-packages.tar
+            cd /root && wget -nv http://ci.bbbvm.imdt.com.br/cache-3rd-part-packages.tar
             cp -r /home/runner/work/bigbluebutton/bigbluebutton/artifacts/ /artifacts/
             cd /artifacts && tar xf /root/cache-3rd-part-packages.tar
             cd /artifacts && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -113,7 +113,7 @@ jobs:
             sudo -i <<EOF
             set -e
             apt install -yq dpkg-dev
-            cd /root && wget -nv http://ci.bbbvm.imdt.com.br/cache-3rd-part-packages.tar
+            cd /root && wget -nv http://ci.bbb.imdt.dev/cache-3rd-part-packages.tar
             cp -r /home/runner/work/bigbluebutton/bigbluebutton/artifacts/ /artifacts/
             cd /artifacts && tar xf /root/cache-3rd-part-packages.tar
             cd /artifacts && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz


### PR DESCRIPTION
This PR aims to improve the handling of failures during the automated-test workflow.

Currently, most of the commands run inside a block like this:
```
sudo sh -c '
            command 1
            command 2
            command 3
'
````
As it turns out, if command 2 fails and command 3 succeeds, the Step will still be marked as Successful. However, the correct behavior would be for it to fail!

So, I've tweaked most of the steps to run in a block like this:

```
sudo -i <<EOF
            set -e
            command 1
            command 2
            command 3
EOF
```

In this way, if one of the commands fails, the Step will be marked as a Failure. This will help us identify where the problem lies.

Additionally, I've tweaked the `wget` command to use the `-nv` (non-verbose) parameter instead of `-q`. This is because `-q` was suppressing the error message, making it more difficult to pinpoint the problem.