### PR TITLE
ci(tests) fix: Checkout failing when it's not a Pull Request (push event)

### DIFF
--- a/.github/workflows/automated-tests-build-package-job.yml
+++ b/.github/workflows/automated-tests-build-package-job.yml
@@ -29,7 +29,7 @@ jobs:
           git pull origin pull/${{ github.event.number }}/head:${{ github.head_ref }}
       - name: Set cache-key vars
         run: |
-          echo "CACHE_KEY_FILES=$(echo '${{ inputs.cache-files-list }}' | xargs -n1 git log -1 --format=%h -- | tr '\n' '-' | sed 's/-$//')" >> $GITHUB_ENV
+          echo "CACHE_KEY_FILES=$(echo '${{ inputs.cache-files-list }} .gitlab-ci.yml' | xargs -n1 git log -1 --format=%h -- | tr '\n' '-' | sed 's/-$//')" >> $GITHUB_ENV
           echo "CACHE_KEY_URLS=$(echo '${{ inputs.cache-urls-list }}' | xargs -r -n 1 curl -Is | grep -i 'Last-Modified' | md5sum | cut -c1-10)" >> $GITHUB_ENV
           cat bigbluebutton-config/bigbluebutton-release >> $GITHUB_ENV
           echo "FORCE_GIT_REV=0" >> $GITHUB_ENV #used by setup.sh

--- a/.github/workflows/automated-tests-build-package-job.yml
+++ b/.github/workflows/automated-tests-build-package-job.yml
@@ -12,7 +12,7 @@ on:
       cache-urls-list:
         type: string
 jobs:
-  build-and-cache:
+  b:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout ${{ github.event.pull_request.base.ref || 'master' }}

--- a/.github/workflows/automated-tests-build-package-job.yml
+++ b/.github/workflows/automated-tests-build-package-job.yml
@@ -15,12 +15,13 @@ jobs:
   build-and-cache:
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout ${{ github.event.pull_request.base.ref }}
+      - name: Checkout ${{ github.event.pull_request.base.ref || 'master' }}
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.event.pull_request.base.ref || '' }}
           fetch-depth: 0 # Fetch all history
       - name: Merge pr-${{ github.event.number }} into ${{ github.event.pull_request.base.ref }}
+        if: github.event_name == 'pull_request'
         run: |
           git config user.name "BBB Automated Tests"
           git config user.email "tests@bigbluebutton.org"

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -88,12 +88,13 @@ jobs:
     needs: [build-bbb-apps-akka, build-bbb-config, build-bbb-export-annotations, build-bbb-learning-dashboard, build-bbb-playback-record, build-bbb-etherpad, build-bbb-bbb-web, build-bbb-fsesl-akka, build-bbb-html5, build-bbb-freeswitch, build-bbb-webrtc, build-others]
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout ${{ github.event.pull_request.base.ref }}
+      - name: Checkout ${{ github.event.pull_request.base.ref || 'master' }}
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.event.pull_request.base.ref || '' }}
           fetch-depth: 0 # Fetch all history
       - name: Merge pr-${{ github.event.number }} into ${{ github.event.pull_request.base.ref }}
+        if: github.event_name == 'pull_request'
         run: |
           git config user.name "BBB Automated Tests"
           git config user.email "tests@bigbluebutton.org"


### PR DESCRIPTION
This PR:
- Makes it checkout master branch when the event is a `push` (instead of `pull_request`)
- Rename the job to improve visualization of the Actions/Summary screen
- Add `.gitlab-ci.yml` to be part of the cache-key of all packages