### PR TITLE
fix (bbb-web): Getting wrong final URL (from redirect) on presentation upload

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/PresentationUrlDownloadService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/PresentationUrlDownloadService.java
@@ -12,14 +12,12 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
-
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.entity.ContentType;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.impl.nio.client.HttpAsyncClients;
@@ -197,6 +195,7 @@ public class PresentationUrlDownloadService {
             conn.setReadTimeout(60000);
             conn.addRequestProperty("Accept-Language", "en-US,en;q=0.8");
             conn.addRequestProperty("User-Agent", "Mozilla");
+            conn.setInstanceFollowRedirects(false);
 
             // normally, 3xx is redirect
             int status = conn.getResponseCode();
@@ -287,10 +286,21 @@ public class PresentationUrlDownloadService {
         String finalUrl = followRedirect(meetingId, urlString, 0, urlString);
 
         if (finalUrl == null) return false;
+        if(!finalUrl.equals(urlString)) {
+            log.info("Redirected to Final URL [{}]", finalUrl);
+        }
 
         boolean success = false;
 
-        CloseableHttpAsyncClient httpclient = HttpAsyncClients.createDefault();
+        //Disable follow redirect since finalUrl already did it
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setRedirectsEnabled(false)
+                .build();
+
+        CloseableHttpAsyncClient httpclient = HttpAsyncClients.custom()
+                .setDefaultRequestConfig(requestConfig)
+                .build();
+
         try {
             httpclient.start();
             File download = new File(filename);


### PR DESCRIPTION
The function `followRedirect` was supposed to obtain the final URL when the first URL is a redirect link.
Turned out that it is always returning the first URL instead of follow the redirect and return the final URL.

This PR fix it.

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/73fd8d90-4438-453f-a8d4-6a0807be35cc)
