### PR TITLE
fix: Mouse Wheel Zoom Disrupting Slide Position

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -463,6 +463,20 @@ export default function Whiteboard(props) {
       const newZoom = calculateZoom(slidePosition.viewBoxWidth, slidePosition.viewBoxHeight);
       tldrawAPI?.setCamera([slidePosition.x, slidePosition.y], newZoom, 'zoomed');
     }
+
+    const camera = tldrawAPI?.getPageState()?.camera;
+    if (isPresenter && slidePosition && camera) {
+      const zoomFitSlide = calculateZoom(slidePosition.width, slidePosition.height);
+      const zoomCamera = (zoomFitSlide * zoomValue) / HUNDRED_PERCENT;
+      let zoomToolbar = Math.round(
+        ((HUNDRED_PERCENT * camera.zoom) / zoomFitSlide) * 100,
+      ) / 100;
+
+      if (zoom !== zoomToolbar) {
+        setZoom(zoomToolbar);
+        zoomChanger(zoomToolbar);
+      }
+    }
   }, [curPageId, slidePosition]);
 
   // update zoom according to toolbar

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -98,6 +98,7 @@ export default function Whiteboard(props) {
   const prevSlidePosition = usePrevious(slidePosition);
   const prevFitToWidth = usePrevious(fitToWidth);
   const prevSvgUri = usePrevious(svgUri);
+  const prevPageId = usePrevious(curPageId);
   const language = mapLanguage(Settings?.application?.locale?.toLowerCase() || 'en');
   const [currentTool, setCurrentTool] = React.useState(null);
   const [currentStyle, setCurrentStyle] = React.useState({});
@@ -471,8 +472,7 @@ export default function Whiteboard(props) {
       let zoomToolbar = Math.round(
         ((HUNDRED_PERCENT * camera.zoom) / zoomFitSlide) * 100,
       ) / 100;
-
-      if (zoom !== zoomToolbar) {
+      if ((zoom !== zoomToolbar) && (curPageId && curPageId !== prevPageId)) {
         setZoom(zoomToolbar);
         zoomChanger(zoomToolbar);
       }


### PR DESCRIPTION
### What does this PR do?
This PR addresses two issues related to slide zoom functionality:

- It prevents the slide position from breaking when using mouse wheel zoom.
- It ensures the zoom value displayed on the presentation toolbar updates correctly when switching between slides.

### Closes Issue(s)
Closes #18645 
