### PR TITLE
graphql-middlware: Make graphql-middleware more configurable

### DIFF
--- a/bbb-graphql-middleware/bbb-graphql-middleware-config.env
+++ b/bbb-graphql-middleware/bbb-graphql-middleware-config.env
@@ -1,4 +1,11 @@
 BBB_GRAPHQL_MIDDLEWARE_LISTEN_PORT=8378
+BBB_GRAPHQL_MIDDLEWARE_REDIS_ADDRESS=127.0.0.1:6379
+BBB_GRAPHQL_MIDDLEWARE_REDIS_PASSWORD=
+BBB_GRAPHQL_MIDDLEWARE_HASURA_WS=ws://127.0.0.1:8080/v1/graphql
+
 # If you are running a cluster proxy setup, you need to configure the Origin of
 # the frontend. See https://docs.bigbluebutton.org/administration/cluster-proxy
 # BBB_GRAPHQL_MIDDLEWARE_ORIGIN=bbb-proxy.example.com
+
+# LOG_LEVEL options: PANIC, FATAL, ERROR, WARN, INFO, DEBUG, TRACE
+BBB_GRAPHQL_MIDDLEWARE_LOG_LEVEL=INFO

--- a/bbb-graphql-middleware/cmd/bbb-graphql-middleware/main.go
+++ b/bbb-graphql-middleware/cmd/bbb-graphql-middleware/main.go
@@ -12,9 +12,16 @@ import (
 
 func main() {
 	// Configure logger
-	log.SetLevel(log.InfoLevel)
+	if logLevelFromEnvVar, err := log.ParseLevel(os.Getenv("BBB_GRAPHQL_MIDDLEWARE_LOG_LEVEL")); err == nil {
+		log.SetLevel(logLevelFromEnvVar)
+	} else {
+		log.SetLevel(log.InfoLevel)
+	}
+
 	log.SetFormatter(&log.JSONFormatter{})
 	log := log.WithField("_routine", "main")
+
+	log.Infof("Logger level=%v", log.Logger.Level)
 
 	//Clear cache from last exec
 	msgpatch.ClearAllCaches()

--- a/bbb-graphql-middleware/internal/hascli/client.go
+++ b/bbb-graphql-middleware/internal/hascli/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"os"
 	"sync"
 
 	"github.com/iMDT/bbb-graphql-middleware/internal/common"
@@ -18,7 +19,7 @@ import (
 )
 
 var lastHasuraConnectionId int
-var hasuraEndpoint = "ws://127.0.0.1:8080/v1/graphql"
+var hasuraEndpoint = os.Getenv("BBB_GRAPHQL_MIDDLEWARE_HASURA_WS")
 
 // Hasura client connection
 func HasuraClient(browserConnection *common.BrowserConnection, cookies []*http.Cookie, fromBrowserChannel chan interface{}, toBrowserChannel chan interface{}) error {

--- a/bbb-graphql-middleware/internal/websrv/rediscli.go
+++ b/bbb-graphql-middleware/internal/websrv/rediscli.go
@@ -6,13 +6,14 @@ import (
 	"fmt"
 	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
+	"os"
 	"strings"
 	"time"
 )
 
 var redisClient = redis.NewClient(&redis.Options{
-	Addr:     "127.0.0.1:6379",
-	Password: "",
+	Addr:     os.Getenv("BBB_GRAPHQL_MIDDLEWARE_REDIS_ADDRESS"),
+	Password: os.Getenv("BBB_GRAPHQL_MIDDLEWARE_REDIS_PASSWORD"),
 	DB:       0,
 })
 


### PR DESCRIPTION
The following configs was introduced via ENV VAR:
```
BBB_GRAPHQL_MIDDLEWARE_REDIS_ADDRESS=127.0.0.1:6379
BBB_GRAPHQL_MIDDLEWARE_REDIS_PASSWORD=
BBB_GRAPHQL_MIDDLEWARE_HASURA_WS=ws://127.0.0.1:8080/v1/graphql

# LOG_LEVEL options: PANIC, FATAL, ERROR, WARN, INFO, DEBUG, TRACE
BBB_GRAPHQL_MIDDLEWARE_LOG_LEVEL=INFO
```