### PR TITLE
ci(tests): Speed up building time by using cache

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -25,6 +25,8 @@ jobs:
       - run: echo "CACHE_AKKA_APPS_KEY=$(git log -1 --format=%H -- akka-bbb-apps)" >> $GITHUB_ENV
       - run: echo "CACHE_COMMON_MSG_KEY=$(git log -1 --format=%H -- bbb-common-message)" >> $GITHUB_ENV
       - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
@@ -35,8 +37,6 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
-          echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-          echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
           ./build/setup.sh bbb-apps-akka
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -49,10 +49,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
       - run: |
           ./build/get_external_dependencies.sh
-          echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-          echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
           ./build/setup.sh bbb-config
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -64,10 +64,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
       - run: |
           ./build/get_external_dependencies.sh
-          echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-          echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
           ./build/setup.sh bbb-export-annotations
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -83,6 +83,8 @@ jobs:
           fetch-depth: 0 # Fetch all history
       - run: echo "CACHE_LEARNING_DASHBOARD_KEY=$(git log -1 --format=%H -- bbb-learning-dashboard)" >> $GITHUB_ENV
       - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
@@ -93,8 +95,6 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
-          echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-          echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
           ./build/setup.sh bbb-learning-dashboard
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -136,6 +136,8 @@ jobs:
       - run: echo "CACHE_URL3_KEY=$(curl -s https://api.github.com/repos/mconf/ep_redis_publisher/commits | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV
       - run: echo "CACHE_URL4_KEY=$(curl -s https://api.github.com/repos/alangecker/bbb-etherpad-skin/commits | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV
       - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
@@ -146,8 +148,6 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
-          echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-          echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
           ./build/setup.sh bbb-etherpad
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -166,6 +166,8 @@ jobs:
       - run: echo "CACHE_COMMON_MSG_KEY=$(git log -1 --format=%H -- bbb-common-message)" >> $GITHUB_ENV
       - run: echo "CACHE_COMMON_WEB_KEY=$(git log -1 --format=%H -- bbb-common-web)" >> $GITHUB_ENV
       - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
@@ -176,8 +178,6 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
-          echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-          echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
           ./build/setup.sh bbb-web
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -195,6 +195,8 @@ jobs:
       - run: echo "CACHE_AKKA_FSESL_KEY=$(git log -1 --format=%H -- akka-bbb-fsesl)" >> $GITHUB_ENV
       - run: echo "CACHE_COMMON_MSG_KEY=$(git log -1 --format=%H -- bbb-common-message)" >> $GITHUB_ENV
       - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
@@ -205,8 +207,6 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
-          echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-          echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
           ./build/setup.sh bbb-fsesl-akka
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -223,6 +223,8 @@ jobs:
           fetch-depth: 0 # Fetch all history
       - run: echo "CACHE_KEY=$(git log -1 --format=%H -- bigbluebutton-html5)" >> $GITHUB_ENV
       - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
@@ -233,8 +235,6 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
-          echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-          echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
           ./build/setup.sh bbb-html5-nodejs
           ./build/setup.sh bbb-html5
           tar cvf artifacts.tar artifacts/
@@ -254,6 +254,8 @@ jobs:
       - run: echo "CACHE_FREESWITCH_SOUNDS_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-sounds)" >> $GITHUB_ENV
       - run: echo "CACHE_SOUNDS_KEY=$(curl -Is http://bigbluebutton.org/downloads/sounds.tar.gz | grep "Last-Modified" | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV
       - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
@@ -264,8 +266,6 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
-          echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-          echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
           ./build/setup.sh bbb-freeswitch-core
           ./build/setup.sh bbb-freeswitch-sounds
           tar cvf artifacts.tar artifacts/

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -85,10 +85,22 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - run: ./build/get_external_dependencies.sh
-      - run: ./build/setup.sh bbb-html5-nodejs
-      - run: ./build/setup.sh bbb-html5
-      - run: tar cvf artifacts.tar artifacts/
+      - run: echo "CACHE_KEY=$(git log -1 --format=%H -- bigbluebutton-html5)" >> $GITHUB_ENV
+      - name: Cache bigbluebutton-html5
+        id: cache-bigbluebutton-html5
+        uses: actions/cache@v3
+        env:
+          cache-name: test
+        with:
+          path: artifacts.tar
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.CACHE_KEY }}
+      - if: ${{ steps.cache-bigbluebutton-html5.outputs.cache-hit != 'true' }}
+        name: Generate html5 artifacts
+        run: |
+          ./build/get_external_dependencies.sh
+          ./build/setup.sh bbb-html5-nodejs
+          ./build/setup.sh bbb-html5
+          tar cvf artifacts.tar artifacts/
       - name: Archive packages
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -72,15 +72,26 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - run: ./build/get_external_dependencies.sh
-      - run: ./build/setup.sh bbb-learning-dashboard
-      - run: tar cvf artifacts.tar artifacts/
+        with:
+          fetch-depth: 0 # Fetch all history
+      - run: echo "CACHE_LEARNING_DASHBOARD_KEY=$(git log -1 --format=%H -- bbb-learning-dashboard)" >> $GITHUB_ENV
+      - name: Handle cache
+        id: cache-action
+        uses: actions/cache@v3
+        with:
+          path: artifacts.tar
+          key: ${{ runner.os }}-bbb-learning-dashboard-${{ env.CACHE_LEARNING_DASHBOARD_KEY }}
+      - if: ${{ steps.cache-action.outputs.cache-hit != 'true' }}
+        name: Generate artifacts
+        run: |
+          ./build/get_external_dependencies.sh
+          ./build/setup.sh bbb-learning-dashboard
+          tar cvf artifacts.tar artifacts/
       - name: Archive packages
         uses: actions/upload-artifact@v3
         with:
           name: artifacts_bbb-learning-dashboard.tar
-          path: |
-            artifacts.tar
+          path: artifacts.tar
   build-bbb-playback-record:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -345,11 +345,15 @@ jobs:
           echo "----ls artifacts/----"
           ls artifacts/
           COMMIT_DATE="$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%dT%H%M%S')"
-          VERSION_NUMBER="$(cat "$SOURCE/bigbluebutton-config/bigbluebutton-release" | cut -d '=' -f2 | cut -d "-" -f1)"
-          VERSION_ADDON="$(cat "$SOURCE/bigbluebutton-config/bigbluebutton-release" | cut -d '=' -f2 | cut -d "-" -f2)"
+          VERSION_NUMBER="$(cat bigbluebutton-config/bigbluebutton-release | cut -d '=' -f2 | cut -d "-" -f1)"
+          VERSION_ADDON="$(cat bigbluebutton-config/bigbluebutton-release | cut -d '=' -f2 | cut -d "-" -f2)"
           GIT_REV=$(git rev-parse HEAD)
           GIT_REV="local-build-${GIT_REV:0:10}"
           VERSION="${VERSION_NUMBER}~${VERSION_ADDON}+${COMMIT_DATE}-git.${GIT_REV}"
+          echo "COMMIT_DATE: $COMMIT_DATE"
+          echo "VERSION_NUMBER: $VERSION_NUMBER"
+          echo "VERSION_ADDON: $VERSION_ADDON"
+          echo "GIT_REV: $GIT_REV"
           echo "VERSION: $VERSION"
           mv artifacts/bbb-apps-akka_2* artifacts/bbb-apps-akka_2:${VERSION}_all.deb
           mv artifacts/bbb-fsesl-akka_2* artifacts/bbb-fsesl-akka_2:${VERSION}_all.deb

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -117,7 +117,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0 # Fetch all history
+          fetch-depth: 1000 # Fetch all history
       - run: echo "CACHE_FREESWITCH_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-core)" >> $GITHUB_ENV
       - run: echo "CACHE_FREESWITCH_SOUNDS_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-sounds)" >> $GITHUB_ENV
       - run: echo "CACHE_SOUNDS_KEY=$(curl -Is http://bigbluebutton.org/downloads/sounds.tar.gz | grep "Last-Modified" | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -255,7 +255,7 @@ jobs:
       #     mv artifacts /home/runner/work/bigbluebutton/bigbluebutton/artifacts/
       #     EOF
   install-and-run-tests:
-    needs: [build-bbb-apps-akka, build-bbb-config, build-export-annotations, build-learning-dashboard, build-bbb-etherpad, build-bbb-bbb-web, build-bbb-fsesl-akka, build-bbb-html5, build-bbb-freeswitch, build-others]
+    needs: [build-bbb-apps-akka, build-bbb-config, build-bbb-export-annotations, build-bbb-learning-dashboard, build-bbb-etherpad, build-bbb-bbb-web, build-bbb-fsesl-akka, build-bbb-html5, build-bbb-freeswitch, build-others]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -270,15 +270,15 @@ jobs:
         with:
           name: artifacts_bbb-config.tar
       - run: tar xf artifacts.tar
-      - name: Download artifacts_export-annotations
+      - name: Download artifacts_bbb-export-annotations
         uses: actions/download-artifact@v3
         with:
-          name: artifacts_export-annotations.tar
+          name: artifacts_bbb-export-annotations.tar
       - run: tar xf artifacts.tar
-      - name: Download artifacts_learning-dashboard
+      - name: Download artifacts_bbb-learning-dashboard
         uses: actions/download-artifact@v3
         with:
-          name: artifacts_learning-dashboard.tar
+          name: artifacts_bbb-learning-dashboard.tar
       - run: tar xf artifacts.tar
       - name: Download artifacts_bbb-etherpad
         uses: actions/download-artifact@v3

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -86,15 +86,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 5 # Fetch all history
-      - run: ls
-      - run: git status
-      - run: echo $(git log -n 6)
-      - run: echo $(git log --full-history -n 6 bigbluebutton-html5)
-      - run: echo $(git log --full-history -n 6 akka-bbb-fsesl)
-      - run: echo $(git log --full-history -n 6 bbb-learning-dashboard)
-      - run: echo $(git log -1 bigbluebutton-html5)
-      - run: echo "CACHE_KEY=$(git log --full-history -1 --format=%H -- bigbluebutton-html5)" >> $GITHUB_ENV
+          fetch-depth: 0 # Fetch all history
+      - run: echo "CACHE_KEY=$(git log -1 --format=%H -- bigbluebutton-html5)" >> $GITHUB_ENV
       - name: Cache bigbluebutton-html5
         id: cache-bigbluebutton-html5
         uses: actions/cache@v3
@@ -119,7 +112,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 1000 # Fetch all history
+          fetch-depth: 0 # Fetch all history
       - run: echo "CACHE_FREESWITCH_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-core)" >> $GITHUB_ENV
       - run: echo "CACHE_FREESWITCH_SOUNDS_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-sounds)" >> $GITHUB_ENV
       - run: echo "CACHE_SOUNDS_KEY=$(curl -Is http://bigbluebutton.org/downloads/sounds.tar.gz | grep "Last-Modified" | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -384,19 +384,19 @@ jobs:
           echo "VERSION_ADDON: $VERSION_ADDON"
           echo "GIT_REV: $GIT_REV"
           echo "VERSION: $VERSION"
-#          mv artifacts/bbb-apps-akka_2* artifacts/bbb-apps-akka_2:${VERSION}_all.deb 2>/dev/null || true
-#          mv artifacts/bbb-fsesl-akka_2* artifacts/bbb-fsesl-akka_2:${VERSION}_all.deb 2>/dev/null || true
-#          mv artifacts/bbb-etherpad* artifacts/bbb-etherpad_${VERSION}_amd64.deb 2>/dev/null || true
-#          mv artifacts/bbb-freeswitch-core* artifacts/bbb-freeswitch-core_${VERSION}_amd64.deb 2>/dev/null || true
-#          mv artifacts/bbb-freeswitch-sounds* artifacts/bbb-freeswitch-sounds_${VERSION}_amd64.deb 2>/dev/null || true
-#          mv artifacts/bbb-html5-nodejs* artifacts/bbb-html5-nodejs_${VERSION}_amd64.deb 2>/dev/null || true
-#          mv artifacts/bbb-html5_* artifacts/bbb-html5_${VERSION}_amd64.deb 2>/dev/null || true
-#          mv artifacts/bbb-web_* artifacts/bbb-web_${VERSION}_amd64.deb 2>/dev/null || true
-#          mv artifacts/bbb-learning-dashboard_* artifacts/bbb-learning-dashboard_${VERSION}_amd64.deb 2>/dev/null || true
-#          mv artifacts/bbb-config_* artifacts/bbb-config_${VERSION}_amd64.deb 2>/dev/null || true
-#          echo "----Renamed----"
-#          ls artifacts/
           echo "Done"
+        #          mv artifacts/bbb-apps-akka_2* artifacts/bbb-apps-akka_2:${VERSION}_all.deb 2>/dev/null || true
+        #          mv artifacts/bbb-fsesl-akka_2* artifacts/bbb-fsesl-akka_2:${VERSION}_all.deb 2>/dev/null || true
+        #          mv artifacts/bbb-etherpad* artifacts/bbb-etherpad_${VERSION}_amd64.deb 2>/dev/null || true
+        #          mv artifacts/bbb-freeswitch-core* artifacts/bbb-freeswitch-core_${VERSION}_amd64.deb 2>/dev/null || true
+        #          mv artifacts/bbb-freeswitch-sounds* artifacts/bbb-freeswitch-sounds_${VERSION}_amd64.deb 2>/dev/null || true
+        #          mv artifacts/bbb-html5-nodejs* artifacts/bbb-html5-nodejs_${VERSION}_amd64.deb 2>/dev/null || true
+        #          mv artifacts/bbb-html5_* artifacts/bbb-html5_${VERSION}_amd64.deb 2>/dev/null || true
+        #          mv artifacts/bbb-web_* artifacts/bbb-web_${VERSION}_amd64.deb 2>/dev/null || true
+        #          mv artifacts/bbb-learning-dashboard_* artifacts/bbb-learning-dashboard_${VERSION}_amd64.deb 2>/dev/null || true
+        #          mv artifacts/bbb-config_* artifacts/bbb-config_${VERSION}_amd64.deb 2>/dev/null || true
+        #          echo "----Renamed----"
+        #          ls artifacts/
       - name: Generate CA
         run: |
           sudo -i <<EOF

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -86,15 +86,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 1 # Fetch all history
+          fetch-depth: 5 # Fetch all history
       - run: ls
       - run: git status
       - run: echo $(git log -n 6)
-      - run: echo $(git log -n 6 bigbluebutton-html5)
-      - run: echo $(git log -n 6 akka-bbb-fsesl)
-      - run: echo $(git log -n 6 bbb-learning-dashboard)
+      - run: echo $(git log --full-history -n 6 bigbluebutton-html5)
+      - run: echo $(git log --full-history -n 6 akka-bbb-fsesl)
+      - run: echo $(git log --full-history -n 6 bbb-learning-dashboard)
       - run: echo $(git log -1 bigbluebutton-html5)
-      - run: echo "CACHE_KEY=$(git log -1 --format=%H -- bigbluebutton-html5)" >> $GITHUB_ENV
+      - run: echo "CACHE_KEY=$(git log --full-history -1 --format=%H -- bigbluebutton-html5)" >> $GITHUB_ENV
       - name: Cache bigbluebutton-html5
         id: cache-bigbluebutton-html5
         uses: actions/cache@v3
@@ -119,7 +119,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0 # Fetch all history
+          fetch-depth: 1000 # Fetch all history
       - run: echo "CACHE_FREESWITCH_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-core)" >> $GITHUB_ENV
       - run: echo "CACHE_FREESWITCH_SOUNDS_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-sounds)" >> $GITHUB_ENV
       - run: echo "CACHE_SOUNDS_KEY=$(curl -Is http://bigbluebutton.org/downloads/sounds.tar.gz | grep "Last-Modified" | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -344,8 +344,6 @@ jobs:
           pwd
           echo "----ls artifacts/----"
           ls artifacts/
-# renane to avoid error: Depends: bbb-apps-akka (= 2:2.7.0~beta.3+20230802T211649-git.local-build-3632c35759) but 2:2.7.0~beta.3+20230802T145515-git.local-build-53a0c6e8ad is to be installed
-# "${PACKAGE}_${VERSION}_${DISTRO}"
           COMMIT_DATE="$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%dT%H%M%S')"
           VERSION_NUMBER="$(cat "$SOURCE/bigbluebutton-config/bigbluebutton-release" | cut -d '=' -f2 | cut -d "-" -f1)"
           VERSION_ADDON="$(cat "$SOURCE/bigbluebutton-config/bigbluebutton-release" | cut -d '=' -f2 | cut -d "-" -f2)"

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -359,6 +359,7 @@ jobs:
           mv artifacts/bbb-html5-nodejs* artifacts/bbb-html5-nodejs_${VERSION}_amd64.deb
           mv artifacts/bbb-html5_* artifacts/bbb-html5_${VERSION}_amd64.deb
           mv artifacts/bbb-web_* artifacts/bbb-web_${VERSION}_amd64.deb
+          mv artifacts/bbb-learning-dashboard_* artifacts/bbb-learning-dashboard_${VERSION}_amd64.deb
           mv artifacts/bbb-config_* artifacts/bbb-config_${VERSION}_amd64.deb
           echo "----Renamed----"
           ls artifacts/

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -91,6 +91,8 @@ jobs:
       - run: git status
       - run: echo $(git log -n 6)
       - run: echo $(git log -n 6 bigbluebutton-html5)
+      - run: echo $(git log -n 6 bbb-graphql-middleware)
+      - run: echo $(git log -n 6 bbb-learning-dashboard)
       - run: echo $(git log -1 bigbluebutton-html5)
       - run: echo "CACHE_KEY=$(git log -1 --format=%H -- bigbluebutton-html5)" >> $GITHUB_ENV
       - name: Cache bigbluebutton-html5
@@ -117,7 +119,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 1000 # Fetch all history
+          fetch-depth: 500 # Fetch all history
       - run: echo "CACHE_FREESWITCH_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-core)" >> $GITHUB_ENV
       - run: echo "CACHE_FREESWITCH_SOUNDS_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-sounds)" >> $GITHUB_ENV
       - run: echo "CACHE_SOUNDS_KEY=$(curl -Is http://bigbluebutton.org/downloads/sounds.tar.gz | grep "Last-Modified" | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -86,21 +86,19 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0 # Fetch all history
+          fetch-depth: 5 # Fetch all history
       - run: ls
       - run: git status
-      - run: echo $(git log -n 5)
-      - run: echo $(git log -n 5 bigbluebutton-html5)
+      - run: echo $(git log -n 6)
+      - run: echo $(git log -n 6 bigbluebutton-html5)
       - run: echo $(git log -1 bigbluebutton-html5)
       - run: echo "CACHE_KEY=$(git log -1 --format=%H -- bigbluebutton-html5)" >> $GITHUB_ENV
       - name: Cache bigbluebutton-html5
         id: cache-bigbluebutton-html5
         uses: actions/cache@v3
-        env:
-          cache-name: test
         with:
           path: artifacts.tar
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ env.CACHE_KEY }}
+          key: ${{ runner.os }}-bbb-html5-${{ env.CACHE_KEY }}
       - if: ${{ steps.cache-bigbluebutton-html5.outputs.cache-hit != 'true' }}
         name: Generate html5 artifacts
         run: |

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -55,6 +55,32 @@ jobs:
           name: artifacts_bbb-config.tar
           path: |
             artifacts.tar
+  build-bbb-export-annotations:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: ./build/get_external_dependencies.sh
+      - run: ./build/setup.sh bbb-export-annotations
+      - run: tar cvf artifacts.tar artifacts/
+      - name: Archive packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts_bbb-export-annotations.tar
+          path: |
+            artifacts.tar
+  build-bbb-learning-dashboard:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: ./build/get_external_dependencies.sh
+      - run: ./build/setup.sh bbb-learning-dashboard
+      - run: tar cvf artifacts.tar artifacts/
+      - name: Archive packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts_bbb-learning-dashboard.tar
+          path: |
+            artifacts.tar
   build-bbb-etherpad:
     runs-on: ubuntu-20.04
     steps:
@@ -197,8 +223,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: ./build/get_external_dependencies.sh
-      - run: ./build/setup.sh bbb-export-annotations
-      - run: ./build/setup.sh bbb-learning-dashboard
       - run: ./build/setup.sh bbb-libreoffice-docker
       - run: ./build/setup.sh bbb-mkclean
       - run: ./build/setup.sh bbb-pads
@@ -231,7 +255,7 @@ jobs:
       #     mv artifacts /home/runner/work/bigbluebutton/bigbluebutton/artifacts/
       #     EOF
   install-and-run-tests:
-    needs: [build-bbb-apps-akka, build-bbb-config, build-bbb-etherpad, build-bbb-bbb-web, build-bbb-fsesl-akka, build-bbb-html5, build-bbb-freeswitch, build-others]
+    needs: [build-bbb-apps-akka, build-bbb-config, build-export-annotations, build-learning-dashboard, build-bbb-etherpad, build-bbb-bbb-web, build-bbb-fsesl-akka, build-bbb-html5, build-bbb-freeswitch, build-others]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -245,6 +269,16 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: artifacts_bbb-config.tar
+      - run: tar xf artifacts.tar
+      - name: Download artifacts_export-annotations
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts_export-annotations.tar
+      - run: tar xf artifacts.tar
+      - name: Download artifacts_learning-dashboard
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts_learning-dashboard.tar
       - run: tar xf artifacts.tar
       - name: Download artifacts_bbb-etherpad
         uses: actions/download-artifact@v3

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -25,8 +25,8 @@ jobs:
       - run: echo "CACHE_AKKA_APPS_KEY=$(git log -1 --format=%H -- akka-bbb-apps)" >> $GITHUB_ENV
       - run: echo "CACHE_COMMON_MSG_KEY=$(git log -1 --format=%H -- bbb-common-message)" >> $GITHUB_ENV
       - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
-      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV #used by setup.sh
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV #used by setup.sh
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
@@ -49,8 +49,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV #used by setup.sh
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV #used by setup.sh
       - run: |
           ./build/get_external_dependencies.sh
           ./build/setup.sh bbb-config
@@ -64,8 +64,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV #used by setup.sh
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV #used by setup.sh
       - run: |
           ./build/get_external_dependencies.sh
           ./build/setup.sh bbb-export-annotations
@@ -83,8 +83,8 @@ jobs:
           fetch-depth: 0 # Fetch all history
       - run: echo "CACHE_LEARNING_DASHBOARD_KEY=$(git log -1 --format=%H -- bbb-learning-dashboard)" >> $GITHUB_ENV
       - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
-      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV #used by setup.sh
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV #used by setup.sh
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
@@ -107,8 +107,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: ./build/get_external_dependencies.sh
-      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV #used by setup.sh
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV #used by setup.sh
       - run: ./build/setup.sh bbb-playback
       - run: ./build/setup.sh bbb-playback-notes
       - run: ./build/setup.sh bbb-playback-podcast
@@ -136,8 +136,8 @@ jobs:
       - run: echo "CACHE_URL3_KEY=$(curl -s https://api.github.com/repos/mconf/ep_redis_publisher/commits | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV
       - run: echo "CACHE_URL4_KEY=$(curl -s https://api.github.com/repos/alangecker/bbb-etherpad-skin/commits | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV
       - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
-      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV #used by setup.sh
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV #used by setup.sh
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
@@ -166,8 +166,8 @@ jobs:
       - run: echo "CACHE_COMMON_MSG_KEY=$(git log -1 --format=%H -- bbb-common-message)" >> $GITHUB_ENV
       - run: echo "CACHE_COMMON_WEB_KEY=$(git log -1 --format=%H -- bbb-common-web)" >> $GITHUB_ENV
       - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
-      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV #used by setup.sh
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV #used by setup.sh
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
@@ -195,8 +195,8 @@ jobs:
       - run: echo "CACHE_AKKA_FSESL_KEY=$(git log -1 --format=%H -- akka-bbb-fsesl)" >> $GITHUB_ENV
       - run: echo "CACHE_COMMON_MSG_KEY=$(git log -1 --format=%H -- bbb-common-message)" >> $GITHUB_ENV
       - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
-      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV #used by setup.sh
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV #used by setup.sh
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
@@ -223,8 +223,8 @@ jobs:
           fetch-depth: 0 # Fetch all history
       - run: echo "CACHE_KEY=$(git log -1 --format=%H -- bigbluebutton-html5)" >> $GITHUB_ENV
       - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
-      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV #used by setup.sh
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV #used by setup.sh
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
@@ -254,8 +254,8 @@ jobs:
       - run: echo "CACHE_FREESWITCH_SOUNDS_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-sounds)" >> $GITHUB_ENV
       - run: echo "CACHE_SOUNDS_KEY=$(curl -Is http://bigbluebutton.org/downloads/sounds.tar.gz | grep "Last-Modified" | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV
       - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
-      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV #used by setup.sh
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV #used by setup.sh
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
@@ -280,8 +280,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: ./build/get_external_dependencies.sh
-      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
-      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV #used by setup.sh
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV #used by setup.sh
       - run: ./build/setup.sh bbb-mkclean
       - run: ./build/setup.sh bbb-pads
       - run: ./build/setup.sh bbb-libreoffice-docker
@@ -374,18 +374,6 @@ jobs:
           echo "----ls artifacts/----"
           ls artifacts/
           echo "Done"
-        #          COMMIT_DATE="$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%dT%H%M%S')"
-        #          VERSION_NUMBER="$(cat bigbluebutton-config/bigbluebutton-release | cut -d '=' -f2 | cut -d "-" -f1)"
-        #          VERSION_ADDON="$(cat bigbluebutton-config/bigbluebutton-release | cut -d '=' -f2 | cut -d "-" -f2)"
-        #          GIT_REV=$(git rev-parse HEAD)
-        #          GIT_REV="local-build-${GIT_REV:0:10}"
-        #          VERSION="${VERSION_NUMBER}~${VERSION_ADDON}+${COMMIT_DATE}-git.${GIT_REV}"
-        #          echo "COMMIT_DATE: $COMMIT_DATE"
-        #          echo "VERSION_NUMBER: $VERSION_NUMBER"
-        #          echo "VERSION_ADDON: $VERSION_ADDON"
-        #          echo "GIT_REV: $GIT_REV"
-        #          echo "VERSION: $VERSION"
-
       - name: Generate CA
         run: |
           sudo -i <<EOF

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -373,18 +373,19 @@ jobs:
           pwd
           echo "----ls artifacts/----"
           ls artifacts/
-#          COMMIT_DATE="$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%dT%H%M%S')"
-#          VERSION_NUMBER="$(cat bigbluebutton-config/bigbluebutton-release | cut -d '=' -f2 | cut -d "-" -f1)"
-#          VERSION_ADDON="$(cat bigbluebutton-config/bigbluebutton-release | cut -d '=' -f2 | cut -d "-" -f2)"
-#          GIT_REV=$(git rev-parse HEAD)
-#          GIT_REV="local-build-${GIT_REV:0:10}"
-#          VERSION="${VERSION_NUMBER}~${VERSION_ADDON}+${COMMIT_DATE}-git.${GIT_REV}"
-#          echo "COMMIT_DATE: $COMMIT_DATE"
-#          echo "VERSION_NUMBER: $VERSION_NUMBER"
-#          echo "VERSION_ADDON: $VERSION_ADDON"
-#          echo "GIT_REV: $GIT_REV"
-#          echo "VERSION: $VERSION"
           echo "Done"
+        #          COMMIT_DATE="$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%dT%H%M%S')"
+        #          VERSION_NUMBER="$(cat bigbluebutton-config/bigbluebutton-release | cut -d '=' -f2 | cut -d "-" -f1)"
+        #          VERSION_ADDON="$(cat bigbluebutton-config/bigbluebutton-release | cut -d '=' -f2 | cut -d "-" -f2)"
+        #          GIT_REV=$(git rev-parse HEAD)
+        #          GIT_REV="local-build-${GIT_REV:0:10}"
+        #          VERSION="${VERSION_NUMBER}~${VERSION_ADDON}+${COMMIT_DATE}-git.${GIT_REV}"
+        #          echo "COMMIT_DATE: $COMMIT_DATE"
+        #          echo "VERSION_NUMBER: $VERSION_NUMBER"
+        #          echo "VERSION_ADDON: $VERSION_ADDON"
+        #          echo "GIT_REV: $GIT_REV"
+        #          echo "VERSION: $VERSION"
+
       - name: Generate CA
         run: |
           sudo -i <<EOF

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -85,14 +85,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Fetch all history
       - run: ls
-      - run: echo "-----------_"
       - run: git status
       - run: echo $(git log -n 5)
-      - run: echo "-----------_"
       - run: echo $(git log -n 5 bigbluebutton-html5)
-      - run: echo "-----------_"
-      - run: echo $(git log -1 bigbluebutton-html5)"
+      - run: echo $(git log -1 bigbluebutton-html5)
       - run: echo "CACHE_KEY=$(git log -1 --format=%H -- bigbluebutton-html5)" >> $GITHUB_ENV
       - name: Cache bigbluebutton-html5
         id: cache-bigbluebutton-html5
@@ -119,6 +118,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Fetch all history
       - run: echo "CACHE_FREESWITCH_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-core)" >> $GITHUB_ENV
       - run: echo "CACHE_FREESWITCH_SOUNDS_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-sounds)" >> $GITHUB_ENV
       - run: echo "CACHE_SOUNDS_KEY=$(curl -Is http://bigbluebutton.org/downloads/sounds.tar.gz | grep "Last-Modified" | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -81,6 +81,19 @@ jobs:
           name: artifacts_bbb-learning-dashboard.tar
           path: |
             artifacts.tar
+  build-bbb-libreoffice-docker:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: ./build/get_external_dependencies.sh
+      - run: ./build/setup.sh bbb-libreoffice-docker
+      - run: tar cvf artifacts.tar artifacts/
+      - name: Archive packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts_bbb-libreoffice-docker.tar
+          path: |
+            artifacts.tar
   build-bbb-etherpad:
     runs-on: ubuntu-20.04
     steps:
@@ -223,7 +236,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: ./build/get_external_dependencies.sh
-      - run: ./build/setup.sh bbb-libreoffice-docker
       - run: ./build/setup.sh bbb-mkclean
       - run: ./build/setup.sh bbb-pads
       - run: ./build/setup.sh bbb-playback
@@ -255,7 +267,7 @@ jobs:
       #     mv artifacts /home/runner/work/bigbluebutton/bigbluebutton/artifacts/
       #     EOF
   install-and-run-tests:
-    needs: [build-bbb-apps-akka, build-bbb-config, build-bbb-export-annotations, build-bbb-learning-dashboard, build-bbb-etherpad, build-bbb-bbb-web, build-bbb-fsesl-akka, build-bbb-html5, build-bbb-freeswitch, build-others]
+    needs: [build-bbb-apps-akka, build-bbb-config, build-bbb-export-annotations, build-bbb-learning-dashboard, build-bbb-libreoffice-docker, build-bbb-etherpad, build-bbb-bbb-web, build-bbb-fsesl-akka, build-bbb-html5, build-bbb-freeswitch, build-others]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -279,6 +291,11 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: artifacts_bbb-learning-dashboard.tar
+      - run: tar xf artifacts.tar
+      - name: Download artifacts_bbb-libreoffice-docker
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts_bbb-libreoffice-docker.tar
       - run: tar xf artifacts.tar
       - name: Download artifacts_bbb-etherpad
         uses: actions/download-artifact@v3

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -85,6 +85,14 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+      - run: ls
+      - run: echo "-----------_"
+      - run: git status
+      - run: echo $(git log -n 5)
+      - run: echo "-----------_"
+      - run: echo $(git log -n 5 bigbluebutton-html5)
+      - run: echo "-----------_"
+      - run: echo $(git log -1 bigbluebutton-html5)"
       - run: echo "CACHE_KEY=$(git log -1 --format=%H -- bigbluebutton-html5)" >> $GITHUB_ENV
       - name: Cache bigbluebutton-html5
         id: cache-bigbluebutton-html5
@@ -113,7 +121,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: echo "CACHE_FREESWITCH_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-core)" >> $GITHUB_ENV
       - run: echo "CACHE_FREESWITCH_SOUNDS_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-sounds)" >> $GITHUB_ENV
-      - run: echo "CACHE_SOUNDS_KEY=$(curl -Is http://bigbluebutton.org/downloads/sounds.tar.gz | grep "Last-Modified")" >> $GITHUB_ENV
+      - run: echo "CACHE_SOUNDS_KEY=$(curl -Is http://bigbluebutton.org/downloads/sounds.tar.gz | grep "Last-Modified" | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -35,8 +35,8 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
-          FORCE_GIT_REV="0"
-          FORCE_COMMIT_DATE="0"
+          echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+          echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
           ./build/setup.sh bbb-apps-akka
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -51,8 +51,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: |
           ./build/get_external_dependencies.sh
-          FORCE_GIT_REV="0"
-          FORCE_COMMIT_DATE="0"
+          echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+          echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
           ./build/setup.sh bbb-config
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -66,8 +66,8 @@ jobs:
       - uses: actions/checkout@v3
       - run: |
           ./build/get_external_dependencies.sh
-          FORCE_GIT_REV="0"
-          FORCE_COMMIT_DATE="0"
+          echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+          echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
           ./build/setup.sh bbb-export-annotations
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -93,8 +93,8 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
-          FORCE_GIT_REV="0"
-          FORCE_COMMIT_DATE="0"
+          echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+          echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
           ./build/setup.sh bbb-learning-dashboard
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -146,8 +146,8 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
-          FORCE_GIT_REV="0"
-          FORCE_COMMIT_DATE="0"
+          echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+          echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
           ./build/setup.sh bbb-etherpad
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -176,8 +176,8 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
-          FORCE_GIT_REV="0"
-          FORCE_COMMIT_DATE="0"
+          echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+          echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
           ./build/setup.sh bbb-web
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -205,8 +205,8 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
-          FORCE_GIT_REV="0"
-          FORCE_COMMIT_DATE="0"
+          echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+          echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
           ./build/setup.sh bbb-fsesl-akka
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -233,8 +233,8 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
-          FORCE_GIT_REV="0"
-          FORCE_COMMIT_DATE="0"
+          echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+          echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
           ./build/setup.sh bbb-html5-nodejs
           ./build/setup.sh bbb-html5
           tar cvf artifacts.tar artifacts/
@@ -264,8 +264,8 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
-          FORCE_GIT_REV="0"
-          FORCE_COMMIT_DATE="0"
+          echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+          echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
           ./build/setup.sh bbb-freeswitch-core
           ./build/setup.sh bbb-freeswitch-sounds
           tar cvf artifacts.tar artifacts/

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -111,10 +111,22 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - run: ./build/get_external_dependencies.sh
-      - run: ./build/setup.sh bbb-freeswitch-core
-      - run: ./build/setup.sh bbb-freeswitch-sounds
-      - run: tar cvf artifacts.tar artifacts/
+      - run: echo "CACHE_FREESWITCH_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-core)" >> $GITHUB_ENV
+      - run: echo "CACHE_FREESWITCH_SOUNDS_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-sounds)" >> $GITHUB_ENV
+      - run: echo "CACHE_SOUNDS_KEY=$(curl -Is http://bigbluebutton.org/downloads/sounds.tar.gz | grep "Last-Modified")" >> $GITHUB_ENV
+      - name: Handle cache
+        id: cache-action
+        uses: actions/cache@v3
+        with:
+          path: artifacts.tar
+          key: ${{ runner.os }}-bbb-freeswitch-${{ env.CACHE_FREESWITCH_KEY }}-${{ env.CACHE_FREESWITCH_SOUNDS_KEY }}-${{ env.CACHE_SOUNDS_KEY }}
+      - if: ${{ steps.cache-action.outputs.cache-hit != 'true' }}
+        name: Generate artifacts
+        run: |
+          ./build/get_external_dependencies.sh
+          ./build/setup.sh bbb-freeswitch-core
+          ./build/setup.sh bbb-freeswitch-sounds
+          tar cvf artifacts.tar artifacts/
       - name: Archive packages
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -34,6 +34,8 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
+          FORCE_GIT_REV="0"
+          FORCE_COMMIT_DATE="0"
           ./build/setup.sh bbb-apps-akka
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -46,28 +48,32 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - run: ./build/get_external_dependencies.sh
-      - run: ./build/setup.sh bbb-config
-      - run: tar cvf artifacts.tar artifacts/
+      - run: |
+          ./build/get_external_dependencies.sh
+          FORCE_GIT_REV="0"
+          FORCE_COMMIT_DATE="0"
+          ./build/setup.sh bbb-config
+          tar cvf artifacts.tar artifacts/
       - name: Archive packages
         uses: actions/upload-artifact@v3
         with:
           name: artifacts_bbb-config.tar
-          path: |
-            artifacts.tar
+          path: artifacts.tar
   build-bbb-export-annotations:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - run: ./build/get_external_dependencies.sh
-      - run: ./build/setup.sh bbb-export-annotations
-      - run: tar cvf artifacts.tar artifacts/
+      - run: |
+          ./build/get_external_dependencies.sh
+          FORCE_GIT_REV="0"
+          FORCE_COMMIT_DATE="0"
+          ./build/setup.sh bbb-export-annotations
+          tar cvf artifacts.tar artifacts/
       - name: Archive packages
         uses: actions/upload-artifact@v3
         with:
           name: artifacts_bbb-export-annotations.tar
-          path: |
-            artifacts.tar
+          path: artifacts.tar
   build-bbb-learning-dashboard:
     runs-on: ubuntu-20.04
     steps:
@@ -85,6 +91,8 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
+          FORCE_GIT_REV="0"
+          FORCE_COMMIT_DATE="0"
           ./build/setup.sh bbb-learning-dashboard
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -97,6 +105,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: ./build/get_external_dependencies.sh
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
       - run: ./build/setup.sh bbb-playback
       - run: ./build/setup.sh bbb-playback-notes
       - run: ./build/setup.sh bbb-playback-podcast
@@ -133,6 +143,8 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
+          FORCE_GIT_REV="0"
+          FORCE_COMMIT_DATE="0"
           ./build/setup.sh bbb-etherpad
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -160,6 +172,8 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
+          FORCE_GIT_REV="0"
+          FORCE_COMMIT_DATE="0"
           ./build/setup.sh bbb-web
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -186,6 +200,8 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
+          FORCE_GIT_REV="0"
+          FORCE_COMMIT_DATE="0"
           ./build/setup.sh bbb-fsesl-akka
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
@@ -211,6 +227,8 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
+          FORCE_GIT_REV="0"
+          FORCE_COMMIT_DATE="0"
           ./build/setup.sh bbb-html5-nodejs
           ./build/setup.sh bbb-html5
           tar cvf artifacts.tar artifacts/
@@ -239,6 +257,8 @@ jobs:
         name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
+          FORCE_GIT_REV="0"
+          FORCE_COMMIT_DATE="0"
           ./build/setup.sh bbb-freeswitch-core
           ./build/setup.sh bbb-freeswitch-sounds
           tar cvf artifacts.tar artifacts/
@@ -253,6 +273,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: ./build/get_external_dependencies.sh
+      - run: echo "FORCE_GIT_REV=0" >> $GITHUB_ENV
+      - run: echo "FORCE_COMMIT_DATE=0" >> $GITHUB_ENV
       - run: ./build/setup.sh bbb-mkclean
       - run: ./build/setup.sh bbb-pads
       - run: ./build/setup.sh bbb-libreoffice-docker
@@ -355,18 +377,18 @@ jobs:
           echo "VERSION_ADDON: $VERSION_ADDON"
           echo "GIT_REV: $GIT_REV"
           echo "VERSION: $VERSION"
-          mv artifacts/bbb-apps-akka_2* artifacts/bbb-apps-akka_2:${VERSION}_all.deb 2>/dev/null || true
-          mv artifacts/bbb-fsesl-akka_2* artifacts/bbb-fsesl-akka_2:${VERSION}_all.deb 2>/dev/null || true
-          mv artifacts/bbb-etherpad* artifacts/bbb-etherpad_${VERSION}_amd64.deb 2>/dev/null || true
-          mv artifacts/bbb-freeswitch-core* artifacts/bbb-freeswitch-core_${VERSION}_amd64.deb 2>/dev/null || true
-          mv artifacts/bbb-freeswitch-sounds* artifacts/bbb-freeswitch-sounds_${VERSION}_amd64.deb 2>/dev/null || true
-          mv artifacts/bbb-html5-nodejs* artifacts/bbb-html5-nodejs_${VERSION}_amd64.deb 2>/dev/null || true
-          mv artifacts/bbb-html5_* artifacts/bbb-html5_${VERSION}_amd64.deb 2>/dev/null || true
-          mv artifacts/bbb-web_* artifacts/bbb-web_${VERSION}_amd64.deb 2>/dev/null || true
-          mv artifacts/bbb-learning-dashboard_* artifacts/bbb-learning-dashboard_${VERSION}_amd64.deb 2>/dev/null || true
-          mv artifacts/bbb-config_* artifacts/bbb-config_${VERSION}_amd64.deb 2>/dev/null || true
-          echo "----Renamed----"
-          ls artifacts/
+#          mv artifacts/bbb-apps-akka_2* artifacts/bbb-apps-akka_2:${VERSION}_all.deb 2>/dev/null || true
+#          mv artifacts/bbb-fsesl-akka_2* artifacts/bbb-fsesl-akka_2:${VERSION}_all.deb 2>/dev/null || true
+#          mv artifacts/bbb-etherpad* artifacts/bbb-etherpad_${VERSION}_amd64.deb 2>/dev/null || true
+#          mv artifacts/bbb-freeswitch-core* artifacts/bbb-freeswitch-core_${VERSION}_amd64.deb 2>/dev/null || true
+#          mv artifacts/bbb-freeswitch-sounds* artifacts/bbb-freeswitch-sounds_${VERSION}_amd64.deb 2>/dev/null || true
+#          mv artifacts/bbb-html5-nodejs* artifacts/bbb-html5-nodejs_${VERSION}_amd64.deb 2>/dev/null || true
+#          mv artifacts/bbb-html5_* artifacts/bbb-html5_${VERSION}_amd64.deb 2>/dev/null || true
+#          mv artifacts/bbb-web_* artifacts/bbb-web_${VERSION}_amd64.deb 2>/dev/null || true
+#          mv artifacts/bbb-learning-dashboard_* artifacts/bbb-learning-dashboard_${VERSION}_amd64.deb 2>/dev/null || true
+#          mv artifacts/bbb-config_* artifacts/bbb-config_${VERSION}_amd64.deb 2>/dev/null || true
+#          echo "----Renamed----"
+#          ls artifacts/
           echo "Done"
       - name: Generate CA
         run: |

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -20,9 +20,22 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - run: ./build/get_external_dependencies.sh
-      - run: ./build/setup.sh bbb-apps-akka
-      - run: tar cvf artifacts.tar artifacts/
+        with:
+          fetch-depth: 0 # Fetch all history
+      - run: echo "CACHE_AKKA_APPS_KEY=$(git log -1 --format=%H -- akka-bbb-apps)" >> $GITHUB_ENV
+      - run: echo "CACHE_COMMON_MSG_KEY=$(git log -1 --format=%H -- bbb-common-message)" >> $GITHUB_ENV
+      - name: Handle cache
+        id: cache-action
+        uses: actions/cache@v3
+        with:
+          path: artifacts.tar
+          key: ${{ runner.os }}-bbb-apps-akka-${{ env.CACHE_AKKA_APPS_KEY }}-${{ env.CACHE_COMMON_MSG_KEY }}
+      - if: ${{ steps.cache-action.outputs.cache-hit != 'true' }}
+        name: Generate artifacts
+        run: |
+          ./build/get_external_dependencies.sh
+          ./build/setup.sh bbb-apps-akka
+          tar cvf artifacts.tar artifacts/
       - name: Archive packages
         uses: actions/upload-artifact@v3
         with:
@@ -46,9 +59,26 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - run: ./build/get_external_dependencies.sh
-      - run: ./build/setup.sh bbb-etherpad
-      - run: tar cvf artifacts.tar artifacts/
+        with:
+          fetch-depth: 0 # Fetch all history
+      - run: echo "CACHE_ETHERPAD_VERSION_KEY=$(git log -1 --format=%H -- bbb-etherpad.placeholder.sh)" >> $GITHUB_ENV
+      - run: echo "CACHE_ETHERPAD_BUILD_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-etherpad)" >> $GITHUB_ENV
+      - run: echo "CACHE_URL1_KEY=$(curl -s https://api.github.com/repos/mconf/ep_pad_ttl/commits | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV
+      - run: echo "CACHE_URL2_KEY=$(curl -s https://api.github.com/repos/alangecker/bbb-etherpad-plugin/commits | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV
+      - run: echo "CACHE_URL3_KEY=$(curl -s https://api.github.com/repos/mconf/ep_redis_publisher/commits | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV
+      - run: echo "CACHE_URL4_KEY=$(curl -s https://api.github.com/repos/alangecker/bbb-etherpad-skin/commits | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV
+      - name: Handle cache
+        id: cache-action
+        uses: actions/cache@v3
+        with:
+          path: artifacts.tar
+          key: ${{ runner.os }}-bbb-etherpad-${{ env.CACHE_ETHERPAD_VERSION_KEY }}-${{ env.CACHE_ETHERPAD_BUILD_KEY }}-${{ env.CACHE_URL1_KEY }}-${{ env.CACHE_URL2_KEY }}-${{ env.CACHE_URL3_KEY }}-${{ env.CACHE_URL4_KEY }}
+      - if: ${{ steps.cache-action.outputs.cache-hit != 'true' }}
+        name: Generate artifacts
+        run: |
+          ./build/get_external_dependencies.sh
+          ./build/setup.sh bbb-etherpad
+          tar cvf artifacts.tar artifacts/
       - name: Archive packages
         uses: actions/upload-artifact@v3
         with:
@@ -59,9 +89,23 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - run: ./build/get_external_dependencies.sh
-      - run: ./build/setup.sh bbb-web
-      - run: tar cvf artifacts.tar artifacts/
+        with:
+          fetch-depth: 0 # Fetch all history
+      - run: echo "CACHE_BBB_WEB_KEY=$(git log -1 --format=%H -- bigbluebutton-web)" >> $GITHUB_ENV
+      - run: echo "CACHE_COMMON_MSG_KEY=$(git log -1 --format=%H -- bbb-common-message)" >> $GITHUB_ENV
+      - run: echo "CACHE_COMMON_WEB_KEY=$(git log -1 --format=%H -- bbb-common-web)" >> $GITHUB_ENV
+      - name: Handle cache
+        id: cache-action
+        uses: actions/cache@v3
+        with:
+          path: artifacts.tar
+          key: ${{ runner.os }}-bbb-web-${{ env.CACHE_BBB_WEB_KEY }}-${{ env.CACHE_COMMON_MSG_KEY }}-${{ env.CACHE_COMMON_WEB_KEY }}
+      - if: ${{ steps.cache-action.outputs.cache-hit != 'true' }}
+        name: Generate artifacts
+        run: |
+          ./build/get_external_dependencies.sh
+          ./build/setup.sh bbb-web
+          tar cvf artifacts.tar artifacts/
       - name: Archive packages
         uses: actions/upload-artifact@v3
         with:
@@ -72,9 +116,22 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - run: ./build/get_external_dependencies.sh
-      - run: ./build/setup.sh bbb-fsesl-akka
-      - run: tar cvf artifacts.tar artifacts/
+        with:
+          fetch-depth: 0 # Fetch all history
+      - run: echo "CACHE_AKKA_FSESL_KEY=$(git log -1 --format=%H -- akka-bbb-fsesl)" >> $GITHUB_ENV
+      - run: echo "CACHE_COMMON_MSG_KEY=$(git log -1 --format=%H -- bbb-common-message)" >> $GITHUB_ENV
+      - name: Handle cache
+        id: cache-action
+        uses: actions/cache@v3
+        with:
+          path: artifacts.tar
+          key: ${{ runner.os }}-bbb-fsesl-akka-${{ env.CACHE_AKKA_FSESL_KEY }}-${{ env.CACHE_COMMON_MSG_KEY }}
+      - if: ${{ steps.cache-action.outputs.cache-hit != 'true' }}
+        name: Generate artifacts
+        run: |
+          ./build/get_external_dependencies.sh
+          ./build/setup.sh bbb-fsesl-akka
+          tar cvf artifacts.tar artifacts/
       - name: Archive packages
         uses: actions/upload-artifact@v3
         with:
@@ -88,14 +145,14 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history
       - run: echo "CACHE_KEY=$(git log -1 --format=%H -- bigbluebutton-html5)" >> $GITHUB_ENV
-      - name: Cache bigbluebutton-html5
-        id: cache-bigbluebutton-html5
+      - name: Handle cache
+        id: cache-action
         uses: actions/cache@v3
         with:
           path: artifacts.tar
           key: ${{ runner.os }}-bbb-html5-${{ env.CACHE_KEY }}
-      - if: ${{ steps.cache-bigbluebutton-html5.outputs.cache-hit != 'true' }}
-        name: Generate html5 artifacts
+      - if: ${{ steps.cache-action.outputs.cache-hit != 'true' }}
+        name: Generate artifacts
         run: |
           ./build/get_external_dependencies.sh
           ./build/setup.sh bbb-html5-nodejs

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Archive packages
         uses: actions/upload-artifact@v3
         with:
-          name: artifacts_bbb-bbb-playback-record.tar
+          name: artifacts_bbb-playback-record.tar
           path: |
             artifacts.tar
   build-bbb-etherpad:
@@ -267,7 +267,7 @@ jobs:
       #     mv artifacts /home/runner/work/bigbluebutton/bigbluebutton/artifacts/
       #     EOF
   install-and-run-tests:
-    needs: [build-bbb-apps-akka, build-bbb-config, build-bbb-export-annotations, build-bbb-learning-dashboard, build-bbb-bbb-playback-record, build-bbb-etherpad, build-bbb-bbb-web, build-bbb-fsesl-akka, build-bbb-html5, build-bbb-freeswitch, build-others]
+    needs: [build-bbb-apps-akka, build-bbb-config, build-bbb-export-annotations, build-bbb-learning-dashboard, build-bbb-playback-record, build-bbb-etherpad, build-bbb-bbb-web, build-bbb-fsesl-akka, build-bbb-html5, build-bbb-freeswitch, build-others]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -292,10 +292,10 @@ jobs:
         with:
           name: artifacts_bbb-learning-dashboard.tar
       - run: tar xf artifacts.tar
-      - name: Download artifacts_bbb-bbb-playback-record
+      - name: Download artifacts_bbb-playback-record
         uses: actions/download-artifact@v3
         with:
-          name: artifacts_bbb-bbb-playback-record.tar
+          name: artifacts_bbb-playback-record.tar
       - run: tar xf artifacts.tar
       - name: Download artifacts_bbb-etherpad
         uses: actions/download-artifact@v3

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -373,30 +373,18 @@ jobs:
           pwd
           echo "----ls artifacts/----"
           ls artifacts/
-          COMMIT_DATE="$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%dT%H%M%S')"
-          VERSION_NUMBER="$(cat bigbluebutton-config/bigbluebutton-release | cut -d '=' -f2 | cut -d "-" -f1)"
-          VERSION_ADDON="$(cat bigbluebutton-config/bigbluebutton-release | cut -d '=' -f2 | cut -d "-" -f2)"
-          GIT_REV=$(git rev-parse HEAD)
-          GIT_REV="local-build-${GIT_REV:0:10}"
-          VERSION="${VERSION_NUMBER}~${VERSION_ADDON}+${COMMIT_DATE}-git.${GIT_REV}"
-          echo "COMMIT_DATE: $COMMIT_DATE"
-          echo "VERSION_NUMBER: $VERSION_NUMBER"
-          echo "VERSION_ADDON: $VERSION_ADDON"
-          echo "GIT_REV: $GIT_REV"
-          echo "VERSION: $VERSION"
+#          COMMIT_DATE="$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%dT%H%M%S')"
+#          VERSION_NUMBER="$(cat bigbluebutton-config/bigbluebutton-release | cut -d '=' -f2 | cut -d "-" -f1)"
+#          VERSION_ADDON="$(cat bigbluebutton-config/bigbluebutton-release | cut -d '=' -f2 | cut -d "-" -f2)"
+#          GIT_REV=$(git rev-parse HEAD)
+#          GIT_REV="local-build-${GIT_REV:0:10}"
+#          VERSION="${VERSION_NUMBER}~${VERSION_ADDON}+${COMMIT_DATE}-git.${GIT_REV}"
+#          echo "COMMIT_DATE: $COMMIT_DATE"
+#          echo "VERSION_NUMBER: $VERSION_NUMBER"
+#          echo "VERSION_ADDON: $VERSION_ADDON"
+#          echo "GIT_REV: $GIT_REV"
+#          echo "VERSION: $VERSION"
           echo "Done"
-        #          mv artifacts/bbb-apps-akka_2* artifacts/bbb-apps-akka_2:${VERSION}_all.deb 2>/dev/null || true
-        #          mv artifacts/bbb-fsesl-akka_2* artifacts/bbb-fsesl-akka_2:${VERSION}_all.deb 2>/dev/null || true
-        #          mv artifacts/bbb-etherpad* artifacts/bbb-etherpad_${VERSION}_amd64.deb 2>/dev/null || true
-        #          mv artifacts/bbb-freeswitch-core* artifacts/bbb-freeswitch-core_${VERSION}_amd64.deb 2>/dev/null || true
-        #          mv artifacts/bbb-freeswitch-sounds* artifacts/bbb-freeswitch-sounds_${VERSION}_amd64.deb 2>/dev/null || true
-        #          mv artifacts/bbb-html5-nodejs* artifacts/bbb-html5-nodejs_${VERSION}_amd64.deb 2>/dev/null || true
-        #          mv artifacts/bbb-html5_* artifacts/bbb-html5_${VERSION}_amd64.deb 2>/dev/null || true
-        #          mv artifacts/bbb-web_* artifacts/bbb-web_${VERSION}_amd64.deb 2>/dev/null || true
-        #          mv artifacts/bbb-learning-dashboard_* artifacts/bbb-learning-dashboard_${VERSION}_amd64.deb 2>/dev/null || true
-        #          mv artifacts/bbb-config_* artifacts/bbb-config_${VERSION}_amd64.deb 2>/dev/null || true
-        #          echo "----Renamed----"
-        #          ls artifacts/
       - name: Generate CA
         run: |
           sudo -i <<EOF

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -81,17 +81,23 @@ jobs:
           name: artifacts_bbb-learning-dashboard.tar
           path: |
             artifacts.tar
-  build-bbb-libreoffice-docker:
+  build-bbb-playback-record:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - run: ./build/get_external_dependencies.sh
-      - run: ./build/setup.sh bbb-libreoffice-docker
+      - run: ./build/setup.sh bbb-playback
+      - run: ./build/setup.sh bbb-playback-notes
+      - run: ./build/setup.sh bbb-playback-podcast
+      - run: ./build/setup.sh bbb-playback-presentation
+      - run: ./build/setup.sh bbb-playback-screenshare
+      - run: ./build/setup.sh bbb-playback-video
+      - run: ./build/setup.sh bbb-record-core
       - run: tar cvf artifacts.tar artifacts/
       - name: Archive packages
         uses: actions/upload-artifact@v3
         with:
-          name: artifacts_bbb-libreoffice-docker.tar
+          name: artifacts_bbb-bbb-playback-record.tar
           path: |
             artifacts.tar
   build-bbb-etherpad:
@@ -238,13 +244,7 @@ jobs:
       - run: ./build/get_external_dependencies.sh
       - run: ./build/setup.sh bbb-mkclean
       - run: ./build/setup.sh bbb-pads
-      - run: ./build/setup.sh bbb-playback
-      - run: ./build/setup.sh bbb-playback-notes
-      - run: ./build/setup.sh bbb-playback-podcast
-      - run: ./build/setup.sh bbb-playback-presentation
-      - run: ./build/setup.sh bbb-playback-screenshare
-      - run: ./build/setup.sh bbb-playback-video
-      - run: ./build/setup.sh bbb-record-core
+      - run: ./build/setup.sh bbb-libreoffice-docker
       - run: ./build/setup.sh bbb-webrtc-sfu
       - run: ./build/setup.sh bbb-webrtc-recorder
       - run: ./build/setup.sh bbb-transcription-controller
@@ -267,7 +267,7 @@ jobs:
       #     mv artifacts /home/runner/work/bigbluebutton/bigbluebutton/artifacts/
       #     EOF
   install-and-run-tests:
-    needs: [build-bbb-apps-akka, build-bbb-config, build-bbb-export-annotations, build-bbb-learning-dashboard, build-bbb-libreoffice-docker, build-bbb-etherpad, build-bbb-bbb-web, build-bbb-fsesl-akka, build-bbb-html5, build-bbb-freeswitch, build-others]
+    needs: [build-bbb-apps-akka, build-bbb-config, build-bbb-export-annotations, build-bbb-learning-dashboard, build-bbb-bbb-playback-record, build-bbb-etherpad, build-bbb-bbb-web, build-bbb-fsesl-akka, build-bbb-html5, build-bbb-freeswitch, build-others]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -292,10 +292,10 @@ jobs:
         with:
           name: artifacts_bbb-learning-dashboard.tar
       - run: tar xf artifacts.tar
-      - name: Download artifacts_bbb-libreoffice-docker
+      - name: Download artifacts_bbb-bbb-playback-record
         uses: actions/download-artifact@v3
         with:
-          name: artifacts_bbb-libreoffice-docker.tar
+          name: artifacts_bbb-bbb-playback-record.tar
       - run: tar xf artifacts.tar
       - name: Download artifacts_bbb-etherpad
         uses: actions/download-artifact@v3

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -355,16 +355,16 @@ jobs:
           echo "VERSION_ADDON: $VERSION_ADDON"
           echo "GIT_REV: $GIT_REV"
           echo "VERSION: $VERSION"
-          mv artifacts/bbb-apps-akka_2* artifacts/bbb-apps-akka_2:${VERSION}_all.deb
-          mv artifacts/bbb-fsesl-akka_2* artifacts/bbb-fsesl-akka_2:${VERSION}_all.deb
-          mv artifacts/bbb-etherpad* artifacts/bbb-etherpad_${VERSION}_amd64.deb
-          mv artifacts/bbb-freeswitch-core* artifacts/bbb-freeswitch-core_${VERSION}_amd64.deb
-          mv artifacts/bbb-freeswitch-sounds* artifacts/bbb-freeswitch-sounds_${VERSION}_amd64.deb
-          mv artifacts/bbb-html5-nodejs* artifacts/bbb-html5-nodejs_${VERSION}_amd64.deb
-          mv artifacts/bbb-html5_* artifacts/bbb-html5_${VERSION}_amd64.deb
-          mv artifacts/bbb-web_* artifacts/bbb-web_${VERSION}_amd64.deb
-          mv artifacts/bbb-learning-dashboard_* artifacts/bbb-learning-dashboard_${VERSION}_amd64.deb
-          mv artifacts/bbb-config_* artifacts/bbb-config_${VERSION}_amd64.deb
+          mv artifacts/bbb-apps-akka_2* artifacts/bbb-apps-akka_2:${VERSION}_all.deb 2>/dev/null || true
+          mv artifacts/bbb-fsesl-akka_2* artifacts/bbb-fsesl-akka_2:${VERSION}_all.deb 2>/dev/null || true
+          mv artifacts/bbb-etherpad* artifacts/bbb-etherpad_${VERSION}_amd64.deb 2>/dev/null || true
+          mv artifacts/bbb-freeswitch-core* artifacts/bbb-freeswitch-core_${VERSION}_amd64.deb 2>/dev/null || true
+          mv artifacts/bbb-freeswitch-sounds* artifacts/bbb-freeswitch-sounds_${VERSION}_amd64.deb 2>/dev/null || true
+          mv artifacts/bbb-html5-nodejs* artifacts/bbb-html5-nodejs_${VERSION}_amd64.deb 2>/dev/null || true
+          mv artifacts/bbb-html5_* artifacts/bbb-html5_${VERSION}_amd64.deb 2>/dev/null || true
+          mv artifacts/bbb-web_* artifacts/bbb-web_${VERSION}_amd64.deb 2>/dev/null || true
+          mv artifacts/bbb-learning-dashboard_* artifacts/bbb-learning-dashboard_${VERSION}_amd64.deb 2>/dev/null || true
+          mv artifacts/bbb-config_* artifacts/bbb-config_${VERSION}_amd64.deb 2>/dev/null || true
           echo "----Renamed----"
           ls artifacts/
           echo "Done"

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -342,7 +342,27 @@ jobs:
         run: |
           set -e
           pwd
-          ls
+          echo "----ls artifacts/----"
+          ls artifacts/
+# renane to avoid error: Depends: bbb-apps-akka (= 2:2.7.0~beta.3+20230802T211649-git.local-build-3632c35759) but 2:2.7.0~beta.3+20230802T145515-git.local-build-53a0c6e8ad is to be installed
+# "${PACKAGE}_${VERSION}_${DISTRO}"
+          COMMIT_DATE="$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%dT%H%M%S')"
+          VERSION_NUMBER="$(cat "$SOURCE/bigbluebutton-config/bigbluebutton-release" | cut -d '=' -f2 | cut -d "-" -f1)"
+          VERSION_ADDON="$(cat "$SOURCE/bigbluebutton-config/bigbluebutton-release" | cut -d '=' -f2 | cut -d "-" -f2)"
+          GIT_REV=$(git rev-parse HEAD)
+          GIT_REV="local-build-${GIT_REV:0:10}"
+          VERSION="${VERSION_NUMBER}~${VERSION_ADDON}+${COMMIT_DATE}-git.${GIT_REV}"
+          echo "VERSION: $VERSION"
+          mv artifacts/bbb-apps-akka_2* artifacts/bbb-apps-akka_2:${VERSION}_all.deb
+          mv artifacts/bbb-fsesl-akka_2* artifacts/bbb-fsesl-akka_2:${VERSION}_all.deb
+          mv artifacts/bbb-etherpad* artifacts/bbb-etherpad_${VERSION}_amd64.deb
+          mv artifacts/bbb-freeswitch-core* artifacts/bbb-freeswitch-core_${VERSION}_amd64.deb
+          mv artifacts/bbb-freeswitch-sounds* artifacts/bbb-freeswitch-sounds_${VERSION}_amd64.deb
+          mv artifacts/bbb-html5-nodejs* artifacts/bbb-html5-nodejs_${VERSION}_amd64.deb
+          mv artifacts/bbb-html5_* artifacts/bbb-html5_${VERSION}_amd64.deb
+          mv artifacts/bbb-web_* artifacts/bbb-web_${VERSION}_amd64.deb
+          mv artifacts/bbb-config_* artifacts/bbb-config_${VERSION}_amd64.deb
+          echo "----Renamed----"
           ls artifacts/
           echo "Done"
       - name: Generate CA

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -86,12 +86,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 5 # Fetch all history
+          fetch-depth: 1 # Fetch all history
       - run: ls
       - run: git status
       - run: echo $(git log -n 6)
       - run: echo $(git log -n 6 bigbluebutton-html5)
-      - run: echo $(git log -n 6 bbb-graphql-middleware)
+      - run: echo $(git log -n 6 akka-bbb-fsesl)
       - run: echo $(git log -n 6 bbb-learning-dashboard)
       - run: echo $(git log -1 bigbluebutton-html5)
       - run: echo "CACHE_KEY=$(git log -1 --format=%H -- bigbluebutton-html5)" >> $GITHUB_ENV
@@ -119,7 +119,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 500 # Fetch all history
+          fetch-depth: 0 # Fetch all history
       - run: echo "CACHE_FREESWITCH_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-core)" >> $GITHUB_ENV
       - run: echo "CACHE_FREESWITCH_SOUNDS_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-sounds)" >> $GITHUB_ENV
       - run: echo "CACHE_SOUNDS_KEY=$(curl -Is http://bigbluebutton.org/downloads/sounds.tar.gz | grep "Last-Modified" | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -24,12 +24,13 @@ jobs:
           fetch-depth: 0 # Fetch all history
       - run: echo "CACHE_AKKA_APPS_KEY=$(git log -1 --format=%H -- akka-bbb-apps)" >> $GITHUB_ENV
       - run: echo "CACHE_COMMON_MSG_KEY=$(git log -1 --format=%H -- bbb-common-message)" >> $GITHUB_ENV
+      - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
         with:
           path: artifacts.tar
-          key: ${{ runner.os }}-bbb-apps-akka-${{ env.CACHE_AKKA_APPS_KEY }}-${{ env.CACHE_COMMON_MSG_KEY }}
+          key: ${{ runner.os }}-bbb-apps-akka-${{ env.CACHE_AKKA_APPS_KEY }}-${{ env.CACHE_COMMON_MSG_KEY }}-${{ env.CACHE_BBB_RELEASE_KEY }}
       - if: ${{ steps.cache-action.outputs.cache-hit != 'true' }}
         name: Generate artifacts
         run: |
@@ -81,12 +82,13 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history
       - run: echo "CACHE_LEARNING_DASHBOARD_KEY=$(git log -1 --format=%H -- bbb-learning-dashboard)" >> $GITHUB_ENV
+      - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
         with:
           path: artifacts.tar
-          key: ${{ runner.os }}-bbb-learning-dashboard-${{ env.CACHE_LEARNING_DASHBOARD_KEY }}
+          key: ${{ runner.os }}-bbb-learning-dashboard-${{ env.CACHE_LEARNING_DASHBOARD_KEY }}-${{ env.CACHE_BBB_RELEASE_KEY }}
       - if: ${{ steps.cache-action.outputs.cache-hit != 'true' }}
         name: Generate artifacts
         run: |
@@ -133,12 +135,13 @@ jobs:
       - run: echo "CACHE_URL2_KEY=$(curl -s https://api.github.com/repos/alangecker/bbb-etherpad-plugin/commits | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV
       - run: echo "CACHE_URL3_KEY=$(curl -s https://api.github.com/repos/mconf/ep_redis_publisher/commits | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV
       - run: echo "CACHE_URL4_KEY=$(curl -s https://api.github.com/repos/alangecker/bbb-etherpad-skin/commits | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV
+      - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
         with:
           path: artifacts.tar
-          key: ${{ runner.os }}-bbb-etherpad-${{ env.CACHE_ETHERPAD_VERSION_KEY }}-${{ env.CACHE_ETHERPAD_BUILD_KEY }}-${{ env.CACHE_URL1_KEY }}-${{ env.CACHE_URL2_KEY }}-${{ env.CACHE_URL3_KEY }}-${{ env.CACHE_URL4_KEY }}
+          key: ${{ runner.os }}-bbb-etherpad-${{ env.CACHE_ETHERPAD_VERSION_KEY }}-${{ env.CACHE_ETHERPAD_BUILD_KEY }}-${{ env.CACHE_URL1_KEY }}-${{ env.CACHE_URL2_KEY }}-${{ env.CACHE_URL3_KEY }}-${{ env.CACHE_URL4_KEY }}-${{ env.CACHE_BBB_RELEASE_KEY }}
       - if: ${{ steps.cache-action.outputs.cache-hit != 'true' }}
         name: Generate artifacts
         run: |
@@ -162,12 +165,13 @@ jobs:
       - run: echo "CACHE_BBB_WEB_KEY=$(git log -1 --format=%H -- bigbluebutton-web)" >> $GITHUB_ENV
       - run: echo "CACHE_COMMON_MSG_KEY=$(git log -1 --format=%H -- bbb-common-message)" >> $GITHUB_ENV
       - run: echo "CACHE_COMMON_WEB_KEY=$(git log -1 --format=%H -- bbb-common-web)" >> $GITHUB_ENV
+      - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
         with:
           path: artifacts.tar
-          key: ${{ runner.os }}-bbb-web-${{ env.CACHE_BBB_WEB_KEY }}-${{ env.CACHE_COMMON_MSG_KEY }}-${{ env.CACHE_COMMON_WEB_KEY }}
+          key: ${{ runner.os }}-bbb-web-${{ env.CACHE_BBB_WEB_KEY }}-${{ env.CACHE_COMMON_MSG_KEY }}-${{ env.CACHE_COMMON_WEB_KEY }}-${{ env.CACHE_BBB_RELEASE_KEY }}
       - if: ${{ steps.cache-action.outputs.cache-hit != 'true' }}
         name: Generate artifacts
         run: |
@@ -190,12 +194,13 @@ jobs:
           fetch-depth: 0 # Fetch all history
       - run: echo "CACHE_AKKA_FSESL_KEY=$(git log -1 --format=%H -- akka-bbb-fsesl)" >> $GITHUB_ENV
       - run: echo "CACHE_COMMON_MSG_KEY=$(git log -1 --format=%H -- bbb-common-message)" >> $GITHUB_ENV
+      - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
         with:
           path: artifacts.tar
-          key: ${{ runner.os }}-bbb-fsesl-akka-${{ env.CACHE_AKKA_FSESL_KEY }}-${{ env.CACHE_COMMON_MSG_KEY }}
+          key: ${{ runner.os }}-bbb-fsesl-akka-${{ env.CACHE_AKKA_FSESL_KEY }}-${{ env.CACHE_COMMON_MSG_KEY }}-${{ env.CACHE_BBB_RELEASE_KEY }}
       - if: ${{ steps.cache-action.outputs.cache-hit != 'true' }}
         name: Generate artifacts
         run: |
@@ -217,12 +222,13 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history
       - run: echo "CACHE_KEY=$(git log -1 --format=%H -- bigbluebutton-html5)" >> $GITHUB_ENV
+      - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
         with:
           path: artifacts.tar
-          key: ${{ runner.os }}-bbb-html5-${{ env.CACHE_KEY }}
+          key: ${{ runner.os }}-bbb-html5-${{ env.CACHE_KEY }}-${{ env.CACHE_BBB_RELEASE_KEY }}
       - if: ${{ steps.cache-action.outputs.cache-hit != 'true' }}
         name: Generate artifacts
         run: |
@@ -247,12 +253,13 @@ jobs:
       - run: echo "CACHE_FREESWITCH_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-core)" >> $GITHUB_ENV
       - run: echo "CACHE_FREESWITCH_SOUNDS_KEY=$(git log -1 --format=%H -- build/packages-template/bbb-freeswitch-sounds)" >> $GITHUB_ENV
       - run: echo "CACHE_SOUNDS_KEY=$(curl -Is http://bigbluebutton.org/downloads/sounds.tar.gz | grep "Last-Modified" | md5sum | awk '{ print $1 }')" >> $GITHUB_ENV
+      - run: echo "CACHE_BBB_RELEASE_KEY=$(git log -1 --format=%H -- bigbluebutton-config/bigbluebutton-release)" >> $GITHUB_ENV
       - name: Handle cache
         id: cache-action
         uses: actions/cache@v3
         with:
           path: artifacts.tar
-          key: ${{ runner.os }}-bbb-freeswitch-${{ env.CACHE_FREESWITCH_KEY }}-${{ env.CACHE_FREESWITCH_SOUNDS_KEY }}-${{ env.CACHE_SOUNDS_KEY }}
+          key: ${{ runner.os }}-bbb-freeswitch-${{ env.CACHE_FREESWITCH_KEY }}-${{ env.CACHE_FREESWITCH_SOUNDS_KEY }}-${{ env.CACHE_SOUNDS_KEY }}-${{ env.CACHE_BBB_RELEASE_KEY }}
       - if: ${{ steps.cache-action.outputs.cache-hit != 'true' }}
         name: Generate artifacts
         run: |

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -106,6 +106,7 @@ class BigBlueButtonActor(
   }
 
   def handleCreateMeetingReqMsg(msg: CreateMeetingReqMsg): Unit = {
+    //test
     log.debug("RECEIVED CreateMeetingReqMsg msg {}", msg)
 
     RunningMeetings.findWithId(meetings, msg.body.props.meetingProp.intId) match {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -106,7 +106,6 @@ class BigBlueButtonActor(
   }
 
   def handleCreateMeetingReqMsg(msg: CreateMeetingReqMsg): Unit = {
-    //test
     log.debug("RECEIVED CreateMeetingReqMsg msg {}", msg)
 
     RunningMeetings.findWithId(meetings, msg.body.props.meetingProp.intId) match {

--- a/build/setup.sh
+++ b/build/setup.sh
@@ -24,10 +24,11 @@ else
 fi
 COMMIT_DATE="$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%dT%H%M%S')"
 
+# FORCE_GIT_REV and FORCE_COMMIT_DATE are useful for Github Actions be able to cache previous packages
+# It sets FORCE_GIT_REV=0 and FORCE_COMMIT_DATE=0 in order to keep the same package version always
 if [ ! -z "$FORCE_GIT_REV" ]; then
     GIT_REV=$FORCE_GIT_REV
 fi
-
 if [ ! -z "$FORCE_COMMIT_DATE" ]; then
     COMMIT_DATE=$FORCE_COMMIT_DATE
 fi

--- a/build/setup.sh
+++ b/build/setup.sh
@@ -24,6 +24,14 @@ else
 fi
 COMMIT_DATE="$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%dT%H%M%S')"
 
+if [ ! -z "$FORCE_GIT_REV" ]; then
+    GIT_REV=$FORCE_GIT_REV
+fi
+
+if [ ! -z "$FORCE_COMMIT_DATE" ]; then
+    COMMIT_DATE=$FORCE_COMMIT_DATE
+fi
+
 # Arrange to write the docker container ID to a temp file, then run
 # the container detached and immediately attach it (without stdin) so
 # we can catch CTRL-C in this script and kill the container if so.


### PR DESCRIPTION
It stores the built packages in Github cache.
Then in the next run it can re-use the cached package if the code of that project was untouched. 
It reduces a lot the time of the building step.

<table>
<tr>
<td>
<b>Before</b> (11min on average)
<br>
Without cache
</td>
<td>
<b>After</b> (4min on average)
<br>
Using actions/cache@v3
</td>
</tr>
<tr>
<td>

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/555f4639-9f16-4699-b4b8-d4ddc7ef8804)

</td>
<td>

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/ce7967f8-959c-46e1-92d5-29baab4df879)

</td>
</tr>
</table>



