### PR TITLE
fix (akka-apps / plugins): path for plugin in data channel validation

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/ClientSettings.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/ClientSettings.scala
@@ -73,7 +73,7 @@ object ClientSettings extends SystemConfiguration {
   def getPluginsFromConfig(config: Map[String, Any]): Map[String, Plugin] = {
     var pluginsFromConfig: Map[String, Plugin] = Map()
 
-    val pluginsConfig = getConfigPropertyValueByPath(config, "public.app.plugins")
+    val pluginsConfig = getConfigPropertyValueByPath(config, "public.plugins")
     pluginsConfig match {
       case Some(plugins: List[Map[String, Any]]) =>
         for {


### PR DESCRIPTION
### What does this PR do?

Just a hot fix correcting the path of plugins in akka