### PR TITLE
fix: Remove leaveAudio data-test from the reaction buttons

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -110,7 +110,6 @@ const ReactionsButton = (props) => {
     actions.push({
       label: <Styled.ButtonWrapper active={currentUserReaction === native}><Emoji key={id} emoji={{ id }} {...emojiProps} /></Styled.ButtonWrapper>,
       key: id,
-      dataTest: 'leaveAudio',
       onClick: () => handleReactionSelect(native),
       customStyles: actionCustomStyles,
     });


### PR DESCRIPTION
### What does this PR do?
it's been recently introduced, which displays the same `leaveAudio` data-test (used for listen-only tests) for all reaction buttons. This PR just removes this line, which should bring listen-only tests passing again

![image](https://github.com/bigbluebutton/bigbluebutton/assets/56703993/4fce0b64-e930-4663-a2a0-0e2176120d04)
![image](https://github.com/bigbluebutton/bigbluebutton/assets/56703993/e9c79ce2-d7a8-4f24-a375-f3a645216112)
