### PR TITLE
refactor: Add a toast warning you that your webcam is still streaming…

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.jsx
@@ -10,6 +10,7 @@ import * as PluginSdk from 'bigbluebutton-html-plugin-sdk';
 import Styled from './styles';
 import Auth from '/imports/ui/services/auth';
 import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
+import { notify } from '/imports/ui/services/notification';
 
 const intlMessages = defineMessages({
   focusLabel: {
@@ -65,6 +66,9 @@ const intlMessages = defineMessages({
   disableDesc: {
     id: 'app.videoDock.webcamDisableDesc',
   },
+  disableWarning: {
+    id: 'app.videoDock.webcamDisableWarning',
+  },
 });
 
 const UserActions = (props) => {
@@ -101,6 +105,7 @@ const UserActions = (props) => {
     const toggleDisableCam = () => {
       if (!isCameraDisabled) {
         Session.set('disabledCams', [...disabledCams, cameraId]);
+        notify(intl.formatMessage(intlMessages.disableWarning), 'info', 'warning');
       } else {
         Session.set('disabledCams', disabledCams.filter((cId) => cId !== cameraId));
       }

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1171,6 +1171,7 @@
     "app.videoDock.webcamDisableLabelAllCams": "Disable self-view (all cameras)",
     "app.videoDock.webcamEnableLabel": "Enable self-view",
     "app.videoDock.webcamDisableDesc": "Self-view disabled",
+    "app.videoDock.webcamDisableWarning": "Your webcam is still visible to others! Only your local view is disabled.",
     "app.videoDock.webcamPinLabel": "Pin",
     "app.videoDock.webcamPinDesc": "Pin the selected webcam",
     "app.videoDock.webcamFullscreenLabel": "Fullscreen webcam",


### PR DESCRIPTION
… (self view disabled)

### What does this PR do?
Adds a notification to help you remember that your webcam is indeed still streaming.

### Closes Issue(s)
Closes https://github.com/bigbluebutton/bigbluebutton/issues/19050

### Motivation
Some people are not aware their webcam is still on/streaming. We're trying to help them be aware.
