### PR TITLE
!build: require node 18 to install bbb packages

### DIFF
--- a/build/packages-template/bbb-etherpad/build.sh
+++ b/build/packages-template/bbb-etherpad/build.sh
@@ -80,5 +80,6 @@ fpm -s dir -C ./staging -n $PACKAGE \
     --after-remove after-remove.sh \
     --description "The EtherPad Lite components for BigBlueButton" \
     $DIRECTORIES \
-    $OPTS
+    $OPTS \
+    -d 'nodejs (>= 18)' -d 'yq (<< 20)'
 

--- a/build/packages-template/bbb-export-annotations/build.sh
+++ b/build/packages-template/bbb-export-annotations/build.sh
@@ -43,5 +43,6 @@ fpm -s dir -C ./staging -n $PACKAGE \
     --before-remove before-remove.sh \
     --description "BigBlueButton Export Annotations" \
     $DIRECTORIES \
-    $OPTS
+    $OPTS \
+    -d 'nodejs (>= 18)' -d 'yq (<< 20)'
 

--- a/build/packages-template/bbb-pads/build.sh
+++ b/build/packages-template/bbb-pads/build.sh
@@ -38,5 +38,6 @@ fpm -s dir -C ./staging -n $PACKAGE \
     --before-remove before-remove.sh \
     --description "BigBlueButton Pads" \
     $DIRECTORIES \
-    $OPTS
+    $OPTS \
+    -d 'nodejs (>= 18)' -d 'yq (<< 20)'
 

--- a/build/packages-template/bbb-webhooks/build.sh
+++ b/build/packages-template/bbb-webhooks/build.sh
@@ -46,4 +46,5 @@ fpm -s dir -C ./staging -n $PACKAGE                 \
     --description "BigBlueButton Webhooks"          \
     $DIRECTORIES                                    \
     $OPTS                                           \
-    -d 'yq (>= 3)' -d 'yq (<< 4)'
+    -d 'yq (>= 3)' -d 'yq (<< 4)' \
+    -d 'nodejs (>= 18)' -d 'yq (<< 20)'

--- a/build/packages-template/bbb-webrtc-sfu/build.sh
+++ b/build/packages-template/bbb-webrtc-sfu/build.sh
@@ -64,4 +64,5 @@ fpm -s dir -C ./staging -n $PACKAGE                 \
     --description "BigBlueButton WebRTC SFU"        \
     $DIRECTORIES                                    \
     $OPTS                                           \
-    -d 'yq (>= 3)' -d 'yq (<< 4)'
+    -d 'yq (>= 3)' -d 'yq (<< 4)' \
+    -d 'nodejs (>= 18)' -d 'yq (<< 20)'


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none
Related #18680 


### Motivation
Without this step existing BigBlueButton 2.6 servers will upgrade to 2.6.14 fine but the system NodeJS installed and used for our packages will remain v16.

With this change, the following message will be displayed and will block the install 

```
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 bbb-export-annotations : Depends: nodejs (>= 18)
E: Unable to correct problems, you have held broken packages.
```


<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
