### PR TITLE
Fix: away and raiseHands 'reactions' being hidden by avatar image

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-item/component.jsx
@@ -636,7 +636,9 @@ class UserListItem extends PureComponent {
       size: '1.3rem',
     };
 
-    let userAvatarFiltered = user.avatar;
+    const userAvatarFiltered = (user.raiseHand === true || user.away === true || user.reaction !== 'none')
+      ? ''
+      : user.avatar;
 
     const emojiIcons = [
       {
@@ -661,7 +663,6 @@ class UserListItem extends PureComponent {
       } if (user.emoji !== 'none' && user.emoji !== 'notAway') {
         return <Icon iconName={normalizeEmojiName(user.emoji)} />;
       } if (user.reaction !== 'none') {
-        userAvatarFiltered = '';
         return user.reaction;
       } if (user.name) {
         return user.name.toLowerCase().slice(0, 2);


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/bigbluebutton/bigbluebutton/issues/19263 by also filtering the avatar when user.away or user.raiseHands are true. Before it was only done for the reactions from the reactions bar.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #19263
