### PR TITLE
Fix graphql API for clusterproxy setup

### DIFF
--- a/bbb-graphql-middleware/bbb-graphql-middleware-config.env
+++ b/bbb-graphql-middleware/bbb-graphql-middleware-config.env
@@ -1,1 +1,4 @@
 BBB_GRAPHQL_MIDDLEWARE_LISTEN_PORT=8378
+# If you are running a cluster proxy setup, you need to configure the Origin of
+# the frontend. See https://docs.bigbluebutton.org/administration/cluster-proxy
+# BBB_GRAPHQL_MIDDLEWARE_ORIGIN=bbb-proxy.example.com

--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -11,6 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"net/http"
 	"nhooyr.io/websocket"
+	"os"
 	"sync"
 	"time"
 )
@@ -41,6 +42,10 @@ func ConnectionHandler(w http.ResponseWriter, r *http.Request) {
 	// Add sub-protocol
 	var acceptOptions websocket.AcceptOptions
 	acceptOptions.Subprotocols = append(acceptOptions.Subprotocols, "graphql-ws")
+	bbbOrigin := os.Getenv("BBB_GRAPHQL_MIDDLEWARE_ORIGIN")
+	if bbbOrigin != "" {
+		acceptOptions.OriginPatterns = append(acceptOptions.OriginPatterns, bbbOrigin)
+	}
 
 	c, err := websocket.Accept(w, r, &acceptOptions)
 	if err != nil {

--- a/bigbluebutton-html5/imports/ui/components/graphql-provider/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/graphql-provider/component.tsx
@@ -15,8 +15,14 @@ const GraphqlProvider = ({ children }: Props): React.ReactNode => {
   // const [link, setLink] = React.useState<WebSocketLink | null>(null);
   const [apolloClient, setApolloClient] = React.useState<ApolloClient<NormalizedCacheObject> | null>(null);
   useEffect(() => {
+    let GRAPHQL_URL = null;
+    if ('graphqlUrl' in Meteor.settings.public.app) {
+      GRAPHQL_URL = Meteor.settings.public.app.graphqlUrl;
+    } else {
+      GRAPHQL_URL = `wss://${window.location.hostname}/v1/graphql`;
+    }
     const wsLink = new WebSocketLink(
-      new SubscriptionClient(`wss://${window.location.hostname}/v1/graphql`, {
+      new SubscriptionClient(GRAPHQL_URL, {
         reconnect: true,
         timeout: 30000,
         connectionParams: {

--- a/docs/docs/administration/cluster-proxy.md
+++ b/docs/docs/administration/cluster-proxy.md
@@ -108,6 +108,7 @@ public:
     basename: '/bbb-01/html5client'
     bbbWebBase: 'https://bbb-01.example.com/bigbluebutton'
     learningDashboardBase: 'https://bbb-01.example.com/learning-dashboard'
+    graphqlUrl: wss://bbb-01.example.com/v1/graphql
   media:
     stunTurnServersFetchAddress: 'https://bbb-01.example.com/bigbluebutton/api/stuns'
     sip_ws_host: 'bbb-01.example.com'
@@ -184,6 +185,17 @@ Adjust the CORS settings in `/etc/default/bbb-web`:
 ```shell
 JDK_JAVA_OPTIONS="-Dgrails.cors.enabled=true -Dgrails.cors.allowCredentials=true -Dgrails.cors.allowedOrigins=https://bbb-proxy.example.org,https://https://bbb-01.example.com"
 ```
+
+Adjust the CORS setting in `/etc/default/bbb-graphql-middleware`:
+
+```shell
+BBB_GRAPHQL_MIDDLEWARE_LISTEN_PORT=8378
+# If you are running a cluster proxy setup, you need to configure the Origin of
+# the frontend. See https://docs.bigbluebutton.org/administration/cluster-proxy
+BBB_GRAPHQL_MIDDLEWARE_ORIGIN=bbb-proxy.example.org
+```
+
+Pay attention that this one is without protocol, just the hostname.
 
 
 Restart BigBlueButton:


### PR DESCRIPTION
### What does this PR do?

It fixes BBB 3.0 for a cluster proxy setup. Two things have to be fixed:

* the client needs to make a connection directly to the BBB server
* the bbb-graphql-middleware needs to accept requests with a different `Origin` header.

Updated setup instructions accordingly.

### Motivation

I want client settings in local storage consistent across all my BBB server. I need a cluster setup.

