### PR TITLE
(sec)build(bbb-libreoffice): bump to 7.5.7.1

### DIFF
--- a/bbb-libreoffice/docker/Dockerfile
+++ b/bbb-libreoffice/docker/Dockerfile
@@ -1,1 +1,1 @@
-FROM bigbluebutton/bbb-libreoffice:7.5.7-2023-10-19-110211
+FROM bigbluebutton/bbb-libreoffice:7.6.2-20231020-161900

--- a/bbb-libreoffice/docker/Dockerfile
+++ b/bbb-libreoffice/docker/Dockerfile
@@ -1,1 +1,1 @@
-FROM bigbluebutton/bbb-libreoffice:latest
+FROM bigbluebutton/bbb-libreoffice:7.5.7-2023-10-19-110211


### PR DESCRIPTION
### What does this PR do?

Upgrades LibreOffice (used for document conversion) from 7.3.7.2 to 7.5.7.1

Closes Issue(s)
Closes #none

Motivation
https://nvd.nist.gov/vuln/detail/CVE-2023-4863

More
Quoting from @GhaziTriki 's response on https://groups.google.com/g/bigbluebutton-dev/c/9zdWgkM1c6o

LIbreoffice has been patched on September 2023 https://9to5linux.com/libreoffice-7-6-2-and-7-5-7-released-to-address-critical-webp-vulnerability

Libreoffice in BBB is a kind of jail and has access to only a necessary amount of computing resources.

More investigation about the current version is needed, but I assume that updating the LibreOffice docker image in BBB should be safe.

As mentioned in the original PR by @antobinary - https://github.com/bigbluebutton/bigbluebutton/pull/18974

Bumped one more time to 7.6.2.1 as done by @antobinary on PR - https://github.com/bigbluebutton/bigbluebutton/pull/19046