### PR TITLE
fix: Page dimension parse error with decimal numbers 

### DIFF
--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -84,11 +84,11 @@ object MsgBuilder {
       val imgUrl = new URL(svgUrl)
       val imgContent = XML.load(imgUrl)
 
-      val w = (imgContent \ "@width").text.replaceAll("[^\\d]", "")
-      val h = (imgContent \ "@height").text.replaceAll("[^\\d]", "")
+      val w = (imgContent \ "@width").text.replaceAll("[^.0-9]", "")
+      val h = (imgContent \ "@height").text.replaceAll("[^.0-9]", "")
 
-      val width = w.toInt
-      val height = h.toInt
+      val width = w.toDouble
+      val height = h.toDouble
 
       PresentationPageConvertedVO(
         id = id,


### PR DESCRIPTION
### What does this PR do?

Changes the regex pattern for parsing presentation SVG page sizes to include decimal numbers.


### Motivation

Presentation page sizes were failing to be parsed when the values for `height` and `width` were decimal numbers instead of integer numbers.