### PR TITLE
build: TEMP ensure CI runs on 2.8 by masking recording services

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -69,7 +69,7 @@
 #   2020-10-22 AGG  Removing Flash/Red5 related code (yay!)
 #   2021-07-16 JFS  Add defaultMeetingLayout information
 
-set -x
+#set -x
 #set -e
 
 PATH=$PATH:/sbin

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -367,6 +367,9 @@ start_bigbluebutton () {
     echo "Starting BigBlueButton"
 
     systemctl mask bbb-rap-resque-worker
+    systemctl mask bbb-rap-starter
+    systemctl mask bbb-rap-caption-inbox
+
     systemctl restart bigbluebutton.target
 
     if [ -f /usr/lib/systemd/system/bbb-html5.service ]; then

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -366,6 +366,7 @@ start_bigbluebutton () {
 
     echo "Starting BigBlueButton"
 
+    systemctl mask bbb-rap-resque-worker
     systemctl restart bigbluebutton.target
 
     if [ -f /usr/lib/systemd/system/bbb-html5.service ]; then

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -69,7 +69,7 @@
 #   2020-10-22 AGG  Removing Flash/Red5 related code (yay!)
 #   2021-07-16 JFS  Add defaultMeetingLayout information
 
-#set -x
+set -x
 #set -e
 
 PATH=$PATH:/sbin


### PR DESCRIPTION
To be reverted when the recording services function again on 22.04