### PR TITLE
fix: whiteboard access icon in userlist

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
@@ -159,6 +159,8 @@ const UserListItem: React.FC<UserListItemProps> = ({ user, lockSettings }) => {
     ? user.lastBreakoutRoom?.sequence
     : iconUser;
 
+  const hasWhiteboardAccess = user?.presPagesWritable?.some((page) => page.isCurrentPage);
+
   return (
     <Styled.UserItemContents data-test={(user.userId === Auth.userID) ? 'userListItemCurrent' : 'userListItem'}>
       <Styled.Avatar
@@ -173,7 +175,7 @@ const UserListItem: React.FC<UserListItemProps> = ({ user, lockSettings }) => {
         voice={voiceUser?.joined}
         noVoice={!voiceUser?.joined}
         color={user.color}
-        whiteboardAccess={user?.presPagesWritable?.length > 0}
+        whiteboardAccess={hasWhiteboardAccess}
         animations
         emoji={user.emoji !== 'none'}
         avatar={userAvatarFiltered}


### PR DESCRIPTION
### What does this PR do?

Fix for an issue with the whiteboard access icon (multi user whiteboard) not being removed if the presentation page is changed

![2023-11-08_14-46](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/5dc4ec52-eea5-4011-b30d-23a13e3126e1)
