### PR TITLE
Fix: Moderator lowering hand from toast broken

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/raisehand-notifier/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/raisehand-notifier/component.jsx
@@ -121,7 +121,7 @@ class RaiseHandNotifier extends Component {
   }
 
   raisedHandAvatars() {
-    const { raiseHandUsers, clearUserStatus, intl } = this.props;
+    const { raiseHandUsers, lowerUserHands, intl } = this.props;
     let users = raiseHandUsers;
     if (raiseHandUsers.length > MAX_AVATAR_COUNT) users = users.slice(0, MAX_AVATAR_COUNT);
 
@@ -134,8 +134,8 @@ class RaiseHandNotifier extends Component {
           role="button"
           tabIndex={0}
           style={{ backgroundColor: `${u.color}` }}
-          onClick={() => clearUserStatus(u.userId)}
-          onKeyDown={(e) => (e.keyCode === ENTER ? clearUserStatus(u.userId) : null)}
+          onClick={() => lowerUserHands(u.userId)}
+          onKeyDown={(e) => (e.keyCode === ENTER ? lowerUserHands(u.userId) : null)}
           data-test="avatarsWrapperAvatar"
           moderator={u.role === ROLE_MODERATOR}
           avatar={u.avatar}

--- a/bigbluebutton-tests/playwright/user/user.spec.js
+++ b/bigbluebutton-tests/playwright/user/user.spec.js
@@ -204,7 +204,7 @@ test.describe.parallel('User', () => {
         await lockViewers.lockSeeOtherViewersUserList();
       });
 
-      test('Lock see other viewers annotations', async ({ browser, context, page }) => {
+      test('Lock see other viewers annotations @flaky', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initPages(page);
         await lockViewers.lockSeeOtherViewersAnnotations();


### PR DESCRIPTION
### What does this PR do?

This PR fixes the bug where the Moderator can't lower hands by clicking the avatr in the modal.

As provided on the original PR by myself. - https://github.com/bigbluebutton/bigbluebutton/pull/18977
