### PR TITLE
test: add flaky flag to presentation tests

### DIFF
--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.js
@@ -84,13 +84,15 @@ test.describe.parallel('Presentation', () => {
     });
 
     // https://docs.bigbluebutton.org/2.6/release-tests.html#enabling-and-disabling-presentation-download-automated
-    test('Enable and disable original presentation download @ci', async ({ browser, context, page }, testInfo) => {
+    // flaky: update is needed due to changes made on https://github.com/bigbluebutton/bigbluebutton/pull/18411
+    test('Enable and disable original presentation download @flaky', async ({ browser, context, page }, testInfo) => {
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page);
       await presentation.enableAndDisablePresentationDownload(testInfo);
     });
 
-    test('Send presentation in the current state (with annotations) to chat for downloading @ci', async ({ browser, context, page }, testInfo) => {
+    // flaky: update is needed due to changes made on https://github.com/bigbluebutton/bigbluebutton/pull/18411
+    test('Send presentation in the current state (with annotations) to chat for downloading @flaky', async ({ browser, context, page }, testInfo) => {
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page);
       await presentation.sendPresentationToDownload(testInfo);


### PR DESCRIPTION
### What does this PR do?
Tests currently failing since changes made to the presentation download button and setting. Adding `@flaky` test flag to avoid them in CI, it will be removed once we fix it