### PR TITLE
ci(tests): cancel previous PR runs on github-actions when push a new commit

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -15,6 +15,9 @@ on:
       - '**/*.md'
 permissions:
   contents: read
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   build-bbb-apps-akka:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Cancel previous jobs of github-actions when push a new commit.

![previous-canceled](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/3b61c3b3-3d3f-4649-bcf9-4bfa4d85bc89)

> Concurrency ensures that only a single job or workflow using the same concurrency group will run at a time.

More info: https://docs.github.com/en/actions/using-jobs/using-concurrency