### PR TITLE
Adds custom color highlight option for webcam

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -53,7 +53,7 @@ const VideoListItem = (props) => {
   const videoContainer = useRef();
 
   const videoIsReady = isStreamHealthy && videoDataLoaded && !isSelfViewDisabled;
-  const { animations } = Settings.application;
+  const { animations, webcamBorderHighlightColor } = Settings.application;
   const talking = voiceUser?.talking;
 
   const onStreamStateChange = (e) => {
@@ -225,6 +225,7 @@ const VideoListItem = (props) => {
     <Styled.Content
       ref={videoContainer}
       talking={talking}
+      customHighlight={webcamBorderHighlightColor}
       fullscreen={isFullscreenContext}
       data-test={talking ? 'webcamItemTalkingUser' : 'webcamItem'}
       animations={animations}

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/styles.js
@@ -43,12 +43,16 @@ const Content = styled.div`
     border: 2px solid ${colorBlack};
     border-radius: 10px;
 
-    ${({ isStream }) => !isStream   && `
+    ${({ isStream }) => !isStream && `
       border: 2px solid ${webcamPlaceholderBorder};
     `}
 
     ${({ talking }) => talking && `
       border: 2px solid ${colorPrimary};
+    `}
+
+    ${({ talking, customHighlight }) => talking && customHighlight && customHighlight.length > 0 && `
+      border: 2px solid rgb(${customHighlight[0]}, ${customHighlight[1]}, ${customHighlight[2]});
     `}
 
     ${({ animations }) => animations && `

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -201,6 +201,8 @@ public:
         whiteboardToolbarAutoHide: false
         autoCloseReactionsBar: true
         darkTheme: false
+        # set a custom color for talking highlight in webcam
+        webcamBorderHighlightColor: []
         # fallbackLocale: if the locale the client is loaded in does not have a
         # translation a string, it will use the translation from the locale
         # specified in fallbackLocale. Note that fallbackLocale should be a


### PR DESCRIPTION
### What does this PR do?

This PR enables the modification of the highlight color for the webcam (when someone is talking) via settings.yml file with a rgb color code.

Code example:
`webcamBorderHighlightColor: [50, 255, 50]`

<details>
<summary>Result preview</summary>

 
![image](https://github.com/bigbluebutton/bigbluebutton/assets/9675166/fa553567-04d3-45e3-874a-da9a7bdf212a)

</details>

### Closes Issue(s)
Closes #16068 




