### PR TITLE
graphql-server: New endpoint to get server current_time

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1295,3 +1295,12 @@ JOIN "v_meeting_breakoutPolicies"vmbp using("meetingId")
 JOIN "breakoutRoom" br ON br."parentMeetingId" = vmbp."parentId" AND br."externalId" = m."extId";
 
 
+----------------------
+DROP VIEW IF EXISTS v_current_time;
+
+CREATE OR REPLACE VIEW "v_current_time" AS
+SELECT
+	current_timestamp AS "currentTimestampWithTimeZone",
+	localtimestamp AS "currentTimestampWithoutTimeZone",
+	current_timestamp AT TIME ZONE 'UTC' AS "currentTimestampUTC",
+	EXTRACT(EPOCH FROM current_timestamp) * 1000 AS "currentTimeMillis";

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_current_time.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_current_time.yaml
@@ -1,0 +1,17 @@
+table:
+  name: v_current_time
+  schema: public
+configuration:
+  column_config: {}
+  custom_column_names: {}
+  custom_name: current_time
+  custom_root_fields: {}
+select_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - currentTimestampWithTimeZone
+        - currentTimestampWithoutTimeZone
+        - currentTimestampUTC
+        - currentTimeMillis
+      filter: {}

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -8,6 +8,7 @@
 - "!include public_v_chat.yaml"
 - "!include public_v_chat_message_private.yaml"
 - "!include public_v_chat_message_public.yaml"
+- "!include public_v_current_time.yaml"
 - "!include public_v_external_video.yaml"
 - "!include public_v_meeting_breakoutPolicies.yaml"
 - "!include public_v_meeting_group.yaml"


### PR DESCRIPTION
This endpoint is useful to synchronize the time of the Client with the time of the Server.

```gql
query {
  current_time {
    currentTimeMillis
    currentTimestampUTC
    currentTimestampWithTimeZone
    currentTimestampWithoutTimeZone
  }
}
```

Result:
```json
{
  "data": {
    "current_time": [
      {
        "currentTimeMillis": 1690939172815.8418,
        "currentTimestampUTC": "2023-08-02T01:19:32.815842",
        "currentTimestampWithTimeZone": "2023-08-01T22:19:32.815842-03:00",
        "currentTimestampWithoutTimeZone": "2023-08-01T22:19:32.815842"
      }
    ]
  }
}
```
