### PR TITLE
fix: 2.8 warnings and missing styles

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -236,7 +236,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
   const pagesToLoad = (totalPages - firstPageToLoad) || 1;
   return (
     [
-      <MessageListWrapper>
+      <MessageListWrapper key="message-list-wrapper">
         <MessageList
           ref={messageListRef}
           onWheel={(e) => {

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
@@ -23,6 +23,7 @@ import ConfirmationModal from '/imports/ui/components/common/modal/confirmation/
 
 import BBBMenu from '/imports/ui/components/common/menu/component';
 import { setPendingChat } from '/imports/ui/core/local-states/usePendingChat';
+import Styled from './styles';
 
 interface UserActionsProps {
   user: User;
@@ -375,7 +376,7 @@ const UserActions: React.FC<UserActionsProps> = ({
     <BBBMenu
       trigger={
         (
-          <div
+          <Styled.UserActionsTrigger
             isActionsOpen={selected}
             selected={selected === true}
             tabIndex={-1}
@@ -388,7 +389,7 @@ const UserActions: React.FC<UserActionsProps> = ({
             role="button"
           >
             {children}
-          </div>
+          </Styled.UserActionsTrigger>
         )
       }
       actions={actions}

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/styles.ts
@@ -1,0 +1,51 @@
+import styled from 'styled-components';
+
+import {
+  smPaddingY,
+  borderSize,
+} from '/imports/ui/stylesheets/styled-components/general';
+import {
+  listItemBgHover,
+  itemFocusBorder,
+} from '/imports/ui/stylesheets/styled-components/palette';
+
+interface UserActionsTriggerProps {
+  selected: boolean;
+  isActionsOpen: boolean;
+}
+
+const UserActionsTrigger = styled.div<UserActionsTriggerProps>`
+    & > div {
+        border: none;
+        padding: 0.6rem;
+
+        ${({ selected }) => selected && `
+        background-color: ${listItemBgHover};
+        border-top-left-radius: ${smPaddingY};
+        border-bottom-left-radius: ${smPaddingY};
+    
+        &:focus {
+          box-shadow: inset 0 0 0 ${borderSize} ${itemFocusBorder}, inset 1px 0 0 1px ${itemFocusBorder};
+        }
+      `}
+      
+      ${({ isActionsOpen }) => isActionsOpen && `
+      outline: transparent;
+      outline-width: ${borderSize};
+      outline-style: solid;
+      background-color: ${listItemBgHover};
+      box-shadow: inset 0 0 0 ${borderSize} ${itemFocusBorder}, inset 1px 0 0 1px ${itemFocusBorder};
+      border-top-left-radius: ${smPaddingY};
+      border-bottom-left-radius: ${smPaddingY};
+  
+      &:focus {
+        outline-style: solid;
+        outline-color: transparent !important;
+      }
+    `}
+    }
+`;
+
+export default {
+  UserActionsTrigger,
+}


### PR DESCRIPTION
### What does this PR do?

A follow up to #18675, this PR:
- adds missing `key` to message list wrapper

![2023-08-31_11-33_1](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/cb750c51-ccbd-4274-9db8-9f4b8b8f274c)

- restores active styles in userlist actions button

before:
![2023-08-31_11-33](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/b76dc371-a942-46f5-9e3a-b3b6806d65e5)

after:
![2023-08-31_11-32](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/cf87bc71-affa-4314-b28c-811fd4682336)
