### PR TITLE
fix: Button 'Open Tablet app' breaks when the meeting name contains white space

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/mobile-app-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/mobile-app-modal/component.jsx
@@ -97,7 +97,9 @@ class MobileAppModal extends Component {
   }
 
   render() {
-    const { intl, isOpen, onRequestClose, priority, } = this.props;
+    const {
+      intl, isOpen, onRequestClose, priority,
+    } = this.props;
     const { url, urlMessage, meetingName } = this.state;
 
     return (
@@ -121,7 +123,7 @@ class MobileAppModal extends Component {
               color="primary"
               disabled={url === ''}
               label={intl.formatMessage(intlMessages.openApp)}
-              onClick={() => window.open(`${BBB_TABLET_APP_CONFIG.iosAppUrlScheme}://${meetingName}/${encodeURIComponent(url)}`, '_blank')}
+              onClick={() => window.open(`${BBB_TABLET_APP_CONFIG.iosAppUrlScheme}://${encodeURIComponent(meetingName)}/${encodeURIComponent(url)}`, '_blank')}
               role="button"
               size="lg"
             />


### PR DESCRIPTION
This button breaks when the meeting name contains white space!

![open-bbb-tablet-app-btn](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/3fb4f586-8b38-4ef7-8380-a5ae878b5649)



This PR fix the problem, I tested even using `/` in the name of the meeting and it's working properly now:

https://github.com/bigbluebutton/bigbluebutton/assets/5660191/ba34ffa5-8ce9-46ff-b4b8-f6c9f84be412

