### PR TITLE
feature(html5): Change return type of the graphql data hook

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/hook.ts
+++ b/bigbluebutton-html5/imports/ui/Types/hook.ts
@@ -1,0 +1,5 @@
+import { FetchResult } from '@apollo/client';
+
+export type GraphqlDataHookSubscriptionResponse<T> = FetchResult<T> & {
+  loading: boolean;
+};

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/component.tsx
@@ -113,7 +113,7 @@ const AudioControls: React.FC<AudioControlsProps> = ({
 };
 
 export const AudioControlsContainer: React.FC = () => {
-  const currentUser: Partial<User> = useCurrentUser((u: Partial<User>) => {
+  const { data: currentUser } = useCurrentUser((u: Partial<User>) => {
     return {
       presenter: u.presenter,
       isModerator: u.isModerator,
@@ -122,7 +122,7 @@ export const AudioControlsContainer: React.FC = () => {
     };
   });
 
-  const currentMeeting: Partial<Meeting> = useMeeting((m: Partial<Meeting>) => {
+  const { data: currentMeeting } = useMeeting((m: Partial<Meeting>) => {
     return {
       lockSettings: m.lockSettings,
     };

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/component.tsx
@@ -216,7 +216,7 @@ const InputStreamLiveSelector: React.FC<InputStreamLiveSelectorProps> = ({
 };
 
 const InputStreamLiveSelectorContainer: React.FC = () => {
-  const currentUser: Partial<User> = useCurrentUser((u: Partial<User>) => {
+  const { data: currentUser } = useCurrentUser((u: Partial<User>) => {
     if (!u.voice) {
       return {
         presenter: u.presenter,
@@ -237,7 +237,7 @@ const InputStreamLiveSelectorContainer: React.FC = () => {
     };
   });
 
-  const currentMeeting: Partial<Meeting> = useMeeting((m: Partial<Meeting>) => {
+  const { data: currentMeeting } = useMeeting((m: Partial<Meeting>) => {
     return {
       lockSettings: m?.lockSettings,
       isBreakout: m?.isBreakout,

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -27,10 +27,11 @@ import useMeeting from '/imports/ui/core/hooks/useMeeting';
 
 import ChatOfflineIndicator from './chat-offline-indicator/component';
 import { ChatEvents } from '/imports/ui/core/enums/chat';
-import { FetchResult, useMutation } from '@apollo/client';
+import { useMutation } from '@apollo/client';
 import { SEND_GROUP_CHAT_MSG } from './mutations';
 import Storage from '/imports/ui/services/storage/session';
 import { indexOf, without } from '/imports/utils/array-utils';
+import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
 
 // @ts-ignore - temporary, while meteor exists in the project
 const CHAT_CONFIG = Meteor.settings.public.chat;
@@ -398,7 +399,7 @@ const ChatMessageFormContainer: React.FC = ({
     participant: c?.participant,
     chatId: c?.chatId,
     public: c?.public,
-  }), idChatOpen) as FetchResult<Partial<Chat>>;
+  }), idChatOpen) as GraphqlDataHookSubscriptionResponse<Partial<Chat>>;
 
   const { data: currentUser } = useCurrentUser((c) => ({
     isModerator: c?.isModerator,

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -27,7 +27,7 @@ import useMeeting from '/imports/ui/core/hooks/useMeeting';
 
 import ChatOfflineIndicator from './chat-offline-indicator/component';
 import { ChatEvents } from '/imports/ui/core/enums/chat';
-import { useMutation } from '@apollo/client';
+import { FetchResult, useMutation } from '@apollo/client';
 import { SEND_GROUP_CHAT_MSG } from './mutations';
 import Storage from '/imports/ui/services/storage/session';
 import { indexOf, without } from '/imports/utils/array-utils';
@@ -394,13 +394,13 @@ const ChatMessageFormContainer: React.FC = ({
   const intl = useIntl();
   const [showEmojiPicker, setShowEmojiPicker] = React.useState(false);
   const idChatOpen: string = layoutSelect((i: Layout) => i.idChatOpen);
-  const chat = useChat((c: Partial<Chat>) => ({
+  const { data: chat } = useChat((c: Partial<Chat>) => ({
     participant: c?.participant,
     chatId: c?.chatId,
     public: c?.public,
-  }), idChatOpen) as Partial<Chat>;
+  }), idChatOpen) as FetchResult<Partial<Chat>>;
 
-  const currentUser = useCurrentUser((c) => ({
+  const { data: currentUser } = useCurrentUser((c) => ({
     isModerator: c?.isModerator,
     locked: c?.locked,
   }));
@@ -409,7 +409,7 @@ const ChatMessageFormContainer: React.FC = ({
     ? intl.formatMessage(messages.titlePrivate, { 0: chat?.participant?.name })
     : intl.formatMessage(messages.titlePublic);
 
-  const meeting = useMeeting((m) => ({
+  const { data: meeting } = useMeeting((m) => ({
     lockSettings: m?.lockSettings,
   }));
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -6,7 +6,7 @@ import React, {
   useMemo,
 } from 'react';
 import { Meteor } from 'meteor/meteor';
-import { makeVar, useMutation } from '@apollo/client';
+import { FetchResult, makeVar, useMutation } from '@apollo/client';
 import { defineMessages, useIntl } from 'react-intl';
 import LAST_SEEN_MUTATION from './queries';
 import {
@@ -316,14 +316,14 @@ const ChatMessageListContainer: React.FC = () => {
   const idChatOpen = layoutSelect((i: Layout) => i.idChatOpen);
   const isPublicChat = idChatOpen === PUBLIC_CHAT_KEY;
   const chatId = !isPublicChat ? idChatOpen : PUBLIC_GROUP_CHAT_KEY;
-  const currentChat = useChat((chat) => {
+  const { data: currentChat } = useChat((chat) => {
     return {
       chatId: chat.chatId,
       totalMessages: chat.totalMessages,
       totalUnread: chat.totalUnread,
       lastSeenAt: chat.lastSeenAt,
     };
-  }, chatId) as Partial<Chat>;
+  }, chatId) as FetchResult<Partial<Chat>>;
 
   const [setMessageAsSeenMutation] = useMutation(LAST_SEEN_MUTATION);
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -6,7 +6,7 @@ import React, {
   useMemo,
 } from 'react';
 import { Meteor } from 'meteor/meteor';
-import { FetchResult, makeVar, useMutation } from '@apollo/client';
+import { makeVar, useMutation } from '@apollo/client';
 import { defineMessages, useIntl } from 'react-intl';
 import LAST_SEEN_MUTATION from './queries';
 import {
@@ -23,6 +23,7 @@ import { Message } from '/imports/ui/Types/message';
 import ChatPopupContainer from '../chat-popup/component';
 import { ChatEvents } from '/imports/ui/core/enums/chat';
 import { Layout } from '../../../layout/layoutTypes';
+import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
 
 // @ts-ignore - temporary, while meteor exists in the project
 const CHAT_CONFIG = Meteor.settings.public.chat;
@@ -323,7 +324,7 @@ const ChatMessageListContainer: React.FC = () => {
       totalUnread: chat.totalUnread,
       lastSeenAt: chat.lastSeenAt,
     };
-  }, chatId) as FetchResult<Partial<Chat>>;
+  }, chatId) as GraphqlDataHookSubscriptionResponse<Partial<Chat>>;
 
   const [setMessageAsSeenMutation] = useMutation(LAST_SEEN_MUTATION);
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import React from 'react';
-import { FetchResult } from '@apollo/client';
 import {
   CHAT_MESSAGE_PUBLIC_SUBSCRIPTION,
   CHAT_MESSAGE_PRIVATE_SUBSCRIPTION,
@@ -8,6 +7,7 @@ import {
 import { Message } from '/imports/ui/Types/message';
 import ChatMessage from './chat-message/component';
 import { useCreateUseSubscription } from '/imports/ui/core/hooks/createUseSubscription';
+import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
 
 // @ts-ignore - temporary, while meteor exists in the project
 const CHAT_CONFIG = Meteor.settings.public.chat;
@@ -78,7 +78,9 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
     ? defaultVariables : { ...defaultVariables, requestedChatId: chatId };
 
   const useChatMessageSubscription = useCreateUseSubscription<Message>(chatQuery, variables, true);
-  const { data: chatMessageData } = useChatMessageSubscription((msg) => msg) as FetchResult<Message[]>;
+  const {
+    data: chatMessageData,
+  } = useChatMessageSubscription((msg) => msg) as GraphqlDataHookSubscriptionResponse<Message[]>;
 
   if (chatMessageData) {
     if (chatMessageData.length > 0 && chatMessageData[chatMessageData.length - 1].user?.userId) {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import React from 'react';
+import { FetchResult } from '@apollo/client';
 import {
   CHAT_MESSAGE_PUBLIC_SUBSCRIPTION,
   CHAT_MESSAGE_PRIVATE_SUBSCRIPTION,
@@ -76,22 +77,24 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
   const variables = isPublicChat
     ? defaultVariables : { ...defaultVariables, requestedChatId: chatId };
 
-  const useChatMessageSubscription = useCreateUseSubscription<Partial<Message>>(chatQuery, variables, true);
-  const chatMessageData = useChatMessageSubscription((msg) => msg) as Array<Message>;
+  const useChatMessageSubscription = useCreateUseSubscription<Message>(chatQuery, variables, true);
+  const { data: chatMessageData } = useChatMessageSubscription((msg) => msg) as FetchResult<Message[]>;
 
-  if (chatMessageData.length > 0) {
-    setLastSender(page, chatMessageData[chatMessageData.length - 1].user?.userId);
-  }
+  if (chatMessageData) {
+    if (chatMessageData.length > 0 && chatMessageData[chatMessageData.length - 1].user?.userId) {
+      setLastSender(page, chatMessageData[chatMessageData.length - 1].user?.userId);
+    }
 
-  return (
-    <ChatListPage
-      messages={chatMessageData}
-      lastSenderPreviousPage={lastSenderPreviousPage}
-      page={page}
-      markMessageAsSeen={markMessageAsSeen}
-      scrollRef={scrollRef}
-    />
-  );
+    return (
+      <ChatListPage
+        messages={chatMessageData}
+        lastSenderPreviousPage={lastSenderPreviousPage}
+        page={page}
+        markMessageAsSeen={markMessageAsSeen}
+        scrollRef={scrollRef}
+      />
+    );
+  } return (<></>);
 };
 
 export default ChatListPageContainer;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-typing-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-typing-indicator/component.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FetchResult, useSubscription } from '@apollo/client';
+import { useSubscription } from '@apollo/client';
 import {
   IS_TYPING_PUBLIC_SUBSCRIPTION,
   IS_TYPING_PRIVATE_SUBSCRIPTION,
@@ -18,6 +18,7 @@ import { Layout } from '../../../layout/layoutTypes';
 import useChat from '/imports/ui/core/hooks/useChat';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import { Chat } from '/imports/ui/Types/chat';
+import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
 
 const DEBUG_CONSOLE = false;
 
@@ -126,7 +127,7 @@ const TypingIndicatorContainer: React.FC = () => {
       chatId: c?.chatId,
       public: c?.public,
     };
-  }, idChatOpen) as FetchResult<Chat>;
+  }, idChatOpen) as GraphqlDataHookSubscriptionResponse<Chat>;
 
   const { data: meeting } = useMeeting((m) => ({
     lockSettings: m?.lockSettings,

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-typing-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-typing-indicator/component.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useSubscription } from '@apollo/client';
+import { FetchResult, useSubscription } from '@apollo/client';
 import {
   IS_TYPING_PUBLIC_SUBSCRIPTION,
   IS_TYPING_PRIVATE_SUBSCRIPTION,
@@ -111,7 +111,7 @@ const TypingIndicator: React.FC<TypingIndicatorProps> = ({
 const TypingIndicatorContainer: React.FC = () => {
   const idChatOpen: string = layoutSelect((i: Layout) => i.idChatOpen);
   const intl = useIntl();
-  const currentUser = useCurrentUser((user: Partial<User>) => {
+  const { data: currentUser } = useCurrentUser((user: Partial<User>) => {
     return {
       userId: user.userId,
       isModerator: user.isModerator,
@@ -120,15 +120,15 @@ const TypingIndicatorContainer: React.FC = () => {
   });
   // eslint-disable-next-line no-unused-expressions, no-console
   DEBUG_CONSOLE && console.log('TypingIndicatorContainer:currentUser', currentUser);
-  const chat = useChat((c) => {
+  const { data: chat } = useChat((c) => {
     return {
       participant: c?.participant,
       chatId: c?.chatId,
       public: c?.public,
     };
-  }, idChatOpen) as Partial<Chat>;
+  }, idChatOpen) as FetchResult<Chat>;
 
-  const meeting = useMeeting((m) => ({
+  const { data: meeting } = useMeeting((m) => ({
     lockSettings: m?.lockSettings,
   }));
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FetchResult } from '@apollo/client';
 import ChatHeader from './chat-header/component';
 import { layoutSelect, layoutSelectInput } from '../../layout/context';
 import { Input, Layout } from '../../layout/layoutTypes';
@@ -14,6 +13,7 @@ import useChat from '/imports/ui/core/hooks/useChat';
 import { Chat as ChatType } from '/imports/ui/Types/chat';
 import { layoutDispatch } from '/imports/ui/components/layout/context';
 import browserInfo from '/imports/utils/browserInfo';
+import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
 
 interface ChatProps {
 
@@ -49,7 +49,7 @@ const ChatContainer: React.FC = () => {
       chatId: chat.chatId,
       participant: chat.participant,
     };
-  }) as FetchResult<Partial<ChatType>[]>;
+  }) as GraphqlDataHookSubscriptionResponse<Partial<ChatType>[]>;
 
   const [pendingChat, setPendingChat] = usePendingChat();
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FetchResult } from '@apollo/client';
 import ChatHeader from './chat-header/component';
 import { layoutSelect, layoutSelectInput } from '../../layout/context';
 import { Input, Layout } from '../../layout/layoutTypes';
@@ -43,16 +44,16 @@ const ChatContainer: React.FC = () => {
   const idChatOpen = layoutSelect((i: Layout) => i.idChatOpen);
   const sidebarContent = layoutSelectInput((i: Input) => i.sidebarContent);
   const layoutContextDispatch = layoutDispatch();
-  const chats = useChat((chat) => {
+  const { data: chats } = useChat((chat) => {
     return {
       chatId: chat.chatId,
       participant: chat.participant,
     };
-  }) as Partial<ChatType>[];
+  }) as FetchResult<Partial<ChatType>[]>;
 
   const [pendingChat, setPendingChat] = usePendingChat();
 
-  if (pendingChat) {
+  if (pendingChat && chats) {
     const chat = chats.find((c) => {
       return c.participant?.userId === pendingChat;
     });

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -316,11 +316,11 @@ const ExternalVideoPlayerContainer: React.FC = () => {
   // @ts-ignore - temporary while hybrid (meteor+GraphQl)
   const isEchoTest = useReactiveVar(audioManager._isEchoTest.value) as boolean;
 
-  const currentUser = useCurrentUser((user) => ({
+  const { data: currentUser } = useCurrentUser((user) => ({
     presenter: user.presenter,
   }));
 
-  const currentMeeting = useMeeting((m) => ({
+  const { data: currentMeeting } = useMeeting((m) => ({
     externalVideo: m.externalVideo,
   }));
 

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
@@ -294,7 +294,7 @@ const RecordingIndicatorContainer: React.FC = () => {
     error: meetingRecordingError,
   } = useSubscription<getMeetingRecordingData>(GET_MEETING_RECORDING_DATA);
 
-  const currentUser = useCurrentUser((user: Partial<User>) => ({
+  const { data: currentUser } = useCurrentUser((user: Partial<User>) => ({
     userId: user.userId,
     isModerator: user.isModerator,
     voice: user.voice
@@ -305,7 +305,7 @@ const RecordingIndicatorContainer: React.FC = () => {
       : null,
   } as Partial<User>));
 
-  const currentMeeting = useMeeting((meeting) => ({
+  const { data: currentMeeting } = useMeeting((meeting) => ({
     meetingId: meeting.meetingId,
     notifyRecordingIsOn: meeting.notifyRecordingIsOn,
   }));

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
@@ -170,7 +170,7 @@ const TalkingIndicator: React.FC<TalkingIndicatorProps> = ({
 const TalkingIndicatorContainer: React.FC = (() => {
   if (!enableTalkingIndicator) return () => null;
   return () => {
-    const currentUser: Partial<User> = useCurrentUser((u: Partial<User>) => ({
+    const { data: currentUser } = useCurrentUser((u: Partial<User>) => ({
       userId: u?.userId,
       isModerator: u?.isModerator,
     }));

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/plugin-hooks-handler/use-current-presentation/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/plugin-hooks-handler/use-current-presentation/container.tsx
@@ -24,7 +24,7 @@ const projectCurrentPresentation = (
 const CurrentPresentationHookContainer = () => {
   const [sendSignal, setSendSignal] = useState(false);
 
-  const currentPresentation = useCurrentPresentation(
+  const { data: currentPresentation } = useCurrentPresentation(
     (currentPres: Partial<CurrentPresentation>) => currentPres,
   );
 

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/plugin-hooks-handler/use-current-user/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/plugin-hooks-handler/use-current-user/container.tsx
@@ -54,7 +54,7 @@ const projectCurrentUser = (
 const CurrentUserHookContainer = () => {
   const [sendSignal, setSendSignal] = useState(false);
 
-  const currentUser = useCurrentUser(
+  const { data: currentUser } = useCurrentUser(
     (currentUser: Partial<User>) => currentUser,
   );
 

--- a/bigbluebutton-html5/imports/ui/components/timer/timer-graphql/indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/timer-graphql/indicator/component.tsx
@@ -143,7 +143,7 @@ const TimerIndicator: React.FC<TimerIndicatorProps> = ({
 };
 
 const TimerIndicatorContainer: React.FC = () => {
-  const currentUser = useCurrentUser((u) => ({
+  const { data: currentUser } = useCurrentUser((u) => ({
     isModerator: u.isModerator,
   }));
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/component.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FetchResult } from '@apollo/client';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import { defineMessages, useIntl } from 'react-intl';
 import { findDOMNode } from 'react-dom';
@@ -81,10 +82,12 @@ const ChatList: React.FC<ChatListProps> = ({ chats }) => {
 };
 
 const ChatListContainer: React.FC = () => {
-  const chats = useChat((chat) => chat) as Chat[];
-  return (
-    <ChatList chats={chats} />
-  );
+  const { data: chats } = useChat((chat) => chat) as FetchResult<Chat[]>;
+  if (chats) {
+    return (
+      <ChatList chats={chats} />
+    );
+  } return <></>;
 };
 
 export default ChatListContainer;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/component.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FetchResult } from '@apollo/client';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import { defineMessages, useIntl } from 'react-intl';
 import { findDOMNode } from 'react-dom';
@@ -8,6 +7,7 @@ import ChatListItem from './chat-list-item/component';
 import useChat from '/imports/ui/core/hooks/useChat';
 import { Chat } from '/imports/ui/Types/chat';
 import Service from '/imports/ui/components/user-list/service';
+import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
 
 const intlMessages = defineMessages({
   messagesTitle: {
@@ -82,7 +82,7 @@ const ChatList: React.FC<ChatListProps> = ({ chats }) => {
 };
 
 const ChatListContainer: React.FC = () => {
-  const { data: chats } = useChat((chat) => chat) as FetchResult<Chat[]>;
+  const { data: chats } = useChat((chat) => chat) as GraphqlDataHookSubscriptionResponse<Chat[]>;
   if (chats) {
     return (
       <ChatList chats={chats} />

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/component.tsx
@@ -164,7 +164,7 @@ const UserListParticipantsContainer: React.FC = () => {
   } = useSubscription(USER_AGGREGATE_COUNT_SUBSCRIPTION);
   const count = countData?.user_aggregate?.aggregate?.count || 0;
 
-  const currentUser = useCurrentUser((c: Partial<User>) => ({
+  const { data: currentUser } = useCurrentUser((c: Partial<User>) => ({
     isModerator: c.isModerator,
     userId: c.userId,
     presenter: c.presenter,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/guest-panel-opener/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/guest-panel-opener/component.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { Meteor } from 'meteor/meteor';
-import { Meeting } from '/imports/ui/Types/meeting';
 import { useMeeting } from '/imports/ui/core/hooks/useMeeting';
 import { useSubscription } from '@apollo/client';
 import { GET_GUESTS_COUNT, GuestUsersCountResponse } from './queries';
@@ -86,7 +85,7 @@ const GuestPanelOpener: React.FC<GuestPanelOpenerProps> = ({
 };
 
 const GuestPanelOpenerContainer: React.FC = () => {
-  const currentMeeting: Partial<Meeting> = useMeeting((meeting) => {
+  const { data: currentMeeting } = useMeeting((meeting) => {
     const a = {
       usersPolicies: meeting.usersPolicies,
     };

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/component.tsx
@@ -339,14 +339,14 @@ const UserTitleOptions: React.FC<UserTitleOptionsProps> = ({
 
 const UserTitleOptionsContainer: React.FC = () => {
   const isRTL = layoutSelect((i: Layout) => i.isRTL);
-  const meetingInfo = useMeeting((meeting: Partial<Meeting>) => ({
+  const { data: meetingInfo } = useMeeting((meeting: Partial<Meeting>) => ({
     voiceSettings: meeting?.voiceSettings,
     isBreakout: meeting?.isBreakout,
     breakoutPolicies: meeting?.breakoutPolicies,
     name: meeting?.name,
   }));
 
-  const currentUser = useCurrentUser((user: Partial<User>) => ({
+  const { data: currentUser } = useCurrentUser((user: Partial<User>) => ({
     userId: user?.userId,
     isModerator: user?.isModerator,
   }));

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/waiting-users-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/waiting-users-graphql/component.tsx
@@ -29,7 +29,6 @@ import Header from '/imports/ui/components/common/control-header/component';
 import TextInput from '/imports/ui/components/text-input/component';
 import renderNoUserWaitingItem from './guest-items/noPendingGuestUser';
 import renderPendingUsers from './guest-items/guestPendingUser';
-import { Meeting } from '/imports/ui/Types/meeting';
 import logger from '/imports/startup/client/logger';
 
 // @ts-ignore - temporary, while meteor exists in the project
@@ -367,7 +366,7 @@ const GuestUsersManagementPanelContainer: React.FC = () => {
     error: guestWaitingUsersError,
   } = useSubscription<GuestWaitingUsers>(GET_GUEST_WAITING_USERS_SUBSCRIPTION);
 
-  const currentMeeting: Partial<Meeting> = useMeeting((meeting) => {
+  const { data: currentMeeting } = useMeeting((meeting) => {
     const a = {
       usersPolicies: meeting.usersPolicies,
     };

--- a/bigbluebutton-html5/imports/ui/core/hooks/useChat.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useChat.ts
@@ -1,18 +1,25 @@
+import { FetchResult } from '@apollo/client';
 import createUseSubscription from './createUseSubscription';
 import CHATS_SUBSCRIPTION from '../graphql/queries/chatSubscription';
 import { Chat } from '../../Types/chat';
 
-const useChatSubscription = createUseSubscription<Partial<Chat>>(CHATS_SUBSCRIPTION);
+const useChatSubscription = createUseSubscription<Chat>(CHATS_SUBSCRIPTION);
 
-const useChat = (fn: (c: Partial<Chat>)=> Partial<Chat>, chatId?: string): Array<Partial<Chat>> | Partial<Chat>
-| null => {
-  const chats = useChatSubscription(fn);
-  if (chatId) {
-    return chats.find((c) => {
+const useChat = (
+  fn: (c: Partial<Chat>)=> Partial<Chat>,
+  chatId?: string,
+): FetchResult<Array<Partial<Chat>> | Partial<Chat>> => {
+  const response = useChatSubscription(fn);
+  if (chatId && response.data) {
+    const selectedChat = response.data.find((c: Partial<Chat>) => {
       return c.chatId === chatId;
     }) ?? null;
+    return {
+      ...response,
+      data: selectedChat,
+    } as FetchResult<Array<Chat> | Chat>;
   }
-  return chats;
+  return response;
 };
 
 export default useChat;

--- a/bigbluebutton-html5/imports/ui/core/hooks/useChat.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useChat.ts
@@ -1,6 +1,6 @@
-import { FetchResult } from '@apollo/client';
 import createUseSubscription from './createUseSubscription';
 import CHATS_SUBSCRIPTION from '../graphql/queries/chatSubscription';
+import { GraphqlDataHookSubscriptionResponse } from '../../Types/hook';
 import { Chat } from '../../Types/chat';
 
 const useChatSubscription = createUseSubscription<Chat>(CHATS_SUBSCRIPTION);
@@ -8,7 +8,7 @@ const useChatSubscription = createUseSubscription<Chat>(CHATS_SUBSCRIPTION);
 const useChat = (
   fn: (c: Partial<Chat>)=> Partial<Chat>,
   chatId?: string,
-): FetchResult<Array<Partial<Chat>> | Partial<Chat>> => {
+): GraphqlDataHookSubscriptionResponse<Array<Partial<Chat>> | Partial<Chat>> => {
   const response = useChatSubscription(fn);
   if (chatId && response.data) {
     const selectedChat = response.data.find((c: Partial<Chat>) => {
@@ -17,7 +17,7 @@ const useChat = (
     return {
       ...response,
       data: selectedChat,
-    } as FetchResult<Array<Chat> | Chat>;
+    } as GraphqlDataHookSubscriptionResponse<Array<Chat> | Chat>;
   }
   return response;
 };

--- a/bigbluebutton-html5/imports/ui/core/hooks/useCurrentPresentation.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useCurrentPresentation.ts
@@ -2,13 +2,17 @@ import createUseSubscription from './createUseSubscription';
 import CURRENT_PRESENTATION_SUBSCRIPTION from '../graphql/queries/currentPresentationSubscription';
 import { CurrentPresentation } from '../../Types/presentation';
 
-const useCurrentPresentationSubscription = createUseSubscription<Partial<CurrentPresentation>>(
+const useCurrentPresentationSubscription = createUseSubscription<CurrentPresentation>(
   CURRENT_PRESENTATION_SUBSCRIPTION,
 );
 
 const useCurrentPresentation = (fn: (c: Partial<CurrentPresentation>) => Partial<CurrentPresentation>) => {
-  const currentPresentation = useCurrentPresentationSubscription(fn)[0];
-  return currentPresentation;
+  const response = useCurrentPresentationSubscription(fn);
+  const returnObject = {
+    ...response,
+    data: response.data?.[0],
+  };
+  return returnObject;
 };
 
 export default useCurrentPresentation;

--- a/bigbluebutton-html5/imports/ui/core/hooks/useCurrentUser.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useCurrentUser.ts
@@ -2,11 +2,15 @@ import createUseSubscription from './createUseSubscription';
 import CURRENT_USER_SUBSCRIPTION from '../graphql/queries/currentUserSubscription';
 import { User } from '../../Types/user';
 
-const useCurrentUserSubscription = createUseSubscription<Partial<User>>(CURRENT_USER_SUBSCRIPTION);
+const useCurrentUserSubscription = createUseSubscription<User>(CURRENT_USER_SUBSCRIPTION);
 
 const useCurrentUser = (fn: (c: Partial<User>) => Partial<User>) => {
-  const currentUser = useCurrentUserSubscription(fn)[0];
-  return currentUser;
+  const response = useCurrentUserSubscription(fn);
+  const returnObject = {
+    ...response,
+    data: response.data?.[0],
+  };
+  return returnObject;
 };
 
 export default useCurrentUser;

--- a/bigbluebutton-html5/imports/ui/core/hooks/useMeeting.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useMeeting.ts
@@ -2,11 +2,15 @@ import createUseSubscription from './createUseSubscription';
 import MEETING_SUBSCRIPTION from '../graphql/queries/meetingSubscription';
 import { Meeting } from '../../Types/meeting';
 
-const useMeetingSubscription = createUseSubscription<Partial<Meeting>>(MEETING_SUBSCRIPTION);
+const useMeetingSubscription = createUseSubscription<Meeting>(MEETING_SUBSCRIPTION);
 
-export const useMeeting = (fn: (c: Partial<Meeting>) => Partial<Meeting>): Partial<Meeting> => {
-  const meeting = useMeetingSubscription(fn)[0];
-  return meeting;
+export const useMeeting = (fn: (c: Partial<Meeting>) => Partial<Meeting>) => {
+  const response = useMeetingSubscription(fn);
+  const returnObject = {
+    ...response,
+    data: response.data?.[0],
+  };
+  return returnObject;
 };
 
 export default useMeeting;


### PR DESCRIPTION
### What does this PR do?

It changes the return type of the graphql data hooks. 

### Motivation

It will contain more information such as error that can possibly happen, whether it is still loading the data... In addition to that, it will also fit the return type expected for the new plugin hooks architecture, which will have the error object and load information as well.