### PR TITLE
test: Add @flaky test flag and avoid them when running the tests on CI

### DIFF
--- a/bigbluebutton-tests/playwright/package.json
+++ b/bigbluebutton-tests/playwright/package.json
@@ -5,8 +5,8 @@
     "test:filter": "npx playwright test -g",
     "test:headed": "npx playwright test --headed",
     "test:debug": "npx playwright test --debug -g",
-    "test-chromium-ci": "export CI='true' && npx playwright test --project=chromium --grep @ci",
-    "test-firefox-ci": "export CI='true' && npx playwright test --project=firefox --grep @ci",
+    "test-chromium-ci": "export CI='true' && npx playwright test --project=chromium --grep @ci --grep-invert @flaky",
+    "test-firefox-ci": "export CI='true' && npx playwright test --project=firefox --grep @ci --grep-invert @flaky",
     "rewrite-snapshots": "read -p 'CAUTION: You will delete ALL testing folders containing snapshots and run the tests to rewrite these files.\nProceed? (y/n) ' confirm && test $confirm = 'y' && sh core/scripts/rewrite-snapshots.sh"
   },
   "dependencies": {

--- a/bigbluebutton-tests/playwright/parameters/parameters.spec.js
+++ b/bigbluebutton-tests/playwright/parameters/parameters.spec.js
@@ -4,6 +4,7 @@ const { DisabledFeatures } = require('./disabledFeatures');
 const c = require('./constants');
 const { encodeCustomParams, getAllShortcutParams, hexToRgb } = require('./util');
 const { CreateParameters } = require('./createParameters');
+const { linkIssue } = require('../core/helpers');
 
 test.describe.parallel('Create Parameters', () => {
   test('Record Meeting', async ({ browser, context, page }) => {
@@ -246,18 +247,19 @@ test.describe.parallel('Create Parameters', () => {
     });
   
     test.describe.serial(() => {
-      test('Download Presentation With Annotations', async ({ browser, context, page }) => {
+      test('Download Presentation With Annotations @flaky', async ({ browser, context, page }) => {
+        linkIssue('18408');
         const disabledFeatures = new DisabledFeatures(browser, context);
         await disabledFeatures.initModPage(page, true, { createParameter: c.downloadPresentationWithAnnotationsDisabled });
         await disabledFeatures.downloadPresentationWithAnnotations();
       });
-      test('Download Presentation With Annotations (exclude)', async ({ browser, context, page }) => {
+      test('Download Presentation With Annotations (exclude) @flaky', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
         await disabledFeatures.initModPage(page, true, { createParameter: c.downloadPresentationWithAnnotationsExclude });
         await disabledFeatures.downloadPresentationWithAnnotationsExclude();
       });
     });
-  
+
     test.describe.serial(() => {
       test('Import Presentation With Annotations From Breakout Rooms', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);

--- a/bigbluebutton-tests/playwright/webcam/webcam.spec.js
+++ b/bigbluebutton-tests/playwright/webcam/webcam.spec.js
@@ -2,9 +2,9 @@ const { test } = require('@playwright/test');
 const { MultiUsers } = require('../user/multiusers');
 const { Webcam } = require('./webcam');
 
-test.describe.parallel('Webcam @ci', () => {
+test.describe.parallel('Webcam', () => {
   // https://docs.bigbluebutton.org/2.6/release-tests.html#joining-webcam-automated
-  test('Shares webcam', async ({ browser, page }) => {
+  test('Shares webcam @ci', async ({ browser, page }) => {
     const webcam = new Webcam(browser, page);
     await webcam.init(true, true);
     await webcam.share();
@@ -49,7 +49,9 @@ test.describe.parallel('Webcam @ci', () => {
       await webcam.applyBackground();
     });
 
-    test('Managing new background', async ({ browser, page }) => {
+    // following test is throwing failures due to mis-comparison screenshot
+    // as the emulated video is not static, we may add a mask in the middle part - where it moves the most
+    test('Managing new background @flaky', async ({ browser, page }) => {
       const webcam = new Webcam(browser, page);
       await webcam.init(true, true);
       await webcam.managingNewBackground();


### PR DESCRIPTION
### What does this PR do?
- Adds `@flaky` test flag - the idea is to use it on the tests that are failing due to a known bug, aiming to keep the CI outputs as clear and reliable as possible. We'll avoid the to run on CI and will re-add it once we have the bug fixed
- Skipping the `Disabled features > Download Presentation With Annotations` test on CI due to a reported bug - 