### PR TITLE
fix: RTL on mobile - webcam not centered

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -197,7 +197,7 @@ const SmartLayout = (props) => {
 
     cameraDockBounds.top = navBarHeight;
     cameraDockBounds.left = mediaAreaBounds.left;
-    cameraDockBounds.right = isRTL ? sidebarSize + camerasMargin * 2 : null;
+    cameraDockBounds.right = isRTL ? sidebarSize : null;
     cameraDockBounds.zIndex = 1;
 
     if (mediaBounds.width < mediaAreaBounds.width) {


### PR DESCRIPTION
### What does this PR do?

Adjusts cameraDock margin in smart layout for RTL languages.

### Closes Issue(s)
Closes #18816