### PR TITLE
fix: Add Whiteboard Dropdown As Element To Autohide

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -371,8 +371,9 @@ const notifyShapeNumberExceeded = (intl, limit) => {
 };
 
 const toggleToolsAnimations = (activeAnim, anim, time) => {
-  const tdTools = document.querySelector("#TD-Tools");
-  const topToolbar = document.getElementById("TD-Styles")?.parentElement;
+  const tdTools = document.querySelector('#TD-Tools');
+  const topToolbar = document.getElementById('TD-Styles')?.parentElement;
+  const optionsDropdown = document.getElementById('WhiteboardOptionButton');
   if (tdTools && topToolbar) {
     tdTools.classList.remove(activeAnim);
     topToolbar.classList.remove(activeAnim);
@@ -380,6 +381,11 @@ const toggleToolsAnimations = (activeAnim, anim, time) => {
     tdTools.style.transition = `opacity ${time} ease-in-out`;
     tdTools?.classList?.add(anim);
     topToolbar?.classList?.add(anim);
+  }
+  if (optionsDropdown) {
+    optionsDropdown.classList.remove(activeAnim);
+    optionsDropdown.style.transition = `opacity ${time} ease-in-out`;
+    optionsDropdown?.classList?.add(anim);
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR adds the whiteboard dropdown menu to the list of elements that are set to autohide. This ensures that the dropdown does not obstruct any slide content, especially after its position was recently changed.

![autohide-opts](https://github.com/bigbluebutton/bigbluebutton/assets/22058534/bc0c9d63-ccc0-40cc-b9d7-2d257923f9fe)


### Motivation
the position of the whiteboard dropdown menu was moved and this change created instances where the dropdown could overlap with some of the slide content, obstructing the view for users. 