### PR TITLE
upgrade tooltip dependency and fix open tooltip on mobile

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/tooltip/bbbtip.css
+++ b/bigbluebutton-html5/imports/ui/components/common/tooltip/bbbtip.css
@@ -1,16 +1,16 @@
-.tippy-tooltip.bbbtip-theme{
+.tippy-box[data-theme~='bbbtip']{
     color:#fff;
     background-color:#333333;
     padding: .25rem .5rem;
     border-radius: 4px;
 }
 
-.tippy-tooltip.bbbtip-theme>.tippy-svg-arrow{
+.tippy-box[data-theme~='bbbtip']>.tippy-svg-arrow{
     fill: #333333;
     background-color: transparent;
 }
 
-.tippy-tooltip.bbbtip-theme>.tippy-content{
+.tippy-box[data-theme~='bbbtip']>.tippy-content{
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/bigbluebutton-html5/imports/ui/components/common/tooltip/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/tooltip/component.jsx
@@ -15,7 +15,7 @@ const ANIMATION_DURATION = 350;
 const ANIMATION_DELAY = [150, 50];
 const DEFAULT_ANIMATION = 'shift-away';
 const ANIMATION_NONE = 'none';
-const TIP_OFFSET = '0, 10';
+const TIP_OFFSET = [0, 10];
 
 const propTypes = {
   title: PropTypes.string,
@@ -62,7 +62,7 @@ class Tooltip extends Component {
     } = this.props;
 
     const { animations } = Settings.application;
-    
+
     const overridePlacement = placement ? placement : position;
     let overrideDelay;
     if (animations) {
@@ -87,7 +87,7 @@ class Tooltip extends Component {
       onHide: this.onHide,
       offset: TIP_OFFSET,
       placement: overridePlacement,
-      touch: 'hold',
+      touch: ['hold', 1000],
       theme: 'bbbtip',
       multiple: false,
     };

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -6111,11 +6111,6 @@
         "semver-compare": "^1.0.0"
       }
     },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
-    },
     "postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -7153,11 +7148,11 @@
       "dev": true
     },
     "tippy.js": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-5.2.1.tgz",
-      "integrity": "sha512-66UT6JRVn3dXNCORE+0UvUK3JZqV/VhLlU6HTDm3FmrweUUFUxUGvT8tUQ7ycMp+uhuLAwQw6dBabyC+iKf/MA==",
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
       "requires": {
-        "popper.js": "^1.16.0"
+        "@popperjs/core": "^2.9.0"
       }
     },
     "to-fast-properties": {

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -91,7 +91,7 @@
     "smile2emoji": "^3.8.3",
     "string-hash": "~1.1.3",
     "styled-components": "^5.3.3",
-    "tippy.js": "^5.1.3",
+    "tippy.js": "^6.3.7",
     "use-context-selector": "^1.3.7",
     "wasm-feature-detect": "^1.5.1",
     "webrtc-adapter": "^8.1.1",


### PR DESCRIPTION
### What does this PR do?

Upgrades tippy to latest version and set it to only display a tooltip on mobile after a long press (1 second), preventing it from appearing by mistake when a user clicks on a button

https://github.com/bigbluebutton/bigbluebutton/assets/3728706/6a3ede92-9829-49bd-b612-6f16ea7d22d0

### Closes Issue(s)
Closes #16945
Closes #19110