### PR TITLE
fix: 2.8 warnings

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -5,6 +5,7 @@ import BBBMenu from '/imports/ui/components/common/menu/component';
 import UserReactionService from '/imports/ui/components/user-reaction/service';
 import UserListService from '/imports/ui/components/user-list/service';
 import { Emoji } from 'emoji-mart';
+import { convertRemToPixels } from '/imports/utils/dom-utils';
 
 import Styled from './styles';
 
@@ -74,7 +75,7 @@ const ReactionsButton = (props) => {
 
   const emojiProps = {
     native: true,
-    size: '1.5rem',
+    size: convertRemToPixels(1.5),
     padding: '4px',
   };
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/component.tsx
@@ -173,7 +173,7 @@ export const ChatActions: React.FC = () => {
         keepMounted: true,
         transitionDuration: 0,
         elevation: 3,
-        getContentAnchorEl: null,
+        getcontentanchorel: null,
         fullwidth: 'true',
         anchorOrigin: { vertical: 'bottom', horizontal: isRTL ? 'right' : 'left' },
         transformOrigin: { vertical: 'top', horizontal: isRTL ? 'right' : 'left' },

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-popup/popup-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-popup/popup-content/component.tsx
@@ -1,11 +1,21 @@
 import React from 'react';
 import { PopupContentBox, PopupContentHeader, PopupContentBody, CloseButton } from './styles';
+import { defineMessages, useIntl } from "react-intl";
+
 interface PopupContentProps {
   message: string;
   closePopup?: () => void;
 }
 
+const intlMessages = defineMessages({
+  closePopup: {
+    id: 'app.chat.closePopup',
+    description: 'close popup button label'
+  },
+});
+
 const PopupContent: React.FC<PopupContentProps> = ({ message, closePopup }) => {
+  const intl = useIntl();
   const [showPopup, setShowPopup] = React.useState(true);
   if (!showPopup) return null;
   return (
@@ -13,6 +23,8 @@ const PopupContent: React.FC<PopupContentProps> = ({ message, closePopup }) => {
       <PopupContentHeader>
         <CloseButton
           size="sm"
+          label={intl.formatMessage(intlMessages.closePopup)}
+          hideLabel
           icon="close"
           onClick={() => {
             setShowPopup(false);

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/chat-list-item/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/chat-list-item/styles.ts
@@ -159,6 +159,7 @@ const ChatListItem = styled.button`
   border-bottom-right-radius: 0;
   cursor: pointer;
   border-color: transparent;
+  border-width: 0;
 
   [dir="rtl"] & {
     border-top-left-radius: 0;

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -35,6 +35,7 @@
     "app.chat.two.typing": "{0} and {1} are typing",
     "app.chat.copySuccess": "Copied chat transcript",
     "app.chat.copyErr": "Copy chat transcript failed",
+    "app.chat.closePopup": "Close",
     "app.emojiPicker.search": "Search",
     "app.emojiPicker.notFound": "No Emoji Found",
     "app.emojiPicker.skintext": "Choose your default skin tone",


### PR DESCRIPTION
### What does this PR do?

Fixes the following issues and warnings:

- adjusts chat list item border

- add close button label in welcome message popup
![label-prop](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/45350ae4-0965-48b8-bd7f-addb3c664a08)

- fix getcontentanchorel typo
![anchorel](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/ff099b67-1fc9-434e-9366-f9cf8635c3c4)

- fix `size` prop type in emoji component
![size](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/37f401cc-6a83-42fb-9758-4d375a779dfc)
