### PR TITLE
chore: Bump bbb-pads to 1.5.2 (backport)

### DIFF
--- a/bbb-pads.placeholder.sh
+++ b/bbb-pads.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v1.5.1 --depth 1 https://github.com/bigbluebutton/bbb-pads bbb-pads
+git clone --branch v1.5.2 --depth 1 https://github.com/bigbluebutton/bbb-pads bbb-pads


### PR DESCRIPTION
Backport of #19070 to BBB 2.6