### PR TITLE
Remove package-lock.json from main directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "bigbluebutton",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
In PR #18454 a `package-lock.json` file was added by mistake.
This doesn't cause any issue, but the file should not be there.
This pull request removes this file.
