### PR TITLE
fix: replace links in chat with markdown links

### DIFF
--- a/bigbluebutton-html5/imports/api/common/server/helpers.js
+++ b/bigbluebutton-html5/imports/api/common/server/helpers.js
@@ -36,20 +36,6 @@ export const parseMessage = (message) => {
   return parsedMessage;
 };
 
-export const textToMarkdown = (message) => {
-  let parsedMessage = message || '';
-  parsedMessage = parsedMessage.trim();
-
-  // replace url with markdown links
-  const urlRegex = /(?<!\]\()https?:\/\/([\w-]+\.)+\w{1,6}([/?=&#.]?[\w-]+)*/gm;
-  parsedMessage = parsedMessage.replace(urlRegex, '[$&]($&)');
-
-  // replace new lines with markdown new lines
-  parsedMessage = parsedMessage.replace(/\n\r?/g, '  \n');
-
-  return parsedMessage;
-};
-
 export const spokeTimeoutHandles = {};
 export const clearSpokeTimeout = (meetingId, userId) => {
   if (spokeTimeoutHandles[`${meetingId}-${userId}`]) {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -19,6 +19,7 @@ import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import {
   startUserTyping,
   stopUserTyping,
+  textToMarkdown,
 } from './service';
 import { Chat } from '/imports/ui/Types/chat';
 import { Layout } from '../../../layout/layoutTypes';
@@ -243,7 +244,7 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
     const handleSubmit = (e: React.FormEvent<HTMLFormElement> | React.KeyboardEvent<HTMLInputElement> | Event) => {
       e.preventDefault();
 
-      const msg = message.trim();
+      const msg = textToMarkdown(message);
 
       if (msg.length < minMessageLength) return;
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/service.ts
@@ -15,7 +15,22 @@ export const startUserTyping = throttle(
 );
 export const stopUserTyping = () => makeCall('stopUserTyping');
 
+export const textToMarkdown = (message: string) => {
+  let parsedMessage = message || '';
+  parsedMessage = parsedMessage.trim();
+
+  // replace url with markdown links
+  const urlRegex = /(?<!\]\()https?:\/\/([\w-]+\.)+\w{1,6}([/?=&#.]?[\w-]+)*/gm;
+  parsedMessage = parsedMessage.replace(urlRegex, '[$&]($&)');
+
+  // replace new lines with markdown new lines
+  parsedMessage = parsedMessage.replace(/\n\r?/g, '  \n');
+
+  return parsedMessage;
+};
+
 export default {
   startUserTyping,
   stopUserTyping,
+  textToMarkdown,
 };


### PR DESCRIPTION
### What does this PR do?

Fix textToMarkdown helper not being used in chat input