### PR TITLE
fix: do not escape text twice

### DIFF
--- a/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addBulkGroupChatMsgs.js
+++ b/bigbluebutton-html5/imports/api/group-chat-msg/server/modifiers/addBulkGroupChatMsgs.js
@@ -2,7 +2,7 @@ import { GroupChatMsg } from '/imports/api/group-chat-msg';
 import GroupChat from '/imports/api/group-chat';
 import Logger from '/imports/startup/server/logger';
 import flat from 'flat';
-import { parseMessage } from '/imports/api/common/server/helpers';
+import { parseMessage } from './addGroupChatMsg';
 
 export default async function addBulkGroupChatMsgs(msgs) {
   if (!msgs.length) return;


### PR DESCRIPTION
The refactoring in 838accf0158f1ecf0fdf60c6319d200a98ab9106 incorrectly replaced the wrong `parseMessage()` function in `addBulkGroupChatMsgs.js`

This bug is only triggered when the option `public.chat.bufferChatInsertsMs` does not equal `0`.

This also needs to be fixed in `v2.7.x-release`

Fixes #18429