### PR TITLE
refactor (graphql-server): Improves build script

### DIFF
--- a/bbb-graphql-server/update_graphql_data.sh
+++ b/bbb-graphql-server/update_graphql_data.sh
@@ -17,12 +17,12 @@ fi
 
 echo "Restarting database bbb_graphql"
 sudo -u postgres psql -c "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE datname = 'bbb_graphql'"
-sudo -u postgres psql -c "drop database if exists bbb_graphql"
+sudo -u postgres psql -c "drop database if exists bbb_graphql with (force)"
 sudo -u postgres psql -c "create database bbb_graphql WITH TEMPLATE template0 LC_COLLATE 'C.UTF-8'"
 sudo -u postgres psql -c "alter database bbb_graphql set timezone to 'UTC'"
 
 echo "Creating tables in bbb_graphql"
-sudo -u postgres psql -U postgres -d bbb_graphql -a -f bbb_schema.sql --set ON_ERROR_STOP=on
+sudo -u postgres psql -U postgres -d bbb_graphql -q -f bbb_schema.sql --set ON_ERROR_STOP=on
 
 if [ "$hasura_status" = "active" ]; then
   echo "Starting Hasura"

--- a/build/packages-template/bbb-graphql-server/after-install.sh
+++ b/build/packages-template/bbb-graphql-server/after-install.sh
@@ -6,10 +6,10 @@ case "$1" in
   fc-cache -f
 
   sudo -u postgres psql -c "alter user postgres password 'bbb_graphql'"
-  sudo -u postgres psql -c "drop database if exists bbb_graphql"
+  sudo -u postgres psql -c "drop database if exists bbb_graphql with (force)"
   sudo -u postgres psql -c "create database bbb_graphql WITH TEMPLATE template0 LC_COLLATE 'C.UTF-8'"
   sudo -u postgres psql -c "alter database bbb_graphql set timezone to 'UTC'"
-  sudo -u postgres psql -U postgres -d bbb_graphql -a -f /usr/share/bbb-graphql-server/bbb_schema.sql --set ON_ERROR_STOP=on
+  sudo -u postgres psql -U postgres -d bbb_graphql -q -f /usr/share/bbb-graphql-server/bbb_schema.sql --set ON_ERROR_STOP=on
 
   DATABASE_NAME="hasura_app"
   DB_EXISTS=$(sudo -u postgres psql -U postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$DATABASE_NAME'")


### PR DESCRIPTION
This PR introduces 3 tweaks:

# Command `drop database`
- Adds the param `with (force)` in order to avoid the error `database "bbb_graphql" is being accessed by other users`

<table><tr><td>

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/f6c079ed-94b9-437b-b65c-9534f7687f4d)

</td></tr></table>

https://www.postgresql.org/docs/current/sql-dropdatabase.html
It requires PostgreSQL >= 13 (by default BBB installs v14.9)

# Execution of `bbb_schema.sql`
- Remove the param `-a` to reduce logs

<table><tr><td>

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/65b8b594-37a3-40b2-b82e-90a6846e2bde)

</td></tr></table>

- Include the param `-q` to reduce logs

<table><tr><td>

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/2017f781-f742-4fa2-904e-c00d9c2c9d7e)
</td></tr></table>

https://www.postgresql.org/docs/current/app-psql.html