### PR TITLE
Reactions - allow for two alternative views

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -16,6 +16,7 @@ const ReactionsButton = (props) => {
     raiseHand,
     isMobile,
     currentUserReaction,
+    autoCloseReactionsBar,
   } = props;
 
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
@@ -152,7 +153,7 @@ const ReactionsButton = (props) => {
       isHorizontal={!isMobile}
       isMobile={isMobile}
       roundButtons={true}
-      keepOpen={true}
+      keepOpen={!autoCloseReactionsBar}
       opts={{
         id: 'reactions-dropdown-menu',
         keepMounted: true,

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -123,19 +123,24 @@ const ReactionsButton = (props) => {
     customStyles: {...actionCustomStyles, width: 'auto'},
   });
 
+  const icon = currentUserReaction === 'none' ? 'hand' : null;
+  const currentUserReactionEmoji = reactions.find(({ native }) => native === currentUserReaction);
+  const customIcon = !icon ? <Emoji key={currentUserReactionEmoji?.id} emoji={{ id: currentUserReactionEmoji?.id }} {...emojiProps} /> : null;
+
   return (
     <BBBMenu
       trigger={(
         <Styled.ReactionsDropdown>
           <Styled.RaiseHandButton
             data-test="reactionsButton"
-            icon="hand"
+            icon={icon}
+            customIcon={customIcon}
             label={intl.formatMessage(intlMessages.reactionsLabel)}
             description="Reactions"
-            ghost={!showEmojiPicker}
+            ghost={!showEmojiPicker && !customIcon}
             onKeyPress={() => {}}
             onClick={() => setShowEmojiPicker(true)}
-            color={showEmojiPicker ? 'primary' : 'default'}
+            color={showEmojiPicker || customIcon ? 'primary' : 'default'}
             hideLabel
             circle
             size="lg"

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/container.jsx
@@ -6,6 +6,7 @@ import ReactionsButton from './component';
 import actionsBarService from '../service';
 import UserReactionService from '/imports/ui/components/user-reaction/service';
 import { SMALL_VIEWPORT_BREAKPOINT } from '/imports/ui/components/layout/enums';
+import SettingsService from '/imports/ui/services/settings';
 
 const ReactionsButtonContainer = ({ ...props }) => {
   const layoutContextDispatch = layoutDispatch();
@@ -32,6 +33,7 @@ export default injectIntl(withTracker(() => {
     emoji: currentUser.emoji,
     currentUserReaction: currentUserReaction.reaction,
     raiseHand: currentUser.raiseHand,
+    autoCloseReactionsBar: SettingsService?.application?.autoCloseReactionsBar,
   };
 })(ReactionsButtonContainer));
 

--- a/bigbluebutton-html5/imports/ui/components/settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/component.jsx
@@ -94,6 +94,7 @@ const propTypes = {
   updateSettings: PropTypes.func.isRequired,
   availableLocales: PropTypes.objectOf(PropTypes.array).isRequired,
   showToggleLabel: PropTypes.bool.isRequired,
+  isReactionsEnabled: PropTypes.bool.isRequired,
 };
 
 class Settings extends Component {
@@ -173,6 +174,7 @@ class Settings extends Component {
       selectedLayout,
       isScreenSharingEnabled,
       isVideoEnabled,
+      isReactionsEnabled,
     } = this.props;
 
     const {
@@ -225,6 +227,7 @@ class Settings extends Component {
             layoutContextDispatch={layoutContextDispatch}
             selectedLayout={selectedLayout}
             isPresenter={isPresenter}
+            isReactionsEnabled={isReactionsEnabled}
           />
         </Styled.SettingsTabPanel>
         <Styled.SettingsTabPanel selectedClassName="is-selected">

--- a/bigbluebutton-html5/imports/ui/components/settings/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/container.jsx
@@ -4,6 +4,7 @@ import SettingsService from '/imports/ui/services/settings';
 import Settings from './component';
 import { layoutDispatch } from '../layout/context';
 import { isScreenSharingEnabled } from '/imports/ui/services/features';
+import UserReactionService from '/imports/ui/components/user-reaction/service';
 
 import {
   getUserRoles,
@@ -32,4 +33,5 @@ export default withTracker((props) => ({
   showToggleLabel: false,
   isScreenSharingEnabled: isScreenSharingEnabled(),
   isVideoEnabled: Meteor.settings.public.kurento.enableVideo,
+  isReactionsEnabled: UserReactionService.isEnabled(),
 }))(SettingsContainer);

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -411,7 +411,11 @@ class ApplicationMenu extends BaseMenu {
 
   render() {
     const {
-      allLocales, intl, showToggleLabel, displaySettingsStatus,
+      allLocales,
+      intl,
+      showToggleLabel,
+      displaySettingsStatus,
+      isReactionsEnabled,
     } = this.props;
     const {
       isLargestFontSize, isSmallestFontSize, settings,
@@ -513,27 +517,29 @@ class ApplicationMenu extends BaseMenu {
             </Styled.Col>
           </Styled.Row>
 
-          <Styled.Row>
-            <Styled.Col aria-hidden="true">
-              <Styled.FormElement>
-                <Styled.Label>
-                  {intl.formatMessage(intlMessages.autoCloseReactionsBarLabel)}
-                </Styled.Label>
-              </Styled.FormElement>
-            </Styled.Col>
-            <Styled.Col>
-              <Styled.FormElementRight>
-                {displaySettingsStatus(settings.autoCloseReactionsBar)}
-                <Toggle
-                  icons={false}
-                  defaultChecked={settings.autoCloseReactionsBar}
-                  onChange={() => this.handleToggle('autoCloseReactionsBar')}
-                  ariaLabel={`${intl.formatMessage(intlMessages.autoCloseReactionsBarLabel)} - ${displaySettingsStatus(settings.autoCloseReactionsBar, false)}`}
-                  showToggleLabel={showToggleLabel}
-                />
-              </Styled.FormElementRight>
-            </Styled.Col>
-          </Styled.Row>
+          {isReactionsEnabled && (
+            <Styled.Row>
+              <Styled.Col aria-hidden="true">
+                <Styled.FormElement>
+                  <Styled.Label>
+                    {intl.formatMessage(intlMessages.autoCloseReactionsBarLabel)}
+                  </Styled.Label>
+                </Styled.FormElement>
+              </Styled.Col>
+              <Styled.Col>
+                <Styled.FormElementRight>
+                  {displaySettingsStatus(settings.autoCloseReactionsBar)}
+                  <Toggle
+                    icons={false}
+                    defaultChecked={settings.autoCloseReactionsBar}
+                    onChange={() => this.handleToggle('autoCloseReactionsBar')}
+                    ariaLabel={`${intl.formatMessage(intlMessages.autoCloseReactionsBarLabel)} - ${displaySettingsStatus(settings.autoCloseReactionsBar, false)}`}
+                    showToggleLabel={showToggleLabel}
+                  />
+                </Styled.FormElementRight>
+              </Styled.Col>
+            </Styled.Row>
+          )}
 
           <Styled.Row>
             <Styled.Col>

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -125,6 +125,9 @@ const intlMessages = defineMessages({
   disableLabel: {
     id: 'app.videoDock.webcamDisableLabelAllCams',
   },
+  autoCloseReactionsBarLabel: {
+    id: 'app.actionsBar.reactions.autoCloseReactionsBarLabel',
+  },
 });
 
 class ApplicationMenu extends BaseMenu {
@@ -504,6 +507,28 @@ class ApplicationMenu extends BaseMenu {
                   defaultChecked={settings.selfViewDisable}
                   onChange={() => this.handleToggle('selfViewDisable')}
                   ariaLabel={`${intl.formatMessage(intlMessages.disableLabel)} - ${displaySettingsStatus(settings.selfViewDisable, false)}`}
+                  showToggleLabel={showToggleLabel}
+                />
+              </Styled.FormElementRight>
+            </Styled.Col>
+          </Styled.Row>
+
+          <Styled.Row>
+            <Styled.Col aria-hidden="true">
+              <Styled.FormElement>
+                <Styled.Label>
+                  {intl.formatMessage(intlMessages.autoCloseReactionsBarLabel)}
+                </Styled.Label>
+              </Styled.FormElement>
+            </Styled.Col>
+            <Styled.Col>
+              <Styled.FormElementRight>
+                {displaySettingsStatus(settings.autoCloseReactionsBar)}
+                <Toggle
+                  icons={false}
+                  defaultChecked={settings.autoCloseReactionsBar}
+                  onChange={() => this.handleToggle('autoCloseReactionsBar')}
+                  ariaLabel={`${intl.formatMessage(intlMessages.autoCloseReactionsBarLabel)} - ${displaySettingsStatus(settings.autoCloseReactionsBar, false)}`}
                   showToggleLabel={showToggleLabel}
                 />
               </Styled.FormElementRight>

--- a/bigbluebutton-html5/imports/ui/services/features/index.js
+++ b/bigbluebutton-html5/imports/ui/services/features/index.js
@@ -85,7 +85,10 @@ export function isPresentationEnabled() {
 }
 
 export function isReactionsEnabled() {
-  return getDisabledFeatures().indexOf('reactions') === -1;
+  const USER_REACTIONS_ENABLED = Meteor.settings.public.userReaction.enabled;
+  const REACTIONS_BUTTON_ENABLED = Meteor.settings.public.app.reactionsButton.enabled;
+
+  return getDisabledFeatures().indexOf('reactions') === -1 && USER_REACTIONS_ENABLED && REACTIONS_BUTTON_ENABLED;
 }
 
 export function isTimerFeatureEnabled() {

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -191,6 +191,7 @@ public:
         wakeLock: true
         paginationEnabled: true
         whiteboardToolbarAutoHide: false
+        autoCloseReactionsBar: false
         darkTheme: false
         # fallbackLocale: if the locale the client is loaded in does not have a
         # translation a string, it will use the translation from the locale

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -191,7 +191,7 @@ public:
         wakeLock: true
         paginationEnabled: true
         whiteboardToolbarAutoHide: false
-        autoCloseReactionsBar: false
+        autoCloseReactionsBar: true
         darkTheme: false
         # fallbackLocale: if the locale the client is loaded in does not have a
         # translation a string, it will use the translation from the locale

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -641,6 +641,7 @@
     "app.actionsBar.reactions.reactionsButtonLabel": "Reactions bar",
     "app.actionsBar.reactions.raiseHand": "Raise your hand",
     "app.actionsBar.reactions.lowHand": "Lower your hand",
+    "app.actionsBar.reactions.autoCloseReactionsBarLabel": "Auto close the reactions bar",
     "app.actionsBar.emojiMenu.statusTriggerLabel": "Set status",
     "app.actionsBar.emojiMenu.awayLabel": "Away",
     "app.actionsBar.emojiMenu.awayDesc": "Change your status to away",


### PR DESCRIPTION
### What does this PR do?

- introduces a Setting toggle on the main settings screen: Auto close the reactions bar with default value `true`
- add `autoCloseReactionsBar` in settings.yml config so the default value could be overridden by the administrator.
- display the selected emoji in the action bar button

### Closes Issue(s)
Closes #18443