### PR TITLE
fix: size prop type warning

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -5,6 +5,7 @@ import BBBMenu from '/imports/ui/components/common/menu/component';
 import UserReactionService from '/imports/ui/components/user-reaction/service';
 import UserListService from '/imports/ui/components/user-list/service';
 import { Emoji } from 'emoji-mart';
+import { convertRemToPixels } from '/imports/utils/dom-utils';
 
 import Styled from './styles';
 
@@ -74,7 +75,7 @@ const ReactionsButton = (props) => {
 
   const emojiProps = {
     native: true,
-    size: '1.5rem',
+    size: convertRemToPixels(1.5),
     padding: '4px',
   };
 


### PR DESCRIPTION
### What does this PR do?

backport (from https://github.com/bigbluebutton/bigbluebutton/pull/18675) for the emoji prop warning fix:

![size](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/37f401cc-6a83-42fb-9758-4d375a779dfc)