### PR TITLE
fix: video dropdown chevron in rtl

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.jsx
@@ -180,6 +180,7 @@ const UserActions = (props) => {
               <Styled.DropdownTrigger
                 tabIndex={0}
                 data-test="dropdownWebcamButton"
+                isRTL={isRTL}
               >
                 {name}
               </Styled.DropdownTrigger>

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/styles.js
@@ -23,6 +23,9 @@ const DropdownTrigger = styled(DivElipsis)`
     content: "\\203a";
     position: absolute;
     transform: rotate(90deg);
+    ${({ isRTL }) => isRTL && `
+      transform: rotate(-90deg);
+    `}
     top: 45%;
     width: 0;
     line-height: 0;


### PR DESCRIPTION
### What does this PR do?

Adjusts webcam dropdown chevron position in RTL languages.

#### before
![2023-09-28_14-04](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/d136c19f-da17-477b-b4e8-9c6e8f39291e)

#### after
![2023-09-28_14-03](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/02e473fc-4239-4224-9ada-0c6fac5bf4b8)
