### PR TITLE
refactor (graphql/html5): Make chat receive graphql data (messages) using Json Patch

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -6,7 +6,7 @@ import {
 } from './queries';
 import { Message } from '/imports/ui/Types/message';
 import ChatMessage from './chat-message/component';
-import createUseSubscription from '/imports/ui/core/hooks/createUseSubscription';
+import { useCreateUseSubscription } from '/imports/ui/core/hooks/createUseSubscription';
 
 // @ts-ignore - temporary, while meteor exists in the project
 const CHAT_CONFIG = Meteor.settings.public.chat;
@@ -76,7 +76,7 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
   const variables = isPublicChat
     ? defaultVariables : { ...defaultVariables, requestedChatId: chatId };
 
-  const useChatMessageSubscription = createUseSubscription<Partial<Message>>(chatQuery, variables, true);
+  const useChatMessageSubscription = useCreateUseSubscription<Partial<Message>>(chatQuery, variables, true);
   const chatMessageData = useChatMessageSubscription((msg) => msg) as Array<Message>;
 
   if (chatMessageData.length > 0) {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -1,14 +1,12 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import React from 'react';
-import { useSubscription } from '@apollo/client';
 import {
   CHAT_MESSAGE_PUBLIC_SUBSCRIPTION,
   CHAT_MESSAGE_PRIVATE_SUBSCRIPTION,
-  ChatMessagePrivateSubscriptionResponse,
-  ChatMessagePublicSubscriptionResponse,
 } from './queries';
 import { Message } from '/imports/ui/Types/message';
 import ChatMessage from './chat-message/component';
+import createUseSubscription from '/imports/ui/core/hooks/createUseSubscription';
 
 // @ts-ignore - temporary, while meteor exists in the project
 const CHAT_CONFIG = Meteor.settings.public.chat;
@@ -33,13 +31,6 @@ interface ChatListPageProps {
   markMessageAsSeen: (message: Message)=> void;
   scrollRef: React.RefObject<HTMLDivElement>;
 }
-
-const verifyIfIsPublicChat = (message: unknown):
-// eslint-disable-next-line max-len
-message is ChatMessagePublicSubscriptionResponse => (message as ChatMessagePublicSubscriptionResponse).chat_message_public !== undefined;
-
-// eslint-disable-next-line max-len
-const verifyIfIsPrivateChat = (message: unknown): message is ChatMessagePrivateSubscriptionResponse => (message as ChatMessagePrivateSubscriptionResponse).chat_message_private !== undefined;
 
 const ChatListPage: React.FC<ChatListPageProps> = ({
   messages,
@@ -84,38 +75,17 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
   const defaultVariables = { offset: (page) * pageSize, limit: pageSize };
   const variables = isPublicChat
     ? defaultVariables : { ...defaultVariables, requestedChatId: chatId };
-  const {
-    data: chatMessageData,
-    loading: chatMessageLoading,
-    error: chatMessageError,
-  } = useSubscription<ChatMessagePublicSubscriptionResponse|ChatMessagePrivateSubscriptionResponse>(
-    chatQuery,
-    { variables },
-  );
 
-  if (chatMessageError) {
-    return (
-      <p>
-        chatMessageError:
-        {JSON.stringify(chatMessageError)}
-      </p>
-    );
-  }
-  if (chatMessageLoading) return null;
-  let messages: Array<Message> = [];
-  if (verifyIfIsPublicChat(chatMessageData)) {
-    messages = chatMessageData.chat_message_public || [];
-  } else if (verifyIfIsPrivateChat(chatMessageData)) {
-    messages = chatMessageData.chat_message_private || [];
-  }
+  const useChatMessageSubscription = createUseSubscription<Partial<Message>>(chatQuery, true, variables);
+  const chatMessageData = useChatMessageSubscription((msg) => msg) as Array<Message>;
 
-  if (messages.length > 0) {
-    setLastSender(page, messages[messages.length - 1].user?.userId);
+  if (chatMessageData.length > 0) {
+    setLastSender(page, chatMessageData[chatMessageData.length - 1].user?.userId);
   }
 
   return (
     <ChatListPage
-      messages={messages}
+      messages={chatMessageData}
       lastSenderPreviousPage={lastSenderPreviousPage}
       page={page}
       markMessageAsSeen={markMessageAsSeen}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -76,7 +76,7 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
   const variables = isPublicChat
     ? defaultVariables : { ...defaultVariables, requestedChatId: chatId };
 
-  const useChatMessageSubscription = createUseSubscription<Partial<Message>>(chatQuery, true, variables);
+  const useChatMessageSubscription = createUseSubscription<Partial<Message>>(chatQuery, variables, true);
   const chatMessageData = useChatMessageSubscription((msg) => msg) as Array<Message>;
 
   if (chatMessageData.length > 0) {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/queries.ts
@@ -1,14 +1,5 @@
 /* eslint-disable camelcase */
 import { gql } from '@apollo/client';
-import { Message } from '/imports/ui/Types/message';
-
-export interface ChatMessagePublicSubscriptionResponse {
-  chat_message_public: Array<Message>;
-}
-
-export interface ChatMessagePrivateSubscriptionResponse {
-  chat_message_private: Array<Message>;
-}
 
 export const CHAT_MESSAGE_PUBLIC_SUBSCRIPTION = gql`
   subscription chatMessages($limit: Int!, $offset: Int!) {

--- a/bigbluebutton-html5/imports/ui/core/hooks/createUseSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/createUseSubscription.ts
@@ -1,39 +1,65 @@
 import { TypedQueryDocumentNode, DocumentNode } from 'graphql';
 import { useRef, useState, useEffect } from 'react';
 
-import { useApolloClient } from '@apollo/client';
+import { gql, useApolloClient } from '@apollo/client';
 import R from 'ramda';
+import { applyPatch } from 'fast-json-patch';
 
 function createUseSubscription<T>(
   query: DocumentNode | TypedQueryDocumentNode,
   usePatchedSubscription = false,
+  variables = {},
 ) {
   return function useGeneratedUseSubscription(projectionFunction: (element: Partial<T>) => void): Array<Partial<T>> {
     const client = useApolloClient();
     const [projectedData, setProjectedData] = useState<Array<T>>([]);
     const oldProjectionOfDataRef = useRef<Array<T>>([]);
+    const dataRef = useRef<Array<T>>([]);
 
+    let newSubscriptionGQL = query;
     if (usePatchedSubscription) {
-      // eslint-disable-next-line no-alert
-      alert('Not implemented');
+      if (!query) {
+        throw new Error('Error: query is not defined');
+      }
+
+      // Check if the loc property is defined
+      if (!query.loc) {
+        throw new Error('Error: query.loc is not defined');
+      }
+
+      // Prepend `Patched_` to the query operationName to inform the middleware that this subscription support jsonPatch
+      // It will also set {fetchPolicy: 'no-cache'} because the cache would not work properly when using json-patch
+      const regexSubscriptionOperationName = /subscription\s+([^{]*)\{/g;
+      if (!regexSubscriptionOperationName.exec(query.loc.source.body)) {
+        throw new Error('Error prepending Patched_ to subscription name - check the provided gql');
+      }
+
+      const newQueryString = query.loc.source.body.replace(regexSubscriptionOperationName, 'subscription Patched_$1 {');
+      newSubscriptionGQL = gql`${newQueryString}`;
     }
 
-    // TODO - manipulate query if usePatchedSubscription===true
     useEffect(() => {
       const apolloSubscription = client
         .subscribe({
-          query,
+          query: newSubscriptionGQL,
+          variables,
+          fetchPolicy: usePatchedSubscription ? 'no-cache' : undefined,
         })
         .subscribe({
           next({ data }) {
-          // TODO - manipulate data if usePatchedSubscription===true
-          // and response data contains patch attribute
-            const resultSetKey = Object.keys(data)[0];
-            // console.log('resultSetKey', resultSetKey);
-            const resultSet = data[resultSetKey];
-            // console.log('resultSet', resultSet);
+            let currentData = [];
+            if (usePatchedSubscription && data.patch) {
+              const patchedData = applyPatch(dataRef.current, data.patch).newDocument;
+              currentData = [...patchedData];
+            } else {
+              const resultSetKey = Object.keys(data)[0];
+              currentData = data[resultSetKey];
+            }
+            if (usePatchedSubscription) {
+              dataRef.current = currentData;
+            }
 
-            const newProjectionOfData = resultSet.map((element: Partial<T>) => projectionFunction(element));
+            const newProjectionOfData = currentData.map((element: Partial<T>) => projectionFunction(element));
             if (!R.equals(oldProjectionOfDataRef.current, newProjectionOfData)) {
               oldProjectionOfDataRef.current = newProjectionOfData;
               setProjectedData(newProjectionOfData);
@@ -46,6 +72,7 @@ function createUseSubscription<T>(
         });
       return () => apolloSubscription.unsubscribe();
     }, []);
+
     return projectedData;
   };
 }

--- a/bigbluebutton-html5/imports/ui/core/hooks/createUseSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/createUseSubscription.ts
@@ -25,7 +25,6 @@ function createUseSubscription<T>(
         throw new Error('Error: query is not defined');
       }
 
-      // Check if the loc property is defined
       if (!query.loc) {
         throw new Error('Error: query.loc is not defined');
       }
@@ -74,7 +73,7 @@ function createUseSubscription<T>(
           },
         });
       return () => apolloSubscription.unsubscribe();
-    }, [JSON.stringify(variables)]);
+    }, [variables]);
 
     return projectedData;
   };

--- a/bigbluebutton-html5/imports/ui/core/hooks/createUseSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/createUseSubscription.ts
@@ -3,7 +3,7 @@ import {
   useRef, useState, useEffect, useMemo,
 } from 'react';
 
-import { OperationVariables, gql, useApolloClient } from '@apollo/client';
+import { gql, useApolloClient } from '@apollo/client';
 import R from 'ramda';
 import { applyPatch } from 'fast-json-patch';
 

--- a/bigbluebutton-html5/imports/ui/core/hooks/createUseSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/createUseSubscription.ts
@@ -1,5 +1,7 @@
 import { TypedQueryDocumentNode, DocumentNode } from 'graphql';
-import { useRef, useState, useEffect } from 'react';
+import {
+  useRef, useState, useEffect, useMemo,
+} from 'react';
 
 import { gql, useApolloClient } from '@apollo/client';
 import R from 'ramda';
@@ -7,14 +9,15 @@ import { applyPatch } from 'fast-json-patch';
 
 function createUseSubscription<T>(
   query: DocumentNode | TypedQueryDocumentNode,
+  queryVariables = {},
   usePatchedSubscription = false,
-  variables = {},
 ) {
   return function useGeneratedUseSubscription(projectionFunction: (element: Partial<T>) => void): Array<Partial<T>> {
     const client = useApolloClient();
     const [projectedData, setProjectedData] = useState<Array<T>>([]);
     const oldProjectionOfDataRef = useRef<Array<T>>([]);
     const dataRef = useRef<Array<T>>([]);
+    const variables = useMemo(() => queryVariables, [JSON.stringify(queryVariables)]);
 
     let newSubscriptionGQL = query;
     if (usePatchedSubscription) {
@@ -71,7 +74,7 @@ function createUseSubscription<T>(
           },
         });
       return () => apolloSubscription.unsubscribe();
-    }, []);
+    }, [JSON.stringify(variables)]);
 
     return projectedData;
   };

--- a/bigbluebutton-html5/imports/ui/core/hooks/useCurrentPresentation.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useCurrentPresentation.ts
@@ -3,7 +3,7 @@ import CURRENT_PRESENTATION_SUBSCRIPTION from '../graphql/queries/currentPresent
 import { CurrentPresentation } from '../../Types/presentation';
 
 const useCurrentPresentationSubscription = createUseSubscription<Partial<CurrentPresentation>>(
-  CURRENT_PRESENTATION_SUBSCRIPTION, false,
+  CURRENT_PRESENTATION_SUBSCRIPTION,
 );
 
 const useCurrentPresentation = (fn: (c: Partial<CurrentPresentation>) => Partial<CurrentPresentation>) => {

--- a/bigbluebutton-html5/imports/ui/core/hooks/useCurrentUser.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useCurrentUser.ts
@@ -2,7 +2,7 @@ import createUseSubscription from './createUseSubscription';
 import CURRENT_USER_SUBSCRIPTION from '../graphql/queries/currentUserSubscription';
 import { User } from '../../Types/user';
 
-const useCurrentUserSubscription = createUseSubscription<Partial<User>>(CURRENT_USER_SUBSCRIPTION, false);
+const useCurrentUserSubscription = createUseSubscription<Partial<User>>(CURRENT_USER_SUBSCRIPTION);
 
 const useCurrentUser = (fn: (c: Partial<User>) => Partial<User>) => {
   const currentUser = useCurrentUserSubscription(fn)[0];

--- a/bigbluebutton-html5/imports/ui/core/hooks/useMeeting.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useMeeting.ts
@@ -2,7 +2,7 @@ import createUseSubscription from './createUseSubscription';
 import MEETING_SUBSCRIPTION from '../graphql/queries/meetingSubscription';
 import { Meeting } from '../../Types/meeting';
 
-const useMeetingSubscription = createUseSubscription<Partial<Meeting>>(MEETING_SUBSCRIPTION, false);
+const useMeetingSubscription = createUseSubscription<Partial<Meeting>>(MEETING_SUBSCRIPTION);
 
 export const useMeeting = (fn: (c: Partial<Meeting>) => Partial<Meeting>): Partial<Meeting> => {
   const meeting = useMeetingSubscription(fn)[0];

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -5084,6 +5084,11 @@
         "micromatch": "^4.0.4"
       }
     },
+    "fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -52,6 +52,7 @@
     "darkreader": "^4.9.46",
     "emoji-mart": "^3.0.1",
     "eventemitter2": "~6.4.6",
+    "fast-json-patch": "^3.1.1",
     "fastdom": "^1.0.10",
     "fibers": "^4.0.2",
     "flat": "^5.0.2",


### PR DESCRIPTION
Following #17854 and #17992.

This PR add support for **JsonPatch** in the project `bbb-html5` through the hook `createUseSubscription`.
And make the component `ChatMessageList` make use of it.

Motivation:
- Issue #17810
- Avoid sending an entire document when only a small part has changed (reducing payload size)
- Contribute to overall network efficiency

A few advantages of this strategy was explained during the BigBlueButtonWorld 2023: https://youtu.be/2v6X8-_B3lk?t=1207

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/158b3ac5-6d5f-446e-ae36-5e28add27256)

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/209c5939-c8b5-478f-8c55-5dd19324835e)
