### PR TITLE
fix: Bump Etherpad's export rate limiting

### DIFF
--- a/build/packages-template/bbb-etherpad/settings.json
+++ b/build/packages-template/bbb-etherpad/settings.json
@@ -540,7 +540,7 @@
     "windowMs": 90000,
 
     // maximum number of requests per IP to allow during the rate limit window
-    "max": 16
+    "max": 32
   },
 
   /*


### PR DESCRIPTION
### What does this PR do?
Increases the number of export requests Etherpad can handle in a 90-second window from 16 to 32.
Some users reported not seeing the shared notes in the recording playback due to Etherpad's rate limiter. The previous value accommodates the capture of the notes up to the maximum number of simultaneous breakout rooms. Both features pull the file from the same endpoint as the recordings and may, therefore, interfere in rare instances.

### Motivation
Issue #19118 

### More
For reference, Etherpad's default is 10. See original discussion in https://github.com/bigbluebutton/bbb-pads/pull/17.
