### PR TITLE
fix: do not display reactions button if reactions are disabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
@@ -51,8 +51,10 @@ const RAISE_HAND_BUTTON_ENABLED = Meteor.settings.public.app.raiseHandActionButt
 const RAISE_HAND_BUTTON_CENTERED = Meteor.settings.public.app.raiseHandActionButton.centered;
 
 const isReactionsButtonEnabled = () => {
+  const USER_REACTIONS_ENABLED = Meteor.settings.public.userReaction.enabled;
   const REACTIONS_BUTTON_ENABLED = Meteor.settings.public.app.reactionsButton.enabled;
-  return getFromUserSettings('enable-reactions-button', REACTIONS_BUTTON_ENABLED);
+
+  return USER_REACTIONS_ENABLED && REACTIONS_BUTTON_ENABLED;
 };
 
 export default withTracker(() => ({


### PR DESCRIPTION
### What does this PR do?

Hides reactions button if `userReaction.enabled` is set to false.