### PR TITLE
fix: Raised hand button incorrect state

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -123,9 +123,18 @@ const ReactionsButton = (props) => {
     customStyles: {...actionCustomStyles, width: 'auto'},
   });
 
-  const icon = currentUserReaction === 'none' ? 'hand' : null;
+  const icon = !raiseHand && currentUserReaction === 'none' ? 'hand' : null;
   const currentUserReactionEmoji = reactions.find(({ native }) => native === currentUserReaction);
-  const customIcon = !icon ? <Emoji key={currentUserReactionEmoji?.id} emoji={{ id: currentUserReactionEmoji?.id }} {...emojiProps} /> : null;
+
+  let customIcon = null;
+
+  if (raiseHand) {
+    customIcon = <Emoji key="hand" emoji={{ id: 'hand' }} {...emojiProps} />;
+  } else {
+    if (!icon) {
+      customIcon = <Emoji key={currentUserReactionEmoji?.id} emoji={{ id: currentUserReactionEmoji?.id }} {...emojiProps} />;
+    }
+  }
 
   return (
     <BBBMenu


### PR DESCRIPTION
### What does this PR do?

Adjust reactions button icon and styles when raise hand is active.

![2023-09-04_15-30](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/c09db4a5-6f6b-43b7-91bf-9d638046d9ec)


### Closes Issue(s)
Closes #18696