### PR TITLE
fix (html5): tweak func that waits for port 27017 to be ready before init replicaset

### DIFF
--- a/build/packages-template/bbb-html5/workers-start.sh
+++ b/build/packages-template/bbb-html5/workers-start.sh
@@ -3,12 +3,11 @@
 echo "Starting mongoDB"
 
 #wait for mongo startup
-MONGO_OK=0
-
-while [ "$MONGO_OK" = "0" ]; do
-    MONGO_OK=$(ss -lan | grep 127.0.1.1 | grep 27017 &> /dev/null && echo 1 || echo 0)
-    sleep 1;
-done;
+MONGO_PORT=27017
+while ! netstat -tuln | grep ":$MONGO_PORT " > /dev/null; do
+    echo "Waiting for Mongo's port ($MONGO_PORT) to be ready..."
+    sleep 1
+done
 
 echo "Mongo started";
 


### PR DESCRIPTION
Fix Automated tests that was very often failing on step `Install BBB`

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/9428fbf8-fe9c-4f2d-b793-c82b46eb6708)
