### PR TITLE
build(bbb-webrtc-sfu): use bbb-webrtc-recorder, drop kurento from config

### DIFF
--- a/build/packages-template/bbb-webrtc-sfu/after-install.sh
+++ b/build/packages-template/bbb-webrtc-sfu/after-install.sh
@@ -43,7 +43,10 @@ case "$1" in
     touch /var/log/bbb-webrtc-sfu/bbb-webrtc-sfu.log
 
     yq e -i '.recordWebcams = true' $TARGET
-
+    # Set bbb-webrtc-recorder as the default recordingAdapter
+    yq e -i '.recordingAdapter = "bbb-webrtc-recorder"' $TARGET
+    # Do not configure any Kurento instances - BBB >= 2.8 doesn't provide Kurento by default
+    yq e -i '.kurento = []' $TARGET
 
     echo "Resetting mcs-address from localhost to 127.0.0.1"
     yq e -i '.mcs-address = "127.0.0.1"' $TARGET


### PR DESCRIPTION

### What does this PR do?

- [build(bbb-webrtc-sfu): use bbb-webrtc-recorder, drop kurento from config](https://github.com/bigbluebutton/bigbluebutton/commit/a3759f681f1648347b656e65a03ba1310677123b) 
  - Set bbb-webrtc-recorder as the default `recordingAdapter` in bbb-webrtc-sfu by default
  - Set `kurento` in SFU's config to an empty array; Kurento isn't provided by 2.8+ by default

### Closes Issue(s)

None
