### PR TITLE
Adds new layouts for specific integration scenarios

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -15,6 +15,7 @@ import { uniqueId } from '/imports/utils/string-utils';
 import { isPresentationEnabled, isLayoutsEnabled } from '/imports/ui/services/features';
 import VideoPreviewContainer from '/imports/ui/components/video-preview/container';
 import { screenshareHasEnded } from '/imports/ui/components/screenshare/service';
+import Settings from '/imports/ui/services/settings';
 
 const propTypes = {
   amIPresenter: PropTypes.bool.isRequired,
@@ -281,7 +282,12 @@ class ActionsDropdown extends PureComponent {
       });
     }
 
-    if (isLayoutsEnabled()) {
+    const { selectedLayout } = Settings.application;
+    const shouldShowManageLayoutButton = selectedLayout !== LAYOUT_TYPE.CAMERAS_ONLY
+      && selectedLayout !== LAYOUT_TYPE.PRESENTATION_ONLY
+      && selectedLayout !== LAYOUT_TYPE.PARTICIPANTS_CHAT_ONLY;
+
+    if (shouldShowManageLayoutButton && isLayoutsEnabled()) {
       actions.push({
         icon: 'manage_layout',
         label: intl.formatMessage(intlMessages.layoutModal),
@@ -301,9 +307,9 @@ class ActionsDropdown extends PureComponent {
         onClick: hasCameraAsContent
           ? screenshareHasEnded
           : () => {
-              screenshareHasEnded();
-              this.setCameraAsContentModalIsOpen(true);
-            },
+            screenshareHasEnded();
+            this.setCameraAsContentModalIsOpen(true);
+          },
         dataTest: 'shareCameraAsContent',
       });
     }
@@ -349,11 +355,11 @@ class ActionsDropdown extends PureComponent {
         return (
           {
             customStyles: p.current ? customStyles : null,
-            icon: "file",
+            icon: 'file',
             iconRight: p.current ? 'check' : null,
-            selected: p.current ? true : false,
+            selected: !!p.current,
             label: p.name,
-            description: "uploaded presentation file",
+            description: 'uploaded presentation file',
             key: `uploaded-presentation-${p.presentationId}`,
             onClick: () => {
               setPresentationFitToWidth(false);
@@ -384,6 +390,7 @@ class ActionsDropdown extends PureComponent {
   setPropsToPassModal(value) {
     this.setState({ propsToPassModal: value });
   }
+
   setForceOpen(value) {
     this.setState({ forceOpen: value });
   }
@@ -503,7 +510,7 @@ class ActionsDropdown extends PureComponent {
               }}
               {...propsToPassModal}
             />
-          )
+          ),
         )}
       </>
     );

--- a/bigbluebutton-html5/imports/ui/components/layout/enums.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/enums.js
@@ -3,6 +3,9 @@ export const LAYOUT_TYPE = {
   SMART_LAYOUT: 'smart',
   PRESENTATION_FOCUS: 'presentationFocus',
   VIDEO_FOCUS: 'videoFocus',
+  CAMERAS_ONLY: 'camerasOnly',
+  PRESENTATION_ONLY: 'presentationOnly',
+  PARTICIPANTS_CHAT_ONLY: 'participantsChatOnly',
 };
 
 export const DEVICE_TYPE = {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/camerasOnly.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/camerasOnly.jsx
@@ -164,8 +164,8 @@ const CamerasOnlyLayout = (props) => {
       type: ACTIONS.SET_SIDEBAR_NAVIGATION_OUTPUT,
       value: {
         display: false,
-        minWidth: sidebarNavWidth.minWidth,
-        width: sidebarNavWidth.width,
+        minWidth: 0,
+        width: 0,
         maxWidth: sidebarNavWidth.maxWidth,
         height: sidebarNavHeight,
         top: sidebarNavBounds.top,
@@ -191,8 +191,8 @@ const CamerasOnlyLayout = (props) => {
       type: ACTIONS.SET_SIDEBAR_CONTENT_OUTPUT,
       value: {
         display: false,
-        minWidth: sidebarContentWidth.minWidth,
-        width: sidebarContentWidth.width,
+        minWidth: 0,
+        width: 0,
         maxWidth: sidebarContentWidth.maxWidth,
         minHeight: sidebarContentHeight.minHeight,
         height: sidebarContentHeight.height,
@@ -338,9 +338,13 @@ const CamerasOnlyLayout = (props) => {
         {
           sidebarNavigation: {
             isOpen: false,
+            width: 0,
+            height: 0,
           },
           sidebarContent: {
             isOpen: false,
+            width: 0,
+            height: 0,
           },
           SidebarContentHorizontalResizer: {
             isOpen: false,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/camerasOnly.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/camerasOnly.jsx
@@ -1,0 +1,383 @@
+import { useEffect, useRef } from 'react';
+import { throttle } from '/imports/utils/throttle';
+import {
+  layoutDispatch,
+  layoutSelect,
+  layoutSelectInput,
+} from '/imports/ui/components/layout/context';
+import DEFAULT_VALUES from '/imports/ui/components/layout/defaultValues';
+import { INITIAL_INPUT_STATE } from '/imports/ui/components/layout/initState';
+import { ACTIONS } from '/imports/ui/components/layout/enums';
+import { defaultsDeep } from '/imports/utils/array-utils';
+
+const CamerasOnlyLayout = (props) => {
+  const { bannerAreaHeight, isMobile } = props;
+
+  function usePrevious(value) {
+    const ref = useRef();
+    useEffect(() => {
+      ref.current = value;
+    });
+    return ref.current;
+  }
+
+  const input = layoutSelect((i) => i.input);
+  const deviceType = layoutSelect((i) => i.deviceType);
+  const isRTL = layoutSelect((i) => i.isRTL);
+  const fullscreen = layoutSelect((i) => i.fullscreen);
+  const fontSize = layoutSelect((i) => i.fontSize);
+  const currentPanelType = layoutSelect((i) => i.currentPanelType);
+  const cameraDockInput = layoutSelectInput((i) => i.cameraDock);
+  const navbarInput = layoutSelectInput((i) => i.navBar);
+  const actionbarInput = layoutSelectInput((i) => i.actionBar);
+  const layoutContextDispatch = layoutDispatch();
+  const prevDeviceType = usePrevious(deviceType);
+
+  const calculatesCameraDockBounds = (mediaAreaBounds, sidebarSize) => {
+    const { baseCameraDockBounds } = props;
+
+    const baseBounds = baseCameraDockBounds(mediaAreaBounds, sidebarSize);
+
+    // do not proceed if using values from LayoutEngine
+    if (Object.keys(baseBounds).length > 0) {
+      return baseBounds;
+    }
+
+    const { navBarHeight } = DEFAULT_VALUES;
+
+    const cameraDockBounds = {};
+
+    const mobileCameraHeight = mediaAreaBounds.height * 0.7 - bannerAreaHeight();
+    const cameraHeight = mediaAreaBounds.height - bannerAreaHeight();
+
+    if (isMobile) {
+      cameraDockBounds.minHeight = mobileCameraHeight;
+      cameraDockBounds.height = mobileCameraHeight;
+      cameraDockBounds.maxHeight = mobileCameraHeight;
+    } else {
+      cameraDockBounds.minHeight = cameraHeight;
+      cameraDockBounds.height = cameraHeight;
+      cameraDockBounds.maxHeight = cameraHeight;
+    }
+
+    cameraDockBounds.top = navBarHeight + bannerAreaHeight();
+    cameraDockBounds.left = !isRTL ? mediaAreaBounds.left : null;
+    cameraDockBounds.right = isRTL ? sidebarSize : null;
+    cameraDockBounds.minWidth = mediaAreaBounds.width;
+    cameraDockBounds.width = mediaAreaBounds.width;
+    cameraDockBounds.maxWidth = mediaAreaBounds.width;
+    cameraDockBounds.zIndex = 1;
+
+    return cameraDockBounds;
+  };
+
+  const calculatesMediaBounds = () => {
+    const mediaBounds = {};
+    mediaBounds.width = 0;
+    mediaBounds.height = 0;
+    mediaBounds.top = 0;
+    mediaBounds.left = 0;
+
+    return mediaBounds;
+  };
+
+  const calculatesSidebarContentHeight = () => ({
+    minHeight: 0,
+    height: 0,
+    maxHeight: 0,
+  });
+
+  const calculatesLayout = () => {
+    const {
+      calculatesNavbarBounds,
+      calculatesActionbarBounds,
+      calculatesSidebarNavWidth,
+      calculatesSidebarNavHeight,
+      calculatesSidebarNavBounds,
+      calculatesSidebarContentWidth,
+      calculatesSidebarContentBounds,
+      calculatesMediaAreaBounds,
+      isTablet,
+    } = props;
+    const { captionsMargin } = DEFAULT_VALUES;
+
+    const sidebarNavWidth = calculatesSidebarNavWidth();
+    const sidebarNavHeight = calculatesSidebarNavHeight();
+    const sidebarContentWidth = calculatesSidebarContentWidth();
+    const sidebarNavBounds = calculatesSidebarNavBounds();
+    const sidebarContentBounds = calculatesSidebarContentBounds(sidebarNavWidth.width);
+    const mediaAreaBounds = calculatesMediaAreaBounds(
+      sidebarNavWidth.width,
+      sidebarContentWidth.width,
+    );
+    const navbarBounds = calculatesNavbarBounds(mediaAreaBounds);
+    const actionbarBounds = calculatesActionbarBounds(mediaAreaBounds);
+    const sidebarSize = sidebarContentWidth.width + sidebarNavWidth.width;
+    const cameraDockBounds = calculatesCameraDockBounds(mediaAreaBounds, sidebarSize);
+    const sidebarContentHeight = calculatesSidebarContentHeight();
+    const mediaBounds = calculatesMediaBounds(
+      mediaAreaBounds,
+      cameraDockBounds,
+      sidebarNavWidth.width,
+      sidebarContentWidth.width,
+      sidebarContentHeight.height,
+    );
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_NAVBAR_OUTPUT,
+      value: {
+        display: navbarInput.hasNavBar,
+        width: navbarBounds.width,
+        height: navbarBounds.height,
+        top: navbarBounds.top,
+        left: navbarBounds.left,
+        tabOrder: DEFAULT_VALUES.navBarTabOrder,
+        zIndex: navbarBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_ACTIONBAR_OUTPUT,
+      value: {
+        display: actionbarInput.hasActionBar,
+        width: actionbarBounds.width,
+        height: actionbarBounds.height,
+        innerHeight: actionbarBounds.innerHeight,
+        top: actionbarBounds.top,
+        left: actionbarBounds.left,
+        padding: actionbarBounds.padding,
+        tabOrder: DEFAULT_VALUES.actionBarTabOrder,
+        zIndex: actionbarBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_CAPTIONS_OUTPUT,
+      value: {
+        left: !isRTL ? sidebarSize + captionsMargin : null,
+        right: isRTL ? sidebarSize + captionsMargin : null,
+        maxWidth: mediaAreaBounds.width - captionsMargin * 2,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_NAVIGATION_OUTPUT,
+      value: {
+        display: false,
+        minWidth: sidebarNavWidth.minWidth,
+        width: sidebarNavWidth.width,
+        maxWidth: sidebarNavWidth.maxWidth,
+        height: sidebarNavHeight,
+        top: sidebarNavBounds.top,
+        left: sidebarNavBounds.left,
+        right: sidebarNavBounds.right,
+        tabOrder: DEFAULT_VALUES.sidebarNavTabOrder,
+        isResizable: !isMobile && !isTablet,
+        zIndex: sidebarNavBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_NAVIGATION_RESIZABLE_EDGE,
+      value: {
+        top: false,
+        right: !isRTL,
+        bottom: false,
+        left: isRTL,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_OUTPUT,
+      value: {
+        display: false,
+        minWidth: sidebarContentWidth.minWidth,
+        width: sidebarContentWidth.width,
+        maxWidth: sidebarContentWidth.maxWidth,
+        minHeight: sidebarContentHeight.minHeight,
+        height: sidebarContentHeight.height,
+        maxHeight: sidebarContentHeight.maxHeight,
+        top: sidebarContentBounds.top,
+        left: sidebarContentBounds.left,
+        right: sidebarContentBounds.right,
+        currentPanelType,
+        tabOrder: DEFAULT_VALUES.sidebarContentTabOrder,
+        isResizable: !isMobile && !isTablet,
+        zIndex: sidebarContentBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_RESIZABLE_EDGE,
+      value: {
+        top: false,
+        right: !isRTL,
+        bottom: true,
+        left: isRTL,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_MEDIA_AREA_SIZE,
+      value: {
+        width: mediaAreaBounds.width,
+        height: mediaAreaBounds.height,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_CAMERA_DOCK_OUTPUT,
+      value: {
+        display: true,
+        minWidth: cameraDockBounds.minWidth,
+        width: cameraDockBounds.width,
+        maxWidth: cameraDockBounds.maxWidth,
+        minHeight: cameraDockBounds.minHeight,
+        height: cameraDockBounds.height,
+        maxHeight: cameraDockBounds.maxHeight,
+        top: cameraDockBounds.top,
+        left: cameraDockBounds.left,
+        right: cameraDockBounds.right,
+        tabOrder: 4,
+        isDraggable: false,
+        resizableEdge: {
+          top: false,
+          right: false,
+          bottom: false,
+          left: false,
+        },
+        zIndex: cameraDockBounds.zIndex,
+        focusedId: input.cameraDock.focusedId,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_PRESENTATION_OUTPUT,
+      value: {
+        display: false,
+        width: mediaBounds.width,
+        height: mediaBounds.height,
+        top: mediaBounds.top,
+        left: mediaBounds.left,
+        right: isRTL ? mediaBounds.right : null,
+        tabOrder: DEFAULT_VALUES.presentationTabOrder,
+        isResizable: !isMobile && !isTablet,
+        zIndex: mediaBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_PRESENTATION_RESIZABLE_EDGE,
+      value: {
+        top: true,
+        right: false,
+        bottom: false,
+        left: false,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SCREEN_SHARE_OUTPUT,
+      value: {
+        display: false,
+        width: mediaBounds.width,
+        height: mediaBounds.height,
+        top: mediaBounds.top,
+        left: mediaBounds.left,
+        right: isRTL ? mediaBounds.right : null,
+        zIndex: mediaBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_EXTERNAL_VIDEO_OUTPUT,
+      value: {
+        display: false,
+        width: mediaBounds.width,
+        height: mediaBounds.height,
+        top: mediaBounds.top,
+        left: mediaBounds.left,
+        right: isRTL ? mediaBounds.right : null,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SHARED_NOTES_OUTPUT,
+      value: {
+        display: false,
+        width: mediaBounds.width,
+        height: mediaBounds.height,
+        top: mediaBounds.top,
+        left: mediaBounds.left,
+        right: isRTL ? mediaBounds.right : null,
+      },
+    });
+  };
+
+  const throttledCalculatesLayout = throttle(() => calculatesLayout(), 50, {
+    trailing: true,
+    leading: true,
+  });
+
+  useEffect(() => {
+    window.addEventListener('resize', () => {
+      layoutContextDispatch({
+        type: ACTIONS.SET_BROWSER_SIZE,
+        value: {
+          width: window.document.documentElement.clientWidth,
+          height: window.document.documentElement.clientHeight,
+        },
+      });
+    });
+  }, []);
+
+  const init = () => {
+    layoutContextDispatch({
+      type: ACTIONS.SET_LAYOUT_INPUT,
+      value: defaultsDeep(
+        {
+          sidebarNavigation: {
+            isOpen: false,
+          },
+          sidebarContent: {
+            isOpen: false,
+          },
+          SidebarContentHorizontalResizer: {
+            isOpen: false,
+          },
+          presentation: {
+            isOpen: false,
+          },
+          cameraDock: {
+            numCameras: cameraDockInput.numCameras,
+          },
+          externalVideo: {
+            hasExternalVideo: false,
+          },
+          screenShare: {
+            hasScreenShare: false,
+          },
+        },
+        INITIAL_INPUT_STATE,
+      ),
+    });
+    Session.set('layoutReady', true);
+    throttledCalculatesLayout();
+  };
+
+  // eslint-disable-next-line consistent-return
+  useEffect(() => {
+    if (deviceType === null) return () => null;
+
+    if (deviceType !== prevDeviceType) {
+      // reset layout if deviceType changed
+      // not all options is supported in all devices
+      init();
+    } else {
+      throttledCalculatesLayout();
+    }
+  }, [input, deviceType, isRTL, fontSize, fullscreen]);
+  return null;
+};
+
+export default CamerasOnlyLayout;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/camerasOnly.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/camerasOnly.jsx
@@ -115,13 +115,7 @@ const CamerasOnlyLayout = (props) => {
     const sidebarSize = sidebarContentWidth.width + sidebarNavWidth.width;
     const cameraDockBounds = calculatesCameraDockBounds(mediaAreaBounds, sidebarSize);
     const sidebarContentHeight = calculatesSidebarContentHeight();
-    const mediaBounds = calculatesMediaBounds(
-      mediaAreaBounds,
-      cameraDockBounds,
-      sidebarNavWidth.width,
-      sidebarContentWidth.width,
-      sidebarContentHeight.height,
-    );
+    const mediaBounds = calculatesMediaBounds();
 
     layoutContextDispatch({
       type: ACTIONS.SET_NAVBAR_OUTPUT,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
@@ -8,6 +8,9 @@ import CustomLayout from '/imports/ui/components/layout/layout-manager/customLay
 import SmartLayout from '/imports/ui/components/layout/layout-manager/smartLayout';
 import PresentationFocusLayout from '/imports/ui/components/layout/layout-manager/presentationFocusLayout';
 import VideoFocusLayout from '/imports/ui/components/layout/layout-manager/videoFocusLayout';
+import CamerasOnlyLayout from '/imports/ui/components/layout/layout-manager/camerasOnly';
+import PresentationOnlyLayout from '/imports/ui/components/layout/layout-manager/presentationOnlyLayout';
+import ParticipantsChatOnlyLayout from '/imports/ui/components/layout/layout-manager/participantsChatOnlyLayout';
 import { isPresentationEnabled } from '/imports/ui/services/features';
 
 const propTypes = {
@@ -62,8 +65,9 @@ const LayoutEngine = ({ layoutType }) => {
       return cameraDockBounds;
     }
 
-    const hasPresentation = isPresentationEnabled() && slidesLength !== 0
-    const isGeneralMediaOff = !hasPresentation && !hasExternalVideo && !hasScreenShare && !isSharedNotesPinned;
+    const hasPresentation = isPresentationEnabled() && slidesLength !== 0;
+    const isGeneralMediaOff = !hasPresentation
+      && !hasExternalVideo && !hasScreenShare && !isSharedNotesPinned;
 
     if (!isOpen || isGeneralMediaOff) {
       cameraDockBounds.width = mediaAreaBounds.width;
@@ -292,24 +296,33 @@ const LayoutEngine = ({ layoutType }) => {
     isMobile,
     isTablet,
   };
-  
+
   const layout = document.getElementById('layout');
 
   switch (layoutType) {
     case LAYOUT_TYPE.CUSTOM_LAYOUT:
-      layout?.setAttribute("data-layout", LAYOUT_TYPE.CUSTOM_LAYOUT);
+      layout?.setAttribute('data-layout', LAYOUT_TYPE.CUSTOM_LAYOUT);
       return <CustomLayout {...common} />;
     case LAYOUT_TYPE.SMART_LAYOUT:
-      layout?.setAttribute("data-layout", LAYOUT_TYPE.SMART_LAYOUT);
+      layout?.setAttribute('data-layout', LAYOUT_TYPE.SMART_LAYOUT);
       return <SmartLayout {...common} />;
     case LAYOUT_TYPE.PRESENTATION_FOCUS:
-      layout?.setAttribute("data-layout", LAYOUT_TYPE.PRESENTATION_FOCUS);
+      layout?.setAttribute('data-layout', LAYOUT_TYPE.PRESENTATION_FOCUS);
       return <PresentationFocusLayout {...common} />;
     case LAYOUT_TYPE.VIDEO_FOCUS:
-      layout?.setAttribute("data-layout",LAYOUT_TYPE.VIDEO_FOCUS);
+      layout?.setAttribute('data-layout', LAYOUT_TYPE.VIDEO_FOCUS);
       return <VideoFocusLayout {...common} />;
+    case LAYOUT_TYPE.CAMERAS_ONLY:
+      layout?.setAttribute('data-layout', LAYOUT_TYPE.CAMERAS_ONLY);
+      return <CamerasOnlyLayout {...common} />;
+    case LAYOUT_TYPE.PRESENTATION_ONLY:
+      layout?.setAttribute('data-layout', LAYOUT_TYPE.PRESENTATION_ONLY);
+      return <PresentationOnlyLayout {...common} />;
+    case LAYOUT_TYPE.PARTICIPANTS_CHAT_ONLY:
+      layout?.setAttribute('data-layout', LAYOUT_TYPE.PARTICIPANTS_CHAT_ONLY);
+      return <ParticipantsChatOnlyLayout {...common} />;
     default:
-      layout?.setAttribute("data-layout", LAYOUT_TYPE.CUSTOM_LAYOUT);
+      layout?.setAttribute('data-layout', LAYOUT_TYPE.CUSTOM_LAYOUT);
       return <CustomLayout {...common} />;
   }
 };

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/participantsChatOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/participantsChatOnlyLayout.jsx
@@ -42,19 +42,48 @@ const ParticipantsChatOnlyLayout = (props) => {
 
   const prevDeviceType = usePrevious(deviceType);
 
-  const calculatesSidebarContentHeight = () => {
+  const calculatesSidebarNavHeight = (navbarHeight, actionbarHeight) => {
+    let sidebarNavHeight = 0;
+    if (isMobile) {
+      sidebarNavHeight = windowHeight() - navbarHeight - bannerAreaHeight() - actionbarHeight;
+    } else {
+      sidebarNavHeight = windowHeight() - bannerAreaHeight() - navbarHeight - actionbarHeight;
+    }
+    return sidebarNavHeight;
+  };
+
+  const calculatesSidebarContentHeight = (navbarHeight, actionbarHeight) => {
     let height = 0;
     let minHeight = 0;
     let maxHeight = 0;
-    if (sidebarContentInput.isOpen) {
-      height = windowHeight() - bannerAreaHeight();
-      minHeight = height;
-      maxHeight = height;
-    }
+    height = windowHeight() - bannerAreaHeight() - navbarHeight - actionbarHeight;
+    minHeight = height;
+    maxHeight = height;
     return {
       height,
       minHeight,
       maxHeight,
+    };
+  };
+
+  const calculatesSidebarContentWidth = (sidebarNavWidth) => {
+    let minWidth = 0;
+    let width = 0;
+    let maxWidth = 0;
+
+    if (isMobile) {
+      minWidth = windowWidth();
+      width = windowWidth();
+      maxWidth = windowWidth();
+    } else {
+      minWidth = windowWidth() - sidebarNavWidth;
+      width = windowWidth() - sidebarNavWidth;
+      maxWidth = windowWidth() - sidebarNavWidth;
+    }
+    return {
+      minWidth,
+      width,
+      maxWidth,
     };
   };
 
@@ -111,29 +140,28 @@ const ParticipantsChatOnlyLayout = (props) => {
       calculatesNavbarBounds,
       calculatesActionbarBounds,
       calculatesSidebarNavWidth,
-      calculatesSidebarNavHeight,
       calculatesSidebarNavBounds,
-      calculatesSidebarContentWidth,
       calculatesSidebarContentBounds,
-      calculatesMediaAreaBounds,
       isTablet,
     } = props;
     const { captionsMargin } = DEFAULT_VALUES;
 
     const sidebarNavWidth = calculatesSidebarNavWidth();
-    const sidebarNavHeight = calculatesSidebarNavHeight();
-    const sidebarContentWidth = calculatesSidebarContentWidth();
+    const sidebarContentWidth = calculatesSidebarContentWidth(sidebarNavWidth.width);
     const sidebarNavBounds = calculatesSidebarNavBounds();
     const sidebarContentBounds = calculatesSidebarContentBounds(sidebarNavWidth.width);
-    const mediaAreaBounds = calculatesMediaAreaBounds(
-      sidebarNavWidth.width,
-      sidebarContentWidth.width,
-    );
+    const mediaAreaBounds = {
+      width: sidebarNavWidth.width + sidebarContentWidth.width,
+      left: 0,
+    };
     const navbarBounds = calculatesNavbarBounds(mediaAreaBounds);
     const actionbarBounds = calculatesActionbarBounds(mediaAreaBounds);
+    const sidebarNavHeight = calculatesSidebarNavHeight(navbarBounds.height,
+      actionbarBounds.height);
     const sidebarSize = sidebarContentWidth.width + sidebarNavWidth.width;
     const mediaBounds = calculatesMediaBounds(mediaAreaBounds, sidebarSize);
-    const sidebarContentHeight = calculatesSidebarContentHeight();
+    const sidebarContentHeight = calculatesSidebarContentHeight(navbarBounds.height,
+      actionbarBounds.height);
     const cameraDockBounds = calculatesCameraDockBounds(
       mediaBounds,
       mediaAreaBounds,
@@ -188,7 +216,7 @@ const ParticipantsChatOnlyLayout = (props) => {
         width: sidebarNavWidth.width,
         maxWidth: sidebarNavWidth.maxWidth,
         height: sidebarNavHeight,
-        top: sidebarNavBounds.top,
+        top: navbarBounds.height,
         left: sidebarNavBounds.left,
         right: sidebarNavBounds.right,
         tabOrder: DEFAULT_VALUES.sidebarNavTabOrder,
@@ -217,7 +245,7 @@ const ParticipantsChatOnlyLayout = (props) => {
         minHeight: sidebarContentHeight.minHeight,
         height: sidebarContentHeight.height,
         maxHeight: sidebarContentHeight.maxHeight,
-        top: sidebarContentBounds.top,
+        top: navbarBounds.height,
         left: sidebarContentBounds.left,
         right: sidebarContentBounds.right,
         currentPanelType,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/participantsChatOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/participantsChatOnlyLayout.jsx
@@ -162,13 +162,7 @@ const ParticipantsChatOnlyLayout = (props) => {
     const mediaBounds = calculatesMediaBounds(mediaAreaBounds, sidebarSize);
     const sidebarContentHeight = calculatesSidebarContentHeight(navbarBounds.height,
       actionbarBounds.height);
-    const cameraDockBounds = calculatesCameraDockBounds(
-      mediaBounds,
-      mediaAreaBounds,
-      sidebarNavWidth.width,
-      sidebarContentWidth.width,
-      sidebarContentHeight.height,
-    );
+    const cameraDockBounds = calculatesCameraDockBounds();
     const { isOpen } = presentationInput;
 
     layoutContextDispatch({

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/participantsChatOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/participantsChatOnlyLayout.jsx
@@ -1,0 +1,406 @@
+import { useEffect, useRef } from 'react';
+import { throttle } from '/imports/utils/throttle';
+import { layoutDispatch, layoutSelect, layoutSelectInput } from '/imports/ui/components/layout/context';
+import DEFAULT_VALUES from '/imports/ui/components/layout/defaultValues';
+import { INITIAL_INPUT_STATE } from '/imports/ui/components/layout/initState';
+import {
+  ACTIONS,
+  PANELS,
+  CAMERADOCK_POSITION,
+} from '/imports/ui/components/layout/enums';
+import { defaultsDeep } from '/imports/utils/array-utils';
+
+const windowWidth = () => window.document.documentElement.clientWidth;
+const windowHeight = () => window.document.documentElement.clientHeight;
+
+const ParticipantsChatOnlyLayout = (props) => {
+  const { bannerAreaHeight, isMobile } = props;
+
+  function usePrevious(value) {
+    const ref = useRef();
+    useEffect(() => {
+      ref.current = value;
+    });
+    return ref.current;
+  }
+
+  const input = layoutSelect((i) => i.input);
+  const deviceType = layoutSelect((i) => i.deviceType);
+  const isRTL = layoutSelect((i) => i.isRTL);
+  const fullscreen = layoutSelect((i) => i.fullscreen);
+  const fontSize = layoutSelect((i) => i.fontSize);
+  const currentPanelType = layoutSelect((i) => i.currentPanelType);
+
+  const presentationInput = layoutSelectInput((i) => i.presentation);
+
+  const sidebarNavigationInput = layoutSelectInput((i) => i.sidebarNavigation);
+  const sidebarContentInput = layoutSelectInput((i) => i.sidebarContent);
+  const cameraDockInput = layoutSelectInput((i) => i.cameraDock);
+  const actionbarInput = layoutSelectInput((i) => i.actionBar);
+  const navbarInput = layoutSelectInput((i) => i.navBar);
+  const layoutContextDispatch = layoutDispatch();
+
+  const prevDeviceType = usePrevious(deviceType);
+
+  const calculatesSidebarContentHeight = () => {
+    let height = 0;
+    let minHeight = 0;
+    let maxHeight = 0;
+    if (sidebarContentInput.isOpen) {
+      height = windowHeight() - bannerAreaHeight();
+      minHeight = height;
+      maxHeight = height;
+    }
+    return {
+      height,
+      minHeight,
+      maxHeight,
+    };
+  };
+
+  const calculatesCameraDockBounds = () => {
+    const cameraDockBounds = {};
+
+    cameraDockBounds.top = 0;
+    cameraDockBounds.left = 0;
+    cameraDockBounds.right = 0;
+    cameraDockBounds.minWidth = 0;
+    cameraDockBounds.width = 0;
+    cameraDockBounds.maxWidth = 0;
+    cameraDockBounds.minHeight = 0;
+    cameraDockBounds.height = 0;
+    cameraDockBounds.maxHeight = 0;
+
+    return cameraDockBounds;
+  };
+
+  const calculatesMediaBounds = (mediaAreaBounds, sidebarSize) => {
+    const mediaBounds = {};
+    const { element: fullscreenElement } = fullscreen;
+
+    if (
+      fullscreenElement === 'Presentation'
+      || fullscreenElement === 'Screenshare'
+      || fullscreenElement === 'ExternalVideo'
+    ) {
+      mediaBounds.width = windowWidth();
+      mediaBounds.height = windowHeight();
+      mediaBounds.top = 0;
+      mediaBounds.left = !isRTL ? 0 : null;
+      mediaBounds.right = isRTL ? 0 : null;
+      mediaBounds.zIndex = 99;
+      return mediaBounds;
+    }
+
+    if (isMobile && cameraDockInput.numCameras > 0) {
+      mediaBounds.height = mediaAreaBounds.height * 0.7;
+    } else {
+      mediaBounds.height = mediaAreaBounds.height;
+    }
+    mediaBounds.width = mediaAreaBounds.width;
+    mediaBounds.top = DEFAULT_VALUES.navBarHeight + bannerAreaHeight();
+    mediaBounds.left = !isRTL ? mediaAreaBounds.left : null;
+    mediaBounds.right = isRTL ? sidebarSize : null;
+    mediaBounds.zIndex = 1;
+
+    return mediaBounds;
+  };
+
+  const calculatesLayout = () => {
+    const {
+      calculatesNavbarBounds,
+      calculatesActionbarBounds,
+      calculatesSidebarNavWidth,
+      calculatesSidebarNavHeight,
+      calculatesSidebarNavBounds,
+      calculatesSidebarContentWidth,
+      calculatesSidebarContentBounds,
+      calculatesMediaAreaBounds,
+      isTablet,
+    } = props;
+    const { captionsMargin } = DEFAULT_VALUES;
+
+    const sidebarNavWidth = calculatesSidebarNavWidth();
+    const sidebarNavHeight = calculatesSidebarNavHeight();
+    const sidebarContentWidth = calculatesSidebarContentWidth();
+    const sidebarNavBounds = calculatesSidebarNavBounds();
+    const sidebarContentBounds = calculatesSidebarContentBounds(sidebarNavWidth.width);
+    const mediaAreaBounds = calculatesMediaAreaBounds(
+      sidebarNavWidth.width,
+      sidebarContentWidth.width,
+    );
+    const navbarBounds = calculatesNavbarBounds(mediaAreaBounds);
+    const actionbarBounds = calculatesActionbarBounds(mediaAreaBounds);
+    const sidebarSize = sidebarContentWidth.width + sidebarNavWidth.width;
+    const mediaBounds = calculatesMediaBounds(mediaAreaBounds, sidebarSize);
+    const sidebarContentHeight = calculatesSidebarContentHeight();
+    const cameraDockBounds = calculatesCameraDockBounds(
+      mediaBounds,
+      mediaAreaBounds,
+      sidebarNavWidth.width,
+      sidebarContentWidth.width,
+      sidebarContentHeight.height,
+    );
+    const { isOpen } = presentationInput;
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_NAVBAR_OUTPUT,
+      value: {
+        display: navbarInput.hasNavBar,
+        width: navbarBounds.width,
+        height: navbarBounds.height,
+        top: navbarBounds.top,
+        left: navbarBounds.left,
+        tabOrder: DEFAULT_VALUES.navBarTabOrder,
+        zIndex: navbarBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_ACTIONBAR_OUTPUT,
+      value: {
+        display: actionbarInput.hasActionBar,
+        width: actionbarBounds.width,
+        height: actionbarBounds.height,
+        innerHeight: actionbarBounds.innerHeight,
+        top: actionbarBounds.top,
+        left: actionbarBounds.left,
+        padding: actionbarBounds.padding,
+        tabOrder: DEFAULT_VALUES.actionBarTabOrder,
+        zIndex: actionbarBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_CAPTIONS_OUTPUT,
+      value: {
+        left: !isRTL ? sidebarSize + captionsMargin : null,
+        right: isRTL ? sidebarSize + captionsMargin : null,
+        maxWidth: mediaAreaBounds.width - captionsMargin * 2,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_NAVIGATION_OUTPUT,
+      value: {
+        display: sidebarNavigationInput.isOpen,
+        minWidth: sidebarNavWidth.minWidth,
+        width: sidebarNavWidth.width,
+        maxWidth: sidebarNavWidth.maxWidth,
+        height: sidebarNavHeight,
+        top: sidebarNavBounds.top,
+        left: sidebarNavBounds.left,
+        right: sidebarNavBounds.right,
+        tabOrder: DEFAULT_VALUES.sidebarNavTabOrder,
+        isResizable: !isMobile && !isTablet,
+        zIndex: sidebarNavBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_NAVIGATION_RESIZABLE_EDGE,
+      value: {
+        top: false,
+        right: !isRTL,
+        bottom: false,
+        left: isRTL,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_OUTPUT,
+      value: {
+        display: sidebarContentInput.isOpen,
+        minWidth: sidebarContentWidth.minWidth,
+        width: sidebarContentWidth.width,
+        maxWidth: sidebarContentWidth.maxWidth,
+        minHeight: sidebarContentHeight.minHeight,
+        height: sidebarContentHeight.height,
+        maxHeight: sidebarContentHeight.maxHeight,
+        top: sidebarContentBounds.top,
+        left: sidebarContentBounds.left,
+        right: sidebarContentBounds.right,
+        currentPanelType,
+        tabOrder: DEFAULT_VALUES.sidebarContentTabOrder,
+        isResizable: !isMobile && !isTablet,
+        zIndex: sidebarContentBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_RESIZABLE_EDGE,
+      value: {
+        top: false,
+        right: !isRTL,
+        bottom: cameraDockInput.numCameras > 0,
+        left: isRTL,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_MEDIA_AREA_SIZE,
+      value: {
+        width: mediaAreaBounds.width,
+        height: mediaAreaBounds.height,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_CAMERA_DOCK_OUTPUT,
+      value: {
+        display: false,
+        position: CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM,
+        minWidth: cameraDockBounds.minWidth,
+        width: cameraDockBounds.width,
+        maxWidth: cameraDockBounds.maxWidth,
+        minHeight: cameraDockBounds.minHeight,
+        height: cameraDockBounds.height,
+        maxHeight: cameraDockBounds.maxHeight,
+        top: cameraDockBounds.top,
+        left: cameraDockBounds.left,
+        right: cameraDockBounds.right,
+        tabOrder: 4,
+        isDraggable: false,
+        resizableEdge: {
+          top: false,
+          right: false,
+          bottom: false,
+          left: false,
+        },
+        focusedId: input.cameraDock.focusedId,
+        zIndex: cameraDockBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_PRESENTATION_OUTPUT,
+      value: {
+        display: false,
+        width: 0,
+        height: 0,
+        top: mediaBounds.top,
+        left: mediaBounds.left,
+        right: isRTL ? mediaBounds.right : null,
+        tabOrder: DEFAULT_VALUES.presentationTabOrder,
+        isResizable: false,
+        zIndex: mediaBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SCREEN_SHARE_OUTPUT,
+      value: {
+        display: false,
+        width: 0,
+        height: 0,
+        top: mediaBounds.top,
+        left: mediaBounds.left,
+        right: mediaBounds.right,
+        zIndex: mediaBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_EXTERNAL_VIDEO_OUTPUT,
+      value: {
+        display: false,
+        width: 0,
+        height: 0,
+        top: mediaBounds.top,
+        left: mediaBounds.left,
+        right: mediaBounds.right,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SHARED_NOTES_OUTPUT,
+      value: {
+        display: false,
+        width: isOpen ? mediaBounds.width : 0,
+        height: isOpen ? mediaBounds.height : 0,
+        top: mediaBounds.top,
+        left: mediaBounds.left,
+        right: mediaBounds.right,
+      },
+    });
+  };
+
+  const throttledCalculatesLayout = throttle(() => calculatesLayout(),
+    50, { trailing: true, leading: true });
+
+  useEffect(() => {
+    window.addEventListener('resize', () => {
+      layoutContextDispatch({
+        type: ACTIONS.SET_BROWSER_SIZE,
+        value: {
+          width: window.document.documentElement.clientWidth,
+          height: window.document.documentElement.clientHeight,
+        },
+      });
+    });
+  }, []);
+
+  const init = () => {
+    const { sidebarContentPanel } = sidebarContentInput;
+    layoutContextDispatch({
+      type: ACTIONS.SET_LAYOUT_INPUT,
+      value: defaultsDeep(
+        {
+          sidebarNavigation: {
+            isOpen:
+              input.sidebarNavigation.isOpen || sidebarContentPanel !== PANELS.NONE || false,
+          },
+          sidebarContent: {
+            isOpen: sidebarContentPanel !== PANELS.NONE,
+            sidebarContentPanel,
+          },
+          SidebarContentHorizontalResizer: {
+            isOpen: false,
+          },
+          presentation: {
+            isOpen: false,
+            slidesLength: presentationInput.slidesLength,
+            currentSlide: {
+              ...presentationInput.currentSlide,
+            },
+            width: 0,
+            height: 0,
+          },
+          cameraDock: {
+            numCameras: 0,
+          },
+          externalVideo: {
+            hasExternalVideo: false,
+            width: 0,
+            height: 0,
+          },
+          screenShare: {
+            hasScreenShare: false,
+            width: 0,
+            height: 0,
+          },
+        },
+        INITIAL_INPUT_STATE,
+      ),
+    });
+    Session.set('layoutReady', true);
+    throttledCalculatesLayout();
+  };
+
+  // eslint-disable-next-line consistent-return
+  useEffect(() => {
+    if (deviceType === null) return () => null;
+
+    if (deviceType !== prevDeviceType) {
+      // reset layout if deviceType changed
+      // not all options is supported in all devices
+      init();
+    } else {
+      throttledCalculatesLayout();
+    }
+  }, [input, deviceType, isRTL, fontSize, fullscreen]);
+
+  return null;
+};
+
+export default ParticipantsChatOnlyLayout;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationOnlyLayout.jsx
@@ -1,0 +1,377 @@
+import { useEffect, useRef } from 'react';
+import { throttle } from '/imports/utils/throttle';
+import { layoutDispatch, layoutSelect, layoutSelectInput } from '/imports/ui/components/layout/context';
+import DEFAULT_VALUES from '/imports/ui/components/layout/defaultValues';
+import { INITIAL_INPUT_STATE } from '/imports/ui/components/layout/initState';
+import {
+  ACTIONS,
+  CAMERADOCK_POSITION,
+} from '/imports/ui/components/layout/enums';
+import { defaultsDeep } from '/imports/utils/array-utils';
+
+const windowWidth = () => window.document.documentElement.clientWidth;
+const windowHeight = () => window.document.documentElement.clientHeight;
+
+const PresentationOnlyLayout = (props) => {
+  const { bannerAreaHeight, isMobile } = props;
+
+  function usePrevious(value) {
+    const ref = useRef();
+    useEffect(() => {
+      ref.current = value;
+    });
+    return ref.current;
+  }
+
+  const input = layoutSelect((i) => i.input);
+  const deviceType = layoutSelect((i) => i.deviceType);
+  const isRTL = layoutSelect((i) => i.isRTL);
+  const fullscreen = layoutSelect((i) => i.fullscreen);
+  const fontSize = layoutSelect((i) => i.fontSize);
+  const currentPanelType = layoutSelect((i) => i.currentPanelType);
+
+  const presentationInput = layoutSelectInput((i) => i.presentation);
+  const actionbarInput = layoutSelectInput((i) => i.actionBar);
+  const navbarInput = layoutSelectInput((i) => i.navBar);
+  const layoutContextDispatch = layoutDispatch();
+
+  const prevDeviceType = usePrevious(deviceType);
+
+  const calculatesMediaBounds = (mediaAreaBounds, sidebarSize) => {
+    const mediaBounds = {};
+    const { element: fullscreenElement } = fullscreen;
+
+    if (
+      fullscreenElement === 'Presentation'
+      || fullscreenElement === 'Screenshare'
+      || fullscreenElement === 'ExternalVideo'
+    ) {
+      mediaBounds.width = windowWidth();
+      mediaBounds.height = windowHeight();
+      mediaBounds.top = 0;
+      mediaBounds.left = !isRTL ? 0 : null;
+      mediaBounds.right = isRTL ? 0 : null;
+      mediaBounds.zIndex = 99;
+      return mediaBounds;
+    }
+
+    mediaBounds.height = mediaAreaBounds.height;
+    mediaBounds.width = mediaAreaBounds.width;
+    mediaBounds.top = DEFAULT_VALUES.navBarHeight + bannerAreaHeight();
+    mediaBounds.left = !isRTL ? mediaAreaBounds.left : null;
+    mediaBounds.right = isRTL ? sidebarSize : null;
+    mediaBounds.zIndex = 1;
+
+    return mediaBounds;
+  };
+
+  const calculatesSidebarContentHeight = () => ({
+    height: 0,
+    minHeight: 0,
+    maxHeight: 0,
+  });
+
+  const calculatesCameraDockBounds = () => {
+    const cameraDockBounds = {};
+
+    cameraDockBounds.top = 0;
+    cameraDockBounds.left = 0;
+    cameraDockBounds.right = 0;
+    cameraDockBounds.minWidth = 0;
+    cameraDockBounds.width = 0;
+    cameraDockBounds.maxWidth = 0;
+    cameraDockBounds.minHeight = 0;
+    cameraDockBounds.height = 0;
+    cameraDockBounds.maxHeight = 0;
+
+    return cameraDockBounds;
+  };
+
+  const calculatesLayout = () => {
+    const {
+      calculatesNavbarBounds,
+      calculatesActionbarBounds,
+      calculatesSidebarNavWidth,
+      calculatesSidebarNavHeight,
+      calculatesSidebarNavBounds,
+      calculatesSidebarContentWidth,
+      calculatesSidebarContentBounds,
+      calculatesMediaAreaBounds,
+      isTablet,
+    } = props;
+    const { captionsMargin } = DEFAULT_VALUES;
+
+    const sidebarNavWidth = calculatesSidebarNavWidth();
+    const sidebarNavHeight = calculatesSidebarNavHeight();
+    const sidebarContentWidth = calculatesSidebarContentWidth();
+    const sidebarNavBounds = calculatesSidebarNavBounds();
+    const sidebarContentBounds = calculatesSidebarContentBounds(sidebarNavWidth.width);
+    const mediaAreaBounds = calculatesMediaAreaBounds(
+      sidebarNavWidth.width,
+      sidebarContentWidth.width,
+    );
+    const navbarBounds = calculatesNavbarBounds(mediaAreaBounds);
+    const actionbarBounds = calculatesActionbarBounds(mediaAreaBounds);
+    const sidebarSize = sidebarContentWidth.width + sidebarNavWidth.width;
+    const mediaBounds = calculatesMediaBounds(mediaAreaBounds, sidebarSize);
+    const sidebarContentHeight = calculatesSidebarContentHeight();
+    const cameraDockBounds = calculatesCameraDockBounds(
+      mediaBounds,
+      mediaAreaBounds,
+      sidebarNavWidth.width,
+      sidebarContentWidth.width,
+      sidebarContentHeight.height,
+    );
+    const { isOpen } = presentationInput;
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_NAVBAR_OUTPUT,
+      value: {
+        display: navbarInput.hasNavBar,
+        width: navbarBounds.width,
+        height: navbarBounds.height,
+        top: navbarBounds.top,
+        left: navbarBounds.left,
+        tabOrder: DEFAULT_VALUES.navBarTabOrder,
+        zIndex: navbarBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_ACTIONBAR_OUTPUT,
+      value: {
+        display: actionbarInput.hasActionBar,
+        width: actionbarBounds.width,
+        height: actionbarBounds.height,
+        innerHeight: actionbarBounds.innerHeight,
+        top: actionbarBounds.top,
+        left: actionbarBounds.left,
+        padding: actionbarBounds.padding,
+        tabOrder: DEFAULT_VALUES.actionBarTabOrder,
+        zIndex: actionbarBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_CAPTIONS_OUTPUT,
+      value: {
+        left: !isRTL ? sidebarSize + captionsMargin : null,
+        right: isRTL ? sidebarSize + captionsMargin : null,
+        maxWidth: mediaAreaBounds.width - captionsMargin * 2,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_NAVIGATION_OUTPUT,
+      value: {
+        display: false,
+        minWidth: sidebarNavWidth.minWidth,
+        width: sidebarNavWidth.width,
+        maxWidth: sidebarNavWidth.maxWidth,
+        height: sidebarNavHeight,
+        top: sidebarNavBounds.top,
+        left: sidebarNavBounds.left,
+        right: sidebarNavBounds.right,
+        tabOrder: DEFAULT_VALUES.sidebarNavTabOrder,
+        isResizable: !isMobile && !isTablet,
+        zIndex: sidebarNavBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_NAVIGATION_RESIZABLE_EDGE,
+      value: {
+        top: false,
+        right: !isRTL,
+        bottom: false,
+        left: isRTL,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_OUTPUT,
+      value: {
+        display: false,
+        minWidth: sidebarContentWidth.minWidth,
+        width: sidebarContentWidth.width,
+        maxWidth: sidebarContentWidth.maxWidth,
+        minHeight: sidebarContentHeight.minHeight,
+        height: sidebarContentHeight.height,
+        maxHeight: sidebarContentHeight.maxHeight,
+        top: sidebarContentBounds.top,
+        left: sidebarContentBounds.left,
+        right: sidebarContentBounds.right,
+        currentPanelType,
+        tabOrder: DEFAULT_VALUES.sidebarContentTabOrder,
+        isResizable: !isMobile && !isTablet,
+        zIndex: sidebarContentBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_RESIZABLE_EDGE,
+      value: {
+        top: false,
+        right: !isRTL,
+        bottom: false,
+        left: isRTL,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_MEDIA_AREA_SIZE,
+      value: {
+        width: mediaAreaBounds.width,
+        height: mediaAreaBounds.height,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_CAMERA_DOCK_OUTPUT,
+      value: {
+        display: false,
+        position: CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM,
+        minWidth: cameraDockBounds.minWidth,
+        width: cameraDockBounds.width,
+        maxWidth: cameraDockBounds.maxWidth,
+        minHeight: cameraDockBounds.minHeight,
+        height: cameraDockBounds.height,
+        maxHeight: cameraDockBounds.maxHeight,
+        top: cameraDockBounds.top,
+        left: cameraDockBounds.left,
+        right: cameraDockBounds.right,
+        tabOrder: 4,
+        isDraggable: false,
+        resizableEdge: {
+          top: false,
+          right: false,
+          bottom: false,
+          left: false,
+        },
+        focusedId: input.cameraDock.focusedId,
+        zIndex: cameraDockBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_PRESENTATION_OUTPUT,
+      value: {
+        display: true,
+        width: mediaBounds.width,
+        height: mediaBounds.height,
+        top: mediaBounds.top,
+        left: mediaBounds.left,
+        right: isRTL ? mediaBounds.right : null,
+        tabOrder: DEFAULT_VALUES.presentationTabOrder,
+        isResizable: false,
+        zIndex: mediaBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SCREEN_SHARE_OUTPUT,
+      value: {
+        width: mediaBounds.width,
+        height: isOpen ? mediaBounds.height : 0,
+        top: mediaBounds.top,
+        left: mediaBounds.left,
+        right: mediaBounds.right,
+        zIndex: mediaBounds.zIndex,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_EXTERNAL_VIDEO_OUTPUT,
+      value: {
+        width: isOpen ? mediaBounds.width : 0,
+        height: isOpen ? mediaBounds.height : 0,
+        top: mediaBounds.top,
+        left: mediaBounds.left,
+        right: mediaBounds.right,
+      },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SHARED_NOTES_OUTPUT,
+      value: {
+        width: isOpen ? mediaBounds.width : 0,
+        height: isOpen ? mediaBounds.height : 0,
+        top: mediaBounds.top,
+        left: mediaBounds.left,
+        right: mediaBounds.right,
+      },
+    });
+  };
+
+  const throttledCalculatesLayout = throttle(() => calculatesLayout(),
+    50, { trailing: true, leading: true });
+
+  useEffect(() => {
+    window.addEventListener('resize', () => {
+      layoutContextDispatch({
+        type: ACTIONS.SET_BROWSER_SIZE,
+        value: {
+          width: window.document.documentElement.clientWidth,
+          height: window.document.documentElement.clientHeight,
+        },
+      });
+    });
+  }, []);
+
+  const init = () => {
+    layoutContextDispatch({
+      type: ACTIONS.SET_LAYOUT_INPUT,
+      value: defaultsDeep(
+        {
+          sidebarNavigation: {
+            isOpen: false,
+          },
+          sidebarContent: {
+            isOpen: false,
+          },
+          SidebarContentHorizontalResizer: {
+            isOpen: false,
+          },
+          presentation: {
+            isOpen: true,
+            slidesLength: presentationInput.slidesLength,
+            currentSlide: {
+              ...presentationInput.currentSlide,
+            },
+          },
+          cameraDock: {
+            numCameras: 0,
+          },
+          externalVideo: {
+            hasExternalVideo: input.externalVideo.hasExternalVideo,
+          },
+          screenShare: {
+            hasScreenShare: input.screenShare.hasScreenShare,
+            width: input.screenShare.width,
+            height: input.screenShare.height,
+          },
+        },
+        INITIAL_INPUT_STATE,
+      ),
+    });
+    Session.set('layoutReady', true);
+    throttledCalculatesLayout();
+  };
+
+  // eslint-disable-next-line consistent-return
+  useEffect(() => {
+    if (deviceType === null) return () => null;
+
+    if (deviceType !== prevDeviceType) {
+      // reset layout if deviceType changed
+      // not all options is supported in all devices
+      init();
+    } else {
+      throttledCalculatesLayout();
+    }
+  }, [input, deviceType, isRTL, fontSize, fullscreen]);
+
+  return null;
+};
+
+export default PresentationOnlyLayout;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationOnlyLayout.jsx
@@ -115,13 +115,7 @@ const PresentationOnlyLayout = (props) => {
     const sidebarSize = sidebarContentWidth.width + sidebarNavWidth.width;
     const mediaBounds = calculatesMediaBounds(mediaAreaBounds, sidebarSize);
     const sidebarContentHeight = calculatesSidebarContentHeight();
-    const cameraDockBounds = calculatesCameraDockBounds(
-      mediaBounds,
-      mediaAreaBounds,
-      sidebarNavWidth.width,
-      sidebarContentWidth.width,
-      sidebarContentHeight.height,
-    );
+    const cameraDockBounds = calculatesCameraDockBounds();
     const { isOpen } = presentationInput;
 
     layoutContextDispatch({

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationOnlyLayout.jsx
@@ -165,8 +165,8 @@ const PresentationOnlyLayout = (props) => {
       type: ACTIONS.SET_SIDEBAR_NAVIGATION_OUTPUT,
       value: {
         display: false,
-        minWidth: sidebarNavWidth.minWidth,
-        width: sidebarNavWidth.width,
+        minWidth: 0,
+        width: 0,
         maxWidth: sidebarNavWidth.maxWidth,
         height: sidebarNavHeight,
         top: sidebarNavBounds.top,
@@ -192,8 +192,8 @@ const PresentationOnlyLayout = (props) => {
       type: ACTIONS.SET_SIDEBAR_CONTENT_OUTPUT,
       value: {
         display: false,
-        minWidth: sidebarContentWidth.minWidth,
-        width: sidebarContentWidth.width,
+        minWidth: 0,
+        width: 0,
         maxWidth: sidebarContentWidth.maxWidth,
         minHeight: sidebarContentHeight.minHeight,
         height: sidebarContentHeight.height,
@@ -325,9 +325,13 @@ const PresentationOnlyLayout = (props) => {
         {
           sidebarNavigation: {
             isOpen: false,
+            width: 0,
+            height: 0,
           },
           sidebarContent: {
             isOpen: false,
+            width: 0,
+            height: 0,
           },
           SidebarContentHorizontalResizer: {
             isOpen: false,

--- a/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
@@ -80,7 +80,7 @@ const LayoutModalComponent = (props) => {
   const handleUpdateLayout = (updateAll) => {
     const obj = {
       application:
-      { ...application, selectedLayout, pushLayout: updateAll },
+        { ...application, selectedLayout, pushLayout: updateAll },
     };
     updateSettings(obj, intlMessages.layoutToastLabel);
     setIsOpen(false);
@@ -107,6 +107,11 @@ const LayoutModalComponent = (props) => {
   const renderLayoutButtons = () => (
     <Styled.ButtonsContainer>
       {Object.values(LAYOUT_TYPE)
+        .filter((layout) => (
+          layout !== LAYOUT_TYPE.CAMERAS_ONLY
+          && layout !== LAYOUT_TYPE.PRESENTATION_ONLY
+          && layout !== LAYOUT_TYPE.PARTICIPANTS_CHAT_ONLY
+        ))
         .map((layout) => (
           <Styled.ButtonLayoutContainer key={layout}>
             <Styled.LayoutBtn
@@ -116,7 +121,7 @@ const LayoutModalComponent = (props) => {
                   src={`${LAYOUTS_PATH}${layout}.svg`}
                   alt={`${layout} ${intl.formatMessage(intlMessages.layoutSingular)}`}
                 />
-                )}
+              )}
               onClick={() => {
                 handleSwitchLayout(layout);
                 if (layout === LAYOUT_TYPE.CUSTOM_LAYOUT && application.selectedLayout !== layout) {

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -13,9 +13,10 @@ import OptionsDropdownContainer from './options-dropdown/container';
 import TimerIndicatorContainer from '/imports/ui/components/timer/timer-graphql/indicator/component';
 import browserInfo from '/imports/utils/browserInfo';
 import deviceInfo from '/imports/utils/deviceInfo';
-import { PANELS, ACTIONS } from '../layout/enums';
+import { PANELS, ACTIONS, LAYOUT_TYPE } from '../layout/enums';
 import Button from '/imports/ui/components/common/button/component';
 import { isEqual } from 'radash';
+import Settings from '/imports/ui/services/settings';
 
 const intlMessages = defineMessages({
   toggleUserListLabel: {
@@ -131,8 +132,8 @@ class NavBar extends Component {
     super(props);
 
     this.state = {
-        acs: props.activeChats,
-    }
+      acs: props.activeChats,
+    };
 
     this.handleToggleUserList = this.handleToggleUserList.bind(this);
     this.splitPluginItems = this.splitPluginItems.bind(this);
@@ -179,7 +180,7 @@ class NavBar extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     if (!isEqual(prevProps.activeChats, this.props.activeChats)) {
-      this.setState({ acs: this.props.activeChats})
+      this.setState({ acs: this.props.activeChats });
     }
   }
 
@@ -279,7 +280,6 @@ class NavBar extends Component {
     const isExpanded = sidebarNavigation.isOpen;
     const { isPhone } = deviceInfo;
 
-
     const { acs } = this.state;
 
     activeChats.map((c, i) => {
@@ -289,6 +289,11 @@ class NavBar extends Component {
     });
 
     const { leftPluginItems, centerPluginItems, rightPluginItems } = this.splitPluginItems();
+
+    const { selectedLayout } = Settings.application;
+    const shouldShowNavBarToggleButton = selectedLayout !== LAYOUT_TYPE.CAMERAS_ONLY
+      && selectedLayout !== LAYOUT_TYPE.PRESENTATION_ONLY
+      && selectedLayout !== LAYOUT_TYPE.PARTICIPANTS_CHAT_ONLY;
 
     return (
       <Styled.Navbar
@@ -311,28 +316,30 @@ class NavBar extends Component {
       >
         <Styled.Top>
           <Styled.Left>
-            {isExpanded && document.dir === 'ltr'
+            {shouldShowNavBarToggleButton && isExpanded && document.dir === 'ltr'
               && <Styled.ArrowLeft iconName="left_arrow" />}
-            {!isExpanded && document.dir === 'rtl'
+            {shouldShowNavBarToggleButton && !isExpanded && document.dir === 'rtl'
               && <Styled.ArrowLeft iconName="left_arrow" />}
-            <Styled.NavbarToggleButton
-              onClick={this.handleToggleUserList}
-              color={isPhone && isExpanded ? 'primary' : 'dark'}
-              size='md'
-              circle
-              hideLabel
-              data-test={hasNotification ? 'hasUnreadMessages' : 'toggleUserList'}
-              label={intl.formatMessage(intlMessages.toggleUserListLabel)}
-              tooltipLabel={intl.formatMessage(intlMessages.toggleUserListLabel)}
-              aria-label={ariaLabel}
-              icon="user"
-              aria-expanded={isExpanded}
-              accessKey={TOGGLE_USERLIST_AK}
-              hasNotification={hasNotification}
-            />
-            {!isExpanded && document.dir === 'ltr'
+            {shouldShowNavBarToggleButton && (
+              <Styled.NavbarToggleButton
+                onClick={this.handleToggleUserList}
+                color={isPhone && isExpanded ? 'primary' : 'dark'}
+                size="md"
+                circle
+                hideLabel
+                data-test={hasNotification ? 'hasUnreadMessages' : 'toggleUserList'}
+                label={intl.formatMessage(intlMessages.toggleUserListLabel)}
+                tooltipLabel={intl.formatMessage(intlMessages.toggleUserListLabel)}
+                aria-label={ariaLabel}
+                icon="user"
+                aria-expanded={isExpanded}
+                accessKey={TOGGLE_USERLIST_AK}
+                hasNotification={hasNotification}
+              />
+            )}
+            {shouldShowNavBarToggleButton && !isExpanded && document.dir === 'ltr'
               && <Styled.ArrowRight iconName="right_arrow" />}
-            {isExpanded && document.dir === 'rtl'
+            {shouldShowNavBarToggleButton && isExpanded && document.dir === 'rtl'
               && <Styled.ArrowRight iconName="right_arrow" />}
             {renderPluginItems(leftPluginItems)}
           </Styled.Left>


### PR DESCRIPTION
### What does this PR do?

This PR adds 3 new layouts: "Cameras Only", "Presentation Only", and "Participants and Chat Only", as requested in issue #18879. The layouts are not visible to the user and can only be activated via custom parameters. To improve these layouts, some issues need to be addressed:

* Should the hidden features in each layout remain hidden? For example, in "Cameras Only", should controls such as displaying the user list, opening presentations, sharing screens, etc., be hidden?
* In the "Presentation Only" layout, does external video and screen sharing count as part of the presentation?
* In the "Participants and Chat Only" layout, should the components take up the entire screen?
These questions have not been resolved as they are not part of the scope of the task and are considered as improvements.

### Closes Issue(s)
Closes #18879

### Preview
<details>
<summary>Cameras Only</summary>

![image](https://github.com/bigbluebutton/bigbluebutton/assets/9675166/918a3613-b3f1-41f3-86ed-9080f6cd02b8)

</details>

<details>
<summary>Presentation Only</summary>

![image](https://github.com/bigbluebutton/bigbluebutton/assets/9675166/67ecb8ae-79a8-4cd3-88f5-eef0c5f6ff58)

</details>

<details>
<summary>Participants and Chat Only</summary>

![image](https://github.com/bigbluebutton/bigbluebutton/assets/9675166/72d71eac-50e4-44ad-a76c-fa8b761cdfed)

</details>


Addendum:
For this delivery, the controls that have been hidden are using the layout type information to remain hidden. As a suggestion for improvement, it would be beneficial if the layout included information about which controls should be hidden.
