### PR TITLE
refactor (graphql-server): Expire audio caption after 5 seconds

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1411,8 +1411,10 @@ CREATE TABLE "audio_caption" (
     "createdAt" timestamp with time zone
 );
 
-CREATE VIEW "v_audio_caption" AS
-SELECT * FROM "audio_caption";
+CREATE OR REPLACE VIEW "v_audio_caption" AS
+SELECT *
+FROM "audio_caption"
+WHERE "createdAt" > current_timestamp - INTERVAL '5 seconds';
 
 ------------------------------------
 ----


### PR DESCRIPTION
For now it's hard coded 5 seconds.
In the future it will get the time from client config `public.captions.time` (After #18712).

Necessary for #18822 