### PR TITLE
fix: download of original presentation not working not working

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
@@ -164,7 +164,7 @@ trait MakePresentationDownloadReqMsgHdlr extends RightsManagementTrait {
 
         PresentationSender.broadcastSetPresentationDownloadableEvtMsg(bus, meetingId, "DEFAULT_PRESENTATION_POD", "not-used", presId, true, filename)
 
-        val fileURI = List("bigbluebutton", "presentation", "download", meetingId, s"${presId}?presFilename=${presId}.${presFilenameExt}&filename=${filename}").mkString("", File.separator, "")
+        val fileURI = List("presentation", "download", meetingId, s"${presId}?presFilename=${presId}.${presFilenameExt}&filename=${filename}").mkString("", File.separator, "")
         val event = buildNewPresFileAvailable(fileURI, presId, m.body.typeOfExport)
 
         handle(event, liveMeeting, bus)

--- a/bigbluebutton-html5/imports/ui/components/presentation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/service.js
@@ -6,6 +6,7 @@ import { safeMatch } from '/imports/utils/string-utils';
 const POLL_SETTINGS = Meteor.settings.public.poll;
 const MAX_CUSTOM_FIELDS = POLL_SETTINGS.maxCustom;
 const MAX_CHAR_LIMIT = POLL_SETTINGS.maxTypedAnswerLength;
+const APP = Meteor.settings.public.app;
 
 const getCurrentPresentation = (podId) => Presentations.findOne({
   podId,
@@ -19,7 +20,7 @@ const downloadPresentationUri = (podId) => {
   }
 
   const { originalFileURI: uri } = currentPresentation;
-  return uri;
+  return `${APP.bbbWebBase}/${uri}`;
 };
 
 const isPresentationDownloadable = (podId) => {


### PR DESCRIPTION
### What does this PR do?

This fixes the issue where it is not possible to download the original presentation. 

### Closes Issue(s)

Closes #18446 


### Motivation

As mentioned by @danielpetri1 in https://github.com/bigbluebutton/bigbluebutton/pull/18150, we changed the way we build the absolute URL for downloading the presentations due to clustering issues:
> From now on, links will be created without the need for the bbbWebBase information, letting Meteor alone handle this on the client side

### More

This PR was already tested on a cluster environment, but any further testing is welcome!!
@schrd, if you have any suggestions, please, comment them down!! Thank you in advance!