### PR TITLE
fix: Correct Tab Order For Presentation Options Dropdown

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -6,7 +6,6 @@ import { SPACE } from '/imports/utils/keyCodes';
 import { defineMessages, injectIntl } from 'react-intl';
 import { toast } from 'react-toastify';
 import { Session } from 'meteor/session';
-import { debounce } from 'radash';
 import PresentationToolbarContainer from './presentation-toolbar/container';
 import PresentationMenu from './presentation-menu/container';
 import Styled from './styles';
@@ -19,6 +18,7 @@ import { colorContentBackground } from '/imports/ui/stylesheets/styled-component
 import browserInfo from '/imports/utils/browserInfo';
 import { addNewAlert } from '../screenreader-alert/service';
 import { clearCursors } from '/imports/ui/components/whiteboard/cursors/service';
+import { debounce } from 'radash';
 
 const intlMessages = defineMessages({
   presentationLabel: {
@@ -92,7 +92,8 @@ class Presentation extends PureComponent {
     this.panAndZoomChanger = this.panAndZoomChanger.bind(this);
     this.fitToWidthHandler = this.fitToWidthHandler.bind(this);
     this.onFullscreenChange = this.onFullscreenChange.bind(this);
-    this.getPresentationSizesAvailable = this.getPresentationSizesAvailable.bind(this);
+    this.getPresentationSizesAvailable =
+      this.getPresentationSizesAvailable.bind(this);
     this.handleResize = debounce({ delay: 200 }, this.handleResize.bind(this));
     this.setTldrawAPI = this.setTldrawAPI.bind(this);
     this.setIsPanning = this.setIsPanning.bind(this);
@@ -101,7 +102,8 @@ class Presentation extends PureComponent {
     this.renderPresentationMenu = this.renderPresentationMenu.bind(this);
 
     this.onResize = () => setTimeout(this.handleResize.bind(this), 0);
-    this.renderCurrentPresentationToast = this.renderCurrentPresentationToast.bind(this);
+    this.renderCurrentPresentationToast =
+      this.renderCurrentPresentationToast.bind(this);
     this.setPresentationRef = this.setPresentationRef.bind(this);
     this.setTldrawIsMounting = this.setTldrawIsMounting.bind(this);
     Session.set('componentPresentationWillUnmount', false);
@@ -112,15 +114,16 @@ class Presentation extends PureComponent {
     const stateChange = { prevProps: props };
 
     if (
-      props.userIsPresenter
-      && (!prevProps || !prevProps.userIsPresenter)
-      && props.currentSlide
-      && props.slidePosition
+      props.userIsPresenter &&
+      (!prevProps || !prevProps.userIsPresenter) &&
+      props.currentSlide &&
+      props.slidePosition
     ) {
-      let potentialZoom = 100 / (props.slidePosition.viewBoxWidth / props.slidePosition.width);
+      let potentialZoom =
+        100 / (props.slidePosition.viewBoxWidth / props.slidePosition.width);
       potentialZoom = Math.max(
         HUNDRED_PERCENT,
-        Math.min(MAX_PERCENT, potentialZoom),
+        Math.min(MAX_PERCENT, potentialZoom)
       );
       stateChange.zoom = potentialZoom;
     }
@@ -129,8 +132,8 @@ class Presentation extends PureComponent {
 
     // When presenter is changed or slide changed we reset localPosition
     if (
-      prevProps.currentSlide?.id !== props.currentSlide?.id
-      || prevProps.userIsPresenter !== props.userIsPresenter
+      prevProps.currentSlide?.id !== props.currentSlide?.id ||
+      prevProps.userIsPresenter !== props.userIsPresenter
     ) {
       stateChange.localPosition = undefined;
     }
@@ -142,15 +145,15 @@ class Presentation extends PureComponent {
     this.getInitialPresentationSizes();
     this.refPresentationContainer.addEventListener(
       'keydown',
-      this.handlePanShortcut,
+      this.handlePanShortcut
     );
     this.refPresentationContainer.addEventListener(
       'keyup',
-      this.handlePanShortcut,
+      this.handlePanShortcut
     );
     this.refPresentationContainer.addEventListener(
       FULLSCREEN_CHANGE_EVENT,
-      this.onFullscreenChange,
+      this.onFullscreenChange
     );
     window.addEventListener('resize', this.onResize, false);
 
@@ -236,28 +239,29 @@ class Presentation extends PureComponent {
     }
 
     if (
-      currentSlide?.num != null
-      && prevProps?.currentSlide?.num != null
-      && currentSlide?.num !== prevProps.currentSlide?.num
+      currentSlide?.num != null &&
+      prevProps?.currentSlide?.num != null &&
+      currentSlide?.num !== prevProps.currentSlide?.num
     ) {
       addNewAlert(
         intl.formatMessage(intlMessages.slideContentChanged, {
           0: currentSlide.num,
-        }),
+        })
       );
     }
 
     if (currentPresentation) {
-      const downloadableOn = !prevProps?.currentPresentation?.downloadable
-        && currentPresentation.downloadable;
+      const downloadableOn =
+        !prevProps?.currentPresentation?.downloadable &&
+        currentPresentation.downloadable;
 
       const shouldCloseToast = !(
         currentPresentation.downloadable && !userIsPresenter
       );
 
       if (
-        prevProps?.currentPresentation?.id !== currentPresentation.id
-        || (downloadableOn && !userIsPresenter)
+        prevProps?.currentPresentation?.id !== currentPresentation.id ||
+        (downloadableOn && !userIsPresenter)
       ) {
         if (this.currentPresentationToastId) {
           toast.update(this.currentPresentationToastId, {
@@ -273,13 +277,14 @@ class Presentation extends PureComponent {
               },
               autoClose: shouldCloseToast,
               className: 'actionToast currentPresentationToast',
-            },
+            }
           );
         }
       }
 
-      const downloadableOff = prevProps?.currentPresentation?.downloadable
-        && !currentPresentation.downloadable;
+      const downloadableOff =
+        prevProps?.currentPresentation?.downloadable &&
+        !currentPresentation.downloadable;
 
       if (this.currentPresentationToastId && downloadableOff) {
         toast.update(this.currentPresentationToastId, {
@@ -304,23 +309,24 @@ class Presentation extends PureComponent {
       }
       const presentationChanged = presentationId !== currentPresentationId;
 
-      const { isInitialPresentation } = currentPresentation;
+      const isInitialPresentation = currentPresentation.isInitialPresentation;
 
       if (
-        !presentationIsOpen
-        && restoreOnUpdate
-        && (currentSlide || presentationChanged)
+        !presentationIsOpen &&
+        restoreOnUpdate &&
+        (currentSlide || presentationChanged)
       ) {
         const slideChanged = currentSlide.id !== prevProps.currentSlide.id;
-        const positionChanged = slidePosition.viewBoxHeight
-            !== prevProps.slidePosition.viewBoxHeight
-          || slidePosition.viewBoxWidth !== prevProps.slidePosition.viewBoxWidth;
+        const positionChanged =
+          slidePosition.viewBoxHeight !==
+            prevProps.slidePosition.viewBoxHeight ||
+          slidePosition.viewBoxWidth !== prevProps.slidePosition.viewBoxWidth;
         const pollPublished = publishedPoll && !prevProps.publishedPoll;
         if (
-          slideChanged
-          || positionChanged
-          || pollPublished
-          || (presentationChanged && (hadPresentation || !isInitialPresentation))
+          slideChanged ||
+          positionChanged ||
+          pollPublished ||
+          (presentationChanged && (hadPresentation || !isInitialPresentation))
         ) {
           setPresentationIsOpen(layoutContextDispatch, !presentationIsOpen);
         }
@@ -334,9 +340,10 @@ class Presentation extends PureComponent {
       }
 
       if (
-        presentationBounds !== prevPresentationBounds
-        || (!presentationWidth && !presentationHeight)
-      ) this.onResize();
+        presentationBounds !== prevPresentationBounds ||
+        (!presentationWidth && !presentationHeight)
+      )
+        this.onResize();
     } else if (slidePosition) {
       const { width: currWidth, height: currHeight } = slidePosition;
 
@@ -354,8 +361,8 @@ class Presentation extends PureComponent {
     }
 
     if (
-      (zoom <= HUNDRED_PERCENT && isPanning && !fitToWidth)
-      || (!userIsPresenter && prevProps.userIsPresenter)
+      (zoom <= HUNDRED_PERCENT && isPanning && !fitToWidth) ||
+      (!userIsPresenter && prevProps.userIsPresenter)
     ) {
       this.setIsPanning();
     }
@@ -368,15 +375,15 @@ class Presentation extends PureComponent {
     window.removeEventListener('resize', this.onResize, false);
     this.refPresentationContainer.removeEventListener(
       FULLSCREEN_CHANGE_EVENT,
-      this.onFullscreenChange,
+      this.onFullscreenChange
     );
     this.refPresentationContainer.removeEventListener(
       'keydown',
-      this.handlePanShortcut,
+      this.handlePanShortcut
     );
     this.refPresentationContainer.removeEventListener(
       'keyup',
-      this.handlePanShortcut,
+      this.handlePanShortcut
     );
 
     if (fullscreenContext) {
@@ -421,7 +428,7 @@ class Presentation extends PureComponent {
   onFullscreenChange() {
     const { isFullscreen } = this.state;
     const newIsFullscreen = FullscreenService.isFullScreen(
-      this.refPresentationContainer,
+      this.refPresentationContainer
     );
     if (isFullscreen !== newIsFullscreen) {
       this.setState({ isFullscreen: newIsFullscreen });
@@ -471,9 +478,11 @@ class Presentation extends PureComponent {
     };
 
     if (newPresentationAreaSize) {
-      presentationSizes.presentationWidth = newPresentationAreaSize.presentationAreaWidth;
-      presentationSizes.presentationHeight = newPresentationAreaSize.presentationAreaHeight
-        - (getToolbarHeight() || 0);
+      presentationSizes.presentationWidth =
+        newPresentationAreaSize.presentationAreaWidth;
+      presentationSizes.presentationHeight =
+        newPresentationAreaSize.presentationAreaHeight -
+        (getToolbarHeight() || 0);
       return presentationSizes;
     }
 
@@ -603,11 +612,12 @@ class Presentation extends PureComponent {
 
     const { presentationToolbarMinWidth } = DEFAULT_VALUES;
 
-    const toolbarWidth = (this.refWhiteboardArea && svgWidth > presentationToolbarMinWidth)
-      || isMobile
-      || (layoutType === LAYOUT_TYPE.VIDEO_FOCUS && numCameras > 0)
-      ? svgWidth
-      : presentationToolbarMinWidth;
+    const toolbarWidth =
+      (this.refWhiteboardArea && svgWidth > presentationToolbarMinWidth) ||
+      isMobile ||
+      (layoutType === LAYOUT_TYPE.VIDEO_FOCUS && numCameras > 0)
+        ? svgWidth
+        : presentationToolbarMinWidth;
     return (
       <PresentationToolbarContainer
         {...{
@@ -649,14 +659,14 @@ class Presentation extends PureComponent {
     const { downloadable } = currentPresentation;
 
     return (
-      <Styled.InnerToastWrapper data-test="currentPresentationToast">
+      <Styled.InnerToastWrapper data-test='currentPresentationToast'>
         <Styled.ToastIcon>
           <Styled.IconWrapper>
-            <Icon iconName="presentation" />
+            <Icon iconName='presentation' />
           </Styled.IconWrapper>
         </Styled.ToastIcon>
 
-        <Styled.ToastTextContent data-test="toastSmallMsg">
+        <Styled.ToastTextContent data-test='toastSmallMsg'>
           <div>{`${intl.formatMessage(intlMessages.changeNotification)}`}</div>
           <Styled.PresentationName>{`${currentPresentation.name}`}</Styled.PresentationName>
         </Styled.ToastTextContent>
@@ -665,13 +675,13 @@ class Presentation extends PureComponent {
           <Styled.ToastDownload>
             <Styled.ToastSeparator />
             <a
-              data-test="toastDownload"
+              data-test='toastDownload'
               aria-label={`${intl.formatMessage(intlMessages.downloadLabel)} ${
                 currentPresentation.name
               }`}
               href={downloadPresentationUri}
-              target="_blank"
-              rel="noopener noreferrer"
+              target='_blank'
+              rel='noopener noreferrer'
             >
               {intl.formatMessage(intlMessages.downloadLabel)}
             </a>
@@ -763,11 +773,12 @@ class Presentation extends PureComponent {
 
     const { presentationToolbarMinWidth } = DEFAULT_VALUES;
 
-    const isLargePresentation = (svgWidth > presentationToolbarMinWidth || isMobile)
-      && !(
-        layoutType === LAYOUT_TYPE.VIDEO_FOCUS
-        && numCameras > 0
-        && !fullscreenContext
+    const isLargePresentation =
+      (svgWidth > presentationToolbarMinWidth || isMobile) &&
+      !(
+        layoutType === LAYOUT_TYPE.VIDEO_FOCUS &&
+        numCameras > 0 &&
+        !fullscreenContext
       );
 
     const containerWidth = isLargePresentation
@@ -783,8 +794,8 @@ class Presentation extends PureComponent {
     return (
       <>
         <Styled.PresentationContainer
-          role="region"
-          data-test="presentationContainer"
+          role='region'
+          data-test='presentationContainer'
           ref={(ref) => {
             this.refPresentationContainer = ref;
           }}
@@ -798,9 +809,9 @@ class Presentation extends PureComponent {
             overflow: 'hidden',
             zIndex: fullscreenContext ? presentationBounds.zIndex : undefined,
             background:
-              layoutType === LAYOUT_TYPE.VIDEO_FOCUS
-              && numCameras > 0
-              && !fullscreenContext
+              layoutType === LAYOUT_TYPE.VIDEO_FOCUS &&
+              numCameras > 0 &&
+              !fullscreenContext
                 ? colorContentBackground
                 : null,
           }}
@@ -823,14 +834,14 @@ class Presentation extends PureComponent {
                   textAlign: 'center',
                   display: !presentationIsOpen ? 'none' : 'block',
                 }}
-                id="presentationInnerWrapper"
+                id='presentationInnerWrapper'
               >
-                <Styled.VisuallyHidden id="currentSlideText">
+                <Styled.VisuallyHidden id='currentSlideText'>
                   {slideContent}
                 </Styled.VisuallyHidden>
-                {!tldrawIsMounting
-                  && currentSlide
-                  && this.renderPresentationMenu()}
+                {!tldrawIsMounting &&
+                  currentSlide &&
+                  this.renderPresentationMenu()}
                 <WhiteboardContainer
                   whiteboardId={currentSlide?.id}
                   podId={podId}

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -1,64 +1,64 @@
-import React, { PureComponent } from "react";
-import PropTypes from "prop-types";
-import WhiteboardContainer from "/imports/ui/components/whiteboard/container";
-import { HUNDRED_PERCENT, MAX_PERCENT } from "/imports/utils/slideCalcUtils";
-import { SPACE } from "/imports/utils/keyCodes";
-import { defineMessages, injectIntl } from "react-intl";
-import { toast } from "react-toastify";
-import { Session } from "meteor/session";
-import PresentationToolbarContainer from "./presentation-toolbar/container";
-import PresentationMenu from "./presentation-menu/container";
-import Styled from "./styles";
-import FullscreenService from "/imports/ui/components/common/fullscreen-button/service";
-import Icon from "/imports/ui/components/common/icon/component";
-import PollingContainer from "/imports/ui/components/polling/container";
-import { ACTIONS, LAYOUT_TYPE } from "../layout/enums";
-import DEFAULT_VALUES from "../layout/defaultValues";
-import { colorContentBackground } from "/imports/ui/stylesheets/styled-components/palette";
-import browserInfo from "/imports/utils/browserInfo";
-import { addNewAlert } from "../screenreader-alert/service";
-import { clearCursors } from "/imports/ui/components/whiteboard/cursors/service";
-import { debounce } from "radash";
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import WhiteboardContainer from '/imports/ui/components/whiteboard/container';
+import { HUNDRED_PERCENT, MAX_PERCENT } from '/imports/utils/slideCalcUtils';
+import { SPACE } from '/imports/utils/keyCodes';
+import { defineMessages, injectIntl } from 'react-intl';
+import { toast } from 'react-toastify';
+import { Session } from 'meteor/session';
+import { debounce } from 'radash';
+import PresentationToolbarContainer from './presentation-toolbar/container';
+import PresentationMenu from './presentation-menu/container';
+import Styled from './styles';
+import FullscreenService from '/imports/ui/components/common/fullscreen-button/service';
+import Icon from '/imports/ui/components/common/icon/component';
+import PollingContainer from '/imports/ui/components/polling/container';
+import { ACTIONS, LAYOUT_TYPE } from '../layout/enums';
+import DEFAULT_VALUES from '../layout/defaultValues';
+import { colorContentBackground } from '/imports/ui/stylesheets/styled-components/palette';
+import browserInfo from '/imports/utils/browserInfo';
+import { addNewAlert } from '../screenreader-alert/service';
+import { clearCursors } from '/imports/ui/components/whiteboard/cursors/service';
 
 const intlMessages = defineMessages({
   presentationLabel: {
-    id: "app.presentationUploder.title",
-    description: "presentation area element label",
+    id: 'app.presentationUploder.title',
+    description: 'presentation area element label',
   },
   changeNotification: {
-    id: "app.presentation.notificationLabel",
-    description: "label displayed in toast when presentation switches",
+    id: 'app.presentation.notificationLabel',
+    description: 'label displayed in toast when presentation switches',
   },
   downloadLabel: {
-    id: "app.presentation.downloadLabel",
-    description: "label for downloadable presentations",
+    id: 'app.presentation.downloadLabel',
+    description: 'label for downloadable presentations',
   },
   slideContentStart: {
-    id: "app.presentation.startSlideContent",
-    description: "Indicate the slide content start",
+    id: 'app.presentation.startSlideContent',
+    description: 'Indicate the slide content start',
   },
   slideContentEnd: {
-    id: "app.presentation.endSlideContent",
-    description: "Indicate the slide content end",
+    id: 'app.presentation.endSlideContent',
+    description: 'Indicate the slide content end',
   },
   slideContentChanged: {
-    id: "app.presentation.changedSlideContent",
-    description: "Indicate the slide content has changed",
+    id: 'app.presentation.changedSlideContent',
+    description: 'Indicate the slide content has changed',
   },
   noSlideContent: {
-    id: "app.presentation.emptySlideContent",
-    description: "No content available for slide",
+    id: 'app.presentation.emptySlideContent',
+    description: 'No content available for slide',
   },
 });
 
 const { isSafari } = browserInfo;
 const FULLSCREEN_CHANGE_EVENT = isSafari
-  ? "webkitfullscreenchange"
-  : "fullscreenchange";
+  ? 'webkitfullscreenchange'
+  : 'fullscreenchange';
 
 const getToolbarHeight = () => {
   let height = 0;
-  const toolbarEl = document.getElementById("presentationToolbarWrapper");
+  const toolbarEl = document.getElementById('presentationToolbarWrapper');
   if (toolbarEl) {
     const { clientHeight } = toolbarEl;
     height = clientHeight;
@@ -92,8 +92,7 @@ class Presentation extends PureComponent {
     this.panAndZoomChanger = this.panAndZoomChanger.bind(this);
     this.fitToWidthHandler = this.fitToWidthHandler.bind(this);
     this.onFullscreenChange = this.onFullscreenChange.bind(this);
-    this.getPresentationSizesAvailable =
-      this.getPresentationSizesAvailable.bind(this);
+    this.getPresentationSizesAvailable = this.getPresentationSizesAvailable.bind(this);
     this.handleResize = debounce({ delay: 200 }, this.handleResize.bind(this));
     this.setTldrawAPI = this.setTldrawAPI.bind(this);
     this.setIsPanning = this.setIsPanning.bind(this);
@@ -102,11 +101,10 @@ class Presentation extends PureComponent {
     this.renderPresentationMenu = this.renderPresentationMenu.bind(this);
 
     this.onResize = () => setTimeout(this.handleResize.bind(this), 0);
-    this.renderCurrentPresentationToast =
-      this.renderCurrentPresentationToast.bind(this);
+    this.renderCurrentPresentationToast = this.renderCurrentPresentationToast.bind(this);
     this.setPresentationRef = this.setPresentationRef.bind(this);
     this.setTldrawIsMounting = this.setTldrawIsMounting.bind(this);
-    Session.set("componentPresentationWillUnmount", false);
+    Session.set('componentPresentationWillUnmount', false);
   }
 
   static getDerivedStateFromProps(props, state) {
@@ -114,16 +112,15 @@ class Presentation extends PureComponent {
     const stateChange = { prevProps: props };
 
     if (
-      props.userIsPresenter &&
-      (!prevProps || !prevProps.userIsPresenter) &&
-      props.currentSlide &&
-      props.slidePosition
+      props.userIsPresenter
+      && (!prevProps || !prevProps.userIsPresenter)
+      && props.currentSlide
+      && props.slidePosition
     ) {
-      let potentialZoom =
-        100 / (props.slidePosition.viewBoxWidth / props.slidePosition.width);
+      let potentialZoom = 100 / (props.slidePosition.viewBoxWidth / props.slidePosition.width);
       potentialZoom = Math.max(
         HUNDRED_PERCENT,
-        Math.min(MAX_PERCENT, potentialZoom)
+        Math.min(MAX_PERCENT, potentialZoom),
       );
       stateChange.zoom = potentialZoom;
     }
@@ -132,8 +129,8 @@ class Presentation extends PureComponent {
 
     // When presenter is changed or slide changed we reset localPosition
     if (
-      prevProps.currentSlide?.id !== props.currentSlide?.id ||
-      prevProps.userIsPresenter !== props.userIsPresenter
+      prevProps.currentSlide?.id !== props.currentSlide?.id
+      || prevProps.userIsPresenter !== props.userIsPresenter
     ) {
       stateChange.localPosition = undefined;
     }
@@ -144,18 +141,18 @@ class Presentation extends PureComponent {
   componentDidMount() {
     this.getInitialPresentationSizes();
     this.refPresentationContainer.addEventListener(
-      "keydown",
-      this.handlePanShortcut
+      'keydown',
+      this.handlePanShortcut,
     );
     this.refPresentationContainer.addEventListener(
-      "keyup",
-      this.handlePanShortcut
+      'keyup',
+      this.handlePanShortcut,
     );
     this.refPresentationContainer.addEventListener(
       FULLSCREEN_CHANGE_EVENT,
-      this.onFullscreenChange
+      this.onFullscreenChange,
     );
-    window.addEventListener("resize", this.onResize, false);
+    window.addEventListener('resize', this.onResize, false);
 
     const {
       currentSlide,
@@ -239,29 +236,28 @@ class Presentation extends PureComponent {
     }
 
     if (
-      currentSlide?.num != null &&
-      prevProps?.currentSlide?.num != null &&
-      currentSlide?.num !== prevProps.currentSlide?.num
+      currentSlide?.num != null
+      && prevProps?.currentSlide?.num != null
+      && currentSlide?.num !== prevProps.currentSlide?.num
     ) {
       addNewAlert(
         intl.formatMessage(intlMessages.slideContentChanged, {
           0: currentSlide.num,
-        })
+        }),
       );
     }
 
     if (currentPresentation) {
-      const downloadableOn =
-        !prevProps?.currentPresentation?.downloadable &&
-        currentPresentation.downloadable;
+      const downloadableOn = !prevProps?.currentPresentation?.downloadable
+        && currentPresentation.downloadable;
 
       const shouldCloseToast = !(
         currentPresentation.downloadable && !userIsPresenter
       );
 
       if (
-        prevProps?.currentPresentation?.id !== currentPresentation.id ||
-        (downloadableOn && !userIsPresenter)
+        prevProps?.currentPresentation?.id !== currentPresentation.id
+        || (downloadableOn && !userIsPresenter)
       ) {
         if (this.currentPresentationToastId) {
           toast.update(this.currentPresentationToastId, {
@@ -276,15 +272,14 @@ class Presentation extends PureComponent {
                 this.currentPresentationToastId = null;
               },
               autoClose: shouldCloseToast,
-              className: "actionToast currentPresentationToast",
-            }
+              className: 'actionToast currentPresentationToast',
+            },
           );
         }
       }
 
-      const downloadableOff =
-        prevProps?.currentPresentation?.downloadable &&
-        !currentPresentation.downloadable;
+      const downloadableOff = prevProps?.currentPresentation?.downloadable
+        && !currentPresentation.downloadable;
 
       if (this.currentPresentationToastId && downloadableOff) {
         toast.update(this.currentPresentationToastId, {
@@ -309,24 +304,23 @@ class Presentation extends PureComponent {
       }
       const presentationChanged = presentationId !== currentPresentationId;
 
-      const isInitialPresentation = currentPresentation.isInitialPresentation;
+      const { isInitialPresentation } = currentPresentation;
 
       if (
-        !presentationIsOpen &&
-        restoreOnUpdate &&
-        (currentSlide || presentationChanged)
+        !presentationIsOpen
+        && restoreOnUpdate
+        && (currentSlide || presentationChanged)
       ) {
         const slideChanged = currentSlide.id !== prevProps.currentSlide.id;
-        const positionChanged =
-          slidePosition.viewBoxHeight !==
-            prevProps.slidePosition.viewBoxHeight ||
-          slidePosition.viewBoxWidth !== prevProps.slidePosition.viewBoxWidth;
+        const positionChanged = slidePosition.viewBoxHeight
+            !== prevProps.slidePosition.viewBoxHeight
+          || slidePosition.viewBoxWidth !== prevProps.slidePosition.viewBoxWidth;
         const pollPublished = publishedPoll && !prevProps.publishedPoll;
         if (
-          slideChanged ||
-          positionChanged ||
-          pollPublished ||
-          (presentationChanged && (hadPresentation || !isInitialPresentation))
+          slideChanged
+          || positionChanged
+          || pollPublished
+          || (presentationChanged && (hadPresentation || !isInitialPresentation))
         ) {
           setPresentationIsOpen(layoutContextDispatch, !presentationIsOpen);
         }
@@ -340,10 +334,9 @@ class Presentation extends PureComponent {
       }
 
       if (
-        presentationBounds !== prevPresentationBounds ||
-        (!presentationWidth && !presentationHeight)
-      )
-        this.onResize();
+        presentationBounds !== prevPresentationBounds
+        || (!presentationWidth && !presentationHeight)
+      ) this.onResize();
     } else if (slidePosition) {
       const { width: currWidth, height: currHeight } = slidePosition;
 
@@ -361,37 +354,37 @@ class Presentation extends PureComponent {
     }
 
     if (
-      (zoom <= HUNDRED_PERCENT && isPanning && !fitToWidth) ||
-      (!userIsPresenter && prevProps.userIsPresenter)
+      (zoom <= HUNDRED_PERCENT && isPanning && !fitToWidth)
+      || (!userIsPresenter && prevProps.userIsPresenter)
     ) {
       this.setIsPanning();
     }
   }
 
   componentWillUnmount() {
-    Session.set("componentPresentationWillUnmount", true);
+    Session.set('componentPresentationWillUnmount', true);
     const { fullscreenContext, layoutContextDispatch } = this.props;
 
-    window.removeEventListener("resize", this.onResize, false);
+    window.removeEventListener('resize', this.onResize, false);
     this.refPresentationContainer.removeEventListener(
       FULLSCREEN_CHANGE_EVENT,
-      this.onFullscreenChange
+      this.onFullscreenChange,
     );
     this.refPresentationContainer.removeEventListener(
-      "keydown",
-      this.handlePanShortcut
+      'keydown',
+      this.handlePanShortcut,
     );
     this.refPresentationContainer.removeEventListener(
-      "keyup",
-      this.handlePanShortcut
+      'keyup',
+      this.handlePanShortcut,
     );
 
     if (fullscreenContext) {
       layoutContextDispatch({
         type: ACTIONS.SET_FULLSCREEN_ELEMENT,
         value: {
-          element: "",
-          group: "",
+          element: '',
+          group: '',
         },
       });
     }
@@ -402,9 +395,9 @@ class Presentation extends PureComponent {
     const { isPanning } = this.state;
     if (e.keyCode === SPACE && userIsPresenter) {
       switch (e.type) {
-        case "keyup":
+        case 'keyup':
           return isPanning && this.setIsPanning();
-        case "keydown":
+        case 'keydown':
           return !isPanning && this.setIsPanning();
         default:
       }
@@ -416,7 +409,7 @@ class Presentation extends PureComponent {
     const presentationSizes = this.getPresentationSizesAvailable();
     if (Object.keys(presentationSizes).length > 0) {
       // updating the size of the space available for the slide
-      if (!Session.get("componentPresentationWillUnmount")) {
+      if (!Session.get('componentPresentationWillUnmount')) {
         this.setState({
           presentationHeight: presentationSizes.presentationHeight,
           presentationWidth: presentationSizes.presentationWidth,
@@ -428,7 +421,7 @@ class Presentation extends PureComponent {
   onFullscreenChange() {
     const { isFullscreen } = this.state;
     const newIsFullscreen = FullscreenService.isFullScreen(
-      this.refPresentationContainer
+      this.refPresentationContainer,
     );
     if (isFullscreen !== newIsFullscreen) {
       this.setState({ isFullscreen: newIsFullscreen });
@@ -478,11 +471,9 @@ class Presentation extends PureComponent {
     };
 
     if (newPresentationAreaSize) {
-      presentationSizes.presentationWidth =
-        newPresentationAreaSize.presentationAreaWidth;
-      presentationSizes.presentationHeight =
-        newPresentationAreaSize.presentationAreaHeight -
-        (getToolbarHeight() || 0);
+      presentationSizes.presentationWidth = newPresentationAreaSize.presentationAreaWidth;
+      presentationSizes.presentationHeight = newPresentationAreaSize.presentationAreaHeight
+        - (getToolbarHeight() || 0);
       return presentationSizes;
     }
 
@@ -573,7 +564,7 @@ class Presentation extends PureComponent {
       if (svgHeight > presentationHeight) svgHeight = presentationHeight;
     }
 
-    if (typeof svgHeight !== "number" || typeof svgWidth !== "number") {
+    if (typeof svgHeight !== 'number' || typeof svgWidth !== 'number') {
       return { width: 0, height: 0 };
     }
 
@@ -612,12 +603,11 @@ class Presentation extends PureComponent {
 
     const { presentationToolbarMinWidth } = DEFAULT_VALUES;
 
-    const toolbarWidth =
-      (this.refWhiteboardArea && svgWidth > presentationToolbarMinWidth) ||
-      isMobile ||
-      (layoutType === LAYOUT_TYPE.VIDEO_FOCUS && numCameras > 0)
-        ? svgWidth
-        : presentationToolbarMinWidth;
+    const toolbarWidth = (this.refWhiteboardArea && svgWidth > presentationToolbarMinWidth)
+      || isMobile
+      || (layoutType === LAYOUT_TYPE.VIDEO_FOCUS && numCameras > 0)
+      ? svgWidth
+      : presentationToolbarMinWidth;
     return (
       <PresentationToolbarContainer
         {...{
@@ -773,12 +763,11 @@ class Presentation extends PureComponent {
 
     const { presentationToolbarMinWidth } = DEFAULT_VALUES;
 
-    const isLargePresentation =
-      (svgWidth > presentationToolbarMinWidth || isMobile) &&
-      !(
-        layoutType === LAYOUT_TYPE.VIDEO_FOCUS &&
-        numCameras > 0 &&
-        !fullscreenContext
+    const isLargePresentation = (svgWidth > presentationToolbarMinWidth || isMobile)
+      && !(
+        layoutType === LAYOUT_TYPE.VIDEO_FOCUS
+        && numCameras > 0
+        && !fullscreenContext
       );
 
     const containerWidth = isLargePresentation
@@ -805,13 +794,13 @@ class Presentation extends PureComponent {
             right: presentationBounds.right,
             width: presentationBounds.width,
             height: presentationBounds.height,
-            display: !presentationIsOpen ? "none" : "flex",
-            overflow: "hidden",
+            display: !presentationIsOpen ? 'none' : 'flex',
+            overflow: 'hidden',
             zIndex: fullscreenContext ? presentationBounds.zIndex : undefined,
             background:
-              layoutType === LAYOUT_TYPE.VIDEO_FOCUS &&
-              numCameras > 0 &&
-              !fullscreenContext
+              layoutType === LAYOUT_TYPE.VIDEO_FOCUS
+              && numCameras > 0
+              && !fullscreenContext
                 ? colorContentBackground
                 : null,
           }}
@@ -828,20 +817,20 @@ class Presentation extends PureComponent {
             >
               <div
                 style={{
-                  position: "absolute",
+                  position: 'absolute',
                   width: svgDimensions.width < 0 ? 0 : svgDimensions.width,
                   height: svgDimensions.height < 0 ? 0 : svgDimensions.height,
-                  textAlign: "center",
-                  display: !presentationIsOpen ? "none" : "block",
+                  textAlign: 'center',
+                  display: !presentationIsOpen ? 'none' : 'block',
                 }}
                 id="presentationInnerWrapper"
               >
                 <Styled.VisuallyHidden id="currentSlideText">
                   {slideContent}
                 </Styled.VisuallyHidden>
-                {!tldrawIsMounting &&
-                  currentSlide &&
-                  this.renderPresentationMenu()}
+                {!tldrawIsMounting
+                  && currentSlide
+                  && this.renderPresentationMenu()}
                 <WhiteboardContainer
                   whiteboardId={currentSlide?.id}
                   podId={podId}
@@ -849,7 +838,7 @@ class Presentation extends PureComponent {
                   getSvgRef={this.getSvgRef}
                   tldrawAPI={tldrawAPI}
                   setTldrawAPI={this.setTldrawAPI}
-                  curPageId={currentSlide?.num.toString() || "0"}
+                  curPageId={currentSlide?.num.toString() || '0'}
                   svgUri={currentSlide?.svgUri}
                   intl={intl}
                   presentationWidth={svgWidth}

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { TldrawApp, Tldraw } from '@tldraw/tldraw';
@@ -19,6 +20,7 @@ import PanToolInjector from './pan-tool-injector/component';
 import {
   findRemoved, filterInvalidShapes, mapLanguage, sendShapeChanges, usePrevious,
 } from './utils';
+import PresentationOpsContainer from './presentation-ops-injector/container';
 
 const SMALL_HEIGHT = 435;
 const SMALLEST_DOCK_HEIGHT = 475;
@@ -75,6 +77,11 @@ export default function Whiteboard(props) {
     sidebarNavigationWidth,
     animations,
     isToolbarVisible,
+    fullscreenRef,
+    fullscreen,
+    setIsToolbarVisible,
+    fullscreenElementId,
+    layoutContextDispatch,
   } = props;
   const { pages, pageStates } = initDefaultPages(curPres?.pages.length || 1);
   const rDocument = React.useRef({
@@ -104,6 +111,37 @@ export default function Whiteboard(props) {
   const isMountedRef = React.useRef(true);
   const [isToolLocked, setIsToolLocked] = React.useState(tldrawAPI?.appState?.isToolLocked);
   const [bgShape, setBgShape] = React.useState(null);
+  const [labels, setLabels] = React.useState({
+    closeLabel: '',
+    activeLable: '',
+    optionsLabel: '',
+    fullscreenLabel: '',
+    exitFullscreenLabel: '',
+    hideToolsDesc: '',
+    showToolsDesc: '',
+    downloading: '',
+    downloaded: '',
+    downloadFailed: '',
+    snapshotLabel: '',
+    whiteboardLabel: '',
+  });
+
+  React.useEffect(() => {
+   setLabels({
+      closeLabel: intl.formatMessage({id: 'app.dropdown.close', description: 'Close button label'}),
+      activeLable: intl.formatMessage({id: 'app.dropdown.list.item.activeLabel', description: 'active item label'}),
+      optionsLabel: intl.formatMessage({id: 'app.navBar.settingsDropdown.optionsLabel', description: 'Options button label'}),
+      fullscreenLabel: intl.formatMessage({id: 'app.presentation.options.fullscreen', description: 'Fullscreen label'}),
+      exitFullscreenLabel: intl.formatMessage({id: 'app.presentation.options.exitFullscreen', description: 'Exit fullscreen label'}),
+      hideToolsDesc: intl.formatMessage({id: 'app.presentation.presentationToolbar.hideToolsDesc', description: 'Hide toolbar label'}),
+      showToolsDesc: intl.formatMessage({id: 'app.presentation.presentationToolbar.showToolsDesc', description: 'Show toolbar label'}),
+      downloading: intl.formatMessage({id: 'app.presentation.options.downloading', description: 'Downloading label'}),
+      downloaded: intl.formatMessage({id: 'app.presentation.options.downloaded', description: 'Downloaded label'}),
+      downloadFailed: intl.formatMessage({id: 'app.presentation.options.downloadFailed', description: 'Downloaded failed label'}),
+      snapshotLabel: intl.formatMessage({id: 'app.presentation.options.snapshot', description: 'Snapshot of current slide label'}),
+      whiteboardLabel: intl.formatMessage({id: 'app.shortcut-help.whiteboard', description: 'used for aria whiteboard options button label'}),
+    });
+  }, [intl?.locale]);
 
   // eslint-disable-next-line arrow-body-style
   React.useEffect(() => {
@@ -545,11 +583,8 @@ export default function Whiteboard(props) {
 
   const fullscreenToggleHandler = () => {
     const {
-      fullscreenElementId,
       isFullscreen,
-      layoutContextDispatch,
       fullscreenAction,
-      fullscreenRef,
       handleToggleFullScreen,
     } = props;
 
@@ -676,6 +711,44 @@ export default function Whiteboard(props) {
 
   const onPatch = (e, t, reason) => {
     if (!e?.pageState || !reason) return;
+    // Append Presentation Options to Tldraw
+    const tdStylesParent = document.getElementById('TD-Styles-Parent');
+    if (tdStylesParent) {
+      tdStylesParent.style.right = '0px';
+      tdStylesParent.style.width = '17.75rem';
+      let presentationMenuNode = document.getElementById('PresentationMenuId');
+      if (!presentationMenuNode) {
+        presentationMenuNode = document.createElement('div');
+        presentationMenuNode.setAttribute('id', 'PresentationMenuId');
+        tdStylesParent.appendChild(presentationMenuNode);
+      }
+
+      ReactDOM.render(
+        <PresentationOpsContainer
+          fullscreenRef={fullscreenRef}
+          elementId={fullscreenElementId}
+          fullscreen={fullscreen}
+          isRTL={isRTL}
+          setIsToolbarVisible={setIsToolbarVisible}
+          isToolbarVisible={isToolbarVisible}
+          layoutContextDispatch={layoutContextDispatch}
+          tldrawAPI={e}
+          closeLabel={labels.closeLabel}
+          activeLable={labels.activeLable}
+          optionsLabel={labels.optionsLabel}
+          fullscreenLabel={labels.fullscreenLabel}
+          exitFullscreenLabel={labels.exitFullscreenLabel}
+          hideToolsDesc={labels.hideToolsDesc}
+          showToolsDesc={labels.showToolsDesc}
+          downloading={labels.downloading}
+          downloaded={labels.downloaded}
+          downloadFailed={labels.downloadFailed}
+          snapshotLabel={labels.snapshotLabel}
+          whiteboardLabel={labels.whiteboardLabel}
+        />, presentationMenuNode
+      );
+    }
+
     if (((isPanning || panSelected) && (reason === 'selected' || reason === 'set_hovered_id'))) {
       e.patchState(
         {
@@ -936,7 +1009,10 @@ export default function Whiteboard(props) {
     if (command && command?.id?.includes('change_page')) {
       const camera = tldrawAPI?.getPageState()?.camera;
       if (currentCameraPoint[app?.currentPageId] && camera) {
-        tldrawAPI?.setCamera([currentCameraPoint[app?.currentPageId][0], currentCameraPoint[app?.currentPageId][1]], camera?.zoom);
+        tldrawAPI?.setCamera(
+          [currentCameraPoint[app?.currentPageId][0], currentCameraPoint[app?.currentPageId][1]],
+          camera?.zoom
+        );
       }
     }
 
@@ -1058,7 +1134,7 @@ export default function Whiteboard(props) {
   const menuOffset = menuOffsetValues[isRTL][isIphone];
 
   return (
-    <div key={`animations=-${animations}`}>
+    <div key={`animations=-${animations}-${intl?.locale}-${isToolbarVisible}`}>
       <Cursors
         tldrawAPI={tldrawAPI}
         currentUser={currentUser}

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -1,8 +1,10 @@
-import { withTracker } from "meteor/react-meteor-data";
-import PropTypes from "prop-types";
-import React, { useContext } from "react";
-import { ColorStyle, DashStyle, SizeStyle, TDShapeType } from "@tldraw/tldraw";
-import SettingsService from "/imports/ui/services/settings";
+import { withTracker } from 'meteor/react-meteor-data';
+import PropTypes from 'prop-types';
+import React, { useContext } from 'react';
+import {
+  ColorStyle, DashStyle, SizeStyle, TDShapeType,
+} from '@tldraw/tldraw';
+import SettingsService from '/imports/ui/services/settings';
 import {
   getShapes,
   getCurrentPres,
@@ -15,17 +17,17 @@ import {
   notifyNotAllowedChange,
   notifyShapeNumberExceeded,
   toggleToolsAnimations,
-} from "./service";
-import Whiteboard from "./component";
-import { UsersContext } from "../components-data/users-context/context";
-import Auth from "/imports/ui/services/auth";
-import PresentationToolbarService from "../presentation/presentation-toolbar/service";
+} from './service';
+import Whiteboard from './component';
+import { UsersContext } from '../components-data/users-context/context';
+import Auth from '/imports/ui/services/auth';
+import PresentationToolbarService from '../presentation/presentation-toolbar/service';
 import {
   layoutSelect,
   layoutDispatch,
-} from "/imports/ui/components/layout/context";
-import FullscreenService from "/imports/ui/components/common/fullscreen-button/service";
-import deviceInfo from "/imports/utils/deviceInfo";
+} from '/imports/ui/components/layout/context';
+import FullscreenService from '/imports/ui/components/common/fullscreen-button/service';
+import deviceInfo from '/imports/utils/deviceInfo';
 
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 const WHITEBOARD_CONFIG = Meteor.settings.public.whiteboard;
@@ -36,7 +38,7 @@ const WhiteboardContainer = (props) => {
   const width = layoutSelect((i) => i?.output?.presentation?.width);
   const height = layoutSelect((i) => i?.output?.presentation?.height);
   const sidebarNavigationWidth = layoutSelect(
-    (i) => i?.output?.sidebarNavigation?.width
+    (i) => i?.output?.sidebarNavigation?.width,
   );
   const { users } = usingUsersContext;
   const currentUser = users[Auth.meetingID][Auth.userID];
@@ -45,22 +47,20 @@ const WhiteboardContainer = (props) => {
   const { maxStickyNoteLength, maxNumberOfAnnotations } = WHITEBOARD_CONFIG;
   const fontFamily = WHITEBOARD_CONFIG.styles.text.family;
   const fullscreen = layoutSelect((i) => i.fullscreen);
-  const handleToggleFullScreen = (ref) =>
-    FullscreenService.toggleFullScreen(ref);
+  const handleToggleFullScreen = (ref) => FullscreenService.toggleFullScreen(ref);
   const layoutContextDispatch = layoutDispatch();
 
   const { shapes } = props;
   const hasShapeAccess = (id) => {
     const owner = shapes[id]?.userId;
-    const isBackgroundShape = id?.includes("slide-background");
-    const isPollsResult = shapes[id]?.name?.includes("poll-result");
-    const hasAccess =
-      (!isBackgroundShape && !isPollsResult) ||
-      (isPresenter &&
-        ((owner && owner === currentUser?.userId) ||
-          !owner ||
-          isPresenter ||
-          isModerator));
+    const isBackgroundShape = id?.includes('slide-background');
+    const isPollsResult = shapes[id]?.name?.includes('poll-result');
+    const hasAccess = (!isBackgroundShape && !isPollsResult)
+      || (isPresenter
+        && ((owner && owner === currentUser?.userId)
+          || !owner
+          || isPresenter
+          || isModerator));
 
     return hasAccess;
   };
@@ -111,11 +111,11 @@ export default withTracker(
     const curPres = getCurrentPres();
     const { isIphone } = deviceInfo;
 
-    shapes["slide-background-shape"] = {
+    shapes['slide-background-shape'] = {
       assetId: `slide-background-asset-${curPageId}`,
       childIndex: -1,
-      id: "slide-background-shape",
-      name: "Image",
+      id: 'slide-background-shape',
+      name: 'Image',
       type: TDShapeType.Image,
       parentId: `${curPageId}`,
       point: [0, 0],
@@ -133,7 +133,7 @@ export default withTracker(
       id: `slide-background-asset-${curPageId}`,
       size: [slidePosition?.width || 0, slidePosition?.height || 0],
       src: svgUri,
-      type: "image",
+      type: 'image',
     };
 
     return {
@@ -152,7 +152,7 @@ export default withTracker(
       previousSlide: PresentationToolbarService.previousSlide,
       numberOfSlides: PresentationToolbarService.getNumberOfSlides(
         podId,
-        presentationId
+        presentationId,
       ),
       notifyNotAllowedChange,
       notifyShapeNumberExceeded,
@@ -163,7 +163,7 @@ export default withTracker(
       toggleToolsAnimations,
       isIphone,
     };
-  }
+  },
 )(WhiteboardContainer);
 
 WhiteboardContainer.propTypes = {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -1,13 +1,8 @@
-import { withTracker } from 'meteor/react-meteor-data';
-import PropTypes from 'prop-types';
-import React, { useContext } from 'react';
-import {
-  ColorStyle,
-  DashStyle,
-  SizeStyle,
-  TDShapeType,
-} from '@tldraw/tldraw';
-import SettingsService from '/imports/ui/services/settings';
+import { withTracker } from "meteor/react-meteor-data";
+import PropTypes from "prop-types";
+import React, { useContext } from "react";
+import { ColorStyle, DashStyle, SizeStyle, TDShapeType } from "@tldraw/tldraw";
+import SettingsService from "/imports/ui/services/settings";
 import {
   getShapes,
   getCurrentPres,
@@ -20,14 +15,17 @@ import {
   notifyNotAllowedChange,
   notifyShapeNumberExceeded,
   toggleToolsAnimations,
-} from './service';
-import Whiteboard from './component';
-import { UsersContext } from '../components-data/users-context/context';
-import Auth from '/imports/ui/services/auth';
-import PresentationToolbarService from '../presentation/presentation-toolbar/service';
-import { layoutSelect } from '../layout/context';
-import FullscreenService from '/imports/ui/components/common/fullscreen-button/service';
-import deviceInfo from '/imports/utils/deviceInfo';
+} from "./service";
+import Whiteboard from "./component";
+import { UsersContext } from "../components-data/users-context/context";
+import Auth from "/imports/ui/services/auth";
+import PresentationToolbarService from "../presentation/presentation-toolbar/service";
+import {
+  layoutSelect,
+  layoutDispatch,
+} from "/imports/ui/components/layout/context";
+import FullscreenService from "/imports/ui/components/common/fullscreen-button/service";
+import deviceInfo from "/imports/utils/deviceInfo";
 
 const ROLE_MODERATOR = Meteor.settings.public.user.role_moderator;
 const WHITEBOARD_CONFIG = Meteor.settings.public.whiteboard;
@@ -37,22 +35,33 @@ const WhiteboardContainer = (props) => {
   const isRTL = layoutSelect((i) => i.isRTL);
   const width = layoutSelect((i) => i?.output?.presentation?.width);
   const height = layoutSelect((i) => i?.output?.presentation?.height);
-  const sidebarNavigationWidth = layoutSelect((i) => i?.output?.sidebarNavigation?.width);
+  const sidebarNavigationWidth = layoutSelect(
+    (i) => i?.output?.sidebarNavigation?.width
+  );
   const { users } = usingUsersContext;
   const currentUser = users[Auth.meetingID][Auth.userID];
   const isPresenter = currentUser.presenter;
   const isModerator = currentUser.role === ROLE_MODERATOR;
   const { maxStickyNoteLength, maxNumberOfAnnotations } = WHITEBOARD_CONFIG;
   const fontFamily = WHITEBOARD_CONFIG.styles.text.family;
-  const handleToggleFullScreen = (ref) => FullscreenService.toggleFullScreen(ref);
+  const fullscreen = layoutSelect((i) => i.fullscreen);
+  const handleToggleFullScreen = (ref) =>
+    FullscreenService.toggleFullScreen(ref);
+  const layoutContextDispatch = layoutDispatch();
 
   const { shapes } = props;
   const hasShapeAccess = (id) => {
     const owner = shapes[id]?.userId;
-    const isBackgroundShape = id?.includes('slide-background');
-    const isPollsResult = shapes[id]?.name?.includes('poll-result');
-    const hasAccess = !isBackgroundShape && !isPollsResult || isPresenter
-      && ((owner && owner === currentUser?.userId) || !owner || isPresenter || isModerator);
+    const isBackgroundShape = id?.includes("slide-background");
+    const isPollsResult = shapes[id]?.name?.includes("poll-result");
+    const hasAccess =
+      (!isBackgroundShape && !isPollsResult) ||
+      (isPresenter &&
+        ((owner && owner === currentUser?.userId) ||
+          !owner ||
+          isPresenter ||
+          isModerator));
+
     return hasAccess;
   };
   // set shapes as locked for those who aren't allowed to edit it
@@ -65,7 +74,7 @@ const WhiteboardContainer = (props) => {
 
   return (
     <Whiteboard
-      {... {
+      {...{
         isPresenter,
         isModerator,
         currentUser,
@@ -75,9 +84,11 @@ const WhiteboardContainer = (props) => {
         maxStickyNoteLength,
         maxNumberOfAnnotations,
         fontFamily,
+        fullscreen,
         hasShapeAccess,
         handleToggleFullScreen,
         sidebarNavigationWidth,
+        layoutContextDispatch,
       }}
       {...props}
       meetingId={Auth.meetingID}
@@ -85,69 +96,75 @@ const WhiteboardContainer = (props) => {
   );
 };
 
-export default withTracker(({
-  whiteboardId,
-  curPageId,
-  intl,
-  slidePosition,
-  svgUri,
-  podId,
-  presentationId,
-  darkTheme,
-}) => {
-  const shapes = getShapes(whiteboardId, curPageId, intl);
-  const curPres = getCurrentPres();
-  const { isIphone } = deviceInfo;
-
-  shapes['slide-background-shape'] = {
-    assetId: `slide-background-asset-${curPageId}`,
-    childIndex: -1,
-    id: 'slide-background-shape',
-    name: 'Image',
-    type: TDShapeType.Image,
-    parentId: `${curPageId}`,
-    point: [0, 0],
-    isLocked: true,
-    size: [slidePosition?.width || 0, slidePosition?.height || 0],
-    style: {
-      dash: DashStyle.Draw,
-      size: SizeStyle.Medium,
-      color: ColorStyle.Blue,
-    },
-  };
-
-  const assets = {};
-  assets[`slide-background-asset-${curPageId}`] = {
-    id: `slide-background-asset-${curPageId}`,
-    size: [slidePosition?.width || 0, slidePosition?.height || 0],
-    src: svgUri,
-    type: 'image',
-  };
-
-  return {
-    initDefaultPages,
-    persistShape,
-    isMultiUserActive,
-    hasMultiUserAccess,
-    changeCurrentSlide,
-    shapes,
-    assets,
-    curPres,
-    removeShapes,
-    zoomSlide: PresentationToolbarService.zoomSlide,
-    skipToSlide: PresentationToolbarService.skipToSlide,
-    nextSlide: PresentationToolbarService.nextSlide,
-    previousSlide: PresentationToolbarService.previousSlide,
-    numberOfSlides: PresentationToolbarService.getNumberOfSlides(podId, presentationId),
-    notifyNotAllowedChange,
-    notifyShapeNumberExceeded,
+export default withTracker(
+  ({
+    whiteboardId,
+    curPageId,
+    intl,
+    slidePosition,
+    svgUri,
+    podId,
+    presentationId,
     darkTheme,
-    whiteboardToolbarAutoHide: SettingsService?.application?.whiteboardToolbarAutoHide,
-    animations: SettingsService?.application?.animations,
-    toggleToolsAnimations,
-    isIphone,
-  };
-})(WhiteboardContainer);
+  }) => {
+    const shapes = getShapes(whiteboardId, curPageId, intl);
+    const curPres = getCurrentPres();
+    const { isIphone } = deviceInfo;
+
+    shapes["slide-background-shape"] = {
+      assetId: `slide-background-asset-${curPageId}`,
+      childIndex: -1,
+      id: "slide-background-shape",
+      name: "Image",
+      type: TDShapeType.Image,
+      parentId: `${curPageId}`,
+      point: [0, 0],
+      isLocked: true,
+      size: [slidePosition?.width || 0, slidePosition?.height || 0],
+      style: {
+        dash: DashStyle.Draw,
+        size: SizeStyle.Medium,
+        color: ColorStyle.Blue,
+      },
+    };
+
+    const assets = {};
+    assets[`slide-background-asset-${curPageId}`] = {
+      id: `slide-background-asset-${curPageId}`,
+      size: [slidePosition?.width || 0, slidePosition?.height || 0],
+      src: svgUri,
+      type: "image",
+    };
+
+    return {
+      initDefaultPages,
+      persistShape,
+      isMultiUserActive,
+      hasMultiUserAccess,
+      changeCurrentSlide,
+      shapes,
+      assets,
+      curPres,
+      removeShapes,
+      zoomSlide: PresentationToolbarService.zoomSlide,
+      skipToSlide: PresentationToolbarService.skipToSlide,
+      nextSlide: PresentationToolbarService.nextSlide,
+      previousSlide: PresentationToolbarService.previousSlide,
+      numberOfSlides: PresentationToolbarService.getNumberOfSlides(
+        podId,
+        presentationId
+      ),
+      notifyNotAllowedChange,
+      notifyShapeNumberExceeded,
+      darkTheme,
+      whiteboardToolbarAutoHide:
+        SettingsService?.application?.whiteboardToolbarAutoHide,
+      animations: SettingsService?.application?.animations,
+      toggleToolsAnimations,
+      isIphone,
+    };
+  }
+)(WhiteboardContainer);
 
 WhiteboardContainer.propTypes = {
   shapes: PropTypes.objectOf(PropTypes.shape).isRequired,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -1,9 +1,7 @@
 import { withTracker } from 'meteor/react-meteor-data';
 import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
-import {
-  ColorStyle, DashStyle, SizeStyle, TDShapeType,
-} from '@tldraw/tldraw';
+import { ColorStyle, DashStyle, SizeStyle, TDShapeType } from '@tldraw/tldraw';
 import SettingsService from '/imports/ui/services/settings';
 import {
   getShapes,
@@ -38,7 +36,7 @@ const WhiteboardContainer = (props) => {
   const width = layoutSelect((i) => i?.output?.presentation?.width);
   const height = layoutSelect((i) => i?.output?.presentation?.height);
   const sidebarNavigationWidth = layoutSelect(
-    (i) => i?.output?.sidebarNavigation?.width,
+    (i) => i?.output?.sidebarNavigation?.width
   );
   const { users } = usingUsersContext;
   const currentUser = users[Auth.meetingID][Auth.userID];
@@ -47,7 +45,8 @@ const WhiteboardContainer = (props) => {
   const { maxStickyNoteLength, maxNumberOfAnnotations } = WHITEBOARD_CONFIG;
   const fontFamily = WHITEBOARD_CONFIG.styles.text.family;
   const fullscreen = layoutSelect((i) => i.fullscreen);
-  const handleToggleFullScreen = (ref) => FullscreenService.toggleFullScreen(ref);
+  const handleToggleFullScreen = (ref) =>
+    FullscreenService.toggleFullScreen(ref);
   const layoutContextDispatch = layoutDispatch();
 
   const { shapes } = props;
@@ -55,12 +54,13 @@ const WhiteboardContainer = (props) => {
     const owner = shapes[id]?.userId;
     const isBackgroundShape = id?.includes('slide-background');
     const isPollsResult = shapes[id]?.name?.includes('poll-result');
-    const hasAccess = (!isBackgroundShape && !isPollsResult)
-      || (isPresenter
-        && ((owner && owner === currentUser?.userId)
-          || !owner
-          || isPresenter
-          || isModerator));
+    const hasAccess =
+      (!isBackgroundShape && !isPollsResult) ||
+      (isPresenter &&
+        ((owner && owner === currentUser?.userId) ||
+          !owner ||
+          isPresenter ||
+          isModerator));
 
     return hasAccess;
   };
@@ -152,7 +152,7 @@ export default withTracker(
       previousSlide: PresentationToolbarService.previousSlide,
       numberOfSlides: PresentationToolbarService.getNumberOfSlides(
         podId,
-        presentationId,
+        presentationId
       ),
       notifyNotAllowedChange,
       notifyShapeNumberExceeded,
@@ -163,7 +163,7 @@ export default withTracker(
       toggleToolsAnimations,
       isIphone,
     };
-  },
+  }
 )(WhiteboardContainer);
 
 WhiteboardContainer.propTypes = {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/presentation-ops-injector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/presentation-ops-injector/component.jsx
@@ -1,0 +1,317 @@
+import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { toPng } from 'html-to-image';
+import { toast } from 'react-toastify';
+import logger from '/imports/startup/client/logger';
+import Styled from '/imports/ui/components/presentation/presentation-menu/styles';
+import BBBMenu from './menu/component';
+import TooltipContainer from '/imports/ui/components/common/tooltip/container';
+import { ACTIONS } from '/imports/ui/components/layout/enums';
+import browserInfo from '/imports/utils/browserInfo';
+import AppService from '/imports/ui/components/app/service';
+
+const propTypes = {
+  handleToggleFullscreen: PropTypes.func.isRequired,
+  isFullscreen: PropTypes.bool,
+  elementName: PropTypes.string,
+  fullscreenRef: PropTypes.instanceOf(Element),
+  meetingName: PropTypes.string,
+  isIphone: PropTypes.bool,
+  elementId: PropTypes.string,
+  elementGroup: PropTypes.string,
+  currentElement: PropTypes.string,
+  currentGroup: PropTypes.string,
+  layoutContextDispatch: PropTypes.func.isRequired,
+  isRTL: PropTypes.bool,
+  tldrawAPI: PropTypes.shape({
+    copySvg: PropTypes.func.isRequired,
+    getShapes: PropTypes.func.isRequired,
+    currentPageId: PropTypes.string.isRequired,
+  }),
+};
+
+const defaultProps = {
+  isIphone: false,
+  isFullscreen: false,
+  isRTL: false,
+  elementName: '',
+  meetingName: '',
+  fullscreenRef: null,
+  elementId: '',
+  elementGroup: '',
+  currentElement: '',
+  currentGroup: '',
+  tldrawAPI: null,
+};
+
+const PresentationOps = (props) => {
+  const {
+    isFullscreen,
+    elementId,
+    elementName,
+    elementGroup,
+    currentElement,
+    currentGroup,
+    fullscreenRef,
+    tldrawAPI,
+    handleToggleFullscreen,
+    layoutContextDispatch,
+    meetingName,
+    isIphone,
+    isRTL,
+    isToolbarVisible,
+    setIsToolbarVisible,
+    exitFullscreenLabel,
+    fullscreenLabel,
+    hideToolsDesc,
+    showToolsDesc,
+    downloading,
+    downloaded,
+    downloadFailed,
+    snapshotLabel,
+    hasWBAccess,
+    amIPresenter,
+    optionsLabel,
+    whiteboardLabel,
+  } = props;
+
+  const [state, setState] = useState({
+    hasError: false,
+    loading: false,
+  });
+
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const toastId = useRef(null);
+  const dropdownRef = useRef(null);
+
+  const formattedLabel = (fullscreen) => (fullscreen
+    ? exitFullscreenLabel
+    : fullscreenLabel
+  );
+  
+  const formattedVisibilityLabel = (visible) => (visible
+    ? hideToolsDesc
+    : showToolsDesc
+  );
+
+  function renderToastContent() {
+    const { loading, hasError } = state;
+
+    let icon = loading ? 'blank' : 'check';
+    if (hasError) icon = 'circle_close';
+
+    return (
+      <Styled.Line>
+        <Styled.ToastText>
+          <span>
+            {loading && !hasError && downloading}
+            {!loading && !hasError && downloaded}
+            {!loading && hasError && downloadFailed}
+          </span>
+        </Styled.ToastText>
+        <Styled.StatusIcon>
+          <Styled.ToastIcon
+            done={!loading && !hasError}
+            error={hasError}
+            loading={loading}
+            iconName={icon}
+          />
+        </Styled.StatusIcon>
+      </Styled.Line>
+    );
+  }
+
+  function getAvailableOptions() {
+    const menuItems = [];
+
+    if (!isIphone) {
+      menuItems.push(
+        {
+          key: 'list-item-fullscreen',
+          dataTest: 'presentationFullscreen',
+          label: formattedLabel(isFullscreen),
+          icon: isFullscreen ? 'exit_fullscreen' : 'fullscreen',
+          onClick: () => {
+            handleToggleFullscreen(fullscreenRef);
+            const newElement = (elementId === currentElement) ? '' : elementId;
+            const newGroup = (elementGroup === currentGroup) ? '' : elementGroup;
+
+            layoutContextDispatch({
+              type: ACTIONS.SET_FULLSCREEN_ELEMENT,
+              value: {
+                element: newElement,
+                group: newGroup,
+              },
+            });
+          },
+        },
+      );
+    }
+
+    const { isSafari } = browserInfo;
+
+    if (!isSafari) {
+      menuItems.push(
+        {
+          key: 'list-item-screenshot',
+          label: snapshotLabel,
+          dataTest: 'presentationSnapshot',
+          icon: 'video',
+          onClick: async () => {
+            setState({
+              loading: true,
+              hasError: false,
+            });
+
+            toastId.current = toast.info(renderToastContent(), {
+              hideProgressBar: true,
+              autoClose: false,
+              newestOnTop: true,
+              closeOnClick: true,
+              onClose: () => {
+                toastId.current = null;
+              },
+            });
+
+            // This is a workaround to a conflict of the
+            // dark mode's styles and the html-to-image lib.
+            // Issue:
+            //  https://github.com/bubkoo/html-to-image/issues/370
+            const darkThemeState = AppService.isDarkThemeEnabled();
+            AppService.setDarkTheme(false);
+
+            try {
+              const { copySvg, getShapes, currentPageId } = tldrawAPI;
+              const svgString = await copySvg(getShapes(currentPageId).map((shape) => shape.id));
+              const container = document.createElement('div');
+              container.innerHTML = svgString;
+              const svgElem = container.firstChild;
+              const width = svgElem?.width?.baseVal?.value ?? window.screen.width;
+              const height = svgElem?.height?.baseVal?.value ?? window.screen.height;
+
+              const data = await toPng(svgElem, { width, height, backgroundColor: '#FFF' });
+
+              const anchor = document.createElement('a');
+              anchor.href = data;
+              anchor.setAttribute(
+                'download',
+                `${elementName}_${meetingName}_${new Date().toISOString()}.png`,
+              );
+              anchor.click();
+
+              setState({
+                loading: false,
+                hasError: false,
+              });
+            } catch (e) {
+              setState({
+                loading: false,
+                hasError: true,
+              });
+
+              logger.warn({
+                logCode: 'presentation_snapshot_error',
+                extraInfo: e,
+              });
+            } finally {
+              // Workaround
+              AppService.setDarkTheme(darkThemeState);
+            }
+          },
+        },
+      );
+    }
+    
+    const tools = document.querySelector('#TD-Tools');
+    if (tools && (hasWBAccess || amIPresenter)){
+      menuItems.push(
+        {
+          key: 'list-item-toolvisibility',
+          dataTest: 'toolVisibility',
+          label: formattedVisibilityLabel(isToolbarVisible),
+          icon: isToolbarVisible ? 'close' : 'pen_tool',
+          onClick: () => {
+            setIsToolbarVisible(!isToolbarVisible);
+          },
+        },
+      );
+    }
+
+    return menuItems;
+  }
+
+  useEffect(() => {
+    if (toastId.current) {
+      toast.update(toastId.current, {
+        render: renderToastContent(),
+        hideProgressBar: state.loading,
+        autoClose: state.loading ? false : 3000,
+        newestOnTop: true,
+        closeOnClick: true,
+        onClose: () => {
+          toastId.current = null;
+        },
+      });
+    }
+
+    if (dropdownRef.current) {
+      document.activeElement.blur();
+      dropdownRef.current.focus();
+    }
+  });
+
+  const options = getAvailableOptions();
+
+  if (options.length === 0) {
+    const undoCtrls = document.getElementById('TD-Styles')?.nextSibling;
+    if (undoCtrls?.style) {
+      undoCtrls.style = 'padding:0px';
+    }
+    const styleTool = document.getElementById('TD-Styles')?.parentNode;
+    if (styleTool?.style) {
+      styleTool.style = 'right:0px';
+    }
+    return null;
+  }
+
+  return (
+    <Styled.Right id='WhiteboardOptionButton'>
+      <BBBMenu
+        {...{
+            ...props,
+        }}
+        trigger={(
+          <TooltipContainer title={optionsLabel}>
+            <Styled.DropdownButton
+              state={isDropdownOpen ? 'open' : 'closed'}
+              aria-label={`${whiteboardLabel} ${optionsLabel}`}
+              data-test="whiteboardOptionsButton"
+              onClick={() => {
+                setIsDropdownOpen((isOpen) => !isOpen);
+              }}
+            >
+              <Styled.ButtonIcon iconName="more" />
+            </Styled.DropdownButton>
+          </TooltipContainer>
+        )}
+        opts={{
+          id: 'presentation-dropdown-menu',
+          keepMounted: true,
+          transitionDuration: 0,
+          elevation: 3,
+          getContentAnchorEl: null,
+          fullwidth: 'true',
+          anchorOrigin: { vertical: 'bottom', horizontal: isRTL ? 'right' : 'left' },
+          transformOrigin: { vertical: 'top', horizontal: isRTL ? 'right' : 'left' },
+          container: fullscreenRef,
+        }}
+        actions={options}
+      />
+    </Styled.Right>
+  );
+};
+
+PresentationOps.propTypes = propTypes;
+PresentationOps.defaultProps = defaultProps;
+
+export default PresentationOps;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/presentation-ops-injector/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/presentation-ops-injector/container.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withTracker } from 'meteor/react-meteor-data';
+import PresentationOps from './component';
+import FullscreenService from '/imports/ui/components/common/fullscreen-button/service';
+import Auth from '/imports/ui/services/auth';
+import Meetings from '/imports/api/meetings';
+import WhiteboardService from '/imports/ui/components/whiteboard/service';
+import UserService from '/imports/ui/components/user-list/service';
+
+const PresentationOpsContainer = (props) => {
+  const { elementId, isRTL, layoutContextDispatch, fullscreen } = props;
+  const { element: currentElement, group: currentGroup } = fullscreen;
+  const isFullscreen = currentElement === elementId;
+
+  return (
+    <PresentationOps
+      {...props}
+      {...{
+        currentElement,
+        currentGroup,
+        isFullscreen,
+        layoutContextDispatch,
+        isRTL,
+      }}
+    />
+  );
+};
+
+export default withTracker((props) => {
+  const handleToggleFullscreen = (ref) => FullscreenService.toggleFullScreen(ref);
+  const isIphone = !!(navigator.userAgent.match(/iPhone/i));
+  const meetingId = Auth.meetingID;
+  const meetingObject = Meetings.findOne({ meetingId }, { fields: { 'meetingProp.name': 1 } });
+  const hasWBAccess = WhiteboardService.hasMultiUserAccess(
+    WhiteboardService.getCurrentWhiteboardId(),
+    Auth.userID
+  );
+  const amIPresenter = UserService.isUserPresenter(Auth.userID);
+  return {
+    ...props,
+    handleToggleFullscreen,
+    isIphone,
+    isDropdownOpen: Session.get('dropdownOpen'),
+    meetingName: meetingObject.meetingProp.name,
+    hasWBAccess,
+    amIPresenter,
+  };
+})(PresentationOpsContainer);
+
+PresentationOpsContainer.propTypes = {
+  elementId: PropTypes.string.isRequired,
+};

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/presentation-ops-injector/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/presentation-ops-injector/menu/component.jsx
@@ -1,0 +1,253 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import Menu from "@material-ui/core/Menu";
+import { Divider } from "@material-ui/core";
+import Icon from "/imports/ui/components/common/icon/component";
+import { SMALL_VIEWPORT_BREAKPOINT } from '/imports/ui/components/layout/enums';
+import KEY_CODES from '/imports/utils/keyCodes';
+
+import { ENTER } from "/imports/utils/keyCodes";
+
+import Styled from '/imports/ui/components/common/menu/styles';
+
+class BBBMenu extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      anchorEl: null,
+    };
+
+    this.optsToMerge = {};
+    this.autoFocus = false;
+
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleClick = this.handleClick.bind(this);
+    this.handleClose = this.handleClose.bind(this);
+  }
+
+  componentDidUpdate() {
+    const { anchorEl } = this.state;
+    const { open } = this.props;
+    if (open === false && anchorEl) {
+      this.setState({ anchorEl: null });
+    } else if (open === true && !anchorEl) {
+      this.setState({ anchorEl: this.anchorElRef });
+    }
+  }
+
+  handleKeyDown(event) {
+    const { anchorEl } = this.state;
+    const isMenuOpen = Boolean(anchorEl);
+
+
+    if ([KEY_CODES.ESCAPE, KEY_CODES.TAB].includes(event.which)) {
+      this.handleClose();
+      return;
+    }
+
+    if (isMenuOpen && [KEY_CODES.ARROW_UP, KEY_CODES.ARROW_DOWN].includes(event.which)) {
+      event.preventDefault();
+      event.stopPropagation();
+      const menuItems = Array.from(document.querySelectorAll('[data-key^="menuItem-"]'));
+      if (menuItems.length === 0) return;
+
+      const focusedIndex = menuItems.findIndex(item => item === document.activeElement);
+      const nextIndex = event.which === KEY_CODES.ARROW_UP ? focusedIndex - 1 : focusedIndex + 1;
+      let indexToFocus = 0;
+      if (nextIndex < 0) {
+        indexToFocus = menuItems.length - 1;
+      } else if (nextIndex >= menuItems.length) {
+        indexToFocus = 0;
+      } else {
+        indexToFocus = nextIndex;
+      }
+
+      menuItems[indexToFocus].focus();
+    }
+  };
+
+  handleClick(event) {
+    this.setState({ anchorEl: event.currentTarget });
+  };
+
+  handleClose(event) {
+    const { onCloseCallback } = this.props;
+    this.setState({ anchorEl: null }, onCloseCallback());
+
+    if (event) {
+      event.persist();
+
+      if (event.type === 'click') {
+        setTimeout(() => {
+          document.activeElement.blur();
+        }, 0);
+      }
+    }
+  };
+
+  makeMenuItems() {
+    const { actions, selectedEmoji, activeLabel } = this.props;
+
+    return actions?.map(a => {
+      const { dataTest, label, onClick, key, disabled, description, selected } = a;
+      const emojiSelected = key?.toLowerCase()?.includes(selectedEmoji?.toLowerCase());
+
+      let customStyles = {
+        paddingLeft: '16px',
+        paddingRight: '16px',
+        paddingTop: '12px',
+        paddingBottom: '12px',
+        marginLeft: '0px',
+        marginRight: '0px',
+      };
+
+      if (a.customStyles) {
+        customStyles = { ...customStyles, ...a.customStyles };
+      }
+
+      return [
+        a.dividerTop && <Divider disabled />,
+        <Styled.BBBMenuItem
+          emoji={emojiSelected ? 'yes' : 'no'}
+          key={label}
+          data-test={dataTest}
+          data-key={`menuItem-${dataTest}`}
+          disableRipple={true}
+          disableGutters={true}
+          disabled={disabled}
+          style={customStyles}
+          onClick={(event) => {
+            onClick();
+            const close = !key?.includes('setstatus') && !key?.includes('back');
+            // prevent menu close for sub menu actions
+            if (close) this.handleClose(event);
+            event.stopPropagation();
+          }}>
+          <Styled.MenuItemWrapper>
+            {a.icon ? <Icon iconName={a.icon} key="icon" /> : null}
+            <Styled.Option aria-describedby={`${key}-option-desc`}>{label}</Styled.Option>
+            {description && <div className="sr-only" id={`${key}-option-desc`}>{`${description}${selected ? ` - ${activeLabel}` : ''}`}</div>}
+            {a.iconRight ? <Styled.IconRight iconName={a.iconRight} key="iconRight" /> : null}
+          </Styled.MenuItemWrapper>
+        </Styled.BBBMenuItem>,
+        a.divider && <Divider disabled />
+      ];
+    });
+  }
+
+  render() {
+    const { anchorEl } = this.state;
+    const { trigger, customStyles, dataTest, opts, accessKey, closeLabel } = this.props;
+    const actionsItems = this.makeMenuItems();
+
+    let menuStyles = { zIndex: 9999 };
+
+    if (customStyles) {
+      menuStyles = { ...menuStyles, ...customStyles };
+    }
+
+    return (
+      <>
+        <div
+          onClick={(e) => {
+            e.persist();
+            // 1 = mouse, 5 = touch (firefox only)
+            const firefoxInputSource = !([1, 5].includes(e.nativeEvent.mozInputSource));
+            const chromeInputSource = !(['mouse', 'touch'].includes(e.nativeEvent.pointerType));
+            this.optsToMerge.autoFocus = firefoxInputSource && chromeInputSource;
+            this.handleClick(e);
+          }}
+          onKeyPress={(e) => {
+            e.persist();
+            if (e.which !== ENTER) return null;
+            return this.handleClick(e);
+          }}
+          accessKey={accessKey}
+          ref={(ref) => { this.anchorElRef = ref; return null; }}
+          role="button"
+          tabIndex={-1}
+        >
+          {trigger}
+        </div>
+
+        <Menu
+          {...opts}
+          {...this.optsToMerge}
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={this.handleClose}
+          style={menuStyles}
+          data-test={dataTest}
+          onKeyDownCapture={this.handleKeyDown}
+        >
+          {actionsItems}
+          {anchorEl && window.innerWidth < SMALL_VIEWPORT_BREAKPOINT &&
+            <Styled.CloseButton
+              label={closeLabel}
+              size="lg"
+              color="default"
+              onClick={this.handleClose}
+            />
+          }
+        </Menu>
+      </>
+    );
+  }
+}
+
+export default BBBMenu;
+
+BBBMenu.defaultProps = {
+  opts: {
+    id: "default-dropdown-menu",
+    autoFocus: false,
+    keepMounted: true,
+    transitionDuration: 0,
+    elevation: 3,
+    getContentAnchorEl: null,
+    fullwidth: "true",
+    anchorOrigin: { vertical: 'top', horizontal: 'right' },
+    transformorigin: { vertical: 'top', horizontal: 'right' },
+  },
+  dataTest: "",
+  onCloseCallback: () => { },
+};
+
+BBBMenu.propTypes = {
+  trigger: PropTypes.element.isRequired,
+
+  actions: PropTypes.arrayOf(PropTypes.shape({
+    key: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    onClick: PropTypes.func,
+    icon: PropTypes.string,
+    iconRight: PropTypes.string,
+    disabled: PropTypes.bool,
+    divider: PropTypes.bool,
+    dividerTop: PropTypes.bool,
+    accessKey: PropTypes.string,
+    dataTest: PropTypes.string,
+  })).isRequired,
+
+  opts: PropTypes.shape({
+    id: PropTypes.string,
+    autoFocus: PropTypes.bool,
+    keepMounted: PropTypes.bool,
+    transitionDuration: PropTypes.number,
+    elevation: PropTypes.number,
+    getContentAnchorEl: PropTypes.element,
+    fullwidth: PropTypes.string,
+    anchorOrigin: PropTypes.shape({ 
+      vertical: PropTypes.string, 
+      horizontal: PropTypes.string 
+    }),
+    transformorigin: PropTypes.shape({ 
+      vertical: PropTypes.string, 
+      horizontal: PropTypes.string 
+    }),
+  }),
+
+  onCloseCallback: PropTypes.func,
+  dataTest: PropTypes.string,
+};


### PR DESCRIPTION
### What does this PR do?
This PR addresses the issue of the incorrect tab order in the presentation options dropdown.

At first, thought of cloning the entire menu element and programmatically moving it to the intended location. However, this method was problematic as we lost the click handlers, thereby affecting the component's interactivity.

Next, considered importing the menu directly into its new location within the TLdraw UI. Unfortunately, this approach also hit a roadblock due to the loss of the Intl and Layout context.

To navigate these challenges. I duplicated the menu component and removed the Intl and Layout related items. Then, passed these elements as props to the component.

![correct-tab-order](https://github.com/bigbluebutton/bigbluebutton/assets/22058534/8453adb1-fa13-43fe-be19-bd26dcd6e3dd)


### Closes Issue(s)
Closes #18257 