### PR TITLE
fix: Add Bounds to Presentation Zoom Changer

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -504,7 +504,13 @@ class Presentation extends PureComponent {
   }
 
   zoomChanger(zoom) {
-    this.setState({ zoom });
+    let boundZoom = parseInt(zoom);
+    if (boundZoom < HUNDRED_PERCENT) {
+      boundZoom = HUNDRED_PERCENT
+    } else if (boundZoom > MAX_PERCENT) {
+      boundZoom = MAX_PERCENT
+    }
+    this.setState({ zoom: boundZoom });
   }
 
   fitToWidthHandler() {


### PR DESCRIPTION
### What does this PR do?
This PR adds bounds to the presentation zoom changer to ensure that the zoom value remains within an acceptable range.

### Closes Issue(s)
Closes #18837 