### PR TITLE
test: changes on download presentation

### DIFF
--- a/bigbluebutton-tests/playwright/core/settings.js
+++ b/bigbluebutton-tests/playwright/core/settings.js
@@ -28,7 +28,8 @@ async function generateSettingsData(page) {
       pollEnabled: settingsData.poll.enabled,
       pollChatMessage: settingsData.poll.chatMessage,
       // Presentation
-      presentationDownloadable: settingsData.presentation.allowDownloadable,
+      originalPresentationDownloadable: settingsData.presentation.allowDownloadOriginal,
+      presentationWithAnnotationsDownloadable: settingsData.presentation.allowDownloadWithAnnotations,
       externalVideoPlayer: settingsData.externalVideoPlayer.enabled,
       presentationHidden: settingsData.layout.hidePresentation,
       // Screensharing

--- a/bigbluebutton-tests/playwright/parameters/parameters.spec.js
+++ b/bigbluebutton-tests/playwright/parameters/parameters.spec.js
@@ -247,13 +247,12 @@ test.describe.parallel('Create Parameters', () => {
     });
   
     test.describe.serial(() => {
-      test('Download Presentation With Annotations @flaky', async ({ browser, context, page }) => {
-        linkIssue('18408');
+      test('Download Presentation With Annotations', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
         await disabledFeatures.initModPage(page, true, { createParameter: c.downloadPresentationWithAnnotationsDisabled });
         await disabledFeatures.downloadPresentationWithAnnotations();
       });
-      test('Download Presentation With Annotations (exclude) @flaky', async ({ browser, context, page }) => {
+      test('Download Presentation With Annotations (exclude)', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
         await disabledFeatures.initModPage(page, true, { createParameter: c.downloadPresentationWithAnnotationsExclude });
         await disabledFeatures.downloadPresentationWithAnnotationsExclude();

--- a/bigbluebutton-tests/playwright/presentation/presentation.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.js
@@ -122,8 +122,8 @@ class Presentation extends MultiUsers {
   }
 
   async enableAndDisablePresentationDownload(testInfo) {
-    const { presentationDownloadable } = getSettings();
-    test.fail(!presentationDownloadable, 'Presentation download is disable');
+    const { originalPresentationDownloadable } = getSettings();
+    test.fail(!originalPresentationDownloadable, 'Presentation download is disable');
 
     await this.modPage.waitForSelector(e.whiteboard, ELEMENT_WAIT_LONGER_TIME);
     // enable original presentation download
@@ -152,8 +152,8 @@ class Presentation extends MultiUsers {
   }
 
   async sendPresentationToDownload(testInfo) {
-    const { presentationDownloadable } = getSettings();
-    test.fail(!presentationDownloadable, 'Presentation download is disable');
+    const { presentationWithAnnotationsDownloadable } = getSettings();
+    test.fail(!presentationWithAnnotationsDownloadable, 'Presentation download is disable');
 
     await this.modPage.waitForSelector(e.whiteboard, ELEMENT_WAIT_LONGER_TIME);
     await this.modPage.waitAndClick(e.actions);

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.js
@@ -84,13 +84,13 @@ test.describe.parallel('Presentation', () => {
     });
 
     // https://docs.bigbluebutton.org/2.6/release-tests.html#enabling-and-disabling-presentation-download-automated
-    test('Enable and disable original presentation download', async ({ browser, context, page }, testInfo) => {
+    test('Enable and disable original presentation download @ci', async ({ browser, context, page }, testInfo) => {
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page);
       await presentation.enableAndDisablePresentationDownload(testInfo);
     });
     
-    test('Send presentation in the current state (with annotations) to chat for downloading ', async ({ browser, context, page }, testInfo) => {
+    test('Send presentation in the current state (with annotations) to chat for downloading @ci', async ({ browser, context, page }, testInfo) => {
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page);
       await presentation.sendPresentationToDownload(testInfo);

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.js
@@ -84,15 +84,13 @@ test.describe.parallel('Presentation', () => {
     });
 
     // https://docs.bigbluebutton.org/2.6/release-tests.html#enabling-and-disabling-presentation-download-automated
-    // flaky: update is needed due to changes made on https://github.com/bigbluebutton/bigbluebutton/pull/18411
-    test('Enable and disable original presentation download @flaky', async ({ browser, context, page }, testInfo) => {
+    test('Enable and disable original presentation download', async ({ browser, context, page }, testInfo) => {
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page);
       await presentation.enableAndDisablePresentationDownload(testInfo);
     });
-
-    // flaky: update is needed due to changes made on https://github.com/bigbluebutton/bigbluebutton/pull/18411
-    test('Send presentation in the current state (with annotations) to chat for downloading @flaky', async ({ browser, context, page }, testInfo) => {
+    
+    test('Send presentation in the current state (with annotations) to chat for downloading ', async ({ browser, context, page }, testInfo) => {
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page);
       await presentation.sendPresentationToDownload(testInfo);


### PR DESCRIPTION
### What does this PR do?
Changes two tests, the enable download original presentation and the download presentation with annotations.
And removed the @flaky because the tests are not failing anymore since the bug was fixed.