### PR TITLE
build(freeswitch): bump to signalwire/freeswitch/master@41507363

### DIFF
--- a/freeswitch.placeholder.sh
+++ b/freeswitch.placeholder.sh
@@ -5,4 +5,4 @@ git remote add origin https://github.com/signalwire/freeswitch.git
 #git fetch --depth 1 origin v1.10.9
 #git checkout FETCH_HEAD
 git fetch origin master
-git checkout 67840823c178153cb013014c4fa780fe233612cb # branch 'master' on Aug 10, 2023
+git checkout 41507363f3fffcdad547b168e55fbe3383a24c3d # branch 'master' on Aug 10, 2023


### PR DESCRIPTION
### What does this PR do?

- [build(freeswitch): bump to](https://github.com/bigbluebutton/bigbluebutton/commit/a3264bb1526b6e98a31f4050bd4ac1e20718c15a) https://github.com/signalwire/freeswitch/commit/41507363 
  - See https://github.com/signalwire/freeswitch/commit/41507363f3fffcdad547b168e55fbe3383a24c3d

### Closes Issue(s)

n/a

### Motivation

Follow up to https://github.com/bigbluebutton/bigbluebutton/pull/18517

