### PR TITLE
refactor: Store presentation text content in Postgres

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationPageConvertedSysMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationPageConvertedSysMsgHdlr.scala
@@ -55,6 +55,7 @@ trait PresentationPageConvertedSysMsgHdlr {
       msg.body.page.id,
       msg.body.page.num,
       msg.body.page.urls,
+      msg.body.page.content,
       msg.body.page.current,
       width = msg.body.page.width,
       height = msg.body.page.height,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPresentationDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPresentationDAO.scala
@@ -90,7 +90,7 @@ object PresPresentationDAO {
                   presentationId = presentation.id,
                   num = page._2.num,
                   urls = page._2.urls.toJson.asJsObject.compactPrint,
-                  content = "Slide Content TODO", //TODO Get content from slide.txtUri (bbb-web should send its content)
+                  content = page._2.content,
                   slideRevealed = page._2.current,
                   current = page._2.current,
                   xOffset = page._2.xOffset,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/PresentationPods.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/PresentationPods.scala
@@ -25,6 +25,7 @@ case class PresentationPage(
     id:          String,
     num:         Int,
     urls:        Map[String, String],
+    content:     String,
     current:     Boolean             = false,
     xOffset:     Double              = 0,
     yOffset:     Double              = 0,

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Presentation.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Presentation.scala
@@ -15,6 +15,7 @@ case class PresentationPageConvertedVO(
     id:      String,
     num:     Int,
     urls:    Map[String, String],
+    content: String,
     current: Boolean             = false,
     width:   Double              = 1440D,
     height:  Double              = 1080D

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -100,7 +100,7 @@ object MsgBuilder {
       val height = h.toDouble
 
       val contentUrl = new URL(txtUrl)
-      val reader = new BufferedReader(new InputStreamReader(contentUrl.openStream()))
+      val reader = new BufferedReader(new InputStreamReader(contentUrl.openStream(), StandardCharsets.UTF_8))
       val content = reader.lines().collect(Collectors.joining("\n"))
 
       PresentationPageConvertedVO(

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -6,8 +6,9 @@ import org.bigbluebutton.common2.domain.{ DefaultProps, PageVO, PresentationPage
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.presentation.messages._
 
-import java.io.IOException
+import java.io.{ BufferedReader, IOException, InputStreamReader }
 import java.net.URL
+import java.util.stream.Collectors
 import javax.imageio.ImageIO
 import scala.xml.XML
 
@@ -90,10 +91,15 @@ object MsgBuilder {
       val width = w.toDouble
       val height = h.toDouble
 
+      val contentUrl = new URL(txtUrl)
+      val reader = new BufferedReader(new InputStreamReader(contentUrl.openStream()))
+      val content = reader.lines().collect(Collectors.joining("\n"))
+
       PresentationPageConvertedVO(
         id = id,
         num = page,
         urls = urls,
+        content = content,
         current = current,
         width = width,
         height = height
@@ -105,6 +111,7 @@ object MsgBuilder {
           id = id,
           num = page,
           urls = urls,
+          content = "",
           current = current
         )
     }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -8,6 +8,7 @@ import org.bigbluebutton.presentation.messages._
 
 import java.io.{ BufferedReader, IOException, InputStreamReader }
 import java.net.URL
+import java.nio.charset.StandardCharsets
 import java.util.stream.Collectors
 import javax.imageio.ImageIO
 import scala.io.Source


### PR DESCRIPTION
### What does this PR do?

Sends the text content of each presentation from `bbb-web` to `akka-apps` so that it can be stored in Postgres.


### Motivation

Currently the BBB client parses a presentation's text content from the `txtUri` that is associated with each page in the presentation. Instead of doing this `bbb-web` now directly sends the text content of each page to `akka-apps` to be stored in Postgres so that it can be accessed directly by the client.
