### PR TITLE
fix (bbb-web): Null pointer exception when parent meeting does not exist

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -1152,6 +1152,11 @@ public class ParamsProcessorUtil {
 		return true;
 	}
 
+    public boolean parentMeetingExists(String parentMeetingId) {
+        Meeting meeting = ServiceUtils.findMeetingFromMeetingID(parentMeetingId);
+        return meeting != null;
+    }
+
 	/*************************************************
 	 * Setters
 	 ************************************************/

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -130,9 +130,20 @@ class ApiController {
       return
     }
 
-    if(params.isBreakout == "true" && !params.parentMeetingID) {
-      invalid("parentMeetingIDMissing", "No parent meeting ID was provided for the breakout room")
-      return
+    Boolean isBreakoutRoom = false
+    if (!StringUtils.isEmpty(params.isBreakout)) {
+      isBreakoutRoom = Boolean.parseBoolean(params.isBreakout)
+    }
+
+    if(isBreakoutRoom) {
+      if(StringUtils.isEmpty(params.parentMeetingID)) {
+        invalid("parentMeetingIDMissing", "No parent meeting ID was provided for the breakout room")
+        return
+      }
+      if(!paramsProcessorUtil.parentMeetingExists(params.parentMeetingID)) {
+        invalid("parentMeetingDoesNotExist", "No parent meeting exists for the breakout room")
+        return
+      }
     }
 
     // Ensure unique TelVoice. Uniqueness is not guaranteed by paramsProcessorUtil.


### PR DESCRIPTION
### What does this PR do?

Performs a check when creating a breakout room through the API to see if the parent meeting exists.

### Motivation

Currently no check is done to see if the meeting corresponding to the provided parentMeetingID actually exists which can lead to an error.

As mentioned on the original PR by @paultrudel - https://github.com/bigbluebutton/bigbluebutton/pull/18986