### PR TITLE
build: start replicaset once, before bbb-html5- backends frontends

### DIFF
--- a/build/packages-template/bbb-html5/systemd_start.sh
+++ b/build/packages-template/bbb-html5/systemd_start.sh
@@ -3,31 +3,6 @@
 #Allow to run outside of directory
 cd $(dirname $0)
 
-echo "Starting mongoDB"
-
-#wait for mongo startup
-MONGO_OK=0
-
-while [ "$MONGO_OK" = "0" ]; do
-    MONGO_OK=$(ss -lan | grep 127.0.1.1 | grep 27017 &> /dev/null && echo 1 || echo 0)
-    sleep 1;
-done;
-
-echo "Mongo started";
-
-echo "Initializing replicaset"
-mongosh 127.0.1.1 --eval 'rs.initiate({ _id: "rs0", members: [ {_id: 0, host: "127.0.1.1"} ]})'
-
-
-echo "Waiting to become a master"
-IS_MASTER="XX"
-while [ "$IS_MASTER" \!= "true" ]; do
-    IS_MASTER=$(mongosh mongodb://127.0.1.1:27017/ --eval  'db.isMaster().ismaster' | tail -n 1)
-    sleep 0.5;
-done;
-
-echo "I'm the master!"
-
 if [ -z $1 ]
 then
   INSTANCE_ID=1

--- a/build/packages-template/bbb-html5/systemd_start_frontend.sh
+++ b/build/packages-template/bbb-html5/systemd_start_frontend.sh
@@ -3,31 +3,6 @@
 #Allow to run outside of directory
 cd $(dirname $0)
 
-echo "Starting mongoDB"
-
-#wait for mongo startup
-MONGO_OK=0
-
-while [ "$MONGO_OK" = "0" ]; do
-    MONGO_OK=$(ss -lan | grep 127.0.1.1 | grep 27017 &> /dev/null && echo 1 || echo 0)
-    sleep 1;
-done;
-
-echo "Mongo started";
-
-echo "Initializing replicaset"
-mongosh 127.0.1.1 --eval 'rs.initiate({ _id: "rs0", members: [ {_id: 0, host: "127.0.1.1"} ]})'
-
-
-echo "Waiting to become a master"
-IS_MASTER="XX"
-while [ "$IS_MASTER" \!= "true" ]; do
-    IS_MASTER=$(mongosh mongodb://127.0.1.1:27017/ --eval  'db.isMaster().ismaster' | tail -n 1)
-    sleep 0.5;
-done;
-
-echo "I'm the master!"
-
 if [ -z $1 ]
 then
   INSTANCE_ID=1
@@ -52,4 +27,3 @@ export NODE_ENV=production
 export SERVER_WEBSOCKET_COMPRESSION='{"level":5, "maxWindowBits":13, "memLevel":7, "requestMaxWindowBits":13}'
 export BIND_IP=127.0.0.1
 PORT=$PORT /usr/lib/bbb-html5/node/bin/node --max-old-space-size=2048 --max_semi_space_size=128 main.js
-

--- a/build/packages-template/bbb-html5/workers-start.sh
+++ b/build/packages-template/bbb-html5/workers-start.sh
@@ -1,4 +1,30 @@
 #!/bin/bash
+
+echo "Starting mongoDB"
+
+#wait for mongo startup
+MONGO_OK=0
+
+while [ "$MONGO_OK" = "0" ]; do
+    MONGO_OK=$(ss -lan | grep 127.0.1.1 | grep 27017 &> /dev/null && echo 1 || echo 0)
+    sleep 1;
+done;
+
+echo "Mongo started";
+
+echo "Initializing replicaset"
+mongosh 127.0.1.1 --eval 'rs.initiate({ _id: "rs0", members: [ {_id: 0, host: "127.0.1.1"} ]})'
+
+echo "Waiting to become a master"
+IS_MASTER="XX"
+while [ "$IS_MASTER" \!= "true" ]; do
+    IS_MASTER=$(mongosh mongodb://127.0.1.1:27017/ --eval  'db.isMaster().ismaster' | tail -n 1)
+    sleep 0.5;
+done;
+
+echo "I'm the master!"
+
+
 # Start parallel nodejs processes for bbb-html5. Number varies on restrictions file bbb-html5-with-roles.conf
 
 source /usr/share/meteor/bundle/bbb-html5-with-roles.conf


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Moves the code for initializing MongoDB replicaset outside (and before) of the `bbb-html5-backend` and `bbb-html5-frontend` process starting scripts.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none


### Motivation
This was triggered by the fact that MongoDB 6.x+ allows for only one replicaset initialization and back on 4.x we were initializing on the start of every bbb-html5-* service (likely unnecessarily and wrongly).
<!-- What inspired you to submit this pull request? -->

### More
I can't yet tell if there is any drawback to this change but will know quite soon. This is a stepping stone to continue the work on installing/running BBB on Ubuntu 22.04
