### PR TITLE
refactor(bbb-libreoffice): Switch Docker image to use the one built by BBB (reducing install time significantly)

### DIFF
--- a/bbb-libreoffice/docker/Dockerfile
+++ b/bbb-libreoffice/docker/Dockerfile
@@ -1,3 +1,1 @@
-FROM amazoncorretto:17-alpine
-
-RUN apk add fontconfig libreoffice
+FROM bigbluebutton/bbb-libreoffice:latest


### PR DESCRIPTION
Building the Docker image that runs Libreoffice (for conversions) was quite time-consuming. Specifically, the phase involving the installation of Libreoffice into the container running Alpine took a while.
```
FROM amazoncorretto:17-alpine
RUN apk add fontconfig libreoffice
```

To decrease this installation time, we created a new Docker image. This updated image comes with both Alpine and Libreoffice pre-installed. This is a departure from the previous approach, where the Docker image was first downloaded with just Alpine, and then Libreoffice was added in a subsequent step. This modification significantly cuts down the installation time.

<table>
<tr>
<td>Before (~2m43s)</td>
<td>After (~22s)</td>
</tr>
<tr>
<td>

![install-libreoffice-before](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/e268879f-b6af-4c6a-9101-a74b7768015e)


</td>
<td>

![install-libreoffice-after](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/8da594fc-16ac-4b94-8cda-4425226028d3)


</td>
</tr>
</table>

New Docker Image: https://hub.docker.com/r/bigbluebutton/bbb-libreoffice
New Docker Image (source): https://github.com/bigbluebutton/bigbluebutton-docker-libreoffice