### PR TITLE
docs: updated greenlight docs to include user:set_admin_role rake task

### DIFF
--- a/docs/docs/greenlight/v3/install.md
+++ b/docs/docs/greenlight/v3/install.md
@@ -48,6 +48,12 @@ You can also run it without any arguments to create the default admin account, w
 docker exec -it greenlight-v3 bundle exec rake admin:create
 ```
 
+### Upgrading an existing account to an Admin Account
+
+You can do that by running the following command:
+```bash
+docker exec -it greenlight-v3 bundle exec rake user:set_admin_role['email']
+```
 
 ## Installing on a Standalone Server
 ### Greenlight Install Script


### PR DESCRIPTION
### What does this PR do?

Updated greenlight docs install.md to include instructions for usage of rake task user:set_admin_role which upgrades an existing user account to Administrator

### Closes Issue(s)
Closes issue [#5515](https://github.com/bigbluebutton/greenlight/issues/5515) on greenlight repo

### Motivation

Updated greenlight repo to include the rake task and just updating the corresponding greenlight documentation here.
