### PR TITLE
fix: Labels flowing out of a <div> in breakout rooms creation view

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.js
@@ -57,7 +57,7 @@ const FreeJoinLabel = styled.label`
   display: flex;
   align-items: center;
   font-size: ${fontSizeSmall};
-  margin-bottom: 0;
+  margin-bottom: 0.2rem;
 
   & > * {
     margin: 0 .5rem 0 0;
@@ -125,9 +125,9 @@ const RoomName = styled(BreakoutNameInput)`
 
 const BreakoutSettings = styled.div`
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr; 
+  grid-template-columns: 1fr 1fr 2fr;
   grid-template-rows: 1fr;
-  grid-gap: 4rem;
+  grid-gap: 2rem;
 
   @media ${smallOnly} {
     grid-template-columns: 1fr ;
@@ -235,7 +235,6 @@ const AssignBtns = styled(Button)`
 `;
 
 const CheckBoxesContainer = styled(FlexRow)`
-  white-space: nowrap;
   display: flex;
   flex-flow: column;
   justify-content: flex-end; 


### PR DESCRIPTION
### What does this PR do?

Fix issue with breakout settings being cut out of the modal if text is long.

#### before

![2023-08-07_11-35](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/cc360981-9937-405b-ad76-ecb5a18d22e5)

#### after

![2023-08-07_11-33](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/09f55567-d651-4316-8256-060191d97b5e)

### Closes Issue(s)
Closes #18434
