### PR TITLE
Fix: Userlist keyboard interactions

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
@@ -160,7 +160,7 @@ const UserListItem: React.FC<UserListItemProps> = ({ user, lockSettings }) => {
     : iconUser;
 
   return (
-    <Styled.UserItemContents data-test={(user.userId === Auth.userID) ? 'userListItemCurrent' : 'userListItem'}>
+    <Styled.UserItemContents tabIndex={0} data-test={(user.userId === Auth.userID) ? 'userListItemCurrent' : 'userListItem'}>
       <Styled.Avatar
         data-test={user.role === ROLE_MODERATOR ? 'moderatorAvatar' : 'viewerAvatar'}
         data-test-presenter={user.presenter ? '' : undefined}


### PR DESCRIPTION
### What does this PR do?

This PR enhances accessibility by making the UserListItem component keyboard-navigable and actionable via the Enter key, improving user experience for keyboard users.

![userlist](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/a3727797-f1a5-41c7-b4c8-ab121b25f256)
