### PR TITLE
build: fix nodejs version paste error in #18686

### DIFF
--- a/build/packages-template/bbb-etherpad/build.sh
+++ b/build/packages-template/bbb-etherpad/build.sh
@@ -81,5 +81,5 @@ fpm -s dir -C ./staging -n $PACKAGE \
     --description "The EtherPad Lite components for BigBlueButton" \
     $DIRECTORIES \
     $OPTS \
-    -d 'nodejs (>= 18)' -d 'yq (<< 20)'
+    -d 'nodejs (>= 18)' -d 'nodejs (<< 20)'
 

--- a/build/packages-template/bbb-export-annotations/build.sh
+++ b/build/packages-template/bbb-export-annotations/build.sh
@@ -44,5 +44,5 @@ fpm -s dir -C ./staging -n $PACKAGE \
     --description "BigBlueButton Export Annotations" \
     $DIRECTORIES \
     $OPTS \
-    -d 'nodejs (>= 18)' -d 'yq (<< 20)'
+    -d 'nodejs (>= 18)' -d 'nodejs (<< 20)'
 

--- a/build/packages-template/bbb-pads/build.sh
+++ b/build/packages-template/bbb-pads/build.sh
@@ -39,5 +39,5 @@ fpm -s dir -C ./staging -n $PACKAGE \
     --description "BigBlueButton Pads" \
     $DIRECTORIES \
     $OPTS \
-    -d 'nodejs (>= 18)' -d 'yq (<< 20)'
+    -d 'nodejs (>= 18)' -d 'nodejs (<< 20)'
 

--- a/build/packages-template/bbb-webhooks/build.sh
+++ b/build/packages-template/bbb-webhooks/build.sh
@@ -47,4 +47,4 @@ fpm -s dir -C ./staging -n $PACKAGE                 \
     $DIRECTORIES                                    \
     $OPTS                                           \
     -d 'yq (>= 3)' -d 'yq (<< 4)' \
-    -d 'nodejs (>= 18)' -d 'yq (<< 20)'
+    -d 'nodejs (>= 18)' -d 'nodejs (<< 20)'

--- a/build/packages-template/bbb-webrtc-sfu/build.sh
+++ b/build/packages-template/bbb-webrtc-sfu/build.sh
@@ -65,4 +65,4 @@ fpm -s dir -C ./staging -n $PACKAGE                 \
     $DIRECTORIES                                    \
     $OPTS                                           \
     -d 'yq (>= 3)' -d 'yq (<< 4)' \
-    -d 'nodejs (>= 18)' -d 'yq (<< 20)'
+    -d 'nodejs (>= 18)' -d 'nodejs (<< 20)'


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Fixes a copy-paste error -- correcting the upper boundary for accepted `nodejs` version in packages. Thanks @schrd for spotting and reporting this!
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none
Related to #18686 


### Motivation

<!-- What inspired you to submit this pull request? -->

