### PR TITLE
fix(html5): backport 'Replace wasm detection library #18557' to 2.6

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/virtual-background/index.js
+++ b/bigbluebutton-html5/imports/ui/services/virtual-background/index.js
@@ -3,7 +3,6 @@
  * It is partially copied under the Apache Public License 2.0 (see https://www.apache.org/licenses/LICENSE-2.0).
  */
 
-import * as wasmcheck from 'wasm-check';
 import {
     CLEAR_TIMEOUT,
     TIMEOUT_TICK,
@@ -16,6 +15,8 @@ import {
   getVirtualBgImagePath,
 } from '/imports/ui/services/virtual-background/service'
 import logger from '/imports/startup/client/logger';
+
+import { simd } from 'wasm-feature-detect/dist/cjs/index';
 
 const blurValue = '25px';
 
@@ -367,8 +368,9 @@ class VirtualBackgroundService {
 export async function createVirtualBackgroundService(parameters = null) {
     let tflite;
     let modelResponse;
+    const simdSupported = await simd();
 
-    if (wasmcheck.feature.simd) {
+    if (simdSupported) {
         tflite = await window.createTFLiteSIMDModule();
         modelResponse = await fetch(BASE_PATH+MODELS.model144.path);
     } else {
@@ -401,7 +403,7 @@ export async function createVirtualBackgroundService(parameters = null) {
     tflite._loadModel(model.byteLength);
 
     const options = {
-        ...wasmcheck.feature.simd ? MODELS.model144.segmentationDimensions : MODELS.model96.segmentationDimensions,
+        ... simdSupported ? MODELS.model144.segmentationDimensions : MODELS.model96.segmentationDimensions,
         virtualBackground: parameters
     };
 

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -7004,10 +7004,10 @@
         "loose-envify": "^1.0.0"
       }
     },
-    "wasm-check": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/wasm-check/-/wasm-check-2.0.3.tgz",
-      "integrity": "sha512-UbZqpDMO4TZskoVKDH3B9NqY+yJllDJX8I9lUU4nuQjBGeU57jCjjgCslP3r8xiE+yf5GTIfeGvznvubgCdbhw=="
+    "wasm-feature-detect": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.5.1.tgz",
+      "integrity": "sha512-GHr23qmuehNXHY4902/hJ6EV5sUANIJC3R/yMfQ7hWDg3nfhlcJfnIL96R2ohpIwa62araN6aN4bLzzzq5GXkg=="
     },
     "webrtc-adapter": {
       "version": "8.1.1",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -89,7 +89,7 @@
     "styled-components": "^5.3.3",
     "tippy.js": "^5.1.3",
     "use-context-selector": "^1.3.7",
-    "wasm-check": "^2.0.3",
+    "wasm-feature-detect": "^1.5.1",
     "webrtc-adapter": "^8.1.1",
     "winston": "^3.7.2",
     "yaml": "^2.2.2"


### PR DESCRIPTION
Backport of #18557 to BigBlueButton 2.6