### PR TITLE
fix: The shortcut for raising hand is not functioning as expected @ 2…

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -6,6 +6,7 @@ import UserReactionService from '/imports/ui/components/user-reaction/service';
 import UserListService from '/imports/ui/components/user-list/service';
 import { convertRemToPixels } from '/imports/utils/dom-utils';
 import data from '@emoji-mart/data';
+import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
 import { init } from 'emoji-mart';
 
 import Styled from './styles';
@@ -19,6 +20,7 @@ const ReactionsButton = (props) => {
     userId,
     raiseHand,
     isMobile,
+    shortcuts,
     currentUserReaction,
     autoCloseReactionsBar,
   } = props;
@@ -101,7 +103,7 @@ const ReactionsButton = (props) => {
   });
 
   actions.push({
-    label: <Styled.RaiseHandButtonWrapper isMobile={isMobile} data-test={raiseHand ? 'lowerHandBtn' : 'raiseHandBtn'} active={raiseHand}><em-emoji key={handReaction.id} native={handReaction.native} emoji={{ id: handReaction.id }} {...emojiProps} />{RaiseHandButtonLabel()}</Styled.RaiseHandButtonWrapper>,
+    label: <Styled.RaiseHandButtonWrapper accessKey={shortcuts.raisehand} isMobile={isMobile} data-test={raiseHand ? 'lowerHandBtn' : 'raiseHandBtn'} active={raiseHand}><em-emoji key={handReaction.id} native={handReaction.native} emoji={{ id: handReaction.id }} {...emojiProps} />{RaiseHandButtonLabel()}</Styled.RaiseHandButtonWrapper>,
     key: 'hand',
     onClick: () => handleRaiseHandButtonClick(),
     customStyles: {...actionCustomStyles, width: 'auto'},
@@ -176,4 +178,4 @@ const propTypes = {
 
 ReactionsButton.propTypes = propTypes;
 
-export default ReactionsButton;
+export default withShortcutHelper(ReactionsButton, ['raiseHand']);


### PR DESCRIPTION
### What does this PR do?
Makes raise hand shortcut work with the new reactions bar

### Closes Issue(s)
Closes https://github.com/bigbluebutton/bigbluebutton/issues/18937

As mentioned in the original PR by @ramonlsouza - https://github.com/bigbluebutton/bigbluebutton/pull/19072