### PR TITLE
fix: remove "a" in user avatar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -161,7 +161,7 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
           color={messageContent.color}
           moderator={messageContent.isModerator}
         >
-          {!message.user || message.user?.avatar.length === 0 ? messageContent.name.toLowerCase().slice(0, 2) || 'q' : 'a'}
+          {!message.user || message.user?.avatar.length === 0 ? messageContent.name.toLowerCase().slice(0, 2) || '' : ''}
         </ChatAvatar>
       )}
       <ChatContent sameSender={message?.user ? sameSender : false}>


### PR DESCRIPTION
### What does this PR do?

Fix `A` letter appearing on top of user avatar when avatarURL is provided

![2023-10-17_08-57](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/c6e3676f-dad9-4612-a52a-eebff51b3fac)
