### PR TITLE
fix(build): Hasura installation fails on its first attempt

### DIFF
--- a/build/packages-template/bbb-graphql-server/after-install.sh
+++ b/build/packages-template/bbb-graphql-server/after-install.sh
@@ -27,6 +27,7 @@ case "$1" in
     systemctl enable bbb-graphql-server.service
     systemctl daemon-reload
     startService bbb-graphql-server || echo "bbb-graphql-server service could not be registered or started"
+    sleep 2 #Avoid applying metadata before Hasura is ready
 
     # Apply BBB metadata in Hasura
     cd /usr/share/bbb-graphql-server


### PR DESCRIPTION
The package `bbb-graphql-server` (Hasura) is failing during bbb-install, then it try again and the second attempt works.
It happens because hasura-cli try to apply metadata before the server is ready:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/fea852d3-7218-4552-85b8-1bf554cfa7c6)

Including a delay of 2 seconds to run `/usr/local/bin/hasura metadata apply` must tackle the issue.