### PR TITLE
fix: check for presence of parentMeetingID if isBreakout is true

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -127,8 +127,8 @@ class ApiController {
       return
     }
 
-    if(params.isBreakout && !params.parentIdMeetingId) {
-      invalid("parentMeetingIdMissing", "No parent meeting ID was provided for the breakout room")
+    if(params.isBreakout == "true" && !params.parentMeetingID) {
+      invalid("parentMeetingIDMissing", "No parent meeting ID was provided for the breakout room")
       return
     }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do
<!-- A brief description of each change being made with this pull request. -->

Fix the check for presence of parentMeetingID when isBreakout is true. There were two problems:

1. The first part of the if-clause would always be true when isBreakout was set to any value. It should only be true when isBreakout is passed as true. This is achieved by checking ` isBreakout == "true"`.
2. The second part of the if-clause used the parameter "parentIdMeetingId", but the correct parameter according to API Docs is parentMeetingID . The parameter has been renamed appropriately.

For more details on the effect of these problems see the linked issue.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #18961
