### PR TITLE
Fix: Talking indicador too close from user list button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/styles.ts
@@ -143,6 +143,7 @@ const IsTalkingWrapper = styled.div`
   flex-direction: row;
   position: relative;
   overflow: hidden;
+  margin-top: 0.5rem;
 `;
 
 const Speaking = styled.div`


### PR DESCRIPTION
### What does this PR do?

This PR adds some margin so the talking indicator doesn't get too close to user list button.