### PR TITLE
fix (akka-apps): Automatically reset values upon switching between Stopwatch and Timer

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/timer/SwitchTimerReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/timer/SwitchTimerReqMsgHdlr.scala
@@ -34,6 +34,7 @@ trait SwitchTimerReqMsgHdlr extends RightsManagementTrait {
     } else {
       if (TimerModel.getStopwatch(liveMeeting.timerModel) != msg.body.stopwatch) {
         TimerModel.setStopwatch(liveMeeting.timerModel, msg.body.stopwatch)
+        TimerModel.reset(liveMeeting.timerModel) //Reset on switch Stopwatch/Timer
         if (msg.body.stopwatch) {
           TimerModel.setTrack(liveMeeting.timerModel, "noTrack")
         }


### PR DESCRIPTION
Following the behavior of 2.7.