### PR TITLE
fix (graphql): Userlist sorting uppercase wrongly (introduces user.nameSortable)

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -268,7 +268,7 @@ ALTER TABLE "user" ADD COLUMN "isDenied" boolean GENERATED ALWAYS AS ("guestStat
 
 ALTER TABLE "user" ADD COLUMN "registeredAt" timestamp with time zone GENERATED ALWAYS AS (to_timestamp(("registeredOn" + 6000) / 1000)) STORED;
 
---User for the userlist
+--Used to sort the Userlist
 ALTER TABLE "user" ADD COLUMN "nameSortable" varchar(255) GENERATED ALWAYS AS (immutable_lower_unaccent("name")) STORED;
 
 CREATE INDEX "idx_user_waiting" ON "user"("meetingId") where "isWaiting" is true;

--- a/bbb-graphql-server/install-hasura.sh
+++ b/bbb-graphql-server/install-hasura.sh
@@ -12,7 +12,7 @@ apt update
 apt install postgresql postgresql-contrib -y
 sudo -u postgres psql -c "alter user postgres password 'bbb_graphql'"
 sudo -u postgres psql -c "drop database if exists bbb_graphql"
-sudo -u postgres psql -c "create database bbb_graphql"
+sudo -u postgres psql -c "create database bbb_graphql WITH TEMPLATE template0 LC_COLLATE 'C.UTF-8'"
 sudo -u postgres psql -c "alter database bbb_graphql set timezone to 'UTC'"
 sudo -u postgres psql -U postgres -d bbb_graphql -a -f bbb_schema.sql --set ON_ERROR_STOP=on
 sudo -u postgres psql -c "drop database if exists hasura_app"

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
@@ -100,6 +100,7 @@ select_permissions:
         - loggedOut
         - mobile
         - name
+        - nameSortable
         - pinned
         - presenter
         - raiseHand

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
@@ -154,6 +154,7 @@ select_permissions:
         - loggedOut
         - mobile
         - name
+        - nameSortable
         - pinned
         - presenter
         - raiseHand

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_ref.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_ref.yaml
@@ -31,6 +31,7 @@ select_permissions:
         - loggedOut
         - mobile
         - name
+        - nameSortable
         - pinned
         - presenter
         - raiseHand

--- a/bbb-graphql-server/update_graphql_data.sh
+++ b/bbb-graphql-server/update_graphql_data.sh
@@ -18,7 +18,7 @@ fi
 echo "Restarting database bbb_graphql"
 sudo -u postgres psql -c "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE datname = 'bbb_graphql'"
 sudo -u postgres psql -c "drop database if exists bbb_graphql"
-sudo -u postgres psql -c "create database bbb_graphql"
+sudo -u postgres psql -c "create database bbb_graphql WITH TEMPLATE template0 LC_COLLATE 'C.UTF-8'"
 sudo -u postgres psql -c "alter database bbb_graphql set timezone to 'UTC'"
 
 echo "Creating tables in bbb_graphql"

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
@@ -9,7 +9,7 @@ export const USER_LIST_SUBSCRIPTION = gql`subscription Users($offset: Int!, $lim
                   {emojiTime: asc_nulls_last},
                   {isDialIn: desc},
                   {hasDrawPermissionOnCurrentPage: desc},
-                  {name: asc},
+                  {nameSortable: asc},
                   {userId: asc}
                 ]) {
     userId

--- a/build/packages-template/bbb-graphql-server/after-install.sh
+++ b/build/packages-template/bbb-graphql-server/after-install.sh
@@ -7,7 +7,7 @@ case "$1" in
 
   sudo -u postgres psql -c "alter user postgres password 'bbb_graphql'"
   sudo -u postgres psql -c "drop database if exists bbb_graphql"
-  sudo -u postgres psql -c "create database bbb_graphql"
+  sudo -u postgres psql -c "create database bbb_graphql WITH TEMPLATE template0 LC_COLLATE 'C.UTF-8'"
   sudo -u postgres psql -c "alter database bbb_graphql set timezone to 'UTC'"
   sudo -u postgres psql -U postgres -d bbb_graphql -a -f /usr/share/bbb-graphql-server/bbb_schema.sql --set ON_ERROR_STOP=on
 


### PR DESCRIPTION
The userlist is being sorted wrongly because of Upper/Lowercase and Accents chars.
This PR fix this problem:

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/7496fde7-1de1-455b-b9ce-deeb8e4c61b7)

</td>

<td>

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/f047ae06-ff69-459d-a1e7-54f8b04787e9)

</td>
</tr>
</table>


Moreover:
- **Collate C.UTF-8**: On creating `bbb_graphql` database set `LC_COLLATE 'C.UTF-8'` - forcing the database to behave in same way independently of the server locale
- **`nameSortable`**: Add a new indexed column `nameSortable` to `user` table, which is the `name` in lowercase and without accents, meant for sorting