### PR TITLE
Fix: Talking indicator order

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
@@ -62,7 +62,13 @@ const TalkingIndicator: React.FC<TalkingIndicatorProps> = ({
   isModerator,
 }) => {
   const intl = useIntl();
-  const talkingElements = useMemo(() => talkingUsers.map((talkingUser: Partial<UserVoice>) => {
+  const sortedTalkingUsers = [...talkingUsers];
+  sortedTalkingUsers.sort((a, b) => {
+    const nameA = a.user?.name || '';
+    const nameB = b.user?.name || '';
+    return nameA.localeCompare(nameB);
+  });
+  const talkingElements = useMemo(() => sortedTalkingUsers.map((talkingUser: Partial<UserVoice>) => {
     const {
       talking,
       muted,
@@ -122,7 +128,7 @@ const TalkingIndicator: React.FC<TalkingIndicatorProps> = ({
         </Styled.TalkingIndicatorButton>
       </Styled.TalkingIndicatorWrapper>
     );
-  }), [talkingUsers]);
+  }), [sortedTalkingUsers]);
 
   const maxIndicator = () => {
     if (!moreThanMaxIndicators) return null;


### PR DESCRIPTION
### What does this PR do?

This PR sets the talking indicator names order to alphabetical order.