### PR TITLE
fix (akka-apps): None.get error on change user Emoji

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserEmojiCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserEmojiCmdMsgHdlr.scala
@@ -29,32 +29,36 @@ trait ChangeUserEmojiCmdMsgHdlr extends RightsManagementTrait {
       msg.header.userId
     )
 
-    val initialEmojiState = Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId).get.emoji
-    val nextEmojiState = msg.body.emoji
+    for {
+      user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
+    } yield {
+      val initialEmojiState = user.emoji
+      val nextEmojiState = msg.body.emoji
 
-    if (isUserSettingOwnEmoji
-      || isUserModerator && nextEmojiState.equals("none")
-      || isUserPresenter && initialEmojiState.equals("raiseHand") && nextEmojiState.equals("none")) {
-      for {
-        uvo <- Users2x.setEmojiStatus(liveMeeting.users2x, msg.body.userId, msg.body.emoji)
-      } yield {
-        outGW.send(MsgBuilder.buildUserEmojiChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.userId, msg.body.emoji))
+      if (isUserSettingOwnEmoji
+        || isUserModerator && nextEmojiState.equals("none")
+        || isUserPresenter && initialEmojiState.equals("raiseHand") && nextEmojiState.equals("none")) {
+        for {
+          uvo <- Users2x.setEmojiStatus(liveMeeting.users2x, msg.body.userId, msg.body.emoji)
+        } yield {
+          outGW.send(MsgBuilder.buildUserEmojiChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.userId, msg.body.emoji))
 
-        if (initialEmojiState == "raiseHand" || nextEmojiState == "raiseHand") {
-          Users2x.setUserRaiseHand(liveMeeting.users2x, msg.body.userId, msg.body.emoji == "raiseHand")
-          outGW.send(MsgBuilder.buildUserRaiseHandChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.userId, msg.body.emoji == "raiseHand"))
+          if (initialEmojiState == "raiseHand" || nextEmojiState == "raiseHand") {
+            Users2x.setUserRaiseHand(liveMeeting.users2x, msg.body.userId, msg.body.emoji == "raiseHand")
+            outGW.send(MsgBuilder.buildUserRaiseHandChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.userId, msg.body.emoji == "raiseHand"))
+          }
+
+          if (initialEmojiState == "away" || nextEmojiState == "away") {
+            Users2x.setUserAway(liveMeeting.users2x, msg.body.userId, msg.body.emoji == "away")
+            outGW.send(MsgBuilder.buildUserAwayChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.userId, msg.body.emoji == "away"))
+          }
+
         }
-
-        if (initialEmojiState == "away" || nextEmojiState == "away") {
-          Users2x.setUserAway(liveMeeting.users2x, msg.body.userId, msg.body.emoji == "away")
-          outGW.send(MsgBuilder.buildUserAwayChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.userId, msg.body.emoji == "away"))
-        }
-
+      } else {
+        val meetingId = liveMeeting.props.meetingProp.intId
+        val reason = "No permission to clear change user emoji status."
+        PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)
       }
-    } else {
-      val meetingId = liveMeeting.props.meetingProp.intId
-      val reason = "No permission to clear change user emoji status."
-      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)
     }
   }
 


### PR DESCRIPTION
Closes #18574 

I was not able to reproduce the problem.
Considering that "We haven't had any reports from users about problems with the emoji selector".
I just improved the code to avoid running the function when the user is not found.
It will prevent from getting this error again.