### PR TITLE
chore: Bump Etherpad to 1.9.4

### DIFF
--- a/bbb-etherpad.placeholder.sh
+++ b/bbb-etherpad.placeholder.sh
@@ -1,2 +1,1 @@
-git clone --branch 1.9.1 --depth 1 https://github.com/ether/etherpad-lite bbb-etherpad
-
+git clone --branch 1.9.4 --depth 1 https://github.com/ether/etherpad-lite bbb-etherpad


### PR DESCRIPTION
Backport of #19041 (and prior) to BBB 2.6