### PR TITLE
fix (html5): Unable to choose same Reaction emoji twice in a row

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -199,7 +199,7 @@ object Users2x {
     for {
       u <- findWithIntId(users, intId)
     } yield {
-      val newUserState = u.modify(_.away).setTo(raiseHand)
+      val newUserState = u.modify(_.raiseHand).setTo(raiseHand)
       users.save(newUserState)
       newUserState
     }

--- a/bigbluebutton-html5/imports/api/user-reaction/server/helpers.js
+++ b/bigbluebutton-html5/imports/api/user-reaction/server/helpers.js
@@ -16,7 +16,6 @@ const notifyExpiredReaction = (meetingId, userId) => {
     check(meetingId, String);
 
     const payload = {
-      emoji,
       userId,
     };
 


### PR DESCRIPTION
If the user selects an Reaction emoji and it automatically expires after 1 minute.
The user is not able to select exactly the same Emoji again.

This PR fix it.