### PR TITLE
ci: Refresh package's cache whenever there are changes in its build directory

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -80,10 +80,8 @@ jobs:
       - name: Set cache-key vars
         run: |
           BUILD_DIRS="$(echo '${{ matrix.build-list || matrix.package }}' | sed 's/[^ ]\+/build\/packages-template\/&/g')"
-          echo "Using the variable: $BUILD_DIRS"
-          echo "Using the variable: ${BUILD_DIRS}"
-          echo "CACHE_KEY_FILES=$(echo '${{ matrix.cache-files-list }} $BUILD_DIRS .gitlab-ci.yml build/deb-helper.sh' | xargs -n1 git log -1 --format=%h -- | tr '\n' '-' | sed 's/-$//')" >> $GITHUB_ENV
-          echo "Using the variable: $CACHE_KEY_FILES"
+          echo "Including build dirs: $BUILD_DIRS"
+          echo "CACHE_KEY_FILES=$(echo '${{ matrix.cache-files-list }} '$BUILD_DIRS' .gitlab-ci.yml build/deb-helper.sh' | xargs -n1 git log -1 --format=%h -- | tr '\n' '-' | sed 's/-$//')" >> $GITHUB_ENV
           echo "CACHE_KEY_URLS=$(echo '${{ matrix.cache-urls-list }}' | xargs -r -n 1 curl -Is | grep -i 'Last-Modified' | md5sum | cut -c1-10)" >> $GITHUB_ENV
           cat bigbluebutton-config/bigbluebutton-release >> $GITHUB_ENV
           echo "FORCE_GIT_REV=0" >> $GITHUB_ENV #used by setup.sh

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -79,11 +79,9 @@ jobs:
         uses: ./.github/actions/merge-branches
       - name: Set cache-key vars
         run: |
-          echo "BUILD_DIRS=$(echo '${{ matrix.build-list || matrix.package }}' | sed 's/[^ ]\+/build\/packages-template\/&/g')" >> $GITHUB_ENV
+          BUILD_DIRS="$(echo '${{ matrix.build-list || matrix.package }}' | sed 's/[^ ]\+/build\/packages-template\/&/g')"
           echo "Using the variable: $BUILD_DIRS"
           echo "Using the variable: ${BUILD_DIRS}"
-          echo "Using the variable: ${{ BUILD_DIRS }}"
-          echo "Using the variable: ${{ env.BUILD_DIRS }}"
           echo "CACHE_KEY_FILES=$(echo '${{ matrix.cache-files-list }} $BUILD_DIRS .gitlab-ci.yml build/deb-helper.sh' | xargs -n1 git log -1 --format=%h -- | tr '\n' '-' | sed 's/-$//')" >> $GITHUB_ENV
           echo "Using the variable: $CACHE_KEY_FILES"
           echo "CACHE_KEY_URLS=$(echo '${{ matrix.cache-urls-list }}' | xargs -r -n 1 curl -Is | grep -i 'Last-Modified' | md5sum | cut -c1-10)" >> $GITHUB_ENV

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Set cache-key vars
         run: |
           echo "BUILD_DIRS=$(echo '${{ matrix.build-list || matrix.package }}' | sed 's/[^ ]\+/build\/packages-template\/&/g')" >> $GITHUB_ENV
-          echo "CACHE_KEY_FILES=$(echo '${{ matrix.cache-files-list }} ${{ env.BUILD_DIRS }} .gitlab-ci.yml build/deb-helper.sh' | xargs -n1 git log -1 --format=%h -- | tr '\n' '-' | sed 's/-$//')" >> $GITHUB_ENV
+          echo "CACHE_KEY_FILES=$(echo '${{ matrix.cache-files-list }} $BUILD_DIRS .gitlab-ci.yml build/deb-helper.sh' | xargs -n1 git log -1 --format=%h -- | tr '\n' '-' | sed 's/-$//')" >> $GITHUB_ENV
           echo "CACHE_KEY_URLS=$(echo '${{ matrix.cache-urls-list }}' | xargs -r -n 1 curl -Is | grep -i 'Last-Modified' | md5sum | cut -c1-10)" >> $GITHUB_ENV
           cat bigbluebutton-config/bigbluebutton-release >> $GITHUB_ENV
           echo "FORCE_GIT_REV=0" >> $GITHUB_ENV #used by setup.sh

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -80,7 +80,12 @@ jobs:
       - name: Set cache-key vars
         run: |
           echo "BUILD_DIRS=$(echo '${{ matrix.build-list || matrix.package }}' | sed 's/[^ ]\+/build\/packages-template\/&/g')" >> $GITHUB_ENV
+          echo "Using the variable: $BUILD_DIRS"
+          echo "Using the variable: ${BUILD_DIRS}"
+          echo "Using the variable: ${{ BUILD_DIRS }}"
+          echo "Using the variable: ${{ env.BUILD_DIRS }}"
           echo "CACHE_KEY_FILES=$(echo '${{ matrix.cache-files-list }} $BUILD_DIRS .gitlab-ci.yml build/deb-helper.sh' | xargs -n1 git log -1 --format=%h -- | tr '\n' '-' | sed 's/-$//')" >> $GITHUB_ENV
+          echo "Using the variable: $CACHE_KEY_FILES"
           echo "CACHE_KEY_URLS=$(echo '${{ matrix.cache-urls-list }}' | xargs -r -n 1 curl -Is | grep -i 'Last-Modified' | md5sum | cut -c1-10)" >> $GITHUB_ENV
           cat bigbluebutton-config/bigbluebutton-release >> $GITHUB_ENV
           echo "FORCE_GIT_REV=0" >> $GITHUB_ENV #used by setup.sh

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -79,8 +79,8 @@ jobs:
         uses: ./.github/actions/merge-branches
       - name: Set cache-key vars
         run: |
-          BUILD_DIRS=$(echo "${{ matrix.build-list || matrix.package }}" | sed 's/[^ ]\+/build\/packages-template\/&/g')
-          echo "CACHE_KEY_FILES=$(echo '${{ matrix.cache-files-list }} $BUILD_DIRS .gitlab-ci.yml build/deb-helper.sh' | xargs -n1 git log -1 --format=%h -- | tr '\n' '-' | sed 's/-$//')" >> $GITHUB_ENV
+          echo "BUILD_DIRS=$(echo '${{ matrix.build-list || matrix.package }}' | sed 's/[^ ]\+/build\/packages-template\/&/g')" >> $GITHUB_ENV
+          echo "CACHE_KEY_FILES=$(echo '${{ matrix.cache-files-list }} ${{ env.BUILD_DIRS }} .gitlab-ci.yml build/deb-helper.sh' | xargs -n1 git log -1 --format=%h -- | tr '\n' '-' | sed 's/-$//')" >> $GITHUB_ENV
           echo "CACHE_KEY_URLS=$(echo '${{ matrix.cache-urls-list }}' | xargs -r -n 1 curl -Is | grep -i 'Last-Modified' | md5sum | cut -c1-10)" >> $GITHUB_ENV
           cat bigbluebutton-config/bigbluebutton-release >> $GITHUB_ENV
           echo "FORCE_GIT_REV=0" >> $GITHUB_ENV #used by setup.sh

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -55,7 +55,7 @@ jobs:
             build-name: bbb-graphql-server
             build-list: bbb-graphql-server bbb-graphql-middleware
           - package: bbb-etherpad
-            cache-files-list: bbb-etherpad.placeholder.sh build/packages-template/bbb-etherpad
+            cache-files-list: bbb-etherpad.placeholder.sh
             cache-urls-list: https://api.github.com/repos/mconf/ep_pad_ttl/commits https://api.github.com/repos/alangecker/bbb-etherpad-plugin/commits https://api.github.com/repos/mconf/ep_redis_publisher/commits https://api.github.com/repos/alangecker/bbb-etherpad-skin/commits
           - package: bbb-web
             cache-files-list: bigbluebutton-web bbb-common-message bbb-common-web
@@ -66,11 +66,11 @@ jobs:
             cache-files-list: bigbluebutton-html5
           - package: bbb-freeswitch
             build-list: bbb-freeswitch-core bbb-freeswitch-sounds
-            cache-files-list: freeswitch.placeholder.sh build/packages-template/bbb-freeswitch-core build/packages-template/bbb-freeswitch-sounds
+            cache-files-list: freeswitch.placeholder.sh
             cache-urls-list: http://bigbluebutton.org/downloads/sounds.tar.gz
           - package: bbb-webrtc
             build-list: bbb-webrtc-sfu bbb-webrtc-recorder
-            cache-files-list: bbb-webrtc-sfu.placeholder.sh bbb-webrtc-recorder.placeholder.sh build/packages-template/bbb-webrtc-sfu build/packages-template/bbb-webrtc-recorder
+            cache-files-list: bbb-webrtc-sfu.placeholder.sh bbb-webrtc-recorder.placeholder.sh
           - package: others
             build-list: bbb-mkclean bbb-pads bbb-libreoffice-docker bbb-transcription-controller bigbluebutton
     steps:
@@ -79,7 +79,8 @@ jobs:
         uses: ./.github/actions/merge-branches
       - name: Set cache-key vars
         run: |
-          echo "CACHE_KEY_FILES=$(echo '${{ matrix.cache-files-list }} .gitlab-ci.yml build/deb-helper.sh' | xargs -n1 git log -1 --format=%h -- | tr '\n' '-' | sed 's/-$//')" >> $GITHUB_ENV
+          BUILD_DIRS=$(echo "${{ matrix.build-list || matrix.package }}" | sed 's/[^ ]\+/build\/packages-template\/&/g')
+          echo "CACHE_KEY_FILES=$(echo '${{ matrix.cache-files-list }} $BUILD_DIRS .gitlab-ci.yml build/deb-helper.sh' | xargs -n1 git log -1 --format=%h -- | tr '\n' '-' | sed 's/-$//')" >> $GITHUB_ENV
           echo "CACHE_KEY_URLS=$(echo '${{ matrix.cache-urls-list }}' | xargs -r -n 1 curl -Is | grep -i 'Last-Modified' | md5sum | cut -c1-10)" >> $GITHUB_ENV
           cat bigbluebutton-config/bigbluebutton-release >> $GITHUB_ENV
           echo "FORCE_GIT_REV=0" >> $GITHUB_ENV #used by setup.sh


### PR DESCRIPTION
In the automated tests since PR #18426, the build phase monitors specific directories for each package to determine a `CACHE_KEY` based on the last commit in those directories. 

The build process utilizes code from `build/packages-template/$PACKAGE_NAME` to generate the artifact.

To ensure accuracy and consistency, it's crucial that the cache is refreshed whenever there are changes in a package's build directory. 
This pull request ensures that a new cache is generated whenever modifications are detected in the respective build directory.

For instance:
If the file `build/packages-template/bbb-fsesl-akka/build.sh` was changed in the current PR, it will obtain a new `CACHE_CACHE` and therefore will run the build for `bbb-fsesl-akka` instead of use the cache of any previous PR.