### PR TITLE
Fix: listen only wrong color

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/styles.ts
@@ -284,6 +284,7 @@ const Avatar = styled.div<AvatarProps>`
       opacity: 1;
       width: 1.2rem;
       height: 1.2rem;
+      background-color: ${colorSuccess};
     }
   `}
 


### PR DESCRIPTION
### What does this PR do?

This PR corrects the color of the listen only icon. 

![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/30207780-86de-4c1c-8a37-973761953039)
