### PR TITLE
Add new shell scripts useful for development

### DIFF
--- a/bbb-export-annotations/deploy.sh
+++ b/bbb-export-annotations/deploy.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+cd "$(dirname "$0")"
+
+for var in "$@"
+do
+    if [[ $var == --reset ]] ; then
+    	echo "Performing a full reset..."
+      rm -rf node_modules
+    fi
+done
+
+if [ ! -d ./node_modules ] ; then
+	npm install --production
+fi
+
+sudo cp -r ./* /usr/local/bigbluebutton/bbb-export-annotations
+sudo systemctl restart bbb-export-annotations
+echo ''
+echo ''
+echo '----------------'
+echo 'bbb-export-annotations updated'

--- a/bbb-export-annotations/run-dev.sh
+++ b/bbb-export-annotations/run-dev.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+cd "$(dirname "$0")"
+
+for var in "$@"
+do
+    if [[ $var == --reset ]] ; then
+    	echo "Performing a full reset..."
+      rm -rf node_modules
+    fi
+done
+
+if [ ! -d ./node_modules ] ; then
+	npm install
+fi
+
+sudo systemctl stop bbb-export-annotations
+npm start

--- a/bbb-graphql-actions-adapter-server/deploy.sh
+++ b/bbb-graphql-actions-adapter-server/deploy.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+cd "$(dirname "$0")"
+
+for var in "$@"
+do
+    if [[ $var == --reset ]] ; then
+    	echo "Performing a full reset..."
+      rm -rf node_modules
+    fi
+done
+
+if [ ! -d ./node_modules ] ; then
+  npm ci --no-progress
+fi
+
+npm run build
+
+mv -f dist/index.js dist/bbb-graphql-actions-adapter-server.js
+sudo cp -rf dist/* /usr/local/bigbluebutton/bbb-graphql-actions-adapter-server/
+sudo systemctl restart bbb-graphql-actions-adapter-server
+echo ''
+echo ''
+echo '----------------'
+echo 'bbb-graphql-actions-adapter-server updated'

--- a/bbb-graphql-actions-adapter-server/run-dev.sh
+++ b/bbb-graphql-actions-adapter-server/run-dev.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+cd "$(dirname "$0")"
+
+for var in "$@"
+do
+    if [[ $var == --reset ]] ; then
+    	echo "Performing a full reset..."
+      rm -rf node_modules
+    fi
+done
+
+if [ ! -d ./node_modules ] ; then
+	npm install
+fi
+
+sudo systemctl stop bbb-graphql-actions-adapter-server
+npm start
+xxx

--- a/bbb-graphql-actions-adapter-server/run-dev.sh
+++ b/bbb-graphql-actions-adapter-server/run-dev.sh
@@ -15,4 +15,3 @@ fi
 
 sudo systemctl stop bbb-graphql-actions-adapter-server
 npm start
-xxx

--- a/bbb-graphql-middleware/install-graphql-middleware.sh
+++ b/bbb-graphql-middleware/install-graphql-middleware.sh
@@ -8,11 +8,11 @@ cd "$(dirname "$0")"
 
 #Install Go
 #sudo apt install golang -y
-GO_VERSION=1.20.6
+GO_VERSION=1.20.8
 wget --no-verbose https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz \
-  && tar -xzf go${GO_VERSION}.linux-amd64.tar.gz \
-  && ln -s ${PWD}/go/bin/go /usr/bin/go \
-  && rm go${GO_VERSION}.linux-amd64.tar.gz
+  && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz \
+  && rm go${GO_VERSION}.linux-amd64.tar.gz \
+  && ln -sf /usr/local/go/bin/go /usr/bin/go
 
 go version
 


### PR DESCRIPTION
In order to facilitate the development environment, I added some useful scripts:

- `bbb-export-annotations/deploy.sh`
- `bbb-export-annotations/run-dev.sh`
- `bbb-graphql-actions-adapter-server/deploy.sh`
- `bbb-graphql-actions-adapter-server/run-dev.sh`

This scripts are becoming default for every application:
- `run-dev.sh` : Stops the service and execute the application
- `deploy.sh`: Build a new version of the application, copy to the service directory, and restart the service