### PR TITLE
layout improvements

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -285,7 +285,7 @@ class ActionsDropdown extends PureComponent {
     const { selectedLayout } = Settings.application;
     const shouldShowManageLayoutButton = selectedLayout !== LAYOUT_TYPE.CAMERAS_ONLY
       && selectedLayout !== LAYOUT_TYPE.PRESENTATION_ONLY
-      && selectedLayout !== LAYOUT_TYPE.PARTICIPANTS_CHAT_ONLY;
+      && selectedLayout !== LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY;
 
     if (shouldShowManageLayoutButton && isLayoutsEnabled()) {
       actions.push({

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -131,9 +131,9 @@ class ActionsBar extends PureComponent {
 
     const { selectedLayout } = Settings.application;
     const shouldShowPresentationButton = selectedLayout !== LAYOUT_TYPE.CAMERAS_ONLY
-      && selectedLayout !== LAYOUT_TYPE.PARTICIPANTS_CHAT_ONLY;
+      && selectedLayout !== LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY;
     const shouldShowVideoButton = selectedLayout !== LAYOUT_TYPE.PRESENTATION_ONLY
-      && selectedLayout !== LAYOUT_TYPE.PARTICIPANTS_CHAT_ONLY;
+      && selectedLayout !== LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY;
 
     const shouldShowOptionsButton = (isPresentationEnabled() && isThereCurrentPresentation)
       || isSharingVideo || hasScreenshare || isSharedNotesPinned;

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -253,6 +253,8 @@ class App extends Component {
       layoutContextDispatch,
       numCameras,
       presentationIsOpen,
+      hideActionsBar,
+      hideNavBar,
     } = this.props;
 
     this.renderDarkMode();
@@ -322,6 +324,15 @@ class App extends Component {
         });
       }, 0);
     }
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_HAS_ACTIONBAR,
+      value: !hideActionsBar,
+    });
+    layoutContextDispatch({
+      type: ACTIONS.SET_HAS_NAVBAR,
+      value: !hideNavBar,
+    });
   }
 
   componentWillUnmount() {

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -336,6 +336,7 @@ export default withTracker(() => {
     ),
     hidePresentationOnJoin: getFromUserSettings('bbb_hide_presentation_on_join', LAYOUT_CONFIG.hidePresentationOnJoin),
     hideActionsBar: getFromUserSettings('bbb_hide_actions_bar', false),
+    hideNavBar: getFromUserSettings('bbb_hide_nav_bar', false),
     ignorePollNotifications: Session.get('ignorePollNotifications'),
     isSharedNotesPinned: MediaService.shouldShowSharedNotes(),
   };

--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -189,6 +189,24 @@ const reducer = (state, action) => {
     }
 
     // NAV BAR
+
+    case ACTIONS.SET_HAS_NAVBAR: {
+      const { navBar } = state.input;
+      if (navBar.hasNavBar === action.value) {
+        return state;
+      }
+      return {
+        ...state,
+        input: {
+          ...state.input,
+          navBar: {
+            ...navBar,
+            hasNavBar: action.value,
+          },
+        },
+      };
+    }
+
     case ACTIONS.SET_NAVBAR_OUTPUT: {
       const {
         display, width, height, top, left, tabOrder, zIndex,
@@ -222,6 +240,23 @@ const reducer = (state, action) => {
     }
 
     // ACTION BAR
+    case ACTIONS.SET_HAS_ACTIONBAR: {
+      const { actionBar } = state.input;
+      if (actionBar.hasActionBar === action.value) {
+        return state;
+      }
+      return {
+        ...state,
+        input: {
+          ...state.input,
+          actionBar: {
+            ...actionBar,
+            hasActionBar: action.value,
+          },
+        },
+      };
+    }
+
     case ACTIONS.SET_ACTIONBAR_OUTPUT: {
       const {
         display, width, height, innerHeight, top, left, padding, tabOrder, zIndex,

--- a/bigbluebutton-html5/imports/ui/components/layout/enums.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/enums.js
@@ -5,7 +5,7 @@ export const LAYOUT_TYPE = {
   VIDEO_FOCUS: 'videoFocus',
   CAMERAS_ONLY: 'camerasOnly',
   PRESENTATION_ONLY: 'presentationOnly',
-  PARTICIPANTS_CHAT_ONLY: 'participantsChatOnly',
+  PARTICIPANTS_AND_CHAT_ONLY: 'participantsAndChatOnly',
 };
 
 export const DEVICE_TYPE = {

--- a/bigbluebutton-html5/imports/ui/components/layout/enums.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/enums.js
@@ -26,6 +26,13 @@ export const CAMERADOCK_POSITION = {
   SIDEBAR_CONTENT_BOTTOM: 'sidebarContentBottom',
 };
 
+// list of layouts that are only available through join parameters
+export const HIDDEN_LAYOUTS = [
+  LAYOUT_TYPE.CAMERAS_ONLY,
+  LAYOUT_TYPE.PRESENTATION_ONLY,
+  LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY,
+];
+
 export const ACTIONS = {
   SET_AUTO_ARRANGE_LAYOUT: 'setAutoArrangeLayout',
   SET_IS_RTL: 'setIsRTL',

--- a/bigbluebutton-html5/imports/ui/components/layout/enums.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/enums.js
@@ -54,8 +54,10 @@ export const ACTIONS = {
   SET_HAS_BANNER_BAR: 'setHasBannerBar',
   SET_HAS_NOTIFICATIONS_BAR: 'setHasNotificationsBar',
 
+  SET_HAS_NAVBAR: 'setHasNavBar',
   SET_NAVBAR_OUTPUT: 'setNavBarOutput',
 
+  SET_HAS_ACTIONBAR: 'setHasActionBar',
   SET_ACTIONBAR_OUTPUT: 'setActionBarOutput',
 
   SET_SIDEBAR_NAVIGATION_IS_OPEN: 'setSidebarNavigationIsOpen',

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/camerasOnly.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/camerasOnly.jsx
@@ -11,7 +11,7 @@ import { ACTIONS } from '/imports/ui/components/layout/enums';
 import { defaultsDeep } from '/imports/utils/array-utils';
 
 const CamerasOnlyLayout = (props) => {
-  const { bannerAreaHeight, isMobile } = props;
+  const { bannerAreaHeight, isMobile, calculatesNavbarHeight } = props;
 
   function usePrevious(value) {
     const ref = useRef();
@@ -43,7 +43,7 @@ const CamerasOnlyLayout = (props) => {
       return baseBounds;
     }
 
-    const { navBarHeight } = DEFAULT_VALUES;
+    const navBarHeight = calculatesNavbarHeight();
 
     const cameraDockBounds = {};
 
@@ -110,6 +110,7 @@ const CamerasOnlyLayout = (props) => {
       sidebarNavWidth.width,
       sidebarContentWidth.width,
     );
+    console.log({mediaAreaBounds})
     const navbarBounds = calculatesNavbarBounds(mediaAreaBounds);
     const actionbarBounds = calculatesActionbarBounds(mediaAreaBounds);
     const sidebarSize = sidebarContentWidth.width + sidebarNavWidth.width;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -14,7 +14,7 @@ const min = (value1, value2) => (value1 <= value2 ? value1 : value2);
 const max = (value1, value2) => (value1 >= value2 ? value1 : value2);
 
 const CustomLayout = (props) => {
-  const { bannerAreaHeight, calculatesActionbarHeight, isMobile } = props;
+  const { bannerAreaHeight, calculatesActionbarHeight, calculatesNavbarHeight, isMobile } = props;
 
   function usePrevious(value) {
     const ref = useRef();
@@ -405,12 +405,13 @@ const CustomLayout = (props) => {
     const { isPinned: isSharedNotesPinned } = sharedNotesInput;
 
     const { height: actionBarHeight } = calculatesActionbarHeight();
+    const navBarHeight = calculatesNavbarHeight();
     const mediaAreaHeight =
       windowHeight() - (DEFAULT_VALUES.navBarHeight + actionBarHeight + bannerAreaHeight());
     const mediaAreaWidth = windowWidth() - (sidebarNavWidth + sidebarContentWidth);
     const mediaBounds = {};
     const { element: fullscreenElement } = fullscreen;
-    const { navBarHeight, camerasMargin } = DEFAULT_VALUES;
+    const { camerasMargin } = DEFAULT_VALUES;
 
     const hasPresentation = isPresentationEnabled() && slidesLength !== 0;
     const isGeneralMediaOff =
@@ -495,7 +496,7 @@ const CustomLayout = (props) => {
     } else {
       mediaBounds.width = mediaAreaWidth;
       mediaBounds.height = mediaAreaHeight;
-      mediaBounds.top = DEFAULT_VALUES.navBarHeight + bannerAreaHeight();
+      mediaBounds.top = navBarHeight + bannerAreaHeight();
       mediaBounds.left = !isRTL ? sidebarSize : null;
       mediaBounds.right = isRTL ? sidebarSize : null;
     }

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
@@ -10,7 +10,7 @@ import PresentationFocusLayout from '/imports/ui/components/layout/layout-manage
 import VideoFocusLayout from '/imports/ui/components/layout/layout-manager/videoFocusLayout';
 import CamerasOnlyLayout from '/imports/ui/components/layout/layout-manager/camerasOnly';
 import PresentationOnlyLayout from '/imports/ui/components/layout/layout-manager/presentationOnlyLayout';
-import ParticipantsChatOnlyLayout from '/imports/ui/components/layout/layout-manager/participantsChatOnlyLayout';
+import ParticipantsAndChatOnlyLayout from '/imports/ui/components/layout/layout-manager/participantsAndChatOnlyLayout';
 import { isPresentationEnabled } from '/imports/ui/services/features';
 
 const propTypes = {
@@ -318,9 +318,9 @@ const LayoutEngine = ({ layoutType }) => {
     case LAYOUT_TYPE.PRESENTATION_ONLY:
       layout?.setAttribute('data-layout', LAYOUT_TYPE.PRESENTATION_ONLY);
       return <PresentationOnlyLayout {...common} />;
-    case LAYOUT_TYPE.PARTICIPANTS_CHAT_ONLY:
-      layout?.setAttribute('data-layout', LAYOUT_TYPE.PARTICIPANTS_CHAT_ONLY);
-      return <ParticipantsChatOnlyLayout {...common} />;
+    case LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY:
+      layout?.setAttribute('data-layout', LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY);
+      return <ParticipantsAndChatOnlyLayout {...common} />;
     default:
       layout?.setAttribute('data-layout', LAYOUT_TYPE.CUSTOM_LAYOUT);
       return <CustomLayout {...common} />;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
@@ -23,6 +23,7 @@ const LayoutEngine = ({ layoutType }) => {
   const cameraDockInput = layoutSelectInput((i) => i.cameraDock);
   const presentationInput = layoutSelectInput((i) => i.presentation);
   const actionbarInput = layoutSelectInput((i) => i.actionBar);
+  const navBarInput = layoutSelectInput((i) => i.navBar);
   const sidebarNavigationInput = layoutSelectInput((i) => i.sidebarNavigation);
   const sidebarContentInput = layoutSelectInput((i) => i.sidebarContent);
   const externalVideoInput = layoutSelectInput((i) => i.externalVideo);
@@ -65,6 +66,7 @@ const LayoutEngine = ({ layoutType }) => {
       return cameraDockBounds;
     }
 
+    const navBarHeight = calculatesNavbarHeight();
     const hasPresentation = isPresentationEnabled() && slidesLength !== 0;
     const isGeneralMediaOff = !hasPresentation
       && !hasExternalVideo && !hasScreenShare && !isSharedNotesPinned;
@@ -74,7 +76,7 @@ const LayoutEngine = ({ layoutType }) => {
       cameraDockBounds.maxWidth = mediaAreaBounds.width;
       cameraDockBounds.height = mediaAreaBounds.height - bannerAreaHeight();
       cameraDockBounds.maxHeight = mediaAreaBounds.height;
-      cameraDockBounds.top = DEFAULT_VALUES.navBarHeight + bannerAreaHeight();
+      cameraDockBounds.top = navBarHeight + bannerAreaHeight();
       cameraDockBounds.left = !isRTL ? mediaAreaBounds.left : 0;
       cameraDockBounds.right = isRTL ? sidebarSize : null;
     }
@@ -97,8 +99,26 @@ const LayoutEngine = ({ layoutType }) => {
     return cameraDockBounds;
   };
 
+  const calculatesNavbarHeight = () => {
+    const { navBarHeight } = DEFAULT_VALUES;
+
+    return navBarInput.hasNavBar ? navBarHeight : 0;
+  };
+
   const calculatesNavbarBounds = (mediaAreaBounds) => {
-    const { navBarHeight, navBarTop } = DEFAULT_VALUES;
+    const { navBarTop } = DEFAULT_VALUES;
+
+    const navBarHeight = calculatesNavbarHeight();
+
+    if (!navBarInput.hasNavBar) {
+      return {
+        width: 0,
+        height: 0,
+        top: 0,
+        left: 0,
+        zIndex: 0,
+      };
+    }
 
     return {
       width: mediaAreaBounds.width,
@@ -110,6 +130,14 @@ const LayoutEngine = ({ layoutType }) => {
   };
 
   const calculatesActionbarHeight = () => {
+    if (!actionbarInput.hasActionBar) {
+      return {
+        height: 0,
+        innerHeight: 0,
+        padding: 0,
+      };
+    }
+
     const { actionBarHeight, actionBarPadding } = DEFAULT_VALUES;
 
     const BASE_FONT_SIZE = 14; // 90% font size
@@ -262,8 +290,9 @@ const LayoutEngine = ({ layoutType }) => {
   };
 
   const calculatesMediaAreaBounds = (sidebarNavWidth, sidebarContentWidth) => {
-    const { navBarHeight } = DEFAULT_VALUES;
     const { height: actionBarHeight } = calculatesActionbarHeight();
+    const navBarHeight = calculatesNavbarHeight();
+
     let left = 0;
     let width = 0;
     if (isMobile) {
@@ -284,6 +313,7 @@ const LayoutEngine = ({ layoutType }) => {
   const common = {
     bannerAreaHeight,
     baseCameraDockBounds,
+    calculatesNavbarHeight,
     calculatesNavbarBounds,
     calculatesActionbarHeight,
     calculatesActionbarBounds,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/participantsAndChatOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/participantsAndChatOnlyLayout.jsx
@@ -13,7 +13,7 @@ import { defaultsDeep } from '/imports/utils/array-utils';
 const windowWidth = () => window.document.documentElement.clientWidth;
 const windowHeight = () => window.document.documentElement.clientHeight;
 
-const ParticipantsChatOnlyLayout = (props) => {
+const ParticipantsAndChatOnlyLayout = (props) => {
   const { bannerAreaHeight, isMobile } = props;
 
   function usePrevious(value) {
@@ -425,4 +425,4 @@ const ParticipantsChatOnlyLayout = (props) => {
   return null;
 };
 
-export default ParticipantsChatOnlyLayout;
+export default ParticipantsAndChatOnlyLayout;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationOnlyLayout.jsx
@@ -13,7 +13,7 @@ const windowWidth = () => window.document.documentElement.clientWidth;
 const windowHeight = () => window.document.documentElement.clientHeight;
 
 const PresentationOnlyLayout = (props) => {
-  const { bannerAreaHeight, isMobile } = props;
+  const { bannerAreaHeight, calculatesNavbarHeight, isMobile } = props;
 
   function usePrevious(value) {
     const ref = useRef();
@@ -41,6 +41,8 @@ const PresentationOnlyLayout = (props) => {
     const mediaBounds = {};
     const { element: fullscreenElement } = fullscreen;
 
+    const navBarHeight = calculatesNavbarHeight();
+
     if (
       fullscreenElement === 'Presentation'
       || fullscreenElement === 'Screenshare'
@@ -57,7 +59,7 @@ const PresentationOnlyLayout = (props) => {
 
     mediaBounds.height = mediaAreaBounds.height;
     mediaBounds.width = mediaAreaBounds.width;
-    mediaBounds.top = DEFAULT_VALUES.navBarHeight + bannerAreaHeight();
+    mediaBounds.top = navBarHeight + bannerAreaHeight();
     mediaBounds.left = !isRTL ? mediaAreaBounds.left : null;
     mediaBounds.right = isRTL ? sidebarSize : null;
     mediaBounds.zIndex = 1;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -11,7 +11,7 @@ const windowWidth = () => window.document.documentElement.clientWidth;
 const windowHeight = () => window.document.documentElement.clientHeight;
 
 const SmartLayout = (props) => {
-  const { bannerAreaHeight, isMobile } = props;
+  const { bannerAreaHeight, isMobile, calculatesNavbarHeight } = props;
 
   function usePrevious(value) {
     const ref = useRef();
@@ -184,7 +184,8 @@ const SmartLayout = (props) => {
       return baseBounds;
     }
 
-    const { camerasMargin, presentationToolbarMinWidth, navBarHeight } = DEFAULT_VALUES;
+    const { camerasMargin, presentationToolbarMinWidth } = DEFAULT_VALUES;
+    const navBarHeight = calculatesNavbarHeight();
 
     const cameraDockBounds = {};
 

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -16,7 +16,7 @@ const windowWidth = () => window.document.documentElement.clientWidth;
 const windowHeight = () => window.document.documentElement.clientHeight;
 
 const VideoFocusLayout = (props) => {
-  const { bannerAreaHeight, isMobile } = props;
+  const { bannerAreaHeight, isMobile, calculatesNavbarHeight } = props;
 
   function usePrevious(value) {
     const ref = useRef();
@@ -167,6 +167,7 @@ const VideoFocusLayout = (props) => {
     const { hasScreenShare } = screenShareInput;
     const { isPinned: isSharedNotesPinned } = sharedNotesInput;
 
+    const navBarHeight = calculatesNavbarHeight();
     const hasPresentation = isPresentationEnabled() && slidesLength !== 0;
     const isGeneralMediaOff =
       !hasPresentation && !hasExternalVideo && !hasScreenShare && !isSharedNotesPinned;
@@ -176,7 +177,7 @@ const VideoFocusLayout = (props) => {
     let maxHeight = 0;
     if (sidebarContentInput.isOpen) {
       if (isMobile) {
-        height = windowHeight() - DEFAULT_VALUES.navBarHeight - bannerAreaHeight();
+        height = windowHeight() - navBarHeight - bannerAreaHeight();
         minHeight = height;
         maxHeight = height;
       } else if (isOpen && !isGeneralMediaOff) {
@@ -220,7 +221,7 @@ const VideoFocusLayout = (props) => {
       return baseBounds;
     }
 
-    const { navBarHeight } = DEFAULT_VALUES;
+    const navBarHeight = calculatesNavbarHeight();
 
     const cameraDockBounds = {};
 

--- a/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
-import { LAYOUT_TYPE, CAMERADOCK_POSITION } from '/imports/ui/components/layout/enums';
+import { LAYOUT_TYPE, CAMERADOCK_POSITION, HIDDEN_LAYOUTS } from '/imports/ui/components/layout/enums';
 import SettingsService from '/imports/ui/components/settings/service';
 import deviceInfo from '/imports/utils/deviceInfo';
 import Button from '/imports/ui/components/common/button/component';
@@ -107,11 +107,7 @@ const LayoutModalComponent = (props) => {
   const renderLayoutButtons = () => (
     <Styled.ButtonsContainer>
       {Object.values(LAYOUT_TYPE)
-        .filter((layout) => (
-          layout !== LAYOUT_TYPE.CAMERAS_ONLY
-          && layout !== LAYOUT_TYPE.PRESENTATION_ONLY
-          && layout !== LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY
-        ))
+        .filter((layout) => !HIDDEN_LAYOUTS.includes(layout))
         .map((layout) => (
           <Styled.ButtonLayoutContainer key={layout}>
             <Styled.LayoutBtn

--- a/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
@@ -110,7 +110,7 @@ const LayoutModalComponent = (props) => {
         .filter((layout) => (
           layout !== LAYOUT_TYPE.CAMERAS_ONLY
           && layout !== LAYOUT_TYPE.PRESENTATION_ONLY
-          && layout !== LAYOUT_TYPE.PARTICIPANTS_CHAT_ONLY
+          && layout !== LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY
         ))
         .map((layout) => (
           <Styled.ButtonLayoutContainer key={layout}>

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -293,7 +293,7 @@ class NavBar extends Component {
     const { selectedLayout } = Settings.application;
     const shouldShowNavBarToggleButton = selectedLayout !== LAYOUT_TYPE.CAMERAS_ONLY
       && selectedLayout !== LAYOUT_TYPE.PRESENTATION_ONLY
-      && selectedLayout !== LAYOUT_TYPE.PARTICIPANTS_CHAT_ONLY;
+      && selectedLayout !== LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY;
 
     return (
       <Styled.Navbar


### PR DESCRIPTION
### What does this PR do?

Makes the following updates to the layouts:
- renames `participantsChatOnly` to `participantsAndChatOnly`;
- moves the list of layouts that should appear in the layout modal to `/imports/ui/components/layout/enums` file
- removes empty space on top and bottom of the main area when `userdata-bbb_hide_nav_bar` and/or `userdata-bbb_hide_actions_bar` are set to true