### PR TITLE
Delete presentation from Postgres when presentation is removed

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/RemovePresentationPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/RemovePresentationPubMsgHdlr.scala
@@ -3,6 +3,7 @@ package org.bigbluebutton.core.apps.presentationpod
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.MessageBus
+import org.bigbluebutton.core.db.PresPresentationDAO
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.LiveMeeting
 
@@ -37,6 +38,8 @@ trait RemovePresentationPubMsgHdlr extends RightsManagementTrait {
 
       val podId = msg.body.podId
       val presentationId = msg.body.presentationId
+
+      PresPresentationDAO.delete(presentationId)
 
       val newState = for {
         pod <- PresentationPodsApp.getPresentationPod(state, podId)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPresentationDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPresentationDAO.scala
@@ -114,4 +114,15 @@ object PresPresentationDAO {
       }
   }
 
+  def delete(presentationId: String) = {
+    DatabaseConnection.db.run(
+      TableQuery[PresPresentationDbTableDef]
+        .filter(_.presentationId === presentationId)
+        .delete
+    ).onComplete {
+        case Success(rowAffected) => DatabaseConnection.logger.debug(s"$rowAffected row(s) deleted presentation on PresPresentation table")
+        case Failure(e)           => DatabaseConnection.logger.error(s"Error deleting presentation on PresPresentation: $e")
+      }
+  }
+
 }


### PR DESCRIPTION
### What does this PR do?

Deletes presentations from the Postgres when the presentation has been removed from a meeting.


### Motivation

Previously when a presentation was removed from a meeting the presentation would remain in Postgres instead of also being removed there.
