### PR TITLE
refactor (graphql-server): ExternalVideo data schema enhanced

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/externalvideo/StopExternalVideoPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/externalvideo/StopExternalVideoPubMsgHdlr.scala
@@ -20,7 +20,7 @@ trait StopExternalVideoPubMsgHdlr extends RightsManagementTrait {
     } else {
       ExternalVideoModel.clear(liveMeeting.externalVideoModel)
 
-      ExternalVideoDAO.updateStopped(liveMeeting.props.meetingProp.intId)
+      ExternalVideoDAO.updateStoppedSharing(liveMeeting.props.meetingProp.intId)
 
       //broadcastEvent
       val msgEvent = MsgBuilder.buildStopExternalVideoEvtMsg(liveMeeting.props.meetingProp.intId, msg.header.userId)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ExternalVideoDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ExternalVideoDAO.scala
@@ -19,7 +19,7 @@ case class ExternalVideoDbModel(
     playerPlaying:      Boolean
 )
 
-class ExternalVideoDbTableDef(tag: Tag) extends Table[ExternalVideoDbModel](tag, "external_video") {
+class ExternalVideoDbTableDef(tag: Tag) extends Table[ExternalVideoDbModel](tag, "externalVideo") {
   val externalVideoId = column[String]("externalVideoId", O.PrimaryKey)
   val meetingId = column[String]("meetingId")
   val externalVideoUrl = column[String]("externalVideoUrl")

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ExternalVideoDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ExternalVideoDAO.scala
@@ -5,33 +5,31 @@ import slick.jdbc.PostgresProfile.api._
 import slick.lifted.ProvenShape
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.{Failure, Success}
+import scala.util.{ Failure, Success }
 
 case class ExternalVideoDbModel(
-    externalVideoId:  String,
-    meetingId:        String,
-    externalVideoUrl: String,
-    startedAt:        java.sql.Timestamp         = new java.sql.Timestamp(System.currentTimeMillis()),
-    stoppedAt:        Option[java.sql.Timestamp],
-    lastEventAt:      Option[java.sql.Timestamp],
-    lastEventDesc:    String,
-    playerRate:       Double,
-    playerTime:       Double,
-    playerState:      Int
+    externalVideoId:    String,
+    meetingId:          String,
+    externalVideoUrl:   String,
+    startedSharingAt:   java.sql.Timestamp,
+    stoppedSharingAt:   Option[java.sql.Timestamp],
+    updatedAt:          java.sql.Timestamp,
+    playerPlaybackRate: Double,
+    playerCurrentTime:  Double,
+    playerPlaying:      Boolean
 )
 
 class ExternalVideoDbTableDef(tag: Tag) extends Table[ExternalVideoDbModel](tag, "external_video") {
   val externalVideoId = column[String]("externalVideoId", O.PrimaryKey)
   val meetingId = column[String]("meetingId")
   val externalVideoUrl = column[String]("externalVideoUrl")
-  val startedAt = column[java.sql.Timestamp]("startedAt")
-  val stoppedAt = column[Option[java.sql.Timestamp]]("stoppedAt")
-  val lastEventAt = column[Option[java.sql.Timestamp]]("lastEventAt")
-  val lastEventDesc = column[String]("lastEventDesc")
-  val playerRate = column[Double]("playerRate")
-  val playerTime = column[Double]("playerTime")
-  val playerState = column[Int]("playerState")
-  override def * : ProvenShape[ExternalVideoDbModel] = (externalVideoId, meetingId, externalVideoUrl, startedAt, stoppedAt, lastEventAt, lastEventDesc, playerRate, playerTime, playerState) <> (ExternalVideoDbModel.tupled, ExternalVideoDbModel.unapply)
+  val startedSharingAt = column[java.sql.Timestamp]("startedSharingAt")
+  val stoppedSharingAt = column[Option[java.sql.Timestamp]]("stoppedSharingAt")
+  val updatedAt = column[java.sql.Timestamp]("updatedAt")
+  val playerPlaybackRate = column[Double]("playerPlaybackRate")
+  val playerCurrentTime = column[Double]("playerCurrentTime")
+  val playerPlaying = column[Boolean]("playerPlaying")
+  override def * : ProvenShape[ExternalVideoDbModel] = (externalVideoId, meetingId, externalVideoUrl, startedSharingAt, stoppedSharingAt, updatedAt, playerPlaybackRate, playerCurrentTime, playerPlaying) <> (ExternalVideoDbModel.tupled, ExternalVideoDbModel.unapply)
 }
 
 object ExternalVideoDAO {
@@ -42,18 +40,17 @@ object ExternalVideoDAO {
           externalVideoId = System.currentTimeMillis() + "-" + RandomStringGenerator.randomAlphanumericString(8),
           meetingId = meetingId,
           externalVideoUrl = externalVideoUrl,
-          startedAt = new java.sql.Timestamp(System.currentTimeMillis()),
-          stoppedAt = None,
-          lastEventAt = None,
-          lastEventDesc = "",
-          playerRate = 0,
-          playerTime = 0,
-          playerState = 0,
+          startedSharingAt = new java.sql.Timestamp(System.currentTimeMillis()),
+          stoppedSharingAt = None,
+          updatedAt = new java.sql.Timestamp(System.currentTimeMillis()),
+          playerPlaybackRate = 1,
+          playerCurrentTime = 0,
+          playerPlaying = true
         )
       )
     ).onComplete {
         case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted in ExternalVideo table!")
-        case Failure(e) => DatabaseConnection.logger.error(s"Error inserting ExternalVideo: $e")
+        case Failure(e)            => DatabaseConnection.logger.error(s"Error inserting ExternalVideo: $e")
       }
   }
 
@@ -61,26 +58,38 @@ object ExternalVideoDAO {
     DatabaseConnection.db.run(
       TableQuery[ExternalVideoDbTableDef]
         .filter(_.meetingId === meetingId)
-        .filter(_.stoppedAt.isEmpty)
-        .map(ev => (ev.lastEventDesc, ev.playerRate, ev.playerTime, ev.playerState, ev.lastEventAt))
-        .update((status, rate, time, state, Some(new java.sql.Timestamp(System.currentTimeMillis()))))
+        .filter(_.stoppedSharingAt.isEmpty)
+        .map(ev => (ev.playerPlaybackRate, ev.playerCurrentTime, ev.playerPlaying, ev.updatedAt))
+        .update((
+          rate,
+          time,
+          status match {
+            case "play" => true
+            case "stop" => false
+            case _ => state match {
+              case 1 => true
+              case 0 => false
+            }
+          },
+          new java.sql.Timestamp(System.currentTimeMillis())
+        ))
     ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated on ExternalVideo table!")
-      case Failure(e) => DatabaseConnection.logger.debug(s"Error updating ExternalVideo: $e")
-    }
+        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated on ExternalVideo table!")
+        case Failure(e)            => DatabaseConnection.logger.debug(s"Error updating ExternalVideo: $e")
+      }
   }
 
-  def updateStopped(meetingId: String) = {
+  def updateStoppedSharing(meetingId: String) = {
     DatabaseConnection.db.run(
       TableQuery[ExternalVideoDbTableDef]
         .filter(_.meetingId === meetingId)
-        .filter(_.stoppedAt.isEmpty)
-        .map(ev => ev.stoppedAt)
-        .update(Some(new java.sql.Timestamp(System.currentTimeMillis())))
+        .filter(_.stoppedSharingAt.isEmpty)
+        .map(ev => (ev.stoppedSharingAt, ev.playerPlaying))
+        .update(Some(new java.sql.Timestamp(System.currentTimeMillis())), false)
     ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated stoppedAt on ExternalVideo table!")
-      case Failure(e) => DatabaseConnection.logger.debug(s"Error updating stoppedAt on ExternalVideo: $e")
-    }
+        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated stoppedSharingAt on ExternalVideo table!")
+        case Failure(e)            => DatabaseConnection.logger.debug(s"Error updating stoppedSharingAt on ExternalVideo: $e")
+      }
   }
 
 }

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1171,19 +1171,18 @@ create table "external_video"(
 "externalVideoId" varchar(100) primary key,
 "meetingId" varchar(100) REFERENCES "meeting"("meetingId") ON DELETE CASCADE,
 "externalVideoUrl" varchar(500),
-"startedAt" timestamp with time zone,
-"stoppedAt" timestamp with time zone,
-"lastEventAt" timestamp with time zone,
-"lastEventDesc" varchar(50),
-"playerRate" numeric,
-"playerTime" numeric,
-"playerState" integer
+"startedSharingAt" timestamp with time zone,
+"stoppedSharingAt" timestamp with time zone,
+"updatedAt" timestamp with time zone,
+"playerPlaybackRate" numeric,
+"playerCurrentTime" numeric,
+"playerPlaying" boolean
 );
-create index "external_video_meetingId_current" on "external_video"("meetingId") WHERE "stoppedAt" IS NULL;
+create index "external_video_meetingId_current" on "external_video"("meetingId") WHERE "stoppedSharingAt" IS NULL;
 
 CREATE VIEW "v_external_video" AS
 SELECT * FROM "external_video"
-WHERE "stoppedAt" IS NULL;
+WHERE "stoppedSharingAt" IS NULL;
 
 --------------------------------
 ----Screenshare

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1167,7 +1167,7 @@ WHERE poll."type" != 'R-';
 --------------------------------
 ----External video
 
-create table "external_video"(
+create table "externalVideo"(
 "externalVideoId" varchar(100) primary key,
 "meetingId" varchar(100) REFERENCES "meeting"("meetingId") ON DELETE CASCADE,
 "externalVideoUrl" varchar(500),
@@ -1178,10 +1178,10 @@ create table "external_video"(
 "playerCurrentTime" numeric,
 "playerPlaying" boolean
 );
-create index "external_video_meetingId_current" on "external_video"("meetingId") WHERE "stoppedSharingAt" IS NULL;
+create index "externalVideo_meetingId_current" on "externalVideo"("meetingId") WHERE "stoppedSharingAt" IS NULL;
 
-CREATE VIEW "v_external_video" AS
-SELECT * FROM "external_video"
+CREATE VIEW "v_externalVideo" AS
+SELECT * FROM "externalVideo"
 WHERE "stoppedSharingAt" IS NULL;
 
 --------------------------------

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_externalVideo.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_externalVideo.yaml
@@ -1,10 +1,10 @@
 table:
-  name: v_external_video
+  name: v_externalVideo
   schema: public
 configuration:
   column_config: {}
   custom_column_names: {}
-  custom_name: external_video
+  custom_name: externalVideo
   custom_root_fields: {}
 select_permissions:
   - role: bbb_client

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_external_video.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_external_video.yaml
@@ -12,13 +12,12 @@ select_permissions:
       columns:
         - externalVideoId
         - externalVideoUrl
-        - lastEventAt
-        - lastEventDesc
-        - playerRate
-        - playerState
-        - playerTime
-        - startedAt
-        - stoppedAt
+        - playerPlaybackRate
+        - playerPlaying
+        - playerCurrentTime
+        - startedSharingAt
+        - stoppedSharingAt
+        - updatedAt
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
@@ -23,7 +23,7 @@ object_relationships:
           meetingId: meetingId
         insertion_order: null
         remote_table:
-          name: v_external_video
+          name: v_externalVideo
           schema: public
   - name: lockSettings
     using:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -8,7 +8,7 @@
 - "!include public_v_chat_message_public.yaml"
 - "!include public_v_chat_user.yaml"
 - "!include public_v_current_time.yaml"
-- "!include public_v_external_video.yaml"
+- "!include public_v_externalVideo.yaml"
 - "!include public_v_meeting.yaml"
 - "!include public_v_meeting_breakoutPolicies.yaml"
 - "!include public_v_meeting_group.yaml"

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
@@ -296,9 +296,10 @@ class VideoPlayer extends Component {
     const { playing } = this.state;
 
     const curTime = this.getCurrentTime();
+    const rate = this.getCurrentPlaybackRate();
 
     if (isPresenter && !playing) {
-      this.sendSyncMessage('play', { time: curTime });
+      this.sendSyncMessage('play', { rate, time: curTime });
     }
     this.setState({ playing: true });
 
@@ -314,9 +315,10 @@ class VideoPlayer extends Component {
     const { playing } = this.state;
 
     const curTime = this.getCurrentTime();
+    const rate = this.getCurrentPlaybackRate();
 
     if (isPresenter && playing) {
-      this.sendSyncMessage('stop', { time: curTime });
+      this.sendSyncMessage('stop', { rate, time: curTime });
     }
     this.setState({ playing: false });
 


### PR DESCRIPTION
Some enhancements on the database schema of `externalVideo` in graphql-server:

- new query
```gql
subscription {
  externalVideo {
    externalVideoId
    externalVideoUrl
    playerCurrentTime
    playerPlaybackRate
    playerPlaying
    startedSharingAt
    stoppedSharingAt
    updatedAt
  } 
}
```
- new result
```json
{
  "data": {
    "externalVideo": [
      {
        "externalVideoId": "1694030652352-hyagul55",
        "externalVideoUrl": "https://youtu.be/WLqpjAM?si=ZfX0-urN3W0",
        "playerCurrentTime": 24,
        "playerPlaybackRate": 1,
        "playerPlaying": false,
        "startedSharingAt": "2023-09-06T20:04:12.372+00:00",
        "stoppedSharingAt": null,
        "updatedAt": "2023-09-06T20:16:08.144+00:00"
      }
    ]
  }
}
```

It is ready for the refactor of the client, a few instructions for the client refactor:
- Calc the player current time based on `updatedAt` + (`playerCurrentTime` * `playerPlaybackRate`)
- Stop sending the current status each 5 seconds and send only when something was changed
- Try to use `onSeek` and `onPlaybackRateChange` callbacks as a trigger to send current status (https://github.com/CookPete/react-player)
- Looks like `onSeek` is not working for youtube (track https://github.com/cookpete/react-player/pull/1419)