### PR TITLE
Add more options to getJoinUrl API, allowing moderators to create joi…

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1260,7 +1260,7 @@ class ApiController {
         // If the user calling getJoinUrl is a moderator (except in breakout rooms), allow to specify additional parameters
         if (us.role.equals(ROLE_MODERATOR) && !meeting.isBreakout()) {
           request.getParameterMap()
-            .findAll { key, value -> ["enforceLayout", "role", "fullName", "userID", "avatarURL"].contains(key) || key.startsWith("userdata-") }
+            .findAll { key, value -> ["enforceLayout", "role", "fullName", "userID", "avatarURL", "redirect", "excludeFromDashboard"].contains(key) || key.startsWith("userdata-") }
             .findAll { key, value -> !StringUtils.isEmpty(value[-1]) }
             .each { key, value -> queryParameters.put(key, value[-1]) };
         }

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -43,6 +43,7 @@ import org.bigbluebutton.web.services.turn.StunTurnService
 import org.bigbluebutton.web.services.turn.TurnEntry
 import org.bigbluebutton.web.services.turn.StunServer
 import org.bigbluebutton.web.services.turn.RemoteIceCandidate
+import org.codehaus.groovy.util.ListHashMap
 import org.json.JSONArray
 
 
@@ -1240,22 +1241,36 @@ class ApiController {
         logData.put("userid", us.internalUserId);
         logData.put("sessionToken", sessionToken);
         logData.put("logCode", "getJoinUrl");
-        logData.put("description", "Request join URL.");
+        logData.put("description", "Request join URL");
         Gson gson = new Gson();
         String logStr = gson.toJson(logData);
 
         log.info(" --analytics-- data=" + logStr);
 
         String method = 'join'
-        String extId = validationService.encodeString(meeting.getExternalId())
+        String externalMeetingId = validationService.encodeString(meeting.getExternalId())
         String fullName = validationService.encodeString(us.fullname)
-        String query = "fullName=${fullName}&meetingID=${extId}&role=${us.role.equals(ROLE_MODERATOR) ? ROLE_MODERATOR : ROLE_ATTENDEE}&redirect=true&userID=${us.getExternUserID()}"
+        ListHashMap<String, String> queryParameters = new ListHashMap<>();
+        queryParameters.put("fullName", fullName);
+        queryParameters.put("meetingID", externalMeetingId);
+        queryParameters.put("role", us.role.equals(ROLE_MODERATOR) ? ROLE_MODERATOR : ROLE_ATTENDEE);
+        queryParameters.put("redirect", "true");
+        queryParameters.put("userID", us.getExternUserID());
 
-        if (!StringUtils.isEmpty(params.enforceLayout)) {
-          query += "&enforceLayout=${validationService.encodeString(params.enforceLayout)}";
+        // If the user calling getJoinUrl is a moderator (except in breakout rooms), allow to specify additional parameters
+        if (us.role.equals(ROLE_MODERATOR) && !meeting.isBreakout()) {
+          request.getParameterMap()
+            .findAll { key, value -> ["enforceLayout", "role", "fullName", "userID", "avatarURL"].contains(key) || key.startsWith("userdata-") }
+            .findAll { key, value -> !StringUtils.isEmpty(value[-1]) }
+            .each { key, value -> queryParameters.put(key, value[-1]) };
         }
 
-        String checksum = DigestUtils.sha1Hex(method + query + validationService.getSecuritySalt())
+        String httpQueryString = "";
+        for(String parameterName : queryParameters.keySet()) {
+          httpQueryString += ( queryParameters.isEmpty() ? "?" : "&" ) + parameterName + "=" + validationService.encodeString(queryParameters.get(parameterName));
+        }
+
+        String checksum = DigestUtils.sha1Hex(method + httpQueryString + validationService.getSecuritySalt())
         String defaultServerUrl = paramsProcessorUtil.defaultServerUrl
         response.addHeader("Cache-Control", "no-cache")
         withFormat {
@@ -1264,7 +1279,7 @@ class ApiController {
             builder.response {
               returncode RESP_CODE_SUCCESS
               message "Join URL provided successfully."
-              url "${defaultServerUrl}/bigbluebutton/api/${method}?${query}&checksum=${checksum}"
+              url "${defaultServerUrl}/bigbluebutton/api/${method}?${httpQueryString}&checksum=${checksum}"
             }
             render(contentType: "application/json", text: builder.toPrettyString())
           }


### PR DESCRIPTION
This PR extends the `getJoinUrl` parameter to allow moderators to pass extra parameters to it.

The main motivation of this is to allow plugins (in this case, the hybrid classroom plugin) to generate invitation links, so "the classroom" can join the room with multiple sessions, each one using a specific layout and userdata- parameters.

Parameters that a moderator can define:

- enforceLayout
- role
- fullName
- userID
- avatarURL
- excludeFromDashboard
- redirect
- userdata-*

PS: this PR also ensures that these parameters can't be specified from a breakout room (as everyone is moderator in a breakout).
