### PR TITLE
fix(build): do not package .git for bbb-transcription-controller

### DIFF
--- a/build/packages-template/bbb-transcription-controller/build.sh
+++ b/build/packages-template/bbb-transcription-controller/build.sh
@@ -16,7 +16,7 @@ rm -rf staging
 
 mkdir -p staging/usr/local/bigbluebutton/bbb-transcription-controller
 
-find -maxdepth 1 ! -path . ! -name staging $(printf "! -name %s " $(cat .build-files)) -exec cp -r {} staging/usr/local/bigbluebutton/bbb-transcription-controller/ \;
+find -maxdepth 1 ! -path . ! -name staging ! -name .git $(printf "! -name %s " $(cat .build-files)) -exec cp -r {} staging/usr/local/bigbluebutton/bbb-transcription-controller/ \;
 
 pushd .
 cd staging/usr/local/bigbluebutton/bbb-transcription-controller/


### PR DESCRIPTION
### What does this PR do?

Fixes accidential packaging of `.git` for the `bbb-transcription-controller` package.

`Note:` Please test this before merging. It should work, but the new 2.7 build environment doesn't work here yet, so I didn't have a chance to test.