### PR TITLE
CI: Introduces automated tests output comment on PR

### DIFF
--- a/.github/workflows/publish-test-report.yml
+++ b/.github/workflows/publish-test-report.yml
@@ -1,0 +1,88 @@
+name: Publish Test Results
+on:
+  workflow_run:
+    workflows:
+      - Automated tests
+    types:
+      - completed
+
+jobs:
+  get-pr-data:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    outputs:
+      pr-number: ${{ steps.set-env.outputs.pr-number }}
+      workflow-id: ${{ steps.set-env.outputs.workflow-id }}
+    steps:
+      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
+      - name: Download artifact
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr-comment-data"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr-comment-data.zip`, Buffer.from(download.data));
+      - name: Unzip artifact
+        run: unzip pr-comment-data.zip
+      - name: Set env variables
+        id: set-env
+        run: |
+          echo "pr-number=$(cat ./pr_number)" >> $GITHUB_OUTPUT
+          echo "workflow-id=$(cat ./workflow_id)" >> $GITHUB_OUTPUT
+  comment-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    needs: get-pr-data
+    steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ needs.get-pr-data.outputs.pr-number }}
+          comment-author: "github-actions[bot]"
+          body-includes: Automated tests Summary
+      - name: Remove previous comment
+        if: steps.fc.outputs.comment-id != ''
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.deleteComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ steps.fc.outputs.comment-id }}
+            })
+      - name: Passing tests comment
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ needs.get-pr-data.outputs.pr-number }}
+          body: |
+            <h1>Automated tests Summary</h1>
+            <h3><strong>:white_check_mark:</strong> All the CI tests have passed!</h3>
+      - name: Failing tests comment
+        if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ needs.get-pr-data.outputs.pr-number }}
+          body: |
+            <h1> Automated tests Summary</h1>
+            <h3><strong>:rotating_light:</strong> Test workflow has failed</h3>
+
+            ___
+
+            [Click here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ needs.get-pr-data.outputs.workflow-id }}) to check the action test reports


### PR DESCRIPTION
### What does this PR do?
Introduces a comment when the testing workflow ends informing which is the output status. If a commit is pushed when there's already a comment, the previous one will be deleted. Failed runs will contain a link to the automated tests summary check

| Passing  | Failing |
| --- | --- |
| ![Screenshot from 2023-08-11 16-28-07](https://github.com/bigbluebutton/bigbluebutton/assets/56703993/b108a250-057c-4c77-bcc6-0c90580a62da) | ![Screenshot from 2023-08-11 16-28-18](https://github.com/bigbluebutton/bigbluebutton/assets/56703993/6c608fd5-fb60-4efe-a16d-7be5de0f1c21) |
