### PR TITLE
fix: specify a unique mock authToken for dial-in users, +

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
@@ -34,8 +34,8 @@ trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration {
 
     def registerUserInRegisteredUsers() = {
       val regUser = RegisteredUsers.create(msg.body.intId, msg.body.voiceUserId,
-        msg.body.callerIdName, Roles.VIEWER_ROLE, msg.body.intId, userColor,
-        "", true, true, GuestStatus.WAIT, true, false)
+        msg.body.callerIdName, Roles.VIEWER_ROLE, msg.body.intId, "",
+        userColor, true, true, GuestStatus.WAIT, true, false)
       RegisteredUsers.add(liveMeeting.registeredUsers, regUser)
     }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
@@ -34,7 +34,7 @@ trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration {
 
     def registerUserInRegisteredUsers() = {
       val regUser = RegisteredUsers.create(msg.body.intId, msg.body.voiceUserId,
-        msg.body.callerIdName, Roles.VIEWER_ROLE, "", userColor,
+        msg.body.callerIdName, Roles.VIEWER_ROLE, msg.body.intId, userColor,
         "", true, true, GuestStatus.WAIT, true, false)
       RegisteredUsers.add(liveMeeting.registeredUsers, regUser)
     }


### PR DESCRIPTION
### What does this PR do?

* [fix: specify a unique mock authToken for dial-in users](https://github.com/bigbluebutton/bigbluebutton/commit/2f12992c20b0350bd7581e9d910416a229f0b108) 
  - Every dial in user has its RegistedUser authToken set to an empty string.
Since authToken is the RegUser's HashMap indexing key, this causes a
bunch of inconsistencies; eg.: endpoint ejection will stop working if
more than one dial-in user joined a single meeting because the
later dial-in devices overwrite the earlier ones in the RegUsers map.
  - The authToken is now mocked as the user's intId (which, for dial-in, is
the voice user ID) so that some sort of uniqueness is guaranteed within
the voice conf scope.
* [fix: reversed userColor and avatar args in dial-in user creation](https://github.com/bigbluebutton/bigbluebutton/commit/c6ccb19fdc77a80f2c1f2c24fffd916b5b618683) 
  - Benign: userColor and avatar arguments of RegisteredUsers.create were incorrectly placed

### Closes Issue(s)

None