### PR TITLE
Fix: Page up and down on chat afecting presentation.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -216,8 +216,9 @@ class PresentationToolbar extends PureComponent {
   switchSlide(event) {
     const { target, which } = event;
     const isBody = target.nodeName === 'BODY';
+    const isElementFocused = document.getElementById('presentationToolbarWrapper').matches(':focus');
 
-    if (isBody) {
+    if (isElementFocused && isBody) {
       switch (which) {
         case KEY_CODES.ARROW_LEFT:
         case KEY_CODES.PAGE_UP:


### PR DESCRIPTION
### What does this PR do?

This PR fixes the bug on shortcuts behaviour where the Page up and Page down were working for both presentation and chat.

Example (after fix):
![scrollPgup](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/f50e703d-4c3c-4cba-88f8-8b4e1b66ffa5)
