### PR TITLE
Fix: Removing some inconvinient user selection from certain items

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/tooltip/bbbtip.css
+++ b/bigbluebutton-html5/imports/ui/components/common/tooltip/bbbtip.css
@@ -3,6 +3,7 @@
     background-color:#333333;
     padding: .25rem .5rem;
     border-radius: 4px;
+    user-select: none;
 }
 
 .tippy-tooltip.bbbtip-theme>.tippy-svg-arrow{

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/styles.ts
@@ -29,6 +29,7 @@ const RecordingIndicatorIcon = styled.span<RecordingIndicatorIconProps>`
   width: ${fontSizeLarge};
   height: ${fontSizeLarge};
   font-size: ${fontSizeBase};
+  user-select: none;
 
   ${({ titleMargin }) => titleMargin && `
     [dir="ltr"] & {
@@ -40,6 +41,7 @@ const RecordingIndicatorIcon = styled.span<RecordingIndicatorIconProps>`
 const RecordingControl = styled.div<RecordingIndicatorProps>`
   display: flex;
   align-items: center;
+  user-select: none;
 
   span {
     border: none;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/styles.js
@@ -6,6 +6,7 @@ import { fontSizeSmaller } from '/imports/ui/stylesheets/styled-components/typog
 import Button from '/imports/ui/components/common/button/component';
 
 const DropdownTrigger = styled(DivElipsis)`
+  user-select: none;
   position: relative;
   // Keep the background with 0.5 opacity, but leave the text with 1
   background-color: rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
### What does this PR do?

This PR removes user selection from following items to avoid inconvinient unintentional selection:

- Tooltips in general
- recording indicator
- user-actions from webcam framing