### PR TITLE
feature: Support pass param enforceLayout to Api /getJoinUrl

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ParamsUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ParamsUtil.java
@@ -21,10 +21,6 @@ public class ParamsUtil {
     return text.replaceAll("\\p{Cc}", "").trim();
   }
 
-  public static String stripSpecialChars(String text) {
-    return text.replaceAll("\\W", "");
-  }
-
   public static String escapeHTMLTags(String value) {
     return StringEscapeUtils.escapeHtml4(value);
   }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ParamsUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ParamsUtil.java
@@ -21,6 +21,10 @@ public class ParamsUtil {
     return text.replaceAll("\\p{Cc}", "").trim();
   }
 
+  public static String stripSpecialChars(String text) {
+    return text.replaceAll("\\W", "");
+  }
+
   public static String escapeHTMLTags(String value) {
     return StringEscapeUtils.escapeHtml4(value);
   }

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1250,6 +1250,11 @@ class ApiController {
         String extId = validationService.encodeString(meeting.getExternalId())
         String fullName = validationService.encodeString(us.fullname)
         String query = "fullName=${fullName}&meetingID=${extId}&role=${us.role.equals(ROLE_MODERATOR) ? ROLE_MODERATOR : ROLE_ATTENDEE}&redirect=true&userID=${us.getExternUserID()}"
+
+        if (!StringUtils.isEmpty(params.enforceLayout)) {
+          query += "&enforceLayout=${ParamsUtil.stripSpecialChars(params.enforceLayout)}";
+        }
+
         String checksum = DigestUtils.sha1Hex(method + query + validationService.getSecuritySalt())
         String defaultServerUrl = paramsProcessorUtil.defaultServerUrl
         response.addHeader("Cache-Control", "no-cache")

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1252,7 +1252,7 @@ class ApiController {
         String query = "fullName=${fullName}&meetingID=${extId}&role=${us.role.equals(ROLE_MODERATOR) ? ROLE_MODERATOR : ROLE_ATTENDEE}&redirect=true&userID=${us.getExternUserID()}"
 
         if (!StringUtils.isEmpty(params.enforceLayout)) {
-          query += "&enforceLayout=${ParamsUtil.stripSpecialChars(params.enforceLayout)}";
+          query += "&enforceLayout=${validationService.encodeString(params.enforceLayout)}";
         }
 
         String checksum = DigestUtils.sha1Hex(method + query + validationService.getSecuritySalt())


### PR DESCRIPTION
Now it's possible to call the API `/getJoinUrl` passing a `enforceLayout` param to be appended to the generated URL.

For instance:

GET Request: 
`https://bbb30.bbb.imdt.dev/bigbluebutton/api/getJoinUrl?sessionToken=bdikzqbnorrr2qeb&enforceLayout=camerasOnly`

Return:
```json
{
    "response": {
        "returncode": "SUCCESS",
        "message": "Join URL provided successfully.",
        "url": "https://bbb30.myserver.dev/bigbluebutton/api/join?fullName=teacher+1&meetingID=random-8878255&role=MODERATOR&redirect=true&userID=w_ioptwwjej6ae&enforceLayout=camerasOnly&checksum=aaa"
    }
}
``` 

Closes #19140