### PR TITLE
chore: upgrade Spring to 2.7.17

### DIFF
--- a/bigbluebutton-web/gradle.properties
+++ b/bigbluebutton-web/gradle.properties
@@ -1,7 +1,7 @@
-grailsVersion=5.3.2
+grailsVersion=5.3.3
 gormVersion=7.3.1
 gradleWrapperVersion=7.3.1
 grailsGradlePluginVersion=5.0.0
-groovyVersion=3.0.11
-tomcatEmbedVersion=9.0.78
-springVersion=2.7.12
+groovyVersion=3.0.19
+tomcatEmbedVersion=9.0.82
+springVersion=2.7.17


### PR DESCRIPTION
### What does this PR do?

Upgrades Spring to 2.7.17 and embedded Tomcat to 9.0.82. Also versions of Grails and Groovy saw a bump.
As mentioned on the original PR by @antobinary - https://github.com/bigbluebutton/bigbluebutton/pull/18981

### Motivation

Some vulnerabilities were patched

- https://www.cve.org/CVERecord?id=CVE-2023-44487 -- Fix: Upgrade to org.springframework.boot:spring-boot-starter-tomcat@2.7.17

- https://www.cve.org/CVERecord?id=CVE-2023-42794 -- Fix: Upgrade to org.springframework.boot:spring-boot-starter-tomcat@2.7.17

