### PR TITLE
fix: restore unread messages button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -6,6 +6,7 @@ import {
   ButtonLoadMore,
   MessageList,
   MessageListWrapper,
+  UnreadButton,
 } from "./styles";
 import { layoutSelect } from "../../../layout/context";
 import ChatListPage from "./page/component";
@@ -29,6 +30,10 @@ const intlMessages = defineMessages({
   loadMoreButtonLabel: {
     id: 'app.chat.loadMoreButtonLabel',
     description: 'Label for load more button',
+  },
+  moreMessages: {
+    id: 'app.chat.moreMessages',
+    description: 'Chat message when the user has unread messages below the scroll',
   },
 });
 
@@ -97,15 +102,18 @@ const ChatMessageList: React.FC<ChatListProps> = ({
   chatId,
   setMessageAsSeenMutation,
   lastSeenAt,
+  totalUnread,
 }) => {
   const intl = useIntl();
   const messageListRef = React.useRef<HTMLDivElement>();
   const contentRef = React.useRef<HTMLDivElement>();
   // I used a ref here because I don't want to re-render the component when the last sender changes
   const lastSenderPerPage = React.useRef<Map<number, string>>(new Map());
+  const messagesEndRef = React.useRef<HTMLDivElement>();
   const [userLoadedBackUntilPage, setUserLoadedBackUntilPage] = useState<number | null>(null);
   const [lastMessageCreatedTime, setLastMessageCreatedTime] = useState<number>(0);
   const [followingTail, setFollowingTail] = React.useState(true);
+  const [userScrolledBack, setUserScrolledBack] = React.useState(false);
   useEffect(() => {
     setter({
       ...setter(),
@@ -167,6 +175,31 @@ const ChatMessageList: React.FC<ChatListProps> = ({
     }
   };
 
+  const renderUnreadNotification = () => {
+    if (totalUnread && userScrolledBack) {
+      return (
+        <UnreadButton
+          aria-hidden="true"
+          color="primary"
+          size="sm"
+          key="unread-messages"
+          label={intl.formatMessage(intlMessages.moreMessages)}
+          onClick={() => {
+            messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
+          }}
+        />
+      );
+    }
+    return null;
+  }
+
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    const scrolledToBottom = e.currentTarget.scrollHeight - e.currentTarget.scrollTop === e.currentTarget.clientHeight;
+    if (scrolledToBottom) {
+      setUserScrolledBack(false);
+    }
+  }
+
   useEffect(() => {
     const setScrollToTailEventHandler = () => {
       if (scrollObserver && contentRef.current) {
@@ -209,66 +242,72 @@ const ChatMessageList: React.FC<ChatListProps> = ({
     ? userLoadedBackUntilPage : Math.max(totalPages - 2, 0);
   const pagesToLoad = (totalPages - firstPageToLoad) || 1;
   return (
-    <MessageListWrapper>
-      <MessageList
-        ref={messageListRef}
-        onWheel={(e) => {
-          if (e.deltaY < 0) {
-            if (isElement(contentRef.current) && followingTail) {
-              toggleFollowingTail(false)
+    [
+      <MessageListWrapper>
+        <MessageList
+          ref={messageListRef}
+          onWheel={(e) => {
+            if (e.deltaY < 0) {
+              if (isElement(contentRef.current) && followingTail) {
+                toggleFollowingTail(false)
+              }
+              setUserScrolledBack(true);
+            } else if (e.deltaY > 0) {
+              setScrollToTailEventHandler(messageListRef.current as HTMLDivElement);
             }
-          } else if (e.deltaY > 0) {
+          }}
+          onMouseUp={() => {
             setScrollToTailEventHandler(messageListRef.current as HTMLDivElement);
-          }
-        }}
-        onMouseUp={() => {
-          setScrollToTailEventHandler(messageListRef.current as HTMLDivElement);
-        }}
-        onTouchEnd={() => {
-          setScrollToTailEventHandler(messageListRef.current as HTMLDivElement);
-        }}
-      >
-        <span>
-          {
-            (userLoadedBackUntilPage)
-              ? (
-                <ButtonLoadMore
-                  onClick={() => {
-                    if (followingTail) {
-                      toggleFollowingTail(false);
+          }}
+          onTouchEnd={() => {
+            setScrollToTailEventHandler(messageListRef.current as HTMLDivElement);
+          }}
+          onScroll={handleScroll}
+        >
+          <span>
+            {
+              (userLoadedBackUntilPage)
+                ? (
+                  <ButtonLoadMore
+                    onClick={() => {
+                      if (followingTail) {
+                        toggleFollowingTail(false);
+                      }
+                      setUserLoadedBackUntilPage(userLoadedBackUntilPage - 1);
                     }
-                    setUserLoadedBackUntilPage(userLoadedBackUntilPage - 1);
-                  }
-                  }
-                >
-                  {intl.formatMessage(intlMessages.loadMoreButtonLabel)}
-                </ButtonLoadMore>
-              ) : null
-          }
-        </span>
-        <div id="contentRef" ref={contentRef}>
-          <ChatPopupContainer />
-          {
-            // @ts-ignore
-            Array.from({ length: pagesToLoad }, (v, k) => k + (firstPageToLoad)).map((page) => {
-              return (
-                <ChatListPage
-                  key={`page-${page}`}
-                  page={page}
-                  pageSize={PAGE_SIZE}
-                  setLastSender={setLastSender(lastSenderPerPage.current)}
-                  lastSenderPreviousPage={page ? lastSenderPerPage.current.get(page - 1) : undefined}
-                  chatId={chatId}
-                  markMessageAsSeen={markMessageAsSeen}
-                  scrollRef={messageListRef}
-                  lastSeenAt={lastSeenAt}
-                />
-              )
-            })
-          }
-        </div>
-      </MessageList>
-    </MessageListWrapper >
+                    }
+                  >
+                    {intl.formatMessage(intlMessages.loadMoreButtonLabel)}
+                  </ButtonLoadMore>
+                ) : null
+            }
+          </span>
+          <div id="contentRef" ref={contentRef}>
+            <ChatPopupContainer />
+            {
+              // @ts-ignore
+              Array.from({ length: pagesToLoad }, (v, k) => k + (firstPageToLoad)).map((page) => {
+                return (
+                  <ChatListPage
+                    key={`page-${page}`}
+                    page={page}
+                    pageSize={PAGE_SIZE}
+                    setLastSender={setLastSender(lastSenderPerPage.current)}
+                    lastSenderPreviousPage={page ? lastSenderPerPage.current.get(page - 1) : undefined}
+                    chatId={chatId}
+                    markMessageAsSeen={markMessageAsSeen}
+                    scrollRef={messageListRef}
+                    lastSeenAt={lastSeenAt}
+                  />
+                )
+              })
+            }
+          </div>
+          <div ref={messagesEndRef} />
+        </MessageList>
+      </MessageListWrapper >,
+      renderUnreadNotification(),
+    ]
   );
 }
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState, useMemo } from "react";
 import { Meteor } from "meteor/meteor";
 import { makeVar, useMutation } from "@apollo/client";
 import { LAST_SEEN_MUTATION } from "./queries";
@@ -113,7 +113,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
   const [userLoadedBackUntilPage, setUserLoadedBackUntilPage] = useState<number | null>(null);
   const [lastMessageCreatedTime, setLastMessageCreatedTime] = useState<number>(0);
   const [followingTail, setFollowingTail] = React.useState(true);
-  const [userScrolledBack, setUserScrolledBack] = React.useState(false);
+
   useEffect(() => {
     setter({
       ...setter(),
@@ -175,8 +175,8 @@ const ChatMessageList: React.FC<ChatListProps> = ({
     }
   };
 
-  const renderUnreadNotification = () => {
-    if (totalUnread && userScrolledBack) {
+  const renderUnreadNotification = useMemo(() => {
+    if (totalUnread && !followingTail) {
       return (
         <UnreadButton
           aria-hidden="true"
@@ -191,14 +191,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
       );
     }
     return null;
-  }
-
-  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
-    const scrolledToBottom = e.currentTarget.scrollHeight - e.currentTarget.scrollTop === e.currentTarget.clientHeight;
-    if (scrolledToBottom) {
-      setUserScrolledBack(false);
-    }
-  }
+  }, [totalUnread, followingTail]);
 
   useEffect(() => {
     const setScrollToTailEventHandler = () => {
@@ -251,7 +244,6 @@ const ChatMessageList: React.FC<ChatListProps> = ({
               if (isElement(contentRef.current) && followingTail) {
                 toggleFollowingTail(false)
               }
-              setUserScrolledBack(true);
             } else if (e.deltaY > 0) {
               setScrollToTailEventHandler(messageListRef.current as HTMLDivElement);
             }
@@ -262,7 +254,6 @@ const ChatMessageList: React.FC<ChatListProps> = ({
           onTouchEnd={() => {
             setScrollToTailEventHandler(messageListRef.current as HTMLDivElement);
           }}
-          onScroll={handleScroll}
         >
           <span>
             {
@@ -306,7 +297,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
           <div ref={messagesEndRef} />
         </MessageList>
       </MessageListWrapper >,
-      renderUnreadNotification(),
+      renderUnreadNotification,
     ]
   );
 }

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/styles.ts
@@ -7,6 +7,7 @@ import {
 } from '/imports/ui/stylesheets/styled-components/general';
 import { ScrollboxVertical } from '/imports/ui/stylesheets/styled-components/scrollable';
 import { colorGrayDark } from '/imports/ui/stylesheets/styled-components/palette';
+import { ButtonElipsis } from '/imports/ui/stylesheets/styled-components/placeholders';
 
 export const MessageListWrapper = styled.div`
   height: 100%;
@@ -54,7 +55,16 @@ export const ButtonLoadMore = styled.button`
   border: 1px ridge ${colorGrayDark};
 `;
 
+export const UnreadButton = styled(ButtonElipsis)`
+  flex-shrink: 0;
+  width: 100%;
+  text-transform: uppercase;
+  margin-bottom: .25rem;
+  z-index: 3;
+`;
+
 export default {
   MessageListWrapper,
   MessageList,
+  UnreadButton,
 };


### PR DESCRIPTION
### What does this PR do?

Reimplements the "more messages below" button so the feature works with the new graphQL components.

![2023-08-24_10-55](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/aacad82c-11c4-4de6-9570-ea6e7b888792)




