### PR TITLE
docs: Update outdated reference to index.html path

### DIFF
--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1030,7 +1030,7 @@ $ sudo apt-get purge bbb-demo
 The default HTML landing page is located in
 
 ```bash
-/var/www/bigbluebutton-default/index.html
+/var/www/bigbluebutton-default/assets/index.html
 ```
 
 Change this page to create your own landing page (and keep a back-up copy of it as it will be overwritten during package updates to `bbb-conf`).


### PR DESCRIPTION
Very minor change. Files were moved to the `assets` folder but the documentation was still referencing the old path.