### PR TITLE
fix (learning-dashboard): Learning Dashboard not showing Reactions

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
@@ -397,7 +397,7 @@ class LearningDashboardActor(
       user <- findUserByIntId(meeting, msg.body.userId)
     } yield {
       if (msg.body.reactionEmoji != "none") {
-        //Not considering flooding reactions, ignoring if same Emoji was sent in the last 30 seconds
+        //Ignore multiple Reactions to prevent flooding
         val hasSameReactionInLast30Seconds = user.reactions.filter(r => {
           System.currentTimeMillis() - r.sentOn < (30 * 1000) && r.name == msg.body.reactionEmoji
         }).length > 0


### PR DESCRIPTION
The Learning Dashboard does not support the new Reactions feature, as it was only designed to handle the old EmojiStatus. Therefore, this pull request (PR) will convert Reactions to EmojiStatus from the perspective of the Learning Dashboard to ensure seamless functionality. 

Additionally, this PR will ignore multiple Reactions to prevent flooding: if a user tries to send the same emoji within a 30-second span, only the first submission will be considered.

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/17c19d83-8da6-401d-bc63-9c82b04c7760)

Future work: Stop converting Reactions to EmojiStatus and make the Dashboard start to read Reactions properly.