### PR TITLE
refactor (graphql-server): Adds new chat msg type 'breakoutRoomModeratorMsg'

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/SendMessageToBreakoutRoomInternalMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/SendMessageToBreakoutRoomInternalMsgHdlr.scala
@@ -1,6 +1,6 @@
 package org.bigbluebutton.core.apps.breakout
 
-import org.bigbluebutton.common2.msgs.{ GroupChatAccess, GroupChatMsgFromUser }
+import org.bigbluebutton.common2.msgs.{ GroupChatAccess, GroupChatMessageType, GroupChatMsgFromUser }
 import org.bigbluebutton.core.api.SendMessageToBreakoutRoomInternalMsg
 import org.bigbluebutton.core.apps.groupchats.GroupChatApp
 import org.bigbluebutton.core.bus.MessageBus
@@ -20,7 +20,7 @@ trait SendMessageToBreakoutRoomInternalMsgHdlr {
     } yield {
       val groupChatMsgFromUser = GroupChatMsgFromUser(sender.id, sender.copy(name = msg.senderName), true, msg.msg)
       val gcm = GroupChatApp.toGroupChatMessage(sender.copy(name = msg.senderName), groupChatMsgFromUser)
-      val gcs = GroupChatApp.addGroupChatMessage(liveMeeting.props.meetingProp.intId, chat, state.groupChats, gcm)
+      val gcs = GroupChatApp.addGroupChatMessage(liveMeeting.props.meetingProp.intId, chat, state.groupChats, gcm, GroupChatMessageType.BREAKOUTROOM_MOD_MSG)
 
       val event = buildGroupChatMessageBroadcastEvtMsg(
         liveMeeting.props.meetingProp.intId,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/chat/ClearPublicChatHistoryPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/chat/ClearPublicChatHistoryPubMsgHdlr.scala
@@ -33,7 +33,7 @@ trait ClearPublicChatHistoryPubMsgHdlr extends LogHelper with RightsManagementTr
         gc <- state.groupChats.find(msg.body.chatId)
       } yield {
         ChatMessageDAO.deleteAllFromChat(liveMeeting.props.meetingProp.intId, msg.body.chatId)
-        ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, msg.body.chatId, "", "publicChatHistoryCleared", Map(), "")
+        ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, msg.body.chatId, "", GroupChatMessageType.PUBLIC_CHAT_HIST_CLEARED, Map(), "")
         broadcastEvent(msg)
         val newGc = gc.clearMessages()
         val gcs = state.groupChats.update(newGc)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChat.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChat.scala
@@ -1,6 +1,6 @@
 package org.bigbluebutton.core.apps.groupchats
 
-import org.bigbluebutton.common2.msgs.{ GroupChatAccess, GroupChatMsgFromUser, GroupChatMsgToUser, GroupChatUser }
+import org.bigbluebutton.common2.msgs.{ GroupChatAccess, GroupChatMessageType, GroupChatMsgFromUser, GroupChatMsgToUser, GroupChatUser }
 import org.bigbluebutton.core.db.ChatMessageDAO
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models._
@@ -32,9 +32,9 @@ object GroupChatApp {
   }
 
   def addGroupChatMessage(meetingId: String, chat: GroupChat, chats: GroupChats,
-                          msg: GroupChatMessage): GroupChats = {
+                          msg: GroupChatMessage, messageType: String = GroupChatMessageType.DEFAULT): GroupChats = {
     if (msg.sender.id == SystemUser.ID) {
-      ChatMessageDAO.insertSystemMsg(meetingId, chat.id, msg.message, "default", Map(), msg.sender.name)
+      ChatMessageDAO.insertSystemMsg(meetingId, chat.id, msg.message, messageType, Map(), msg.sender.name)
     } else {
       ChatMessageDAO.insert(meetingId, chat.id, msg)
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/ShowPollResultReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/ShowPollResultReqMsgHdlr.scala
@@ -77,7 +77,7 @@ trait ShowPollResultReqMsgHdlr extends RightsManagementTrait {
           "numResponders" -> result.numResponders,
         )
 
-        ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, "", "poll", resultAsSimpleMap, "")
+        ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, "", GroupChatMessageType.POLL, resultAsSimpleMap, "")
         broadcastEvent(msg, result, annotationProp)
       }
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
@@ -247,7 +247,7 @@ trait MakePresentationDownloadReqMsgHdlr extends RightsManagementTrait {
         "fileURI" -> m.body.annotatedFileURI,
         "filename" -> "annotated_slides.pdf"
       )
-      ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, "", "presentation", presentationDownloadInfo, "")
+      ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, "", GroupChatMessageType.PRESENTATION, presentationDownloadInfo, "")
     }
 
     bus.outGW.send(buildBroadcastNewPresFileAvailable(m, liveMeeting))

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
@@ -5,6 +5,14 @@ object GroupChatAccess {
   val PRIVATE = "PRIVATE_ACCESS"
 }
 
+object GroupChatMessageType {
+  val DEFAULT = "default"
+  val PRESENTATION = "presentation"
+  val POLL = "poll"
+  val BREAKOUTROOM_MOD_MSG = "breakoutRoomModeratorMsg"
+  val PUBLIC_CHAT_HIST_CLEARED = "publicChatHistoryCleared"
+}
+
 case class GroupChatUser(id: String, name: String = "", role: String = "VIEWER")
 case class GroupChatMsgFromUser(correlationId: String, sender: GroupChatUser, chatEmphasizedText: Boolean = false, message: String)
 case class GroupChatMsgToUser(id: String, timestamp: Long, correlationId: String, sender: GroupChatUser, chatEmphasizedText: Boolean = false, message: String)


### PR DESCRIPTION
It creates a new type of message that will be used by the feature "Message all rooms".

<table><tr><td>

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/3fd5d11c-f6f6-4e21-a7e0-11eb61718c8a)

</td></tr></table>

```json
{
  "data": {
    "chat_message_public": [
      {
        "chatEmphasizedText": false,
        "chatId": "MAIN-PUBLIC-GROUP-CHAT",
        "correlationId": "",
        "createdTime": 1695656059903,
        "createdTimeAsDate": "2023-09-25T15:34:19+00:00",
        "meetingId": "e3b3e9772e39335b7d040274237e0b75db08f0d3-1695656051491",
        "message": "my msg content",
        "messageId": "1695656059902-5292rtm4",
        "messageMetadata": "{}",
        "messageType": "breakoutRoomModeratorMsg",
        "senderId": null,
        "senderName": "teacher 1",
        "senderRole": null
      }
    ]
  }
}
```