### PR TITLE
doc: what's new in 2.7 link not proper

### DIFF
--- a/docs/docs/administration/install.md
+++ b/docs/docs/administration/install.md
@@ -333,7 +333,7 @@ You can upgrade in a few steps:
 
   Then run the `bbb-install.sh` script -- it will download and install the latest release of BigBlueButton 2.7 on top of your old 2.5 version.
   
-  Make sure you read through the "what's new in 2.7" document https://docs.bigbluebutton.org/2.7/new and specifically https://docs.bigbluebutton.org/2.7/new#other-notable-changes
+  Make sure you read through the "what's new in 2.7" document https://docs.bigbluebutton.org/2.7/new-features and specifically https://docs.bigbluebutton.org/2.7/new-features#other-notable-changes
 
 ### Upgrading from BigBlueButton 2.4
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

link path at line 336 path doesn't exist. modified with actual path.

-->

### What does this PR do?

This PR adress the Page not found issue 
link path at line 336 path doesn't exist. modified with actual path.

### Closes Issue(s)

Closes #19164 

### Motivation

<!-- Documentation issue in v2.7 -->

### More

- [ ] Added/updated documentation
