### PR TITLE
build: start bbb-graphql-server before bbb-apps-akka

### DIFF
--- a/akka-bbb-apps/src/templates/systemloader/systemd/start-template
+++ b/akka-bbb-apps/src/templates/systemloader/systemd/start-template
@@ -1,8 +1,8 @@
 [Unit]
 Description=BigBlueButton Apps (Akka)
 Requires=network.target
-Wants=redis-server.service bbb-fsesl-akka.service postgresql.service
-After=redis-server.service bbb-fsesl-akka.service postgresql.service
+Wants=redis-server.service bbb-fsesl-akka.service postgresql.service bbb-graphql-server.service
+After=redis-server.service bbb-fsesl-akka.service postgresql.service bbb-graphql-server.service
 PartOf=bigbluebutton.target
 
 [Service]


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Specifies that `bbb-graphql-server` has to start before `bbb-apps-akka`.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none


### Motivation
We've had a few instances where `bbb-apps-akka` starts before `bbb-graphql-server` and the latter fails. BigBlueButton does not fully start in those cases.
<!-- What inspired you to submit this pull request? -->

Likely also related to recent CI failures in the BBB restart step.

### More

<!-- Anything else we should know when reviewing? -->

