### PR TITLE
test: Skip webcam test to run on CI

### DIFF
--- a/bigbluebutton-tests/playwright/package.json
+++ b/bigbluebutton-tests/playwright/package.json
@@ -5,8 +5,8 @@
     "test:filter": "npx playwright test -g",
     "test:headed": "npx playwright test --headed",
     "test:debug": "npx playwright test --debug -g",
-    "test-chromium-ci": "export CI='true' && npx playwright test --project=chromium --grep @ci",
-    "test-firefox-ci": "export CI='true' && npx playwright test --project=firefox --grep @ci",
+    "test-chromium-ci": "export CI='true' && npx playwright test --project=chromium --grep @ci --grep-invert @flaky",
+    "test-firefox-ci": "export CI='true' && npx playwright test --project=firefox --grep @ci --grep-invert @flaky",
     "rewrite-snapshots": "read -p 'CAUTION: You will delete ALL testing folders containing snapshots and run the tests to rewrite these files.\nProceed? (y/n) ' confirm && test $confirm = 'y' && sh core/scripts/rewrite-snapshots.sh"
   },
   "dependencies": {

--- a/bigbluebutton-tests/playwright/webcam/webcam.spec.js
+++ b/bigbluebutton-tests/playwright/webcam/webcam.spec.js
@@ -49,7 +49,7 @@ test.describe.parallel('Webcam @ci', () => {
       await webcam.applyBackground();
     });
 
-    test('Managing new background', async ({ browser, page }) => {
+    test('Managing new background @flaky', async ({ browser, page }) => {
       const webcam = new Webcam(browser, page);
       await webcam.init(true, true);
       await webcam.managingNewBackground();


### PR DESCRIPTION
### What does this PR do?
- Adds the `@flaky` flag to the webcam background test preventing it from running in CI temporarily due to recent failures