### PR TITLE
Fix: user list tooltip hindering talking indicator

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -16,6 +16,7 @@ import deviceInfo from '/imports/utils/deviceInfo';
 import { PANELS, ACTIONS } from '../layout/enums';
 import Button from '/imports/ui/components/common/button/component';
 import { isEqual } from 'radash';
+import Right from '../common/control-header/right/component';
 
 const intlMessages = defineMessages({
   toggleUserListLabel: {
@@ -316,6 +317,7 @@ class NavBar extends Component {
             {!isExpanded && document.dir === 'rtl'
               && <Styled.ArrowLeft iconName="left_arrow" />}
             <Styled.NavbarToggleButton
+              tooltipplacement="right"
               onClick={this.handleToggleUserList}
               color={isPhone && isExpanded ? 'primary' : 'dark'}
               size='md'

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -16,7 +16,6 @@ import deviceInfo from '/imports/utils/deviceInfo';
 import { PANELS, ACTIONS } from '../layout/enums';
 import Button from '/imports/ui/components/common/button/component';
 import { isEqual } from 'radash';
-import Right from '../common/control-header/right/component';
 
 const intlMessages = defineMessages({
   toggleUserListLabel: {


### PR DESCRIPTION
### What does this PR do?

This PR changes user list tooltip's position to stop it from hindering the talking indicator button.

Before:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/14822e43-cdb3-4089-9eff-acb7bf00d23d)

After:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/4c4dfa87-95a7-4f7f-986f-07cc47b02d2e)
