### PR TITLE
Add haproxy and coturn to bbb-conf status check

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -400,7 +400,7 @@ start_bigbluebutton () {
 }
 
 display_bigbluebutton_status () {
-    units="nginx freeswitch $REDIS_SERVICE bbb-apps-akka bbb-fsesl-akka"
+    units="haproxy nginx freeswitch $REDIS_SERVICE bbb-apps-akka bbb-fsesl-akka"
 
     if [ -d $TOMCAT_DIR ]; then
         units="$units $TOMCAT_USER"
@@ -468,12 +468,16 @@ display_bigbluebutton_status () {
     if [ -f /usr/lib/systemd/system/bbb-rap-starter.service ]; then
         units="$units bbb-rap-starter"
     fi
+	
+    if [ -f /usr/lib/systemd/system/coturn.service ]; then
+        units="$units coturn"
+    fi
 
     if systemctl list-units --full -all | grep -q $TOMCAT_USER.service; then
       TOMCAT_SERVICE=$TOMCAT_USER
     fi
 
-    line='——————————————————————►'
+    line='——————————————————————————————►'
     for unit in $units; do
         status=$(systemctl is-active "$unit")
         if [ "$status" = "active" ]; then


### PR DESCRIPTION
### What does this PR do?

Add haproxy and coturn to bbb-conf status check

### Motivation

Haproxy is now part of BigBlueButton and optionally coturn. We have no visibility on each of them status.
