### PR TITLE
refactor: End meeting button tweaks

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -85,8 +85,8 @@ const intlMessages = defineMessages({
     id: 'app.navBar.settingsDropdown.helpDesc',
     description: 'Describes help option',
   },
-  endMeetingLabel: {
-    id: 'app.navBar.settingsDropdown.endMeetingLabel',
+  endMeetingForAllLabel: {
+    id: 'app.navBar.settingsDropdown.endMeetingForAllLabel',
     description: 'End meeting options label',
   },
   endMeetingDesc: {
@@ -362,7 +362,7 @@ class SettingsDropdown extends PureComponent {
         {
           key: 'list-item-end-meeting',
           icon: 'application',
-          label: intl.formatMessage(intlMessages.endMeetingLabel),
+          label: intl.formatMessage(intlMessages.endMeetingForAllLabel),
           description: intl.formatMessage(intlMessages.endMeetingDesc),
           customStyles,
           onClick: () => this.setEndMeetingConfirmationModalIsOpen(true),

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -361,7 +361,7 @@ class SettingsDropdown extends PureComponent {
       this.menuItems.push(
         {
           key: 'list-item-end-meeting',
-          icon: 'application',
+          icon: 'close',
           label: intl.formatMessage(intlMessages.endMeetingForAllLabel),
           description: intl.formatMessage(intlMessages.endMeetingDesc),
           customStyles,


### PR DESCRIPTION
### What does this PR do?

Apply changes made in https://github.com/bigbluebutton/bigbluebutton/pull/19232  towards the "End meeting (for all)" button in the dropdown of the optional leave-meeting-button to the end meeting button found in the settings dropdown when using the default configuration (i.e. Leave Meeting button not enabled):

- Add and use app.navBar.settingsDropdown.endMeetingForAllLabel (with text "End Meeting for all") for the End Meeting button
- Change the icon of the End Meeting button from icon-bbb-application to icon-bbb-close