### PR TITLE
Fix parameter check on checkout-to-pr script

### DIFF
--- a/scripts/code-review/checkout-to-pr.sh
+++ b/scripts/code-review/checkout-to-pr.sh
@@ -10,7 +10,7 @@ if ! command -v jq &> /dev/null; then
 fi
 
 # Check if both the PR number is provided
-if [ ! $# -gt 0 ]; then
+if [  $# -le 0 ]; then
     echo "Usage: $0 <PR_NUMBER>"
     exit 1
 fi

--- a/scripts/code-review/checkout-to-pr.sh
+++ b/scripts/code-review/checkout-to-pr.sh
@@ -10,7 +10,7 @@ if ! command -v jq &> /dev/null; then
 fi
 
 # Check if both the PR number is provided
-if [ ! $# > 0 ]; then
+if [ ! $# -gt 0 ]; then
     echo "Usage: $0 <PR_NUMBER>"
     exit 1
 fi


### PR DESCRIPTION
Fixes the `./scripts/code-review/checkout-to-pr.sh` parameter count check, that was using `! > 0`.

Now it uses the syntax `-le` that correctly applies the check and also have better readability.


