### PR TITLE
graphql-server: Add readOnlyId prop to sharedNotes

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadCreatedEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadCreatedEvtMsgHdlr.scala
@@ -24,7 +24,7 @@ trait PadCreatedEvtMsgHdlr {
 
     Pads.getGroupById(liveMeeting.pads, msg.body.groupId) match {
       case Some(group) => {
-        SharedNotesDAO.insert(liveMeeting.props.meetingProp.intId, group, msg.body.padId, msg.body.name)
+        SharedNotesDAO.insert(liveMeeting.props.meetingProp.intId, group, msg.body.padId, msg.body.name, msg.body.readOnlyId)
         broadcastEvent(group.externalId, group.userId, msg.body.padId, msg.body.name)
       }
       case _ =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/SharedNotesDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/SharedNotesDAO.scala
@@ -9,6 +9,7 @@ case class SharedNotesDbModel(
     meetingId:        String,
     sharedNotesExtId: String,
     padId:            String,
+    readOnlyId:       String,
     model:            String,
     name:             String,
     pinned:           Boolean
@@ -18,22 +19,24 @@ class SharedNotesDbTableDef(tag: Tag) extends Table[SharedNotesDbModel](tag, Non
   val meetingId = column[String]("meetingId", O.PrimaryKey)
   val sharedNotesExtId = column[String]("sharedNotesExtId", O.PrimaryKey)
   val padId = column[String]("padId")
+  val readOnlyId = column[String]("readOnlyId")
   val model = column[String]("model")
   val name = column[String]("name")
   val pinned = column[Boolean]("pinned")
   val * = (
-    meetingId, sharedNotesExtId, padId, model, name, pinned
+    meetingId, sharedNotesExtId, padId, readOnlyId, model, name, pinned
   ) <> (SharedNotesDbModel.tupled, SharedNotesDbModel.unapply)
 }
 
 object SharedNotesDAO {
-  def insert(meetingId: String, group: PadGroup, padId: String, name: String) = {
+  def insert(meetingId: String, group: PadGroup, padId: String, name: String, readOnlyId: String) = {
     DatabaseConnection.db.run(
       TableQuery[SharedNotesDbTableDef].insertOrUpdate(
         SharedNotesDbModel(
           meetingId = meetingId,
           sharedNotesExtId = group.externalId,
           padId = padId,
+          readOnlyId = readOnlyId,
           model = group.model,
           name = name,
           pinned = false

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PadsMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PadsMsgs.scala
@@ -37,7 +37,7 @@ case class PadCreateCmdMsgBody(groupId: String, name: String)
 // pads -> apps
 object PadCreatedEvtMsg { val NAME = "PadCreatedEvtMsg" }
 case class PadCreatedEvtMsg(header: BbbCoreHeaderWithMeetingId, body: PadCreatedEvtMsgBody) extends PadStandardMsg
-case class PadCreatedEvtMsgBody(groupId: String, padId: String, name: String)
+case class PadCreatedEvtMsgBody(groupId: String, padId: String, name: String, readOnlyId: String)
 
 // apps -> client
 object PadCreatedRespMsg { val NAME = "PadCreatedRespMsg" }

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1288,6 +1288,7 @@ create table "sharedNotes" (
     "meetingId" varchar(100) references "meeting"("meetingId") ON DELETE CASCADE,
     "sharedNotesExtId" varchar(25),
     "padId" varchar(25),
+    "readOnlyId" varchar(50),
     "model" varchar(25),
     "name" varchar(25),
     "pinned" boolean,
@@ -1324,9 +1325,10 @@ LEFT JOIN "sharedNotes_rev" snr ON snr."meetingId" = sn."meetingId" AND snr."sha
 GROUP BY sn."meetingId", sn."sharedNotesExtId";
 
 create view "v_sharedNotes_session" as
-SELECT sns.*, sn."padId"
-FROM "sharedNotes_session" sns
-JOIN "sharedNotes" sn ON sn."meetingId" = sns."meetingId" AND sn."sharedNotesExtId" = sn."sharedNotesExtId";
+SELECT u."userId", u."meetingId", sn."sharedNotesExtId", sns."sessionId", sn."padId", sn."readOnlyId"
+FROM "user" u
+JOIN "sharedNotes" sn ON sn."meetingId" = u."meetingId"
+LEFT JOIN "sharedNotes_session" sns on sns."meetingId" = sn."meetingId" and sns."sharedNotesExtId" = sn."sharedNotesExtId";
 
 ----------------------
 

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_sharedNotes.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_sharedNotes.yaml
@@ -15,6 +15,7 @@ select_permissions:
         - name
         - padId
         - pinned
+        - readOnlyId
         - sharedNotesExtId
       filter:
         meetingId:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_sharedNotes_session.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_sharedNotes_session.yaml
@@ -22,6 +22,7 @@ select_permissions:
     permission:
       columns:
         - padId
+        - readOnlyId
         - sessionId
         - sharedNotesExtId
       filter:


### PR DESCRIPTION
BBB used to employ Etherpad's read-only view for users who didn't have writing privileges. This functionality was modified by  https://github.com/bigbluebutton/bigbluebutton/pull/13916.

After some tests, I found that `bbb-pads` automatically invalidates a user's session once they lose writing rights. As a result, even if the user tries to restore their previous session, they will no longer have the ability to modify the note.

For the upcoming BBB 2.8 release, I plan to conduct tests utilizing Etherpad's read-only mode. This is because the read-only mode offers a significantly improved user experience.

This particular PR handle the `PadCreatedEvtMsg` message which will begin to bring `readOnlyID`, store it in the database and provide through Graphql.

Depends on: https://github.com/bigbluebutton/bbb-pads/pull/34 (and then tweak https://github.com/bigbluebutton/bigbluebutton/blob/develop/bbb-pads.placeholder.sh)