### PR TITLE
fix: Bump Etherpad's export rate limiting (2.7)

### DIFF
--- a/build/packages-template/bbb-etherpad/settings.json
+++ b/build/packages-template/bbb-etherpad/settings.json
@@ -540,7 +540,7 @@
     "windowMs": 90000,
 
     // maximum number of requests per IP to allow during the rate limit window
-    "max": 16
+    "max": 32
   },
 
   /*


### PR DESCRIPTION
### What does this PR do?
Same as #19131, but targeting `v2.7.x-release`.