### PR TITLE
build: bbb-webhooks set secret and url

### DIFF
--- a/build/packages-template/bbb-webhooks/after-install.sh
+++ b/build/packages-template/bbb-webhooks/after-install.sh
@@ -9,8 +9,8 @@ case "$1" in
     chmod 644 $TARGET
     chown bigbluebutton:bigbluebutton $TARGET
 
-    BBB_SECRET=$(cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties | grep securitySalt | cut -d= -f2)
-    BBB_HOST=$(cat $SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties | sed -n '/^bigbluebutton.web.serverURL/{s/.*\///;p}')
+    BBB_HOST=$(bbb-conf --secret | grep -F URL: | sed 's#^.*://##; s#/.*##')
+    BBB_SECRET=$(bbb-conf --secret | grep -F Secret: | sed 's/.*Secret: //')    
 
     yq w -i $TARGET bbb.sharedSecret "$BBB_SECRET"
     yq w -i $TARGET bbb.serverDomain "$BBB_HOST"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Sets the correct salt + url for bbb-webhooks
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes https://github.com/bigbluebutton/bigbluebutton/issues/18740


### Motivation
We were using bigbluebutton.properties rather than /etc/bigbluebutton/bbb-web.properties. I was trying to think of scenarios where `bbb-conf` does not exist at the time of `bbb-webhooks` installation, but can't think of one.
<!-- What inspired you to submit this pull request? -->

### More
Credits: @snadal for suggesting this in https://github.com/bigbluebutton/bigbluebutton/issues/18740#issuecomment-1710605206
