### PR TITLE
fix: "Convert notes to presentation" not working when it contains emojis

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/Png2SvgConversionHandler.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/Png2SvgConversionHandler.java
@@ -3,6 +3,26 @@ package org.bigbluebutton.presentation.handlers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
 public class Png2SvgConversionHandler extends AbstractCommandHandler {
+
+    private final StringBuilder stderr = new StringBuilder();
+
+    @Override
+    public void onStderr(ByteBuffer buffer, boolean closed) {
+        if (!closed) {
+            byte[] bytes = new byte[buffer.remaining()];
+            buffer.get(bytes);
+            stderr.append(new String(bytes, StandardCharsets.UTF_8));
+        }
+    }
+
+    public String getStderrString() {
+        return stderr.toString();
+    }
+
+
     private static Logger log = LoggerFactory.getLogger(Png2SvgConversionHandler.class);
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -252,8 +252,14 @@ public class SvgImageCreatorImp implements SvgImageCreator {
                 if(svgHandler.isCommandTimeout()) {
                     log.error("Command execution (convertPngToSvg) exceeded the {} secs timeout for {} page {}.", convPdfToSvgTimeout, pres.getName(), page);
                 }
-
                 done = svgHandler.isCommandSuccessful();
+
+                if(!svgHandler.isCommandSuccessful()) {
+                    String errorOutput = svgHandler.getStderrString();
+                    if (!errorOutput.isEmpty()) {
+                        log.error("Error during conversion from PNG to SVG: " + errorOutput);
+                    }
+                }
 
                 if(destsvg.length() > 0) {
                     // Step 3: Add SVG namespace to the destionation file
@@ -272,7 +278,6 @@ public class SvgImageCreatorImp implements SvgImageCreator {
                     } catch (InterruptedException e) {
                         log.error("Interrupted Exception while adding SVG namespace {}", pres.getName(), e);
                     }
-
                     if (namespaceHandler.isCommandTimeout()) {
                         log.error("Command execution (addNameSpaceToSVG) exceeded the {} secs timeout for {} page {}.", convPdfToSvgTimeout, pres.getName(), page);
                     }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -9,6 +9,7 @@ import org.bigbluebutton.presentation.messages._
 import java.io.IOException
 import java.net.URL
 import javax.imageio.ImageIO
+import scala.io.Source
 import scala.xml.XML
 
 object MsgBuilder {
@@ -81,11 +82,16 @@ object MsgBuilder {
     val urls = Map("thumb" -> thumbUrl, "text" -> txtUrl, "svg" -> svgUrl, "png" -> pngUrl)
 
     try {
-      val imgUrl = new URL(svgUrl)
-      val imgContent = XML.load(imgUrl)
+      val svgContent = Source.fromURL(new URL(svgUrl)).mkString
 
-      val w = (imgContent \ "@width").text.replaceAll("[^.0-9]", "")
-      val h = (imgContent \ "@height").text.replaceAll("[^.0-9]", "")
+      // XML parser configuration in use disallows the DOCTYPE declaration within the XML document
+      // Sanitize the XML content removing DOCTYPE
+      val sanitizedSvgContent = "(?i)<!DOCTYPE[^>]*>".r.replaceAllIn(svgContent, "")
+
+      val xmlContent = XML.loadString(sanitizedSvgContent)
+
+      val w = (xmlContent \ "@width").text.replaceAll("[^.0-9]", "")
+      val h = (xmlContent \ "@height").text.replaceAll("[^.0-9]", "")
 
       val width = w.toDouble
       val height = h.toDouble

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -82,7 +82,9 @@ object MsgBuilder {
     val urls = Map("thumb" -> thumbUrl, "text" -> txtUrl, "svg" -> svgUrl, "png" -> pngUrl)
 
     try {
-      val svgContent = Source.fromURL(new URL(svgUrl)).mkString
+      val svgSource = Source.fromURL(new URL(svgUrl))
+      val svgContent = svgSource.mkString
+      svgSource.close()
 
       // XML parser configuration in use disallows the DOCTYPE declaration within the XML document
       // Sanitize the XML content removing DOCTYPE

--- a/build/packages-template/bbb-web/opts-jammy.sh
+++ b/build/packages-template/bbb-web/opts-jammy.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d zip,unzip,imagemagick,redis-server,xpdf-utils,bbb-libreoffice-docker,psmisc,fonts-crosextra-carlito,fonts-crosextra-caladea,fonts-noto,openjdk-17-jdk,file"
+OPTS="$OPTS -t deb -d zip,unzip,imagemagick,redis-server,xpdf-utils,bbb-libreoffice-docker,psmisc,fonts-crosextra-carlito,fonts-crosextra-caladea,fonts-noto,openjdk-17-jdk,file,potrace"


### PR DESCRIPTION
Currently the option "Convert notes to presentation" is not working when the notes contain Emojis:

https://github.com/bigbluebutton/bigbluebutton/assets/5660191/577965b6-ee4f-47de-aa35-37e9ac0c735a

This PR adds a log to inform which error occured during the command `convert /tmp/test.png /tmp/test1.svg`.
This log helped to identify the error:

![err-sharedNotes-emoji](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/7c2353b7-d65a-4d60-8850-b55ab13b7646)

The error is: `convert-im6.q16: delegate failed 'potrace' --svg --output '%o' '%i'' @ error/delegate.c/InvokeDelegate/1966.`.
The error is from the ImageMagick convert command, specifically its inability to handle the conversion process due to a missing delegate. Delegates in ImageMagick are external programs that ImageMagick uses to handle formats it doesn't natively support. In this case, it's trying to use 'potrace' for the conversion to SVG and failing because it's either not installed or not configured correctly.

To fix this issue I had to install `potrace`: `sudo apt-get install potrace`
Testing after:

https://github.com/bigbluebutton/bigbluebutton/assets/5660191/80e2dade-5f2b-47a0-bf77-c7d9e71bdea7

So this PR adds `potrace` as requirement for `bbb-web` package.

_You may notice that the emojis are being shown in grayscale. But this is another known issue that is being discussed at https://github.com/bigbluebutton/bigbluebutton/issues/11096_