### PR TITLE
feature (api): Add preUploadedPresentation param to API's /create via GET

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/Util.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/Util.java
@@ -2,11 +2,14 @@ package org.bigbluebutton.api;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 
 public final class Util {
@@ -50,8 +53,19 @@ public final class Util {
 		return DigestUtils.sha1Hex(presFilename + uuid) + "-" + timestamp;
 	}
 
+	public static String extractFilenameFromUrl(String preUploadedPresentation) throws MalformedURLException {
+		URL url = new URL(preUploadedPresentation);
+		String filename = FilenameUtils.getName(url.getPath());
+		String extension = FilenameUtils.getExtension(url.getPath());
+		if (extension == null || extension.isEmpty()) return null;
+		return filename;
+	}
 	public static String createNewFilename(String presId, String fileExt) {
-		return presId + "." + fileExt;
+		if (!fileExt.isEmpty()) {
+			return presId + "." + fileExt;
+		} else {
+			return presId;
+		}
 	}
 	
 	public static File createPresentationDir(String meetingId, String presentationDir, String presentationId) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/MimeTypeUtils.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/MimeTypeUtils.java
@@ -1,5 +1,7 @@
 package org.bigbluebutton.presentation;
 
+import org.bigbluebutton.api.domain.Extension;
+
 import java.util.*;
 
 import static org.bigbluebutton.presentation.FileTypeConstants.*;
@@ -43,7 +45,16 @@ public class MimeTypeUtils {
             put(FileTypeConstants.SVG, Arrays.asList(SVG));
         }
     };
-    
+
+    public String getExtensionBasedOnMimeType(String mimeType) {
+        return EXTENSIONS_MIME.entrySet()
+                .stream()
+                .filter(entry -> entry.getValue().contains(mimeType))
+                .map(Map.Entry::getKey)
+                .findFirst()
+                .orElse(null);
+    }
+
     public Boolean extensionMatchMimeType(String mimeType, String finalExtension) {
         finalExtension = finalExtension.toLowerCase();
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/SupportedFileTypes.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/SupportedFileTypes.java
@@ -108,14 +108,21 @@ public final class SupportedFileTypes {
 		return "";
 	}
 
+	public static String detectFileExtensionBasedOnMimeType(File pres) {
+		String mimeType = detectMimeType(pres);
+		return mimeTypeUtils.getExtensionBasedOnMimeType(mimeType);
+	}
+
 	public static Boolean isPresentationMimeTypeValid(File pres, String fileExtension) {
 		String mimeType = detectMimeType(pres);
 
 		if (mimeType.equals("")) {
+			log.error("Not able to detect mimeType.");
 			return false;
 		}
 
 		if (!mimeTypeUtils.getValidMimeTypes().contains(mimeType)) {
+			log.error("MimeType is not valid for this meeting, [{}]", mimeType);
 			return false;
 		}
 

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1382,18 +1382,18 @@ class ApiController {
     Boolean hasPresentationUrlInParameter = false
 
 
-    String[] pu = request.getParameterMap().get("presentationURL")
+    String[] pu = request.getParameterMap().get("preUploadedPresentation")
     if (pu != null) {
-      String presentationURL = pu[0]
+      String preUploadedPresentation = pu[0]
       hasPresentationUrlInParameter = true
       def xmlString = new StringWriter()
       def xml = new MarkupBuilder(xmlString)
       xml.document (
         removable: "true",
         downloadable: "false",
-        url: presentationURL,
-        filename: extractFilenameFromUrl(presentationURL),
-        name: extractFilenameFromUrl(presentationURL)
+        url: preUploadedPresentation,
+        filename: extractFilenameFromUrl(preUploadedPresentation),
+        name: extractFilenameFromUrl(preUploadedPresentation)
       )
 
       def parsedXml = new XmlSlurper().parseText(xmlString.toString())

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -21,6 +21,7 @@ package org.bigbluebutton.web.controllers
 import com.google.gson.Gson
 import grails.web.context.ServletContextHolder
 import groovy.json.JsonBuilder
+import groovy.xml.MarkupBuilder
 import org.apache.commons.codec.binary.Base64
 import org.apache.commons.codec.digest.DigestUtils
 import org.apache.commons.io.FilenameUtils
@@ -1378,6 +1379,27 @@ class ApiController {
     Boolean isDefaultPresentationCurrent = false;
     def listOfPresentation = []
     def presentationListHasCurrent = false
+    Boolean hasPresentationUrlInParameter = false
+
+
+    String[] pu = request.getParameterMap().get("presentationURL")
+    if (pu != null) {
+      String presentationURL = pu[0]
+      hasPresentationUrlInParameter = true
+      def xmlString = new StringWriter()
+      def xml = new MarkupBuilder(xmlString)
+      xml.document (
+        removable: "true",
+        downloadable: "false",
+        url: presentationURL,
+        filename: extractFilenameFromUrl(presentationURL),
+        name: extractFilenameFromUrl(presentationURL)
+      )
+
+      def parsedXml = new XmlSlurper().parseText(xmlString.toString())
+
+      listOfPresentation << parsedXml
+    }
 
     // This part of the code is responsible for organize the presentations in a certain order
     // It selects the one that has the current=true, and put it in the 0th place.
@@ -1387,10 +1409,17 @@ class ApiController {
         log.warn("Insert Document API called without a payload - ignoring")
         return;
       }
-      listOfPresentation << [name: "default", current: true];
+      if (hasPresentationUrlInParameter) {
+        if (!preUploadedPresentationOverrideDefault) {
+          listOfPresentation << [name: "default", current: false]
+        }
+      } else {
+        listOfPresentation << [name: "default", current: true]
+      }
+
     } else {
       def xml = new XmlSlurper().parseText(requestBody);
-      Boolean hasCurrent = false;
+      Boolean hasCurrent = hasPresentationUrlInParameter;
       xml.children().each { module ->
         log.debug("module config found: [${module.@name}]");
 
@@ -1476,6 +1505,10 @@ class ApiController {
       }
     }
     return true
+  }
+
+  def extractFilenameFromUrl(String url) {
+    return url.split('/')[-1]
   }
 
   def processDocumentFromRawBytes(bytes, presOrigFilename, meetingId, current, isDownloadable, isRemovable,

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1420,7 +1420,7 @@ class ApiController {
       }
       if (hasPresentationUrlInParameter) {
         if (!preUploadedPresentationOverrideDefault) {
-          listOfPresentation << [name: "default", current: false]
+          listOfPresentation << [name: "default", current: true]
         }
       } else {
         listOfPresentation << [name: "default", current: true]

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -44,7 +44,6 @@ import org.bigbluebutton.web.services.turn.TurnEntry
 import org.bigbluebutton.web.services.turn.StunServer
 import org.bigbluebutton.web.services.turn.RemoteIceCandidate
 import org.json.JSONArray
-import org.apache.commons.io.FilenameUtils
 import javax.servlet.ServletRequest
 
 class ApiController {


### PR DESCRIPTION
### What does this PR do?

It basically implements the pre-upload presentation via GET, so now it is possible to pass a download URL to the create endpoint.

The behavior now is: if one passes in `preUploadedPresentation`, then this presentation will override the `default.pdf`, since `preUploadedPresentationOverrideDefault=true` by default in the `application.properties`. To avoid that, it is necessary to also send in `preUploadedPresentationOverrideDefault=false`.


### Closes Issue(s)

Closes #18924 

### More

Notice that all requirements of precedence are respected. 

**Naming discussion:**
One of the main concerns when doing this feature was how to name the presentation sent in the parameter, when the only thing we have is the URL to access it. It can be of the form:

```
<host>/presentation-name.pdf
<host>/presentation-name.pdf?query1=1
<host>/simply-a-hash-here (just like a shortened link)
```

So the idea is we are going to let the user specify the presentation's name with a new parameter `preUploadedPresentationName`, and that will have the priority. 

If the name is not specified, it will enter a flow to deduce it from the URL provided.

For the first 2 cases mentioned previously (the examples I gave for the URLs), the links have the extension plugged in, so it is pretty straight forward, the `FilenameUtils` will extract the name out (with it's logic) and done. 

But for the last case, we will consider that if there is no extension explicitly written in the URL, that URL doesn't have the filename in it. And therefore we have no clue what to guess (once we do not want to request the link to see the header, or else we would have to do some more validations due to possible security issues). With that in mind, we will simply name the presentation `untitled.<extension>` and the extension will be guessed further in the flow based on the mimetype.
