### PR TITLE
(sec)build(bbb-libreoffice): bump to 7.5.7.1

### DIFF
--- a/bbb-libreoffice/docker/Dockerfile
+++ b/bbb-libreoffice/docker/Dockerfile
@@ -1,1 +1,2 @@
-FROM bigbluebutton/bbb-libreoffice:latest
+FROM bigbluebutton/bbb-libreoffice:7.5.7-20231019
+

--- a/bbb-libreoffice/docker/Dockerfile
+++ b/bbb-libreoffice/docker/Dockerfile
@@ -1,2 +1,2 @@
-FROM bigbluebutton/bbb-libreoffice:7.5.7-20231019
+FROM bigbluebutton/bbb-libreoffice:7.5.7-2023-10-19-110211
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Upgrades LibreOffice (used for document conversion) from 7.3.7.2 to 7.5.7.1
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none


### Motivation
https://nvd.nist.gov/vuln/detail/CVE-2023-4863
<!-- What inspired you to submit this pull request? -->

### More

Quoting from @GhaziTriki 's response on https://groups.google.com/g/bigbluebutton-dev/c/9zdWgkM1c6o

>LIbreoffice has been patched on September 2023 https://9to5linux.com/libreoffice-7-6-2-and-7-5-7-released-to-address-critical-webp-vulnerability

>Libreoffice in BBB is a kind of jail and has access to only a necessary amount of computing resources.

>More investigation about the current version is needed, but I assume that updating the LibreOffice docker image in BBB should be safe.
