### PR TITLE
fix (graphql-actions): Unlocked users can't send chat message

### DIFF
--- a/bbb-graphql-actions-adapter-server/src/actions/sendGroupChatMsg.ts
+++ b/bbb-graphql-actions-adapter-server/src/actions/sendGroupChatMsg.ts
@@ -4,7 +4,7 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
   const eventName = `SendGroupChatMessageMsg`;
 
   const routing = {
-    meetingId: sessionVariables['x-hasura-lockedinmeeting'] as String,
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
     userId: sessionVariables['x-hasura-userid'] as String
   };
 


### PR DESCRIPTION
Fix errors identified by Automated Tests related with unlocked users sending chat messages:

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/5d693b46-7ad5-4ceb-8c9c-64768676ca33)

Thanks a lot for testing team @antonbsa @gabriellpr. It's a really edge case which would be really hard to find without Automated tests.