### PR TITLE
graphql-server: Upgrade Hasura to version 2.32.1 and change hasura-cli path

### DIFF
--- a/bbb-graphql-server/install-hasura.sh
+++ b/bbb-graphql-server/install-hasura.sh
@@ -39,7 +39,7 @@ systemctl restart nginx
 #chmod +x /usr/local/bin/hasura-graphql-engine
 
 #Hasura 2.29+ requires Ubuntu 22
-git clone --branch v2.28.2 https://github.com/iMDT/hasura-graphql-engine.git
+git clone --branch v2.32.1 https://github.com/iMDT/hasura-graphql-engine.git
 cat hasura-graphql-engine/hasura-graphql.part-a* > hasura-graphql
 rm -rf hasura-graphql-engine/
 chmod +x hasura-graphql
@@ -58,7 +58,7 @@ systemctl start bbb-graphql-server
 curl -L https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh | bash
 
 # Apply BBB metadata in Hasura
-/usr/local/bin/hasura metadata apply
+hasura metadata apply
 
 echo ""
 echo ""

--- a/build/packages-template/bbb-graphql-server/after-install.sh
+++ b/build/packages-template/bbb-graphql-server/after-install.sh
@@ -30,7 +30,7 @@ case "$1" in
 
     # Apply BBB metadata in Hasura
     cd /usr/share/bbb-graphql-server
-    /usr/local/bin/hasura/hasura metadata apply
+    /usr/local/bin/hasura metadata apply
     cd ..
     rm -rf /usr/share/bbb-graphql-server/metadata
   fi

--- a/build/packages-template/bbb-graphql-server/after-remove.sh
+++ b/build/packages-template/bbb-graphql-server/after-remove.sh
@@ -5,7 +5,7 @@ case "$1" in
 
    ;;
    purge)
-     rm -rf /usr/local/bin/hasura
+     rm  /usr/local/bin/hasura
      rm -rf /usr/local/bin/hasura-graphql-engine
      rm -rf /usr/share/bbb-graphql-server
    ;;

--- a/build/packages-template/bbb-graphql-server/build.sh
+++ b/build/packages-template/bbb-graphql-server/build.sh
@@ -17,12 +17,12 @@ rm -rf staging
 # package
 
 # Create directories for fpm to process
-DIRS="/usr/local/bin /etc/default /usr/share/bbb-graphql-server /lib/systemd/system /usr/local/bin/hasura"
+DIRS="/usr/local/bin /etc/default /usr/share/bbb-graphql-server /lib/systemd/system"
 for dir in $DIRS; do
   mkdir -p staging$dir
 done
 
-git clone --branch v2.28.1 https://github.com/iMDT/hasura-graphql-engine.git
+git clone --branch v2.32.1 https://github.com/iMDT/hasura-graphql-engine.git
 cat hasura-graphql-engine/hasura-graphql.part-a* > hasura-graphql
 rm -rf hasura-graphql-engine/
 chmod +x hasura-graphql
@@ -36,7 +36,7 @@ cp ./bbb-graphql-server.service staging/lib/systemd/system/bbb-graphql-server.se
 mkdir -p hasura-cli
 cd hasura-cli
 npm install --save-dev hasura-cli
-cp -r node_modules/hasura-cli/* ../staging/usr/local/bin/hasura
+cp node_modules/hasura-cli/hasura ../staging/usr/local/bin/hasura
 cd ..
 rm -rf hasura-cli
 


### PR DESCRIPTION
- Upgrade Hasura version to 2.32.1 (we were stuck on 2.29+ because newer versions requires Ubuntu 22)
- Test copying only hasura-cli binary instead of the whole `node_modules/hasura-cli/`  dir