### PR TITLE
fix(audio): clear connection timeout on autoplay failures

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
@@ -280,6 +280,11 @@ export default class SFUAudioBridge extends BaseAudioBridge {
           },
         }, 'SFU audio media play failed due to autoplay error');
         this.dispatchAutoplayHandlingEvent(mediaElement);
+        // For connection purposes, this worked - the autoplay thing is a client
+        // side soft issue to be handled at the UI/UX level, not WebRTC/negotiation
+        // So: clear the connection timer
+        this.clearConnectionTimeout();
+        this.reconnecting = false;
       } else {
         const normalizedError = {
           errorCode: 1004,


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): clear connection timeout on autoplay failures](https://github.com/bigbluebutton/bigbluebutton/commit/b8a1b881c51e3af851f82666019773f8d5013844) 
  * If the autoplay block is triggered in listen only, the connection timer
keeps ticking even if the user correctly accepts the audio play prompt.
That causes an audio re-connect once the timeout expires.
  * Clear the connection timer if the audio bridge starts with
NotAllowedError as a soft error. For connection purposes, the audio join
procedure worked. The autoplay thing is at the UI/UX level, not WebRTC.

### Closes Issue(s)

None

### More

Follow up to https://github.com/bigbluebutton/bigbluebutton/pull/18407