### PR TITLE
fix(chat): exported presentation notification

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/alert/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/alert/component.jsx
@@ -16,6 +16,7 @@ const CHAT_CONFIG = Meteor.settings.public.chat;
 const PUBLIC_CHAT_CLEAR = CHAT_CONFIG.chat_clear;
 const PUBLIC_CHAT_ID = CHAT_CONFIG.public_id;
 const POLL_RESULT_KEY = CHAT_CONFIG.system_messages_keys.chat_poll_result;
+const EXPORTED_PRESENTATION_KEY = CHAT_CONFIG.system_messages_keys.chat_exported_presentation;
 
 const propTypes = {
   pushAlertEnabled: PropTypes.bool.isRequired,
@@ -66,6 +67,10 @@ const intlMessages = defineMessages({
     id: 'app.toast.chat.pollClick',
     description: 'chat toast click message for polls',
   },
+  exportedPresentation: {
+    id: 'app.toast.chat.exportedPresentation',
+    description: 'chat toast message for exportedPresentation',
+  }
 });
 
 const ALERT_INTERVAL = 5000; // 5 seconds
@@ -189,6 +194,13 @@ const ChatAlert = (props) => {
     </Styled.PushMessageContent>
   );
 
+  const createExportedPresentationMessage = (filename) => (
+    <Styled.PushMessageContent>
+      <Styled.UserNameMessage>{intl.formatMessage(intlMessages.exportedPresentation)}</Styled.UserNameMessage>
+      <Styled.ContentMessageExportedPresentation>{filename}</Styled.ContentMessageExportedPresentation>
+    </Styled.PushMessageContent>
+  );
+
   if (isEqual(prevUnreadMessages, unreadMessages)) {
     return null;
   }
@@ -203,6 +215,8 @@ const ChatAlert = (props) => {
         if (mappedMessage.id.includes(POLL_RESULT_KEY)) {
           content = createPollMessage();
           isPollResult = true;
+        } else if (mappedMessage.id.includes(EXPORTED_PRESENTATION_KEY)) {
+          content = createExportedPresentationMessage(mappedMessage.extra.filename);
         } else {
           content = createMessage(mappedMessage.sender.name, mappedMessage.content.slice(-5));
         }

--- a/bigbluebutton-html5/imports/ui/components/chat/alert/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/alert/styles.js
@@ -42,9 +42,14 @@ const ContentMessagePoll = styled(ContentMessage)`
   margin-top: ${fontSizeSmall};
 `;
 
+const ContentMessageExportedPresentation = styled(ContentMessage)`
+  margin-top: ${fontSizeSmall};
+`;
+
 export default {
   PushMessageContent,
   UserNameMessage,
   ContentMessage,
   ContentMessagePoll,
+  ContentMessageExportedPresentation,
 };

--- a/bigbluebutton-html5/imports/ui/components/chat/service.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/service.js
@@ -83,7 +83,8 @@ const mapGroupMessage = (message) => {
     time: message.timestamp || message.time,
     sender: null,
     key: message.key,
-    chatId: message.chatId
+    chatId: message.chatId,
+    extra: message.extra,
   };
 
   if (message.sender && message.sender !== SYSTEM_CHAT_TYPE) {

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -885,6 +885,7 @@
     "app.toast.chat.system": "System",
     "app.toast.chat.poll": "Poll Results",
     "app.toast.chat.pollClick": "Poll results were published. Click here to see.",
+    "app.toast.chat.exportedPresentation": "Presentation file",
     "app.toast.clearedEmoji.label": "Emoji status cleared",
     "app.toast.setEmoji.label": "Emoji status set to {0}",
     "app.toast.meetingMuteOn.label": "All users have been muted",


### PR DESCRIPTION
### What does this PR do?

Adds a specific function to handle the creation of the exported presentation's toast notification that were missing.

### Closes Issue(s)
Closes #19278 
