### PR TITLE
build(bbb-webrtc-sfu): v2.12.0-beta.1, build(bbb-webrtc-recorder): v0.5.1

### DIFF
--- a/bbb-webrtc-recorder.placeholder.sh
+++ b/bbb-webrtc-recorder.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v0.4.1 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-recorder bbb-webrtc-recorder
+git clone --branch v0.5.1 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-recorder bbb-webrtc-recorder

--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.11.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.12.0-beta.1 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?


- [build(bbb-webrtc-sfu): v2.12.0-beta.1](https://github.com/bigbluebutton/bigbluebutton/pull/18669/commits/8dbe6ae8fc1115f2ae43fa92693aa570b19c666b) 
  * feat: add recordingFallbackOnFailure option
  * feat: improve recording retry and recovery, add carbon copies
  * feat(recorder): add keep-alive and handle crashes/shutdowns
  * feat: new metrics
    - sfu_video_recorder_status
    - sfu_video_recorder_restarts_total
    - sfu_video_recording_errors_total
    - sfu_screenshare_recorder_status
    - sfu_screenshare_recorder_restarts_total
    - sfu_screenshare_recording_errors_total
  * fix(video): log start failures in VideoManager
  * fix(mediasoup): propagate conference-media-specs to router settings
  * build(mediasoup): 3.12.10
- [build(bbb-webrtc-recorder): v0.5.1](https://github.com/bigbluebutton/bigbluebutton/pull/18669/commits/b65ffa964300b5a61723cb329371978d783126f3) 
  * https://github.com/bigbluebutton/bbb-webrtc-recorder/blob/v0.5.1/CHANGELOG.md
  
### Closes Issue(s)

n/a, ref #13999 
