### PR TITLE
fix(recording): handle archive remux failures

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl.rb
@@ -47,7 +47,10 @@ module BigBlueButton
         ffmpeg_cmd += [*pass, '-passlogfile', output_basename, lastoutput]
         Dir.chdir(File.dirname(output)) do
           exitstatus = BigBlueButton.exec_ret(*ffmpeg_cmd)
-          raise "ffmpeg failed, exit code #{exitstatus}" if exitstatus != 0
+          if exitstatus != 0
+            FileUtils.rm_f(lastoutput) if File.exists?(lastoutput)
+            raise "ffmpeg failed, exit code #{exitstatus}"
+          end
         end
       end
 

--- a/record-and-playback/core/scripts/archive/archive.rb
+++ b/record-and-playback/core/scripts/archive/archive.rb
@@ -139,6 +139,11 @@ def remux_and_archive(source_dir, dest_dir)
       format,
       output_basename
     )
+  rescue StandardError => e
+    BigBlueButton.logger.warn("Failed to remux #{file}, archiving anyways: #{e}")
+    # Archive the file anyways - later steps (eg sanity) might strip it out
+    # if invalid or fix it if necessary
+    FileUtils.cp(file, "#{output_basename}#{ext}")
   end
 end
 


### PR DESCRIPTION
### What does this PR do?

- [fix(recording): handle archive remux failures](https://github.com/bigbluebutton/bigbluebutton/commit/286434e833f62a059c3d3a6a3ec74587b48a590c) 
  * Recording archive may fail when remuxing invalid files from KMS or the
new recorder - eg when the raw files are 0-byte sized.
  * This commit handles the exception raised by EDL::encode so archive keeps
going, logs the issue as a warning and archives the problematic file anyways.
  * EDL::encode now removes the temporary file when the ffmpeg command execution
fails - this should avoid leaving any stale files around in case of failure
  * No specific check for the nature of the error is done - the idea is that
subsequent phases will discard or fix the files if necessary according
to the processing scripts' necessities, making the behavior (in this
specific scenario) similar to what it was before the archive remuxing was
introduced.

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/18720
