### PR TITLE
Fix: Mute button moving right

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/styles.ts
@@ -24,7 +24,6 @@ const pulse = keyframes`
 
 // @ts-ignore - as button comes from JS, we can't provide its props
 export const MuteToggleButton = styled(Button)`
-  margin-right: 0.5rem;
   ${({ ghost }) => ghost && `
     span {
       box-shadow: none;


### PR DESCRIPTION
### What does this PR do?

This PR fixes an unexpected behaviour introduced in the 3.0 migration, where the mute button was moving to the right.