### PR TITLE
fix (learning-dashboard): Learning Dashboard not showing Reactions

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
@@ -397,10 +397,33 @@ class LearningDashboardActor(
       user <- findUserByIntId(meeting, msg.body.userId)
     } yield {
       if (msg.body.reactionEmoji != "none") {
-        val updatedUser = user.copy(reactions = user.reactions :+ Emoji(msg.body.reactionEmoji))
-        val updatedMeeting = meeting.copy(users = meeting.users + (updatedUser.userKey -> updatedUser))
+        //Ignore multiple Reactions to prevent flooding
+        val hasSameReactionInLast30Seconds = user.reactions.filter(r => {
+          System.currentTimeMillis() - r.sentOn < (30 * 1000) && r.name == msg.body.reactionEmoji
+        }).length > 0
 
-        meetings += (updatedMeeting.intId -> updatedMeeting)
+        if(!hasSameReactionInLast30Seconds) {
+          val updatedUser = user.copy(reactions = user.reactions :+ Emoji(msg.body.reactionEmoji))
+          val updatedMeeting = meeting.copy(users = meeting.users + (updatedUser.userKey -> updatedUser))
+          meetings += (updatedMeeting.intId -> updatedMeeting)
+
+          //Convert Reactions to legacy Emoji (while LearningDashboard doesn't support Reactions)
+          val emoji = msg.body.reactionEmoji.codePointAt(0) match {
+            case 128515 => "happy"
+            case 128528 => "neutral"
+            case 128577 => "sad"
+            case 128077 => "thumbsUp"
+            case 128078 => "thumbsDown"
+            case 128079 => "applause"
+            case _ => "none"
+          }
+
+          if (emoji != "none") {
+            val updatedUserWithEmoji = updatedUser.copy(emojis = user.emojis :+ Emoji(emoji))
+            val updatedMeetingWithEmoji = meeting.copy(users = meeting.users + (updatedUserWithEmoji.userKey -> updatedUserWithEmoji))
+            meetings += (updatedMeeting.intId -> updatedMeetingWithEmoji)
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
The Learning Dashboard does not support the new Reactions feature, as it was only designed to handle the old EmojiStatus. Therefore, this pull request (PR) will convert Reactions to EmojiStatus from the perspective of the Learning Dashboard to ensure seamless functionality.

Additionally, this PR will ignore multiple Reactions to prevent flooding: if a user tries to send the same emoji within a 30-second span, only the first submission will be considered.

![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/be8521cb-92ea-46b6-bd71-1704a0d0b028)

Future work: Stop converting Reactions to EmojiStatus and make the Dashboard start to read Reactions properly

As mentioned in the original PR by @gustavotrott - https://github.com/bigbluebutton/bigbluebutton/pull/19088