### PR TITLE
refactor: add isSeparator option as a menu item

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -186,6 +186,7 @@ class ActionsDropdown extends PureComponent {
       hasCameraAsContent,
       isCameraAsContentEnabled,
       isTimerFeatureEnabled,
+      presentations,
     } = this.props;
 
     const { pollBtnLabel, presentationLabel, takePresenter } = intlMessages;
@@ -195,13 +196,18 @@ class ActionsDropdown extends PureComponent {
     const actions = [];
 
     if (amIPresenter && isPresentationEnabled()) {
+      if (presentations && presentations.length > 1) {
+        actions.push({
+          key: 'separator-01',
+          isSeparator: true,
+        });
+      }
       actions.push({
         icon: 'upload',
         dataTest: 'managePresentations',
         label: formatMessage(presentationLabel),
         key: this.presentationItemId,
         onClick: handlePresentationClick,
-        dividerTop: this.props?.presentations?.length > 1 ? true : false,
       });
     }
 

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/input-stream-live-selector/component.jsx
@@ -264,7 +264,10 @@ class InputStreamLiveSelector extends Component {
         iconRight: (deviceKind === 'audioinput') ? 'unmute' : 'volume_level_2',
         disabled: true,
         customStyles: Styled.DisabledLabel,
-        divider: true,
+      },
+      {
+        key: 'separator-01',
+        isSeparator: true,
       },
     ];
 
@@ -416,11 +419,15 @@ class InputStreamLiveSelector extends Component {
       key: 'leaveAudioOption',
       dataTest: 'leaveAudio',
       customStyles: Styled.DangerColor,
-      dividerTop: true,
       onClick: () => handleLeaveAudio(),
     };
 
-    const dropdownListComplete = inputDeviceList.concat(outputDeviceList).concat(leaveAudioOption);
+    const dropdownListComplete = inputDeviceList.concat(outputDeviceList)
+      .concat({
+        key: 'separator-02',
+        isSeparator: true,
+      })
+      .concat(leaveAudioOption);
     const customStyles = { top: '-1rem' };
 
     return (

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/LiveSelection.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/LiveSelection.tsx
@@ -3,6 +3,7 @@ import deviceInfo from '/imports/utils/deviceInfo';
 import { defineMessages, useIntl } from "react-intl";
 import { useShortcut } from "/imports/ui/core/hooks/useShortcut";
 import BBBMenu from '/imports/ui/components/common/menu/component';
+import { MenuSeparatorItemType, MenuOptionItemType } from '/imports/ui/components/common/menu/menuTypes'
 import Styled from '../styles';
 import {
   handleLeaveAudio,
@@ -54,21 +55,6 @@ const intlMessages = defineMessages({
   },
 });
 
-type DeviceListItemType = {
-  key?: string;
-  dataTest?: string;
-  label?: string;
-  customStyles?: object;
-  iconRight?: string;
-  onClick?: Function;
-  disabled?: boolean;
-};
-
-type SeparatorItemType = {
-  isSeparator?: boolean;
-  key?: string;
-}
-
 interface MuteToggleProps {
   talking: boolean;
   muted: boolean;
@@ -118,14 +104,14 @@ export const LiveSelection: React.FC<LiveSelectionProps> = ({
         iconRight: (deviceKind === 'audioinput') ? 'unmute' : 'volume_level_2',
         disabled: true,
         customStyles: Styled.DisabledLabel,
-      } as DeviceListItemType,
+      } as MenuOptionItemType,
       {
         key: 'separator-01',
         isSeparator: true,
-      } as SeparatorItemType,
+      } as MenuSeparatorItemType,
     ];
 
-    let deviceList: DeviceListItemType[] = [];
+    let deviceList: MenuOptionItemType[] = [];
 
     if (listLength > 0) {
       deviceList = list.map((device, index) => (
@@ -136,7 +122,7 @@ export const LiveSelection: React.FC<LiveSelectionProps> = ({
           customStyles: (device.deviceId === currentDeviceId) ? Styled.SelectedLabel : null,
           iconRight: (device.deviceId === currentDeviceId) ? 'check' : null,
           onClick: () => onDeviceListClick(device.deviceId, deviceKind, callback),
-        } as DeviceListItemType
+        } as MenuOptionItemType
       ));
     } else if (deviceKind === AUDIO_OUTPUT && !SET_SINK_ID_SUPPORTED && listLength === 0) {
       // If the browser doesn't support setSinkId, show the chosen output device
@@ -148,7 +134,7 @@ export const LiveSelection: React.FC<LiveSelectionProps> = ({
           customStyles: Styled.SelectedLabel,
           iconRight: 'check',
           disabled: true,
-        } as DeviceListItemType
+        } as MenuOptionItemType,
       ];
     } else {
       deviceList = [
@@ -157,7 +143,7 @@ export const LiveSelection: React.FC<LiveSelectionProps> = ({
           label: listLength < 0
             ? intl.formatMessage(intlMessages.loading)
             : intl.formatMessage(intlMessages.noDeviceFound),
-        } as DeviceListItemType,
+        } as MenuOptionItemType,
       ];
     }
 

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/LiveSelection.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/LiveSelection.tsx
@@ -62,8 +62,12 @@ type DeviceListItemType = {
   iconRight?: string;
   onClick?: Function;
   disabled?: boolean;
-  isSeparator?: boolean;
 };
+
+type SeparatorItemType = {
+  isSeparator?: boolean;
+  key?: string;
+}
 
 interface MuteToggleProps {
   talking: boolean;
@@ -118,7 +122,7 @@ export const LiveSelection: React.FC<LiveSelectionProps> = ({
       {
         key: 'separator-01',
         isSeparator: true,
-      } as DeviceListItemType,
+      } as SeparatorItemType,
     ];
 
     let deviceList: DeviceListItemType[] = [];

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/LiveSelection.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/LiveSelection.tsx
@@ -62,7 +62,7 @@ type DeviceListItemType = {
   iconRight?: string;
   onClick?: Function;
   disabled?: boolean;
-  divider?: true,
+  isSeparator?: boolean;
 };
 
 interface MuteToggleProps {
@@ -114,7 +114,10 @@ export const LiveSelection: React.FC<LiveSelectionProps> = ({
         iconRight: (deviceKind === 'audioinput') ? 'unmute' : 'volume_level_2',
         disabled: true,
         customStyles: Styled.DisabledLabel,
-        divider: true,
+      } as DeviceListItemType,
+      {
+        key: 'separator-01',
+        isSeparator: true,
       } as DeviceListItemType,
     ];
 
@@ -193,10 +196,14 @@ export const LiveSelection: React.FC<LiveSelectionProps> = ({
     key: 'leaveAudioOption',
     dataTest: 'leaveAudio',
     customStyles: Styled.DangerColor,
-    dividerTop: true,
     onClick: () => handleLeaveAudio(meetingIsBreakout),
   };
-  const dropdownListComplete = inputDeviceList.concat(outputDeviceList).concat(leaveAudioOption);
+  const dropdownListComplete = inputDeviceList.concat(outputDeviceList)
+    .concat({
+      key: 'separator-02',
+      isSeparator: true,
+    })
+    .concat(leaveAudioOption);
   const customStyles = { top: '-1rem' };
   const { isMobile } = deviceInfo;
   return (

--- a/bigbluebutton-html5/imports/ui/components/audio/captions/button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/captions/button/component.jsx
@@ -108,23 +108,37 @@ const CaptionsButton = ({
 
   const shouldRenderChevron = isSupported && isVoiceUser;
 
-  const getAvailableLocales = () => (
-    availableVoices.map((availableVoice) => (
-      {
-        icon: '',
-        label: intl.formatMessage(intlMessages[availableVoice]),
-        key: availableVoice,
-        iconRight: selectedLocale.current === availableVoice ? 'check' : null,
-        customStyles: (selectedLocale.current === availableVoice) && Styled.SelectedLabel,
-        disabled: isTranscriptionDisabled(),
-        dividerTop: availableVoice === availableVoices[0],
-        onClick: () => {
-          selectedLocale.current = availableVoice;
-          SpeechService.setSpeechLocale(selectedLocale.current);
-        },
+  const getAvailableLocales = () => {
+    let indexToInsertSeparator = -1;
+    const availableVoicesObjectToMenu = availableVoices.map((availableVoice, index) => {
+      if (availableVoice === availableVoices[0]) {
+        indexToInsertSeparator = index;
       }
-    ))
-  );
+      return (
+        {
+          icon: '',
+          label: intl.formatMessage(intlMessages[availableVoice]),
+          key: availableVoice,
+          iconRight: selectedLocale.current === availableVoice ? 'check' : null,
+          customStyles: (selectedLocale.current === availableVoice) && Styled.SelectedLabel,
+          disabled: isTranscriptionDisabled(),
+          onClick: () => {
+            selectedLocale.current = availableVoice;
+            SpeechService.setSpeechLocale(selectedLocale.current);
+          },
+        }
+      );
+    });
+    if (indexToInsertSeparator >= 0) {
+      availableVoicesObjectToMenu.splice(indexToInsertSeparator, 0, {
+        key: 'separator-01',
+        isSeparator: true,
+      });
+    }
+    return [
+      ...availableVoicesObjectToMenu,
+    ];
+  };
 
   const toggleTranscription = () => {
     SpeechService.setSpeechLocale(isTranscriptionDisabled() ? selectedLocale.current : DISABLED);
@@ -136,7 +150,6 @@ const CaptionsButton = ({
       label: intl.formatMessage(intlMessages.language),
       customStyles: Styled.TitleLabel,
       disabled: true,
-      dividerTop: false,
     },
     ...getAvailableLocales(),
     {
@@ -144,7 +157,12 @@ const CaptionsButton = ({
       label: intl.formatMessage(intlMessages.transcription),
       customStyles: Styled.TitleLabel,
       disabled: true,
-    }, {
+    },
+    {
+      key: 'separator-02',
+      isSeparator: true,
+    },
+    {
       key: 'transcriptionStatus',
       label: intl.formatMessage(
         isTranscriptionDisabled()
@@ -154,7 +172,6 @@ const CaptionsButton = ({
       customStyles: isTranscriptionDisabled()
         ? Styled.EnableTrascription : Styled.DisableTrascription,
       disabled: false,
-      dividerTop: true,
       onClick: toggleTranscription,
     }]
   );

--- a/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
@@ -118,32 +118,33 @@ class BBBMenu extends React.Component {
       }
 
       return [
-        a.dividerTop && <Divider disabled />,
-        <Styled.BBBMenuItem
-          emoji={emojiSelected ? 'yes' : 'no'}
-          key={label}
-          data-test={dataTest}
-          data-key={`menuItem-${dataTest}`}
-          disableRipple={true}
-          disableGutters={true}
-          disabled={disabled}
-          style={customStyles}
-          $roundButtons={roundButtons}
-          onClick={(event) => {
-            onClick();
-            const close = !keepOpen && !key?.includes('setstatus') && !key?.includes('back');
-            // prevent menu close for sub menu actions
-            if (close) this.handleClose(event);
-            event.stopPropagation();
-          }}>
-          <Styled.MenuItemWrapper>
-            {a.icon ? <Icon iconName={a.icon} key="icon" /> : null}
-            <Styled.Option isHorizontal={isHorizontal} isMobile={isMobile} aria-describedby={`${key}-option-desc`}>{label}</Styled.Option>
-            {description && <div className="sr-only" id={`${key}-option-desc`}>{`${description}${selected ? ` - ${intl.formatMessage(intlMessages.active)}` : ''}`}</div>}
-            {a.iconRight ? <Styled.IconRight iconName={a.iconRight} key="iconRight" /> : null}
-          </Styled.MenuItemWrapper>
-        </Styled.BBBMenuItem>,
-        a.divider && <Divider disabled />
+        !a.isSeparator && (
+          <Styled.BBBMenuItem
+            emoji={emojiSelected ? 'yes' : 'no'}
+            key={label}
+            data-test={dataTest}
+            data-key={`menuItem-${dataTest}`}
+            disableRipple={true}
+            disableGutters={true}
+            disabled={disabled}
+            style={customStyles}
+            $roundButtons={roundButtons}
+            onClick={(event) => {
+              onClick();
+              const close = !keepOpen && !key?.includes('setstatus') && !key?.includes('back');
+              // prevent menu close for sub menu actions
+              if (close) this.handleClose(event);
+              event.stopPropagation();
+            }}>
+            <Styled.MenuItemWrapper>
+              {a.icon ? <Icon iconName={a.icon} key="icon" /> : null}
+              <Styled.Option isHorizontal={isHorizontal} isMobile={isMobile} aria-describedby={`${key}-option-desc`}>{label}</Styled.Option>
+              {description && <div className="sr-only" id={`${key}-option-desc`}>{`${description}${selected ? ` - ${intl.formatMessage(intlMessages.active)}` : ''}`}</div>}
+              {a.iconRight ? <Styled.IconRight iconName={a.iconRight} key="iconRight" /> : null}
+            </Styled.MenuItemWrapper>
+          </Styled.BBBMenuItem>
+        ),
+        a.isSeparator && <Divider disabled />
       ];
     }) ?? [];
   }

--- a/bigbluebutton-html5/imports/ui/components/common/menu/menuTypes.ts
+++ b/bigbluebutton-html5/imports/ui/components/common/menu/menuTypes.ts
@@ -1,0 +1,22 @@
+export type MenuOptionItemType = {
+  key: string;
+  dataTest?: string;
+  label?: string;
+  customStyles?: object;
+  iconRight?: string;
+  onClick?: () => void;
+  disabled?: boolean;
+};
+
+export type MenuSeparatorItemType = {
+  key: string;
+  isSeparator?: boolean;
+};
+
+export type MenuTextItemType = {
+  key: string;
+  dataTest?: string;
+  label?: string;
+  customStyles?: object;
+  iconRight?: string;
+}

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -317,7 +317,10 @@ class SettingsDropdown extends PureComponent {
         label: intl.formatMessage(intlMessages.hotkeysLabel),
         description: intl.formatMessage(intlMessages.hotkeysDesc),
         onClick: () => this.setShortcutHelpModalIsOpen(true),
-        divider: true,
+      },
+      {
+        key: 'separator-01',
+        isSeparator: true,
       },
     );
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
@@ -363,7 +363,11 @@ class UserListItem extends PureComponent {
         label: intl.formatMessage(messages.backTriggerLabel),
         onClick: () => this.setState({ showNestedOptions: false }),
         icon: 'left_arrow',
-        divider: true,
+      },
+      {
+        allowed: showNestedOptions && isMeteorConnected && allowedToChangeStatus,
+        key: 'separator-01',
+        isSeparator: true,
       },
       {
         allowed: isSharingWebcam

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
@@ -351,7 +351,11 @@ const UserActions: React.FC<UserActionsProps> = ({
       label: intl.formatMessage(messages.backTriggerLabel),
       onClick: () => setShowNestedOptions(false),
       icon: 'left_arrow',
-      divider: true,
+    },
+    {
+      allowed: showNestedOptions,
+      key: 'separator-01',
+      isSeparator: true,
     },
     ...Object.keys(EMOJI_STATUSES).map((key) => ({
       allowed: showNestedOptions,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -281,8 +281,12 @@ class UserOptions extends PureComponent {
           onClick: this.onSaveUserNames,
           icon: 'download',
           dataTest: 'downloadUserNamesList',
-          divider: !USER_STATUS_ENABLED,
-        });
+        },
+        {
+          key: 'separator-01',
+          isSeparator: !USER_STATUS_ENABLED,
+        }
+        );
       }
 
       if (USER_STATUS_ENABLED) {
@@ -292,7 +296,10 @@ class UserOptions extends PureComponent {
           description: intl.formatMessage(intlMessages.clearAllDesc),
           onClick: toggleStatus,
           icon: 'clear_status',
-          divider: true,
+        },
+        {
+          key: 'separator-02',
+          isSeparator: true,
         });
       }
 
@@ -303,7 +310,10 @@ class UserOptions extends PureComponent {
           description: intl.formatMessage(intlMessages.clearAllReactionsDesc),
           onClick: toggleReactions,
           icon: 'clear_status',
-          divider: true,
+        },
+        {
+          key: 'separator-03',
+          isSeparator: true,
         });
       }
 
@@ -331,13 +341,16 @@ class UserOptions extends PureComponent {
       if (amIModerator) {
         if (isLearningDashboardEnabled()) {
           this.menuItems.push({
+            key: 'separator-04',
+            isSeparator: true,
+            },
+            {
             icon: 'multi_whiteboard',
             iconRight: 'popout_window',
             label: intl.formatMessage(intlMessages.learningDashboardLabel),
             description: `${intl.formatMessage(intlMessages.learningDashboardDesc)} ${intl.formatMessage(intlMessages.newTab)}`,
             key: this.learningDashboardId,
             onClick: () => { openLearningDashboardUrl(locale); },
-            dividerTop: true,
             dataTest: 'learningDashboard'
           });
         }

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/component.tsx
@@ -215,7 +215,11 @@ const UserTitleOptions: React.FC<UserTitleOptionsProps> = ({
         description: intl.formatMessage(intlMessages.clearAllDesc),
         onClick: toggleStatus.bind(null, intl),
         icon: 'clear_status',
-        divider: true,
+      },
+      {
+        key: 'separator-01',
+        isSeparator: true,
+        allow: true,
       },
       {
         allow: canCreateBreakout,
@@ -236,6 +240,11 @@ const UserTitleOptions: React.FC<UserTitleOptionsProps> = ({
         dataTest: 'writeClosedCaptions',
       },
       {
+        key: 'separator-02',
+        isSeparator: true,
+        allow: true,
+      },
+      {
         allow: isLearningDashboardEnabled(),
         icon: 'multi_whiteboard',
         iconRight: 'popout_window',
@@ -243,7 +252,6 @@ const UserTitleOptions: React.FC<UserTitleOptionsProps> = ({
         description: `${intl.formatMessage(intlMessages.learningDashboardDesc)} ${intl.formatMessage(intlMessages.newTab)}`,
         key: uuids.current[8],
         onClick: () => { openLearningDashboardUrl(locale); },
-        dividerTop: true,
         dataTest: 'learningDashboard'
       },
     ].filter(({ allow }) => allow);


### PR DESCRIPTION
### What does this PR do?

It adds the option `isSeparator` to the `BBBMenu` items so that it enhances readability in the code.


### Motivation

Not only it will enhance readability but it will also give us another type of item to work with in the menus. It will specially be useful for PR https://github.com/bigbluebutton/bigbluebutton/pull/18607 where one of the possible menu items the plugin developer can choose is the separator itself.

### Quick demos:

Below we have some screenshots of the new menus on the following order:
`develop` branch -> `refactor-bbb-menu` branch

Actions dropdown menu
![collage-action-dropdown](https://github.com/bigbluebutton/bigbluebutton/assets/69865537/472df73d-5dc2-4103-92fc-679e08562ed2)

Audio control menu
![collage-audio-controls](https://github.com/bigbluebutton/bigbluebutton/assets/69865537/8ea0b913-23be-4cbc-9aa2-aed0f9e82751)

Captions menu
![collage-captions-menu](https://github.com/bigbluebutton/bigbluebutton/assets/69865537/e6bd1c3c-1a77-49a9-8f45-4e052888f7bb)

Settings dropdown menu
![collage-captions-menu](https://github.com/bigbluebutton/bigbluebutton/assets/69865537/bd17119c-fe6e-4041-870b-1215d1e65952)

User list dropdown item - nested item
![collage-user-list-nested](https://github.com/bigbluebutton/bigbluebutton/assets/69865537/f7cbd278-671e-414d-8818-7889ff5f81ef)

User list options dropdown menu
![collage-user-list-actions](https://github.com/bigbluebutton/bigbluebutton/assets/69865537/c1acbb82-65d4-498e-b8f1-7c9ad8379874)
