### PR TITLE
refactor (graphql-server): Add field `joinURL` and `showInvitation` flag to breakoutRoom collection

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutRoomUsersUpdateMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutRoomUsersUpdateMsgHdlr.scala
@@ -2,7 +2,7 @@ package org.bigbluebutton.core.apps.breakout
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.api.BreakoutRoomUsersUpdateInternalMsg
-import org.bigbluebutton.core.db.UserBreakoutRoomDAO
+import org.bigbluebutton.core.db.{ BreakoutRoomUserDAO, UserBreakoutRoomDAO }
 import org.bigbluebutton.core.domain.{ BreakoutRoom2x, MeetingState2x }
 import org.bigbluebutton.core.models.{ RegisteredUsers, Users2x }
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
@@ -53,8 +53,8 @@ trait BreakoutRoomUsersUpdateMsgHdlr {
         breakoutRoomUser <- updatedRoom.users
         u <- RegisteredUsers.findWithBreakoutRoomId(breakoutRoomUser.id, liveMeeting.registeredUsers)
       } yield u.id
-
       UserBreakoutRoomDAO.updateLastBreakoutRoom(usersInRoom, updatedRoom)
+      BreakoutRoomUserDAO.updateUserJoined(usersInRoom, updatedRoom)
       model.update(updatedRoom)
     }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/ChangeUserBreakoutReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/ChangeUserBreakoutReqMsgHdlr.scala
@@ -29,7 +29,6 @@ trait ChangeUserBreakoutReqMsgHdlr extends RightsManagementTrait {
       for {
         breakoutModel <- state.breakout
       } yield {
-
         //Eject user from room From
         for {
           roomFrom <- breakoutModel.rooms.get(msg.body.fromBreakoutId)
@@ -58,7 +57,7 @@ trait ChangeUserBreakoutReqMsgHdlr extends RightsManagementTrait {
         )
 
         //Update database
-        BreakoutRoomUserDAO.updateRoomChanged(msg.body.userId, msg.body.fromBreakoutId, msg.body.toBreakoutId)
+        BreakoutRoomUserDAO.updateRoomChanged(msg.body.userId, msg.body.fromBreakoutId, msg.body.toBreakoutId, redirectToHtml5JoinURL)
 
 
         //Send notification to moved User

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -86,7 +86,7 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
     }
 
     val breakoutModel = new BreakoutModel(None, msg.body.durationInMinutes * 60, rooms, msg.body.sendInviteToModerators)
-    BreakoutRoomDAO.insert(breakoutModel)
+    BreakoutRoomDAO.insert(breakoutModel, liveMeeting)
     state.update(Some(breakoutModel))
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/RequestBreakoutJoinURLReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/RequestBreakoutJoinURLReqMsgHdlr.scala
@@ -4,7 +4,8 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
-import org.bigbluebutton.core.models.{ Users2x, Roles }
+import org.bigbluebutton.core.db.BreakoutRoomUserDAO
+import org.bigbluebutton.core.models.{ Roles, Users2x }
 
 trait RequestBreakoutJoinURLReqMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
@@ -23,6 +24,9 @@ trait RequestBreakoutJoinURLReqMsgHdlr extends RightsManagementTrait {
         requesterUser <- Users2x.findWithIntId(liveMeeting.users2x, msg.header.userId)
       } yield {
         if (requesterUser.role == Roles.MODERATOR_ROLE || room.freeJoin) {
+
+          BreakoutRoomUserDAO.insertBreakoutRoom(requesterUser.intId, room, liveMeeting)
+
           BreakoutHdlrHelpers.sendJoinURL(
             liveMeeting,
             outGW,

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_breakoutRoom.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_breakoutRoom.yaml
@@ -31,19 +31,25 @@ select_permissions:
       columns:
         - assignedAt
         - breakoutRoomId
-        - currentIsOnline
-        - currentJoined
-        - currentRegisteredOn
+        - currentRoomIsOnline
+        - currentRoomJoined
+        - currentRoomPriority
+        - currentRoomRegisteredAt
         - durationInSeconds
         - endedAt
         - freeJoin
+        - inviteDismissedAt
         - isDefaultName
+        - joinURL
+        - lastRoomIsOnline
+        - lastRoomJoinedAt
+        - lastRoomJoinedId
         - name
         - sendInvitationToModerators
         - sequence
         - shortName
+        - showInvitation
         - startedAt
-        - willEndAt
       filter:
         userId:
           _eq: X-Hasura-UserId

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_breakoutRoom_user.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_breakoutRoom_user.yaml
@@ -1,0 +1,31 @@
+table:
+  name: v_breakoutRoom_user
+  schema: public
+configuration:
+  column_config: {}
+  custom_column_names: {}
+  custom_name: breakoutRoom_user
+  custom_root_fields: {}
+select_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - assignedAt
+        - breakoutRoomId
+        - inviteDismissedAt
+        - joinURL
+        - joinedAt
+      filter:
+        userId:
+          _eq: X-Hasura-UserId
+    comment: ""
+update_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - inviteDismissedAt
+      filter:
+        userId:
+          _eq: X-Hasura-UserId
+      check: null
+    comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -2,6 +2,7 @@
 - "!include public_v_breakoutRoom.yaml"
 - "!include public_v_breakoutRoom_assignedUser.yaml"
 - "!include public_v_breakoutRoom_participant.yaml"
+- "!include public_v_breakoutRoom_user.yaml"
 - "!include public_v_chat.yaml"
 - "!include public_v_chat_message_private.yaml"
 - "!include public_v_chat_message_public.yaml"

--- a/bbb-graphql-server/update_graphql_data.sh
+++ b/bbb-graphql-server/update_graphql_data.sh
@@ -35,4 +35,4 @@ if [ "$akka_apps_status" = "active" ]; then
 fi
 
 echo "Applying new metadata to Hasura"
-/usr/local/bin/hasura/hasura metadata apply
+hasura metadata apply


### PR DESCRIPTION
- A few columns were added to `breakoutRoom` collection in graphql-server, in special `joinURL` and `showInvitation`.
```gql
subscription {
  breakoutRoom {
    breakoutRoomId
    joinURL
    showInvitation
    currentRoomPriority
  }
}
```

- The `showInvitation` flag will be used to inform when the invitation modal should be rendered in the screen (removing this logic from the client as it is currently).
- The `currentRoomPriority` prop will indicate which room should come selected by default (1 = highest priority).
- `joinURL` is used as address of the new tab to join in a breakoutRoom

- `inviteDismissedAt` is used to inform the server when the user dismiss the invitation modal (when user chose not to join any room).
```gql
mutation {
  update_breakoutRoom_user(where: {}, _set: {inviteDismissedAt: "now()"}) {
    affected_rows
  }
}
```