### PR TITLE
fix (accessibility): Improve Keyboard Functionality With Tldraw Style Menu

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -597,6 +597,11 @@ export default function Whiteboard(props) {
           tldrawAPI?.selectAll();
         }
         break;
+      case KEY_CODES.ARROW_DOWN:
+      case KEY_CODES.ARROW_UP:
+        event.preventDefault();
+        event.stopPropagation();
+        break;
       default:
     }
   };


### PR DESCRIPTION
### What does this PR do?
This PR enhances the keyboard functionality within the tldraw style menu. Users can now navigate items using just the arrow keys, eliminating the need to hold down the tab key in combination with the arrow keys.

### Motivation
The existing setup did not provide a straightforward way for users to access style options via the keyboard. Previously, after activating the style menu using the spacebar, users had to hold down the 'tab' key and use the 'up' or 'down' arrow keys to navigate the list. This change offers a more intuitive user experience.