### PR TITLE
test: Avoid whiteboard dropdown tests running on CI

### DIFF
--- a/bigbluebutton-tests/playwright/package.json
+++ b/bigbluebutton-tests/playwright/package.json
@@ -5,8 +5,8 @@
     "test:filter": "npx playwright test -g",
     "test:headed": "npx playwright test --headed",
     "test:debug": "npx playwright test --debug -g",
-    "test-chromium-ci": "export CI='true' && npx playwright test --project=chromium --grep @ci",
-    "test-firefox-ci": "export CI='true' && npx playwright test --project=firefox --grep @ci",
+    "test-chromium-ci": "export CI='true' && npx playwright test presentation --project=chromium --grep @ci --grep-invert @flaky",
+    "test-firefox-ci": "export CI='true' && npx playwright test --project=firefox --grep @ci --grep-invert @flaky",
     "rewrite-snapshots": "read -p 'CAUTION: You will delete ALL testing folders containing snapshots and run the tests to rewrite these files.\nProceed? (y/n) ' confirm && test $confirm = 'y' && sh core/scripts/rewrite-snapshots.sh"
   },
   "dependencies": {

--- a/bigbluebutton-tests/playwright/package.json
+++ b/bigbluebutton-tests/playwright/package.json
@@ -5,7 +5,7 @@
     "test:filter": "npx playwright test -g",
     "test:headed": "npx playwright test --headed",
     "test:debug": "npx playwright test --debug -g",
-    "test-chromium-ci": "export CI='true' && npx playwright test presentation --project=chromium --grep @ci --grep-invert @flaky",
+    "test-chromium-ci": "export CI='true' && npx playwright test --project=chromium --grep @ci --grep-invert @flaky",
     "test-firefox-ci": "export CI='true' && npx playwright test --project=firefox --grep @ci --grep-invert @flaky",
     "rewrite-snapshots": "read -p 'CAUTION: You will delete ALL testing folders containing snapshots and run the tests to rewrite these files.\nProceed? (y/n) ' confirm && test $confirm = 'y' && sh core/scripts/rewrite-snapshots.sh"
   },

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.js
@@ -34,19 +34,23 @@ test.describe.parallel('Presentation', () => {
     await presentation.fitToWidthTest();
   });
 
-  test('Presentation fullscreen @ci', async ({ browser, context, page }) => {
+  /**
+   * following 3 tests failing due to multiple render of whiteboard options dropdown
+   * https://github.com/bigbluebutton/bigbluebutton/issues/18505
+   */
+  test('Presentation fullscreen @ci @flaky', async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
     await presentation.initPages(page);
     await presentation.presentationFullscreen();
   });
 
-  test('Presentation snapshot @ci', async ({ browser, context, page }, testInfo) => {
+  test('Presentation snapshot @ci @flaky', async ({ browser, context, page }, testInfo) => {
     const presentation = new Presentation(browser, context);
     await presentation.initPages(page);
     await presentation.presentationSnapshot(testInfo);
   });
 
-  test('Hide Presentation Toolbar @ci', async ({ browser, context, page }) => {
+  test('Hide Presentation Toolbar @ci @flaky', async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
     await presentation.initPages(page);
     await presentation.hidePresentationToolbar();


### PR DESCRIPTION
### What does this PR do?
Skips the following 3 tests since failures due to multiple renders of the whiteboard options dropdown - https://github.com/bigbluebutton/bigbluebutton/issues/18505
- `Presentation fullscreen`
- `Presentation snapshot`
- `Hide Presentation Toolbar`