### PR TITLE
fix: user name on top of avatar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
@@ -122,7 +122,7 @@ const UserListItem: React.FC<UserListItemProps> = ({ user, lockSettings }) => {
       <Styled.Avatar
         data-test={user.role === ROLE_MODERATOR ? 'moderatorAvatar' : 'viewerAvatar'}
         data-test-presenter={user.presenter ? '' : undefined}
-        data-test-avatar='userAvatar'
+        data-test-avatar="userAvatar"
         moderator={user.role === ROLE_MODERATOR}
         presenter={user.presenter}
         talking={voiceUser?.talking}

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
@@ -108,9 +108,9 @@ const UserListItem: React.FC<UserListItemProps> = ({ user, lockSettings }) => {
         : <Icon iconName={normalizeEmojiName('away')} />;
     } if (user.emoji !== 'none' && user.emoji !== 'notAway') {
       return <Icon iconName={normalizeEmojiName(user.emoji)} />;
-    } if (user.name) {
+    } if (user.name && userAvatarFiltered.length === 0) {
       return user.name.toLowerCase().slice(0, 2);
-    } return '??';
+    } return '';
   };
 
   const iconUser = getIconUser();

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/styles.ts
@@ -312,10 +312,11 @@ const Avatar = styled.div<AvatarProps>`
   `}
   // ================ talking animation ================
   // ================ image ================
-  ${({ avatar, emoji }) => avatar?.length !== 0 && !emoji && css`
+  ${({ avatar, emoji, color }) => avatar?.length !== 0 && !emoji && css`
     background-image: url(${avatar});
     background-repeat: no-repeat;
     background-size: contain;
+    border: 2px solid ${color};
   `}
   // ================ image ================
 


### PR DESCRIPTION
### What does this PR do?

Fix regression of user name appearing on top of user avatar when `avatarURL` is provided

#### before
![avatar-before](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/2e232bbc-ecd2-4b4e-9ba6-1317f27d926a)

#### after
![avatar-after](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/3e6b94b1-c272-4400-a6e3-c4268d3ce764)
