### PR TITLE
Fix: Welcome message transparent background

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-popup/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-popup/styles.ts
@@ -6,6 +6,7 @@ export const PopupContainer = styled.div`
   top: 0;
   max-height: 80%;
   z-index: 3;
+  background-color: white;
 `;
 
 export const PopupContents = styled(ScrollboxVertical)`


### PR DESCRIPTION
### What does this PR do?

This PR adds the white color to welcome message background.

Example:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/d90be2bc-aa58-49a7-9b84-b5f09621d708)
