### PR TITLE
Reset timer graphql

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/TimerModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/TimerModel.scala
@@ -16,7 +16,7 @@ object TimerModel {
 
   def reset(model: TimerModel) : Unit = {
     model.accumulated = 0
-    model.startedAt = 0
+    model.startedAt = System.currentTimeMillis()
     model.endedAt = 0
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/TimerModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/TimerModel.scala
@@ -16,7 +16,7 @@ object TimerModel {
 
   def reset(model: TimerModel) : Unit = {
     model.accumulated = 0
-    model.startedAt = System.currentTimeMillis()
+    model.startedAt = if (model.running) System.currentTimeMillis() else 0
     model.endedAt = 0
   }
 
@@ -24,7 +24,7 @@ object TimerModel {
     model.isActive = active
   }
 
-  def getIsACtive(model: TimerModel): Boolean = {
+  def getIsActive(model: TimerModel): Boolean = {
     model.isActive
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/TimerDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/TimerDAO.scala
@@ -1,7 +1,7 @@
 package org.bigbluebutton.core.db
 
 import org.bigbluebutton.core.apps.TimerModel
-import org.bigbluebutton.core.apps.TimerModel.{getAccumulated, getEndedAt, getIsACtive, getRunning, getStartedAt, getStopwatch, getTime, getTrack}
+import org.bigbluebutton.core.apps.TimerModel.{getAccumulated, getEndedAt, getIsActive, getRunning, getStartedAt, getStopwatch, getTime, getTrack}
 import slick.jdbc.PostgresProfile.api._
 
 import scala.util.{Failure, Success}
@@ -59,7 +59,7 @@ object TimerDAO {
       TableQuery[TimerDbTableDef]
         .filter(_.meetingId === meetingId)
         .map(t => (t.stopwatch, t.running, t.active, t.time, t.accumulated, t.startedAt, t.endedAt, t.songTrack))
-        .update((getStopwatch(timerModel), getRunning(timerModel), getIsACtive(timerModel), getTime(timerModel), getAccumulated(timerModel), getStartedAt(timerModel), getEndedAt(timerModel), getTrack(timerModel))
+        .update((getStopwatch(timerModel), getRunning(timerModel), getIsActive(timerModel), getTime(timerModel), getAccumulated(timerModel), getStartedAt(timerModel), getEndedAt(timerModel), getTrack(timerModel))
         )
     ).onComplete {
       case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated on Timer table!")


### PR DESCRIPTION
### What does this PR do?

Resets the `startedAt` value of the timer/stopwatch to the current time if the reset occurred while the timer is running. Otherwise, if the timer is stopped `startedAt` is reset to the initial value of 0.


### Motivation

Currently when the timer is reset the `startedAt` value is always set to 0 instead of the current time.
