### PR TITLE
graphql: refactor presentation props

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
@@ -259,11 +259,12 @@ trait MakePresentationDownloadReqMsgHdlr extends RightsManagementTrait {
       )
       ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, "", GroupChatMessageType.PRESENTATION, presentationDownloadInfo, "")
     } else if (m.body.fileStateType == "Converted") {
-      PresPresentationDAO.updatDownloadUri(m.body.presId, m.body.convertedFileURI)
+      PresPresentationDAO.updateDownloadUri(m.body.presId, m.body.convertedFileURI)
     } else if (m.body.fileStateType == "Original") {
-      PresPresentationDAO.updatDownloadUri(m.body.presId, m.body.originalFileURI)
+      PresPresentationDAO.updateDownloadUri(m.body.presId, m.body.originalFileURI)
     }
 
+    PresPresentationDAO.updateExportToChatStatus(m.body.presId, "EXPORTED")
     bus.outGW.send(buildBroadcastNewPresFileAvailable(m, liveMeeting))
   }
 
@@ -279,6 +280,7 @@ trait MakePresentationDownloadReqMsgHdlr extends RightsManagementTrait {
   }
 
   def handle(m: PresAnnStatusMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
+    PresPresentationDAO.updateExportToChat(m.body.presId, m.body.status, m.body.pageNumber, m.body.error)
     bus.outGW.send(buildBroadcastPresAnnStatusMsg(m, liveMeeting))
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPageDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPageDAO.scala
@@ -1,39 +1,38 @@
 package org.bigbluebutton.core.db
 
 import org.bigbluebutton.core.models.{ PresentationInPod, PresentationPage }
-
-import org.bigbluebutton.core.models.PresentationInPod
-import slick.jdbc.PostgresProfile.api._
+import PostgresProfile.api._
+import spray.json.JsValue
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{ Failure, Success }
 
 case class PresPageDbModel(
-    pageId:         String,
-    presentationId: String,
-    num:            Int,
-    urls:           String,
-    content:        String,
-    slideRevealed:  Boolean,
-    current:        Boolean,
-    xOffset:        Double,
-    yOffset:        Double,
-    widthRatio:     Double,
-    heightRatio:    Double,
-    width:          Double,
-    height:         Double,
-    viewBoxWidth:   Double,
-    viewBoxHeight:  Double,
-    maxImageWidth:  Int,
-    maxImageHeight: Int,
-    converted:      Boolean
+    pageId:          String,
+    presentationId:  String,
+    num:             Int,
+    urlsJson:        JsValue,
+    content:         String,
+    slideRevealed:   Boolean,
+    current:         Boolean,
+    xOffset:         Double,
+    yOffset:         Double,
+    widthRatio:      Double,
+    heightRatio:     Double,
+    width:           Double,
+    height:          Double,
+    viewBoxWidth:    Double,
+    viewBoxHeight:   Double,
+    maxImageWidth:   Int,
+    maxImageHeight:  Int,
+    uploadCompleted: Boolean
 )
 
 class PresPageDbTableDef(tag: Tag) extends Table[PresPageDbModel](tag, None, "pres_page") {
   val pageId = column[String]("pageId", O.PrimaryKey)
   val presentationId = column[String]("presentationId")
   val num = column[Int]("num")
-  val urls = column[String]("urls")
+  val urlsJson = column[JsValue]("urlsJson")
   val content = column[String]("content")
   val slideRevealed = column[Boolean]("slideRevealed")
   val current = column[Boolean]("current")
@@ -47,9 +46,9 @@ class PresPageDbTableDef(tag: Tag) extends Table[PresPageDbModel](tag, None, "pr
   val viewBoxHeight = column[Double]("viewBoxHeight")
   val maxImageWidth = column[Int]("maxImageWidth")
   val maxImageHeight = column[Int]("maxImageHeight")
-  val converted = column[Boolean]("converted")
+  val uploadCompleted = column[Boolean]("uploadCompleted")
   //  val presentation = foreignKey("presentation_fk", presentationId, Presentations)(_.presentationId, onDelete = ForeignKeyAction.Cascade)
-  def * = (pageId, presentationId, num, urls, content, slideRevealed, current, xOffset, yOffset, widthRatio, heightRatio, width, height, viewBoxWidth, viewBoxHeight, maxImageWidth, maxImageHeight, converted) <> (PresPageDbModel.tupled, PresPageDbModel.unapply)
+  def * = (pageId, presentationId, num, urlsJson, content, slideRevealed, current, xOffset, yOffset, widthRatio, heightRatio, width, height, viewBoxWidth, viewBoxHeight, maxImageWidth, maxImageHeight, uploadCompleted) <> (PresPageDbModel.tupled, PresPageDbModel.unapply)
 }
 
 object PresPageDAO {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPresentationDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPresentationDAO.scala
@@ -1,6 +1,6 @@
 package org.bigbluebutton.core.db
 
-import slick.jdbc.PostgresProfile.api._
+import PostgresProfile.api._
 import org.bigbluebutton.core.models.{ PresentationInPod }
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -8,20 +8,24 @@ import scala.util.{ Failure, Success }
 import spray.json._
 
 case class PresPresentationDbModel(
-    presentationId:        String,
-    meetingId:             String,
-    name:                  String,
-    filenameConverted:     String,
-    isDefault:             Boolean,
-    current:               Boolean,
-    downloadable:          Boolean,
-    downloadFileExtension: Option[String],
-    downloadFileUri:       Option[String],
-    removable:             Boolean,
-    uploadCompleted:       Boolean,
-    numPages:              Int,
-    errorMsgKey:           String,
-    errorDetails:          String
+    presentationId:         String,
+    meetingId:              String,
+    name:                   String,
+    filenameConverted:      String,
+    isDefault:              Boolean,
+    current:                Boolean,
+    downloadable:           Boolean,
+    downloadFileExtension:  Option[String],
+    downloadFileUri:        Option[String],
+    removable:              Boolean,
+    uploadInProgress:       Boolean,
+    uploadCompleted:        Boolean,
+    uploadErrorMsgKey:      String,
+    uploadErrorDetailsJson: JsValue,
+    totalPages:             Int,
+    exportToChatStatus:     Option[String],
+    exportToChatCurrentPage: Option[Int],
+    exportToChatHasError:   Option[Boolean]
 )
 
 class PresPresentationDbTableDef(tag: Tag) extends Table[PresPresentationDbModel](tag, None, "pres_presentation") {
@@ -35,14 +39,21 @@ class PresPresentationDbTableDef(tag: Tag) extends Table[PresPresentationDbModel
   val downloadFileExtension = column[Option[String]]("downloadFileExtension")
   val downloadFileUri = column[Option[String]]("downloadFileUri")
   val removable = column[Boolean]("removable")
+  val uploadInProgress = column[Boolean]("uploadInProgress")
   val uploadCompleted = column[Boolean]("uploadCompleted")
-  val numPages = column[Int]("numPages")
-  val errorMsgKey = column[String]("errorMsgKey")
-  val errorDetails = column[String]("errorDetails")
+  val uploadErrorMsgKey = column[String]("uploadErrorMsgKey")
+  val uploadErrorDetailsJson = column[JsValue]("uploadErrorDetailsJson")
+  val totalPages = column[Int]("totalPages")
+  val exportToChatStatus = column[Option[String]]("exportToChatStatus")
+  val exportToChatCurrentPage = column[Option[Int]]("exportToChatCurrentPage")
+  val exportToChatHasError = column[Option[Boolean]]("exportToChatHasError")
+
   //  val meeting = foreignKey("meeting_fk", meetingId, Meetings)(_.meetingId, onDelete = ForeignKeyAction.Cascade)
 
   def * = (
-    presentationId, meetingId, name, filenameConverted, isDefault, current, downloadable, downloadFileExtension, downloadFileUri, removable, uploadCompleted, numPages, errorMsgKey, errorDetails
+    presentationId, meetingId, name, filenameConverted, isDefault, current, downloadable, downloadFileExtension, downloadFileUri, removable,
+    uploadInProgress, uploadCompleted, uploadErrorMsgKey, uploadErrorDetailsJson, totalPages,
+    exportToChatStatus, exportToChatCurrentPage, exportToChatHasError
   ) <> (PresPresentationDbModel.tupled, PresPresentationDbModel.unapply)
 }
 
@@ -70,10 +81,14 @@ object PresPresentationDAO {
           },
           downloadFileUri = None,
           removable = presentation.removable,
+          uploadInProgress = !presentation.uploadCompleted,
           uploadCompleted = presentation.uploadCompleted,
-          numPages = presentation.numPages,
-          errorMsgKey = presentation.errorMsgKey,
-          errorDetails = presentation.errorDetails.toJson.asJsObject.compactPrint
+          totalPages = presentation.numPages,
+          uploadErrorMsgKey = presentation.errorMsgKey,
+          uploadErrorDetailsJson = presentation.errorDetails.toJson,
+          exportToChatStatus = None,
+          exportToChatCurrentPage = None,
+          exportToChatHasError = None,
         )
       )
     ).onComplete {
@@ -89,7 +104,7 @@ object PresPresentationDAO {
                   pageId = page._2.id,
                   presentationId = presentation.id,
                   num = page._2.num,
-                  urls = page._2.urls.toJson.asJsObject.compactPrint,
+                  urlsJson = page._2.urls.toJson,
                   content = "Slide Content TODO", //TODO Get content from slide.txtUri (bbb-web should send its content)
                   slideRevealed = page._2.current,
                   current = page._2.current,
@@ -103,7 +118,7 @@ object PresPresentationDAO {
                   viewBoxHeight = 1,
                   maxImageWidth = 1440,
                   maxImageHeight = 1080,
-                  converted = page._2.converted
+                  uploadCompleted = page._2.converted
                 )
               )
             }
@@ -133,7 +148,7 @@ object PresPresentationDAO {
       }
   }
 
-  def updatDownloadUri(presentationId: String, downloadFileUri: String) = {
+  def updateDownloadUri(presentationId: String, downloadFileUri: String) = {
     DatabaseConnection.db.run(
       TableQuery[PresPresentationDbTableDef]
         .filter(_.presentationId === presentationId)
@@ -149,12 +164,36 @@ object PresPresentationDAO {
     DatabaseConnection.db.run(
       TableQuery[PresPresentationDbTableDef]
         .filter(_.presentationId === presentationId)
-        .map(p => (p.errorMsgKey, p.errorDetails))
-        .update(errorMsgKey, errorDetails.toJson.asJsObject.compactPrint)
+        .map(p => (p.uploadErrorMsgKey, p.uploadErrorDetailsJson))
+        .update(errorMsgKey, errorDetails.toJson)
     ).onComplete {
         case Success(rowAffected) => DatabaseConnection.logger.debug(s"$rowAffected row(s) updated errorMsgKey on PresPresentation table")
         case Failure(e)           => DatabaseConnection.logger.error(s"Error updating errorMsgKey on PresPresentation: $e")
       }
+  }
+
+  def updateExportToChat(presentationId: String, exportToChatStatus: String, exportToChatCurrentPage: Int, exportToChatHasError: Boolean) = {
+    DatabaseConnection.db.run(
+      TableQuery[PresPresentationDbTableDef]
+        .filter(_.presentationId === presentationId)
+        .map(p => (p.exportToChatStatus, p.exportToChatCurrentPage, p.exportToChatHasError))
+        .update(Some(exportToChatStatus), Some(exportToChatCurrentPage), Some(exportToChatHasError))
+    ).onComplete {
+      case Success(rowAffected) => DatabaseConnection.logger.debug(s"$rowAffected row(s) updated exportToChat on PresPresentation table")
+      case Failure(e) => DatabaseConnection.logger.error(s"Error updating exportToChat on PresPresentation: $e")
+    }
+  }
+
+  def updateExportToChatStatus(presentationId: String, exportToChatStatus: String) = {
+    DatabaseConnection.db.run(
+      TableQuery[PresPresentationDbTableDef]
+        .filter(_.presentationId === presentationId)
+        .map(p => p.exportToChatStatus)
+        .update(Some(exportToChatStatus))
+    ).onComplete {
+      case Success(rowAffected) => DatabaseConnection.logger.debug(s"$rowAffected row(s) updated exportToChatStatus on PresPresentation table")
+      case Failure(e) => DatabaseConnection.logger.error(s"Error updating exportToChatStatus on PresPresentation: $e")
+    }
   }
 
   def delete(presentationId: String) = {

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -869,15 +869,18 @@ CREATE TABLE "pres_presentation" (
 	"filenameConverted" varchar(500),
 	"isDefault" boolean,
 	"current" boolean,
+	"removable" boolean,
 	"downloadable" boolean,
 	"downloadFileExtension" varchar(25),
 	"downloadFileUri" varchar(500),
-	"removable" boolean,
-    "converting" boolean,
+    "uploadInProgress" boolean,
     "uploadCompleted" boolean,
-    "numPages" integer,
-    "errorMsgKey" varchar(100),
-    "errorDetails" TEXT
+    "uploadErrorMsgKey" varchar(100),
+    "uploadErrorDetailsJson" jsonb,
+    "totalPages" integer,
+    "exportToChatStatus" varchar(25),
+    "exportToChatCurrentPage" integer,
+    "exportToChatHasError" boolean
 );
 CREATE INDEX "idx_pres_presentation_meetingId" ON "pres_presentation"("meetingId");
 CREATE INDEX "idx_pres_presentation_meetingId_curr" ON "pres_presentation"("meetingId") where "current" is true;
@@ -886,7 +889,7 @@ CREATE TABLE "pres_page" (
 	"pageId" varchar(100) PRIMARY KEY,
 	"presentationId" varchar(100) REFERENCES "pres_presentation"("presentationId") ON DELETE CASCADE,
 	"num" integer,
-	"urls" TEXT,
+	"urlsJson" jsonb,
 	"content" TEXT,
 	"slideRevealed" boolean default false,
 	"current" boolean,
@@ -900,7 +903,7 @@ CREATE TABLE "pres_page" (
     "viewBoxHeight" NUMERIC,
     "maxImageWidth" integer,
     "maxImageHeight" integer,
-    "converted" boolean
+    "uploadCompleted" boolean
 );
 CREATE INDEX "idx_pres_page_presentationId" ON "pres_page"("presentationId");
 CREATE INDEX "idx_pres_page_presentationId_curr" ON "pres_page"("presentationId") where "current" is true;
@@ -916,12 +919,23 @@ SELECT pres_presentation."meetingId",
 	pres_presentation."downloadFileExtension",
 	pres_presentation."downloadFileUri",
 	pres_presentation."removable",
-    pres_presentation."converting",
+    pres_presentation."uploadInProgress",
     pres_presentation."uploadCompleted",
-    pres_presentation."numPages",
-    pres_presentation."errorMsgKey",
-    pres_presentation."errorDetails",
-    (SELECT count(*) FROM pres_page WHERE pres_page."presentationId" = pres_presentation."presentationId" AND "converted" is true) as "pagesUploaded"
+    pres_presentation."totalPages",
+    (   SELECT count(*)
+        FROM pres_page
+        WHERE pres_page."presentationId" = pres_presentation."presentationId"
+        AND "uploadCompleted" is true
+    ) as "totalPagesUploaded",
+    pres_presentation."uploadErrorMsgKey",
+    pres_presentation."uploadErrorDetailsJson",
+    case when pres_presentation."exportToChatStatus" is not null
+                and pres_presentation."exportToChatStatus" != 'EXPORTED'
+                and pres_presentation."exportToChatHasError" is not true
+                then true else false end "exportToChatInProgress",
+    pres_presentation."exportToChatStatus",
+    pres_presentation."exportToChatCurrentPage",
+    pres_presentation."exportToChatHasError"
    FROM pres_presentation;
 
 CREATE OR REPLACE VIEW public.v_pres_page AS
@@ -929,7 +943,7 @@ SELECT pres_presentation."meetingId",
 	pres_page."presentationId",
 	pres_page."pageId",
     pres_page.num,
-    pres_page.urls,
+    pres_page."urlsJson",
     pres_page.content,
     pres_page."slideRevealed",
     CASE WHEN pres_presentation."current" IS TRUE AND pres_page."current" IS TRUE THEN true ELSE false END AS "isCurrentPage",
@@ -945,7 +959,7 @@ SELECT pres_presentation."meetingId",
     (pres_page."height" * LEAST(pres_page."maxImageWidth" / pres_page."width", pres_page."maxImageHeight" / pres_page."height")) AS "scaledHeight",
     (pres_page."width" * pres_page."widthRatio" / 100 * LEAST(pres_page."maxImageWidth" / pres_page."width", pres_page."maxImageHeight" / pres_page."height")) AS "scaledViewBoxWidth",
     (pres_page."height" * pres_page."heightRatio" / 100 * LEAST(pres_page."maxImageWidth" / pres_page."width", pres_page."maxImageHeight" / pres_page."height")) AS "scaledViewBoxHeight",
-    pres_page."converted"
+    pres_page."uploadCompleted"
 FROM pres_page
 JOIN pres_presentation ON pres_presentation."presentationId" = pres_page."presentationId";
 
@@ -960,9 +974,9 @@ SELECT pres_presentation."meetingId",
 	case when pres_presentation."downloadable" then pres_presentation."downloadFileExtension" else null end "downloadFileExtension",
 	case when pres_presentation."downloadable" then pres_presentation."downloadFileUri" else null end "downloadFileUri",
     pres_presentation."removable",
-    pres_presentation."numPages",
+    pres_presentation."totalPages",
     pres_page.num,
-    pres_page.urls,
+    pres_page."urlsJson",
     pres_page.content,
     pres_page."slideRevealed",
     CASE WHEN pres_presentation."current" IS TRUE AND pres_page."current" IS TRUE THEN true ELSE false END AS "isCurrentPage",

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pres_page.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pres_page.yaml
@@ -32,7 +32,7 @@ select_permissions:
         - scaledViewBoxWidth
         - scaledWidth
         - slideRevealed
-        - urls
+        - urlsJson
         - viewBoxHeight
         - viewBoxWidth
         - width

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pres_page_curr.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pres_page_curr.yaml
@@ -19,7 +19,7 @@ select_permissions:
         - isCurrentPage
         - isDefaultPresentation
         - num
-        - numPages
+        - totalPages
         - pageId
         - presentationFilenameConverted
         - presentationId
@@ -30,7 +30,7 @@ select_permissions:
         - scaledViewBoxWidth
         - scaledWidth
         - slideRevealed
-        - urls
+        - urlsJson
         - viewBoxHeight
         - viewBoxWidth
         - width

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pres_presentation.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pres_presentation.yaml
@@ -20,21 +20,24 @@ select_permissions:
   - role: bbb_client
     permission:
       columns:
-        - converting
         - current
         - downloadFileUri
         - downloadable
         - downloadFileExtension
-        - errorDetails
-        - errorMsgKey
+        - uploadInProgress
+        - uploadCompleted
+        - uploadErrorMsgKey
+        - uploadErrorDetailsJson
+        - exportToChatStatus
+        - exportToChatCurrentPage
+        - exportToChatHasError
         - filenameConverted
         - isDefault
         - name
-        - numPages
-        - pagesUploaded
+        - totalPages
+        - totalPagesUploaded
         - presentationId
         - removable
-        - uploadCompleted
       filter:
         meetingId:
           _eq: X-Hasura-PresenterInMeeting


### PR DESCRIPTION
Rename the following props:

### Type `pres_presentation`
| Before  | After | Detail |
|--------|--------|--------|
| numPages  | totalPages |
| pagesUploaded  | totalPagesUploaded |
|  | uploadCompleted | not changed |
| converting  | uploadInProgress |
| errorMsgKey  | uploadErrorMsgKey |
| errorDetails  | uploadErrorDetailsJson | (type changed to jsonb) |
|  | exportToChatInProgress | new prop |
|  | exportToChatStatus | new prop |
|  | exportToChatCurrentPage | new prop |
|  | exportToChatHasError | new prop |

### Type `pres_page`
| Before  | After | Detail |
|--------|--------|--------|
| converted  | uploadCompleted |
| urls  | urlsJson | (type changed to jsonb) |