### PR TITLE
chore: Upgrade Grails to 6.1

### DIFF
--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -9,7 +9,7 @@ buildscript {
   dependencies {
     classpath "org.grails:grails-gradle-plugin:${grailsGradlePluginVersion}"
     classpath "org.grails.plugins:hibernate5:${gormVersion}"
-    classpath "com.bertramlabs.plugins:asset-pipeline-gradle:4.0.0"
+    classpath "com.bertramlabs.plugins:asset-pipeline-gradle:4.3.0"
     classpath "gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin:2.6"
     classpath "org.grails.plugins:views-gradle:2.1.1"
     classpath "org.grails.plugins:views-json:2.1.1"
@@ -53,10 +53,10 @@ repositories {
 }
 
 dependencies {
-  runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:4.0.0"
+  runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:4.3.0"
 
-  implementation "org.springframework:spring-core:5.3.21"
-  implementation "org.springframework:spring-context:5.3.27"
+  implementation "org.springframework:spring-core:5.3.31"
+  implementation "org.springframework:spring-context:5.3.31"
   implementation "org.springframework.boot:spring-boot:${springVersion}"
   implementation "org.springframework.boot:spring-boot-starter-logging:${springVersion}"
   implementation "org.springframework.boot:spring-boot-autoconfigure:${springVersion}"
@@ -65,7 +65,7 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-tomcat:${springVersion}"
 
   implementation "org.grails:grails-web-boot:5.2.5"
-  implementation "org.springframework:spring-webmvc:5.3.27"
+  implementation "org.springframework:spring-webmvc:5.3.31"
 
   implementation "org.grails:grails-logging"
   implementation "org.grails:grails-plugin-rest:5.2.5"
@@ -79,7 +79,7 @@ dependencies {
   implementation "org.grails.plugins:views-json:2.1.1"
   implementation "org.grails.plugins:cache"
   implementation "org.apache.xmlbeans:xmlbeans:5.0.3"
-  implementation "org.grails:grails-gradle-plugin:5.1.4"
+  implementation "org.grails:grails-gradle-plugin:${grailsGradlePluginVersion}"
   implementation "org.grails.plugins:async"
   implementation "org.grails.plugins:scaffolding"
   implementation "org.grails.plugins:events"
@@ -109,7 +109,7 @@ dependencies {
   //--- BigBlueButton Dependencies End
   console "org.grails:grails-console:5.2.0"
   profile "org.grails.profiles:web"
-  runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:4.0.0"
+  runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:4.3.0"
   testImplementation "org.grails:grails-gorm-testing-support"
   testImplementation "org.grails.plugins:geb"
   testImplementation "org.grails:grails-web-testing-support"
@@ -127,6 +127,8 @@ configurations.implementation {
     exclude group: 'io.micronaut', module: 'micronaut-aop'
     exclude group: 'com.h2database', module: 'h2'
     exclude group: 'org.graalvm.sdk', module: 'graal-sdk'
+    exclude group: 'io.github.gradle-nexus', module: 'publish-plugin'
+    exclude group: 'org.grails', module: 'grails-shell'
 }
 
 configurations {

--- a/bigbluebutton-web/gradle.properties
+++ b/bigbluebutton-web/gradle.properties
@@ -1,7 +1,7 @@
-grailsVersion=5.3.3
+grailsVersion=6.1.0
 gormVersion=7.3.1
-gradleWrapperVersion=7.3.1
-grailsGradlePluginVersion=5.0.0
+gradleWrapperVersion=7.6.3
+grailsGradlePluginVersion=6.1.0
 groovyVersion=3.0.19
 tomcatEmbedVersion=9.0.82
 springVersion=2.7.17

--- a/bigbluebutton-web/gradle/wrapper/gradle-wrapper.properties
+++ b/bigbluebutton-web/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-bin.zip


### PR DESCRIPTION
### What does this PR do?

Upgrades `bbb-web` to the latest versions of Grails and Spring 5.


### Motivation

The purpose of this Grails upgrade is to make the transition to Grails 7 easier when it releases. The Spring upgrade is to address the vulnerabilities, [CVE-2023-20863](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-20863) and [CVE-2023-20861](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-20861) present in `spring-core` version 5.3.21.
