### PR TITLE
feat(code-review): Add Shell Script for Checking Out Pull Requests

### DIFF
--- a/scripts/code-review/checkout-to-pr.sh
+++ b/scripts/code-review/checkout-to-pr.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+set -x
+
+# Check if `jq` is available
+if ! command -v jq &> /dev/null; then
+    echo "Error: 'jq' is not installed. Please install 'jq' before using this script."
+    exit 1
+fi
+
+# Check if both the PR number is provided
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <PR_NUMBER>"
+    exit 1
+fi
+
+PR_NUMBER=$1
+REPO_URL="https://github.com/bigbluebutton/bigbluebutton.git"
+
+# Get the PR branch name
+PR_BRANCH=$(curl -s https://api.github.com/repos/bigbluebutton/bigbluebutton/pulls/${PR_NUMBER} | jq -r '.head.ref')
+
+# Get the sender's username
+SENDER_USERNAME=$(curl -s https://api.github.com/repos/bigbluebutton/bigbluebutton/pulls/${PR_NUMBER} | jq -r '.head.repo.owner.login')
+
+# Configure the sender's fork as a remote with a name based on the sender's username
+REMOTE_NAME="upstream_${SENDER_USERNAME}"
+if git remote | grep -q "^$REMOTE_NAME$"; then
+  git remote remove $REMOTE_NAME
+fi
+
+git remote add ${REMOTE_NAME} git@github.com:${SENDER_USERNAME}/bigbluebutton.git
+
+# Fetch the PR branch and create a local branch to track it
+LOCAL_BRANCH="PR_${PR_NUMBER}"
+git fetch ${REMOTE_NAME} ${PR_BRANCH}
+if git branch --list ${LOCAL_BRANCH} | grep ${LOCAL_BRANCH}; then
+  git checkout develop
+  git branch -D ${LOCAL_BRANCH}
+fi
+git checkout -b ${LOCAL_BRANCH} ${REMOTE_NAME}/${PR_BRANCH}
+
+echo "Created and checked out local branch '${LOCAL_BRANCH}'"
+echo "Configured '${SENDER_USERNAME}' fork as '${REMOTE_NAME}'"
+echo "Tracking '${PR_BRANCH}' from '${REMOTE_NAME}'"
+


### PR DESCRIPTION
This pull request introduces a new shell script, `checkout-to-pr.sh`, designed to streamline the process of checking out pull requests in the BigBlueButton repository. The script falls under the code-review category of features, aiming to enhance our code review workflow. By automating the steps involved in fetching and setting up the necessary branches, this script contributes to a more efficient review process.

Here's a breakdown of what the script accomplishes:

1. **Dependency Check**: The script starts by checking if the command-line tool `jq` is installed. If not, an error message is displayed, guiding users to install `jq` before proceeding.

2. **Usage Instructions**: The script ensures that the correct number of arguments is provided. It expects a single argument: the pull request number. If the argument count is incorrect, usage instructions are displayed.

3. **Fetch PR Information**: The script utilizes GitHub's API to retrieve information about the specified pull request, including the branch name of the PR and the username of the sender.

4. **Configure Remote**: It configures a remote named based on the sender's username, linking it to the sender's fork of the BigBlueButton repository. If the remote already exists, it is removed before being reconfigured.

5. **Fetch and Track Branch**: The script fetches the PR branch from the sender's fork and creates a local branch based on the PR number. If the local branch already exists, it switches to the develop branch.

By following semantic versioning principles and categorizing this pull request under code-review, we aim to maintain clarity and consistency in our development process. Your valuable feedback on the script and its functionality is greatly appreciated.




