### PR TITLE
graphql-server: Allow user_camera_aggregate

### DIFF
--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_camera.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_camera.yaml
@@ -25,3 +25,4 @@ select_permissions:
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId
+      allow_aggregations: true


### PR DESCRIPTION
Allow to query aggregate functions on `user_camera`.