### PR TITLE
Refactor: Add chat message to Postgres when user status changes 

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserAwayReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserAwayReqMsgHdlr.scala
@@ -46,8 +46,12 @@ trait ChangeUserAwayReqMsgHdlr extends RightsManagementTrait {
         outGW.send(MsgBuilder.buildUserEmojiChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.userId, "none"))
       }
 
-      val chatMsg = s"${user.name} is " + (if (msg.body.away) "now " else "no longer ") + "away"
-      ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, chatMsg, GroupChatMessageType.SYSTEM, Map(), "")
+      val msgMeta = Map(
+        "user" -> user.name,
+        "away" -> msg.body.away
+      )
+
+      ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, "", GroupChatMessageType.USER_AWAY_STATUS_MSG, msgMeta, "")
 
       broadcast(newUserState, msg.body.away)
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserAwayReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserAwayReqMsgHdlr.scala
@@ -2,7 +2,9 @@ package org.bigbluebutton.core.apps.users
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.RightsManagementTrait
-import org.bigbluebutton.core.models.{ UserState, Users2x }
+import org.bigbluebutton.core.apps.groupchats.GroupChatApp
+import org.bigbluebutton.core.db.ChatMessageDAO
+import org.bigbluebutton.core.models.{ GroupChatFactory, GroupChatMessage, UserState, Users2x }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
@@ -43,6 +45,9 @@ trait ChangeUserAwayReqMsgHdlr extends RightsManagementTrait {
         Users2x.setEmojiStatus(liveMeeting.users2x, msg.body.userId, "none")
         outGW.send(MsgBuilder.buildUserEmojiChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.userId, "none"))
       }
+
+      val chatMsg = s"${user.name} is " + (if (msg.body.away) "now " else "no longer ") + "away"
+      ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, chatMsg, GroupChatMessageType.DEFAULT, Map(), "")
 
       broadcast(newUserState, msg.body.away)
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserAwayReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserAwayReqMsgHdlr.scala
@@ -45,9 +45,9 @@ trait ChangeUserAwayReqMsgHdlr extends RightsManagementTrait {
         Users2x.setEmojiStatus(liveMeeting.users2x, msg.body.userId, "none")
         outGW.send(MsgBuilder.buildUserEmojiChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.userId, "none"))
       }
-
+      
       val chatMsg = s"${user.name} is " + (if (msg.body.away) "now " else "no longer ") + "away"
-      ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, chatMsg, GroupChatMessageType.DEFAULT, Map(), "")
+      ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, chatMsg, GroupChatMessageType.SYSTEM, Map(), "")
 
       broadcast(newUserState, msg.body.away)
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserAwayReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserAwayReqMsgHdlr.scala
@@ -45,7 +45,7 @@ trait ChangeUserAwayReqMsgHdlr extends RightsManagementTrait {
         Users2x.setEmojiStatus(liveMeeting.users2x, msg.body.userId, "none")
         outGW.send(MsgBuilder.buildUserEmojiChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.userId, "none"))
       }
-      
+
       val chatMsg = s"${user.name} is " + (if (msg.body.away) "now " else "no longer ") + "away"
       ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, chatMsg, GroupChatMessageType.SYSTEM, Map(), "")
 

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
@@ -11,6 +11,7 @@ object GroupChatMessageType {
   val POLL = "poll"
   val BREAKOUTROOM_MOD_MSG = "breakoutRoomModeratorMsg"
   val PUBLIC_CHAT_HIST_CLEARED = "publicChatHistoryCleared"
+  val SYSTEM = "system"
 }
 
 case class GroupChatUser(id: String, name: String = "", role: String = "VIEWER")

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
@@ -11,7 +11,7 @@ object GroupChatMessageType {
   val POLL = "poll"
   val BREAKOUTROOM_MOD_MSG = "breakoutRoomModeratorMsg"
   val PUBLIC_CHAT_HIST_CLEARED = "publicChatHistoryCleared"
-  val SYSTEM = "system"
+  val USER_AWAY_STATUS_MSG = "userAwayStatusMsg"
 }
 
 case class GroupChatUser(id: String, name: String = "", role: String = "VIEWER")

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -12,6 +12,7 @@ import java.nio.charset.StandardCharsets
 import java.util.stream.Collectors
 import javax.imageio.ImageIO
 import scala.io.Source
+import scala.util.{ Failure, Success, Try, Using }
 import scala.xml.XML
 
 object MsgBuilder {
@@ -83,7 +84,55 @@ object MsgBuilder {
 
     val urls = Map("thumb" -> thumbUrl, "text" -> txtUrl, "svg" -> svgUrl, "png" -> pngUrl)
 
-    try {
+    //    try {
+    //      val svgSource = Source.fromURL(new URL(svgUrl))
+    //      val svgContent = svgSource.mkString
+    //      svgSource.close()
+    //
+    //      // XML parser configuration in use disallows the DOCTYPE declaration within the XML document
+    //      // Sanitize the XML content removing DOCTYPE
+    //      val sanitizedSvgContent = "(?i)<!DOCTYPE[^>]*>".r.replaceAllIn(svgContent, "")
+    //
+    //      val xmlContent = XML.loadString(sanitizedSvgContent)
+    //
+    //      val w = (xmlContent \ "@width").text.replaceAll("[^.0-9]", "")
+    //      val h = (xmlContent \ "@height").text.replaceAll("[^.0-9]", "")
+    //
+    //      val width = w.toDouble
+    //      val height = h.toDouble
+    //
+    //      val contentUrl = new URL(txtUrl)
+    //      val stream = new InputStreamReader(contentUrl.openStream(), StandardCharsets.UTF_8)
+    //      val reader = new BufferedReader(stream)
+    //      val content = reader.lines().collect(Collectors.joining("\n"))
+    //
+    //      PresentationPageConvertedVO(
+    //        id = id,
+    //        num = page,
+    //        urls = urls,
+    //        content = content,
+    //        current = current,
+    //        width = width,
+    //        height = height
+    //      )
+    //    } catch {
+    //      case e: Exception =>
+    //        e.printStackTrace()
+    //        PresentationPageConvertedVO(
+    //          id = id,
+    //          num = page,
+    //          urls = urls,
+    //          content = "",
+    //          current = current
+    //        )
+    //    }
+
+    val result = Using.Manager { use =>
+      val contentUrl = new URL(txtUrl)
+      val stream = use(new InputStreamReader(contentUrl.openStream(), StandardCharsets.UTF_8))
+      val reader = use(new BufferedReader(stream))
+      val content = reader.lines().collect(Collectors.joining("\n"))
+
       val svgSource = Source.fromURL(new URL(svgUrl))
       val svgContent = svgSource.mkString
       svgSource.close()
@@ -100,10 +149,6 @@ object MsgBuilder {
       val width = w.toDouble
       val height = h.toDouble
 
-      val contentUrl = new URL(txtUrl)
-      val reader = new BufferedReader(new InputStreamReader(contentUrl.openStream(), StandardCharsets.UTF_8))
-      val content = reader.lines().collect(Collectors.joining("\n"))
-
       PresentationPageConvertedVO(
         id = id,
         num = page,
@@ -113,7 +158,7 @@ object MsgBuilder {
         width = width,
         height = height
       )
-    } catch {
+    } recover {
       case e: Exception =>
         e.printStackTrace()
         PresentationPageConvertedVO(
@@ -124,6 +169,18 @@ object MsgBuilder {
           current = current
         )
     }
+
+    val presentationPage = result.getOrElse(
+      PresentationPageConvertedVO(
+        id = id,
+        num = page,
+        urls = urls,
+        content = "",
+        current = current
+      )
+    )
+
+    presentationPage
   }
 
   def buildPresentationPageConvertedSysMsg(msg: DocPageGeneratedProgress): BbbCommonEnvCoreMsg = {

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -84,49 +84,6 @@ object MsgBuilder {
 
     val urls = Map("thumb" -> thumbUrl, "text" -> txtUrl, "svg" -> svgUrl, "png" -> pngUrl)
 
-    //    try {
-    //      val svgSource = Source.fromURL(new URL(svgUrl))
-    //      val svgContent = svgSource.mkString
-    //      svgSource.close()
-    //
-    //      // XML parser configuration in use disallows the DOCTYPE declaration within the XML document
-    //      // Sanitize the XML content removing DOCTYPE
-    //      val sanitizedSvgContent = "(?i)<!DOCTYPE[^>]*>".r.replaceAllIn(svgContent, "")
-    //
-    //      val xmlContent = XML.loadString(sanitizedSvgContent)
-    //
-    //      val w = (xmlContent \ "@width").text.replaceAll("[^.0-9]", "")
-    //      val h = (xmlContent \ "@height").text.replaceAll("[^.0-9]", "")
-    //
-    //      val width = w.toDouble
-    //      val height = h.toDouble
-    //
-    //      val contentUrl = new URL(txtUrl)
-    //      val stream = new InputStreamReader(contentUrl.openStream(), StandardCharsets.UTF_8)
-    //      val reader = new BufferedReader(stream)
-    //      val content = reader.lines().collect(Collectors.joining("\n"))
-    //
-    //      PresentationPageConvertedVO(
-    //        id = id,
-    //        num = page,
-    //        urls = urls,
-    //        content = content,
-    //        current = current,
-    //        width = width,
-    //        height = height
-    //      )
-    //    } catch {
-    //      case e: Exception =>
-    //        e.printStackTrace()
-    //        PresentationPageConvertedVO(
-    //          id = id,
-    //          num = page,
-    //          urls = urls,
-    //          content = "",
-    //          current = current
-    //        )
-    //    }
-
     val result = Using.Manager { use =>
       val contentUrl = new URL(txtUrl)
       val stream = use(new InputStreamReader(contentUrl.openStream(), StandardCharsets.UTF_8))

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -39,11 +39,11 @@ const intlMessages = defineMessages({
   },
   userAway: {
     id: 'app.chat.away',
-    description: 'message when user is away'
+    description: 'message when user is away',
   },
   userNotAway: {
     id: 'app.chat.notAway',
-    description: 'message when user is no longer away'
+    description: 'message when user is no longer away',
   },
 });
 
@@ -145,19 +145,20 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
             />
           ),
         };
-      case ChatMessageType.USER_AWAY_STATUS_MSG:
-        const {user, away} = JSON.parse(message.messageMetadata)
+      case ChatMessageType.USER_AWAY_STATUS_MSG: {
+        const { away } = JSON.parse(message.messageMetadata);
         return {
-          name: intl.formatMessage(intlMessages.systemLabel),
+          name: message.senderName,
           color: '#0F70D7',
           isModerator: true,
           component: (
             <ChatMessageTextContent
               emphasizedMessage
-              text={user + " " + ((away) ? intl.formatMessage(intlMessages.userAway) : intl.formatMessage(intlMessages.userNotAway))}
+              text={(away) ? intl.formatMessage(intlMessages.userAway) : intl.formatMessage(intlMessages.userNotAway)}
             />
           ),
         };
+      }  
       case ChatMessageType.TEXT:
       default:
         return {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -158,7 +158,7 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
             />
           ),
         };
-      }  
+      }
       case ChatMessageType.TEXT:
       default:
         return {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -148,7 +148,7 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
               text={message.message}
             />
           ),
-        } ; 
+        }; 
       case ChatMessageType.TEXT:
       default:
         return {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -148,7 +148,7 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
               text={message.message}
             />
           ),
-        }; 
+        };
       case ChatMessageType.TEXT:
       default:
         return {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -137,6 +137,18 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
             />
           ),
         };
+      case ChatMessageType.SYSTEM:
+        return {
+          name: intl.formatMessage(intlMessages.systemLabel),
+          color: '#0F70D7',
+          isModerator: true,
+          component: (
+            <ChatMessageTextContent
+              emphasizedMessage
+              text={message.message}
+            />
+          ),
+        } ; 
       case ChatMessageType.TEXT:
       default:
         return {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -37,6 +37,14 @@ const intlMessages = defineMessages({
     id: 'app.chat.clearPublicChatMessage',
     description: 'message of when clear the public chat',
   },
+  userAway: {
+    id: 'app.chat.away',
+    description: 'message when user is away'
+  },
+  userNotAway: {
+    id: 'app.chat.notAway',
+    description: 'message when user is no longer away'
+  },
 });
 
 function isInViewport(el: HTMLDivElement) {
@@ -137,7 +145,8 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
             />
           ),
         };
-      case ChatMessageType.SYSTEM:
+      case ChatMessageType.USER_AWAY_STATUS_MSG:
+        const {user, away} = JSON.parse(message.messageMetadata)
         return {
           name: intl.formatMessage(intlMessages.systemLabel),
           color: '#0F70D7',
@@ -145,7 +154,7 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
           component: (
             <ChatMessageTextContent
               emphasizedMessage
-              text={message.message}
+              text={user + " " + ((away) ? intl.formatMessage(intlMessages.userAway) : intl.formatMessage(intlMessages.userNotAway))}
             />
           ),
         };

--- a/bigbluebutton-html5/imports/ui/core/enums/chat.ts
+++ b/bigbluebutton-html5/imports/ui/core/enums/chat.ts
@@ -12,5 +12,5 @@ export const enum ChatMessageType {
   PRESENTATION = 'presentation',
   CHAT_CLEAR = 'publicChatHistoryCleared',
   BREAKOUT_ROOM = 'breakoutRoomModeratorMsg',
-  SYSTEM = 'system'
+  USER_AWAY_STATUS_MSG = "userAwayStatusMsg"
 }

--- a/bigbluebutton-html5/imports/ui/core/enums/chat.ts
+++ b/bigbluebutton-html5/imports/ui/core/enums/chat.ts
@@ -12,4 +12,5 @@ export const enum ChatMessageType {
   PRESENTATION = 'presentation',
   CHAT_CLEAR = 'publicChatHistoryCleared',
   BREAKOUT_ROOM = 'breakoutRoomModeratorMsg',
+  SYSTEM = 'system'
 }

--- a/bigbluebutton-html5/imports/ui/core/enums/chat.ts
+++ b/bigbluebutton-html5/imports/ui/core/enums/chat.ts
@@ -12,5 +12,5 @@ export const enum ChatMessageType {
   PRESENTATION = 'presentation',
   CHAT_CLEAR = 'publicChatHistoryCleared',
   BREAKOUT_ROOM = 'breakoutRoomModeratorMsg',
-  USER_AWAY_STATUS_MSG = "userAwayStatusMsg"
+  USER_AWAY_STATUS_MSG = 'userAwayStatusMsg'
 }


### PR DESCRIPTION
### What does this PR do?

Inserts a chat message from the system into Postgres when a user changes their away status. 


### Motivation

When a user's away status changes a message should be sent in chat to notify other users of this change.
