### PR TITLE
chore: Bump Etherpad to 1.9.4

### DIFF
--- a/bbb-etherpad.placeholder.sh
+++ b/bbb-etherpad.placeholder.sh
@@ -1,2 +1,2 @@
-git clone --branch 1.9.1 --depth 1 https://github.com/ether/etherpad-lite bbb-etherpad
+git clone --branch 1.9.4 --depth 1 https://github.com/ether/etherpad-lite bbb-etherpad
 


### PR DESCRIPTION
### What does this PR do?

Upgraded Etherpad to from 1.9.3 to 1.9.4

Closes Issue(s)
Closes #

Motivation
Mostly for the Log4j and axios upgrades

More
https://github.com/ether/etherpad-lite/releases/tag/v1.9.4

As providaded in the original PR by @antobinary - https://github.com/bigbluebutton/bigbluebutton/pull/19041