### PR TITLE
fix: whiteboard access label in userlist

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
@@ -239,6 +239,8 @@ const UserActions: React.FC<UserActionsProps> = ({
     (item: PluginSdk.UserListDropdownItem) => (user?.userId === item?.userId),
   );
 
+  const hasWhiteboardAccess = user.presPagesWritable?.length > 0;
+
   const dropdownOptions = [
     ...makeDropdownPluginItem(userDropdownItems.filter(
       (item: PluginSdk.UserListDropdownItem) => (item?.type === PluginSdk.UserListDropdownItemType.INFORMATION),
@@ -339,11 +341,11 @@ const UserActions: React.FC<UserActionsProps> = ({
         && !user.presenter
         && !isVoiceOnlyUser(user.userId),
       key: 'changeWhiteboardAccess',
-      label: user.whiteboardAccess
+      label: hasWhiteboardAccess
         ? intl.formatMessage(messages.removeWhiteboardAccess)
         : intl.formatMessage(messages.giveWhiteboardAccess),
       onClick: () => {
-        changeWhiteboardAccess(user.userId, user.presPagesWritable.length > 0);
+        changeWhiteboardAccess(user.userId, hasWhiteboardAccess);
         setSelected(false);
       },
       icon: 'pen_tool',


### PR DESCRIPTION
### What does this PR do?

Give/remove whiteboard access was not being updated correctly

#### before
https://github.com/bigbluebutton/bigbluebutton/assets/3728706/c9c5d696-f3f5-4995-b865-7759395b04fa

#### after
https://github.com/bigbluebutton/bigbluebutton/assets/3728706/b1a17044-c62b-4714-a77d-51bb4f234886

