### PR TITLE
graphql: Client Settings Retrieval through Graphql

### DIFF
--- a/akka-bbb-apps/project/Dependencies.scala
+++ b/akka-bbb-apps/project/Dependencies.scala
@@ -1,7 +1,6 @@
 package org.bigbluebutton.build
 
 import sbt._
-import Keys._
 
 object Dependencies {
 
@@ -65,6 +64,8 @@ object Dependencies {
     val slick = "com.typesafe.slick" %% "slick" % Versions.slick
     val slickHikaricp = "com.typesafe.slick" %% "slick-hikaricp" % Versions.slick
     val slickPg = "com.github.tminglei" %% "slick-pg" % Versions.slickPg
+    val slickPgSprayJson = "com.github.tminglei" %% "slick-pg_spray-json" % Versions.slickPg
+
     val postgresql = "org.postgresql" % "postgresql" % Versions.postgresql
     val jacksonDataFormat = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jacksonDataFormat
     val snakeYaml = "org.yaml" % "snakeyaml"
@@ -104,6 +105,7 @@ object Dependencies {
     Compile.slick,
     Compile.slickHikaricp,
     Compile.slickPg,
+    Compile.slickPgSprayJson,
     Compile.postgresql,
     Compile.jacksonDataFormat) ++ testing
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ChatMessageDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ChatMessageDAO.scala
@@ -82,7 +82,7 @@ object ChatMessageDAO {
           chatEmphasizedText = false,
           message = message,
           messageType = messageType,
-          messageMetadata = Some(JsonUtils.mapToJson(messageMetadata)),
+          messageMetadata = Some(JsonUtils.mapToJson(messageMetadata).compactPrint),
           senderId = None,
           senderName = senderName,
           senderRole = None

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingClientSettingsDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingClientSettingsDAO.scala
@@ -1,0 +1,38 @@
+package org.bigbluebutton.core.db
+
+import PostgresProfile.api._
+import slick.lifted.ProvenShape
+import spray.json.JsValue
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Success}
+
+case class MeetingClientSettingsDbModel(
+    meetingId:              String,
+    clientSettingsJson:     JsValue,
+)
+
+class MeetingClientSettingsDbTableDef(tag: Tag) extends Table[MeetingClientSettingsDbModel](tag, "meeting_clientSettings") {
+  val meetingId = column[String]("meetingId", O.PrimaryKey)
+  val clientSettingsJson = column[JsValue]("clientSettingsJson")
+
+  override def * : ProvenShape[MeetingClientSettingsDbModel] = (meetingId, clientSettingsJson) <> (MeetingClientSettingsDbModel.tupled, MeetingClientSettingsDbModel.unapply)
+}
+
+object MeetingClientSettingsDAO {
+  def insert(meetingId: String, clientSettingsJson: JsValue) = {
+    DatabaseConnection.db.run(
+      TableQuery[MeetingClientSettingsDbTableDef].forceInsert(
+        MeetingClientSettingsDbModel(
+          meetingId = meetingId,
+          clientSettingsJson = clientSettingsJson
+        )
+      )
+    ).onComplete {
+        case Success(rowsAffected) => {
+          DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted in MeetingClientSettings table!")
+        }
+        case Failure(e) => DatabaseConnection.logger.error(s"Error inserting MeetingClientSettings: $e")
+      }
+  }
+
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingDAO.scala
@@ -55,7 +55,7 @@ class MeetingDbTableDef(tag: Tag) extends Table[MeetingDbModel](tag, None, "meet
 }
 
 object MeetingDAO {
-  def insert(meetingProps: DefaultProps) = {
+  def insert(meetingProps: DefaultProps, clientSettings: Map[String, Object]) = {
     DatabaseConnection.db.run(
       TableQuery[MeetingDbTableDef].forceInsert(
         MeetingDbModel(
@@ -88,6 +88,7 @@ object MeetingDAO {
           MeetingBreakoutDAO.insert(meetingProps.meetingProp.intId, meetingProps.breakoutProps)
           TimerDAO.insert(meetingProps.meetingProp.intId)
           LayoutDAO.insert(meetingProps.meetingProp.intId, meetingProps.usersProp.meetingLayout)
+          MeetingClientSettingsDAO.insert(meetingProps.meetingProp.intId, JsonUtils.mapToJson(clientSettings))
         }
         case Failure(e) => DatabaseConnection.logger.error(s"Error inserting Meeting: $e")
       }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PostgresProfile.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PostgresProfile.scala
@@ -2,11 +2,12 @@ package org.bigbluebutton.core.db
 
 import com.github.tminglei.slickpg._
 import spray.json.{ JsArray, JsBoolean, JsNumber, JsObject, JsString, JsValue, JsonWriter }
-import spray.json.{ _ }
+import spray.json._
 
 trait PostgresProfile extends ExPostgresProfile
-  with PgArraySupport {
-  //  def pgjson = "jsonb" // jsonb support is in postgres 9.4.0 onward; for 9.3.x use "json"
+  with PgArraySupport
+  with PgSprayJsonSupport {
+  def pgjson = "jsonb" // jsonb support is in postgres 9.4.0 onward; for 9.3.x use "json"
 
   // Add back `capabilities.insertOrUpdate` to enable native `upsert` support; for postgres 9.5+
   override protected def computeCapabilities: Set[slick.basic.Capability] =
@@ -14,7 +15,7 @@ trait PostgresProfile extends ExPostgresProfile
 
   override val api = PgAPI
 
-  object PgAPI extends API with ArrayImplicits //    with DateTimeImplicits
+  object PgAPI extends API with ArrayImplicits with SprayJsonImplicits //    with DateTimeImplicits
   {
     implicit val strListTypeMapper = new SimpleArrayJdbcType[String]("text").to(_.toList)
   }
@@ -47,7 +48,7 @@ object JsonUtils {
   }
 
   def mapToJson(genericMap: Map[String, Any]) = {
-    genericMap.toJson.compactPrint
+    genericMap.toJson
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresAnnotationDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresAnnotationDAO.scala
@@ -36,7 +36,7 @@ object PresAnnotationDAO {
               annotationId = annotation.id,
               pageId = annotation.wbId,
               userId = annotation.userId,
-              annotationInfo = JsonUtils.mapToJson(annotation.annotationInfo),
+              annotationInfo = JsonUtils.mapToJson(annotation.annotationInfo).compactPrint,
               lastHistorySequence = sequence.getOrElse(0),
               lastUpdatedAt = new java.sql.Timestamp(System.currentTimeMillis())
             )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresAnnotationHistoryDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresAnnotationHistoryDAO.scala
@@ -34,7 +34,7 @@ object PresAnnotationHistoryDAO {
           annotationId = annotationDiff.id,
           pageId = annotationDiff.wbId,
           userId = annotationDiff.userId,
-          annotationInfo = JsonUtils.mapToJson(annotationDiff.annotationInfo)
+          annotationInfo = JsonUtils.mapToJson(annotationDiff.annotationInfo).compactPrint
         )
     )
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/LiveMeeting.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/LiveMeeting.scala
@@ -26,5 +26,5 @@ class LiveMeeting(
     val voiceUsers:          VoiceUsers,
     val users2x:             Users2x,
     val guestsWaiting:       GuestsWaiting,
-    val clientSettings: Map[String, Object],
+    val clientSettings:      Map[String, Object],
 )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/RunningMeeting.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/RunningMeeting.scala
@@ -35,7 +35,7 @@ class RunningMeeting(val props: DefaultProps, outGW: OutMessageGateway,
   private val deskshareModel = new ScreenshareModel
   private val audioCaptions = new AudioCaptions
   private val timerModel = new TimerModel
-  private val clientSettings: Map[String, Object] = ClientSettings.getClientSettingsWithOverride(props.overrideClientSettings)
+  val clientSettings: Map[String, Object] = ClientSettings.getClientSettingsWithOverride(props.overrideClientSettings)
 
   // meetingModel.setGuestPolicy(props.usersProp.guestPolicy)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/RunningMeetings.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/RunningMeetings.scala
@@ -10,7 +10,7 @@ object RunningMeetings {
 
   def add(meetings: RunningMeetings, meeting: RunningMeeting): RunningMeeting = {
     meetings.save(meeting)
-    MeetingDAO.insert(meeting.props)
+    MeetingDAO.insert(meeting.props, meeting.clientSettings)
     meeting
   }
 

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -198,6 +198,13 @@ WHERE "hideUserList" IS FALSE;
 
 CREATE INDEX "idx_meeting_lockSettings_hideUserList_false" ON "meeting_lockSettings"("meetingId") WHERE "hideUserList" IS FALSE;
 
+create table "meeting_clientSettings" (
+	"meetingId" 		varchar(100) primary key references "meeting"("meetingId") ON DELETE CASCADE,
+    "clientSettingsJson"             text
+);
+
+CREATE VIEW "v_meeting_clientSettings" AS SELECT * FROM "meeting_clientSettings";
+
 
 create table "meeting_group" (
 	"meetingId"  varchar(100) references "meeting"("meetingId") ON DELETE CASCADE,

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
@@ -16,6 +16,15 @@ object_relationships:
         remote_table:
           name: v_meeting_breakoutPolicies
           schema: public
+  - name: clientSettings
+    using:
+      manual_configuration:
+        column_mapping:
+          meetingId: meetingId
+        insertion_order: null
+        remote_table:
+          name: v_meeting_clientSettings
+          schema: public
   - name: externalVideo
     using:
       manual_configuration:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_clientSettings.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_clientSettings.yaml
@@ -1,0 +1,17 @@
+table:
+  name: v_meeting_clientSettings
+  schema: public
+configuration:
+  column_config: {}
+  custom_column_names: {}
+  custom_name: meeting_clientSettings
+  custom_root_fields: {}
+select_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - clientSettingsJson
+      filter:
+        meetingId:
+          _eq: X-Hasura-MeetingId
+    comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -12,6 +12,7 @@
 - "!include public_v_layout.yaml"
 - "!include public_v_meeting.yaml"
 - "!include public_v_meeting_breakoutPolicies.yaml"
+- "!include public_v_meeting_clientSettings.yaml"
 - "!include public_v_meeting_group.yaml"
 - "!include public_v_meeting_lockSettings.yaml"
 - "!include public_v_meeting_recording.yaml"


### PR DESCRIPTION
**Description**:
- Introduces a new GraphQL Type named `meeting_clientSettings`.
- Includes a field called `clientSettingsJson`.

**Motivation**:
This change allows clients to fetch their settings directly via GraphQL, serving as an alternative to the existing method that relies on `Meteor.settings` (which sources from a yml config file).

----
**`meeting.clientSettings`**:
The field will also be available inside the Type `meeting`:
```gql
subscription {
  meeting {
    meetingId
    clientSettings {
      clientSettingsJson
    }
  }
}
```

----

**Querying only specific setting property**:
It's also possible to query directly the Type `meeting_clientSettings` and bring only a specific field from the settings.
This example query only `appName` and `paginationSorting` instead of query the whole json of settings (it's possible using alias):
```gql
subscription {
  meeting_clientSettings {
    appName: clientSettingsJson(path: "$.public.app.appName")
    paginationSorting: clientSettingsJson(path: "$.public.kurento.cameraSortingModes.paginationSorting")    
  }
}
```
----
**Filtering by a setting property**:
It's also possible to filter by a setting property that is part of the json.
This example filter by `clientSettingsJson.public.app.appName == "BigBlueButton HTML5 Client"`:
```gql
subscription {
  meeting_clientSettings(where: { clientSettingsJson: {
  _contains:{
    public: {
      app: {
        appName: "BigBlueButton HTML5 Client"
      }
    }
  }  
  }}) {
    appName: clientSettingsJson(path: "$.public.app.appName")
  }
}
```

----
**Postgresql type `jsonb`**:
In the database the column `clientSettingsJson` is stored as type `jsonb`, this type was chosen instead of `json` because it's faster for querying and allows for indexing.

Example of a Postgresql query fetching only a specific field of the `json`:
```sql
SELECT "clientSettingsJson" #>> '{public,app,appName}' AS "appName",
		jsonb_extract_path("clientSettingsJson", 'public', 'app', 'appName') AS "appNameAlternative"
FROM "meeting_clientSettings"
```