### PR TITLE
fix: expose camera as content in mobile endpoints

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -280,7 +280,7 @@ class ActionsDropdown extends PureComponent {
       });
     }
 
-    if (isCameraAsContentEnabled && amIPresenter && !isMobile) {
+    if (isCameraAsContentEnabled && amIPresenter) {
       actions.push({
         icon: hasCameraAsContent ? 'video_off' : 'video',
         label: hasCameraAsContent


### PR DESCRIPTION
### What does this PR do?

- [fix: expose camera as content in mobile endpoints](https://github.com/bigbluebutton/bigbluebutton/commit/38965d100c283f72c5840fe7c8ac6b80d5060883) 
  * It's actively blocked in code, but I think that's an oversight -
probably leftover from an initial iteration of the feature.
It should be useful in mobile endpoints and it's also supposed to work
seamlessly due to how the feature is implemented.
  * Lift the mobile block and expose "camera as content" in the presenter's
actions dropdown.

### Closes Issue(s)

Closes #18640 