### PR TITLE
fix: videoPreview not working

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -144,6 +144,9 @@ class AudioContainer extends PureComponent {
       /> : null}
       {isVideoPreviewModalOpen ? <VideoPreviewContainer 
         {...{
+          callbackToClose: () => {
+            setVideoPreviewModalIsOpen(false);
+          },
           priority: "low",
           setIsOpen: setVideoPreviewModalIsOpen,
           isOpen: isVideoPreviewModalOpen


### PR DESCRIPTION
### What does this PR do?

It basically fixes the `videoPreview` crashing when `userdata-bbb_auto_share_webcam=true` and the user clicks on `Start Sharing`.

### Closes Issue(s)

Closes #18736 

