### PR TITLE
fix (backport 2.7): Button 'Open Tablet app' breaks when the meeting name contains white space

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/mobile-app-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/mobile-app-modal/component.jsx
@@ -121,7 +121,7 @@ class MobileAppModal extends Component {
               color="primary"
               disabled={url === ''}
               label={intl.formatMessage(intlMessages.openApp)}
-              onClick={() => window.open(`${BBB_TABLET_APP_CONFIG.iosAppUrlScheme}://${meetingName}/${encodeURIComponent(url)}`, '_blank')}
+              onClick={() => window.open(`${BBB_TABLET_APP_CONFIG.iosAppUrlScheme}://${encodeURIComponent(meetingName)}/${encodeURIComponent(url)}`, '_blank')}
               role="button"
               size="lg"
             />


### PR DESCRIPTION
Backport of #19201