### PR TITLE
fix: check for presence of parentMeetingID if isBreakout is true

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -129,8 +129,8 @@ class ApiController {
       return
     }
 
-    if(params.isBreakout && !params.parentIdMeetingId) {
-      invalid("parentMeetingIdMissing", "No parent meeting ID was provided for the breakout room")
+    if(params.isBreakout == "true" && !params.parentMeetingID) {
+      invalid("parentMeetingIDMissing", "No parent meeting ID was provided for the breakout room")
       return
     }
 


### PR DESCRIPTION
### What does this PR do?

Fix the check for presence of parentMeetingID when isBreakout is true. There were two problems:

1. The first part of the if-clause would always be true when isBreakout was set to any value. It should only be true when isBreakout is passed as true. This is achieved by checking  isBreakout == "true".
2. The second part of the if-clause used the parameter "parentIdMeetingId", but the correct parameter according to API Docs is parentMeetingID . The parameter has been renamed appropriately.
For more details on the effect of these problems see the linked issue.

As mentioned in the original PR by @Ithanil - https://github.com/bigbluebutton/bigbluebutton/pull/18975 

