### PR TITLE
fix: disable self-view label

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.jsx
@@ -73,14 +73,14 @@ const UserActions = (props) => {
     const userId = user?.userId;
     const isPinnedIntlKey = !pinned ? 'pin' : 'unpin';
     const isFocusedIntlKey = !focused ? 'focus' : 'unfocus';
-    const enableSelfCamIntlKey = !isSelfViewDisabled ? 'disable' : 'enable';
+    const disabledCams = Session.get('disabledCams') || [];
+    const isCameraDisabled = disabledCams && disabledCams?.includes(cameraId);
+    const enableSelfCamIntlKey = !isCameraDisabled ? 'disable' : 'enable';
 
     const menuItems = [];
 
     const toggleDisableCam = () => {
-      const disabledCams = Session.get('disabledCams') || [];
-      const isDisabled = disabledCams && disabledCams?.includes(cameraId);
-      if (!isDisabled) {
+      if (!isCameraDisabled) {
         Session.set('disabledCams', [...disabledCams, cameraId]);
       } else {
         Session.set('disabledCams', disabledCams.filter((cId) => cId !== cameraId));


### PR DESCRIPTION
### What does this PR do?

Adjusts self-view label so the label changes to "enable self-view" if a camera is disabled.

![2023-08-24_16-41](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/d31c5dc8-b00a-4191-b66e-0a9a875e5b8c)
