### PR TITLE
fix (graphql-server): Meeting duration not updating when breakout rooms receive a new time

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/UpdateBreakoutRoomsTimeMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/UpdateBreakoutRoomsTimeMsgHdlr.scala
@@ -4,7 +4,7 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.api.{ SendTimeRemainingAuditInternalMsg, UpdateBreakoutRoomTimeInternalMsg }
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.BigBlueButtonEvent
-import org.bigbluebutton.core.db.BreakoutRoomDAO
+import org.bigbluebutton.core.db.{ BreakoutRoomDAO, MeetingDAO }
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
@@ -78,6 +78,7 @@ trait UpdateBreakoutRoomsTimeMsgHdlr extends RightsManagementTrait {
 
           log.debug("Updating {} minutes for breakout rooms time in meeting {}", msg.body.timeInMinutes, props.meetingProp.intId)
           BreakoutRoomDAO.updateRoomsDuration(props.meetingProp.intId, newDurationInSeconds)
+          MeetingDAO.updateMeetingDurationByParentMeeting(props.meetingProp.intId, newDurationInSeconds)
           breakoutModel.setTime(newDurationInSeconds)
         }
       }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomDAO.scala
@@ -175,10 +175,11 @@ object BreakoutRoomDAO {
     }
   }
 
-  def updateRoomsDuration(meetingId: String, newDurationInSeconds: Int) = {
+  def updateRoomsDuration(parentMeetingId: String, newDurationInSeconds: Int) = {
     DatabaseConnection.db.run(
       TableQuery[BreakoutRoomDbTableDef]
-        .filter(_.parentMeetingId === meetingId)
+        .filter(_.parentMeetingId === parentMeetingId)
+        .filter(_.endedAt.isEmpty)
         .map(u => u.durationInSeconds)
         .update(newDurationInSeconds)
     ).onComplete {


### PR DESCRIPTION
Fix the following prop:

```gql
subscription {
  meeting {
    duration
  }
}

```