### PR TITLE
refactor (graphql-server): General improvements related to Graphql

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -13,7 +13,7 @@ import org.bigbluebutton.SystemConfiguration
 
 import java.util.concurrent.TimeUnit
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.db.{ MeetingDAO, UserDAO }
+import org.bigbluebutton.core.db.{ DatabaseConnection, MeetingDAO }
 import org.bigbluebutton.core.running.RunningMeeting
 import org.bigbluebutton.core.util.ColorPicker
 import org.bigbluebutton.core2.RunningMeetings
@@ -56,6 +56,7 @@ class BigBlueButtonActor(
 
   override def preStart() {
     bbbMsgBus.subscribe(self, meetingManagerChannel)
+    DatabaseConnection.initialize()
   }
 
   override def postStop() {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
@@ -9,4 +9,13 @@ object DatabaseConnection {
   val db = Database.forConfig("postgres")
   //  implicit val session: Session = db.createSession()
   val logger = LoggerFactory.getLogger(this.getClass)
+
+  def initialize(): Unit = {
+    db.run(sql"SELECT current_timestamp".as[java.sql.Timestamp]).map { timestamp =>
+      logger.debug(s"Database initialized, current timestamp is: $timestamp")
+    }.recover {
+      case ex: Exception =>
+        logger.error(s"Failed to initialize database: ${ex.getMessage}")
+    }
+  }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPageCursorDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPageCursorDAO.scala
@@ -40,7 +40,7 @@ object PresPageCursorDAO {
         )
       )
     )).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on pres_page_cursor table!")
+      case Success(rowsAffected) => // DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on pres_page_cursor table!")
       case Failure(e) => DatabaseConnection.logger.error(s"Error inserting pres_page_cursor: $e")
     }
   }

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -245,7 +245,6 @@ CREATE TABLE "user" (
 CREATE INDEX "idx_user_meetingId" ON "user"("meetingId");
 CREATE INDEX "idx_user_extId" ON "user"("meetingId", "extId");
 
-
 --hasDrawPermissionOnCurrentPage is necessary to improve the performance of the order by of userlist
 COMMENT ON COLUMN "user"."hasDrawPermissionOnCurrentPage" IS 'This column is dynamically populated by triggers of tables: user, pres_presentation, pres_page, pres_page_writers';
 COMMENT ON COLUMN "user"."disconnected" IS 'This column is set true when the user closes the window or his with the server is over';
@@ -788,7 +787,7 @@ SELECT 	"user"."userId",
 		cu."visible",
 		chat_with."userId" AS "participantId",
 		count(DISTINCT cm."messageId") "totalMessages",
-		sum(CASE WHEN cm."senderId" != "user"."userId" and cm."createdTime" > coalesce(cu."lastSeenAt",0) THEN 1 ELSE 0 end) "totalUnread",
+		sum(CASE WHEN cm."senderId" != "user"."userId" and cm."createdTime" > coalesce(NULLIF(cu."lastSeenAt",0),"user"."registeredOn") THEN 1 ELSE 0 end) "totalUnread",
 		cu."lastSeenAt",
 		CASE WHEN chat."access" = 'PUBLIC_ACCESS' THEN true ELSE false end public
 FROM "user"

--- a/bbb-graphql-server/update_graphql_data.sh
+++ b/bbb-graphql-server/update_graphql_data.sh
@@ -27,6 +27,7 @@ sudo -u postgres psql -U postgres -d bbb_graphql -a -f bbb_schema.sql --set ON_E
 if [ "$hasura_status" = "active" ]; then
   echo "Starting Hasura"
   sudo systemctl start bbb-graphql-server
+  sleep 2
 fi
 if [ "$akka_apps_status" = "active" ]; then
   echo "Starting Akka-apps"


### PR DESCRIPTION
- Count as unread message only messages sent after `user.registeredOn` time
- Remove log when inserting `pres_page_cursor`, it was flooding akka-apps logs
- Initialize Postgres connection right away when Akka-apps starts (the first meeting was taking longer to initialize because there were no connections ready)
- Add a delay 2 seconds to run `hasura metadata apply` (to prevent errors where the service didn't initialize)