### PR TITLE
fix: incorrect set logoutUrl in join handler

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/component.jsx
@@ -184,7 +184,7 @@ class JoinHandler extends Component {
     const parseToJson = await fetchContent.json();
     const { response } = parseToJson;
 
-    setLogoutURL(response);
+    setLogoutURL(response.logoutUrl);
     logUserInfo();
 
     if (response.returncode !== 'FAILED') {


### PR DESCRIPTION
### What does this PR do?

Prevents a crash caused by incorrect value for logoutUrl being set on join.

### Closes Issue(s)
Closes #18767