### PR TITLE
refactor (Github Actions): Run typescript workflows only when ts/tsx within bbb-html5 was modified

### DIFF
--- a/.github/workflows/ts-code-compilation.yml
+++ b/.github/workflows/ts-code-compilation.yml
@@ -8,11 +8,15 @@ on:
     paths:
       - "bigbluebutton-html5/**.ts"
       - "bigbluebutton-html5/**.tsx"
+      - "bigbluebutton-html5/package.json"
+      - "bigbluebutton-html5/package-lock.json"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - "bigbluebutton-html5/**.ts"
       - "bigbluebutton-html5/**.tsx"
+      - "bigbluebutton-html5/package.json"
+      - "bigbluebutton-html5/package-lock.json"
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/ts-code-compilation.yml
+++ b/.github/workflows/ts-code-compilation.yml
@@ -5,14 +5,14 @@ on:
       - "develop"
       - "v2.[5-9].x-release"
       - "v[3-9].*.x-release"
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "bigbluebutton-html5/**.ts"
+      - "bigbluebutton-html5/**.tsx"
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "bigbluebutton-html5/**.ts"
+      - "bigbluebutton-html5/**.tsx"
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/ts-code-validation.yml
+++ b/.github/workflows/ts-code-validation.yml
@@ -8,11 +8,15 @@ on:
     paths:
       - "bigbluebutton-html5/**.ts"
       - "bigbluebutton-html5/**.tsx"
+      - "bigbluebutton-html5/package.json"
+      - "bigbluebutton-html5/package-lock.json"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - "bigbluebutton-html5/**.ts"
       - "bigbluebutton-html5/**.tsx"
+      - "bigbluebutton-html5/package.json"
+      - "bigbluebutton-html5/package-lock.json"
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/ts-code-validation.yml
+++ b/.github/workflows/ts-code-validation.yml
@@ -5,14 +5,14 @@ on:
       - "develop"
       - "v2.[5-9].x-release"
       - "v[3-9].*.x-release"
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "bigbluebutton-html5/**.ts"
+      - "bigbluebutton-html5/**.tsx"
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
+    paths:
+      - "bigbluebutton-html5/**.ts"
+      - "bigbluebutton-html5/**.tsx"
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
It will ignore the Typescript related workflows when no TS/TSX files was changed.
And it will monitor only the directory `bigbluebutton-html5`.