### PR TITLE
build(bbb-libreoffice): Switch the LibreOffice Docker image to use the one built by BBB (backport to 2.7)

### DIFF
--- a/bbb-libreoffice/docker/Dockerfile
+++ b/bbb-libreoffice/docker/Dockerfile
@@ -1,3 +1,1 @@
-FROM amazoncorretto:17-alpine
-
-RUN apk add fontconfig libreoffice
+FROM bigbluebutton/bbb-libreoffice:latest


### PR DESCRIPTION
Backport to BBB 2.7 of #18818
