### PR TITLE
refactor(video): guarantee connectStreams scope is valid

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -175,6 +175,7 @@ class VideoProvider extends Component {
     this.onWsClose = this.onWsClose.bind(this);
     this.onWsMessage = this.onWsMessage.bind(this);
     this.updateStreams = this.updateStreams.bind(this);
+    this.connectStreams = this.connectStreams.bind(this);
     this.debouncedConnectStreams = debounce(
       this.connectStreams,
       VideoService.getPageChangeDebounceTime(),


### PR DESCRIPTION
### What does this PR do?

- [refactor(video): guarantee connectStreams scope is valid](https://github.com/bigbluebutton/bigbluebutton/commit/f3bd84e81f030edf5d187c31aa3043cf6e6ee6ff)
  * The original debounce implementation (lodash) preserved the caller's context - radash didn't, so it was failing and it wasn't noticed.
  * The new debounce implementation with the native function seems to preserve caller's context, but as a safety measure this commit binds the method to its appropriate scope.


### Closes Issue(s)

None


### More

Found while reviewing the grid size PR.
