### PR TITLE
fix: String substitution whenever the word constructor is typed in general chat

### DIFF
--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -6560,9 +6560,9 @@
       }
     },
     "smile2emoji": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/smile2emoji/-/smile2emoji-2.8.0.tgz",
-      "integrity": "sha512-TDdBc3lFKNodwgRN33GhjzaqAfRHjorFCJu57L6gdaF9Y6iIxKeVhzY2GW6EFNUL5YedC+Cp86rydnit7LZvNg=="
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/smile2emoji/-/smile2emoji-3.8.3.tgz",
+      "integrity": "sha512-j1UZSmk6V4cQ7F2M969tD31QoVKHbPyM1bEaWRcqMW+f7LcBAPppgzVrF1lGf9sga4I0+H5yCZfyfZ1LStrFGg=="
     },
     "source-map": {
       "version": "0.5.7",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -86,7 +86,7 @@
     "sanitize-html": "2.7.1",
     "scheduler": "^0.20.2",
     "sdp-transform": "2.7.0",
-    "smile2emoji": "^2.8.0",
+    "smile2emoji": "^3.8.3",
     "string-hash": "~1.1.3",
     "styled-components": "^5.3.3",
     "tippy.js": "^5.1.3",


### PR DESCRIPTION
### What does this PR do?

Updates smile2emoji dependency to the latest version in order to fix a bug with some strings being incorrectly replaced.

### Closes Issue(s)
Closes #18808