### PR TITLE
Fix: Chat poll results being cut off

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
@@ -61,13 +61,13 @@ const ChatPollContent: React.FC<ChatPollContentProps> = ({
       <Styled.PollText>
         {pollData.questionText}
       </Styled.PollText>
-      <ResponsiveContainer width="100%" height={250}>
+      <ResponsiveContainer width="90%" height={250}>
         <BarChart
           data={pollData.answers}
           layout="vertical"
         >
           <XAxis type="number" />
-          <YAxis type="category" dataKey="key" />
+          <YAxis width={70} type="category" dataKey="key" />
           <Bar dataKey="numVotes" fill="#0C57A7" />
         </BarChart>
       </ResponsiveContainer>


### PR DESCRIPTION
### What does this PR do?

This PR fixes a big where the chat poll results were being cut off.

Examples: 
Before:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/c4416462-4d30-4f8d-b006-ec9cf47072ba)

After:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/28412184-82f8-4b55-ac60-70911ab90ff1)
