### PR TITLE
fix: markdown line breaks

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/styles.ts
@@ -23,6 +23,11 @@ export const ChatMessage = styled.div<ChatMessageProps>`
 
   & p {
     margin: 0;
+    white-space: pre-wrap;
+  }
+
+  & code {
+    white-space: pre-wrap;
   }
 `;
 


### PR DESCRIPTION
### What does this PR do?

Adjusts chat styles so line breaks are correctly displayed in `p` and `code` elements.

#### before


https://github.com/bigbluebutton/bigbluebutton/assets/3728706/835e14c1-afe8-488a-bc57-85e74371b56e


#### after

https://github.com/bigbluebutton/bigbluebutton/assets/3728706/f03c05cc-5cf6-4208-b8ec-502098a370e3

