### PR TITLE
chore: Bump bbb-playback to 5.0.2 (backport)

### DIFF
--- a/bbb-playback.placeholder.sh
+++ b/bbb-playback.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v5.0.0 --depth 1 https://github.com/bigbluebutton/bbb-playback bbb-playback
+git clone --branch v5.0.2 --depth 1 https://github.com/bigbluebutton/bbb-playback bbb-playback


### PR DESCRIPTION
Backport of #19071 (and #18788) to BBB 2.6 