### PR TITLE
fix: Disabling the presentation download with annotation is also disabling the original presentation download

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -20,7 +20,8 @@ import { isPresentationEnabled } from '/imports/ui/services/features';
 
 const { isMobile } = deviceInfo;
 const propTypes = {
-  allowDownloadable: PropTypes.bool.isRequired,
+  allowDownloadOriginal: PropTypes.bool.isRequired,
+  allowDownloadWithAnnotations: PropTypes.bool.isRequired,
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
@@ -804,7 +805,7 @@ class PresentationUploader extends Component {
 
   renderPresentationList() {
     const { presentations } = this.state;
-    const { intl, allowDownloadable } = this.props;
+    const { intl } = this.props;
 
     let presentationsSorted = presentations;
 
@@ -846,9 +847,7 @@ class PresentationUploader extends Component {
             </tr>
             <Styled.Head>
               <th colSpan={4}>{intl.formatMessage(intlMessages.currentLabel)}</th>
-              {
-                allowDownloadable ? <th>{intl.formatMessage(intlMessages.actionsLabel)}</th> : null
-              }
+              <th>{intl.formatMessage(intlMessages.actionsLabel)}</th>
             </Styled.Head>
           </thead>
           <tbody>
@@ -978,10 +977,10 @@ class PresentationUploader extends Component {
   renderDownloadableWithAnnotationsHint() {
     const {
       intl,
-      allowDownloadable,
+      allowDownloadWithAnnotations,
     } = this.props;
 
-    return allowDownloadable ? (
+    return allowDownloadWithAnnotations ? (
       <Styled.ExportHint>
         {intl.formatMessage(intlMessages.exportHint)}
       </Styled.ExportHint>
@@ -994,7 +993,8 @@ class PresentationUploader extends Component {
     const {
       intl,
       selectedToBeNextCurrent,
-      allowDownloadable,
+      allowDownloadOriginal,
+      allowDownloadWithAnnotations,
       renderPresentationItemStatus,
       hasAnnotations,
     } = this.props;
@@ -1068,8 +1068,8 @@ class PresentationUploader extends Component {
         </Styled.TableItemStatus>
         {
         hasError ? null : (
-          <Styled.TableItemActions notDownloadable={!allowDownloadable}>
-            {allowDownloadable ? (
+          <Styled.TableItemActions notDownloadable={!allowDownloadOriginal}>
+            {allowDownloadOriginal || allowDownloadWithAnnotations ? (
               <PresentationDownloadDropdown
                 hasAnnotations={hasAnyAnnotation}
                 disabled={shouldDisableExportButton}
@@ -1077,6 +1077,8 @@ class PresentationUploader extends Component {
                 aria-label={formattedDownloadAriaLabel}
                 color="primary"
                 isDownloadable={isDownloadable}
+                allowDownloadOriginal={allowDownloadOriginal}
+                allowDownloadWithAnnotations={allowDownloadWithAnnotations}
                 handleToggleDownloadable={this.handleToggleDownloadable}
                 item={item}
                 closeModal={() => Session.set('showUploadPresentationView', false)}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/container.jsx
@@ -8,7 +8,11 @@ import PresUploaderToast from '/imports/ui/components/presentation/presentation-
 import PresentationUploader from './component';
 import { UsersContext } from '/imports/ui/components/components-data/users-context/context';
 import Auth from '/imports/ui/services/auth';
-import { isDownloadPresentationWithAnnotationsEnabled, isPresentationEnabled } from '/imports/ui/services/features';
+import {
+  isDownloadPresentationWithAnnotationsEnabled,
+  isDownloadOriginalPresentationEnabled,
+  isPresentationEnabled,
+} from '/imports/ui/services/features';
 import { hasAnnotations } from '/imports/ui/components/whiteboard/service';
 
 const PRESENTATION_CONFIG = Meteor.settings.public.presentation;
@@ -44,7 +48,8 @@ export default withTracker(() => {
     fileSizeMax: PRESENTATION_CONFIG.mirroredFromBBBCore.uploadSizeMax,
     filePagesMax: PRESENTATION_CONFIG.mirroredFromBBBCore.uploadPagesMax,
     fileValidMimeTypes: PRESENTATION_CONFIG.uploadValidMimeTypes,
-    allowDownloadable: isDownloadPresentationWithAnnotationsEnabled(),
+    allowDownloadOriginal: isDownloadOriginalPresentationEnabled(),
+    allowDownloadWithAnnotations: isDownloadPresentationWithAnnotationsEnabled(),
     handleSave: Service.handleSavePresentation,
     handleDismissToast: PresUploaderToast.handleDismissToast,
     renderToastList: Service.renderToastList,

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/presentation-download-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/presentation-download-dropdown/component.jsx
@@ -74,6 +74,8 @@ class PresentationDownloadDropdown extends PureComponent {
       handleDownloadingOfPresentation,
       handleToggleDownloadable,
       isDownloadable,
+      allowDownloadOriginal,
+      allowDownloadWithAnnotations,
       item,
       closeModal,
     } = this.props;
@@ -88,31 +90,35 @@ class PresentationDownloadDropdown extends PureComponent {
       closeModal();
     };
 
-    if (!isDownloadable) {
+    if (allowDownloadOriginal) {
+      if (!isDownloadable) {
+        this.menuItems.push({
+          key: this.actionsKey[0],
+          dataTest: 'enableOriginalPresentationDownload',
+          label: intl.formatMessage(intlMessages.enableOriginalPresentationDownload),
+          onClick: () => toggleDownloadOriginalPresentation(true),
+        });
+      } else {
+        this.menuItems.push({
+          key: this.actionsKey[0],
+          dataTest: 'disableOriginalPresentationDownload',
+          label: intl.formatMessage(intlMessages.disableOriginalPresentationDownload),
+          onClick: () => toggleDownloadOriginalPresentation(false),
+        });
+      }
+    }
+    if (allowDownloadWithAnnotations) {
       this.menuItems.push({
-        key: this.actionsKey[0],
-        dataTest: 'enableOriginalPresentationDownload',
-        label: intl.formatMessage(intlMessages.enableOriginalPresentationDownload),
-        onClick: () => toggleDownloadOriginalPresentation(true),
-      });
-    } else {
-      this.menuItems.push({
-        key: this.actionsKey[0],
-        dataTest: 'disableOriginalPresentationDownload',
-        label: intl.formatMessage(intlMessages.disableOriginalPresentationDownload),
-        onClick: () => toggleDownloadOriginalPresentation(false),
+        key: this.actionsKey[1],
+        id: 'sendCurrentStateDocument',
+        dataTest: 'sendCurrentStateDocument',
+        label: intl.formatMessage(intlMessages.sendCurrentStateDocument),
+        onClick: () => {
+          closeModal();
+          handleDownloadingOfPresentation('Annotated');
+        },
       });
     }
-    this.menuItems.push({
-      key: this.actionsKey[1],
-      id: 'sendCurrentStateDocument',
-      dataTest: 'sendCurrentStateDocument',
-      label: intl.formatMessage(intlMessages.sendCurrentStateDocument),
-      onClick: () => {
-        closeModal();
-        handleDownloadingOfPresentation('Annotated');
-      },
-    });
     return this.menuItems;
   }
 

--- a/bigbluebutton-html5/imports/ui/services/features/index.js
+++ b/bigbluebutton-html5/imports/ui/services/features/index.js
@@ -61,7 +61,11 @@ export function isCustomVirtualBackgroundsEnabled() {
 }
 
 export function isDownloadPresentationWithAnnotationsEnabled() {
-  return getDisabledFeatures().indexOf('downloadPresentationWithAnnotations') === -1 && Meteor.settings.public.presentation.allowDownloadable;
+  return getDisabledFeatures().indexOf('downloadPresentationWithAnnotations') === -1 && Meteor.settings.public.presentation.allowDownloadWithAnnotations;
+}
+
+export function isDownloadOriginalPresentationEnabled() {
+  return getDisabledFeatures().indexOf('downloadOriginalPresentation') === -1 && Meteor.settings.public.presentation.allowDownloadOriginal;
 }
 
 export function isSnapshotOfCurrentSlideEnabled() {

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -742,7 +742,8 @@ public:
       - critical
     help: STATS_HELP_URL
   presentation:
-    allowDownloadable: true
+    allowDownloadOriginal: true
+    allowDownloadWithAnnotations: true
     allowSnapshotOfCurrentSlide: true
     panZoomThrottle: 32
     restoreOnUpdate: true

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -432,7 +432,8 @@ endWhenNoModeratorDelayInMinutes=1
 # Available options:
 # chat, sharedNotes, polls, screenshare, externalVideos, presentation, downloadPresentationWithAnnotations
 # learningDashboard, layouts, captions, liveTranscription, virtualBackgrounds, customVirtualBackgrounds
-# breakoutRooms, importSharedNotesFromBreakoutRooms, importPresentationWithAnnotationsFromBreakoutRooms
+# breakoutRooms, importSharedNotesFromBreakoutRooms, importPresentationWithAnnotationsFromBreakoutRooms, 
+# downloadOriginalPresentation
 disabledFeatures=
 
 # Notify users that recording is on


### PR DESCRIPTION
### What does this PR do?

- "actions" label in presentation uploader will always be displayed
- splits disabled download of presentation params (allowDownloadable -> allowDownloadOriginal and allowDownloadWithAnnotations)
- only hide download presentation dropdown if both download presentation options are disabled

### Closes Issue(s)
Closes #18408
