### PR TITLE
fix: Bump Etherpad's export rate limiting (3.0)

### DIFF
--- a/build/packages-template/bbb-etherpad/settings.json
+++ b/build/packages-template/bbb-etherpad/settings.json
@@ -540,7 +540,7 @@
     "windowMs": 90000,
 
     // maximum number of requests per IP to allow during the rate limit window
-    "max": 16
+    "max": 32
   },
 
   /*


### PR DESCRIPTION
### What does this PR do?
Same as https://github.com/bigbluebutton/bigbluebutton/pull/19131, but targeting v3.0.x-release. (Was 2.7)

 As mentioned in the original PR by @danielpetri1 - https://github.com/bigbluebutton/bigbluebutton/pull/19132