### PR TITLE
fix(bbb-conf): Handle yq upgrade related issues

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -170,10 +170,10 @@ else
     HTML5_CONFIG=$(yq e $HTML5_DEFAULT_CONFIG > /dev/null)
 fi
 
-mkdir -p $(dirname $WEBRTC_SFU_ETC_CONFIG)
-touch $WEBRTC_SFU_ETC_CONFIG # create it as it gets modified later in this script
+mkdir -p /etc/bigbluebutton/bbb-webrtc-sfu
 WEBRTC_SFU_DEFAULT_CONFIG=/usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml
 WEBRTC_SFU_ETC_CONFIG=/etc/bigbluebutton/bbb-webrtc-sfu/production.yml
+touch $WEBRTC_SFU_ETC_CONFIG # create it as it gets modified later in this script
 WEBRTC_SFU_CONFIG=$(yq eval-all '. as $item ireduce ({}; . * $item )' $WEBRTC_SFU_DEFAULT_CONFIG $WEBRTC_SFU_ETC_CONFIG > /dev/null)
 
 BBB_WEB_CONFIG="$SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties"

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -1706,7 +1706,10 @@ if [ -n "$HOST" ]; then
         sudo sed -i "s/ClueCon/$ESL_PASSWORD/g" /etc/bigbluebutton/bbb-fsesl-akka.conf
     fi
 
-    sudo yq e -i ".freeswitch.esl_password = \"$ESL_PASSWORD\"" /etc/bigbluebutton/bbb-webrtc-sfu/production.yml
+    if [ ! -f $WEBRTC_SFU_ETC_CONFIG ]; then
+        touch $WEBRTC_SFU_ETC_CONFIG
+    fi
+    sudo yq e -i ".freeswitch.esl_password = \"$ESL_PASSWORD\"" $WEBRTC_SFU_ETC_CONFIG
     sudo xmlstarlet edit --inplace --update 'configuration/settings//param[@name="password"]/@value' --value $ESL_PASSWORD /opt/freeswitch/etc/freeswitch/autoload_configs/event_socket.conf.xml
     if [ -f /usr/local/bigbluebutton/bbb-transcription-controller/config/default.yml ]; then
         sudo yq w -i /usr/local/bigbluebutton/bbb-transcription-controller/config/default.yml freeswitch.esl_password "$ESL_PASSWORD"

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash
 #
 # BlueButton open source conferencing system - https://www.bigbluebutton.org/
 #
@@ -69,8 +69,8 @@
 #   2020-10-22 AGG  Removing Flash/Red5 related code (yay!)
 #   2021-07-16 JFS  Add defaultMeetingLayout information
 
-#set -x
-#set -e
+set -x
+set -e
 
 PATH=$PATH:/sbin
 

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 #
 # BlueButton open source conferencing system - https://www.bigbluebutton.org/
 #

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -176,6 +176,7 @@ if [ -f $WEBRTC_SFU_ETC_CONFIG ]; then
     WEBRTC_SFU_CONFIG=$(yq eval-all '. as $item ireduce ({}; . * $item )' $WEBRTC_SFU_DEFAULT_CONFIG $WEBRTC_SFU_ETC_CONFIG)
 else
     WEBRTC_SFU_CONFIG=$(yq e $WEBRTC_SFU_DEFAULT_CONFIG)
+    touch $WEBRTC_SFU_ETC_CONFIG # create it as it gets modified later in this script
 fi
 
 BBB_WEB_CONFIG="$SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties"

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -1146,18 +1146,7 @@ check_state() {
         echo "#"
     fi
 
-    if [ `yq e '.public.media.sipjsHackViaWs' "$HTML5_CONFIG" ` != "true" ]; then
-      if [ "$PROTOCOL" == "https" ]; then
-        if ! cat $SIP_CONFIG |  grep -v '#' | grep proxy_pass | head -n 1 | grep -q https; then
-          echo "# Warning: You have this server defined for https, but in"
-          echo "#"
-          echo "#   $SIP_CONFIG"
-          echo "#"
-          echo "#  did not find the use of https in definition for proxy_pass"
-          echo "#"
-          echo "#    $(cat $SIP_CONFIG |  grep -v '#' | grep proxy_pass | head -n 1)"
-          echo "#"
-        fi
+    if [ `echo "$HTML5_CONFIG" | yq e '.public.media.sipjsHackViaWs' -` != "true" ]; then
 
       if [ "$SIP_NGINX_IP" != $IP ]; then
         if [ "$SIP_NGINX_IP" != "\$freeswitch_addr" ]; then
@@ -1231,7 +1220,7 @@ check_state() {
     fi
 
     FREESWITCH_SIP=$(ss -anlt4 | grep :5066 | grep -v tcp6 | grep LISTEN | sed 's/ [ ]*/ /g' | cut -d' ' -f4 | sed 's/:5066//g')
-    WEBRTC_SFU_SIP_IP=$(yq e '.freeswitch.sip_ip' "$WEBRTC_SFU_CONFIG" )
+    WEBRTC_SFU_SIP_IP=$(echo "$WEBRTC_SFU_CONFIG" | yq e '.freeswitch.sip_ip' -)
 
     if [ ! -z "$FREESWITCH_SIP" ]; then
       if [ "$FREESWITCH_SIP" != "$WEBRTC_SFU_SIP_IP" ]; then
@@ -1405,8 +1394,8 @@ if [ $CHECK ]; then
     echo
     echo "                        FreeSWITCH: $(xmlstarlet sel -t -m './configuration/settings/param[@name="rtp-start-port"]' -v @value $FREESWITCH_SWITCH_CONF)-$(xmlstarlet sel -t -m './configuration/settings/param[@name="rtp-end-port"]' -v @value $FREESWITCH_SWITCH_CONF)"
 
-    echo "                    bbb-webrtc-sfu: $(yq e '.mediasoup.worker.rtcMinPort' "$WEBRTC_SFU_CONFIG")-$(yq e '.mediasoup.worker.rtcMaxPort' "$WEBRTC_SFU_CONFIG")"
-    echo "                    bbb-webrtc-recorder: $(yq e '.webrtc.rtcMinPort' "$WEBRTC_RECORDER_CONFIG")-$(yq e '.webrtc.rtcMaxPort' "$WEBRTC_RECORDER_CONFIG")"
+    echo "                    bbb-webrtc-sfu: $(echo "$WEBRTC_SFU_CONFIG" | yq e '.mediasoup.worker.rtcMinPort' -)-$(echo "$WEBRTC_SFU_CONFIG" |yq e '.mediasoup.worker.rtcMaxPort' -)"
+    echo "                    bbb-webrtc-recorder: $(echo "$WEBRTC_RECORDER_CONFIG" | yq e '.webrtc.rtcMinPort' -)-$(echo "$WEBRTC_RECORDER_CONFIG" | yq e '.webrtc.rtcMaxPort' -)"
 
 
 
@@ -1433,19 +1422,19 @@ if [ $CHECK ]; then
     fi
 
     if [ -n "$WEBRTC_SFU_CONFIG" ]; then
-        MEDIASOUP_WEBRTC_IPS=$(yq e '.mediasoup.webrtc.listenIps.[] | .announcedIp' "$WEBRTC_SFU_CONFIG")
-        MEDIASOUP_PLAINRTP_IPS=$(yq e '.mediasoup.plainRtp.listenIp[] | .announcedIp' "$WEBRTC_SFU_CONFIG")
+        MEDIASOUP_WEBRTC_IPS=$(echo "$WEBRTC_SFU_CONFIG" | yq e '.mediasoup.webrtc.listenIps.[] | .announcedIp' -)
+        MEDIASOUP_PLAINRTP_IPS=$(echo "$WEBRTC_SFU_CONFIG" | yq e '.mediasoup.plainRtp.listenIp | .announcedIp' -)
         echo
         echo "/usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml (bbb-webrtc-sfu)"
         echo "/etc/bigbluebutton/bbb-webrtc-sfu/production.yml (bbb-webrtc-sfu - override)"
         echo "    mediasoup.webrtc.*.announcedIp: $(echo "$MEDIASOUP_WEBRTC_IPS" | awk -v ORS=", " '{ print $1 }' | sed 's/, $//')"
         echo "  mediasoup.plainRtp.*.announcedIp: $(echo "$MEDIASOUP_PLAINRTP_IPS" | awk -v ORS=", " '{ print $1 }' | sed 's/, $//')"
-        echo "                 freeswitch.sip_ip: $(yq e '.freeswitch.sip_ip' "$WEBRTC_SFU_CONFIG")"
-        echo "                  recordingAdapter: $(yq e '.recordingAdapter' "$WEBRTC_SFU_CONFIG")"
-        echo "               recordScreenSharing: $(yq e '.recordScreenSharing' "$WEBRTC_SFU_CONFIG")"
-        echo "                     recordWebcams: $(yq e '.recordWebcams' "$WEBRTC_SFU_CONFIG")"
-        echo "                  codec_video_main: $(yq e '.conference-media-specs.codec_video_main' "$WEBRTC_SFU_CONFIG")"
-        echo "               codec_video_content: $(yq e '.conference-media-specs.codec_video_content' "$WEBRTC_SFU_CONFIG")"
+        echo "                 freeswitch.sip_ip: $(echo "$WEBRTC_SFU_CONFIG" | yq e '.freeswitch.sip_ip' -)"
+        echo "                  recordingAdapter: $(echo "$WEBRTC_SFU_CONFIG" | yq e '.recordingAdapter' -)"
+        echo "               recordScreenSharing: $(echo "$WEBRTC_SFU_CONFIG" | yq e '.recordScreenSharing' -)"
+        echo "                     recordWebcams: $(echo "$WEBRTC_SFU_CONFIG" | yq e '.recordWebcams' -)"
+        echo "                  codec_video_main: $(echo "$WEBRTC_SFU_CONFIG" | yq e '.conference-media-specs.codec_video_main' -)"
+        echo "               codec_video_content: $(echo "$WEBRTC_SFU_CONFIG" | yq e '.conference-media-specs.codec_video_content' -)"
 
     fi
 
@@ -1453,19 +1442,19 @@ if [ $CHECK ]; then
         echo
         echo "/etc/bbb-webrtc-recorder/bbb-webrtc-recorder.yml (bbb-webrtc-recorder)"
         echo "/etc/bigbluebutton/bbb-webrtc-recorder.yml (bbb-webrtc-recorder - override)"
-        echo "               debug: $(yq e '.debug' "$WEBRTC_RECORDER_CONFIG")"
-        echo "               recorder.directory: $(yq e '.recorder.directory' "$WEBRTC_RECORDER_CONFIG")"
+        echo "               debug: $(echo "$WEBRTC_RECORDER_CONFIG" | yq e '.debug' -)"
+        echo "               recorder.directory: $(echo "$WEBRTC_RECORDER_CONFIG" | yq e '.recorder.directory' -)"
     fi
 
     if [ -n "$HTML5_CONFIG" ]; then
     echo
     echo "/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml (HTML5 client)"
     echo "/etc/bigbluebutton/bbb-html5.yml (HTML5 client config override)"
-    echo "                             build: $(yq e '.public.app.html5ClientBuild' "$HTML5_CONFIG")"
-    echo "                        kurentoUrl: $(yq e '.public.kurento.wsUrl' "$HTML5_CONFIG")"
-    echo "            defaultFullAudioBridge: $(yq e '.public.media.audio.defaultFullAudioBridge' "$HTML5_CONFIG")"
-    echo "           defaultListenOnlyBridge: $(yq e '.public.media.audio.defaultListenOnlyBridge' "$HTML5_CONFIG")"
-    echo "                    sipjsHackViaWs: $(yq e '.public.media.sipjsHackViaWs' "$HTML5_CONFIG")"
+    echo "                             build: $(echo "$HTML5_CONFIG" | yq e '.public.app.html5ClientBuild' -)"
+    echo "                        kurentoUrl: $(echo "$HTML5_CONFIG" | yq e '.public.kurento.wsUrl' -)"
+    echo "            defaultFullAudioBridge: $(echo "$HTML5_CONFIG" | yq e '.public.media.audio.defaultFullAudioBridge' -)"
+    echo "           defaultListenOnlyBridge: $(echo "$HTML5_CONFIG" | yq e '.public.media.audio.defaultListenOnlyBridge' -)"
+    echo "                    sipjsHackViaWs: $(echo "$HTML5_CONFIG" | yq e '.public.media.sipjsHackViaWs' -)"
     fi
 
     if [ ! -z "$STUN" ]; then
@@ -1706,9 +1695,6 @@ if [ -n "$HOST" ]; then
         sudo sed -i "s/ClueCon/$ESL_PASSWORD/g" /etc/bigbluebutton/bbb-fsesl-akka.conf
     fi
 
-    if [ ! -f $WEBRTC_SFU_ETC_CONFIG ]; then
-        touch $WEBRTC_SFU_ETC_CONFIG
-    fi
     sudo yq e -i ".freeswitch.esl_password = \"$ESL_PASSWORD\"" $WEBRTC_SFU_ETC_CONFIG
     sudo xmlstarlet edit --inplace --update 'configuration/settings//param[@name="password"]/@value' --value $ESL_PASSWORD /opt/freeswitch/etc/freeswitch/autoload_configs/event_socket.conf.xml
     if [ -f /usr/local/bigbluebutton/bbb-transcription-controller/config/default.yml ]; then

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -157,25 +157,25 @@ RECORD_CONFIG=/usr/local/bigbluebutton/core/scripts/bigbluebutton.yml
 WEBRTC_RECORDER_DEFAULT_CONFIG=/etc/bbb-webrtc-recorder/bbb-webrtc-recorder.yml
 WEBRTC_RECORDER_ETC_CONFIG=/etc/bigbluebutton/bbb-webrtc-recorder.yml
 if [ -f $WEBRTC_RECORDER_ETC_CONFIG ]; then
-    WEBRTC_RECORDER_CONFIG=$(yq eval-all '. as $item ireduce ({}; . * $item )' $WEBRTC_RECORDER_DEFAULT_CONFIG $WEBRTC_RECORDER_ETC_CONFIG)
+    WEBRTC_RECORDER_CONFIG=$(yq eval-all '. as $item ireduce ({}; . * $item )' $WEBRTC_RECORDER_DEFAULT_CONFIG $WEBRTC_RECORDER_ETC_CONFIG > /dev/null)
 else
-    WEBRTC_RECORDER_CONFIG=$(yq e $WEBRTC_RECORDER_DEFAULT_CONFIG)
+    WEBRTC_RECORDER_CONFIG=$(yq e $WEBRTC_RECORDER_DEFAULT_CONFIG > /dev/null)
 fi
 
 HTML5_DEFAULT_CONFIG=/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml
 HTML5_ETC_CONFIG=/etc/bigbluebutton/bbb-html5.yml
 if [ -f $HTML5_ETC_CONFIG ]; then
-    HTML5_CONFIG=$(yq eval-all '. as $item ireduce ({}; . * $item )' $HTML5_DEFAULT_CONFIG $HTML5_ETC_CONFIG)
+    HTML5_CONFIG=$(yq eval-all '. as $item ireduce ({}; . * $item )' $HTML5_DEFAULT_CONFIG $HTML5_ETC_CONFIG > /dev/null)
 else
-    HTML5_CONFIG=$(yq e $HTML5_DEFAULT_CONFIG)
+    HTML5_CONFIG=$(yq e $HTML5_DEFAULT_CONFIG > /dev/null)
 fi
 
 WEBRTC_SFU_DEFAULT_CONFIG=/usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml
 WEBRTC_SFU_ETC_CONFIG=/etc/bigbluebutton/bbb-webrtc-sfu/production.yml
 if [ -f $WEBRTC_SFU_ETC_CONFIG ]; then
-    WEBRTC_SFU_CONFIG=$(yq eval-all '. as $item ireduce ({}; . * $item )' $WEBRTC_SFU_DEFAULT_CONFIG $WEBRTC_SFU_ETC_CONFIG)
+    WEBRTC_SFU_CONFIG=$(yq eval-all '. as $item ireduce ({}; . * $item )' $WEBRTC_SFU_DEFAULT_CONFIG $WEBRTC_SFU_ETC_CONFIG > /dev/null)
 else
-    WEBRTC_SFU_CONFIG=$(yq e $WEBRTC_SFU_DEFAULT_CONFIG)
+    WEBRTC_SFU_CONFIG=$(yq e $WEBRTC_SFU_DEFAULT_CONFIG > /dev/null)
     touch $WEBRTC_SFU_ETC_CONFIG # create it as it gets modified later in this script
 fi
 

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -1147,7 +1147,17 @@ check_state() {
     fi
 
     if [ $(echo "$HTML5_CONFIG" | yq e '.public.media.sipjsHackViaWs' -) != "true" ]; then
-
+      if [ "$PROTOCOL" == "https" ]; then
+        if ! cat $SIP_CONFIG |  grep -v '#' | grep proxy_pass | head -n 1 | grep -q https; then
+          echo "# Warning: You have this server defined for https, but in"
+          echo "#"
+          echo "#   $SIP_CONFIG"
+          echo "#"
+          echo "#  did not find the use of https in definition for proxy_pass"
+          echo "#"
+          echo "#    $(cat $SIP_CONFIG |  grep -v '#' | grep proxy_pass | head -n 1)"
+          echo "#"
+        fi
       if [ "$SIP_NGINX_IP" != $IP ]; then
         if [ "$SIP_NGINX_IP" != "\$freeswitch_addr" ]; then
           echo "# Warning: The setting of $SIP_NGINX_IP for proxy_pass in"

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -170,14 +170,11 @@ else
     HTML5_CONFIG=$(yq e $HTML5_DEFAULT_CONFIG > /dev/null)
 fi
 
+mkdir -p $(dirname $WEBRTC_SFU_ETC_CONFIG)
+touch $WEBRTC_SFU_ETC_CONFIG # create it as it gets modified later in this script
 WEBRTC_SFU_DEFAULT_CONFIG=/usr/local/bigbluebutton/bbb-webrtc-sfu/config/default.yml
 WEBRTC_SFU_ETC_CONFIG=/etc/bigbluebutton/bbb-webrtc-sfu/production.yml
-if [ -f $WEBRTC_SFU_ETC_CONFIG ]; then
-    WEBRTC_SFU_CONFIG=$(yq eval-all '. as $item ireduce ({}; . * $item )' $WEBRTC_SFU_DEFAULT_CONFIG $WEBRTC_SFU_ETC_CONFIG > /dev/null)
-else
-    WEBRTC_SFU_CONFIG=$(yq e $WEBRTC_SFU_DEFAULT_CONFIG > /dev/null)
-    touch $WEBRTC_SFU_ETC_CONFIG # create it as it gets modified later in this script
-fi
+WEBRTC_SFU_CONFIG=$(yq eval-all '. as $item ireduce ({}; . * $item )' $WEBRTC_SFU_DEFAULT_CONFIG $WEBRTC_SFU_ETC_CONFIG > /dev/null)
 
 BBB_WEB_CONFIG="$SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties"
 BBB_WEB_ETC_CONFIG="/etc/bigbluebutton/bbb-web.properties"
@@ -709,8 +706,6 @@ if [[ $PORT_RANGE ]]; then
         xmlstarlet edit --inplace --update '/configuration/settings/param[@name="rtp-start-port"]/@value' --value $START_PORT $FREESWITCH_SWITCH_CONF
         xmlstarlet edit --inplace --update '/configuration/settings/param[@name="rtp-end-port"]/@value' --value $END_PORT $FREESWITCH_SWITCH_CONF
 
-        mkdir -p $(dirname $WEBRTC_SFU_ETC_CONFIG)
-        touch $WEBRTC_SFU_ETC_CONFIG
         yq e -i ".mediasoup.worker.rtcMinPort = \"$START_PORT\"" $WEBRTC_SFU_ETC_CONFIG
         yq e -i ".mediasoup.worker.rtcMaxPort = \"$END_PORT\"" $WEBRTC_SFU_ETC_CONFIG
 

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -70,7 +70,7 @@
 #   2021-07-16 JFS  Add defaultMeetingLayout information
 
 set -x
-set -e
+#set -e
 
 PATH=$PATH:/sbin
 

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -1146,7 +1146,7 @@ check_state() {
         echo "#"
     fi
 
-    if [ `echo "$HTML5_CONFIG" | yq e '.public.media.sipjsHackViaWs' -` != "true" ]; then
+    if [ $(echo "$HTML5_CONFIG" | yq e '.public.media.sipjsHackViaWs' -) != "true" ]; then
 
       if [ "$SIP_NGINX_IP" != $IP ]; then
         if [ "$SIP_NGINX_IP" != "\$freeswitch_addr" ]; then
@@ -1411,6 +1411,7 @@ if [ $CHECK ]; then
         echo "$RECORD_CONFIG (record and playback)"
         echo "                     playback_host: $(yq e '.playback_host' $RECORD_CONFIG)"
         echo "                 playback_protocol: $(yq e '.playback_protocol' $RECORD_CONFIG)"
+
         echo "                            ffmpeg: $(ffmpeg -version 2>/dev/null | grep ffmpeg | cut -d ' ' -f3 | sed 's/--.*//g' | tr -d '\n')"
     fi
 

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -186,14 +186,14 @@ NCPU=$(nproc --all)
 
 BBB_USER=bigbluebutton
 
-if [ $EUID == 0 ]; then
-  TURN=$SERVLET_DIR/WEB-INF/classes/spring/turn-stun-servers.xml
-  TURN_ETC_CONFIG=/etc/bigbluebutton/turn-stun-servers.xml
-  if [ -f "$TURN_ETC_CONFIG" ]; then
-    TURN=$TURN_ETC_CONFIG
-  fi
-  STUN="$(xmlstarlet sel -N x="http://www.springframework.org/schema/beans" -t -m '_:beans/_:bean[@class="org.bigbluebutton.web.services.turn.StunTurnService"]/_:property[@name="stunServers"]/_:set/_:ref' -v @bean -nl $TURN)"
-fi
+#if [ $EUID == 0 ]; then
+#  TURN=$SERVLET_DIR/WEB-INF/classes/spring/turn-stun-servers.xml
+#  TURN_ETC_CONFIG=/etc/bigbluebutton/turn-stun-servers.xml
+#  if [ -f "$TURN_ETC_CONFIG" ]; then
+#    TURN=$TURN_ETC_CONFIG
+#  fi
+#  STUN="$(xmlstarlet sel -N x="http://www.springframework.org/schema/beans" -t -m '_:beans/_:bean[@class="org.bigbluebutton.web.services.turn.StunTurnService"]/_:property[@name="stunServers"]/_:set/_:ref' -v @bean -nl $TURN)"
+#fi
 
 PROTOCOL=http
 if [ -f $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties ]; then

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -69,7 +69,7 @@
 #   2020-10-22 AGG  Removing Flash/Red5 related code (yay!)
 #   2021-07-16 JFS  Add defaultMeetingLayout information
 
-set -x
+#set -x
 #set -e
 
 PATH=$PATH:/sbin
@@ -186,14 +186,14 @@ NCPU=$(nproc --all)
 
 BBB_USER=bigbluebutton
 
-#if [ $EUID == 0 ]; then
-#  TURN=$SERVLET_DIR/WEB-INF/classes/spring/turn-stun-servers.xml
-#  TURN_ETC_CONFIG=/etc/bigbluebutton/turn-stun-servers.xml
-#  if [ -f "$TURN_ETC_CONFIG" ]; then
-#    TURN=$TURN_ETC_CONFIG
-#  fi
-#  STUN="$(xmlstarlet sel -N x="http://www.springframework.org/schema/beans" -t -m '_:beans/_:bean[@class="org.bigbluebutton.web.services.turn.StunTurnService"]/_:property[@name="stunServers"]/_:set/_:ref' -v @bean -nl $TURN)"
-#fi
+if [ $EUID == 0 ]; then
+  TURN=$SERVLET_DIR/WEB-INF/classes/spring/turn-stun-servers.xml
+  TURN_ETC_CONFIG=/etc/bigbluebutton/turn-stun-servers.xml
+  if [ -f "$TURN_ETC_CONFIG" ]; then
+    TURN=$TURN_ETC_CONFIG
+  fi
+  STUN="$(xmlstarlet sel -N x="http://www.springframework.org/schema/beans" -t -m '_:beans/_:bean[@class="org.bigbluebutton.web.services.turn.StunTurnService"]/_:property[@name="stunServers"]/_:set/_:ref' -v @bean -nl $TURN)"
+fi
 
 PROTOCOL=http
 if [ -f $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties ]; then
@@ -1154,6 +1154,7 @@ check_state() {
           echo "#    $(cat $SIP_CONFIG |  grep -v '#' | grep proxy_pass | head -n 1)"
           echo "#"
         fi
+
       if [ "$SIP_NGINX_IP" != $IP ]; then
         if [ "$SIP_NGINX_IP" != "\$freeswitch_addr" ]; then
           echo "# Warning: The setting of $SIP_NGINX_IP for proxy_pass in"
@@ -1417,7 +1418,6 @@ if [ $CHECK ]; then
         echo "$RECORD_CONFIG (record and playback)"
         echo "                     playback_host: $(yq e '.playback_host' $RECORD_CONFIG)"
         echo "                 playback_protocol: $(yq e '.playback_protocol' $RECORD_CONFIG)"
-
         echo "                            ffmpeg: $(ffmpeg -version 2>/dev/null | grep ffmpeg | cut -d ' ' -f3 | sed 's/--.*//g' | tr -d '\n')"
     fi
 

--- a/build/packages-template/bbb-html5/bbb-html5-with-roles.conf
+++ b/build/packages-template/bbb-html5/bbb-html5-with-roles.conf
@@ -1,9 +1,9 @@
-# Default = 1; Min = 1; Max = 4
+# Default = 2; Min = 1; Max = 4
 # On powerful systems with high number of meetings you can set values up to 4 to accelerate handling of events
-NUMBER_OF_BACKEND_NODEJS_PROCESSES=1
-# Default = 0; Min = 0; Max = 8
+NUMBER_OF_BACKEND_NODEJS_PROCESSES=2
+# Default = 2; Min = 0; Max = 8
 # If 0 is set, bbb-html5 will handle both backend and frontend roles in one process (default until Feb 2021)
 # Set a number between 1 and 4 times the value of NUMBER_OF_BACKEND_NODEJS_PROCESSES where higher number helps with meetings
 # stretching the recommended number of users in BigBlueButton
-NUMBER_OF_FRONTEND_NODEJS_PROCESSES=0
+NUMBER_OF_FRONTEND_NODEJS_PROCESSES=2
 

--- a/build/packages-template/bbb-html5/bbb-html5-with-roles.conf
+++ b/build/packages-template/bbb-html5/bbb-html5-with-roles.conf
@@ -1,9 +1,9 @@
-# Default = 2; Min = 1; Max = 4
+# Default = 1; Min = 1; Max = 4
 # On powerful systems with high number of meetings you can set values up to 4 to accelerate handling of events
-NUMBER_OF_BACKEND_NODEJS_PROCESSES=2
-# Default = 2; Min = 0; Max = 8
+NUMBER_OF_BACKEND_NODEJS_PROCESSES=1
+# Default = 0; Min = 0; Max = 8
 # If 0 is set, bbb-html5 will handle both backend and frontend roles in one process (default until Feb 2021)
 # Set a number between 1 and 4 times the value of NUMBER_OF_BACKEND_NODEJS_PROCESSES where higher number helps with meetings
 # stretching the recommended number of users in BigBlueButton
-NUMBER_OF_FRONTEND_NODEJS_PROCESSES=2
+NUMBER_OF_FRONTEND_NODEJS_PROCESSES=0
 


### PR DESCRIPTION
After upgrading yq to 4.x the combined yml configuration for bbb-html, bbb-webrtc-sfu and bbb-webrtc-recorder variables contain the actual yml, not the uri to the yml.
Recovered a block of code which was accidentally removed and its omission was causing a syntax error.

-----

<details>
A subsequent PR will continue the work of ...

Resending #18409

Basically, using CI to try to bypass some Mongo4.4 ->6.0 upgrade configuration changes (replica set initialization) which are blocking us from starting `bbb-html5-*` processes. This PR contains a config change which forces only one copy of the `bbb-html5-backend` process to handle both backend and frontend roles.
</details>